### PR TITLE
chores: harden serverless infra before onboarding work

### DIFF
--- a/scripts/game-control-db.ts
+++ b/scripts/game-control-db.ts
@@ -10,10 +10,8 @@
  *   bun run scripts/game-control-db.ts status  - Check game status
  */
 
-import { PrismaClient } from '@prisma/client';
 import { logger } from '@/lib/logger';
-
-const prisma = new PrismaClient();
+import { prisma } from '@/lib/prisma';
 
 async function controlGame(action: 'start' | 'pause') {
   try {
@@ -156,4 +154,3 @@ main().catch((error) => {
   logger.error('Script failed:', error, 'Game Control');
   process.exit(1);
 });
-

--- a/src/app/api/agents/auth/route.ts
+++ b/src/app/api/agents/auth/route.ts
@@ -38,7 +38,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
   const sessionToken = randomBytes(32).toString('hex');
 
   // Create session
-  const session = createAgentSession(agentId, sessionToken);
+  const session = await createAgentSession(agentId, sessionToken);
 
   logger.info(`Agent ${agentId} authenticated successfully`, undefined, 'POST /api/agents/auth');
 

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -9,12 +9,10 @@ import { gameService } from '@/lib/game-service';
 import type { NextRequest} from 'next/server';
 import { NextResponse } from 'next/server';
 import { authenticate, errorResponse, successResponse } from '@/lib/api/auth-middleware';
-import { PrismaClient } from '@prisma/client';
 import { v4 as uuidv4 } from 'uuid';
 import { logger } from '@/lib/logger';
 import { broadcastToChannel } from '@/lib/sse/event-broadcaster';
-
-const prisma = new PrismaClient();
+import { prisma } from '@/lib/prisma';
 
 /**
  * Safely convert a date value to ISO string

--- a/src/app/mcp/route.ts
+++ b/src/app/mcp/route.ts
@@ -157,7 +157,7 @@ async function authenticateAgent(auth: {
 }): Promise<{ agentId: string; userId: string } | null> {
   // Method 1: Session Token (from /api/agents/auth)
   if (auth.token) {
-    const session = verifyAgentSession(auth.token)
+    const session = await verifyAgentSession(auth.token)
     if (session) {
       // Find user ID for this agent
       const user = await prisma.user.findUnique({
@@ -401,4 +401,3 @@ async function executeQueryFeed(
     }))
   })
 }
-

--- a/src/lib/api/auth-middleware.ts
+++ b/src/lib/api/auth-middleware.ts
@@ -72,7 +72,7 @@ export async function authenticate(request: NextRequest): Promise<AuthenticatedU
   const token = authHeader.substring(7);
 
   // Try agent session authentication first (faster)
-  const agentSession = verifyAgentSession(token);
+  const agentSession = await verifyAgentSession(token);
   if (agentSession) {
     return {
       userId: agentSession.agentId,


### PR DESCRIPTION
## Summary
- unify Prisma usage to the shared singleton so serverless runs stop exhausting the pool
- persist agent sessions (and SSE state) in Redis with in-memory fallback
- add LLM retry/backoff + tick time budgeting to keep serverless cron under 60s
- await post-tag generation and surface errors to the logs

## Testing
- bun run type-check