### PR TITLE
fix: resolve UI layout issues in chats and profile pages

### DIFF
--- a/src/app/chats/page.tsx
+++ b/src/app/chats/page.tsx
@@ -481,7 +481,7 @@ export default function ChatsPage() {
         }
       })
     }
-  }, [realtimeMessages, chatDetails])
+  }, [realtimeMessages])
 
   // Scroll to bottom when messages change
   useEffect(() => {
@@ -840,7 +840,7 @@ export default function ChatsPage() {
               <Separator orientation="vertical" className="shrink-0" />
 
               {/* Right Column: Chat View */}
-              <div className="flex-1 flex flex-col bg-background">
+              <div className="flex-1 flex flex-col bg-background min-h-screen h-screen">
                 {selectedChatId && chatDetails ? (
                   <>
                     {/* Chat Header */}
@@ -1324,7 +1324,7 @@ export default function ChatsPage() {
               {selectedChatId && chatDetails && (
                 <div
                   className={cn(
-                    'flex-1 flex-col bg-background',
+                    'flex-1 flex-col bg-background min-h-screen h-screen',
                     !selectedChatId ? 'hidden lg:flex' : 'flex',
                   )}
                 >

--- a/src/app/profile/[id]/page.tsx
+++ b/src/app/profile/[id]/page.tsx
@@ -583,7 +583,7 @@ export default function ActorProfilePage() {
               ) : null
             })()}
             <div className={cn(
-              "w-full h-full bg-gradient-to-br from-primary/20 to-primary/5",
+              "absolute inset-0 w-full h-full bg-gradient-to-br from-primary/20 to-primary/5 pointer-events-none",
               actorInfo.type === 'actor' || actorInfo.type === 'organization' ? "hidden" : ""
             )} />
           </div>
@@ -891,7 +891,7 @@ export default function ActorProfilePage() {
                 ) : null
               })()}
               <div className={cn(
-                "w-full h-full bg-gradient-to-br from-primary/20 to-primary/5",
+                "absolute inset-0 w-full h-full bg-gradient-to-br from-primary/20 to-primary/5 pointer-events-none",
                 actorInfo.type === 'actor' || actorInfo.type === 'organization' ? "hidden" : ""
               )} />
             </div>


### PR DESCRIPTION
- Fix infinite re-render in ChatsPage by removing chatDetails from useEffect dependency array
- Add min-h-screen and h-screen classes to chat view containers for proper full-height layout
- Fix gradient overlay positioning in profile page banners by adding absolute positioning and pointer-events-none