### PR TITLE
fix: Agent chat failing due to missing plugin registration

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,6 +29,8 @@
     "@babylon/training": "workspace:*",
     "@elizaos/core": "^1.6.4",
     "@elizaos/plugin-sql": "^1.6.4",
+    "@elizaos/plugin-openai": "1.5.18",
+    "@elizaos/plugin-anthropic": "1.5.12",
     "@fal-ai/client": "^1.7.2",
     "@farcaster/auth-client": "^0.7.0",
     "@farcaster/auth-kit": "^0.8.1",

--- a/apps/web/src/app/agents/[agentId]/page.tsx
+++ b/apps/web/src/app/agents/[agentId]/page.tsx
@@ -107,6 +107,10 @@ export default function AgentDetailPage() {
   const [agent, setAgent] = useState<Agent | null>(null);
   const [loading, setLoading] = useState(true);
 
+  const handleBalanceUpdate = useCallback((newBalance: number) => {
+    setAgent((prev) => prev ? { ...prev, pointsBalance: newBalance } : prev);
+  }, []);
+
   const fetchAgent = useCallback(async () => {
     setLoading(true);
     const token = await getAccessToken();
@@ -325,7 +329,7 @@ export default function AgentDetailPage() {
 
           <div className="mt-6">
             <TabsContent value="chat">
-              <AgentChat agent={agent} onUpdate={fetchAgent} />
+              <AgentChat agent={agent} onBalanceUpdate={handleBalanceUpdate} />
             </TabsContent>
 
             <TabsContent value="performance">

--- a/apps/web/src/components/agents/AgentChat.tsx
+++ b/apps/web/src/components/agents/AgentChat.tsx
@@ -44,7 +44,7 @@ interface Message {
  * ```tsx
  * <AgentChat
  *   agent={agentData}
- *   onUpdate={() => refreshAgent()}
+ *   onBalanceUpdate={(newBalance) => setAgent(prev => ({ ...prev, pointsBalance: newBalance }))}
  * />
  * ```
  */
@@ -56,10 +56,10 @@ interface AgentChatProps {
     pointsBalance: number;
     modelTier: 'free' | 'pro';
   };
-  onUpdate: () => void;
+  onBalanceUpdate?: (newBalance: number) => void;
 }
 
-export function AgentChat({ agent, onUpdate }: AgentChatProps) {
+export function AgentChat({ agent, onBalanceUpdate }: AgentChatProps) {
   const { user, getAccessToken } = useAuth();
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
@@ -166,6 +166,7 @@ export function AgentChat({ agent, onUpdate }: AgentChatProps) {
         response: string;
         modelUsed: string;
         pointsCost: number;
+        balanceAfter: number;
       };
 
       if (!data.response || !data.messageId) {
@@ -183,9 +184,8 @@ export function AgentChat({ agent, onUpdate }: AgentChatProps) {
       };
       setMessages((prev) => [...prev, assistantMessage]);
 
-      // Update agent balance
-      onUpdate();
-
+      // Update agent balance without full page refresh
+      onBalanceUpdate?.(data.balanceAfter);
       toast.success(`Message sent (-${data.pointsCost} points)`);
     } catch (error) {
       // Remove optimistic message on error

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -33,6 +33,8 @@
     "@babylon/shared": "workspace:*",
     "@babylon/training": "workspace:*",
     "@elizaos/core": "^1.6.4",
+    "@elizaos/plugin-anthropic": "^1.5.12",
+    "@elizaos/plugin-openai": "^1.5.18",
     "@huggingface/hub": "^2.6.12",
     "@privy-io/server-auth": "^1.32.5",
     "agent0-sdk": "^0.31.0",

--- a/packages/agents/src/runtime/AgentRuntimeManager.ts
+++ b/packages/agents/src/runtime/AgentRuntimeManager.ts
@@ -38,6 +38,8 @@ import {
   wrapPluginProviders,
 } from '../plugins/plugin-trajectory-logger/src/action-interceptor';
 import { TrajectoryLoggerService } from '../plugins/plugin-trajectory-logger/src/TrajectoryLoggerService';
+import { openaiPlugin } from '@elizaos/plugin-openai';
+import { anthropicPlugin } from '@elizaos/plugin-anthropic';
 
 /**
  * Extended AgentRuntime with Babylon-specific properties
@@ -260,9 +262,12 @@ export class AgentRuntimeManager {
     // Create runtime with groq, experience, and trajectory logger plugins
     // Type cast plugins to ensure compatibility across different @elizaos/core versions
     const plugins: Plugin[] = [
-      groqPlugin as Plugin,
       experiencePlugin as Plugin,
       trajectoryLoggerPlugin as Plugin,
+      // Conditionally add LLM plugins based on available API keys
+      ...(process.env.GROQ_API_KEY ? [groqPlugin as Plugin] : []),
+      ...(process.env.ANTHROPIC_API_KEY ? [anthropicPlugin as Plugin] : []),
+      ...(process.env.OPENAI_API_KEY ? [openaiPlugin as Plugin] : []),
     ];
 
     const runtimeConfig = {
@@ -535,9 +540,12 @@ export class AgentRuntimeManager {
 
     // Create runtime with standard plugins
     const plugins: Plugin[] = [
-      groqPlugin as Plugin,
       experiencePlugin as Plugin,
       trajectoryLoggerPlugin as Plugin,
+      // Conditionally add LLM plugins based on available API keys
+      ...(process.env.GROQ_API_KEY ? [groqPlugin as Plugin] : []),
+      ...(process.env.ANTHROPIC_API_KEY ? [anthropicPlugin as Plugin] : []),
+      ...(process.env.OPENAI_API_KEY ? [openaiPlugin as Plugin] : []),
     ];
 
     const runtimeConfig = {

--- a/packages/agents/src/runtime/AgentRuntimeManager.ts
+++ b/packages/agents/src/runtime/AgentRuntimeManager.ts
@@ -324,25 +324,6 @@ export class AgentRuntimeManager {
       runtime.logger = customLogger as typeof runtime.logger;
     }
 
-    // // Cannot call initialize() without SQL plugin - manually register models instead
-    // // CRITICAL: Must set modelDelegates, not models Map
-    // // This is what runtime.initialize() does internally
-    // if (groqPlugin.models) {
-    //   const modelDelegates = runtime.modelDelegates || {};
-    //   for (const [type, handler] of Object.entries(groqPlugin.models)) {
-    //     modelDelegates[type] = handler;
-    //   }
-    //   runtime.modelDelegates = modelDelegates;
-    //   logger.info(
-    //     `Registered ${Object.keys(modelDelegates).length} Groq model handlers`,
-    //     {
-    //       agentUserId,
-    //       types: Object.keys(modelDelegates),
-    //     }
-    //   );
-    // }
-    // runtime.registerPlugin(groqPlugin);
-
     // Wrap Babylon plugin BEFORE registering (so wrapped version is used)
     // This ensures all actions and provider accesses are logged when executed
     let wrappedBabylonPlugin = babylonPlugin;

--- a/packages/agents/src/runtime/AgentRuntimeManager.ts
+++ b/packages/agents/src/runtime/AgentRuntimeManager.ts
@@ -280,6 +280,19 @@ export class AgentRuntimeManager {
 
     runtime.currentModel = 'groq';
 
+    // Override adapter.log to prevent undefined logger errors
+    runtime.adapter = {
+      ...runtime.adapter,
+      log: async (_params: {
+        body: { [key: string]: unknown };
+        entityId: string;
+        roomId: string;
+        type: string;
+      }): Promise<void> => {
+        // No-op to prevent errors - we use runtime.logger instead
+      },
+    } as typeof runtime.adapter;
+
     // Configure logger
     if (!runtime.logger || !runtime.logger.log) {
       const customLogger = {
@@ -311,23 +324,24 @@ export class AgentRuntimeManager {
       runtime.logger = customLogger as typeof runtime.logger;
     }
 
-    // Cannot call initialize() without SQL plugin - manually register models instead
-    // CRITICAL: Must set modelDelegates, not models Map
-    // This is what runtime.initialize() does internally
-    if (groqPlugin.models) {
-      const modelDelegates = runtime.modelDelegates || {};
-      for (const [type, handler] of Object.entries(groqPlugin.models)) {
-        modelDelegates[type] = handler;
-      }
-      runtime.modelDelegates = modelDelegates;
-      logger.info(
-        `Registered ${Object.keys(modelDelegates).length} Groq model handlers`,
-        {
-          agentUserId,
-          types: Object.keys(modelDelegates),
-        }
-      );
-    }
+    // // Cannot call initialize() without SQL plugin - manually register models instead
+    // // CRITICAL: Must set modelDelegates, not models Map
+    // // This is what runtime.initialize() does internally
+    // if (groqPlugin.models) {
+    //   const modelDelegates = runtime.modelDelegates || {};
+    //   for (const [type, handler] of Object.entries(groqPlugin.models)) {
+    //     modelDelegates[type] = handler;
+    //   }
+    //   runtime.modelDelegates = modelDelegates;
+    //   logger.info(
+    //     `Registered ${Object.keys(modelDelegates).length} Groq model handlers`,
+    //     {
+    //       agentUserId,
+    //       types: Object.keys(modelDelegates),
+    //     }
+    //   );
+    // }
+    // runtime.registerPlugin(groqPlugin);
 
     // Wrap Babylon plugin BEFORE registering (so wrapped version is used)
     // This ensures all actions and provider accesses are logged when executed
@@ -360,6 +374,16 @@ export class AgentRuntimeManager {
       undefined,
       'AgentRuntimeManager'
     );
+    
+    const pluginRegistrationPromises: Promise<void>[] = [];
+    const pluginsToLoad = plugins;
+
+    for (const plugin of pluginsToLoad) {
+      if (plugin) {
+        pluginRegistrationPromises.push(runtime.registerPlugin(plugin));
+      }
+    }
+    await Promise.all(pluginRegistrationPromises);
 
     return runtime;
   }

--- a/packages/agents/src/runtime/AgentRuntimeManager.ts
+++ b/packages/agents/src/runtime/AgentRuntimeManager.ts
@@ -289,7 +289,7 @@ export class AgentRuntimeManager {
         roomId: string;
         type: string;
       }): Promise<void> => {
-        // No-op to prevent errors - we use runtime.logger instead
+        // No-op to prevent errors
       },
     } as typeof runtime.adapter;
 

--- a/packages/agents/src/runtime/AgentRuntimeManager.ts
+++ b/packages/agents/src/runtime/AgentRuntimeManager.ts
@@ -355,6 +355,7 @@ export class AgentRuntimeManager {
       'AgentRuntimeManager'
     );
     
+    // Register plugins
     const pluginRegistrationPromises: Promise<void>[] = [];
     const pluginsToLoad = plugins;
 
@@ -573,7 +574,7 @@ export class AgentRuntimeManager {
     // Configure logger
     this.configureLogger(runtime, character.name);
 
-    // Register Groq model handlers
+    // Register plugins
     const pluginRegistrationPromises: Promise<void>[] = [];
     const pluginsToLoad = plugins;
 

--- a/packages/agents/src/runtime/AgentRuntimeManager.ts
+++ b/packages/agents/src/runtime/AgentRuntimeManager.ts
@@ -47,7 +47,6 @@ interface ExtendedAgentRuntime extends AgentRuntime {
   currentModelVersion?: string;
   currentModel?: string;
   trajectoryLogger?: TrajectoryLoggerService;
-  modelDelegates?: Record<string, unknown>;
 }
 
 /** Global runtime cache for warm container reuse */
@@ -558,11 +557,32 @@ export class AgentRuntimeManager {
     }
     runtime.currentModel = 'groq';
 
+    // Override adapter.log to prevent undefined logger errors
+    runtime.adapter = {
+      ...runtime.adapter,
+      log: async (_params: {
+        body: { [key: string]: unknown };
+        entityId: string;
+        roomId: string;
+        type: string;
+      }): Promise<void> => {
+        // No-op to prevent errors
+      },
+    } as typeof runtime.adapter;
+
     // Configure logger
     this.configureLogger(runtime, character.name);
 
     // Register Groq model handlers
-    this.registerModelHandlers(runtime, agentId);
+    const pluginRegistrationPromises: Promise<void>[] = [];
+    const pluginsToLoad = plugins;
+
+    for (const plugin of pluginsToLoad) {
+      if (plugin) {
+        pluginRegistrationPromises.push(runtime.registerPlugin(plugin));
+      }
+    }
+    await Promise.all(pluginRegistrationPromises);
 
     // Wrap and enhance with Babylon plugin
     await this.enhanceWithBabylon(runtime, agentId, trajectoryLogger);
@@ -618,28 +638,6 @@ export class AgentRuntimeManager {
         child: () => customLogger,
       } as typeof runtime.logger;
       runtime.logger = customLogger;
-    }
-  }
-
-  /**
-   * Register Groq model handlers on runtime
-   */
-  private registerModelHandlers(runtime: AgentRuntime, agentId: string): void {
-    const extendedRuntime = runtime as ExtendedAgentRuntime;
-    if (groqPlugin.models) {
-      const modelDelegates = extendedRuntime.modelDelegates || {};
-      for (const [type, handler] of Object.entries(groqPlugin.models)) {
-        modelDelegates[type] = handler;
-      }
-      extendedRuntime.modelDelegates = modelDelegates;
-      logger.info(
-        `Registered ${Object.keys(modelDelegates).length} Groq model handlers`,
-        {
-          agentId,
-          types: Object.keys(modelDelegates),
-        },
-        'AgentRuntimeManager'
-      );
     }
   }
 


### PR DESCRIPTION
### Question

In this PR I removed the manual `modelDelegates` assignment and switched to using `runtime.registerPlugin()` instead.

**Previously we were doing:**
runtime.modelDelegates[type] = handler;

**Now we're doing:**
await runtime.registerPlugin(groqPlugin);

Just want to confirm was `modelDelegates` being used anywhere else or for any other purpose I might have missed? Want to make sure this change doesn't break anything downstream.

result:

<img width="1423" height="849" alt="Screenshot 2025-12-03 at 3 42 44 AM" src="https://github.com/user-attachments/assets/dcb5d6b5-e529-4da4-a24e-c22866a21acb" />



### Problem

Agent chat was returning 500 errors with two distinct issues:

1. **"No handler found for delegate type: TEXT_LARGE"** - Model handlers weren't registered because we were manually setting `modelDelegates` instead of properly calling `runtime.registerPlugin()`.

2. **"Cannot read properties of undefined (reading 'log')"** - After fixing plugin registration, ElizaOS runtime's internal `useModel` method was calling `adapter.log` which was undefined.

### Solution

- **Removed manual `modelDelegates` assignment** - The runtime expects plugins to be registered via `registerPlugin()`.

- **Register all plugins via `runtime.registerPlugin()`** - Now properly registering `groqPlugin`, `experiencePlugin`, and `trajectoryLoggerPlugin` using the official API.

- **Override `adapter.log` with no-op** (expects `{ body, entityId, roomId, type }`). 