### PR TITLE
Release: staging → production

### DIFF
--- a/src/generator/llm/openai-client.ts
+++ b/src/generator/llm/openai-client.ts
@@ -218,12 +218,18 @@ export class BabylonLLMClient {
 
     while (true) {
       try {
+        // For qwen3 models, disable reasoning to prevent token consumption on thinking
+        // See: https://console.groq.com/docs/reasoning
+        const isQwen3Model = model.includes('qwen3');
+
         const response = await this.client.chat.completions.create({
           model,
           messages,
           ...(useJsonFormat ? { response_format: useJsonFormat } : {}),
           temperature,
           max_tokens: maxTokens,
+          // Disable reasoning for qwen3 models to prevent thinking tokens from consuming output budget
+          ...(isQwen3Model ? { reasoning_effort: 'none' as const } : {}),
         });
 
         let content = response.choices[0]!.message.content!;
@@ -277,6 +283,7 @@ export class BabylonLLMClient {
               ...(useJsonFormat ? { response_format: useJsonFormat } : {}),
               temperature,
               max_tokens: maxTokens,
+              ...(isQwen3Model ? { reasoning_effort: 'none' as const } : {}),
             });
             
             const continuationContent = continuationResponse.choices[0]!.message.content!;

--- a/tests/unit/waitlist-service.test.ts
+++ b/tests/unit/waitlist-service.test.ts
@@ -753,14 +753,14 @@ describeWaitlist('WaitlistService', () => {
         const awarded2 = await WaitlistService.awardWalletBonus(user.id, '0x5678')
         expect(awarded2).toBe(false) // Should not award twice
 
-        // Verify only 25 points awarded
+        // Verify only 300 points awarded (wallet bonus amount)
         const updatedUser = await prisma.user.findUnique({
           where: { id: user.id },
           select: { bonusPoints: true, reputationPoints: true },
         })
 
-        expect(updatedUser?.bonusPoints).toBe(25)
-        expect(updatedUser?.reputationPoints).toBe(125)
+        expect(updatedUser?.bonusPoints).toBe(300)
+        expect(updatedUser?.reputationPoints).toBe(400)
       })
     })
 

--- a/vercel.json
+++ b/vercel.json
@@ -27,7 +27,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "frame-src 'self' https://auth.privy.io https://verify.walletconnect.com https://verify.walletconnect.org https://vercel.live; frame-ancestors 'self'"
+          "value": "frame-src 'self' https://auth.privy.io https://privy.babylon.market https://verify.walletconnect.com https://verify.walletconnect.org https://vercel.live https://farcaster.xyz; frame-ancestors 'self' https://farcaster.xyz https://warpcast.com"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- fix(csp): update Content-Security-Policy for Farcaster and Privy
  - Add `https://privy.babylon.market` to frame-src for custom Privy domain
  - Add `https://farcaster.xyz` to frame-src for Farcaster frame support
  - Add `https://farcaster.xyz` and `https://warpcast.com` to frame-ancestors

## Test plan
- [ ] Verify Privy authentication works correctly
- [ ] Verify Farcaster frames render properly
- [ ] Verify WalletConnect continues to function