### PR TITLE
fix: preserve isLiked/isShared state from store and use original post…

### DIFF
--- a/src/app/post/[id]/page.tsx
+++ b/src/app/post/[id]/page.tsx
@@ -107,17 +107,24 @@ export default function PostPage({ params }: PostPageProps) {
       });
       
       // Update the interaction store with fresh API data
-      const store = useInteractionStore.getState();
-      const updatedInteractions = new Map(store.postInteractions);
-      updatedInteractions.set(postId, {
-        postId,
-        likeCount: postData.likeCount ?? 0,
-        commentCount: postData.commentCount ?? 0,
-        shareCount: postData.shareCount ?? 0,
-        isLiked: postData.isLiked ?? false,
-        isShared: postData.isShared ?? false,
-      });
-      useInteractionStore.setState({ postInteractions: updatedInteractions });
+      const { postInteractions } = useInteractionStore.getState();
+      const storeData = postInteractions.get(postId);
+      
+      // Only update store if likeCount or commentCount changed to avoid overwriting isLiked/isShared
+      if (postData.likeCount !== undefined || postData.commentCount !== undefined) {
+        const store = useInteractionStore.getState();
+        const updatedInteractions = new Map(store.postInteractions);
+        updatedInteractions.set(postId, {
+          postId,
+          likeCount: postData.likeCount ?? 0,
+          commentCount: postData.commentCount ?? 0,
+          shareCount: postData.shareCount ?? 0,
+          // Preserve existing isLiked/isShared from store, don't overwrite with API
+          isLiked: storeData?.isLiked ?? postData.isLiked ?? false,
+          isShared: storeData?.isShared ?? postData.isShared ?? false,
+        });
+        useInteractionStore.setState({ postInteractions: updatedInteractions });
+      }
       
       setIsLoading(false);
     };

--- a/src/app/post/[id]/page.tsx
+++ b/src/app/post/[id]/page.tsx
@@ -107,15 +107,17 @@ export default function PostPage({ params }: PostPageProps) {
       });
       
       // Update the interaction store with fresh API data
+      // For reposts, use the original post ID to match InteractionBar's behavior
+      const interactionPostId = postData.originalPostId || postId;
       const { postInteractions } = useInteractionStore.getState();
-      const storeData = postInteractions.get(postId);
+      const storeData = postInteractions.get(interactionPostId);
       
       // Only update store if likeCount or commentCount changed to avoid overwriting isLiked/isShared
       if (postData.likeCount !== undefined || postData.commentCount !== undefined) {
         const store = useInteractionStore.getState();
         const updatedInteractions = new Map(store.postInteractions);
-        updatedInteractions.set(postId, {
-          postId,
+        updatedInteractions.set(interactionPostId, {
+          postId: interactionPostId,
           likeCount: postData.likeCount ?? 0,
           commentCount: postData.commentCount ?? 0,
           shareCount: postData.shareCount ?? 0,

--- a/src/components/interactions/InteractionBar.tsx
+++ b/src/components/interactions/InteractionBar.tsx
@@ -53,28 +53,38 @@ export function InteractionBar({
   const { authenticated } = useAuth();
   const { showLoginModal } = useLoginModal();
 
+  // For reposts, use the original post ID for tracking interactions (isLiked/isShared)
+  // This ensures likes on a repost actually like the original post
+  const interactionPostId = postData?.originalPostId || postId;
+
   // Get interaction data from store (synced via polling) or fall back to initial values
-  const storeData = postInteractions.get(postId);
+  const storeData = postInteractions.get(interactionPostId);
   const likeCount = storeData?.likeCount ?? initialInteractions?.likeCount ?? 0;
   const commentCount = storeData?.commentCount ?? initialInteractions?.commentCount ?? 0;
   const shareCount = storeData?.shareCount ?? initialInteractions?.shareCount ?? 0;
   const isLiked = storeData?.isLiked ?? initialInteractions?.isLiked ?? false;
   const isShared = storeData?.isShared ?? initialInteractions?.isShared ?? false;
 
-  // Always sync store with latest initial values from API
+  // Update store with latest counts from API, but preserve isLiked/isShared from store
   useEffect(() => {
-    const store = useInteractionStore.getState();
-    const updatedInteractions = new Map(store.postInteractions);
-    updatedInteractions.set(postId, {
-      postId,
-      likeCount: initialInteractions?.likeCount ?? 0,
-      commentCount: initialInteractions?.commentCount ?? 0,
-      shareCount: initialInteractions?.shareCount ?? 0,
-      isLiked: initialInteractions?.isLiked ?? false,
-      isShared: initialInteractions?.isShared ?? false,
-    });
-    useInteractionStore.setState({ postInteractions: updatedInteractions });
-  }, [postId, initialInteractions?.likeCount, initialInteractions?.commentCount, initialInteractions?.shareCount, initialInteractions?.isLiked, initialInteractions?.isShared]);
+    if (initialInteractions) {
+      const store = useInteractionStore.getState();
+      const currentStoreData = store.postInteractions.get(interactionPostId);
+      const updatedInteractions = new Map(store.postInteractions);
+      
+      updatedInteractions.set(interactionPostId, {
+        postId: interactionPostId,
+        // Use fresh counts from API
+        likeCount: initialInteractions.likeCount ?? 0,
+        commentCount: initialInteractions.commentCount ?? 0,
+        shareCount: initialInteractions.shareCount ?? 0,
+        // Preserve isLiked/isShared from store (localStorage), don't overwrite with API
+        isLiked: currentStoreData?.isLiked ?? initialInteractions.isLiked ?? false,
+        isShared: currentStoreData?.isShared ?? initialInteractions.isShared ?? false,
+      });
+      useInteractionStore.setState({ postInteractions: updatedInteractions });
+    }
+  }, [interactionPostId, initialInteractions?.likeCount, initialInteractions?.commentCount, initialInteractions?.shareCount]);
 
   const handleCommentClick = () => {
     if (!authenticated) {
@@ -142,7 +152,7 @@ export function InteractionBar({
         {/* Like button with reaction picker */}
         <div onClick={(e) => e.stopPropagation()}>
           <LikeButton
-            targetId={postId}
+            targetId={postData?.originalPostId || postId}
             targetType="post"
             initialLiked={isLiked}
             initialCount={likeCount}


### PR DESCRIPTION
Problem:

- Like button not highlighted after refresh: When users refreshed the page, posts they had already liked didn't show as liked (heart icon wasn't filled), even though the like count was correct.

- Reposts showing wrong isLiked status: On profile pages, reposted posts used the repost's ID instead of the original post ID, so the like status was incorrect.

Root Causes:
- Store being overwritten with API data: The interaction store (with localStorage persistence) was being completely overwritten with API response data, which had hardcoded isLiked: false values. This erased the user's actual interaction state.

- Wrong post ID for repost interactions: InteractionBar was using the repost's post ID for like tracking instead of the original post ID.

Solution:
- Counts (likeCount, commentCount, shareCount) come from API (database is source of truth)
- User state (isLiked, isShared) comes from store (localStorage persists user interactions)
