### PR TITLE
fix dm chat - don't merge

### DIFF
--- a/src/app/chats/page.tsx
+++ b/src/app/chats/page.tsx
@@ -485,7 +485,7 @@ export default function ChatsPage() {
 
   // Update chatDetails with realtime messages
   useEffect(() => {
-    if (chatDetails && realtimeMessages.length > 0) {
+    if (realtimeMessages.length > 0) {
       setChatDetails(prev => {
         if (!prev) return prev
         return {
@@ -494,7 +494,7 @@ export default function ChatsPage() {
         }
       })
     }
-  }, [realtimeMessages, chatDetails])
+  }, [realtimeMessages])
 
   // Scroll to bottom when messages change
   useEffect(() => {

--- a/src/app/chats/page.tsx
+++ b/src/app/chats/page.tsx
@@ -93,13 +93,14 @@ export default function ChatsPage() {
   const [messageInput, setMessageInput] = useState('')
   const [_loading, setLoading] = useState(true)
   const [loadingChat, setLoadingChat] = useState(false)
-  const [isLoadingNewDM, setIsLoadingNewDM] = useState(false)
   const [sending, setSending] = useState(false)
   const [sendError, setSendError] = useState<string | null>(null)
   const [sendSuccess, setSendSuccess] = useState(false)
   const [isLeaveConfirmOpen, setLeaveConfirmOpen] = useState(false)
   const [isLeavingChat, setIsLeavingChat] = useState(false)
   const [leaveChatError, setLeaveChatError] = useState<string | null>(null)
+  // Track chats that are new DMs (not yet persisted to DB)
+  const [newDMChats, setNewDMChats] = useState<Set<string>>(new Set())
   // Group modals
   const [isCreateGroupModalOpen, setIsCreateGroupModalOpen] = useState(false)
   const [isGroupManagementModalOpen, setIsGroupManagementModalOpen] = useState(false)
@@ -355,38 +356,37 @@ export default function ChatsPage() {
   }, [loadChats, selectedChatId, loadChatDetails])
 
   const loadNewDMChat = useCallback(async (chatId: string, targetUserId: string) => {
-    setIsLoadingNewDM(true)
+    console.log('[ChatsPage] Loading new DM chat:', chatId, targetUserId)
     setLoadingChat(true)
+    
+    // Mark this as a new DM chat
+    setNewDMChats(prev => new Set(prev).add(chatId))
     
     const token = await getAccessToken()
     if (!token) {
       console.error('Failed to get access token')
       setLoadingChat(false)
-      setIsLoadingNewDM(false)
       return
     }
 
-    // Fetch target user info
-    const response = await fetch(`/api/users/${targetUserId}/profile`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    }).catch(() => {
-      console.error('Failed to load user info')
-      setLoadingChat(false)
-      setIsLoadingNewDM(false)
-      throw new Error('Failed to load user info')
-    })
-    
-    if (!response.ok) {
-      console.error('Failed to load user info')
-      setLoadingChat(false)
-      setIsLoadingNewDM(false)
-      return
-    }
+    try {
+      // Fetch target user info
+      const response = await fetch(`/api/users/${targetUserId}/profile`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      })
+      
+      if (!response.ok) {
+        console.error('Failed to load user info')
+        setLoadingChat(false)
+        return
+      }
 
-    const userData = await response.json()
-    const targetUser = userData.user
+      const userData = await response.json()
+      const targetUser = userData.user
+        
+      console.log('[ChatsPage] Creating virtual chat details for new DM')
       
       // Create a virtual chat details object for new DM
       setChatDetails({
@@ -437,8 +437,12 @@ export default function ChatsPage() {
         return [newChat, ...prev]
       })
       
+      console.log('[ChatsPage] New DM chat loaded successfully')
+    } catch (error) {
+      console.error('[ChatsPage] Error loading new DM chat:', error)
+    } finally {
       setLoadingChat(false)
-      setIsLoadingNewDM(false)
+    }
   }, [getAccessToken, user])
   
   // Check for chat ID in URL query params
@@ -471,11 +475,13 @@ export default function ChatsPage() {
 
   // Load selected chat details from database
   useEffect(() => {
-    // Skip loadChatDetails if we're loading a new DM (it will be handled by loadNewDMChat)
-    if (selectedChatId && !isLoadingNewDM) {
-      loadChatDetails(selectedChatId)
+    if (selectedChatId) {
+      // Skip loading for new DM chats (they're handled by loadNewDMChat)
+      if (!newDMChats.has(selectedChatId)) {
+        loadChatDetails(selectedChatId)
+      }
     }
-  }, [selectedChatId, isLoadingNewDM, loadChatDetails])
+  }, [selectedChatId, loadChatDetails, newDMChats])
 
   // Update chatDetails with realtime messages
   useEffect(() => {
@@ -488,7 +494,7 @@ export default function ChatsPage() {
         }
       })
     }
-  }, [realtimeMessages]) // Remove chatDetails from dependencies to avoid infinite loop
+  }, [realtimeMessages, chatDetails])
 
   // Scroll to bottom when messages change
   useEffect(() => {
@@ -599,6 +605,17 @@ export default function ChatsPage() {
     } else {
       setSendSuccess(true)
       setTimeout(() => setSendSuccess(false), 2000)
+      
+      // If this was a new DM chat, remove it from newDMChats set
+      // (the chat has now been created in the DB)
+      if (newDMChats.has(selectedChatId)) {
+        console.log('[ChatsPage] Removing new DM flag after first message sent')
+        setNewDMChats(prev => {
+          const newSet = new Set(prev)
+          newSet.delete(selectedChatId)
+          return newSet
+        })
+      }
     }
 
     // SSE will handle adding the message in real-time
@@ -693,10 +710,10 @@ export default function ChatsPage() {
           }
         `
       }} />
-      <PageContainer noPadding className="flex flex-col h-full">
+      <PageContainer noPadding className="flex flex-col">
         {/* Desktop: Two Column Layout */}
-        <div className="hidden xl:flex flex-1 flex-col overflow-hidden h-full">
-          <div className="flex-1 overflow-hidden h-full">
+        <div className="hidden xl:flex flex-1 flex-col overflow-hidden">
+          <div className="flex-1 overflow-hidden">
             <div className="flex h-full">
               {/* Left Column: Chat List with Filters */}
               <div className="w-96 flex flex-col bg-background">
@@ -847,8 +864,8 @@ export default function ChatsPage() {
               <Separator orientation="vertical" className="shrink-0" />
 
               {/* Right Column: Chat View */}
-              <div className="flex-1 flex flex-col bg-background overflow-hidden h-full min-h-0">
-                {selectedChatId && chatDetails && chatDetails.chat ? (
+              <div className="flex-1 flex flex-col bg-background">
+                {selectedChatId && chatDetails ? (
                   <>
                     {/* Chat Header */}
                     <div className="px-4 py-4 bg-background flex items-center justify-between">
@@ -1169,8 +1186,8 @@ export default function ChatsPage() {
         </div>
 
         {/* Mobile/Tablet: Responsive Layout */}
-        <div className="flex xl:hidden flex-col flex-1 overflow-hidden h-full">
-          <div className="flex-1 overflow-hidden h-full">
+        <div className="flex xl:hidden flex-col flex-1 overflow-hidden">
+          <div className="flex-1 overflow-hidden">
             <div className="flex h-full">
               {/* Chat List (full screen on mobile, side panel on tablet when chat selected) */}
               <div
@@ -1328,10 +1345,10 @@ export default function ChatsPage() {
               )}
 
               {/* Chat View (full screen on mobile, shared on tablet) */}
-              {selectedChatId && chatDetails && chatDetails.chat && (
+              {selectedChatId && chatDetails && (
                 <div
                   className={cn(
-                    'flex flex-col bg-background overflow-hidden flex-1 h-full min-h-0',
+                    'flex-1 flex-col bg-background',
                     !selectedChatId ? 'hidden lg:flex' : 'flex',
                   )}
                 >

--- a/src/app/chats/page.tsx
+++ b/src/app/chats/page.tsx
@@ -693,10 +693,10 @@ export default function ChatsPage() {
           }
         `
       }} />
-      <PageContainer noPadding className="flex flex-col">
+      <PageContainer noPadding className="flex flex-col h-full">
         {/* Desktop: Two Column Layout */}
-        <div className="hidden xl:flex flex-1 flex-col overflow-hidden">
-          <div className="flex-1 overflow-hidden">
+        <div className="hidden xl:flex flex-1 flex-col overflow-hidden h-full">
+          <div className="flex-1 overflow-hidden h-full">
             <div className="flex h-full">
               {/* Left Column: Chat List with Filters */}
               <div className="w-96 flex flex-col bg-background">
@@ -847,7 +847,7 @@ export default function ChatsPage() {
               <Separator orientation="vertical" className="shrink-0" />
 
               {/* Right Column: Chat View */}
-              <div className="flex-1 flex flex-col bg-background">
+              <div className="flex-1 flex flex-col bg-background overflow-hidden h-full min-h-0">
                 {selectedChatId && chatDetails && chatDetails.chat ? (
                   <>
                     {/* Chat Header */}
@@ -1169,8 +1169,8 @@ export default function ChatsPage() {
         </div>
 
         {/* Mobile/Tablet: Responsive Layout */}
-        <div className="flex xl:hidden flex-col flex-1 overflow-hidden">
-          <div className="flex-1 overflow-hidden">
+        <div className="flex xl:hidden flex-col flex-1 overflow-hidden h-full">
+          <div className="flex-1 overflow-hidden h-full">
             <div className="flex h-full">
               {/* Chat List (full screen on mobile, side panel on tablet when chat selected) */}
               <div
@@ -1331,7 +1331,7 @@ export default function ChatsPage() {
               {selectedChatId && chatDetails && chatDetails.chat && (
                 <div
                   className={cn(
-                    'flex-1 flex-col bg-background',
+                    'flex flex-col bg-background overflow-hidden flex-1 h-full min-h-0',
                     !selectedChatId ? 'hidden lg:flex' : 'flex',
                   )}
                 >

--- a/src/app/chats/page.tsx
+++ b/src/app/chats/page.tsx
@@ -93,6 +93,7 @@ export default function ChatsPage() {
   const [messageInput, setMessageInput] = useState('')
   const [_loading, setLoading] = useState(true)
   const [loadingChat, setLoadingChat] = useState(false)
+  const [isLoadingNewDM, setIsLoadingNewDM] = useState(false)
   const [sending, setSending] = useState(false)
   const [sendError, setSendError] = useState<string | null>(null)
   const [sendSuccess, setSendSuccess] = useState(false)
@@ -354,12 +355,14 @@ export default function ChatsPage() {
   }, [loadChats, selectedChatId, loadChatDetails])
 
   const loadNewDMChat = useCallback(async (chatId: string, targetUserId: string) => {
+    setIsLoadingNewDM(true)
     setLoadingChat(true)
     
     const token = await getAccessToken()
     if (!token) {
       console.error('Failed to get access token')
       setLoadingChat(false)
+      setIsLoadingNewDM(false)
       return
     }
 
@@ -371,12 +374,14 @@ export default function ChatsPage() {
     }).catch(() => {
       console.error('Failed to load user info')
       setLoadingChat(false)
+      setIsLoadingNewDM(false)
       throw new Error('Failed to load user info')
     })
     
     if (!response.ok) {
       console.error('Failed to load user info')
       setLoadingChat(false)
+      setIsLoadingNewDM(false)
       return
     }
 
@@ -433,6 +438,7 @@ export default function ChatsPage() {
       })
       
       setLoadingChat(false)
+      setIsLoadingNewDM(false)
   }, [getAccessToken, user])
   
   // Check for chat ID in URL query params
@@ -465,10 +471,11 @@ export default function ChatsPage() {
 
   // Load selected chat details from database
   useEffect(() => {
-    if (selectedChatId) {
+    // Skip loadChatDetails if we're loading a new DM (it will be handled by loadNewDMChat)
+    if (selectedChatId && !isLoadingNewDM) {
       loadChatDetails(selectedChatId)
     }
-  }, [selectedChatId, loadChatDetails])
+  }, [selectedChatId, isLoadingNewDM, loadChatDetails])
 
   // Update chatDetails with realtime messages
   useEffect(() => {
@@ -481,7 +488,7 @@ export default function ChatsPage() {
         }
       })
     }
-  }, [realtimeMessages, chatDetails])
+  }, [realtimeMessages]) // Remove chatDetails from dependencies to avoid infinite loop
 
   // Scroll to bottom when messages change
   useEffect(() => {
@@ -841,7 +848,7 @@ export default function ChatsPage() {
 
               {/* Right Column: Chat View */}
               <div className="flex-1 flex flex-col bg-background">
-                {selectedChatId && chatDetails ? (
+                {selectedChatId && chatDetails && chatDetails.chat ? (
                   <>
                     {/* Chat Header */}
                     <div className="px-4 py-4 bg-background flex items-center justify-between">
@@ -1321,7 +1328,7 @@ export default function ChatsPage() {
               )}
 
               {/* Chat View (full screen on mobile, shared on tablet) */}
-              {selectedChatId && chatDetails && (
+              {selectedChatId && chatDetails && chatDetails.chat && (
                 <div
                   className={cn(
                     'flex-1 flex-col bg-background',

--- a/src/app/chats/page.tsx
+++ b/src/app/chats/page.tsx
@@ -864,7 +864,7 @@ export default function ChatsPage() {
               <Separator orientation="vertical" className="shrink-0" />
 
               {/* Right Column: Chat View */}
-              <div className="flex-1 flex flex-col bg-background">
+              <div className="flex-1 flex flex-col bg-background min-h-screen h-screen">
                 {selectedChatId && chatDetails ? (
                   <>
                     {/* Chat Header */}
@@ -1348,7 +1348,7 @@ export default function ChatsPage() {
               {selectedChatId && chatDetails && (
                 <div
                   className={cn(
-                    'flex-1 flex-col bg-background',
+                    'flex-1 flex-col bg-background min-h-screen h-screen',
                     !selectedChatId ? 'hidden lg:flex' : 'flex',
                   )}
                 >

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -92,14 +92,14 @@ export default function RootLayout({
             <MobileHeader />
           </Suspense>
 
-          <div className="flex min-h-screen max-w-screen-xl mx-auto bg-sidebar">
+          <div className="flex h-screen max-w-screen-xl mx-auto bg-sidebar overflow-hidden">
             {/* Desktop Sidebar - Sticky, not affected by pull-to-refresh */}
             <Suspense fallback={null}>
               <Sidebar />
             </Suspense>
 
             {/* Main Content Area - Scrollable content with pull-to-refresh */}
-            <main className="flex-1 min-h-screen w-full pt-14 pb-14 md:pt-0 md:pb-0 bg-background">
+            <main className="flex-1 h-full w-full pt-14 pb-14 md:pt-0 md:pb-0 bg-background overflow-hidden">
               {children}
             </main>
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -92,14 +92,14 @@ export default function RootLayout({
             <MobileHeader />
           </Suspense>
 
-          <div className="flex h-screen max-w-screen-xl mx-auto bg-sidebar overflow-hidden">
+          <div className="flex min-h-screen max-w-screen-xl mx-auto bg-sidebar">
             {/* Desktop Sidebar - Sticky, not affected by pull-to-refresh */}
             <Suspense fallback={null}>
               <Sidebar />
             </Suspense>
 
             {/* Main Content Area - Scrollable content with pull-to-refresh */}
-            <main className="flex-1 h-full w-full pt-14 pb-14 md:pt-0 md:pb-0 bg-background overflow-hidden">
+            <main className="flex-1 min-h-screen w-full pt-14 pb-14 md:pt-0 md:pb-0 bg-background">
               {children}
             </main>
 

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -111,6 +111,7 @@ export default function ActorProfilePage() {
 
   // Handle creating DM with user
   const handleMessageClick = async () => {
+    console.log('!!!!!!!!!!!!!!!!!!!!!!!! handleMessageClick')
     if (!authenticated || !actorInfo?.id || isCreatingDM || !user?.id) return
 
     setIsCreatingDM(true)
@@ -583,7 +584,7 @@ export default function ActorProfilePage() {
               ) : null
             })()}
             <div className={cn(
-              "w-full h-full bg-gradient-to-br from-primary/20 to-primary/5",
+              "absolute inset-0 w-full h-full bg-gradient-to-br from-primary/20 to-primary/5 pointer-events-none",
               actorInfo.type === 'actor' || actorInfo.type === 'organization' ? "hidden" : ""
             )} />
           </div>
@@ -891,7 +892,7 @@ export default function ActorProfilePage() {
                 ) : null
               })()}
               <div className={cn(
-                "w-full h-full bg-gradient-to-br from-primary/20 to-primary/5",
+                "absolute inset-0 w-full h-full bg-gradient-to-br from-primary/20 to-primary/5 pointer-events-none",
                 actorInfo.type === 'actor' || actorInfo.type === 'organization' ? "hidden" : ""
               )} />
             </div>

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -111,7 +111,6 @@ export default function ActorProfilePage() {
 
   // Handle creating DM with user
   const handleMessageClick = async () => {
-    console.log('!!!!!!!!!!!!!!!!!!!!!!!! handleMessageClick')
     if (!authenticated || !actorInfo?.id || isCreatingDM || !user?.id) return
 
     setIsCreatingDM(true)

--- a/src/components/shared/PageContainer.tsx
+++ b/src/components/shared/PageContainer.tsx
@@ -31,8 +31,8 @@ export const PageContainer = forwardRef<HTMLDivElement, PageContainerProps>(
         ref={ref}
         className={cn(
           // Sharp corners, simple boxy layout
-          'bg-background overflow-hidden',
-          'h-full min-h-full w-full',
+          'bg-background',
+          'h-full w-full',
           // Desktop: Simple container - use full height
           'md:h-full',
           // Consistent padding: 16px mobile, 24px desktop

--- a/src/hooks/useChatMessages.ts
+++ b/src/hooks/useChatMessages.ts
@@ -106,6 +106,12 @@ export function useChatMessages(chatId: string | null) {
           hasMore: data.pagination?.hasMore 
         }, 'useChatMessages');
       }
+    } else if (response.status === 404) {
+      // Chat doesn't exist yet (new DM that hasn't been persisted)
+      // This is expected for new DMs - chat will be created when first message is sent
+      logger.debug(`Chat not found (likely new DM): ${chatId}`, { chatId }, 'useChatMessages');
+      setMessages([]);
+      hasLoadedRef.current.add(chatId); // Mark as loaded to prevent retries
     } else {
       const errorData = await response.json().catch(() => null);
       logger.error(`Failed to load messages`, { chatId, errorData, status: response.status }, 'useChatMessages');


### PR DESCRIPTION
# Issue: DM Button Not Clickable, Chat Race Conditions, and Layout Overflow

before:

https://github.com/user-attachments/assets/884097e3-def8-45ed-8b4a-cb3645393c38


after:


https://github.com/user-attachments/assets/3ca617cd-c898-44a1-838c-6137b723a2fb



## 1. Message (DM) Button Not Clickable
On the profile page, the **Message** button cannot be clicked.  
A gradient fallback layer is overlapping the action buttons, blocking pointer events and preventing interaction.

## 2. Fix: 404 Error and Infinite Loop When Creating New DM Chats

### Problem
When clicking the message button on a user's profile page to start a new DM conversation, users encountered:
1. **404 errors** in the console when trying to load messages for a chat that doesn't exist yet
2. **Infinite re-render loop** ("Maximum update depth exceeded" error) in the chats page

### Root Cause
1. The DM chat flow was creating a deterministic chat ID and navigating to the chats page, but the chat didn't exist in the database yet (only created when first message is sent)
2. `useChatMessages` hook was attempting to fetch messages from a non-existent chat, resulting in 404 errors
3. `loadChatDetails` was also trying to load the chat, creating a race condition with `loadNewDMChat`
4. The `chatDetails` state was included in a useEffect dependency array that also called `setChatDetails`, causing an infinite loop


## 3. Chat Page Layout Overflow
When viewing long chats:
- The *entire page* becomes scrollable (header and input area included).
- The input area and header can scroll off-screen, breaking the UX.

This PR fixes the layout so that:
- **Only the message list scrolls**,  
- The header and input area stay fixed and visible.

