### PR TITLE
Release: Fix signup referral and auth token staleness

### DIFF
--- a/src/app/api/users/signup/route.ts
+++ b/src/app/api/users/signup/route.ts
@@ -211,10 +211,9 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
       // Resolve referral (if provided)
       let resolvedReferrerId: string | null = null
       let resolvedReferralRecordId: string | null = null
+      const normalizedCode = referralCode?.trim() || null
 
-      if (referralCode) {
-        const normalizedCode = referralCode.trim()
-
+      if (normalizedCode) {
         // First, try to find referrer by username (legacy system)
         const referrerByUsername = await tx.user.findUnique({
           where: { username: normalizedCode },
@@ -235,31 +234,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
           }
         }
 
-        // Create or update referral record (idempotent for retries)
-        if (resolvedReferrerId) {
-          const newReferralRecord = await tx.referral.upsert({
-            where: {
-              referralCode_referredUserId: {
-                referralCode: normalizedCode,
-                referredUserId: canonicalUserId,
-              },
-            },
-            create: {
-              id: await generateSnowflakeId(),
-              referrerId: resolvedReferrerId,
-              referralCode: normalizedCode,
-              referredUserId: canonicalUserId,
-              status: 'pending',
-            },
-            update: {
-              // On retry, keep existing record but ensure status is pending
-              status: 'pending',
-            },
-            select: { id: true },
-          })
-          
-          resolvedReferralRecordId = newReferralRecord.id
-        }
+        // Note: Referral record will be created AFTER user upsert to satisfy FK constraint
       }
 
       const baseUserData = {
@@ -339,14 +314,29 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
         select: selectUserSummary,
       })
 
-      if (resolvedReferralRecordId) {
-        await tx.referral.update({
-          where: { id: resolvedReferralRecordId },
-          data: {
+      // Create referral record AFTER user exists (to satisfy FK constraint)
+      if (resolvedReferrerId && normalizedCode) {
+        const referralRecord = await tx.referral.upsert({
+          where: {
+            referralCode_referredUserId: {
+              referralCode: normalizedCode,
+              referredUserId: user.id,
+            },
+          },
+          create: {
+            id: await generateSnowflakeId(),
+            referrerId: resolvedReferrerId,
+            referralCode: normalizedCode,
             referredUserId: user.id,
             status: 'pending',
           },
+          update: {
+            // On retry, keep existing record but ensure status is pending
+            status: 'pending',
+          },
+          select: { id: true },
         })
+        resolvedReferralRecordId = referralRecord.id
       }
 
       return {

--- a/src/lib/api/fetch.ts
+++ b/src/lib/api/fetch.ts
@@ -18,27 +18,33 @@ export interface ApiFetchOptions extends RequestInit {
 
 /**
  * Get a fresh Privy access token
- * 
- * @description Retrieves a fresh Privy access token from the window object.
- * Uses the Privy hook's getAccessToken if available, otherwise falls back
- * to cached token. Returns null in server-side environments.
- * 
+ *
+ * @description Retrieves a fresh Privy access token by calling Privy's getAccessToken().
+ * Per Privy best practices, this function ALWAYS calls getAccessToken() on-demand
+ * which automatically refreshes tokens nearing expiration. Never relies on cached
+ * tokens which can become stale. Returns null in server-side environments.
+ *
+ * @see https://docs.privy.io/authentication/user-authentication/access-tokens
  * @returns {Promise<string | null>} Access token or null if unavailable
  * @private
  */
-async function getPrivyAccessToken(): Promise<string | null> {
+export async function getPrivyAccessToken(): Promise<string | null> {
   if (typeof window === 'undefined') return null;
-  
-  // Use the Privy hook's getAccessToken if available (preferred - gets fresh token)
+
+  // ALWAYS call getAccessToken() on-demand - it auto-refreshes expired tokens
+  // Per Privy best practices: never rely on cached tokens, always fetch fresh
   if (window.__privyGetAccessToken) {
-    const token = await window.__privyGetAccessToken();
-    // Update the cached token
-    window.__privyAccessToken = token;
-    return token;
+    try {
+      const token = await window.__privyGetAccessToken();
+      return token;
+    } catch {
+      // If getAccessToken fails, user will be logged out by Privy automatically
+      return null;
+    }
   }
-  
-  // Fallback to cached token
-  return window.__privyAccessToken ?? null;
+
+  // No token available - user not authenticated via Privy hook
+  return null;
 }
 
 /**


### PR DESCRIPTION
## Summary
- **fix(auth)**: Always call `getAccessToken()` on-demand per Privy best practices - fixes JWT token expiration errors
- **refactor**: Streamline referral code handling in user signup process - fixes Prisma FK constraint error

## Changes
1. **Token Staleness Fix** (`src/lib/api/fetch.ts`)
   - Always fetch fresh tokens via `getAccessToken()` instead of relying on stale cached tokens
   - Tokens auto-refresh when nearing expiration per Privy best practices

2. **Referral FK Constraint Fix** (`src/app/api/users/signup/route.ts`)
   - Moved referral record creation to AFTER user creation to satisfy foreign key constraint
   - Fixes `Referral_referredUserId_fkey` error for new user signups with referral codes

## Test plan
- [ ] Test user signup with referral code (new user)
- [ ] Test user signup without referral code
- [ ] Test authenticated API calls after 1+ hour session (token refresh)
- [ ] Verify no 401 errors on notifications API