### PR TITLE
docs: update CLAUDE.md with workflow guidelines and fix outdated info

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,11 +47,15 @@ apps/* → packages/* → contracts
 
 ### Key Packages
 - **engine:** Game world, perpetuals, simulation logic (domain)
-- **agents:** Agent runtime, Agent0/A2A/MCP integrations
+- **agents:** Agent runtime, autonomous execution, multi-step actions
+- **core:** Market services (perps, prediction), shared domain logic
 - **api:** Server utilities (auth, rate limit, redis, SSE, token counting)
 - **db:** Drizzle schema and client
 - **shared:** Client-safe types, utils, config
 - **contracts:** Smart contracts (Hardhat + Foundry)
+- **a2a:** Agent-to-Agent protocol integration
+- **mcp:** Model Context Protocol server
+- **training:** Agent training pipelines
 
 ## Development Workflow
 
@@ -85,6 +89,48 @@ Only consider work done after all three pass without errors.
 - **Commits:** Imperative mood, prefixed (`feat:`, `fix:`, `chore:`)
 - **Main branch:** `staging` (not `main`)
 - **Pre-commit:** Biome format check via Husky
+
+### PR Review Process
+- PRs are automatically reviewed by `claude[bot]` and `coderabbitai[bot]`
+- Wait for both reviews before merging
+- Address review comments or explain design decisions by tagging `@claude`
+- If reviewers disagree with intentional design choices, consult by commenting with rationale
+
+### Parallel Development
+- Use git worktrees for independent fixes: `git worktree add ../path branch-name`
+- Can run multiple fixes in parallel when issues don't overlap
+- Each worktree gets its own feature branch → separate PR
+
+### Code Patterns
+
+**Trust the Schema**
+- If column has `.notNull().default()`, don't add defensive null checks
+- Fail fast on invariant violations rather than masking with defaults
+
+**Drizzle Decimal Comparisons**
+```typescript
+// ❌ String comparison bug: "100" < "9"
+gte(decimalColumn, String(amount))
+
+// ✅ Proper numeric comparison
+gte(sql<number>`${decimalColumn}::numeric`, amount)
+```
+
+**Avoid N+1 Queries**
+```typescript
+// ❌ Query per iteration
+for (const item of items) {
+  const data = await db.select().where(eq(table.id, item.id));
+}
+
+// ✅ Batch fetch + Map lookup
+const allData = await db.select().where(inArray(table.id, ids));
+const dataMap = new Map(allData.map(d => [d.id, d]));
+```
+
+**Rate-Limited Resources**
+- Charge/deduct after lock acquisition, before execution
+- Prevents abuse via intentional errors to get free actions
 
 ## Migration Context
 
@@ -150,9 +196,12 @@ All cron jobs are defined in [`vercel.json`](vercel.json):
 
 | Job | Schedule | Purpose |
 |-----|----------|---------|
-| `game-tick` | Every minute | Content generation, NPC trading, question resolution |
+| `game-tick` | Every minute | Content generation, question resolution |
+| `npc-tick` | Every minute | NPC trading decisions |
 | `agent-tick` | Every minute | Autonomous agent actions |
 | `realtime-drain` | Every minute | Flush SSE outbox to Redis |
+| `health-check` | Every 5 minutes | Cron health monitoring |
+| `training-check` | Hourly | Check training job status |
 | `reputation-sync` | Daily 2am | Sync reputation to blockchain |
 | `perp-funding` | Every 8 hours | Calculate perpetual funding rates |
 | `world-facts` | Every 6 hours | Fetch RSS feeds, generate parody headlines |


### PR DESCRIPTION
## Summary
Updates CLAUDE.md with learnings from recent agent-tick fixes and corrects outdated information.

## Changes

### New Sections Added
- **PR Review Process** - Wait for `claude[bot]` and `coderabbitai[bot]` reviews, how to consult on design decisions
- **Parallel Development** - Using git worktrees for independent fixes
- **Code Patterns** - Common patterns and gotchas:
  - Trust schema constraints (don't add defensive null checks if `.notNull()`)
  - Drizzle decimal comparisons (`sql<number>` cast to avoid string comparison)
  - N+1 query elimination with `inArray()` + Map
  - Rate-limited resources (charge after lock acquisition)

### Outdated Info Fixed
- **Cron jobs table** - Added missing: `npc-tick`, `health-check`, `training-check`
- **Packages list** - Added missing: `core`, `a2a`, `mcp`, `training`
- **agents package description** - Updated to reflect current functionality

## Test plan
- [x] Verified cron jobs match `vercel.json`
- [x] Verified packages match `packages/` directory
- [x] All code examples are accurate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development workflow guidance with PR review processes and parallel development practices.
  * Added standardized code patterns and examples for database operations and resource handling.
  * Expanded operational documentation including health monitoring and job configuration guidance.
  * Enhanced troubleshooting and production operations references.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Updates `CLAUDE.md` with workflow improvements from recent agent-tick debugging and corrects outdated package/cron job lists.

**Key Additions:**
- **PR Review Process** - Wait for bot reviews before merging, consult on design disagreements
- **Parallel Development** - Git worktree workflow for independent fixes
- **Code Patterns** - Best practices from recent fixes:
  - Trust schema constraints (avoid defensive null checks for `.notNull().default()`)
  - Drizzle decimal comparisons (use `sql<number>` cast to prevent string comparison bugs)
  - N+1 query elimination (batch with `inArray()` + Map)
  - Rate-limited resources (charge after lock, before execution)

**Corrections:**
- Added missing cron jobs: `npc-tick`, `health-check`, `training-check`
- Added missing packages: `core`, `a2a`, `mcp`, `training`
- Updated agents package description to reflect current autonomous execution functionality

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - pure documentation updates with verified accuracy
- Documentation-only changes that accurately reflect codebase state (verified against vercel.json and packages/). Adds valuable workflow guidance from real debugging experience. Only minor formatting issues with @ mentions need fixing
- No files require special attention - straightforward documentation update

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| CLAUDE.md | Documentation update adding PR review workflow, parallel development guidance, code patterns (schema trust, decimal comparisons, N+1 queries, rate limiting), and correcting outdated package/cron job lists |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant PR as Pull Request
    participant CB as claude[bot]
    participant CR as coderabbitai[bot]
    participant Repo as Repository

    Dev->>PR: Create PR with CLAUDE.md updates
    PR->>CB: Trigger review
    PR->>CR: Trigger review
    CB->>PR: Add review comments
    CR->>PR: Add review comments
    Dev->>PR: Wait for both reviews
    alt Design decision questioned
        Dev->>PR: Comment with @claude tag
        Dev->>PR: Explain rationale
    end
    Dev->>PR: Address comments
    Dev->>Repo: Merge to staging
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->