### PR TITLE
fix: sync interaction store with fresh API data on page load

### DIFF
--- a/src/app/post/[id]/page.tsx
+++ b/src/app/post/[id]/page.tsx
@@ -74,9 +74,6 @@ export default function PostPage({ params }: PostPageProps) {
         return;
       }
 
-      const { postInteractions } = useInteractionStore.getState();
-      const storeData = postInteractions.get(postId);
-
       setPost({
         id: postData.id,
         type: postData.type || 'post',
@@ -93,11 +90,11 @@ export default function PostPage({ params }: PostPageProps) {
         authorUsername: postData.authorUsername || null,
         authorProfileImageUrl: postData.authorProfileImageUrl || null,
         timestamp: postData.timestamp,
-        likeCount: storeData?.likeCount ?? postData.likeCount ?? 0,
-        commentCount: storeData?.commentCount ?? postData.commentCount ?? 0,
-        shareCount: storeData?.shareCount ?? postData.shareCount ?? 0,
-        isLiked: storeData?.isLiked ?? postData.isLiked ?? false,
-        isShared: storeData?.isShared ?? postData.isShared ?? false,
+        likeCount: postData.likeCount ?? 0,
+        commentCount: postData.commentCount ?? 0,
+        shareCount: postData.shareCount ?? 0,
+        isLiked: postData.isLiked ?? false,
+        isShared: postData.isShared ?? false,
         // Repost metadata
         isRepost: postData.isRepost || false,
         originalPostId: postData.originalPostId || null,
@@ -108,6 +105,20 @@ export default function PostPage({ params }: PostPageProps) {
         originalContent: postData.originalContent || null,
         quoteComment: postData.quoteComment || null,
       });
+      
+      // Update the interaction store with fresh API data
+      const store = useInteractionStore.getState();
+      const updatedInteractions = new Map(store.postInteractions);
+      updatedInteractions.set(postId, {
+        postId,
+        likeCount: postData.likeCount ?? 0,
+        commentCount: postData.commentCount ?? 0,
+        shareCount: postData.shareCount ?? 0,
+        isLiked: postData.isLiked ?? false,
+        isShared: postData.isShared ?? false,
+      });
+      useInteractionStore.setState({ postInteractions: updatedInteractions });
+      
       setIsLoading(false);
     };
 

--- a/src/components/interactions/InteractionBar.tsx
+++ b/src/components/interactions/InteractionBar.tsx
@@ -61,23 +61,20 @@ export function InteractionBar({
   const isLiked = storeData?.isLiked ?? initialInteractions?.isLiked ?? false;
   const isShared = storeData?.isShared ?? initialInteractions?.isShared ?? false;
 
-  // Register this post in the store so polling picks it up
+  // Always sync store with latest initial values from API
   useEffect(() => {
-    if (!storeData) {
-      // Initialize in store with provided initial values
-      const store = useInteractionStore.getState();
-      const updatedInteractions = new Map(store.postInteractions);
-      updatedInteractions.set(postId, {
-        postId,
-        likeCount: initialInteractions?.likeCount ?? 0,
-        commentCount: initialInteractions?.commentCount ?? 0,
-        shareCount: initialInteractions?.shareCount ?? 0,
-        isLiked: initialInteractions?.isLiked ?? false,
-        isShared: initialInteractions?.isShared ?? false,
-      });
-      useInteractionStore.setState({ postInteractions: updatedInteractions });
-    }
-  }, [postId, storeData, initialInteractions]);
+    const store = useInteractionStore.getState();
+    const updatedInteractions = new Map(store.postInteractions);
+    updatedInteractions.set(postId, {
+      postId,
+      likeCount: initialInteractions?.likeCount ?? 0,
+      commentCount: initialInteractions?.commentCount ?? 0,
+      shareCount: initialInteractions?.shareCount ?? 0,
+      isLiked: initialInteractions?.isLiked ?? false,
+      isShared: initialInteractions?.isShared ?? false,
+    });
+    useInteractionStore.setState({ postInteractions: updatedInteractions });
+  }, [postId, initialInteractions?.likeCount, initialInteractions?.commentCount, initialInteractions?.shareCount, initialInteractions?.isLiked, initialInteractions?.isShared]);
 
   const handleCommentClick = () => {
     if (!authenticated) {


### PR DESCRIPTION
### Issue
When refreshing the feed or post page, like/comment/share counts showed outdated values from previous sessions, even though the API was returning correct data. Users only saw updated counts after interacting with the post themselves.

### Solution
- **Post page**: Use fresh API data directly instead of checking store first, then sync store with API data
- **InteractionBar (feed)**: Always update store with latest API counts, removing the conditional check that prevented updates when stale data existed
