### PR TITLE
feat(agents): eliminate double LLM calls with direct executors

### DIFF
--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -1,0 +1,586 @@
+/**
+ * Direct Executors for Multi-Step Agent Actions
+ *
+ * These are "dumb" executors that take specific parameters and execute directly
+ * without making their own LLM calls. The multi-step decision loop handles all
+ * LLM reasoning - these just execute the decided actions.
+ */
+
+import { PerpDbAdapter, PerpMarketService } from '@babylon/core/markets/perps';
+import {
+  actorState,
+  and,
+  asSystem,
+  asUser,
+  comments,
+  db,
+  eq,
+  markets,
+  positions,
+  posts,
+  sql,
+} from '@babylon/db';
+import {
+  type GeneratedTag,
+  generateTagsFromPost,
+  PredictionPricing,
+  StaticDataRegistry,
+  storeTagsForPost,
+  WalletService,
+} from '@babylon/engine';
+import { agentPnLService } from '../services/AgentPnLService';
+import { logger } from '../shared/logger';
+import { generateSnowflakeId } from '../shared/snowflake';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface DirectTradeParams {
+  agentUserId: string;
+  marketType: 'prediction' | 'perp';
+  marketId: string; // Market ID for prediction, ticker for perp
+  side: 'buy_yes' | 'buy_no' | 'open_long' | 'open_short';
+  amount: number;
+  reasoning?: string;
+}
+
+export interface DirectTradeResult {
+  success: boolean;
+  marketId?: string;
+  ticker?: string;
+  side?: string;
+  shares?: number;
+  error?: string;
+}
+
+export interface DirectPostParams {
+  agentUserId: string;
+  content: string;
+}
+
+export interface DirectPostResult {
+  success: boolean;
+  postId?: string;
+  error?: string;
+}
+
+export interface DirectCommentParams {
+  agentUserId: string;
+  postId: string;
+  content: string;
+  parentCommentId?: string;
+}
+
+export interface DirectCommentResult {
+  success: boolean;
+  commentId?: string;
+  error?: string;
+}
+
+// =============================================================================
+// Direct Trade Executor
+// =============================================================================
+
+/**
+ * Execute a trade directly without LLM decision-making.
+ * Just executes the given parameters.
+ */
+export async function executeDirectTrade(
+  params: DirectTradeParams
+): Promise<DirectTradeResult> {
+  const { agentUserId, marketType, marketId, side, amount, reasoning } = params;
+
+  // Check if this is an NPC
+  const npcActor = StaticDataRegistry.getActor(agentUserId);
+  const isNpc = !!npcActor;
+
+  // Get agent's managed by for recording (for USER_CONTROLLED agents)
+  const agentManagedBy = agentUserId;
+
+  logger.info(
+    `[DirectExecutor] Executing ${marketType} trade: ${side} $${amount} on ${marketId}`,
+    { agentUserId, isNpc },
+    'DirectExecutors'
+  );
+
+  if (marketType === 'prediction') {
+    return executePredictionTrade({
+      agentUserId,
+      marketId,
+      side: side as 'buy_yes' | 'buy_no',
+      amount,
+      reasoning,
+      isNpc,
+      agentManagedBy,
+    });
+  }
+  return executePerpTrade({
+    agentUserId,
+    ticker: marketId,
+    side: side as 'open_long' | 'open_short',
+    amount,
+    reasoning,
+    isNpc,
+    agentManagedBy,
+  });
+}
+
+async function executePredictionTrade(params: {
+  agentUserId: string;
+  marketId: string;
+  side: 'buy_yes' | 'buy_no';
+  amount: number;
+  reasoning?: string;
+  isNpc: boolean;
+  agentManagedBy: string;
+}): Promise<DirectTradeResult> {
+  const {
+    agentUserId,
+    marketId,
+    side,
+    amount,
+    reasoning,
+    isNpc,
+    agentManagedBy,
+  } = params;
+
+  // Find the market
+  const [market] = await db
+    .select()
+    .from(markets)
+    .where(eq(markets.id, marketId))
+    .limit(1);
+
+  if (!market) {
+    return { success: false, error: `Market not found: ${marketId}` };
+  }
+
+  const isBuyYes = side === 'buy_yes';
+
+  const tradeOperation = async (
+    txDb: Parameters<Parameters<typeof asUser>[1]>[0]
+  ) => {
+    // Calculate shares and pricing (0.1% fee rate)
+    const TRADING_FEE_RATE = 0.001;
+    const calculation = PredictionPricing.calculateBuyWithFees(
+      Number(market.yesShares),
+      Number(market.noShares),
+      isBuyYes ? 'yes' : 'no',
+      amount,
+      TRADING_FEE_RATE
+    );
+
+    // Debit amount from balance
+    if (isNpc) {
+      await txDb
+        .update(actorState)
+        .set({
+          tradingBalance: sql`${actorState.tradingBalance} - ${amount}`,
+        })
+        .where(eq(actorState.id, agentUserId));
+    } else {
+      await WalletService.debit(
+        agentUserId,
+        amount,
+        'pred_buy',
+        `Bought ${calculation.sharesBought} ${isBuyYes ? 'YES' : 'NO'} shares: ${market.question}`,
+        market.id
+      );
+    }
+
+    // Update market shares
+    await txDb
+      .update(markets)
+      .set({
+        yesShares: isBuyYes
+          ? sql`${markets.yesShares} + ${calculation.sharesBought}`
+          : String(calculation.newYesShares),
+        noShares: isBuyYes
+          ? String(calculation.newNoShares)
+          : sql`${markets.noShares} + ${calculation.sharesBought}`,
+      })
+      .where(eq(markets.id, market.id));
+
+    // Create or update position
+    const existingPositionResult = await txDb
+      .select()
+      .from(positions)
+      .where(
+        and(
+          eq(positions.userId, agentUserId),
+          eq(positions.marketId, market.id)
+        )
+      )
+      .limit(1);
+    const existingPosition = existingPositionResult[0];
+
+    if (existingPosition) {
+      await txDb
+        .update(positions)
+        .set({
+          shares: sql`${positions.shares} + ${calculation.sharesBought}`,
+          amount: sql`${positions.amount} + ${amount}`,
+          updatedAt: new Date(),
+        })
+        .where(eq(positions.id, existingPosition.id));
+    } else {
+      await txDb.insert(positions).values({
+        id: await generateSnowflakeId(),
+        userId: agentUserId,
+        marketId: market.id,
+        side: isBuyYes,
+        shares: String(calculation.sharesBought),
+        avgPrice: String(calculation.avgPrice),
+        amount: String(amount),
+        status: 'active',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      });
+    }
+
+    return { calculation };
+  };
+
+  // Execute with appropriate context
+  const result = isNpc
+    ? await asSystem(tradeOperation, 'npc_prediction_trade')
+    : await asUser({ userId: agentUserId }, tradeOperation);
+
+  // Record in AgentTrade
+  await agentPnLService.recordTrade({
+    agentId: agentUserId,
+    userId: agentManagedBy,
+    marketType: 'prediction',
+    marketId: market.id,
+    action: 'open',
+    side: isBuyYes ? 'yes' : 'no',
+    amount,
+    price: result.calculation.avgPrice,
+    reasoning,
+  });
+
+  logger.info(
+    `[DirectExecutor] Prediction trade executed: ${isBuyYes ? 'YES' : 'NO'} on ${market.question.substring(0, 50)}`,
+    { shares: result.calculation.sharesBought },
+    'DirectExecutors'
+  );
+
+  return {
+    success: true,
+    marketId: market.id,
+    side: isBuyYes ? 'YES' : 'NO',
+    shares: result.calculation.sharesBought,
+  };
+}
+
+async function executePerpTrade(params: {
+  agentUserId: string;
+  ticker: string;
+  side: 'open_long' | 'open_short';
+  amount: number;
+  reasoning?: string;
+  isNpc: boolean;
+  agentManagedBy: string;
+}): Promise<DirectTradeResult> {
+  const { agentUserId, ticker, side, amount, reasoning, isNpc, agentManagedBy } =
+    params;
+
+  const perpSide = side === 'open_long' ? 'long' : 'short';
+
+  // Get org for price (search through all orgs by ticker)
+  const allOrgs = StaticDataRegistry.getAllOrganizations();
+  const org = allOrgs.find((o) => o.ticker === ticker);
+  const currentPrice = org?.initialPrice ?? 100;
+
+  const perpTradeOperation = async () => {
+    // Create wallet adapter
+    const walletAdapter = isNpc
+      ? {
+          debit: async ({
+            userId: uid,
+            amount: amt,
+          }: {
+            userId: string;
+            amount: number;
+            reason: string;
+            description?: string;
+            relatedId?: string;
+          }) => {
+            await db
+              .update(actorState)
+              .set({
+                tradingBalance: sql`${actorState.tradingBalance} - ${amt}`,
+              })
+              .where(eq(actorState.id, uid));
+          },
+          credit: async ({
+            userId: uid,
+            amount: amt,
+          }: {
+            userId: string;
+            amount: number;
+            reason: string;
+            description?: string;
+            relatedId?: string;
+          }) => {
+            await db
+              .update(actorState)
+              .set({
+                tradingBalance: sql`${actorState.tradingBalance} + ${amt}`,
+              })
+              .where(eq(actorState.id, uid));
+          },
+          recordPnL: async (_args: {
+            userId: string;
+            pnl: number;
+            reason: string;
+            relatedId?: string;
+          }) => {
+            // NPCs don't track PnL
+          },
+          getBalance: async (uid: string) => {
+            const [actor] = await db
+              .select({ tradingBalance: actorState.tradingBalance })
+              .from(actorState)
+              .where(eq(actorState.id, uid))
+              .limit(1);
+            return {
+              balance: Number(actor?.tradingBalance ?? 10000),
+              totalDeposited: 0,
+              totalWithdrawn: 0,
+              lifetimePnL: 0,
+            };
+          },
+        }
+      : {
+          debit: ({
+            userId: uid,
+            amount: amt,
+            reason,
+            description,
+            relatedId,
+          }: {
+            userId: string;
+            amount: number;
+            reason: string;
+            description?: string;
+            relatedId?: string;
+          }) =>
+            WalletService.debit(uid, amt, reason, description ?? '', relatedId),
+          credit: ({
+            userId: uid,
+            amount: amt,
+            reason,
+            description,
+            relatedId,
+          }: {
+            userId: string;
+            amount: number;
+            reason: string;
+            description?: string;
+            relatedId?: string;
+          }) =>
+            WalletService.credit(uid, amt, reason, description ?? '', relatedId),
+          recordPnL: async ({
+            userId: uid,
+            pnl,
+            reason,
+            relatedId,
+          }: {
+            userId: string;
+            pnl: number;
+            reason: string;
+            relatedId?: string;
+          }) => {
+            await WalletService.recordPnL(uid, pnl, reason, relatedId);
+          },
+          getBalance: (uid: string) => WalletService.getBalance(uid),
+        };
+
+    const service = new PerpMarketService({
+      db: new PerpDbAdapter(),
+      wallet: walletAdapter,
+      fees: {
+        tradingFeeRate: 0.001,
+        platformShare: 0.5,
+        referrerShare: 0.5,
+        minFeeAmount: 0.01,
+      },
+    });
+
+    await service.openPosition({
+      userId: agentUserId,
+      ticker,
+      side: perpSide,
+      size: amount,
+      leverage: 1,
+    });
+  };
+
+  // Execute with appropriate context
+  if (isNpc) {
+    await asSystem(perpTradeOperation, 'npc_perp_trade');
+  } else {
+    await asUser({ userId: agentUserId }, perpTradeOperation);
+  }
+
+  // Record trade
+  await agentPnLService.recordTrade({
+    agentId: agentUserId,
+    userId: agentManagedBy,
+    marketType: 'perp',
+    ticker,
+    action: 'open',
+    side: perpSide,
+    amount,
+    price: currentPrice,
+    reasoning,
+  });
+
+  logger.info(
+    `[DirectExecutor] Perp trade executed: ${perpSide} $${amount} on ${ticker}`,
+    undefined,
+    'DirectExecutors'
+  );
+
+  return {
+    success: true,
+    ticker,
+    side: perpSide,
+  };
+}
+
+// =============================================================================
+// Direct Post Executor
+// =============================================================================
+
+/**
+ * Create a post directly without LLM decision-making.
+ * Just creates the post with the given content.
+ */
+export async function executeDirectPost(
+  params: DirectPostParams
+): Promise<DirectPostResult> {
+  const { agentUserId, content } = params;
+
+  if (!content || content.trim().length < 5) {
+    return { success: false, error: 'Content too short' };
+  }
+
+  const cleanContent = content.trim();
+
+  // Check if this is an NPC
+  const npcActor = StaticDataRegistry.getActor(agentUserId);
+  const isNpc = !!npcActor;
+
+  logger.info(
+    `[DirectExecutor] Creating post for ${isNpc ? 'NPC' : 'user'} ${agentUserId}`,
+    { contentPreview: cleanContent.substring(0, 50) },
+    'DirectExecutors'
+  );
+
+  // Create the post
+  const postId = await generateSnowflakeId();
+  const now = new Date();
+
+  await db.insert(posts).values({
+    id: postId,
+    content: cleanContent,
+    authorId: agentUserId,
+    timestamp: now,
+    createdAt: now,
+  });
+
+  // Generate and store tags
+  const tags: GeneratedTag[] = await generateTagsFromPost(cleanContent);
+  if (tags.length > 0) {
+    await storeTagsForPost(postId, tags);
+  }
+
+  logger.info(
+    `[DirectExecutor] Post created: ${postId}`,
+    { tags: tags.length },
+    'DirectExecutors'
+  );
+
+  return {
+    success: true,
+    postId,
+  };
+}
+
+// =============================================================================
+// Direct Comment Executor
+// =============================================================================
+
+/**
+ * Create a comment directly without LLM decision-making.
+ * Just creates the comment with the given content.
+ */
+export async function executeDirectComment(
+  params: DirectCommentParams
+): Promise<DirectCommentResult> {
+  const { agentUserId, postId, content, parentCommentId } = params;
+
+  if (!content || content.trim().length < 3) {
+    return { success: false, error: 'Content too short' };
+  }
+
+  const cleanContent = content.trim();
+
+  // Verify post exists
+  const [post] = await db
+    .select({ id: posts.id })
+    .from(posts)
+    .where(eq(posts.id, postId))
+    .limit(1);
+
+  if (!post) {
+    return { success: false, error: `Post not found: ${postId}` };
+  }
+
+  // Verify parent comment if provided
+  if (parentCommentId) {
+    const [parentComment] = await db
+      .select({ id: comments.id })
+      .from(comments)
+      .where(eq(comments.id, parentCommentId))
+      .limit(1);
+
+    if (!parentComment) {
+      return { success: false, error: `Parent comment not found: ${parentCommentId}` };
+    }
+  }
+
+  logger.info(
+    `[DirectExecutor] Creating comment on post ${postId}`,
+    { parentCommentId, contentPreview: cleanContent.substring(0, 50) },
+    'DirectExecutors'
+  );
+
+  const commentId = await generateSnowflakeId();
+  const now = new Date();
+
+  await db.insert(comments).values({
+    id: commentId,
+    content: cleanContent,
+    postId,
+    authorId: agentUserId,
+    parentCommentId: parentCommentId ?? null,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  logger.info(
+    `[DirectExecutor] Comment created: ${commentId}`,
+    undefined,
+    'DirectExecutors'
+  );
+
+  return {
+    success: true,
+    commentId,
+  };
+}
+

--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -4,31 +4,46 @@
  * Implements an iterative decision loop where the LLM decides what action to take
  * based on current state and previous actions taken this tick.
  *
- * Inspired by Otaku's multi-step pattern, adapted for Babylon prediction markets.
+ * Key design: Services are "dumb executors" - all LLM reasoning happens HERE.
+ * This eliminates double LLM calls and makes execution faster.
  */
 
+import { getDbInstance } from '@babylon/db';
 import {
   actorState,
+  and,
   db,
+  desc,
   eq,
+  gte,
+  isNull,
+  lte,
+  markets,
+  ne,
   perpPositions,
   positions,
+  posts,
   users,
 } from '@babylon/db';
+import { StaticDataRegistry, WalletService } from '@babylon/engine';
 import type { IAgentRuntime } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
 import { getAgentConfig } from '../shared/agent-config';
 import { logger } from '../shared/logger';
 import { autonomousBatchResponseService } from './AutonomousBatchResponseService';
-import { autonomousCommentingService } from './AutonomousCommentingService';
-import { autonomousPostingService } from './AutonomousPostingService';
-import { autonomousTradingService } from './AutonomousTradingService';
+import {
+  executeDirectComment,
+  executeDirectPost,
+  executeDirectTrade,
+} from './DirectExecutors';
 import {
   type ActionTraceResult,
   type AgentTickContext,
   buildMultiStepDecisionPrompt,
-  type MarketOpportunity,
   type MultiStepDecision,
+  type PerpMarketContext,
+  type PostContext,
+  type PredictionMarketContext,
 } from './templates/multi-step-decision';
 
 // =============================================================================
@@ -84,7 +99,6 @@ export class MultiStepExecutor {
     );
 
     // Get agent info (for USER_CONTROLLED agents)
-    // NPCs don't have User records - they're validated by AgentRegistry
     let agent: typeof users.$inferSelect | undefined;
     if (!isNpc) {
       const [userAgent] = await db
@@ -107,7 +121,6 @@ export class MultiStepExecutor {
     // Determine enabled features - NPCs have all features enabled by default
     const enabledFeatures: string[] = [];
     if (isNpc) {
-      // NPCs have all autonomous features enabled
       enabledFeatures.push('trading', 'posting', 'commenting', 'DMs');
     } else {
       if (config?.autonomousTrading) enabledFeatures.push('trading');
@@ -132,7 +145,6 @@ export class MultiStepExecutor {
       );
 
       // Build decision prompt
-      // For NPCs, use agentUserId as the name (e.g., "aellai")
       const agentName = agent?.displayName ?? agentUserId;
       const prompt = buildMultiStepDecisionPrompt({
         agentName,
@@ -174,19 +186,17 @@ export class MultiStepExecutor {
         break;
       }
 
-      // Execute the chosen action
+      // Execute the chosen action with parameters
       const actionResult = await this.executeAction(
         agentUserId,
-        runtime,
         decision.action,
-        decision.parameters,
-        decision.thought
+        decision.parameters
       );
 
       trace.push(actionResult);
 
-      // Small delay between iterations
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      // Small delay between iterations (reduced since no double LLM calls)
+      await new Promise((resolve) => setTimeout(resolve, 200));
     }
 
     // Aggregate results
@@ -208,76 +218,53 @@ export class MultiStepExecutor {
 
   /**
    * Gather current context for decision making
-   *
-   * @param agentUserId - User ID for USER_CONTROLLED agents, or actorId for NPCs
-   * @param enabledFeatures - List of enabled features for this agent
-   * @param isNpc - Whether this is an NPC agent (uses ActorState instead of User)
+   * Includes FULL market data so LLM can make specific decisions
    */
   private async gatherContext(
     agentUserId: string,
     enabledFeatures: string[],
     isNpc: boolean
   ): Promise<AgentTickContext> {
+    // Get balance and PnL
     let balance = 0;
     let pnl = 0;
 
     if (isNpc) {
-      // NPCs use ActorState table (no lifetimePnL tracking for NPCs)
       const [actor] = await db
-        .select({
-          tradingBalance: actorState.tradingBalance,
-        })
+        .select({ tradingBalance: actorState.tradingBalance })
         .from(actorState)
         .where(eq(actorState.id, agentUserId))
         .limit(1);
 
       balance = Number(actor?.tradingBalance ?? 10000);
-      pnl = 0; // NPCs don't track lifetimePnL
+      pnl = 0;
     } else {
-      // USER_CONTROLLED agents use User table
-      const [agent] = await db
-        .select({
-          virtualBalance: users.virtualBalance,
-          lifetimePnL: users.lifetimePnL,
-        })
-        .from(users)
-        .where(eq(users.id, agentUserId))
-        .limit(1);
-
-      balance = Number(agent?.virtualBalance ?? 0);
-      pnl = Number(agent?.lifetimePnL ?? 0);
+      const walletBalance = await WalletService.getBalance(agentUserId);
+      balance = walletBalance.balance;
+      pnl = walletBalance.lifetimePnL;
     }
 
-    // Get open positions count (positions table uses userId for both User and NPC)
-    const predPositions = await db
-      .select()
-      .from(positions)
-      .where(eq(positions.userId, agentUserId));
-    const activePositions = predPositions.filter(
-      (p) => p.status === 'active'
-    ).length;
+    // Get prediction markets
+    const predictionMarkets = await this.getPredictionMarkets();
 
-    const perpPositionsList = await db
-      .select()
-      .from(perpPositions)
-      .where(eq(perpPositions.userId, agentUserId));
-    const openPerpPositions = perpPositionsList.filter(
-      (p) => p.closedAt === null
-    ).length;
+    // Get perp markets
+    const perpMarkets = await this.getPerpMarkets();
+
+    // Get agent's positions
+    const agentPositions = await this.getAgentPositions(agentUserId);
+
+    // Get recent posts to engage with
+    const recentPosts = await this.getRecentPosts(agentUserId);
 
     // Get pending interactions
     const pendingInteractions =
-      await autonomousBatchResponseService.gatherPendingInteractions(
-        agentUserId
-      );
-
-    // Get market opportunities (simplified for now)
-    const opportunities = await this.detectOpportunities(agentUserId);
+      await autonomousBatchResponseService.gatherPendingInteractions(agentUserId);
 
     return {
       balance,
       pnl,
-      openPositions: activePositions + openPerpPositions,
+      openPositions:
+        agentPositions.predictions.length + agentPositions.perps.length,
       pendingInteractions: pendingInteractions.length,
       pendingInteractionDetails: pendingInteractions.slice(0, 5).map((i) => ({
         type: i.type as 'comment_reply' | 'dm' | 'mention',
@@ -286,50 +273,196 @@ export class MultiStepExecutor {
         postId: i.postId,
       })),
       enabledFeatures,
-      opportunities,
+      predictionMarkets,
+      perpMarkets,
+      recentPosts,
+      agentPositions,
     };
   }
 
   /**
-   * Detect market opportunities for the agent
+   * Get active prediction markets with pricing
    */
-  private async detectOpportunities(
-    _agentUserId: string
-  ): Promise<MarketOpportunity[]> {
-    const opportunities: MarketOpportunity[] = [];
+  private async getPredictionMarkets(): Promise<PredictionMarketContext[]> {
+    const activeMarkets = await db
+      .select()
+      .from(markets)
+      .where(and(eq(markets.resolved, false), gte(markets.endDate, new Date())))
+      .orderBy(desc(markets.createdAt))
+      .limit(8);
 
-    // Get active prediction markets
-    const activeMarkets = await db.market.findMany({
-      where: {
-        resolved: false,
-        endDate: { gte: new Date() },
-      },
-      orderBy: { createdAt: 'desc' },
-      take: 5,
+    return activeMarkets.map((m) => {
+      const yesShares = Number(m.yesShares || 1);
+      const noShares = Number(m.noShares || 1);
+      const total = yesShares + noShares;
+
+      return {
+        id: m.id,
+        question: m.question,
+        yesPrice: yesShares / total,
+        noPrice: noShares / total,
+        volume: total,
+        endDate: m.endDate?.toISOString().split('T')[0] ?? 'Unknown',
+      };
     });
+  }
 
-    for (const market of activeMarkets) {
-      const yesShares = Number(market.yesShares || 0);
-      const noShares = Number(market.noShares || 0);
-      const totalShares = yesShares + noShares;
+  /**
+   * Get perp markets with current prices
+   */
+  private async getPerpMarkets(): Promise<PerpMarketContext[]> {
+    const orgStates = await getDbInstance().getOrganizationsByPrice();
 
-      if (totalShares > 0) {
-        const yesPrice = yesShares / totalShares;
+    return orgStates
+      .slice(0, 8)
+      .map((state) => {
+        const staticOrg = StaticDataRegistry.getOrganization(state.id);
+        if (!staticOrg || staticOrg.type !== 'company') return null;
 
-        // Flag mispriced markets
-        if (yesPrice < 0.25 || yesPrice > 0.75) {
-          opportunities.push({
-            type: 'prediction',
-            id: market.id,
-            name: market.question.substring(0, 50),
-            description: `YES at ${(yesPrice * 100).toFixed(0)}% - ${yesPrice < 0.5 ? 'potential undervalued' : 'potential overvalued'}`,
-            confidence: Math.abs(yesPrice - 0.5) * 2,
-          });
+        const currentPrice = state.currentPrice ?? staticOrg.initialPrice ?? 100;
+        const initialPrice = staticOrg.initialPrice ?? 100;
+        const changePercent = ((currentPrice - initialPrice) / initialPrice) * 100;
+
+        return {
+          ticker: staticOrg.ticker,
+          name: staticOrg.name,
+          currentPrice,
+          initialPrice,
+          changePercent,
+        };
+      })
+      .filter((m): m is PerpMarketContext => m !== null);
+  }
+
+  /**
+   * Get agent's current positions
+   */
+  private async getAgentPositions(agentUserId: string): Promise<{
+    predictions: { marketId: string; question: string; side: string; shares: number }[];
+    perps: { ticker: string; side: string; size: number; pnl: number }[];
+  }> {
+    // Prediction positions
+    const predPositions = await db
+      .select({
+        marketId: positions.marketId,
+        side: positions.side,
+        shares: positions.shares,
+      })
+      .from(positions)
+      .where(and(eq(positions.userId, agentUserId), eq(positions.status, 'active')))
+      .limit(10);
+
+    // Get market questions for positions
+    const marketIds = predPositions.map((p) => p.marketId).filter(Boolean) as string[];
+    const marketQuestions = new Map<string, string>();
+    if (marketIds.length > 0) {
+      const marketData = await db
+        .select({ id: markets.id, question: markets.question })
+        .from(markets);
+      for (const m of marketData) {
+        if (marketIds.includes(m.id)) {
+          marketQuestions.set(m.id, m.question);
         }
       }
     }
 
-    return opportunities.slice(0, 5);
+    const predictions = predPositions
+      .filter((p) => p.marketId)
+      .map((p) => ({
+        marketId: p.marketId as string,
+        question: marketQuestions.get(p.marketId as string) ?? 'Unknown',
+        side: p.side ? 'YES' : 'NO',
+        shares: Number(p.shares || 0),
+      }));
+
+    // Perp positions
+    const perpPositionsList = await db
+      .select({
+        ticker: perpPositions.ticker,
+        side: perpPositions.side,
+        size: perpPositions.size,
+        unrealizedPnL: perpPositions.unrealizedPnL,
+      })
+      .from(perpPositions)
+      .where(
+        and(eq(perpPositions.userId, agentUserId), isNull(perpPositions.closedAt))
+      )
+      .limit(10);
+
+    const perps = perpPositionsList.map((p) => ({
+      ticker: p.ticker,
+      side: p.side,
+      size: Number(p.size || 0),
+      pnl: Number(p.unrealizedPnL || 0),
+    }));
+
+    return { predictions, perps };
+  }
+
+  /**
+   * Get recent posts to potentially engage with
+   */
+  private async getRecentPosts(agentUserId: string): Promise<PostContext[]> {
+    const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const now = new Date();
+
+    const recentPostsRaw = await db
+      .select({
+        id: posts.id,
+        content: posts.content,
+        authorId: posts.authorId,
+        createdAt: posts.createdAt,
+      })
+      .from(posts)
+      .where(
+        and(
+          ne(posts.authorId, agentUserId),
+          isNull(posts.deletedAt),
+          gte(posts.timestamp, oneDayAgo),
+          lte(posts.timestamp, now)
+        )
+      )
+      .orderBy(desc(posts.createdAt))
+      .limit(8);
+
+    // Get author names
+    const authorIds = [...new Set(recentPostsRaw.map((p) => p.authorId))];
+    const authorNames = new Map<string, string>();
+
+    for (const authorId of authorIds) {
+      // Check static registry first
+      const actor = StaticDataRegistry.getActor(authorId);
+      if (actor) {
+        authorNames.set(authorId, actor.name);
+        continue;
+      }
+      const org = StaticDataRegistry.getOrganization(authorId);
+      if (org) {
+        authorNames.set(authorId, org.name);
+        continue;
+      }
+    }
+
+    // Fetch remaining from DB
+    const missingIds = authorIds.filter((id) => !authorNames.has(id));
+    if (missingIds.length > 0) {
+      const dbUsers = await db
+        .select({ id: users.id, displayName: users.displayName, username: users.username })
+        .from(users);
+      for (const u of dbUsers) {
+        if (missingIds.includes(u.id)) {
+          authorNames.set(u.id, u.displayName || u.username || 'User');
+        }
+      }
+    }
+
+    return recentPostsRaw.map((p) => ({
+      id: p.id,
+      authorName: authorNames.get(p.authorId) || 'User',
+      content: p.content,
+      commentCount: 0, // Simplified - could add actual count if needed
+      timeAgo: getTimeAgo(p.createdAt),
+    }));
   }
 
   /**
@@ -348,7 +481,7 @@ export class MultiStepExecutor {
         system:
           'You are a decision-making agent. Output valid JSON only. No markdown, no explanations.',
         runtime,
-        temperature: attempt > 1 ? 0.5 : 0.7, // Lower temperature on retry
+        temperature: attempt > 1 ? 0.5 : 0.7,
         maxTokens: 1000,
         actionType: 'multi_step_decision',
         purpose: 'action',
@@ -396,14 +529,12 @@ export class MultiStepExecutor {
   }
 
   /**
-   * Execute a single action based on LLM decision
+   * Execute a single action using DIRECT executors (no LLM calls)
    */
   private async executeAction(
     agentUserId: string,
-    runtime: IAgentRuntime,
     action: string,
-    parameters: Record<string, unknown>,
-    _thought: string
+    parameters: Record<string, unknown>
   ): Promise<ActionTraceResult> {
     const normalizedAction = action.toUpperCase();
 
@@ -413,124 +544,176 @@ export class MultiStepExecutor {
       'MultiStepExecutor'
     );
 
-    try {
-      switch (normalizedAction) {
-        case 'TRADE': {
-          const tradeResult = await autonomousTradingService.executeTrades(
-            agentUserId,
-            runtime
-          );
+    switch (normalizedAction) {
+      case 'TRADE': {
+        const marketType = parameters.marketType as 'prediction' | 'perp';
+        const marketId = parameters.marketId as string;
+        const side = parameters.side as
+          | 'buy_yes'
+          | 'buy_no'
+          | 'open_long'
+          | 'open_short';
+        const amount = Number(parameters.amount || 100);
+        const reasoning = parameters.reasoning as string | undefined;
+
+        if (!marketId || !side) {
           return {
             actionType: 'TRADE',
-            success: tradeResult.tradesExecuted > 0,
-            summary:
-              tradeResult.tradesExecuted > 0
-                ? `Executed ${tradeResult.tradesExecuted} trade(s) on ${tradeResult.marketType || 'market'}`
-                : 'Decided to hold - no trade executed',
-            result: {
-              tradesExecuted: tradeResult.tradesExecuted,
-              marketId: tradeResult.marketId,
-              ticker: tradeResult.ticker,
-              side: tradeResult.side,
-            },
+            success: false,
+            summary: 'Missing required parameters (marketId, side)',
+            error: 'Invalid parameters',
             parameters,
             timestamp: Date.now(),
           };
         }
 
-        case 'POST': {
-          const postId = await autonomousPostingService.createAgentPost(
-            agentUserId,
-            runtime
-          );
+        const tradeResult = await executeDirectTrade({
+          agentUserId,
+          marketType: marketType || 'prediction',
+          marketId,
+          side,
+          amount,
+          reasoning,
+        });
+
+        return {
+          actionType: 'TRADE',
+          success: tradeResult.success,
+          summary: tradeResult.success
+            ? `Traded ${side} $${amount} on ${tradeResult.marketId || tradeResult.ticker}`
+            : `Trade failed: ${tradeResult.error}`,
+          result: {
+            success: tradeResult.success,
+            marketId: tradeResult.marketId,
+            ticker: tradeResult.ticker,
+            side: tradeResult.side,
+            shares: tradeResult.shares,
+            error: tradeResult.error,
+          },
+          parameters,
+          timestamp: Date.now(),
+        };
+      }
+
+      case 'POST': {
+        const content = parameters.content as string;
+
+        if (!content) {
           return {
             actionType: 'POST',
-            success: !!postId,
-            summary: postId
-              ? `Created post ${postId}`
-              : 'Failed to create post',
-            result: postId ? { postId } : undefined,
+            success: false,
+            summary: 'Missing content parameter',
+            error: 'No content provided',
             parameters,
             timestamp: Date.now(),
           };
         }
 
-        case 'COMMENT': {
-          const commentId =
-            await autonomousCommentingService.createAgentComment(
-              agentUserId,
-              runtime
-            );
+        const postResult = await executeDirectPost({
+          agentUserId,
+          content,
+        });
+
+        return {
+          actionType: 'POST',
+          success: postResult.success,
+          summary: postResult.success
+            ? `Created post ${postResult.postId}`
+            : `Post failed: ${postResult.error}`,
+          result: {
+            success: postResult.success,
+            postId: postResult.postId,
+            error: postResult.error,
+          },
+          parameters,
+          timestamp: Date.now(),
+        };
+      }
+
+      case 'COMMENT': {
+        const postId = parameters.postId as string;
+        const content = parameters.content as string;
+        const parentCommentId = parameters.parentCommentId as string | undefined;
+
+        if (!postId || !content) {
           return {
             actionType: 'COMMENT',
-            success: !!commentId,
-            summary: commentId
-              ? `Created comment ${commentId}`
-              : 'Failed to create comment',
-            result: commentId ? { commentId } : undefined,
-            parameters,
-            timestamp: Date.now(),
-          };
-        }
-
-        case 'RESPOND': {
-          const responses = await autonomousBatchResponseService.processBatch(
-            agentUserId,
-            runtime
-          );
-          return {
-            actionType: 'RESPOND',
-            success: responses > 0,
-            summary: `Responded to ${responses} interaction(s)`,
-            result: { responsesCreated: responses },
-            parameters,
-            timestamp: Date.now(),
-          };
-        }
-
-        case 'WAIT':
-        case '': {
-          return {
-            actionType: 'WAIT',
-            success: true,
-            summary: 'Agent decided to wait',
-            parameters,
-            timestamp: Date.now(),
-          };
-        }
-
-        default: {
-          logger.warn(
-            `[MultiStep] Unknown action: ${normalizedAction}`,
-            undefined,
-            'MultiStepExecutor'
-          );
-          return {
-            actionType: normalizedAction,
             success: false,
-            summary: `Unknown action: ${normalizedAction}`,
-            error: `Action "${normalizedAction}" is not recognized`,
+            summary: 'Missing required parameters (postId, content)',
+            error: 'Invalid parameters',
             parameters,
             timestamp: Date.now(),
           };
         }
+
+        const commentResult = await executeDirectComment({
+          agentUserId,
+          postId,
+          content,
+          parentCommentId,
+        });
+
+        return {
+          actionType: 'COMMENT',
+          success: commentResult.success,
+          summary: commentResult.success
+            ? `Created comment ${commentResult.commentId}`
+            : `Comment failed: ${commentResult.error}`,
+          result: {
+            success: commentResult.success,
+            commentId: commentResult.commentId,
+            error: commentResult.error,
+          },
+          parameters,
+          timestamp: Date.now(),
+        };
       }
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      logger.error(
-        `[MultiStep] Error executing ${normalizedAction}: ${errorMessage}`,
-        undefined,
-        'MultiStepExecutor'
-      );
-      return {
-        actionType: normalizedAction,
-        success: false,
-        summary: `Error: ${errorMessage}`,
-        error: errorMessage,
-        parameters,
-        timestamp: Date.now(),
-      };
+
+      case 'RESPOND': {
+        // RESPOND still uses the batch service which has its own LLM
+        // for deciding WHICH interactions to respond to
+        // This is acceptable as it's a different kind of decision
+        const responses = await autonomousBatchResponseService.processBatch(
+          agentUserId,
+          {} as IAgentRuntime // Runtime not needed for batch response
+        );
+
+        return {
+          actionType: 'RESPOND',
+          success: responses > 0,
+          summary: `Responded to ${responses} interaction(s)`,
+          result: { responsesCreated: responses },
+          parameters,
+          timestamp: Date.now(),
+        };
+      }
+
+      case 'WAIT':
+      case '': {
+        return {
+          actionType: 'WAIT',
+          success: true,
+          summary: 'Agent decided to wait',
+          parameters,
+          timestamp: Date.now(),
+        };
+      }
+
+      default: {
+        logger.warn(
+          `[MultiStep] Unknown action: ${normalizedAction}`,
+          undefined,
+          'MultiStepExecutor'
+        );
+        return {
+          actionType: normalizedAction,
+          success: false,
+          summary: `Unknown action: ${normalizedAction}`,
+          error: `Action "${normalizedAction}" is not recognized`,
+          parameters,
+          timestamp: Date.now(),
+        };
+      }
     }
   }
 
@@ -553,12 +736,14 @@ export class MultiStepExecutor {
 
       switch (result.actionType) {
         case 'TRADE':
-          counts.trades += (result.result?.tradesExecuted as number) || 1;
+          counts.trades++;
           break;
         case 'POST':
           counts.posts++;
           break;
         case 'COMMENT':
+          counts.comments++;
+          break;
         case 'RESPOND':
           counts.comments += (result.result?.responsesCreated as number) || 1;
           break;
@@ -580,6 +765,23 @@ export class MultiStepExecutor {
       duration: Date.now() - startTime,
     };
   }
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function getTimeAgo(date: Date): string {
+  const now = Date.now();
+  const diffMs = now - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  return `${diffDays}d ago`;
 }
 
 // Export singleton instance

--- a/packages/agents/src/autonomous/index.ts
+++ b/packages/agents/src/autonomous/index.ts
@@ -24,6 +24,17 @@ export {
 export { autonomousPostingService } from './AutonomousPostingService';
 export { autonomousTradingService } from './AutonomousTradingService';
 export {
+  type DirectCommentParams,
+  type DirectCommentResult,
+  type DirectPostParams,
+  type DirectPostResult,
+  type DirectTradeParams,
+  type DirectTradeResult,
+  executeDirectComment,
+  executeDirectPost,
+  executeDirectTrade,
+} from './DirectExecutors';
+export {
   MultiStepExecutor,
   type MultiStepExecutorResult,
   multiStepExecutor,
@@ -36,4 +47,8 @@ export {
   buildMultiStepDecisionPrompt,
   buildMultiStepSummaryPrompt,
   type MultiStepDecision,
+  type PendingInteraction,
+  type PerpMarketContext,
+  type PostContext,
+  type PredictionMarketContext,
 } from './templates/multi-step-decision';

--- a/packages/agents/src/autonomous/templates/multi-step-decision.ts
+++ b/packages/agents/src/autonomous/templates/multi-step-decision.ts
@@ -2,8 +2,85 @@
  * Multi-Step Decision Template for Babylon Agents
  *
  * Determines the next action an agent should take in a tick.
- * Adapted from Otaku's multi-step pattern for Babylon's prediction market context.
+ * Provides FULL context so the LLM can make actionable decisions with specific parameters.
+ * Services are "dumb executors" - all reasoning happens here.
  */
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface ActionTraceResult {
+  actionType: string;
+  success: boolean;
+  summary?: string;
+  error?: string;
+  result?: {
+    [key: string]: string | number | boolean | null | undefined;
+  };
+  parameters?: Record<string, unknown>;
+  timestamp: number;
+}
+
+export interface PredictionMarketContext {
+  id: string;
+  question: string;
+  yesPrice: number; // 0-1
+  noPrice: number; // 0-1
+  volume: number;
+  endDate: string;
+}
+
+export interface PerpMarketContext {
+  ticker: string;
+  name: string;
+  currentPrice: number;
+  initialPrice: number;
+  changePercent: number;
+}
+
+export interface PostContext {
+  id: string;
+  authorName: string;
+  content: string;
+  commentCount: number;
+  timeAgo: string;
+}
+
+export interface PendingInteraction {
+  type: 'comment_reply' | 'dm' | 'mention';
+  author: string;
+  content: string;
+  postId?: string;
+}
+
+export interface AgentTickContext {
+  balance: number;
+  pnl: number;
+  openPositions: number;
+  pendingInteractions: number;
+  pendingInteractionDetails: PendingInteraction[];
+  enabledFeatures: string[];
+  // Rich context for actionable decisions
+  predictionMarkets: PredictionMarketContext[];
+  perpMarkets: PerpMarketContext[];
+  recentPosts: PostContext[];
+  agentPositions: {
+    predictions: { marketId: string; question: string; side: string; shares: number }[];
+    perps: { ticker: string; side: string; size: number; pnl: number }[];
+  };
+}
+
+export interface MultiStepDecision {
+  thought: string;
+  action: string;
+  parameters: Record<string, unknown>;
+  isFinish: boolean;
+}
+
+// =============================================================================
+// Prompt Builder
+// =============================================================================
 
 /**
  * Build the multi-step decision prompt for an agent tick
@@ -30,19 +107,18 @@ export function buildMultiStepDecisionPrompt(params: {
       ? traceActionResults
           .map(
             (r, i) =>
-              `${i + 1}. ${r.actionType}: ${r.success ? '✓ Success' : '✗ Failed'}${r.summary ? ` - ${r.summary}` : ''}${r.error ? ` (Error: ${r.error})` : ''}`
+              `${i + 1}. ${r.actionType}: ${r.success ? '✓' : '✗'} ${r.summary || ''}${r.error ? ` (Error: ${r.error})` : ''}`
           )
           .join('\n')
       : 'No actions taken yet this tick.';
 
   return `${systemPrompt}
 
-You are ${agentName}, an autonomous agent on Babylon prediction market.
+You are ${agentName}, an autonomous agent on Babylon prediction markets.
 
 # Current Execution Context
-**Current Step**: ${iterationCount} of ${maxIterations} maximum iterations
+**Step**: ${iterationCount}/${maxIterations}
 **Actions Completed This Tick**: ${traceActionResults.length}
-${traceActionResults.length > 0 ? `You have ALREADY taken ${traceActionResults.length} action(s) this tick. Review them before deciding.` : 'This is your FIRST decision - no actions taken yet.'}
 
 # Your Current State
 - Balance: $${context.balance.toFixed(2)}
@@ -50,11 +126,17 @@ ${traceActionResults.length > 0 ? `You have ALREADY taken ${traceActionResults.l
 - Open Positions: ${context.openPositions}
 - Pending Interactions: ${context.pendingInteractions}
 
-# Available Actions
-${formatAvailableActions(context.enabledFeatures)}
+# Your Open Positions
+${formatAgentPositions(context.agentPositions)}
 
-# Market Opportunities
-${formatMarketOpportunities(context.opportunities)}
+# Available Prediction Markets
+${formatPredictionMarkets(context.predictionMarkets)}
+
+# Available Perp Markets
+${formatPerpMarkets(context.perpMarkets)}
+
+# Recent Posts (can comment on)
+${formatRecentPosts(context.recentPosts)}
 
 # Pending Interactions
 ${formatPendingInteractions(context.pendingInteractionDetails)}
@@ -62,45 +144,168 @@ ${formatPendingInteractions(context.pendingInteractionDetails)}
 # Actions Completed This Tick
 ${actionsCompletedText}
 
-# Decision Process
-1. **Understand Current State**: What have you already done? What's most important now?
-2. **Evaluate Redundancy vs Complementarity**:
-   - ❌ AVOID: Repeating the SAME action with SAME parameters
-   - ❌ AVOID: Multiple trades on the same market
-   - ✅ ENCOURAGE: Different actions that provide different value
-   - ✅ ENCOURAGE: Related actions that build on each other (e.g., respond to comment then post insight)
-3. **Choose Next Action**: Based on what adds the MOST value right now
-4. **Know When to Stop**: Set isFinish=true when you've done enough for this tick
+# Available Actions
+${formatAvailableActions(context.enabledFeatures)}
 
 # Decision Rules
-1. **Step Awareness**: You are on step ${iterationCount}/${maxIterations}. Check what you've already done.
-2. **Request Type**:
-   - Trading: Execute trades when you see clear opportunities
-   - Social: Respond to interactions, create content when valuable
-   - Research: Analyze markets before trading if uncertain
-3. **When to Finish** (isFinish: true):
-   - You've taken 2-3 meaningful actions
-   - No more valuable opportunities
-   - You're about to repeat an identical action
-   - Low balance and should preserve capital
+1. **Be Specific**: Provide exact IDs, amounts, and content in parameters
+2. **One Action**: Choose ONE action per iteration
+3. **No Duplicates**: Don't repeat the same action on the same target
+4. **Know When to Stop**: Set isFinish=true after 2-3 meaningful actions or when done
 
-# Output Format
-Respond with ONLY this JSON structure:
+# Output Format (JSON only, no markdown)
 {
-  "thought": "Step ${iterationCount}/${maxIterations}. Actions taken: ${traceActionResults.length}. [Your reasoning about what to do next and why]",
-  "action": "ACTION_NAME or empty string if finishing",
-  "parameters": { /* action-specific parameters */ },
-  "isFinish": true | false
+  "thought": "Brief reasoning for this decision",
+  "action": "TRADE" | "POST" | "COMMENT" | "RESPOND" | "",
+  "parameters": { /* action-specific, see below */ },
+  "isFinish": false
 }
 
-Available action names: ${context.enabledFeatures.map((f) => getActionName(f)).join(', ')}, or "" to finish
+## Parameter Schemas
+
+TRADE (prediction):
+{
+  "marketType": "prediction",
+  "marketId": "exact_market_id_from_list",
+  "side": "buy_yes" | "buy_no",
+  "amount": 100,
+  "reasoning": "Why this trade"
+}
+
+TRADE (perp):
+{
+  "marketType": "perp",
+  "marketId": "TICKER",
+  "side": "open_long" | "open_short",
+  "amount": 100,
+  "reasoning": "Why this trade"
+}
+
+POST:
+{
+  "content": "Your post content (1-2 sentences, engaging, specific)"
+}
+
+COMMENT:
+{
+  "postId": "exact_post_id_from_list",
+  "content": "Your comment (1-2 sentences)",
+  "parentCommentId": "optional_if_replying_to_comment"
+}
+
+RESPOND:
+{} (batch responds to pending interactions)
+
+FINISH (empty action):
+{
+  "action": "",
+  "isFinish": true
+}
 
 Your decision (JSON only):`;
 }
 
-/**
- * Build the summary prompt after multi-step execution completes
- */
+// =============================================================================
+// Formatters
+// =============================================================================
+
+function formatAgentPositions(positions: AgentTickContext['agentPositions']): string {
+  const lines: string[] = [];
+
+  if (positions.predictions.length > 0) {
+    lines.push('Prediction positions:');
+    for (const p of positions.predictions) {
+      lines.push(`  - ${p.side} on "${p.question.substring(0, 50)}..." (${p.shares} shares)`);
+    }
+  }
+
+  if (positions.perps.length > 0) {
+    lines.push('Perp positions:');
+    for (const p of positions.perps) {
+      lines.push(`  - ${p.side} ${p.ticker}: $${p.size} (P&L: ${p.pnl >= 0 ? '+' : ''}$${p.pnl.toFixed(2)})`);
+    }
+  }
+
+  return lines.length > 0 ? lines.join('\n') : 'No open positions.';
+}
+
+function formatPredictionMarkets(markets: PredictionMarketContext[]): string {
+  if (markets.length === 0) return 'No active prediction markets.';
+
+  return markets
+    .map((m) => {
+      const yesPct = (m.yesPrice * 100).toFixed(0);
+      const noPct = (m.noPrice * 100).toFixed(0);
+      return `- [${m.id}] "${m.question.substring(0, 60)}${m.question.length > 60 ? '...' : ''}"
+    YES: ${yesPct}% | NO: ${noPct}% | Ends: ${m.endDate}`;
+    })
+    .join('\n');
+}
+
+function formatPerpMarkets(markets: PerpMarketContext[]): string {
+  if (markets.length === 0) return 'No perp markets available.';
+
+  return markets
+    .map((m) => {
+      const direction = m.changePercent > 0 ? '📈' : m.changePercent < 0 ? '📉' : '➡️';
+      return `- ${m.ticker}: ${m.name} @ $${m.currentPrice.toFixed(2)} ${direction} ${m.changePercent > 0 ? '+' : ''}${m.changePercent.toFixed(1)}%`;
+    })
+    .join('\n');
+}
+
+function formatRecentPosts(posts: PostContext[]): string {
+  if (posts.length === 0) return 'No recent posts to engage with.';
+
+  return posts
+    .map(
+      (p) =>
+        `- [${p.id}] @${p.authorName} (${p.timeAgo}): "${p.content.substring(0, 80)}${p.content.length > 80 ? '...' : ''}" (${p.commentCount} comments)`
+    )
+    .join('\n');
+}
+
+function formatPendingInteractions(interactions: PendingInteraction[]): string {
+  if (interactions.length === 0) return 'No pending interactions.';
+
+  return interactions
+    .slice(0, 5)
+    .map(
+      (i) =>
+        `- [${i.type}] @${i.author}: "${i.content.substring(0, 60)}${i.content.length > 60 ? '...' : ''}"`
+    )
+    .join('\n');
+}
+
+function formatAvailableActions(enabledFeatures: string[]): string {
+  const actions: string[] = [];
+
+  if (enabledFeatures.includes('trading')) {
+    actions.push(
+      '- TRADE: Buy/sell on prediction markets (buy_yes/buy_no) or perps (open_long/open_short)'
+    );
+  }
+
+  if (enabledFeatures.includes('posting')) {
+    actions.push('- POST: Create a new post (provide content)');
+  }
+
+  if (enabledFeatures.includes('commenting')) {
+    actions.push('- COMMENT: Reply to a post (provide postId and content)');
+  }
+
+  if (enabledFeatures.includes('DMs')) {
+    actions.push('- RESPOND: Batch respond to pending DMs/mentions');
+  }
+
+  actions.push('- (empty action with isFinish=true): Finish this tick');
+
+  return actions.join('\n');
+}
+
+// =============================================================================
+// Summary Prompt (unused but kept for reference)
+// =============================================================================
+
 export function buildMultiStepSummaryPrompt(params: {
   agentName: string;
   systemPrompt: string;
@@ -132,133 +337,10 @@ ${resultsText || 'No actions were taken this tick.'}
 
 # Task
 Generate a brief internal summary of what was accomplished this tick.
-This is for logging purposes, not user-facing.
 
 Respond with JSON:
 {
   "summary": "Brief summary of actions taken and outcomes",
-  "nextTickPriority": "What should be prioritized next tick (trading/social/research)"
+  "nextTickPriority": "trading | social | research"
 }`;
-}
-
-// =============================================================================
-// Types
-// =============================================================================
-
-export interface ActionTraceResult {
-  actionType: string;
-  success: boolean;
-  summary?: string;
-  error?: string;
-  result?: Record<string, unknown>;
-  parameters?: Record<string, unknown>;
-  timestamp: number;
-}
-
-export interface AgentTickContext {
-  balance: number;
-  pnl: number;
-  openPositions: number;
-  pendingInteractions: number;
-  pendingInteractionDetails: PendingInteraction[];
-  enabledFeatures: string[];
-  opportunities: MarketOpportunity[];
-}
-
-export interface PendingInteraction {
-  type: 'comment_reply' | 'dm' | 'mention';
-  author: string;
-  content: string;
-  postId?: string;
-}
-
-export interface MarketOpportunity {
-  type: 'prediction' | 'perp';
-  id: string;
-  name: string;
-  description: string;
-  confidence: number;
-}
-
-export interface MultiStepDecision {
-  thought: string;
-  action: string;
-  parameters: Record<string, unknown>;
-  isFinish: boolean;
-}
-
-// =============================================================================
-// Helpers
-// =============================================================================
-
-function formatAvailableActions(enabledFeatures: string[]): string {
-  const actions: string[] = [];
-
-  if (enabledFeatures.includes('trading')) {
-    actions.push(`- TRADE: Buy/sell on prediction markets or open/close perp positions
-    Parameters: { type: "prediction"|"perp", market: "id or name", action: "buy_yes"|"buy_no"|"open_long"|"open_short"|"close", amount: number }`);
-  }
-
-  if (enabledFeatures.includes('posting')) {
-    actions.push(`- POST: Create a new post sharing insights or analysis
-    Parameters: { content: "your post content" }`);
-  }
-
-  if (enabledFeatures.includes('commenting')) {
-    actions.push(`- COMMENT: Reply to a post or comment
-    Parameters: { targetId: "post or comment id", content: "your reply" }`);
-  }
-
-  if (enabledFeatures.includes('DMs')) {
-    actions.push(`- DM: Send a direct message
-    Parameters: { userId: "recipient id", content: "your message" }`);
-  }
-
-  actions.push(`- WAIT: Do nothing this iteration (use when no good opportunities)
-    Parameters: {}`);
-
-  return actions.join('\n\n');
-}
-
-function formatMarketOpportunities(opportunities: MarketOpportunity[]): string {
-  if (opportunities.length === 0) {
-    return 'No notable opportunities detected.';
-  }
-
-  return opportunities
-    .slice(0, 5)
-    .map(
-      (o) =>
-        `- [${o.type.toUpperCase()}] ${o.name}: ${o.description} (Confidence: ${(o.confidence * 100).toFixed(0)}%)`
-    )
-    .join('\n');
-}
-
-function formatPendingInteractions(interactions: PendingInteraction[]): string {
-  if (interactions.length === 0) {
-    return 'No pending interactions.';
-  }
-
-  return interactions
-    .slice(0, 5)
-    .map(
-      (i) =>
-        `- [${i.type}] @${i.author}: "${i.content.substring(0, 80)}${i.content.length > 80 ? '...' : ''}"`
-    )
-    .join('\n');
-}
-
-function getActionName(feature: string): string {
-  switch (feature) {
-    case 'trading':
-      return 'TRADE';
-    case 'posting':
-      return 'POST';
-    case 'commenting':
-      return 'COMMENT';
-    case 'DMs':
-      return 'DM';
-    default:
-      return feature.toUpperCase();
-  }
 }


### PR DESCRIPTION
## Summary

Refactor MultiStepExecutor to use 'dumb' direct executors instead of smart services that make their own LLM calls. This eliminates the double LLM call pattern and significantly speeds up agent ticks.

## Key Changes

- **Add `DirectExecutors.ts`**: New file with `executeDirectTrade`, `executeDirectPost`, and `executeDirectComment` functions that execute actions without making LLM calls
- **Update `multi-step-decision.ts`**: Rich context template now includes full market data, posts, and positions so the LLM can make specific actionable decisions
- **Refactor `MultiStepExecutor.ts`**: Gathers full context upfront, LLM outputs specific parameters that are passed directly to executors

## Performance Improvement

| Metric | Before | After |
|--------|--------|-------|
| LLM calls per action | 2 (orchestrator + service) | 1 (orchestrator only) |
| Inter-action delay | 500ms | 200ms |
| Estimated tick time (3 actions) | ~9s | ~4s |

## Architecture

**Before**: MultiStepExecutor → Smart Service (makes LLM call) → Execute
**After**: MultiStepExecutor (LLM with rich context) → DirectExecutor (just executes)

## Testing

- [x] `bun run typecheck` passes
- [x] `bun run lint` passes