### PR TITLE
fix(articles): restore article card navigation in feed

### DIFF
--- a/src/components/articles/ArticleCard.tsx
+++ b/src/components/articles/ArticleCard.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { memo } from 'react';
-import { useRouter } from 'next/navigation';
 import { cn } from '@/lib/utils';
 import Link from 'next/link';
 import { Avatar } from '@/components/shared/Avatar';
@@ -64,7 +63,6 @@ export const ArticleCard = memo(function ArticleCard({
   className,
   onClick,
 }: ArticleCardProps) {
-  const router = useRouter();
   const publishedDate = new Date(post.timestamp);
   const now = new Date();
   const diffMs = now.getTime() - publishedDate.getTime();
@@ -93,7 +91,8 @@ export const ArticleCard = memo(function ArticleCard({
     } else {
       // Default behavior: navigate to article page
       // Navigate to /post/[id] which will redirect to /article/[id] if needed
-      router.push(`/post/${post.id}`);
+      // Using window.location.href for reliable navigation (matches LatestNewsPanel pattern)
+      window.location.href = `/post/${post.id}`;
     }
   };
 
@@ -148,6 +147,7 @@ export const ArticleCard = memo(function ArticleCard({
           {post.articleTitle || 'Untitled Article'}
         </h2>
         <button
+          type="button"
           className="inline-flex items-center gap-2 px-3 py-2 bg-[#0066FF] hover:bg-[#2952d9] text-primary-foreground text-sm font-semibold rounded-lg transition-colors whitespace-nowrap shrink-0"
           onClick={handleClick}
         >

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -437,13 +437,8 @@ export function useAuth(): UseAuthReturn {
           if (response.status === 409) {
             // 409 = wallet already linked to another account - don't retry
             failedLinkAttempts.add(walletKey);
-            const shortAddress = `${wallet.address.slice(0, 6)}...${wallet.address.slice(-4)}`;
-            toast.error('Wallet Already Linked', {
-              description: `The wallet ${shortAddress} is already linked to another Babylon account.`,
-              duration: 6000,
-            });
             logger.info(
-              'Wallet already linked to another user, skipping future retries',
+              'Wallet already linked to another account, skipping future retries',
               { address: wallet.address },
               'useAuth'
             );


### PR DESCRIPTION
## Summary
- Replace `router.push()` with `window.location.href` for reliable navigation
- Add `type="button"` attribute to Read Full Article button
- Remove unused `useRouter` import
- Remove spammy wallet linking toast notification, use logger instead

## Problem
Article cards in the feed were not navigating when clicked, while the widget sidebar articles worked correctly. The issue was that `router.push()` was failing silently.

## Solution
Changed to use `window.location.href` which is the same pattern used by the working `LatestNewsPanel` component.

## Test plan
- [ ] Click article card in feed → should navigate to `/post/[id]`
- [ ] Click "Read Full Article" button → should navigate to `/post/[id]`
- [ ] Verify widget sidebar articles still work
- [ ] Verify wallet linking no longer spams toast notifications

Fixes #218