### PR TITLE
fix: fail fast when NPC actorState missing instead of masking with default

### DIFF
--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -277,14 +277,24 @@ export class MultiStepExecutor {
         .where(eq(actorState.id, agentUserId))
         .limit(1);
 
-      if (!actor?.tradingBalance) {
+      if (!actor) {
+        // Missing actorState record is a data issue that should be fixed at bootstrap
+        throw new Error(
+          `NPC ${agentUserId} has no actorState record. Run NPC bootstrap to create it.`
+        );
+      }
+
+      if (actor.tradingBalance === null || actor.tradingBalance === undefined) {
+        // Record exists but balance is null - graceful degradation for edge case
         logger.warn(
-          `NPC ${agentUserId} missing actorState - using default balance`,
+          `NPC ${agentUserId} actorState exists but tradingBalance is null - using default`,
           { defaultBalance: DEFAULT_NPC_BALANCE },
           'MultiStepExecutor'
         );
+        balance = DEFAULT_NPC_BALANCE;
+      } else {
+        balance = Number(actor.tradingBalance);
       }
-      balance = Number(actor?.tradingBalance ?? DEFAULT_NPC_BALANCE);
       pnl = 0;
     } else {
       const walletBalance = await WalletService.getBalance(agentUserId);

--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -42,9 +42,6 @@ import {
 } from './DirectExecutors';
 import { topicDiversityService } from './TopicDiversityService';
 
-/** Default trading balance for NPCs without actorState record */
-const DEFAULT_NPC_BALANCE = 10000;
-
 import {
   type ActionTraceResult,
   type AgentTickContext,
@@ -284,17 +281,7 @@ export class MultiStepExecutor {
         );
       }
 
-      if (actor.tradingBalance === null || actor.tradingBalance === undefined) {
-        // Record exists but balance is null - graceful degradation for edge case
-        logger.warn(
-          `NPC ${agentUserId} actorState exists but tradingBalance is null - using default`,
-          { defaultBalance: DEFAULT_NPC_BALANCE },
-          'MultiStepExecutor'
-        );
-        balance = DEFAULT_NPC_BALANCE;
-      } else {
-        balance = Number(actor.tradingBalance);
-      }
+      balance = Number(actor.tradingBalance);
       pnl = 0;
     } else {
       const walletBalance = await WalletService.getBalance(agentUserId);


### PR DESCRIPTION
## Summary
- When an NPC is missing their actorState record, now throws an error instead of silently using a default balance
- This enables fail-fast behavior for data issues while keeping the code simple

## Problem
The previous code masked data issues by silently using a default balance when an NPC had no actorState record. This made it harder to detect bootstrap problems.

## Solution
- If no actor record found: throw error with clear message to fix NPC bootstrap
- Simplified: removed redundant null check on `tradingBalance` since schema enforces `.notNull().default('10000')`
- Just use `Number(actor.tradingBalance)` directly

## Test plan
- [x] Run typecheck: `bun run typecheck`
- [x] Run lint: `bun run lint`
- [ ] Verify an NPC without actorState record causes MultiStepExecutor to throw with a clear error message
- [ ] Verify an NPC with valid actorState works as before