### PR TITLE
fix: implement complete referral rewards system with referee bonus

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -980,16 +980,17 @@ model Referral {
   id                                 String    @id
   referrerId                         String
   referredUserId                     String?
-  referralCode                       String    @unique
+  referralCode                       String
   status                             String    @default("pending")
   createdAt                          DateTime  @default(now())
   completedAt                        DateTime?
   User_Referral_referredUserIdToUser User?     @relation("Referral_referredUserIdToUser", fields: [referredUserId], references: [id])
   User_Referral_referrerIdToUser     User      @relation("Referral_referrerIdToUser", fields: [referrerId], references: [id], onDelete: Cascade)
 
+  @@unique([referralCode, referredUserId])
   @@index([referralCode])
-  @@index([referredUserId])
   @@index([referrerId])
+  @@index([referredUserId])
   @@index([status, createdAt(sort: Desc)])
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1143,6 +1143,7 @@ model User {
   pointsAwardedForTwitter                                           Boolean                  @default(false)
   pointsAwardedForUsername                                          Boolean                  @default(false)
   pointsAwardedForWallet                                            Boolean                  @default(false)
+  pointsAwardedForReferralBonus                                     Boolean                  @default(false)
   referralCode                                                      String?                  @unique
   referralCount                                                     Int                      @default(0)
   referredBy                                                        String?

--- a/src/app/api/users/[userId]/referral-code/route.ts
+++ b/src/app/api/users/[userId]/referral-code/route.ts
@@ -56,23 +56,13 @@ import {
   successResponse
 } from '@/lib/api/auth-middleware';
 import { prisma } from '@/lib/prisma';
-import { AuthorizationError, InternalServerError, NotFoundError } from '@/lib/errors';
+import { AuthorizationError, NotFoundError } from '@/lib/errors';
 import { withErrorHandling } from '@/lib/errors/error-handler';
 import { logger } from '@/lib/logger';
 import { UserIdParamSchema } from '@/lib/validation/schemas';
 import type { NextRequest } from 'next/server';
 import { requireUserByIdentifier } from '@/lib/users/user-lookup';
-import { generateSnowflakeId } from '@/lib/snowflake';
-
-/**
- * Generate a unique referral code
- */
-function generateReferralCode(userId: string): string {
-  // Use first 8 chars of user ID + random 4 chars
-  const userPrefix = userId.slice(0, 8);
-  const random = Math.random().toString(36).substring(2, 6).toUpperCase();
-  return `${userPrefix}-${random}`;
-}
+import { getOrCreateReferralCode } from '@/lib/services/referral-service';
 
 /**
  * GET /api/users/[userId]/referral-code
@@ -95,11 +85,12 @@ export const GET = withErrorHandling(async (
   }
 
   // Get or create referral code
-  let user = await prisma.user.findUnique({
+  const referralCode = await getOrCreateReferralCode(canonicalUserId);
+
+  // Get user stats
+  const user = await prisma.user.findUnique({
     where: { id: canonicalUserId },
     select: {
-      id: true,
-      referralCode: true,
       referralCount: true,
     },
   });
@@ -108,69 +99,11 @@ export const GET = withErrorHandling(async (
     throw new NotFoundError('User', canonicalUserId);
   }
 
-  // Generate referral code if doesn't exist
-  if (!user.referralCode) {
-    let code = generateReferralCode(canonicalUserId);
-    let attempts = 0;
-    const maxAttempts = 10;
-
-    // Ensure code is unique
-    while (attempts < maxAttempts) {
-      const existing = await prisma.user.findUnique({
-        where: { referralCode: code },
-      });
-
-      if (!existing) {
-        break;
-      }
-
-      code = generateReferralCode(canonicalUserId);
-      attempts++;
-    }
-
-    if (attempts >= maxAttempts) {
-      throw new InternalServerError('Failed to generate unique referral code');
-    }
-
-    // Update user with new referral code
-    user = await prisma.user.update({
-      where: { id: canonicalUserId },
-      data: { referralCode: code },
-      select: {
-        id: true,
-        referralCode: true,
-        referralCount: true,
-      },
-    });
-
-    logger.info(
-      `Generated referral code for user ${canonicalUserId}: ${code}`,
-      { userId: canonicalUserId, code },
-      'GET /api/users/[userId]/referral-code'
-    );
-  }
-
-  // Create referral entry if doesn't exist
-  const existingReferral = await prisma.referral.findUnique({
-    where: { referralCode: user.referralCode! },
-  });
-
-  if (!existingReferral) {
-    await prisma.referral.create({
-      data: {
-        id: await generateSnowflakeId(),
-        referrerId: canonicalUserId,
-        referralCode: user.referralCode!,
-        status: 'pending',
-      },
-    });
-  }
-
-  logger.info('Referral code fetched successfully', { userId: canonicalUserId, referralCode: user.referralCode }, 'GET /api/users/[userId]/referral-code');
+  logger.info('Referral code fetched successfully', { userId: canonicalUserId, referralCode }, 'GET /api/users/[userId]/referral-code');
 
   return successResponse({
-    referralCode: user.referralCode,
+    referralCode,
     referralCount: user.referralCount,
-    referralUrl: `${process.env.NEXT_PUBLIC_APP_URL || 'https://babylon.market'}?ref=${user.referralCode}`,
+    referralUrl: `${process.env.NEXT_PUBLIC_APP_URL || 'https://babylon.market'}?ref=${referralCode}`,
   });
 });

--- a/src/app/api/users/signup/route.ts
+++ b/src/app/api/users/signup/route.ts
@@ -388,19 +388,19 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
       })
     }
     
-    // Auto-follow the referrer
+    // Auto-follow the referrer (new user follows the person who referred them)
     await prisma.follow.upsert({
       where: {
         followerId_followingId: {
-          followerId: result.referrerId,
-          followingId: result.user.id,
+          followerId: result.user.id,       // New user is the follower
+          followingId: result.referrerId,   // Referrer is being followed
         },
       },
       update: {},
       create: {
         id: await generateSnowflakeId(),
-        followerId: result.referrerId,
-        followingId: result.user.id,
+        followerId: result.user.id,
+        followingId: result.referrerId,
       },
     })
     

--- a/src/app/api/users/signup/route.ts
+++ b/src/app/api/users/signup/route.ts
@@ -92,6 +92,7 @@ import { withErrorHandling, successResponse } from '@/lib/errors/error-handler'
 import { OnboardingProfileSchema } from '@/lib/validation/schemas'
 import { prisma } from '@/lib/prisma'
 import { PointsService } from '@/lib/services/points-service'
+import { POINTS } from '@/lib/constants/points'
 import { logger } from '@/lib/logger'
 import { z } from 'zod'
 import { getPrivyClient } from '@/lib/api/auth-middleware'
@@ -362,7 +363,63 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
     twitter: 0,
     wallet: 0,
     profile: 0,
+    referral: 0,
+    referralBonus: 0,
   };
+
+  // Award referral points if user was referred
+  if (result.referrerId) {
+    // Award points to REFERRER
+    const referralResult = await PointsService.awardReferralSignup(result.referrerId, result.user.id)
+    pointsAwarded.referral = referralResult.pointsAwarded
+    
+    // Award bonus to NEW USER (referee) for using referral code
+    const refereeBonus = await PointsService.awardPoints(
+      result.user.id,
+      POINTS.REFERRAL_BONUS,
+      'referral_bonus',
+      { referrerId: result.referrerId }
+    )
+    pointsAwarded.referralBonus = refereeBonus.pointsAwarded
+    
+    // Update referral status to completed
+    if (result.referralRecordId) {
+      await prisma.referral.update({
+        where: { id: result.referralRecordId },
+        data: {
+          status: 'completed',
+          completedAt: new Date(),
+        },
+      })
+    }
+    
+    // Auto-follow the referrer
+    await prisma.follow.upsert({
+      where: {
+        followerId_followingId: {
+          followerId: result.referrerId,
+          followingId: result.user.id,
+        },
+      },
+      update: {},
+      create: {
+        id: await generateSnowflakeId(),
+        followerId: result.referrerId,
+        followingId: result.user.id,
+      },
+    })
+    
+    logger.info(
+      'Awarded referral points to both referrer and referee',
+      { 
+        referrerId: result.referrerId, 
+        referredUserId: result.user.id, 
+        referrerPoints: referralResult.pointsAwarded,
+        refereeBonus: refereeBonus.pointsAwarded,
+      },
+      'POST /api/users/signup'
+    )
+  }
 
   if (identityFarcasterUsername || importedFarcaster) {
     const farcasterUsername = parsedProfile.farcasterUsername ?? identityFarcasterUsername

--- a/src/app/api/users/signup/route.ts
+++ b/src/app/api/users/signup/route.ts
@@ -103,6 +103,7 @@ import { notifyNewAccount } from '@/lib/services/notification-service'
 import { generateSnowflakeId } from '@/lib/snowflake'
 import { withRetry, isRetryableError } from '@/lib/prisma-retry'
 import type { JsonValue } from '@/types/common'
+import { getOrCreateReferralCode } from '@/lib/services/referral-service'
 
 interface SignupRequestBody {
   username: string
@@ -361,6 +362,9 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
     }
     throw error;
   })
+
+  // Generate referral code for new user (ensures they can refer others immediately)
+  await getOrCreateReferralCode(result.user.id)
 
   // Award points for social account linking
   const pointsAwarded = {

--- a/src/app/api/users/signup/route.ts
+++ b/src/app/api/users/signup/route.ts
@@ -230,14 +230,24 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
           }
         }
 
-        // Create a NEW referral record for this signup (one record per referred user)
+        // Create or update referral record (idempotent for retries)
         if (resolvedReferrerId) {
-          const newReferralRecord = await tx.referral.create({
-            data: {
+          const newReferralRecord = await tx.referral.upsert({
+            where: {
+              referralCode_referredUserId: {
+                referralCode: normalizedCode,
+                referredUserId: canonicalUserId,
+              },
+            },
+            create: {
               id: await generateSnowflakeId(),
               referrerId: resolvedReferrerId,
               referralCode: normalizedCode,
               referredUserId: canonicalUserId,
+              status: 'pending',
+            },
+            update: {
+              // On retry, keep existing record but ensure status is pending
               status: 'pending',
             },
             select: { id: true },

--- a/src/app/api/users/signup/route.ts
+++ b/src/app/api/users/signup/route.ts
@@ -210,6 +210,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
       if (referralCode) {
         const normalizedCode = referralCode.trim()
 
+        // First, try to find referrer by username (legacy system)
         const referrerByUsername = await tx.user.findUnique({
           where: { username: normalizedCode },
           select: { id: true },
@@ -217,38 +218,32 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
 
         if (referrerByUsername && referrerByUsername.id !== canonicalUserId) {
           resolvedReferrerId = referrerByUsername.id
-
-          const referralRecord = await tx.referral.upsert({
+        } else {
+          // If not found by username, look up who owns this referral code
+          const referralOwner = await tx.user.findUnique({
             where: { referralCode: normalizedCode },
-            update: {
-              referredUserId: canonicalUserId,
-              status: 'pending',
-            },
-            create: {
+            select: { id: true },
+          })
+
+          if (referralOwner && referralOwner.id !== canonicalUserId) {
+            resolvedReferrerId = referralOwner.id
+          }
+        }
+
+        // Create a NEW referral record for this signup (one record per referred user)
+        if (resolvedReferrerId) {
+          const newReferralRecord = await tx.referral.create({
+            data: {
               id: await generateSnowflakeId(),
-              referrerId: referrerByUsername.id,
+              referrerId: resolvedReferrerId,
               referralCode: normalizedCode,
               referredUserId: canonicalUserId,
               status: 'pending',
             },
             select: { id: true },
           })
-
-          resolvedReferralRecordId = referralRecord.id
-        } else {
-          const referralRecord = await tx.referral.findUnique({
-            where: { referralCode: normalizedCode },
-            select: { id: true, referrerId: true, referredUserId: true },
-          })
-
-          if (
-            referralRecord &&
-            referralRecord.referrerId !== canonicalUserId &&
-            (!referralRecord.referredUserId || referralRecord.referredUserId === canonicalUserId)
-          ) {
-            resolvedReferrerId = referralRecord.referrerId
-            resolvedReferralRecordId = referralRecord.id
-          }
+          
+          resolvedReferralRecordId = newReferralRecord.id
         }
       }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -55,8 +55,10 @@ function HomePageContent() {
         })
       }
 
-      // Redirect to feed
-      router.push('/feed')
+      // Redirect to feed, preserving referral code if present
+      const ref = searchParams.get('ref')
+      const feedUrl = ref ? `/feed?ref=${ref}` : '/feed'
+      router.push(feedUrl)
     }
   }, [authenticated, router, showLoginModal, searchParams])
 

--- a/src/app/share/referral/[userId]/page.tsx
+++ b/src/app/share/referral/[userId]/page.tsx
@@ -6,6 +6,7 @@
 import type { Metadata } from 'next'
 import { prisma } from '@/lib/prisma'
 import { redirect } from 'next/navigation'
+import { getOrCreateReferralCode } from '@/lib/services/referral-service'
 
 interface PageProps {
   params: Promise<{
@@ -14,10 +15,12 @@ interface PageProps {
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-  const { userId } = await params
+  const { userId: rawUserId } = await params
+  // Decode URL-encoded userId (colons in Privy DIDs are encoded as %3A)
+  const userId = decodeURIComponent(rawUserId)
   
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'https://babylon.market'
-  const ogImageUrl = `${appUrl}/api/og/referral/${userId}`
+  const ogImageUrl = `${appUrl}/api/og/referral/${encodeURIComponent(userId)}`
   
   // Get user data
   const user = await prisma.user.findUnique({
@@ -67,24 +70,24 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 }
 
 export default async function ShareReferralPage({ params }: PageProps) {
-  const { userId } = await params
-  
-  // Get user with referral code
+  const { userId: rawUserId } = await params
+  // Decode URL-encoded userId (colons in Privy DIDs are encoded as %3A)
+  const userId = decodeURIComponent(rawUserId)
+
+  // Check if user exists
   const user = await prisma.user.findUnique({
     where: { id: userId },
-    select: {
-      id: true,
-      username: true,
-      referralCode: true,
-    },
+    select: { id: true },
   })
 
-  // Redirect to home with or without referral code
-  if (user?.referralCode) {
-    redirect(`/?ref=${user.referralCode}`)
-  } else {
-    // No user or no referral code - just go home
+  if (!user) {
     redirect('/')
   }
+
+  // Get or create referral code for the user
+  const referralCode = await getOrCreateReferralCode(userId)
+
+  // Redirect to home with referral code
+  redirect(`/?ref=${referralCode}`)
 }
 

--- a/src/app/share/referral/[userId]/page.tsx
+++ b/src/app/share/referral/[userId]/page.tsx
@@ -28,12 +28,22 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     select: {
       username: true,
       displayName: true,
-      referralCode: true,
     },
   })
 
-  const displayName = user?.displayName || user?.username || 'A Babylon Trader'
-  const referralLink = user?.referralCode ? `${appUrl}/?ref=${user.referralCode}` : appUrl
+  if (!user) {
+    // User not found - return default metadata
+    return {
+      title: 'Join Babylon',
+      description: 'Trade narratives, share the upside',
+    }
+  }
+
+  // Generate referral code if it doesn't exist (ensures OG metadata always has ref param)
+  const referralCode = await getOrCreateReferralCode(userId)
+  
+  const displayName = user.displayName || user.username || 'A Babylon Trader'
+  const referralLink = `${appUrl}/?ref=${referralCode}`
 
   return {
     title: `${displayName} invited you to Babylon`,

--- a/src/lib/constants/points.ts
+++ b/src/lib/constants/points.ts
@@ -14,7 +14,8 @@ export const POINTS = {
   WALLET_CONNECT: 1000,
   SHARE_ACTION: 1000,
   SHARE_TO_TWITTER: 1000,
-  REFERRAL_SIGNUP: 250,
+  REFERRAL_SIGNUP: 250, // Reward for referrer
+  REFERRAL_BONUS: 250,  // Bonus for new user who used a referral code
 } as const;
 
 export type PointsReason =
@@ -26,6 +27,7 @@ export type PointsReason =
   | 'share_action'
   | 'share_to_twitter'
   | 'referral_signup'
+  | 'referral_bonus'
   | 'admin_award'
   | 'admin_deduction'
   | 'purchase'

--- a/src/lib/onboarding/onchain-service.ts
+++ b/src/lib/onboarding/onchain-service.ts
@@ -699,13 +699,24 @@ export async function processOnchainRegistration({
     )
 
     if (referralCode) {
-      // Create a new referral record for this signup (one record per referred user)
-      await prisma.referral.create({
-        data: {
+      // Create or update referral record (idempotent for retries)
+      await prisma.referral.upsert({
+        where: {
+          referralCode_referredUserId: {
+            referralCode,
+            referredUserId: dbUser.id,
+          },
+        },
+        create: {
           id: await generateSnowflakeId(),
           referrerId,
           referralCode,
           referredUserId: dbUser.id,
+          status: 'completed',
+          completedAt: new Date(),
+        },
+        update: {
+          // On retry, ensure status is completed
           status: 'completed',
           completedAt: new Date(),
         },

--- a/src/lib/onboarding/onchain-service.ts
+++ b/src/lib/onboarding/onchain-service.ts
@@ -153,7 +153,8 @@ export async function processOnchainRegistration({
       select: { id: true },
     })
 
-    if (referrer) {
+    // Prevent self-referral by username
+    if (referrer && referrer.id !== user.userId) {
       referrerId = referrer.id
       logger.info('Valid referral code (username) found', { referralCode, referrerId }, 'OnboardingOnchain')
     } else {
@@ -163,9 +164,12 @@ export async function processOnchainRegistration({
         select: { id: true },
       })
 
-      if (referralOwner) {
+      // Prevent self-referral by referral code
+      if (referralOwner && referralOwner.id !== user.userId) {
         referrerId = referralOwner.id
         logger.info('Valid referral code found', { referralCode, referrerId }, 'OnboardingOnchain')
+      } else if (referrer?.id === user.userId || referralOwner?.id === user.userId) {
+        logger.warn('Self-referral attempt blocked', { userId: user.userId, referralCode }, 'OnboardingOnchain')
       }
     }
   }

--- a/src/lib/onboarding/onchain-service.ts
+++ b/src/lib/onboarding/onchain-service.ts
@@ -156,14 +156,15 @@ export async function processOnchainRegistration({
       referrerId = referrer.id
       logger.info('Valid referral code (username) found', { referralCode, referrerId }, 'OnboardingOnchain')
     } else {
-      const referral = await prisma.referral.findUnique({
+      // Look up who owns this referral code
+      const referralOwner = await prisma.user.findUnique({
         where: { referralCode },
-        include: { User_Referral_referrerIdToUser: true },
+        select: { id: true },
       })
 
-      if (referral && referral.status === 'pending') {
-        referrerId = referral.referrerId
-        logger.info('Valid referral code (legacy) found', { referralCode, referrerId }, 'OnboardingOnchain')
+      if (referralOwner) {
+        referrerId = referralOwner.id
+        logger.info('Valid referral code found', { referralCode, referrerId }, 'OnboardingOnchain')
       }
     }
   }
@@ -684,14 +685,9 @@ export async function processOnchainRegistration({
     const referralResult = await PointsService.awardReferralSignup(referrerId, dbUser.id)
 
     if (referralCode) {
-      await prisma.referral.upsert({
-        where: { referralCode },
-        update: {
-          status: 'completed',
-          referredUserId: dbUser.id,
-          completedAt: new Date(),
-        },
-        create: {
+      // Create a new referral record for this signup (one record per referred user)
+      await prisma.referral.create({
+        data: {
           id: await generateSnowflakeId(),
           referrerId,
           referralCode,

--- a/src/lib/onboarding/onchain-service.ts
+++ b/src/lib/onboarding/onchain-service.ts
@@ -15,6 +15,7 @@ import { extractErrorMessage } from '@/lib/api/auth-middleware'
 import { syncAfterAgent0Registration } from '@/lib/reputation/agent0-reputation-sync'
 import type { JsonValue } from '@/types/common'
 import { POINTS } from '@/lib/constants/points'
+import { getOrCreateReferralCode } from '@/lib/services/referral-service'
 
 // Use Base Sepolia for contract deployments (chain ID: 84532)
 export const IDENTITY_REGISTRY = process.env.NEXT_PUBLIC_IDENTITY_REGISTRY_BASE_SEPOLIA as Address
@@ -682,6 +683,9 @@ export async function processOnchainRegistration({
   })
 
   logger.info('Successfully awarded 1,000 points to user', undefined, 'OnboardingOnchain')
+
+  // Generate referral code for new user (ensures they can refer others immediately)
+  await getOrCreateReferralCode(dbUser.id)
 
   await notifyNewAccount(dbUser.id)
   logger.info('Welcome notification sent to new user', { userId: dbUser.id }, 'OnboardingOnchain')

--- a/src/lib/onboarding/onchain-service.ts
+++ b/src/lib/onboarding/onchain-service.ts
@@ -14,6 +14,7 @@ import type { AuthenticatedUser } from '@/lib/api/auth-middleware'
 import { extractErrorMessage } from '@/lib/api/auth-middleware'
 import { syncAfterAgent0Registration } from '@/lib/reputation/agent0-reputation-sync'
 import type { JsonValue } from '@/types/common'
+import { POINTS } from '@/lib/constants/points'
 
 // Use Base Sepolia for contract deployments (chain ID: 84532)
 export const IDENTITY_REGISTRY = process.env.NEXT_PUBLIC_IDENTITY_REGISTRY_BASE_SEPOLIA as Address
@@ -682,7 +683,16 @@ export async function processOnchainRegistration({
   logger.info('Welcome notification sent to new user', { userId: dbUser.id }, 'OnboardingOnchain')
 
   if (referrerId) {
+    // Award points to REFERRER
     const referralResult = await PointsService.awardReferralSignup(referrerId, dbUser.id)
+
+    // Award bonus to NEW USER (referee) for using referral code
+    const refereeBonus = await PointsService.awardPoints(
+      dbUser.id,
+      POINTS.REFERRAL_BONUS,
+      'referral_bonus',
+      { referrerId }
+    )
 
     if (referralCode) {
       // Create a new referral record for this signup (one record per referred user)
@@ -714,7 +724,12 @@ export async function processOnchainRegistration({
     })
 
     logger.info('New user auto-followed referrer', { referrerId, referredUserId: dbUser.id }, 'OnboardingOnchain')
-    logger.info('Awarded referral points', { referrerId, referredUserId: dbUser.id, points: referralResult.pointsAwarded }, 'OnboardingOnchain')
+    logger.info('Awarded referral points to both referrer and referee', { 
+      referrerId, 
+      referredUserId: dbUser.id, 
+      referrerPoints: referralResult.pointsAwarded,
+      refereeBonus: refereeBonus.pointsAwarded,
+    }, 'OnboardingOnchain')
   }
 
   return {

--- a/src/lib/onboarding/onchain-service.ts
+++ b/src/lib/onboarding/onchain-service.ts
@@ -701,19 +701,19 @@ export async function processOnchainRegistration({
     await prisma.follow.upsert({
       where: {
         followerId_followingId: {
-          followerId: referrerId,
-          followingId: dbUser.id,
+          followerId: dbUser.id,      // New user is the follower
+          followingId: referrerId,     // Referrer is being followed
         },
       },
       update: {},
       create: {
         id: await generateSnowflakeId(),
-        followerId: referrerId,
-        followingId: dbUser.id,
+        followerId: dbUser.id,
+        followingId: referrerId,
       },
     })
 
-    logger.info('Referrer auto-followed new user', { referrerId, referredUserId: dbUser.id }, 'OnboardingOnchain')
+    logger.info('New user auto-followed referrer', { referrerId, referredUserId: dbUser.id }, 'OnboardingOnchain')
     logger.info('Awarded referral points', { referrerId, referredUserId: dbUser.id, points: referralResult.pointsAwarded }, 'OnboardingOnchain')
   }
 

--- a/src/lib/services/points-service.ts
+++ b/src/lib/services/points-service.ts
@@ -43,6 +43,7 @@ export class PointsService {
         pointsAwardedForFarcaster: true,
         pointsAwardedForTwitter: true,
         pointsAwardedForWallet: true,
+        pointsAwardedForReferralBonus: true,
       },
     });
 
@@ -78,6 +79,7 @@ export class PointsService {
       pointsAwardedForFarcaster?: boolean
       pointsAwardedForTwitter?: boolean
       pointsAwardedForWallet?: boolean
+      pointsAwardedForReferralBonus?: boolean
     } = {
       reputationPoints: pointsAfter,
     };
@@ -102,6 +104,10 @@ export class PointsService {
       case 'wallet_connect':
         updateData.bonusPoints = user.bonusPoints + amount;
         updateData.pointsAwardedForWallet = true;
+        break;
+      case 'referral_bonus':
+        updateData.bonusPoints = user.bonusPoints + amount;
+        updateData.pointsAwardedForReferralBonus = true;
         break;
       case 'share_action':
       case 'share_to_twitter':
@@ -331,6 +337,7 @@ export class PointsService {
       pointsAwardedForFarcaster: boolean;
       pointsAwardedForTwitter: boolean;
       pointsAwardedForWallet: boolean;
+      pointsAwardedForReferralBonus: boolean;
     },
     reason: PointsReason
   ): boolean {
@@ -343,6 +350,8 @@ export class PointsService {
         return user.pointsAwardedForTwitter;
       case 'wallet_connect':
         return user.pointsAwardedForWallet;
+      case 'referral_bonus':
+        return user.pointsAwardedForReferralBonus;
       default:
         return false; // For share actions and referrals, allow multiple awards
     }

--- a/src/lib/services/referral-service.ts
+++ b/src/lib/services/referral-service.ts
@@ -6,7 +6,6 @@
  */
 
 import { prisma } from '@/lib/prisma'
-import { generateSnowflakeId } from '@/lib/snowflake'
 import { logger } from '@/lib/logger'
 
 /**
@@ -83,22 +82,6 @@ export async function getOrCreateReferralCode(userId: string): Promise<string> {
     { userId, code },
     'ReferralService'
   )
-
-  // Create referral entry if doesn't exist
-  const existingReferral = await prisma.referral.findUnique({
-    where: { referralCode: code },
-  })
-
-  if (!existingReferral) {
-    await prisma.referral.create({
-      data: {
-        id: await generateSnowflakeId(),
-        referrerId: userId,
-        referralCode: code,
-        status: 'pending',
-      },
-    })
-  }
 
   return code
 }

--- a/src/lib/services/referral-service.ts
+++ b/src/lib/services/referral-service.ts
@@ -1,0 +1,105 @@
+/**
+ * Referral Service
+ * 
+ * Centralized service for managing user referral codes.
+ * Handles referral code generation, uniqueness validation, and database updates.
+ */
+
+import { prisma } from '@/lib/prisma'
+import { generateSnowflakeId } from '@/lib/snowflake'
+import { logger } from '@/lib/logger'
+
+/**
+ * Generate a referral code from a user ID
+ */
+function generateReferralCode(userId: string): string {
+  // Use first 8 chars of user ID (alphanumeric only) + random 4 chars
+  const userPrefix = userId.replace(/[^a-zA-Z0-9]/g, '').slice(0, 8)
+  const random = Math.random().toString(36).substring(2, 6).toUpperCase()
+  return `${userPrefix}-${random}`
+}
+
+/**
+ * Get or create a referral code for a user
+ * 
+ * @param userId - The user ID
+ * @returns The user's referral code
+ * @throws Error if unable to generate a unique code
+ */
+export async function getOrCreateReferralCode(userId: string): Promise<string> {
+  // Check if user already has a referral code
+  let user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      id: true,
+      referralCode: true,
+    },
+  })
+
+  if (!user) {
+    throw new Error(`User not found: ${userId}`)
+  }
+
+  // Return existing code if present
+  if (user.referralCode) {
+    return user.referralCode
+  }
+
+  // Generate a new unique referral code
+  let code = generateReferralCode(userId)
+  let attempts = 0
+  const maxAttempts = 10
+
+  // Ensure code is unique
+  while (attempts < maxAttempts) {
+    const existing = await prisma.user.findUnique({
+      where: { referralCode: code },
+    })
+
+    if (!existing) {
+      break
+    }
+
+    code = generateReferralCode(userId)
+    attempts++
+  }
+
+  if (attempts >= maxAttempts) {
+    throw new Error('Failed to generate unique referral code')
+  }
+
+  // Update user with new referral code
+  user = await prisma.user.update({
+    where: { id: userId },
+    data: { referralCode: code },
+    select: {
+      id: true,
+      referralCode: true,
+    },
+  })
+
+  logger.info(
+    `Generated referral code for user ${userId}: ${code}`,
+    { userId, code },
+    'ReferralService'
+  )
+
+  // Create referral entry if doesn't exist
+  const existingReferral = await prisma.referral.findUnique({
+    where: { referralCode: code },
+  })
+
+  if (!existingReferral) {
+    await prisma.referral.create({
+      data: {
+        id: await generateSnowflakeId(),
+        referrerId: userId,
+        referralCode: code,
+        status: 'pending',
+      },
+    })
+  }
+
+  return code
+}
+


### PR DESCRIPTION
- Extract referral code generation into shared ReferralService for DRY
- Fix URL decoding for Privy DIDs in referral share page (colons encoded as %3A)
- Preserve ref parameter through home page redirect to /feed
- Award 250 points to referrer on signup (REFERRAL_SIGNUP)
- Award 250 point bonus to referee for using referral code (REFERRAL_BONUS)
- Update referral status to completed and auto-follow referrer on signup
- Create incentive for both sharing and using referral codes
- Remove unique constraint on Referral.referralCode in schema
- Add compound unique on [referralCode, referredUserId] to prevent duplicate signups
- Lookup referral code ownership via User.referralCode (cleaner, no template records)
- Create one Referral record per signup for proper relationship tracking