### PR TITLE
fix: update agent totalDeposited/totalWithdrawn on trading balance transfers

### DIFF
--- a/apps/web/src/components/agents/AgentLogs.tsx
+++ b/apps/web/src/components/agents/AgentLogs.tsx
@@ -250,11 +250,11 @@ export function AgentLogs({ agentId }: AgentLogsProps) {
                           </div>
                         )}
                         {log.metadata && (
-                          <div>
+                          <div className="min-w-0">
                             <div className="mb-1 font-medium text-muted-foreground">
                               Metadata:
                             </div>
-                            <pre className="overflow-x-auto rounded bg-black/30 p-2">
+                            <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded bg-black/30 p-2">
                               {JSON.stringify(log.metadata, null, 2)}
                             </pre>
                           </div>

--- a/packages/agents/src/services/AgentService.ts
+++ b/packages/agents/src/services/AgentService.ts
@@ -750,16 +750,18 @@ export class AgentServiceV2 {
       );
     }
 
-    // Get agent's current balance
+    // Get agent's current balance and totalDeposited
     const agentResult = await db
       .select({
         virtualBalance: users.virtualBalance,
+        totalDeposited: users.totalDeposited,
       })
       .from(users)
       .where(eq(users.id, agentUserId))
       .limit(1);
 
     const agentBalance = Number(agentResult[0]?.virtualBalance ?? 0);
+    const agentTotalDeposited = Number(agentResult[0]?.totalDeposited ?? 0);
 
     await withTransaction(async (tx) => {
       // Debit from manager
@@ -771,11 +773,12 @@ export class AgentServiceV2 {
         })
         .where(eq(users.id, managerUserId));
 
-      // Credit to agent
+      // Credit to agent (update both virtualBalance and totalDeposited)
       await tx
         .update(users)
         .set({
           virtualBalance: String(agentBalance + amount),
+          totalDeposited: String(agentTotalDeposited + amount),
           updatedAt: new Date(),
         })
         .where(eq(users.id, agentUserId));
@@ -843,16 +846,18 @@ export class AgentServiceV2 {
     );
     if (!agentWithConfig) throw new Error('Agent not found');
 
-    // Get agent's trading balance
+    // Get agent's trading balance and totalWithdrawn
     const agentResult = await db
       .select({
         virtualBalance: users.virtualBalance,
+        totalWithdrawn: users.totalWithdrawn,
       })
       .from(users)
       .where(eq(users.id, agentUserId))
       .limit(1);
 
     const agentBalance = Number(agentResult[0]?.virtualBalance ?? 0);
+    const agentTotalWithdrawn = Number(agentResult[0]?.totalWithdrawn ?? 0);
     if (agentBalance < amount) {
       throw new Error(
         `Insufficient agent trading balance. Have: $${agentBalance.toFixed(2)}, Need: $${amount.toFixed(2)}`
@@ -871,11 +876,12 @@ export class AgentServiceV2 {
     const managerBalance = Number(managerResult[0]?.virtualBalance ?? 0);
 
     await withTransaction(async (tx) => {
-      // Debit from agent
+      // Debit from agent (update both virtualBalance and totalWithdrawn)
       await tx
         .update(users)
         .set({
           virtualBalance: String(agentBalance - amount),
+          totalWithdrawn: String(agentTotalWithdrawn + amount),
           updatedAt: new Date(),
         })
         .where(eq(users.id, agentUserId));


### PR DESCRIPTION
## Summary

Fixes agent sidebar showing 0 pts for Points section (Available, In Positions, Total Portfolio) in ProfileWidget when viewing an agent's profile.

## Problem

When trading balance was deposited to or withdrawn from an agent, only `virtualBalance` was being updated, but `totalDeposited` and `totalWithdrawn` were never updated.

The ProfileWidget calculates:
- **Total Portfolio** = `totalDeposited`
- **In Positions** = `totalDeposited - balance`
- **Available** = `balance` (virtualBalance)

Since `totalDeposited` was always 0 for agents, the sidebar showed 0 for everything even though the agent had actual positions/holdings.

## Changes

### `packages/agents/src/services/AgentService.ts`
- **`depositTradingBalance()`**: Now updates both `virtualBalance` AND `totalDeposited` when funding an agent
- **`withdrawTradingBalance()`**: Now updates both `virtualBalance` AND `totalWithdrawn` when withdrawing from an agent

### `apps/web/src/components/agents/AgentLogs.tsx`
- CSS fix for metadata overflow in agent logs (unrelated but included)

## Testing

- `bun run typecheck` ✅
- `bun run lint` ✅

## Note

Existing agents that were funded before this fix will still show 0 until they receive a new deposit or a migration script backfills `totalDeposited` from transaction history.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved metadata display formatting and text wrapping capabilities in agent logs to enhance readability and gracefully handle content overflow.

* **Bug Fixes**
  * Enhanced balance tracking to ensure total deposit and withdrawal amounts are accurately recorded, properly aggregated, and consistently synchronized across all balance transfer operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->