### PR TITLE
Adjust embedded wallet flow for Farcaster Mini App

### DIFF
--- a/src/lib/privy-config.ts
+++ b/src/lib/privy-config.ts
@@ -53,10 +53,10 @@ export const privyConfig: {
     // Reference: https://docs.privy.io/recipes/farcaster/mini-apps
     loginMethods: ['farcaster', 'wallet', 'email'],
     embeddedWallets: {
-      // Embedded wallets are created for all users to enable gas sponsorship
-      // External wallets can still be connected, but embedded wallets are required for gasless transactions
+      // Embedded wallets are created manually post-auth (see FarcasterFrameProvider)
+      // Automatic creation is disabled to stay compatible with Farcaster Mini Apps
       ethereum: {
-        createOnLogin: 'all-users' as const, // Enable for all users to support gas sponsorship
+        createOnLogin: 'off' as const,
       },
       // Explicitly disable Solana to prevent warnings
       solana: {


### PR DESCRIPTION
## Summary
- disable automatic embedded wallet creation in privy config for Mini App compatibility
- add post-auth helper to provision embedded wallets for non-Mini App sessions
- log failures when fallback provisioning is unavailable or fails