### PR TITLE
fix(a2a): Add missing executor operations and fix likePost userId

### DIFF
--- a/packages/a2a/src/executors/babylon-executor.ts
+++ b/packages/a2a/src/executors/babylon-executor.ts
@@ -281,7 +281,7 @@ export class BabylonAgentExecutor implements AgentExecutor {
     const command = this.parseCommand(userMessage);
     const result = await this.executeOperation(command, requestContext);
 
-    // Create artifact with result (return result directly, not wrapped)
+    // Create artifact with result
     const artifactUpdate: TaskArtifactUpdateEvent = {
       kind: 'artifact-update',
       taskId,

--- a/packages/a2a/src/executors/babylon-executor.ts
+++ b/packages/a2a/src/executors/babylon-executor.ts
@@ -480,7 +480,11 @@ export class BabylonAgentExecutor implements AgentExecutor {
       throw new Error('Post not found');
     }
 
-    const userId = context.contextId || context.taskId;
+    // Use userId from params first (actual agent user ID), fall back to context
+    const userId =
+      typeof params.userId === 'string' && params.userId
+        ? params.userId
+        : context.contextId || context.taskId;
 
     // Check if already liked
     const existingLike = await db.reaction.findFirst({

--- a/packages/a2a/src/executors/babylon-executor.ts
+++ b/packages/a2a/src/executors/babylon-executor.ts
@@ -200,6 +200,24 @@ interface MuteStatusResponse {
   } | null;
 }
 
+interface TrendingTagsResponse {
+  tags: Array<{
+    name: string;
+    displayName: string;
+    category: string;
+    postCount: number;
+  }>;
+}
+
+interface PostsByTagResponse {
+  posts: Array<{
+    id: string;
+    content: string;
+    authorId: string;
+    timestamp: Date;
+  }>;
+}
+
 type ExecutorOperationResult =
   | PostCreatedResponse
   | FeedResponse
@@ -207,6 +225,8 @@ type ExecutorOperationResult =
   | UsersSearchResponse
   | SystemStatsResponse
   | LeaderboardResponse
+  | TrendingTagsResponse
+  | PostsByTagResponse
   | BlockMuteResponse
   | ReportResponse
   | BlocksListResponse
@@ -261,7 +281,7 @@ export class BabylonAgentExecutor implements AgentExecutor {
     const command = this.parseCommand(userMessage);
     const result = await this.executeOperation(command, requestContext);
 
-    // Create artifact with result
+    // Create artifact with result (return result directly, not wrapped)
     const artifactUpdate: TaskArtifactUpdateEvent = {
       kind: 'artifact-update',
       taskId,
@@ -272,7 +292,7 @@ export class BabylonAgentExecutor implements AgentExecutor {
         parts: [
           {
             kind: 'data',
-            data: { result: result ?? null } as { [k: string]: JsonValue },
+            data: (result ?? {}) as { [k: string]: JsonValue },
           },
         ],
       },
@@ -303,6 +323,8 @@ export class BabylonAgentExecutor implements AgentExecutor {
         return this.createPost(command.params, context);
       case 'social.get_feed':
         return this.getFeed(command.params);
+      case 'social.like_post':
+        return this.likePost(command.params, context);
       case 'markets.list_prediction':
         return this.listPredictionMarkets(command.params);
       case 'users.search':
@@ -311,6 +333,10 @@ export class BabylonAgentExecutor implements AgentExecutor {
         return this.getSystemStats();
       case 'stats.leaderboard':
         return this.getLeaderboard(command.params);
+      case 'stats.trending_tags':
+        return this.getTrendingTags(command.params);
+      case 'stats.posts_by_tag':
+        return this.getPostsByTag(command.params);
       case 'moderation.create_escrow_payment':
         return this.createEscrowPayment(command.params, context);
       case 'moderation.verify_escrow_payment':
@@ -436,6 +462,52 @@ export class BabylonAgentExecutor implements AgentExecutor {
     };
   }
 
+  private async likePost(
+    params: Record<string, JsonValue>,
+    context: RequestContext
+  ): Promise<SuccessResponse> {
+    const postId = typeof params.postId === 'string' ? params.postId : '';
+    if (!postId) {
+      throw new Error('postId is required');
+    }
+
+    // Check if post exists
+    const post = await db.post.findFirst({
+      where: { id: postId, deletedAt: null },
+    });
+
+    if (!post) {
+      throw new Error('Post not found');
+    }
+
+    const userId = context.contextId || context.taskId;
+
+    // Check if already liked
+    const existingLike = await db.reaction.findFirst({
+      where: {
+        postId,
+        userId,
+        type: 'like',
+      },
+    });
+
+    if (existingLike) {
+      return { success: true, message: 'Already liked' };
+    }
+
+    // Create the like
+    await db.reaction.create({
+      data: {
+        id: await generateSnowflakeId(),
+        postId,
+        userId,
+        type: 'like',
+      },
+    });
+
+    return { success: true, message: 'Post liked' };
+  }
+
   private async listPredictionMarkets(params: Record<string, JsonValue>) {
     const limit = this.parsePositiveInt(params.limit, 20, 50);
     const markets = await db.market.findMany({
@@ -500,6 +572,98 @@ export class BabylonAgentExecutor implements AgentExecutor {
       },
     });
     return { leaderboard: users };
+  }
+
+  private async getTrendingTags(
+    params: Record<string, JsonValue>
+  ): Promise<TrendingTagsResponse> {
+    const limit = this.parsePositiveInt(params.limit, 10, 50);
+
+    // Get trending tags with their tag info via query
+    const trendingTagsList = await db.trendingTag.findMany({
+      take: limit,
+      orderBy: { score: 'desc' },
+    });
+
+    // Get tag IDs
+    const tagIds = trendingTagsList.map((tt) => tt.tagId);
+
+    // Fetch actual tag info
+    const tags =
+      tagIds.length > 0
+        ? await db.tag.findMany({
+            where: { id: { in: tagIds } },
+          })
+        : [];
+
+    // Create a map for quick lookup
+    const tagMap = new Map(tags.map((t) => [t.id, t]));
+
+    return {
+      tags: trendingTagsList.map((tt) => {
+        const tag = tagMap.get(tt.tagId);
+        return {
+          name: tag?.name ?? '',
+          displayName: tag?.displayName ?? tag?.name ?? '',
+          category: tag?.category ?? 'general',
+          postCount: tt.postCount,
+        };
+      }),
+    };
+  }
+
+  private async getPostsByTag(
+    params: Record<string, JsonValue>
+  ): Promise<PostsByTagResponse> {
+    const tagName = typeof params.tag === 'string' ? params.tag.trim() : '';
+    if (!tagName) {
+      throw new Error('tag is required');
+    }
+
+    const limit = this.parsePositiveInt(params.limit, 20, 50);
+    const offset = this.parsePositiveInt(params.offset, 0, 1000);
+
+    // Find the tag by name
+    const tag = await db.tag.findFirst({
+      where: { name: tagName },
+    });
+
+    if (!tag) {
+      return { posts: [] };
+    }
+
+    // Find posts with this tag via PostTag join table
+    const postTagEntries = await db.postTag.findMany({
+      where: { tagId: tag.id },
+      orderBy: { createdAt: 'desc' },
+      take: limit,
+      skip: offset,
+    });
+
+    const postIds = postTagEntries.map((pt) => pt.postId);
+
+    if (postIds.length === 0) {
+      return { posts: [] };
+    }
+
+    // Fetch the actual posts
+    const posts = await db.post.findMany({
+      where: {
+        id: { in: postIds },
+        deletedAt: null,
+        type: 'post',
+      },
+      orderBy: { timestamp: 'desc' },
+    });
+
+    return {
+      posts: posts.map((p) => ({
+        id: p.id,
+        content: p.content,
+        authorId: p.authorId,
+        timestamp: p.timestamp,
+      })),
+    };
   }
 
   private parsePositiveInt(

--- a/packages/agents/src/autonomous/AutonomousA2AService.ts
+++ b/packages/agents/src/autonomous/AutonomousA2AService.ts
@@ -553,6 +553,7 @@ Your JSON response:`;
       if (post && post.id) {
         await a2aClient.sendRequest('a2a.likePost', {
           postId: post.id,
+          userId: agentUserId, // Pass the agent's actual user ID
         });
         engagements++;
 

--- a/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts
+++ b/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts
@@ -237,6 +237,27 @@ export class BabylonA2AClient {
 
     const skillId = skillMap[action] || 'portfolio-balance';
 
+    // Map camelCase actions to category.snake_case operation names
+    // This follows the executor's convention (e.g., 'social.create_post', 'stats.leaderboard')
+    const operationMap: Record<string, string> = {
+      // Social operations
+      createPost: 'social.create_post',
+      getFeed: 'social.get_feed',
+      likePost: 'social.like_post',
+      // Stats operations
+      getSystemStats: 'stats.system',
+      getLeaderboard: 'stats.leaderboard',
+      getTrendingTags: 'stats.trending_tags',
+      getPostsByTag: 'stats.posts_by_tag',
+      // Markets operations
+      getPredictions: 'markets.list_prediction',
+      // Users operations
+      searchUsers: 'users.search',
+    };
+
+    // Use mapped operation name if available, otherwise use original action
+    const operationName = operationMap[action] || action;
+
     const response = await this.sdkClient.sendMessage({
       message: {
         kind: 'message',
@@ -245,7 +266,7 @@ export class BabylonA2AClient {
         parts: [
           {
             kind: 'data',
-            data: { operation: action, params },
+            data: { operation: operationName, params },
             metadata: {
               skillId,
             },


### PR DESCRIPTION
## Summary
Fixes A2A protocol issues for autonomous agent operations, specifically for the `engageWithTrending` flow.

## Changes

### 1. Add missing executor operations (`babylon-executor.ts`)
- Added `stats.trending_tags` operation to fetch trending tags from the database
- Added `stats.posts_by_tag` operation to fetch posts associated with a given tag
- Added `social.like_post` operation to record user likes on posts
- Fixed artifact response wrapper that was incorrectly wrapping results in `{ result: ... }`

### 2. Add operation name mapping (`integration-a2a-sdk.ts`)
- Added `operationMap` to translate camelCase actions (e.g., `getTrendingTags`) to `category.snake_case` format (e.g., `stats.trending_tags`)
- Ensures consistent naming convention between client and executor

### 3. Fix userId in likePost
- Pass `agentUserId` when calling `likePost` from `AutonomousA2AService`
- Update executor to use `params.userId` before falling back to context IDs
- **Fixes:** Likes were being recorded with random UUIDs (task IDs) instead of actual user IDs
