### PR TITLE
fix: strengthen share verification and update profile share URL

### DIFF
--- a/src/app/api/users/[userId]/share/route.ts
+++ b/src/app/api/users/[userId]/share/route.ts
@@ -79,7 +79,7 @@ import { prisma } from '@/lib/prisma'
 import { AuthorizationError } from '@/lib/errors'
 import { withErrorHandling } from '@/lib/errors/error-handler'
 import { logger } from '@/lib/logger'
-import { UserIdParamSchema, SnowflakeIdSchema } from '@/lib/validation/schemas'
+import { UserIdParamSchema } from '@/lib/validation/schemas'
 import type { NextRequest } from 'next/server'
 import { z } from 'zod'
 import { requireUserByIdentifier } from '@/lib/users/user-lookup'
@@ -88,7 +88,7 @@ import { generateSnowflakeId } from '@/lib/snowflake'
 const ShareRequestSchema = z.object({
   platform: z.enum(['twitter', 'farcaster', 'link', 'telegram', 'discord']),
   contentType: z.enum(['post', 'profile', 'market', 'referral', 'leaderboard']),
-  contentId: SnowflakeIdSchema.optional(),
+  contentId: z.string().optional(), // Allow any string (user IDs can be Privy DIDs or Snowflake IDs)
   url: z.string().url().optional()
 });
 

--- a/src/app/api/users/[userId]/verify-share/route.ts
+++ b/src/app/api/users/[userId]/verify-share/route.ts
@@ -231,15 +231,11 @@ export const POST = withErrorHandling(async (
                   const tweetText = (tweetData.data.text || '').toLowerCase();
                   const sharedUrl = shareAction.url?.toLowerCase() || '';
                   
-                  // Check if the tweet contains the shared URL or its domain
-                  const urlDomain = sharedUrl ? new URL(sharedUrl).hostname : '';
-                  const containsUrl = sharedUrl && (
-                    tweetText.includes(sharedUrl) || 
-                    tweetText.includes(urlDomain)
-                  );
+                  // Check if the tweet contains the exact shared URL
+                  const containsUrl = sharedUrl && tweetText.includes(sharedUrl);
 
                   if (!containsUrl && sharedUrl) {
-                    verificationError = `This tweet does not contain the shared link (${urlDomain}). Please paste the tweet where you actually shared the link.`;
+                    verificationError = `This tweet does not contain the shared link (${sharedUrl}). Please paste the tweet where you actually shared the link.`;
                     logger.warn(
                       `Tweet does not contain shared URL: ${shareId}`,
                       { 
@@ -393,15 +389,11 @@ export const POST = withErrorHandling(async (
                 const castText = (neynarData.cast.text || '').toLowerCase();
                 const sharedUrl = shareAction.url?.toLowerCase() || '';
                 
-                // Check if the cast contains the shared URL or its domain
-                const urlDomain = sharedUrl ? new URL(sharedUrl).hostname : '';
-                const containsUrl = sharedUrl && (
-                  castText.includes(sharedUrl) || 
-                  castText.includes(urlDomain)
-                );
+                // Check if the cast contains the exact shared URL
+                const containsUrl = sharedUrl && castText.includes(sharedUrl);
 
                 if (!containsUrl && sharedUrl) {
-                  verificationError = `This cast does not contain the shared link (${urlDomain}). Please paste the cast where you actually shared the link.`;
+                  verificationError = `This cast does not contain the shared link (${sharedUrl}). Please paste the cast where you actually shared the link.`;
                   logger.warn(
                     `Cast does not contain shared URL: ${shareId}`,
                     { 

--- a/src/app/rewards/page.tsx
+++ b/src/app/rewards/page.tsx
@@ -586,6 +586,7 @@ export default function RewardsPage() {
               <ShareButton
                 contentType="profile"
                 contentId={user?.id || ''}
+                url={user?.username && typeof window !== 'undefined' ? `${window.location.origin}/profile/${user.username.startsWith('@') ? user.username.slice(1) : user.username}` : undefined}
                 text="Check out my Babylon profile! 🎮"
                 className="w-full"
               />

--- a/src/components/shared/ExternalShareButton.tsx
+++ b/src/components/shared/ExternalShareButton.tsx
@@ -69,7 +69,11 @@ export function ExternalShareButton({
   const shareText = text || 'Check this out!'
 
   const handleShareToTwitter = async () => {
-    const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(shareUrl)}`
+    // Check if shareText already contains the URL to avoid duplication
+    const textContainsUrl = shareText.includes(shareUrl)
+    const twitterUrl = textContainsUrl
+      ? `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}`
+      : `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(shareUrl)}`
     window.open(twitterUrl, '_blank', 'width=550,height=420')
     
     const result = authenticated && user

--- a/src/components/shared/ShareEarnModal.tsx
+++ b/src/components/shared/ShareEarnModal.tsx
@@ -159,7 +159,11 @@ export function ShareEarnModal({
       twitter: { ...prev.twitter, loading: true }
     }))
 
-    const twitterUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(shareUrl)}`
+    // Check if shareText already contains the URL to avoid duplication
+    const textContainsUrl = shareText.includes(shareUrl)
+    const twitterUrl = textContainsUrl
+      ? `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}`
+      : `https://twitter.com/intent/tweet?text=${encodeURIComponent(shareText)}&url=${encodeURIComponent(shareUrl)}`
     window.open(twitterUrl, '_blank', 'width=550,height=420')
     
     const earned = await trackShare('twitter')


### PR DESCRIPTION
- Change profile share URL from /rewards to /profile/{username}
- Fix contentId validation to accept Privy DIDs (not just Snowflake IDs)
- Strengthen verification to require exact URL match instead of domain match
- Prevent duplicate URLs in Twitter share intent when text already contains URL