### PR TITLE
chore: add CLAUDE, AGENTS files and documentation pull scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,5 @@ _docs/
 # Claude Code
 .claude/
 migration-data/
+# Vendor docs (generated)
+docs/vendors/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,42 +1,41 @@
 # Repository Guidelines (Codex/Claude)
 
+## State (target vs current)
+- Target (in-progress): Elysia host in `apps/server`, background workers in `apps/daemon`, dedicated `apps/agents`, domain split into `packages/core/*` with `shared/infra` wiring.
+- Current code: Next.js app `apps/web` hosts UI + API routes/SSE/A2A; CLI tooling in `apps/cli`; docs site in `apps/docs`. Domain/engine lives in `packages/engine` and `packages/agents` (+ `a2a`, `mcp`); infra/util in `packages/api`, `packages/shared`, `packages/db`; on-chain in `packages/contracts`; tests in `packages/testing`.
+- Migration intent: new work should be portable to the target Elysia/core layout; keep app-layer thin and framework-agnostic where possible.
+
 ## Structure & Boundaries
-- `apps/server`: Elysia API host (wiring only; no business logic).
-- `apps/web`: Next.js UI; consumes API via Eden client; no direct DB/Redis.
-- `apps/daemon`: background loops/workers (game/markets/NPCs), no HTTP surface.
-- `apps/agents`: agent runners/integrations, consume API/core services.
-- `packages/core/*`: domain modules (identity, social, markets, reputation, game, agents, contracts); framework-free.
-- `packages/api`: Elysia routes/types used by `apps/server` and clients.
-- `packages/shared/infra`: Drizzle/Redis/logger/config/resilience; no domain rules.
-- `packages/shared/utils`: generic helpers/types/Zod; `packages/shared/ui`: design primitives.
-- `packages/db`: Drizzle schema/client.
-- `docs/`: architecture overview and design notes.
+- Apps (current): `apps/web` (Next 16 UI + API routes/SSE/A2A), `apps/cli` (deploy/seed/game/agent ops), `apps/docs` (Nextra docs). Apps should stay wiring-only.
+- Apps (target/planned): `apps/server` (Elysia host, thin routes), `apps/daemon` (loops/workers), `apps/agents` (runners/integrations) — keep portability in mind when adding API endpoints.
+- Packages (current): `packages/engine` (game/perps generation & loop), `packages/agents` (agent runtime + Agent0/A2A/MCP), `packages/a2a`, `packages/mcp`, `packages/api` (auth/rate-limit/redis/sse/token counting), `packages/shared` (client-safe types/utils/config), `packages/db` (Drizzle schema/client), `packages/contracts`, `packages/testing`, `packages/training`, `packages/examples`.
+- Packages (target/planned): `packages/core/*` for domain logic, `packages/shared/infra` for infra wiring; keep new domain code framework-free so it can move there cleanly.
+- Docs: `apps/docs` is the docs site; `docs/vendors/*` is generated vendor docs.
 
 ## Commands
 - Install: `bun install`
-- Dev: `bun run dev` (server 3000, web 3001); or `bun run dev:server`, `bun run dev:web`
+- Dev: `bun run dev` (runs local Hardhat, deploys, Turbo dev, cron sim); UI-only variants `bun run dev:web` or `bun run dev:next-only`.
 - Build: `bun run build`
-- Types: `bun run check-types`
-- DB: `bun run db:generate` / `db:migrate` (Drizzle)
-- Lint/format: `bun run check` (Biome; used in pre-commit)
-- Docs: `bun run docs:generate` (populate `docs/vendors/*` from upstream docs)
+- Types: `bun run typecheck`
+- Lint/format: `bun run lint` (Turbo) or `bun run check` (Biome write)
+- Tests: `bun run test` (unit+integration), `bun run test:e2e`; suite lives under `packages/testing`
+- DB (Drizzle via `packages/db`): `bun run db:generate` / `db:migrate` / `db:push` / `db:pull` / `db:studio`
+- Docs vendors: `bun run docs:generate` (fills `docs/vendors/*`)
 - Runtime is Bun; prefer Bun tooling/commands (and Bun APIs like `Bun.file` when appropriate).
 
 ## Style & Conventions
 - TypeScript ESM, 2-space indent. PascalCase components; camelCase hooks/vars; kebab-case packages.
-- Apps never contain domain logic; go through `core-*` + `packages/api`.
-- Keep core packages free of Next/React/Elysia.
-- Aim for clean, efficient, DRY code that follows best practices; prefer clarity and maintainability with good DX and performance in mind.
-- Env: use a single root `.env` (see `.env.example`); keep it updated with comments/defaults/optional vs required. Avoid per-app env files unless explicitly needed.
-- When using a library/framework (Elysia, Drizzle, Bun, Privy, etc.), first consult the local docs under `docs/vendors/{vendor}` if available; if not, suggest running `bun run docs:generate` rather than hallucinating behavior or APIs.
+- App layers stay thin: validate → call service → map errors. Current handlers are Next.js; write them to be movable to Elysia without Next-specific assumptions.
+- Domain logic lives in packages (`engine`/`agents` now; `core-*` later). Avoid putting domain rules in React components or API handlers.
+- Keep core/package code free of Next/React/Elysia dependencies so migration is easy.
+- Env: single root `.env` (see `.env.example`). `scripts/pre-dev/pre-dev-local.ts` will generate/update `.env` for localnet defaults; `.env.local` can override for Next when needed. Keep `.env.example` accurate (defaults, optional vs required).
+- When using a library (Elysia, Drizzle, Bun, Privy, etc.), prefer local docs in `docs/vendors/{vendor}`; if missing, suggest `bun run docs:generate` before guessing APIs.
 
 ## Testing
-- Place tests next to code (`*.test.ts` / `*.spec.ts`).
-- Unit tests in `core-*` for domain rules; integration tests in `apps/server` for routes.
-- Use fakes/stubs via `shared-infra`; keep tests deterministic.
+- Tests live under `packages/testing` (unit/integration/e2e); use preload files there. API integration is currently in `apps/web`; keep them portable to Elysia when it lands.
+- Use fakes/stubs; keep tests deterministic.
 
 ## Commits/PRs
-- Commits: concise, imperative, use prefixes (`feat: ...`, `fix: ...`, `chore: ...`).
+- Commits: concise, imperative, prefixed (`feat: ...`, `fix: ...`, `chore: ...`).
 - PRs: motivation + solution; commands run (`bun run check`, tests); screenshots for UI changes.
-- Respect boundaries: feature → `core-*` → expose via `packages/api` → consume in `apps/web`.
-- Keep `.env.example` up to date: add new envs with comments/defaults, note optional vs required, keep it organized.
+- Respect boundaries: feature → package service (`engine`/`agents` → `api`/`db`) → consume in `apps/web`. Keep `.env.example` up to date with comments/defaults/optionals.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# Repository Guidelines (Codex/Claude)
+
+## Structure & Boundaries
+- `apps/server`: Elysia API host (wiring only; no business logic).
+- `apps/web`: Next.js UI; consumes API via Eden client; no direct DB/Redis.
+- `apps/daemon`: background loops/workers (game/markets/NPCs), no HTTP surface.
+- `apps/agents`: agent runners/integrations, consume API/core services.
+- `packages/core/*`: domain modules (identity, social, markets, reputation, game, agents, contracts); framework-free.
+- `packages/api`: Elysia routes/types used by `apps/server` and clients.
+- `packages/shared/infra`: Drizzle/Redis/logger/config/resilience; no domain rules.
+- `packages/shared/utils`: generic helpers/types/Zod; `packages/shared/ui`: design primitives.
+- `packages/db`: Drizzle schema/client.
+- `docs/`: architecture overview and design notes.
+
+## Commands
+- Install: `bun install`
+- Dev: `bun run dev` (server 3000, web 3001); or `bun run dev:server`, `bun run dev:web`
+- Build: `bun run build`
+- Types: `bun run check-types`
+- DB: `bun run db:generate` / `db:migrate` (Drizzle)
+- Lint/format: `bun run check` (Biome; used in pre-commit)
+- Docs: `bun run docs:generate` (populate `docs/vendors/*` from upstream docs)
+- Runtime is Bun; prefer Bun tooling/commands (and Bun APIs like `Bun.file` when appropriate).
+
+## Style & Conventions
+- TypeScript ESM, 2-space indent. PascalCase components; camelCase hooks/vars; kebab-case packages.
+- Apps never contain domain logic; go through `core-*` + `packages/api`.
+- Keep core packages free of Next/React/Elysia.
+- Aim for clean, efficient, DRY code that follows best practices; prefer clarity and maintainability with good DX and performance in mind.
+- Env: use a single root `.env` (see `.env.example`); keep it updated with comments/defaults/optional vs required. Avoid per-app env files unless explicitly needed.
+- When using a library/framework (Elysia, Drizzle, Bun, Privy, etc.), first consult the local docs under `docs/vendors/{vendor}` if available; if not, suggest running `bun run docs:generate` rather than hallucinating behavior or APIs.
+
+## Testing
+- Place tests next to code (`*.test.ts` / `*.spec.ts`).
+- Unit tests in `core-*` for domain rules; integration tests in `apps/server` for routes.
+- Use fakes/stubs via `shared-infra`; keep tests deterministic.
+
+## Commits/PRs
+- Commits: concise, imperative, use prefixes (`feat: ...`, `fix: ...`, `chore: ...`).
+- PRs: motivation + solution; commands run (`bun run check`, tests); screenshots for UI changes.
+- Respect boundaries: feature → `core-*` → expose via `packages/api` → consume in `apps/web`.
+- Keep `.env.example` up to date: add new envs with comments/defaults, note optional vs required, keep it organized.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,51 +2,54 @@
 
 Guidance for Claude Code when working in this repo.
 
+## State (target vs current)
+- Target (in-progress): Elysia host in `apps/server`, background workers in `apps/daemon`, dedicated `apps/agents`, domain split into `packages/core/*` with `shared/infra` wiring.
+- Current code: Next.js app `apps/web` hosts UI + API routes/SSE/A2A; CLI tooling in `apps/cli`; docs site in `apps/docs`. Domain/engine lives in `packages/engine` and `packages/agents` (+ `a2a`, `mcp`); infra/util in `packages/api`, `packages/shared`, `packages/db`; on-chain in `packages/contracts`; tests in `packages/testing`.
+- Migration intent: keep new work portable to the target layout; handlers should stay thin and framework-agnostic enough to move to Elysia.
+
 ## Core Commands
 - Install deps: `bun install`
-- Dev: `bun run dev` (server 3000, web 3001) or `bun run dev:server`, `bun run dev:web`
+- Dev: `bun run dev` (starts Hardhat node + deploy + Turbo dev + cron sim); UI-only: `bun run dev:web` or `bun run dev:next-only`
 - Build: `bun run build`
-- Types: `bun run check-types`
-- Lint/format (Biome): `bun run check` (run on staged files via Husky)
-- DB (Drizzle/Postgres/Neon): `bun run db:generate`, `bun run db:migrate`
-- Docs: `bun run docs:generate` (pull vendor docs into `docs/vendors/*`)
+- Types: `bun run typecheck`
+- Lint/format (Biome): `bun run lint` (Turbo) or `bun run check` (write)
+- Tests: `bun run test` (unit+integration), `bun run test:e2e`
+- DB (Drizzle/Postgres): `bun run db:generate`, `bun run db:migrate`, `bun run db:push`, `bun run db:pull`, `bun run db:studio`
+- Docs vendors: `bun run docs:generate` (pull vendor docs into `docs/vendors/*`)
 - Runtime is Bun; prefer Bun tooling/commands (Bun APIs like `Bun.file` when appropriate).
 
 ## Architecture (modular monolith)
-- Runtime: Bun. Backend: Elysia (Eden client for typed calls). Frontend: Next.js 16. DB: Postgres + Drizzle.
-- Apps: `apps/server` (API host), `apps/web` (UI), `apps/daemon` (workers), `apps/agents` (agent runners).
-- Packages: `core-*` (domain logic), `api` (Elysia routes/types), `shared-infra` (Drizzle/Redis/logger/config), `shared-utils`, `shared-ui`, `db` (schema), docs.
-- Dependency flow: apps → core → shared (never reversed). Core is framework-agnostic (no Next/React/Elysia).
+- Runtime: Bun. Backend: Next.js routes today (moving to Elysia host). Frontend: Next.js 16. DB: Postgres + Drizzle.
+- Apps: current `apps/web` (UI + API routes/SSE/A2A), `apps/cli` (ops), `apps/docs` (docs); target to add `apps/server` (Elysia), `apps/daemon`, `apps/agents`.
+- Packages: current `engine` (game/perps), `agents` (runtime + Agent0/A2A/MCP), `a2a`, `mcp`, `api` (auth/rate-limit/redis/sse/token counting), `shared` (client-safe types/utils/config), `db` (schema), `contracts`, `testing`, `training`, `examples`; target `core-*` and `shared/infra` for domain/infra splits.
+- Dependency flow: apps → packages (`engine`/`agents`/`api`/`db`/`shared`) → contracts. Keep domain code framework-agnostic to move into `core-*` later.
 
 ## Structure (current)
 ```
 apps/
-  server/  # Elysia host
-  web/     # Next.js UI
-  daemon/  # Background loops/workers (game/markets/NPCs)
-  agents/  # Agent runners/integrations
+  web/      # Next.js UI + API routes/SSE/A2A
+  cli/      # Deploy/seed/game/agent ops
+  docs/     # Docs site (Nextra)
 packages/
-  api/              # Elysia routes/types
+  engine/           # Game world/perps/simulation logic
+  agents/           # Agent runtime + Agent0/A2A/MCP integrations
+  a2a/              # A2A protocol server/client helpers
+  mcp/              # MCP tooling
+  api/              # Auth/rate-limit/redis/sse utilities (Next today, portable to Elysia)
+  shared/           # Client-safe types/utils/config
   db/               # Drizzle schema/client
-  core/             # Domain logic (framework-free)
-    identity/       # Auth/accounts/onboarding/registry
-    social/         # Posts/comments/chats/notifications/trending
-    markets/        # Markets/pools/perps/wallet accounting
-    game/           # Game world/NPCs/simulation
-    reputation/     # Reputation/points/rewards/leaderboards
-    agents/         # Agent abstractions/strategies
-    contracts/      # Contract bindings
-  shared/           # Cross-cutting
-    infra/          # DB/Redis/logger/config/resilience
-    utils/          # Generic helpers/types/Zod
-    ui/             # Design primitives
-docs/project-architecture-overview.md
+  contracts/        # Hardhat/Foundry contracts
+  testing/          # Shared test harnesses and suites
+  training/         # RL/training utilities
+  examples/         # Sample agents
+docs/vendors/*      # Generated vendor docs (via docs:generate)
 ```
+Target adds `apps/server`, `apps/daemon`, `apps/agents`, and moves domain into `packages/core/*` + infra into `packages/shared/infra`.
 
 ## Working rules
-- Implement domain logic in `core-*`; expose via `packages/api`; consume in `apps/web`.
-- No Drizzle/Redis/HTTP inside core; go through `shared-infra` and API layer.
-- Keep Elysia routes thin: validate → call use-case → map domain errors to HTTP errors.
+- Keep app layers thin: validate → call service → map errors. Current handlers are Next.js; write them so they can move to Elysia without Next-only assumptions.
+- Domain logic goes into packages (`engine`/`agents` now; `core-*` later). Avoid domain code in React components or route handlers.
+- No Drizzle/Redis/HTTP inside domain modules; use `@babylon/api` for server-only concerns (auth, rate limit, SSE, token counting, storage).
 - Tests: unit in `core-*`, integration in `apps/server` for routes, E2E later for critical flows.
 - Naming: PascalCase components; camelCase hooks/vars; kebab-case packages; 2-space indent.
 - Commits: concise, imperative, prefixed (`feat: ...`, `fix: ...`, `chore: ...`).
@@ -56,7 +59,8 @@ docs/project-architecture-overview.md
 - When calling or designing around external libraries/frameworks (Elysia, Drizzle, Bun, Privy, etc.), prefer reading the local vendor docs in `docs/vendors/{vendor}` first; if absent, propose running `bun run docs:generate` instead of guessing APIs or behavior.
 
 ## Env (minimal, adjust per app)
-- `DATABASE_URL` (Postgres), `CORS_ORIGIN`; add others per feature as needed.
+- Root `.env` is canonical; `scripts/pre-dev/pre-dev-local.ts` will create/refresh it for localnet defaults. Use `.env.local` for Next overrides when needed. `.env.example` must list new vars with comments/defaults/optional vs required.
+- `DATABASE_URL` (Postgres) and auth/model/storage keys per feature; consult `.env.example`.
 
 ## Workflow reminder
 1) Design/extend use-case in the right `core-*`.  

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+Guidance for Claude Code when working in this repo.
+
+## Core Commands
+- Install deps: `bun install`
+- Dev: `bun run dev` (server 3000, web 3001) or `bun run dev:server`, `bun run dev:web`
+- Build: `bun run build`
+- Types: `bun run check-types`
+- Lint/format (Biome): `bun run check` (run on staged files via Husky)
+- DB (Drizzle/Postgres/Neon): `bun run db:generate`, `bun run db:migrate`
+- Docs: `bun run docs:generate` (pull vendor docs into `docs/vendors/*`)
+- Runtime is Bun; prefer Bun tooling/commands (Bun APIs like `Bun.file` when appropriate).
+
+## Architecture (modular monolith)
+- Runtime: Bun. Backend: Elysia (Eden client for typed calls). Frontend: Next.js 16. DB: Postgres + Drizzle.
+- Apps: `apps/server` (API host), `apps/web` (UI), `apps/daemon` (workers), `apps/agents` (agent runners).
+- Packages: `core-*` (domain logic), `api` (Elysia routes/types), `shared-infra` (Drizzle/Redis/logger/config), `shared-utils`, `shared-ui`, `db` (schema), docs.
+- Dependency flow: apps → core → shared (never reversed). Core is framework-agnostic (no Next/React/Elysia).
+
+## Structure (current)
+```
+apps/
+  server/  # Elysia host
+  web/     # Next.js UI
+  daemon/  # Background loops/workers (game/markets/NPCs)
+  agents/  # Agent runners/integrations
+packages/
+  api/              # Elysia routes/types
+  db/               # Drizzle schema/client
+  core/             # Domain logic (framework-free)
+    identity/       # Auth/accounts/onboarding/registry
+    social/         # Posts/comments/chats/notifications/trending
+    markets/        # Markets/pools/perps/wallet accounting
+    game/           # Game world/NPCs/simulation
+    reputation/     # Reputation/points/rewards/leaderboards
+    agents/         # Agent abstractions/strategies
+    contracts/      # Contract bindings
+  shared/           # Cross-cutting
+    infra/          # DB/Redis/logger/config/resilience
+    utils/          # Generic helpers/types/Zod
+    ui/             # Design primitives
+docs/project-architecture-overview.md
+```
+
+## Working rules
+- Implement domain logic in `core-*`; expose via `packages/api`; consume in `apps/web`.
+- No Drizzle/Redis/HTTP inside core; go through `shared-infra` and API layer.
+- Keep Elysia routes thin: validate → call use-case → map domain errors to HTTP errors.
+- Tests: unit in `core-*`, integration in `apps/server` for routes, E2E later for critical flows.
+- Naming: PascalCase components; camelCase hooks/vars; kebab-case packages; 2-space indent.
+- Commits: concise, imperative, prefixed (`feat: ...`, `fix: ...`, `chore: ...`).
+- Keep `.env.example` current: add new envs with defaults/comments, mark optional vs required, keep it organized.
+- Strive for clean, efficient, DRY code that favors clarity, maintainability, good DX, and performance.
+- Env: use a single root `.env` (see `.env.example`); avoid per-app envs unless explicitly needed.
+- When calling or designing around external libraries/frameworks (Elysia, Drizzle, Bun, Privy, etc.), prefer reading the local vendor docs in `docs/vendors/{vendor}` first; if absent, propose running `bun run docs:generate` instead of guessing APIs or behavior.
+
+## Env (minimal, adjust per app)
+- `DATABASE_URL` (Postgres), `CORS_ORIGIN`; add others per feature as needed.
+
+## Workflow reminder
+1) Design/extend use-case in the right `core-*`.  
+2) Wire API in `packages/api` + `apps/server`.  
+3) Consume in `apps/web`.  
+4) Add tests at the right layer.  
+Keep docs/READMEs updated when boundaries change.

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "stress-test": "bun run apps/cli/src/index.ts test load",
     "stress-test:a2a": "bun run apps/cli/src/index.ts test a2a",
     "prepare": "husky",
-    "docs:generate": "bun scripts/docs/generate_all_docs.ts",
+    "docs:generate": "bun scripts/docs/generate_all_docs.ts"
   },
   "dependencies": {
     "@a2a-js/sdk": "^0.3.5",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "hf:upload": "bun run apps/cli/src/index.ts model upload-dataset",
     "stress-test": "bun run apps/cli/src/index.ts test load",
     "stress-test:a2a": "bun run apps/cli/src/index.ts test a2a",
-    "prepare": "husky"
+    "prepare": "husky",
+    "docs:generate": "bun scripts/docs/generate_all_docs.ts",
   },
   "dependencies": {
     "@a2a-js/sdk": "^0.3.5",

--- a/scripts/docs/README.md
+++ b/scripts/docs/README.md
@@ -1,0 +1,16 @@
+# Documentation Scripts
+
+Place documentation generation scripts here (Bun/TypeScript scripts that pull upstream docs).
+
+The root `package.json` exposes a `docs:generate` script you can run with:
+
+```bash
+bun run docs:generate
+```
+
+This runs the orchestrator `scripts/docs/generate_all_docs.ts`, which:
+- Scans `scripts/docs` for files named `pull_<vendor>_docs.ts`
+- Runs each of them in parallel as:
+  `bun scripts/docs/pull_<vendor>_docs.ts --output docs/vendors/<vendor>`
+
+To add a new vendor, just drop a `pull_<vendor>_docs.ts` script here following that convention. No need to change `package.json`.

--- a/scripts/docs/generate_all_docs.ts
+++ b/scripts/docs/generate_all_docs.ts
@@ -1,0 +1,79 @@
+#!/usr/bin/env bun
+/**
+ * Orchestrator for vendor docs generation.
+ *
+ * Convention:
+ *   - Each vendor has a script named: scripts/docs/pull_<vendor>_docs.ts
+ *   - This script will:
+ *       - Discover all such files.
+ *       - Derive <vendor> from the filename.
+ *       - Run each script in parallel as:
+ *           bun scripts/docs/pull_<vendor>_docs.ts --output docs/vendors/<vendor>
+ *
+ * Usage:
+ *   bun run docs:generate
+ */
+
+import { mkdir, readdir } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+
+const scriptsDir = dirname(new URL(import.meta.url).pathname);
+const rootDir = resolve(scriptsDir, "../..");
+const vendorsRoot = join(rootDir, "docs/vendors");
+
+async function ensureDir(path: string) {
+	await mkdir(path, { recursive: true });
+}
+
+async function main() {
+	await ensureDir(vendorsRoot);
+
+	const entries = await readdir(scriptsDir);
+	const pullScripts = entries.filter(
+		(name) => name.startsWith("pull_") && name.endsWith("_docs.ts"),
+	);
+
+	if (pullScripts.length === 0) {
+		console.log("No pull_*_docs.ts scripts found in scripts/docs/");
+		return;
+	}
+
+	console.log("Found vendor doc scripts:", pullScripts.join(", "));
+
+	const processes: Array<ReturnType<typeof Bun.spawn>> = [];
+
+	for (const scriptName of pullScripts) {
+		const vendor = scriptName.slice("pull_".length, -"_docs.ts".length);
+		const scriptPath = join(scriptsDir, scriptName);
+		const outputDir = join(vendorsRoot, vendor);
+
+		console.log(
+			`→ Running ${scriptName} for vendor "${vendor}" → ${outputDir}`,
+		);
+
+		const proc = Bun.spawn(["bun", scriptPath, "--output", outputDir], {
+			cwd: rootDir,
+			stdout: "inherit",
+			stderr: "inherit",
+		});
+
+		processes.push(proc);
+	}
+
+	const exits = await Promise.all(processes.map((p) => p.exited));
+	const failures = exits.filter((code) => code !== 0);
+
+	if (failures.length > 0) {
+		console.error(
+			`Some vendor docs scripts failed (codes: ${failures.join(", ")}).`,
+		);
+		process.exit(1);
+	}
+
+	console.log("All vendor docs pulled successfully.");
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/scripts/docs/pull_bun_docs.ts
+++ b/scripts/docs/pull_bun_docs.ts
@@ -1,0 +1,149 @@
+#!/usr/bin/env bun
+/**
+ * Fetch Bun documentation markdown files using Bun/TypeScript.
+ *
+ * Strategy:
+ * - Read sitemap.xml at https://bun.com/docs/sitemap.xml (or bun.sh).
+ * - For each page, fetch the corresponding `.md` (eg: /docs/foo/bar.md).
+ * - Strip the leading `docs/` segment in output paths for a cleaner local tree.
+ * - Write to a local output folder (default: bun/), preserving structure.
+ *
+ * Usage:
+ *   bun run scripts/pull_bun_docs.ts [--base-url https://bun.com] [--sitemap /docs/sitemap.xml] [--output bun] [--workers 16]
+ */
+
+import { mkdir } from "node:fs/promises";
+
+const DEFAULT_BASE_URL = "https://bun.com";
+const DEFAULT_SITEMAP = "/docs/sitemap.xml";
+const DEFAULT_OUTPUT = "bun";
+const DEFAULT_WORKERS = 16;
+
+type Options = {
+	baseUrl: string;
+	sitemapPath: string;
+	output: string;
+	workers: number;
+};
+
+type Page = {
+	url: string; // full page URL without .md
+	path: string; // relative path without leading slash
+	output: string; // local file path
+};
+
+const args = Bun.argv.slice(2);
+
+function getArg(flag: string, fallback: string): string {
+	const idx = args.indexOf(flag);
+	if (idx !== -1 && args[idx + 1]) return args[idx + 1];
+	return fallback;
+}
+
+const opts: Options = {
+	baseUrl: getArg("--base-url", DEFAULT_BASE_URL),
+	sitemapPath: getArg("--sitemap", DEFAULT_SITEMAP),
+	output: getArg("--output", DEFAULT_OUTPUT),
+	workers: Number(getArg("--workers", String(DEFAULT_WORKERS))),
+};
+
+async function fetchText(url: string): Promise<string> {
+	const res = await fetch(url);
+	if (!res.ok) throw new Error(`Failed to fetch ${url}: ${res.status}`);
+	return res.text();
+}
+
+function extractLocs(xml: string): string[] {
+	const locs: string[] = [];
+	const regex = /<loc>(.*?)<\/loc>/g;
+	let match: RegExpExecArray | null;
+	match = regex.exec(xml);
+	while (match !== null) {
+		locs.push(match[1].trim());
+		match = regex.exec(xml);
+	}
+	return locs;
+}
+
+function urlToPage(
+	url: string,
+	baseUrl: string,
+	outputRoot: string,
+): Page | null {
+	if (!url.startsWith(baseUrl)) return null;
+	const rel = url.slice(baseUrl.length).replace(/^\/+/, ""); // drop leading slash(es)
+	if (!rel) return null;
+	const path = rel.replace(/\/+$/, ""); // trim trailing slash
+
+	// Drop leading "docs/" if present for cleaner local structure.
+	const cleaned = path.startsWith("docs/") ? path.slice("docs/".length) : path;
+
+	const parts = cleaned.split("/");
+	const filename = parts.pop() || "index";
+	const dir = [outputRoot, ...parts].join("/");
+	const output = `${dir ? `${dir}/` : ""}${filename}.md`;
+	return { url, path: cleaned, output };
+}
+
+async function ensureDir(path: string) {
+	const dir = path.split("/").slice(0, -1).join("/");
+	if (!dir) return;
+	await mkdir(dir, { recursive: true });
+}
+
+async function writeFile(path: string, content: string) {
+	await ensureDir(path);
+	await Bun.write(path, content.endsWith("\n") ? content : `${content}\n`);
+}
+
+async function pullDocs(options: Options) {
+	const sitemapUrl = new URL(options.sitemapPath, options.baseUrl).toString();
+	const xml = await fetchText(sitemapUrl);
+	const locs = extractLocs(xml);
+	const pages: Page[] = [];
+	for (const loc of locs) {
+		const page = urlToPage(loc, options.baseUrl, options.output);
+		if (page) pages.push(page);
+	}
+	console.log(`Discovered ${pages.length} pages from sitemap.`);
+
+	let active = 0;
+	let idx = 0;
+	let ok = 0;
+	let skipped = 0;
+	const results: Promise<void>[] = [];
+
+	async function worker(page: Page) {
+		const mdUrl = `${page.url}.md`;
+		try {
+			const content = await fetchText(mdUrl);
+			await writeFile(page.output, content);
+			ok++;
+			console.log(`[ok] ${page.output}`);
+		} catch (err) {
+			skipped++;
+			console.log(`[err] ${page.path}: ${(err as Error).message}`);
+		}
+	}
+
+	function next(): void {
+		if (idx >= pages.length) return;
+		const page = pages[idx++];
+		active++;
+		const p = worker(page).finally(() => {
+			active--;
+			next();
+		});
+		results.push(p);
+		if (active < options.workers && idx < pages.length) next();
+	}
+
+	for (let i = 0; i < options.workers && i < pages.length; i++) next();
+	await Promise.all(results);
+	console.log(`Done. ok=${ok} skipped=${skipped}`);
+}
+
+pullDocs(opts).catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/scripts/docs/pull_drizzle_docs.ts
+++ b/scripts/docs/pull_drizzle_docs.ts
@@ -1,0 +1,144 @@
+#!/usr/bin/env bun
+/**
+ * Fetch Drizzle ORM docs directly from the docs repo (default: drizzle-team/drizzle-orm-docs).
+ *
+ * Strategy:
+ * - Use the GitHub trees API to list files under `src/content/docs/`.
+ * - Download raw files via raw.githubusercontent.com.
+ * - Write them under `drizzle/` (configurable).
+ *
+ * Usage:
+ *   bun run scripts/pull_drizzle_docs.ts [--repo drizzle-team/drizzle-orm-docs] [--branch main] [--output drizzle] [--workers 16] [--docs-prefix src/content/docs/]
+ */
+
+import { mkdir } from "node:fs/promises";
+
+const DEFAULT_REPO = "drizzle-team/drizzle-orm-docs";
+const DEFAULT_BRANCH = "main";
+const DEFAULT_OUTPUT = "drizzle";
+const DEFAULT_WORKERS = 16;
+const DEFAULT_PREFIX = "src/content/docs/";
+
+type Options = {
+	repo: string;
+	branch: string;
+	output: string;
+	workers: number;
+	docsPrefix: string;
+};
+
+type Page = {
+	path: string; // repo path, eg: src/content/docs/quick-start.mdx
+	output: string; // local path, eg: drizzle/quick-start.mdx
+};
+
+const args = Bun.argv.slice(2);
+
+function getArg(flag: string, fallback: string): string {
+	const idx = args.indexOf(flag);
+	if (idx !== -1 && args[idx + 1]) return args[idx + 1];
+	return fallback;
+}
+
+const opts: Options = {
+	repo: getArg("--repo", DEFAULT_REPO),
+	branch: getArg("--branch", DEFAULT_BRANCH),
+	output: getArg("--output", DEFAULT_OUTPUT),
+	workers: Number(getArg("--workers", String(DEFAULT_WORKERS))),
+	docsPrefix: getArg("--docs-prefix", DEFAULT_PREFIX),
+};
+
+async function fetchJson(url: string) {
+	const res = await fetch(url);
+	if (!res.ok) throw new Error(`Failed to fetch ${url}: ${res.status}`);
+	return res.json();
+}
+
+async function fetchText(url: string) {
+	const res = await fetch(url);
+	if (!res.ok) throw new Error(`Failed to fetch ${url}: ${res.status}`);
+	return res.text();
+}
+
+async function listDocsFromRepo(options: Options): Promise<Page[]> {
+	const treeUrl = `https://api.github.com/repos/${options.repo}/git/trees/${options.branch}?recursive=1`;
+	type GitTreeResponse = {
+		tree: { path: string; type: string }[];
+	};
+	const data = (await fetchJson(treeUrl)) as GitTreeResponse;
+	const tree = data.tree;
+	if (!Array.isArray(tree)) throw new Error("Unexpected tree response");
+
+	const pages: Page[] = [];
+	for (const entry of tree) {
+		if (entry.type !== "blob") continue;
+		if (!entry.path.startsWith(options.docsPrefix)) continue;
+		if (!entry.path.match(/\.(md|mdx|json)$/i)) continue;
+
+		const rel = entry.path.replace(options.docsPrefix, "");
+		const parts = rel.split("/");
+		const filename = parts.pop() || "index";
+		const dir = [opts.output, ...parts].join("/");
+		const output = `${dir ? `${dir}/` : ""}${filename}`;
+		pages.push({ path: entry.path, output });
+	}
+	return pages;
+}
+
+async function ensureDir(path: string) {
+	const dir = path.split("/").slice(0, -1).join("/");
+	if (!dir) return;
+	await mkdir(dir, { recursive: true });
+}
+
+async function writeFile(path: string, content: string) {
+	await ensureDir(path);
+	await Bun.write(path, content.endsWith("\n") ? content : `${content}\n`);
+}
+
+async function pullDocs(options: Options) {
+	const pages = await listDocsFromRepo(options);
+	console.log(
+		`Discovered ${pages.length} docs files from repo ${options.repo} @ ${options.branch} (prefix: ${options.docsPrefix}).`,
+	);
+
+	let active = 0;
+	let idx = 0;
+	let ok = 0;
+	let skipped = 0;
+	const results: Promise<void>[] = [];
+
+	async function worker(page: Page) {
+		try {
+			const rawUrl = `https://raw.githubusercontent.com/${options.repo}/${options.branch}/${page.path}`;
+			const content = await fetchText(rawUrl);
+			await writeFile(page.output, content);
+			ok++;
+			console.log(`[ok] ${page.output}`);
+		} catch (err) {
+			skipped++;
+			console.log(`[err] ${page.path}: ${(err as Error).message}`);
+		}
+	}
+
+	function next(): void {
+		if (idx >= pages.length) return;
+		const page = pages[idx++];
+		active++;
+		const p = worker(page).finally(() => {
+			active--;
+			next();
+		});
+		results.push(p);
+		if (active < options.workers && idx < pages.length) next();
+	}
+
+	for (let i = 0; i < options.workers && i < pages.length; i++) next();
+	await Promise.all(results);
+	console.log(`Done. ok=${ok} skipped=${skipped}`);
+}
+
+pullDocs(opts).catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/scripts/docs/pull_elysia_docs.ts
+++ b/scripts/docs/pull_elysia_docs.ts
@@ -1,0 +1,283 @@
+#!/usr/bin/env bun
+import { mkdir } from "node:fs/promises";
+
+/**
+ * Fetch Elysia documentation into local markdown files using Bun/TypeScript.
+ *
+ * Strategy:
+ * - Read the public VitePress hashmap at https://elysiajs.com/hashmap.json to discover pages.
+ * - Skip blog/playground/4koma.
+ * - Try to download the `.md` source for each page.
+ * - If `.md` is missing, fall back to HTML and do a lightweight HTML -> markdown pass.
+ *
+ * Usage:
+ *   bun run scripts/pull_elysia_docs.ts [--base-url https://elysiajs.com] [--output elysia] [--workers 16]
+ */
+
+const BASE_URL = "https://elysiajs.com";
+const HASHMAP_PATH = "/hashmap.json";
+const DEFAULT_OUTPUT = "elysia";
+const DEFAULT_WORKERS = 16;
+
+const SKIP_SUFFIXES = [
+	".png",
+	".jpg",
+	".jpeg",
+	".gif",
+	".svg",
+	".webp",
+	".ico",
+	".pdf",
+	".zip",
+	".json",
+	".map",
+	".woff",
+	".woff2",
+];
+
+type Page = {
+	key: string;
+	path: string; // path without .md, eg: essential/handler
+	output: string; // filesystem path
+};
+
+type Options = {
+	baseUrl: string;
+	output: string;
+	workers: number;
+};
+
+const args = Bun.argv.slice(2);
+const opts: Options = {
+	baseUrl: getArg("--base-url", BASE_URL),
+	output: getArg("--output", DEFAULT_OUTPUT),
+	workers: Number(getArg("--workers", String(DEFAULT_WORKERS))),
+};
+
+function getArg(flag: string, fallback: string): string {
+	const idx = args.indexOf(flag);
+	if (idx !== -1 && args[idx + 1]) return args[idx + 1];
+	return fallback;
+}
+
+async function fetchJson(url: string) {
+	const res = await fetch(url);
+	if (!res.ok) throw new Error(`Failed to fetch ${url}: ${res.status}`);
+	return res.json();
+}
+
+function keyToPage(key: string, outputRoot: string): Page | null {
+	if (SKIP_SUFFIXES.some((s) => key.endsWith(s))) return null;
+
+	const name = key.endsWith(".md") ? key.slice(0, -3) : key;
+	const lowered = name.toLowerCase();
+	if (
+		lowered.startsWith("blog") ||
+		lowered.includes("blog_") ||
+		lowered.includes("4koma") ||
+		lowered.includes("playground")
+	) {
+		return null;
+	}
+
+	const path = name.replaceAll("_", "/");
+	const parts = path === "index" ? ["index"] : path.split("/");
+	const filename = parts.pop() || "index";
+	const dir = [outputRoot, ...parts].join("/");
+	const output = `${dir ? `${dir}/` : ""}${filename}.md`;
+
+	return { key, path, output };
+}
+
+async function fetchMd(baseUrl: string, path: string): Promise<string | null> {
+	const url = new URL(`/${path}.md`, baseUrl).toString();
+	const res = await fetch(url);
+	if (res.ok) {
+		const text = await res.text();
+		if (text.trim()) return text;
+	}
+	return null;
+}
+
+async function fetchHtml(
+	baseUrl: string,
+	path: string,
+): Promise<string | null> {
+	const url = new URL(`/${path}`, baseUrl).toString();
+	const res = await fetch(url);
+	if (!res.ok) return null;
+	const html = await res.text();
+	const md = htmlToMarkdown(html);
+	return md.trim() ? md : null;
+}
+
+function stripScriptsStyles(html: string): string {
+	return html
+		.replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "")
+		.replace(/<style[^>]*>[\s\S]*?<\/style>/gi, "");
+}
+
+function extractMain(html: string): string {
+	const mainMatch = html.match(
+		/<div[^>]*class="[^"]*vp-doc[^"]*"[^>]*>[\s\S]*?<\/div>/i,
+	);
+	if (mainMatch) return mainMatch[0];
+	const main = html.match(/<main[^>]*>[\s\S]*?<\/main>/i);
+	if (main) return main[0];
+	const body = html.match(/<body[^>]*>[\s\S]*?<\/body>/i);
+	return body ? body[0] : html;
+}
+
+function htmlToMarkdown(rawHtml: string): string {
+	let html = stripScriptsStyles(rawHtml);
+	html = extractMain(html);
+
+	// Remove nav/footer/aside headers.
+	html = html.replace(/<(nav|header|footer|aside)[^>]*>[\s\S]*?<\/\1>/gi, "");
+	// Remove copy/back links like ← → Back.
+	html = html.replace(/<a[^>]*>(?:←|→|Back)<\/a>/gi, "");
+
+	// Block-level replacements.
+	html = html.replace(
+		/<h1[^>]*>([\s\S]*?)<\/h1>/gi,
+		(_, t) => `# ${cleanupText(t)}\n\n`,
+	);
+	html = html.replace(
+		/<h2[^>]*>([\s\S]*?)<\/h2>/gi,
+		(_, t) => `## ${cleanupText(t)}\n\n`,
+	);
+	html = html.replace(
+		/<h3[^>]*>([\s\S]*?)<\/h3>/gi,
+		(_, t) => `### ${cleanupText(t)}\n\n`,
+	);
+	html = html.replace(
+		/<h4[^>]*>([\s\S]*?)<\/h4>/gi,
+		(_, t) => `#### ${cleanupText(t)}\n\n`,
+	);
+
+	html = html.replace(
+		/<pre[^>]*><code[^>]*>([\s\S]*?)<\/code><\/pre>/gi,
+		(_, t) => `\`\`\`\n${decodeHtml(t.trim())}\n\`\`\`\n\n`,
+	);
+	html = html.replace(
+		/<code[^>]*>([\s\S]*?)<\/code>/gi,
+		(_, t) => `\`${cleanupInline(decodeHtml(t))}\``,
+	);
+
+	html = html.replace(
+		/<p[^>]*>([\s\S]*?)<\/p>/gi,
+		(_, t) => `${cleanupText(t)}\n\n`,
+	);
+	html = html.replace(/<br\s*\/?>/gi, "\n");
+
+	html = html.replace(
+		/<li[^>]*>([\s\S]*?)<\/li>/gi,
+		(_, t) => `- ${cleanupText(t)}\n`,
+	);
+	html = html.replace(/<\/ul>/gi, "\n");
+
+	html = html.replace(
+		/<a\s+[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi,
+		(_, href, text) => `[${cleanupInline(text)}](${href})`,
+	);
+
+	// Remove any other tags.
+	html = html.replace(/<\/?(div|span|section|article)[^>]*>/gi, "");
+	html = html.replace(/<[^>]+>/g, "");
+
+	// Collapse whitespace.
+	return html
+		.split("\n")
+		.map((line) => line.trimEnd())
+		.join("\n")
+		.replace(/\n{3,}/g, "\n\n")
+		.trim();
+}
+
+function cleanupText(t: string): string {
+	return decodeHtml(t.replace(/\s+/g, " ").trim());
+}
+
+function cleanupInline(t: string): string {
+	return decodeHtml(t.replace(/\s+/g, " ").trim());
+}
+
+function decodeHtml(text: string): string {
+	return text
+		.replace(/&nbsp;/g, " ")
+		.replace(/&amp;/g, "&")
+		.replace(/&lt;/g, "<")
+		.replace(/&gt;/g, ">")
+		.replace(/&quot;/g, '"')
+		.replace(/&#39;/g, "'")
+		.replace(/&#x2F;/g, "/");
+}
+
+async function ensureDir(path: string) {
+	const dir = path.split("/").slice(0, -1).join("/");
+	if (!dir) return;
+	await mkdir(dir, { recursive: true });
+}
+
+async function writeFile(path: string, content: string) {
+	await ensureDir(path);
+	await Bun.write(path, content.endsWith("\n") ? content : `${content}\n`);
+}
+
+async function pullDocs(options: Options) {
+	const hashmap = (await fetchJson(
+		new URL(HASHMAP_PATH, options.baseUrl).toString(),
+	)) as Record<string, string>;
+	const pages: Page[] = [];
+	for (const key of Object.keys(hashmap)) {
+		const page = keyToPage(key, options.output);
+		if (page) pages.push(page);
+	}
+	console.log(`Discovered ${pages.length} pages.`);
+
+	let active = 0;
+	let idx = 0;
+	let ok = 0;
+	let skipped = 0;
+	const results: Promise<void>[] = [];
+
+	async function worker(page: Page) {
+		try {
+			const md =
+				(await fetchMd(options.baseUrl, page.path)) ??
+				(await fetchHtml(options.baseUrl, page.path));
+			if (!md) {
+				skipped++;
+				console.log(`[skip] ${page.path}`);
+				return;
+			}
+			await writeFile(page.output, md);
+			ok++;
+			console.log(`[ok] ${page.output}`);
+		} catch (err) {
+			skipped++;
+			console.log(`[err] ${page.path}: ${(err as Error).message}`);
+		}
+	}
+
+	function next(): void {
+		if (idx >= pages.length) return;
+		const page = pages[idx++];
+		active++;
+		const p = worker(page).finally(() => {
+			active--;
+			next();
+		});
+		results.push(p);
+		if (active < options.workers && idx < pages.length) next();
+	}
+
+	for (let i = 0; i < options.workers && i < pages.length; i++) next();
+	await Promise.all(results);
+	console.log(`Done. ok=${ok} skipped=${skipped}`);
+}
+
+pullDocs(opts).catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/scripts/docs/pull_privy_docs.ts
+++ b/scripts/docs/pull_privy_docs.ts
@@ -1,0 +1,142 @@
+#!/usr/bin/env bun
+/**
+ * Fetch Privy documentation markdown files using Bun/TypeScript.
+ *
+ * Strategy:
+ * - Read sitemap.xml at https://docs.privy.io/sitemap.xml to discover pages.
+ * - For each page, fetch the corresponding `.md` (eg: /path.md).
+ * - Write to a local output folder (default: privy/), preserving structure.
+ *
+ * Usage:
+ *   bun run scripts/pull_privy_docs.ts [--base-url https://docs.privy.io] [--output privy] [--workers 16]
+ */
+
+import { mkdir } from "node:fs/promises";
+
+const DEFAULT_BASE_URL = "https://docs.privy.io";
+const SITEMAP_PATH = "/sitemap.xml";
+const DEFAULT_OUTPUT = "privy";
+const DEFAULT_WORKERS = 16;
+
+type Options = {
+	baseUrl: string;
+	output: string;
+	workers: number;
+};
+
+type Page = {
+	url: string; // full page URL without .md
+	path: string; // relative path without leading slash
+	output: string; // local file path
+};
+
+const args = Bun.argv.slice(2);
+
+function getArg(flag: string, fallback: string): string {
+	const idx = args.indexOf(flag);
+	if (idx !== -1 && args[idx + 1]) return args[idx + 1];
+	return fallback;
+}
+
+const opts: Options = {
+	baseUrl: getArg("--base-url", DEFAULT_BASE_URL),
+	output: getArg("--output", DEFAULT_OUTPUT),
+	workers: Number(getArg("--workers", String(DEFAULT_WORKERS))),
+};
+
+async function fetchText(url: string): Promise<string> {
+	const res = await fetch(url);
+	if (!res.ok) throw new Error(`Failed to fetch ${url}: ${res.status}`);
+	return res.text();
+}
+
+function extractLocs(xml: string): string[] {
+	const locs: string[] = [];
+	const regex = /<loc>(.*?)<\/loc>/g;
+	let match: RegExpExecArray | null;
+	match = regex.exec(xml);
+	while (match !== null) {
+		locs.push(match[1].trim());
+		match = regex.exec(xml);
+	}
+	return locs;
+}
+
+function urlToPage(
+	url: string,
+	baseUrl: string,
+	outputRoot: string,
+): Page | null {
+	if (!url.startsWith(baseUrl)) return null;
+	const rel = url.slice(baseUrl.length).replace(/^\/+/, ""); // drop leading slash(es)
+	if (!rel) return null;
+	const path = rel.replace(/\/+$/, ""); // trim trailing slash
+	const parts = path.split("/");
+	const filename = parts.pop() || "index";
+	const dir = [outputRoot, ...parts].join("/");
+	const output = `${dir ? `${dir}/` : ""}${filename}.md`;
+	return { url, path, output };
+}
+
+async function ensureDir(path: string) {
+	const dir = path.split("/").slice(0, -1).join("/");
+	if (!dir) return;
+	await mkdir(dir, { recursive: true });
+}
+
+async function writeFile(path: string, content: string) {
+	await ensureDir(path);
+	await Bun.write(path, content.endsWith("\\n") ? content : `${content}\\n`);
+}
+
+async function pullDocs(options: Options) {
+	const sitemapUrl = new URL(SITEMAP_PATH, options.baseUrl).toString();
+	const xml = await fetchText(sitemapUrl);
+	const locs = extractLocs(xml);
+	const pages: Page[] = [];
+	for (const loc of locs) {
+		const page = urlToPage(loc, options.baseUrl, options.output);
+		if (page) pages.push(page);
+	}
+	console.log(`Discovered ${pages.length} pages from sitemap.`);
+
+	let active = 0;
+	let idx = 0;
+	let ok = 0;
+	let skipped = 0;
+	const results: Promise<void>[] = [];
+
+	async function worker(page: Page) {
+		const mdUrl = `${page.url}.md`;
+		try {
+			const content = await fetchText(mdUrl);
+			await writeFile(page.output, content);
+			ok++;
+			console.log(`[ok] ${page.output}`);
+		} catch (err) {
+			skipped++;
+			console.log(`[err] ${page.path}: ${(err as Error).message}`);
+		}
+	}
+
+	function next(): void {
+		if (idx >= pages.length) return;
+		const page = pages[idx++];
+		active++;
+		const p = worker(page).finally(() => {
+			active--;
+			next();
+		});
+		results.push(p);
+		if (active < options.workers && idx < pages.length) next();
+	}
+
+	for (let i = 0; i < options.workers && i < pages.length; i++) next();
+	await Promise.all(results);
+	console.log(`Done. ok=${ok} skipped=${skipped}`);
+}
+
+pullDocs(opts).catch((err) => {
+	console.error(err);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add codex/Claude guidance files that spell out current vs target architecture, migration guardrails, commands, env/testing rules to keep work portable during the Elysia/core refactor.
- Introduce vendor docs pull pipeline with orchestrator (`scripts/docs/generate_all_docs.ts`), per-vendor fetchers (bun, drizzle, elysia, privy), and README; wire `docs:generate` to the orchestrator.
- Keep changes scoped to documentation and scripts; no runtime code paths touched.

## Testing
- Not run (docs/scripts-only).
