### PR TITLE
fix registry search query

### DIFF
--- a/apps/web/src/app/api/registry/all/route.ts
+++ b/apps/web/src/app/api/registry/all/route.ts
@@ -64,24 +64,27 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   // Optional auth - registry is public
   await optionalAuth(request).catch(() => null);
 
-  // Initialize subgraph client for agent data
-  const subgraphClient = new SubgraphClient();
-
   // Fetch users from database
   const fetchUsers = async () => {
     try {
       const dbOperation = async (db: DrizzleClient) => {
-        const where: Record<string, unknown> = {};
+        const conditions: Record<string, unknown>[] = [];
+        
         if (onChainOnly) {
-          where.onChainRegistered = true;
+          conditions.push({ onChainRegistered: true });
         }
+        
         if (search) {
-          where.OR = [
-            { username: { contains: search, mode: 'insensitive' } },
-            { displayName: { contains: search, mode: 'insensitive' } },
-            { bio: { contains: search, mode: 'insensitive' } },
-          ];
+          conditions.push({
+            OR: [
+              { username: { contains: search, mode: 'insensitive' as const } },
+              { displayName: { contains: search, mode: 'insensitive' as const } },
+              { bio: { contains: search, mode: 'insensitive' as const } },
+            ],
+          });
         }
+
+        const where = conditions.length > 0 ? { AND: conditions } : {};
 
         const users = await db.user.findMany({
           where,
@@ -180,14 +183,15 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   const fetchActors = async () => {
     try {
       const dbOperation = async (db: DrizzleClient) => {
-        const where: Record<string, unknown> = {};
-        if (search) {
-          where.OR = [
-            { name: { contains: search, mode: 'insensitive' } },
-            { description: { contains: search, mode: 'insensitive' } },
-            { role: { contains: search, mode: 'insensitive' } },
-          ];
-        }
+        const where = search
+          ? {
+              OR: [
+                { name: { contains: search, mode: 'insensitive' as const } },
+                { description: { contains: search, mode: 'insensitive' as const } },
+                { role: { contains: search, mode: 'insensitive' as const } },
+              ],
+            }
+          : {};
 
         const actors = await db.actor.findMany({
           where,
@@ -254,6 +258,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
 
   const fetchAgents = async () => {
     try {
+      const subgraphClient = new SubgraphClient();
       const agents = await subgraphClient.searchAgents({
         type: 'agent',
         limit: 100,
@@ -294,6 +299,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
 
   const fetchApps = async () => {
     try {
+      const subgraphClient = new SubgraphClient();
       const apps = await subgraphClient.getGamePlatforms({
         minTrustScore: 0,
       });

--- a/apps/web/src/components/explore/EntitySearchAutocomplete.tsx
+++ b/apps/web/src/components/explore/EntitySearchAutocomplete.tsx
@@ -76,6 +76,7 @@ interface EntitySearchAutocompleteProps {
   className?: string;
   compact?: boolean;
   onNavigate?: () => void;
+  searchType?: 'all' | 'users' | 'actors' | 'agents' | 'apps';
 }
 
 export function EntitySearchAutocomplete({
@@ -85,6 +86,7 @@ export function EntitySearchAutocomplete({
   className,
   compact = false,
   onNavigate,
+  searchType = 'all',
 }: EntitySearchAutocompleteProps) {
   const router = useRouter();
   const [suggestions, setSuggestions] = useState<RegistryEntity[]>([]);
@@ -104,9 +106,11 @@ export function EntitySearchAutocomplete({
       }
 
       setLoading(true);
-      const response = await fetch(
-        `/api/registry/all?search=${encodeURIComponent(value)}`
-      );
+      const params = new URLSearchParams({
+        search: value,
+        type: searchType,
+      });
+      const response = await fetch(`/api/registry/all?${params.toString()}`);
       if (response.ok) {
         const data = await response.json();
         const users: RegistryEntity[] = (data.users || []).map(

--- a/apps/web/src/components/shared/WidgetSidebar.tsx
+++ b/apps/web/src/components/shared/WidgetSidebar.tsx
@@ -132,6 +132,7 @@ export function WidgetSidebar() {
             value={searchQuery}
             onChange={setSearchQuery}
             placeholder="Search users..."
+            searchType="users"
           />
         </div>
 


### PR DESCRIPTION
Fixed broken search functionality in the /api/registry/all endpoint by correcting invalid Prisma query syntax that was preventing the EntitySearchAutocomplete component from working. Added an optional searchType parameter to EntitySearchAutocomplete to allow filtering by entity type ('users', 'actors', 'agents', 'apps', or 'all'), and configured WidgetSidebar to search only users for better performance and cleaner results.