### PR TITLE
feat(agents): add partial close for perps + improve trading action error messages

### DIFF
--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/buy-prediction.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/buy-prediction.ts
@@ -94,7 +94,7 @@ export const buyPredictionAction: Action = {
     if (!marketId || !side || !amount) {
       return {
         success: false,
-        text: 'Missing required parameters. Need marketId, side (YES/NO), and amount.',
+        text: 'Missing required parameters. Need marketId, side (YES/NO), and amount. Please call CHECK_PREDICTIONS first to see available markets and get the market ID.',
         data: { error: 'Missing parameters' },
         values: { error: 'Missing parameters' },
       };
@@ -135,9 +135,9 @@ export const buyPredictionAction: Action = {
       if (!market) {
         return {
           success: false,
-          text: 'Market not found or already resolved.',
-          data: { error: 'Market not found' },
-          values: { error: 'Market not found' },
+          text: `Market not found with ID "${marketId}" or already resolved. Please call CHECK_PREDICTIONS first to see available open markets and get the correct market ID.`,
+          data: { error: 'Market not found', providedId: marketId },
+          values: { error: 'Market not found', providedId: marketId },
         };
       }
 
@@ -146,7 +146,7 @@ export const buyPredictionAction: Action = {
       if (balance.balance < amount) {
         return {
           success: false,
-          text: `Insufficient balance. You have $${balance.balance.toFixed(2)} but need $${amount}.`,
+          text: `Insufficient balance. You have $${balance.balance.toFixed(2)} but need $${amount}. Please call CHECK_BALANCE first to verify your available funds.`,
           data: { error: 'Insufficient balance', balance: balance.balance },
           values: { error: 'Insufficient balance', balance: balance.balance },
         };

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/close-perp.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/close-perp.ts
@@ -23,12 +23,18 @@ const agentPnLService = new AgentPnLService();
 export const closePerpAction: Action = {
   name: 'CLOSE_PERP',
   description:
-    'Close an open perpetual position. IMPORTANT: Always call CHECK_PNL first to see your actual open positions - you need the position ID to close. Do NOT rely on conversation history for position data. Requires positionId.',
+    'Close an open perpetual position (full or partial). IMPORTANT: Always call CHECK_PNL first to see your actual open positions - you need the position ID and current size to close. Requires positionId. Optionally specify amount to partially close.',
   parameters: {
     positionId: {
       type: 'string',
       description: 'The ID of the perpetual position to close',
       required: true,
+    },
+    amount: {
+      type: 'number',
+      description:
+        'Dollar amount of position to close. If not specified, closes the entire position.',
+      required: false,
     },
   },
   examples: [
@@ -71,10 +77,11 @@ export const closePerpAction: Action = {
 
     // Get parameters from state
     const actionParams = state?.data?.actionParams as
-      | { positionId?: string }
+      | { positionId?: string; amount?: number }
       | undefined;
 
     const positionId = actionParams?.positionId;
+    const closeAmount = actionParams?.amount;
 
     if (!positionId) {
       return {
@@ -184,13 +191,59 @@ export const closePerpAction: Action = {
       const market = marketSnapshot.find((m) => m.ticker === position.ticker);
       const exitPrice = market?.currentPrice ?? Number(position.entryPrice);
 
-      // Close position
-      const result = await service.closePosition({
-        positionId,
-        userId: agentUserId,
-      });
+      const positionSize = Number(position.size);
+      const isPartialClose =
+        closeAmount !== undefined &&
+        closeAmount > 0 &&
+        closeAmount < positionSize;
 
-      const pnl = result.realizedPnL ?? 0;
+      let pnl: number;
+      let closedAmount: number;
+      let remainingSize: number;
+
+      if (isPartialClose) {
+        // Partial close - calculate proportional P&L and update position
+        closedAmount = closeAmount;
+        const closeRatio = closedAmount / positionSize;
+
+        // Calculate proportional P&L
+        const entryPrice = Number(position.entryPrice);
+        const leverage = position.leverage ?? 1;
+        const priceDiff = exitPrice - entryPrice;
+        const direction = position.side === 'long' ? 1 : -1;
+        const totalUnrealizedPnL =
+          (priceDiff / entryPrice) * positionSize * leverage * direction;
+        pnl = totalUnrealizedPnL * closeRatio;
+
+        // Update position size
+        remainingSize = positionSize - closedAmount;
+        await db
+          .update(perpPositions)
+          .set({
+            size: remainingSize,
+            lastUpdated: new Date(),
+          })
+          .where(eq(perpPositions.id, positionId));
+
+        // Credit wallet with closed amount + P&L
+        await WalletService.credit(
+          agentUserId,
+          closedAmount + pnl,
+          'perp_partial_close',
+          `Partial close ${position.ticker}: ${closedAmount} of ${positionSize}`,
+          positionId
+        );
+      } else {
+        // Full close
+        const result = await service.closePosition({
+          positionId,
+          userId: agentUserId,
+        });
+        pnl = result.realizedPnL ?? 0;
+        closedAmount = positionSize;
+        remainingSize = 0;
+      }
+
       const pnlStr =
         pnl >= 0 ? `+$${pnl.toFixed(2)}` : `-$${Math.abs(pnl).toFixed(2)}`;
 
@@ -202,14 +255,16 @@ export const closePerpAction: Action = {
         ticker: position.ticker,
         action: 'close',
         side: position.side as 'long' | 'short',
-        amount: Number(position.size),
+        amount: closedAmount,
         price: exitPrice,
         pnl,
         reasoning:
           (state?.data?.thought as string) || 'Chat-initiated perp close',
       });
 
-      const responseText = `Closed ${position.side.toUpperCase()} position on ${position.ticker} at $${exitPrice.toFixed(2)}. P&L: ${pnlStr}`;
+      const responseText = isPartialClose
+        ? `Partially closed ${position.side.toUpperCase()} position on ${position.ticker}: $${closedAmount.toFixed(2)} at $${exitPrice.toFixed(2)}. P&L: ${pnlStr}. Remaining: $${remainingSize.toFixed(2)}`
+        : `Closed ${position.side.toUpperCase()} position on ${position.ticker} at $${exitPrice.toFixed(2)}. P&L: ${pnlStr}`;
 
       logger.info('[CLOSE_PERP] Position closed', {
         agentUserId,
@@ -217,7 +272,10 @@ export const closePerpAction: Action = {
         ticker: position.ticker,
         side: position.side,
         exitPrice,
+        closedAmount,
+        remainingSize,
         pnl,
+        isPartialClose,
       });
 
       return {
@@ -228,14 +286,20 @@ export const closePerpAction: Action = {
           ticker: position.ticker,
           side: position.side,
           exitPrice,
+          closedAmount,
+          remainingSize,
           pnl,
+          isPartialClose,
         },
         values: {
           positionId,
           ticker: position.ticker,
           side: position.side,
           exitPrice,
+          closedAmount,
+          remainingSize,
           pnl,
+          isPartialClose,
         },
       };
     } catch (error) {

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/close-perp.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/close-perp.ts
@@ -86,7 +86,7 @@ export const closePerpAction: Action = {
     if (!positionId) {
       return {
         success: false,
-        text: 'Missing required parameter: positionId.',
+        text: 'Missing required parameter: positionId. Please call CHECK_PNL first to see your open perp positions and get the position ID.',
         data: { error: 'Missing positionId' },
         values: { error: 'Missing positionId' },
       };
@@ -109,9 +109,9 @@ export const closePerpAction: Action = {
       if (!position) {
         return {
           success: false,
-          text: 'Position not found, not owned by you, or already closed.',
-          data: { error: 'Position not found' },
-          values: { error: 'Position not found' },
+          text: `Position not found with ID "${positionId}". Please call CHECK_PNL first to see your actual open positions and get the correct position ID. Do not use ticker names - use the position ID from CHECK_PNL results.`,
+          data: { error: 'Position not found', providedId: positionId },
+          values: { error: 'Position not found', providedId: positionId },
         };
       }
 

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/open-perp.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/open-perp.ts
@@ -106,7 +106,7 @@ export const openPerpAction: Action = {
     if (!ticker || !side || !amount) {
       return {
         success: false,
-        text: 'Missing required parameters. Need ticker, side (LONG/SHORT), and amount.',
+        text: 'Missing required parameters. Need ticker, side (LONG/SHORT), and amount. Please call CHECK_PERPS first to see available markets and get the ticker.',
         data: { error: 'Missing parameters' },
         values: { error: 'Missing parameters' },
       };
@@ -136,7 +136,7 @@ export const openPerpAction: Action = {
       if (balance.balance < amount) {
         return {
           success: false,
-          text: `Insufficient balance. You have $${balance.balance.toFixed(2)} but need $${amount}.`,
+          text: `Insufficient balance. You have $${balance.balance.toFixed(2)} but need $${amount}. Please call CHECK_BALANCE first to verify your available funds.`,
           data: { error: 'Insufficient balance', balance: balance.balance },
           values: { error: 'Insufficient balance', balance: balance.balance },
         };
@@ -220,12 +220,12 @@ export const openPerpAction: Action = {
       if (!market) {
         return {
           success: false,
-          text: `Market ${ticker} not found. Available: ${marketSnapshot
+          text: `Market "${ticker}" not found. Please call CHECK_PERPS first to see available markets and get the correct ticker. Available: ${marketSnapshot
             .slice(0, 5)
             .map((m) => m.ticker)
             .join(', ')}`,
-          data: { error: 'Market not found', ticker },
-          values: { error: 'Market not found', ticker },
+          data: { error: 'Market not found', providedTicker: ticker },
+          values: { error: 'Market not found', providedTicker: ticker },
         };
       }
 

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/sell-prediction.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/sell-prediction.ts
@@ -128,8 +128,16 @@ export const sellPredictionAction: Action = {
         return {
           success: false,
           text: `Cannot sell ${sharesToSell} shares. You only have ${currentShares.toFixed(2)} shares. Please call CHECK_PNL to verify your actual share count before selling.`,
-          data: { error: 'Insufficient shares', currentShares, requested: sharesToSell },
-          values: { error: 'Insufficient shares', currentShares, requested: sharesToSell },
+          data: {
+            error: 'Insufficient shares',
+            currentShares,
+            requested: sharesToSell,
+          },
+          values: {
+            error: 'Insufficient shares',
+            currentShares,
+            requested: sharesToSell,
+          },
         };
       }
 

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/sell-prediction.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/sell-prediction.ts
@@ -85,7 +85,7 @@ export const sellPredictionAction: Action = {
     if (!positionId || !sharesToSell) {
       return {
         success: false,
-        text: 'Missing required parameters. Need positionId and shares.',
+        text: 'Missing required parameters. Need positionId and shares. Please call CHECK_PNL first to see your actual positions and get the position ID and current share count.',
         data: { error: 'Missing parameters' },
         values: { error: 'Missing parameters' },
       };
@@ -117,9 +117,9 @@ export const sellPredictionAction: Action = {
       if (!position) {
         return {
           success: false,
-          text: 'Position not found or not owned by you.',
-          data: { error: 'Position not found' },
-          values: { error: 'Position not found' },
+          text: `Position not found with ID "${positionId}". Please call CHECK_PNL first to see your actual open positions and get the correct position ID.`,
+          data: { error: 'Position not found', providedId: positionId },
+          values: { error: 'Position not found', providedId: positionId },
         };
       }
 
@@ -127,9 +127,9 @@ export const sellPredictionAction: Action = {
       if (sharesToSell > currentShares) {
         return {
           success: false,
-          text: `Cannot sell ${sharesToSell} shares. You only have ${currentShares} shares.`,
-          data: { error: 'Insufficient shares', currentShares },
-          values: { error: 'Insufficient shares', currentShares },
+          text: `Cannot sell ${sharesToSell} shares. You only have ${currentShares.toFixed(2)} shares. Please call CHECK_PNL to verify your actual share count before selling.`,
+          data: { error: 'Insufficient shares', currentShares, requested: sharesToSell },
+          values: { error: 'Insufficient shares', currentShares, requested: sharesToSell },
         };
       }
 


### PR DESCRIPTION
## Changes

### Partial Close for Perpetual Positions
Added optional `amount` parameter to `CLOSE_PERP` action allowing partial closes by dollar amount. If amount is less than position size, it closes proportionally and updates the remaining position.

### Improved Error Messages
Updated all trading actions (`BUY_PREDICTION`, `SELL_PREDICTION`, `OPEN_PERP`, `CLOSE_PERP`) to return helpful error messages that guide the agent to call the appropriate check action first (e.g., `CHECK_PREDICTIONS`, `CHECK_PERPS`, `CHECK_PNL`, `CHECK_BALANCE`) before retrying.