### PR TITLE
fix repost

### DIFF
--- a/src/components/interactions/InteractionBar.tsx
+++ b/src/components/interactions/InteractionBar.tsx
@@ -125,7 +125,7 @@ export function InteractionBar({
         {/* Share button */}
         <div onClick={(e) => e.stopPropagation()}>
           <RepostButton
-            postId={postId}
+            postId={postData?.originalPostId || postId}
             shareCount={shareCount}
             initialShared={isShared}
             size="sm"

--- a/src/stores/interactionStore.ts
+++ b/src/stores/interactionStore.ts
@@ -346,12 +346,12 @@ export const useInteractionStore = create<InteractionStore>()(
         setLoading(`share-${postId}`, true);
 
         const method = wasShared ? 'DELETE' : 'POST';
-        const body = !wasShared && comment ? JSON.stringify({ comment }) : undefined;
+        const body = comment ? JSON.stringify({ comment }) : JSON.stringify({});
         const response = await apiCall<{ data: { shareCount: number; isShared: boolean; repostPost?: RepostPost } }>(
           `/api/posts/${postId}/share`,
           { 
             method,
-            ...(body && { body })
+            ...(method === 'POST' && { body })
           }
         );
 

--- a/src/types/interactions.ts
+++ b/src/types/interactions.ts
@@ -352,6 +352,7 @@ export interface InteractionBarProps {
     shareCount?: number;
     isLiked?: boolean;
     isShared?: boolean;
+    originalPostId?: string | null;
   };
 }
 


### PR DESCRIPTION
ssues Fixed
1. Invalid JSON body error when reposting without text
When users clicked the repost button without adding any comment text, the API request failed with a 400 Bad Request error stating "Invalid JSON in request body". Modified the request body handling to always send a valid JSON object for POST requests.
2. 404 error when unsharing reposts
When users tried to unshare a repost, the request failed with a 404 Not Found error because the API was receiving the repost's ID instead of the original post's ID. Updated the component to pass the correct original post ID when unsharing.
