### PR TITLE
Fix points calculation to include base points

### DIFF
--- a/src/components/shared/ComingSoon.tsx
+++ b/src/components/shared/ComingSoon.tsx
@@ -32,6 +32,7 @@ interface WaitlistData {
     invite: number
     earned: number
     bonus: number
+    base: number
   }
   referralCount: number
   weeklyReferralCount?: number

--- a/src/components/shared/ComingSoon.tsx
+++ b/src/components/shared/ComingSoon.tsx
@@ -422,7 +422,8 @@ export function ComingSoon() {
         }
         
         // Verify points calculation consistency
-        const calculatedTotal = (data.pointsBreakdown?.invite || 0) + 
+        const calculatedTotal = (data.pointsBreakdown?.base || 0) +
+                                (data.pointsBreakdown?.invite || 0) + 
                                 (data.pointsBreakdown?.earned || 0) + 
                                 (data.pointsBreakdown?.bonus || 0)
         const reportedTotal = data.points || 0


### PR DESCRIPTION
Updated the points calculation logic in ComingSoon to add base points to the total. This ensures consistency between the calculated and reported points values.