### PR TITLE
feat: detect environment from .env and skip Hardhat for testnet/mainnet

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "postinstall": "bun run scripts/postinstall-solidity-deps.ts && bun run scripts/postinstall-install-python-deps.ts",
-    "dev": "bun run scripts/pre-dev/pre-dev-local.ts && concurrently --kill-others-on-fail --kill-others -n \"hardhat,deploy,next,cron\" -c \"yellow,blue,cyan,magenta\" \"cd packages/contracts && bunx hardhat node --hostname 0.0.0.0\" \"bun run scripts/wait-for-hardhat-and-deploy.ts\" \"bunx turbo dev\" \"bun run scripts/local-cron-simulator.ts\"",
+    "dev": "bun run scripts/pre-dev/pre-dev-local.ts && bun run scripts/dev-wrapper.ts",
     "dev:web": "turbo dev --filter=web",
     "dev:web:staging": "NODE_ENV=development bun --env-file=.env.staging.local run dev:web",
     "dev:web:production": "NODE_ENV=development bun --env-file=.env.production.local run dev:web",

--- a/scripts/dev-wrapper.ts
+++ b/scripts/dev-wrapper.ts
@@ -1,0 +1,41 @@
+#!/usr/bin/env bun
+/**
+ * Development wrapper that conditionally starts Hardhat based on environment
+ */
+
+// @ts-ignore - bun global is available in bun runtime
+import { $ } from 'bun'
+import { existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { detectEnvironment } from '../packages/contracts/src/deployment/env-detection'
+
+// Load .env file to detect environment
+const envPath = join(process.cwd(), '.env')
+if (existsSync(envPath)) {
+  const envContent = readFileSync(envPath, 'utf-8')
+  // Parse .env file and set environment variables
+  for (const line of envContent.split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed && !trimmed.startsWith('#')) {
+      const [key, ...valueParts] = trimmed.split('=')
+      if (key && valueParts.length > 0) {
+        const value = valueParts.join('=').replace(/^["']|["']$/g, '')
+        if (!process.env[key]) {
+          process.env[key] = value
+        }
+      }
+    }
+  }
+}
+
+const detectedEnv = detectEnvironment()
+const isLocalnet = detectedEnv === 'localnet'
+
+if (isLocalnet) {
+  // Start Hardhat, deploy, Next.js, and cron
+  await $`concurrently --kill-others-on-fail --kill-others -n "hardhat,deploy,next,cron" -c "yellow,blue,cyan,magenta" "cd packages/contracts && bunx hardhat node --hostname 0.0.0.0" "bun run scripts/wait-for-hardhat-and-deploy.ts" "bunx turbo dev" "bun run scripts/local-cron-simulator.ts"`.nothrow()
+} else {
+  // Start Next.js and cron only (no Hardhat/deploy)
+  await $`concurrently --kill-others-on-fail --kill-others -n "next,cron" -c "cyan,magenta" "bunx turbo dev" "bun run scripts/local-cron-simulator.ts"`.nothrow()
+}
+

--- a/scripts/pre-dev/pre-dev-local.ts
+++ b/scripts/pre-dev/pre-dev-local.ts
@@ -1,11 +1,10 @@
 #!/usr/bin/env bun
 /**
- * Pre-Development Setup for Localnet
+ * Pre-Development Setup
  *
- * Sets up complete local development environment:
- * - Kills any processes on port 3000
- * - Checks for Hardhat node
- * - Deploys contracts
+ * Sets up complete development environment:
+ * - Detects environment from .env (localnet/testnet/mainnet)
+ * - For localnet: Kills any processes on port 3000, checks for Hardhat node
  * - Starts PostgreSQL, Redis, MinIO
  * - Runs database migrations
  * - Seeds data
@@ -16,7 +15,7 @@
 import { $ } from 'bun'
 import { existsSync, writeFileSync, unlinkSync, readFileSync } from 'fs'
 import { join } from 'path'
-import { validateEnvironment, printValidationResult } from '../../packages/contracts/src/deployment/env-detection'
+import { detectEnvironment, validateEnvironment, printValidationResult, type DeploymentEnv } from '../../packages/contracts/src/deployment/env-detection'
 
 const POSTGRES_CONTAINER = 'babylon-postgres'
 const REDIS_CONTAINER = 'babylon-redis'
@@ -37,7 +36,30 @@ async function killPort(port: number): Promise<number> {
   return pidList.length
 }
 
-console.info('[Script] Setting up localnet development environment...')
+// Load .env file to detect environment
+const envPath = join(process.cwd(), '.env')
+if (existsSync(envPath)) {
+  const envContent = readFileSync(envPath, 'utf-8')
+  // Parse .env file and set environment variables
+  for (const line of envContent.split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed && !trimmed.startsWith('#')) {
+      const [key, ...valueParts] = trimmed.split('=')
+      if (key && valueParts.length > 0) {
+        const value = valueParts.join('=').replace(/^["']|["']$/g, '')
+        if (!process.env[key]) {
+          process.env[key] = value
+        }
+      }
+    }
+  }
+}
+
+// Detect environment from .env or default to localnet
+const detectedEnv = detectEnvironment()
+const isLocalnet = detectedEnv === 'localnet'
+
+console.info(`[Script] Setting up ${detectedEnv} development environment...`)
 console.info('='.repeat(60))
 
 // 0. Kill any processes on port 3000 to prevent port conflicts
@@ -61,10 +83,10 @@ try {
   console.warn('Could not remove Next.js lock file (may not exist)')
 }
 
-// Set environment for localnet
-process.env.DEPLOYMENT_ENV = 'localnet'
-process.env.NEXT_PUBLIC_CHAIN_ID = '31337'
-process.env.NEXT_PUBLIC_RPC_URL = 'http://localhost:8545'
+// Set environment based on detection (don't override if already set in .env)
+if (!process.env.DEPLOYMENT_ENV) {
+  process.env.DEPLOYMENT_ENV = detectedEnv
+}
 
 // 1. Check Docker
 await $`docker --version`.quiet()
@@ -75,9 +97,8 @@ await $`docker info`.quiet().catch(() => {
 })
 console.info('✅ Docker is running')
 
-// 2. Check/create .env file
-const envPath = join(process.cwd(), '.env')
-if (!existsSync(envPath)) {
+// 2. Check/create .env file (only for localnet)
+if (!existsSync(envPath) && isLocalnet) {
   console.info('Creating .env file...')
   // If .env.example exists, use it as a base but override localnet values
   const envExamplePath = join(process.cwd(), '.env.example')
@@ -114,22 +135,26 @@ NEXT_PUBLIC_PRIVY_APP_ID=""
   console.info('✅ .env created from template')
 }
 
-// 3. Start Hardhat Node (background process managed by concurrently in dev script)
-// The pre-dev script just checks if port 8545 is available
-console.info('Checking port 8545 for Hardhat node...')
+// 3. Start Hardhat Node (only for localnet)
+if (isLocalnet) {
+  // The pre-dev script just checks if port 8545 is available
+  console.info('Checking port 8545 for Hardhat node...')
 
-// Kill any process on port 8545 to ensure clean start
-const killed8545 = await killPort(8545)
-if (killed8545 > 0) {
-  console.info(`✅ Killed ${killed8545} process(es) on port 8545`)
-  // Wait a moment for port to be fully released
-  await new Promise(resolve => setTimeout(resolve, 1000))
+  // Kill any process on port 8545 to ensure clean start
+  const killed8545 = await killPort(8545)
+  if (killed8545 > 0) {
+    console.info(`✅ Killed ${killed8545} process(es) on port 8545`)
+    // Wait a moment for port to be fully released
+    await new Promise(resolve => setTimeout(resolve, 1000))
+  } else {
+    console.info('✅ Port 8545 is free')
+  }
+
+  console.info('Note: Hardhat node will be started automatically by the dev script')
+  console.info('      Contracts will be deployed once Hardhat is ready')
 } else {
-  console.info('✅ Port 8545 is free')
+  console.info(`✅ Using ${detectedEnv} network (skipping Hardhat setup)`)
 }
-
-console.info('Note: Hardhat node will be started automatically by the dev script')
-console.info('      Contracts will be deployed once Hardhat is ready')
 
 // 4. Start PostgreSQL
 const postgresRunning = await $`docker ps --filter name=${POSTGRES_CONTAINER} --format "{{.Names}}"`.quiet().text()
@@ -264,15 +289,17 @@ if (needsSeed || actorCount === 0) {
 
 // 10. Validate environment
 console.info('')
-const validation = validateEnvironment('localnet')
+const validation = validateEnvironment(detectedEnv)
 printValidationResult(validation)
 
 console.info('')
 console.info('='.repeat(60))
-console.info('✅ Localnet environment ready!')
+console.info(`✅ ${detectedEnv === 'localnet' ? 'Localnet' : detectedEnv === 'testnet' ? 'Testnet' : 'Mainnet'} environment ready!`)
 console.info('')
 console.info('Services:')
-console.info('  Hardhat:    http://localhost:8545 (will be started automatically)')
+if (isLocalnet) {
+  console.info('  Hardhat:    http://localhost:8545 (will be started automatically)')
+}
 console.info('  PostgreSQL: localhost:5433')
 console.info('  Redis:      localhost:6380')
 console.info('  MinIO:      http://localhost:9000 (console: :9001)')
@@ -281,5 +308,9 @@ console.info('App Routes:')
 console.info('  Main:       http://localhost:3000')
 console.info('  Betting:    http://localhost:3000/betting (Oracle-powered markets)')
 console.info('')
-console.info('Starting services (Hardhat, Next.js, Cron)...')
+if (isLocalnet) {
+  console.info('Starting services (Hardhat, Next.js, Cron)...')
+} else {
+  console.info('Starting services (Next.js, Cron)...')
+}
 console.info('='.repeat(60))


### PR DESCRIPTION
## Summary

This PR modifies `bun run dev` to automatically detect the environment from `.env` and skip Hardhat node startup when using Base Sepolia (testnet Sepolia (testnet) or mainnet.

## Changes

- **Modified `scripts/pre-dev/pre-dev-local.ts`**:
  - Detects environment (localnet/testnet/mainnet) from `.env` using `detectEnvironment()`
  - Skips Hardhat setup (port 8545 cleanup) when environment is testnet/mainnet
  - Only creates `.env` file if it doesn't exist and we're on localnet
  - Updates console messages to reflect the detected environment

- **Created `scripts/dev-wrapper.ts`**:
  - Wrapper script that conditionally starts services based on environment
  - For localnet: Starts Hardhat, deploy script, Next.js, and cron
  - For testnet/mainnet: Starts only Next.js and cron (skips Hardhat/deploy)

- **Updated `package.json`**:
  - Changed `dev` script to use the new wrapper

## How It Works

The script detects the environment by checking (in order):
1. `DEPLOYMENT_ENV` environment variable
2. `NEXT_PUBLIC_CHAIN_ID` (31337 = localnet, 84532 = testnet, 8453 = mainnet)
3. RPC URL patterns (localhost = localnet, sepolia = testnet, etc.)

## Testing

- ✅ TypeScript typecheck passes
- ✅ Linting passes
- ✅ Build succeeds

## Impact

When `.env` has `NEXT_PUBLIC_CHAIN_ID=84532` or `DEPLOYMENT_ENV=testnet`, the dev script will:
- Skip Hardhat node startup
- Skip contract deployment script
- Start only Next.js dev server and cron simulator
- Use Base Sepolia network configuration