### PR TITLE
fix: exclude plugin-babylon and src/eliza from Next.js build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -93,6 +93,8 @@
   "exclude": [
     "node_modules",
     "dist",
+    "plugin-babylon",
+    "src/eliza",
     "**/*.test.ts",
     "**/*.test.tsx",
     "**/__tests__/**"


### PR DESCRIPTION
## Problem
Next.js build was failing with error:
```
Type error: Cannot find module '@elizaos/core' or its corresponding type declarations.
```

This occurred because Next.js was attempting to compile files in `plugin-babylon/` and `src/eliza/` directories that have dependencies not available in the main project.

## Solution
Updated `tsconfig.json` to exclude:
- `plugin-babylon`: Separate ElizaOS plugin with its own dependencies (@elizaos/core)
- `src/eliza`: Standalone CLI scripts that import from plugin-babylon

These are standalone tools meant to be run directly with Bun, not compiled as part of the Next.js application.

## Changes
- Added `plugin-babylon` to tsconfig exclude
- Added `src/eliza` to tsconfig exclude

## Testing
- Build should now complete without TypeScript errors
- These directories can still be used independently via Bun runtime