### PR TITLE
Fix waitlist percentile calculation to show top X% instead of bottom X%

### DIFF
--- a/src/lib/services/waitlist-service.ts
+++ b/src/lib/services/waitlist-service.ts
@@ -324,9 +324,9 @@ export class WaitlistService {
       // Get total waitlist count
       const totalCount = await this.getTotalWaitlistCount()
 
-      // Calculate percentile (what % of people are behind you)
+      // Calculate percentile (Top X% - what percentile you're in from the top)
       const percentile = totalCount > 0 
-        ? Math.round(((totalCount - usersAhead) / totalCount) * 100) 
+        ? Math.round((leaderboardRank / totalCount) * 100) 
         : 100
 
       return {


### PR DESCRIPTION
Fixes the percentile calculation in the waitlist service. Previously it was showing the percentage of people behind you (e.g., 93%), but 'Top X%' should represent what percentile you're in from the top (e.g., 7%).

**Before:** `((totalCount - usersAhead) / totalCount) * 100` - calculated bottom percentage
**After:** `(leaderboardRank / totalCount) * 100` - calculates top percentile

For example, if you're ranked #2724 out of 38,386 users:
- Old: 93% (percentage of people behind you)
- New: 7% (your top percentile)