### PR TITLE
feat(engine): Add tiered group system for scalable NPC group access

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -51,7 +51,7 @@ jobs:
 
             Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
 
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          # Use Claude Opus 4.5 for better code review quality
+          # See https://code.claude.com/docs/en/github-actions for available options
+          claude_args: '--model claude-opus-4-5-20251101 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,8 +43,7 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          # Use Claude Opus 4.5 for better code understanding and implementation
+          # See https://code.claude.com/docs/en/github-actions for available options
+          claude_args: '--model claude-opus-4-5-20251101'
 

--- a/packages/api/src/linear/client.ts
+++ b/packages/api/src/linear/client.ts
@@ -42,7 +42,10 @@ export async function createLinearIssue(
   const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
 
   const client = new GraphQLClient(LINEAR_API_URL, {
-    headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
     signal: controller.signal,
   });
 

--- a/packages/db/drizzle/migrations/0012_add_tiered_group_system.sql
+++ b/packages/db/drizzle/migrations/0012_add_tiered_group_system.sql
@@ -1,0 +1,35 @@
+-- Migration: Add Tiered Group System
+-- Adds tier support to Group and GroupMember tables for NPC groups
+
+-- Add tier columns to Group table
+ALTER TABLE "Group" ADD COLUMN "tier" integer;
+ALTER TABLE "Group" ADD COLUMN "maxMembers" integer;
+ALTER TABLE "Group" ADD COLUMN "parentGroupId" text;
+
+-- Add tier columns to GroupMember table
+ALTER TABLE "GroupMember" ADD COLUMN "tier" integer;
+ALTER TABLE "GroupMember" ADD COLUMN "promotedAt" timestamp;
+ALTER TABLE "GroupMember" ADD COLUMN "demotedAt" timestamp;
+ALTER TABLE "GroupMember" ADD COLUMN "previousTier" integer;
+
+-- Add indexes for efficient tier queries
+CREATE INDEX "Group_tier_idx" ON "Group" ("tier");
+CREATE INDEX "Group_ownerId_tier_idx" ON "Group" ("ownerId", "tier");
+CREATE INDEX "Group_parentGroupId_idx" ON "Group" ("parentGroupId");
+CREATE INDEX "GroupMember_tier_idx" ON "GroupMember" ("tier");
+
+-- Migrate existing NPC groups to Tier 1 (Inner Circle)
+UPDATE "Group"
+SET 
+  "tier" = 1,
+  "maxMembers" = 12
+WHERE "type" = 'npc'
+  AND "tier" IS NULL;
+
+-- Update existing memberships to Tier 1
+UPDATE "GroupMember" gm
+SET "tier" = 1
+FROM "Group" g
+WHERE gm."groupId" = g.id
+  AND g."type" = 'npc'
+  AND gm."tier" IS NULL;

--- a/packages/db/drizzle/migrations/0012_rollback_tiered_group_system.sql
+++ b/packages/db/drizzle/migrations/0012_rollback_tiered_group_system.sql
@@ -1,0 +1,28 @@
+-- Rollback: Remove Tiered Group System
+-- Reverses 0012_add_tiered_group_system.sql
+-- 
+-- IMPORTANT: This script removes tier data. Run only if you need to fully rollback
+-- the tiered group feature. Data in tier columns will be lost.
+--
+-- Usage: Run manually if rollback is needed. Not auto-executed by Drizzle.
+
+-- Drop indexes first (must exist before dropping columns)
+DROP INDEX IF EXISTS "GroupMember_tier_idx";
+DROP INDEX IF EXISTS "Group_parentGroupId_idx";
+DROP INDEX IF EXISTS "Group_ownerId_tier_idx";
+DROP INDEX IF EXISTS "Group_tier_idx";
+
+-- Drop composite indexes from 0013 (if applied)
+DROP INDEX IF EXISTS "GroupMember_userId_isActive_tier_idx";
+DROP INDEX IF EXISTS "GroupMember_isActive_tier_idx";
+
+-- Remove tier columns from GroupMember table
+ALTER TABLE "GroupMember" DROP COLUMN IF EXISTS "previousTier";
+ALTER TABLE "GroupMember" DROP COLUMN IF EXISTS "demotedAt";
+ALTER TABLE "GroupMember" DROP COLUMN IF EXISTS "promotedAt";
+ALTER TABLE "GroupMember" DROP COLUMN IF EXISTS "tier";
+
+-- Remove tier columns from Group table
+ALTER TABLE "Group" DROP COLUMN IF EXISTS "parentGroupId";
+ALTER TABLE "Group" DROP COLUMN IF EXISTS "maxMembers";
+ALTER TABLE "Group" DROP COLUMN IF EXISTS "tier";

--- a/packages/db/drizzle/migrations/0013_add_tier_composite_indexes.sql
+++ b/packages/db/drizzle/migrations/0013_add_tier_composite_indexes.sql
@@ -1,0 +1,12 @@
+-- Migration: Add Composite Indexes for Tier Queries
+-- Improves performance for tiered group system queries (PR #670 fixes)
+
+-- Composite index for getUserTierStatus query
+-- Filters: userId, isActive, tier
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "GroupMember_userId_isActive_tier_idx" 
+  ON "GroupMember"("userId", "isActive", "tier");
+
+-- Composite index for processAllPromotions/Demotions queries  
+-- Filters: isActive, tier
+CREATE INDEX CONCURRENTLY IF NOT EXISTS "GroupMember_isActive_tier_idx"
+  ON "GroupMember"("isActive", "tier");

--- a/packages/db/drizzle/migrations/0013_rollback_tier_composite_indexes.sql
+++ b/packages/db/drizzle/migrations/0013_rollback_tier_composite_indexes.sql
@@ -1,0 +1,7 @@
+-- Rollback: Remove Tier Composite Indexes
+-- Reverses 0013_add_tier_composite_indexes.sql
+--
+-- Usage: Run manually if rollback is needed. Not auto-executed by Drizzle.
+
+DROP INDEX IF EXISTS "GroupMember_userId_isActive_tier_idx";
+DROP INDEX IF EXISTS "GroupMember_isActive_tier_idx";

--- a/packages/db/drizzle/migrations/0014_add_tier_check_constraints.sql
+++ b/packages/db/drizzle/migrations/0014_add_tier_check_constraints.sql
@@ -1,0 +1,11 @@
+-- Migration: Add CHECK constraints for tier column validation
+-- Ensures tier values are always in valid range (1, 2, 3) or NULL
+
+-- Add CHECK constraint to Group table
+ALTER TABLE "Group" ADD CONSTRAINT "Group_tier_check" CHECK ("tier" IS NULL OR "tier" IN (1, 2, 3));
+
+-- Add CHECK constraint to GroupMember table
+ALTER TABLE "GroupMember" ADD CONSTRAINT "GroupMember_tier_check" CHECK ("tier" IS NULL OR "tier" IN (1, 2, 3));
+
+-- Add CHECK constraint to GroupMember previousTier column
+ALTER TABLE "GroupMember" ADD CONSTRAINT "GroupMember_previousTier_check" CHECK ("previousTier" IS NULL OR "previousTier" IN (1, 2, 3));

--- a/packages/db/drizzle/migrations/0014_rollback_tier_check_constraints.sql
+++ b/packages/db/drizzle/migrations/0014_rollback_tier_check_constraints.sql
@@ -1,0 +1,5 @@
+-- Rollback: Remove CHECK constraints for tier column validation
+
+ALTER TABLE "GroupMember" DROP CONSTRAINT IF EXISTS "GroupMember_previousTier_check";
+ALTER TABLE "GroupMember" DROP CONSTRAINT IF EXISTS "GroupMember_tier_check";
+ALTER TABLE "Group" DROP CONSTRAINT IF EXISTS "Group_tier_check";

--- a/packages/db/src/schema/messaging.ts
+++ b/packages/db/src/schema/messaging.ts
@@ -232,6 +232,13 @@ export const groupMembers = pgTable(
     index('GroupMember_lastMessageAt_idx').on(table.lastMessageAt),
     index('GroupMember_role_idx').on(table.role),
     index('GroupMember_tier_idx').on(table.tier),
+    // Composite indexes for tier queries (added for PR #670 fixes)
+    index('GroupMember_userId_isActive_tier_idx').on(
+      table.userId,
+      table.isActive,
+      table.tier
+    ),
+    index('GroupMember_isActive_tier_idx').on(table.isActive, table.tier),
   ]
 );
 

--- a/packages/db/src/schema/messaging.ts
+++ b/packages/db/src/schema/messaging.ts
@@ -153,6 +153,11 @@ export const notifications = pgTable(
  * Supports: user-created groups, NPC-managed groups, agent-created groups
  *
  * Relationship: Chat.groupId → Group.id (one Chat per Group)
+ *
+ * Tiered System (NPC groups only):
+ * - Tier 1 (Inner Circle): 12 members, full alpha
+ * - Tier 2 (Community): 50 members, partial alpha
+ * - Tier 3 (Followers): 500 members, public content
  */
 export const groups = pgTable(
   'Group',
@@ -165,12 +170,19 @@ export const groups = pgTable(
     createdById: text('createdById').notNull(),
     createdAt: timestamp('createdAt', { mode: 'date' }).notNull().defaultNow(),
     updatedAt: timestamp('updatedAt', { mode: 'date' }).notNull(),
+    // Tiered group system fields (NPC groups only)
+    tier: integer('tier'), // 1 = Inner Circle, 2 = Community, 3 = Followers (null for user/agent groups)
+    maxMembers: integer('maxMembers'), // Tier-specific member limit (null uses default)
+    parentGroupId: text('parentGroupId'), // Links tier groups to same NPC's group family
   },
   (table) => [
     index('Group_type_idx').on(table.type),
     index('Group_ownerId_idx').on(table.ownerId),
     index('Group_createdById_idx').on(table.createdById),
     index('Group_createdAt_idx').on(table.createdAt),
+    index('Group_tier_idx').on(table.tier),
+    index('Group_ownerId_tier_idx').on(table.ownerId, table.tier),
+    index('Group_parentGroupId_idx').on(table.parentGroupId),
   ]
 );
 
@@ -204,6 +216,11 @@ export const groupMembers = pgTable(
     // Kick tracking
     kickedAt: timestamp('kickedAt', { mode: 'date' }),
     kickReason: text('kickReason'),
+    // Tiered group system fields (for promotion/demotion tracking)
+    tier: integer('tier'), // Mirrors Group.tier for query efficiency
+    promotedAt: timestamp('promotedAt', { mode: 'date' }),
+    demotedAt: timestamp('demotedAt', { mode: 'date' }),
+    previousTier: integer('previousTier'),
   },
   (table) => [
     // Note: Partial unique index is managed via migration, not here
@@ -214,6 +231,7 @@ export const groupMembers = pgTable(
     index('GroupMember_userId_isActive_idx').on(table.userId, table.isActive),
     index('GroupMember_lastMessageAt_idx').on(table.lastMessageAt),
     index('GroupMember_role_idx').on(table.role),
+    index('GroupMember_tier_idx').on(table.tier),
   ]
 );
 
@@ -324,3 +342,4 @@ export type NewGroupInvite = typeof groupInvites.$inferInsert;
 export type GroupType = 'user' | 'npc' | 'agent';
 export type GroupMemberRole = 'owner' | 'admin' | 'member';
 export type GroupInviteStatus = 'pending' | 'accepted' | 'declined';
+export type TierLevel = 1 | 2 | 3;

--- a/packages/db/src/schema/messaging.ts
+++ b/packages/db/src/schema/messaging.ts
@@ -349,4 +349,4 @@ export type NewGroupInvite = typeof groupInvites.$inferInsert;
 export type GroupType = 'user' | 'npc' | 'agent';
 export type GroupMemberRole = 'owner' | 'admin' | 'member';
 export type GroupInviteStatus = 'pending' | 'accepted' | 'declined';
-export type TierLevel = 1 | 2 | 3;
+// TierLevel is exported from @babylon/shared - use that canonical definition

--- a/packages/engine/src/services/index.ts
+++ b/packages/engine/src/services/index.ts
@@ -29,6 +29,8 @@ export * from './npc-group-dynamics-service';
 export * from './npc-interaction-tracker';
 export * from './npc-persona-generator';
 export * from './reply-rate-limiter';
+export * from './tier-config';
+export * from './tiered-group-service';
 
 // =============================================================================
 // Market Services

--- a/packages/engine/src/services/npc-group-dynamics-service.ts
+++ b/packages/engine/src/services/npc-group-dynamics-service.ts
@@ -546,34 +546,30 @@ export class NPCGroupDynamicsService {
    * - Insider knowledge about questions/markets
    * - Contradictions to their public statements
    * - Strategic coordination with allies
+   *
+   * Optimized: Single query with LEFT JOIN to get tier data upfront instead of N+1.
    */
   private static async postGroupMessages(
     llm: BabylonLLMClient
   ): Promise<number> {
     let messagesPosted = 0;
 
-    // Get active group chats with their group tier info
+    // Get active group chats with tier info in a single query (avoids N+1)
     const groupList = await db
       .select({
         id: chats.id,
         name: chats.name,
         groupId: chats.groupId,
+        tier: groups.tier,
       })
       .from(chats)
+      .leftJoin(groups, eq(groups.id, chats.groupId))
       .where(eq(chats.isGroup, true))
       .limit(20);
 
     for (const group of groupList) {
-      // Get tier from Group table if available
-      let tier: 1 | 2 | 3 | null = null;
-      if (group.groupId) {
-        const [grp] = await db
-          .select({ tier: groups.tier })
-          .from(groups)
-          .where(eq(groups.id, group.groupId))
-          .limit(1);
-        tier = grp?.tier as 1 | 2 | 3 | null;
-      }
+      // Tier is already available from the JOIN
+      const tier = group.tier as 1 | 2 | 3 | null;
 
       // Tier-based message frequency: T1=25%, T2=15%, T3=5%, legacy=25%
       const messageChance =

--- a/packages/engine/src/services/npc-group-dynamics-service.ts
+++ b/packages/engine/src/services/npc-group-dynamics-service.ts
@@ -58,6 +58,9 @@ export interface GroupDynamicsResult {
   usersInvited: number;
   usersKicked: number;
   messagesPosted: number;
+  tieredInvites: number;
+  tieredPromotions: number;
+  tieredDemotions: number;
 }
 
 export class NPCGroupDynamicsService {
@@ -65,7 +68,7 @@ export class NPCGroupDynamicsService {
   private static readonly FORM_NEW_GROUP_CHANCE = 0.05; // 5% chance for each eligible NPC
   private static readonly JOIN_GROUP_CHANCE = 0.1; // 10% chance if eligible
   private static readonly LEAVE_GROUP_CHANCE = 0.02; // 2% chance per membership
-  private static readonly POST_MESSAGE_CHANCE = 0.25; // 25% chance per active group
+  // Message frequency is now tier-based: T1=25%, T2=15%, T3=5%
   private static readonly INVITE_USER_CHANCE = 0.08; // 8% chance per eligible group
   private static readonly KICK_CHECK_CHANCE = 0.15; // 15% chance to check for kicks
 
@@ -88,6 +91,9 @@ export class NPCGroupDynamicsService {
       usersInvited: 0,
       usersKicked: 0,
       messagesPosted: 0,
+      tieredInvites: 0,
+      tieredPromotions: 0,
+      tieredDemotions: 0,
     };
 
     logger.info(
@@ -125,6 +131,14 @@ export class NPCGroupDynamicsService {
     // 6. Kick users based on weighted participation metrics
     const kicks = await NPCGroupDynamicsService.kickUsersWithWeightedLogic();
     result.usersKicked = kicks;
+
+    // 7. Process tiered group system (promotions/demotions run ~daily)
+    const { TieredGroupService } = await import('./tiered-group-service');
+    if (Math.random() < 0.0007) {
+      // ~once per day at 1-min tick rate
+      result.tieredPromotions = await TieredGroupService.processAllPromotions();
+      result.tieredDemotions = await TieredGroupService.processAllDemotions();
+    }
 
     const duration = Date.now() - startTime;
     logger.info(
@@ -538,16 +552,34 @@ export class NPCGroupDynamicsService {
   ): Promise<number> {
     let messagesPosted = 0;
 
-    // Get active group chats
+    // Get active group chats with their group tier info
     const groupList = await db
-      .select()
+      .select({
+        id: chats.id,
+        name: chats.name,
+        groupId: chats.groupId,
+      })
       .from(chats)
       .where(eq(chats.isGroup, true))
       .limit(20);
 
     for (const group of groupList) {
-      // Random chance to post
-      if (Math.random() > NPCGroupDynamicsService.POST_MESSAGE_CHANCE) {
+      // Get tier from Group table if available
+      let tier: 1 | 2 | 3 | null = null;
+      if (group.groupId) {
+        const [grp] = await db
+          .select({ tier: groups.tier })
+          .from(groups)
+          .where(eq(groups.id, group.groupId))
+          .limit(1);
+        tier = grp?.tier as 1 | 2 | 3 | null;
+      }
+
+      // Tier-based message frequency: T1=25%, T2=15%, T3=5%, legacy=25%
+      const messageChance =
+        tier === 1 ? 0.25 : tier === 2 ? 0.15 : tier === 3 ? 0.05 : 0.25;
+
+      if (Math.random() > messageChance) {
         continue;
       }
 
@@ -659,9 +691,29 @@ export class NPCGroupDynamicsService {
       // Get world context for consistent parody names and market awareness
       const worldContext = await generateWorldContext({ maxActors: 20 });
 
-      // Generate INSIDER message - this is the key asymmetric information mechanic!
-      // Each NPC generates their message INDEPENDENTLY with their own personal context
-      const prompt = `You are ${randomNpc.displayName} in a PRIVATE group chat with trusted insiders.
+      // Generate message based on tier - tier determines content level
+      const tierGuidance =
+        tier === 1 || tier === null
+          ? `TIER 1 INNER CIRCLE - share FULL ALPHA:
+- "Just loaded up $50k on [ticker] before the announcement"
+- "Between us, [company] Q3 is $2.3B but they'll announce $2.1B"
+- "Get out of [ticker] before 3pm - trust me"
+- Specific positions, amounts, dates, sources
+- Contradict your public statements with real strategy`
+          : tier === 2
+            ? `TIER 2 COMMUNITY - share PARTIAL ALPHA (hints, not specifics):
+- "Feeling bearish on tech this week"
+- "Smart money is moving out of [sector]"
+- Directional hints without exact amounts
+- Industry insights and sentiment
+- NO exact dollar amounts or dates`
+            : `TIER 3 FOLLOWERS - PUBLIC-FACING content only:
+- "Did you see what happened at [event]? Wild!"
+- "Markets are crazy right now"
+- Personality, banter, engagement
+- NO insider info, NO trading hints`;
+
+      const prompt = `You are ${randomNpc.displayName} in a ${tier ? `TIER ${tier}` : 'private'} group chat.
 ${affiliationContext}
 
 ${personalEventsContext}
@@ -673,32 +725,15 @@ ${positionContext}
 ${worldContext.worldActors}
 ${worldContext.currentMarkets}
 
-This is PRIVATE - share STRATEGIC insider information that you would NEVER post publicly:
+${tierGuidance}
 
-WHAT TO SHARE (pick one that's relevant):
-- React to events that happened to YOU (see above) with insider perspective
-- "Just loaded up on [ticker] before the announcement drops"
-- "Between us, [company] numbers look terrible this quarter"
-- "I'm hearing [rival] is in serious trouble"
-- "Get out of [ticker] now - trust me on this"
-- "Real talk: market is wrong about [question]"
-- Your actual position and why (contradict public statements if needed)
-- Insider knowledge about your affiliated organizations
-- Strategic advice for friends in this group
-
-PRIVATE vs PUBLIC:
-- PUBLIC feed: What you want the market to think
-- PRIVATE chat: What you actually know/believe/plan
-- Help friends make money, hurt enemies
-
-Write a private message (max 200 chars) with ACTIONABLE insider info.
-Be SPECIFIC with tickers, positions, or predictions. Reference your recent events if relevant.
+Write a private message (max 200 chars) appropriate for this tier.
 NO hashtags. Emojis OK (🤫 👀 🔥).
 Use parody names from World Actors (AIlon Musk, not Elon Musk).
 
 Return your response as XML:
 <response>
-  <message>your insider message here</message>
+  <message>your message here</message>
 </response>`;
 
       const rawResponse = await llm.generateJSON<

--- a/packages/engine/src/services/npc-group-dynamics-service.ts
+++ b/packages/engine/src/services/npc-group-dynamics-service.ts
@@ -47,6 +47,8 @@ import { GROUP_CONFIG, generateSnowflakeId, logger } from '@babylon/shared';
 import { MarketContextService } from './market-context-service';
 import { NPCGroupDynamicsCalculations } from './npc-group-dynamics-calculations';
 import { StaticDataRegistry } from './static-data-registry';
+import { getTierMessageGuidance } from './tier-config';
+import { TieredGroupService } from './tiered-group-service';
 
 // Singleton for NPC context
 const marketContextService = new MarketContextService();
@@ -58,7 +60,6 @@ export interface GroupDynamicsResult {
   usersInvited: number;
   usersKicked: number;
   messagesPosted: number;
-  tieredInvites: number;
   tieredPromotions: number;
   tieredDemotions: number;
 }
@@ -91,7 +92,6 @@ export class NPCGroupDynamicsService {
       usersInvited: 0,
       usersKicked: 0,
       messagesPosted: 0,
-      tieredInvites: 0,
       tieredPromotions: 0,
       tieredDemotions: 0,
     };
@@ -134,7 +134,6 @@ export class NPCGroupDynamicsService {
 
     // 7. Process tiered group system (promotions/demotions run ~daily)
     // Probability math: 0.0007 * 60 ticks/hr * 24 hrs = ~1.0 times per day
-    const { TieredGroupService } = await import('./tiered-group-service');
     const DAILY_TICK_PROBABILITY = 0.0007;
     if (Math.random() < DAILY_TICK_PROBABILITY) {
       result.tieredPromotions = await TieredGroupService.processAllPromotions();
@@ -694,7 +693,6 @@ export class NPCGroupDynamicsService {
 
       // Generate message based on tier - tier determines content level
       // Tier guidance extracted to tier-config.ts for maintainability
-      const { getTierMessageGuidance } = await import('./tier-config');
       const tierGuidance = getTierMessageGuidance(tier);
 
       const prompt = `You are ${randomNpc.displayName} in a ${tier ? `TIER ${tier}` : 'private'} group chat.

--- a/packages/engine/src/services/npc-group-dynamics-service.ts
+++ b/packages/engine/src/services/npc-group-dynamics-service.ts
@@ -133,9 +133,10 @@ export class NPCGroupDynamicsService {
     result.usersKicked = kicks;
 
     // 7. Process tiered group system (promotions/demotions run ~daily)
+    // Probability math: 0.0007 * 60 ticks/hr * 24 hrs = ~1.0 times per day
     const { TieredGroupService } = await import('./tiered-group-service');
-    if (Math.random() < 0.0007) {
-      // ~once per day at 1-min tick rate
+    const DAILY_TICK_PROBABILITY = 0.0007;
+    if (Math.random() < DAILY_TICK_PROBABILITY) {
       result.tieredPromotions = await TieredGroupService.processAllPromotions();
       result.tieredDemotions = await TieredGroupService.processAllDemotions();
     }
@@ -692,26 +693,9 @@ export class NPCGroupDynamicsService {
       const worldContext = await generateWorldContext({ maxActors: 20 });
 
       // Generate message based on tier - tier determines content level
-      const tierGuidance =
-        tier === 1 || tier === null
-          ? `TIER 1 INNER CIRCLE - share FULL ALPHA:
-- "Just loaded up $50k on [ticker] before the announcement"
-- "Between us, [company] Q3 is $2.3B but they'll announce $2.1B"
-- "Get out of [ticker] before 3pm - trust me"
-- Specific positions, amounts, dates, sources
-- Contradict your public statements with real strategy`
-          : tier === 2
-            ? `TIER 2 COMMUNITY - share PARTIAL ALPHA (hints, not specifics):
-- "Feeling bearish on tech this week"
-- "Smart money is moving out of [sector]"
-- Directional hints without exact amounts
-- Industry insights and sentiment
-- NO exact dollar amounts or dates`
-            : `TIER 3 FOLLOWERS - PUBLIC-FACING content only:
-- "Did you see what happened at [event]? Wild!"
-- "Markets are crazy right now"
-- Personality, banter, engagement
-- NO insider info, NO trading hints`;
+      // Tier guidance extracted to tier-config.ts for maintainability
+      const { getTierMessageGuidance } = await import('./tier-config');
+      const tierGuidance = getTierMessageGuidance(tier);
 
       const prompt = `You are ${randomNpc.displayName} in a ${tier ? `TIER ${tier}` : 'private'} group chat.
 ${affiliationContext}

--- a/packages/engine/src/services/tier-config.ts
+++ b/packages/engine/src/services/tier-config.ts
@@ -1,0 +1,125 @@
+/**
+ * Tiered Group System Configuration
+ *
+ * Extends GROUP_CONFIG from @babylon/shared with tier-specific settings.
+ * NPC groups can have 3 tiers with different capacities and content levels:
+ * - Tier 1 (Inner Circle): Exclusive, full alpha
+ * - Tier 2 (Community): Medium engagement, partial alpha
+ * - Tier 3 (Followers): Low barrier, public content
+ */
+
+import { GROUP_CONFIG } from '@babylon/shared';
+
+export type TierLevel = 1 | 2 | 3;
+export type AlphaLevel = 'full' | 'partial' | 'public';
+
+export interface TierConfig {
+  name: string;
+  suffix: string;
+  maxMembers: number;
+  minEngagementScore: number;
+  messageFrequency: number;
+  alphaLevel: AlphaLevel;
+  inviteProbability: number;
+  promotionWaitDays: number;
+  demotionInactiveDays: number;
+}
+
+export const TIER_CONFIG: Record<TierLevel, TierConfig> = {
+  1: {
+    name: 'Inner Circle',
+    suffix: "'s Inner Circle",
+    maxMembers: GROUP_CONFIG.MAX_GROUP_SIZE, // 12
+    minEngagementScore: 80,
+    messageFrequency: 0.25,
+    alphaLevel: 'full',
+    inviteProbability: 0.005,
+    promotionWaitDays: 30,
+    demotionInactiveDays: 30,
+  },
+  2: {
+    name: 'Community',
+    suffix: "'s Community",
+    maxMembers: 50,
+    minEngagementScore: 50,
+    messageFrequency: 0.15,
+    alphaLevel: 'partial',
+    inviteProbability: 0.02,
+    promotionWaitDays: 14,
+    demotionInactiveDays: 60,
+  },
+  3: {
+    name: 'Followers',
+    suffix: "'s Followers",
+    maxMembers: 500,
+    minEngagementScore: 20,
+    messageFrequency: 0.05,
+    alphaLevel: 'public',
+    inviteProbability: 0.1,
+    promotionWaitDays: 0,
+    demotionInactiveDays: 90,
+  },
+};
+
+export const ALL_TIERS: TierLevel[] = [1, 2, 3];
+
+/** Get configuration for a specific tier */
+export const getTierConfig = (tier: TierLevel): TierConfig => TIER_CONFIG[tier];
+
+/** Get the tier suffix for group naming */
+export const getTierSuffix = (tier: TierLevel): string =>
+  TIER_CONFIG[tier].suffix;
+
+/** Get the full group name for an NPC at a tier */
+export const getTierGroupName = (npcName: string, tier: TierLevel): string =>
+  `${npcName}${TIER_CONFIG[tier].suffix}`;
+
+/** Determine which tier a user qualifies for based on engagement score */
+export function getTierForEngagementScore(score: number): TierLevel | null {
+  if (score >= TIER_CONFIG[1].minEngagementScore) return 1;
+  if (score >= TIER_CONFIG[2].minEngagementScore) return 2;
+  if (score >= TIER_CONFIG[3].minEngagementScore) return 3;
+  return null;
+}
+
+/** Check if user is eligible for promotion to next tier */
+export function isEligibleForPromotion(
+  currentTier: TierLevel,
+  engagementScore: number,
+  daysInCurrentTier: number
+): boolean {
+  if (currentTier === 1) return false;
+  const targetTier = (currentTier - 1) as TierLevel;
+  const targetConfig = TIER_CONFIG[targetTier];
+  const currentConfig = TIER_CONFIG[currentTier];
+  return (
+    engagementScore >= targetConfig.minEngagementScore &&
+    daysInCurrentTier >= currentConfig.promotionWaitDays
+  );
+}
+
+/** Check if user should be demoted due to inactivity */
+export function shouldDemote(
+  currentTier: TierLevel,
+  daysSinceLastActivity: number
+): boolean {
+  return daysSinceLastActivity >= TIER_CONFIG[currentTier].demotionInactiveDays;
+}
+
+/** Get the next lower tier (for demotion) */
+export function getLowerTier(currentTier: TierLevel): TierLevel | null {
+  if (currentTier === 3) return null;
+  return (currentTier + 1) as TierLevel;
+}
+
+/** Get the next higher tier (for promotion) */
+export function getHigherTier(currentTier: TierLevel): TierLevel | null {
+  if (currentTier === 1) return null;
+  return (currentTier - 1) as TierLevel;
+}
+
+/** Total capacity per NPC across all tiers */
+export const getTotalNpcCapacity = (): number =>
+  TIER_CONFIG[1].maxMembers +
+  TIER_CONFIG[2].maxMembers +
+  TIER_CONFIG[3].maxMembers;

--- a/packages/engine/src/services/tier-config.ts
+++ b/packages/engine/src/services/tier-config.ts
@@ -18,17 +18,13 @@ const VALID_TIERS: readonly TierLevel[] = [1, 2, 3] as const;
 
 /** Type guard to check if a value is a valid TierLevel */
 export function isValidTier(value: unknown): value is TierLevel {
-  return (
-    typeof value === 'number' && VALID_TIERS.includes(value as TierLevel)
-  );
+  return typeof value === 'number' && VALID_TIERS.includes(value as TierLevel);
 }
 
 /** Assert and return a valid TierLevel, throws if invalid */
 export function assertTierLevel(value: unknown): TierLevel {
   if (!isValidTier(value)) {
-    throw new Error(
-      `Invalid tier value: ${value}. Expected 1, 2, or 3.`
-    );
+    throw new Error(`Invalid tier value: ${value}. Expected 1, 2, or 3.`);
   }
   return value;
 }

--- a/packages/engine/src/services/tier-config.ts
+++ b/packages/engine/src/services/tier-config.ts
@@ -13,6 +13,26 @@ import { GROUP_CONFIG } from '@babylon/shared';
 export type TierLevel = 1 | 2 | 3;
 export type AlphaLevel = 'full' | 'partial' | 'public';
 
+/** Valid tier levels */
+const VALID_TIERS: readonly TierLevel[] = [1, 2, 3] as const;
+
+/** Type guard to check if a value is a valid TierLevel */
+export function isValidTier(value: unknown): value is TierLevel {
+  return (
+    typeof value === 'number' && VALID_TIERS.includes(value as TierLevel)
+  );
+}
+
+/** Assert and return a valid TierLevel, throws if invalid */
+export function assertTierLevel(value: unknown): TierLevel {
+  if (!isValidTier(value)) {
+    throw new Error(
+      `Invalid tier value: ${value}. Expected 1, 2, or 3.`
+    );
+  }
+  return value;
+}
+
 export interface TierConfig {
   name: string;
   suffix: string;
@@ -123,3 +143,37 @@ export const getTotalNpcCapacity = (): number =>
   TIER_CONFIG[1].maxMembers +
   TIER_CONFIG[2].maxMembers +
   TIER_CONFIG[3].maxMembers;
+
+/**
+ * Tier-specific message guidance for NPC group chat content generation.
+ * These prompts control the alpha/insider information level shared in each tier.
+ */
+export const TIER_MESSAGE_GUIDANCE: Record<TierLevel, string> = {
+  1: `TIER 1 INNER CIRCLE - share FULL ALPHA:
+- "Just loaded up $50k on [ticker] before the announcement"
+- "Between us, [company] Q3 is $2.3B but they'll announce $2.1B"
+- "Get out of [ticker] before 3pm - trust me"
+- Specific positions, amounts, dates, sources
+- Contradict your public statements with real strategy`,
+
+  2: `TIER 2 COMMUNITY - share PARTIAL ALPHA (hints, not specifics):
+- "Feeling bearish on tech this week"
+- "Smart money is moving out of [sector]"
+- Directional hints without exact amounts
+- Industry insights and sentiment
+- NO exact dollar amounts or dates`,
+
+  3: `TIER 3 FOLLOWERS - PUBLIC-FACING content only:
+- "Did you see what happened at [event]? Wild!"
+- "Markets are crazy right now"
+- Personality, banter, engagement
+- NO insider info, NO trading hints`,
+};
+
+/** Get message guidance for a tier, defaults to Tier 1 for null/legacy groups */
+export function getTierMessageGuidance(tier: TierLevel | null): string {
+  if (tier === null || !isValidTier(tier)) {
+    return TIER_MESSAGE_GUIDANCE[1]; // Legacy groups get full alpha
+  }
+  return TIER_MESSAGE_GUIDANCE[tier];
+}

--- a/packages/engine/src/services/tier-config.ts
+++ b/packages/engine/src/services/tier-config.ts
@@ -8,10 +8,10 @@
  * - Tier 3 (Followers): Low barrier, public content
  */
 
-import { GROUP_CONFIG } from '@babylon/shared';
+import { GROUP_CONFIG, type AlphaLevel, type TierLevel } from '@babylon/shared';
 
-export type TierLevel = 1 | 2 | 3;
-export type AlphaLevel = 'full' | 'partial' | 'public';
+// Re-export for convenience
+export type { AlphaLevel, TierLevel } from '@babylon/shared';
 
 /** Valid tier levels */
 const VALID_TIERS: readonly TierLevel[] = [1, 2, 3] as const;

--- a/packages/engine/src/services/tier-config.ts
+++ b/packages/engine/src/services/tier-config.ts
@@ -8,7 +8,7 @@
  * - Tier 3 (Followers): Low barrier, public content
  */
 
-import { GROUP_CONFIG, type AlphaLevel, type TierLevel } from '@babylon/shared';
+import { type AlphaLevel, GROUP_CONFIG, type TierLevel } from '@babylon/shared';
 
 // Re-export for convenience
 export type { AlphaLevel, TierLevel } from '@babylon/shared';

--- a/packages/engine/src/services/tiered-group-service.ts
+++ b/packages/engine/src/services/tiered-group-service.ts
@@ -19,10 +19,12 @@ import {
   eq,
   groupMembers,
   groups,
+  inArray,
   isNotNull,
   isNull,
   ne,
 } from '@babylon/db';
+import { DistributedLockService } from '@babylon/api';
 import { GROUP_CONFIG, generateSnowflakeId, logger } from '@babylon/shared';
 
 import { NPCInteractionTracker } from './npc-interaction-tracker';
@@ -35,6 +37,7 @@ import {
   getTierForEngagementScore,
   getTierGroupName,
   isEligibleForPromotion,
+  isValidTier,
   shouldDemote,
   TIER_CONFIG,
   type TierLevel,
@@ -95,7 +98,7 @@ export class TieredGroupService {
 
     const existingTierMap = new Map(
       existingGroups
-        .filter((g) => g.tier !== null)
+        .filter((g) => isValidTier(g.tier))
         .map((g) => [g.tier as TierLevel, g])
     );
 
@@ -252,12 +255,22 @@ export class TieredGroupService {
         .where(eq(chats.groupId, g.id))
         .limit(1);
 
-      const config = getTierConfig(g.tier as TierLevel);
+      // Validate tier before processing
+      if (!isValidTier(g.tier)) {
+        logger.warn(
+          `Invalid tier value ${g.tier} for group ${g.id}, skipping`,
+          { groupId: g.id, tier: g.tier },
+          'TieredGroupService'
+        );
+        continue;
+      }
+
+      const config = getTierConfig(g.tier);
       const maxMembers = g.maxMembers ?? config.maxMembers;
       const memberCount = countResult?.count ?? 0;
 
       result.push({
-        tier: g.tier as TierLevel,
+        tier: g.tier,
         groupId: g.id,
         chatId: chat?.id ?? null,
         groupName: g.name,
@@ -306,8 +319,8 @@ export class TieredGroupService {
     let canBePromoted = false;
     let promotionBlockedReason: string | null = null;
 
-    if (membership?.tier !== null && membership?.tier !== undefined) {
-      const currentTier = membership.tier as TierLevel;
+    if (isValidTier(membership?.tier)) {
+      const currentTier = membership.tier;
       const daysInTier = Math.floor(
         (Date.now() - membership.joinedAt.getTime()) / (1000 * 60 * 60 * 24)
       );
@@ -345,7 +358,7 @@ export class TieredGroupService {
     return {
       userId,
       npcId,
-      currentTier: (membership?.tier as TierLevel) ?? null,
+      currentTier: isValidTier(membership?.tier) ? membership.tier : null,
       groupId: membership?.groupId ?? null,
       joinedAt: membership?.joinedAt ?? null,
       engagementScore,
@@ -357,12 +370,30 @@ export class TieredGroupService {
 
   /**
    * Invite user to appropriate tier based on engagement
+   *
+   * Uses distributed locking to prevent race conditions where multiple
+   * concurrent invites could exceed group capacity.
    */
   static async inviteUserToTier(
     userId: string,
     npcId: string
   ): Promise<{ success: boolean; tier: TierLevel | null; reason: string }> {
-    // Check if already in a tier with this NPC
+    // Validate that npcId is a valid NPC
+    const actor = StaticDataRegistry.getActor(npcId);
+    if (!actor) {
+      logger.warn(
+        `inviteUserToTier called with invalid NPC ID: ${npcId}`,
+        { userId, npcId },
+        'TieredGroupService'
+      );
+      return {
+        success: false,
+        tier: null,
+        reason: `Invalid NPC ID: ${npcId}`,
+      };
+    }
+
+    // Check if already in a tier with this NPC (fast-fail before lock)
     const [existing] = await db
       .select({ id: groupMembers.id })
       .from(groupMembers)
@@ -385,7 +416,7 @@ export class TieredGroupService {
       };
     }
 
-    // Check group limit
+    // Check group limit (fast-fail before lock)
     const [groupCount] = await db
       .select({ count: count() })
       .from(groupMembers)
@@ -406,76 +437,107 @@ export class TieredGroupService {
       };
     }
 
-    // Get engagement score
+    // Get engagement score (before lock to minimize lock duration)
     const interactionScore =
       await NPCInteractionTracker.calculateEngagementScore(userId, npcId);
     const engagementScore = interactionScore.engagementScore;
 
-    // Ensure tiers exist
+    // Ensure tiers exist (before lock)
     await this.ensureAllTiersExist(npcId);
 
-    // Find available tier
-    const tiers = await this.getNpcTiers(npcId);
-    let targetTier: TierInfo | null = null;
+    // Generate unique process ID for lock ownership
+    const processId = `invite-${npcId}-${userId}-${Date.now()}`;
+    const lockId = `tier-invite:${npcId}`;
 
-    for (const tier of ALL_TIERS) {
-      if (engagementScore < TIER_CONFIG[tier].minEngagementScore) continue;
-      const tierInfo = tiers.find((t) => t.tier === tier);
-      if (tierInfo && !tierInfo.isFull) {
-        targetTier = tierInfo;
-        break;
-      }
-    }
+    // Acquire distributed lock to prevent race condition on capacity check
+    const lockAcquired = await DistributedLockService.acquireLock({
+      lockId,
+      durationMs: 10_000, // 10 second lock
+      operation: 'tier-invite',
+      processId,
+    });
 
-    if (!targetTier) {
+    if (!lockAcquired) {
       return {
         success: false,
         tier: null,
-        reason: `No available tier (score: ${engagementScore.toFixed(0)}, min: ${TIER_CONFIG[3].minEngagementScore})`,
+        reason: 'Another invite operation in progress, please retry',
       };
     }
 
-    // Add to group
-    await db.insert(groupMembers).values({
-      id: await generateSnowflakeId(),
-      groupId: targetTier.groupId,
-      userId,
-      role: 'member',
-      addedBy: npcId,
-      tier: targetTier.tier,
-    });
+    try {
+      // Re-check capacity inside lock (critical section)
+      const tiers = await this.getNpcTiers(npcId);
+      let targetTier: TierInfo | null = null;
 
-    // Add to chat if exists
-    if (targetTier.chatId) {
-      await db.insert(chatParticipants).values({
-        id: await generateSnowflakeId(),
-        chatId: targetTier.chatId,
-        userId,
-        invitedBy: npcId,
+      for (const tier of ALL_TIERS) {
+        if (engagementScore < TIER_CONFIG[tier].minEngagementScore) continue;
+        const tierInfo = tiers.find((t) => t.tier === tier);
+        if (tierInfo && !tierInfo.isFull) {
+          targetTier = tierInfo;
+          break;
+        }
+      }
+
+      if (!targetTier) {
+        return {
+          success: false,
+          tier: null,
+          reason: `No available tier (score: ${engagementScore.toFixed(0)}, min: ${TIER_CONFIG[3].minEngagementScore})`,
+        };
+      }
+
+      // Wrap multi-step operation in transaction
+      await db.$transaction(async (tx) => {
+        // Add to group
+        await tx.insert(groupMembers).values({
+          id: await generateSnowflakeId(),
+          groupId: targetTier.groupId,
+          userId,
+          role: 'member',
+          addedBy: npcId,
+          tier: targetTier.tier,
+        });
+
+        // Add to chat if exists
+        if (targetTier.chatId) {
+          await tx.insert(chatParticipants).values({
+            id: await generateSnowflakeId(),
+            chatId: targetTier.chatId,
+            userId,
+            invitedBy: npcId,
+          });
+        }
       });
-    }
 
-    logger.info(
-      'User invited to tier',
-      {
-        userId,
-        npcId,
+      logger.info(
+        'User invited to tier',
+        {
+          userId,
+          npcId,
+          tier: targetTier.tier,
+          groupName: targetTier.groupName,
+          engagementScore,
+        },
+        'TieredGroupService'
+      );
+
+      return {
+        success: true,
         tier: targetTier.tier,
-        groupName: targetTier.groupName,
-        engagementScore,
-      },
-      'TieredGroupService'
-    );
-
-    return {
-      success: true,
-      tier: targetTier.tier,
-      reason: `Invited to ${targetTier.groupName}`,
-    };
+        reason: `Invited to ${targetTier.groupName}`,
+      };
+    } finally {
+      // Always release lock
+      await DistributedLockService.releaseLock(lockId, processId);
+    }
   }
 
   /**
    * Promote user to higher tier
+   *
+   * Uses distributed locking to prevent race conditions where multiple
+   * concurrent promotions could exceed group capacity.
    */
   static async promoteUser(userId: string, npcId: string): Promise<boolean> {
     const status = await this.getUserTierStatus(userId, npcId);
@@ -485,100 +547,143 @@ export class TieredGroupService {
     const higherTier = getHigherTier(status.currentTier);
     if (!higherTier) return false;
 
-    const tiers = await this.getNpcTiers(npcId);
-    const targetTier = tiers.find((t) => t.tier === higherTier);
-    if (!targetTier || targetTier.isFull) return false;
+    // Generate unique process ID for lock ownership
+    const processId = `promote-${npcId}-${userId}-${Date.now()}`;
+    const lockId = `tier-promote:${npcId}`;
 
-    // Deactivate old membership
-    await db
-      .update(groupMembers)
-      .set({
-        isActive: false,
-        kickReason: `Promoted to Tier ${higherTier}`,
-        kickedAt: new Date(),
-      })
-      .where(
-        and(
-          eq(groupMembers.groupId, status.groupId),
-          eq(groupMembers.userId, userId)
-        )
-      );
-
-    // Find and deactivate old chat participant
-    const [oldChat] = await db
-      .select({ id: chats.id })
-      .from(chats)
-      .where(eq(chats.groupId, status.groupId))
-      .limit(1);
-
-    if (oldChat) {
-      await db
-        .update(chatParticipants)
-        .set({ isActive: false })
-        .where(
-          and(
-            eq(chatParticipants.chatId, oldChat.id),
-            eq(chatParticipants.userId, userId)
-          )
-        );
-    }
-
-    // Add to new tier
-    await db.insert(groupMembers).values({
-      id: await generateSnowflakeId(),
-      groupId: targetTier.groupId,
-      userId,
-      role: 'member',
-      addedBy: npcId,
-      tier: higherTier,
-      previousTier: status.currentTier,
-      promotedAt: new Date(),
+    // Acquire distributed lock to prevent race condition on capacity check
+    const lockAcquired = await DistributedLockService.acquireLock({
+      lockId,
+      durationMs: 10_000, // 10 second lock
+      operation: 'tier-promote',
+      processId,
     });
 
-    if (targetTier.chatId) {
-      await db.insert(chatParticipants).values({
-        id: await generateSnowflakeId(),
-        chatId: targetTier.chatId,
-        userId,
-        invitedBy: npcId,
-      });
+    if (!lockAcquired) {
+      logger.info(
+        'Promote operation skipped - another promotion in progress',
+        { userId, npcId },
+        'TieredGroupService'
+      );
+      return false;
     }
 
-    logger.info(
-      'User promoted',
-      { userId, npcId, fromTier: status.currentTier, toTier: higherTier },
-      'TieredGroupService'
-    );
+    try {
+      // Re-check capacity inside lock (critical section)
+      const tiers = await this.getNpcTiers(npcId);
+      const targetTier = tiers.find((t) => t.tier === higherTier);
+      if (!targetTier || targetTier.isFull) return false;
 
-    return true;
+      // Capture values for use in transaction (TypeScript narrowing doesn't carry into callbacks)
+      const currentGroupId = status.groupId;
+      const currentTier = status.currentTier;
+
+      // Wrap multi-step operation in transaction to prevent orphaned state
+      await db.$transaction(async (tx) => {
+        // Deactivate old membership
+        await tx
+          .update(groupMembers)
+          .set({
+            isActive: false,
+            kickReason: `Promoted to Tier ${higherTier}`,
+            kickedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(groupMembers.groupId, currentGroupId),
+              eq(groupMembers.userId, userId)
+            )
+          );
+
+        // Find and deactivate old chat participant
+        const [oldChat] = await tx
+          .select({ id: chats.id })
+          .from(chats)
+          .where(eq(chats.groupId, currentGroupId))
+          .limit(1);
+
+        if (oldChat) {
+          await tx
+            .update(chatParticipants)
+            .set({ isActive: false })
+            .where(
+              and(
+                eq(chatParticipants.chatId, oldChat.id),
+                eq(chatParticipants.userId, userId)
+              )
+            );
+        }
+
+        // Add to new tier
+        await tx.insert(groupMembers).values({
+          id: await generateSnowflakeId(),
+          groupId: targetTier.groupId,
+          userId,
+          role: 'member',
+          addedBy: npcId,
+          tier: higherTier,
+          previousTier: currentTier,
+          promotedAt: new Date(),
+        });
+
+        if (targetTier.chatId) {
+          await tx.insert(chatParticipants).values({
+            id: await generateSnowflakeId(),
+            chatId: targetTier.chatId,
+            userId,
+            invitedBy: npcId,
+          });
+        }
+      });
+
+      logger.info(
+        'User promoted',
+        { userId, npcId, fromTier: currentTier, toTier: higherTier },
+        'TieredGroupService'
+      );
+
+      return true;
+    } finally {
+      // Always release lock
+      await DistributedLockService.releaseLock(lockId, processId);
+    }
   }
 
   /**
    * Process promotions for all NPC groups (run daily)
+   *
+   * Optimized: Single batch query for all NPC memberships instead of N+1 pattern.
    */
   static async processAllPromotions(): Promise<number> {
     let promotions = 0;
     const actors = StaticDataRegistry.getAllActors();
+    const actorIds = actors.map((a) => a.id);
 
-    for (const actor of actors) {
-      const memberships = await db
-        .select({ userId: groupMembers.userId, tier: groupMembers.tier })
-        .from(groupMembers)
-        .innerJoin(groups, eq(groupMembers.groupId, groups.id))
-        .where(
-          and(
-            eq(groups.ownerId, actor.id),
-            eq(groups.type, 'npc'),
-            eq(groupMembers.isActive, true),
-            isNotNull(groupMembers.tier),
-            ne(groupMembers.tier, 1)
-          )
-        );
+    if (actorIds.length === 0) return 0;
 
-      for (const m of memberships) {
-        if (await this.promoteUser(m.userId, actor.id)) {
-          promotions++;
-        }
+    // Batch query: Get all promotable memberships across all NPCs in one query
+    const allMemberships = await db
+      .select({
+        userId: groupMembers.userId,
+        tier: groupMembers.tier,
+        npcId: groups.ownerId,
+      })
+      .from(groupMembers)
+      .innerJoin(groups, eq(groupMembers.groupId, groups.id))
+      .where(
+        and(
+          inArray(groups.ownerId, actorIds),
+          eq(groups.type, 'npc'),
+          eq(groupMembers.isActive, true),
+          isNotNull(groupMembers.tier),
+          ne(groupMembers.tier, 1) // Already at highest tier
+        )
+      );
+
+    // Process each membership (promoteUser still needs individual checks)
+    for (const m of allMemberships) {
+      if (await this.promoteUser(m.userId, m.npcId)) {
+        promotions++;
       }
     }
 
@@ -587,34 +692,49 @@ export class TieredGroupService {
 
   /**
    * Process demotions for inactive users (run daily)
+   *
+   * Optimized: Single batch query for all NPC memberships instead of N+1 pattern.
    */
   static async processAllDemotions(): Promise<number> {
     let demotions = 0;
     const actors = StaticDataRegistry.getAllActors();
+    const actorIds = actors.map((a) => a.id);
     const now = Date.now();
 
-    for (const actor of actors) {
-      const memberships = await db
-        .select({
-          userId: groupMembers.userId,
-          groupId: groupMembers.groupId,
-          tier: groupMembers.tier,
-          lastMessageAt: groupMembers.lastMessageAt,
-          joinedAt: groupMembers.joinedAt,
-        })
-        .from(groupMembers)
-        .innerJoin(groups, eq(groupMembers.groupId, groups.id))
-        .where(
-          and(
-            eq(groups.ownerId, actor.id),
-            eq(groups.type, 'npc'),
-            eq(groupMembers.isActive, true),
-            isNotNull(groupMembers.tier)
-          )
-        );
+    if (actorIds.length === 0) return 0;
 
-      for (const m of memberships) {
-        const tier = m.tier as TierLevel;
+    // Batch query: Get all memberships across all NPCs in one query
+    const allMemberships = await db
+      .select({
+        userId: groupMembers.userId,
+        groupId: groupMembers.groupId,
+        tier: groupMembers.tier,
+        lastMessageAt: groupMembers.lastMessageAt,
+        joinedAt: groupMembers.joinedAt,
+        npcId: groups.ownerId,
+      })
+      .from(groupMembers)
+      .innerJoin(groups, eq(groupMembers.groupId, groups.id))
+      .where(
+        and(
+          inArray(groups.ownerId, actorIds),
+          eq(groups.type, 'npc'),
+          eq(groupMembers.isActive, true),
+          isNotNull(groupMembers.tier)
+        )
+      );
+
+    for (const m of allMemberships) {
+        // Validate tier (should be valid due to isNotNull filter, but be defensive)
+        if (!isValidTier(m.tier)) {
+          logger.warn(
+            `Invalid tier value ${m.tier} for membership, skipping demotion check`,
+            { userId: m.userId, groupId: m.groupId, tier: m.tier },
+            'TieredGroupService'
+          );
+          continue;
+        }
+        const tier = m.tier;
         const lastActivity = m.lastMessageAt ?? m.joinedAt;
         const daysSince = Math.floor(
           (now - lastActivity.getTime()) / (1000 * 60 * 60 * 24)
@@ -624,19 +744,47 @@ export class TieredGroupService {
           const lowerTier = getLowerTier(tier);
           const reason = `Inactive for ${daysSince} days`;
 
-          // Deactivate current membership
-          await db
-            .update(groupMembers)
-            .set({ isActive: false, kickReason: reason, kickedAt: new Date() })
-            .where(eq(groupMembers.id, m.groupId));
+          // Pre-fetch data needed for transaction
+          const tiers = lowerTier ? await this.getNpcTiers(m.npcId) : [];
+          const targetTier = lowerTier
+            ? tiers.find((t) => t.tier === lowerTier)
+            : null;
 
-          if (lowerTier) {
-            // Find and add to lower tier
-            const tiers = await this.getNpcTiers(actor.id);
-            const targetTier = tiers.find((t) => t.tier === lowerTier);
+          // Wrap multi-step demotion in transaction to prevent orphaned state
+          await db.$transaction(async (tx) => {
+            // Deactivate current membership
+            await tx
+              .update(groupMembers)
+              .set({ isActive: false, kickReason: reason, kickedAt: new Date() })
+              .where(
+                and(
+                  eq(groupMembers.groupId, m.groupId),
+                  eq(groupMembers.userId, m.userId)
+                )
+              );
 
-            if (targetTier && !targetTier.isFull) {
-              await db.insert(groupMembers).values({
+            // Deactivate chat participant for the old tier's chat
+            const [oldChat] = await tx
+              .select({ id: chats.id })
+              .from(chats)
+              .where(eq(chats.groupId, m.groupId))
+              .limit(1);
+
+            if (oldChat) {
+              await tx
+                .update(chatParticipants)
+                .set({ isActive: false })
+                .where(
+                  and(
+                    eq(chatParticipants.chatId, oldChat.id),
+                    eq(chatParticipants.userId, m.userId)
+                  )
+                );
+            }
+
+            if (lowerTier && targetTier && !targetTier.isFull) {
+              // Add to lower tier
+              await tx.insert(groupMembers).values({
                 id: await generateSnowflakeId(),
                 groupId: targetTier.groupId,
                 userId: m.userId,
@@ -647,21 +795,21 @@ export class TieredGroupService {
               });
 
               if (targetTier.chatId) {
-                await db.insert(chatParticipants).values({
+                await tx.insert(chatParticipants).values({
                   id: await generateSnowflakeId(),
                   chatId: targetTier.chatId,
                   userId: m.userId,
                 });
               }
             }
-          }
+          });
 
           demotions++;
           logger.info(
             'User demoted',
             {
               userId: m.userId,
-              npcId: actor.id,
+              npcId: m.npcId,
               fromTier: tier,
               toTier: lowerTier,
               reason,
@@ -670,13 +818,14 @@ export class TieredGroupService {
           );
         }
       }
-    }
 
     return demotions;
   }
 
   /**
    * Get global tier analytics
+   *
+   * Optimized to use batch queries instead of N+1 pattern.
    */
   static async getGlobalAnalytics(): Promise<{
     totalNpcs: number;
@@ -692,6 +841,34 @@ export class TieredGroupService {
     }[];
   }> {
     const actors = StaticDataRegistry.getAllActors();
+
+    // Batch query 1: Get all NPC tier groups with member counts in a single query
+    const tierGroupsWithCounts = await db
+      .select({
+        groupId: groups.id,
+        ownerId: groups.ownerId,
+        tier: groups.tier,
+        maxMembers: groups.maxMembers,
+        memberCount: count(groupMembers.id),
+      })
+      .from(groups)
+      .leftJoin(
+        groupMembers,
+        and(
+          eq(groupMembers.groupId, groups.id),
+          eq(groupMembers.isActive, true)
+        )
+      )
+      .where(
+        and(
+          eq(groups.type, 'npc'),
+          isNotNull(groups.tier)
+        )
+      )
+      .groupBy(groups.id, groups.ownerId, groups.tier, groups.maxMembers);
+
+    // Track unique NPCs with groups
+    const npcsWithGroups = new Set<string>();
     let totalGroups = 0;
     let totalMembers = 0;
     let totalCapacity = 0;
@@ -703,16 +880,20 @@ export class TieredGroupService {
         3: { members: 0, capacity: 0 },
       };
 
-    for (const actor of actors) {
-      const tiers = await this.getNpcTiers(actor.id);
-      totalGroups += tiers.length;
+    for (const g of tierGroupsWithCounts) {
+      if (!isValidTier(g.tier)) continue;
 
-      for (const t of tiers) {
-        totalMembers += t.memberCount;
-        totalCapacity += t.maxMembers;
-        tierTotals[t.tier].members += t.memberCount;
-        tierTotals[t.tier].capacity += t.maxMembers;
-      }
+      npcsWithGroups.add(g.ownerId);
+      totalGroups++;
+
+      const config = getTierConfig(g.tier);
+      const maxMembers = g.maxMembers ?? config.maxMembers;
+      const memberCount = g.memberCount ?? 0;
+
+      totalMembers += memberCount;
+      totalCapacity += maxMembers;
+      tierTotals[g.tier].members += memberCount;
+      tierTotals[g.tier].capacity += maxMembers;
     }
 
     return {

--- a/packages/engine/src/services/tiered-group-service.ts
+++ b/packages/engine/src/services/tiered-group-service.ts
@@ -68,6 +68,8 @@ export interface UserTierStatus {
 export class TieredGroupService {
   /**
    * Ensure all 3 tier groups exist for an NPC
+   *
+   * Optimized: Uses batch queries with JOINs instead of N+1 pattern for existing tiers.
    */
   static async ensureAllTiersExist(npcId: string): Promise<TierInfo[]> {
     const actor = StaticDataRegistry.getActor(npcId);
@@ -80,24 +82,42 @@ export class TieredGroupService {
       return [];
     }
 
-    const existingGroups = await db
+    // Single batch query with JOINs for all existing tier data (member counts + chat IDs)
+    const existingTiersWithData = await db
       .select({
         id: groups.id,
         tier: groups.tier,
         name: groups.name,
         maxMembers: groups.maxMembers,
+        chatId: chats.id,
+        memberCount: count(groupMembers.id),
       })
       .from(groups)
+      .leftJoin(chats, eq(chats.groupId, groups.id))
+      .leftJoin(
+        groupMembers,
+        and(
+          eq(groupMembers.groupId, groups.id),
+          eq(groupMembers.isActive, true)
+        )
+      )
       .where(
         and(
           eq(groups.ownerId, npcId),
           eq(groups.type, 'npc'),
           isNotNull(groups.tier)
         )
+      )
+      .groupBy(
+        groups.id,
+        groups.tier,
+        groups.name,
+        groups.maxMembers,
+        chats.id
       );
 
     const existingTierMap = new Map(
-      existingGroups
+      existingTiersWithData
         .filter((g) => isValidTier(g.tier))
         .map((g) => [g.tier as TierLevel, g])
     );
@@ -110,30 +130,13 @@ export class TieredGroupService {
       const config = getTierConfig(tier);
 
       if (existing) {
-        const [countResult] = await db
-          .select({ count: count() })
-          .from(groupMembers)
-          .where(
-            and(
-              eq(groupMembers.groupId, existing.id),
-              eq(groupMembers.isActive, true)
-            )
-          );
-
-        const memberCount = countResult?.count ?? 0;
+        const memberCount = existing.memberCount ?? 0;
         const maxMembers = existing.maxMembers ?? config.maxMembers;
-
-        // Find associated chat
-        const [chat] = await db
-          .select({ id: chats.id })
-          .from(chats)
-          .where(eq(chats.groupId, existing.id))
-          .limit(1);
 
         result.push({
           tier,
           groupId: existing.id,
-          chatId: chat?.id ?? null,
+          chatId: existing.chatId ?? null,
           groupName: existing.name,
           memberCount,
           maxMembers,
@@ -498,11 +501,15 @@ export class TieredGroupService {
         };
       }
 
+      // Generate IDs before transaction to minimize transaction duration
+      const memberId = await generateSnowflakeId();
+      const participantId = targetTier.chatId ? await generateSnowflakeId() : null;
+
       // Wrap multi-step operation in transaction
       await db.$transaction(async (tx) => {
         // Add to group
         await tx.insert(groupMembers).values({
-          id: await generateSnowflakeId(),
+          id: memberId,
           groupId: targetTier.groupId,
           userId,
           role: 'member',
@@ -511,9 +518,9 @@ export class TieredGroupService {
         });
 
         // Add to chat if exists
-        if (targetTier.chatId) {
+        if (targetTier.chatId && participantId) {
           await tx.insert(chatParticipants).values({
-            id: await generateSnowflakeId(),
+            id: participantId,
             chatId: targetTier.chatId,
             userId,
             invitedBy: npcId,
@@ -597,6 +604,19 @@ export class TieredGroupService {
       const currentGroupId = status.groupId;
       const currentTier = status.currentTier;
 
+      // Generate IDs before transaction to minimize transaction duration
+      const newMemberId = await generateSnowflakeId();
+      const newParticipantId = targetTier.chatId
+        ? await generateSnowflakeId()
+        : null;
+
+      // Pre-fetch old chat ID before transaction
+      const [oldChat] = await db
+        .select({ id: chats.id })
+        .from(chats)
+        .where(eq(chats.groupId, currentGroupId))
+        .limit(1);
+
       // Wrap multi-step operation in transaction to prevent orphaned state
       await db.$transaction(async (tx) => {
         // Deactivate old membership
@@ -614,13 +634,7 @@ export class TieredGroupService {
             )
           );
 
-        // Find and deactivate old chat participant
-        const [oldChat] = await tx
-          .select({ id: chats.id })
-          .from(chats)
-          .where(eq(chats.groupId, currentGroupId))
-          .limit(1);
-
+        // Deactivate old chat participant
         if (oldChat) {
           await tx
             .update(chatParticipants)
@@ -635,7 +649,7 @@ export class TieredGroupService {
 
         // Add to new tier
         await tx.insert(groupMembers).values({
-          id: await generateSnowflakeId(),
+          id: newMemberId,
           groupId: targetTier.groupId,
           userId,
           role: 'member',
@@ -645,9 +659,9 @@ export class TieredGroupService {
           promotedAt: new Date(),
         });
 
-        if (targetTier.chatId) {
+        if (targetTier.chatId && newParticipantId) {
           await tx.insert(chatParticipants).values({
-            id: await generateSnowflakeId(),
+            id: newParticipantId,
             chatId: targetTier.chatId,
             userId,
             invitedBy: npcId,
@@ -797,6 +811,23 @@ export class TieredGroupService {
             ? tiers.find((t) => t.tier === lowerTier)
             : null;
 
+          // Pre-fetch old chat ID before transaction
+          const [oldChat] = await db
+            .select({ id: chats.id })
+            .from(chats)
+            .where(eq(chats.groupId, m.groupId))
+            .limit(1);
+
+          // Generate IDs before transaction to minimize transaction duration
+          const newMemberId =
+            lowerTier && targetTier && !targetTier.isFull
+              ? await generateSnowflakeId()
+              : null;
+          const newParticipantId =
+            newMemberId && targetTier?.chatId
+              ? await generateSnowflakeId()
+              : null;
+
           // Wrap multi-step demotion in transaction to prevent orphaned state
           await db.$transaction(async (tx) => {
             // Deactivate current membership
@@ -815,12 +846,6 @@ export class TieredGroupService {
               );
 
             // Deactivate chat participant for the old tier's chat
-            const [oldChat] = await tx
-              .select({ id: chats.id })
-              .from(chats)
-              .where(eq(chats.groupId, m.groupId))
-              .limit(1);
-
             if (oldChat) {
               await tx
                 .update(chatParticipants)
@@ -833,10 +858,10 @@ export class TieredGroupService {
                 );
             }
 
-            if (lowerTier && targetTier && !targetTier.isFull) {
+            if (lowerTier && targetTier && !targetTier.isFull && newMemberId) {
               // Add to lower tier
               await tx.insert(groupMembers).values({
-                id: await generateSnowflakeId(),
+                id: newMemberId,
                 groupId: targetTier.groupId,
                 userId: m.userId,
                 role: 'member',
@@ -845,9 +870,9 @@ export class TieredGroupService {
                 demotedAt: new Date(),
               });
 
-              if (targetTier.chatId) {
+              if (targetTier.chatId && newParticipantId) {
                 await tx.insert(chatParticipants).values({
-                  id: await generateSnowflakeId(),
+                  id: newParticipantId,
                   chatId: targetTier.chatId,
                   userId: m.userId,
                 });

--- a/packages/engine/src/services/tiered-group-service.ts
+++ b/packages/engine/src/services/tiered-group-service.ts
@@ -503,7 +503,9 @@ export class TieredGroupService {
 
       // Generate IDs before transaction to minimize transaction duration
       const memberId = await generateSnowflakeId();
-      const participantId = targetTier.chatId ? await generateSnowflakeId() : null;
+      const participantId = targetTier.chatId
+        ? await generateSnowflakeId()
+        : null;
 
       // Wrap multi-step operation in transaction
       await db.$transaction(async (tx) => {

--- a/packages/engine/src/services/tiered-group-service.ts
+++ b/packages/engine/src/services/tiered-group-service.ts
@@ -10,6 +10,7 @@
  * - Tier 3 (Followers): 500 members, public content
  */
 
+import { DistributedLockService } from '@babylon/api';
 import {
   and,
   chatParticipants,
@@ -24,7 +25,6 @@ import {
   isNull,
   ne,
 } from '@babylon/db';
-import { DistributedLockService } from '@babylon/api';
 import { GROUP_CONFIG, generateSnowflakeId, logger } from '@babylon/shared';
 
 import { NPCInteractionTracker } from './npc-interaction-tracker';
@@ -725,99 +725,99 @@ export class TieredGroupService {
       );
 
     for (const m of allMemberships) {
-        // Validate tier (should be valid due to isNotNull filter, but be defensive)
-        if (!isValidTier(m.tier)) {
-          logger.warn(
-            `Invalid tier value ${m.tier} for membership, skipping demotion check`,
-            { userId: m.userId, groupId: m.groupId, tier: m.tier },
-            'TieredGroupService'
-          );
-          continue;
-        }
-        const tier = m.tier;
-        const lastActivity = m.lastMessageAt ?? m.joinedAt;
-        const daysSince = Math.floor(
-          (now - lastActivity.getTime()) / (1000 * 60 * 60 * 24)
+      // Validate tier (should be valid due to isNotNull filter, but be defensive)
+      if (!isValidTier(m.tier)) {
+        logger.warn(
+          `Invalid tier value ${m.tier} for membership, skipping demotion check`,
+          { userId: m.userId, groupId: m.groupId, tier: m.tier },
+          'TieredGroupService'
         );
+        continue;
+      }
+      const tier = m.tier;
+      const lastActivity = m.lastMessageAt ?? m.joinedAt;
+      const daysSince = Math.floor(
+        (now - lastActivity.getTime()) / (1000 * 60 * 60 * 24)
+      );
 
-        if (shouldDemote(tier, daysSince)) {
-          const lowerTier = getLowerTier(tier);
-          const reason = `Inactive for ${daysSince} days`;
+      if (shouldDemote(tier, daysSince)) {
+        const lowerTier = getLowerTier(tier);
+        const reason = `Inactive for ${daysSince} days`;
 
-          // Pre-fetch data needed for transaction
-          const tiers = lowerTier ? await this.getNpcTiers(m.npcId) : [];
-          const targetTier = lowerTier
-            ? tiers.find((t) => t.tier === lowerTier)
-            : null;
+        // Pre-fetch data needed for transaction
+        const tiers = lowerTier ? await this.getNpcTiers(m.npcId) : [];
+        const targetTier = lowerTier
+          ? tiers.find((t) => t.tier === lowerTier)
+          : null;
 
-          // Wrap multi-step demotion in transaction to prevent orphaned state
-          await db.$transaction(async (tx) => {
-            // Deactivate current membership
+        // Wrap multi-step demotion in transaction to prevent orphaned state
+        await db.$transaction(async (tx) => {
+          // Deactivate current membership
+          await tx
+            .update(groupMembers)
+            .set({ isActive: false, kickReason: reason, kickedAt: new Date() })
+            .where(
+              and(
+                eq(groupMembers.groupId, m.groupId),
+                eq(groupMembers.userId, m.userId)
+              )
+            );
+
+          // Deactivate chat participant for the old tier's chat
+          const [oldChat] = await tx
+            .select({ id: chats.id })
+            .from(chats)
+            .where(eq(chats.groupId, m.groupId))
+            .limit(1);
+
+          if (oldChat) {
             await tx
-              .update(groupMembers)
-              .set({ isActive: false, kickReason: reason, kickedAt: new Date() })
+              .update(chatParticipants)
+              .set({ isActive: false })
               .where(
                 and(
-                  eq(groupMembers.groupId, m.groupId),
-                  eq(groupMembers.userId, m.userId)
+                  eq(chatParticipants.chatId, oldChat.id),
+                  eq(chatParticipants.userId, m.userId)
                 )
               );
+          }
 
-            // Deactivate chat participant for the old tier's chat
-            const [oldChat] = await tx
-              .select({ id: chats.id })
-              .from(chats)
-              .where(eq(chats.groupId, m.groupId))
-              .limit(1);
-
-            if (oldChat) {
-              await tx
-                .update(chatParticipants)
-                .set({ isActive: false })
-                .where(
-                  and(
-                    eq(chatParticipants.chatId, oldChat.id),
-                    eq(chatParticipants.userId, m.userId)
-                  )
-                );
-            }
-
-            if (lowerTier && targetTier && !targetTier.isFull) {
-              // Add to lower tier
-              await tx.insert(groupMembers).values({
-                id: await generateSnowflakeId(),
-                groupId: targetTier.groupId,
-                userId: m.userId,
-                role: 'member',
-                tier: lowerTier,
-                previousTier: tier,
-                demotedAt: new Date(),
-              });
-
-              if (targetTier.chatId) {
-                await tx.insert(chatParticipants).values({
-                  id: await generateSnowflakeId(),
-                  chatId: targetTier.chatId,
-                  userId: m.userId,
-                });
-              }
-            }
-          });
-
-          demotions++;
-          logger.info(
-            'User demoted',
-            {
+          if (lowerTier && targetTier && !targetTier.isFull) {
+            // Add to lower tier
+            await tx.insert(groupMembers).values({
+              id: await generateSnowflakeId(),
+              groupId: targetTier.groupId,
               userId: m.userId,
-              npcId: m.npcId,
-              fromTier: tier,
-              toTier: lowerTier,
-              reason,
-            },
-            'TieredGroupService'
-          );
-        }
+              role: 'member',
+              tier: lowerTier,
+              previousTier: tier,
+              demotedAt: new Date(),
+            });
+
+            if (targetTier.chatId) {
+              await tx.insert(chatParticipants).values({
+                id: await generateSnowflakeId(),
+                chatId: targetTier.chatId,
+                userId: m.userId,
+              });
+            }
+          }
+        });
+
+        demotions++;
+        logger.info(
+          'User demoted',
+          {
+            userId: m.userId,
+            npcId: m.npcId,
+            fromTier: tier,
+            toTier: lowerTier,
+            reason,
+          },
+          'TieredGroupService'
+        );
       }
+    }
 
     return demotions;
   }
@@ -859,12 +859,7 @@ export class TieredGroupService {
           eq(groupMembers.isActive, true)
         )
       )
-      .where(
-        and(
-          eq(groups.type, 'npc'),
-          isNotNull(groups.tier)
-        )
-      )
+      .where(and(eq(groups.type, 'npc'), isNotNull(groups.tier)))
       .groupBy(groups.id, groups.ownerId, groups.tier, groups.maxMembers);
 
     // Track unique NPCs with groups

--- a/packages/engine/src/services/tiered-group-service.ts
+++ b/packages/engine/src/services/tiered-group-service.ts
@@ -255,7 +255,13 @@ export class TieredGroupService {
           isNotNull(groups.tier)
         )
       )
-      .groupBy(groups.id, groups.tier, groups.name, groups.maxMembers, chats.id);
+      .groupBy(
+        groups.id,
+        groups.tier,
+        groups.name,
+        groups.maxMembers,
+        chats.id
+      );
 
     const result: TierInfo[] = [];
 
@@ -793,57 +799,61 @@ export class TieredGroupService {
 
           // Wrap multi-step demotion in transaction to prevent orphaned state
           await db.$transaction(async (tx) => {
-          // Deactivate current membership
-          await tx
-            .update(groupMembers)
-            .set({ isActive: false, kickReason: reason, kickedAt: new Date() })
-            .where(
-              and(
-                eq(groupMembers.groupId, m.groupId),
-                eq(groupMembers.userId, m.userId)
-              )
-            );
-
-          // Deactivate chat participant for the old tier's chat
-          const [oldChat] = await tx
-            .select({ id: chats.id })
-            .from(chats)
-            .where(eq(chats.groupId, m.groupId))
-            .limit(1);
-
-          if (oldChat) {
+            // Deactivate current membership
             await tx
-              .update(chatParticipants)
-              .set({ isActive: false })
+              .update(groupMembers)
+              .set({
+                isActive: false,
+                kickReason: reason,
+                kickedAt: new Date(),
+              })
               .where(
                 and(
-                  eq(chatParticipants.chatId, oldChat.id),
-                  eq(chatParticipants.userId, m.userId)
+                  eq(groupMembers.groupId, m.groupId),
+                  eq(groupMembers.userId, m.userId)
                 )
               );
-          }
 
-          if (lowerTier && targetTier && !targetTier.isFull) {
-            // Add to lower tier
-            await tx.insert(groupMembers).values({
-              id: await generateSnowflakeId(),
-              groupId: targetTier.groupId,
-              userId: m.userId,
-              role: 'member',
-              tier: lowerTier,
-              previousTier: tier,
-              demotedAt: new Date(),
-            });
+            // Deactivate chat participant for the old tier's chat
+            const [oldChat] = await tx
+              .select({ id: chats.id })
+              .from(chats)
+              .where(eq(chats.groupId, m.groupId))
+              .limit(1);
 
-            if (targetTier.chatId) {
-              await tx.insert(chatParticipants).values({
-                id: await generateSnowflakeId(),
-                chatId: targetTier.chatId,
-                userId: m.userId,
-              });
+            if (oldChat) {
+              await tx
+                .update(chatParticipants)
+                .set({ isActive: false })
+                .where(
+                  and(
+                    eq(chatParticipants.chatId, oldChat.id),
+                    eq(chatParticipants.userId, m.userId)
+                  )
+                );
             }
-          }
-        });
+
+            if (lowerTier && targetTier && !targetTier.isFull) {
+              // Add to lower tier
+              await tx.insert(groupMembers).values({
+                id: await generateSnowflakeId(),
+                groupId: targetTier.groupId,
+                userId: m.userId,
+                role: 'member',
+                tier: lowerTier,
+                previousTier: tier,
+                demotedAt: new Date(),
+              });
+
+              if (targetTier.chatId) {
+                await tx.insert(chatParticipants).values({
+                  id: await generateSnowflakeId(),
+                  chatId: targetTier.chatId,
+                  userId: m.userId,
+                });
+              }
+            }
+          });
 
           demotions++;
           logger.info(

--- a/packages/engine/src/services/tiered-group-service.ts
+++ b/packages/engine/src/services/tiered-group-service.ts
@@ -1,0 +1,735 @@
+/**
+ * Tiered Group Service
+ *
+ * Manages NPC group tiers for scalable access to the asymmetric information mechanic.
+ * Uses the unified Group/GroupMember schema.
+ *
+ * Each NPC can have 3 tier groups:
+ * - Tier 1 (Inner Circle): 12 members, full alpha
+ * - Tier 2 (Community): 50 members, partial alpha
+ * - Tier 3 (Followers): 500 members, public content
+ */
+
+import {
+  and,
+  chatParticipants,
+  chats,
+  count,
+  db,
+  eq,
+  groupMembers,
+  groups,
+  isNotNull,
+  isNull,
+  ne,
+} from '@babylon/db';
+import { GROUP_CONFIG, generateSnowflakeId, logger } from '@babylon/shared';
+
+import { NPCInteractionTracker } from './npc-interaction-tracker';
+import { StaticDataRegistry } from './static-data-registry';
+import {
+  ALL_TIERS,
+  getHigherTier,
+  getLowerTier,
+  getTierConfig,
+  getTierForEngagementScore,
+  getTierGroupName,
+  isEligibleForPromotion,
+  shouldDemote,
+  TIER_CONFIG,
+  type TierLevel,
+} from './tier-config';
+
+export interface TierInfo {
+  tier: TierLevel;
+  groupId: string;
+  chatId: string | null;
+  groupName: string;
+  memberCount: number;
+  maxMembers: number;
+  isFull: boolean;
+}
+
+export interface UserTierStatus {
+  userId: string;
+  npcId: string;
+  currentTier: TierLevel | null;
+  groupId: string | null;
+  joinedAt: Date | null;
+  engagementScore: number;
+  eligibleTier: TierLevel | null;
+  canBePromoted: boolean;
+  promotionBlockedReason: string | null;
+}
+
+export class TieredGroupService {
+  /**
+   * Ensure all 3 tier groups exist for an NPC
+   */
+  static async ensureAllTiersExist(npcId: string): Promise<TierInfo[]> {
+    const actor = StaticDataRegistry.getActor(npcId);
+    if (!actor) {
+      logger.warn(
+        `Cannot create tiers for unknown NPC: ${npcId}`,
+        undefined,
+        'TieredGroupService'
+      );
+      return [];
+    }
+
+    const existingGroups = await db
+      .select({
+        id: groups.id,
+        tier: groups.tier,
+        name: groups.name,
+        maxMembers: groups.maxMembers,
+      })
+      .from(groups)
+      .where(
+        and(
+          eq(groups.ownerId, npcId),
+          eq(groups.type, 'npc'),
+          isNotNull(groups.tier)
+        )
+      );
+
+    const existingTierMap = new Map(
+      existingGroups
+        .filter((g) => g.tier !== null)
+        .map((g) => [g.tier as TierLevel, g])
+    );
+
+    const result: TierInfo[] = [];
+    let parentGroupId: string | null = existingTierMap.get(1)?.id ?? null;
+
+    for (const tier of ALL_TIERS) {
+      const existing = existingTierMap.get(tier);
+      const config = getTierConfig(tier);
+
+      if (existing) {
+        const [countResult] = await db
+          .select({ count: count() })
+          .from(groupMembers)
+          .where(
+            and(
+              eq(groupMembers.groupId, existing.id),
+              eq(groupMembers.isActive, true)
+            )
+          );
+
+        const memberCount = countResult?.count ?? 0;
+        const maxMembers = existing.maxMembers ?? config.maxMembers;
+
+        // Find associated chat
+        const [chat] = await db
+          .select({ id: chats.id })
+          .from(chats)
+          .where(eq(chats.groupId, existing.id))
+          .limit(1);
+
+        result.push({
+          tier,
+          groupId: existing.id,
+          chatId: chat?.id ?? null,
+          groupName: existing.name,
+          memberCount,
+          maxMembers,
+          isFull: memberCount >= maxMembers,
+        });
+      } else {
+        // Create new tier group
+        const groupId = await generateSnowflakeId();
+        const groupName = getTierGroupName(actor.name, tier);
+
+        if (tier === 1) parentGroupId = groupId;
+
+        await db.insert(groups).values({
+          id: groupId,
+          name: groupName,
+          type: 'npc',
+          ownerId: npcId,
+          createdById: npcId,
+          updatedAt: new Date(),
+          tier,
+          maxMembers: config.maxMembers,
+          parentGroupId,
+        });
+
+        // Create associated chat
+        const chatId = await generateSnowflakeId();
+        await db.insert(chats).values({
+          id: chatId,
+          name: groupName,
+          isGroup: true,
+          groupId,
+          updatedAt: new Date(),
+        });
+
+        // Add NPC as owner
+        await db.insert(groupMembers).values({
+          id: await generateSnowflakeId(),
+          groupId,
+          userId: npcId,
+          role: 'owner',
+          tier,
+        });
+
+        await db.insert(chatParticipants).values({
+          id: await generateSnowflakeId(),
+          chatId,
+          userId: npcId,
+        });
+
+        logger.info(
+          `Created tier ${tier} group for NPC`,
+          { npcId, npcName: actor.name, groupId, groupName, tier },
+          'TieredGroupService'
+        );
+
+        result.push({
+          tier,
+          groupId,
+          chatId,
+          groupName,
+          memberCount: 1,
+          maxMembers: config.maxMembers,
+          isFull: false,
+        });
+      }
+    }
+
+    // Update parentGroupId for all tiers if needed
+    if (parentGroupId) {
+      await db
+        .update(groups)
+        .set({ parentGroupId })
+        .where(
+          and(
+            eq(groups.ownerId, npcId),
+            eq(groups.type, 'npc'),
+            isNotNull(groups.tier),
+            isNull(groups.parentGroupId)
+          )
+        );
+    }
+
+    return result;
+  }
+
+  /**
+   * Get all tier groups for an NPC
+   */
+  static async getNpcTiers(npcId: string): Promise<TierInfo[]> {
+    const tierGroups = await db
+      .select({
+        id: groups.id,
+        tier: groups.tier,
+        name: groups.name,
+        maxMembers: groups.maxMembers,
+      })
+      .from(groups)
+      .where(
+        and(
+          eq(groups.ownerId, npcId),
+          eq(groups.type, 'npc'),
+          isNotNull(groups.tier)
+        )
+      );
+
+    const result: TierInfo[] = [];
+
+    for (const g of tierGroups) {
+      const [countResult] = await db
+        .select({ count: count() })
+        .from(groupMembers)
+        .where(
+          and(eq(groupMembers.groupId, g.id), eq(groupMembers.isActive, true))
+        );
+
+      const [chat] = await db
+        .select({ id: chats.id })
+        .from(chats)
+        .where(eq(chats.groupId, g.id))
+        .limit(1);
+
+      const config = getTierConfig(g.tier as TierLevel);
+      const maxMembers = g.maxMembers ?? config.maxMembers;
+      const memberCount = countResult?.count ?? 0;
+
+      result.push({
+        tier: g.tier as TierLevel,
+        groupId: g.id,
+        chatId: chat?.id ?? null,
+        groupName: g.name,
+        memberCount,
+        maxMembers,
+        isFull: memberCount >= maxMembers,
+      });
+    }
+
+    return result.sort((a, b) => a.tier - b.tier);
+  }
+
+  /**
+   * Get user's tier status with an NPC
+   */
+  static async getUserTierStatus(
+    userId: string,
+    npcId: string
+  ): Promise<UserTierStatus> {
+    // Find active membership
+    const [membership] = await db
+      .select({
+        groupId: groupMembers.groupId,
+        tier: groupMembers.tier,
+        joinedAt: groupMembers.joinedAt,
+      })
+      .from(groupMembers)
+      .innerJoin(groups, eq(groupMembers.groupId, groups.id))
+      .where(
+        and(
+          eq(groupMembers.userId, userId),
+          eq(groupMembers.isActive, true),
+          eq(groups.ownerId, npcId),
+          eq(groups.type, 'npc'),
+          isNotNull(groups.tier)
+        )
+      )
+      .limit(1);
+
+    const interactionScore =
+      await NPCInteractionTracker.calculateEngagementScore(userId, npcId);
+    const engagementScore = interactionScore.engagementScore;
+
+    const eligibleTier = getTierForEngagementScore(engagementScore);
+
+    let canBePromoted = false;
+    let promotionBlockedReason: string | null = null;
+
+    if (membership?.tier !== null && membership?.tier !== undefined) {
+      const currentTier = membership.tier as TierLevel;
+      const daysInTier = Math.floor(
+        (Date.now() - membership.joinedAt.getTime()) / (1000 * 60 * 60 * 24)
+      );
+
+      if (currentTier === 1) {
+        promotionBlockedReason = 'Already at highest tier';
+      } else if (
+        isEligibleForPromotion(currentTier, engagementScore, daysInTier)
+      ) {
+        const higherTier = getHigherTier(currentTier);
+        if (higherTier) {
+          const tiers = await this.getNpcTiers(npcId);
+          const targetTier = tiers.find((t) => t.tier === higherTier);
+          if (targetTier && !targetTier.isFull) {
+            canBePromoted = true;
+          } else {
+            promotionBlockedReason = `Tier ${higherTier} is full`;
+          }
+        }
+      } else {
+        const config = TIER_CONFIG[currentTier];
+        const daysNeeded = config.promotionWaitDays - daysInTier;
+        if (daysNeeded > 0) {
+          promotionBlockedReason = `Need ${daysNeeded} more days in current tier`;
+        } else {
+          const higherTier = getHigherTier(currentTier);
+          if (higherTier) {
+            const needed = TIER_CONFIG[higherTier].minEngagementScore;
+            promotionBlockedReason = `Need engagement score ${needed}+ (current: ${engagementScore.toFixed(0)})`;
+          }
+        }
+      }
+    }
+
+    return {
+      userId,
+      npcId,
+      currentTier: (membership?.tier as TierLevel) ?? null,
+      groupId: membership?.groupId ?? null,
+      joinedAt: membership?.joinedAt ?? null,
+      engagementScore,
+      eligibleTier,
+      canBePromoted,
+      promotionBlockedReason,
+    };
+  }
+
+  /**
+   * Invite user to appropriate tier based on engagement
+   */
+  static async inviteUserToTier(
+    userId: string,
+    npcId: string
+  ): Promise<{ success: boolean; tier: TierLevel | null; reason: string }> {
+    // Check if already in a tier with this NPC
+    const [existing] = await db
+      .select({ id: groupMembers.id })
+      .from(groupMembers)
+      .innerJoin(groups, eq(groupMembers.groupId, groups.id))
+      .where(
+        and(
+          eq(groupMembers.userId, userId),
+          eq(groupMembers.isActive, true),
+          eq(groups.ownerId, npcId),
+          eq(groups.type, 'npc')
+        )
+      )
+      .limit(1);
+
+    if (existing) {
+      return {
+        success: false,
+        tier: null,
+        reason: 'Already in a group with this NPC',
+      };
+    }
+
+    // Check group limit
+    const [groupCount] = await db
+      .select({ count: count() })
+      .from(groupMembers)
+      .innerJoin(groups, eq(groupMembers.groupId, groups.id))
+      .where(
+        and(
+          eq(groupMembers.userId, userId),
+          eq(groupMembers.isActive, true),
+          eq(groups.type, 'npc')
+        )
+      );
+
+    if ((groupCount?.count ?? 0) >= GROUP_CONFIG.MAX_ACTIVE_USER_GROUPS) {
+      return {
+        success: false,
+        tier: null,
+        reason: `At maximum of ${GROUP_CONFIG.MAX_ACTIVE_USER_GROUPS} groups`,
+      };
+    }
+
+    // Get engagement score
+    const interactionScore =
+      await NPCInteractionTracker.calculateEngagementScore(userId, npcId);
+    const engagementScore = interactionScore.engagementScore;
+
+    // Ensure tiers exist
+    await this.ensureAllTiersExist(npcId);
+
+    // Find available tier
+    const tiers = await this.getNpcTiers(npcId);
+    let targetTier: TierInfo | null = null;
+
+    for (const tier of ALL_TIERS) {
+      if (engagementScore < TIER_CONFIG[tier].minEngagementScore) continue;
+      const tierInfo = tiers.find((t) => t.tier === tier);
+      if (tierInfo && !tierInfo.isFull) {
+        targetTier = tierInfo;
+        break;
+      }
+    }
+
+    if (!targetTier) {
+      return {
+        success: false,
+        tier: null,
+        reason: `No available tier (score: ${engagementScore.toFixed(0)}, min: ${TIER_CONFIG[3].minEngagementScore})`,
+      };
+    }
+
+    // Add to group
+    await db.insert(groupMembers).values({
+      id: await generateSnowflakeId(),
+      groupId: targetTier.groupId,
+      userId,
+      role: 'member',
+      addedBy: npcId,
+      tier: targetTier.tier,
+    });
+
+    // Add to chat if exists
+    if (targetTier.chatId) {
+      await db.insert(chatParticipants).values({
+        id: await generateSnowflakeId(),
+        chatId: targetTier.chatId,
+        userId,
+        invitedBy: npcId,
+      });
+    }
+
+    logger.info(
+      'User invited to tier',
+      {
+        userId,
+        npcId,
+        tier: targetTier.tier,
+        groupName: targetTier.groupName,
+        engagementScore,
+      },
+      'TieredGroupService'
+    );
+
+    return {
+      success: true,
+      tier: targetTier.tier,
+      reason: `Invited to ${targetTier.groupName}`,
+    };
+  }
+
+  /**
+   * Promote user to higher tier
+   */
+  static async promoteUser(userId: string, npcId: string): Promise<boolean> {
+    const status = await this.getUserTierStatus(userId, npcId);
+    if (!status.currentTier || !status.groupId || !status.canBePromoted)
+      return false;
+
+    const higherTier = getHigherTier(status.currentTier);
+    if (!higherTier) return false;
+
+    const tiers = await this.getNpcTiers(npcId);
+    const targetTier = tiers.find((t) => t.tier === higherTier);
+    if (!targetTier || targetTier.isFull) return false;
+
+    // Deactivate old membership
+    await db
+      .update(groupMembers)
+      .set({
+        isActive: false,
+        kickReason: `Promoted to Tier ${higherTier}`,
+        kickedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(groupMembers.groupId, status.groupId),
+          eq(groupMembers.userId, userId)
+        )
+      );
+
+    // Find and deactivate old chat participant
+    const [oldChat] = await db
+      .select({ id: chats.id })
+      .from(chats)
+      .where(eq(chats.groupId, status.groupId))
+      .limit(1);
+
+    if (oldChat) {
+      await db
+        .update(chatParticipants)
+        .set({ isActive: false })
+        .where(
+          and(
+            eq(chatParticipants.chatId, oldChat.id),
+            eq(chatParticipants.userId, userId)
+          )
+        );
+    }
+
+    // Add to new tier
+    await db.insert(groupMembers).values({
+      id: await generateSnowflakeId(),
+      groupId: targetTier.groupId,
+      userId,
+      role: 'member',
+      addedBy: npcId,
+      tier: higherTier,
+      previousTier: status.currentTier,
+      promotedAt: new Date(),
+    });
+
+    if (targetTier.chatId) {
+      await db.insert(chatParticipants).values({
+        id: await generateSnowflakeId(),
+        chatId: targetTier.chatId,
+        userId,
+        invitedBy: npcId,
+      });
+    }
+
+    logger.info(
+      'User promoted',
+      { userId, npcId, fromTier: status.currentTier, toTier: higherTier },
+      'TieredGroupService'
+    );
+
+    return true;
+  }
+
+  /**
+   * Process promotions for all NPC groups (run daily)
+   */
+  static async processAllPromotions(): Promise<number> {
+    let promotions = 0;
+    const actors = StaticDataRegistry.getAllActors();
+
+    for (const actor of actors) {
+      const memberships = await db
+        .select({ userId: groupMembers.userId, tier: groupMembers.tier })
+        .from(groupMembers)
+        .innerJoin(groups, eq(groupMembers.groupId, groups.id))
+        .where(
+          and(
+            eq(groups.ownerId, actor.id),
+            eq(groups.type, 'npc'),
+            eq(groupMembers.isActive, true),
+            isNotNull(groupMembers.tier),
+            ne(groupMembers.tier, 1)
+          )
+        );
+
+      for (const m of memberships) {
+        if (await this.promoteUser(m.userId, actor.id)) {
+          promotions++;
+        }
+      }
+    }
+
+    return promotions;
+  }
+
+  /**
+   * Process demotions for inactive users (run daily)
+   */
+  static async processAllDemotions(): Promise<number> {
+    let demotions = 0;
+    const actors = StaticDataRegistry.getAllActors();
+    const now = Date.now();
+
+    for (const actor of actors) {
+      const memberships = await db
+        .select({
+          userId: groupMembers.userId,
+          groupId: groupMembers.groupId,
+          tier: groupMembers.tier,
+          lastMessageAt: groupMembers.lastMessageAt,
+          joinedAt: groupMembers.joinedAt,
+        })
+        .from(groupMembers)
+        .innerJoin(groups, eq(groupMembers.groupId, groups.id))
+        .where(
+          and(
+            eq(groups.ownerId, actor.id),
+            eq(groups.type, 'npc'),
+            eq(groupMembers.isActive, true),
+            isNotNull(groupMembers.tier)
+          )
+        );
+
+      for (const m of memberships) {
+        const tier = m.tier as TierLevel;
+        const lastActivity = m.lastMessageAt ?? m.joinedAt;
+        const daysSince = Math.floor(
+          (now - lastActivity.getTime()) / (1000 * 60 * 60 * 24)
+        );
+
+        if (shouldDemote(tier, daysSince)) {
+          const lowerTier = getLowerTier(tier);
+          const reason = `Inactive for ${daysSince} days`;
+
+          // Deactivate current membership
+          await db
+            .update(groupMembers)
+            .set({ isActive: false, kickReason: reason, kickedAt: new Date() })
+            .where(eq(groupMembers.id, m.groupId));
+
+          if (lowerTier) {
+            // Find and add to lower tier
+            const tiers = await this.getNpcTiers(actor.id);
+            const targetTier = tiers.find((t) => t.tier === lowerTier);
+
+            if (targetTier && !targetTier.isFull) {
+              await db.insert(groupMembers).values({
+                id: await generateSnowflakeId(),
+                groupId: targetTier.groupId,
+                userId: m.userId,
+                role: 'member',
+                tier: lowerTier,
+                previousTier: tier,
+                demotedAt: new Date(),
+              });
+
+              if (targetTier.chatId) {
+                await db.insert(chatParticipants).values({
+                  id: await generateSnowflakeId(),
+                  chatId: targetTier.chatId,
+                  userId: m.userId,
+                });
+              }
+            }
+          }
+
+          demotions++;
+          logger.info(
+            'User demoted',
+            {
+              userId: m.userId,
+              npcId: actor.id,
+              fromTier: tier,
+              toTier: lowerTier,
+              reason,
+            },
+            'TieredGroupService'
+          );
+        }
+      }
+    }
+
+    return demotions;
+  }
+
+  /**
+   * Get global tier analytics
+   */
+  static async getGlobalAnalytics(): Promise<{
+    totalNpcs: number;
+    totalGroups: number;
+    totalMembers: number;
+    totalCapacity: number;
+    fillRate: number;
+    tierBreakdown: {
+      tier: TierLevel;
+      members: number;
+      capacity: number;
+      fillRate: number;
+    }[];
+  }> {
+    const actors = StaticDataRegistry.getAllActors();
+    let totalGroups = 0;
+    let totalMembers = 0;
+    let totalCapacity = 0;
+
+    const tierTotals: Record<TierLevel, { members: number; capacity: number }> =
+      {
+        1: { members: 0, capacity: 0 },
+        2: { members: 0, capacity: 0 },
+        3: { members: 0, capacity: 0 },
+      };
+
+    for (const actor of actors) {
+      const tiers = await this.getNpcTiers(actor.id);
+      totalGroups += tiers.length;
+
+      for (const t of tiers) {
+        totalMembers += t.memberCount;
+        totalCapacity += t.maxMembers;
+        tierTotals[t.tier].members += t.memberCount;
+        tierTotals[t.tier].capacity += t.maxMembers;
+      }
+    }
+
+    return {
+      totalNpcs: actors.length,
+      totalGroups,
+      totalMembers,
+      totalCapacity,
+      fillRate: totalCapacity > 0 ? totalMembers / totalCapacity : 0,
+      tierBreakdown: ALL_TIERS.map((tier) => ({
+        tier,
+        members: tierTotals[tier].members,
+        capacity: tierTotals[tier].capacity,
+        fillRate:
+          tierTotals[tier].capacity > 0
+            ? tierTotals[tier].members / tierTotals[tier].capacity
+            : 0,
+      })),
+    };
+  }
+}

--- a/packages/engine/src/services/tiered-group-service.ts
+++ b/packages/engine/src/services/tiered-group-service.ts
@@ -140,8 +140,13 @@ export class TieredGroupService {
           isFull: memberCount >= maxMembers,
         });
       } else {
-        // Create new tier group
-        const groupId = await generateSnowflakeId();
+        // Create new tier group - batch generate all IDs upfront
+        const [groupId, chatId, memberId, participantId] = await Promise.all([
+          generateSnowflakeId(),
+          generateSnowflakeId(),
+          generateSnowflakeId(),
+          generateSnowflakeId(),
+        ]);
         const groupName = getTierGroupName(actor.name, tier);
 
         if (tier === 1) parentGroupId = groupId;
@@ -159,7 +164,6 @@ export class TieredGroupService {
         });
 
         // Create associated chat
-        const chatId = await generateSnowflakeId();
         await db.insert(chats).values({
           id: chatId,
           name: groupName,
@@ -170,7 +174,7 @@ export class TieredGroupService {
 
         // Add NPC as owner
         await db.insert(groupMembers).values({
-          id: await generateSnowflakeId(),
+          id: memberId,
           groupId,
           userId: npcId,
           role: 'owner',
@@ -178,7 +182,7 @@ export class TieredGroupService {
         });
 
         await db.insert(chatParticipants).values({
-          id: await generateSnowflakeId(),
+          id: participantId,
           chatId,
           userId: npcId,
         });
@@ -221,40 +225,41 @@ export class TieredGroupService {
 
   /**
    * Get all tier groups for an NPC
+   *
+   * Optimized: Single query with LEFT JOINs and GROUP BY instead of N+1 pattern.
    */
   static async getNpcTiers(npcId: string): Promise<TierInfo[]> {
-    const tierGroups = await db
+    // Single batch query with joins for member counts and chat IDs
+    const tierGroupsWithData = await db
       .select({
         id: groups.id,
         tier: groups.tier,
         name: groups.name,
         maxMembers: groups.maxMembers,
+        chatId: chats.id,
+        memberCount: count(groupMembers.id),
       })
       .from(groups)
+      .leftJoin(chats, eq(chats.groupId, groups.id))
+      .leftJoin(
+        groupMembers,
+        and(
+          eq(groupMembers.groupId, groups.id),
+          eq(groupMembers.isActive, true)
+        )
+      )
       .where(
         and(
           eq(groups.ownerId, npcId),
           eq(groups.type, 'npc'),
           isNotNull(groups.tier)
         )
-      );
+      )
+      .groupBy(groups.id, groups.tier, groups.name, groups.maxMembers, chats.id);
 
     const result: TierInfo[] = [];
 
-    for (const g of tierGroups) {
-      const [countResult] = await db
-        .select({ count: count() })
-        .from(groupMembers)
-        .where(
-          and(eq(groupMembers.groupId, g.id), eq(groupMembers.isActive, true))
-        );
-
-      const [chat] = await db
-        .select({ id: chats.id })
-        .from(chats)
-        .where(eq(chats.groupId, g.id))
-        .limit(1);
-
+    for (const g of tierGroupsWithData) {
       // Validate tier before processing
       if (!isValidTier(g.tier)) {
         logger.warn(
@@ -267,12 +272,12 @@ export class TieredGroupService {
 
       const config = getTierConfig(g.tier);
       const maxMembers = g.maxMembers ?? config.maxMembers;
-      const memberCount = countResult?.count ?? 0;
+      const memberCount = g.memberCount ?? 0;
 
       result.push({
         tier: g.tier,
         groupId: g.id,
-        chatId: chat?.id ?? null,
+        chatId: g.chatId ?? null,
         groupName: g.name,
         memberCount,
         maxMembers,
@@ -529,7 +534,15 @@ export class TieredGroupService {
       };
     } finally {
       // Always release lock
-      await DistributedLockService.releaseLock(lockId, processId);
+      await DistributedLockService.releaseLock(lockId, processId).catch(
+        (err) => {
+          logger.error(
+            'Failed to release invite lock',
+            { lockId, processId, error: String(err) },
+            'TieredGroupService'
+          );
+        }
+      );
     }
   }
 
@@ -645,7 +658,15 @@ export class TieredGroupService {
       return true;
     } finally {
       // Always release lock
-      await DistributedLockService.releaseLock(lockId, processId);
+      await DistributedLockService.releaseLock(lockId, processId).catch(
+        (err) => {
+          logger.error(
+            'Failed to release promotion lock',
+            { lockId, processId, error: String(err) },
+            'TieredGroupService'
+          );
+        }
+      );
     }
   }
 
@@ -741,17 +762,37 @@ export class TieredGroupService {
       );
 
       if (shouldDemote(tier, daysSince)) {
-        const lowerTier = getLowerTier(tier);
-        const reason = `Inactive for ${daysSince} days`;
+        // Acquire distributed lock to prevent concurrent demotion of same user
+        const lockId = `tier-op-${m.npcId}-${m.userId}`;
+        const processId = `tiered-group-service-demotion-${await generateSnowflakeId()}`;
+        const lockAcquired = await DistributedLockService.acquireLock({
+          lockId,
+          durationMs: 5000,
+          operation: 'tier-op-demotion',
+          processId,
+        });
 
-        // Pre-fetch data needed for transaction
-        const tiers = lowerTier ? await this.getNpcTiers(m.npcId) : [];
-        const targetTier = lowerTier
-          ? tiers.find((t) => t.tier === lowerTier)
-          : null;
+        if (!lockAcquired) {
+          logger.warn(
+            'Failed to acquire lock for demotion operation',
+            { lockId, userId: m.userId, npcId: m.npcId },
+            'TieredGroupService'
+          );
+          continue;
+        }
 
-        // Wrap multi-step demotion in transaction to prevent orphaned state
-        await db.$transaction(async (tx) => {
+        try {
+          const lowerTier = getLowerTier(tier);
+          const reason = `Inactive for ${daysSince} days`;
+
+          // Pre-fetch data needed for transaction
+          const tiers = lowerTier ? await this.getNpcTiers(m.npcId) : [];
+          const targetTier = lowerTier
+            ? tiers.find((t) => t.tier === lowerTier)
+            : null;
+
+          // Wrap multi-step demotion in transaction to prevent orphaned state
+          await db.$transaction(async (tx) => {
           // Deactivate current membership
           await tx
             .update(groupMembers)
@@ -804,18 +845,29 @@ export class TieredGroupService {
           }
         });
 
-        demotions++;
-        logger.info(
-          'User demoted',
-          {
-            userId: m.userId,
-            npcId: m.npcId,
-            fromTier: tier,
-            toTier: lowerTier,
-            reason,
-          },
-          'TieredGroupService'
-        );
+          demotions++;
+          logger.info(
+            'User demoted',
+            {
+              userId: m.userId,
+              npcId: m.npcId,
+              fromTier: tier,
+              toTier: lowerTier,
+              reason,
+            },
+            'TieredGroupService'
+          );
+        } finally {
+          await DistributedLockService.releaseLock(lockId, processId).catch(
+            (err) => {
+              logger.error(
+                'Failed to release demotion lock',
+                { lockId, processId, error: String(err) },
+                'TieredGroupService'
+              );
+            }
+          );
+        }
       }
     }
 

--- a/packages/shared/src/types/groups.ts
+++ b/packages/shared/src/types/groups.ts
@@ -1,0 +1,18 @@
+/**
+ * Group System Types
+ *
+ * Shared types for the tiered group system.
+ */
+
+/**
+ * Tier levels for NPC groups.
+ * - Tier 1 (Inner Circle): Exclusive, full alpha
+ * - Tier 2 (Community): Medium engagement, partial alpha
+ * - Tier 3 (Followers): Low barrier, public content
+ */
+export type TierLevel = 1 | 2 | 3;
+
+/**
+ * Alpha content level corresponding to each tier.
+ */
+export type AlphaLevel = 'full' | 'partial' | 'public';

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -21,6 +21,8 @@ export {
   isNetworkError,
   isValidationError,
 } from './errors';
+// Group types (tiers, alpha levels)
+export * from './groups';
 // Social interaction types
 export * from './interactions';
 // Agent monitoring types


### PR DESCRIPTION
## Summary

- **Implement 3-tier NPC group system**: Inner Circle (12 max), Community (50 max), Followers (500 max) per NPC
- **Scale capacity**: From 1,680 total users to 78,680 (46x increase for 140 NPCs)
- **Asymmetric information mechanics**: Tier-specific alpha sharing (full → partial → public)

## Type

- [x] Feature

## Context / Links

- Addresses scalability for 300,000 users
- Builds on existing NPC group dynamics

## Scope

- [x] Domain / game engine (`packages/engine`)
- [x] DB (`packages/db`)
- [x] API infra (`packages/api`)
- [x] Web API routes (`apps/web`)
- [x] Tests (`packages/testing`)
- [x] Docs

## Changes

### New Files
- `packages/engine/src/services/tier-config.ts` - TIER_CONFIG constants and helpers
- `packages/engine/src/services/tiered-group-service.ts` - Core service
- `packages/engine/src/prompts/game/group-messages-tier{1,2,3}.ts` - Tier-specific prompts
- `packages/db/drizzle/migrations/0011_add_tiered_group_system.sql` - Migration
- `packages/db/drizzle/migrations/0012_rollback_tiered_group_system.sql` - Rollback
- `apps/web/src/app/api/tiers/` - User tier status endpoints
- `apps/web/src/app/api/admin/tiers/` - Admin analytics endpoint
- `packages/testing/integration/tiered-group-system.test.ts` - 63 tests

### Modified Files
- `npc-group-dynamics-service.ts` - Integrated tiered invitations and promotions
- `notification-service.ts` - Added tier promotion/demotion notifications
- `ChatListItem.tsx` - Added tier badges (Gold/Blue/Gray)
- Chat API routes - Return tier info

## Review guide

**Start here**: `packages/engine/src/services/tier-config.ts` for tier definitions, then `tiered-group-service.ts` for core logic.

**Risk level**: Medium - DB migration required

## Test plan

- [x] `bun run check` (Biome format)
- [x] `bun run lint` (our files pass, pre-existing errors in staging)
- [x] `bun test packages/testing/integration/tiered-group-system.test.ts` (63 pass)
- [ ] `bun run typecheck` (pre-existing errors in babylon-typescript-agent-example)

## Ops / Migration / Deployment

- **DB migration required**: `bun run db:migrate` to apply 0011
- **Rollback available**: 0012_rollback_tiered_group_system.sql
- **No env changes**

## Breaking changes

None - existing groups continue to work, will be migrated to Tier 1 by migration

## Security / privacy

No impact

## Screenshots

No UI changes beyond tier badges in chat list (Gold shield = Inner Circle, Blue = Community, Gray = Followers)

## Checklist (author)

- [x] Self-review done
- [x] Base branch correct (`staging`)
- [x] No screenshots needed (minor badge addition)
- [x] Handlers thin and portable
- [x] Domain logic in packages
- [x] Tests added (63 tests covering config, helpers, and service methods)
- [x] Code owners requested

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tiered group system with three engagement levels (Inner Circle, Community, Followers).
  * Automated invites, promotions, and demotions based on engagement and activity rules.
  * Tier-specific membership limits, messaging frequency, and guidance for richer NPC interactions.
  * New user-facing views: per-NPC tier listings, individual tier status, and global tier analytics/capacity insights.
  * Existing NPC groups and memberships initialized into Tier 1 (Inner Circle) to preserve continuity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->