### PR TITLE
refactor(markets): centralize type definitions and constants

### DIFF
--- a/apps/web/src/app/markets/page.tsx
+++ b/apps/web/src/app/markets/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { UserPredictionPosition } from '@babylon/shared';
 import { cn, logger } from '@babylon/shared';
 import {
   ArrowUpDown,
@@ -29,7 +30,13 @@ import { Skeleton, WidgetPanelSkeleton } from '@/components/shared/Skeleton';
 import { useAuth } from '@/hooks/useAuth';
 import { usePortfolioPnL } from '@/hooks/usePortfolioPnL';
 import { useUserPositions } from '@/hooks/useUserPositions';
-import { type PerpMarket, usePerpMarkets } from '@/stores/perpMarketsStore';
+import { usePerpMarkets } from '@/stores/perpMarketsStore';
+import type {
+  MarketTab,
+  PerpMarket,
+  PredictionMarket,
+  PredictionSort,
+} from '@/types/markets';
 
 // Lazy load heavy modals - not needed for initial render
 const CategoryPnLShareModal = dynamic(
@@ -65,41 +72,13 @@ const MarketsWidgetSidebar = dynamic(
   { ssr: false }
 );
 
-interface PredictionUserPosition {
-  id: string;
-  marketId: string;
-  question?: string;
-  side: 'YES' | 'NO';
-  shares: number;
-  avgPrice: number;
-  currentPrice: number;
-  currentValue: number;
-  costBasis: number;
-  unrealizedPnL: number;
-  resolved?: boolean;
-  resolution?: boolean | null;
+/**
+ * Extended prediction market with user position data for dashboard.
+ */
+interface PredictionMarketWithPosition extends PredictionMarket {
+  userPosition?: UserPredictionPosition | null;
+  userPositions?: UserPredictionPosition[];
 }
-
-interface PredictionMarket {
-  id: number | string;
-  text: string;
-  status: 'active' | 'resolved' | 'cancelled';
-  createdDate?: string;
-  resolutionDate?: string;
-  resolvedOutcome?: boolean;
-  scenario: number;
-  yesShares?: number;
-  noShares?: number;
-  userPosition?: PredictionUserPosition | null;
-  userPositions?: PredictionUserPosition[];
-  oracleCommitTxHash?: string | null;
-  oracleRevealTxHash?: string | null;
-  oraclePublishedAt?: string | null;
-}
-
-type MarketTab = 'dashboard' | 'perps' | 'predictions';
-
-type PredictionSort = 'trending' | 'newest' | 'ending-soon' | 'volume';
 
 export default function MarketsPage() {
   const router = useRouter();
@@ -124,7 +103,9 @@ export default function MarketsPage() {
   } = usePerpMarkets();
 
   // Data
-  const [predictions, setPredictions] = useState<PredictionMarket[]>([]);
+  const [predictions, setPredictions] = useState<
+    PredictionMarketWithPosition[]
+  >([]);
   const [predictionsLoading, setPredictionsLoading] = useState(true);
   const [balanceRefreshTrigger, setBalanceRefreshTrigger] = useState(0);
 
@@ -213,7 +194,11 @@ export default function MarketsPage() {
     } catch (err) {
       // Only ignore abort errors; log other network errors for debugging
       if (err instanceof Error && err.name !== 'AbortError') {
-        logger.warn('Failed to fetch predictions', { error: err.message }, 'MarketsPage');
+        logger.warn(
+          'Failed to fetch predictions',
+          { error: err.message },
+          'MarketsPage'
+        );
       }
     } finally {
       setPredictionsLoading(false);

--- a/apps/web/src/app/markets/page.tsx
+++ b/apps/web/src/app/markets/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import type { UserPredictionPosition } from '@babylon/shared';
 import { cn, logger } from '@babylon/shared';
 import {
   ArrowUpDown,
@@ -35,6 +34,7 @@ import type {
   MarketTab,
   PerpMarket,
   PredictionMarket,
+  PredictionMarketWithPosition,
   PredictionSort,
 } from '@/types/markets';
 
@@ -71,14 +71,6 @@ const MarketsWidgetSidebar = dynamic(
     })),
   { ssr: false }
 );
-
-/**
- * Extended prediction market with user position data for dashboard.
- */
-interface PredictionMarketWithPosition extends PredictionMarket {
-  userPosition?: UserPredictionPosition | null;
-  userPositions?: UserPredictionPosition[];
-}
 
 export default function MarketsPage() {
   const router = useRouter();

--- a/apps/web/src/app/markets/predictions/[id]/page.tsx
+++ b/apps/web/src/app/markets/predictions/[id]/page.tsx
@@ -4,6 +4,7 @@ import {
   calculateExpectedPayout,
   PredictionPricing,
 } from '@babylon/core/markets/prediction/client';
+import type { UserPredictionPosition } from '@babylon/shared';
 import { cn } from '@babylon/shared';
 import {
   ArrowLeft,
@@ -35,32 +36,12 @@ import type {
   PredictionTradeSSE,
 } from '@/hooks/usePredictionMarketStream';
 import { usePredictionMarketStream } from '@/hooks/usePredictionMarketStream';
+import type { PredictionMarket } from '@/types/markets';
 
-interface PredictionPosition {
-  id: string;
-  marketId: string;
-  question: string;
-  side: 'YES' | 'NO';
-  shares: number;
-  avgPrice: number;
-  currentPrice: number;
-  currentValue: number;
-  costBasis: number;
-  unrealizedPnL: number;
-  resolved: boolean;
-  resolution?: boolean | null;
-}
-
-interface PredictionMarket {
-  id: number | string;
-  text: string;
-  status: 'active' | 'resolved' | 'cancelled';
-  createdDate?: string;
-  resolutionDate?: string;
-  resolvedOutcome?: boolean;
-  scenario: number;
-  yesShares?: number;
-  noShares?: number;
+/**
+ * Extended prediction market with detail page specific fields.
+ */
+interface PredictionMarketDetail extends PredictionMarket {
   liquidity?: number;
   resolved?: boolean;
   resolution?: boolean | null;
@@ -68,8 +49,8 @@ interface PredictionMarket {
   resolutionDescription?: string | null;
   yesProbability?: number;
   noProbability?: number;
-  userPosition?: PredictionPosition | null;
-  userPositions?: PredictionPosition[];
+  userPosition?: UserPredictionPosition | null;
+  userPositions?: UserPredictionPosition[];
 }
 
 export default function PredictionDetailPage() {
@@ -81,18 +62,20 @@ export default function PredictionDetailPage() {
   const { trackMarketView } = useMarketTracking();
   const from = searchParams.get('from');
 
-  const [market, setMarket] = useState<PredictionMarket | null>(null);
+  const [market, setMarket] = useState<PredictionMarketDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [side, setSide] = useState<'yes' | 'no'>('yes');
   const [amount, setAmount] = useState('10');
   const [submitting, setSubmitting] = useState(false);
-  const [userPositions, setUserPositions] = useState<PredictionPosition[]>([]);
+  const [userPositions, setUserPositions] = useState<UserPredictionPosition[]>(
+    []
+  );
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
   const pageContainerRef = useRef<HTMLDivElement | null>(null);
 
   const recalculatePositionMetrics = useCallback(
     (
-      positions: PredictionPosition[],
+      positions: UserPredictionPosition[],
       nextYesShares: number,
       nextNoShares: number
     ) => {
@@ -246,9 +229,9 @@ export default function PredictionDetailPage() {
       `/api/markets/predictions/${encodeURIComponent(marketId)}${userQuery}`
     );
     const data = await response.json();
-    const foundMarket: PredictionMarket | null =
-      (data?.market as PredictionMarket | undefined) ??
-      (data as PredictionMarket | undefined) ??
+    const foundMarket: PredictionMarketDetail | null =
+      (data?.market as PredictionMarketDetail | undefined) ??
+      (data as PredictionMarketDetail | undefined) ??
       null;
 
     if (!response.ok || !foundMarket) {
@@ -260,9 +243,9 @@ export default function PredictionDetailPage() {
     setMarket(foundMarket);
     const positions =
       (foundMarket.userPositions ?? []).length > 0
-        ? (foundMarket.userPositions as PredictionPosition[])
+        ? (foundMarket.userPositions as UserPredictionPosition[])
         : foundMarket.userPosition
-          ? [foundMarket.userPosition as PredictionPosition]
+          ? [foundMarket.userPosition as UserPredictionPosition]
           : [];
     setUserPositions(positions);
 

--- a/apps/web/src/app/markets/predictions/page.tsx
+++ b/apps/web/src/app/markets/predictions/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import type { UserPredictionPosition } from '@babylon/shared';
 import { cn, logger } from '@babylon/shared';
 import { ArrowUpDown, Clock, Flame, Search } from 'lucide-react';
 import { useRouter } from 'next/navigation';
@@ -26,17 +25,10 @@ import { useUserPositions } from '@/hooks/useUserPositions';
 import type {
   MarketTab,
   PredictionMarket,
+  PredictionMarketWithPosition,
   PredictionSort,
 } from '@/types/markets';
 import { MARKETS_CONFIG } from '@/types/markets';
-
-/**
- * Extended prediction market with user position data for predictions page.
- */
-interface PredictionMarketWithPosition extends PredictionMarket {
-  userPosition?: UserPredictionPosition | null;
-  userPositions?: UserPredictionPosition[];
-}
 
 export default function PredictionsPage() {
   const router = useRouter();

--- a/apps/web/src/app/markets/predictions/page.tsx
+++ b/apps/web/src/app/markets/predictions/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { UserPredictionPosition } from '@babylon/shared';
 import { cn, logger } from '@babylon/shared';
 import { ArrowUpDown, Clock, Flame, Search } from 'lucide-react';
 import { useRouter } from 'next/navigation';
@@ -15,50 +16,27 @@ import { CategoryPnLCard } from '@/components/markets/CategoryPnLCard';
 import { CategoryPnLShareModal } from '@/components/markets/CategoryPnLShareModal';
 import { PredictionPositionsList } from '@/components/markets/PredictionPositionsList';
 import { PredictionSparkline } from '@/components/markets/PredictionSparkline';
-import {
-  MarketsToggle,
-  type MarketTab,
-} from '@/components/shared/MarketsToggle';
+import { MarketsToggle } from '@/components/shared/MarketsToggle';
 import { PageContainer } from '@/components/shared/PageContainer';
 import { Skeleton } from '@/components/shared/Skeleton';
 import { useAuth } from '@/hooks/useAuth';
 import { usePortfolioPnL } from '@/hooks/usePortfolioPnL';
 import { usePredictionMarketsSubscription } from '@/hooks/usePredictionMarketStream';
 import { useUserPositions } from '@/hooks/useUserPositions';
+import type {
+  MarketTab,
+  PredictionMarket,
+  PredictionSort,
+} from '@/types/markets';
+import { MARKETS_CONFIG } from '@/types/markets';
 
-interface PredictionUserPosition {
-  id: string;
-  marketId: string;
-  question?: string;
-  side: 'YES' | 'NO';
-  shares: number;
-  avgPrice: number;
-  currentPrice: number;
-  currentValue: number;
-  costBasis: number;
-  unrealizedPnL: number;
-  resolved?: boolean;
-  resolution?: boolean | null;
+/**
+ * Extended prediction market with user position data for predictions page.
+ */
+interface PredictionMarketWithPosition extends PredictionMarket {
+  userPosition?: UserPredictionPosition | null;
+  userPositions?: UserPredictionPosition[];
 }
-
-interface PredictionMarket {
-  id: number | string;
-  text: string;
-  status: 'active' | 'resolved' | 'cancelled';
-  createdDate?: string;
-  resolutionDate?: string;
-  resolvedOutcome?: boolean;
-  scenario: number;
-  yesShares?: number;
-  noShares?: number;
-  userPosition?: PredictionUserPosition | null;
-  userPositions?: PredictionUserPosition[];
-  oracleCommitTxHash?: string | null;
-  oracleRevealTxHash?: string | null;
-  oraclePublishedAt?: string | null;
-}
-
-type PredictionSort = 'trending' | 'newest' | 'ending-soon' | 'volume';
 
 export default function PredictionsPage() {
   const router = useRouter();
@@ -80,7 +58,9 @@ export default function PredictionsPage() {
   };
 
   // Data
-  const [predictions, setPredictions] = useState<PredictionMarket[]>([]);
+  const [predictions, setPredictions] = useState<
+    PredictionMarketWithPosition[]
+  >([]);
   const [loading, setLoading] = useState(true);
   const [sparklineData, setSparklineData] = useState<
     Record<string, Array<{ time: number; yesPrice: number; noPrice: number }>>
@@ -192,7 +172,11 @@ export default function PredictionsPage() {
     } catch (err) {
       // Only ignore abort errors; log other network errors for debugging
       if (err instanceof Error && err.name !== 'AbortError') {
-        logger.warn('Failed to fetch predictions', { error: err.message }, 'PredictionsPage');
+        logger.warn(
+          'Failed to fetch predictions',
+          { error: err.message },
+          'PredictionsPage'
+        );
       }
     } finally {
       setLoading(false);
@@ -583,8 +567,8 @@ export default function PredictionsPage() {
                     <div className="flex items-center gap-2">
                       <PredictionSparkline
                         data={sparklineData[prediction.id.toString()] ?? []}
-                        width={80}
-                        height={28}
+                        width={MARKETS_CONFIG.SPARKLINE.WIDTH}
+                        height={MARKETS_CONFIG.SPARKLINE.HEIGHT}
                       />
                       <div className="flex flex-col text-right">
                         <span className="font-medium text-green-600">

--- a/apps/web/src/components/markets/CategoryPnLShareCard.tsx
+++ b/apps/web/src/components/markets/CategoryPnLShareCard.tsx
@@ -1,9 +1,5 @@
 import type { User } from '@/stores/authStore';
-
-/**
- * Market category type for category PnL share card.
- */
-type MarketCategory = 'perps' | 'predictions';
+import type { MarketCategory } from '@/types/markets';
 
 /**
  * Category PnL data structure for category PnL share card.

--- a/apps/web/src/components/markets/CategoryPnLShareModal.tsx
+++ b/apps/web/src/components/markets/CategoryPnLShareModal.tsx
@@ -1,12 +1,8 @@
 'use client';
 
 import type { User } from '@/stores/authStore';
+import type { MarketCategory } from '@/types/markets';
 import { PnLShareModal } from './PnLShareModal';
-
-/**
- * Market category type for category PnL share modal.
- */
-type MarketCategory = 'perps' | 'predictions';
 
 /**
  * Category PnL data structure for category PnL share modal.

--- a/apps/web/src/components/markets/PerpPositionsList.tsx
+++ b/apps/web/src/components/markets/PerpPositionsList.tsx
@@ -7,28 +7,16 @@ import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
 import { useMarketPrices } from '@/hooks/useMarketPrices';
 import { usePerpTrade } from '@/hooks/usePerpTrade';
+import type { DisplayPerpPosition } from '@/types/markets';
 import {
   type ClosePerpDetails,
   TradeConfirmationDialog,
 } from './TradeConfirmationDialog';
 
 /**
- * Perpetual position structure for positions list.
+ * Alias for DisplayPerpPosition for local usage.
  */
-interface PerpPosition {
-  id: string;
-  ticker: string;
-  side: 'long' | 'short';
-  entryPrice: number;
-  currentPrice: number;
-  size: number;
-  leverage: number;
-  unrealizedPnL: number;
-  unrealizedPnLPercent: number;
-  liquidationPrice: number;
-  fundingPaid: number;
-  openedAt: string;
-}
+type PerpPosition = DisplayPerpPosition;
 
 /**
  * Perpetual positions list component for displaying and managing open positions.
@@ -244,63 +232,63 @@ export function PerpPositionsList({
                 </div>
               </div>
 
-            {/* Liquidation Warning */}
-            {isNearLiquidation && (
-              <div className="mb-3 flex items-center gap-2 rounded bg-red-600/20 p-2">
-                <AlertTriangle className="h-4 w-4 flex-shrink-0 text-red-600" />
-                <p className="font-medium text-red-600 text-xs">
-                  Near liquidation! {liquidationDistance.toFixed(2)}% away
-                </p>
-              </div>
-            )}
+              {/* Liquidation Warning */}
+              {isNearLiquidation && (
+                <div className="mb-3 flex items-center gap-2 rounded bg-red-600/20 p-2">
+                  <AlertTriangle className="h-4 w-4 flex-shrink-0 text-red-600" />
+                  <p className="font-medium text-red-600 text-xs">
+                    Near liquidation! {liquidationDistance.toFixed(2)}% away
+                  </p>
+                </div>
+              )}
 
-            {/* Stats Grid */}
-            <div className="mb-3 grid grid-cols-2 gap-2 text-xs">
-              <div>
-                <div className="text-muted-foreground">Entry</div>
-                <div className="font-medium text-foreground">
-                  {formatPrice(position.entryPrice)}
+              {/* Stats Grid */}
+              <div className="mb-3 grid grid-cols-2 gap-2 text-xs">
+                <div>
+                  <div className="text-muted-foreground">Entry</div>
+                  <div className="font-medium text-foreground">
+                    {formatPrice(position.entryPrice)}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-muted-foreground">Current</div>
+                  <div className="font-medium text-foreground">
+                    {formatPrice(currentPrice)}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-muted-foreground">Liquidation</div>
+                  <div className="font-bold text-red-600">
+                    {formatPrice(position.liquidationPrice)}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-muted-foreground">Size</div>
+                  <div className="font-medium text-foreground">
+                    {formatPrice(position.size)}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-muted-foreground">Funding Paid</div>
+                  <div
+                    className={cn(
+                      'font-medium',
+                      position.fundingPaid >= 0
+                        ? 'text-red-600'
+                        : 'text-green-600'
+                    )}
+                  >
+                    {position.fundingPaid >= 0 ? '-' : '+'}
+                    {formatPrice(Math.abs(position.fundingPaid))}
+                  </div>
+                </div>
+                <div>
+                  <div className="text-muted-foreground">Opened</div>
+                  <div className="font-medium text-foreground">
+                    {formatDate(position.openedAt)}
+                  </div>
                 </div>
               </div>
-              <div>
-                <div className="text-muted-foreground">Current</div>
-                <div className="font-medium text-foreground">
-                  {formatPrice(currentPrice)}
-                </div>
-              </div>
-              <div>
-                <div className="text-muted-foreground">Liquidation</div>
-                <div className="font-bold text-red-600">
-                  {formatPrice(position.liquidationPrice)}
-                </div>
-              </div>
-              <div>
-                <div className="text-muted-foreground">Size</div>
-                <div className="font-medium text-foreground">
-                  {formatPrice(position.size)}
-                </div>
-              </div>
-              <div>
-                <div className="text-muted-foreground">Funding Paid</div>
-                <div
-                  className={cn(
-                    'font-medium',
-                    position.fundingPaid >= 0
-                      ? 'text-red-600'
-                      : 'text-green-600'
-                  )}
-                >
-                  {position.fundingPaid >= 0 ? '-' : '+'}
-                  {formatPrice(Math.abs(position.fundingPaid))}
-                </div>
-              </div>
-              <div>
-                <div className="text-muted-foreground">Opened</div>
-                <div className="font-medium text-foreground">
-                  {formatDate(position.openedAt)}
-                </div>
-              </div>
-            </div>
 
               {/* Close Button */}
               <button

--- a/apps/web/src/components/markets/PerpTradingModal.tsx
+++ b/apps/web/src/components/markets/PerpTradingModal.tsx
@@ -14,22 +14,7 @@ import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
 import { usePerpTrade } from '@/hooks/usePerpTrade';
 import { useWalletBalance } from '@/hooks/useWalletBalance';
-
-/**
- * Perpetual market structure for trading modal.
- */
-interface PerpMarket {
-  ticker: string;
-  organizationId: string;
-  name: string;
-  currentPrice: number;
-  fundingRate: {
-    rate: number;
-    nextFundingTime: string;
-  };
-  maxLeverage: number;
-  minOrderSize: number;
-}
+import type { PerpMarket, TradeSide } from '@/types/markets';
 
 /**
  * Perpetual trading modal component for opening new positions.
@@ -77,7 +62,7 @@ export function PerpTradingModal({
   onSuccess,
 }: PerpTradingModalProps) {
   const { user, authenticated, login, getAccessToken } = useAuth();
-  const [side, setSide] = useState<'long' | 'short'>('long');
+  const [side, setSide] = useState<TradeSide>('long');
   const [size, setSize] = useState('100');
   const [leverage, setLeverage] = useState(10);
   const [loading, setLoading] = useState(false);

--- a/apps/web/src/components/markets/PnLShareModal.tsx
+++ b/apps/web/src/components/markets/PnLShareModal.tsx
@@ -10,11 +10,7 @@ import { PortfolioPnLShareCard } from '@/components/markets/PortfolioPnLShareCar
 import type { PortfolioPnLSnapshot } from '@/hooks/usePortfolioPnL';
 import { useTwitterAuth } from '@/hooks/useTwitterAuth';
 import type { User } from '@/stores/authStore';
-
-/**
- * Market category type for PnL share modal.
- */
-type MarketCategory = 'perps' | 'predictions';
+import type { MarketCategory } from '@/types/markets';
 
 /**
  * Category PnL data structure for PnL share modal.

--- a/apps/web/src/components/markets/PredictionPositionsList.tsx
+++ b/apps/web/src/components/markets/PredictionPositionsList.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import type { UserPredictionPosition } from '@babylon/shared';
 import { cn, logger } from '@babylon/shared';
 import { usePrivy } from '@privy-io/react-auth';
 import { CheckCircle, XCircle } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
+import type { ApiErrorResponse } from '@/types/markets';
 import {
   type SellPredictionDetails,
   TradeConfirmationDialog,
@@ -18,30 +20,9 @@ interface SellSharesSuccessResponse {
 }
 
 /**
- * API error response type.
+ * Alias for UserPredictionPosition for local usage.
  */
-interface ApiErrorResponse {
-  error: string | { message: string };
-  message?: string;
-}
-
-/**
- * Prediction position structure for positions list.
- */
-interface PredictionPosition {
-  id: string;
-  marketId: string;
-  question: string;
-  side: 'YES' | 'NO';
-  shares: number;
-  avgPrice: number;
-  currentPrice: number;
-  currentValue: number;
-  costBasis: number;
-  unrealizedPnL: number;
-  resolved: boolean;
-  resolution?: boolean | null;
-}
+type PredictionPosition = UserPredictionPosition;
 
 /**
  * Prediction positions list component for displaying and managing prediction positions.

--- a/apps/web/src/components/markets/PredictionPositionsList.tsx
+++ b/apps/web/src/components/markets/PredictionPositionsList.tsx
@@ -6,18 +6,11 @@ import { usePrivy } from '@privy-io/react-auth';
 import { CheckCircle, XCircle } from 'lucide-react';
 import { useState } from 'react';
 import { toast } from 'sonner';
-import type { ApiErrorResponse } from '@/types/markets';
+import type { ApiErrorResponse, SellSharesSuccessResponse } from '@/types/markets';
 import {
   type SellPredictionDetails,
   TradeConfirmationDialog,
 } from './TradeConfirmationDialog';
-
-/**
- * API response type for selling prediction shares.
- */
-interface SellSharesSuccessResponse {
-  pnl: number;
-}
 
 /**
  * Alias for UserPredictionPosition for local usage.

--- a/apps/web/src/components/markets/PredictionTradingModal.tsx
+++ b/apps/web/src/components/markets/PredictionTradingModal.tsx
@@ -10,21 +10,7 @@ import { CheckCircle, Clock, X, XCircle } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
-
-/**
- * Represents a prediction market question.
- */
-interface PredictionMarket {
-  id: number | string;
-  text: string;
-  status: 'active' | 'resolved' | 'cancelled';
-  createdDate?: string;
-  resolutionDate?: string;
-  resolvedOutcome?: boolean;
-  scenario: number;
-  yesShares?: number;
-  noShares?: number;
-}
+import type { PredictionMarket } from '@/types/markets';
 
 /**
  * Props for the PredictionTradingModal component.

--- a/apps/web/src/components/shared/MarketsToggle.tsx
+++ b/apps/web/src/components/shared/MarketsToggle.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { cn } from '@babylon/shared';
+import type { MarketTab } from '@/types/markets';
 
-export type MarketTab = 'dashboard' | 'perps' | 'predictions';
+// Re-export for backwards compatibility
+export type { MarketTab } from '@/types/markets';
 
 /**
  * Markets toggle component for switching between market views.

--- a/apps/web/src/hooks/usePerpTrade.ts
+++ b/apps/web/src/hooks/usePerpTrade.ts
@@ -1,11 +1,10 @@
 'use client';
 
 import { useCallback } from 'react';
+import type { TradeSide } from '@/types/markets';
 
-/**
- * Side of a perpetual trade position.
- */
-type TradeSide = 'long' | 'short';
+// Re-export for backwards compatibility
+export type { TradeSide } from '@/types/markets';
 
 /**
  * Options for configuring the usePerpTrade hook.

--- a/apps/web/src/hooks/useUserPositions.ts
+++ b/apps/web/src/hooks/useUserPositions.ts
@@ -1,13 +1,12 @@
 'use client';
 
-import type { PerpPosition } from '@babylon/shared';
+import type { PerpPosition, UserPredictionPosition } from '@babylon/shared';
 import { logger } from '@babylon/shared';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 /**
- * Represents a user's position in a prediction market.
+ * Helper to safely convert API values to numbers.
  */
-
 function toNumber(value: unknown, fallback = 0): number {
   if (typeof value === 'number' && Number.isFinite(value)) {
     return value;
@@ -19,20 +18,8 @@ function toNumber(value: unknown, fallback = 0): number {
   return fallback;
 }
 
-export interface UserPredictionPosition {
-  id: string;
-  marketId: string;
-  question: string;
-  side: 'YES' | 'NO';
-  shares: number;
-  avgPrice: number;
-  currentPrice: number;
-  currentValue: number;
-  costBasis: number;
-  unrealizedPnL: number;
-  resolved: boolean;
-  resolution: boolean | null;
-}
+// Re-export for convenience
+export type { UserPredictionPosition } from '@babylon/shared';
 
 interface PerpStats {
   totalPositions: number;

--- a/apps/web/src/stores/perpMarketsStore.ts
+++ b/apps/web/src/stores/perpMarketsStore.ts
@@ -21,29 +21,11 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { create } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
+import type { PerpMarket } from '@/types/markets';
+import { MARKETS_CONFIG } from '@/types/markets';
 
-/**
- * Perp market data structure from API
- */
-export interface PerpMarket {
-  ticker: string;
-  organizationId: string;
-  name: string;
-  currentPrice: number;
-  change24h: number;
-  changePercent24h: number;
-  high24h: number;
-  low24h: number;
-  volume24h: number;
-  openInterest: number;
-  fundingRate: {
-    rate: number;
-    nextFundingTime: string;
-    predictedRate: number;
-  };
-  maxLeverage: number;
-  minOrderSize: number;
-}
+// Re-export for backwards compatibility
+export type { PerpMarket } from '@/types/markets';
 
 interface PerpMarketsState {
   // Data
@@ -62,8 +44,8 @@ interface PerpMarketsState {
   subscribe: (intervalMs: number) => () => void;
 }
 
-// Cache TTL in milliseconds (10 seconds)
-const CACHE_TTL = 10000;
+// Use centralized cache TTL
+const CACHE_TTL = MARKETS_CONFIG.CACHE_TTL_MS;
 
 export const usePerpMarketsStore = create<PerpMarketsState>((set, get) => ({
   markets: [],

--- a/apps/web/src/stores/predictionMarketsStore.ts
+++ b/apps/web/src/stores/predictionMarketsStore.ts
@@ -21,24 +21,11 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { create } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
+import type { PredictionMarket } from '@/types/markets';
+import { MARKETS_CONFIG } from '@/types/markets';
 
-/**
- * Prediction market data structure from API
- */
-export interface PredictionMarket {
-  id: number | string;
-  text: string;
-  status: 'active' | 'resolved' | 'cancelled';
-  createdDate?: string;
-  resolutionDate?: string;
-  resolvedOutcome?: boolean;
-  scenario: number;
-  yesShares?: number;
-  noShares?: number;
-  oracleCommitTxHash?: string | null;
-  oracleRevealTxHash?: string | null;
-  oraclePublishedAt?: string | null;
-}
+// Re-export for backwards compatibility
+export type { PredictionMarket } from '@/types/markets';
 
 interface PredictionMarketsState {
   // Data
@@ -57,8 +44,8 @@ interface PredictionMarketsState {
   subscribe: (intervalMs: number, userId?: string) => () => void;
 }
 
-// Cache TTL in milliseconds (10 seconds)
-const CACHE_TTL = 10000;
+// Use centralized cache TTL
+const CACHE_TTL = MARKETS_CONFIG.CACHE_TTL_MS;
 
 export const usePredictionMarketsStore = create<PredictionMarketsState>(
   (set, get) => ({

--- a/apps/web/src/types/markets.ts
+++ b/apps/web/src/types/markets.ts
@@ -1,0 +1,319 @@
+/**
+ * Markets Types - Centralized type definitions for markets frontend
+ *
+ * This module consolidates all market-related types used across the frontend.
+ * Import from here instead of defining inline types in components.
+ *
+ * @example
+ * ```tsx
+ * import type { PredictionMarket, MarketTab, TradeSide } from '@/types/markets';
+ * import { MARKETS_CONFIG } from '@/types/markets';
+ * ```
+ */
+
+// =============================================================================
+// Re-exports from @babylon/shared
+// =============================================================================
+
+export type {
+  DailyPriceSnapshot,
+  FundingRate,
+  Liquidation,
+  OrderRequest,
+  PerpMarket as SharedPerpMarket,
+  PerpPosition,
+  PositionUpdate,
+  PredictionPosition,
+  TradingStats,
+  UserPredictionPosition,
+} from '@babylon/shared';
+
+export {
+  calculateFundingPayment,
+  calculateLiquidationPrice,
+  calculateMarkPrice,
+  calculateUnrealizedPnL,
+  shouldLiquidate,
+} from '@babylon/shared';
+
+// =============================================================================
+// Market Types
+// =============================================================================
+
+/**
+ * Perp market data structure from API.
+ * Simplified version for frontend display (vs SharedPerpMarket which has more fields).
+ */
+export interface PerpMarket {
+  ticker: string;
+  organizationId: string;
+  name: string;
+  currentPrice: number;
+  change24h: number;
+  changePercent24h: number;
+  high24h: number;
+  low24h: number;
+  volume24h: number;
+  openInterest: number;
+  fundingRate: {
+    rate: number;
+    nextFundingTime: string;
+    predictedRate: number;
+  };
+  maxLeverage: number;
+  minOrderSize: number;
+}
+
+/**
+ * Prediction market data structure from API.
+ */
+export interface PredictionMarket {
+  id: number | string;
+  text: string;
+  status: 'active' | 'resolved' | 'cancelled';
+  createdDate?: string;
+  resolutionDate?: string;
+  resolvedOutcome?: boolean;
+  scenario: number;
+  yesShares?: number;
+  noShares?: number;
+  oracleCommitTxHash?: string | null;
+  oracleRevealTxHash?: string | null;
+  oraclePublishedAt?: string | null;
+}
+
+/**
+ * Extended prediction market with user position data.
+ */
+export interface PredictionMarketWithPosition extends PredictionMarket {
+  userPosition?: {
+    side: 'YES' | 'NO';
+    shares: number;
+    avgPrice: number;
+    currentPrice: number;
+    pnl: number;
+    pnlPercent: number;
+    maxPayout: number;
+  };
+}
+
+// =============================================================================
+// Trading Types
+// =============================================================================
+
+/**
+ * Side of a perpetual trade position.
+ */
+export type TradeSide = 'long' | 'short';
+
+/**
+ * Side of a prediction market position.
+ */
+export type PredictionSide = 'YES' | 'NO';
+
+/**
+ * Market category type for PnL displays and filters.
+ */
+export type MarketCategory = 'perps' | 'predictions';
+
+// =============================================================================
+// UI Types
+// =============================================================================
+
+/**
+ * Tab options for the markets page.
+ */
+export type MarketTab = 'dashboard' | 'perps' | 'predictions';
+
+/**
+ * Sort options for prediction markets list.
+ */
+export type PredictionSort = 'trending' | 'newest' | 'ending-soon' | 'volume';
+
+/**
+ * Sort options for perp markets list.
+ */
+export type PerpSort = 'volume' | 'change' | 'name' | 'price';
+
+// =============================================================================
+// API Response Types
+// =============================================================================
+
+/**
+ * Standard API error response structure.
+ */
+export interface ApiErrorResponse {
+  error?: string | { message?: string; code?: string };
+  message?: string;
+}
+
+/**
+ * Success response for sell shares operation.
+ */
+export interface SellSharesSuccessResponse {
+  success: true;
+  sale: {
+    id: string;
+    proceeds: number;
+    shares: number;
+  };
+}
+
+/**
+ * Success response for buy shares operation.
+ */
+export interface BuySharesSuccessResponse {
+  success: true;
+  purchase: {
+    id: string;
+    cost: number;
+    shares: number;
+    side: PredictionSide;
+  };
+}
+
+// =============================================================================
+// Position Types for Components
+// =============================================================================
+
+/**
+ * Perp position structure for display in lists.
+ */
+export interface DisplayPerpPosition {
+  id: string;
+  ticker: string;
+  side: TradeSide;
+  entryPrice: number;
+  currentPrice: number;
+  size: number;
+  leverage: number;
+  liquidationPrice: number;
+  unrealizedPnL: number;
+  unrealizedPnLPercent: number;
+  fundingPaid: number;
+  openedAt: string;
+}
+
+/**
+ * Prediction position structure for display in lists.
+ */
+export interface DisplayPredictionPosition {
+  id: string;
+  marketId: string;
+  question: string;
+  side: PredictionSide;
+  shares: number;
+  avgPrice: number;
+  currentPrice: number;
+  pnl: number;
+  pnlPercent: number;
+  maxPayout: number;
+  resolved: boolean;
+  resolution: boolean | null;
+}
+
+// =============================================================================
+// History/Chart Types
+// =============================================================================
+
+/**
+ * Price point for perp price charts.
+ */
+export interface PerpHistoryPoint {
+  /** Timestamp in milliseconds */
+  time: number;
+  /** Price at this timestamp */
+  price: number;
+}
+
+/**
+ * Price point for prediction probability charts.
+ */
+export interface PredictionHistoryPoint {
+  /** Timestamp in milliseconds */
+  time: number;
+  /** YES price (0-1) */
+  yesPrice: number;
+  /** NO price (0-1) */
+  noPrice: number;
+}
+
+// =============================================================================
+// SSE Event Types
+// =============================================================================
+
+/**
+ * SSE event for prediction market trades.
+ */
+export interface PredictionTradeSSE {
+  type: 'prediction_trade';
+  marketId: string;
+  userId: string;
+  side: PredictionSide;
+  shares: number;
+  price: number;
+  timestamp: string;
+}
+
+/**
+ * SSE event for prediction market resolution.
+ */
+export interface PredictionResolutionSSE {
+  type: 'prediction_resolution';
+  marketId: string;
+  outcome: boolean;
+  timestamp: string;
+}
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/**
+ * Configuration constants for markets feature.
+ */
+export const MARKETS_CONFIG = {
+  /** Cache TTL for market data in milliseconds */
+  CACHE_TTL_MS: 10_000,
+
+  /** Default polling interval for market data in milliseconds */
+  DEFAULT_POLLING_INTERVAL_MS: 30_000,
+
+  /** Minimum polling interval allowed in milliseconds */
+  MIN_POLLING_INTERVAL_MS: 5_000,
+
+  /** Number of top movers to display */
+  TOP_MOVERS_COUNT: 4,
+
+  /** Number of trending markets to display */
+  TRENDING_MARKETS_COUNT: 6,
+
+  /** Maximum leverage for perp positions */
+  MAX_LEVERAGE: 100,
+
+  /** Minimum order size in USD */
+  MIN_ORDER_SIZE_USD: 1,
+
+  /** Default leverage for new positions */
+  DEFAULT_LEVERAGE: 10,
+
+  /** Liquidation threshold (0.9 = 90% of margin lost) */
+  LIQUIDATION_THRESHOLD: 0.9,
+
+  /** Chart sparkline dimensions */
+  SPARKLINE: {
+    WIDTH: 80,
+    HEIGHT: 28,
+  },
+
+  /** Number of price decimal places for display */
+  PRICE_DECIMALS: 2,
+
+  /** Number of percent decimal places for display */
+  PERCENT_DECIMALS: 2,
+} as const;
+
+/**
+ * Type for MARKETS_CONFIG values.
+ */
+export type MarketsConfig = typeof MARKETS_CONFIG;

--- a/apps/web/src/types/markets.ts
+++ b/apps/web/src/types/markets.ts
@@ -15,6 +15,9 @@
 // Re-exports from @babylon/shared
 // =============================================================================
 
+// Import types for internal use in this file
+import type { UserPredictionPosition as SharedUserPredictionPosition } from '@babylon/shared';
+
 export type {
   DailyPriceSnapshot,
   FundingRate,
@@ -27,6 +30,9 @@ export type {
   TradingStats,
   UserPredictionPosition,
 } from '@babylon/shared';
+
+// Local alias for internal use
+type UserPredictionPosition = SharedUserPredictionPosition;
 
 export {
   calculateFundingPayment,
@@ -84,17 +90,13 @@ export interface PredictionMarket {
 
 /**
  * Extended prediction market with user position data.
+ * Used in dashboard and list views where markets include user-specific position info.
  */
 export interface PredictionMarketWithPosition extends PredictionMarket {
-  userPosition?: {
-    side: 'YES' | 'NO';
-    shares: number;
-    avgPrice: number;
-    currentPrice: number;
-    pnl: number;
-    pnlPercent: number;
-    maxPayout: number;
-  };
+  /** Single user position (legacy format) */
+  userPosition?: UserPredictionPosition | null;
+  /** Array of user positions (current format) */
+  userPositions?: UserPredictionPosition[];
 }
 
 // =============================================================================
@@ -143,7 +145,9 @@ export type PerpSort = 'volume' | 'change' | 'name' | 'price';
  * Standard API error response structure.
  */
 export interface ApiErrorResponse {
-  error?: string | { message?: string; code?: string };
+  /** Error field - string message or object with required message */
+  error?: string | { message: string; code?: string };
+  /** Alternative message field used by some endpoints */
   message?: string;
 }
 

--- a/apps/web/src/types/markets.ts
+++ b/apps/web/src/types/markets.ts
@@ -48,7 +48,13 @@ export {
 
 /**
  * Perp market data structure from API.
- * Simplified version for frontend display (vs SharedPerpMarket which has more fields).
+ *
+ * This is the simplified frontend version used for display in lists and cards.
+ * Differences from SharedPerpMarket (from @babylon/shared):
+ * - PerpMarket: Fewer fields, used for UI display (lists, cards, modals)
+ * - SharedPerpMarket: Full API response with all fields (orderbook, trades, etc.)
+ *
+ * Use PerpMarket for components, SharedPerpMarket for API type validation.
  */
 export interface PerpMarket {
   ticker: string;
@@ -104,7 +110,11 @@ export interface PredictionMarketWithPosition extends PredictionMarket {
 // =============================================================================
 
 /**
- * Side of a perpetual trade position.
+ * Side of a perpetual trade position (frontend format).
+ *
+ * Note: API responses use uppercase 'LONG' | 'SHORT' (see PerpPositionFromAPI in @babylon/shared).
+ * The frontend normalizes these to lowercase for consistency with UI conventions.
+ * Convert with: side.toLowerCase() as TradeSide
  */
 export type TradeSide = 'long' | 'short';
 
@@ -153,14 +163,11 @@ export interface ApiErrorResponse {
 
 /**
  * Success response for sell shares operation.
+ * Returns PnL from the sale for display in success messages.
  */
 export interface SellSharesSuccessResponse {
-  success: true;
-  sale: {
-    id: string;
-    proceeds: number;
-    shares: number;
-  };
+  /** Realized profit/loss from the sale */
+  pnl: number;
 }
 
 /**
@@ -196,24 +203,6 @@ export interface DisplayPerpPosition {
   unrealizedPnLPercent: number;
   fundingPaid: number;
   openedAt: string;
-}
-
-/**
- * Prediction position structure for display in lists.
- */
-export interface DisplayPredictionPosition {
-  id: string;
-  marketId: string;
-  question: string;
-  side: PredictionSide;
-  shares: number;
-  avgPrice: number;
-  currentPrice: number;
-  pnl: number;
-  pnlPercent: number;
-  maxPayout: number;
-  resolved: boolean;
-  resolution: boolean | null;
 }
 
 // =============================================================================

--- a/packages/shared/src/types/profile.ts
+++ b/packages/shared/src/types/profile.ts
@@ -14,7 +14,7 @@ export interface UserBalanceData {
 }
 
 /**
- * Prediction market position from /api/markets/positions/[userId]
+ * Base prediction market position from /api/markets/positions/[userId]
  */
 export interface PredictionPosition {
   id: string;
@@ -26,6 +26,19 @@ export interface PredictionPosition {
   currentPrice: number;
   resolved: boolean;
   resolution?: boolean | null;
+}
+
+/**
+ * Extended prediction position with PnL calculations for user portfolio views.
+ * Extends PredictionPosition with computed fields for display.
+ */
+export interface UserPredictionPosition extends PredictionPosition {
+  /** Current market value of the position (shares × currentPrice) */
+  currentValue: number;
+  /** Original cost of the position (shares × avgPrice) */
+  costBasis: number;
+  /** Unrealized profit/loss (currentValue - costBasis) */
+  unrealizedPnL: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

Centralizes all market-related type definitions into a single source of truth, eliminating duplicate inline type definitions across the markets frontend codebase.

## Changes

### New Files
- `apps/web/src/types/markets.ts` - Centralized types file with:
  - Market types: `PerpMarket`, `PredictionMarket`, `PredictionMarketWithPosition`
  - Position types: `DisplayPerpPosition`, `UserPredictionPosition`
  - Trading types: `TradeSide`, `PredictionSide`, `MarketCategory`
  - UI types: `MarketTab`, `PredictionSort`, `PerpSort`
  - API response types: `ApiErrorResponse`, `SellSharesSuccessResponse`, `BuySharesSuccessResponse`
  - `MARKETS_CONFIG` constants for cache TTL, polling intervals, sparkline dimensions

### Updated Files
- **`@babylon/shared`**: Added `UserPredictionPosition` type extending `PredictionPosition`
- **Stores**: `perpMarketsStore.ts`, `predictionMarketsStore.ts` - Use centralized types and `MARKETS_CONFIG.CACHE_TTL_MS`
- **Hooks**: `useUserPositions.ts`, `usePerpTrade.ts` - Import from centralized types
- **Components**: All trading modals and position lists - Remove inline type definitions
- **Pages**: All markets pages - Use centralized types with proper extensions

## Benefits

1. **Single Source of Truth**: All market types defined in one place
2. **Reduced Duplication**: Eliminated ~20+ duplicate type definitions
3. **Named Constants**: Magic numbers replaced with `MARKETS_CONFIG`
4. **Better Maintainability**: Type changes only need to happen in one place
5. **Backwards Compatibility**: Re-exports maintain existing import paths

## Pre-Flight Checks

- [x] `bun run lint` - Passes (2 pre-existing infos in unrelated files)
- [ ] `bun run typecheck` - My files pass, pre-existing errors in:
  - `@babylon/testing` (missing nanoid, @elizaos/core)
  - `route.ts` files (drizzle-orm type issues)
- [ ] `bun run build` - Deferred to CI

## Screenshots / Recordings

> No visual changes - this is a pure refactoring PR affecting only type definitions and imports. All runtime behavior remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Markets now surface per-market user position data and metrics (current value, cost basis, unrealized P&L) alongside market details and lists.

* **Refactor**
  * Market-related types and MARKETS_CONFIG centralized for consistent sparkline dimensions and cache behavior across the app.

* **Style**
  * Minor logging formatting cleanup; no runtime behavior changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->