### PR TITLE
fix(agents): use correct ticker for perp trades

### DIFF
--- a/packages/agents/src/autonomous/AutonomousTradingService.ts
+++ b/packages/agents/src/autonomous/AutonomousTradingService.ts
@@ -459,8 +459,8 @@ ${contextString}`;
       if (org && trade.amount <= Number(balance.balance)) {
         if (trade.action === 'open_long' || trade.action === 'open_short') {
           const side = trade.action === 'open_long' ? 'long' : 'short';
-          // Use org.name as ticker (Organization model doesn't have ticker field, name is used as ticker)
-          const ticker = org.name;
+          // Use org.ticker for PerpMarketSnapshot lookup, fallback to org.name
+          const ticker = org.ticker || org.name;
 
           await asUser({ userId: agentUserId }, async () => {
             const service = new PerpMarketService({
@@ -509,7 +509,7 @@ ${contextString}`;
             agentId: agentUserId,
             userId: agent.managedBy || agentUserId,
             marketType: 'perp',
-            ticker: org.name, // Use org.name as ticker
+            ticker,
             action: 'open',
             side,
             amount: trade.amount,
@@ -518,7 +518,7 @@ ${contextString}`;
           });
 
           tradesExecuted++;
-          lastTicker = org.name; // Use org.name as ticker
+          lastTicker = ticker;
           lastSide = side;
           lastMarketType = 'perp';
           logger.info(


### PR DESCRIPTION
## Summary

- Fix bug where agents couldn't trade perpetuals due to using organization name instead of ticker
- `PerpMarketService.openPosition()` looks up markets by ticker (e.g., `BLKRK`), but the code was passing `org.name` (e.g., "Block Rock")
- All agent perp trades were silently failing with "Market not found"

**Impact:** 707 prediction trades recorded, but 0 perp trades by agents due to this bug.

## Changes

- Use `org.ticker || org.name` instead of just `org.name` when opening perp positions
- Updated 3 places in `AutonomousTradingService.ts` where ticker was incorrectly derived

## Test plan

- [x] TypeScript compiles without errors (`@babylon/agents:typecheck` passes)
- [x] Lint passes
- [ ] After merge, verify agents start making perp trades in `AgentTrade` table with `marketType = 'perp'`
- [ ] Verify new entries appear in `PerpPosition` table where `userId` is an agent