### PR TITLE
fix: correct GameFeedbackSchema validation for screenshot URLs

### DIFF
--- a/packages/testing/unit/game-feedback-validation.test.ts
+++ b/packages/testing/unit/game-feedback-validation.test.ts
@@ -18,7 +18,7 @@ describe('Game Feedback Validation Schema', () => {
         feedbackType: 'bug',
         description: 'This is a valid bug description',
         stepsToReproduce: '1. Do this\n2. See that',
-        screenshotUrl: 'https://example.com/image.png',
+        screenshotUrl: 'https://test.public.blob.vercel-storage.com/image.png',
       };
       const result = GameFeedbackSchema.safeParse(input);
       expect(result.success).toBe(true);
@@ -119,13 +119,13 @@ describe('Game Feedback Validation Schema', () => {
       expect(result.success).toBe(false);
     });
 
-    test('whitespace-only description counts toward length', () => {
+    test('whitespace-only description is trimmed and rejected', () => {
       const input = {
         feedbackType: 'performance',
         description: ' '.repeat(10),
       };
       const result = GameFeedbackSchema.safeParse(input);
-      expect(result.success).toBe(true); // 10 spaces = 10 chars
+      expect(result.success).toBe(false); // Schema trims whitespace, so 10 spaces becomes empty
     });
   });
 
@@ -295,23 +295,23 @@ describe('Game Feedback Validation Schema', () => {
   // SCREENSHOT URL VALIDATION
   // ============================================
   describe('Screenshot URL Validation', () => {
-    test('valid https URL', () => {
+    test('valid https URL from allowed domain', () => {
       const input = {
         feedbackType: 'bug',
         description: 'Valid bug description',
         stepsToReproduce: 'Steps',
-        screenshotUrl: 'https://example.com/image.png',
+        screenshotUrl: 'https://test.public.blob.vercel-storage.com/image.png',
       };
       const result = GameFeedbackSchema.safeParse(input);
       expect(result.success).toBe(true);
     });
 
-    test('valid http URL', () => {
+    test('valid http URL from allowed domain (local dev)', () => {
       const input = {
         feedbackType: 'bug',
         description: 'Valid bug description',
         stepsToReproduce: 'Steps',
-        screenshotUrl: 'http://localhost:3000/screenshot.jpg',
+        screenshotUrl: 'http://localhost:9000/screenshot.jpg',
       };
       const result = GameFeedbackSchema.safeParse(input);
       expect(result.success).toBe(true);


### PR DESCRIPTION
## Summary
- Update tests to use allowed screenshot URL domains (Vercel Blob Storage, localhost:9000)
- Fix whitespace description test to expect failure (schema trims input)

The `GameFeedbackSchema` correctly restricts screenshot URLs to trusted domains for security. Tests were using `example.com` which is not in the allowed list.

## Test plan
- [x] All 45 game-feedback-validation tests pass locally
- CI should now pass for staging and PR #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed test failures caused by using disallowed screenshot URL domains. The `GameFeedbackSchema` restricts screenshot URLs to trusted domains (Vercel Blob Storage, localhost:9000) for security. Tests were incorrectly using `example.com` which isn't in the allowed list.

- Updated all test screenshot URLs to use `test.public.blob.vercel-storage.com` (production) and `localhost:9000` (local dev)
- Fixed whitespace-only description test to expect failure - schema uses `.trim()` which converts 10 spaces to empty string, causing validation to fail

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - fixes test suite to match schema validation rules
- Changes are test-only with correct fixes: URLs updated to allowed domains per schema security constraints, and whitespace test expectation corrected to match schema's trim behavior. No production code changed.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/testing/unit/game-feedback-validation.test.ts | Fixed test URLs to use allowed domains and corrected whitespace test expectation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as Test Suite
    participant Schema as GameFeedbackSchema
    participant Validator as URL Validator
    
    Note over Test,Validator: Before Fix (Failing)
    Test->>Schema: Parse with screenshotUrl: "https://example.com/image.png"
    Schema->>Validator: isAllowedScreenshotUrl("https://example.com/image.png")
    Validator->>Validator: Check against ALLOWED_SCREENSHOT_DOMAINS
    Note over Validator: example.com not in allowed list
    Validator-->>Schema: false
    Schema-->>Test: Validation fails ❌
    
    Note over Test,Validator: After Fix (Passing)
    Test->>Schema: Parse with screenshotUrl: "https://test.public.blob.vercel-storage.com/image.png"
    Schema->>Validator: isAllowedScreenshotUrl("https://test.public.blob.vercel-storage.com/image.png")
    Validator->>Validator: Check against ALLOWED_SCREENSHOT_DOMAINS
    Note over Validator: Matches .public.blob.vercel-storage.com
    Validator-->>Schema: true
    Schema-->>Test: Validation succeeds ✅
    
    Note over Test,Validator: Whitespace Test Fix
    Test->>Schema: Parse with description: "          " (10 spaces)
    Schema->>Schema: Apply .trim() transformation
    Note over Schema: Trimmed to empty string ""
    Schema->>Schema: Check min length (10 chars)
    Schema-->>Test: Validation fails (< 10 chars) ✅
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->