### PR TITLE
fix(agents): prevent duplicate comments with deduplication + prompt hints

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -190,6 +190,7 @@
         "react-hook-form": "^7.67.0",
         "recharts": "^3.5.1",
         "sonner": "^2.0.7",
+        "streamdown": "^1.4.0",
         "swagger-ui-react": "^5.30.2",
         "tailwind-merge": "^3.4.0",
         "tailwindcss-animate": "^1.0.7",
@@ -3182,6 +3183,8 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
+    "hast": ["hast@1.0.0", "", {}, "sha512-vFUqlRV5C+xqP76Wwq2SrM0kipnmpxJm7OfvVXpB35Fp+Fn4MV+ozr+JZr5qFvyR1q/U+Foim2x+3P+x9S1PLA=="],
+
     "hast-util-from-dom": ["hast-util-from-dom@5.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hastscript": "^9.0.0", "web-namespaces": "^2.0.0" } }, "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q=="],
 
     "hast-util-from-html": ["hast-util-from-html@2.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "devlop": "^1.1.0", "hast-util-from-parse5": "^8.0.0", "parse5": "^7.0.0", "vfile": "^6.0.0", "vfile-message": "^4.0.0" } }, "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw=="],
@@ -3229,6 +3232,8 @@
     "hono": ["hono@4.10.7", "", {}, "sha512-icXIITfw/07Q88nLSkB9aiUrd8rYzSweK681Kjo/TSggaGbOX4RRyxxm71v+3PC8C/j+4rlxGeoTRxQDkaJkUw=="],
 
     "html-to-image": ["html-to-image@1.11.13", "", {}, "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg=="],
+
+    "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
@@ -3639,6 +3644,12 @@
     "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
 
     "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-extension-cjk-friendly": ["micromark-extension-cjk-friendly@1.2.3", "", { "dependencies": { "devlop": "^1.1.0", "micromark-extension-cjk-friendly-util": "2.1.1", "micromark-util-chunked": "^2.0.1", "micromark-util-resolve-all": "^2.0.1", "micromark-util-symbol": "^2.0.1" }, "peerDependencies": { "micromark": "^4.0.0", "micromark-util-types": "^2.0.0" }, "optionalPeers": ["micromark-util-types"] }, "sha512-gRzVLUdjXBLX6zNPSnHGDoo+ZTp5zy+MZm0g3sv+3chPXY7l9gW+DnrcHcZh/jiPR6MjPKO4AEJNp4Aw6V9z5Q=="],
+
+    "micromark-extension-cjk-friendly-gfm-strikethrough": ["micromark-extension-cjk-friendly-gfm-strikethrough@1.2.3", "", { "dependencies": { "devlop": "^1.1.0", "get-east-asian-width": "^1.3.0", "micromark-extension-cjk-friendly-util": "2.1.1", "micromark-util-character": "^2.1.1", "micromark-util-chunked": "^2.0.1", "micromark-util-resolve-all": "^2.0.1", "micromark-util-symbol": "^2.0.1" }, "peerDependencies": { "micromark": "^4.0.0", "micromark-util-types": "^2.0.0" }, "optionalPeers": ["micromark-util-types"] }, "sha512-gSPnxgHDDqXYOBvQRq6lerrq9mjDhdtKn+7XETuXjxWcL62yZEfUdA28Ml1I2vDIPfAOIKLa0h2XDSGkInGHFQ=="],
+
+    "micromark-extension-cjk-friendly-util": ["micromark-extension-cjk-friendly-util@2.1.1", "", { "dependencies": { "get-east-asian-width": "^1.3.0", "micromark-util-character": "^2.1.1", "micromark-util-symbol": "^2.0.1" } }, "sha512-egs6+12JU2yutskHY55FyR48ZiEcFOJFyk9rsiyIhcJ6IvWB6ABBqVrBw8IobqJTDZ/wdSr9eoXDPb5S2nW1bg=="],
 
     "micromark-extension-frontmatter": ["micromark-extension-frontmatter@2.0.0", "", { "dependencies": { "fault": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg=="],
 
@@ -4164,6 +4175,8 @@
 
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
 
+    "rehype-harden": ["rehype-harden@1.1.7", "", { "dependencies": { "unist-util-visit": "^5.0.0" } }, "sha512-j5DY0YSK2YavvNGV+qBHma15J9m0WZmRe8posT5AtKDS6TNWtMVTo6RiqF8SidfcASYz8f3k2J/1RWmq5zTXUw=="],
+
     "rehype-katex": ["rehype-katex@7.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/katex": "^0.16.0", "hast-util-from-html-isomorphic": "^2.0.0", "hast-util-to-text": "^4.0.0", "katex": "^0.16.0", "unist-util-visit-parents": "^6.0.0", "vfile": "^6.0.0" } }, "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA=="],
 
     "rehype-parse": ["rehype-parse@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-from-html": "^2.0.0", "unified": "^11.0.0" } }, "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag=="],
@@ -4173,6 +4186,10 @@
     "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
 
     "rehype-recma": ["rehype-recma@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "hast-util-to-estree": "^3.0.0" } }, "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw=="],
+
+    "remark-cjk-friendly": ["remark-cjk-friendly@1.2.3", "", { "dependencies": { "micromark-extension-cjk-friendly": "1.2.3" }, "peerDependencies": { "@types/mdast": "^4.0.0", "unified": "^11.0.0" }, "optionalPeers": ["@types/mdast"] }, "sha512-UvAgxwlNk+l9Oqgl/9MWK2eWRS7zgBW/nXX9AthV7nd/3lNejF138E7Xbmk9Zs4WjTJGs721r7fAEc7tNFoH7g=="],
+
+    "remark-cjk-friendly-gfm-strikethrough": ["remark-cjk-friendly-gfm-strikethrough@1.2.3", "", { "dependencies": { "micromark-extension-cjk-friendly-gfm-strikethrough": "1.2.3" }, "peerDependencies": { "@types/mdast": "^4.0.0", "unified": "^11.0.0" }, "optionalPeers": ["@types/mdast"] }, "sha512-bXfMZtsaomK6ysNN/UGRIcasQAYkC10NtPmP0oOHOV8YOhA2TXmwRXCku4qOzjIFxAPfish5+XS0eIug2PzNZA=="],
 
     "remark-frontmatter": ["remark-frontmatter@5.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-frontmatter": "^2.0.0", "micromark-extension-frontmatter": "^2.0.0", "unified": "^11.0.0" } }, "sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ=="],
 
@@ -4193,6 +4210,8 @@
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
     "remarkable": ["remarkable@2.0.1", "", { "dependencies": { "argparse": "^1.0.10", "autolinker": "^3.11.0" }, "bin": { "remarkable": "bin/remarkable.js" } }, "sha512-YJyMcOH5lrR+kZdmB0aJJ4+93bEojRZ1HGDn9Eagu6ibg7aVZhc3OWbbShRid+Q5eAfsEqWxpe+g5W5nYNfNiA=="],
+
+    "remend": ["remend@1.0.1", "", {}, "sha512-152puVH0qMoRJQFnaMG+rVDdf01Jq/CaED+MBuXExurJgdbkLp0c3TIe4R12o28Klx8uyGsjvFNG05aFG69G9w=="],
 
     "repeat-string": ["repeat-string@1.6.1", "", {}, "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w=="],
 
@@ -4393,6 +4412,8 @@
     "stream-shift": ["stream-shift@1.0.3", "", {}, "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="],
 
     "stream-to-it": ["stream-to-it@0.2.4", "", { "dependencies": { "get-iterator": "^1.0.2" } }, "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ=="],
+
+    "streamdown": ["streamdown@1.6.10", "", { "dependencies": { "clsx": "^2.1.1", "hast": "^1.0.0", "hast-util-to-jsx-runtime": "^2.3.6", "html-url-attributes": "^3.0.1", "katex": "^0.16.22", "lucide-react": "^0.542.0", "marked": "^16.2.1", "mermaid": "^11.11.0", "rehype-harden": "^1.1.6", "rehype-katex": "^7.0.1", "rehype-raw": "^7.0.0", "remark-cjk-friendly": "^1.2.3", "remark-cjk-friendly-gfm-strikethrough": "^1.2.3", "remark-gfm": "^4.0.1", "remark-math": "^6.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remend": "1.0.1", "shiki": "^3.12.2", "tailwind-merge": "^3.3.1", "unified": "^11.0.5", "unist-util-visit": "^5.0.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-B4Y3Z/qiXl1Dc+LzAB5c52Cd1QGRiFjaDwP+ERoj1JtCykdRDM8X6HwQnn3YkpkSk0x3R7S/6LrGe1nQiElHQQ=="],
 
     "strict-uri-encode": ["strict-uri-encode@2.0.0", "", {}, "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="],
 
@@ -5853,6 +5874,8 @@
     "speech-rule-engine/commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
 
     "stacktrace-parser/type-fest": ["type-fest@0.7.1", "", {}, "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="],
+
+    "streamdown/lucide-react": ["lucide-react@0.542.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-w3hD8/SQB7+lzU2r4VdFyzzOzKnUjTZIF/MQJGSSvni7Llewni4vuViRppfRAa2guOsY5k4jZyxw/i9DQHv+dw=="],
 
     "styled-components/csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
 

--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -16,6 +16,7 @@ import {
   comments,
   db,
   eq,
+  isNull,
   markets,
   messages,
   positions,
@@ -606,7 +607,9 @@ export async function executeDirectPost(
 
 /**
  * Create a comment directly without LLM decision-making.
- * Just creates the comment with the given content.
+ * Includes deduplication check to prevent agents from:
+ * - Making multiple top-level comments on the same post
+ * - Making multiple replies to the same parent comment
  */
 export async function executeDirectComment(
   params: DirectCommentParams
@@ -630,8 +633,34 @@ export async function executeDirectComment(
     return { success: false, error: `Post not found: ${postId}` };
   }
 
-  // Verify parent comment if provided
+  // DEDUPLICATION CHECK: Prevent duplicate comments
   if (parentCommentId) {
+    // Replying to a specific comment - check if agent already replied to this comment
+    const [existingReply] = await db
+      .select({ id: comments.id })
+      .from(comments)
+      .where(
+        and(
+          eq(comments.postId, postId),
+          eq(comments.authorId, agentUserId),
+          eq(comments.parentCommentId, parentCommentId)
+        )
+      )
+      .limit(1);
+
+    if (existingReply) {
+      logger.info(
+        `[DirectExecutor] Agent already replied to comment ${parentCommentId} - skipping duplicate`,
+        { agentUserId, postId, existingReplyId: existingReply.id },
+        'DirectExecutors'
+      );
+      return {
+        success: false,
+        error: `Already replied to this comment`,
+      };
+    }
+
+    // Verify parent comment exists
     const [parentComment] = await db
       .select({ id: comments.id })
       .from(comments)
@@ -642,6 +671,31 @@ export async function executeDirectComment(
       return {
         success: false,
         error: `Parent comment not found: ${parentCommentId}`,
+      };
+    }
+  } else {
+    // Top-level comment - check if agent already commented on this post
+    const [existingComment] = await db
+      .select({ id: comments.id })
+      .from(comments)
+      .where(
+        and(
+          eq(comments.postId, postId),
+          eq(comments.authorId, agentUserId),
+          isNull(comments.parentCommentId)
+        )
+      )
+      .limit(1);
+
+    if (existingComment) {
+      logger.info(
+        `[DirectExecutor] Agent already made top-level comment on post ${postId} - skipping duplicate`,
+        { agentUserId, existingCommentId: existingComment.id },
+        'DirectExecutors'
+      );
+      return {
+        success: false,
+        error: `Already commented on this post`,
       };
     }
   }

--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -11,11 +11,13 @@
 import {
   actorState,
   and,
+  comments,
   db,
   desc,
   eq,
   getDbInstance,
   gte,
+  inArray,
   isNull,
   lte,
   markets,
@@ -432,6 +434,7 @@ export class MultiStepExecutor {
 
   /**
    * Get recent posts to potentially engage with
+   * Includes agent's existing comments so the LLM knows what it already said
    */
   private async getRecentPosts(agentUserId: string): Promise<PostContext[]> {
     const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
@@ -491,12 +494,40 @@ export class MultiStepExecutor {
       }
     }
 
+    // Fetch agent's existing comments on these posts (top-level only)
+    const postIds = recentPostsRaw.map((p) => p.id);
+    const agentComments = new Map<string, string>();
+
+    if (postIds.length > 0) {
+      const existingComments = await db
+        .select({
+          postId: comments.postId,
+          content: comments.content,
+        })
+        .from(comments)
+        .where(
+          and(
+            inArray(comments.postId, postIds),
+            eq(comments.authorId, agentUserId),
+            isNull(comments.parentCommentId), // Top-level comments only
+            isNull(comments.deletedAt)
+          )
+        );
+
+      for (const comment of existingComments) {
+        if (comment.postId) {
+          agentComments.set(comment.postId, comment.content);
+        }
+      }
+    }
+
     return recentPostsRaw.map((p) => ({
       id: p.id,
       authorName: authorNames.get(p.authorId) || 'User',
       content: p.content,
       commentCount: 0, // Simplified - could add actual count if needed
       timeAgo: getTimeAgo(p.createdAt),
+      agentComment: agentComments.get(p.id),
     }));
   }
 

--- a/packages/agents/src/autonomous/templates/multi-step-decision.ts
+++ b/packages/agents/src/autonomous/templates/multi-step-decision.ts
@@ -45,6 +45,8 @@ export interface PostContext {
   content: string;
   commentCount: number;
   timeAgo: string;
+  /** Agent's existing comment on this post, if any */
+  agentComment?: string;
 }
 
 export interface PendingInteraction {
@@ -304,11 +306,21 @@ function formatRecentPosts(posts: PostContext[]): string {
   if (posts.length === 0) return 'No recent posts to engage with.';
 
   return posts
-    .map(
-      (p, idx) =>
-        // Use short index for display, store real ID for parameters
-        `- Post #${idx + 1} (id: ${p.id}) @${p.authorName} (${p.timeAgo}): "${p.content.substring(0, 80)}${p.content.length > 80 ? '...' : ''}" (${p.commentCount} comments)`
-    )
+    .map((p, idx) => {
+      // Use short index for display, store real ID for parameters
+      const baseInfo = `- Post #${idx + 1} (id: ${p.id}) @${p.authorName} (${p.timeAgo}): "${p.content.substring(0, 80)}${p.content.length > 80 ? '...' : ''}" (${p.commentCount} comments)`;
+
+      // Show agent's existing comment if any
+      if (p.agentComment) {
+        const truncatedComment =
+          p.agentComment.length > 60
+            ? `${p.agentComment.substring(0, 60)}...`
+            : p.agentComment;
+        return `${baseInfo}\n    [Already commented: "${truncatedComment}"]`;
+      }
+
+      return baseInfo;
+    })
     .join('\n');
 }
 


### PR DESCRIPTION
## Summary

Agents were responding to posts they had already responded to. This PR adds two layers of protection:

1. **🧠 Soft hint** - Show the agent what it already commented in the prompt context
2. **🛡️ Hard block** - Reject duplicate comments at execution time

---

## 🐛 The Bug (Before)

Agents would spam the same post/comment multiple times across ticks:

```
POST by @Alice: "What do you think about TeslAI's new product?"
│
├── Comment by @Bob: "I think it's revolutionary!"
│   │
│   ├── Reply by @AgentMax: "Agreed, the tech looks promising"  ← Tick 1
│   │
│   ├── Reply by @AgentMax: "Yes, I'm bullish on this!"         ← Tick 2 ❌ DUPLICATE
│   │
│   └── Reply by @AgentMax: "The innovation is impressive"      ← Tick 3 ❌ DUPLICATE
│
└── Comment by @Charlie: "I'm skeptical..."
    │
    ├── Reply by @AgentMax: "Here's why you should reconsider"  ← Tick 1
    │
    └── Reply by @AgentMax: "The data supports my view"         ← Tick 2 ❌ DUPLICATE
```

---

## ✅ The Fix (After)

### Layer 1: Prompt Context Shows Existing Comments

The LLM now sees what it already said:

```
# Recent Posts (can comment on)
- Post #1 (id: abc123) @Alice (2h ago): "What do you think about TeslAI?" (3 comments)
    [Already commented: "I think it's revolutionary..."]
    
- Post #2 (id: def456) @Bob (4h ago): "BitcAIn is pumping!" (1 comments)

- Post #3 (id: ghi789) @Charlie (5h ago): "Market looking rough" (0 comments)
```

👆 The agent can see it already commented on Post #1, so it knows to skip it.

### Layer 2: Hard Deduplication at Execution

If the LLM still tries to comment, execution is blocked:

```
┌─────────────────────────────────────────────────────────────┐
│  Agent wants to comment on Post #1 (id: abc123)             │
└─────────────────────────────────────────────────────────────┘
                          │
                          ▼
┌─────────────────────────────────────────────────────────────┐
│  Check: Does agent already have a top-level comment here?   │
└─────────────────────────────────────────────────────────────┘
                          │
                          ▼
                    ┌──────────┐
                    │   YES    │
                    └──────────┘
                          │
                          ▼
         ┌────────────────────────────────────┐
         │  ❌ BLOCKED                         │
         │  Return: "Already commented on     │
         │  this post"                        │
         └────────────────────────────────────┘
```

**Result:**

```
POST by @Alice: "What do you think about TeslAI's new product?"
│
├── Comment by @Bob: "I think it's revolutionary!"
│   │
│   └── Reply by @AgentMax: "Agreed, the tech looks promising"  ← Tick 1 ✅
│       │
│       (Tick 2: Sees [Already commented] in prompt → skips)    ← ✅ SAVED
│       (Tick 3: Even if tried → blocked at execution)          ← ✅ BLOCKED
│
└── Comment by @Charlie: "I'm skeptical..."
    │
    └── Reply by @AgentMax: "Here's why you should reconsider"  ← Tick 1 ✅
        │
        (Tick 2+: Same protection applies)                       ← ✅ PROTECTED
```

---

## 🔀 Nested Replies Still Work!

The fix only blocks **duplicate** replies. Natural conversation flow is preserved:

```
POST by @Alice: "What about TeslAI?"
│
└── Comment by @Bob (id: 100): "I think it's great!"
    │
    └── Reply by @AgentMax (parent: 100): "Agreed!"              ← ✅ OK
        │
        └── Reply by @Charlie (parent: 101): "Why do you agree?"
            │
            └── Reply by @AgentMax (parent: 102): "Here's why..."  ← ✅ ALLOWED!
                │                                                     (different parent)
                └── Reply by @Charlie (parent: 103): "Interesting"
                    │
                    └── Reply by @AgentMax (parent: 104): "Thanks!"  ← ✅ ALLOWED!
                                                                        (different parent)
```

**Key insight**: Each reply has a different `parentCommentId`, so the agent can continue conversations. It just can't reply to the **same** comment twice.

---

## 📁 Files Changed

| File | Change |
|------|--------|
| `DirectExecutors.ts` | Added deduplication checks before creating comments |
| `MultiStepExecutor.ts` | Fetch agent's existing comments on recent posts |
| `templates/multi-step-decision.ts` | Display `[Already commented: "..."]` in prompt |

---

## ✔️ Test Plan

- [ ] Agent can make initial comment on a post
- [ ] Agent cannot make second top-level comment on same post  
- [ ] Agent can reply to different comments on same post
- [ ] Agent cannot reply to same comment twice
- [ ] Nested conversation threads still work
- [ ] Prompt shows `[Already commented: ...]` for posts agent commented on