### PR TITLE
fix: use numeric comparison for NPC balance checks in DirectExecutors

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "babylon",

--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -16,6 +16,7 @@ import {
   comments,
   db,
   eq,
+  gte,
   isNull,
   markets,
   messages,
@@ -231,7 +232,7 @@ async function executePredictionTrade(params: {
         .where(
           and(
             eq(actorState.id, agentUserId),
-            sql`${actorState.tradingBalance}::numeric >= ${amount}`
+            gte(sql<number>`${actorState.tradingBalance}::numeric`, amount)
           )
         )
         .returning({ id: actorState.id });
@@ -388,7 +389,7 @@ async function executePerpTrade(params: {
               .where(
                 and(
                   eq(actorState.id, uid),
-                  sql`${actorState.tradingBalance}::numeric >= ${amt}`
+                  gte(sql<number>`${actorState.tradingBalance}::numeric`, amt)
                 )
               )
               .returning({ id: actorState.id });

--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -16,7 +16,6 @@ import {
   comments,
   db,
   eq,
-  gte,
   isNull,
   markets,
   messages,
@@ -232,7 +231,7 @@ async function executePredictionTrade(params: {
         .where(
           and(
             eq(actorState.id, agentUserId),
-            gte(actorState.tradingBalance, String(amount))
+            sql`${actorState.tradingBalance}::numeric >= ${amount}`
           )
         )
         .returning({ id: actorState.id });
@@ -389,7 +388,7 @@ async function executePerpTrade(params: {
               .where(
                 and(
                   eq(actorState.id, uid),
-                  gte(actorState.tradingBalance, String(amt))
+                  sql`${actorState.tradingBalance}::numeric >= ${amt}`
                 )
               )
               .returning({ id: actorState.id });

--- a/packages/engine/src/services/initial-investment-service.ts
+++ b/packages/engine/src/services/initial-investment-service.ts
@@ -576,7 +576,7 @@ Generate investments for ALL ${npcs.length} NPCs. Each NPC must have 2-5 investm
       .where(
         and(
           eq(actorState.id, investment.npcId),
-          gte(actorState.tradingBalance, String(investment.amount))
+          gte(sql<number>`${actorState.tradingBalance}::numeric`, investment.amount)
         )
       )
       .returning({ id: actorState.id });

--- a/packages/engine/src/services/npc-wallet-adapter.ts
+++ b/packages/engine/src/services/npc-wallet-adapter.ts
@@ -48,7 +48,7 @@ export function createNpcWalletAdapter(
         .where(
           and(
             eq(actorState.id, actorId),
-            gte(actorState.tradingBalance, String(amount))
+            gte(sql<number>`${actorState.tradingBalance}::numeric`, amount)
           )
         )
         .returning({ id: actorState.id });

--- a/packages/engine/src/services/trade-execution-service.ts
+++ b/packages/engine/src/services/trade-execution-service.ts
@@ -939,7 +939,7 @@ export class TradeExecutionService {
           .where(
             and(
               eq(actorState.id, actorId),
-              gte(actorState.tradingBalance, String(amount))
+              gte(sql<number>`${actorState.tradingBalance}::numeric`, amount)
             )
           )
           .returning({ id: actorState.id });


### PR DESCRIPTION
## Summary
- Fixes type coercion bug in NPC balance comparisons across the codebase
- String comparison was incorrect (e.g., "10" < "9" lexicographically)
- Uses PostgreSQL `::numeric` cast with Drizzle's `gte()` for proper numeric comparison

## Changes
All 5 occurrences of the buggy pattern fixed:
- `packages/agents/src/autonomous/DirectExecutors.ts` (2 locations)
- `packages/engine/src/services/initial-investment-service.ts`
- `packages/engine/src/services/npc-wallet-adapter.ts`
- `packages/engine/src/services/trade-execution-service.ts`

Pattern changed from:
```typescript
gte(actorState.tradingBalance, String(amount))  // String comparison - buggy
```
To:
```typescript
gte(sql<number>\`${actorState.tradingBalance}::numeric\`, amount)  // Numeric comparison
```

## Test plan
- [x] Run typecheck: `bun run typecheck`
- [x] Run lint: `bun run lint`
- [ ] Test NPC trades with balances like 10, 9, 100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved numeric handling for trading balance checks and debits to ensure correct balance validation and updates across prediction and perpetual trade flows; behavior unchanged for public APIs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->