### PR TITLE
fix: correct @ mention and $ cashtag routing in tagged text

### DIFF
--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { cn } from '@babylon/shared';
+import { cn, getProfileUrl } from '@babylon/shared';
 import {
   AlertCircle,
   ArrowLeft,
@@ -900,7 +900,17 @@ export default function ProfilePage() {
               <TaggedText
                 text={reply.content}
                 onTagClick={(tag) => {
-                  router.push(`/feed?search=${encodeURIComponent(tag)}`);
+                  if (tag.startsWith('@')) {
+                    // Handle @mentions - route to profile
+                    const username = tag.slice(1);
+                    router.push(getProfileUrl('', username));
+                  } else if (tag.startsWith('$')) {
+                    // Handle $cashtags - route to markets
+                    const symbol = tag.slice(1);
+                    router.push(
+                      `/markets?search=${encodeURIComponent(symbol)}`
+                    );
+                  }
                 }}
               />
             </div>
@@ -919,7 +929,17 @@ export default function ProfilePage() {
               <TaggedText
                 text={reply.post.content.substring(0, 100) + '...'}
                 onTagClick={(tag) => {
-                  router.push(`/feed?search=${encodeURIComponent(tag)}`);
+                  if (tag.startsWith('@')) {
+                    // Handle @mentions - route to profile
+                    const username = tag.slice(1);
+                    router.push(getProfileUrl('', username));
+                  } else if (tag.startsWith('$')) {
+                    // Handle $cashtags - route to markets
+                    const symbol = tag.slice(1);
+                    router.push(
+                      `/markets?search=${encodeURIComponent(symbol)}`
+                    );
+                  }
                 }}
               />
             </div>

--- a/apps/web/src/components/interactions/CommentCard.tsx
+++ b/apps/web/src/components/interactions/CommentCard.tsx
@@ -5,7 +5,7 @@ import type {
   CommentData,
   CommentWithReplies,
 } from '@babylon/shared';
-import { cn } from '@babylon/shared';
+import { cn, getProfileUrl } from '@babylon/shared';
 import { formatDistanceToNow } from 'date-fns';
 import { Edit2, MoreVertical, Reply, Trash2 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
@@ -228,7 +228,15 @@ export function CommentCard({
             <TaggedText
               text={comment.content}
               onTagClick={(tag) => {
-                router.push(`/feed?search=${encodeURIComponent(tag)}`);
+                if (tag.startsWith('@')) {
+                  // Handle @mentions - route to profile
+                  const username = tag.slice(1);
+                  router.push(getProfileUrl('', username));
+                } else if (tag.startsWith('$')) {
+                  // Handle $cashtags - route to markets
+                  const symbol = tag.slice(1);
+                  router.push(`/markets?search=${encodeURIComponent(symbol)}`);
+                }
               }}
             />
           </p>

--- a/apps/web/src/components/posts/PostCard.tsx
+++ b/apps/web/src/components/posts/PostCard.tsx
@@ -392,10 +392,17 @@ export const PostCard = memo(function PostCard({
               <TaggedText
                 text={post.quoteComment}
                 onTagClick={(tag) => {
-                  // Extract tag name (remove # prefix) and convert to slug
-                  const tagName = tag.startsWith('#') ? tag.slice(1) : tag;
-                  const tagSlug = tagName.toLowerCase().replace(/\s+/g, '-');
-                  router.push(`/trending/${encodeURIComponent(tagSlug)}`);
+                  if (tag.startsWith('@')) {
+                    // Handle @mentions - route to profile
+                    const username = tag.slice(1);
+                    router.push(getProfileUrl('', username));
+                  } else if (tag.startsWith('$')) {
+                    // Handle $cashtags - route to markets
+                    const symbol = tag.slice(1);
+                    router.push(
+                      `/markets?search=${encodeURIComponent(symbol)}`
+                    );
+                  }
                 }}
               />
             </div>
@@ -473,12 +480,17 @@ export const PostCard = memo(function PostCard({
                   <TaggedText
                     text={post.originalPost.content}
                     onTagClick={(tag) => {
-                      // Extract tag name (remove # prefix) and convert to slug
-                      const tagName = tag.startsWith('#') ? tag.slice(1) : tag;
-                      const tagSlug = tagName
-                        .toLowerCase()
-                        .replace(/\s+/g, '-');
-                      router.push(`/trending/${encodeURIComponent(tagSlug)}`);
+                      if (tag.startsWith('@')) {
+                        // Handle @mentions - route to profile
+                        const username = tag.slice(1);
+                        router.push(getProfileUrl('', username));
+                      } else if (tag.startsWith('$')) {
+                        // Handle $cashtags - route to markets
+                        const symbol = tag.slice(1);
+                        router.push(
+                          `/markets?search=${encodeURIComponent(symbol)}`
+                        );
+                      }
                     }}
                   />
                 </div>
@@ -496,10 +508,15 @@ export const PostCard = memo(function PostCard({
           <TaggedText
             text={post.content || ''}
             onTagClick={(tag) => {
-              // Extract tag name (remove # prefix) and convert to slug
-              const tagName = tag.startsWith('#') ? tag.slice(1) : tag;
-              const tagSlug = tagName.toLowerCase().replace(/\s+/g, '-');
-              router.push(`/trending/${encodeURIComponent(tagSlug)}`);
+              if (tag.startsWith('@')) {
+                // Handle @mentions - route to profile
+                const username = tag.slice(1);
+                router.push(getProfileUrl('', username));
+              } else if (tag.startsWith('$')) {
+                // Handle $cashtags - route to markets
+                const symbol = tag.slice(1);
+                router.push(`/markets?search=${encodeURIComponent(symbol)}`);
+              }
             }}
           />
         </div>

--- a/apps/web/src/components/shared/TaggedText.tsx
+++ b/apps/web/src/components/shared/TaggedText.tsx
@@ -5,9 +5,10 @@ import { cn } from '@babylon/shared';
 /**
  * Tagged text component for parsing and highlighting social tags.
  *
- * Parses and highlights @mentions, #hashtags, and $cashtags in text.
+ * Parses and highlights @mentions and $cashtags in text.
  * Tags are clickable and styled in blue with hover effects. Handles
  * edge cases like null/undefined text and empty strings gracefully.
+ * Note: Prices like $120k, $19.99 are NOT treated as cashtags.
  *
  * @param props - TaggedText component props
  * @returns Tagged text element with highlighted tags
@@ -15,7 +16,7 @@ import { cn } from '@babylon/shared';
  * @example
  * ```tsx
  * <TaggedText
- *   text="Check out @username and #hashtag $AAPL"
+ *   text="Check out @username and $AAPL stock"
  *   onTagClick={(tag) => console.log('Clicked:', tag)}
  * />
  * ```
@@ -37,10 +38,12 @@ export function TaggedText({ text, onTagClick, className }: TaggedTextProps) {
     return <span className={className}></span>;
   }
 
-  // Regex to match @mentions, #hashtags, and $cashtags
-  // Matches: @username, #hashtag, $cashtag, $19.99
-  // Captures everything until a space (allows periods, hyphens, numbers, etc.)
-  const tagRegex = /(@|#|\$)([^\s]+)/g;
+  // Regex to match @mentions and $cashtags (excluding prices)
+  // @mentions: followed by word characters
+  // $cashtags: only match if followed by letters (not numbers) to avoid matching prices like $120k, $19.99
+  // Examples: @username, $AAPL, $BTC (but NOT $120k, $19.99)
+  // Note: #hashtags are ignored - not used in the app
+  const tagRegex = /(@[\w-]+)|(\$[A-Za-z][\w]*)/g;
 
   const parts: Array<{
     text: string;
@@ -62,9 +65,10 @@ export function TaggedText({ text, onTagClick, className }: TaggedTextProps) {
       });
     }
 
-    // Add the tag
+    // Add the tag - match[0] is the full match
+    // match[1] = @mention, match[2] = #hashtag, match[3] = $cashtag
     const fullTag = match[0]; // e.g., "@username" or "#hashtag" or "$cashtag"
-    const tagType = match[1] as '@' | '#' | '$';
+    const tagType = fullTag[0] as '@' | '#' | '$';
     parts.push({
       text: fullTag,
       isTag: true,


### PR DESCRIPTION
## Summary
- Fix @ mentions to route to profile pages instead of trending pages
- Fix possessive 's being captured in usernames (e.g., `@zohranmamdanAI's` now correctly routes to `@zohranmamdanAI`)
- Remove hashtag detection (unused feature, not needed in the app)
- Fix $ cashtags to only match stock symbols, not prices (e.g., `$AAPL` is clickable, `$120k` is not)

## Changes
- Updated `TaggedText.tsx` regex to use word boundaries and letter-only cashtag matching
- Removed hashtag routing logic from all click handlers
- Added proper tag type detection (@ vs $) in `PostCard.tsx`, `CommentCard.tsx`, and `profile/page.tsx`
- @ mentions → route to `/profile/username`
- $ cashtags → route to `/markets?search=symbol`

## Testing
- ✅ TypeScript typecheck passed
- ✅ Biome lint passed
- Manually tested on staging site at https://staging.babylon.market/feed

Fixes issue where clicking @mentions in posts was incorrectly routing to trending pages instead of profile pages.