### PR TITLE
fix: prevent agents from posting repetitive content + add agent action logging

### DIFF
--- a/apps/web/src/components/agents/AgentLogs.tsx
+++ b/apps/web/src/components/agents/AgentLogs.tsx
@@ -125,6 +125,10 @@ export function AgentLogs({ agentId }: AgentLogsProps) {
         return 'bg-blue-500/10 border-blue-500/20';
       case 'tick':
         return 'bg-purple-500/10 border-purple-500/20';
+      case 'post':
+        return 'bg-orange-500/10 border-orange-500/20';
+      case 'comment':
+        return 'bg-cyan-500/10 border-cyan-500/20';
       default:
         return 'bg-muted/30 border-border/50';
     }
@@ -145,6 +149,8 @@ export function AgentLogs({ agentId }: AgentLogsProps) {
             <option value="chat">Chat</option>
             <option value="tick">Tick</option>
             <option value="trade">Trade</option>
+            <option value="post">Post</option>
+            <option value="comment">Comment</option>
             <option value="error">Error</option>
             <option value="system">System</option>
           </select>

--- a/packages/agents/src/autonomous/AutonomousCommentingService.ts
+++ b/packages/agents/src/autonomous/AutonomousCommentingService.ts
@@ -30,6 +30,7 @@ import { StaticDataRegistry } from '@babylon/engine';
 import type { IAgentRuntime } from '@elizaos/core';
 import { parseKeyValueXml } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
+import { agentService } from '../services/AgentService';
 import { getAgentConfig } from '../shared/agent-config';
 import { logger } from '../shared/logger';
 import { getAgentContext } from './agent-context';
@@ -467,73 +468,68 @@ If you want to skip (no relevant posts):
       content?: string;
       reason?: string;
     } | null = null;
+    let llmCompletion: string | null = null;
+    let usedPrompt: string | null = null;
 
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-      try {
-        const isRetry = attempt > 1;
-        const currentPrompt = isRetry
-          ? `${finalPrompt}\n\nREMINDER: No <think> tags. Start DIRECTLY with <response>. Output only valid XML.`
-          : finalPrompt;
+      const isRetry = attempt > 1;
+      const currentPrompt = isRetry
+        ? `${finalPrompt}\n\nREMINDER: No <think> tags. Start DIRECTLY with <response>. Output only valid XML.`
+        : finalPrompt;
 
-        const responseText = await Promise.race([
-          callGroqDirect({
-            prompt: currentPrompt,
-            system: config?.systemPrompt ?? undefined,
-            modelSize: 'large',
-            runtime: _runtime,
-            temperature: isRetry ? 0.5 : 0.7,
-            maxTokens: 16384,
-            actionType: 'evaluate_comment_opportunity',
-            purpose: 'evaluation',
-          }),
-          new Promise<string>((_, reject) => {
-            setTimeout(() => reject(new Error('Timeout')), 20000);
-          }),
-        ]);
+      const responseText = await Promise.race([
+        callGroqDirect({
+          prompt: currentPrompt,
+          system: config?.systemPrompt ?? undefined,
+          modelSize: 'large',
+          runtime: _runtime,
+          temperature: isRetry ? 0.5 : 0.7,
+          maxTokens: 16384,
+          actionType: 'evaluate_comment_opportunity',
+          purpose: 'evaluation',
+        }),
+        new Promise<string>((_, reject) => {
+          setTimeout(() => reject(new Error('Timeout')), 20000);
+        }),
+      ]);
 
-        // Extract response block
-        const responseMatch = responseText.match(
-          /<response>([\s\S]*?)<\/response>/i
-        );
-        if (!responseMatch) {
-          logger.warn(
-            'No <response> block found in comment evaluation',
-            { attempt, raw: responseText.substring(0, 200) },
-            'AutonomousCommenting'
-          );
-          continue;
-        }
-
-        const parsed = parseKeyValueXml(responseMatch[0]) as {
-          action?: string;
-          post_index?: string;
-          reply_to_comment_id?: string;
-          content?: string;
-          reason?: string;
-        } | null;
-
-        if (!parsed?.action) {
-          continue;
-        }
-
-        decision = {
-          action: parsed.action,
-          postIndex: parsed.post_index
-            ? parseInt(parsed.post_index, 10)
-            : undefined,
-          replyToCommentId: parsed.reply_to_comment_id || undefined,
-          content: parsed.content,
-          reason: parsed.reason,
-        };
-        break;
-      } catch (error) {
-        const errorMsg = error instanceof Error ? error.message : String(error);
+      // Extract response block
+      const responseMatch = responseText.match(
+        /<response>([\s\S]*?)<\/response>/i
+      );
+      if (!responseMatch) {
         logger.warn(
-          `Comment evaluation attempt ${attempt} failed: ${errorMsg}`,
-          { agentUserId },
+          'No <response> block found in comment evaluation',
+          { attempt, raw: responseText.substring(0, 200) },
           'AutonomousCommenting'
         );
+        continue;
       }
+
+      const parsed = parseKeyValueXml(responseMatch[0]) as {
+        action?: string;
+        post_index?: string;
+        reply_to_comment_id?: string;
+        content?: string;
+        reason?: string;
+      } | null;
+
+      if (!parsed?.action) {
+        continue;
+      }
+
+      decision = {
+        action: parsed.action,
+        postIndex: parsed.post_index
+          ? parseInt(parsed.post_index, 10)
+          : undefined,
+        replyToCommentId: parsed.reply_to_comment_id || undefined,
+        content: parsed.content,
+        reason: parsed.reason,
+      };
+      llmCompletion = responseText;
+      usedPrompt = currentPrompt;
+      break;
     }
 
     if (!decision) {
@@ -616,6 +612,22 @@ If you want to skip (no relevant posts):
         );
         return null;
       }
+
+      // Log the comment with prompt and completion for debugging/review
+      await agentService.createLog(agentUserId, {
+        type: 'comment',
+        level: 'info',
+        message: `Created comment on post ${selectedPost.id}${parentCommentId ? ` (reply to ${parentCommentId})` : ''}: ${cleanContent.substring(0, 100)}${cleanContent.length > 100 ? '...' : ''}`,
+        prompt: usedPrompt ?? undefined,
+        completion: llmCompletion ?? undefined,
+        metadata: {
+          commentId: result.commentId ?? null,
+          postId: selectedPost.id,
+          parentCommentId: parentCommentId ?? null,
+          contentLength: cleanContent.length,
+          agentDisplayName,
+        },
+      });
 
       logger.info(
         `Agent ${agentDisplayName} commented on post ${selectedPost.id}${parentCommentId ? ` (reply to ${parentCommentId})` : ''}`,

--- a/packages/agents/src/autonomous/AutonomousPostingService.ts
+++ b/packages/agents/src/autonomous/AutonomousPostingService.ts
@@ -15,6 +15,7 @@ import {
 import type { IAgentRuntime } from '@elizaos/core';
 import { parseKeyValueXml } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
+import { agentService } from '../services/AgentService';
 import { getAgentConfig } from '../shared/agent-config';
 import { logger } from '../shared/logger';
 import { getAgentContext } from './agent-context';
@@ -308,85 +309,82 @@ To skip (if you've recently covered this topic or have nothing new to add):
     // Use large model (qwen3-32b or trained W&B model) for post generation with retry loop
     const MAX_ATTEMPTS = 3;
     let cleanContent: string | null = null;
+    let llmCompletion: string | null = null;
+    let usedPrompt: string | null = null;
 
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-      try {
-        const isRetry = attempt > 1;
-        const currentPrompt = isRetry
-          ? `${finalPrompt}\n\nREMINDER: You MUST output valid XML. Start with <response>, include <action> (post or skip), and <text> for posts. No <think> tags.`
-          : finalPrompt;
+      const isRetry = attempt > 1;
+      const currentPrompt = isRetry
+        ? `${finalPrompt}\n\nREMINDER: You MUST output valid XML. Start with <response>, include <action> (post or skip), and <text> for posts. No <think> tags.`
+        : finalPrompt;
 
-        const postContent = await callGroqDirect({
-          prompt: currentPrompt,
-          system: config?.systemPrompt ?? undefined,
-          modelSize: 'large', // Uses trained W&B model if available, else qwen3-32b
-          runtime: _runtime, // Pass runtime to access W&B trained models AND trajectory context
-          temperature: isRetry ? 0.6 : 0.8,
-          maxTokens: MAX_TOKENS,
-          actionType: 'generate_autonomous_post',
-          purpose: 'action', // RLAIF: This is a content generation action
-        });
+      const postContent = await callGroqDirect({
+        prompt: currentPrompt,
+        system: config?.systemPrompt ?? undefined,
+        modelSize: 'large', // Uses trained W&B model if available, else qwen3-32b
+        runtime: _runtime, // Pass runtime to access W&B trained models AND trajectory context
+        temperature: isRetry ? 0.6 : 0.8,
+        maxTokens: MAX_TOKENS,
+        actionType: 'generate_autonomous_post',
+        purpose: 'action', // RLAIF: This is a content generation action
+      });
 
-        // Extract <response>...</response> block before parsing
-        const responseMatch = postContent.match(
-          /<response>([\s\S]*?)<\/response>/i
+      // Extract <response>...</response> block before parsing
+      const responseMatch = postContent.match(
+        /<response>([\s\S]*?)<\/response>/i
+      );
+      if (!responseMatch) {
+        logger.warn(
+          'No <response> block found in post generation',
+          {
+            agentUserId,
+            attempt,
+            raw: postContent.substring(0, 300),
+          },
+          'AutonomousPosting'
         );
-        if (!responseMatch) {
-          logger.warn(
-            'No <response> block found in post generation',
-            {
-              agentUserId,
-              attempt,
-              raw: postContent.substring(0, 300),
-            },
-            'AutonomousPosting'
-          );
-          continue;
-        }
-
-        // Parse the extracted XML response
-        const parsed = parseKeyValueXml(responseMatch[0]) as {
-          action?: string;
-          text?: string;
-          reason?: string;
-        } | null;
-
-        // Check if agent chose to skip
-        if (parsed?.action === 'skip') {
-          logger.info(
-            `Agent ${agentDisplayName} chose to skip posting`,
-            {
-              agentUserId,
-              reason: parsed.reason || 'No reason given',
-            },
-            'AutonomousPosting'
-          );
-          return null;
-        }
-
-        // Check if we got valid text
-        if (!parsed?.text || parsed.text.trim().length === 0) {
-          logger.warn(
-            'Failed to parse XML response in post generation',
-            {
-              agentUserId,
-              attempt,
-              raw: postContent.substring(0, 300),
-            },
-            'AutonomousPosting'
-          );
-          continue;
-        }
-
-        // Success! Clean up the response
-        cleanContent = parsed.text.trim().replace(/^["']|["']$/g, '');
-        break;
-      } catch (error) {
-        logger.warn(`Post generation attempt ${attempt} failed`, {
-          agentUserId,
-          error: String(error),
-        });
+        continue;
       }
+
+      // Parse the extracted XML response
+      const parsed = parseKeyValueXml(responseMatch[0]) as {
+        action?: string;
+        text?: string;
+        reason?: string;
+      } | null;
+
+      // Check if agent chose to skip
+      if (parsed?.action === 'skip') {
+        logger.info(
+          `Agent ${agentDisplayName} chose to skip posting`,
+          {
+            agentUserId,
+            reason: parsed.reason || 'No reason given',
+          },
+          'AutonomousPosting'
+        );
+        return null;
+      }
+
+      // Check if we got valid text
+      if (!parsed?.text || parsed.text.trim().length === 0) {
+        logger.warn(
+          'Failed to parse XML response in post generation',
+          {
+            agentUserId,
+            attempt,
+            raw: postContent.substring(0, 300),
+          },
+          'AutonomousPosting'
+        );
+        continue;
+      }
+
+      // Success! Clean up the response and capture LLM output
+      cleanContent = parsed.text.trim().replace(/^["']|["']$/g, '');
+      llmCompletion = postContent;
+      usedPrompt = currentPrompt;
+      break;
     }
 
     // If all attempts failed, return null
@@ -450,6 +448,20 @@ To skip (if you've recently covered this topic or have nothing new to add):
       );
       return null;
     }
+
+    // Log the post with prompt and completion for debugging/review
+    await agentService.createLog(agentUserId, {
+      type: 'post',
+      level: 'info',
+      message: `Created post: ${cleanContent.substring(0, 100)}${cleanContent.length > 100 ? '...' : ''}`,
+      prompt: usedPrompt ?? undefined,
+      completion: llmCompletion ?? undefined,
+      metadata: {
+        postId: result.postId ?? null,
+        contentLength: cleanContent.length,
+        agentDisplayName,
+      },
+    });
 
     logger.info(
       `Agent ${agentDisplayName} created post: ${result.postId}`,

--- a/packages/agents/src/autonomous/AutonomousPostingService.ts
+++ b/packages/agents/src/autonomous/AutonomousPostingService.ts
@@ -96,8 +96,15 @@ Your recent activity:
 ${recentTrades.length > 0 ? `- Recent trades: ${JSON.stringify(recentTrades.map((t) => ({ action: t.action, ticker: t.ticker, pnl: t.pnl })))}` : '- No recent trades'}
 - Your P&L: ${agentLifetimePnL}
 
-YOUR RECENT POSTS (avoid repeating themes/openings):
+YOUR RECENT POSTS (CRITICAL - avoid repeating themes/phrases/structure):
 ${recentPosts.length > 0 ? recentPosts.map((p, i) => `[${i + 1}] "${p.content}" (${getTimeAgo(p.createdAt)})`).join('\n') : 'No recent posts'}
+
+⚠️ BEFORE POSTING - Check your recent posts above and ask:
+1. Am I using the same phrases? (e.g., "crowd consensus", "asymmetry", "exit liquidity") → USE DIFFERENT WORDS
+2. Am I posting about the same market/topic? → PICK A DIFFERENT MARKET
+3. Am I starting the same way? → USE A COMPLETELY DIFFERENT OPENING
+4. Am I making the same type of argument? (e.g., always contrarian) → TRY A DIFFERENT ANGLE
+If ANY answer is YES, you MUST change your approach completely.
 
 WORLD CONTEXT:
 ${worldContext.worldActors}
@@ -141,6 +148,28 @@ BANNED PATTERNS (-100 points each - INSTANT FAILURE):
 ❌ "I'm closely watching..." followed by "and considering..."
 ❌ Posts starting with: "Just saw" / "I'm considering" / "Noticing" / "Given"
 ❌ Pattern: [observation] + "and I'm considering" + [action]
+
+BANNED REPETITIVE PHRASES (-100 points each - INSTANT FAILURE):
+These phrases are overused. NEVER use them:
+❌ "[N]% crowd consensus" or "crowd consensus at [N]%"
+❌ "[N]:1 asymmetry" or "risk asymmetry" or "asymmetry = [N]:1"
+❌ "exit liquidity" / "exit liquidity gets harvested"
+❌ "fade the herd" / "fading the herd"
+❌ "when everyone's [certain/bullish/bearish/long/short]"
+❌ "security first" / "security rule" / "security 101"
+❌ "cascade liquidations" / "liquidations inbound"
+❌ "crowded long" / "crowded short" / "crowded trade"
+❌ "mean reversion" / "mean-reversion"
+❌ "the crowd is wrong" / "crowd reversal"
+❌ "who's left to buy" / "who's left to sell"
+❌ Formulas like "[percentage] YES/NO = [ratio] odds"
+
+Instead, express ideas FRESHLY each time:
+✅ Be specific about WHY you disagree (not just "crowd is wrong")
+✅ Name specific catalysts or events
+✅ Make concrete predictions with reasoning
+✅ Share personal trading actions with context
+✅ Ask thought-provoking questions
 
 SCORING RUBRIC (aim for 90+ points):
 
@@ -233,13 +262,16 @@ FINAL REQUIREMENTS:
 - Valuable to the community
 
 CRITICAL SCORING CHECK:
-1. Review YOUR RECENT POSTS above - note their opening words and structure
-2. Pick a DIFFERENT strategy and opening than you've used recently
-3. Mentally calculate your score using the rubric above
-4. TARGET: 90+ points (must get variation bonuses!)
-5. If below 70 points, try a completely different approach
-6. NEVER post anything with banned patterns (-100 pts = instant fail)
-7. NEVER repeat the same topic/market you just posted about
+1. Review YOUR RECENT POSTS above - note their opening words, phrases, and topics
+2. EXTRACT KEY PHRASES from your recent posts - if you're about to use ANY of them, STOP and rephrase
+3. Check what markets/topics you covered recently - pick a DIFFERENT one
+4. Pick a DIFFERENT strategy and opening than you've used recently
+5. Mentally calculate your score using the rubric above
+6. TARGET: 90+ points (must get variation bonuses!)
+7. If below 70 points, try a completely different approach
+8. NEVER post anything with banned patterns or phrases (-100 pts = instant fail)
+9. NEVER repeat the same topic/market you just posted about
+10. If you've posted 3+ times about the same market, you MUST skip or post about something else
 ${contextString}
 
 # Required Output Format (use exactly this structure)

--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -31,6 +31,7 @@ import { StaticDataRegistry, WalletService } from '@babylon/engine';
 import type { IAgentRuntime } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
 import { getNpcGameContext } from '../plugins/babylon/providers/npc-game-context';
+import { agentService } from '../services/AgentService';
 import { getAgentConfig } from '../shared/agent-config';
 import { logger } from '../shared/logger';
 import { autonomousBatchResponseService } from './AutonomousBatchResponseService';
@@ -186,14 +187,14 @@ export class MultiStepExecutor {
       });
 
       // Get LLM decision
-      const decision = await this.getDecision(
+      const decisionResult = await this.getDecision(
         prompt,
         runtime,
         iteration,
         systemPrompt
       );
 
-      if (!decision) {
+      if (!decisionResult) {
         logger.warn(
           `[MultiStep] Failed to parse decision at iteration ${iteration}, finishing`,
           undefined,
@@ -201,6 +202,8 @@ export class MultiStepExecutor {
         );
         break;
       }
+
+      const { decision, rawResponse } = decisionResult;
 
       logger.info(
         `[MultiStep] Decision: ${decision.action || 'FINISH'}`,
@@ -225,7 +228,8 @@ export class MultiStepExecutor {
       const actionResult = await this.executeAction(
         agentUserId,
         decision.action,
-        decision.parameters
+        decision.parameters,
+        { prompt, completion: rawResponse, thought: decision.thought }
       );
 
       trace.push(actionResult);
@@ -568,13 +572,14 @@ export class MultiStepExecutor {
 
   /**
    * Get LLM decision with retry logic
+   * Returns both parsed decision and raw response for logging
    */
   private async getDecision(
     prompt: string,
     runtime: IAgentRuntime,
     _iteration: number,
     systemPrompt?: string
-  ): Promise<MultiStepDecision | null> {
+  ): Promise<{ decision: MultiStepDecision; rawResponse: string } | null> {
     const maxRetries = 3;
 
     // Use agent's system prompt + JSON instruction
@@ -621,7 +626,7 @@ export class MultiStepExecutor {
           parsed.thought = '';
         }
 
-        return parsed;
+        return { decision: parsed, rawResponse: response };
       } catch {
         logger.warn(
           `[MultiStep] Failed to parse JSON (attempt ${attempt})`,
@@ -640,7 +645,8 @@ export class MultiStepExecutor {
   private async executeAction(
     agentUserId: string,
     action: string,
-    parameters: Record<string, unknown>
+    parameters: Record<string, unknown>,
+    logContext?: { prompt: string; completion: string; thought: string }
   ): Promise<ActionTraceResult> {
     const normalizedAction = action.toUpperCase();
 
@@ -720,6 +726,22 @@ export class MultiStepExecutor {
           content,
         });
 
+        // Log the post with prompt and completion for debugging/review
+        if (postResult.success && logContext) {
+          await agentService.createLog(agentUserId, {
+            type: 'post',
+            level: 'info',
+            message: `Created post: ${content.substring(0, 100)}${content.length > 100 ? '...' : ''}`,
+            prompt: logContext.prompt,
+            completion: logContext.completion,
+            thinking: logContext.thought,
+            metadata: {
+              postId: postResult.postId ?? null,
+              contentLength: content.length,
+            },
+          });
+        }
+
         return {
           actionType: 'POST',
           success: postResult.success,
@@ -760,6 +782,24 @@ export class MultiStepExecutor {
           content,
           parentCommentId,
         });
+
+        // Log the comment with prompt and completion for debugging/review
+        if (commentResult.success && logContext) {
+          await agentService.createLog(agentUserId, {
+            type: 'comment',
+            level: 'info',
+            message: `Created comment on post ${postId}${parentCommentId ? ` (reply to ${parentCommentId})` : ''}: ${content.substring(0, 100)}${content.length > 100 ? '...' : ''}`,
+            prompt: logContext.prompt,
+            completion: logContext.completion,
+            thinking: logContext.thought,
+            metadata: {
+              commentId: commentResult.commentId ?? null,
+              postId,
+              parentCommentId: parentCommentId ?? null,
+              contentLength: content.length,
+            },
+          });
+        }
 
         return {
           actionType: 'COMMENT',

--- a/packages/agents/src/autonomous/TopicDiversityService.ts
+++ b/packages/agents/src/autonomous/TopicDiversityService.ts
@@ -60,7 +60,25 @@ const TOPIC_TRACKING_WINDOW_MS = 30 * 60 * 1000;
 const MAX_TOPIC_COVERAGE = 5;
 
 /** Minimum word overlap to consider posts similar */
-const SIMILARITY_THRESHOLD = 0.5; // Raised to allow more variety in similar topics
+const SIMILARITY_THRESHOLD = 0.3; // Lower threshold for stricter duplicate detection
+
+/** Common repetitive phrases to detect and block */
+const REPETITIVE_PHRASE_PATTERNS = [
+  // Statistical patterns
+  /\d+%\s*crowd\s*consensus/i,
+  /\d+:\d+\s*asymmetry/i,
+  /\d+%\s*(yes|no)\s*(on|for|against)/i,
+  // Trading cliches
+  /exit\s*liquidity/i,
+  /fade\s*the\s*herd/i,
+  /when\s*everyone['']?s\s*(certain|bullish|bearish|long|short)/i,
+  /security\s*(first|rule|101)/i,
+  /risk\s*asymmetry/i,
+  /consensus\s*(reversal|flips?)/i,
+  /mean[\s-]?reversion/i,
+  /cascade\s*liquidations?/i,
+  /crowded\s*(long|short|trade)/i,
+];
 
 /** Angles for variety in posting */
 const POSTING_ANGLES = [
@@ -86,6 +104,12 @@ export class TopicDiversityService {
 
   /** Agent to assigned topic mapping for current tick batch */
   private agentAssignments: Map<string, TopicAssignment> = new Map();
+
+  /** Per-agent phrase tracking to prevent repetitive patterns */
+  private agentPhraseHistory: Map<
+    string,
+    { phrases: string[]; lastUpdated: Date }
+  > = new Map();
 
   /** Last cleanup timestamp */
   private lastCleanup = 0;
@@ -252,6 +276,74 @@ export class TopicDiversityService {
   }
 
   /**
+   * Extract repetitive phrases from content for tracking
+   */
+  extractRepetitivePhrases(content: string): string[] {
+    const phrases: string[] = [];
+    for (const pattern of REPETITIVE_PHRASE_PATTERNS) {
+      const match = content.match(pattern);
+      if (match) {
+        phrases.push(match[0].toLowerCase());
+      }
+    }
+    return phrases;
+  }
+
+  /**
+   * Check if content uses repetitive phrases the agent has used recently
+   */
+  hasRepetitivePhrases(
+    agentId: string,
+    content: string
+  ): { hasRepetition: boolean; repeatedPhrase?: string } {
+    const contentPhrases = this.extractRepetitivePhrases(content);
+    if (contentPhrases.length === 0) {
+      return { hasRepetition: false };
+    }
+
+    const history = this.agentPhraseHistory.get(agentId);
+    if (!history) {
+      return { hasRepetition: false };
+    }
+
+    // Check if any phrase has been used before
+    for (const phrase of contentPhrases) {
+      // Normalize for comparison
+      const normalizedPhrase = phrase.replace(/\d+/g, 'N'); // Replace numbers with N for pattern matching
+      for (const historyPhrase of history.phrases) {
+        const normalizedHistory = historyPhrase.replace(/\d+/g, 'N');
+        if (normalizedPhrase === normalizedHistory) {
+          return { hasRepetition: true, repeatedPhrase: phrase };
+        }
+      }
+    }
+
+    return { hasRepetition: false };
+  }
+
+  /**
+   * Record phrases used by an agent
+   */
+  recordAgentPhrases(agentId: string, content: string): void {
+    const phrases = this.extractRepetitivePhrases(content);
+    const existing = this.agentPhraseHistory.get(agentId);
+
+    if (existing) {
+      // Add new phrases, keep last 20
+      existing.phrases.push(...phrases);
+      if (existing.phrases.length > 20) {
+        existing.phrases = existing.phrases.slice(-20);
+      }
+      existing.lastUpdated = new Date();
+    } else {
+      this.agentPhraseHistory.set(agentId, {
+        phrases,
+        lastUpdated: new Date(),
+      });
+    }
+  }
+
+  /**
    * Record that a topic was covered by an agent
    */
   recordTopicCoverage(
@@ -283,6 +375,9 @@ export class TopicDiversityService {
         sampleContent: [content.substring(0, 200)],
       });
     }
+
+    // Also record phrase patterns for per-agent tracking
+    this.recordAgentPhrases(agentId, content);
   }
 
   /**
@@ -355,6 +450,14 @@ export class TopicDiversityService {
     if (similarityCheck.isSimilar) {
       issues.push(
         `Content is ${Math.round((similarityCheck.similarity ?? 0) * 100)}% similar to a recent post. Add your unique take.`
+      );
+    }
+
+    // Check phrase repetition - prevent repetitive patterns
+    const phraseCheck = this.hasRepetitivePhrases(agentId, content);
+    if (phraseCheck.hasRepetition) {
+      issues.push(
+        `You've used the phrase pattern "${phraseCheck.repeatedPhrase}" recently. Try a different angle or phrasing.`
       );
     }
 
@@ -462,7 +565,10 @@ export class TopicDiversityService {
 
     logger.info(
       `Seeded topic tracker with ${recentPosts.length} recent posts`,
-      { topicsTracked: this.topicCoverage.size },
+      {
+        topicsTracked: this.topicCoverage.size,
+        agentsWithPhraseHistory: this.agentPhraseHistory.size,
+      },
       'TopicDiversityService'
     );
   }
@@ -562,6 +668,13 @@ You could trade this, post about it, or comment on price action.
         this.topicCoverage.delete(key);
       }
     }
+
+    // Also clean up old phrase history (same window)
+    for (const [agentId, history] of this.agentPhraseHistory.entries()) {
+      if (history.lastUpdated < cutoff) {
+        this.agentPhraseHistory.delete(agentId);
+      }
+    }
   }
 
   /**
@@ -570,6 +683,7 @@ You could trade this, post about it, or comment on price action.
   getTopicStats(): {
     topicsTracked: number;
     mostCovered: { topic: string; count: number }[];
+    agentsWithPhraseHistory: number;
   } {
     const sorted = Array.from(this.topicCoverage.entries())
       .map(([key, coverage]) => ({
@@ -581,6 +695,7 @@ You could trade this, post about it, or comment on price action.
     return {
       topicsTracked: this.topicCoverage.size,
       mostCovered: sorted.slice(0, 10),
+      agentsWithPhraseHistory: this.agentPhraseHistory.size,
     };
   }
 }

--- a/packages/engine/src/prompts/shared-sections.ts
+++ b/packages/engine/src/prompts/shared-sections.ts
@@ -370,6 +370,28 @@ These patterns make you sound like a robot, not a person:
 - Mentioning specific dates: "by Dec 13", "in 3 days"
 - Sounding like a market analyst or news reporter
 
+=== BANNED REPETITIVE PHRASES (instant rejection) ===
+These phrases are overused cliches. NEVER use them:
+
+- "[N]% crowd consensus" / "crowd consensus at [N]%"
+- "[N]:1 asymmetry" / "risk asymmetry" / "asymmetry = [N]:1"
+- "exit liquidity" / "exit liquidity gets harvested"
+- "fade the herd" / "fading the herd"
+- "when everyone's [certain/bullish/bearish/long/short]"
+- "security first" / "security rule" / "security 101"
+- "cascade liquidations" / "liquidations inbound"
+- "crowded long" / "crowded short" / "crowded trade"
+- "mean reversion" / "mean-reversion"
+- "the crowd is wrong" / "crowd reversal"
+- "who's left to buy" / "who's left to sell"
+- Formulas like "[percentage] YES/NO = [ratio] odds"
+
+Instead, express ideas FRESHLY:
+- Be specific about WHY you disagree
+- Name specific catalysts or events
+- Make concrete predictions with reasoning
+- Share personal trading actions with context
+
 === QUALITY SCORING (aim for 90+ points) ===
 +30: Direct statement or bold claim
 +25: Prediction with conviction (no hedging)


### PR DESCRIPTION
## Problem

PhiProtocol agent (and potentially others) was posting very similar content repeatedly with phrases like:
- "85% crowd consensus = 5.7:1 asymmetry"
- "exit liquidity gets harvested"
- "fade the herd"

See: https://staging.babylon.market/profile/agent_phiprotocol_1411_yg2mlg

## Solution

### 1. TopicDiversityService - Stricter Duplicate Detection

- **Lowered similarity threshold** from 0.5 to 0.3 for more aggressive duplicate detection
- **Added phrase-level repetition detection** with regex patterns for common cliches:
  - `N% crowd consensus`, `N:1 asymmetry`, `exit liquidity`
  - `fade the herd`, `cascade liquidations`, `mean reversion`, etc.
- **Per-agent phrase tracking**: Each agent now has their own phrase history
  - If an agent uses "85% consensus" once, they cannot use similar patterns for 30 minutes
  - Numbers are normalized (85% → N%) so "85% consensus" and "73% consensus" are treated as the same pattern

### 2. AutonomousPostingService - Improved Prompt

- **Explicit banned phrases** in the prompt with -100 point penalty
- **Self-check warning** after showing recent posts asking:
  - Am I using the same phrases?
  - Am I posting about the same market/topic?
  - Am I starting the same way?
- **Enhanced scoring check** with skip rule if 3+ posts about same market

### 3. Banned Phrases in Shared Prompts

- Added banned repetitive phrases section to `packages/engine/src/prompts/shared-sections.ts`
- Quality rules now apply to **all agents** (not just NPCs) via `multi-step-decision.ts`

### 4. Agent Action Logging (NEW)

Added comprehensive logging for agent post/comment actions to enable debugging and review:

- **AutonomousPostingService**: Logs post creation with prompt, completion, and metadata
- **AutonomousCommentingService**: Logs comment creation with prompt, completion, and metadata
- **MultiStepExecutor**: Logs post/comment actions from multi-step execution with thinking context
- **AgentLogs UI**: Added styling and filter options for `post` and `comment` log types (orange/cyan)

Each log entry includes:
- The full prompt sent to the LLM
- The raw LLM completion
- Metadata (postId, commentId, content length, etc.)
- For multi-step: the `thinking` field from agent reasoning

### 5. Code Quality Improvements

- **Removed defensive try/catch blocks** in AutonomousPostingService and AutonomousCommentingService
- Follows fail-fast principle per project guidelines

## Testing

- `bun run typecheck` ✅
- `bun run lint` ✅ (pre-existing warnings in web package unrelated to this PR)

## Files Changed

| File | Changes |
|------|---------|
| `TopicDiversityService.ts` | Phrase tracking, stricter detection |
| `AutonomousPostingService.ts` | Banned phrases prompt, action logging |
| `AutonomousCommentingService.ts` | Action logging, removed try/catch |
| `MultiStepExecutor.ts` | Action logging for posts/comments |
| `multi-step-decision.ts` | Quality rules for all agents |
| `shared-sections.ts` | Banned repetitive phrases |
| `AgentLogs.tsx` | Post/comment log type styling |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stronger post-quality rules: critical header, proactive pre-posting checklist, banned repetitive-phrases guidance, and a multi-step post-generation rubric.
  * Per-agent phrase tracking surfaced in stats and used to block/reject repetitive content.
  * New log types and UI filters for posts/comments; richer logging that captures prompt/completion and metadata.

* **Bug Fixes**
  * Tighter duplicate detection, stricter validation/retry flow, and improved failure logging to reduce invalid or repetitive posts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->