### PR TITLE
refactor(agents): use ActionResult from @elizaos/core and standardize action returns

### DIFF
--- a/apps/web/src/app/api/agents/[agentId]/chat/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/chat/route.ts
@@ -10,15 +10,12 @@
  * Uses runtime.composeState() for providers and runtime.processActions() for execution.
  */
 
-import {
-  type ActionTraceResult,
-  agentRuntimeManager,
-  agentService,
-} from '@babylon/agents';
+import { agentRuntimeManager, agentService } from '@babylon/agents';
 import { authenticateUser, withErrorHandling } from '@babylon/api';
 import { db, eq, userAgentConfigs } from '@babylon/db';
 import { checkUserInput, logger } from '@babylon/shared';
 import {
+  type ActionResult,
   composePromptFromState,
   type Memory,
   ModelType,
@@ -165,7 +162,7 @@ YOUR FINAL OUTPUT MUST BE IN THIS XML FORMAT:
 </response>
 </output>`;
 
-const multiStepSummaryTemplate = `Generate a response to the user. Stay in character.
+const multiStepSummaryTemplate = `You are responding to a user after completing actions. Generate a helpful response.
 
 # Your Character
 {{system}}
@@ -174,23 +171,23 @@ const multiStepSummaryTemplate = `Generate a response to the user. Stay in chara
 Personality: {{personality}}
 {{/if}}
 
-# User Asked
+# User's Message
 {{currentMessage}}
 
-# What You Did
+# Actions You Completed
 {{actionResults}}
 
-# Rules
-- Be conversational and natural
-- Stay in character
-- Include relevant details from actions when appropriate
-- Write your ACTUAL response in the <text> tag - do NOT output placeholder text
+# Your Task
+Write a natural response to the user that:
+- Summarizes what you did and the results
+- Includes specific numbers, names, or data from the action results
+- Stays in character with your personality
 
-IMPORTANT: Output ONLY the XML below. No thinking, no explanation. Replace the content inside tags with your actual response.
+Output ONLY this XML with your actual response (not examples or placeholders):
 
 <response>
-<thought>your brief reasoning here</thought>
-<text>your conversational response to the user here</text>
+<thought>Brief reasoning about what to tell the user</thought>
+<text>Your helpful response with specific details from the actions</text>
 </response>`;
 
 // =============================================================================
@@ -261,7 +258,14 @@ export const POST = withErrorHandling(
 
     // Multi-step execution
     const MAX_ITERATIONS = 6;
-    const traceActionResults: ActionTraceResult[] = [];
+    // Store action results with metadata for tracking
+    const traceActionResults: Array<
+      ActionResult & {
+        actionType: string;
+        parameters?: Record<string, unknown>;
+        timestamp: number;
+      }
+    > = [];
     let finalResponse: string | null = null;
 
     for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
@@ -393,33 +397,74 @@ export const POST = withErrorHandling(
 
       try {
         // Use runtime.processActions - adapter.createMemory is now stubbed
+        // Capture result through callback
+        let actionResult: {
+          success?: boolean;
+        text?: string;
+          values?: Record<string, unknown>;
+        } | null = null;
+
         await runtime.processActions(
           elizaMessage,
           [actionMessage],
           state,
-          async () => []
+          async (results: unknown) => {
+            // Capture the first result from callback
+            const resultsArray = results as Array<{
+              content?: {
+                success?: boolean;
+                text?: string;
+                values?: Record<string, unknown>;
+              };
+            }> | null;
+            if (resultsArray && resultsArray.length > 0) {
+              const firstResult = resultsArray[0];
+              if (firstResult) {
+                actionResult = {
+                  success: firstResult.content?.success ?? true,
+                  text:
+                    typeof firstResult.content?.text === 'string'
+                      ? firstResult.content.text
+                      : undefined,
+                  values: firstResult.content?.values,
+                };
+              }
+            }
+            return [];
+          }
         );
 
-        // Get result from state cache
-        const cachedState = (
-          runtime as unknown as { stateCache?: Map<string, unknown> }
-        ).stateCache?.get(`${elizaMessage.id}_action_results`) as
-          | {
-              values?: {
-                actionResults?: Array<{ success?: boolean; text?: string }>;
-              };
-            }
-          | undefined;
-        const actionResultsFromCache = cachedState?.values?.actionResults || [];
-        const result =
-          actionResultsFromCache.length > 0 ? actionResultsFromCache[0] : null;
-        const success = result?.success ?? true;
+        // Fallback to state cache if callback didn't capture
+        if (!actionResult) {
+          const cachedState = (
+            runtime as unknown as { stateCache?: Map<string, unknown> }
+          ).stateCache?.get(`${elizaMessage.id}_action_results`) as
+            | {
+                values?: {
+                  actionResults?: Array<{
+                    success?: boolean;
+                    text?: string;
+                    values?: Record<string, unknown>;
+                  }>;
+                };
+              }
+            | undefined;
+          const actionResultsFromCache =
+            cachedState?.values?.actionResults || [];
+          actionResult =
+            actionResultsFromCache.length > 0
+              ? (actionResultsFromCache[0] ?? null)
+              : null;
+        }
+
+        const success = actionResult?.success ?? true;
 
         traceActionResults.push({
           actionType: action,
           success,
-          summary: result?.text || `${action} executed`,
-          error: success ? undefined : result?.text,
+          text: actionResult?.text || `${action} executed`,
+          error: success ? undefined : actionResult?.text,
+          values: actionResult?.values,
           parameters: actionParams,
           timestamp: Date.now(),
         });
@@ -429,7 +474,7 @@ export const POST = withErrorHandling(
         traceActionResults.push({
           actionType: action,
           success: false,
-          summary: `Action failed: ${errorMsg}`,
+          text: `Action failed: ${errorMsg}`,
           error: errorMsg,
           parameters: actionParams,
           timestamp: Date.now(),
@@ -593,7 +638,7 @@ export const POST = withErrorHandling(
         actions: traceActionResults.map((a) => ({
           type: a.actionType,
           success: a.success,
-          summary: a.summary,
+          text: a.text,
         })),
       },
     });

--- a/apps/web/src/app/api/agents/[agentId]/chat/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/chat/route.ts
@@ -400,7 +400,7 @@ export const POST = withErrorHandling(
         // Capture result through callback
         let actionResult: {
           success?: boolean;
-        text?: string;
+          text?: string;
           values?: Record<string, unknown>;
         } | null = null;
 

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/buy-prediction.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/buy-prediction.ts
@@ -94,9 +94,8 @@ export const buyPredictionAction: Action = {
     if (!marketId || !side || !amount) {
       return {
         success: false,
-        text: 'Missing required parameters. Need marketId, side (YES/NO), and amount. Please call CHECK_PREDICTIONS first to see available markets and get the market ID.',
-        data: { error: 'Missing parameters' },
-        values: { error: 'Missing parameters' },
+        text: 'Missing parameters. Call CHECK_PREDICTIONS first to get marketId.',
+        error: 'Missing parameters: marketId, side, or amount',
       };
     }
 
@@ -104,8 +103,7 @@ export const buyPredictionAction: Action = {
       return {
         success: false,
         text: 'Invalid side. Must be YES or NO.',
-        data: { error: 'Invalid side' },
-        values: { error: 'Invalid side' },
+        error: 'Invalid side',
       };
     }
 
@@ -113,8 +111,7 @@ export const buyPredictionAction: Action = {
       return {
         success: false,
         text: 'Amount must be greater than 0.',
-        data: { error: 'Invalid amount' },
-        values: { error: 'Invalid amount' },
+        error: 'Invalid amount',
       };
     }
 
@@ -135,9 +132,8 @@ export const buyPredictionAction: Action = {
       if (!market) {
         return {
           success: false,
-          text: `Market not found with ID "${marketId}" or already resolved. Please call CHECK_PREDICTIONS first to see available open markets and get the correct market ID.`,
-          data: { error: 'Market not found', providedId: marketId },
-          values: { error: 'Market not found', providedId: marketId },
+          text: `Market not found or resolved. Call CHECK_PREDICTIONS first to get valid marketId.`,
+          error: 'Market not found',
         };
       }
 
@@ -146,9 +142,9 @@ export const buyPredictionAction: Action = {
       if (balance.balance < amount) {
         return {
           success: false,
-          text: `Insufficient balance. You have $${balance.balance.toFixed(2)} but need $${amount}. Please call CHECK_BALANCE first to verify your available funds.`,
-          data: { error: 'Insufficient balance', balance: balance.balance },
-          values: { error: 'Insufficient balance', balance: balance.balance },
+          text: `Insufficient balance ($${balance.balance.toFixed(2)}). Call CHECK_BALANCE first.`,
+          error: 'Insufficient balance',
+          values: { balance: balance.balance },
         };
       }
 
@@ -249,8 +245,6 @@ export const buyPredictionAction: Action = {
         reasoning: (state?.data?.thought as string) || 'Chat-initiated trade',
       });
 
-      const responseText = `Bought ${result.calculation.sharesBought.toFixed(2)} ${side} shares at avg price $${result.calculation.avgPrice.toFixed(4)}. Cost: $${amount.toFixed(2)}`;
-
       logger.info('[BUY_PREDICTION] Trade successful', {
         agentUserId,
         marketId,
@@ -262,7 +256,7 @@ export const buyPredictionAction: Action = {
 
       return {
         success: true,
-        text: responseText,
+        text: `Bought ${result.calculation.sharesBought.toFixed(2)} ${side} shares at $${result.calculation.avgPrice.toFixed(4)}.`,
         data: {
           marketId,
           marketQuestion: market.question,
@@ -285,8 +279,7 @@ export const buyPredictionAction: Action = {
       return {
         success: false,
         text: `Failed to buy shares: ${errorMsg}`,
-        data: { error: errorMsg },
-        values: { error: errorMsg },
+        error: errorMsg,
       };
     }
   },

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/check-autonomy.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/check-autonomy.ts
@@ -106,26 +106,8 @@ export const checkAutonomyAction: Action = {
         autonomousGroupChats: config?.autonomousGroupChats ?? false,
       };
 
-      // Format status for display
-      const statusLines = [
-        `• Trading: ${status.autonomousTrading ? '✅ Enabled' : '❌ Disabled'}`,
-        `• Posting: ${status.autonomousPosting ? '✅ Enabled' : '❌ Disabled'}`,
-        `• Commenting: ${status.autonomousCommenting ? '✅ Enabled' : '❌ Disabled'}`,
-        `• DMs: ${status.autonomousDMs ? '✅ Enabled' : '❌ Disabled'}`,
-        `• Group Chats: ${status.autonomousGroupChats ? '✅ Enabled' : '❌ Disabled'}`,
-      ];
-
       const enabledCount = Object.values(status).filter(Boolean).length;
       const totalCount = Object.keys(status).length;
-
-      const summaryText =
-        enabledCount === 0
-          ? 'All autonomous features are currently disabled.'
-          : enabledCount === totalCount
-            ? 'All autonomous features are currently enabled.'
-            : `${enabledCount} of ${totalCount} autonomous features are enabled.`;
-
-      const responseText = `Current Autonomous Feature Status:\n${statusLines.join('\n')}\n\n${summaryText}`;
 
       logger.info(
         `[CHECK_AUTONOMY] Status retrieved for agent: ${agentId}`,
@@ -135,17 +117,14 @@ export const checkAutonomyAction: Action = {
 
       return {
         success: true,
-        text: responseText,
-        data: {
-          status,
-          enabledCount,
-          totalCount,
-        },
+        text: `Autonomy: ${enabledCount}/${totalCount} features enabled.`,
+        data: { status, enabledCount, totalCount },
         values: {
-          ...status,
-          enabledCount,
-          totalCount,
-          statusText: responseText,
+          trading: status.autonomousTrading,
+          posting: status.autonomousPosting,
+          commenting: status.autonomousCommenting,
+          dms: status.autonomousDMs,
+          groupChats: status.autonomousGroupChats,
         },
       };
     } catch (error) {
@@ -156,8 +135,7 @@ export const checkAutonomyAction: Action = {
       return {
         success: false,
         text: `Failed to check autonomy status: ${errorMsg}`,
-        data: { error: errorMsg },
-        values: { error: errorMsg },
+        error: errorMsg,
       };
     }
   },

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/check-balance.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/check-balance.ts
@@ -61,8 +61,6 @@ export const checkBalanceAction: Action = {
       const walletInfo = await WalletService.getBalance(agentUserId);
       const balance = walletInfo.balance;
 
-      const responseText = `Current balance: $${balance.toFixed(2)}`;
-
       logger.info('[CHECK_BALANCE] Retrieved balance', {
         agentUserId,
         balance,
@@ -70,16 +68,9 @@ export const checkBalanceAction: Action = {
 
       return {
         success: true,
-        text: responseText,
-        data: {
-          balance,
-          userId: agentUserId,
-        },
-        values: {
-          balance,
-          hasBalance: balance > 0,
-          canTrade: balance >= 1, // Minimum $1 to trade
-        },
+        text: `Balance: $${balance.toFixed(2)}`,
+        data: { balance, userId: agentUserId },
+        values: { balance },
       };
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : 'Unknown error';
@@ -87,8 +78,7 @@ export const checkBalanceAction: Action = {
       return {
         success: false,
         text: `Failed to check balance: ${errorMsg}`,
-        data: { error: errorMsg },
-        values: { error: errorMsg },
+        error: errorMsg,
       };
     }
   },

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/check-perps.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/check-perps.ts
@@ -119,9 +119,9 @@ export const checkPerpsAction: Action = {
       if (perpMarkets.length === 0) {
         return {
           success: true,
-          text: 'No perpetual markets available at the moment.',
+          text: 'No perpetual markets available.',
           data: { markets: [], count: 0 },
-          values: { markets: [], count: 0, hasMarkets: false },
+          values: { count: 0 },
         };
       }
 
@@ -143,29 +143,12 @@ export const checkPerpsAction: Action = {
 
       const displayedMarkets = sortedMarkets.slice(0, limit);
 
-      // Format response - use ticker for trading (same as OPEN_PERP expects)
-      const marketsList = displayedMarkets
-        .map((m, i) => {
-          const changeStr =
-            m.changePercent24h >= 0
-              ? `+${m.changePercent24h.toFixed(2)}%`
-              : `${m.changePercent24h.toFixed(2)}%`;
-          const changeIcon = m.changePercent24h >= 0 ? '📈' : '📉';
-          return `${i + 1}. **${m.ticker}** (${m.name ?? m.ticker})\n   Price: $${m.currentPrice.toFixed(2)} ${changeIcon} ${changeStr}`;
-        })
-        .join('\n');
-
       const topGainer = displayedMarkets.reduce((max, m) =>
         m.changePercent24h > max.changePercent24h ? m : max
       );
       const topLoser = displayedMarkets.reduce((min, m) =>
         m.changePercent24h < min.changePercent24h ? m : min
       );
-
-      const summary = `Top Gainer: ${topGainer.ticker} (+${topGainer.changePercent24h.toFixed(2)}%) | Top Loser: ${topLoser.ticker} (${topLoser.changePercent24h.toFixed(2)}%)`;
-
-      const responseText = `**Perpetual Markets (${displayedMarkets.length}):**\n${marketsList}\n\n${summary}\n\nTo trade, use OPEN_PERP with ticker (e.g., "${displayedMarkets[0]?.ticker}").`;
-
       logger.info(
         `[CHECK_PERPS] Retrieved ${displayedMarkets.length} markets`,
         { sortBy, limit },
@@ -174,7 +157,7 @@ export const checkPerpsAction: Action = {
 
       return {
         success: true,
-        text: responseText,
+        text: `Retrieved ${displayedMarkets.length} perpetual markets.`,
         data: {
           markets: displayedMarkets.map((m) => ({
             ticker: m.ticker,
@@ -184,13 +167,16 @@ export const checkPerpsAction: Action = {
             volume24h: m.volume24h,
           })),
           count: displayedMarkets.length,
-          topGainer: topGainer.ticker,
-          topLoser: topLoser.ticker,
         },
         values: {
-          markets: displayedMarkets.map((m) => m.ticker),
           count: displayedMarkets.length,
-          hasMarkets: true,
+          tickers: displayedMarkets.map((m) => ({
+            ticker: m.ticker,
+            price: m.currentPrice,
+            change24h: m.changePercent24h,
+          })),
+          topGainer: topGainer.ticker,
+          topLoser: topLoser.ticker,
         },
       };
     } catch (error) {
@@ -199,8 +185,7 @@ export const checkPerpsAction: Action = {
       return {
         success: false,
         text: `Failed to fetch perp markets: ${errorMsg}`,
-        data: { error: errorMsg },
-        values: { error: errorMsg },
+        error: errorMsg,
       };
     }
   },

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/check-pnl.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/check-pnl.ts
@@ -4,7 +4,6 @@
  * Returns the agent's balance, P&L, open positions (with IDs), and recent trades.
  */
 
-import { PerpDbAdapter, PerpMarketService } from '@babylon/core/markets/perps';
 import {
   agentTrades,
   and,
@@ -17,7 +16,7 @@ import {
   positions,
   users,
 } from '@babylon/db';
-import { FEE_CONFIG, WalletService } from '@babylon/engine';
+import { WalletService } from '@babylon/engine';
 import type {
   Action,
   ActionResult,
@@ -27,15 +26,6 @@ import type {
   State,
 } from '@elizaos/core';
 import { logger } from '../../../../shared/logger';
-
-/**
- * Format currency values
- */
-function formatCurrency(value: number): string {
-  return value >= 0
-    ? `+$${value.toFixed(2)}`
-    : `-$${Math.abs(value).toFixed(2)}`;
-}
 
 export const checkPnlAction: Action = {
   name: 'CHECK_PNL',
@@ -141,30 +131,6 @@ export const checkPnlAction: Action = {
           and(eq(perpPositions.userId, agentId), isNull(perpPositions.closedAt))
         );
 
-      // Get current perp prices for P&L calculation
-      const walletAdapter = {
-        debit: async () => {},
-        credit: async () => {},
-        recordPnL: async () => {},
-        getBalance: WalletService.getBalance,
-      };
-
-      const perpService = new PerpMarketService({
-        db: new PerpDbAdapter(),
-        wallet: walletAdapter,
-        fees: {
-          tradingFeeRate: FEE_CONFIG.TRADING_FEE_RATE,
-          platformShare: FEE_CONFIG.PLATFORM_SHARE,
-          referrerShare: FEE_CONFIG.REFERRER_SHARE,
-          minFeeAmount: FEE_CONFIG.MIN_FEE_AMOUNT,
-        },
-      });
-
-      const perpMarkets = await perpService.getMarketsSnapshot();
-      const priceMap = new Map(
-        perpMarkets.map((m) => [m.ticker, m.currentPrice])
-      );
-
       // Get recent trades
       const recentTrades = await db
         .select({
@@ -180,95 +146,6 @@ export const checkPnlAction: Action = {
         .orderBy(desc(agentTrades.executedAt))
         .limit(5);
 
-      // Build response
-      const sections: string[] = [];
-
-      // Summary
-      sections.push(`💰 **Balance**: $${balance.toFixed(2)}`);
-      sections.push(`📊 **Lifetime P&L**: ${formatCurrency(lifetimePnL)}`);
-
-      // Prediction Positions
-      if (predictionPositions.length > 0) {
-        sections.push('\n**📊 Prediction Positions:**');
-        for (const pos of predictionPositions) {
-          const side = pos.side ? 'YES' : 'NO';
-          const shares = Number(pos.shares);
-          const avgPrice = Number(pos.avgPrice);
-          const cost = Number(pos.amount);
-
-          // Calculate current probability and value
-          const yesShares = Number(pos.yesShares ?? 0);
-          const noShares = Number(pos.noShares ?? 0);
-          const totalShares = yesShares + noShares;
-          const currentProb =
-            totalShares > 0
-              ? pos.side
-                ? yesShares / totalShares
-                : noShares / totalShares
-              : 0.5;
-          const currentValue = shares * currentProb;
-          const unrealizedPnL = currentValue - cost;
-          const pnlStr = formatCurrency(unrealizedPnL);
-
-          const question =
-            pos.question && pos.question.length > 40
-              ? pos.question.substring(0, 37) + '...'
-              : (pos.question ?? 'Unknown');
-
-          sections.push(
-            `• **${side}** "${question}"\n` +
-              `  ${shares.toFixed(1)} shares @ $${avgPrice.toFixed(3)} | Value: $${currentValue.toFixed(2)} | P&L: ${pnlStr}\n` +
-              `  ID: \`${pos.id}\``
-          );
-        }
-      }
-
-      // Perp Positions
-      if (perpPositionsList.length > 0) {
-        sections.push('\n**📈 Perp Positions:**');
-        for (const pos of perpPositionsList) {
-          const side = pos.side.toUpperCase();
-          const size = Number(pos.size);
-          const entryPrice = Number(pos.entryPrice);
-          const leverage = pos.leverage ?? 1;
-          const currentPrice = priceMap.get(pos.ticker) ?? entryPrice;
-
-          // Calculate P&L
-          const priceDiff = currentPrice - entryPrice;
-          const direction = pos.side === 'long' ? 1 : -1;
-          const unrealizedPnL =
-            (priceDiff / entryPrice) * size * leverage * direction;
-          const pnlStr = formatCurrency(unrealizedPnL);
-          const pnlPercent = ((unrealizedPnL / size) * 100).toFixed(1);
-
-          sections.push(
-            `• **${pos.ticker}** ${side} ${leverage}x\n` +
-              `  $${size.toFixed(2)} @ $${entryPrice.toFixed(2)} → $${currentPrice.toFixed(2)} | P&L: ${pnlStr} (${pnlPercent}%)\n` +
-              `  ID: \`${pos.id}\``
-          );
-        }
-      }
-
-      // No positions
-      if (predictionPositions.length === 0 && perpPositionsList.length === 0) {
-        sections.push('\n**Open Positions:** None');
-      }
-
-      // Recent Trades
-      if (recentTrades.length > 0) {
-        sections.push('\n**Recent Trades:**');
-        for (const trade of recentTrades) {
-          const pnlStr = trade.pnl
-            ? ` ${formatCurrency(Number(trade.pnl))}`
-            : '';
-          const identifier = trade.ticker || trade.marketId || 'unknown';
-          sections.push(
-            `• ${trade.action} ${identifier}: $${Number(trade.amount).toFixed(2)}${pnlStr}`
-          );
-        }
-      }
-
-      const responseText = sections.join('\n');
       const totalPositions =
         predictionPositions.length + perpPositionsList.length;
 
@@ -280,7 +157,7 @@ export const checkPnlAction: Action = {
 
       return {
         success: true,
-        text: responseText,
+        text: `Retrieved P&L: $${balance.toFixed(2)} balance, ${totalPositions} open positions.`,
         data: {
           balance,
           lifetimePnL,
@@ -304,11 +181,24 @@ export const checkPnlAction: Action = {
         values: {
           balance,
           lifetimePnL,
-          predictionCount: predictionPositions.length,
-          perpCount: perpPositionsList.length,
-          totalPositions,
-          hasPositions: totalPositions > 0,
-          isProfitable: lifetimePnL > 0,
+          predictionPositions: predictionPositions.map((p) => ({
+            id: p.id,
+            question: p.question?.substring(0, 80) || 'Unknown',
+            side: p.side ? 'YES' : 'NO',
+            shares: Number(p.shares),
+          })),
+          perpPositions: perpPositionsList.map((p) => ({
+            id: p.id,
+            ticker: p.ticker,
+            side: p.side,
+            size: Number(p.size),
+          })),
+          recentTrades: recentTrades.map((t) => ({
+            action: t.action,
+            ticker: t.ticker || t.marketId,
+            amount: Number(t.amount),
+            pnl: t.pnl ? Number(t.pnl) : null,
+          })),
         },
       };
     } catch (error) {
@@ -318,8 +208,7 @@ export const checkPnlAction: Action = {
       return {
         success: false,
         text: `Failed to retrieve P&L: ${errorMsg}`,
-        data: { error: errorMsg },
-        values: { error: errorMsg },
+        error: errorMsg,
       };
     }
   },

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/check-predictions.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/check-predictions.ts
@@ -124,12 +124,7 @@ export const checkPredictionsAction: Action = {
           success: true,
           text: `No${statusText} predictions found.`,
           data: { predictions: [], count: 0, status: statusFilter },
-          values: {
-            predictions: [],
-            count: 0,
-            hasPredictions: false,
-            status: statusFilter,
-          },
+          values: { count: 0 },
         };
       }
 
@@ -156,29 +151,6 @@ export const checkPredictionsAction: Action = {
         };
       });
 
-      // Build response text - include market ID for trading
-      const predictionsList = formattedPredictions
-        .map((p) => {
-          if (p.resolved) {
-            const outcomeIcon = p.resolution ? '✅ YES' : '❌ NO';
-            return `${p.index}. [ID: ${p.id}] "${p.question}"\n   Resolved: ${outcomeIcon}`;
-          }
-          const timeStr =
-            p.daysUntil !== null
-              ? p.daysUntil > 0
-                ? `${p.daysUntil}d left`
-                : 'Ending soon'
-              : 'No deadline';
-          return `${p.index}. [ID: ${p.id}] "${p.question}"\n   YES: ${p.yesPercent}% | NO: ${p.noPercent}% (${timeStr})`;
-        })
-        .join('\n');
-
-      const statusLabel =
-        statusFilter === 'all'
-          ? 'All'
-          : statusFilter.charAt(0).toUpperCase() + statusFilter.slice(1);
-      const responseText = `**${statusLabel} Predictions (${formattedPredictions.length}):**\n${predictionsList}`;
-
       logger.info(
         `[CHECK_PREDICTIONS] Retrieved ${predictions.length} ${statusFilter} predictions`,
         undefined,
@@ -187,18 +159,20 @@ export const checkPredictionsAction: Action = {
 
       return {
         success: true,
-        text: responseText,
+        text: `Retrieved ${formattedPredictions.length} ${statusFilter} predictions.`,
         data: {
           predictions: formattedPredictions,
           count: formattedPredictions.length,
           status: statusFilter,
         },
         values: {
-          predictions: formattedPredictions,
           count: formattedPredictions.length,
-          hasPredictions: true,
-          status: statusFilter,
-          predictionsList,
+          markets: formattedPredictions.map((p) => ({
+            id: p.id,
+            yesPercent: p.yesPercent,
+            resolved: p.resolved,
+            daysUntil: p.daysUntil,
+          })),
         },
       };
     } catch (error) {
@@ -207,8 +181,7 @@ export const checkPredictionsAction: Action = {
       return {
         success: false,
         text: `Failed to retrieve predictions: ${errorMsg}`,
-        data: { error: errorMsg },
-        values: { error: errorMsg },
+        error: errorMsg,
       };
     }
   },

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/check-recent-comments.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/check-recent-comments.ts
@@ -175,9 +175,8 @@ export const checkRecentCommentsAction: Action = {
         if (!targetUser) {
           return {
             success: false,
-            text: `User with ID "${targetUserId}" not found. Use LOOKUP_USER to find a valid user ID.`,
-            data: { error: 'User not found' },
-            values: { error: 'User not found' },
+            text: `User not found. Call LOOKUP_USER first to get valid userId.`,
+            error: 'User not found',
           };
         }
         targetName = targetUser.displayName || targetUser.username || 'User';
@@ -198,14 +197,11 @@ export const checkRecentCommentsAction: Action = {
         .limit(limit);
 
       if (recentComments.length === 0) {
-        const noCommentsMsg = isSelf
-          ? "You haven't commented on anything yet."
-          : `${targetName} hasn't commented on anything yet.`;
         return {
           success: true,
-          text: noCommentsMsg,
+          text: isSelf ? 'No comments yet.' : `${targetName} has no comments.`,
           data: { comments: [], count: 0, userId: targetUserId },
-          values: { comments: [], count: 0, hasComments: false },
+          values: { count: 0 },
         };
       }
 
@@ -260,41 +256,6 @@ export const checkRecentCommentsAction: Action = {
         });
       }
 
-      // Format for display
-      const sections = formattedComments.map((c, i) => {
-        const header = `${i + 1}. On @${c.post.authorName}'s post (${c.timeAgo}):`;
-
-        // Show post content (truncated)
-        const postContent =
-          c.post.content.length > 60
-            ? c.post.content.substring(0, 57) + '...'
-            : c.post.content;
-        const postLine = `   POST: "${postContent}"`;
-
-        // Show thread if it's a reply with context
-        let threadLines = '';
-        if (c.isReply && c.thread.length > 1) {
-          threadLines =
-            '\n   THREAD:\n' +
-            c.thread
-              .map((msg, idx) => {
-                const marker =
-                  idx === c.thread.length - 1 ? '→' : msg.isTarget ? '•' : ' ';
-                return `   ${marker} @${msg.authorName}: "${msg.content}"`;
-              })
-              .join('\n');
-        } else {
-          threadLines = `\n   COMMENT: "${c.content}"`;
-        }
-
-        return `${header}\n${postLine}${threadLines}`;
-      });
-
-      const header = isSelf
-        ? 'Your recent comments:'
-        : `${targetName}'s recent comments:`;
-      const responseText = `${header}\n\n${sections.join('\n\n')}`;
-
       logger.info(
         `[CHECK_RECENT_COMMENTS] Retrieved ${recentComments.length} comments for ${isSelf ? 'self' : targetUserId}`,
         undefined,
@@ -303,7 +264,7 @@ export const checkRecentCommentsAction: Action = {
 
       return {
         success: true,
-        text: responseText,
+        text: `Retrieved ${recentComments.length} comments${isSelf ? '' : ` from ${targetName}`}.`,
         data: {
           comments: formattedComments,
           count: recentComments.length,
@@ -311,10 +272,20 @@ export const checkRecentCommentsAction: Action = {
           userName: targetName,
         },
         values: {
-          comments: formattedComments,
           count: recentComments.length,
-          hasComments: true,
-          isSelf,
+          userId: targetUserId,
+          userName: targetName,
+          comments: formattedComments.map((c) => ({
+            id: c.id,
+            postId: c.post.id,
+            content: c.content.substring(0, 100),
+            timeAgo: c.timeAgo,
+            isReply: c.isReply,
+            thread: c.thread.map((t) => ({
+              author: t.authorName,
+              content: t.content.substring(0, 100),
+            })),
+          })),
         },
       };
     } catch (error) {
@@ -324,8 +295,7 @@ export const checkRecentCommentsAction: Action = {
       return {
         success: false,
         text: `Failed to retrieve comments: ${errorMsg}`,
-        data: { error: errorMsg },
-        values: { error: errorMsg },
+        error: errorMsg,
       };
     }
   },

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/check-recent-market-trades.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/check-recent-market-trades.ts
@@ -158,21 +158,9 @@ export const checkRecentMarketTradesAction: Action = {
           success: true,
           text: 'No recent trading activity.',
           data: { trades: [], count: 0 },
-          values: { trades: [], count: 0, hasTrades: false },
+          values: { count: 0 },
         };
       }
-
-      // Build response text
-      const tradesList = allTrades
-        .map((t, i) => {
-          const actionStr = t.side ? `${t.action} ${t.side}` : t.action;
-          const marketStr = t.ticker || t.marketType || 'unknown';
-          const amountStr = t.amount > 0 ? `$${t.amount.toFixed(2)}` : '';
-          return `${i + 1}. **${t.trader}** ${actionStr} ${marketStr} ${amountStr} (${t.timeAgo})`;
-        })
-        .join('\n');
-
-      const responseText = `**Recent Trades (${allTrades.length}):**\n${tradesList}`;
 
       logger.info(
         `[CHECK_RECENT_MARKET_TRADES] Retrieved ${allTrades.length} trades`,
@@ -182,7 +170,7 @@ export const checkRecentMarketTradesAction: Action = {
 
       return {
         success: true,
-        text: responseText,
+        text: `Retrieved ${allTrades.length} recent trades.`,
         data: {
           trades: allTrades,
           count: allTrades.length,
@@ -190,10 +178,13 @@ export const checkRecentMarketTradesAction: Action = {
           agentTradeCount: agentTradeResults.length,
         },
         values: {
-          trades: allTrades,
           count: allTrades.length,
-          hasTrades: true,
-          tradesList,
+          trades: allTrades.map((t) => ({
+            trader: t.trader,
+            action: t.action,
+            ticker: t.ticker,
+            amount: t.amount,
+          })),
         },
       };
     } catch (error) {
@@ -202,8 +193,7 @@ export const checkRecentMarketTradesAction: Action = {
       return {
         success: false,
         text: `Failed to retrieve trades: ${errorMsg}`,
-        data: { error: errorMsg },
-        values: { error: errorMsg },
+        error: errorMsg,
       };
     }
   },

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/check-recent-posts.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/check-recent-posts.ts
@@ -111,9 +111,8 @@ export const checkRecentPostsAction: Action = {
         if (!targetUser) {
           return {
             success: false,
-            text: `User with ID "${targetUserId}" not found. Use LOOKUP_USER to find a valid user ID.`,
-            data: { error: 'User not found' },
-            values: { error: 'User not found' },
+            text: `User not found. Call LOOKUP_USER first to get valid userId.`,
+            error: 'User not found',
           };
         }
         targetName = targetUser.displayName || targetUser.username || 'User';
@@ -131,14 +130,11 @@ export const checkRecentPostsAction: Action = {
         .limit(limit);
 
       if (recentPosts.length === 0) {
-        const noPostsMsg = isSelf
-          ? "You haven't posted anything yet."
-          : `${targetName} hasn't posted anything yet.`;
         return {
           success: true,
-          text: noPostsMsg,
+          text: isSelf ? 'No posts yet.' : `${targetName} has no posts.`,
           data: { posts: [], count: 0, userId: targetUserId },
-          values: { posts: [], count: 0, hasPosts: false },
+          values: { count: 0 },
         };
       }
 
@@ -150,15 +146,6 @@ export const checkRecentPostsAction: Action = {
         id: post.id,
       }));
 
-      const postsList = formattedPosts
-        .map((p) => `${p.index}. "${p.content}" (${p.timeAgo})`)
-        .join('\n');
-
-      const header = isSelf
-        ? 'Your recent posts:'
-        : `${targetName}'s recent posts:`;
-      const responseText = `${header}\n${postsList}`;
-
       logger.info(
         `[CHECK_RECENT_POSTS] Retrieved ${recentPosts.length} posts for ${isSelf ? 'self' : targetUserId}`,
         undefined,
@@ -167,7 +154,7 @@ export const checkRecentPostsAction: Action = {
 
       return {
         success: true,
-        text: responseText,
+        text: `Retrieved ${recentPosts.length} posts${isSelf ? '' : ` from ${targetName}`}.`,
         data: {
           posts: formattedPosts,
           count: recentPosts.length,
@@ -175,10 +162,14 @@ export const checkRecentPostsAction: Action = {
           userName: targetName,
         },
         values: {
-          posts: formattedPosts,
           count: recentPosts.length,
-          hasPosts: true,
-          isSelf,
+          userId: targetUserId,
+          userName: targetName,
+          posts: formattedPosts.map((p) => ({
+            id: p.id,
+            content: p.content.substring(0, 100),
+            timeAgo: p.timeAgo,
+          })),
         },
       };
     } catch (error) {
@@ -188,8 +179,7 @@ export const checkRecentPostsAction: Action = {
       return {
         success: false,
         text: `Failed to retrieve posts: ${errorMsg}`,
-        data: { error: errorMsg },
-        values: { error: errorMsg },
+        error: errorMsg,
       };
     }
   },

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/close-perp.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/close-perp.ts
@@ -86,9 +86,8 @@ export const closePerpAction: Action = {
     if (!positionId) {
       return {
         success: false,
-        text: 'Missing required parameter: positionId. Please call CHECK_PNL first to see your open perp positions and get the position ID.',
-        data: { error: 'Missing positionId' },
-        values: { error: 'Missing positionId' },
+        text: 'Missing positionId. Call CHECK_PNL first to get position IDs.',
+        error: 'Missing positionId',
       };
     }
 
@@ -109,9 +108,8 @@ export const closePerpAction: Action = {
       if (!position) {
         return {
           success: false,
-          text: `Position not found with ID "${positionId}". Please call CHECK_PNL first to see your actual open positions and get the correct position ID. Do not use ticker names - use the position ID from CHECK_PNL results.`,
-          data: { error: 'Position not found', providedId: positionId },
-          values: { error: 'Position not found', providedId: positionId },
+          text: `Position not found. Call CHECK_PNL first to get valid position IDs.`,
+          error: 'Position not found',
         };
       }
 
@@ -262,10 +260,6 @@ export const closePerpAction: Action = {
           (state?.data?.thought as string) || 'Chat-initiated perp close',
       });
 
-      const responseText = isPartialClose
-        ? `Partially closed ${position.side.toUpperCase()} position on ${position.ticker}: $${closedAmount.toFixed(2)} at $${exitPrice.toFixed(2)}. P&L: ${pnlStr}. Remaining: $${remainingSize.toFixed(2)}`
-        : `Closed ${position.side.toUpperCase()} position on ${position.ticker} at $${exitPrice.toFixed(2)}. P&L: ${pnlStr}`;
-
       logger.info('[CLOSE_PERP] Position closed', {
         agentUserId,
         positionId,
@@ -278,9 +272,13 @@ export const closePerpAction: Action = {
         isPartialClose,
       });
 
+      const resultText = isPartialClose
+        ? `Partial close on ${position.ticker}: $${closedAmount.toFixed(2)} closed. P&L: ${pnlStr}. Remaining: $${remainingSize.toFixed(2)}`
+        : `Closed ${position.ticker} position. P&L: ${pnlStr}`;
+
       return {
         success: true,
-        text: responseText,
+        text: resultText,
         data: {
           positionId,
           ticker: position.ticker,
@@ -297,9 +295,8 @@ export const closePerpAction: Action = {
           side: position.side,
           exitPrice,
           closedAmount,
-          remainingSize,
           pnl,
-          isPartialClose,
+          remainingSize,
         },
       };
     } catch (error) {
@@ -308,8 +305,7 @@ export const closePerpAction: Action = {
       return {
         success: false,
         text: `Failed to close position: ${errorMsg}`,
-        data: { error: errorMsg },
-        values: { error: errorMsg },
+        error: errorMsg,
       };
     }
   },

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/create-post.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/create-post.ts
@@ -104,9 +104,8 @@ export const createPostAction: Action = {
       logger.error('[CREATE_POST] No content provided');
       return {
         success: false,
-        text: 'Cannot create post - no content provided.',
-        data: { error: 'No content provided' },
-        values: { error: 'No content provided' },
+        text: 'No content provided.',
+        error: 'No content provided',
       };
     }
 
@@ -115,18 +114,16 @@ export const createPostAction: Action = {
     if (trimmedContent.length < 5) {
       return {
         success: false,
-        text: 'Post content is too short. Please provide more content.',
-        data: { error: 'Content too short' },
-        values: { error: 'Content too short' },
+        text: 'Content too short (min 5 chars).',
+        error: 'Content too short',
       };
     }
 
     if (trimmedContent.length > 1000) {
       return {
         success: false,
-        text: 'Post content is too long. Please keep it under 1000 characters.',
-        data: { error: 'Content too long' },
-        values: { error: 'Content too long' },
+        text: 'Content too long (max 1000 chars).',
+        error: 'Content too long',
       };
     }
 
@@ -170,17 +167,11 @@ export const createPostAction: Action = {
           );
         });
 
-      const resultData = {
-        postId,
-        content: trimmedContent,
-        authorId: agentId,
-      };
-
       return {
         success: true,
-        text: `Post created successfully!`,
-        data: resultData,
-        values: resultData,
+        text: 'Post created.',
+        data: { postId, content: trimmedContent, authorId: agentId },
+        values: { postId },
       };
     } catch (error) {
       const errorMsg =
@@ -190,8 +181,7 @@ export const createPostAction: Action = {
       return {
         success: false,
         text: `Failed to create post: ${errorMsg}`,
-        data: { error: errorMsg },
-        values: { error: errorMsg },
+        error: errorMsg,
       };
     }
   },

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/lookup-user.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/lookup-user.ts
@@ -71,9 +71,8 @@ export const lookupUserAction: Action = {
     if (!searchTerm) {
       return {
         success: false,
-        text: 'Missing username parameter. Please provide a username to look up.',
-        data: { error: 'Missing username' },
-        values: { error: 'Missing username' },
+        text: 'Missing username parameter.',
+        error: 'Missing username',
       };
     }
 
@@ -102,22 +101,9 @@ export const lookupUserAction: Action = {
           success: true,
           text: `No users found matching "${searchTerm}".`,
           data: { users: [], count: 0 },
-          values: { found: false, count: 0 },
+          values: { count: 0 },
         };
       }
-
-      // Format results
-      const userList = foundUsers
-        .map((u) => {
-          const type = u.isAgent ? '🤖 Agent' : '👤 User';
-          return `• **${u.displayName || u.username}** (@${u.username})\n  ${type} | ID: \`${u.id}\``;
-        })
-        .join('\n');
-
-      const responseText =
-        foundUsers.length === 1
-          ? `Found user:\n${userList}\n\nUse this ID with CHECK_RECENT_POSTS or CHECK_RECENT_COMMENTS.`
-          : `Found ${foundUsers.length} users matching "${searchTerm}":\n${userList}\n\nUse a user ID with CHECK_RECENT_POSTS or CHECK_RECENT_COMMENTS.`;
 
       logger.info(
         `[LOOKUP_USER] Found ${foundUsers.length} users for "${searchTerm}"`,
@@ -127,7 +113,7 @@ export const lookupUserAction: Action = {
 
       return {
         success: true,
-        text: responseText,
+        text: `Found ${foundUsers.length} user(s) matching "${searchTerm}".`,
         data: {
           users: foundUsers.map((u) => ({
             id: u.id,
@@ -136,15 +122,12 @@ export const lookupUserAction: Action = {
             isAgent: u.isAgent,
           })),
           count: foundUsers.length,
-          // For convenience, include the first match's ID directly
           userId: foundUsers[0]?.id,
         },
         values: {
-          found: true,
           count: foundUsers.length,
           userId: foundUsers[0]?.id,
           username: foundUsers[0]?.username,
-          displayName: foundUsers[0]?.displayName,
           isAgent: foundUsers[0]?.isAgent,
         },
       };
@@ -155,8 +138,7 @@ export const lookupUserAction: Action = {
       return {
         success: false,
         text: `Failed to look up user: ${errorMsg}`,
-        data: { error: errorMsg },
-        values: { error: errorMsg },
+        error: errorMsg,
       };
     }
   },

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/open-perp.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/open-perp.ts
@@ -106,9 +106,8 @@ export const openPerpAction: Action = {
     if (!ticker || !side || !amount) {
       return {
         success: false,
-        text: 'Missing required parameters. Need ticker, side (LONG/SHORT), and amount. Please call CHECK_PERPS first to see available markets and get the ticker.',
-        data: { error: 'Missing parameters' },
-        values: { error: 'Missing parameters' },
+        text: 'Missing parameters. Call CHECK_PERPS first to get ticker.',
+        error: 'Missing parameters: ticker, side, or amount',
       };
     }
 
@@ -116,8 +115,7 @@ export const openPerpAction: Action = {
       return {
         success: false,
         text: 'Invalid side. Must be LONG or SHORT.',
-        data: { error: 'Invalid side' },
-        values: { error: 'Invalid side' },
+        error: 'Invalid side',
       };
     }
 
@@ -125,8 +123,7 @@ export const openPerpAction: Action = {
       return {
         success: false,
         text: 'Amount must be greater than 0.',
-        data: { error: 'Invalid amount' },
-        values: { error: 'Invalid amount' },
+        error: 'Invalid amount',
       };
     }
 
@@ -136,9 +133,9 @@ export const openPerpAction: Action = {
       if (balance.balance < amount) {
         return {
           success: false,
-          text: `Insufficient balance. You have $${balance.balance.toFixed(2)} but need $${amount}. Please call CHECK_BALANCE first to verify your available funds.`,
-          data: { error: 'Insufficient balance', balance: balance.balance },
-          values: { error: 'Insufficient balance', balance: balance.balance },
+          text: `Insufficient balance ($${balance.balance.toFixed(2)}). Call CHECK_BALANCE first.`,
+          error: 'Insufficient balance',
+          values: { balance: balance.balance },
         };
       }
 
@@ -220,12 +217,8 @@ export const openPerpAction: Action = {
       if (!market) {
         return {
           success: false,
-          text: `Market "${ticker}" not found. Please call CHECK_PERPS first to see available markets and get the correct ticker. Available: ${marketSnapshot
-            .slice(0, 5)
-            .map((m) => m.ticker)
-            .join(', ')}`,
-          data: { error: 'Market not found', providedTicker: ticker },
-          values: { error: 'Market not found', providedTicker: ticker },
+          text: `Market "${ticker}" not found. Call CHECK_PERPS first to get valid ticker.`,
+          error: 'Market not found',
         };
       }
 
@@ -252,8 +245,6 @@ export const openPerpAction: Action = {
           (state?.data?.thought as string) || 'Chat-initiated perp trade',
       });
 
-      const responseText = `Opened ${leverage}x ${side} position on ${ticker} at $${tradeResult.entryPrice.toFixed(2)}. Size: $${amount}. Position ID: ${tradeResult.positionId}`;
-
       logger.info('[OPEN_PERP] Position opened', {
         agentUserId,
         ticker,
@@ -266,7 +257,7 @@ export const openPerpAction: Action = {
 
       return {
         success: true,
-        text: responseText,
+        text: `Opened ${leverage}x ${side} on ${ticker} at $${tradeResult.entryPrice.toFixed(2)}. Size: $${amount}.`,
         data: {
           positionId: tradeResult.positionId,
           ticker,
@@ -290,8 +281,7 @@ export const openPerpAction: Action = {
       return {
         success: false,
         text: `Failed to open position: ${errorMsg}`,
-        data: { error: errorMsg },
-        values: { error: errorMsg },
+        error: errorMsg,
       };
     }
   },

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/sell-prediction.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/sell-prediction.ts
@@ -85,9 +85,8 @@ export const sellPredictionAction: Action = {
     if (!positionId || !sharesToSell) {
       return {
         success: false,
-        text: 'Missing required parameters. Need positionId and shares. Please call CHECK_PNL first to see your actual positions and get the position ID and current share count.',
-        data: { error: 'Missing parameters' },
-        values: { error: 'Missing parameters' },
+        text: 'Missing parameters. Call CHECK_PNL first to get positionId and share count.',
+        error: 'Missing parameters: positionId or shares',
       };
     }
 
@@ -95,8 +94,7 @@ export const sellPredictionAction: Action = {
       return {
         success: false,
         text: 'Shares must be greater than 0.',
-        data: { error: 'Invalid shares' },
-        values: { error: 'Invalid shares' },
+        error: 'Invalid shares',
       };
     }
 
@@ -117,9 +115,8 @@ export const sellPredictionAction: Action = {
       if (!position) {
         return {
           success: false,
-          text: `Position not found with ID "${positionId}". Please call CHECK_PNL first to see your actual open positions and get the correct position ID.`,
-          data: { error: 'Position not found', providedId: positionId },
-          values: { error: 'Position not found', providedId: positionId },
+          text: `Position not found. Call CHECK_PNL first to get valid positionId.`,
+          error: 'Position not found',
         };
       }
 
@@ -127,17 +124,9 @@ export const sellPredictionAction: Action = {
       if (sharesToSell > currentShares) {
         return {
           success: false,
-          text: `Cannot sell ${sharesToSell} shares. You only have ${currentShares.toFixed(2)} shares. Please call CHECK_PNL to verify your actual share count before selling.`,
-          data: {
-            error: 'Insufficient shares',
-            currentShares,
-            requested: sharesToSell,
-          },
-          values: {
-            error: 'Insufficient shares',
-            currentShares,
-            requested: sharesToSell,
-          },
+          text: `Only ${currentShares.toFixed(2)} shares available. Call CHECK_PNL to verify.`,
+          error: 'Insufficient shares',
+          values: { currentShares },
         };
       }
 
@@ -152,8 +141,7 @@ export const sellPredictionAction: Action = {
         return {
           success: false,
           text: 'Market not found.',
-          data: { error: 'Market not found' },
-          values: { error: 'Market not found' },
+          error: 'Market not found',
         };
       }
 
@@ -234,8 +222,6 @@ export const sellPredictionAction: Action = {
         reasoning: (state?.data?.thought as string) || 'Chat-initiated sell',
       });
 
-      const responseText = `Sold ${sharesToSell} ${isSellYes ? 'YES' : 'NO'} shares. Proceeds: $${proceeds.toFixed(2)}. Remaining: ${result.remainingShares} shares.`;
-
       logger.info('[SELL_PREDICTION] Trade successful', {
         agentUserId,
         positionId,
@@ -246,7 +232,7 @@ export const sellPredictionAction: Action = {
 
       return {
         success: true,
-        text: responseText,
+        text: `Sold ${sharesToSell} shares for $${proceeds.toFixed(2)}. Remaining: ${result.remainingShares.toFixed(2)} shares.`,
         data: {
           positionId,
           marketId: position.marketId,
@@ -268,8 +254,7 @@ export const sellPredictionAction: Action = {
       return {
         success: false,
         text: `Failed to sell shares: ${errorMsg}`,
-        data: { error: errorMsg },
-        values: { error: errorMsg },
+        error: errorMsg,
       };
     }
   },

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/toggle-autonomy.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/toggle-autonomy.ts
@@ -130,22 +130,17 @@ export const toggleAutonomyAction: Action = {
       | ToggleAutonomyParams
       | undefined;
 
-    const inputParams = actionParams || { feature: 'unknown', enabled: false };
-
     if (!actionParams) {
       logger.warn(
         '[TOGGLE_AUTONOMY] No action parameters found in state',
         undefined,
         'ToggleAutonomy'
       );
-      const errorData = { error: 'Missing parameters' };
       return {
         success: false,
-        text: 'Missing parameters. Please specify which feature to toggle and whether to enable or disable it.',
-        data: errorData,
-        values: errorData,
-        input: inputParams,
-      } as ActionResult & { input: typeof inputParams };
+        text: 'Missing parameters: feature and enabled required.',
+        error: 'Missing parameters',
+      };
     }
 
     const { feature, enabled } = actionParams;
@@ -161,28 +156,22 @@ export const toggleAutonomyAction: Action = {
     ];
 
     if (!validFeatures.includes(feature)) {
-      const errorData = { error: 'Invalid feature', feature };
       return {
         success: false,
-        text: `Invalid feature "${feature}". Valid options are: ${validFeatures.join(', ')}`,
-        data: errorData,
-        values: errorData,
-        input: inputParams,
-      } as ActionResult & { input: typeof inputParams };
+        text: `Invalid feature "${feature}". Valid: ${validFeatures.join(', ')}`,
+        error: 'Invalid feature',
+      };
     }
 
     try {
       // Get agent to find manager
       const agent = await agentService.getAgent(agentUserId);
       if (!agent) {
-        const errorData = { error: 'Agent not found' };
         return {
           success: false,
-          text: 'Agent not found',
-          data: errorData,
-          values: errorData,
-          input: inputParams,
-        } as ActionResult & { input: typeof inputParams };
+          text: 'Agent not found.',
+          error: 'Agent not found',
+        };
       }
 
       const managerUserId = agent.managedBy || agentUserId;
@@ -214,21 +203,12 @@ export const toggleAutonomyAction: Action = {
         'ToggleAutonomy'
       );
 
-      const successData = {
-        feature,
-        enabled,
-        updatedFields: Object.keys(updates),
-        featureDisplay,
-        statusDisplay,
-      };
-
       return {
         success: true,
-        text: `Successfully ${statusDisplay} ${featureDisplay}.`,
-        data: successData,
-        values: successData,
-        input: inputParams,
-      } as ActionResult & { input: typeof inputParams };
+        text: `${featureDisplay} ${statusDisplay}.`,
+        data: { feature, enabled, updatedFields: Object.keys(updates) },
+        values: { feature, enabled },
+      };
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : 'Unknown error';
@@ -238,14 +218,11 @@ export const toggleAutonomyAction: Action = {
         'ToggleAutonomy'
       );
 
-      const errorData = { error: errorMessage };
       return {
         success: false,
         text: `Failed to update autonomy settings: ${errorMessage}`,
-        data: errorData,
-        values: errorData,
-        input: inputParams,
-      } as ActionResult & { input: typeof inputParams };
+        error: errorMessage,
+      };
     }
   },
 };

--- a/packages/agents/src/plugins/plugin-agent-core/src/providers/action-state.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/providers/action-state.ts
@@ -3,19 +3,34 @@
  *
  * Provides previous action results from the current multi-step execution.
  * This tracks what actions have been taken and their outcomes.
+ *
+ * Pattern (like otaku):
+ * - text: Brief status message (success/failure, what action to call first)
+ * - values: Key data for subsequent actions (IDs, amounts, etc.)
  */
 
 import type {
+  ActionResult,
   IAgentRuntime,
   Memory,
   Provider,
   ProviderResult,
   State,
 } from '@elizaos/core';
-import type { ActionTraceResult } from '../types';
+
+/**
+ * Extended action result with tracking metadata
+ */
+type ActionTraceResult = ActionResult & {
+  actionType: string;
+  parameters?: Record<string, unknown>;
+  timestamp: number;
+};
 
 /**
  * Format action results for LLM context
+ * - Text shows brief status
+ * - Values are formatted as key-value pairs (like otaku)
  */
 function formatActionResults(results: ActionTraceResult[]): string {
   if (results.length === 0) {
@@ -25,24 +40,27 @@ function formatActionResults(results: ActionTraceResult[]): string {
   return results
     .map((result, index) => {
       const status = result.success ? '✓ Success' : '✗ Failed';
-      let text = `${index + 1}. **${result.actionType}** - ${status}`;
+      let output = `${index + 1}. **${result.actionType}** - ${status}`;
 
-      if (result.summary) {
-        text += `\n   Summary: ${result.summary}`;
+      // Show text (brief status)
+      if (result.text) {
+        output += `\n   Summary: ${result.text}`;
       }
 
+      // Show error if failed
       if (result.error) {
-        text += `\n   Error: ${result.error}`;
+        output += `\n   Error: ${result.error}`;
       }
 
-      if (result.result && Object.keys(result.result).length > 0) {
-        const resultStr = Object.entries(result.result)
-          .map(([key, value]) => `${key}: ${JSON.stringify(value)}`)
-          .join(', ');
-        text += `\n   Result: ${resultStr}`;
+      // Format values as key-value pairs (like otaku)
+      if (result.values && Object.keys(result.values).length > 0) {
+        const valuesStr = Object.entries(result.values)
+          .map(([key, value]) => `   - ${key}: ${JSON.stringify(value)}`)
+          .join('\n');
+        output += `\n   Values:\n${valuesStr}`;
       }
 
-      return text;
+      return output;
     })
     .join('\n\n');
 }


### PR DESCRIPTION
## Summary

Standardizes action return format across `plugin-agent-core` to use `ActionResult` type from `@elizaos/core` 


## Changes

### Type Updates
- All actions now import and return `ActionResult` from `@elizaos/core`
- Removed local type definitions in favor of core types

### Action Return Format
Updated all actions to consistently return:
- `text`: Brief status message for the LLM
- `values`: Key data for subsequent actions (IDs, amounts, etc.)
- `error`: Top-level field for error messages (not nested)

### Action State Provider
- Updated to format `values` as key-value pairs
- Uses `result.text` for summary display

### Summary Template
- Improved prompt to prevent LLM outputting placeholder text literally
