### PR TITLE
feat: add NPC agent support to autonomous services

### DIFF
--- a/packages/agents/src/autonomous/AutonomousBatchResponseService.ts
+++ b/packages/agents/src/autonomous/AutonomousBatchResponseService.ts
@@ -29,6 +29,7 @@ import {
   posts,
   users,
 } from '@babylon/db';
+import { StaticDataRegistry } from '@babylon/engine';
 import type { IAgentRuntime } from '@elizaos/core';
 import { parseKeyValueXml } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
@@ -624,16 +625,28 @@ ${chatLines.join('\n\n')}`);
       );
     }
 
-    const [agent] = await db
-      .select({
-        displayName: users.displayName,
-      })
-      .from(users)
-      .where(eq(users.id, agentUserId))
-      .limit(1);
+    // Check if this is an NPC (has entry in StaticDataRegistry)
+    const npcActor = StaticDataRegistry.getActor(agentUserId);
+    const isNpc = !!npcActor;
 
-    if (!agent) {
-      throw new Error('Agent not found');
+    let agentDisplayName: string;
+
+    if (isNpc) {
+      agentDisplayName = npcActor.name;
+    } else {
+      const [agent] = await db
+        .select({
+          displayName: users.displayName,
+        })
+        .from(users)
+        .where(eq(users.id, agentUserId))
+        .limit(1);
+
+      if (!agent) {
+        throw new Error('Agent not found');
+      }
+
+      agentDisplayName = agent.displayName ?? agentUserId;
     }
 
     const config = await getAgentConfig(agentUserId);
@@ -642,7 +655,7 @@ ${chatLines.join('\n\n')}`);
     // This is more robust as it doesn't rely on counting/ordering
     const prompt = `${config?.systemPrompt ?? 'You are an AI agent on Babylon.'}
 
-You are ${agent.displayName}, an AI agent on Babylon. You need to decide which interactions warrant a response.
+You are ${agentDisplayName}, an AI agent on Babylon. You need to decide which interactions warrant a response.
 
 CRITICAL: Be VERY selective. Silence is often the best response.
 
@@ -849,16 +862,28 @@ Do NOT include any explanations, only the XML format above.`;
     interactions: PendingInteraction[],
     decisions: ResponseDecision[]
   ): Promise<number> {
-    const [agent] = await db
-      .select({
-        displayName: users.displayName,
-      })
-      .from(users)
-      .where(eq(users.id, agentUserId))
-      .limit(1);
+    // Check if this is an NPC (has entry in StaticDataRegistry)
+    const npcActor = StaticDataRegistry.getActor(agentUserId);
+    const isNpc = !!npcActor;
 
-    if (!agent) {
-      throw new Error('Agent not found');
+    let agentDisplayName: string;
+
+    if (isNpc) {
+      agentDisplayName = npcActor.name;
+    } else {
+      const [agent] = await db
+        .select({
+          displayName: users.displayName,
+        })
+        .from(users)
+        .where(eq(users.id, agentUserId))
+        .limit(1);
+
+      if (!agent) {
+        throw new Error('Agent not found');
+      }
+
+      agentDisplayName = agent.displayName ?? agentUserId;
     }
 
     const respConfig = await getAgentConfig(agentUserId);
@@ -874,7 +899,7 @@ Do NOT include any explanations, only the XML format above.`;
       // Generate response with retry loop
       const responsePrompt = `${respConfig?.systemPrompt ?? 'You are an AI agent on Babylon.'}
 
-You are ${agent.displayName}, responding to an interaction.
+You are ${agentDisplayName}, responding to an interaction.
 
 ${interaction.context}
 

--- a/packages/agents/src/autonomous/AutonomousCommentingService.ts
+++ b/packages/agents/src/autonomous/AutonomousCommentingService.ts
@@ -65,19 +65,35 @@ interface PostWithComments {
 export class AutonomousCommentingService {
   /**
    * Find relevant posts and create comments using LLM evaluation
+   *
+   * Supports both USER_CONTROLLED agents (User table) and NPCs (StaticDataRegistry)
    */
   async createAgentComment(
     agentUserId: string,
     _runtime: IAgentRuntime
   ): Promise<string | null> {
-    const [agent] = await db
-      .select()
-      .from(users)
-      .where(eq(users.id, agentUserId))
-      .limit(1);
+    // Check if this is an NPC (has entry in StaticDataRegistry)
+    const npcActor = StaticDataRegistry.getActor(agentUserId);
+    const isNpc = !!npcActor;
 
-    if (!agent?.isAgent) {
-      throw new Error('Agent not found');
+    let agentDisplayName: string;
+
+    if (isNpc) {
+      // NPC: Get name from StaticDataRegistry
+      agentDisplayName = npcActor.name;
+    } else {
+      // USER_CONTROLLED: Get from User table
+      const [agent] = await db
+        .select()
+        .from(users)
+        .where(eq(users.id, agentUserId))
+        .limit(1);
+
+      if (!agent?.isAgent) {
+        throw new Error('Agent not found');
+      }
+
+      agentDisplayName = agent.displayName ?? agentUserId;
     }
 
     const now = new Date();
@@ -120,7 +136,7 @@ export class AutonomousCommentingService {
 
     if (uncommentedPosts.length === 0) {
       logger.info(
-        `No uncommented posts for agent ${agent.displayName}`,
+        `No uncommented posts for agent ${agentDisplayName}`,
         undefined,
         'AutonomousCommenting'
       );
@@ -399,7 +415,7 @@ export class AutonomousCommentingService {
 
 ${config?.systemPrompt ?? 'You are an AI agent on Babylon.'}
 
-You are ${agent.displayName}, an AI agent on Babylon.
+You are ${agentDisplayName}, an AI agent on Babylon.
 
 Your trading context:
 ${tradingContext}
@@ -546,7 +562,7 @@ If you want to skip (no relevant posts):
     // Handle skip
     if (decision.action === 'skip') {
       logger.info(
-        `Agent ${agent.displayName} decided to skip commenting: ${decision.reason}`,
+        `Agent ${agentDisplayName} decided to skip commenting: ${decision.reason}`,
         undefined,
         'AutonomousCommenting'
       );
@@ -611,7 +627,7 @@ If you want to skip (no relevant posts):
       });
 
       logger.info(
-        `Agent ${agent.displayName} commented on post ${selectedPost.id}${parentCommentId ? ` (reply to ${parentCommentId})` : ''}`,
+        `Agent ${agentDisplayName} commented on post ${selectedPost.id}${parentCommentId ? ` (reply to ${parentCommentId})` : ''}`,
         { content: cleanContent.substring(0, 50) },
         'AutonomousCommenting'
       );

--- a/packages/agents/src/autonomous/AutonomousDMService.ts
+++ b/packages/agents/src/autonomous/AutonomousDMService.ts
@@ -5,6 +5,7 @@
  */
 
 import { and, db, desc, eq, gte, messages, ne, users } from '@babylon/db';
+import { StaticDataRegistry } from '@babylon/engine';
 import type { IAgentRuntime } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
 import { getAgentConfig } from '../shared/agent-config';
@@ -27,13 +28,28 @@ export class AutonomousDMService {
     agentUserId: string,
     _runtime: IAgentRuntime
   ): Promise<number> {
-    const [agent] = await db
-      .select()
-      .from(users)
-      .where(eq(users.id, agentUserId))
-      .limit(1);
-    if (!agent?.isAgent) {
-      throw new Error('Agent not found');
+    // Check if this is an NPC (has entry in StaticDataRegistry)
+    const npcActor = StaticDataRegistry.getActor(agentUserId);
+    const isNpc = !!npcActor;
+
+    let agentDisplayName: string;
+
+    if (isNpc) {
+      // NPC: Get name from StaticDataRegistry
+      agentDisplayName = npcActor.name;
+    } else {
+      // USER_CONTROLLED: Get from User table
+      const [agent] = await db
+        .select()
+        .from(users)
+        .where(eq(users.id, agentUserId))
+        .limit(1);
+
+      if (!agent?.isAgent) {
+        throw new Error('Agent not found');
+      }
+
+      agentDisplayName = agent.displayName ?? agentUserId;
     }
 
     const config = await getAgentConfig(agentUserId);
@@ -83,7 +99,7 @@ export class AutonomousDMService {
       // Generate response
       const prompt = `${config?.systemPrompt ?? 'You are an AI agent on Babylon.'}
 
-You are ${agent.displayName} in a direct message conversation.
+You are ${agentDisplayName} in a direct message conversation.
 
 Recent conversation:
 ${allMessages
@@ -131,7 +147,7 @@ Generate ONLY the response text, nothing else.`;
 
       responsesCreated++;
       logger.info(
-        `Agent ${agent.displayName} responded to DM in chat ${chat.id}`,
+        `Agent ${agentDisplayName} responded to DM in chat ${chat.id}`,
         undefined,
         'AutonomousDM'
       );

--- a/packages/agents/src/autonomous/AutonomousGroupChatService.ts
+++ b/packages/agents/src/autonomous/AutonomousGroupChatService.ts
@@ -7,6 +7,7 @@
  */
 
 import { and, db, desc, eq, gte, messages, users } from '@babylon/db';
+import { StaticDataRegistry } from '@babylon/engine';
 import type { IAgentRuntime } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
 import { getAgentConfig } from '../shared/agent-config';
@@ -29,13 +30,28 @@ export class AutonomousGroupChatService {
     agentUserId: string,
     _runtime: IAgentRuntime
   ): Promise<number> {
-    const [agent] = await db
-      .select()
-      .from(users)
-      .where(eq(users.id, agentUserId))
-      .limit(1);
-    if (!agent?.isAgent) {
-      throw new Error('Agent not found');
+    // Check if this is an NPC (has entry in StaticDataRegistry)
+    const npcActor = StaticDataRegistry.getActor(agentUserId);
+    const isNpc = !!npcActor;
+
+    let agentDisplayName: string;
+
+    if (isNpc) {
+      // NPC: Get name from StaticDataRegistry
+      agentDisplayName = npcActor.name;
+    } else {
+      // USER_CONTROLLED: Get from User table
+      const [agent] = await db
+        .select()
+        .from(users)
+        .where(eq(users.id, agentUserId))
+        .limit(1);
+
+      if (!agent?.isAgent) {
+        throw new Error('Agent not found');
+      }
+
+      agentDisplayName = agent.displayName ?? agentUserId;
     }
 
     const config = await getAgentConfig(agentUserId);
@@ -71,12 +87,7 @@ export class AutonomousGroupChatService {
       // Check if agent was mentioned or should respond
       const agentMentioned = recentMessages.some(
         (m: { content: string; senderId: string }) =>
-          m.content
-            .toLowerCase()
-            .includes(agent.username?.toLowerCase() || 'agent') ||
-          m.content
-            .toLowerCase()
-            .includes(agent.displayName?.toLowerCase() || 'agent')
+          m.content.toLowerCase().includes(agentDisplayName.toLowerCase())
       );
 
       // Don't spam - only respond if mentioned or if it's been a while
@@ -90,7 +101,7 @@ export class AutonomousGroupChatService {
       // Generate contextual response
       const prompt = `${config?.systemPrompt ?? 'You are an AI agent on Babylon.'}
 
-You are ${agent.displayName} in a group chat.
+You are ${agentDisplayName} in a group chat.
 
 Recent conversation:
 ${recentMessages
@@ -137,7 +148,7 @@ Generate ONLY the message text, or "SKIP" if you shouldn't respond.`;
 
       messagesCreated++;
       logger.info(
-        `Agent ${agent.displayName} participated in group chat ${chat.id}`,
+        `Agent ${agentDisplayName} participated in group chat ${chat.id}`,
         undefined,
         'AutonomousGroupChat'
       );

--- a/packages/agents/src/autonomous/AutonomousPostingService.ts
+++ b/packages/agents/src/autonomous/AutonomousPostingService.ts
@@ -13,6 +13,7 @@ import {
   generateRandomMarketContext,
   generateTagsFromPost,
   generateWorldContext,
+  StaticDataRegistry,
   storeTagsForPost,
 } from '@babylon/engine';
 import type { IAgentRuntime } from '@elizaos/core';
@@ -25,19 +26,39 @@ import { generateSnowflakeId } from '../shared/snowflake';
 export class AutonomousPostingService {
   /**
    * Generate and create a post for an agent
+   *
+   * Supports both USER_CONTROLLED agents (User table) and NPCs (ActorState table)
    */
   async createAgentPost(
     agentUserId: string,
     _runtime: IAgentRuntime
   ): Promise<string | null> {
-    const [agent] = await db
-      .select()
-      .from(users)
-      .where(eq(users.id, agentUserId))
-      .limit(1);
+    // Check if this is an NPC (has entry in StaticDataRegistry)
+    const npcActor = StaticDataRegistry.getActor(agentUserId);
+    const isNpc = !!npcActor;
 
-    if (!agent?.isAgent) {
-      throw new Error('Agent not found');
+    let agentDisplayName: string;
+    let agentLifetimePnL: number;
+
+    if (isNpc) {
+      // NPC: Get data from StaticDataRegistry and ActorState
+      agentDisplayName = npcActor.name;
+      // NPCs don't track lifetime PnL, use 0
+      agentLifetimePnL = 0;
+    } else {
+      // USER_CONTROLLED: Get data from User table
+      const [agent] = await db
+        .select()
+        .from(users)
+        .where(eq(users.id, agentUserId))
+        .limit(1);
+
+      if (!agent?.isAgent) {
+        throw new Error('Agent not found');
+      }
+
+      agentDisplayName = agent.displayName ?? agentUserId;
+      agentLifetimePnL = Number(agent.lifetimePnL ?? 0);
     }
 
     const config = await getAgentConfig(agentUserId);
@@ -76,11 +97,11 @@ export class AutonomousPostingService {
 
 ${config?.systemPrompt ?? 'You are an AI agent on Babylon.'}
 
-You are ${agent.displayName}, an AI agent in the Babylon prediction market community.
+You are ${agentDisplayName}, an AI agent in the Babylon prediction market community.
 
 Your recent activity:
 ${recentTrades.length > 0 ? `- Recent trades: ${JSON.stringify(recentTrades.map((t) => ({ action: t.action, ticker: t.ticker, pnl: t.pnl })))}` : '- No recent trades'}
-- Your P&L: ${agent.lifetimePnL}
+- Your P&L: ${agentLifetimePnL}
 - Last ${recentPosts.length} posts: ${recentPosts.map((p) => p.content).join('; ')}
 
 WORLD CONTEXT:
@@ -375,7 +396,7 @@ ${contextString}
     });
 
     logger.info(
-      `Agent ${agent.displayName} created post: ${postId}`,
+      `Agent ${agentDisplayName} created post: ${postId}`,
       undefined,
       'AutonomousPosting'
     );

--- a/packages/agents/src/autonomous/AutonomousTradingService.ts
+++ b/packages/agents/src/autonomous/AutonomousTradingService.ts
@@ -7,6 +7,7 @@
 import { countTokensSync, truncateToTokenLimitSync } from '@babylon/api';
 import { PerpDbAdapter, PerpMarketService } from '@babylon/core/markets/perps';
 import {
+  actorState,
   and,
   asUser,
   db,
@@ -70,6 +71,10 @@ export class AutonomousTradingService {
     side?: string;
     marketType?: 'prediction' | 'perp';
   }> {
+    // Check if this is an NPC (has entry in StaticDataRegistry)
+    const npcActor = StaticDataRegistry.getActor(agentUserId);
+    const isNpc = !!npcActor;
+
     // Get agent from User table (will be null for NPCs)
     const agentResult = await db
       .select()
@@ -79,7 +84,9 @@ export class AutonomousTradingService {
     const agent = agentResult[0];
 
     // Fallback values for NPCs (who don't have User records)
-    const agentDisplayName = agent?.displayName ?? agentUserId;
+    const agentDisplayName = isNpc
+      ? npcActor.name
+      : (agent?.displayName ?? agentUserId);
     const agentLifetimePnL = agent?.lifetimePnL ?? 0;
     const agentManagedBy = agent?.managedBy ?? agentUserId;
 
@@ -129,7 +136,25 @@ export class AutonomousTradingService {
         (o): o is NonNullable<typeof o> => o !== null && o.type === 'company'
       );
 
-    const balance = await WalletService.getBalance(agentUserId);
+    // Get balance - NPCs use ActorState, Users use WalletService
+    let balance: { balance: number; lifetimePnL: number };
+    if (isNpc) {
+      const [actor] = await db
+        .select({ tradingBalance: actorState.tradingBalance })
+        .from(actorState)
+        .where(eq(actorState.id, agentUserId))
+        .limit(1);
+      balance = {
+        balance: Number(actor?.tradingBalance ?? 10000),
+        lifetimePnL: 0, // NPCs don't track lifetimePnL
+      };
+    } else {
+      const walletBalance = await WalletService.getBalance(agentUserId);
+      balance = {
+        balance: walletBalance.balance,
+        lifetimePnL: walletBalance.lifetimePnL,
+      };
+    }
 
     // Shuffle markets to add variety to prompts
     const shuffledPredictions = shuffleArray(predictionMarkets);
@@ -359,14 +384,23 @@ ${contextString}`;
               TRADING_FEE_RATE
             );
 
-            // Debit amount from balance
-            await WalletService.debit(
-              agentUserId,
-              trade.amount,
-              'pred_buy',
-              `Bought ${calculation.sharesBought} ${side ? 'YES' : 'NO'} shares: ${market.question}`,
-              market.id
-            );
+            // Debit amount from balance (NPCs use ActorState, Users use WalletService)
+            if (isNpc) {
+              await txDb
+                .update(actorState)
+                .set({
+                  tradingBalance: sql`${actorState.tradingBalance} - ${trade.amount}`,
+                })
+                .where(eq(actorState.id, agentUserId));
+            } else {
+              await WalletService.debit(
+                agentUserId,
+                trade.amount,
+                'pred_buy',
+                `Bought ${calculation.sharesBought} ${side ? 'YES' : 'NO'} shares: ${market.question}`,
+                market.id
+              );
+            }
 
             // Update market shares
             await txDb
@@ -467,31 +501,125 @@ ${contextString}`;
           const ticker = org.ticker || org.name;
 
           await asUser({ userId: agentUserId }, async () => {
+            // Create wallet adapter - NPCs use ActorState, Users use WalletService
+            const walletAdapter = isNpc
+              ? {
+                  debit: async ({
+                    userId: uid,
+                    amount,
+                  }: {
+                    userId: string;
+                    amount: number;
+                    reason: string;
+                    description?: string;
+                    relatedId?: string;
+                  }) => {
+                    await db
+                      .update(actorState)
+                      .set({
+                        tradingBalance: sql`${actorState.tradingBalance} - ${amount}`,
+                      })
+                      .where(eq(actorState.id, uid));
+                  },
+                  credit: async ({
+                    userId: uid,
+                    amount,
+                  }: {
+                    userId: string;
+                    amount: number;
+                    reason: string;
+                    description?: string;
+                    relatedId?: string;
+                  }) => {
+                    await db
+                      .update(actorState)
+                      .set({
+                        tradingBalance: sql`${actorState.tradingBalance} + ${amount}`,
+                      })
+                      .where(eq(actorState.id, uid));
+                  },
+                  recordPnL: async (_args: {
+                    userId: string;
+                    pnl: number;
+                    reason: string;
+                    relatedId?: string;
+                  }) => {
+                    // NPCs don't track PnL - no-op
+                  },
+                  getBalance: async (uid: string) => {
+                    const [actor] = await db
+                      .select({ tradingBalance: actorState.tradingBalance })
+                      .from(actorState)
+                      .where(eq(actorState.id, uid))
+                      .limit(1);
+                    return {
+                      balance: Number(actor?.tradingBalance ?? 10000),
+                      totalDeposited: 0,
+                      totalWithdrawn: 0,
+                      lifetimePnL: 0,
+                    };
+                  },
+                }
+              : {
+                  debit: ({
+                    userId: uid,
+                    amount,
+                    reason,
+                    description,
+                    relatedId,
+                  }: {
+                    userId: string;
+                    amount: number;
+                    reason: string;
+                    description?: string;
+                    relatedId?: string;
+                  }) =>
+                    WalletService.debit(
+                      uid,
+                      amount,
+                      reason,
+                      description ?? '',
+                      relatedId
+                    ),
+                  credit: ({
+                    userId: uid,
+                    amount,
+                    reason,
+                    description,
+                    relatedId,
+                  }: {
+                    userId: string;
+                    amount: number;
+                    reason: string;
+                    description?: string;
+                    relatedId?: string;
+                  }) =>
+                    WalletService.credit(
+                      uid,
+                      amount,
+                      reason,
+                      description ?? '',
+                      relatedId
+                    ),
+                  recordPnL: async ({
+                    userId: uid,
+                    pnl,
+                    reason,
+                    relatedId,
+                  }: {
+                    userId: string;
+                    pnl: number;
+                    reason: string;
+                    relatedId?: string;
+                  }) => {
+                    await WalletService.recordPnL(uid, pnl, reason, relatedId);
+                  },
+                  getBalance: (uid: string) => WalletService.getBalance(uid),
+                };
+
             const service = new PerpMarketService({
               db: new PerpDbAdapter(),
-              wallet: {
-                debit: ({ userId, amount, reason, description, relatedId }) =>
-                  WalletService.debit(
-                    userId,
-                    amount,
-                    reason,
-                    description ?? '',
-                    relatedId
-                  ),
-                credit: ({ userId, amount, reason, description, relatedId }) =>
-                  WalletService.credit(
-                    userId,
-                    amount,
-                    reason,
-                    description ?? '',
-                    relatedId
-                  ),
-                recordPnL: async ({ userId, pnl, reason, relatedId }) => {
-                  await WalletService.recordPnL(userId, pnl, reason, relatedId);
-                },
-                getBalance: (userId: string) =>
-                  WalletService.getBalance(userId),
-              },
+              wallet: walletAdapter,
               fees: {
                 tradingFeeRate: 0.001,
                 platformShare: 0.5,


### PR DESCRIPTION
## Summary
Fixes 'Agent not found' and 'User not found' errors for NPC agents (like `aellai`).

## Problem
NPC agents don't have `User` table records - they use `ActorState` and `StaticDataRegistry`. All autonomous services were only querying the `User` table, causing errors when NPCs tried to post, comment, or trade.

## Changes

### Services updated to detect and handle NPCs:
- **AutonomousPostingService** - NPCs can now create posts
- **AutonomousCommentingService** - NPCs can now comment on posts
- **AutonomousTradingService** - Full NPC trading support:
  - Prediction market trades debit from `ActorState.tradingBalance`
  - Perp trades use NPC-aware wallet adapter
- **AutonomousDMService** - NPCs can respond to DMs
- **AutonomousGroupChatService** - NPCs can participate in group chats
- **AutonomousBatchResponseService** - NPCs can respond to batch interactions

### How it works:
1. Each service checks `StaticDataRegistry.getActor(agentUserId)` to detect NPCs
2. NPCs get their display name from the registry
3. NPCs get their balance from `ActorState.tradingBalance` instead of `User.virtualBalance`
4. Trade execution updates `ActorState.tradingBalance` directly instead of using `WalletService`

## Testing
- `bun run typecheck` ✅
- `bun run lint` ✅

## What NPCs can now do:
- ✅ Make prediction market trades (buy YES/NO shares)
- ✅ Open perp positions (long/short)
- ✅ Create posts
- ✅ Comment on posts
- ✅ Respond to DMs and group chats