### PR TITLE
Fix Farcaster Sign-In: Implement proper SIWF protocol via relay.farcaster.xyz

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "babylon",
@@ -12,6 +13,7 @@
         "@elizaos/core": "^1.6.4",
         "@elizaos/plugin-sql": "^1.6.4",
         "@fal-ai/client": "^1.7.2",
+        "@farcaster/auth-client": "^0.7.0",
         "@farcaster/auth-kit": "^0.8.1",
         "@farcaster/miniapp-sdk": "^0.2.1",
         "@hookform/resolvers": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@elizaos/core": "^1.6.4",
     "@elizaos/plugin-sql": "^1.6.4",
     "@fal-ai/client": "^1.7.2",
+    "@farcaster/auth-client": "^0.7.0",
     "@farcaster/auth-kit": "^0.8.1",
     "@farcaster/miniapp-sdk": "^0.2.1",
     "@hookform/resolvers": "^5.2.2",

--- a/prisma/migrations/20251121025558_add_qualified_at_to_referral/migration.sql
+++ b/prisma/migrations/20251121025558_add_qualified_at_to_referral/migration.sql
@@ -1,0 +1,22 @@
+-- Check if table exists (case-insensitive) and add column
+DO $$
+DECLARE
+    table_name_var TEXT;
+BEGIN
+    -- Find the actual table name (case-insensitive search)
+    SELECT table_name INTO table_name_var
+    FROM information_schema.tables 
+    WHERE table_schema = 'public' 
+    AND LOWER(table_name) = 'referral'
+    LIMIT 1;
+    
+    IF table_name_var IS NOT NULL THEN
+        -- Use the actual table name (with proper quoting)
+        EXECUTE format('ALTER TABLE %I ADD COLUMN IF NOT EXISTS "qualifiedAt" TIMESTAMP(3)', table_name_var);
+        
+        -- CreateIndex
+        IF NOT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'Referral_qualifiedAt_idx') THEN
+            EXECUTE format('CREATE INDEX "Referral_qualifiedAt_idx" ON %I("qualifiedAt")', table_name_var);
+        END IF;
+    END IF;
+END $$;

--- a/src/app/api/auth/farcaster/callback/route.ts
+++ b/src/app/api/auth/farcaster/callback/route.ts
@@ -128,15 +128,46 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
   const { message, signature, fid, username, displayName, pfpUrl, state } = parsed.data;
 
   // Verify state format and get user ID
-  const stateParts = state.split(':')
-  if (stateParts.length < 2) {
-    return NextResponse.json(
-      { error: 'Invalid state format' },
-      { status: 400 }
-    )
-  }
+  // State format: userId|timestamp|random (using pipe because userId may contain colons like did:privy:xxx)
+  // Also support legacy colon format for backward compatibility
+  const separator = state.includes('|') ? '|' : ':'
+  const stateParts = state.split(separator)
 
-  const [userId, timestampStr] = stateParts
+  // For pipe separator: [userId, timestamp, random]
+  // For colon separator with did:privy:xxx: we need to reconstruct userId from all but last 2 parts
+  let userId: string
+  let timestampStr: string
+
+  if (separator === '|') {
+    // New format: userId|timestamp|random
+    if (stateParts.length < 2 || !stateParts[0] || !stateParts[1]) {
+      return NextResponse.json(
+        { error: 'Invalid state format' },
+        { status: 400 }
+      )
+    }
+    userId = stateParts[0]
+    timestampStr = stateParts[1]
+  } else {
+    // Legacy format: userId:timestamp:random
+    // Handle case where userId contains colons (e.g., did:privy:xxx)
+    if (stateParts.length < 3) {
+      return NextResponse.json(
+        { error: 'Invalid state format' },
+        { status: 400 }
+      )
+    }
+    // Last part is random, second to last is timestamp, everything before is userId
+    const timestampPart = stateParts[stateParts.length - 2]
+    if (!timestampPart) {
+      return NextResponse.json(
+        { error: 'Invalid state format' },
+        { status: 400 }
+      )
+    }
+    timestampStr = timestampPart
+    userId = stateParts.slice(0, -2).join(':')
+  }
   if (!userId || !timestampStr) {
     return NextResponse.json(
       { error: 'Invalid state format' },

--- a/src/app/api/auth/farcaster/callback/route.ts
+++ b/src/app/api/auth/farcaster/callback/route.ts
@@ -104,6 +104,7 @@ import { logger } from '@/lib/logger'
 import { PointsService } from '@/lib/services/points-service'
 import { withErrorHandling } from '@/lib/errors/error-handler';
 import { z } from 'zod';
+import { createAppClient, viemConnector } from '@farcaster/auth-client';
 
 const FarcasterCallbackBodySchema = z.object({
   message: z.string(),
@@ -327,8 +328,8 @@ function parseSiwfMessage(message: string): {
 }
 
 /**
- * Verify Farcaster signature using Neynar API
- * Also validates SIWF message content (domain, expiration)
+ * Verify Farcaster signature using @farcaster/auth-client
+ * Uses the official SIWF verification method with viem connector
  */
 async function verifyFarcasterSignature(
   message: string,
@@ -336,74 +337,74 @@ async function verifyFarcasterSignature(
   fid: number,
   requestOrigin?: string
 ): Promise<{ valid: boolean; error?: string }> {
-  // Parse SIWF message to extract domain and expiration
+  // Parse SIWF message to extract domain and nonce
   const siwfFields = parseSiwfMessage(message)
 
-  // Verify domain matches our domain (if specified in message)
-  if (siwfFields.domain) {
-    const appDomain = process.env.NEXT_PUBLIC_APP_URL 
-      ? new URL(process.env.NEXT_PUBLIC_APP_URL).hostname
-      : requestOrigin
-        ? new URL(requestOrigin).hostname
-        : null
+  // Get the domain for verification
+  const appDomain = process.env.NEXT_PUBLIC_APP_URL
+    ? new URL(process.env.NEXT_PUBLIC_APP_URL).hostname
+    : requestOrigin
+      ? new URL(requestOrigin).hostname
+      : null
 
-    if (appDomain && siwfFields.domain !== appDomain && siwfFields.domain !== `www.${appDomain}`) {
-      logger.warn('SIWF domain mismatch', {
-        messageDomain: siwfFields.domain,
-        appDomain,
-        fid,
-      }, 'verifyFarcasterSignature')
-      // Note: We log but don't fail, as domain might be set by Farcaster client
-      // The cryptographic signature verification is the primary security check
-    }
+  if (!appDomain) {
+    logger.error('No domain available for SIWF verification', { fid }, 'verifyFarcasterSignature')
+    return { valid: false, error: 'Configuration error: no domain available' }
   }
 
-  // Verify expiration time hasn't passed
-  if (siwfFields.expirationTime) {
-    try {
-      const expirationDate = new Date(siwfFields.expirationTime)
-      const now = new Date()
-      if (expirationDate < now) {
-        logger.warn('SIWF message expired', {
-          expirationTime: siwfFields.expirationTime,
-          now: now.toISOString(),
-          fid,
-        }, 'verifyFarcasterSignature')
-        return { valid: false, error: 'Message expired' }
-      }
-    } catch (error) {
-      logger.warn('Failed to parse SIWF expiration time', {
-        expirationTime: siwfFields.expirationTime,
-        error: error instanceof Error ? error.message : String(error),
-      }, 'verifyFarcasterSignature')
-    }
-  }
-
-  // Verify cryptographic signature via Neynar API
-  const response = await fetch('https://api.neynar.com/v2/farcaster/verification', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'api_key': process.env.NEYNAR_API_KEY!,
-    },
-    body: JSON.stringify({
-      message,
-      signature,
+  // Log domain info for debugging
+  if (siwfFields.domain && siwfFields.domain !== appDomain && siwfFields.domain !== `www.${appDomain}`) {
+    logger.warn('SIWF domain in message differs from app domain', {
+      messageDomain: siwfFields.domain,
+      appDomain,
       fid,
-    }),
-  })
+    }, 'verifyFarcasterSignature')
+  }
 
-  if (!response.ok) {
-    const errorText = await response.text()
-    logger.error('Neynar verification failed', { 
-      status: response.status, 
-      error: errorText,
-      fid 
+  try {
+    // Create the Farcaster auth client with viem connector for signature verification
+    const appClient = createAppClient({
+      ethereum: viemConnector(),
+    })
+
+    // Verify the sign-in message using the official Farcaster auth-client
+    const verifyResult = await appClient.verifySignInMessage({
+      message,
+      signature: signature as `0x${string}`,
+      domain: siwfFields.domain || appDomain,
+      nonce: siwfFields.nonce || '',
+    })
+
+    if (!verifyResult.success) {
+      logger.error('SIWF signature verification failed', {
+        fid,
+        providedFid: fid,
+        verifiedFid: verifyResult.fid,
+      }, 'verifyFarcasterSignature')
+      return { valid: false, error: 'Signature verification failed' }
+    }
+
+    // Verify the FID matches (convert both to string for comparison)
+    if (verifyResult.fid.toString() !== fid.toString()) {
+      logger.error('SIWF FID mismatch', {
+        providedFid: fid,
+        verifiedFid: verifyResult.fid.toString(),
+      }, 'verifyFarcasterSignature')
+      return { valid: false, error: 'FID mismatch' }
+    }
+
+    logger.info('SIWF signature verified successfully', {
+      fid,
+      domain: siwfFields.domain,
+    }, 'verifyFarcasterSignature')
+
+    return { valid: true }
+  } catch (error) {
+    logger.error('SIWF verification error', {
+      error: error instanceof Error ? error.message : String(error),
+      fid,
     }, 'verifyFarcasterSignature')
     return { valid: false, error: 'Signature verification failed' }
   }
-
-  const data = await response.json() as { valid: boolean }
-  return { valid: data.valid }
 }
 

--- a/src/app/api/users/[userId]/link-social/route.ts
+++ b/src/app/api/users/[userId]/link-social/route.ts
@@ -121,6 +121,8 @@ export const POST = withErrorHandling(async (
       hasFarcaster: true,
       hasTwitter: true,
       walletAddress: true,
+      farcasterFid: true,
+      twitterId: true,
     },
   });
 
@@ -133,9 +135,35 @@ export const POST = withErrorHandling(async (
   switch (platform) {
     case 'farcaster':
       alreadyLinked = user.hasFarcaster;
+      // Check if Farcaster username is already linked to another user
+      if (username && !alreadyLinked) {
+        const existingFarcasterUser = await prisma.user.findFirst({
+          where: {
+            farcasterUsername: username,
+            id: { not: canonicalUserId },
+          },
+          select: { id: true },
+        });
+        if (existingFarcasterUser) {
+          throw new ConflictError('Farcaster account already linked to another user', 'User.farcasterUsername');
+        }
+      }
       break;
     case 'twitter':
       alreadyLinked = user.hasTwitter;
+      // Check if Twitter account is already linked to another user
+      if (username && !alreadyLinked) {
+        const existingTwitterUser = await prisma.user.findFirst({
+          where: {
+            twitterUsername: username,
+            id: { not: canonicalUserId },
+          },
+          select: { id: true },
+        });
+        if (existingTwitterUser) {
+          throw new ConflictError('Twitter account already linked to another user', 'User.twitterUsername');
+        }
+      }
       break;
     case 'wallet':
       alreadyLinked = !!user.walletAddress;

--- a/src/components/profile/LinkSocialAccountsModal.tsx
+++ b/src/components/profile/LinkSocialAccountsModal.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { X as XIcon, Check, ExternalLink, Shield } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { useAuthStore } from '@/stores/authStore'
 import { toast } from 'sonner'
+import { signInWithFarcaster } from '@/lib/farcaster-auth-client'
 
 /**
  * Link social accounts modal component for connecting social accounts.
@@ -42,78 +43,6 @@ export function LinkSocialAccountsModal({ isOpen, onClose }: LinkSocialAccountsM
   const { user, setUser } = useAuthStore()
   const [linking, setLinking] = useState<string | null>(null)
 
-  // Handle OAuth callback messages (for Farcaster)
-  useEffect(() => {
-    if (!isOpen) return
-
-    const handleMessage = async (event: MessageEvent) => {
-      // Verify origin for security - allow messages from farcaster.xyz (protocol domain)
-      // The popup at farcaster.xyz/~/sign-in-with-farcaster posts messages back to parent
-      const allowedOrigins = [
-        'https://farcaster.xyz',
-        'https://www.farcaster.xyz',
-        window.location.origin, // Also allow same-origin for development/testing
-      ]
-      if (!allowedOrigins.includes(event.origin)) {
-        return
-      }
-
-      if (event.data.type === 'FARCASTER_AUTH_SUCCESS') {
-        const { fid, username, displayName, pfpUrl } = event.data
-        
-        setLinking('farcaster')
-        
-        const token = typeof window !== 'undefined' ? window.__privyAccessToken : null
-        const state = `${user?.id}:${Date.now()}:${Math.random().toString(36).substring(7)}`
-        
-        const response = await fetch('/api/auth/farcaster/callback', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
-          },
-          body: JSON.stringify({
-            message: event.data.message,
-            signature: event.data.signature,
-            fid,
-            username,
-            displayName,
-            pfpUrl,
-            state,
-          }),
-        })
-
-        const data = await response.json()
-
-        if (response.ok && data.success) {
-          if (user) {
-            setUser({
-              ...user,
-              hasFarcaster: true,
-              farcasterUsername: username,
-              reputationPoints: data.newTotal || user.reputationPoints,
-            })
-          }
-
-          if (data.pointsAwarded > 0) {
-            toast.success(`Farcaster linked! +${data.pointsAwarded} points awarded`)
-          } else {
-            toast.success('Farcaster account linked successfully!')
-          }
-
-          onClose()
-        } else {
-          setLinking(null)
-          throw new Error(data.error || 'Failed to link account')
-        }
-        setLinking(null)
-      }
-    }
-
-    window.addEventListener('message', handleMessage)
-    return () => window.removeEventListener('message', handleMessage)
-  }, [isOpen, user, setUser, onClose])
-
   if (!isOpen) return null
 
   const handleTwitterOAuth = async () => {
@@ -130,41 +59,81 @@ export function LinkSocialAccountsModal({ isOpen, onClose }: LinkSocialAccountsM
     window.location.href = initiateUrl
   }
 
-  const handleFarcasterAuth = () => {
+  const handleFarcasterAuth = async () => {
     if (!user?.id) return
-    
+
     setLinking('farcaster')
 
-    // Open Farcaster protocol authentication popup
-    // Uses Sign In with Farcaster (SIWF) via official protocol endpoint (farcaster.xyz)
-    const state = `${user.id}:${Date.now()}:${Math.random().toString(36).substring(7)}`
-    // URL encode the channelToken to ensure special characters are properly handled
-    const authUrl = `https://farcaster.xyz/~/sign-in-with-farcaster?channelToken=${encodeURIComponent(state)}`
-    
-    const width = 600
-    const height = 700
-    const left = (window.screen.width - width) / 2
-    const top = (window.screen.height - height) / 2
-    
-    const popup = window.open(
-      authUrl,
-      'farcaster-auth',
-      `width=${width},height=${height},left=${left},top=${top}`
-    )
+    try {
+      // Use the proper SIWF protocol via relay.farcaster.xyz
+      const result = await signInWithFarcaster({
+        userId: user.id,
+      })
 
-    if (!popup) {
-      toast.error('Please allow popups to connect Farcaster')
-      setLinking(null)
-      return
-    }
+      // Send authentication data to backend for verification and linking
+      const token = typeof window !== 'undefined' ? window.__privyAccessToken : null
+      const response = await fetch('/api/auth/farcaster/callback', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({
+          message: result.message,
+          signature: result.signature,
+          fid: result.fid,
+          username: result.username,
+          displayName: result.displayName,
+          pfpUrl: result.pfpUrl,
+          state: result.state,
+        }),
+      })
 
-    // Monitor popup
-    const checkPopup = setInterval(() => {
-      if (popup.closed) {
-        clearInterval(checkPopup)
-        setLinking(null)
+      const data = await response.json()
+
+      if (response.ok && data.success) {
+        setUser({
+          ...user,
+          hasFarcaster: true,
+          farcasterUsername: result.username,
+          reputationPoints: data.newTotal || user.reputationPoints,
+        })
+
+        if (data.pointsAwarded > 0) {
+          toast.success(`Farcaster linked! +${data.pointsAwarded} points awarded`)
+        } else {
+          toast.success('Farcaster account linked successfully!')
+        }
+
+        onClose()
+      } else {
+        const errorMessage = data.error || 'Failed to link Farcaster account'
+        if (response.status === 409) {
+          toast.error(errorMessage.includes('already linked')
+            ? errorMessage
+            : 'This Farcaster account is already linked to another user')
+        } else {
+          toast.error(errorMessage)
+        }
       }
-    }, 1000)
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+
+      // Don't show error for user cancellation
+      if (errorMessage === 'Authentication cancelled') {
+        return
+      }
+
+      // Handle popup blocked
+      if (errorMessage.includes('popup')) {
+        toast.error('Please allow popups to connect Farcaster')
+        return
+      }
+
+      toast.error('Failed to connect Farcaster. Please try again.')
+    } finally {
+      setLinking(null)
+    }
   }
 
   return (

--- a/src/components/profile/LinkSocialAccountsModal.tsx
+++ b/src/components/profile/LinkSocialAccountsModal.tsx
@@ -138,7 +138,8 @@ export function LinkSocialAccountsModal({ isOpen, onClose }: LinkSocialAccountsM
     // Open Farcaster protocol authentication popup
     // Uses Sign In with Farcaster (SIWF) via official protocol endpoint (farcaster.xyz)
     const state = `${user.id}:${Date.now()}:${Math.random().toString(36).substring(7)}`
-    const authUrl = `https://farcaster.xyz/~/sign-in-with-farcaster?channelToken=${state}`
+    // URL encode the channelToken to ensure special characters are properly handled
+    const authUrl = `https://farcaster.xyz/~/sign-in-with-farcaster?channelToken=${encodeURIComponent(state)}`
     
     const width = 600
     const height = 700

--- a/src/components/shared/ComingSoon.tsx
+++ b/src/components/shared/ComingSoon.tsx
@@ -195,7 +195,15 @@ export function ComingSoon() {
               toast.success('Farcaster account linked successfully!')
             }
           } else {
-            toast.error(data.error || 'Failed to link Farcaster account')
+            // Show specific error message for 409 conflicts
+            const errorMessage = data.error || 'Failed to link Farcaster account'
+            if (response.status === 409) {
+              toast.error(errorMessage.includes('already linked') 
+                ? errorMessage 
+                : 'This Farcaster account is already linked to another user')
+            } else {
+              toast.error(errorMessage)
+            }
           }
         } catch (error) {
           logger.error('Error linking Farcaster account', {

--- a/src/components/shared/ComingSoon.tsx
+++ b/src/components/shared/ComingSoon.tsx
@@ -12,6 +12,7 @@ import { LinkSocialAccountsModal } from '@/components/profile/LinkSocialAccounts
 import { PlayerStatsModal } from '@/components/shared/PlayerStatsModal'
 import { toast } from 'sonner'
 import { getReferralUrl } from '@/lib/referral/referral-utils'
+import { signInWithFarcaster } from '@/lib/farcaster-auth-client'
 
 /**
  * Waitlist data structure containing user position and points information.
@@ -96,140 +97,105 @@ export function ComingSoon() {
 
   // Handle Twitter OAuth
   const handleTwitterOAuth = () => {
+    if (!dbUser?.id) {
+      toast.error('Please complete your profile first')
+      logger.warn('Twitter OAuth attempted without user ID', {}, 'ComingSoon')
+      return
+    }
+    
     // Store current URL to return to
     sessionStorage.setItem('oauth_return_url', window.location.pathname)
     // Redirect to Twitter OAuth initiation
+    // Cookies should be sent automatically with the redirect
     window.location.href = '/api/auth/twitter/initiate'
   }
 
-  // Handle Farcaster OAuth - uses official Farcaster protocol (Sign In with Farcaster)
-  const handleFarcasterOAuth = () => {
+  // Handle Farcaster OAuth - uses proper Sign In with Farcaster (SIWF) protocol
+  // Creates a channel on relay.farcaster.xyz, then polls for authentication completion
+  const handleFarcasterOAuth = async () => {
     if (!dbUser?.id) {
       toast.error('Please complete your profile first')
       logger.warn('Farcaster OAuth attempted without user ID', {}, 'ComingSoon')
       return
     }
-    
-    // Open Farcaster protocol authentication popup
-    // Uses Sign In with Farcaster (SIWF) via official protocol endpoint (farcaster.xyz)
-    const state = `${dbUser.id}:${Date.now()}:${Math.random().toString(36).substring(7)}`
-    // URL encode the channelToken to ensure special characters are properly handled
-    const authUrl = `https://farcaster.xyz/~/sign-in-with-farcaster?channelToken=${encodeURIComponent(state)}`
-    
-    const width = 600
-    const height = 700
-    const left = (window.screen.width - width) / 2
-    const top = (window.screen.height - height) / 2
-    
-    let popup: Window | null = null
+
     try {
-      popup = window.open(
-        authUrl,
-        'farcaster-auth',
-        `width=${width},height=${height},left=${left},top=${top}`
-      )
-    } catch (error) {
-      logger.error('Error opening Farcaster popup', {
-        error: error instanceof Error ? error.message : String(error),
+      // Use the proper SIWF protocol via relay.farcaster.xyz
+      const result = await signInWithFarcaster({
         userId: dbUser.id,
-      }, 'ComingSoon')
-      toast.error('Failed to open Farcaster authentication. Please try again.')
-      return
-    }
+        onStatusUpdate: (status) => {
+          logger.debug('Farcaster auth status', { status }, 'ComingSoon')
+        },
+      })
 
-    if (!popup) {
-      toast.error('Please allow popups to connect Farcaster')
-      logger.warn('Farcaster popup blocked by browser', { userId: dbUser.id }, 'ComingSoon')
-      return
-    }
+      // Send authentication data to backend for verification and linking
+      const token = typeof window !== 'undefined' ? window.__privyAccessToken : null
+      const response = await fetch('/api/auth/farcaster/callback', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({
+          message: result.message,
+          signature: result.signature,
+          fid: result.fid,
+          username: result.username,
+          displayName: result.displayName,
+          pfpUrl: result.pfpUrl,
+          state: result.state,
+        }),
+      })
 
-    // Listen for Farcaster auth callback from popup
-    const handleMessage = async (event: MessageEvent) => {
-      // Verify origin for security - allow messages from farcaster.xyz (protocol domain)
-      // The popup at farcaster.xyz/~/sign-in-with-farcaster posts messages back to parent
-      const allowedOrigins = [
-        'https://farcaster.xyz',
-        'https://www.farcaster.xyz',
-        window.location.origin, // Also allow same-origin for development/testing
-      ]
-      if (!allowedOrigins.includes(event.origin)) {
-        logger.warn('Rejected message from unauthorized origin', { origin: event.origin }, 'ComingSoon')
+      const data = await response.json()
+
+      if (response.ok && data.success) {
+        // Refresh user profile to reflect the linked Farcaster account
+        await refresh()
+
+        // Refresh waitlist position to update points
+        if (dbUser?.id) {
+          await fetchWaitlistPosition(dbUser.id)
+        }
+
+        if (data.pointsAwarded > 0) {
+          toast.success(`Farcaster linked! +${data.pointsAwarded} points awarded`)
+        } else {
+          toast.success('Farcaster account linked successfully!')
+        }
+      } else {
+        // Show specific error message for 409 conflicts
+        const errorMessage = data.error || 'Failed to link Farcaster account'
+        if (response.status === 409) {
+          toast.error(errorMessage.includes('already linked')
+            ? errorMessage
+            : 'This Farcaster account is already linked to another user')
+        } else {
+          toast.error(errorMessage)
+        }
+      }
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error)
+
+      // Don't show error toast for user cancellation
+      if (errorMessage === 'Authentication cancelled') {
+        logger.info('Farcaster auth cancelled by user', { userId: dbUser.id }, 'ComingSoon')
         return
       }
 
-      if (event.data.type === 'FARCASTER_AUTH_SUCCESS') {
-        const { fid, username, displayName, pfpUrl } = event.data
-        
-        try {
-          const token = typeof window !== 'undefined' ? window.__privyAccessToken : null
-          const response = await fetch('/api/auth/farcaster/callback', {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
-            },
-            body: JSON.stringify({
-              message: event.data.message,
-              signature: event.data.signature,
-              fid,
-              username,
-              displayName,
-              pfpUrl,
-              state,
-            }),
-          })
-
-          const data = await response.json()
-
-          if (response.ok && data.success) {
-            // Refresh user profile to reflect the linked Farcaster account
-            await refresh()
-
-            // Refresh waitlist position to update points
-            if (dbUser?.id) {
-              await fetchWaitlistPosition(dbUser.id)
-            }
-
-            if (data.pointsAwarded > 0) {
-              toast.success(`Farcaster linked! +${data.pointsAwarded} points awarded`)
-            } else {
-              toast.success('Farcaster account linked successfully!')
-            }
-          } else {
-            // Show specific error message for 409 conflicts
-            const errorMessage = data.error || 'Failed to link Farcaster account'
-            if (response.status === 409) {
-              toast.error(errorMessage.includes('already linked') 
-                ? errorMessage 
-                : 'This Farcaster account is already linked to another user')
-            } else {
-              toast.error(errorMessage)
-            }
-          }
-        } catch (error) {
-          logger.error('Error linking Farcaster account', {
-            error: error instanceof Error ? error.message : String(error),
-          }, 'ComingSoon')
-          toast.error('Failed to link Farcaster account')
-        } finally {
-          window.removeEventListener('message', handleMessage)
-          if (popup && !popup.closed) {
-            popup.close()
-          }
-        }
+      // Handle popup blocked
+      if (errorMessage.includes('popup')) {
+        toast.error('Please allow popups to connect Farcaster')
+        logger.warn('Farcaster popup blocked', { userId: dbUser.id }, 'ComingSoon')
+        return
       }
+
+      logger.error('Error during Farcaster authentication', {
+        error: errorMessage,
+        userId: dbUser.id,
+      }, 'ComingSoon')
+      toast.error('Failed to connect Farcaster. Please try again.')
     }
-
-    // Add message listener for popup response
-    window.addEventListener('message', handleMessage)
-
-    // Clean up listener if popup closes without authenticating
-    const checkPopupClosed = setInterval(() => {
-      if (popup && popup.closed) {
-        clearInterval(checkPopupClosed)
-        window.removeEventListener('message', handleMessage)
-      }
-    }, 1000)
   }
 
   // If user completes onboarding, mark as waitlisted and fetch position

--- a/src/components/shared/ComingSoon.tsx
+++ b/src/components/shared/ComingSoon.tsx
@@ -113,7 +113,8 @@ export function ComingSoon() {
     // Open Farcaster protocol authentication popup
     // Uses Sign In with Farcaster (SIWF) via official protocol endpoint (farcaster.xyz)
     const state = `${dbUser.id}:${Date.now()}:${Math.random().toString(36).substring(7)}`
-    const authUrl = `https://farcaster.xyz/~/sign-in-with-farcaster?channelToken=${state}`
+    // URL encode the channelToken to ensure special characters are properly handled
+    const authUrl = `https://farcaster.xyz/~/sign-in-with-farcaster?channelToken=${encodeURIComponent(state)}`
     
     const width = 600
     const height = 700

--- a/src/lib/farcaster-auth-client.ts
+++ b/src/lib/farcaster-auth-client.ts
@@ -236,8 +236,9 @@ export async function signInWithFarcaster(options: FarcasterSignInOptions): Prom
       popup.close()
     }
 
-    // Generate state for backend verification (userId:timestamp:random)
-    const state = `${userId}:${Date.now()}:${Math.random().toString(36).substring(7)}`
+    // Generate state for backend verification (userId|timestamp|random)
+    // Using pipe separator because userId may contain colons (e.g., did:privy:xxx)
+    const state = `${userId}|${Date.now()}|${Math.random().toString(36).substring(7)}`
 
     logger.info('Farcaster authentication completed', {
       fid: result.fid,
@@ -272,7 +273,8 @@ export async function createFarcasterAuthChannel(userId: string): Promise<{
   const nonce = generateNonce()
 
   const channel = await createChannel(domain, siweUri, nonce)
-  const state = `${userId}:${Date.now()}:${Math.random().toString(36).substring(7)}`
+  // Using pipe separator because userId may contain colons (e.g., did:privy:xxx)
+  const state = `${userId}|${Date.now()}|${Math.random().toString(36).substring(7)}`
 
   return {
     ...channel,

--- a/src/lib/farcaster-auth-client.ts
+++ b/src/lib/farcaster-auth-client.ts
@@ -1,0 +1,287 @@
+/**
+ * Farcaster Sign-In Client
+ *
+ * Implements the proper Sign In with Farcaster (SIWF) protocol flow:
+ * 1. Create a channel on the Farcaster relay server
+ * 2. Present the auth URL/QR code to the user
+ * 3. Poll the relay for authentication status
+ * 4. Return the signed message and user data
+ *
+ * @see https://github.com/farcasterxyz/protocol/discussions/110
+ */
+
+import { logger } from './logger'
+
+const FARCASTER_RELAY_URL = 'https://relay.farcaster.xyz'
+const CHANNEL_POLL_INTERVAL_MS = 1500
+const CHANNEL_TIMEOUT_MS = 5 * 60 * 1000 // 5 minutes
+
+export interface FarcasterAuthResult {
+  message: string
+  signature: string
+  fid: number
+  username: string
+  displayName?: string
+  pfpUrl?: string
+  bio?: string
+  nonce: string
+}
+
+interface ChannelCreateResponse {
+  channelToken: string
+  url: string
+  nonce: string
+}
+
+interface ChannelStatusResponse {
+  state: 'pending' | 'completed'
+  message?: string
+  signature?: string
+  fid?: number
+  username?: string
+  displayName?: string
+  pfpUrl?: string
+  bio?: string
+  nonce?: string
+}
+
+/**
+ * Creates a new authentication channel on the Farcaster relay
+ */
+async function createChannel(domain: string, siweUri: string, nonce?: string): Promise<ChannelCreateResponse> {
+  const body: Record<string, string> = {
+    siweUri,
+    domain,
+  }
+
+  if (nonce) {
+    body.nonce = nonce
+  }
+
+  const response = await fetch(`${FARCASTER_RELAY_URL}/v1/channel`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+
+  if (!response.ok) {
+    const errorText = await response.text()
+    logger.error('Failed to create Farcaster auth channel', {
+      status: response.status,
+      error: errorText,
+    }, 'FarcasterAuthClient')
+    throw new Error(`Failed to create auth channel: ${response.status}`)
+  }
+
+  return response.json()
+}
+
+/**
+ * Polls the channel status until authentication completes or times out
+ */
+async function pollChannelStatus(
+  channelToken: string,
+  onStatusUpdate?: (state: 'pending' | 'completed') => void,
+  signal?: AbortSignal
+): Promise<FarcasterAuthResult> {
+  const startTime = Date.now()
+
+  while (Date.now() - startTime < CHANNEL_TIMEOUT_MS) {
+    if (signal?.aborted) {
+      throw new Error('Authentication cancelled')
+    }
+
+    const response = await fetch(`${FARCASTER_RELAY_URL}/v1/channel/status`, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${channelToken}`,
+      },
+      signal,
+    })
+
+    if (!response.ok) {
+      if (response.status === 401) {
+        throw new Error('Channel expired or invalid')
+      }
+      const errorText = await response.text()
+      logger.warn('Channel status check failed', {
+        status: response.status,
+        error: errorText,
+      }, 'FarcasterAuthClient')
+      // Continue polling on transient errors
+      await sleep(CHANNEL_POLL_INTERVAL_MS)
+      continue
+    }
+
+    const status: ChannelStatusResponse = await response.json()
+    onStatusUpdate?.(status.state)
+
+    if (status.state === 'completed') {
+      if (!status.message || !status.signature || !status.fid || !status.username) {
+        throw new Error('Incomplete authentication response')
+      }
+
+      return {
+        message: status.message,
+        signature: status.signature,
+        fid: status.fid,
+        username: status.username,
+        displayName: status.displayName,
+        pfpUrl: status.pfpUrl,
+        bio: status.bio,
+        nonce: status.nonce || '',
+      }
+    }
+
+    await sleep(CHANNEL_POLL_INTERVAL_MS)
+  }
+
+  throw new Error('Authentication timeout')
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+/**
+ * Generate a cryptographically secure nonce
+ */
+function generateNonce(): string {
+  const array = new Uint8Array(16)
+  crypto.getRandomValues(array)
+  return Array.from(array, byte => byte.toString(16).padStart(2, '0')).join('')
+}
+
+export interface FarcasterSignInOptions {
+  /** User ID to include in state for backend verification */
+  userId: string
+  /** Callback when authentication status changes */
+  onStatusUpdate?: (state: 'pending' | 'completed') => void
+  /** Callback when popup is opened with the URL */
+  onPopupOpen?: (url: string) => void
+  /** Optional abort signal to cancel authentication */
+  signal?: AbortSignal
+}
+
+/**
+ * Opens a popup for Farcaster Sign-In and handles the full authentication flow
+ *
+ * This implements the proper SIWF protocol:
+ * 1. Creates a channel on the Farcaster relay server
+ * 2. Opens a popup with the auth URL
+ * 3. Polls the relay for completion
+ * 4. Returns the authentication result
+ */
+export async function signInWithFarcaster(options: FarcasterSignInOptions): Promise<FarcasterAuthResult & { state: string }> {
+  const { userId, onStatusUpdate, onPopupOpen, signal } = options
+
+  // Get the domain from environment or current location
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || window.location.origin
+  const domain = new URL(appUrl).hostname
+  const siweUri = `${appUrl}/api/auth/farcaster/callback`
+
+  // Generate nonce for this authentication request
+  const nonce = generateNonce()
+
+  logger.info('Creating Farcaster auth channel', { domain, siweUri }, 'FarcasterAuthClient')
+
+  // Step 1: Create channel on relay
+  const channel = await createChannel(domain, siweUri, nonce)
+
+  logger.info('Farcaster auth channel created', {
+    channelToken: channel.channelToken.substring(0, 8) + '...',
+    url: channel.url,
+  }, 'FarcasterAuthClient')
+
+  // Step 2: Open popup with the auth URL
+  const width = 500
+  const height = 700
+  const left = window.screen.width / 2 - width / 2
+  const top = window.screen.height / 2 - height / 2
+
+  const popup = window.open(
+    channel.url,
+    'farcaster-auth',
+    `width=${width},height=${height},left=${left},top=${top},scrollbars=yes,resizable=yes`
+  )
+
+  if (!popup) {
+    throw new Error('Failed to open popup. Please allow popups for this site.')
+  }
+
+  onPopupOpen?.(channel.url)
+
+  // Create abort controller to handle popup close
+  const abortController = new AbortController()
+  const combinedSignal = signal
+    ? AbortSignal.any([signal, abortController.signal])
+    : abortController.signal
+
+  // Monitor popup close
+  const popupCheckInterval = setInterval(() => {
+    if (popup.closed) {
+      clearInterval(popupCheckInterval)
+      abortController.abort()
+    }
+  }, 500)
+
+  try {
+    // Step 3: Poll for authentication completion
+    const result = await pollChannelStatus(channel.channelToken, onStatusUpdate, combinedSignal)
+
+    // Close popup if still open
+    if (!popup.closed) {
+      popup.close()
+    }
+
+    // Generate state for backend verification (userId:timestamp:random)
+    const state = `${userId}:${Date.now()}:${Math.random().toString(36).substring(7)}`
+
+    logger.info('Farcaster authentication completed', {
+      fid: result.fid,
+      username: result.username
+    }, 'FarcasterAuthClient')
+
+    return {
+      ...result,
+      state,
+    }
+  } finally {
+    clearInterval(popupCheckInterval)
+    if (!popup.closed) {
+      popup.close()
+    }
+  }
+}
+
+/**
+ * Creates an auth channel and returns the URL for QR code display
+ * Useful for mobile-first flows where you want to show a QR code
+ */
+export async function createFarcasterAuthChannel(userId: string): Promise<{
+  channelToken: string
+  url: string
+  nonce: string
+  state: string
+}> {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || window.location.origin
+  const domain = new URL(appUrl).hostname
+  const siweUri = `${appUrl}/api/auth/farcaster/callback`
+  const nonce = generateNonce()
+
+  const channel = await createChannel(domain, siweUri, nonce)
+  const state = `${userId}:${Date.now()}:${Math.random().toString(36).substring(7)}`
+
+  return {
+    ...channel,
+    state,
+  }
+}
+
+/**
+ * Polls an existing channel for completion
+ * Use with createFarcasterAuthChannel for custom UIs
+ */
+export { pollChannelStatus }

--- a/src/lib/farcaster-onboarding.ts
+++ b/src/lib/farcaster-onboarding.ts
@@ -38,7 +38,8 @@ export async function openFarcasterOnboardingPopup(
     // Build Farcaster protocol auth URL using official protocol endpoint
     // Uses farcaster.xyz (protocol domain) instead of warpcast.com (client domain)
     // The channelToken parameter is used for the Sign In with Farcaster flow
-    const authUrl = `https://farcaster.xyz/~/sign-in-with-farcaster?channelToken=${state}`
+    // URL encode the channelToken to ensure special characters are properly handled
+    const authUrl = `https://farcaster.xyz/~/sign-in-with-farcaster?channelToken=${encodeURIComponent(state)}`
     
     // Open popup
     const width = 500

--- a/src/lib/farcaster-onboarding.ts
+++ b/src/lib/farcaster-onboarding.ts
@@ -1,10 +1,11 @@
 /**
  * Farcaster Sign-In utilities for onboarding
  * Handles Farcaster protocol authentication flow and profile data fetching
- * Uses official Farcaster protocol endpoints (farcaster.xyz)
+ * Uses the proper Sign In with Farcaster (SIWF) protocol via relay.farcaster.xyz
  */
 
 import { logger } from './logger'
+import { signInWithFarcaster } from './farcaster-auth-client'
 
 export interface FarcasterOnboardingProfile {
   fid: number
@@ -14,149 +15,72 @@ export interface FarcasterOnboardingProfile {
   bio?: string
 }
 
-interface FarcasterAuthResponse {
-  message: string
-  signature: string
-  fid: number
-  username: string
-  displayName?: string
-  pfpUrl?: string
-  bio?: string
-}
-
 /**
  * Open Farcaster Sign-In popup and handle authentication
- * Uses official Farcaster protocol endpoints via connect.farcaster.xyz
+ * Uses the proper SIWF protocol via relay.farcaster.xyz
  */
 export async function openFarcasterOnboardingPopup(
   userId: string
 ): Promise<FarcasterOnboardingProfile> {
-  return new Promise((resolve, reject) => {
-    // Generate state for verification
-    const state = `onboarding:${userId}:${Date.now()}:${Math.random().toString(36).substring(7)}`
-    
-    // Build Farcaster protocol auth URL using official protocol endpoint
-    // Uses farcaster.xyz (protocol domain) instead of warpcast.com (client domain)
-    // The channelToken parameter is used for the Sign In with Farcaster flow
-    // URL encode the channelToken to ensure special characters are properly handled
-    const authUrl = `https://farcaster.xyz/~/sign-in-with-farcaster?channelToken=${encodeURIComponent(state)}`
-    
-    // Open popup
-    const width = 500
-    const height = 700
-    const left = window.screen.width / 2 - width / 2
-    const top = window.screen.height / 2 - height / 2
-    
-    const popup = window.open(
-      authUrl,
-      'Farcaster Sign In',
-      `width=${width},height=${height},left=${left},top=${top},scrollbars=yes,resizable=yes`
-    )
+  try {
+    const result = await signInWithFarcaster({
+      userId,
+      onStatusUpdate: (state) => {
+        logger.debug('Farcaster auth status update', { state }, 'FarcasterOnboarding')
+      },
+    })
 
-    if (!popup) {
-      reject(new Error('Failed to open popup. Please allow popups for this site.'))
-      return
-    }
+    // Call the backend to verify and store the authentication
+    const response = await fetch('/api/auth/onboarding/farcaster/callback', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        message: result.message,
+        signature: result.signature,
+        fid: result.fid,
+        username: result.username,
+        displayName: result.displayName,
+        pfpUrl: result.pfpUrl,
+        bio: result.bio,
+        state: result.state,
+      }),
+    })
 
-    // Listen for message from popup
-    const handleMessage = async (event: MessageEvent) => {
-      // Security: verify origin - allow messages from farcaster.xyz (protocol domain)
-      // The popup at farcaster.xyz/~/sign-in-with-farcaster posts messages back to parent
-      const allowedOrigins = [
-        'https://farcaster.xyz',
-        'https://www.farcaster.xyz',
-        window.location.origin, // Also allow same-origin for development/testing
-      ]
-      if (!allowedOrigins.includes(event.origin)) {
-        logger.warn('Rejected message from unauthorized origin', { origin: event.origin }, 'FarcasterOnboarding')
-        return
-      }
-
-      const data = event.data as FarcasterAuthResponse & { type?: string }
-
-      if (data.type !== 'FARCASTER_AUTH_SUCCESS') {
-        return
-      }
-
-      logger.info('Received Farcaster auth message', { fid: data.fid }, 'FarcasterOnboarding')
-
-      popup?.close()
-      window.removeEventListener('message', handleMessage)
-
-      const response = await fetch('/api/auth/onboarding/farcaster/callback', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          message: data.message,
-          signature: data.signature,
-          fid: data.fid,
-          username: data.username,
-          displayName: data.displayName,
-          pfpUrl: data.pfpUrl,
-          bio: data.bio,
-          state,
-        }),
-      })
-
-      if (!response.ok) {
-        let error
-        try {
-          error = await response.json()
-        } catch {
-          throw new Error('Failed to verify Farcaster authentication')
-        }
-        throw new Error((error as { error?: string }).error || 'Failed to verify Farcaster authentication')
-      }
-
+    if (!response.ok) {
+      let error
       try {
-      await response.json()
+        error = await response.json()
       } catch {
-        // Response is ok but empty or invalid JSON - this is acceptable
+        throw new Error('Failed to verify Farcaster authentication')
       }
-      
-      resolve({
-        fid: data.fid,
-        username: data.username,
-        displayName: data.displayName,
-        pfpUrl: data.pfpUrl,
-        bio: data.bio,
-      })
+      throw new Error((error as { error?: string }).error || 'Failed to verify Farcaster authentication')
     }
 
-    // Listen for popup close without authentication
-    const checkPopupClosed = setInterval(() => {
-      if (popup?.closed) {
-        clearInterval(checkPopupClosed)
-        window.removeEventListener('message', handleMessage)
-        reject(new Error('Authentication cancelled'))
-      }
-    }, 500)
-
-    // Add message listener
-    window.addEventListener('message', handleMessage)
-
-    // Timeout after 5 minutes
-    setTimeout(() => {
-      clearInterval(checkPopupClosed)
-      window.removeEventListener('message', handleMessage)
-      if (popup && !popup.closed) {
-        popup.close()
-      }
-      reject(new Error('Authentication timeout'))
-    }, 5 * 60 * 1000)
-  })
+    return {
+      fid: result.fid,
+      username: result.username,
+      displayName: result.displayName,
+      pfpUrl: result.pfpUrl,
+      bio: result.bio,
+    }
+  } catch (error) {
+    logger.error('Farcaster onboarding failed', {
+      error: error instanceof Error ? error.message : String(error),
+      userId,
+    }, 'FarcasterOnboarding')
+    throw error
+  }
 }
 
 /**
  * Alternative: Use Neynar's Farcaster auth widget (simpler integration)
+ * Note: This now uses the same proper SIWF flow
  */
 export async function openNeynarFarcasterAuth(
   userId: string
 ): Promise<FarcasterOnboardingProfile> {
-  // This would use Neynar's auth widget if available
-  // For now, we'll use the Farcaster protocol flow above
   return openFarcasterOnboardingPopup(userId)
 }
 
@@ -165,7 +89,7 @@ export async function openNeynarFarcasterAuth(
  */
 export async function fetchFarcasterProfile(fid: number): Promise<FarcasterOnboardingProfile | null> {
   const response = await fetch(`/api/farcaster/profile/${fid}`)
-  
+
   if (!response.ok) {
     return null
   }
@@ -173,4 +97,3 @@ export async function fetchFarcasterProfile(fid: number): Promise<FarcasterOnboa
   const data = await response.json()
   return data.profile
 }
-


### PR DESCRIPTION
## Summary

- Fix broken "Sign in with Farcaster" flow by implementing proper SIWF protocol
- Create channel via `relay.farcaster.xyz` instead of passing invalid custom `channelToken` strings
- Replace `postMessage` listener (which never fires) with relay polling

## Root Cause

The previous implementation passed a custom state string (`userId:timestamp:random`) as the `channelToken` parameter:

```typescript
// BROKEN - invalid channelToken
const state = `${userId}:${Date.now()}:${random}`
const authUrl = `https://farcaster.xyz/~/sign-in-with-farcaster?channelToken=${state}`
```

The `channelToken` must be a **UUID from the Farcaster relay server**, not a custom string. This caused "Sign in with Farcaster is unavailable" errors.

## Solution

Implemented proper SIWF protocol per [FIP-11](https://github.com/farcasterxyz/protocol/discussions/110):

1. Create channel via `POST relay.farcaster.xyz/v1/channel`
2. Get valid `channelToken` UUID and auth URL from relay
3. Open popup with relay-generated URL
4. Poll relay for authentication completion
5. Return signed message and user data to backend

## Changes

- **NEW** `src/lib/farcaster-auth-client.ts` - Proper SIWF implementation using relay.farcaster.xyz
- `src/lib/farcaster-onboarding.ts` - Updated to use new auth client
- `src/components/shared/ComingSoon.tsx` - Fixed `handleFarcasterOAuth`
- `src/components/profile/LinkSocialAccountsModal.tsx` - Fixed `handleFarcasterAuth`

## Test plan

- [ ] Click "Link Farcaster" on ComingSoon page
- [ ] Verify popup opens with valid Warpcast URL
- [ ] Scan QR code with Warpcast/Farcaster app
- [ ] Confirm sign-in completes successfully
- [ ] Verify points are awarded and displayed