### PR TITLE
feat: Free chat for free mode, 1 point for pro mode with groq-70b/8b models

### DIFF
--- a/apps/web/src/app/api/agents/[agentId]/chat/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/chat/route.ts
@@ -235,14 +235,20 @@ export const POST = withErrorHandling(
     }
     const agentConfig = agentWithConfig.agentConfig;
 
-    const pointsCost = 1;
+    const pointsCost = usePro ? 1 : 0;
+    const modelType = usePro ? ModelType.TEXT_LARGE : ModelType.TEXT_SMALL;
     const modelUsed = usePro ? 'groq-70b' : 'groq-8b';
-    const newBalance = await agentService.deductPoints(
-      agentId,
-      pointsCost,
-      `Chat message (${usePro ? 'pro' : 'free'} mode)`,
-      undefined
-    );
+    
+    // Only deduct points for pro mode
+    let newBalance = agentConfig?.pointsBalance ?? 0;
+    if (pointsCost > 0) {
+      newBalance = await agentService.deductPoints(
+        agentId,
+        pointsCost,
+        `Chat message (pro mode)`,
+        undefined
+      );
+    }
 
     // Get runtime
     const runtime = await agentRuntimeManager.getRuntime(agentId);
@@ -312,7 +318,7 @@ export const POST = withErrorHandling(
       let parsedStep: Record<string, unknown> | null = null;
 
       for (let attempt = 1; attempt <= MAX_PARSE_RETRIES; attempt++) {
-        const response = await runtime.useModel(ModelType.TEXT_LARGE, {
+        const response = await runtime.useModel(modelType, {
           prompt,
           temperature: attempt > 1 ? 0.5 : 0.7,
         });
@@ -516,7 +522,7 @@ export const POST = withErrorHandling(
       let extractedText: string | undefined;
 
       for (let attempt = 1; attempt <= SUMMARY_RETRIES; attempt++) {
-        const summaryResponse = await runtime.useModel(ModelType.TEXT_LARGE, {
+        const summaryResponse = await runtime.useModel(modelType, {
           prompt: summaryPrompt,
           temperature: attempt > 1 ? 0.5 : 0.7,
         });

--- a/apps/web/src/components/agents/AgentChat.tsx
+++ b/apps/web/src/components/agents/AgentChat.tsx
@@ -67,7 +67,7 @@ export function AgentChat({ agent, onBalanceUpdate }: AgentChatProps) {
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
   const [sending, setSending] = useState(false);
-  const [usePro, setUsePro] = useState(false);
+  const [usePro, setUsePro] = useState(agent.modelTier === 'pro');
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -202,7 +202,9 @@ export function AgentChat({ agent, onBalanceUpdate }: AgentChatProps) {
 
     // Update agent balance without full page refresh
     onBalanceUpdate?.(data.balanceAfter);
-    toast.success(`Message sent (-${data.pointsCost} points)`);
+    if (data.pointsCost > 0) {
+      toast.success(`Message sent (-${data.pointsCost} points)`);
+    }
     setSending(false);
   };
 
@@ -366,34 +368,36 @@ export function AgentChat({ agent, onBalanceUpdate }: AgentChatProps) {
 
       {/* Input */}
       <div className="border-border border-t p-4">
-        {agent.pointsBalance < 1 ? (
+        {usePro && agent.pointsBalance < 1 ? (
           <div className="py-2 text-center text-red-600 text-sm">
-            Insufficient points. Please deposit points to continue chatting.
+            Insufficient points for Pro mode. Switch to Free mode or deposit
+            points.
           </div>
-        ) : (
-          <div className="flex items-end gap-2">
-            <Textarea
-              ref={textareaRef}
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder="Type your message..."
-              disabled={sending}
-              className={cn(
-                'max-h-40 min-h-10 flex-1 resize-none overflow-y-auto py-2.5',
-                'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
-              )}
-              rows={1}
-            />
-            <button
-              onClick={sendMessage}
-              disabled={!input.trim() || sending || agent.pointsBalance < 1}
-              className="flex h-10 items-center gap-2 rounded-lg bg-[#0066FF] px-4 py-2 font-medium text-primary-foreground transition-all hover:bg-[#2952d9] disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <Send className="h-4 w-4" />
-            </button>
-          </div>
-        )}
+        ) : null}
+        <div className="flex items-end gap-2">
+          <Textarea
+            ref={textareaRef}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Type your message..."
+            disabled={sending}
+            className={cn(
+              'max-h-40 min-h-10 flex-1 resize-none overflow-y-auto py-2.5',
+              'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring'
+            )}
+            rows={1}
+          />
+          <button
+            onClick={sendMessage}
+            disabled={
+              !input.trim() || sending || (usePro && agent.pointsBalance < 1)
+            }
+            className="flex h-10 items-center gap-2 rounded-lg bg-[#0066FF] px-4 py-2 font-medium text-primary-foreground transition-all hover:bg-[#2952d9] disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Send className="h-4 w-4" />
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/packages/agents/src/plugins/groq.ts
+++ b/packages/agents/src/plugins/groq.ts
@@ -220,7 +220,7 @@ export const groqPlugin: Plugin = {
       const model =
         runtime.getSetting('GROQ_SMALL_MODEL') ??
         runtime.getSetting('SMALL_MODEL') ??
-        'llama-3.1-8b-instant';
+        'llama-3.1-8b-instant'; // groq-8b
 
       interface RuntimeWithExtensions extends IAgentRuntime {
         trajectoryLogger?: TrajectoryLoggerService;
@@ -269,7 +269,7 @@ export const groqPlugin: Plugin = {
       const model =
         runtime.getSetting('GROQ_LARGE_MODEL') ??
         runtime.getSetting('LARGE_MODEL') ??
-        'qwen/qwen3-32b';
+        'llama-3.3-70b-versatile'; // groq-70b
 
       type RuntimeWithTrajectory = typeof runtime & {
         trajectoryLogger?: TrajectoryLoggerService;

--- a/packages/agents/src/runtime/AgentRuntimeManager.ts
+++ b/packages/agents/src/runtime/AgentRuntimeManager.ts
@@ -208,8 +208,8 @@ export class AgentRuntimeManager {
       settings: {
         // GROQ configuration (always available)
         GROQ_API_KEY: process.env.GROQ_API_KEY || '',
-        LARGE_GROQ_MODEL: 'qwen/qwen3-32b',
-        SMALL_GROQ_MODEL: 'llama-3.1-8b-instant',
+        GROQ_LARGE_MODEL: process.env.GROQ_LARGE_MODEL || 'llama-3.3-70b-versatile',
+        GROQ_SMALL_MODEL: process.env.GROQ_SMALL_MODEL || 'llama-3.1-8b-instant',
         ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY || '',
       },
     };


### PR DESCRIPTION

# PR Description

## Summary

This PR updates the agent chat pricing model so that **free mode is completely free** (0 points) while **pro mode costs 1 point per message**. It also ensures the correct Groq models are used for each tier.

## Changes

### Pricing Changes
- **Free mode**: 0 points per message
- **Pro mode**: 1 point per message

### Model Configuration
- **Free mode (TEXT_SMALL)**: `llama-3.1-8b-instant` (groq-8b)
- **Pro mode (TEXT_LARGE)**: `llama-3.3-70b-versatile` (groq-70b)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pro tier users now benefit from optimized model selection for enhanced responses.
  * Points deduction now operates conditionally—free-tier users experience no balance changes.

* **Improvements**
  * Insufficient points messaging displays only for Pro mode users.
  * Point usage notifications appear exclusively when points are deducted.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->