### PR TITLE
refactor: replace repost text pattern with database fields (needs regression checks)

### DIFF
--- a/src/app/api/posts/[id]/route.ts
+++ b/src/app/api/posts/[id]/route.ts
@@ -74,34 +74,6 @@ import type { NextRequest } from 'next/server';
 import type { JsonValue } from '@/types/common';
 
 /**
- * Parse repost content to extract metadata
- * Returns null if not a repost, otherwise returns parsed data
- */
-function parseRepostContent(content: string): {
-  isRepost: true;
-  quoteComment: string | null;
-  originalContent: string;
-  originalAuthorUsername: string;
-} | null {
-  const separatorPattern = /\n\n--- Reposted from @(.+?) ---\n/;
-  const match = content.match(separatorPattern);
-  
-  if (!match) return null;
-  
-  const parts = content.split(separatorPattern);
-  const quoteComment = parts[0]?.trim() || null;
-  const originalContent = parts[2]?.trim() || '';
-  const originalAuthorUsername = match[1] || '';
-  
-  return {
-    isRepost: true,
-    quoteComment,
-    originalContent,
-    originalAuthorUsername,
-  };
-}
-
-/**
  * GET /api/posts/[id]
  * Get a single post by ID
  */
@@ -172,6 +144,17 @@ export const GET = withErrorHandling(async (
                 id: true,
               },
             },
+        // Include original post for reposts/quotes
+        Post_Post_originalPostIdToPost: {
+          where: { deletedAt: null },
+          select: {
+            id: true,
+            content: true,
+            authorId: true,
+            timestamp: true,
+            createdAt: true,
+          }
+        }
       },
     })
   })
@@ -214,6 +197,17 @@ export const GET = withErrorHandling(async (
             id: true,
           },
         },
+        // Include original post for reposts/quotes
+        Post_Post_originalPostIdToPost: {
+          where: { deletedAt: null },
+          select: {
+            id: true,
+            content: true,
+            authorId: true,
+            timestamp: true,
+            createdAt: true,
+          }
+        }
       },
     })
   });
@@ -303,112 +297,61 @@ export const GET = withErrorHandling(async (
         const timestampStr = gamePost.timestamp as string;
         const createdAtStr = (gamePost.createdAt || timestampStr) as string;
 
-        // Parse repost metadata if this is a repost
-        const parsedRepostData = gamePost.content ? parseRepostContent(gamePost.content) : null;
+        // Check for repost metadata from originalPostId field (no legacy text parsing)
         let repostMetadata = {};
         
         const originalPostIdFromGame = 'originalPostId' in gamePost ? (gamePost as Record<string, JsonValue>).originalPostId as string | undefined : undefined;
-        if (parsedRepostData || originalPostIdFromGame) {
-          // Try to get original author info
-          let originalAuthor = null;
-          const originalPostId = originalPostIdFromGame || null;
-          let effectiveRepostData = parsedRepostData;
+        if (originalPostIdFromGame) {
+          const originalPost = await asPublic(async (db) => {
+            return await db.post.findUnique({
+              where: { id: originalPostIdFromGame },
+              select: { authorId: true, content: true },
+            });
+          });
           
-          if (parsedRepostData) {
-            // Parse from content if available (fallback for old posts)
-            originalAuthor = await asPublic(async (db) => {
+          if (originalPost) {
+            // Fetch author details
+            const originalAuthor = await asPublic(async (db) => {
               const usr = await db.user.findUnique({
-                where: { username: parsedRepostData.originalAuthorUsername },
+                where: { id: originalPost.authorId },
                 select: { id: true, username: true, displayName: true, profileImageUrl: true },
               });
               
               if (usr) return usr;
               
-              const act = await db.actor.findFirst({
-                where: { id: parsedRepostData.originalAuthorUsername },
+              const act = await db.actor.findUnique({
+                where: { id: originalPost.authorId },
                 select: { id: true, name: true, profileImageUrl: true },
               });
               
               if (act) return act;
               
-              const org = await db.organization.findFirst({
-                where: { id: parsedRepostData.originalAuthorUsername },
+              const org = await db.organization.findUnique({
+                where: { id: originalPost.authorId },
                 select: { id: true, name: true, imageUrl: true },
               });
               
               return org;
             });
-          }
-          
-          // If we have originalPostId but no author info yet, fetch from original post
-          if (originalPostId && !originalAuthor) {
-            const originalPost = await asPublic(async (db) => {
-              return await db.post.findUnique({
-                where: { id: originalPostId },
-                select: { authorId: true, content: true },
-              });
-            });
             
-            if (originalPost) {
-              // Fetch author details
-              originalAuthor = await asPublic(async (db) => {
-                const usr = await db.user.findUnique({
-                  where: { id: originalPost.authorId },
-                  select: { id: true, username: true, displayName: true, profileImageUrl: true },
-                });
-                
-                if (usr) return usr;
-                
-                const act = await db.actor.findUnique({
-                  where: { id: originalPost.authorId },
-                  select: { id: true, name: true, profileImageUrl: true },
-                });
-                
-                if (act) return act;
-                
-                const org = await db.organization.findUnique({
-                  where: { id: originalPost.authorId },
-                  select: { id: true, name: true, imageUrl: true },
-                });
-                
-                return org;
-              });
-              
-              // Create repostData with actual original content if not already set
-              if (!parsedRepostData && originalAuthor) {
-                effectiveRepostData = {
-                  isRepost: true,
-                  quoteComment: null,
-                  originalContent: originalPost.content,
-                  originalAuthorUsername: 'username' in originalAuthor ? originalAuthor.username! : originalPost.authorId,
-                };
-              }
+            if (originalAuthor) {
+              const isQuote = gamePost.content && gamePost.content.length > 0;
+              repostMetadata = {
+                isRepost: true,
+                isQuote,
+                quoteComment: isQuote ? gamePost.content : null,
+                originalPostId: originalPostIdFromGame,
+                originalPost: {
+                  id: originalPostIdFromGame,
+                  content: originalPost.content,
+                  authorId: originalPost.authorId,
+                  authorName: 'name' in originalAuthor ? originalAuthor.name : originalAuthor.displayName,
+                  authorUsername: 'username' in originalAuthor ? originalAuthor.username : originalAuthor.id,
+                  authorProfileImageUrl: 'profileImageUrl' in originalAuthor ? originalAuthor.profileImageUrl : ('imageUrl' in originalAuthor ? originalAuthor.imageUrl : null),
+                  timestamp: new Date().toISOString(),
+                }
+              };
             }
-          }
-          
-          if (originalAuthor && effectiveRepostData) {
-            repostMetadata = {
-              isRepost: true,
-              quoteComment: effectiveRepostData.quoteComment,
-              originalContent: effectiveRepostData.originalContent,
-              originalPostId: originalPostId,
-              originalAuthorId: originalAuthor.id,
-              originalAuthorName: 'name' in originalAuthor ? originalAuthor.name : originalAuthor.displayName,
-              originalAuthorUsername: 'username' in originalAuthor ? originalAuthor.username : originalAuthor.id,
-              originalAuthorProfileImageUrl: 'profileImageUrl' in originalAuthor ? originalAuthor.profileImageUrl : ('imageUrl' in originalAuthor ? originalAuthor.imageUrl : null),
-            };
-          } else if (effectiveRepostData) {
-            // Fallback if we can't find the original author
-            repostMetadata = {
-              isRepost: true,
-              quoteComment: effectiveRepostData.quoteComment,
-              originalContent: effectiveRepostData.originalContent,
-              originalPostId: originalPostId,
-              originalAuthorId: effectiveRepostData.originalAuthorUsername,
-              originalAuthorName: effectiveRepostData.originalAuthorUsername,
-              originalAuthorUsername: effectiveRepostData.originalAuthorUsername,
-              originalAuthorProfileImageUrl: null,
-            };
           }
         }
 
@@ -525,6 +468,17 @@ export const GET = withErrorHandling(async (
                     id: true,
                   },
                 },
+                // Include original post for reposts/quotes
+                Post_Post_originalPostIdToPost: {
+                  where: { deletedAt: null },
+                  select: {
+                    id: true,
+                    content: true,
+                    authorId: true,
+                    timestamp: true,
+                    createdAt: true,
+                  }
+                }
               },
             });
           })
@@ -568,6 +522,17 @@ export const GET = withErrorHandling(async (
                     id: true,
                   },
                 },
+                // Include original post for reposts/quotes
+                Post_Post_originalPostIdToPost: {
+                  where: { deletedAt: null },
+                  select: {
+                    id: true,
+                    content: true,
+                    authorId: true,
+                    timestamp: true,
+                    createdAt: true,
+                  }
+                }
               },
             });
           });
@@ -626,29 +591,31 @@ export const GET = withErrorHandling(async (
     const reactionsArray = post.Reaction && Array.isArray(post.Reaction) ? post.Reaction : [];
     const sharesArray = post.Share && Array.isArray(post.Share) ? post.Share : [];
 
-    // Parse repost metadata if this is a repost
-    const repostData = post.content ? parseRepostContent(post.content) : null;
+    // Build repost metadata from originalPostId (clean, no regex parsing)
     let repostMetadata = {};
     
-    if (repostData) {
-      // Look up original author by username (could be User, Actor, or Organization)
+    if (post.originalPostId && post.Post_Post_originalPostIdToPost) {
+      const originalPost = post.Post_Post_originalPostIdToPost;
+      const isQuote = post.content && post.content.length > 0;
+      
+      // Get original post author
       const originalAuthor = await asPublic(async (db) => {
         const usr = await db.user.findUnique({
-          where: { username: repostData.originalAuthorUsername },
+          where: { id: originalPost.authorId },
           select: { id: true, username: true, displayName: true, profileImageUrl: true },
         });
         
         if (usr) return usr;
         
         const act = await db.actor.findFirst({
-          where: { id: repostData.originalAuthorUsername },
+          where: { id: originalPost.authorId },
           select: { id: true, name: true, profileImageUrl: true },
         });
         
         if (act) return act;
         
         const org = await db.organization.findFirst({
-          where: { id: repostData.originalAuthorUsername },
+          where: { id: originalPost.authorId },
           select: { id: true, name: true, imageUrl: true },
         });
         
@@ -656,59 +623,20 @@ export const GET = withErrorHandling(async (
       });
       
       if (originalAuthor) {
-        // Find the Share record for this repost to get the original post ID
-        const shareRecord = await asPublic(async (db) => {
-          return await db.share.findFirst({
-            where: { 
-              userId: post.authorId || '',
-              Post: {
-                authorId: originalAuthor.id
-              }
-            },
-            orderBy: { createdAt: 'desc' },
-            select: { postId: true },
-          });
-        });
-        
-        let originalPostId = shareRecord?.postId || null;
-        
-        // If Share lookup failed, try to find the original post by content and author
-        if (!originalPostId && repostData.originalContent) {
-          const originalPost = await asPublic(async (db) => {
-            return await db.post.findFirst({
-              where: {
-                authorId: originalAuthor.id,
-                content: repostData.originalContent,
-                deletedAt: null,
-              },
-              orderBy: { timestamp: 'desc' },
-              select: { id: true },
-            });
-          });
-          originalPostId = originalPost?.id || null;
-        }
-        
         repostMetadata = {
           isRepost: true,
-          quoteComment: repostData.quoteComment,
-          originalContent: repostData.originalContent,
-          originalPostId: originalPostId,
-          originalAuthorId: originalAuthor.id,
-          originalAuthorName: 'name' in originalAuthor ? originalAuthor.name : originalAuthor.displayName,
-          originalAuthorUsername: 'username' in originalAuthor ? originalAuthor.username : originalAuthor.id,
-          originalAuthorProfileImageUrl: 'profileImageUrl' in originalAuthor ? originalAuthor.profileImageUrl : ('imageUrl' in originalAuthor ? originalAuthor.imageUrl : null),
-        };
-      } else {
-        // Even if we can't find the original author, still mark as repost
-        repostMetadata = {
-          isRepost: true,
-          quoteComment: repostData.quoteComment,
-          originalContent: repostData.originalContent,
-          originalPostId: null,
-          originalAuthorId: repostData.originalAuthorUsername,
-          originalAuthorName: repostData.originalAuthorUsername,
-          originalAuthorUsername: repostData.originalAuthorUsername,
-          originalAuthorProfileImageUrl: null,
+          isQuote,
+          quoteComment: isQuote ? post.content : null,
+          originalPostId: originalPost.id,
+          originalPost: {
+            id: originalPost.id,
+            content: originalPost.content,
+            authorId: originalPost.authorId,
+            authorName: 'name' in originalAuthor ? originalAuthor.name : originalAuthor.displayName,
+            authorUsername: 'username' in originalAuthor ? originalAuthor.username : originalAuthor.id,
+            authorProfileImageUrl: 'profileImageUrl' in originalAuthor ? originalAuthor.profileImageUrl : ('imageUrl' in originalAuthor ? originalAuthor.imageUrl : null),
+            timestamp: originalPost.timestamp?.toISOString?.() || new Date().toISOString(),
+          }
         };
       }
     }

--- a/src/app/api/posts/[id]/share/route.ts
+++ b/src/app/api/posts/[id]/share/route.ts
@@ -275,11 +275,10 @@ export const POST = withErrorHandling(async (
       const originalAuthorUsername = originalUser?.username || originalPost.authorId;
       const originalAuthorProfileImageUrl = originalUser?.profileImageUrl || originalActor?.profileImageUrl || originalOrg?.imageUrl;
 
-      // If quote comment is provided, create a quote post with commentary
-      // Otherwise, create a simple repost
-      const repostContent = quoteComment 
-        ? `${quoteComment}\n\n--- Reposted from @${originalAuthorUsername} ---\n${originalPost.content}`
-        : originalPost.content;
+      // Create repost post with reference to original
+      // For quote posts: content = quote commentary only
+      // For simple reposts: content = empty string
+      const repostContent = quoteComment || '';
 
       // Create repost post with reference to original
       const createdRepost = await prisma.post.create({
@@ -295,7 +294,7 @@ export const POST = withErrorHandling(async (
       // Format repost data for broadcast
       repostPostData = {
         id: createdRepost.id,
-        content: createdRepost.content,
+        content: createdRepost.content, // Quote commentary or empty string
         authorId: createdRepost.authorId,
         authorName: canonicalUser.username || canonicalUser.displayName || `user_${canonicalUserId.slice(0, 8)}`,
         authorUsername: canonicalUser.username,
@@ -303,12 +302,17 @@ export const POST = withErrorHandling(async (
         authorProfileImageUrl: canonicalUser.profileImageUrl,
         timestamp: createdRepost.timestamp.toISOString(),
         isRepost: true,
+        isQuote: !!quoteComment,
         originalPostId: postId,
-        originalAuthorId: originalPost.authorId,
-        originalAuthorName: originalAuthorName,
-        originalAuthorUsername: originalAuthorUsername,
-        originalAuthorProfileImageUrl: originalAuthorProfileImageUrl,
-        originalContent: originalPost.content, // Include original content separately
+        originalPost: {
+          id: postId,
+          content: originalPost.content,
+          authorId: originalPost.authorId,
+          authorName: originalAuthorName,
+          authorUsername: originalAuthorUsername,
+          authorProfileImageUrl: originalAuthorProfileImageUrl,
+          timestamp: originalPost.timestamp.toISOString(),
+        },
         quoteComment: quoteComment || null,
       };
 

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -596,20 +596,27 @@ export const GET = withErrorHandling(async (request: Request) => {
     
     // Get interaction counts for all posts in parallel
     const postIds = posts.map(p => p.id);
+    // Also collect original post IDs for reposts to get their interaction counts
+    const originalPostIds = posts
+      .filter(p => p.originalPostId)
+      .map(p => p.originalPostId)
+      .filter((id): id is string => id !== null);
+    const allPostIds = [...new Set([...postIds, ...originalPostIds])];
+    
     const [allReactions, allComments, allShares] = await Promise.all([
       prisma.reaction.groupBy({
         by: ['postId'],
-        where: { postId: { in: postIds }, type: 'like' },
+        where: { postId: { in: allPostIds }, type: 'like' },
         _count: { postId: true },
       }),
       prisma.comment.groupBy({
         by: ['postId'],
-        where: { postId: { in: postIds } },
+        where: { postId: { in: allPostIds } },
         _count: { postId: true },
       }),
       prisma.share.groupBy({
         by: ['postId'],
-        where: { postId: { in: postIds } },
+        where: { postId: { in: allPostIds } },
         _count: { postId: true },
       }),
     ]);
@@ -698,8 +705,21 @@ export const GET = withErrorHandling(async (request: Request) => {
           originalAuthorProfileImageUrl = originalUser.profileImageUrl;
         }
         
+        // For simple reposts (not quotes), use the original post's interaction counts
+        // For quote posts, keep the quote post's interaction counts
+        const interactionCounts = !isQuote ? {
+          likeCount: reactionMap.get(originalPost.id) ?? 0,
+          commentCount: commentMap.get(originalPost.id) ?? 0,
+          shareCount: shareMap.get(originalPost.id) ?? 0,
+        } : {
+          likeCount: basePost.likeCount,
+          commentCount: basePost.commentCount,
+          shareCount: basePost.shareCount,
+        };
+        
         return {
           ...basePost,
+          ...interactionCounts,
           isRepost: true,
           isQuote,
           quoteComment: isQuote ? post.content : null,

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -255,6 +255,7 @@ type PostWithOriginal = Post & {
     authorId: string;
     timestamp: Date;
     createdAt: Date;
+    deletedAt: Date | null;
   } | null;
 };
 
@@ -514,13 +515,13 @@ export const GET = withErrorHandling(async (request: Request) => {
         take: limit,
         include: {
           Post_Post_originalPostIdToPost: {
-            where: { deletedAt: null },
             select: {
               id: true,
               content: true,
               authorId: true,
               timestamp: true,
               createdAt: true,
+              deletedAt: true,
             }
           }
         }
@@ -568,8 +569,26 @@ export const GET = withErrorHandling(async (request: Request) => {
     // Get unique author IDs to fetch author data (users, actors, or organizations)
     // Include both post authors and original post authors (for reposts/quotes)
     const postsWithOriginal = posts as PostWithOriginal[];
-    const postAuthorIds = postsWithOriginal.map(p => p.authorId).filter((id): id is string => id !== undefined);
-    const originalPostAuthorIds = postsWithOriginal
+    
+    // Filter out reposts where the original post is deleted
+    const validPosts = postsWithOriginal.filter(post => {
+      // If it's a repost, check if original post exists and is not deleted
+      if (post.originalPostId) {
+        const hasOriginalPost = post.Post_Post_originalPostIdToPost && !post.Post_Post_originalPostIdToPost.deletedAt;
+        const isQuote = post.content && post.content.length > 0;
+        
+        // For quote posts, keep them even if original is deleted (user has commentary)
+        // For simple reposts, filter out if original is deleted
+        if (isQuote) {
+          return true; // Keep quote posts regardless
+        }
+        return hasOriginalPost; // Filter out simple reposts with deleted originals
+      }
+      return true;
+    });
+    
+    const postAuthorIds = validPosts.map(p => p.authorId).filter((id): id is string => id !== undefined);
+    const originalPostAuthorIds = validPosts
       .filter(p => p.originalPostId && p.Post_Post_originalPostIdToPost)
       .map(p => p.Post_Post_originalPostIdToPost!.authorId)
       .filter((id): id is string => id !== undefined);
@@ -595,9 +614,9 @@ export const GET = withErrorHandling(async (request: Request) => {
     const orgMap = new Map(organizations.map(o => [o.id, o]));
     
     // Get interaction counts for all posts in parallel
-    const postIds = posts.map(p => p.id);
+    const postIds = validPosts.map(p => p.id);
     // Also collect original post IDs for reposts to get their interaction counts
-    const originalPostIds = posts
+    const originalPostIds = validPosts
       .filter(p => p.originalPostId)
       .map(p => p.originalPostId)
       .filter((id): id is string => id !== null);
@@ -627,7 +646,7 @@ export const GET = withErrorHandling(async (request: Request) => {
     const shareMap = new Map(allShares.map(s => [s.postId, s._count.postId]));
     
     // Format posts - simple transformation, no async queries needed!
-    const formattedPosts = postsWithOriginal.map((post) => {
+    const formattedPosts = validPosts.map((post) => {
       const user = userMap.get(post.authorId!)
       const actor = actorMap.get(post.authorId!)
       const org = orgMap.get(post.authorId!)
@@ -680,60 +699,75 @@ export const GET = withErrorHandling(async (request: Request) => {
       };
       
       // Check if this is a repost/quote by presence of originalPostId
-      if (post.originalPostId && post.Post_Post_originalPostIdToPost) {
-        const originalPost = post.Post_Post_originalPostIdToPost;
+      if (post.originalPostId) {
         const isQuote = post.content && post.content.length > 0;
+        const originalPost = post.Post_Post_originalPostIdToPost;
         
-        // Get original post author info
-        const originalUser = userMap.get(originalPost.authorId);
-        const originalActor = actorMap.get(originalPost.authorId);
-        const originalOrg = orgMap.get(originalPost.authorId);
-        
-        let originalAuthorName = originalPost.authorId;
-        let originalAuthorUsername: string | null = null;
-        let originalAuthorProfileImageUrl: string | null = null;
-        
-        if (originalActor) {
-          originalAuthorName = originalActor.name;
-          originalAuthorProfileImageUrl = originalActor.profileImageUrl!;
-        } else if (originalOrg) {
-          originalAuthorName = originalOrg.name;
-          originalAuthorProfileImageUrl = originalOrg.imageUrl!;
-        } else if (originalUser) {
-          originalAuthorName = originalUser.displayName!;
-          originalAuthorUsername = originalUser.username!;
-          originalAuthorProfileImageUrl = originalUser.profileImageUrl;
-        }
-        
-        // For simple reposts (not quotes), use the original post's interaction counts
-        // For quote posts, keep the quote post's interaction counts
-        const interactionCounts = !isQuote ? {
-          likeCount: reactionMap.get(originalPost.id) ?? 0,
-          commentCount: commentMap.get(originalPost.id) ?? 0,
-          shareCount: shareMap.get(originalPost.id) ?? 0,
-        } : {
-          likeCount: basePost.likeCount,
-          commentCount: basePost.commentCount,
-          shareCount: basePost.shareCount,
-        };
-        
-        return {
-          ...basePost,
-          ...interactionCounts,
-          isRepost: true,
-          isQuote,
-          quoteComment: isQuote ? post.content : null,
-          originalPostId: originalPost.id,
-          originalPost: {
-            id: originalPost.id,
-            content: originalPost.content,
-            authorId: originalPost.authorId,
-            authorName: originalAuthorName,
-            authorUsername: originalAuthorUsername,
-            authorProfileImageUrl: originalAuthorProfileImageUrl,
-            timestamp: toISOStringSafe(originalPost.timestamp),
+        // If original post exists and is not deleted
+        if (originalPost && !originalPost.deletedAt) {
+          // Get original post author info
+          const originalUser = userMap.get(originalPost.authorId);
+          const originalActor = actorMap.get(originalPost.authorId);
+          const originalOrg = orgMap.get(originalPost.authorId);
+          
+          let originalAuthorName = originalPost.authorId;
+          let originalAuthorUsername: string | null = null;
+          let originalAuthorProfileImageUrl: string | null = null;
+          
+          if (originalActor) {
+            originalAuthorName = originalActor.name;
+            originalAuthorProfileImageUrl = originalActor.profileImageUrl!;
+          } else if (originalOrg) {
+            originalAuthorName = originalOrg.name;
+            originalAuthorProfileImageUrl = originalOrg.imageUrl!;
+          } else if (originalUser) {
+            originalAuthorName = originalUser.displayName!;
+            originalAuthorUsername = originalUser.username!;
+            originalAuthorProfileImageUrl = originalUser.profileImageUrl;
           }
-        };
+          
+          // For simple reposts (not quotes), use the original post's interaction counts
+          // For quote posts, keep the quote post's interaction counts
+          const interactionCounts = !isQuote ? {
+            likeCount: reactionMap.get(originalPost.id) ?? 0,
+            commentCount: commentMap.get(originalPost.id) ?? 0,
+            shareCount: shareMap.get(originalPost.id) ?? 0,
+          } : {
+            likeCount: basePost.likeCount,
+            commentCount: basePost.commentCount,
+            shareCount: basePost.shareCount,
+          };
+          
+          return {
+            ...basePost,
+            ...interactionCounts,
+            isRepost: true,
+            isQuote,
+            quoteComment: isQuote ? post.content : null,
+            originalPostId: originalPost.id,
+            originalPost: {
+              id: originalPost.id,
+              content: originalPost.content,
+              authorId: originalPost.authorId,
+              authorName: originalAuthorName,
+              authorUsername: originalAuthorUsername,
+              authorProfileImageUrl: originalAuthorProfileImageUrl,
+              timestamp: toISOStringSafe(originalPost.timestamp),
+            }
+          };
+        } 
+        
+        // If original post is deleted but this is a quote post, return with null originalPost
+        if (isQuote) {
+          return {
+            ...basePost,
+            isRepost: true,
+            isQuote: true,
+            quoteComment: post.content,
+            originalPostId: post.originalPostId,
+            originalPost: null,
+          };
+        }
       }
       
       return basePost;

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -240,12 +240,23 @@ import { generateSnowflakeId } from '@/lib/snowflake';
 import { broadcastToChannel } from '@/lib/sse/event-broadcaster';
 import { ensureUserForAuth } from '@/lib/users/ensure-user';
 import type { NextRequest } from 'next/server'
-import type { JsonValue } from '@/types/common';
 import { NextResponse } from 'next/server';
 import { trackServerEvent } from '@/lib/posthog/server';
 import { checkRateLimitAndDuplicates, RATE_LIMIT_CONFIGS, DUPLICATE_DETECTION_CONFIGS } from '@/lib/rate-limiting';
 import { notifyMention } from '@/lib/services/notification-service';
 import { getBlockedUserIds, getMutedUserIds, getBlockedByUserIds } from '@/lib/moderation/filters';
+import type { Post } from '@prisma/client';
+
+// Type for posts with included original post relation
+type PostWithOriginal = Post & {
+  Post_Post_originalPostIdToPost?: {
+    id: string;
+    content: string;
+    authorId: string;
+    timestamp: Date;
+    createdAt: Date;
+  } | null;
+};
 
 /**
  * Safely convert a date value to ISO string
@@ -271,34 +282,6 @@ function toISOStringSafe(date: Date | string | null | undefined): string {
   }
   // Fallback to current date
   return new Date().toISOString();
-}
-
-/**
- * Parse repost content to extract metadata
- * Returns null if not a repost, otherwise returns parsed data
- */
-function parseRepostContent(content: string): {
-  isRepost: true;
-  quoteComment: string | null;
-  originalContent: string;
-  originalAuthorUsername: string;
-} | null {
-  const separatorPattern = /\n\n--- Reposted from @(.+?) ---\n/;
-  const match = content.match(separatorPattern);
-  
-  if (!match) return null;
-  
-  const parts = content.split(separatorPattern);
-  const quoteComment = parts[0]?.trim() || null;
-  const originalContent = parts[2]?.trim() || '';
-  const originalAuthorUsername = match[1] || '';
-  
-  return {
-    isRepost: true,
-    quoteComment,
-    originalContent,
-    originalAuthorUsername,
-  };
 }
 
 export const GET = withErrorHandling(async (request: Request) => {
@@ -384,11 +367,23 @@ export const GET = withErrorHandling(async (request: Request) => {
 
       // Get user data for filtered posts
       const authorIds = [...new Set(filteredPosts.map(p => p.authorId).filter((id): id is string => id !== undefined))];
-      const users = await prisma.user.findMany({
-        where: { id: { in: authorIds } },
-        select: { id: true, username: true, displayName: true },
-      });
+      const [users, actors, organizations] = await Promise.all([
+        prisma.user.findMany({
+          where: { id: { in: authorIds } },
+          select: { id: true, username: true, displayName: true, profileImageUrl: true },
+        }),
+        prisma.actor.findMany({
+          where: { id: { in: authorIds } },
+          select: { id: true, name: true, profileImageUrl: true },
+        }),
+        prisma.organization.findMany({
+          where: { id: { in: authorIds } },
+          select: { id: true, name: true, imageUrl: true },
+        }),
+      ]);
       const userMap = new Map(users.map(u => [u.id, u]));
+      const actorMap = new Map(actors.map(a => [a.id, a]));
+      const orgMap = new Map(organizations.map(o => [o.id, o]));
       
       // Get interaction counts for all filtered posts in parallel
       const postIds = filteredPosts.map(p => p.id);
@@ -409,130 +404,80 @@ export const GET = withErrorHandling(async (request: Request) => {
       const reactionMap = new Map(allReactions.map(r => [r.postId, r._count.postId]));
       const commentMap = new Map(allComments.map(c => [c.postId, c._count.postId]));
       
-      // OPTIMIZED: Batch repost metadata lookups to avoid N+1
-      // First, identify all reposts and extract original usernames
-      const repostDataMap = new Map<string, ReturnType<typeof parseRepostContent>>();
-      const originalUsernames = new Set<string>();
-      
-      for (const post of filteredPosts) {
-        const repostData = parseRepostContent(post.content || '');
-        if (repostData) {
-          repostDataMap.set(post.id, repostData);
-          originalUsernames.add(repostData.originalAuthorUsername);
-        }
-      }
-
-      // Batch lookup original authors (users and actors)
-      const originalAuthorsMap = new Map<string, { id: string; name: string; username: string; profileImageUrl: string | null }>();
-      
-      if (originalUsernames.size > 0) {
-        const usernameArray = Array.from(originalUsernames);
-        const [originalUsers, originalActors] = await Promise.all([
-          prisma.user.findMany({
-            where: { username: { in: usernameArray } },
-            select: { id: true, username: true, displayName: true, profileImageUrl: true },
-          }),
-          prisma.actor.findMany({
-            where: { id: { in: usernameArray } },
-            select: { id: true, name: true, profileImageUrl: true },
-          }),
-        ]);
-
-        // Map users
-        for (const user of originalUsers) {
-          originalAuthorsMap.set(user.username!, {
-            id: user.id,
-            name: user.displayName || user.username || user.id,
-            username: user.username!,
-            profileImageUrl: user.profileImageUrl,
-          });
-        }
-
-        // Map actors
-        for (const actor of originalActors) {
-          originalAuthorsMap.set(actor.id, {
-            id: actor.id,
-            name: actor.name,
-            username: actor.id,
-            profileImageUrl: actor.profileImageUrl,
-          });
-        }
-
-        // Batch lookup share records for all reposters
-        const reposterIds = posts.filter(p => repostDataMap.has(p.id)).map(p => p.authorId).filter((id): id is string => !!id);
-        const shareRecords = await prisma.share.findMany({
-          where: { userId: { in: reposterIds } },
-          select: { postId: true, userId: true },
-          orderBy: { createdAt: 'desc' },
-        });
-
-        const shareMap = new Map(shareRecords.map(s => [s.userId, s.postId]));
-
-        // Build repost metadata lookup
-        const repostMetadataMap = new Map<string, Record<string, JsonValue>>();
-        for (const [postId, repostData] of repostDataMap.entries()) {
-          if (!repostData) continue; // Skip null entries
-          
-          const originalAuthor = originalAuthorsMap.get(repostData.originalAuthorUsername);
-          const post = posts.find(p => p.id === postId);
-          const shareRecord = post?.authorId ? shareMap.get(post.authorId) : undefined;
-
-          if (originalAuthor) {
-            repostMetadataMap.set(postId, {
-              isRepost: true,
-              quoteComment: repostData.quoteComment,
-              originalContent: repostData.originalContent,
-              originalPostId: shareRecord ?? null,
-              originalAuthorId: originalAuthor.id,
-              originalAuthorName: originalAuthor.name,
-              originalAuthorUsername: originalAuthor.username,
-              originalAuthorProfileImageUrl: originalAuthor.profileImageUrl,
-            });
-          } else {
-            repostMetadataMap.set(postId, {
-              isRepost: true,
-              quoteComment: repostData.quoteComment,
-              originalContent: repostData.originalContent,
-              originalPostId: null,
-              originalAuthorId: repostData.originalAuthorUsername,
-              originalAuthorName: repostData.originalAuthorUsername,
-              originalAuthorUsername: repostData.originalAuthorUsername,
-              originalAuthorProfileImageUrl: null,
-            });
-          }
-        }
-
-        // Format following posts synchronously using lookup maps
-        const formattedFollowingPosts = posts.map((post) => {
-          const user = post.authorId ? userMap.get(post.authorId) : undefined;
-          const repostMetadata = repostMetadataMap.get(post.id) || {};
-          
-          return {
-            id: post.id,
-            content: post.content,
-            author: post.authorId,
-            authorId: post.authorId,
-            authorName: user?.displayName || user?.username || post.authorId || 'Unknown',
-            authorUsername: user?.username || null,
-            timestamp: toISOStringSafe(post.timestamp),
-            createdAt: toISOStringSafe(post.createdAt),
-            likeCount: reactionMap.get(post.id) ?? 0,
-            commentCount: commentMap.get(post.id) ?? 0,
-            shareCount: 0, // Share count not currently tracked in feed
-            isLiked: false,
-            isShared: false,
-            ...repostMetadata,
-          };
-        });
+      // Format following posts synchronously using lookup maps
+      // Note: filteredPosts already includes originalPost via the include in the query above
+      const formattedFollowingPosts = posts.map((post) => {
+        const postsWithOriginal = post as PostWithOriginal;
+        const user = post.authorId ? userMap.get(post.authorId) : undefined;
         
-        return NextResponse.json({
-          success: true,
-          posts: formattedFollowingPosts,
-          limit,
-          source: 'following',
-        });
-      }
+        // Build repost metadata from originalPost if it exists (clean, no text parsing)
+        const repostMetadata: Record<string, unknown> = {};
+        if (postsWithOriginal.originalPostId && postsWithOriginal.Post_Post_originalPostIdToPost) {
+          const originalPost = postsWithOriginal.Post_Post_originalPostIdToPost;
+          const isQuote = post.content && post.content.length > 0;
+          
+          // Get original author from our maps
+          const originalUser = userMap.get(originalPost.authorId);
+          const originalActor = actorMap.get(originalPost.authorId);
+          const originalOrg = orgMap.get(originalPost.authorId);
+          
+          let originalAuthorName = originalPost.authorId;
+          let originalAuthorUsername: string | null = null;
+          let originalAuthorProfileImageUrl: string | null = null;
+          
+          if (originalActor) {
+            originalAuthorName = originalActor.name;
+            originalAuthorProfileImageUrl = originalActor.profileImageUrl!;
+          } else if (originalOrg) {
+            originalAuthorName = originalOrg.name;
+            originalAuthorProfileImageUrl = originalOrg.imageUrl!;
+          } else if (originalUser) {
+            originalAuthorName = originalUser.displayName!;
+            originalAuthorUsername = originalUser.username!;
+            originalAuthorProfileImageUrl = originalUser.profileImageUrl || null;
+          }
+          
+          repostMetadata.isRepost = true;
+          repostMetadata.isQuote = isQuote;
+          repostMetadata.quoteComment = isQuote ? post.content : null;
+          repostMetadata.originalPostId = originalPost.id;
+          repostMetadata.originalPost = {
+            id: originalPost.id,
+            content: originalPost.content,
+            authorId: originalPost.authorId,
+            authorName: originalAuthorName,
+            authorUsername: originalAuthorUsername,
+            authorProfileImageUrl: originalAuthorProfileImageUrl,
+            timestamp: toISOStringSafe(originalPost.timestamp),
+          };
+        }
+          
+        return {
+          id: post.id,
+          content: post.content,
+          author: post.authorId,
+          authorId: post.authorId,
+          authorName: user?.displayName || user?.username || post.authorId || 'Unknown',
+          authorUsername: user?.username || null,
+          timestamp: toISOStringSafe(post.timestamp),
+          createdAt: toISOStringSafe(post.createdAt),
+          likeCount: reactionMap.get(post.id) ?? 0,
+          commentCount: commentMap.get(post.id) ?? 0,
+          shareCount: 0, // Share count not currently tracked in feed
+          isLiked: false,
+          isShared: false,
+          ...repostMetadata,
+        };
+      });
+        
+      return NextResponse.json({
+        success: true,
+        posts: formattedFollowingPosts,
+        limit,
+        source: 'following',
+      });
     }
+    
     // Get posts from database with cursor-based pagination
     let posts;
     
@@ -567,6 +512,18 @@ export const GET = withErrorHandling(async (request: Request) => {
         where,
         orderBy: { timestamp: 'desc' },
         take: limit,
+        include: {
+          Post_Post_originalPostIdToPost: {
+            where: { deletedAt: null },
+            select: {
+              id: true,
+              content: true,
+              authorId: true,
+              timestamp: true,
+              createdAt: true,
+            }
+          }
+        }
       });
       
       logger.info('Fetched posts by type', { type, count: posts.length }, 'GET /api/posts');
@@ -609,7 +566,16 @@ export const GET = withErrorHandling(async (request: Request) => {
     }
     
     // Get unique author IDs to fetch author data (users, actors, or organizations)
-    const authorIds = [...new Set(posts.map(p => p.authorId).filter((id): id is string => id !== undefined))];
+    // Include both post authors and original post authors (for reposts/quotes)
+    const postsWithOriginal = posts as PostWithOriginal[];
+    const postAuthorIds = postsWithOriginal.map(p => p.authorId).filter((id): id is string => id !== undefined);
+    const originalPostAuthorIds = postsWithOriginal
+      .filter(p => p.originalPostId && p.Post_Post_originalPostIdToPost)
+      .map(p => p.Post_Post_originalPostIdToPost!.authorId)
+      .filter((id): id is string => id !== undefined);
+    
+    const authorIds = [...new Set([...postAuthorIds, ...originalPostAuthorIds])];
+    
     const [users, actors, organizations] = await Promise.all([
       prisma.user.findMany({
         where: { id: { in: authorIds } },
@@ -653,7 +619,8 @@ export const GET = withErrorHandling(async (request: Request) => {
     const commentMap = new Map(allComments.map(c => [c.postId, c._count.postId]));
     const shareMap = new Map(allShares.map(s => [s.postId, s._count.postId]));
     
-    const formattedPosts = await Promise.all(posts.map(async (post) => {
+    // Format posts - simple transformation, no async queries needed!
+    const formattedPosts = postsWithOriginal.map((post) => {
       const user = userMap.get(post.authorId!)
       const actor = actorMap.get(post.authorId!)
       const org = orgMap.get(post.authorId!)
@@ -677,84 +644,8 @@ export const GET = withErrorHandling(async (request: Request) => {
       const timestamp = toISOStringSafe(post.timestamp)
       const createdAt = toISOStringSafe(post.createdAt)
       
-      // Check if this is a repost by parsing content or checking originalPostId field
-      const parsedRepostData = parseRepostContent(post.content!)
-      let repostMetadata = {}
-      
-      if (parsedRepostData || post.originalPostId) {
-        // Try to get original author info
-        let originalAuthor = null
-        const originalPostId = post.originalPostId || null
-        let effectiveRepostData = parsedRepostData
-        
-        if (parsedRepostData) {
-          // Parse from content if available (fallback for old posts)
-          originalAuthor = await prisma.user.findUnique({
-            where: { username: parsedRepostData.originalAuthorUsername },
-            select: { id: true, username: true, displayName: true, profileImageUrl: true },
-          }) || await prisma.actor.findFirst({
-            where: { id: parsedRepostData.originalAuthorUsername },
-            select: { id: true, name: true, profileImageUrl: true },
-          }) || await prisma.organization.findFirst({
-            where: { id: parsedRepostData.originalAuthorUsername },
-            select: { id: true, name: true, imageUrl: true },
-          })
-        }
-        
-        // If we have originalPostId but no author info yet, fetch from original post
-        if (originalPostId && !originalAuthor) {
-          const originalPost = await prisma.post.findUnique({
-            where: { id: originalPostId },
-            select: { authorId: true, content: true },
-          })
-          
-          if (originalPost) {
-            // Fetch author details
-            const [user, actor, org] = await Promise.all([
-              prisma.user.findUnique({
-                where: { id: originalPost.authorId },
-                select: { id: true, username: true, displayName: true, profileImageUrl: true },
-              }),
-              prisma.actor.findUnique({
-                where: { id: originalPost.authorId },
-                select: { id: true, name: true, profileImageUrl: true },
-              }),
-              prisma.organization.findUnique({
-                where: { id: originalPost.authorId },
-                select: { id: true, name: true, imageUrl: true },
-              }),
-            ])
-            
-            originalAuthor = user || actor || org
-            
-            // Create repostData with actual original content if not already set
-            if (!effectiveRepostData || !effectiveRepostData.originalContent) {
-              effectiveRepostData = {
-                ...(effectiveRepostData || {}),
-                isRepost: true,
-                quoteComment: effectiveRepostData?.quoteComment ?? null,
-                originalContent: originalPost.content,
-                originalAuthorUsername: user?.username || originalPost.authorId,
-              };
-            }
-          }
-        }
-        
-        if (originalAuthor && effectiveRepostData) {
-          repostMetadata = {
-            isRepost: true,
-            quoteComment: effectiveRepostData.quoteComment,
-            originalContent: effectiveRepostData.originalContent,
-            originalPostId: originalPostId,
-            originalAuthorId: originalAuthor.id,
-            originalAuthorName: 'name' in originalAuthor ? originalAuthor.name : originalAuthor.displayName!,
-            originalAuthorUsername: 'username' in originalAuthor ? originalAuthor.username! : originalAuthor.id,
-            originalAuthorProfileImageUrl: 'imageUrl' in originalAuthor ? originalAuthor.imageUrl : originalAuthor.profileImageUrl,
-          }
-        }
-      }
-      
-      return {
+      // Build base post object
+      const basePost = {
         id: post.id,
         type: post.type || undefined,
         content: post.content!,
@@ -779,11 +670,54 @@ export const GET = withErrorHandling(async (request: Request) => {
         shareCount: shareMap.get(post.id) ?? 0,
         isLiked: false,
         isShared: false,
-        ...repostMetadata,
+      };
+      
+      // Check if this is a repost/quote by presence of originalPostId
+      if (post.originalPostId && post.Post_Post_originalPostIdToPost) {
+        const originalPost = post.Post_Post_originalPostIdToPost;
+        const isQuote = post.content && post.content.length > 0;
+        
+        // Get original post author info
+        const originalUser = userMap.get(originalPost.authorId);
+        const originalActor = actorMap.get(originalPost.authorId);
+        const originalOrg = orgMap.get(originalPost.authorId);
+        
+        let originalAuthorName = originalPost.authorId;
+        let originalAuthorUsername: string | null = null;
+        let originalAuthorProfileImageUrl: string | null = null;
+        
+        if (originalActor) {
+          originalAuthorName = originalActor.name;
+          originalAuthorProfileImageUrl = originalActor.profileImageUrl!;
+        } else if (originalOrg) {
+          originalAuthorName = originalOrg.name;
+          originalAuthorProfileImageUrl = originalOrg.imageUrl!;
+        } else if (originalUser) {
+          originalAuthorName = originalUser.displayName!;
+          originalAuthorUsername = originalUser.username!;
+          originalAuthorProfileImageUrl = originalUser.profileImageUrl;
+        }
+        
+        return {
+          ...basePost,
+          isRepost: true,
+          isQuote,
+          quoteComment: isQuote ? post.content : null,
+          originalPostId: originalPost.id,
+          originalPost: {
+            id: originalPost.id,
+            content: originalPost.content,
+            authorId: originalPost.authorId,
+            authorName: originalAuthorName,
+            authorUsername: originalAuthorUsername,
+            authorProfileImageUrl: originalAuthorProfileImageUrl,
+            timestamp: toISOStringSafe(originalPost.timestamp),
+          }
+        };
       }
-
-      logger.error('Error formatting post', { postId: post?.id, post }, 'GET /api/posts')
-    }))
+      
+      return basePost;
+    })
     
     logger.info('Formatted posts', { 
       originalCount: posts.length, 

--- a/src/app/api/users/[userId]/posts/route.ts
+++ b/src/app/api/users/[userId]/posts/route.ts
@@ -103,6 +103,7 @@ type PostWithOriginal = Post & {
     content: string;
     authorId: string;
     timestamp: Date;
+    deletedAt: Date | null;
   } | null;
 };
 
@@ -292,12 +293,12 @@ export const GET = withErrorHandling(async (
             : false,
           // Include original post for reposts/quotes
           Post_Post_originalPostIdToPost: {
-            where: { deletedAt: null },
             select: {
               id: true,
               content: true,
               authorId: true,
               timestamp: true,
+              deletedAt: true,
             }
           }
         },
@@ -320,7 +321,25 @@ export const GET = withErrorHandling(async (
       
       // Get unique author IDs from original posts (for reposts/quotes)
       const postsWithOriginal = posts as PostWithOriginal[];
-      const originalPostAuthorIds = postsWithOriginal
+      
+      // Filter out reposts where the original post is deleted
+      const validPosts = postsWithOriginal.filter(post => {
+        // If it's a repost, check if original post exists and is not deleted
+        if (post.originalPostId) {
+          const hasOriginalPost = post.Post_Post_originalPostIdToPost && !post.Post_Post_originalPostIdToPost.deletedAt;
+          const isQuote = post.content && post.content.length > 0;
+          
+          // For quote posts, keep them even if original is deleted (user has commentary)
+          // For simple reposts, filter out if original is deleted
+          if (isQuote) {
+            return true; // Keep quote posts regardless
+          }
+          return hasOriginalPost; // Filter out simple reposts with deleted originals
+        }
+        return true;
+      });
+      
+      const originalPostAuthorIds = validPosts
         .filter(p => p.originalPostId && p.Post_Post_originalPostIdToPost)
         .map(p => p.Post_Post_originalPostIdToPost!.authorId)
         .filter((id): id is string => !!id);
@@ -362,7 +381,7 @@ export const GET = withErrorHandling(async (
       const orgAuthorsMap = new Map(originalAuthorsOrgs.map(o => [o.id, o]));
       
       // Get interaction counts for original posts (for reposts)
-      const originalPostIds = postsWithOriginal
+      const originalPostIds = validPosts
         .filter(p => p.originalPostId)
         .map(p => p.originalPostId)
         .filter((id): id is string => id !== null);
@@ -391,7 +410,7 @@ export const GET = withErrorHandling(async (
       const originalShareMap = new Map(originalPostShares.map(s => [s.postId, s._count.postId]));
       
       // Format posts (includes both regular posts and reposts/quotes)
-      const formattedPosts = postsWithOriginal.map((post) => {
+      const formattedPosts = validPosts.map((post) => {
         const basePost = {
           id: post.id,
           content: post.content,
@@ -414,44 +433,59 @@ export const GET = withErrorHandling(async (
         };
         
         // Check if this is a repost/quote
-        if (post.originalPostId && post.Post_Post_originalPostIdToPost) {
-          const originalPost = post.Post_Post_originalPostIdToPost;
+        if (post.originalPostId) {
           const isQuote = post.content && post.content.length > 0;
+          const originalPost = post.Post_Post_originalPostIdToPost;
           
-          // Get original post author info
-          const originalUser = userAuthorsMap.get(originalPost.authorId);
-          const originalActor = actorAuthorsMap.get(originalPost.authorId);
-          const originalOrg = orgAuthorsMap.get(originalPost.authorId);
+          // If original post exists and is not deleted
+          if (originalPost && !originalPost.deletedAt) {
+            // Get original post author info
+            const originalUser = userAuthorsMap.get(originalPost.authorId);
+            const originalActor = actorAuthorsMap.get(originalPost.authorId);
+            const originalOrg = orgAuthorsMap.get(originalPost.authorId);
+            
+            // For simple reposts (not quotes), use the original post's interaction counts
+            // For quote posts, keep the quote post's interaction counts
+            const interactionCounts = !isQuote ? {
+              likeCount: originalReactionMap.get(originalPost.id) ?? 0,
+              commentCount: originalCommentMap.get(originalPost.id) ?? 0,
+              shareCount: originalShareMap.get(originalPost.id) ?? 0,
+            } : {
+              likeCount: basePost.likeCount,
+              commentCount: basePost.commentCount,
+              shareCount: basePost.shareCount,
+            };
+            
+            return {
+              ...basePost,
+              ...interactionCounts,
+              isRepost: true,
+              isQuote,
+              quoteComment: isQuote ? post.content : null,
+              originalPostId: originalPost.id,
+              originalPost: {
+                id: originalPost.id,
+                content: originalPost.content,
+                authorId: originalPost.authorId,
+                authorName: originalUser?.displayName || originalActor?.name || originalOrg?.name || originalPost.authorId,
+                authorUsername: originalUser?.username || null,
+                authorProfileImageUrl: originalUser?.profileImageUrl || originalActor?.profileImageUrl || originalOrg?.imageUrl || null,
+                timestamp: originalPost.timestamp.toISOString(),
+              }
+            };
+          }
           
-          // For simple reposts (not quotes), use the original post's interaction counts
-          // For quote posts, keep the quote post's interaction counts
-          const interactionCounts = !isQuote ? {
-            likeCount: originalReactionMap.get(originalPost.id) ?? 0,
-            commentCount: originalCommentMap.get(originalPost.id) ?? 0,
-            shareCount: originalShareMap.get(originalPost.id) ?? 0,
-          } : {
-            likeCount: basePost.likeCount,
-            commentCount: basePost.commentCount,
-            shareCount: basePost.shareCount,
-          };
-          
-          return {
-            ...basePost,
-            ...interactionCounts,
-            isRepost: true,
-            isQuote,
-            quoteComment: isQuote ? post.content : null,
-            originalPostId: originalPost.id,
-            originalPost: {
-              id: originalPost.id,
-              content: originalPost.content,
-              authorId: originalPost.authorId,
-              authorName: originalUser?.displayName || originalActor?.name || originalOrg?.name || originalPost.authorId,
-              authorUsername: originalUser?.username || null,
-              authorProfileImageUrl: originalUser?.profileImageUrl || originalActor?.profileImageUrl || originalOrg?.imageUrl || null,
-              timestamp: originalPost.timestamp.toISOString(),
-            }
-          };
+          // If original post is deleted but this is a quote post, return with null originalPost
+          if (isQuote) {
+            return {
+              ...basePost,
+              isRepost: true,
+              isQuote: true,
+              quoteComment: post.content,
+              originalPostId: post.originalPostId,
+              originalPost: null,
+            };
+          }
         }
         
         return basePost;

--- a/src/app/api/users/[userId]/posts/route.ts
+++ b/src/app/api/users/[userId]/posts/route.ts
@@ -87,6 +87,24 @@ import { withErrorHandling, successResponse } from '@/lib/errors/error-handler';
 import { UserIdParamSchema, UserPostsQuerySchema } from '@/lib/validation/schemas';
 import { logger } from '@/lib/logger';
 import { findUserByIdentifier } from '@/lib/users/user-lookup';
+import type { Post } from '@prisma/client';
+
+// Type for posts with included original post relation
+type PostWithOriginal = Post & {
+  _count: {
+    Reaction: number;
+    Comment: number;
+    Share: number;
+  };
+  Reaction: Array<{ id: string }>;
+  Share: Array<{ id: string }>;
+  Post_Post_originalPostIdToPost?: {
+    id: string;
+    content: string;
+    authorId: string;
+    timestamp: Date;
+  } | null;
+};
 
 /**
  * GET /api/users/[userId]/posts
@@ -244,7 +262,6 @@ export const GET = withErrorHandling(async (
           authorId: canonicalUserId,
           deletedAt: null, // Filter out deleted posts
           timestamp: { lte: now }, // ✅ No future posts
-          // Exclude reposts (posts with replyTo field will be handled separately)
         },
         include: {
           _count: {
@@ -273,42 +290,19 @@ export const GET = withErrorHandling(async (
                 select: { id: true },
               }
             : false,
-        },
-        orderBy: {
-          timestamp: 'desc',
-        },
-        take: 100,
-      });
-
-      // Also get user's shares (reposts) - only for posts up to current time
-      const shares = await prisma.share.findMany({
-        where: {
-          userId: canonicalUserId,
-          Post: {
-            timestamp: { lte: now }, // ✅ No future posts
-          },
-        },
-        include: {
-          Post: {
+          // Include original post for reposts/quotes
+          Post_Post_originalPostIdToPost: {
+            where: { deletedAt: null },
             select: {
               id: true,
               content: true,
               authorId: true,
               timestamp: true,
-              _count: {
-                select: {
-                  Reaction: {
-                    where: { type: 'like' },
-                  },
-                  Comment: true,
-                  Share: true,
-                },
-              },
-            },
-          },
+            }
+          }
         },
         orderBy: {
-          createdAt: 'desc',
+          timestamp: 'desc',
         },
         take: 100,
       });
@@ -324,13 +318,19 @@ export const GET = withErrorHandling(async (
         },
       });
       
-      // Get unique author IDs from shared posts
-      const sharedPostAuthorIds = [...new Set(shares.map(s => s.Post.authorId))];
+      // Get unique author IDs from original posts (for reposts/quotes)
+      const postsWithOriginal = posts as PostWithOriginal[];
+      const originalPostAuthorIds = postsWithOriginal
+        .filter(p => p.originalPostId && p.Post_Post_originalPostIdToPost)
+        .map(p => p.Post_Post_originalPostIdToPost!.authorId)
+        .filter((id): id is string => !!id);
       
-      // Fetch User, Actor, and Organization info for shared post authors
-      const [sharedAuthorsUsers, sharedAuthorsActors, sharedAuthorsOrgs] = await Promise.all([
+      const uniqueOriginalAuthorIds = [...new Set(originalPostAuthorIds)];
+      
+      // Fetch User, Actor, and Organization info for original post authors
+      const [originalAuthorsUsers, originalAuthorsActors, originalAuthorsOrgs] = await Promise.all([
         prisma.user.findMany({
-          where: { id: { in: sharedPostAuthorIds } },
+          where: { id: { in: uniqueOriginalAuthorIds } },
           select: {
             id: true,
             displayName: true,
@@ -339,7 +339,7 @@ export const GET = withErrorHandling(async (
           },
         }),
         prisma.actor.findMany({
-          where: { id: { in: sharedPostAuthorIds } },
+          where: { id: { in: uniqueOriginalAuthorIds } },
           select: {
             id: true,
             name: true,
@@ -347,7 +347,7 @@ export const GET = withErrorHandling(async (
           },
         }),
         prisma.organization.findMany({
-          where: { id: { in: sharedPostAuthorIds } },
+          where: { id: { in: uniqueOriginalAuthorIds } },
           select: {
             id: true,
             name: true,
@@ -357,78 +357,66 @@ export const GET = withErrorHandling(async (
       ]);
       
       // Create author lookup maps
-      const userAuthorsMap = new Map(sharedAuthorsUsers.map(u => [u.id, u]));
-      const actorAuthorsMap = new Map(sharedAuthorsActors.map(a => [a.id, a]));
-      const orgAuthorsMap = new Map(sharedAuthorsOrgs.map(o => [o.id, o]));
+      const userAuthorsMap = new Map(originalAuthorsUsers.map(u => [u.id, u]));
+      const actorAuthorsMap = new Map(originalAuthorsActors.map(a => [a.id, a]));
+      const orgAuthorsMap = new Map(originalAuthorsOrgs.map(o => [o.id, o]));
       
-      // Format posts
-      const formattedPosts = posts.map((post) => ({
-        id: post.id,
-        content: post.content,
-        authorId: post.authorId,
-        timestamp: post.timestamp.toISOString(),
-        createdAt: post.createdAt.toISOString(),
-        likeCount: post._count.Reaction,
-        commentCount: post._count.Comment,
-        shareCount: post._count.Share,
-        isLiked: post.Reaction.length > 0,
-        isShared: post.Share.length > 0,
-        author: postAuthor
-          ? {
-              id: postAuthor.id,
-              displayName: postAuthor.displayName,
-              username: postAuthor.username,
-              profileImageUrl: postAuthor.profileImageUrl,
-            }
-          : null,
-      }));
-
-      // Format shares as reposts
-      const reposts = shares.map((share) => {
-        const authorUser = userAuthorsMap.get(share.Post.authorId);
-        const authorActor = actorAuthorsMap.get(share.Post.authorId);
-        const authorOrg = orgAuthorsMap.get(share.Post.authorId);
-        
-        return {
-          id: `share-${share.id}`,
-          content: share.Post.content,
-          authorId: share.Post.authorId,
-          timestamp: share.createdAt.toISOString(),
-          createdAt: share.createdAt.toISOString(),
-          likeCount: share.Post._count.Reaction,
-          commentCount: share.Post._count.Comment,
-          shareCount: share.Post._count.Share,
-          isLiked: false, // Could check if user liked original post
-          isShared: true,
-          isRepost: true,
-          originalPostId: share.Post.id,
-          author: authorUser
+      // Format posts (includes both regular posts and reposts/quotes)
+      const formattedPosts = postsWithOriginal.map((post) => {
+        const basePost = {
+          id: post.id,
+          content: post.content,
+          authorId: post.authorId,
+          timestamp: post.timestamp.toISOString(),
+          createdAt: post.createdAt.toISOString(),
+          likeCount: post._count.Reaction,
+          commentCount: post._count.Comment,
+          shareCount: post._count.Share,
+          isLiked: post.Reaction.length > 0,
+          isShared: post.Share.length > 0,
+          author: postAuthor
             ? {
-                id: authorUser.id,
-                displayName: authorUser.displayName,
-                username: authorUser.username,
-                profileImageUrl: authorUser.profileImageUrl,
+                id: postAuthor.id,
+                displayName: postAuthor.displayName,
+                username: postAuthor.username,
+                profileImageUrl: postAuthor.profileImageUrl,
               }
-            : authorActor
-              ? {
-                  id: authorActor.id,
-                  displayName: authorActor.name,
-                  username: null,
-                  profileImageUrl: authorActor.profileImageUrl,
-                }
-              : authorOrg
-              ? {
-                  id: authorOrg.id,
-                  displayName: authorOrg.name,
-                  username: null,
-                  profileImageUrl: authorOrg.imageUrl,
-                }
-              : null,
+            : null,
         };
+        
+        // Check if this is a repost/quote
+        if (post.originalPostId && post.Post_Post_originalPostIdToPost) {
+          const originalPost = post.Post_Post_originalPostIdToPost;
+          const isQuote = post.content && post.content.length > 0;
+          
+          // Get original post author info
+          const originalUser = userAuthorsMap.get(originalPost.authorId);
+          const originalActor = actorAuthorsMap.get(originalPost.authorId);
+          const originalOrg = orgAuthorsMap.get(originalPost.authorId);
+          
+          return {
+            ...basePost,
+            isRepost: true,
+            isQuote,
+            quoteComment: isQuote ? post.content : null,
+            originalPostId: originalPost.id,
+            originalPost: {
+              id: originalPost.id,
+              content: originalPost.content,
+              authorId: originalPost.authorId,
+              authorName: originalUser?.displayName || originalActor?.name || originalOrg?.name || originalPost.authorId,
+              authorUsername: originalUser?.username || null,
+              authorProfileImageUrl: originalUser?.profileImageUrl || originalActor?.profileImageUrl || originalOrg?.imageUrl || null,
+              timestamp: originalPost.timestamp.toISOString(),
+            }
+          };
+        }
+        
+        return basePost;
       });
 
-      // Combine and sort by timestamp
-      const allItems = [...formattedPosts, ...reposts].sort(
+      // Sort by timestamp (posts already include reposts/quotes)
+      const allItems = formattedPosts.sort(
         (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
       );
 

--- a/src/app/api/users/[userId]/posts/route.ts
+++ b/src/app/api/users/[userId]/posts/route.ts
@@ -361,6 +361,35 @@ export const GET = withErrorHandling(async (
       const actorAuthorsMap = new Map(originalAuthorsActors.map(a => [a.id, a]));
       const orgAuthorsMap = new Map(originalAuthorsOrgs.map(o => [o.id, o]));
       
+      // Get interaction counts for original posts (for reposts)
+      const originalPostIds = postsWithOriginal
+        .filter(p => p.originalPostId)
+        .map(p => p.originalPostId)
+        .filter((id): id is string => id !== null);
+      
+      const [originalPostReactions, originalPostComments, originalPostShares] = await Promise.all([
+        originalPostIds.length > 0 ? prisma.reaction.groupBy({
+          by: ['postId'],
+          where: { postId: { in: originalPostIds }, type: 'like' },
+          _count: { postId: true },
+        }) : Promise.resolve([]),
+        originalPostIds.length > 0 ? prisma.comment.groupBy({
+          by: ['postId'],
+          where: { postId: { in: originalPostIds } },
+          _count: { postId: true },
+        }) : Promise.resolve([]),
+        originalPostIds.length > 0 ? prisma.share.groupBy({
+          by: ['postId'],
+          where: { postId: { in: originalPostIds } },
+          _count: { postId: true },
+        }) : Promise.resolve([]),
+      ]);
+      
+      // Create interaction count maps for original posts
+      const originalReactionMap = new Map(originalPostReactions.map(r => [r.postId, r._count.postId]));
+      const originalCommentMap = new Map(originalPostComments.map(c => [c.postId, c._count.postId]));
+      const originalShareMap = new Map(originalPostShares.map(s => [s.postId, s._count.postId]));
+      
       // Format posts (includes both regular posts and reposts/quotes)
       const formattedPosts = postsWithOriginal.map((post) => {
         const basePost = {
@@ -394,8 +423,21 @@ export const GET = withErrorHandling(async (
           const originalActor = actorAuthorsMap.get(originalPost.authorId);
           const originalOrg = orgAuthorsMap.get(originalPost.authorId);
           
+          // For simple reposts (not quotes), use the original post's interaction counts
+          // For quote posts, keep the quote post's interaction counts
+          const interactionCounts = !isQuote ? {
+            likeCount: originalReactionMap.get(originalPost.id) ?? 0,
+            commentCount: originalCommentMap.get(originalPost.id) ?? 0,
+            shareCount: originalShareMap.get(originalPost.id) ?? 0,
+          } : {
+            likeCount: basePost.likeCount,
+            commentCount: basePost.commentCount,
+            shareCount: basePost.shareCount,
+          };
+          
           return {
             ...basePost,
+            ...interactionCounts,
             isRepost: true,
             isQuote,
             quoteComment: isQuote ? post.content : null,

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -499,7 +499,7 @@ function FeedPageContent() {
                       shareCount: ('shareCount' in post ? (post.shareCount as number) : 0) || 0,
                       isLiked: ('isLiked' in post ? (post.isLiked as boolean) : false) || false,
                       isShared: ('isShared' in post ? (post.isShared as boolean) : false) || false,
-                      // Repost metadata (new clean structure)
+                      // Repost metadata
                       isRepost: ('isRepost' in post ? (post.isRepost as boolean) : false) || false,
                       isQuote: ('isQuote' in post ? (post.isQuote as boolean) : false) || false,
                       quoteComment: ('quoteComment' in post ? (post.quoteComment as string | null) : null) || null,

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -512,12 +512,10 @@ function FeedPageContent() {
                         {postData.type && postData.type === 'article' ? (
                           <ArticleCard
                             post={postData}
-                            onClick={() => router.push(`/post/${post.id}`)}
                           />
                         ) : (
                           <PostCard
                             post={postData}
-                            onClick={() => router.push(`/post/${post.id}`)}
                           />
                         )}
                         {showBannerAfterThisPost && (

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -2,7 +2,7 @@
 
 import { ArticleCard } from '@/components/articles/ArticleCard'
 import { CreatePostModal } from '@/components/posts/CreatePostModal'
-import { PostCard } from '@/components/posts/PostCard'
+import { PostCard, type PostCardProps } from '@/components/posts/PostCard'
 import { FeedToggle } from '@/components/shared/FeedToggle'
 import { InviteFriendsBanner } from '@/components/shared/InviteFriendsBanner'
 import { PageContainer } from '@/components/shared/PageContainer'
@@ -499,15 +499,12 @@ function FeedPageContent() {
                       shareCount: ('shareCount' in post ? (post.shareCount as number) : 0) || 0,
                       isLiked: ('isLiked' in post ? (post.isLiked as boolean) : false) || false,
                       isShared: ('isShared' in post ? (post.isShared as boolean) : false) || false,
-                      // Repost metadata
-                      isRepost: ('isRepost' in post ? post.isRepost : false) || false,
-                      originalPostId: ('originalPostId' in post ? post.originalPostId : null) || null,
-                      originalAuthorId: ('originalAuthorId' in post ? post.originalAuthorId : null) || null,
-                      originalAuthorName: ('originalAuthorName' in post ? post.originalAuthorName : null) || null,
-                      originalAuthorUsername: ('originalAuthorUsername' in post ? post.originalAuthorUsername : null) || null,
-                      originalAuthorProfileImageUrl: ('originalAuthorProfileImageUrl' in post ? post.originalAuthorProfileImageUrl : null) || null,
-                      originalContent: ('originalContent' in post ? post.originalContent : null) || null,
-                      quoteComment: ('quoteComment' in post ? post.quoteComment : null) || null,
+                      // Repost metadata (new clean structure)
+                      isRepost: ('isRepost' in post ? (post.isRepost as boolean) : false) || false,
+                      isQuote: ('isQuote' in post ? (post.isQuote as boolean) : false) || false,
+                      quoteComment: ('quoteComment' in post ? (post.quoteComment as string | null) : null) || null,
+                      originalPostId: ('originalPostId' in post ? (post.originalPostId as string | null) : null) || null,
+                      originalPost: ('originalPost' in post ? (post.originalPost as PostCardProps['post']['originalPost']) : null) || null,
                     }
 
                     return (

--- a/src/app/post/[id]/page.tsx
+++ b/src/app/post/[id]/page.tsx
@@ -45,15 +45,20 @@ export default function PostPage({ params }: PostPageProps) {
     shareCount: number;
     isLiked: boolean;
     isShared: boolean;
-    // Repost metadata
+    // Repost metadata (new clean structure)
     isRepost?: boolean;
-    originalPostId?: string | null;
-    originalAuthorId?: string | null;
-    originalAuthorName?: string | null;
-    originalAuthorUsername?: string | null;
-    originalAuthorProfileImageUrl?: string | null;
-    originalContent?: string | null;
+    isQuote?: boolean;
     quoteComment?: string | null;
+    originalPostId?: string | null;
+    originalPost?: {
+      id: string;
+      content: string;
+      authorId: string;
+      authorName: string;
+      authorUsername: string | null;
+      authorProfileImageUrl: string | null;
+      timestamp: string;
+    } | null;
   } | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -95,15 +100,12 @@ export default function PostPage({ params }: PostPageProps) {
         shareCount: postData.shareCount ?? 0,
         isLiked: postData.isLiked ?? false,
         isShared: postData.isShared ?? false,
-        // Repost metadata
+        // Repost metadata (new clean structure)
         isRepost: postData.isRepost || false,
-        originalPostId: postData.originalPostId || null,
-        originalAuthorId: postData.originalAuthorId || null,
-        originalAuthorName: postData.originalAuthorName || null,
-        originalAuthorUsername: postData.originalAuthorUsername || null,
-        originalAuthorProfileImageUrl: postData.originalAuthorProfileImageUrl || null,
-        originalContent: postData.originalContent || null,
+        isQuote: postData.isQuote || false,
         quoteComment: postData.quoteComment || null,
+        originalPostId: postData.originalPostId || null,
+        originalPost: postData.originalPost || null,
       });
       
       // Update the interaction store with fresh API data

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -820,13 +820,11 @@ export default function ActorProfilePage() {
                   <ArticleCard
                     key={`${item.post.id}-${i}`}
                     post={postData}
-                    onClick={() => router.push(`/post/${item.post.id}`)}
                   />
                 ) : (
                   <PostCard
                     key={`${item.post.id}-${i}`}
                     post={postData}
-                    onClick={() => router.push(`/post/${item.post.id}`)}
                     showInteractions={true}
                   />
                 );
@@ -1095,13 +1093,11 @@ export default function ActorProfilePage() {
                     <ArticleCard
                       key={`${item.post.id}-${i}`}
                       post={postData}
-                      onClick={() => router.push(`/post/${item.post.id}`)}
                     />
                   ) : (
                     <PostCard
                       key={`${item.post.id}-${i}`}
                       post={postData}
-                      onClick={() => router.push(`/post/${item.post.id}`)}
                       showInteractions={true}
                     />
                   );

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -90,6 +90,20 @@ export default function ActorProfilePage() {
     shareCount?: number
     isLiked?: boolean
     isShared?: boolean
+    // Repost metadata
+    isRepost?: boolean
+    isQuote?: boolean
+    quoteComment?: string | null
+    originalPostId?: string | null
+    originalPost?: {
+      id: string
+      content: string
+      authorId: string
+      authorName: string
+      authorUsername: string | null
+      authorProfileImageUrl: string | null
+      timestamp: string
+    } | null
   }>>([])
   const [loadingPosts, setLoadingPosts] = useState(false)
   
@@ -416,6 +430,12 @@ export default function ActorProfilePage() {
           shareCount: apiPost.shareCount,
           isLiked: apiPost.isLiked,
           isShared: apiPost.isShared,
+          // Repost metadata (pass through from API)
+          isRepost: apiPost.isRepost,
+          isQuote: apiPost.isQuote,
+          quoteComment: apiPost.quoteComment,
+          originalPostId: apiPost.originalPostId,
+          originalPost: apiPost.originalPost,
         },
         gameId: '',
         gameName: '',
@@ -788,15 +808,12 @@ export default function ActorProfilePage() {
                   shareCount: item.post.shareCount,
                   isLiked: item.post.isLiked,
                   isShared: item.post.isShared,
-                  // Repost metadata
+                  // Repost metadata (new clean structure)
                   isRepost: item.post.isRepost || false,
-                  originalPostId: item.post.originalPostId || null,
-                  originalAuthorId: item.post.originalAuthorId || null,
-                  originalAuthorName: item.post.originalAuthorName || null,
-                  originalAuthorUsername: item.post.originalAuthorUsername || null,
-                  originalAuthorProfileImageUrl: item.post.originalAuthorProfileImageUrl || null,
-                  originalContent: item.post.originalContent || null,
+                  isQuote: item.post.isQuote || false,
                   quoteComment: item.post.quoteComment || null,
+                  originalPostId: item.post.originalPostId || null,
+                  originalPost: item.post.originalPost || null,
                 };
                 
                 return postData.type && postData.type === 'article' ? (
@@ -1066,15 +1083,12 @@ export default function ActorProfilePage() {
                     shareCount: item.post.shareCount,
                     isLiked: item.post.isLiked,
                     isShared: item.post.isShared,
-                    // Repost metadata
+                    // Repost metadata (new clean structure)
                     isRepost: item.post.isRepost || false,
-                    originalPostId: item.post.originalPostId || null,
-                    originalAuthorId: item.post.originalAuthorId || null,
-                    originalAuthorName: item.post.originalAuthorName || null,
-                    originalAuthorUsername: item.post.originalAuthorUsername || null,
-                    originalAuthorProfileImageUrl: item.post.originalAuthorProfileImageUrl || null,
-                    originalContent: item.post.originalContent || null,
+                    isQuote: item.post.isQuote || false,
                     quoteComment: item.post.quoteComment || null,
+                    originalPostId: item.post.originalPostId || null,
+                    originalPost: item.post.originalPost || null,
                   };
                   
                   return postData.type && postData.type === 'article' ? (

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -808,7 +808,7 @@ export default function ActorProfilePage() {
                   shareCount: item.post.shareCount,
                   isLiked: item.post.isLiked,
                   isShared: item.post.isShared,
-                  // Repost metadata (new clean structure)
+                  // Repost metadata
                   isRepost: item.post.isRepost || false,
                   isQuote: item.post.isQuote || false,
                   quoteComment: item.post.quoteComment || null,
@@ -1083,7 +1083,7 @@ export default function ActorProfilePage() {
                     shareCount: item.post.shareCount,
                     isLiked: item.post.isLiked,
                     isShared: item.post.isShared,
-                    // Repost metadata (new clean structure)
+                    // Repost metadata
                     isRepost: item.post.isRepost || false,
                     isQuote: item.post.isQuote || false,
                     quoteComment: item.post.quoteComment || null,

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -785,13 +785,11 @@ export default function ProfilePage() {
                         <ArticleCard
                           key={item.id}
                           post={postData}
-                          onClick={() => router.push(`/post/${item.id}`)}
                         />
                       ) : (
                         <PostCard
                           key={item.id}
                           post={postData}
-                          onClick={() => router.push(`/post/${item.id}`)}
                           showInteractions
                         />
                       )

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -773,7 +773,7 @@ export default function ProfilePage() {
                         shareCount: item.shareCount,
                         isLiked: item.isLiked,
                         isShared: item.isShared,
-                        // Repost metadata (new clean structure)
+                        // Repost metadata
                         isRepost: item.isRepost || false,
                         isQuote: item.isQuote || false,
                         quoteComment: item.quoteComment || null,

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -136,10 +136,6 @@ export default function ProfilePage() {
   }>>([])
   const [loadingPosts, setLoadingPosts] = useState(false)
 
-  useEffect(() => {
-    console.log("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!", posts)
-  }, [posts])
-
   // Social visibility toggles
   const [socialVisibility, setSocialVisibility] = useState<SocialVisibility>({
     twitter: true,

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -104,15 +104,21 @@ export default function ProfilePage() {
     authorProfileImageUrl?: string | null
     isLiked?: boolean
     isShared?: boolean
+    // New clean repost structure
     isRepost?: boolean
-    originalPostId?: string | null
-    originalAuthorId?: string | null
-    originalAuthorName?: string | null
-    originalAuthorUsername?: string | null
-    originalAuthorProfileImageUrl?: string | null
-    originalContent?: string | null
+    isQuote?: boolean
     quoteComment?: string | null
-  }>>([])
+    originalPostId?: string | null
+    originalPost?: {
+      id: string
+      content: string
+      authorId: string
+      authorName: string
+      authorUsername: string | null
+      authorProfileImageUrl: string | null
+      timestamp: string
+    } | null
+  }>>([]);
   const [replies, setReplies] = useState<Array<{
     id: string
     content: string
@@ -129,6 +135,10 @@ export default function ProfilePage() {
     }
   }>>([])
   const [loadingPosts, setLoadingPosts] = useState(false)
+
+  useEffect(() => {
+    console.log("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!", posts)
+  }, [posts])
 
   // Social visibility toggles
   const [socialVisibility, setSocialVisibility] = useState<SocialVisibility>({
@@ -767,15 +777,12 @@ export default function ProfilePage() {
                         shareCount: item.shareCount,
                         isLiked: item.isLiked,
                         isShared: item.isShared,
-                        // Repost metadata
+                        // Repost metadata (new clean structure)
                         isRepost: item.isRepost || false,
-                        originalPostId: item.originalPostId || null,
-                        originalAuthorId: item.originalAuthorId || null,
-                        originalAuthorName: item.originalAuthorName || null,
-                        originalAuthorUsername: item.originalAuthorUsername || null,
-                        originalAuthorProfileImageUrl: item.originalAuthorProfileImageUrl || null,
-                        originalContent: item.originalContent || null,
+                        isQuote: item.isQuote || false,
                         quoteComment: item.quoteComment || null,
+                        originalPostId: item.originalPostId || null,
+                        originalPost: item.originalPost || null,
                       };
                       
                       return postData.type === 'article' ? (

--- a/src/app/trending/[tag]/page.tsx
+++ b/src/app/trending/[tag]/page.tsx
@@ -188,7 +188,6 @@ export default function TrendingTagPage() {
                   <PostCard
                     key={post.id}
                     post={post}
-                    onClick={() => router.push(`/post/${post.id}`)}
                   />
                 ))}
                 
@@ -241,7 +240,6 @@ export default function TrendingTagPage() {
               <PostCard
                 key={post.id}
                 post={post}
-                onClick={() => router.push(`/post/${post.id}`)}
               />
             ))}
             

--- a/src/app/trending/group/page.tsx
+++ b/src/app/trending/group/page.tsx
@@ -121,7 +121,6 @@ export default function GroupedTrendingPage() {
                 <PostCard
                   key={post.id}
                   post={post}
-                  onClick={() => router.push(`/post/${post.id}`)}
                 />
               ))}
               

--- a/src/components/interactions/InteractionBar.tsx
+++ b/src/components/interactions/InteractionBar.tsx
@@ -53,9 +53,15 @@ export function InteractionBar({
   const { authenticated } = useAuth();
   const { showLoginModal } = useLoginModal();
 
-  // For reposts, use the original post ID for tracking interactions (isLiked/isShared)
-  // This ensures likes on a repost actually like the original post
-  const interactionPostId = postData?.originalPostId || postId;
+  // Determine if this is a simple repost (no quote commentary)
+  // Simple repost: has originalPostId but no quote commentary
+  // Quote post: has originalPostId AND has quote commentary (isQuote or quoteComment)
+  const isSimpleRepost = postData?.originalPostId && !postData?.isQuote && !postData?.quoteComment;
+  
+  // For SIMPLE reposts only, use the original post ID for tracking interactions
+  // This ensures interactions on a simple repost affect the original post
+  // For QUOTE posts, use the quote post's own ID (they have independent interactions)
+  const interactionPostId = (isSimpleRepost && postData?.originalPostId) ? postData.originalPostId : postId;
 
   // Get interaction data from store (synced via polling) or fall back to initial values
   const storeData = postInteractions.get(interactionPostId);
@@ -132,7 +138,7 @@ export function InteractionBar({
         {/* Share button */}
         <div onClick={(e) => e.stopPropagation()}>
           <RepostButton
-            postId={postData?.originalPostId || postId}
+            postId={interactionPostId}
             shareCount={shareCount}
             initialShared={isShared}
             size="sm"
@@ -152,7 +158,7 @@ export function InteractionBar({
         {/* Like button with reaction picker */}
         <div onClick={(e) => e.stopPropagation()}>
           <LikeButton
-            targetId={postData?.originalPostId || postId}
+            targetId={interactionPostId}
             targetType="post"
             initialLiked={isLiked}
             initialCount={likeCount}

--- a/src/components/posts/PostCard.tsx
+++ b/src/components/posts/PostCard.tsx
@@ -234,13 +234,17 @@ export const PostCard = memo(function PostCard({
           <Repeat2 size={14} className="text-green-600" />
           <span>
             Reposted by{' '}
-            <Link
-              href={getProfileUrl(post.authorId, post.authorUsername)}
-              className="font-semibold hover:underline text-foreground"
-              onClick={(e) => e.stopPropagation()}
-            >
-              {post.authorName}
-            </Link>
+            {user?.id === post.authorId ? (
+              <span className="font-semibold text-foreground">you</span>
+            ) : (
+              <Link
+                href={getProfileUrl(post.authorId, post.authorUsername)}
+                className="font-semibold hover:underline text-foreground"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {post.authorName}
+              </Link>
+            )}
           </span>
         </div>
       )}

--- a/src/components/posts/PostCard.tsx
+++ b/src/components/posts/PostCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { memo, useState, useEffect, useMemo, type MouseEvent, type KeyboardEvent } from 'react';
+import { memo, useState, useEffect, type MouseEvent, type KeyboardEvent } from 'react';
 import { cn } from '@/lib/utils';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
@@ -65,15 +65,20 @@ export interface PostCardProps {
     isLiked?: boolean;
     isShared?: boolean;
     deletedAt?: string | null; // Soft delete timestamp
-    // Repost metadata
+    // Repost metadata (new clean structure)
     isRepost?: boolean;
+    isQuote?: boolean; // True if it has quote commentary
+    quoteComment?: string | null; // The quote commentary text
     originalPostId?: string | null;
-    originalAuthorId?: string | null;
-    originalAuthorName?: string | null;
-    originalAuthorUsername?: string | null;
-    originalAuthorProfileImageUrl?: string | null;
-    originalContent?: string | null;
-    quoteComment?: string | null;
+    originalPost?: {
+      id: string;
+      content: string;
+      authorId: string;
+      authorName: string;
+      authorUsername: string | null;
+      authorProfileImageUrl: string | null;
+      timestamp: string;
+    } | null;
   };
   className?: string;
   onClick?: () => void;
@@ -137,70 +142,22 @@ export const PostCard = memo(function PostCard({
     isShared: post.isShared ?? false,
   };
 
-  // Client-side fallback: Parse repost content if API didn't populate metadata
-  const clientSideRepostData = useMemo(() => {
-    // If already has repost metadata, use it
-    if (post.isRepost && post.originalAuthorId) {
-      return null;
-    }
-    
-    // Guard against undefined/null content
-    if (!post.content || typeof post.content !== 'string') {
-      return null;
-    }
-    
-    // Otherwise, try to parse from content
-    const separatorPattern = /\n\n--- Reposted from @(.+?) ---\n/;
-    const match = post.content.match(separatorPattern);
-    
-    if (!match) return null;
-    
-    const parts = post.content.split(separatorPattern);
-    const quoteComment = parts[0]?.trim() || null;
-    const originalContent = parts[2]?.trim() || '';
-    const originalAuthorUsername = match[1] || '';
-    
-    return {
-      isRepost: true,
-      quoteComment,
-      originalContent,
-      originalAuthorUsername,
-      originalAuthorId: originalAuthorUsername,
-      originalAuthorName: originalAuthorUsername,
-    };
-  }, [post.content, post.isRepost, post.originalAuthorId]);
-
-  // Use client-side parsed data if API data is missing
-  const effectivePost = useMemo(() => {
-    if (clientSideRepostData) {
-      return {
-        ...post,
-        isRepost: true,
-        quoteComment: clientSideRepostData.quoteComment,
-        originalContent: clientSideRepostData.originalContent,
-        originalAuthorId: clientSideRepostData.originalAuthorId,
-        originalAuthorName: clientSideRepostData.originalAuthorName,
-        originalAuthorUsername: clientSideRepostData.originalAuthorUsername,
-        originalPostId: null,
-        originalAuthorProfileImageUrl: null,
-      };
-    }
-    return post;
-  }, [post, clientSideRepostData]);
-
-  // For QUOTE posts (isRepost with quoteComment), show the REPOSTER's info in the header
-  // For simple reposts (isRepost without quoteComment), show the ORIGINAL author's info
-  const isSimpleRepost = effectivePost.isRepost && !effectivePost.quoteComment;
+  // Determine if this is a simple repost (no quote) or a quote post
+  // Simple repost: isRepost && !isQuote (or !quoteComment)
+  // Quote post: isRepost && isQuote (or has quoteComment)
+  const isSimpleRepost = post.isRepost && !post.isQuote && !post.quoteComment;
   
-  const displayAuthorId = isSimpleRepost && effectivePost.originalAuthorId ? effectivePost.originalAuthorId : effectivePost.authorId;
-  const displayAuthorName = isSimpleRepost && effectivePost.originalAuthorName ? effectivePost.originalAuthorName : effectivePost.authorName;
-  const displayAuthorUsername = isSimpleRepost && effectivePost.originalAuthorUsername ? effectivePost.originalAuthorUsername : effectivePost.authorUsername;
-  const displayAuthorProfileImageUrl = isSimpleRepost && effectivePost.originalAuthorProfileImageUrl ? effectivePost.originalAuthorProfileImageUrl : effectivePost.authorProfileImageUrl;
+  // For QUOTE posts, show the REPOSTER's info in the header
+  // For simple reposts, show the ORIGINAL author's info
+  const displayAuthorId = isSimpleRepost && post.originalPost ? post.originalPost.authorId : post.authorId;
+  const displayAuthorName = isSimpleRepost && post.originalPost ? post.originalPost.authorName : post.authorName;
+  const displayAuthorUsername = isSimpleRepost && post.originalPost ? post.originalPost.authorUsername : post.authorUsername;
+  const displayAuthorProfileImageUrl = isSimpleRepost && post.originalPost ? post.originalPost.authorProfileImageUrl : post.authorProfileImageUrl;
   
   const authorIsNPC = isNpcIdentifier(displayAuthorId);
   const showVerifiedBadge = authorIsNPC;
 
-  const quotedPostId = effectivePost.originalPostId ?? post.originalPostId ?? null;
+  const quotedPostId = post.originalPostId ?? null;
 
   const handleQuotedPostClick = (event: MouseEvent<HTMLDivElement>) => {
     // Always stop propagation to prevent parent card click
@@ -273,18 +230,18 @@ export const PostCard = memo(function PostCard({
           <span>
             Reposted by{' '}
             <Link
-              href={getProfileUrl(effectivePost.authorId, effectivePost.authorUsername)}
+              href={getProfileUrl(post.authorId, post.authorUsername)}
               className="font-semibold hover:underline text-foreground"
               onClick={(e) => e.stopPropagation()}
             >
-              {effectivePost.authorName}
+              {post.authorName}
             </Link>
           </span>
         </div>
       )}
 
       {/* Row 1: Avatar + Name/Handle/Timestamp Header */}
-      <div className="flex items-start gap-3 w-full mb-3">
+      {!isSimpleRepost && <div className="flex items-start gap-3 w-full mb-3">
         {/* Avatar - Clickable, Round - Shows original author for simple reposts, reposter for quote posts */}
         <Link
           href={getProfileUrl(displayAuthorId, displayAuthorUsername)}
@@ -345,7 +302,7 @@ export const PostCard = memo(function PostCard({
             )}
           </div>
         </div>
-      </div>
+      </div>}
 
       {/* Row 2: Post Content - Full width */}
       {post.type === 'article' ? (
@@ -376,14 +333,14 @@ export const PostCard = memo(function PostCard({
             {post.content}
           </div>
         </div>
-      ) : effectivePost.isRepost && effectivePost.originalAuthorId ? (
-        // Repost (with or without quote comment) - show embedded card if we have original author info
+      ) : post.isRepost && post.originalPost ? (
+        // Repost (with or without quote comment) - show embedded card
         <div className="w-full mb-4">
           {/* Quote comment (if present) */}
-          {effectivePost.quoteComment && (
+          {post.quoteComment && (
             <div className="text-foreground leading-relaxed whitespace-pre-wrap break-words mb-4 post-content">
               <TaggedText
-                text={effectivePost.quoteComment}
+                text={post.quoteComment}
                 onTagClick={(tag) => {
                   router.push(`/feed?search=${encodeURIComponent(tag)}`)
                 }}
@@ -408,45 +365,45 @@ export const PostCard = memo(function PostCard({
             {/* Original post author */}
             <div className="flex items-start gap-3 mb-3">
               <Link
-                href={getProfileUrl(effectivePost.originalAuthorId || '', effectivePost.originalAuthorUsername)}
+                href={getProfileUrl(post.originalPost.authorId, post.originalPost.authorUsername)}
                 className="shrink-0 hover:opacity-80 transition-opacity"
                 onClick={(e) => e.stopPropagation()}
               >
                 <Avatar
-                  id={effectivePost.originalAuthorId || ''}
-                  name={effectivePost.originalAuthorName || ''}
+                  id={post.originalPost.authorId}
+                  name={post.originalPost.authorName}
                   type="actor"
                   size="sm"
-                  src={effectivePost.originalAuthorProfileImageUrl || undefined}
+                  src={post.originalPost.authorProfileImageUrl || undefined}
                 />
               </Link>
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2">
                   <Link
-                    href={getProfileUrl(effectivePost.originalAuthorId || '', effectivePost.originalAuthorUsername)}
+                    href={getProfileUrl(post.originalPost.authorId, post.originalPost.authorUsername)}
                     className="font-semibold text-foreground hover:underline truncate"
                     onClick={(e) => e.stopPropagation()}
                   >
-                    {effectivePost.originalAuthorName}
+                    {post.originalPost.authorName}
                   </Link>
-                  {effectivePost.originalAuthorId && isNpcIdentifier(effectivePost.originalAuthorId) && (
+                  {isNpcIdentifier(post.originalPost.authorId) && (
                     <VerifiedBadge size="sm" />
                   )}
                 </div>
                 <Link
-                  href={getProfileUrl(effectivePost.originalAuthorId || '', effectivePost.originalAuthorUsername)}
+                  href={getProfileUrl(post.originalPost.authorId, post.originalPost.authorUsername)}
                   className="text-foreground/50 text-sm hover:underline"
                   onClick={(e) => e.stopPropagation()}
                 >
-                  @{effectivePost.originalAuthorUsername || effectivePost.originalAuthorId}
+                  @{post.originalPost.authorUsername || post.originalPost.authorId}
                 </Link>
               </div>
             </div>
 
-            {/* Original post content - Use originalContent if available, otherwise parse */}
+            {/* Original post content */}
             <div className="text-foreground/90 leading-relaxed whitespace-pre-wrap break-words">
               <TaggedText 
-                text={effectivePost.originalContent || ''}
+                text={post.originalPost.content}
                 onTagClick={(tag) => {
                   router.push(`/feed?search=${encodeURIComponent(tag)}`)
                 }} 

--- a/src/components/posts/PostCard.tsx
+++ b/src/components/posts/PostCard.tsx
@@ -65,7 +65,7 @@ export interface PostCardProps {
     isLiked?: boolean;
     isShared?: boolean;
     deletedAt?: string | null; // Soft delete timestamp
-    // Repost metadata (new clean structure)
+    // Repost metadata
     isRepost?: boolean;
     isQuote?: boolean; // True if it has quote commentary
     quoteComment?: string | null; // The quote commentary text

--- a/src/components/posts/PostCard.tsx
+++ b/src/components/posts/PostCard.tsx
@@ -155,7 +155,9 @@ export const PostCard = memo(function PostCard({
   const authorIsNPC = isNpcIdentifier(displayAuthorId);
   const showVerifiedBadge = authorIsNPC;
 
-  const quotedPostId = post.originalPostId ?? null;
+  // For quote posts with deleted originals, link to the quote post itself
+  // For other reposts, link to the original post (if it exists)
+  const quotedPostId = post.originalPost ? post.originalPostId : (post.isRepost && post.isQuote ? post.id : null);
 
   // Internal click handler that navigates to the correct post
   // For simple reposts, navigate to the original post
@@ -342,7 +344,7 @@ export const PostCard = memo(function PostCard({
             {post.content}
           </div>
         </div>
-      ) : post.isRepost && post.originalPost ? (
+      ) : post.isRepost ? (
         // Repost (with or without quote comment) - show embedded card
         <div className="w-full mb-4">
           {/* Quote comment (if present) */}
@@ -371,53 +373,61 @@ export const PostCard = memo(function PostCard({
             onClick={handleQuotedPostClick}
             onKeyDown={handleQuotedPostKeyDown}
           >
-            {/* Original post author */}
-            <div className="flex items-start gap-3 mb-3">
-              <Link
-                href={getProfileUrl(post.originalPost.authorId, post.originalPost.authorUsername)}
-                className="shrink-0 hover:opacity-80 transition-opacity"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <Avatar
-                  id={post.originalPost.authorId}
-                  name={post.originalPost.authorName}
-                  type="actor"
-                  size="sm"
-                  src={post.originalPost.authorProfileImageUrl || undefined}
-                />
-              </Link>
-              <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2">
+            {post.originalPost ? (
+              <>
+                {/* Original post author */}
+                <div className="flex items-start gap-3 mb-3">
                   <Link
                     href={getProfileUrl(post.originalPost.authorId, post.originalPost.authorUsername)}
-                    className="font-semibold text-foreground hover:underline truncate"
+                    className="shrink-0 hover:opacity-80 transition-opacity"
                     onClick={(e) => e.stopPropagation()}
                   >
-                    {post.originalPost.authorName}
+                    <Avatar
+                      id={post.originalPost.authorId}
+                      name={post.originalPost.authorName}
+                      type="actor"
+                      size="sm"
+                      src={post.originalPost.authorProfileImageUrl || undefined}
+                    />
                   </Link>
-                  {isNpcIdentifier(post.originalPost.authorId) && (
-                    <VerifiedBadge size="sm" />
-                  )}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <Link
+                        href={getProfileUrl(post.originalPost.authorId, post.originalPost.authorUsername)}
+                        className="font-semibold text-foreground hover:underline truncate"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        {post.originalPost.authorName}
+                      </Link>
+                      {isNpcIdentifier(post.originalPost.authorId) && (
+                        <VerifiedBadge size="sm" />
+                      )}
+                    </div>
+                    <Link
+                      href={getProfileUrl(post.originalPost.authorId, post.originalPost.authorUsername)}
+                      className="text-foreground/50 text-sm hover:underline"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      @{post.originalPost.authorUsername || post.originalPost.authorId}
+                    </Link>
+                  </div>
                 </div>
-                <Link
-                  href={getProfileUrl(post.originalPost.authorId, post.originalPost.authorUsername)}
-                  className="text-foreground/50 text-sm hover:underline"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  @{post.originalPost.authorUsername || post.originalPost.authorId}
-                </Link>
-              </div>
-            </div>
 
-            {/* Original post content */}
-            <div className="text-foreground/90 leading-relaxed whitespace-pre-wrap break-words">
-              <TaggedText 
-                text={post.originalPost.content}
-                onTagClick={(tag) => {
-                  router.push(`/feed?search=${encodeURIComponent(tag)}`)
-                }} 
-              />
-            </div>
+                {/* Original post content */}
+                <div className="text-foreground/90 leading-relaxed whitespace-pre-wrap break-words">
+                  <TaggedText 
+                    text={post.originalPost.content}
+                    onTagClick={(tag) => {
+                      router.push(`/feed?search=${encodeURIComponent(tag)}`)
+                    }} 
+                  />
+                </div>
+              </>
+            ) : (
+              <div className="text-foreground/50 italic py-4 text-center">
+                This post has been deleted
+              </div>
+            )}
           </div>
         </div>
       ) : (

--- a/src/components/posts/PostCard.tsx
+++ b/src/components/posts/PostCard.tsx
@@ -81,7 +81,6 @@ export interface PostCardProps {
     } | null;
   };
   className?: string;
-  onClick?: () => void;
   onCommentClick?: () => void;
   showInteractions?: boolean;
   isDetail?: boolean;
@@ -90,7 +89,6 @@ export interface PostCardProps {
 export const PostCard = memo(function PostCard({
   post,
   className,
-  onClick,
   onCommentClick,
   showInteractions = true,
   isDetail = false,
@@ -159,6 +157,19 @@ export const PostCard = memo(function PostCard({
 
   const quotedPostId = post.originalPostId ?? null;
 
+  // Internal click handler that navigates to the correct post
+  // For simple reposts, navigate to the original post
+  // For quote posts and regular posts, navigate to the post itself
+  const handleCardClick = () => {
+    // For simple reposts, go to the original post
+    if (isSimpleRepost && post.originalPostId) {
+      router.push(`/post/${post.originalPostId}`);
+    } else {
+      // For quote posts and regular posts, go to this post
+      router.push(`/post/${post.id}`);
+    }
+  };
+
   const handleQuotedPostClick = (event: MouseEvent<HTMLDivElement>) => {
     // Always stop propagation to prevent parent card click
     event.preventDefault();
@@ -182,12 +193,6 @@ export const PostCard = memo(function PostCard({
     // Only navigate if we have a valid post ID
     if (quotedPostId) {
       router.push(`/post/${quotedPostId}`);
-    }
-  };
-
-  const handleClick = () => {
-    if (onClick) {
-      onClick();
     }
   };
 
@@ -221,7 +226,7 @@ export const PostCard = memo(function PostCard({
       style={{
         fontSize: `${fontSize}rem`,
       }}
-      onClick={!isDetail ? handleClick : undefined}
+      onClick={!isDetail ? handleCardClick : undefined}
     >
       {/* Repost Indicator - Only show for simple reposts (not quote posts) */}
       {isSimpleRepost && (
@@ -316,7 +321,7 @@ export const PostCard = memo(function PostCard({
             {!isDetail && (
               <button
                 className="inline-flex items-center gap-2 px-3 py-2 bg-[#0066FF] hover:bg-[#2952d9] text-primary-foreground text-sm font-semibold rounded-lg transition-colors whitespace-nowrap shrink-0"
-                onClick={handleClick}
+                onClick={handleCardClick}
               >
                 Read Full Article →
               </button>

--- a/src/lib/database-service.ts
+++ b/src/lib/database-service.ts
@@ -302,6 +302,18 @@ class DatabaseService {
       take: limit * 2, // Fetch more than needed to account for filtering
       skip: cursor ? 0 : offset, // Only use skip if using offset pagination
       orderBy: { timestamp: 'desc' },
+      include: {
+        Post_Post_originalPostIdToPost: {
+          where: { deletedAt: null },
+          select: {
+            id: true,
+            content: true,
+            authorId: true,
+            timestamp: true,
+            createdAt: true,
+          }
+        }
+      }
     });
     
     // Get all author IDs
@@ -406,6 +418,18 @@ class DatabaseService {
       take: limit,
       skip: cursor ? 0 : offset, // Only use skip if using offset pagination
       orderBy: { timestamp: 'desc' },
+      include: {
+        Post_Post_originalPostIdToPost: {
+          where: { deletedAt: null },
+          select: {
+            id: true,
+            content: true,
+            authorId: true,
+            timestamp: true,
+            createdAt: true,
+          }
+        }
+      }
     });
     
     logger.info('DatabaseService.getPostsByActor completed', {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -247,15 +247,26 @@ export interface FeedPost {
   shareCount?: number;
   isLiked?: boolean;
   isShared?: boolean;
-  // Repost metadata
+  // Repost metadata (new clean structure)
   isRepost?: boolean;
+  isQuote?: boolean; // True if it has quote commentary
+  quoteComment?: string | null; // The quote commentary text
   originalPostId?: string | null;
+  originalPost?: {
+    id: string;
+    content: string;
+    authorId: string;
+    authorName: string;
+    authorUsername: string | null;
+    authorProfileImageUrl: string | null;
+    timestamp: string;
+  } | null;
+  // Legacy fields (for backward compatibility with old posts)
   originalAuthorId?: string | null;
   originalAuthorName?: string | null;
   originalAuthorUsername?: string | null;
   originalAuthorProfileImageUrl?: string | null;
-  originalContent?: string | null; // Original post content for quote posts
-  quoteComment?: string | null;
+  originalContent?: string | null;
 }
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -247,7 +247,7 @@ export interface FeedPost {
   shareCount?: number;
   isLiked?: boolean;
   isShared?: boolean;
-  // Repost metadata (new clean structure)
+  // Repost metadata
   isRepost?: boolean;
   isQuote?: boolean; // True if it has quote commentary
   quoteComment?: string | null; // The quote commentary text

--- a/src/types/interactions.ts
+++ b/src/types/interactions.ts
@@ -352,6 +352,10 @@ export interface InteractionBarProps {
     shareCount?: number;
     isLiked?: boolean;
     isShared?: boolean;
+    // Repost metadata
+    isRepost?: boolean;
+    isQuote?: boolean;
+    quoteComment?: string | null;
     originalPostId?: string | null;
   };
 }


### PR DESCRIPTION
## Issues

Before this change, the UI behaved incorrectly on the feed/post page and the profile page:

- Reposts appeared as duplicated posts  
- The UI showed **reposted by {{original post author}}** instead of the actual reposter  
- The interaction bar (likes, comments, etc.) displayed incorrect counts  

### Before:
https://github.com/user-attachments/assets/6ffa260a-9895-4fcd-bd41-f9a62503d00b

### After:
https://github.com/user-attachments/assets/1d330e09-9a47-44fb-9c9a-02ab18e8b041



## The Problem

The system was storing repost metadata as embedded text patterns inside post content (like `[REPOST] @username: content`), which meant we had to parse these patterns with regex every time a post was rendered. While this approach worked initially, it had some limitations as the codebase grew:

- Regex parsing on every post display added overhead
- Text patterns needed to be consistent across all components
- Distinguishing between simple reposts and quote posts required additional parsing logic
- Multiple API endpoints and components were handling the same parsing logic
- Querying or filtering reposts at the database level wasn't straightforward

As we added more features around reposts, it became clear that a database-backed approach would be more maintainable.

## What Changed

### Core Data Structure

Instead of embedding metadata in text, we now store repost information properly:

- `isQuote`: Boolean flag to distinguish quote posts from simple reposts
- `quoteComment`: The commentary text for quote posts
- `originalPost`: Full nested object containing the original post's data (id, content, author info, timestamp)

The database already had `originalPostId` as a foreign key, so we leveraged the Prisma relation `Post_Post_originalPostIdToPost` to include the full original post data in a single query. This eliminated the need for text parsing and allowed us to enrich API responses with proper nested data.

### API Endpoints

Rewrote the repost handling in three key endpoints:

**`/api/posts/route.ts`**
- Removed all regex parsing logic
- Now joins on `originalPostId` to fetch the full original post
- Batch-fetches original post author information
- Returns clean, structured repost metadata

**`/api/posts/[id]/route.ts`**  
- Simplified repost detection (no more text parsing)
- Returns original post data as a nested object
- Cleaner response structure

**`/api/users/[userId]/posts/route.ts`**
- Updated to return reposts with proper author information for both the reposter and original author
- Handles interaction counts correctly

### Frontend Components

**`PostCard.tsx`**
- Completely removed regex parsing
- Simplified the repost display logic significantly
- Added smart navigation: clicking a simple repost now takes you to the original post, while clicking a quote post takes you to the quote page
- Shows "Reposted by you" instead of your username for your own reposts

**Other Components**
- Updated `InteractionBar`, feed pages, profile pages, trending pages to work with the new structure
- All components now receive clean, structured data instead of having to parse text

### Interaction Counts Fix

This was a separate issue we discovered while refactoring. Repost interaction counts were wrong:

- Simple reposts now correctly show the original post's like, comment, and share counts
- Quote posts show their own interaction counts
- Fixed the bug where profile pages showed 0 counts for all reposts
