### PR TITLE
feat(agents): Smart LLM-based post selection and comment threading for autonomous commenting

### DIFF
--- a/apps/web/src/app/api/comments/[id]/route.ts
+++ b/apps/web/src/app/api/comments/[id]/route.ts
@@ -144,6 +144,7 @@ import {
   reactions,
   users,
 } from '@babylon/db';
+import { StaticDataRegistry } from '@babylon/engine';
 import { IdParamSchema, logger, UpdateCommentSchema } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 
@@ -284,19 +285,46 @@ export const GET = withErrorHandling(
       .where(eq(posts.id, comment.postId))
       .limit(1);
 
-    // Get post author info
-    const [postAuthor] = post
-      ? await db
-          .select({
-            id: users.id,
-            displayName: users.displayName,
-            username: users.username,
-            profileImageUrl: users.profileImageUrl,
-          })
-          .from(users)
-          .where(eq(users.id, post.authorId))
-          .limit(1)
-      : [null];
+    // Get post author info - check StaticDataRegistry first (for actors/orgs), then database
+    let postAuthorName = post?.authorId || 'Unknown';
+    let postAuthorUsername: string | null = null;
+    let postAuthorProfileImageUrl: string | null = null;
+
+    if (post) {
+      // Check if it's an actor (NPC/agent)
+      const actor = StaticDataRegistry.getActor(post.authorId);
+      if (actor) {
+        postAuthorName = actor.name;
+        postAuthorProfileImageUrl =
+          actor.profileImageUrl || `/images/actors/${actor.id}.jpg`;
+      } else {
+        // Check if it's an organization
+        const org = StaticDataRegistry.getOrganization(post.authorId);
+        if (org) {
+          postAuthorName = org.name;
+          postAuthorProfileImageUrl =
+            org.imageUrl || `/images/organizations/${org.id}.jpg`;
+        } else {
+          // Fall back to database user lookup
+          const [userRecord] = await db
+            .select({
+              displayName: users.displayName,
+              username: users.username,
+              profileImageUrl: users.profileImageUrl,
+            })
+            .from(users)
+            .where(eq(users.id, post.authorId))
+            .limit(1);
+
+          if (userRecord) {
+            postAuthorName =
+              userRecord.displayName || userRecord.username || post.authorId;
+            postAuthorUsername = userRecord.username || null;
+            postAuthorProfileImageUrl = userRecord.profileImageUrl || null;
+          }
+        }
+      }
+    }
 
     // Get comment author info
     const [commentAuthor] = await db
@@ -466,9 +494,9 @@ export const GET = withErrorHandling(
             id: post.id,
             content: post.content,
             authorId: post.authorId,
-            authorName: postAuthor?.displayName || 'Unknown',
-            authorUsername: postAuthor?.username || null,
-            authorProfileImageUrl: postAuthor?.profileImageUrl || null,
+            authorName: postAuthorName,
+            authorUsername: postAuthorUsername,
+            authorProfileImageUrl: postAuthorProfileImageUrl,
             createdAt: post.createdAt,
           }
         : null,

--- a/packages/agents/src/autonomous/AutonomousCommentingService.ts
+++ b/packages/agents/src/autonomous/AutonomousCommentingService.ts
@@ -36,6 +36,21 @@ import { generateSnowflakeId } from '../shared/snowflake';
 
 // Max characters for comment content in prompts
 const MAX_COMMENT_CHARS = 200;
+// Max thread depth to walk up when building context
+const MAX_THREAD_DEPTH = 5;
+
+interface ThreadMessage {
+  id: string;
+  authorName: string;
+  content: string;
+  depth: number;
+}
+
+interface CommentThread {
+  targetCommentId: string; // The comment to potentially reply to
+  thread: ThreadMessage[]; // Conversation path from root to target
+  likeCount: number;
+}
 
 interface PostWithComments {
   id: string;
@@ -44,12 +59,7 @@ interface PostWithComments {
   authorName: string;
   createdAt: Date;
   commentCount: number;
-  topComments: {
-    id: string;
-    content: string;
-    authorName: string;
-    createdAt: Date;
-  }[];
+  commentThreads: CommentThread[]; // Threads built from bottom up
 }
 
 export class AutonomousCommentingService {
@@ -117,7 +127,7 @@ export class AutonomousCommentingService {
       return null;
     }
 
-    // Get comments for these posts
+    // Get comments for these posts (including parentCommentId for threading)
     const postIds = uncommentedPosts.map((p) => p.id);
     const allComments = await db
       .select({
@@ -125,12 +135,13 @@ export class AutonomousCommentingService {
         content: comments.content,
         postId: comments.postId,
         authorId: comments.authorId,
+        parentCommentId: comments.parentCommentId,
         createdAt: comments.createdAt,
       })
       .from(comments)
       .where(isNull(comments.deletedAt))
       .orderBy(desc(comments.createdAt))
-      .limit(100);
+      .limit(200); // Increased to capture more thread context
 
     // Filter comments to our posts
     const postComments = allComments.filter(
@@ -204,14 +215,109 @@ export class AutonomousCommentingService {
       }
     }
 
-    // Build posts with comments (sorted by popularity/likes)
+    // Helper: Build thread from bottom by walking UP from target comment
+    const buildThreadFromBottom = (
+      targetComment: (typeof postCommentsWithLikes)[0],
+      commentMap: Map<string, (typeof postCommentsWithLikes)[0]>
+    ): ThreadMessage[] => {
+      const chain: (typeof postCommentsWithLikes)[0][] = [targetComment];
+      let currentParentId = targetComment.parentCommentId;
+
+      // Walk UP the parent chain
+      while (currentParentId && chain.length < MAX_THREAD_DEPTH) {
+        const parent = commentMap.get(currentParentId);
+        if (!parent) break;
+        chain.unshift(parent); // prepend = oldest first
+        currentParentId = parent.parentCommentId;
+      }
+
+      return chain.map((c, i) => ({
+        id: c.id,
+        authorName: authorMap.get(c.authorId) || 'User',
+        content: c.content,
+        depth: i,
+      }));
+    };
+
+    // Build thread structure for each post (from bottom up)
+    const buildCommentThreads = (
+      postId: string
+    ): { commentThreads: CommentThread[]; totalCount: number } => {
+      const postCommentsList = postCommentsWithLikes.filter(
+        (c) => c.postId === postId
+      );
+      const totalCount = postCommentsList.length;
+
+      if (totalCount === 0) {
+        return { commentThreads: [], totalCount: 0 };
+      }
+
+      // Create a map of comments by ID
+      const commentMap = new Map(postCommentsList.map((c) => [c.id, c]));
+
+      // Find which comments have replies (children)
+      const hasReplies = new Set<string>();
+      for (const c of postCommentsList) {
+        if (c.parentCommentId) {
+          hasReplies.add(c.parentCommentId);
+        }
+      }
+
+      // Identify "interesting" comments to show threads for:
+      // 1. Leaf comments (no replies) - end of conversation
+      // 2. Top-level comments with high engagement
+      // Sort by: leaf status, then popularity
+      const candidateComments = postCommentsList
+        .map((c) => ({
+          ...c,
+          isLeaf: !hasReplies.has(c.id),
+        }))
+        .sort((a, b) => {
+          // Prioritize leaf comments, then by likes
+          if (a.isLeaf !== b.isLeaf) return a.isLeaf ? -1 : 1;
+          return b.likeCount - a.likeCount;
+        });
+
+      // Build threads for top 5 candidate comments
+      const commentThreads: CommentThread[] = [];
+      const seenCommentIds = new Set<string>(); // Track all comments we've shown
+
+      for (const candidate of candidateComments.slice(0, 8)) {
+        // Skip if we've already shown this comment in another thread
+        if (seenCommentIds.has(candidate.id)) {
+          continue;
+        }
+
+        const thread = buildThreadFromBottom(candidate, commentMap);
+
+        // Skip if any comment in this thread was already shown
+        const hasOverlap = thread.some((msg) => seenCommentIds.has(msg.id));
+        if (hasOverlap) {
+          continue;
+        }
+
+        // Mark all comments in this thread as seen
+        for (const msg of thread) {
+          seenCommentIds.add(msg.id);
+        }
+
+        commentThreads.push({
+          targetCommentId: candidate.id,
+          thread,
+          likeCount: candidate.likeCount,
+        });
+
+        if (commentThreads.length >= 5) break;
+      }
+
+      return { commentThreads, totalCount };
+    };
+
+    // Build posts with threaded comments (built from bottom up)
     const postsWithComments: PostWithComments[] = uncommentedPosts
       .slice(0, 8)
       .map((post) => {
-        // Get top 5 most popular comments for this post (already sorted by likes)
-        const topCommentsForPost = postCommentsWithLikes
-          .filter((c) => c.postId === post.id)
-          .slice(0, 5);
+        const { commentThreads, totalCount } = buildCommentThreads(post.id);
 
         return {
           id: post.id,
@@ -219,15 +325,8 @@ export class AutonomousCommentingService {
           authorId: post.authorId,
           authorName: authorMap.get(post.authorId) || 'User',
           createdAt: post.createdAt,
-          commentCount: postCommentsWithLikes.filter(
-            (c) => c.postId === post.id
-          ).length,
-          topComments: topCommentsForPost.map((c) => ({
-            id: c.id,
-            content: c.content,
-            authorName: authorMap.get(c.authorId) || 'User',
-            createdAt: c.createdAt,
-          })),
+          commentCount: totalCount,
+          commentThreads,
         };
       });
 
@@ -257,22 +356,34 @@ export class AutonomousCommentingService {
 
     const config = await getAgentConfig(agentUserId);
 
+    // Helper to format a comment thread (built from bottom, shows conversation path)
+    const formatCommentThread = (commentThread: CommentThread): string => {
+      const { thread } = commentThread;
+
+      const threadLines = thread.map((msg, idx) => {
+        const depthLabel =
+          idx === 0 ? 'Comment' : `Reply (depth ${msg.depth})`;
+        const truncatedContent =
+          msg.content.substring(0, MAX_COMMENT_CHARS) +
+          (msg.content.length > MAX_COMMENT_CHARS ? '...' : '');
+
+        return `    - ${depthLabel} [comment_id: ${msg.id}] @${msg.authorName}: "${truncatedContent}"`;
+      });
+
+      return threadLines.join('\n');
+    };
+
     // Build the evaluation prompt
     const postsContext = postsWithComments
       .map((post, idx) => {
-        const commentsText =
-          post.topComments.length > 0
-            ? `\n  Recent comments:\n${post.topComments
-                .map(
-                  (c) =>
-                    `    - [comment_id: ${c.id}] @${c.authorName}: "${c.content.substring(0, MAX_COMMENT_CHARS)}${c.content.length > MAX_COMMENT_CHARS ? '...' : ''}"`
-                )
-                .join('\n')}`
+        const threadsText =
+          post.commentThreads.length > 0
+            ? `\n  Conversation threads:\n${post.commentThreads.map((ct) => formatCommentThread(ct)).join('\n\n')}`
             : '\n  No comments yet';
 
         return `[${idx + 1}] Post by @${post.authorName}:
 "${post.content.substring(0, 300)}${post.content.length > 300 ? '...' : ''}"
-  (${post.commentCount} comments)${commentsText}`;
+  (${post.commentCount} comments)${threadsText}`;
       })
       .join('\n\n');
 
@@ -465,21 +576,23 @@ If you want to skip (no relevant posts):
       }
 
       // Validate reply_to_comment_id if provided
+      // Collect all comment IDs from comment threads
+      const allCommentIds = selectedPost.commentThreads.flatMap((ct) =>
+        ct.thread.map((msg) => msg.id)
+      );
+
       let parentCommentId: string | null = null;
       if (decision.replyToCommentId) {
-        const validComment = selectedPost.topComments.find(
-          (c) => c.id === decision.replyToCommentId
-        );
-        if (validComment) {
+        if (allCommentIds.includes(decision.replyToCommentId)) {
           parentCommentId = decision.replyToCommentId;
         } else {
-          // LLM returned an ID but it wasn't in our topComments - log this
+          // LLM returned an ID but it wasn't in our comment threads - log this
           logger.warn(
-            `LLM returned replyToCommentId "${decision.replyToCommentId}" but it wasn't found in topComments. Creating top-level comment instead.`,
+            `LLM returned replyToCommentId "${decision.replyToCommentId}" but it wasn't found in comment threads. Creating top-level comment instead.`,
             {
               agentUserId,
               postId: selectedPost.id,
-              availableIds: selectedPost.topComments.map((c) => c.id),
+              availableIds: allCommentIds,
             },
             'AutonomousCommenting'
           );

--- a/packages/agents/src/autonomous/AutonomousCommentingService.ts
+++ b/packages/agents/src/autonomous/AutonomousCommentingService.ts
@@ -22,6 +22,7 @@ import {
   perpPositions,
   positions,
   posts,
+  reactions,
   users,
 } from '@babylon/db';
 import type { IAgentRuntime } from '@elizaos/core';
@@ -122,31 +123,55 @@ export class AutonomousCommentingService {
         createdAt: comments.createdAt,
       })
       .from(comments)
-      .where(
-        and(
-          isNull(comments.deletedAt),
-          // Only get comments for our posts - filter in memory since inArray might not work
-        )
-      )
+      .where(isNull(comments.deletedAt))
       .orderBy(desc(comments.createdAt))
       .limit(100);
 
     // Filter comments to our posts
-    const postComments = allComments.filter((c) => c.postId && postIds.includes(c.postId));
+    const postComments = allComments.filter(
+      (c) => c.postId && postIds.includes(c.postId)
+    );
+
+    // Get like counts for these comments
+    const commentIds = postComments.map((c) => c.id);
+    const likeCountsRaw = await db
+      .select({
+        commentId: reactions.commentId,
+      })
+      .from(reactions)
+      .where(and(eq(reactions.type, 'like')));
+
+    // Count likes per comment (filter in memory since inArray might not work)
+    const likeCounts = new Map<string, number>();
+    for (const r of likeCountsRaw) {
+      if (r.commentId && commentIds.includes(r.commentId)) {
+        likeCounts.set(r.commentId, (likeCounts.get(r.commentId) || 0) + 1);
+      }
+    }
+
+    // Add like counts to comments and sort by popularity
+    const postCommentsWithLikes = postComments
+      .map((c) => ({
+        ...c,
+        likeCount: likeCounts.get(c.id) || 0,
+      }))
+      .sort((a, b) => b.likeCount - a.likeCount);
 
     // Get author names for posts and comments
     const authorIds = new Set([
       ...uncommentedPosts.map((p) => p.authorId),
       ...postComments.map((c) => c.authorId),
     ]);
+    // Get all authors - filter in memory since we have a set of IDs
     const authorUsers = await db
-      .select({ id: users.id, displayName: users.displayName, username: users.username })
+      .select({
+        id: users.id,
+        displayName: users.displayName,
+        username: users.username,
+      })
       .from(users)
-      .where(
-        // Filter in memory
-      )
-      .limit(50);
-    
+      .limit(100);
+
     // Filter to only the authors we need
     const authorMap = new Map(
       authorUsers
@@ -154,27 +179,30 @@ export class AutonomousCommentingService {
         .map((u) => [u.id, u.displayName || u.username || 'User'])
     );
 
-    // Build posts with comments
-    const postsWithComments: PostWithComments[] = uncommentedPosts.slice(0, 8).map((post) => {
-      const postCommentsFiltered = postComments
-        .filter((c) => c.postId === post.id)
-        .slice(0, 5);
-      
-      return {
-        id: post.id,
-        content: post.content,
-        authorId: post.authorId,
-        authorName: authorMap.get(post.authorId) || 'User',
-        createdAt: post.createdAt,
-        commentCount: postComments.filter((c) => c.postId === post.id).length,
-        topComments: postCommentsFiltered.map((c) => ({
-          id: c.id,
-          content: c.content,
-          authorName: authorMap.get(c.authorId) || 'User',
-          createdAt: c.createdAt,
-        })),
-      };
-    });
+    // Build posts with comments (sorted by popularity/likes)
+    const postsWithComments: PostWithComments[] = uncommentedPosts
+      .slice(0, 8)
+      .map((post) => {
+        // Get top 5 most popular comments for this post (already sorted by likes)
+        const topCommentsForPost = postCommentsWithLikes
+          .filter((c) => c.postId === post.id)
+          .slice(0, 5);
+
+        return {
+          id: post.id,
+          content: post.content,
+          authorId: post.authorId,
+          authorName: authorMap.get(post.authorId) || 'User',
+          createdAt: post.createdAt,
+          commentCount: postCommentsWithLikes.filter((c) => c.postId === post.id).length,
+          topComments: topCommentsForPost.map((c) => ({
+            id: c.id,
+            content: c.content,
+            authorName: authorMap.get(c.authorId) || 'User',
+            createdAt: c.createdAt,
+          })),
+        };
+      });
 
     if (postsWithComments.length === 0) {
       return null;
@@ -205,11 +233,15 @@ export class AutonomousCommentingService {
     // Build the evaluation prompt
     const postsContext = postsWithComments
       .map((post, idx) => {
-        const commentsText = post.topComments.length > 0
-          ? `\n  Recent comments:\n${post.topComments
-              .map((c) => `    - @${c.authorName}: "${c.content.substring(0, 100)}${c.content.length > 100 ? '...' : ''}"`)
-              .join('\n')}`
-          : '\n  No comments yet';
+        const commentsText =
+          post.topComments.length > 0
+            ? `\n  Recent comments:\n${post.topComments
+                .map(
+                  (c) =>
+                    `    - [comment_id: ${c.id}] @${c.authorName}: "${c.content.substring(0, 100)}${c.content.length > 100 ? '...' : ''}"`
+                )
+                .join('\n')}`
+            : '\n  No comments yet';
 
         return `[${idx + 1}] Post by @${post.authorName}:
 "${post.content.substring(0, 300)}${post.content.length > 300 ? '...' : ''}"
@@ -246,13 +278,26 @@ DECISION CRITERIA:
 - Engagement: Are there interesting threads to join?
 - Avoid: Posts where you have nothing meaningful to add
 
+IMPORTANT THREADING RULE:
+- If you want to respond to/agree with/reference another user's comment, you MUST use reply_to_comment_id to reply to their comment
+- Do NOT make a top-level comment that mentions another commenter - that creates duplicate threads
+- Only leave reply_to_comment_id empty if your comment is a NEW perspective on the post itself
+
 OUTPUT FORMAT:
-If you want to comment:
+If commenting directly on a post:
 <response>
 <action>comment</action>
 <post_index>1-${postsWithComments.length}</post_index>
-<reply_to_comment_id>comment_id or empty if commenting on post directly</reply_to_comment_id>
+<reply_to_comment_id></reply_to_comment_id>
 <content>Your comment here (1-2 sentences, under 200 chars)</content>
+</response>
+
+If replying to an existing comment (use the comment_id shown in brackets):
+<response>
+<action>comment</action>
+<post_index>1-${postsWithComments.length}</post_index>
+<reply_to_comment_id>the_comment_id_from_brackets</reply_to_comment_id>
+<content>Your reply here (1-2 sentences, under 200 chars)</content>
 </response>
 
 If you want to skip (no relevant posts):
@@ -332,7 +377,9 @@ If you want to skip (no relevant posts):
 
         decision = {
           action: parsed.action,
-          postIndex: parsed.post_index ? parseInt(parsed.post_index, 10) : undefined,
+          postIndex: parsed.post_index
+            ? parseInt(parsed.post_index, 10)
+            : undefined,
           replyToCommentId: parsed.reply_to_comment_id || undefined,
           content: parsed.content,
           reason: parsed.reason,
@@ -368,7 +415,11 @@ If you want to skip (no relevant posts):
     }
 
     // Handle comment
-    if (decision.action === 'comment' && decision.postIndex && decision.content) {
+    if (
+      decision.action === 'comment' &&
+      decision.postIndex &&
+      decision.content
+    ) {
       const selectedPost = postsWithComments[decision.postIndex - 1];
       if (!selectedPost) {
         logger.warn(
@@ -392,6 +443,17 @@ If you want to skip (no relevant posts):
         );
         if (validComment) {
           parentCommentId = decision.replyToCommentId;
+        } else {
+          // LLM returned an ID but it wasn't in our topComments - log this
+          logger.warn(
+            `LLM returned replyToCommentId "${decision.replyToCommentId}" but it wasn't found in topComments. Creating top-level comment instead.`,
+            { 
+              agentUserId, 
+              postId: selectedPost.id,
+              availableIds: selectedPost.topComments.map(c => c.id)
+            },
+            'AutonomousCommenting'
+          );
         }
       }
 

--- a/packages/agents/src/autonomous/AutonomousCommentingService.ts
+++ b/packages/agents/src/autonomous/AutonomousCommentingService.ts
@@ -16,6 +16,7 @@ import {
   desc,
   eq,
   gte,
+  inArray,
   isNull,
   lte,
   ne,
@@ -25,12 +26,16 @@ import {
   reactions,
   users,
 } from '@babylon/db';
+import { StaticDataRegistry } from '@babylon/engine';
 import type { IAgentRuntime } from '@elizaos/core';
 import { parseKeyValueXml } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
 import { getAgentConfig } from '../shared/agent-config';
 import { logger } from '../shared/logger';
 import { generateSnowflakeId } from '../shared/snowflake';
+
+// Max characters for comment content in prompts
+const MAX_COMMENT_CHARS = 200;
 
 interface PostWithComments {
   id: string;
@@ -158,26 +163,46 @@ export class AutonomousCommentingService {
       .sort((a, b) => b.likeCount - a.likeCount);
 
     // Get author names for posts and comments
-    const authorIds = new Set([
-      ...uncommentedPosts.map((p) => p.authorId),
-      ...postComments.map((c) => c.authorId),
-    ]);
-    // Get all authors - filter in memory since we have a set of IDs
-    const authorUsers = await db
-      .select({
-        id: users.id,
-        displayName: users.displayName,
-        username: users.username,
-      })
-      .from(users)
-      .limit(100);
+    const authorIds = [
+      ...new Set([
+        ...uncommentedPosts.map((p) => p.authorId),
+        ...postComments.map((c) => c.authorId),
+      ]),
+    ];
 
-    // Filter to only the authors we need
-    const authorMap = new Map(
-      authorUsers
-        .filter((u) => authorIds.has(u.id))
-        .map((u) => [u.id, u.displayName || u.username || 'User'])
-    );
+    // First check StaticDataRegistry for actors/organizations
+    const authorMap = new Map<string, string>();
+    const missingAuthorIds: string[] = [];
+
+    for (const authorId of authorIds) {
+      const actor = StaticDataRegistry.getActor(authorId);
+      if (actor) {
+        authorMap.set(authorId, actor.name);
+        continue;
+      }
+      const org = StaticDataRegistry.getOrganization(authorId);
+      if (org) {
+        authorMap.set(authorId, org.name);
+        continue;
+      }
+      missingAuthorIds.push(authorId);
+    }
+
+    // Fetch remaining authors from database
+    if (missingAuthorIds.length > 0) {
+      const authorUsers = await db
+        .select({
+          id: users.id,
+          displayName: users.displayName,
+          username: users.username,
+        })
+        .from(users)
+        .where(inArray(users.id, missingAuthorIds));
+
+      for (const u of authorUsers) {
+        authorMap.set(u.id, u.displayName || u.username || 'User');
+      }
+    }
 
     // Build posts with comments (sorted by popularity/likes)
     const postsWithComments: PostWithComments[] = uncommentedPosts
@@ -194,7 +219,9 @@ export class AutonomousCommentingService {
           authorId: post.authorId,
           authorName: authorMap.get(post.authorId) || 'User',
           createdAt: post.createdAt,
-          commentCount: postCommentsWithLikes.filter((c) => c.postId === post.id).length,
+          commentCount: postCommentsWithLikes.filter(
+            (c) => c.postId === post.id
+          ).length,
           topComments: topCommentsForPost.map((c) => ({
             id: c.id,
             content: c.content,
@@ -238,7 +265,7 @@ export class AutonomousCommentingService {
             ? `\n  Recent comments:\n${post.topComments
                 .map(
                   (c) =>
-                    `    - [comment_id: ${c.id}] @${c.authorName}: "${c.content.substring(0, 100)}${c.content.length > 100 ? '...' : ''}"`
+                    `    - [comment_id: ${c.id}] @${c.authorName}: "${c.content.substring(0, MAX_COMMENT_CHARS)}${c.content.length > MAX_COMMENT_CHARS ? '...' : ''}"`
                 )
                 .join('\n')}`
             : '\n  No comments yet';
@@ -258,7 +285,9 @@ export class AutonomousCommentingService {
         : 'No perp positions',
     ].join('\n');
 
-    const prompt = `${config?.systemPrompt ?? 'You are an AI agent on Babylon.'}
+    const prompt = `CRITICAL: Your response MUST start with <response> immediately. No <think> tags. No reasoning. Output only the XML.
+
+${config?.systemPrompt ?? 'You are an AI agent on Babylon.'}
 
 You are ${agent.displayName}, an AI agent on Babylon.
 
@@ -289,7 +318,7 @@ If commenting directly on a post:
 <action>comment</action>
 <post_index>1-${postsWithComments.length}</post_index>
 <reply_to_comment_id></reply_to_comment_id>
-<content>Your comment here (1-2 sentences, under 200 chars)</content>
+<content>Your comment here (1-2 sentences, under ${MAX_COMMENT_CHARS} chars)</content>
 </response>
 
 If replying to an existing comment (use the comment_id shown in brackets):
@@ -297,7 +326,7 @@ If replying to an existing comment (use the comment_id shown in brackets):
 <action>comment</action>
 <post_index>1-${postsWithComments.length}</post_index>
 <reply_to_comment_id>the_comment_id_from_brackets</reply_to_comment_id>
-<content>Your reply here (1-2 sentences, under 200 chars)</content>
+<content>Your reply here (1-2 sentences, under ${MAX_COMMENT_CHARS} chars)</content>
 </response>
 
 If you want to skip (no relevant posts):
@@ -331,17 +360,17 @@ If you want to skip (no relevant posts):
       try {
         const isRetry = attempt > 1;
         const currentPrompt = isRetry
-          ? `${finalPrompt}\n\nREMINDER: You MUST output valid XML in <response> tags.`
+          ? `${finalPrompt}\n\nREMINDER: No <think> tags. Start DIRECTLY with <response>. Output only valid XML.`
           : finalPrompt;
 
         const responseText = await Promise.race([
           callGroqDirect({
             prompt: currentPrompt,
             system: config?.systemPrompt ?? undefined,
-            modelSize: 'small',
+            modelSize: 'large',
             runtime: _runtime,
             temperature: isRetry ? 0.5 : 0.7,
-            maxTokens: 500,
+            maxTokens: 16384,
             actionType: 'evaluate_comment_opportunity',
             purpose: 'evaluation',
           }),
@@ -447,10 +476,10 @@ If you want to skip (no relevant posts):
           // LLM returned an ID but it wasn't in our topComments - log this
           logger.warn(
             `LLM returned replyToCommentId "${decision.replyToCommentId}" but it wasn't found in topComments. Creating top-level comment instead.`,
-            { 
-              agentUserId, 
+            {
+              agentUserId,
               postId: selectedPost.id,
-              availableIds: selectedPost.topComments.map(c => c.id)
+              availableIds: selectedPost.topComments.map((c) => c.id),
             },
             'AutonomousCommenting'
           );

--- a/packages/agents/src/autonomous/AutonomousCommentingService.ts
+++ b/packages/agents/src/autonomous/AutonomousCommentingService.ts
@@ -1,9 +1,14 @@
 /**
  * Autonomous Commenting Service
  *
- * Handles agents commenting on posts autonomously
+ * Handles agents commenting on posts autonomously.
+ * Uses LLM to intelligently select which post to comment on based on:
+ * - Agent's trading positions and strategy
+ * - Post relevance to agent's expertise
+ * - Existing comment threads
  */
 
+import { countTokensSync, truncateToTokenLimitSync } from '@babylon/api';
 import {
   and,
   comments,
@@ -14,18 +19,36 @@ import {
   isNull,
   lte,
   ne,
+  perpPositions,
+  positions,
   posts,
   users,
 } from '@babylon/db';
 import type { IAgentRuntime } from '@elizaos/core';
+import { parseKeyValueXml } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
 import { getAgentConfig } from '../shared/agent-config';
 import { logger } from '../shared/logger';
 import { generateSnowflakeId } from '../shared/snowflake';
 
+interface PostWithComments {
+  id: string;
+  content: string;
+  authorId: string;
+  authorName: string;
+  createdAt: Date;
+  commentCount: number;
+  topComments: {
+    id: string;
+    content: string;
+    authorName: string;
+    createdAt: Date;
+  }[];
+}
+
 export class AutonomousCommentingService {
   /**
-   * Find relevant posts and create comments
+   * Find relevant posts and create comments using LLM evaluation
    */
   async createAgentComment(
     agentUserId: string,
@@ -50,13 +73,18 @@ export class AutonomousCommentingService {
       .from(comments)
       .where(eq(comments.authorId, agentUserId));
 
-    const commentedPostIds = agentComments
-      .map((c) => c.postId)
-      .filter((id) => id !== null) as string[];
+    const commentedPostIds = new Set(
+      agentComments.map((c) => c.postId).filter((id) => id !== null) as string[]
+    );
 
-    // Get recent posts that agent hasn't commented on
-    const recentPostsQuery = db
-      .select()
+    // Get recent posts with author info
+    const recentPostsRaw = await db
+      .select({
+        id: posts.id,
+        content: posts.content,
+        authorId: posts.authorId,
+        createdAt: posts.createdAt,
+      })
       .from(posts)
       .where(
         and(
@@ -67,78 +95,328 @@ export class AutonomousCommentingService {
         )
       )
       .orderBy(desc(posts.createdAt))
-      .limit(10);
-
-    // If there are commented posts, exclude them
-    const recentPosts = await recentPostsQuery;
+      .limit(15);
 
     // Filter to posts agent hasn't commented on
-    const uncommentedPosts = recentPosts.filter(
-      (p) => !commentedPostIds.includes(p.id)
+    const uncommentedPosts = recentPostsRaw.filter(
+      (p) => !commentedPostIds.has(p.id)
     );
 
     if (uncommentedPosts.length === 0) {
-      return null; // Nothing to comment on
-    }
-
-    // Pick the first relevant post
-    const post = uncommentedPosts[0];
-
-    if (!post) {
+      logger.info(
+        `No uncommented posts for agent ${agent.displayName}`,
+        undefined,
+        'AutonomousCommenting'
+      );
       return null;
     }
+
+    // Get comments for these posts
+    const postIds = uncommentedPosts.map((p) => p.id);
+    const allComments = await db
+      .select({
+        id: comments.id,
+        content: comments.content,
+        postId: comments.postId,
+        authorId: comments.authorId,
+        createdAt: comments.createdAt,
+      })
+      .from(comments)
+      .where(
+        and(
+          isNull(comments.deletedAt),
+          // Only get comments for our posts - filter in memory since inArray might not work
+        )
+      )
+      .orderBy(desc(comments.createdAt))
+      .limit(100);
+
+    // Filter comments to our posts
+    const postComments = allComments.filter((c) => c.postId && postIds.includes(c.postId));
+
+    // Get author names for posts and comments
+    const authorIds = new Set([
+      ...uncommentedPosts.map((p) => p.authorId),
+      ...postComments.map((c) => c.authorId),
+    ]);
+    const authorUsers = await db
+      .select({ id: users.id, displayName: users.displayName, username: users.username })
+      .from(users)
+      .where(
+        // Filter in memory
+      )
+      .limit(50);
+    
+    // Filter to only the authors we need
+    const authorMap = new Map(
+      authorUsers
+        .filter((u) => authorIds.has(u.id))
+        .map((u) => [u.id, u.displayName || u.username || 'User'])
+    );
+
+    // Build posts with comments
+    const postsWithComments: PostWithComments[] = uncommentedPosts.slice(0, 8).map((post) => {
+      const postCommentsFiltered = postComments
+        .filter((c) => c.postId === post.id)
+        .slice(0, 5);
+      
+      return {
+        id: post.id,
+        content: post.content,
+        authorId: post.authorId,
+        authorName: authorMap.get(post.authorId) || 'User',
+        createdAt: post.createdAt,
+        commentCount: postComments.filter((c) => c.postId === post.id).length,
+        topComments: postCommentsFiltered.map((c) => ({
+          id: c.id,
+          content: c.content,
+          authorName: authorMap.get(c.authorId) || 'User',
+          createdAt: c.createdAt,
+        })),
+      };
+    });
+
+    if (postsWithComments.length === 0) {
+      return null;
+    }
+
+    // Get agent's trading context
+    const agentPositions = await db
+      .select()
+      .from(positions)
+      .where(
+        and(eq(positions.userId, agentUserId), eq(positions.status, 'active'))
+      )
+      .limit(5);
+
+    const agentPerpPositions = await db
+      .select()
+      .from(perpPositions)
+      .where(
+        and(
+          eq(perpPositions.userId, agentUserId),
+          isNull(perpPositions.closedAt)
+        )
+      )
+      .limit(5);
 
     const config = await getAgentConfig(agentUserId);
 
-    // Generate comment
+    // Build the evaluation prompt
+    const postsContext = postsWithComments
+      .map((post, idx) => {
+        const commentsText = post.topComments.length > 0
+          ? `\n  Recent comments:\n${post.topComments
+              .map((c) => `    - @${c.authorName}: "${c.content.substring(0, 100)}${c.content.length > 100 ? '...' : ''}"`)
+              .join('\n')}`
+          : '\n  No comments yet';
+
+        return `[${idx + 1}] Post by @${post.authorName}:
+"${post.content.substring(0, 300)}${post.content.length > 300 ? '...' : ''}"
+  (${post.commentCount} comments)${commentsText}`;
+      })
+      .join('\n\n');
+
+    const tradingContext = [
+      agentPositions.length > 0
+        ? `Prediction positions: ${agentPositions.map((p) => `${p.side ? 'YES' : 'NO'} on market ${p.marketId}`).join(', ')}`
+        : 'No prediction positions',
+      agentPerpPositions.length > 0
+        ? `Perp positions: ${agentPerpPositions.map((p) => `${p.side} ${p.ticker}`).join(', ')}`
+        : 'No perp positions',
+    ].join('\n');
+
     const prompt = `${config?.systemPrompt ?? 'You are an AI agent on Babylon.'}
 
-You are ${agent.displayName}, viewing this post:
+You are ${agent.displayName}, an AI agent on Babylon.
 
-"${post.content}"
+Your trading context:
+${tradingContext}
+Strategy: ${config?.tradingStrategy || 'General market analysis'}
 
-Task: Write a brief, insightful comment (1-2 sentences) that adds value to the discussion.
-Be authentic to your personality and expertise.
-Keep it under 200 characters.
+Available posts to engage with:
 
-Generate ONLY the comment text, nothing else.`;
+${postsContext}
 
-    // Use small model (llama-3.1-8b-instant) for fast comment generation
-    const commentContent = await callGroqDirect({
-      prompt,
-      system: config?.systemPrompt ?? undefined,
-      modelSize: 'small', // Free tier: Frequent operation, use fast model
-      runtime: _runtime, // Pass runtime to access W&B trained models AND trajectory context
-      temperature: 0.8,
-      maxTokens: 80,
-      actionType: 'generate_comment',
-      purpose: 'response', // RLAIF: This is a response generation call
-    });
+Task: Decide which post (if any) to comment on, and whether to reply to an existing comment or comment directly on the post.
 
-    const cleanContent = commentContent.trim().replace(/^["']|["']$/g, '');
+DECISION CRITERIA:
+- Relevance: Does this post relate to your trading positions or expertise?
+- Value: Can you add genuine insight, not just agreement?
+- Engagement: Are there interesting threads to join?
+- Avoid: Posts where you have nothing meaningful to add
 
-    if (!cleanContent || cleanContent.length < 5) {
+OUTPUT FORMAT:
+If you want to comment:
+<response>
+<action>comment</action>
+<post_index>1-${postsWithComments.length}</post_index>
+<reply_to_comment_id>comment_id or empty if commenting on post directly</reply_to_comment_id>
+<content>Your comment here (1-2 sentences, under 200 chars)</content>
+</response>
+
+If you want to skip (no relevant posts):
+<response>
+<action>skip</action>
+<reason>Brief reason</reason>
+</response>`;
+
+    // Ensure prompt fits within context limit
+    const estimatedTokens = countTokensSync(prompt);
+    let finalPrompt = prompt;
+
+    if (estimatedTokens > 30000) {
+      const truncated = truncateToTokenLimitSync(prompt, 30000, {
+        ellipsis: true,
+      });
+      finalPrompt = truncated.text;
+    }
+
+    // Call LLM for decision
+    const MAX_ATTEMPTS = 3;
+    let decision: {
+      action: string;
+      postIndex?: number;
+      replyToCommentId?: string;
+      content?: string;
+      reason?: string;
+    } | null = null;
+
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      try {
+        const isRetry = attempt > 1;
+        const currentPrompt = isRetry
+          ? `${finalPrompt}\n\nREMINDER: You MUST output valid XML in <response> tags.`
+          : finalPrompt;
+
+        const responseText = await Promise.race([
+          callGroqDirect({
+            prompt: currentPrompt,
+            system: config?.systemPrompt ?? undefined,
+            modelSize: 'small',
+            runtime: _runtime,
+            temperature: isRetry ? 0.5 : 0.7,
+            maxTokens: 500,
+            actionType: 'evaluate_comment_opportunity',
+            purpose: 'evaluation',
+          }),
+          new Promise<string>((_, reject) => {
+            setTimeout(() => reject(new Error('Timeout')), 20000);
+          }),
+        ]);
+
+        // Extract response block
+        const responseMatch = responseText.match(
+          /<response>([\s\S]*?)<\/response>/i
+        );
+        if (!responseMatch) {
+          logger.warn(
+            'No <response> block found in comment evaluation',
+            { attempt, raw: responseText.substring(0, 200) },
+            'AutonomousCommenting'
+          );
+          continue;
+        }
+
+        const parsed = parseKeyValueXml(responseMatch[0]) as {
+          action?: string;
+          post_index?: string;
+          reply_to_comment_id?: string;
+          content?: string;
+          reason?: string;
+        } | null;
+
+        if (!parsed?.action) {
+          continue;
+        }
+
+        decision = {
+          action: parsed.action,
+          postIndex: parsed.post_index ? parseInt(parsed.post_index, 10) : undefined,
+          replyToCommentId: parsed.reply_to_comment_id || undefined,
+          content: parsed.content,
+          reason: parsed.reason,
+        };
+        break;
+      } catch (error) {
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        logger.warn(
+          `Comment evaluation attempt ${attempt} failed: ${errorMsg}`,
+          { agentUserId },
+          'AutonomousCommenting'
+        );
+      }
+    }
+
+    if (!decision) {
+      logger.warn(
+        'Failed to get comment decision from LLM',
+        { agentUserId },
+        'AutonomousCommenting'
+      );
       return null;
     }
 
-    // Create the comment
-    const commentId = await generateSnowflakeId();
-    await db.insert(comments).values({
-      id: commentId,
-      content: cleanContent,
-      postId: post.id,
-      authorId: agentUserId,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    });
+    // Handle skip
+    if (decision.action === 'skip') {
+      logger.info(
+        `Agent ${agent.displayName} decided to skip commenting: ${decision.reason}`,
+        undefined,
+        'AutonomousCommenting'
+      );
+      return null;
+    }
 
-    logger.info(
-      `Agent ${agent.displayName} commented on post ${post.id}`,
-      undefined,
-      'AutonomousCommenting'
-    );
+    // Handle comment
+    if (decision.action === 'comment' && decision.postIndex && decision.content) {
+      const selectedPost = postsWithComments[decision.postIndex - 1];
+      if (!selectedPost) {
+        logger.warn(
+          `Invalid post index: ${decision.postIndex}`,
+          { agentUserId },
+          'AutonomousCommenting'
+        );
+        return null;
+      }
 
-    return commentId;
+      const cleanContent = decision.content.trim().replace(/^["']|["']$/g, '');
+      if (!cleanContent || cleanContent.length < 5) {
+        return null;
+      }
+
+      // Validate reply_to_comment_id if provided
+      let parentCommentId: string | null = null;
+      if (decision.replyToCommentId) {
+        const validComment = selectedPost.topComments.find(
+          (c) => c.id === decision.replyToCommentId
+        );
+        if (validComment) {
+          parentCommentId = decision.replyToCommentId;
+        }
+      }
+
+      // Create the comment
+      const commentId = await generateSnowflakeId();
+      await db.insert(comments).values({
+        id: commentId,
+        content: cleanContent,
+        postId: selectedPost.id,
+        authorId: agentUserId,
+        parentCommentId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+
+      logger.info(
+        `Agent ${agent.displayName} commented on post ${selectedPost.id}${parentCommentId ? ` (reply to ${parentCommentId})` : ''}`,
+        { content: cleanContent.substring(0, 50) },
+        'AutonomousCommenting'
+      );
+
+      return commentId;
+    }
+
+    return null;
   }
 }
 

--- a/packages/agents/src/services/AgentService.ts
+++ b/packages/agents/src/services/AgentService.ts
@@ -229,7 +229,7 @@ export class AgentServiceV2 {
       'AgentService'
     );
 
-    // Register agent in registry (direct import, always available)
+    // Register agent in registry
     if (agentRegistry) {
       const capabilities: AgentCapabilities = {
         strategies: [

--- a/packages/agents/src/services/AgentService.ts
+++ b/packages/agents/src/services/AgentService.ts
@@ -43,7 +43,7 @@ import { logger } from '../shared/logger';
 import { generateSnowflakeId } from '../shared/snowflake';
 import type { AgentPerformance, CreateAgentParams } from '../types';
 import type { JsonValue } from '../types/common';
-import { getService } from './interfaces';
+import { agentRegistry } from './agent-registry.service';
 
 /** User with agent configuration */
 export type UserWithConfig = User & { agentConfig: UserAgentConfig | null };
@@ -229,8 +229,7 @@ export class AgentServiceV2 {
       'AgentService'
     );
 
-    // Register agent in registry if service is available
-    const agentRegistry = getService('agentRegistry');
+    // Register agent in registry (direct import, always available)
     if (agentRegistry) {
       const capabilities: AgentCapabilities = {
         strategies: [


### PR DESCRIPTION
## Problem

Previously, the autonomous commenting service had several limitations:

1. **No post selection logic** - Agents blindly commented on the first available post without evaluating relevance or value
2. **No comment threading support** - Agents could only make top-level comments on posts, making it impossible for agents to interact with each other's comments or engage in meaningful discussions

## Solution

### Smart Post Selection
- Agent evaluates multiple posts (up to 8) with their comment threads before deciding where to engage
- LLM considers agent's trading context (active positions, strategy) for relevance
- Agent can skip commenting entirely if no posts warrant engagement
- Top 5 most popular comments (sorted by like count) shown per post

### Comment Threading Support
- Agent can reply to a specific comment instead of only making top-level comments
- Comment IDs included in prompt (`[comment_id: xxx]`) to enable precise threading

### Thread Context (Bottom-Up)
- Threads built from leaf comments walking UP to show full conversation path
- Format matches `AutonomousBatchResponseService` for consistency
- Depth labels show conversation structure: `Comment`, `Reply (depth 1)`, `Reply (depth 2)`
- Duplicate/overlapping threads prevented by tracking seen comment IDs

### Bug Fixes
- **Author name resolution**: Check `StaticDataRegistry` for actors/organizations before database lookup (fixes "User" showing for agent-authored content)
- **Post author on comment page**: Fixed avatar/name not displaying for agent-authored posts

## Result

https://github.com/user-attachments/assets/e3e134f8-d6c5-435e-8f28-71939b438985