### PR TITLE
chore: replace Blacksmith runners with GitHub-hosted runners

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   test-all:
     name: Run All Tests
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 60
 
     services:

--- a/.github/workflows/ci-unit-integration.yml
+++ b/.github/workflows/ci-unit-integration.yml
@@ -17,7 +17,7 @@ env:
 jobs:
   test-unit-integration:
     name: Unit & Integration Tests
-    runs-on: blacksmith-2vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 45
 
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,27 +14,11 @@ env:
   NODE_ENV: test
   CI: true
 
-# Maximum performance with Blacksmith runners:
-# Runners:
-# - Build: blacksmith-8vcpu-ubuntu-2404 (fastest compilation, type checking, linting)
-# - Unit/Integration: blacksmith-2vcpu-ubuntu-2404 (optimized for test execution)
-# - E2E & Synpress: blacksmith-8vcpu-ubuntu-2404 (Playwright benefits from high CPU)
-# - All jobs: 2x faster bare metal gaming CPUs with highest single-core performance
-# Cache (automatic optimizations):
-# - 4x faster cache downloads (colocated in same datacenter)
-# - Existing actions/cache@v4 automatically accelerated (node_modules, .next)
-# - Docker pull cache for postgres:16 service images (automatic)
-# - 25GB free cache storage per repo/week (2.5x GitHub's 10GB limit)
-# 
-# Artifact strategy:
-# - All jobs run in parallel - no artifact dependencies
-# - Each job builds its own environment to maximize speed
-
 jobs:
   # Build, typecheck, and lint job
   build-and-check:
     name: Build, Type Check & Lint
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db


### PR DESCRIPTION
## Summary

Remove Blacksmith runners and use standard GitHub-hosted runners (`ubuntu-latest`) for all CI workflows.

## Changes

- `.github/workflows/ci.yml`: `blacksmith-8vcpu-ubuntu-2404` → `ubuntu-latest`
- `.github/workflows/ci-unit-integration.yml`: `blacksmith-2vcpu-ubuntu-2404` → `ubuntu-latest`
- `.github/workflows/ci-tests.yml`: `blacksmith-8vcpu-ubuntu-2404` → `ubuntu-latest`
- Removed Blacksmith-specific comments from `ci.yml`

## Checklist

- [x] No code changes, only CI configuration
- [x] Workflows remain functional with standard runners