### PR TITLE
chore: add PR template and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,120 @@
+# Babylon CODEOWNERS
+#
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# Notes:
+# - Patterns use gitignore-style matching.
+# - If multiple patterns match a file, the LAST match wins.
+
+# ----------------------------
+# Agents (runtime / A2A / MCP)
+# ----------------------------
+/packages/agents/ @wtfsayo
+/packages/a2a/ @wtfsayo
+/packages/mcp/ @wtfsayo
+/packages/examples/babylon-typescript-agent/ @wtfsayo
+/packages/examples/babylon-langgraph-agent/ @wtfsayo
+/packages/examples/harness/ @wtfsayo
+
+/apps/web/src/app/agents/ @wtfsayo
+/apps/web/src/app/api/agents/ @wtfsayo
+/apps/web/src/app/api/a2a/ @wtfsayo
+/apps/web/src/app/api/agent-templates/ @wtfsayo
+/apps/web/src/app/mcp/ @wtfsayo
+/apps/web/src/components/agents/ @wtfsayo
+/apps/web/public/agent-templates/ @wtfsayo
+/apps/web/src/app/api/cron/agent-tick/ @wtfsayo
+
+# --------------------------
+# Markets + trading + Privy
+# --------------------------
+/packages/core/markets/ @slkzgm
+/packages/contracts/src/prediction-markets/ @slkzgm
+
+/apps/web/src/app/markets/ @slkzgm
+/apps/web/src/app/betting/ @slkzgm
+/apps/web/src/components/markets/ @slkzgm
+/apps/web/src/components/trades/ @slkzgm
+/apps/web/src/app/api/markets/ @slkzgm
+/apps/web/src/app/api/trades/ @slkzgm
+/apps/web/src/app/api/questions/ @slkzgm
+/apps/web/src/app/api/cron/perp-funding/ @slkzgm
+
+# Privy (auth/wallet plumbing)
+/packages/shared/src/auth/privy-config.ts @slkzgm
+/packages/shared/src/auth/wallet-utils.ts @slkzgm
+/packages/api/src/fetch.ts @slkzgm
+/packages/api/src/global.d.ts @slkzgm
+
+/apps/web/src/hooks/useAuth.ts @slkzgm
+/apps/web/src/hooks/useSmartWallet.ts @slkzgm
+/apps/web/src/utils/api-fetch.ts @slkzgm
+/apps/web/src/global.d.ts @slkzgm
+/apps/web/src/app/api/users/me/ @slkzgm
+
+# Auth flows (Twitter, shared auth wiring, etc.) — overridden below for Discord/Farcaster.
+/apps/web/src/app/api/auth/ @slkzgm
+
+# ----------------
+# Game engine core
+# ----------------
+/packages/engine/ @SYMBaiEX
+/apps/web/src/app/game/ @SYMBaiEX
+/apps/web/src/app/api/game/ @SYMBaiEX
+/apps/web/src/app/api/npc/ @SYMBaiEX
+/apps/web/src/components/npc/ @SYMBaiEX
+/apps/web/src/app/api/cron/game-tick/ @SYMBaiEX
+/apps/web/src/app/api/cron/world-facts/ @SYMBaiEX
+
+# -------------
+# RL / training
+# -------------
+/packages/training/ @revlentless
+/apps/web/src/app/admin/rl-training/ @revlentless
+/apps/web/src/app/api/training/ @revlentless
+/apps/web/src/app/api/_training/ @revlentless
+/apps/web/src/app/api/huggingface/ @revlentless
+/apps/web/src/app/api/admin/training/ @revlentless
+/apps/web/src/app/api/admin/training-data/ @revlentless
+/apps/web/src/app/api/admin/ai-models/ @revlentless
+/apps/web/src/app/api/cron/training/ @revlentless
+/apps/web/src/app/api/cron/training-check/ @revlentless
+/apps/web/src/app/api/cron/_training/ @revlentless
+/apps/web/src/app/api/cron/weekly-dataset-upload/ @revlentless
+
+# -----------------------------
+# Discord bot / automations
+# -----------------------------
+/apps/web/src/app/api/auth/discord/ @odilitime
+/apps/web/src/app/api/users/\[userId\]/verify-discord-join/ @odilitime
+
+# -------
+# Chats
+# -------
+/apps/web/src/app/chats/ @tcm390
+/apps/web/src/app/api/chats/ @tcm390
+/apps/web/src/components/chat/ @tcm390
+/apps/web/src/components/chats/ @tcm390
+/apps/web/src/app/api/realtime/token/ @tcm390
+
+/packages/db/src/schema/messaging.ts @tcm390
+/packages/api/src/realtime/ @tcm390
+/packages/api/src/sse/ @tcm390
+/packages/testing/synpress/07-chats.synpress.spec.ts @tcm390
+/packages/testing/synpress/helpers/test-data.ts @tcm390
+
+# -----------------------------------
+# Farcaster mini app / integration
+# -----------------------------------
+/apps/web/public/farcaster.json @xR0am
+/apps/web/next.config.ts @xR0am
+/apps/web/src/components/providers/FarcasterMiniAppProvider.tsx @xR0am
+/apps/web/src/app/api/frame/ @xR0am
+/apps/web/src/app/api/embed/post/ @xR0am
+/apps/web/src/app/api/auth/farcaster/ @xR0am
+/apps/web/src/app/api/auth/onboarding/farcaster/ @xR0am
+/apps/web/src/app/api/users/\[userId\]/verify-farcaster-follow/ @xR0am
+/apps/web/src/hooks/useSocialVerification.ts @xR0am @odilitime
+/apps/web/src/stores/authStore.ts @xR0am
+
+/packages/shared/src/auth/farcaster-auth-client.ts @xR0am
+/packages/shared/src/auth/farcaster-onboarding.ts @xR0am

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -68,24 +68,28 @@
 # -------------
 # RL / training
 # -------------
-/packages/training/ @revlentless
-/apps/web/src/app/admin/rl-training/ @revlentless
-/apps/web/src/app/api/training/ @revlentless
-/apps/web/src/app/api/_training/ @revlentless
-/apps/web/src/app/api/huggingface/ @revlentless
-/apps/web/src/app/api/admin/training/ @revlentless
-/apps/web/src/app/api/admin/training-data/ @revlentless
-/apps/web/src/app/api/admin/ai-models/ @revlentless
-/apps/web/src/app/api/cron/training/ @revlentless
-/apps/web/src/app/api/cron/training-check/ @revlentless
-/apps/web/src/app/api/cron/_training/ @revlentless
-/apps/web/src/app/api/cron/weekly-dataset-upload/ @revlentless
+# TEMP: fallback owner until @revlentless has access to the repo.
+# Replace @SYMBaiEX → @revlentless when added.
+/packages/training/ @SYMBaiEX
+/apps/web/src/app/admin/rl-training/ @SYMBaiEX
+/apps/web/src/app/api/training/ @SYMBaiEX
+/apps/web/src/app/api/_training/ @SYMBaiEX
+/apps/web/src/app/api/huggingface/ @SYMBaiEX
+/apps/web/src/app/api/admin/training/ @SYMBaiEX
+/apps/web/src/app/api/admin/training-data/ @SYMBaiEX
+/apps/web/src/app/api/admin/ai-models/ @SYMBaiEX
+/apps/web/src/app/api/cron/training/ @SYMBaiEX
+/apps/web/src/app/api/cron/training-check/ @SYMBaiEX
+/apps/web/src/app/api/cron/_training/ @SYMBaiEX
+/apps/web/src/app/api/cron/weekly-dataset-upload/ @SYMBaiEX
 
 # -----------------------------
 # Discord bot / automations
 # -----------------------------
-/apps/web/src/app/api/auth/discord/ @odilitime
-/apps/web/src/app/api/users/\[userId\]/verify-discord-join/ @odilitime
+# TEMP: fallback owner until @odilitime has access to the repo.
+# Replace @SYMBaiEX → @odilitime when added.
+/apps/web/src/app/api/auth/discord/ @SYMBaiEX
+/apps/web/src/app/api/users/\[userId\]/verify-discord-join/ @SYMBaiEX
 
 # -------
 # Chats
@@ -113,7 +117,9 @@
 /apps/web/src/app/api/auth/farcaster/ @xR0am
 /apps/web/src/app/api/auth/onboarding/farcaster/ @xR0am
 /apps/web/src/app/api/users/\[userId\]/verify-farcaster-follow/ @xR0am
-/apps/web/src/hooks/useSocialVerification.ts @xR0am @odilitime
+# TEMP: fallback owner until @odilitime has access to the repo.
+# Replace @SYMBaiEX → @odilitime when added.
+/apps/web/src/hooks/useSocialVerification.ts @xR0am @SYMBaiEX
 /apps/web/src/stores/authStore.ts @xR0am
 
 /packages/shared/src/auth/farcaster-auth-client.ts @xR0am

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,160 @@
+<!--
+Babylon PR template
+
+Goal: make PRs easy to review + easy to ship.
+- Prefer small, focused PRs (one theme). Avoid catch‑all PRs.
+- Keep app-layer thin and portable (validate → service → map errors).
+- Put domain logic in packages (framework-agnostic), not in Next handlers/components.
+- Before requesting review, run the relevant checks (see "Test plan").
+-->
+
+## Summary
+<!-- 1–3 bullets: what changed + why (user impact / business goal). -->
+
+- …
+
+## Type
+<!-- Helps triage + release notes. -->
+
+- [ ] Feature
+- [ ] Bug fix
+- [ ] Refactor / cleanup (no behavior change)
+- [ ] Performance
+- [ ] Infra / ops
+- [ ] Docs
+- [ ] Contracts / on-chain
+- [ ] Other: …
+
+## Context / Links
+<!-- Link issues, Linear tickets, docs, prior PRs. -->
+
+- …
+
+## Scope (keep it focused)
+<!-- If you had to touch multiple areas, explain why and what you intentionally left out. -->
+
+- [ ] This PR is focused on a single change/theme (not a catch‑all)
+- [ ] Drive‑by refactors are excluded or split into a separate PR
+- [ ] Non‑goals / follow‑ups are listed below (with links)
+
+**Areas touched**
+- [ ] Web UI (`apps/web`)
+- [ ] Web API routes / SSE / A2A (`apps/web`)
+- [ ] CLI (`apps/cli`)
+- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
+- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
+- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
+- [ ] API infra (`packages/api`)
+- [ ] DB (`packages/db`)
+- [ ] Contracts / on-chain (`packages/contracts`)
+- [ ] Shared types/utils (`packages/shared`)
+- [ ] Tests (`packages/testing`)
+- [ ] Other: …
+
+## Changes
+<!-- List the notable changes (what is new/removed/modified). Link key files if it helps. -->
+
+- …
+
+## Review guide
+<!-- Help reviewers go fast: where to start, what to ignore, tricky bits, key decisions. -->
+
+**Start here**
+- `…`
+
+**Risk**
+- [ ] Low
+- [ ] Medium
+- [ ] High
+
+**Notes for reviewers**
+- …
+
+## Test plan
+<!-- Tick what you ran. Add manual steps for anything user-facing. -->
+
+**Commands run**
+- [ ] `bun run check` (Biome format)
+- [ ] `bun run typecheck`
+- [ ] `bun run lint`
+- [ ] `bun run build`
+- [ ] `bun run test` (unit + integration)
+- [ ] `bun run test:e2e` (if critical flows changed)
+- [ ] `bun run contracts:test` (if contracts changed)
+- [ ] `bun run db:check` (if DB schema/queries changed)
+
+**Manual verification**
+1. …
+
+## Ops / Migration / Deployment
+<!-- Anything that impacts deploys, data, cron, config, or rollouts. -->
+
+- [ ] No deploy impact
+- [ ] Requires env var updates (listed below + `.env.example` updated)
+- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
+- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
+- [ ] Rollout behind a flag / gradual rollout
+
+**Env vars (added/changed/removed)**
+- Added: `…`
+- Changed: `…`
+- Removed: `…`
+
+**DB / data migration**
+- Migration(s): `…`
+- Backfill/seed: `…` (command/script + expected runtime)
+
+**Rollout / rollback plan**
+- Rollout: …
+- Rollback: …
+
+## Breaking changes
+
+- [ ] None
+- [ ] Yes (describe + migration guide below)
+
+**Migration guide**
+- …
+
+## Security / privacy
+<!-- Authn/authz, secrets handling, PII, prompt injection surfaces, etc. -->
+
+- [ ] No security impact
+- [ ] Needs extra review (describe)
+
+<details>
+<summary>Area-specific notes (expand if relevant)</summary>
+
+### API / contracts between services
+<!-- New/changed endpoints, SSE event payloads, shared types. -->
+- …
+
+### Database
+<!-- Tables/columns/indexes, perf implications, how to verify. -->
+- …
+
+### Contracts / on-chain
+<!-- Network(s), addresses, upgrade/migration notes, how to verify. -->
+- …
+
+### Docs
+<!-- If you touched generated vendor docs, regenerate via `bun run docs:generate`. -->
+- …
+
+</details>
+
+## Screenshots / recordings (UI)
+<!-- UI changes: add before/after screenshots, or a short recording. -->
+
+- …
+
+## Checklist (author)
+- [ ] Self-review done (diff + critical paths)
+- [ ] Base branch is correct (`staging` by default)
+- [ ] Handlers remain thin and portable (validate → service → map errors)
+- [ ] Domain logic stays in packages (no Next/React/Elysia coupling in core)
+- [ ] `.env.example` updated (if env changed) and variables documented above
+- [ ] Docs updated (and `bun run docs:generate` if needed)
+- [ ] Tests added/updated for behavior changes (or rationale provided)
+- [ ] Dependency changes are intentional (`bun.lock` updated)
+- [ ] Code owners requested (auto via CODEOWNERS or manual)


### PR DESCRIPTION
## Summary
- Add a Babylon-specific PR template to standardize PRs and speed up reviews.
- Introduce `CODEOWNERS` to automatically request reviews from the right domain owners and enforce ownership on `staging`.

## Changes
- Add `.github/pull_request_template.md` (GitHub default PR template) and keep `pull_request_template.md` in sync.
- Add `.github/CODEOWNERS` with path-based ownership for major domains (agents, markets/privy, engine, RL/training, chats, Farcaster).
- Temporary fallback owners: RL + Discord scopes use `@SYMBaiEX` until `@revlentless` / `@odilitime` have repo access (explicitly marked in `CODEOWNERS`).

## Review guide
- Start with `.github/pull_request_template.md`
- Then review `.github/CODEOWNERS` for mapping correctness + any missing paths

## Test plan
- N/A (docs/config only)

## Ops / Deployment
- No deploy impact
- Repo config note: enable/verify “Require review from Code Owners” on `staging` branch protection

## Checklist
- [x] Focused PR (template + ownership only)
- [x] Temporary ownership noted for later cleanup
