### PR TITLE
fix: charge points after lock acquisition to prevent free actions on errors

### DIFF
--- a/apps/web/src/app/api/cron/agent-tick/route.ts
+++ b/apps/web/src/app/api/cron/agent-tick/route.ts
@@ -348,11 +348,21 @@ export async function POST(_req: NextRequest) {
       continue;
     }
 
+    // Always 1pt per tick for USER agents
+    const pointsCost = 1;
+
+    // CRITICAL: Deduct points immediately after lock acquisition, BEFORE tick execution.
+    // This ensures points are always charged once we commit to running the tick.
+    // If we deducted after tick execution, errors in executeAutonomousTick() would
+    // skip the deduction (catch block), allowing agents to get free actions on errors.
+    await agentService.deductPoints(
+      eligibleAgent.user.id,
+      pointsCost,
+      'Autonomous tick'
+    );
+
     // Process agent with error handling to ensure lock is always released
     try {
-      // Always 1pt per tick for USER agents
-      const pointsCost = 1;
-
       // Use agent runtime manager for both USER and NPC agents
       const runtime = await agentRuntimeManager.getRuntime(
         eligibleAgent.agentId
@@ -379,14 +389,6 @@ export async function POST(_req: NextRequest) {
         runtime,
         true, // Always record trajectories
         false // isNpc = false for user agents
-      );
-
-      // Deduct points AFTER tick execution to prevent loss on failure
-      // Points are charged whether tick succeeded or not, as long as it ran
-      await agentService.deductPoints(
-        eligibleAgent.user.id,
-        pointsCost,
-        'Autonomous tick'
       );
 
       // Validation: Verify tick executed successfully

--- a/apps/web/src/app/api/cron/agent-tick/route.ts
+++ b/apps/web/src/app/api/cron/agent-tick/route.ts
@@ -353,12 +353,6 @@ export async function POST(_req: NextRequest) {
       // Always 1pt per tick for USER agents
       const pointsCost = 1;
 
-      await agentService.deductPoints(
-        eligibleAgent.user.id,
-        pointsCost,
-        'Autonomous tick'
-      );
-
       // Use agent runtime manager for both USER and NPC agents
       const runtime = await agentRuntimeManager.getRuntime(
         eligibleAgent.agentId
@@ -385,6 +379,14 @@ export async function POST(_req: NextRequest) {
         runtime,
         true, // Always record trajectories
         false // isNpc = false for user agents
+      );
+
+      // Deduct points AFTER tick execution to prevent loss on failure
+      // Points are charged whether tick succeeded or not, as long as it ran
+      await agentService.deductPoints(
+        eligibleAgent.user.id,
+        pointsCost,
+        'Autonomous tick'
       );
 
       // Validation: Verify tick executed successfully


### PR DESCRIPTION
## Summary
- Moved points deduction to immediately AFTER lock acquisition but BEFORE tick execution
- This ensures points are always charged once we commit to running an agent's tick
- Prevents abuse where agents could get free actions by causing errors during execution

## Rationale
Previously, points were deducted after `executeAutonomousTick()`. If that threw an exception, the catch block was hit and points were never deducted - agents got free actions on errors.

Now the flow is:
1. Acquire lock for agent
2. **Deduct points immediately** (commit to charging)
3. Get runtime
4. Execute autonomous tick
5. Process results
6. Release lock

## Test plan
- [x] Run typecheck: `bun run typecheck`
- [x] Run lint: `bun run lint`
- [ ] Verify points are deducted even if tick execution fails
- [ ] Verify lock is always released in finally block