### PR TITLE
fix: pass isNpc flag to AutonomousCoordinator for NPC agent support

### DIFF
--- a/apps/web/src/app/api/cron/agent-tick/route.ts
+++ b/apps/web/src/app/api/cron/agent-tick/route.ts
@@ -400,10 +400,19 @@ export async function POST(_req: NextRequest) {
       }
 
       // Always record trajectories for RL training data collection
+      // For USER_CONTROLLED agents, pass user.id (userId for User table lookup)
+      // For NPCs, pass agentId (they don't have User records)
+      const isNpc = eligibleAgent.type === AgentType.NPC;
+      const tickAgentId =
+        eligibleAgent.type === AgentType.USER_CONTROLLED && eligibleAgent.user
+          ? eligibleAgent.user.id
+          : eligibleAgent.agentId;
+
       const tickResult = await autonomousCoordinator.executeAutonomousTick(
-        eligibleAgent.agentId,
+        tickAgentId,
         runtime,
-        true // Always record trajectories
+        true, // Always record trajectories
+        isNpc
       );
 
       // Validation: Verify tick executed successfully

--- a/packages/agents/src/autonomous/AutonomousCoordinator.ts
+++ b/packages/agents/src/autonomous/AutonomousCoordinator.ts
@@ -48,11 +48,13 @@ export class AutonomousCoordinator {
    * @param agentUserId - Agent user ID
    * @param runtime - Agent runtime
    * @param recordTrajectories - Enable trajectory recording for RL training (default: false)
+   * @param isNpc - Whether this is an NPC agent (skips User table lookup)
    */
   async executeAutonomousTick(
     agentUserId: string,
     runtime: IAgentRuntime,
-    recordTrajectories = false
+    recordTrajectories = false,
+    isNpc = false
   ): Promise<AutonomousTickResult> {
     const startTime = Date.now();
 
@@ -99,20 +101,23 @@ export class AutonomousCoordinator {
       'AutonomousCoordinator'
     );
 
-    // Get agent user
-    const agentResult = await db
-      .select({ id: users.id, isAgent: users.isAgent })
-      .from(users)
-      .where(eq(users.id, agentUserId))
-      .limit(1);
+    // For NPCs, skip User table lookup (they don't have User records)
+    // For USER_CONTROLLED agents, verify they exist in User table
+    if (!isNpc) {
+      const agentResult = await db
+        .select({ id: users.id, isAgent: users.isAgent })
+        .from(users)
+        .where(eq(users.id, agentUserId))
+        .limit(1);
 
-    const agent = agentResult[0];
-    if (!agent || !agent.isAgent) {
-      throw new Error('Agent not found or not an agent');
+      const agent = agentResult[0];
+      if (!agent || !agent.isAgent) {
+        throw new Error('Agent not found or not an agent');
+      }
     }
 
-    // Get agent config
-    const config = await getAgentConfig(agentUserId);
+    // Get agent config (only for USER_CONTROLLED agents, NPCs don't have UserAgentConfig)
+    const config = isNpc ? null : await getAgentConfig(agentUserId);
 
     // Check if agent has goals configured
     const hasGoals =

--- a/packages/agents/src/autonomous/AutonomousTradingService.ts
+++ b/packages/agents/src/autonomous/AutonomousTradingService.ts
@@ -70,6 +70,7 @@ export class AutonomousTradingService {
     side?: string;
     marketType?: 'prediction' | 'perp';
   }> {
+    // Get agent from User table (will be null for NPCs)
     const agentResult = await db
       .select()
       .from(users)
@@ -77,11 +78,12 @@ export class AutonomousTradingService {
       .limit(1);
     const agent = agentResult[0];
 
-    if (!agent?.isAgent) {
-      logger.error('Agent not found or not an agent', { agentUserId });
-      throw new Error('Agent not found');
-    }
+    // Fallback values for NPCs (who don't have User records)
+    const agentDisplayName = agent?.displayName ?? agentUserId;
+    const agentLifetimePnL = agent?.lifetimePnL ?? 0;
+    const agentManagedBy = agent?.managedBy ?? agentUserId;
 
+    // Get agent config (may be null for NPCs)
     const config = await getAgentConfig(agentUserId);
 
     // Get agent's positions separately
@@ -148,13 +150,13 @@ export class AutonomousTradingService {
     // and appear in agent context automatically via providers
     const prompt = `${config?.systemPrompt ?? 'You are an autonomous trading agent on Babylon.'}
 
-You are ${agent.displayName}, an autonomous trading agent.
+You are ${agentDisplayName}, an autonomous trading agent.
 
 Trading Strategy: ${config?.tradingStrategy ?? 'General market analysis'}
 
 Current Status:
 - Balance: $${balance.balance}
-- P&L: ${agent.lifetimePnL}
+- P&L: ${agentLifetimePnL}
 - Open Positions: ${positionsResult.length + perpPositionsResult.length}
 
 Available Prediction Markets:
@@ -429,7 +431,7 @@ ${contextString}`;
           // Record in AgentTrade
           await agentPnLService.recordTrade({
             agentId: agentUserId,
-            userId: agent.managedBy || agentUserId,
+            userId: agentManagedBy,
             marketType: 'prediction',
             marketId: market.id,
             action: 'open',
@@ -445,7 +447,7 @@ ${contextString}`;
           lastSide = side ? 'YES' : 'NO';
           lastMarketType = 'prediction';
           logger.info(
-            `Agent ${agent.displayName} bought ${side ? 'YES' : 'NO'} on ${market.question}`,
+            `Agent ${agentDisplayName} bought ${side ? 'YES' : 'NO'} on ${market.question}`,
             undefined,
             'AutonomousTrading'
           );
@@ -509,7 +511,7 @@ ${contextString}`;
 
           await agentPnLService.recordTrade({
             agentId: agentUserId,
-            userId: agent.managedBy || agentUserId,
+            userId: agentManagedBy,
             marketType: 'perp',
             ticker,
             action: 'open',
@@ -524,7 +526,7 @@ ${contextString}`;
           lastSide = side;
           lastMarketType = 'perp';
           logger.info(
-            `Agent ${agent.displayName} opened ${side} position on ${org.name}`,
+            `Agent ${agentDisplayName} opened ${side} position on ${org.name}`,
             undefined,
             'AutonomousTrading'
           );


### PR DESCRIPTION
## Problem
Agent tick was failing for all agents (both USER_CONTROLLED and NPCs) with error:
```
Error processing agent AellAI {"agentId":"aellai","agentType":"NPC","error":"Agent not found or not an agent"}
```

## Root Cause
The `AutonomousCoordinator.executeAutonomousTick` was querying the User table for all agents, but:
- NPCs don't have User records (they exist in Actor table)
- USER_CONTROLLED agents were being passed the wrong ID (agentId instead of userId)

## Solution
1. Pass `isNpc` flag from agent-tick route to AutonomousCoordinator
2. Skip User table lookup for NPCs (they're already validated by AgentRegistry)
3. Pass correct `userId` for USER_CONTROLLED agents (from `eligibleAgent.user.id`)
4. Update AutonomousTradingService to use fallback values for NPCs who don't have User records

## Changes
- `apps/web/src/app/api/cron/agent-tick/route.ts`: Pass isNpc flag and correct userId
- `packages/agents/src/autonomous/AutonomousCoordinator.ts`: Accept isNpc parameter, skip User lookup for NPCs
- `packages/agents/src/autonomous/AutonomousTradingService.ts`: Use fallback values for agent display name/PnL/managedBy

## Testing
- `bun run typecheck` ✅
- `bun run lint` ✅