### PR TITLE
feat: add automatic post tagging and improve trending accuracy

### DIFF
--- a/apps/web/src/app/api/posts/route.ts
+++ b/apps/web/src/app/api/posts/route.ts
@@ -239,11 +239,6 @@ import {
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
-import {
-  generateTagsFromPost,
-  storeTagsForPost,
-  type GeneratedTag,
-} from '@babylon/engine';
 import type { Post } from '@babylon/db';
 import {
   actors,
@@ -269,6 +264,11 @@ import {
   userActorFollows,
   users,
 } from '@babylon/db';
+import {
+  type GeneratedTag,
+  generateTagsFromPost,
+  storeTagsForPost,
+} from '@babylon/engine';
 import { generateSnowflakeId, logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';

--- a/apps/web/src/app/api/posts/route.ts
+++ b/apps/web/src/app/api/posts/route.ts
@@ -239,6 +239,11 @@ import {
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
+import {
+  generateTagsFromPost,
+  storeTagsForPost,
+  type GeneratedTag,
+} from '@babylon/engine';
 import type { Post } from '@babylon/db';
 import {
   actors,
@@ -1115,6 +1120,29 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
     contentLength: content.trim().length,
     hasUsername: Boolean(canonicalUser.username),
   });
+
+  // Generate and store tags asynchronously (don't block response)
+  // This allows posts to be tagged for trending without slowing down the API
+  void generateTagsFromPost(content.trim())
+    .then((generatedTags: GeneratedTag[]) => {
+      if (generatedTags.length > 0) {
+        return storeTagsForPost(post.id, generatedTags).then(() => {
+          logger.info(
+            'Tagged user post',
+            { postId: post.id, tagCount: generatedTags.length },
+            'POST /api/posts'
+          );
+        });
+      }
+      return Promise.resolve();
+    })
+    .catch((tagError: Error) => {
+      logger.warn(
+        'Failed to tag post',
+        { postId: post.id, error: tagError },
+        'POST /api/posts'
+      );
+    });
 
   return successResponse({
     success: true,

--- a/apps/web/src/app/api/trending/group/route.ts
+++ b/apps/web/src/app/api/trending/group/route.ts
@@ -70,6 +70,7 @@ import {
 } from '@babylon/api';
 import {
   actors,
+  and,
   asPublic,
   asUser,
   comments,
@@ -77,6 +78,7 @@ import {
   desc,
   eq,
   inArray,
+  isNull,
   organizations,
   posts,
   postTags,
@@ -164,6 +166,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   }
 
   // Get posts that have any of these tags
+  // Filter out deleted posts to match what users can actually see
   const postTagRelations =
     authUser && authUser.userId
       ? await asUser(authUser, async (db) => {
@@ -182,7 +185,12 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
             })
             .from(postTags)
             .innerJoin(posts, eq(postTags.postId, posts.id))
-            .where(inArray(postTags.tagId, tagIds))
+            .where(
+              and(
+                inArray(postTags.tagId, tagIds),
+                isNull(posts.deletedAt)
+              )
+            )
             .orderBy(desc(postTags.createdAt))
             .limit(limit * 2); // Get more to deduplicate
         })
@@ -202,7 +210,12 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
             })
             .from(postTags)
             .innerJoin(posts, eq(postTags.postId, posts.id))
-            .where(inArray(postTags.tagId, tagIds))
+            .where(
+              and(
+                inArray(postTags.tagId, tagIds),
+                isNull(posts.deletedAt)
+              )
+            )
             .orderBy(desc(postTags.createdAt))
             .limit(limit * 2);
         });

--- a/apps/web/src/app/api/trending/group/route.ts
+++ b/apps/web/src/app/api/trending/group/route.ts
@@ -186,10 +186,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
             .from(postTags)
             .innerJoin(posts, eq(postTags.postId, posts.id))
             .where(
-              and(
-                inArray(postTags.tagId, tagIds),
-                isNull(posts.deletedAt)
-              )
+              and(inArray(postTags.tagId, tagIds), isNull(posts.deletedAt))
             )
             .orderBy(desc(postTags.createdAt))
             .limit(limit * 2); // Get more to deduplicate
@@ -211,10 +208,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
             .from(postTags)
             .innerJoin(posts, eq(postTags.postId, posts.id))
             .where(
-              and(
-                inArray(postTags.tagId, tagIds),
-                isNull(posts.deletedAt)
-              )
+              and(inArray(postTags.tagId, tagIds), isNull(posts.deletedAt))
             )
             .orderBy(desc(postTags.createdAt))
             .limit(limit * 2);

--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -150,6 +150,7 @@ import {
 } from '@babylon/api';
 import { db, eq, users } from '@babylon/db';
 import { logger } from '@babylon/shared';
+import type { NextRequest } from 'next/server';
 import type { User as PrivyUser } from '@privy-io/server-auth';
 
 type PrivyWalletLite = {

--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -150,8 +150,8 @@ import {
 } from '@babylon/api';
 import { db, eq, users } from '@babylon/db';
 import { logger } from '@babylon/shared';
-import type { NextRequest } from 'next/server';
 import type { User as PrivyUser } from '@privy-io/server-auth';
+import type { NextRequest } from 'next/server';
 
 type PrivyWalletLite = {
   id?: string | null;

--- a/packages/agents/src/autonomous/AutonomousPostingService.ts
+++ b/packages/agents/src/autonomous/AutonomousPostingService.ts
@@ -10,7 +10,9 @@ import {
   countTokensSync,
   formatRandomContext,
   generateRandomMarketContext,
+  generateTagsFromPost,
   generateWorldContext,
+  storeTagsForPost,
   truncateToTokenLimitSync,
 } from '@babylon/engine';
 import type { IAgentRuntime } from '@elizaos/core';
@@ -273,6 +275,28 @@ ${contextString}
       undefined,
       'AutonomousPosting'
     );
+
+    // Generate and store tags asynchronously
+    void generateTagsFromPost(cleanContent)
+      .then((generatedTags) => {
+        if (generatedTags.length > 0) {
+          return storeTagsForPost(postId, generatedTags).then(() => {
+            logger.info(
+              'Tagged agent post',
+              { postId, agentId: agentUserId, tagCount: generatedTags.length },
+              'AutonomousPosting'
+            );
+          });
+        }
+        return Promise.resolve();
+      })
+      .catch((tagError) => {
+        logger.warn(
+          'Failed to tag agent post',
+          { postId, agentId: agentUserId, error: tagError },
+          'AutonomousPosting'
+        );
+      });
 
     return postId;
   }

--- a/packages/engine/src/serverless-game-tick.ts
+++ b/packages/engine/src/serverless-game-tick.ts
@@ -1064,14 +1064,14 @@ async function bootstrapTrending(): Promise<void> {
       };
     }
 
-    // Create trending entry
+    // Create trending entry with real post count (0 since no posts are tagged yet)
     const score = (sampleTags.length - i) * 10 + Math.random() * 5;
 
     await db.insert(trendingTags).values({
       id: await generateSnowflakeId(),
       tagId: tag.id,
       score,
-      postCount: Math.floor(Math.random() * 10) + 5,
+      postCount: 0, // Real count - will be updated when trending is calculated
       rank: i + 1,
       windowStart: weekAgo,
       windowEnd: now,

--- a/packages/engine/src/services/post-generation-helpers.ts
+++ b/packages/engine/src/services/post-generation-helpers.ts
@@ -14,6 +14,8 @@ import {
 import { logger } from '@babylon/shared';
 import type { BabylonLLMClient } from '../llm/openai-client';
 import { characterMappingService } from './character-mapping-service';
+import type { GeneratedTag } from './tag-service';
+import { generateTagsFromPost, storeTagsForPost } from './tag-service';
 
 // Minimal question type for post generation (only fields actually used)
 type QuestionForPost = Pick<Question, 'id' | 'text' | 'questionNumber'>;
@@ -286,8 +288,9 @@ Return your response as XML in this exact format:
     );
   }
 
+  const postId = await generateSnowflakeId();
   await getDbInstance().createPostWithAllFields({
-    id: await generateSnowflakeId(),
+    id: postId,
     type: 'article',
     content: transformedSummary.transformedText,
     fullContent: transformedBody.transformedText,
@@ -303,5 +306,28 @@ Return your response as XML in this exact format:
     { org: org.name, timestamp },
     'PostGeneration'
   );
+
+  // Generate and store tags asynchronously
+  void generateTagsFromPost(transformedSummary.transformedText)
+    .then((generatedTags: GeneratedTag[]) => {
+      if (generatedTags.length > 0) {
+        return storeTagsForPost(postId, generatedTags).then(() => {
+          logger.info(
+            'Tagged org article',
+            { postId, orgName: org.name, tagCount: generatedTags.length },
+            'PostGeneration'
+          );
+        });
+      }
+      return Promise.resolve();
+    })
+    .catch((tagError: Error) => {
+      logger.warn(
+        'Failed to tag org article',
+        { postId, orgName: org.name, error: tagError },
+        'PostGeneration'
+      );
+    });
+
   return true;
 }

--- a/packages/engine/src/services/tag-service.ts
+++ b/packages/engine/src/services/tag-service.ts
@@ -509,9 +509,9 @@ export async function getTagStatistics(
         whereGte(pt.createdAt, windowStart),
         whereLte(pt.createdAt, windowEnd)
       ),
-    with: { 
+    with: {
       tag: true,
-      post: true
+      post: true,
     },
     orderBy: asc(postTags.createdAt),
   });

--- a/packages/engine/src/services/tag-service.ts
+++ b/packages/engine/src/services/tag-service.ts
@@ -502,15 +502,22 @@ export async function getTagStatistics(
 > {
   const last24Hours = new Date(windowEnd.getTime() - 24 * 60 * 60 * 1000);
 
-  const postTagsList = await db.query.postTags.findMany({
+  // Query postTags within time window, then filter out deleted posts
+  const allPostTags = await db.query.postTags.findMany({
     where: (pt, { and: andOp, gte: whereGte, lte: whereLte }) =>
       andOp(
         whereGte(pt.createdAt, windowStart),
         whereLte(pt.createdAt, windowEnd)
       ),
-    with: { tag: true },
+    with: { 
+      tag: true,
+      post: true
+    },
     orderBy: asc(postTags.createdAt),
   });
+
+  // Filter out postTags where the post is deleted
+  const postTagsList = allPostTags.filter((pt) => !pt.post.deletedAt);
 
   const tagStats = new Map<
     string,


### PR DESCRIPTION
## Summary
- Automatically generate and store tags for all post types (user posts, agent posts, org articles)
- Improve trending accuracy by filtering out deleted posts
- Fix tag statistics to exclude deleted posts
- Initialize trending tags with accurate counts instead of random values

## Changes
### Auto-tagging
- **User posts** (`apps/web/src/app/api/posts/route.ts`): Tag generation happens asynchronously after post creation
- **Agent posts** (`packages/agents/src/autonomous/AutonomousPostingService.ts`): Tags generated for autonomous agent posts
- **Org articles** (`packages/engine/src/services/post-generation-helpers.ts`): Tags generated for organization articles

### Trending improvements
- **Trending groups** (`apps/web/src/app/api/trending/group/route.ts`): Filter out deleted posts using `isNull(posts.deletedAt)`
- **Tag statistics** (`packages/engine/src/services/tag-service.ts`): Exclude deleted posts from stats calculations
- **Bootstrap data** (`packages/engine/src/serverless-game-tick.ts`): Initialize trending tags with `postCount: 0` (real value) instead of random

### Implementation details
- Tag generation is async and non-blocking to avoid slowing down post creation
- Proper error handling with logging for tag generation failures
- Uses existing `generateTagsFromPost()` and `storeTagsForPost()` functions from tag service

## Test plan
- [x] Verify user posts are tagged automatically
- [x] Verify agent posts are tagged automatically  
- [x] Verify org articles are tagged automatically
- [x] Verify trending groups exclude deleted posts
- [x] Verify tag statistics exclude deleted posts
- [x] Verify post creation is not blocked by tag generation
- [x] Verify error handling works when tag generation fails