### PR TITLE
fix: agent tick uses userId for USER_CONTROLLED agents

### DIFF
--- a/packages/agents/src/autonomous/AutonomousCoordinator.ts
+++ b/packages/agents/src/autonomous/AutonomousCoordinator.ts
@@ -22,8 +22,8 @@ import { logger } from '../shared/logger';
 
 // Import services
 import { autonomousGroupChatService } from './AutonomousGroupChatService';
-import { multiStepExecutor } from './MultiStepExecutor';
 import { autonomousPlanningCoordinator } from './AutonomousPlanningCoordinator';
+import { multiStepExecutor } from './MultiStepExecutor';
 
 export interface AutonomousTickResult {
   success: boolean;

--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -19,9 +19,9 @@ import { autonomousTradingService } from './AutonomousTradingService';
 import {
   type ActionTraceResult,
   type AgentTickContext,
+  buildMultiStepDecisionPrompt,
   type MarketOpportunity,
   type MultiStepDecision,
-  buildMultiStepDecisionPrompt,
 } from './templates/multi-step-decision';
 
 // =============================================================================
@@ -206,9 +206,7 @@ export class MultiStepExecutor {
     const perpPositionsList = await db
       .select()
       .from(perpPositions)
-      .where(
-        eq(perpPositions.userId, agentUserId)
-      );
+      .where(eq(perpPositions.userId, agentUserId));
     const openPerpPositions = perpPositionsList.filter(
       (p) => p.closedAt === null
     ).length;
@@ -371,9 +369,10 @@ export class MultiStepExecutor {
           return {
             actionType: 'TRADE',
             success: tradeResult.tradesExecuted > 0,
-            summary: tradeResult.tradesExecuted > 0
-              ? `Executed ${tradeResult.tradesExecuted} trade(s) on ${tradeResult.marketType || 'market'}`
-              : 'Decided to hold - no trade executed',
+            summary:
+              tradeResult.tradesExecuted > 0
+                ? `Executed ${tradeResult.tradesExecuted} trade(s) on ${tradeResult.marketType || 'market'}`
+                : 'Decided to hold - no trade executed',
             result: {
               tradesExecuted: tradeResult.tradesExecuted,
               marketId: tradeResult.marketId,
@@ -393,7 +392,9 @@ export class MultiStepExecutor {
           return {
             actionType: 'POST',
             success: !!postId,
-            summary: postId ? `Created post ${postId}` : 'Failed to create post',
+            summary: postId
+              ? `Created post ${postId}`
+              : 'Failed to create post',
             result: postId ? { postId } : undefined,
             parameters,
             timestamp: Date.now(),
@@ -419,11 +420,10 @@ export class MultiStepExecutor {
         }
 
         case 'RESPOND': {
-          const responses =
-            await autonomousBatchResponseService.processBatch(
-              agentUserId,
-              runtime
-            );
+          const responses = await autonomousBatchResponseService.processBatch(
+            agentUserId,
+            runtime
+          );
           return {
             actionType: 'RESPOND',
             success: responses > 0,
@@ -514,7 +514,9 @@ export class MultiStepExecutor {
       }
     }
 
-    const hasSuccessfulActions = trace.some((r) => r.success && r.actionType !== 'WAIT');
+    const hasSuccessfulActions = trace.some(
+      (r) => r.success && r.actionType !== 'WAIT'
+    );
 
     return {
       success: hasSuccessfulActions,

--- a/packages/agents/src/autonomous/index.ts
+++ b/packages/agents/src/autonomous/index.ts
@@ -18,22 +18,22 @@ export {
 export { autonomousDMService } from './AutonomousDMService';
 export { autonomousGroupChatService } from './AutonomousGroupChatService';
 export {
-  MultiStepExecutor,
-  multiStepExecutor,
-  type MultiStepExecutorResult,
-} from './MultiStepExecutor';
-export {
   autonomousPlanningCoordinator,
   type PlannedAction,
 } from './AutonomousPlanningCoordinator';
 export { autonomousPostingService } from './AutonomousPostingService';
 export { autonomousTradingService } from './AutonomousTradingService';
+export {
+  MultiStepExecutor,
+  type MultiStepExecutorResult,
+  multiStepExecutor,
+} from './MultiStepExecutor';
 
 // Multi-step decision templates
 export {
   type ActionTraceResult,
   type AgentTickContext,
-  type MultiStepDecision,
   buildMultiStepDecisionPrompt,
   buildMultiStepSummaryPrompt,
+  type MultiStepDecision,
 } from './templates/multi-step-decision';

--- a/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts
+++ b/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts
@@ -11,7 +11,7 @@
 
 import type { Message, Task } from '@a2a-js/sdk';
 import { A2AClient } from '@a2a-js/sdk/client';
-import { db } from '@babylon/db';
+import { db, executeRaw, sql } from '@babylon/db';
 import type { AgentRuntime, Plugin } from '@elizaos/core';
 import { agentWalletService } from '../../identity/AgentWalletService';
 import { logger } from '../../shared/logger';
@@ -45,6 +45,7 @@ const AGENT_IDENTITY_MAX_SIZE = 10000;
 /**
  * Get agent identity from cache or database
  * Optimized for high concurrency with lazy refresh
+ * Supports both USER_CONTROLLED agents (User table) and NPCs (Actor table)
  */
 async function getCachedAgentIdentity(
   agentUserId: string
@@ -57,8 +58,8 @@ async function getCachedAgentIdentity(
     return cached;
   }
 
-  // Fetch from database
-  const agent = await db.user.findUnique({
+  // First try User table (USER_CONTROLLED agents)
+  const user = await db.user.findUnique({
     where: { id: agentUserId },
     select: {
       id: true,
@@ -69,18 +70,50 @@ async function getCachedAgentIdentity(
     },
   });
 
-  if (!agent || !agent.isAgent) {
-    return null;
+  if (user && user.isAgent) {
+    const identity: CachedAgentIdentity = {
+      agentUserId,
+      walletAddress: user.walletAddress,
+      agent0TokenId: user.agent0TokenId,
+      displayName: user.displayName,
+      cachedAt: now,
+    };
+
+    cacheIdentity(agentUserId, identity);
+    return identity;
   }
 
-  const identity: CachedAgentIdentity = {
-    agentUserId,
-    walletAddress: agent.walletAddress,
-    agent0TokenId: agent.agent0TokenId,
-    displayName: agent.displayName,
-    cachedAt: now,
-  };
+  // Fall back to Actor table (NPC agents) using raw SQL
+  // Actor table is a legacy table not in Drizzle schema
+  const actorResult = await executeRaw<{ id: string; name: string }>(
+    sql`SELECT id, name FROM "Actor" WHERE id = ${agentUserId} LIMIT 1`
+  );
 
+  const actor = actorResult[0];
+  if (actor) {
+    // NPCs don't have wallets or tokens - create minimal identity
+    const identity: CachedAgentIdentity = {
+      agentUserId,
+      walletAddress: null,
+      agent0TokenId: null,
+      displayName: actor.name,
+      cachedAt: now,
+    };
+
+    cacheIdentity(agentUserId, identity);
+    return identity;
+  }
+
+  return null;
+}
+
+/**
+ * Helper to cache identity with LRU eviction
+ */
+function cacheIdentity(
+  agentUserId: string,
+  identity: CachedAgentIdentity
+): void {
   // LRU eviction if at capacity
   if (AGENT_IDENTITY_CACHE.size >= AGENT_IDENTITY_MAX_SIZE) {
     const oldestKey = AGENT_IDENTITY_CACHE.keys().next().value;
@@ -90,7 +123,6 @@ async function getCachedAgentIdentity(
   }
 
   AGENT_IDENTITY_CACHE.set(agentUserId, identity);
-  return identity;
 }
 
 /**

--- a/packages/agents/src/runtime/AgentRuntimeManager.ts
+++ b/packages/agents/src/runtime/AgentRuntimeManager.ts
@@ -413,7 +413,12 @@ export class AgentRuntimeManager {
     };
 
     // Create runtime with standard plugins
-    return this.createRuntimeWithPlugins(registration.agentId, character);
+    // Pass userId for Babylon integration (User table lookup)
+    return this.createRuntimeWithPlugins(
+      registration.agentId,
+      character,
+      registration.userId
+    );
   }
 
   /**
@@ -490,10 +495,15 @@ export class AgentRuntimeManager {
   /**
    * Create AgentRuntime with standard plugin configuration
    * Shared logic for all agent types
+   *
+   * @param agentId - The agent's unique identifier (used for Eliza runtime)
+   * @param character - Character configuration
+   * @param userId - Optional User table ID for USER_CONTROLLED agents (used for Babylon integration)
    */
   private async createRuntimeWithPlugins(
     agentId: string,
-    character: Character
+    character: Character,
+    userId?: string
   ): Promise<AgentRuntime> {
     // Database configuration
     const dbPort = process.env.POSTGRES_DEV_PORT || 5432;
@@ -562,7 +572,9 @@ export class AgentRuntimeManager {
     await Promise.all(pluginRegistrationPromises);
 
     // Wrap and enhance with Babylon plugin
-    await this.enhanceWithBabylon(runtime, agentId, trajectoryLogger);
+    // Use userId for USER_CONTROLLED agents (User table lookup), agentId for NPCs
+    const babylonAgentId = userId || agentId;
+    await this.enhanceWithBabylon(runtime, babylonAgentId, trajectoryLogger);
 
     // Store trajectory logger reference on runtime
     runtime.trajectoryLogger = trajectoryLogger;


### PR DESCRIPTION
## Problem

Agent tick was failing with error:
```
Agent user agent_photonmax_4340_v7x7bc not found or not an agent
```

The issue was that `agentId` (username like `agent_photonmax_4340_v7x7bc`) was being passed to functions expecting `userId` (snowflake ID like `257060932163731456`) for User table lookups.

## Solution

### AgentRuntimeManager.ts
- Modified `createUserAgentRuntime` to pass `userId` to `createRuntimeWithPlugins`
- Updated `createRuntimeWithPlugins` to accept optional `userId` parameter
- For USER_CONTROLLED agents, uses `userId` for Babylon integration (User table lookup)
- For NPCs, uses `agentId` (which works with Actor table lookup)

### integration-a2a-sdk.ts
- Modified `getCachedAgentIdentity` to support both:
  - **USER_CONTROLLED agents** → looks up `User` table by `userId`
  - **NPCs** → looks up `Actor` table (legacy table not in Drizzle schema) by `agentId` using raw SQL

## Testing

- `bun run typecheck` ✅
- `bun run lint` ✅

## Notes

The `Actor` table exists in the database but is NOT in the Drizzle TypeScript schema - it's a legacy table from the initial migration. The raw SQL query approach handles this correctly.