### PR TITLE
feat: allow disabling Sentry via env flag

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -15,17 +15,24 @@
 
 import * as Sentry from '@sentry/nextjs'
 
+const sentryDisabled =
+  process.env.NEXT_PUBLIC_DISABLE_SENTRY === 'true' ||
+  process.env.DISABLE_SENTRY === 'true'
+
 // Log initialization status in development
 if (process.env.NODE_ENV === 'development') {
-  if (!process.env.NEXT_PUBLIC_SENTRY_DSN) {
+  if (sentryDisabled) {
+    console.info('[Sentry Client] Disabled via DISABLE_SENTRY flag')
+  } else if (!process.env.NEXT_PUBLIC_SENTRY_DSN) {
     console.warn('[Sentry Client] NEXT_PUBLIC_SENTRY_DSN is not configured. Add it to your .env.local file to enable error tracking.')
   } else {
     console.log('[Sentry Client] Initializing with DSN:', process.env.NEXT_PUBLIC_SENTRY_DSN.substring(0, 20) + '...')
   }
 }
 
-Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+if (!sentryDisabled) {
+  Sentry.init({
+    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
   
   // Environment detection
   environment: process.env.NODE_ENV || 'development',
@@ -160,8 +167,8 @@ Sentry.init({
     }
     return event
   },
-})
+  })
+}
 
 // Export router transition handler for Next.js App Router
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart
-

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -8,6 +8,11 @@
  */
 
 import * as Sentry from '@sentry/nextjs'
+import { registerBabylonGame } from './src/lib/babylon-registry-init'
+
+const sentryDisabled =
+  process.env.DISABLE_SENTRY === 'true' ||
+  process.env.NEXT_PUBLIC_DISABLE_SENTRY === 'true'
 
 export async function register() {
   // Skip instrumentation during build phase
@@ -15,19 +20,19 @@ export async function register() {
     return
   }
   
+  if (sentryDisabled && process.env.NODE_ENV === 'development') {
+    console.info('[Sentry] Disabled via DISABLE_SENTRY flag')
+  }
+  
   // Initialize Sentry for server-side (Node.js runtime)
-  if (process.env.NEXT_RUNTIME === 'nodejs') {
+  if (!sentryDisabled && process.env.NEXT_RUNTIME === 'nodejs') {
     await import('./sentry.server.config')
   }
   
   // Temporarily disabled to prevent blocking dev server
   // Re-enable when agent0-sdk is properly installed
-  // Use dynamic import to avoid loading Node.js-specific code in Edge Runtime
-  // This prevents static analyzer warnings about process.argv and other Node.js APIs
-  if (false && process.env.NEXT_RUNTIME === 'nodejs') {
+  if (!sentryDisabled && false && process.env.NEXT_RUNTIME === 'nodejs') {
     // Register Babylon game (will skip if already registered or disabled)
-    // Dynamic import ensures babylon-registry-init.ts (and prisma.ts) are only loaded in Node.js runtime
-    const { registerBabylonGame } = await import('./src/lib/babylon-registry-init')
     await registerBabylonGame().catch((error: Error) => {
       // Don't fail startup if registration fails
       console.error('Failed to register Babylon game on startup:', error)
@@ -41,4 +46,3 @@ export async function register() {
 
 // Export request error handler for Next.js App Router
 export const onRequestError = Sentry.captureRequestError
-

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -8,7 +8,6 @@
  */
 
 import * as Sentry from '@sentry/nextjs'
-import { registerBabylonGame } from './src/lib/babylon-registry-init'
 
 const sentryDisabled =
   process.env.DISABLE_SENTRY === 'true' ||
@@ -31,8 +30,12 @@ export async function register() {
   
   // Temporarily disabled to prevent blocking dev server
   // Re-enable when agent0-sdk is properly installed
-  if (!sentryDisabled && false && process.env.NEXT_RUNTIME === 'nodejs') {
-    // Register Babylon game (will skip if already registered or disabled)
+  if (
+    !sentryDisabled &&
+    false &&
+    process.env.NEXT_RUNTIME === 'nodejs'
+  ) {
+    const { registerBabylonGame } = await import('./src/lib/babylon-registry-init')
     await registerBabylonGame().catch((error: Error) => {
       // Don't fail startup if registration fails
       console.error('Failed to register Babylon game on startup:', error)


### PR DESCRIPTION
# Allow disabling Sentry via env flag

## Summary
- Adds guards to `instrumentation.ts` and `instrumentation-client.ts` so Sentry only initializes when not
explicitly disabled.
- Keeps default behavior untouched—if the env vars are absent, Sentry behaves exactly as before.
- When disabled, both server and client stop logging tracing spans and don’t attempt to send events.

## Usage
Add the following to `.env.local` (or the relevant environment) when you want Sentry completely silent:


DISABLE_SENTRY=true
NEXT_PUBLIC_DISABLE_SENTRY=true


Remove or omit those variables to re-enable Sentry.