### PR TITLE
fix: prevent NPC/agent negative balance via atomic debit operations

### DIFF
--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -16,6 +16,7 @@ import {
   comments,
   db,
   eq,
+  gte,
   isNull,
   markets,
   messages,
@@ -220,14 +221,26 @@ async function executePredictionTrade(params: {
       TRADING_FEE_RATE
     );
 
-    // Debit amount from balance
+    // Debit amount from balance (atomic check to prevent negative balance)
     if (isNpc) {
-      await txDb
+      const debitResult = await txDb
         .update(actorState)
         .set({
           tradingBalance: sql`${actorState.tradingBalance} - ${amount}`,
+          updatedAt: new Date(),
         })
-        .where(eq(actorState.id, agentUserId));
+        .where(
+          and(
+            eq(actorState.id, agentUserId),
+            gte(actorState.tradingBalance, String(amount))
+          )
+        )
+        .returning({ id: actorState.id });
+
+      // Check if debit succeeded (empty array means insufficient funds or actor not found)
+      if (debitResult.length === 0) {
+        throw new Error(`Insufficient NPC balance for trade: $${amount}`);
+      }
     } else {
       const sharesRounded = Math.round(calculation.sharesBought * 100) / 100;
       await WalletService.debit(
@@ -366,12 +379,24 @@ async function executePerpTrade(params: {
             description?: string;
             relatedId?: string;
           }) => {
-            await db
+            // Atomic debit with balance check to prevent negative balance
+            const result = await db
               .update(actorState)
               .set({
                 tradingBalance: sql`${actorState.tradingBalance} - ${amt}`,
+                updatedAt: new Date(),
               })
-              .where(eq(actorState.id, uid));
+              .where(
+                and(
+                  eq(actorState.id, uid),
+                  gte(actorState.tradingBalance, String(amt))
+                )
+              )
+              .returning({ id: actorState.id });
+
+            if (result.length === 0) {
+              throw new Error(`Insufficient NPC balance for perp trade: $${amt}`);
+            }
           },
           credit: async ({
             userId: uid,
@@ -387,6 +412,7 @@ async function executePerpTrade(params: {
               .update(actorState)
               .set({
                 tradingBalance: sql`${actorState.tradingBalance} + ${amt}`,
+                updatedAt: new Date(),
               })
               .where(eq(actorState.id, uid));
           },

--- a/packages/db/src/schema/actor-state.ts
+++ b/packages/db/src/schema/actor-state.ts
@@ -1,5 +1,7 @@
+import { sql } from 'drizzle-orm';
 import {
   boolean,
+  check,
   decimal,
   index,
   integer,
@@ -29,6 +31,8 @@ export const actorState = pgTable(
   (table) => [
     index('ActorState_hasPool_idx').on(table.hasPool),
     index('ActorState_reputationPoints_idx').on(table.reputationPoints),
+    // Prevent negative trading balance at database level
+    check('positive_trading_balance', sql`${table.tradingBalance} >= 0`),
   ]
 );
 

--- a/packages/engine/src/services/initial-investment-service.ts
+++ b/packages/engine/src/services/initial-investment-service.ts
@@ -7,7 +7,7 @@
  * Uses LLM to determine appropriate investments based on NPC characteristics.
  */
 
-import { actorState, db, eq, getDbInstance, sql } from '@babylon/db';
+import { actorState, and, db, eq, getDbInstance, gte, sql } from '@babylon/db';
 import {
   BabylonLLMClient,
   loadActorById,
@@ -566,13 +566,26 @@ Generate investments for ALL ${npcs.length} NPCs. Each NPC must have 2-5 investm
       },
     });
 
-    // Deduct from NPC trading balance using raw SQL decrement
-    await db
+    // Deduct from NPC trading balance (atomic check to prevent negative balance)
+    const debitResult = await db
       .update(actorState)
       .set({
         tradingBalance: sql`${actorState.tradingBalance} - ${investment.amount}`,
+        updatedAt: new Date(),
       })
-      .where(eq(actorState.id, investment.npcId));
+      .where(
+        and(
+          eq(actorState.id, investment.npcId),
+          gte(actorState.tradingBalance, String(investment.amount))
+        )
+      )
+      .returning({ id: actorState.id });
+
+    if (debitResult.length === 0) {
+      throw new Error(
+        `Insufficient NPC balance for initial investment: ${investment.npcName} → ${investment.ticker} $${investment.amount}`
+      );
+    }
 
     // Record the trade
     await db.npcTrade.create({

--- a/packages/engine/src/services/npc-wallet-adapter.ts
+++ b/packages/engine/src/services/npc-wallet-adapter.ts
@@ -4,15 +4,29 @@
  * Wraps actorState table operations to implement WalletPort interface.
  * This allows NPC trades to use the core PerpMarketService while
  * managing balances in the actorState table.
+ *
+ * Uses atomic SQL operations to prevent race conditions that could
+ * lead to negative balances.
  */
 import type { WalletPort } from '@babylon/core/markets/shared';
-import { actorState, db as defaultDb, eq, type Transaction } from '@babylon/db';
+import {
+  actorState,
+  and,
+  db as defaultDb,
+  eq,
+  gte,
+  sql,
+  type Transaction,
+} from '@babylon/db';
 
 type DbClient = typeof defaultDb | Transaction;
 
 /**
  * Creates a WalletPort implementation for NPC actors.
  * Uses actorState.tradingBalance instead of user wallets.
+ *
+ * All debit operations are atomic - the balance check and update happen
+ * in a single SQL statement to prevent race conditions.
  */
 export function createNpcWalletAdapter(
   actorId: string,
@@ -22,67 +36,62 @@ export function createNpcWalletAdapter(
 
   return {
     async debit({ amount, reason }: { amount: number; reason: string }) {
-      const [actor] = await db
-        .select({ tradingBalance: actorState.tradingBalance })
-        .from(actorState)
-        .where(eq(actorState.id, actorId))
-        .limit(1);
+      // Atomic debit: check balance AND update in single statement
+      // This prevents race conditions where concurrent debits could
+      // both pass the balance check and cause negative balance
+      const result = await db
+        .update(actorState)
+        .set({
+          tradingBalance: sql`${actorState.tradingBalance} - ${amount}`,
+          updatedAt: new Date(),
+        })
+        .where(
+          and(
+            eq(actorState.id, actorId),
+            gte(actorState.tradingBalance, String(amount))
+          )
+        )
+        .returning({ id: actorState.id });
 
-      if (!actor) {
-        throw new Error(`Actor not found: ${actorId}`);
-      }
+      // If no rows updated, either actor doesn't exist or insufficient balance
+      if (result.length === 0) {
+        // Check if actor exists to provide better error message
+        const [actor] = await db
+          .select({ tradingBalance: actorState.tradingBalance })
+          .from(actorState)
+          .where(eq(actorState.id, actorId))
+          .limit(1);
 
-      const currentBalance = Number(actor.tradingBalance);
-      if (currentBalance < amount) {
+        if (!actor) {
+          throw new Error(`Actor not found: ${actorId}`);
+        }
+
+        const currentBalance = Number(actor.tradingBalance);
         throw new Error(
           `Insufficient trading balance: ${currentBalance.toFixed(2)} < ${amount.toFixed(2)} (${reason})`
         );
       }
-
-      await db
-        .update(actorState)
-        .set({
-          tradingBalance: String(currentBalance - amount),
-          updatedAt: new Date(),
-        })
-        .where(eq(actorState.id, actorId));
     },
 
     async credit({ amount }: { amount: number }) {
-      const [actor] = await db
-        .select({ tradingBalance: actorState.tradingBalance })
-        .from(actorState)
-        .where(eq(actorState.id, actorId))
-        .limit(1);
-
-      if (!actor) {
-        throw new Error(`Actor not found: ${actorId}`);
-      }
-
-      const currentBalance = Number(actor.tradingBalance);
-
-      await db
+      // Atomic credit using SQL increment
+      const result = await db
         .update(actorState)
         .set({
-          tradingBalance: String(currentBalance + amount),
+          tradingBalance: sql`${actorState.tradingBalance} + ${amount}`,
           updatedAt: new Date(),
         })
-        .where(eq(actorState.id, actorId));
+        .where(eq(actorState.id, actorId))
+        .returning({ id: actorState.id });
+
+      if (result.length === 0) {
+        throw new Error(`Actor not found: ${actorId}`);
+      }
     },
 
     async recordPnL({ pnl, reason }: { pnl: number; reason: string }) {
       // For NPCs, we just update the trading balance directly
       // No separate PnL tracking like user wallets
-      const [actor] = await db
-        .select({ tradingBalance: actorState.tradingBalance })
-        .from(actorState)
-        .where(eq(actorState.id, actorId))
-        .limit(1);
-
-      if (!actor) {
-        throw new Error(`Actor not found: ${actorId}`);
-      }
-
       // Log PnL for debugging but don't modify balance here
       // (credit/debit already handles the balance changes)
       if (process.env.NODE_ENV === 'development') {

--- a/packages/engine/src/services/trade-execution-service.ts
+++ b/packages/engine/src/services/trade-execution-service.ts
@@ -15,12 +15,15 @@ import {
 import type { WalletPort } from '@babylon/core/markets/shared';
 import {
   actorState,
+  and,
   db,
   eq,
+  gte,
   npcTrades,
   organizationState,
   perpPositions,
   poolPositions,
+  sql,
   type Transaction,
 } from '@babylon/db';
 import { generateSnowflakeId, logger } from '@babylon/shared';
@@ -869,22 +872,30 @@ export class TradeExecutionService {
     return {
       getBalance: async () => ({ balance: await getBalance() }),
       debit: async ({ amount }: { amount: number }) => {
-        const balance = await getBalance();
-        if (balance < amount) throw new Error('Insufficient funds');
-        await db
+        // Atomic debit with balance check to prevent negative balance
+        const result = await db
           .update(actorState)
           .set({
-            tradingBalance: String(balance - amount),
+            tradingBalance: sql`${actorState.tradingBalance} - ${amount}`,
             updatedAt: new Date(),
           })
-          .where(eq(actorState.id, actorId));
+          .where(
+            and(
+              eq(actorState.id, actorId),
+              gte(actorState.tradingBalance, String(amount))
+            )
+          )
+          .returning({ id: actorState.id });
+
+        if (result.length === 0) {
+          throw new Error(`Insufficient NPC funds: actor ${actorId}, amount $${amount}`);
+        }
       },
       credit: async ({ amount }: { amount: number }) => {
-        const balance = await getBalance();
         await db
           .update(actorState)
           .set({
-            tradingBalance: String(balance + amount),
+            tradingBalance: sql`${actorState.tradingBalance} + ${amount}`,
             updatedAt: new Date(),
           })
           .where(eq(actorState.id, actorId));


### PR DESCRIPTION
## Summary

- Fix race conditions in NPC wallet operations that could cause negative balances when concurrent trades passed the balance check before either completed the debit
- Make all NPC debit operations atomic using `gte()` in WHERE clause
- Add database CHECK constraint on `ActorState.tradingBalance >= 0` as a safety net
- Use `.returning()` to detect if update affected any rows (no rows = insufficient funds)

## Files Changed

- `packages/db/src/schema/actor-state.ts` - Add CHECK constraint
- `packages/agents/src/autonomous/DirectExecutors.ts` - Fix prediction and perp trade debits
- `packages/engine/src/services/npc-wallet-adapter.ts` - Fix NPC wallet adapter
- `packages/engine/src/services/trade-execution-service.ts` - Fix buildActorWallet
- `packages/engine/src/services/initial-investment-service.ts` - Fix initial investment debit

## Root Cause

All implementations followed a flawed check-then-debit pattern:
1. Read balance
2. Check if sufficient (in application code)
3. Update balance (separate statement)

Between steps 2 and 3, concurrent operations could cause the balance to go negative.

## Solution

The atomic pattern ensures balance check and debit happen in a single SQL statement:
```typescript
.where(
  and(
    eq(actorState.id, actorId),
    gte(actorState.tradingBalance, String(amount))
  )
)
.returning({ id: actorState.id })
```

If no rows are returned, the balance was insufficient.

## Test Plan

- [ ] Run `bun run typecheck` - passes
- [ ] Run `bun run lint` - passes
- [ ] Verify NPC trades fail gracefully when insufficient balance
- [ ] Run Drizzle migration to apply CHECK constraint