### PR TITLE
fix(agents): include question in CHECK_PREDICTIONS values

### DIFF
--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/check-predictions.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/check-predictions.ts
@@ -169,6 +169,10 @@ export const checkPredictionsAction: Action = {
           count: formattedPredictions.length,
           markets: formattedPredictions.map((p) => ({
             id: p.id,
+            question:
+              p.question.length > 80
+                ? p.question.substring(0, 80) + '...'
+                : p.question,
             yesPercent: p.yesPercent,
             resolved: p.resolved,
             daysUntil: p.daysUntil,


### PR DESCRIPTION
- Add truncated question (80 chars) to values.markets
- Agent can now see what each prediction is about