### PR TITLE
feat(agents): Refactor wallet UI with separate Ops Budget and Trading Balance tabs

### DIFF
--- a/apps/web/src/app/agents/[agentId]/page.tsx
+++ b/apps/web/src/app/agents/[agentId]/page.tsx
@@ -115,10 +115,13 @@ interface Agent {
   bio?: string[];
   personality?: string;
   tradingStrategy?: string;
+  // Points balance (for operations)
   pointsBalance: number;
   totalDeposited: number;
   totalWithdrawn: number;
   totalPointsSpent: number;
+  // Trading balance (for trades)
+  virtualBalance?: number;
   isActive: boolean;
   autonomousEnabled: boolean;
   modelTier: 'free' | 'pro';
@@ -313,15 +316,27 @@ export default function AgentDetailPage() {
           </div>
 
           {/* Stats Row */}
-          <div className="mt-6 grid grid-cols-2 place-items-center gap-4 border-border border-t pt-6 text-center">
+          <div className="mt-6 grid grid-cols-3 place-items-center gap-4 border-border border-t pt-6 text-center">
             <div>
-              <div className="mb-1 text-muted-foreground text-xs">Balance</div>
-              <div className="font-semibold text-xl">
-                {agent.pointsBalance} pts
+              <div className="mb-1 text-muted-foreground text-xs">
+                Ops Budget
+              </div>
+              <div className="font-semibold text-[#0066FF] text-xl">
+                {agent.pointsBalance.toFixed(2)} pts
               </div>
             </div>
             <div>
-              <div className="mb-1 text-muted-foreground text-xs">P&L</div>
+              <div className="mb-1 text-muted-foreground text-xs">
+                Trading Balance
+              </div>
+              <div className="font-semibold text-emerald-600 text-xl">
+                {(agent.virtualBalance ?? 0).toFixed(2)} pts
+              </div>
+            </div>
+            <div>
+              <div className="mb-1 text-muted-foreground text-xs">
+                Lifetime P&L
+              </div>
               <div
                 className={cn(
                   'font-semibold text-xl',
@@ -330,7 +345,7 @@ export default function AgentDetailPage() {
                     : 'text-red-600'
                 )}
               >
-                {parseFloat(agent.lifetimePnL).toFixed(2)}
+                {parseFloat(agent.lifetimePnL).toFixed(2)} pts
               </div>
             </div>
           </div>

--- a/apps/web/src/app/api/agents/[agentId]/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/route.ts
@@ -251,10 +251,13 @@ export async function GET(
           );
           return tradingStrategyMatch ? tradingStrategyMatch[1]!.trim() : '';
         })(),
+      // Points balance (for operations)
       pointsBalance: config?.pointsBalance ?? 0,
       totalDeposited: config?.totalDeposited ?? 0,
       totalWithdrawn: config?.totalWithdrawn ?? 0,
       totalPointsSpent: config?.totalPointsSpent ?? 0,
+      // Trading balance (for trades)
+      virtualBalance: Number(agent!.virtualBalance),
       isActive: config?.status === 'active',
       autonomousEnabled: config?.autonomousTrading ?? false,
       autonomousTrading: config?.autonomousTrading ?? false,

--- a/apps/web/src/app/api/agents/[agentId]/trading-balance/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/trading-balance/route.ts
@@ -1,0 +1,166 @@
+/**
+ * Agent Trading Balance API
+ *
+ * @route GET /api/agents/[agentId]/trading-balance - Get trading balance info
+ * @route POST /api/agents/[agentId]/trading-balance - Deposit/withdraw trading balance
+ * @access Authenticated (owner only)
+ *
+ * @description
+ * Manages agent trading balance (virtualBalance). This is the USD balance used
+ * for actual trades on prediction markets and perps. Separate from points balance
+ * which is used for agent operations (chat, tick, posting).
+ */
+
+import { agentService } from '@babylon/agents';
+import { authenticateUser } from '@babylon/api';
+import { db, balanceTransactions, eq, desc, users } from '@babylon/db';
+import { logger } from '@babylon/shared';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ agentId: string }> }
+) {
+  const user = await authenticateUser(req);
+  const { agentId } = await params;
+
+  // Verify ownership
+  await agentService.getAgent(agentId, user.id);
+
+  // Get agent's trading balance
+  const agentResult = await db
+    .select({
+      virtualBalance: users.virtualBalance,
+      lifetimePnL: users.lifetimePnL,
+      totalDeposited: users.totalDeposited,
+      totalWithdrawn: users.totalWithdrawn,
+    })
+    .from(users)
+    .where(eq(users.id, agentId))
+    .limit(1);
+
+  const agent = agentResult[0];
+  if (!agent) {
+    return NextResponse.json({ success: false, error: 'Agent not found' }, { status: 404 });
+  }
+
+  // Get user's trading balance for display
+  const userResult = await db
+    .select({
+      virtualBalance: users.virtualBalance,
+    })
+    .from(users)
+    .where(eq(users.id, user.id))
+    .limit(1);
+
+  const userBalance = Number(userResult[0]?.virtualBalance ?? 0);
+
+  // Get recent trading balance transactions
+  const transactions = await db
+    .select()
+    .from(balanceTransactions)
+    .where(eq(balanceTransactions.userId, agentId))
+    .orderBy(desc(balanceTransactions.createdAt))
+    .limit(50);
+
+  return NextResponse.json({
+    success: true,
+    agentBalance: {
+      tradingBalance: Number(agent.virtualBalance),
+      lifetimePnL: Number(agent.lifetimePnL),
+      totalDeposited: Number(agent.totalDeposited),
+      totalWithdrawn: Number(agent.totalWithdrawn),
+    },
+    userBalance: userBalance,
+    transactions: transactions.map((tx) => ({
+      id: tx.id,
+      type: tx.type,
+      amount: Number(tx.amount),
+      balanceBefore: Number(tx.balanceBefore),
+      balanceAfter: Number(tx.balanceAfter),
+      description: tx.description,
+      relatedId: tx.relatedId,
+      createdAt: tx.createdAt.toISOString(),
+    })),
+  });
+}
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ agentId: string }> }
+) {
+  const user = await authenticateUser(req);
+  const { agentId } = await params;
+  const body = await req.json();
+
+  const { action, amount } = body;
+
+  if (!action || !['deposit', 'withdraw'].includes(action)) {
+    return NextResponse.json(
+      { success: false, error: 'Invalid action. Must be "deposit" or "withdraw"' },
+      { status: 400 }
+    );
+  }
+
+  if (!amount || amount <= 0) {
+    return NextResponse.json(
+      { success: false, error: 'Amount must be a positive number' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    if (action === 'deposit') {
+      await agentService.depositTradingBalance(agentId, user.id, amount);
+      logger.info(
+        `Deposited $${amount} trading balance to agent ${agentId}`,
+        undefined,
+        'AgentsAPI'
+      );
+    } else {
+      await agentService.withdrawTradingBalance(agentId, user.id, amount);
+      logger.info(
+        `Withdrew $${amount} trading balance from agent ${agentId}`,
+        undefined,
+        'AgentsAPI'
+      );
+    }
+
+    // Get updated balances
+    const agentResult = await db
+      .select({
+        virtualBalance: users.virtualBalance,
+        lifetimePnL: users.lifetimePnL,
+      })
+      .from(users)
+      .where(eq(users.id, agentId))
+      .limit(1);
+
+    const userResult = await db
+      .select({
+        virtualBalance: users.virtualBalance,
+      })
+      .from(users)
+      .where(eq(users.id, user.id))
+      .limit(1);
+
+    return NextResponse.json({
+      success: true,
+      agentBalance: {
+        tradingBalance: Number(agentResult[0]?.virtualBalance ?? 0),
+        lifetimePnL: Number(agentResult[0]?.lifetimePnL ?? 0),
+      },
+      userBalance: Number(userResult[0]?.virtualBalance ?? 0),
+      message: `${action === 'deposit' ? 'Deposited' : 'Withdrew'} $${amount.toFixed(2)} successfully`,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Transaction failed';
+    logger.error(`Trading balance ${action} failed: ${message}`, undefined, 'AgentsAPI');
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 400 }
+    );
+  }
+}
+

--- a/apps/web/src/app/api/agents/[agentId]/wallet/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/wallet/route.ts
@@ -143,7 +143,7 @@
 
 import { agentService, getAgentConfig } from '@babylon/agents';
 import { authenticateUser } from '@babylon/api';
-import { db } from '@babylon/db';
+import { db, users, eq } from '@babylon/db';
 import { logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
@@ -161,6 +161,15 @@ export async function GET(
   // Get agent config for balance info
   const config = await getAgentConfig(agentId);
 
+  // Get user's trading balance (source for ops budget)
+  const userResult = await db
+    .select({ virtualBalance: users.virtualBalance })
+    .from(users)
+    .where(eq(users.id, user.id))
+    .limit(1);
+
+  const userBalance = Number(userResult[0]?.virtualBalance ?? 0);
+
   const transactions = await db.agentPointsTransaction.findMany({
     where: { agentUserId: agentId },
     orderBy: { createdAt: 'desc' },
@@ -175,6 +184,7 @@ export async function GET(
       totalWithdrawn: config?.totalWithdrawn ?? 0,
       totalSpent: config?.totalPointsSpent ?? 0,
     },
+    userBalance: userBalance,
     transactions: transactions.map((tx) => ({
       id: tx.id,
       type: tx.type,
@@ -201,21 +211,28 @@ export async function POST(
   if (action === 'deposit') {
     await agentService.depositPoints(agentId, user.id, amount);
     logger.info(
-      `Deposited ${amount} points to agent ${agentId}`,
+      `Deposited $${amount} ops budget to agent ${agentId}`,
       undefined,
       'AgentsAPI'
     );
   } else {
     await agentService.withdrawPoints(agentId, user.id, amount);
     logger.info(
-      `Withdrew ${amount} points from agent ${agentId}`,
+      `Withdrew $${amount} ops budget from agent ${agentId}`,
       undefined,
       'AgentsAPI'
     );
   }
 
-  // Re-fetch config for updated balance
+  // Re-fetch config and user balance
   const updatedConfig = await getAgentConfig(agentId);
+  const userResult = await db
+    .select({ virtualBalance: users.virtualBalance })
+    .from(users)
+    .where(eq(users.id, user.id))
+    .limit(1);
+
+  const userBalance = Number(userResult[0]?.virtualBalance ?? 0);
 
   return NextResponse.json({
     success: true,
@@ -224,6 +241,7 @@ export async function POST(
       totalDeposited: updatedConfig?.totalDeposited ?? 0,
       totalWithdrawn: updatedConfig?.totalWithdrawn ?? 0,
     },
-    message: `${action === 'deposit' ? 'Deposited' : 'Withdrew'} ${amount} points successfully`,
+    userBalance: userBalance,
+    message: `${action === 'deposit' ? 'Deposited' : 'Withdrew'} $${amount.toFixed(2)} successfully`,
   });
 }

--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -247,10 +247,13 @@ export async function GET(req: NextRequest) {
         name: agent.displayName,
         description: agent.bio,
         profileImageUrl: agent.profileImageUrl,
+        // Points balance (for operations)
         pointsBalance: config?.pointsBalance ?? 0,
         totalDeposited: config?.totalDeposited ?? 0,
         totalWithdrawn: config?.totalWithdrawn ?? 0,
         totalPointsSpent: config?.totalPointsSpent ?? 0,
+        // Trading balance (for trades)
+        virtualBalance: Number(agent.virtualBalance),
         autonomousEnabled: config?.autonomousTrading ?? false,
         autonomousTrading: config?.autonomousTrading ?? false,
         autonomousPosting: config?.autonomousPosting ?? false,

--- a/apps/web/src/components/agents/AgentWallet.tsx
+++ b/apps/web/src/components/agents/AgentWallet.tsx
@@ -1,7 +1,14 @@
 'use client';
 
-import { cn, logger } from '@babylon/shared';
-import { ArrowDownToLine, ArrowUpFromLine, History } from 'lucide-react';
+import { cn } from '@babylon/shared';
+import {
+  ArrowDownToLine,
+  ArrowUpFromLine,
+  Coins,
+  History,
+  TrendingUp,
+  Zap,
+} from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { Input } from '@/components/ui/input';
@@ -21,64 +28,64 @@ interface Transaction {
 }
 
 /**
- * Agent wallet component for managing agent points balance.
+ * Agent wallet component for managing agent balances.
  *
- * Provides interface for depositing and withdrawing points to/from agent
- * wallet. Displays current balance, transaction history, and wallet
- * statistics. Handles balance transfers from user's reputation points.
- *
- * Features:
- * - Balance display
- * - Deposit functionality
- * - Withdraw functionality
- * - Transaction history
- * - Wallet statistics
- * - Loading states
- * - Error handling
+ * Provides interface for:
+ * - Ops Budget: Points used for AI operations like chat/tick (pointsBalance)
+ * - Trading Balance: Points used for actual trades (virtualBalance)
  *
  * @param props - AgentWallet component props
  * @returns Agent wallet element
- *
- * @example
- * ```tsx
- * <AgentWallet
- *   agent={agentData}
- *   onUpdate={() => refreshAgent()}
- * />
- * ```
  */
 interface AgentWalletProps {
   agent: {
     id: string;
     name: string;
+    // Points balance (for operations)
     pointsBalance: number;
     totalDeposited: number;
     totalWithdrawn: number;
     totalPointsSpent: number;
+    // Trading balance (for trades) - optional for backwards compat
+    virtualBalance?: number;
+    lifetimePnL?: string;
   };
   onUpdate: () => void;
 }
 
 export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
-  const { user, getAccessToken } = useAuth();
-  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const { getAccessToken } = useAuth();
+
+  // Points transactions (for ops budget)
+  const [pointsTransactions, setPointsTransactions] = useState<Transaction[]>(
+    []
+  );
+  // Trading balance transactions
+  const [tradingTransactions, setTradingTransactions] = useState<Transaction[]>(
+    []
+  );
+
   const [loading, setLoading] = useState(false);
   const [amount, setAmount] = useState('');
   const [action, setAction] = useState<'deposit' | 'withdraw'>('deposit');
   const [processing, setProcessing] = useState(false);
 
-  const fetchTransactions = useCallback(async () => {
-    setLoading(true);
+  // Which wallet are we managing: 'ops' or 'trading'
+  const [activeWallet, setActiveWallet] = useState<'trading' | 'ops'>('ops');
+
+  // Trading balance state
+  const [tradingBalance, setTradingBalance] = useState({
+    agentBalance: agent.virtualBalance ?? 1000,
+    userBalance: 0,
+    lifetimePnL: parseFloat(agent.lifetimePnL ?? '0'),
+  });
+
+  const fetchPointsTransactions = useCallback(async () => {
     const token = await getAccessToken();
-    if (!token) {
-      setLoading(false);
-      return;
-    }
+    if (!token) return;
 
     const res = await fetch(`/api/agents/${agent.id}/wallet`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
+      headers: { Authorization: `Bearer ${token}` },
     });
 
     if (res.ok) {
@@ -87,120 +94,242 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
         transactions: Transaction[];
       };
       if (data.success && data.transactions) {
-        setTransactions(data.transactions);
+        setPointsTransactions(data.transactions);
       }
-    } else {
-      logger.error('Failed to fetch transactions', undefined, 'AgentWallet');
     }
-    setLoading(false);
+  }, [agent.id, getAccessToken]);
+
+  const fetchTradingBalance = useCallback(async () => {
+    const token = await getAccessToken();
+    if (!token) return;
+
+    const res = await fetch(`/api/agents/${agent.id}/trading-balance`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    if (res.ok) {
+      const data = await res.json();
+      if (data.success) {
+        setTradingBalance({
+          agentBalance: data.agentBalance.tradingBalance,
+          userBalance: data.userBalance,
+          lifetimePnL: data.agentBalance.lifetimePnL,
+        });
+        setTradingTransactions(data.transactions || []);
+      }
+    }
   }, [agent.id, getAccessToken]);
 
   useEffect(() => {
-    fetchTransactions();
-  }, [fetchTransactions]);
+    setLoading(true);
+    Promise.all([fetchPointsTransactions(), fetchTradingBalance()]).finally(
+      () => setLoading(false)
+    );
+  }, [fetchPointsTransactions, fetchTradingBalance]);
 
   const handleTransaction = async () => {
-    const amountNum = parseInt(amount);
+    const amountNum = parseFloat(amount);
 
     if (!amountNum || amountNum <= 0) {
       toast.error('Please enter a valid amount');
       return;
     }
 
-    const totalPoints = user?.reputationPoints || 0;
-
-    if (action === 'deposit' && amountNum > totalPoints) {
-      toast.error(`Insufficient balance. You have ${totalPoints} points`);
-      return;
-    }
-
-    if (action === 'withdraw' && amountNum > agent.pointsBalance) {
-      toast.error(
-        `Insufficient agent balance. Agent has ${agent.pointsBalance} points`
-      );
-      return;
+    if (activeWallet === 'trading') {
+      // Trading balance transfer
+      if (action === 'deposit' && amountNum > tradingBalance.userBalance) {
+        toast.error(
+          `Insufficient balance. You have ${tradingBalance.userBalance.toFixed(2)} pts`
+        );
+        return;
+      }
+      if (action === 'withdraw' && amountNum > tradingBalance.agentBalance) {
+        toast.error(
+          `Insufficient agent trading balance. Agent has ${tradingBalance.agentBalance.toFixed(2)} pts`
+        );
+        return;
+      }
+    } else {
+      // Ops budget transfer (also from trading balance)
+      if (action === 'deposit' && amountNum > tradingBalance.userBalance) {
+        toast.error(
+          `Insufficient balance. You have ${tradingBalance.userBalance.toFixed(2)} pts`
+        );
+        return;
+      }
+      if (action === 'withdraw' && amountNum > agent.pointsBalance) {
+        toast.error(
+          `Insufficient agent ops budget. Agent has ${agent.pointsBalance.toFixed(2)} pts`
+        );
+        return;
+      }
     }
 
     setProcessing(true);
     const token = await getAccessToken();
     if (!token) {
       setProcessing(false);
-      throw new Error('Authentication required');
+      toast.error('Authentication required');
+      return;
     }
 
-    const res = await fetch(`/api/agents/${agent.id}/wallet`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ action, amount: amountNum }),
-    });
+    const endpoint =
+      activeWallet === 'trading'
+        ? `/api/agents/${agent.id}/trading-balance`
+        : `/api/agents/${agent.id}/wallet`;
 
-    if (!res.ok) {
-      const error = await res.json();
+    try {
+      const res = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ action, amount: amountNum }),
+      });
+
+      if (!res.ok) {
+        const error = await res.json();
+        throw new Error(error.error || 'Transaction failed');
+      }
+
+      const data = await res.json();
+      toast.success(data.message);
+      setAmount('');
+
+      // Refresh data
+      if (activeWallet === 'trading') {
+        await fetchTradingBalance();
+      } else {
+        await fetchPointsTransactions();
+      }
+      onUpdate();
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : 'Transaction failed'
+      );
+    } finally {
       setProcessing(false);
-      throw new Error(error.error || 'Transaction failed');
     }
-
-    const data = await res.json();
-    toast.success(data.message);
-    setAmount('');
-    fetchTransactions();
-    onUpdate();
-    setProcessing(false);
   };
 
-  const userTotalPoints = user?.reputationPoints || 0;
+  const transactions =
+    activeWallet === 'trading' ? tradingTransactions : pointsTransactions;
 
   return (
     <div className="space-y-6">
-      {/* Balance Cards */}
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-        <div className="rounded-lg border border-border bg-card/50 p-6 backdrop-blur">
-          <div className="mb-2 text-muted-foreground text-sm">
-            Agent Balance
+      {/* Wallet Type Toggle */}
+      <div className="grid grid-cols-2 gap-2">
+        <button
+          onClick={() => setActiveWallet('ops')}
+          className={cn(
+            'flex items-center justify-center gap-2 rounded-lg px-4 py-3 font-medium transition-all',
+            activeWallet === 'ops'
+              ? 'bg-[#0066FF] text-white'
+              : 'bg-muted text-foreground hover:bg-muted/80'
+          )}
+        >
+          <Zap className="h-4 w-4" />
+          <span>Ops Budget</span>
+        </button>
+        <button
+          onClick={() => setActiveWallet('trading')}
+          className={cn(
+            'flex items-center justify-center gap-2 rounded-lg px-4 py-3 font-medium transition-all',
+            activeWallet === 'trading'
+              ? 'bg-emerald-600 text-white'
+              : 'bg-muted text-foreground hover:bg-muted/80'
+          )}
+        >
+          <Coins className="h-4 w-4" />
+          <span>Trading Balance</span>
+        </button>
+      </div>
+
+      {/* Balance Card */}
+      {activeWallet === 'ops' ? (
+        <div className="rounded-lg border border-[#0066FF]/30 bg-[#0066FF]/5 p-6">
+          <div className="mb-2 flex items-center gap-2 text-[#0066FF] text-sm">
+            <Zap className="h-4 w-4" />
+            Agent Ops Budget
           </div>
           <div className="mb-4 font-bold text-3xl">
-            {agent.pointsBalance} pts
+            {agent.pointsBalance.toFixed(2)} pts
           </div>
           <div className="space-y-1 text-muted-foreground text-sm">
             <div className="flex justify-between">
               <span>Total Deposited:</span>
-              <span>{agent.totalDeposited} pts</span>
+              <span>{agent.totalDeposited.toFixed(2)} pts</span>
             </div>
             <div className="flex justify-between">
               <span>Total Withdrawn:</span>
-              <span>{agent.totalWithdrawn} pts</span>
+              <span>{agent.totalWithdrawn.toFixed(2)} pts</span>
             </div>
             <div className="flex justify-between">
               <span>Total Spent:</span>
-              <span>{agent.totalPointsSpent} pts</span>
+              <span>{agent.totalPointsSpent.toFixed(2)} pts</span>
             </div>
           </div>
-        </div>
-
-        <div className="rounded-lg border border-border bg-card/50 p-6 backdrop-blur">
-          <div className="mb-2 text-muted-foreground text-sm">Your Balance</div>
-          <div className="mb-4 font-bold text-3xl">{userTotalPoints} pts</div>
-          <p className="text-muted-foreground text-sm">
-            Available for deposit to agents
+          <p className="mt-3 text-muted-foreground text-xs">
+            Used for AI operations (chat, autonomous actions)
           </p>
         </div>
-      </div>
+      ) : (
+        <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/5 p-6">
+          <div className="mb-2 flex items-center gap-2 text-emerald-600 text-sm">
+            <Coins className="h-4 w-4" />
+            Agent Trading Balance
+          </div>
+          <div className="mb-4 font-bold text-3xl">
+            {tradingBalance.agentBalance.toFixed(2)} pts
+          </div>
+          <div className="space-y-1 text-muted-foreground text-sm">
+            <div className="flex items-center justify-between">
+              <span className="flex items-center gap-1">
+                <TrendingUp className="h-3 w-3" />
+                Lifetime P&L:
+              </span>
+              <span
+                className={cn(
+                  'font-medium',
+                  tradingBalance.lifetimePnL >= 0
+                    ? 'text-green-600'
+                    : 'text-red-600'
+                )}
+              >
+                {tradingBalance.lifetimePnL >= 0 ? '+' : ''}
+                {tradingBalance.lifetimePnL.toFixed(2)} pts
+              </span>
+            </div>
+          </div>
+          <p className="mt-3 text-muted-foreground text-xs">
+            Used for prediction market and perp trades
+          </p>
+        </div>
+      )}
 
       {/* Transaction Form */}
       <div className="rounded-lg border border-border bg-card/50 p-4 backdrop-blur sm:p-6">
-        <h3 className="mb-4 font-semibold text-lg">Transfer Points</h3>
+        <div className="mb-4 flex items-center justify-between">
+          <h3 className="font-semibold text-lg">
+            Transfer to {activeWallet === 'ops' ? 'Ops Budget' : 'Trading Balance'}
+          </h3>
+          <div className="text-right text-sm">
+            <span className="text-muted-foreground">Your Balance: </span>
+            <span className="font-medium">{tradingBalance.userBalance.toFixed(2)} pts</span>
+          </div>
+        </div>
 
-        {/* Action Toggle - Full width buttons */}
+        {/* Action Toggle */}
         <div className="mb-4 grid grid-cols-2 gap-2">
           <button
             onClick={() => setAction('deposit')}
             className={cn(
               'flex items-center justify-center gap-2 rounded-lg px-3 py-3 font-medium transition-all sm:px-4',
               action === 'deposit'
-                ? 'bg-[#0066FF] text-primary-foreground'
+                ? activeWallet === 'ops'
+                  ? 'bg-[#0066FF] text-primary-foreground'
+                  : 'bg-emerald-600 text-white'
                 : 'bg-muted text-foreground hover:bg-muted/80'
             )}
           >
@@ -212,7 +341,9 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
             className={cn(
               'flex items-center justify-center gap-2 rounded-lg px-3 py-3 font-medium transition-all sm:px-4',
               action === 'withdraw'
-                ? 'bg-[#0066FF] text-primary-foreground'
+                ? activeWallet === 'ops'
+                  ? 'bg-[#0066FF] text-primary-foreground'
+                  : 'bg-emerald-600 text-white'
                 : 'bg-muted text-foreground hover:bg-muted/80'
             )}
           >
@@ -221,21 +352,33 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
           </button>
         </div>
 
-        {/* Amount input and submit - Stack on mobile, inline on larger screens */}
+        {/* Amount input and submit */}
         <div className="flex flex-col gap-3 sm:flex-row sm:gap-2">
           <Input
             type="number"
             value={amount}
             onChange={(e) => setAmount(e.target.value)}
-            placeholder="Enter amount..."
-            min={1}
-            max={action === 'deposit' ? userTotalPoints : agent.pointsBalance}
+            placeholder="Enter amount (pts)..."
+            min={0.01}
+            step={0.01}
+            max={
+              action === 'deposit'
+                ? tradingBalance.userBalance
+                : activeWallet === 'trading'
+                  ? tradingBalance.agentBalance
+                  : agent.pointsBalance
+            }
             className="h-12 w-full text-base sm:h-10 sm:flex-1 sm:text-sm"
           />
           <button
             onClick={handleTransaction}
             disabled={processing || !amount}
-            className="h-12 w-full rounded-lg bg-[#0066FF] px-6 font-medium text-primary-foreground transition-all hover:bg-[#2952d9] disabled:cursor-not-allowed disabled:opacity-50 sm:h-10 sm:w-auto"
+            className={cn(
+              'h-12 w-full rounded-lg px-6 font-medium text-white transition-all disabled:cursor-not-allowed disabled:opacity-50 sm:h-10 sm:w-auto',
+              activeWallet === 'ops'
+                ? 'bg-[#0066FF] hover:bg-[#2952d9]'
+                : 'bg-emerald-600 hover:bg-emerald-700'
+            )}
           >
             {processing
               ? 'Processing...'
@@ -247,8 +390,8 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
 
         <p className="mt-3 text-muted-foreground text-xs">
           {action === 'deposit'
-            ? `Transfer points from your account to ${agent.name}`
-            : `Transfer points from ${agent.name} to your account`}
+            ? `Transfer pts from your balance to ${agent.name}'s ${activeWallet === 'ops' ? 'ops budget' : 'trading balance'}`
+            : `Transfer pts from ${agent.name}'s ${activeWallet === 'ops' ? 'ops budget' : 'trading balance'} to your balance`}
         </p>
       </div>
 
@@ -256,7 +399,10 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
       <div className="rounded-lg border border-border bg-card/50 p-6 backdrop-blur">
         <div className="mb-4 flex items-center gap-2">
           <History className="h-5 w-5" />
-          <h3 className="font-semibold text-lg">Transaction History</h3>
+          <h3 className="font-semibold text-lg">
+            {activeWallet === 'ops' ? 'Ops Budget' : 'Trading Balance'}{' '}
+            Transaction History
+          </h3>
         </div>
 
         {loading ? (
@@ -276,7 +422,7 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
               >
                 <div className="flex-1">
                   <div className="font-medium capitalize">
-                    {tx.type.replace('_', ' ')}
+                    {tx.type.replace(/_/g, ' ')}
                   </div>
                   <div className="text-muted-foreground text-sm">
                     {tx.description}
@@ -292,11 +438,10 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
                       tx.amount > 0 ? 'text-green-600' : 'text-red-600'
                     )}
                   >
-                    {tx.amount > 0 ? '+' : ''}
-                    {tx.amount} pts
+                    {tx.amount > 0 ? '+' : ''}{Math.abs(tx.amount).toFixed(2)} pts
                   </div>
                   <div className="text-muted-foreground text-xs">
-                    Balance: {tx.balanceAfter} pts
+                    Balance: {tx.balanceAfter.toFixed(2)} pts
                   </div>
                 </div>
               </div>

--- a/packages/agents/src/services/AgentService.ts
+++ b/packages/agents/src/services/AgentService.ts
@@ -20,10 +20,10 @@ import {
   agentPointsTransactions,
   agentTrades,
   and,
+  balanceTransactions,
   db,
   desc,
   eq,
-  pointsTransactions,
   type User,
   type UserAgentConfig,
   userAgentConfigs,
@@ -120,10 +120,10 @@ export class AgentServiceV2 {
     if (!manager) throw new Error('Manager user not found');
 
     if (initialDeposit && initialDeposit > 0) {
-      const totalPoints = manager.reputationPoints;
-      if (totalPoints < initialDeposit) {
+      const managerBalance = Number(manager.virtualBalance);
+      if (managerBalance < initialDeposit) {
         throw new Error(
-          `Insufficient points. Have: ${totalPoints}, Need: ${initialDeposit}`
+          `Insufficient balance. Have: $${managerBalance.toFixed(2)}, Need: $${initialDeposit.toFixed(2)}`
         );
       }
     }
@@ -179,16 +179,18 @@ export class AgentServiceV2 {
       });
 
       if (initialDeposit && initialDeposit > 0) {
-        const initialManagerPoints = manager.reputationPoints;
+        const initialManagerBalance = Number(manager.virtualBalance);
 
+        // Debit from manager's trading balance
         await tx
           .update(users)
           .set({
-            reputationPoints: manager.reputationPoints - initialDeposit,
+            virtualBalance: String(initialManagerBalance - initialDeposit),
             updatedAt: new Date(),
           })
           .where(eq(users.id, managerUserId));
 
+        // Record agent ops deposit
         await tx.insert(agentPointsTransactions).values({
           id: await generateSnowflakeId(),
           agentUserId,
@@ -197,17 +199,19 @@ export class AgentServiceV2 {
           amount: initialDeposit,
           balanceBefore: 0,
           balanceAfter: initialDeposit,
-          description: 'Initial deposit',
+          description: 'Initial ops budget deposit',
         });
 
-        await tx.insert(pointsTransactions).values({
+        // Record balance transaction for manager
+        await tx.insert(balanceTransactions).values({
           id: await generateSnowflakeId(),
           userId: managerUserId,
-          amount: -initialDeposit,
-          pointsBefore: initialManagerPoints,
-          pointsAfter: initialManagerPoints - initialDeposit,
-          reason: `Deposit to agent: ${name}`,
-          metadata: JSON.stringify({ agentUserId, agentName: name }),
+          type: 'agent_ops_deposit',
+          amount: String(-initialDeposit),
+          balanceBefore: String(initialManagerBalance),
+          balanceAfter: String(initialManagerBalance - initialDeposit),
+          relatedId: agentUserId,
+          description: `Initial ops budget deposit to agent: ${name}`,
         });
       }
 
@@ -452,35 +456,33 @@ export class AgentServiceV2 {
     const pointsBalance = agentWithConfig.agentConfig?.pointsBalance ?? 0;
 
     await withTransaction(async (tx) => {
-      // Return remaining points to manager
+      // Return remaining ops budget to manager's trading balance
       if (pointsBalance > 0) {
         const managerResult = await tx
-          .select({ reputationPoints: users.reputationPoints })
+          .select({ virtualBalance: users.virtualBalance })
           .from(users)
           .where(eq(users.id, managerUserId))
           .limit(1);
 
-        const currentPoints = managerResult[0]?.reputationPoints || 0;
+        const currentBalance = Number(managerResult[0]?.virtualBalance ?? 0);
 
         await tx
           .update(users)
           .set({
-            reputationPoints: currentPoints + pointsBalance,
+            virtualBalance: String(currentBalance + pointsBalance),
             updatedAt: new Date(),
           })
           .where(eq(users.id, managerUserId));
 
-        await tx.insert(pointsTransactions).values({
+        await tx.insert(balanceTransactions).values({
           id: await generateSnowflakeId(),
           userId: managerUserId,
-          amount: pointsBalance,
-          pointsBefore: currentPoints,
-          pointsAfter: currentPoints + pointsBalance,
-          reason: `Agent deleted, points returned: ${agentWithConfig.displayName}`,
-          metadata: JSON.stringify({
-            agentUserId,
-            agentName: agentWithConfig.displayName,
-          }),
+          type: 'agent_ops_return',
+          amount: String(pointsBalance),
+          balanceBefore: String(currentBalance),
+          balanceAfter: String(currentBalance + pointsBalance),
+          relatedId: agentUserId,
+          description: `Ops budget returned from deleted agent: ${agentWithConfig.displayName}`,
         });
       }
 
@@ -499,6 +501,18 @@ export class AgentServiceV2 {
     logger.info(`Agent deleted: ${agentUserId}`, undefined, 'AgentService');
   }
 
+  /**
+   * Deposit ops budget points from manager's virtualBalance to agent's pointsBalance
+   *
+   * Transfers USD from user's trading balance to fund agent operations.
+   * This is used for AI operations like chat, tick, posting.
+   *
+   * @param agentUserId - Agent user ID
+   * @param managerUserId - Manager (owner) user ID
+   * @param amount - Amount to deposit
+   * @returns Updated agent User
+   * @throws Error if insufficient balance or agent not found
+   */
   async depositPoints(
     agentUserId: string,
     managerUserId: string,
@@ -514,8 +528,11 @@ export class AgentServiceV2 {
     const config = agentWithConfig.agentConfig;
     if (!config) throw new Error('Agent config not found');
 
+    // Get manager's trading balance (virtualBalance)
     const managerResult = await db
-      .select()
+      .select({
+        virtualBalance: users.virtualBalance,
+      })
       .from(users)
       .where(eq(users.id, managerUserId))
       .limit(1);
@@ -523,14 +540,15 @@ export class AgentServiceV2 {
     const manager = managerResult[0];
     if (!manager) throw new Error('Manager not found');
 
-    const totalPoints = manager.reputationPoints;
-    if (totalPoints < amount) {
+    const managerBalance = Number(manager.virtualBalance);
+    if (managerBalance < amount) {
       throw new Error(
-        `Insufficient points. Have: ${totalPoints}, Need: ${amount}`
+        `Insufficient balance. Have: $${managerBalance.toFixed(2)}, Need: $${amount.toFixed(2)}`
       );
     }
 
     await withTransaction(async (tx) => {
+      // Add to agent's ops budget (pointsBalance)
       await tx
         .update(userAgentConfigs)
         .set({
@@ -540,14 +558,16 @@ export class AgentServiceV2 {
         })
         .where(eq(userAgentConfigs.userId, agentUserId));
 
+      // Debit from manager's trading balance
       await tx
         .update(users)
         .set({
-          reputationPoints: manager.reputationPoints - amount,
+          virtualBalance: String(managerBalance - amount),
           updatedAt: new Date(),
         })
         .where(eq(users.id, managerUserId));
 
+      // Record agent points transaction
       await tx.insert(agentPointsTransactions).values({
         id: await generateSnowflakeId(),
         agentUserId,
@@ -556,25 +576,24 @@ export class AgentServiceV2 {
         amount,
         balanceBefore: config.pointsBalance,
         balanceAfter: config.pointsBalance + amount,
-        description: 'Points deposit',
+        description: 'Ops budget deposit from trading balance',
       });
 
-      await tx.insert(pointsTransactions).values({
+      // Record balance transaction for manager
+      await tx.insert(balanceTransactions).values({
         id: await generateSnowflakeId(),
         userId: managerUserId,
-        amount: -amount,
-        pointsBefore: totalPoints,
-        pointsAfter: totalPoints - amount,
-        reason: `Deposit to agent: ${agentWithConfig.displayName}`,
-        metadata: JSON.stringify({
-          agentUserId,
-          agentName: agentWithConfig.displayName,
-        }),
+        type: 'agent_ops_deposit',
+        amount: String(-amount),
+        balanceBefore: String(managerBalance),
+        balanceAfter: String(managerBalance - amount),
+        relatedId: agentUserId,
+        description: `Ops budget deposit to agent: ${agentWithConfig.displayName}`,
       });
     });
 
     logger.info(
-      `Deposited ${amount} points to agent ${agentUserId}`,
+      `Deposited $${amount} ops budget to agent ${agentUserId}`,
       undefined,
       'AgentService'
     );
@@ -587,6 +606,17 @@ export class AgentServiceV2 {
     return result[0]!;
   }
 
+  /**
+   * Withdraw ops budget points from agent's pointsBalance to manager's virtualBalance
+   *
+   * Transfers USD from agent's ops budget back to user's trading balance.
+   *
+   * @param agentUserId - Agent user ID
+   * @param managerUserId - Manager (owner) user ID
+   * @param amount - Amount to withdraw
+   * @returns Updated agent User
+   * @throws Error if insufficient balance or agent not found
+   */
   async withdrawPoints(
     agentUserId: string,
     managerUserId: string,
@@ -604,11 +634,12 @@ export class AgentServiceV2 {
 
     if (config.pointsBalance < amount) {
       throw new Error(
-        `Insufficient balance. Have: ${config.pointsBalance}, Need: ${amount}`
+        `Insufficient ops budget. Have: $${config.pointsBalance.toFixed(2)}, Need: $${amount.toFixed(2)}`
       );
     }
 
     await withTransaction(async (tx) => {
+      // Debit from agent's ops budget
       await tx
         .update(userAgentConfigs)
         .set({
@@ -618,22 +649,25 @@ export class AgentServiceV2 {
         })
         .where(eq(userAgentConfigs.userId, agentUserId));
 
+      // Get manager's current trading balance
       const managerResult = await tx
-        .select({ reputationPoints: users.reputationPoints })
+        .select({ virtualBalance: users.virtualBalance })
         .from(users)
         .where(eq(users.id, managerUserId))
         .limit(1);
 
-      const managerPoints = managerResult[0]?.reputationPoints || 0;
+      const managerBalance = Number(managerResult[0]?.virtualBalance ?? 0);
 
+      // Credit to manager's trading balance
       await tx
         .update(users)
         .set({
-          reputationPoints: managerPoints + amount,
+          virtualBalance: String(managerBalance + amount),
           updatedAt: new Date(),
         })
         .where(eq(users.id, managerUserId));
 
+      // Record agent points transaction
       await tx.insert(agentPointsTransactions).values({
         id: await generateSnowflakeId(),
         agentUserId,
@@ -642,20 +676,19 @@ export class AgentServiceV2 {
         amount: -amount,
         balanceBefore: config.pointsBalance,
         balanceAfter: config.pointsBalance - amount,
-        description: 'Points withdrawal',
+        description: 'Ops budget withdrawal to trading balance',
       });
 
-      await tx.insert(pointsTransactions).values({
+      // Record balance transaction for manager
+      await tx.insert(balanceTransactions).values({
         id: await generateSnowflakeId(),
         userId: managerUserId,
-        amount,
-        pointsBefore: managerPoints,
-        pointsAfter: managerPoints + amount,
-        reason: `Withdrawal from agent: ${agentWithConfig.displayName}`,
-        metadata: JSON.stringify({
-          agentUserId,
-          agentName: agentWithConfig.displayName,
-        }),
+        type: 'agent_ops_withdraw',
+        amount: String(amount),
+        balanceBefore: String(managerBalance),
+        balanceAfter: String(managerBalance + amount),
+        relatedId: agentUserId,
+        description: `Ops budget withdrawal from agent: ${agentWithConfig.displayName}`,
       });
     });
 
@@ -671,6 +704,228 @@ export class AgentServiceV2 {
       .where(eq(users.id, agentUserId))
       .limit(1);
     return result[0]!;
+  }
+
+  /**
+   * Deposit trading balance (virtualBalance) from manager to agent
+   *
+   * Transfers USD from user's trading balance to agent's trading balance.
+   * This is the capital agents use for actual trades on markets.
+   *
+   * @param agentUserId - Agent user ID
+   * @param managerUserId - Manager (owner) user ID
+   * @param amount - Amount to deposit
+   * @returns Updated agent User
+   * @throws Error if insufficient balance or agent not found
+   */
+  async depositTradingBalance(
+    agentUserId: string,
+    managerUserId: string,
+    amount: number
+  ): Promise<User> {
+    if (amount <= 0) throw new Error('Amount must be positive');
+
+    const agentWithConfig = await this.getAgentWithConfig(
+      agentUserId,
+      managerUserId
+    );
+    if (!agentWithConfig) throw new Error('Agent not found');
+
+    // Get manager's trading balance
+    const managerResult = await db
+      .select({
+        virtualBalance: users.virtualBalance,
+      })
+      .from(users)
+      .where(eq(users.id, managerUserId))
+      .limit(1);
+
+    const manager = managerResult[0];
+    if (!manager) throw new Error('Manager not found');
+
+    const managerBalance = Number(manager.virtualBalance);
+    if (managerBalance < amount) {
+      throw new Error(
+        `Insufficient trading balance. Have: $${managerBalance.toFixed(2)}, Need: $${amount.toFixed(2)}`
+      );
+    }
+
+    // Get agent's current balance
+    const agentResult = await db
+      .select({
+        virtualBalance: users.virtualBalance,
+      })
+      .from(users)
+      .where(eq(users.id, agentUserId))
+      .limit(1);
+
+    const agentBalance = Number(agentResult[0]?.virtualBalance ?? 0);
+
+    await withTransaction(async (tx) => {
+      // Debit from manager
+      await tx
+        .update(users)
+        .set({
+          virtualBalance: String(managerBalance - amount),
+          updatedAt: new Date(),
+        })
+        .where(eq(users.id, managerUserId));
+
+      // Credit to agent
+      await tx
+        .update(users)
+        .set({
+          virtualBalance: String(agentBalance + amount),
+          updatedAt: new Date(),
+        })
+        .where(eq(users.id, agentUserId));
+
+      // Record transaction for manager (debit)
+      await tx.insert(balanceTransactions).values({
+        id: await generateSnowflakeId(),
+        userId: managerUserId,
+        type: 'agent_deposit',
+        amount: String(-amount),
+        balanceBefore: String(managerBalance),
+        balanceAfter: String(managerBalance - amount),
+        relatedId: agentUserId,
+        description: `Deposit to agent: ${agentWithConfig.displayName}`,
+      });
+
+      // Record transaction for agent (credit)
+      await tx.insert(balanceTransactions).values({
+        id: await generateSnowflakeId(),
+        userId: agentUserId,
+        type: 'owner_deposit',
+        amount: String(amount),
+        balanceBefore: String(agentBalance),
+        balanceAfter: String(agentBalance + amount),
+        relatedId: managerUserId,
+        description: `Deposit from owner`,
+      });
+    });
+
+    logger.info(
+      `Deposited $${amount} trading balance to agent ${agentUserId}`,
+      undefined,
+      'AgentService'
+    );
+
+    const finalResult = await db
+      .select()
+      .from(users)
+      .where(eq(users.id, agentUserId))
+      .limit(1);
+    return finalResult[0]!;
+  }
+
+  /**
+   * Withdraw trading balance (virtualBalance) from agent to manager
+   *
+   * Transfers USD from agent's trading balance back to user's trading balance.
+   *
+   * @param agentUserId - Agent user ID
+   * @param managerUserId - Manager (owner) user ID
+   * @param amount - Amount to withdraw
+   * @returns Updated agent User
+   * @throws Error if insufficient balance or agent not found
+   */
+  async withdrawTradingBalance(
+    agentUserId: string,
+    managerUserId: string,
+    amount: number
+  ): Promise<User> {
+    if (amount <= 0) throw new Error('Amount must be positive');
+
+    const agentWithConfig = await this.getAgentWithConfig(
+      agentUserId,
+      managerUserId
+    );
+    if (!agentWithConfig) throw new Error('Agent not found');
+
+    // Get agent's trading balance
+    const agentResult = await db
+      .select({
+        virtualBalance: users.virtualBalance,
+      })
+      .from(users)
+      .where(eq(users.id, agentUserId))
+      .limit(1);
+
+    const agentBalance = Number(agentResult[0]?.virtualBalance ?? 0);
+    if (agentBalance < amount) {
+      throw new Error(
+        `Insufficient agent trading balance. Have: $${agentBalance.toFixed(2)}, Need: $${amount.toFixed(2)}`
+      );
+    }
+
+    // Get manager's current balance
+    const managerResult = await db
+      .select({
+        virtualBalance: users.virtualBalance,
+      })
+      .from(users)
+      .where(eq(users.id, managerUserId))
+      .limit(1);
+
+    const managerBalance = Number(managerResult[0]?.virtualBalance ?? 0);
+
+    await withTransaction(async (tx) => {
+      // Debit from agent
+      await tx
+        .update(users)
+        .set({
+          virtualBalance: String(agentBalance - amount),
+          updatedAt: new Date(),
+        })
+        .where(eq(users.id, agentUserId));
+
+      // Credit to manager
+      await tx
+        .update(users)
+        .set({
+          virtualBalance: String(managerBalance + amount),
+          updatedAt: new Date(),
+        })
+        .where(eq(users.id, managerUserId));
+
+      // Record transaction for agent (debit)
+      await tx.insert(balanceTransactions).values({
+        id: await generateSnowflakeId(),
+        userId: agentUserId,
+        type: 'owner_withdraw',
+        amount: String(-amount),
+        balanceBefore: String(agentBalance),
+        balanceAfter: String(agentBalance - amount),
+        relatedId: managerUserId,
+        description: `Withdrawal to owner`,
+      });
+
+      // Record transaction for manager (credit)
+      await tx.insert(balanceTransactions).values({
+        id: await generateSnowflakeId(),
+        userId: managerUserId,
+        type: 'agent_withdraw',
+        amount: String(amount),
+        balanceBefore: String(managerBalance),
+        balanceAfter: String(managerBalance + amount),
+        relatedId: agentUserId,
+        description: `Withdrawal from agent: ${agentWithConfig.displayName}`,
+      });
+    });
+
+    logger.info(
+      `Withdrew $${amount} trading balance from agent ${agentUserId}`,
+      undefined,
+      'AgentService'
+    );
+
+    const finalResult = await db
+      .select()
+      .from(users)
+      .where(eq(users.id, agentUserId))
+      .limit(1);
+    return finalResult[0]!;
   }
 
   async deductPoints(


### PR DESCRIPTION
## Result



https://github.com/user-attachments/assets/ecc04a16-16f6-444c-b1bc-1fb282adbe37




## Summary

Add separate tabs for Ops Budget and Trading Balance in AgentWallet, allowing users to manage both agent operational points and trading funds from their `virtualBalance`.

---

## Background: The Three Currency Problem

Previously, the system had **3 different currency types** which caused confusion:

| Currency | Table | Purpose |
|----------|-------|---------|
| `reputationPoints` | `User` | Gamification points (earned through activity) |
| `virtualBalance` | `User` | Trading balance for perps/predictions |
| `pointsBalance` | `UserAgentConfig` | Agent operational budget (chat, autonomous actions) |

### Table Design

**Why separate `User` and `UserAgentConfig` tables?**

- **`User` table**: Contains universal user data applicable to all users
- **`UserAgentConfig` table**: Contains agent-specific configuration and operational data

This separation was intentional because:
1. Most users are NOT agents - storing agent config in User table would waste space
2. Agent-specific fields (personality, trading strategy, model tier, etc.) are only relevant to agent users
3. Clean separation of concerns between user identity and agent behavior

**Why separate `virtualBalance` and `pointsBalance`?**

- `virtualBalance` (User): Funds used for actual market trades (perps, predictions)
- `pointsBalance` (UserAgentConfig): Budget consumed by AI operations (each chat message, each autonomous tick costs points)

These serve fundamentally different purposes - one is for trading, one is for AI compute costs.

---

## Issues Fixed

### 1. Misuse of Reputation Points

Previously, the agent deposit/withdraw operations were incorrectly using `reputationPoints`:

Reputation points are gamification rewards, NOT a funding source for agent operations.

### 2. No Way to Manage Agent Trading Balance

There was no UI or API to:
- Deposit funds to an agent's trading balance (`virtualBalance`)
- Withdraw funds from an agent's trading balance
- View the agent's trading balance separately from ops budget

---

## Solution

### Unified Funding Source

Both agent **ops budget** and **trading balance** are now funded from the user's `virtualBalance`:

```
User's virtualBalance
    ├── Deposit to Agent's pointsBalance (Ops Budget)
    ├── Withdraw from Agent's pointsBalance (Ops Budget)
    ├── Deposit to Agent's virtualBalance (Trading Balance)
    └── Withdraw from Agent's virtualBalance (Trading Balance)
```

### New UI with Tabs

The AgentWallet component now has two tabs:

1. **Ops Budget** (first tab)
   - Shows agent's `pointsBalance`
   - Tracks total deposited, withdrawn, spent
   - Used for AI operations (chat, autonomous actions)

2. **Trading Balance** (second tab)
   - Shows agent's `virtualBalance`
   - Tracks lifetime P&L
   - Used for prediction market and perp trades

### New API Endpoint

Added `/api/agents/[agentId]/trading-balance` for managing agent trading funds.

### Updated AgentService

New methods:
- `depositTradingBalance(agentUserId, managerUserId, amount)`
- `withdrawTradingBalance(agentUserId, managerUserId, amount)`

Updated methods to use `virtualBalance` instead of `reputationPoints`:
- `depositPoints()`
- `withdrawPoints()`

---

## Future: Reputation Points Conversion

Reputation points (`reputationPoints`) are currently left untouched. In the future, we can implement a conversion feature:

- Allow users to convert `reputationPoints` → `virtualBalance`
- Conversion ratio does NOT need to be 1:1 (can be configurable)
- This gives reputation points actual utility while maintaining their gamification purpose

---

