### PR TITLE
refactor: dedupe agent context resolution across autonomous services

### DIFF
--- a/packages/agents/src/autonomous/AutonomousA2AService.ts
+++ b/packages/agents/src/autonomous/AutonomousA2AService.ts
@@ -10,9 +10,9 @@
 import { db, eq, users } from '@babylon/db';
 import type { IAgentRuntime } from '@elizaos/core';
 import type { BabylonRuntime } from '../plugins/babylon/types';
+import { agentPnLService } from '../services/AgentPnLService';
 import { getAgentConfig } from '../shared/agent-config';
 import { logger } from '../shared/logger';
-import { generateSnowflakeId } from '../shared/snowflake';
 
 /**
  * Type guard to check if runtime has A2A client
@@ -356,18 +356,17 @@ Your JSON response:`;
         reasoning,
       });
 
-      await db.agentTrade.create({
-        data: {
-          id: await generateSnowflakeId(),
-          agentUserId,
-          marketType: 'perp',
-          ticker,
-          action: 'open',
-          side: side.toLowerCase() as 'long' | 'short',
-          amount: size,
-          price: tradeResult.entryPrice || 0,
-          reasoning: `LLM decision (${perpLeverage}x leverage): ${reasoning}`,
-        },
+      // Record trade via shared service (DRY - same as DirectExecutors)
+      await agentPnLService.recordTrade({
+        agentId: agentUserId,
+        userId: agentUserId, // A2A trades are self-managed
+        marketType: 'perp',
+        ticker,
+        action: 'open',
+        side: side.toLowerCase() as 'long' | 'short',
+        amount: size,
+        price: tradeResult.entryPrice || 0,
+        reasoning: `LLM decision (${perpLeverage}x leverage): ${reasoning}`,
       });
 
       return {
@@ -419,18 +418,17 @@ Your JSON response:`;
       reasoning,
     });
 
-    await db.agentTrade.create({
-      data: {
-        id: await generateSnowflakeId(),
-        agentUserId,
-        marketType: 'prediction',
-        marketId,
-        action: 'open',
-        side: outcome.toLowerCase() as 'yes' | 'no',
-        amount,
-        price: tradeResult.avgPrice || 0,
-        reasoning: `LLM decision: ${reasoning}`,
-      },
+    // Record trade via shared service (DRY - same as DirectExecutors)
+    await agentPnLService.recordTrade({
+      agentId: agentUserId,
+      userId: agentUserId, // A2A trades are self-managed
+      marketType: 'prediction',
+      marketId,
+      action: 'open',
+      side: outcome.toLowerCase() as 'yes' | 'no',
+      amount,
+      price: tradeResult.avgPrice || 0,
+      reasoning: `LLM decision: ${reasoning}`,
     });
 
     return {

--- a/packages/agents/src/autonomous/AutonomousBatchResponseService.ts
+++ b/packages/agents/src/autonomous/AutonomousBatchResponseService.ts
@@ -27,14 +27,13 @@ import {
   messages,
   ne,
   posts,
-  users,
 } from '@babylon/db';
-import { StaticDataRegistry } from '@babylon/engine';
 import type { IAgentRuntime } from '@elizaos/core';
 import { parseKeyValueXml } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
 import { getAgentConfig } from '../shared/agent-config';
 import { logger } from '../shared/logger';
+import { getAgentContext } from './agent-context';
 import { executeDirectComment, executeDirectMessage } from './DirectExecutors';
 
 // =============================================================================
@@ -625,29 +624,9 @@ ${chatLines.join('\n\n')}`);
       );
     }
 
-    // Check if this is an NPC (has entry in StaticDataRegistry)
-    const npcActor = StaticDataRegistry.getActor(agentUserId);
-    const isNpc = !!npcActor;
-
-    let agentDisplayName: string;
-
-    if (isNpc) {
-      agentDisplayName = npcActor.name;
-    } else {
-      const [agent] = await db
-        .select({
-          displayName: users.displayName,
-        })
-        .from(users)
-        .where(eq(users.id, agentUserId))
-        .limit(1);
-
-      if (!agent) {
-        throw new Error('Agent not found');
-      }
-
-      agentDisplayName = agent.displayName ?? agentUserId;
-    }
+    // Resolve agent context (NPC vs USER_CONTROLLED)
+    const { displayName: agentDisplayName } =
+      await getAgentContext(agentUserId);
 
     const config = await getAgentConfig(agentUserId);
 
@@ -862,29 +841,9 @@ Do NOT include any explanations, only the XML format above.`;
     interactions: PendingInteraction[],
     decisions: ResponseDecision[]
   ): Promise<number> {
-    // Check if this is an NPC (has entry in StaticDataRegistry)
-    const npcActor = StaticDataRegistry.getActor(agentUserId);
-    const isNpc = !!npcActor;
-
-    let agentDisplayName: string;
-
-    if (isNpc) {
-      agentDisplayName = npcActor.name;
-    } else {
-      const [agent] = await db
-        .select({
-          displayName: users.displayName,
-        })
-        .from(users)
-        .where(eq(users.id, agentUserId))
-        .limit(1);
-
-      if (!agent) {
-        throw new Error('Agent not found');
-      }
-
-      agentDisplayName = agent.displayName ?? agentUserId;
-    }
+    // Resolve agent context (NPC vs USER_CONTROLLED)
+    const { displayName: agentDisplayName } =
+      await getAgentContext(agentUserId);
 
     const respConfig = await getAgentConfig(agentUserId);
 

--- a/packages/agents/src/autonomous/AutonomousCommentingService.ts
+++ b/packages/agents/src/autonomous/AutonomousCommentingService.ts
@@ -32,6 +32,7 @@ import { parseKeyValueXml } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
 import { getAgentConfig } from '../shared/agent-config';
 import { logger } from '../shared/logger';
+import { getAgentContext } from './agent-context';
 import { executeDirectComment } from './DirectExecutors';
 
 // Max characters for comment content in prompts
@@ -72,29 +73,9 @@ export class AutonomousCommentingService {
     agentUserId: string,
     _runtime: IAgentRuntime
   ): Promise<string | null> {
-    // Check if this is an NPC (has entry in StaticDataRegistry)
-    const npcActor = StaticDataRegistry.getActor(agentUserId);
-    const isNpc = !!npcActor;
-
-    let agentDisplayName: string;
-
-    if (isNpc) {
-      // NPC: Get name from StaticDataRegistry
-      agentDisplayName = npcActor.name;
-    } else {
-      // USER_CONTROLLED: Get from User table
-      const [agent] = await db
-        .select()
-        .from(users)
-        .where(eq(users.id, agentUserId))
-        .limit(1);
-
-      if (!agent?.isAgent) {
-        throw new Error('Agent not found');
-      }
-
-      agentDisplayName = agent.displayName ?? agentUserId;
-    }
+    // Resolve agent context (NPC vs USER_CONTROLLED)
+    const { displayName: agentDisplayName } =
+      await getAgentContext(agentUserId);
 
     const now = new Date();
     const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);

--- a/packages/agents/src/autonomous/AutonomousDMService.ts
+++ b/packages/agents/src/autonomous/AutonomousDMService.ts
@@ -4,12 +4,12 @@
  * Handles agents responding to direct messages autonomously
  */
 
-import { and, db, desc, eq, gte, messages, ne, users } from '@babylon/db';
-import { StaticDataRegistry } from '@babylon/engine';
+import { and, db, desc, eq, gte, messages, ne } from '@babylon/db';
 import type { IAgentRuntime } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
 import { getAgentConfig } from '../shared/agent-config';
 import { logger } from '../shared/logger';
+import { getAgentContext } from './agent-context';
 import { executeDirectMessage } from './DirectExecutors';
 
 /**
@@ -28,29 +28,9 @@ export class AutonomousDMService {
     agentUserId: string,
     _runtime: IAgentRuntime
   ): Promise<number> {
-    // Check if this is an NPC (has entry in StaticDataRegistry)
-    const npcActor = StaticDataRegistry.getActor(agentUserId);
-    const isNpc = !!npcActor;
-
-    let agentDisplayName: string;
-
-    if (isNpc) {
-      // NPC: Get name from StaticDataRegistry
-      agentDisplayName = npcActor.name;
-    } else {
-      // USER_CONTROLLED: Get from User table
-      const [agent] = await db
-        .select()
-        .from(users)
-        .where(eq(users.id, agentUserId))
-        .limit(1);
-
-      if (!agent?.isAgent) {
-        throw new Error('Agent not found');
-      }
-
-      agentDisplayName = agent.displayName ?? agentUserId;
-    }
+    // Resolve agent context (NPC vs USER_CONTROLLED)
+    const { displayName: agentDisplayName } =
+      await getAgentContext(agentUserId);
 
     const config = await getAgentConfig(agentUserId);
 

--- a/packages/agents/src/autonomous/AutonomousGroupChatService.ts
+++ b/packages/agents/src/autonomous/AutonomousGroupChatService.ts
@@ -6,12 +6,12 @@
  * @packageDocumentation
  */
 
-import { and, db, desc, eq, gte, messages, users } from '@babylon/db';
-import { StaticDataRegistry } from '@babylon/engine';
+import { and, db, desc, eq, gte, messages } from '@babylon/db';
 import type { IAgentRuntime } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
 import { getAgentConfig } from '../shared/agent-config';
 import { logger } from '../shared/logger';
+import { getAgentContext } from './agent-context';
 import { executeDirectMessage } from './DirectExecutors';
 
 /**
@@ -30,29 +30,9 @@ export class AutonomousGroupChatService {
     agentUserId: string,
     _runtime: IAgentRuntime
   ): Promise<number> {
-    // Check if this is an NPC (has entry in StaticDataRegistry)
-    const npcActor = StaticDataRegistry.getActor(agentUserId);
-    const isNpc = !!npcActor;
-
-    let agentDisplayName: string;
-
-    if (isNpc) {
-      // NPC: Get name from StaticDataRegistry
-      agentDisplayName = npcActor.name;
-    } else {
-      // USER_CONTROLLED: Get from User table
-      const [agent] = await db
-        .select()
-        .from(users)
-        .where(eq(users.id, agentUserId))
-        .limit(1);
-
-      if (!agent?.isAgent) {
-        throw new Error('Agent not found');
-      }
-
-      agentDisplayName = agent.displayName ?? agentUserId;
-    }
+    // Resolve agent context (NPC vs USER_CONTROLLED)
+    const { displayName: agentDisplayName } =
+      await getAgentContext(agentUserId);
 
     const config = await getAgentConfig(agentUserId);
 

--- a/packages/agents/src/autonomous/AutonomousPostingService.ts
+++ b/packages/agents/src/autonomous/AutonomousPostingService.ts
@@ -5,19 +5,19 @@
  */
 
 import { countTokensSync, truncateToTokenLimitSync } from '@babylon/api';
-import { agentTrades, db, desc, eq, posts, users } from '@babylon/db';
+import { agentTrades, db, desc, eq, posts } from '@babylon/db';
 import {
   characterMappingService,
   formatRandomContext,
   generateRandomMarketContext,
   generateWorldContext,
-  StaticDataRegistry,
 } from '@babylon/engine';
 import type { IAgentRuntime } from '@elizaos/core';
 import { parseKeyValueXml } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
 import { getAgentConfig } from '../shared/agent-config';
 import { logger } from '../shared/logger';
+import { getAgentContext } from './agent-context';
 import { executeDirectPost } from './DirectExecutors';
 
 /**
@@ -46,33 +46,9 @@ export class AutonomousPostingService {
     agentUserId: string,
     _runtime: IAgentRuntime
   ): Promise<string | null> {
-    // Check if this is an NPC (has entry in StaticDataRegistry)
-    const npcActor = StaticDataRegistry.getActor(agentUserId);
-    const isNpc = !!npcActor;
-
-    let agentDisplayName: string;
-    let agentLifetimePnL: number;
-
-    if (isNpc) {
-      // NPC: Get data from StaticDataRegistry and ActorState
-      agentDisplayName = npcActor.name;
-      // NPCs don't track lifetime PnL, use 0
-      agentLifetimePnL = 0;
-    } else {
-      // USER_CONTROLLED: Get data from User table
-      const [agent] = await db
-        .select()
-        .from(users)
-        .where(eq(users.id, agentUserId))
-        .limit(1);
-
-      if (!agent?.isAgent) {
-        throw new Error('Agent not found');
-      }
-
-      agentDisplayName = agent.displayName ?? agentUserId;
-      agentLifetimePnL = Number(agent.lifetimePnL ?? 0);
-    }
+    // Resolve agent context (NPC vs USER_CONTROLLED)
+    const { displayName: agentDisplayName, lifetimePnL: agentLifetimePnL } =
+      await getAgentContext(agentUserId);
 
     const config = await getAgentConfig(agentUserId);
 

--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -395,7 +395,9 @@ async function executePerpTrade(params: {
               .returning({ id: actorState.id });
 
             if (result.length === 0) {
-              throw new Error(`Insufficient NPC balance for perp trade: $${amt}`);
+              throw new Error(
+                `Insufficient NPC balance for perp trade: $${amt}`
+              );
             }
           },
           credit: async ({

--- a/packages/agents/src/autonomous/agent-context.ts
+++ b/packages/agents/src/autonomous/agent-context.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared Agent Context Resolution
+ *
+ * Provides utilities for resolving agent identity (NPC vs USER_CONTROLLED).
+ * Eliminates duplicate boilerplate across autonomous services.
+ */
+
+import { db, eq, users } from '@babylon/db';
+import { StaticDataRegistry } from '@babylon/engine';
+
+export interface AgentContext {
+  agentUserId: string;
+  displayName: string;
+  isNpc: boolean;
+  /** Lifetime P&L (0 for NPCs) */
+  lifetimePnL: number;
+}
+
+/**
+ * Resolve agent context from user ID.
+ *
+ * Checks StaticDataRegistry first (for NPCs), then falls back to User table.
+ * This pattern is used across all autonomous services for consistent agent resolution.
+ *
+ * @param agentUserId - Agent user ID
+ * @returns Agent context with display name, NPC status, and P&L
+ * @throws Error if agent not found and not an NPC
+ */
+export async function getAgentContext(
+  agentUserId: string
+): Promise<AgentContext> {
+  // Check if this is an NPC (has entry in StaticDataRegistry)
+  const npcActor = StaticDataRegistry.getActor(agentUserId);
+  const isNpc = !!npcActor;
+
+  if (isNpc) {
+    return {
+      agentUserId,
+      displayName: npcActor.name,
+      isNpc: true,
+      lifetimePnL: 0, // NPCs don't track P&L
+    };
+  }
+
+  // USER_CONTROLLED: Get from User table
+  const [agent] = await db
+    .select({
+      id: users.id,
+      displayName: users.displayName,
+      isAgent: users.isAgent,
+      lifetimePnL: users.lifetimePnL,
+    })
+    .from(users)
+    .where(eq(users.id, agentUserId))
+    .limit(1);
+
+  if (!agent?.isAgent) {
+    throw new Error(`Agent not found: ${agentUserId}`);
+  }
+
+  return {
+    agentUserId,
+    displayName: agent.displayName ?? agentUserId,
+    isNpc: false,
+    lifetimePnL: Number(agent.lifetimePnL ?? 0),
+  };
+}
+
+/**
+ * Check if a user ID represents an NPC.
+ *
+ * @param userId - User ID to check
+ * @returns True if the user is an NPC in StaticDataRegistry
+ */
+export function isNpcUser(userId: string): boolean {
+  return !!StaticDataRegistry.getActor(userId);
+}

--- a/packages/agents/src/autonomous/index.ts
+++ b/packages/agents/src/autonomous/index.ts
@@ -23,6 +23,8 @@ export {
 } from './AutonomousPlanningCoordinator';
 export { autonomousPostingService } from './AutonomousPostingService';
 export { autonomousTradingService } from './AutonomousTradingService';
+// Agent context utilities
+export { type AgentContext, getAgentContext, isNpcUser } from './agent-context';
 export {
   type DirectCommentParams,
   type DirectCommentResult,

--- a/packages/engine/src/services/trade-execution-service.ts
+++ b/packages/engine/src/services/trade-execution-service.ts
@@ -888,7 +888,9 @@ export class TradeExecutionService {
           .returning({ id: actorState.id });
 
         if (result.length === 0) {
-          throw new Error(`Insufficient NPC funds: actor ${actorId}, amount $${amount}`);
+          throw new Error(
+            `Insufficient NPC funds: actor ${actorId}, amount $${amount}`
+          );
         }
       },
       credit: async ({ amount }: { amount: number }) => {


### PR DESCRIPTION
## Summary
- Create shared `getAgentContext()` helper in `agent-context.ts` to eliminate duplicate NPC/agent resolution boilerplate
- Refactor `AutonomousA2AService` to use `agentPnLService.recordTrade` instead of direct `db.agentTrade.create()` calls
- Update 6 Autonomous* services to use the shared helper (~140 lines removed)

## Changes
- **New file**: `packages/agents/src/autonomous/agent-context.ts`
- **Updated**: `AutonomousA2AService.ts`, `AutonomousBatchResponseService.ts`, `AutonomousCommentingService.ts`, `AutonomousDMService.ts`, `AutonomousGroupChatService.ts`, `AutonomousPostingService.ts`, `index.ts`

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes
- [ ] CI build passes