### PR TITLE
fix(agents): Enable autonomous posting with agent registry integration

### DIFF
--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -25,6 +25,20 @@ export async function register() {
     // Import from main package entry point
     const { setPointsService, setNotificationService, PointsService, createNotification } = await import('@babylon/api');
 
+    // Initialize agent service container with required services
+    // Uses globalThis to persist across module instances
+    try {
+      const { setServiceContainer, agentRegistry } = await import('@babylon/agents');
+      setServiceContainer({
+        agentRegistry,
+      });
+    } catch (error) {
+      console.warn(
+        '[Agents] Service container initialization failed:',
+        error instanceof Error ? error.message : String(error)
+      );
+    }
+    
     // Initialize shared moderation services with web app implementations
     setPointsService({
       awardPoints: async (userId, amount, reason, metadata) => {

--- a/apps/web/src/app/api/cron/agent-tick/route.ts
+++ b/apps/web/src/app/api/cron/agent-tick/route.ts
@@ -192,7 +192,7 @@ export async function POST(_req: NextRequest) {
   // NEW: Query via AgentRegistry to include both USER agents and NPCs
   const registeredAgents = await agentRegistry.discoverAgents({
     types: [AgentType.USER_CONTROLLED, AgentType.NPC],
-    statuses: [AgentStatus.ACTIVE, AgentStatus.INITIALIZED],
+    statuses: [AgentStatus.ACTIVE, AgentStatus.INITIALIZED, AgentStatus.REGISTERED],
     limit: 500, // Increase limit to ensure we process all agents in test environments
   });
 

--- a/packages/agents/src/autonomous/AutonomousCoordinator.ts
+++ b/packages/agents/src/autonomous/AutonomousCoordinator.ts
@@ -314,11 +314,19 @@ export class AutonomousCoordinator {
     // === PRIORITY 3: SOCIAL (Posting) ===
     if (agent.autonomousPosting) {
       if (useA2A) {
-        const trendingResult = await autonomousA2AService.engageWithTrending(
-          agentUserId,
-          runtime
-        );
-        result.actionsExecuted.engagements += trendingResult.engagements;
+        try {
+          const trendingResult = await autonomousA2AService.engageWithTrending(
+            agentUserId,
+            runtime
+          );
+          result.actionsExecuted.engagements += trendingResult.engagements;
+        } catch (a2aError) {
+          logger.warn(
+            'A2A trending engagement failed, continuing with direct posting',
+            { error: a2aError instanceof Error ? a2aError.message : String(a2aError) },
+            'AutonomousCoordinator'
+          );
+        }
       }
 
       // Capture initial state if recording trajectories

--- a/packages/agents/src/autonomous/AutonomousPostingService.ts
+++ b/packages/agents/src/autonomous/AutonomousPostingService.ts
@@ -65,7 +65,7 @@ export class AutonomousPostingService {
     const worldContext = await generateWorldContext({ maxActors: 20 });
 
     // Build prompt for post generation
-    const MAX_TOKENS = 100;
+    const MAX_TOKENS = 280;
     const prompt = `CRITICAL: You have only ${MAX_TOKENS} tokens. Your response MUST start with <response> immediately. No <think> tags. No reasoning.
 
 ${agent.agentSystem}
@@ -107,7 +107,7 @@ Topics you can post about (MUST reference specific entities):
 - Reactions to SPECIFIC recent trades or events (mention who/what)
 
 Keep it:
-- Short (under 280 characters)
+- Short (under ${MAX_TOKENS} tokens)
 - Authentic to your personality
 - Valuable to the community
 - SPECIFIC - reference actual entities from WORLD CONTEXT

--- a/packages/agents/src/autonomous/AutonomousPostingService.ts
+++ b/packages/agents/src/autonomous/AutonomousPostingService.ts
@@ -12,6 +12,7 @@ import {
   generateWorldContext,
 } from '@babylon/engine';
 import type { IAgentRuntime } from '@elizaos/core';
+import { parseKeyValueXml } from '@elizaos/core';
 import { logger } from '../shared/logger';
 import { generateSnowflakeId } from '../shared/snowflake';
 import { countTokensSync, truncateToTokenLimitSync } from '@babylon/engine';
@@ -64,7 +65,10 @@ export class AutonomousPostingService {
     const worldContext = await generateWorldContext({ maxActors: 20 });
 
     // Build prompt for post generation
-    const prompt = `${agent.agentSystem}
+    const MAX_TOKENS = 100;
+    const prompt = `CRITICAL: You have only ${MAX_TOKENS} tokens. Your response MUST start with <response> immediately. No <think> tags. No reasoning.
+
+${agent.agentSystem}
 
 You are ${agent.displayName}, an AI agent in the Babylon prediction market community.
 
@@ -110,7 +114,10 @@ Keep it:
 - Not repetitive of recent posts
 ${contextString}
 
-Generate ONLY the post text, nothing else.`;
+# Required Output Format (use exactly this structure)
+<response>
+<text>your post content here</text>
+</response>`;
 
     // Ensure prompt fits within 32K context limit (W&B trained models)
     const estimatedTokens = countTokensSync(prompt);
@@ -129,20 +136,88 @@ Generate ONLY the post text, nothing else.`;
       logger.info(`Truncated to ${truncated.tokens} tokens`, { agentUserId });
     }
 
-    // Use large model (qwen3-32b or trained W&B model) for post generation
-    const postContent = await callGroqDirect({
-      prompt: finalPrompt,
-      system: agent.agentSystem || undefined,
-      modelSize: 'large', // Uses trained W&B model if available, else qwen3-32b
-      runtime: _runtime, // Pass runtime to access W&B trained models AND trajectory context
-      temperature: 0.8,
-      maxTokens: 100,
-      actionType: 'generate_autonomous_post',
-      purpose: 'action', // RLAIF: This is a content generation action
-    });
+    // Use large model (qwen3-32b or trained W&B model) for post generation with retry loop
+    const MAX_ATTEMPTS = 3;
+    let cleanContent: string | null = null;
 
-    // Clean up the response
-    let cleanContent = postContent.trim().replace(/^["']|["']$/g, '');
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      try {
+        const isRetry = attempt > 1;
+        const currentPrompt = isRetry
+          ? `${finalPrompt}\n\nREMINDER: You MUST output valid XML. Start with <response> and include <text> with your post content. No <think> tags.`
+          : finalPrompt;
+
+        const postContent = await callGroqDirect({
+          prompt: currentPrompt,
+          system: agent.agentSystem || undefined,
+          modelSize: 'large', // Uses trained W&B model if available, else qwen3-32b
+          runtime: _runtime, // Pass runtime to access W&B trained models AND trajectory context
+          temperature: isRetry ? 0.6 : 0.8,
+          maxTokens: MAX_TOKENS,
+          actionType: 'generate_autonomous_post',
+          purpose: 'action', // RLAIF: This is a content generation action
+        });
+
+        // Extract <response>...</response> block before parsing
+        const responseMatch = postContent.match(
+          /<response>([\s\S]*?)<\/response>/i
+        );
+        if (!responseMatch) {
+          logger.warn(
+            'No <response> block found in post generation',
+            {
+              agentUserId,
+              attempt,
+              raw: postContent.substring(0, 300),
+            },
+            'AutonomousPosting'
+          );
+          continue;
+        }
+
+        // Parse the extracted XML response
+        const parsed = parseKeyValueXml(responseMatch[0]) as {
+          text?: string;
+        } | null;
+
+        // Check if we got valid text
+        if (!parsed?.text || parsed.text.trim().length === 0) {
+          logger.warn(
+            'Failed to parse XML response in post generation',
+            {
+              agentUserId,
+              attempt,
+              raw: postContent.substring(0, 300),
+            },
+            'AutonomousPosting'
+          );
+          continue;
+        }
+
+        // Success! Clean up the response
+        cleanContent = parsed.text.trim().replace(/^["']|["']$/g, '');
+        break;
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        logger.error(
+          'Failed to generate post',
+          { error: errorMessage, agentUserId, attempt },
+          'AutonomousPosting'
+        );
+        continue;
+      }
+    }
+
+    // If all attempts failed, return null
+    if (!cleanContent) {
+      logger.error(
+        `Failed to generate valid post after ${MAX_ATTEMPTS} attempts`,
+        { agentUserId },
+        'AutonomousPosting'
+      );
+      return null;
+    }
 
     // Post-process to fix any real names that slipped through
     const processed = await characterMappingService.transformText(cleanContent);
@@ -163,8 +238,7 @@ Generate ONLY the post text, nothing else.`;
       'LLM generated post',
       {
         agentUserId,
-        raw: postContent,
-        cleaned: cleanContent,
+        content: cleanContent,
         length: cleanContent.length,
       },
       'AutonomousPosting'

--- a/packages/agents/src/services/AgentService.ts
+++ b/packages/agents/src/services/AgentService.ts
@@ -32,7 +32,6 @@ import { logger } from '../shared/logger';
 import { getService } from './interfaces';
 import { generateSnowflakeId } from '../shared/snowflake';
 import type { AgentCapabilities } from '@babylon/shared';
-import { AgentType } from '../types/agent-registry';
 import type { JsonValue } from '../types/common';
 import { agentIdentityService } from '../identity/AgentIdentityService';
 import type { AgentPerformance, CreateAgentParams } from '../types';

--- a/packages/agents/src/services/AgentService.ts
+++ b/packages/agents/src/services/AgentService.ts
@@ -229,9 +229,7 @@ export class AgentServiceV2 {
           domains: [],
         };
 
-        await agentRegistry.register({
-          agentId: agentUserId,
-          type: AgentType.USER_CONTROLLED,
+        await agentRegistry.registerUserAgent({
           userId: agentUserId,
           name: name,
           systemPrompt:

--- a/packages/agents/src/services/interfaces.ts
+++ b/packages/agents/src/services/interfaces.ts
@@ -11,7 +11,6 @@ import type { JsonValue } from '../types/common';
 import type {
   AgentCapabilities,
   UnifiedAgentRegistration,
-  AgentType,
   AgentStatus,
   TrustLevel,
   AgentDiscoveryFilter,

--- a/packages/agents/src/services/interfaces.ts
+++ b/packages/agents/src/services/interfaces.ts
@@ -24,24 +24,23 @@ export interface IAgentRegistry {
   /**
    * Register a new agent
    */
-  register(params: {
-    agentId: string;
-    type: AgentType;
-    userId?: string | null;
+  registerUserAgent(params: {
+    userId: string;
     name: string;
     systemPrompt: string;
     capabilities: AgentCapabilities;
+    trustLevel?: TrustLevel;
   }): Promise<UnifiedAgentRegistration>;
 
   /**
    * Get agent by ID
    */
-  getAgent(agentId: string): Promise<UnifiedAgentRegistration | null>;
+  getAgentById(agentId: string): Promise<UnifiedAgentRegistration | null>;
 
   /**
    * Update agent status
    */
-  updateStatus(agentId: string, status: AgentStatus): Promise<void>;
+  updateAgentStatus(agentId: string, status: AgentStatus): Promise<UnifiedAgentRegistration>;
 
   /**
    * Update agent trust level
@@ -51,12 +50,7 @@ export interface IAgentRegistry {
   /**
    * Discover agents matching filter
    */
-  discover(filter: AgentDiscoveryFilter): Promise<UnifiedAgentRegistration[]>;
-
-  /**
-   * Check if agent exists
-   */
-  exists(agentId: string): Promise<boolean>;
+  discoverAgents(filter: AgentDiscoveryFilter): Promise<UnifiedAgentRegistration[]>;
 }
 
 /**
@@ -310,22 +304,29 @@ export interface IServiceContainer {
 }
 
 /**
- * Global service container instance
+ * Global service container for cross-module dependency injection.
+ * Uses globalThis to ensure consistent state across dynamic and static imports.
  */
-let serviceContainer: IServiceContainer = {};
-
-/**
- * Set the service container
- */
-export function setServiceContainer(container: IServiceContainer): void {
-  serviceContainer = { ...serviceContainer, ...container };
+declare global {
+  // eslint-disable-next-line no-var
+  var __babylon_agents_services__: IServiceContainer | undefined;
 }
 
 /**
- * Get the service container
+ * Set the service container (merges with existing services)
+ */
+export function setServiceContainer(container: IServiceContainer): void {
+  globalThis.__babylon_agents_services__ = {
+    ...globalThis.__babylon_agents_services__,
+    ...container,
+  };
+}
+
+/**
+ * Get the full service container
  */
 export function getServiceContainer(): IServiceContainer {
-  return serviceContainer;
+  return globalThis.__babylon_agents_services__ ?? {};
 }
 
 /**
@@ -334,6 +335,6 @@ export function getServiceContainer(): IServiceContainer {
 export function getService<K extends keyof IServiceContainer>(
   key: K
 ): IServiceContainer[K] {
-  return serviceContainer[key];
+  return globalThis.__babylon_agents_services__?.[key];
 }
 


### PR DESCRIPTION
result:

<img width="608" height="348" alt="Screenshot 2025-12-05 at 12 18 17 AM" src="https://github.com/user-attachments/assets/20d3f176-349a-45b9-99cc-d72b464c5daa" />


This PR fixes autonomous posting by ensuring agents are properly registered in the agent registry when created. Currently, agent auto posting is not working because newly created agents are not being discovered by the cron job since they are not in the registry.

Key changes include: initializing the service container with `agentRegistry` at server startup via `instrumentation.ts`, using `registerUserAgent` in `AgentService.createAgent`, and including the `REGISTERED` status in the agent discovery filter. Additionally, A2A service calls in the autonomous coordinator now have graceful error handling to prevent crashes when the A2A protocol is unavailable.