### PR TITLE
fix(agents): improve GroupChatService spam prevention and reliability

### DIFF
--- a/packages/agents/src/autonomous/AutonomousGroupChatService.ts
+++ b/packages/agents/src/autonomous/AutonomousGroupChatService.ts
@@ -7,6 +7,7 @@
  */
 
 import { and, db, desc, eq, gte, messages } from '@babylon/db';
+import { shuffleArray } from '@babylon/engine';
 import type { IAgentRuntime } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
 import { getAgentConfig } from '../shared/agent-config';
@@ -162,13 +163,6 @@ Generate ONLY the message text, or "SKIP" if you shouldn't respond.`;
 
     return messagesCreated;
   }
-}
-
-/**
- * Shuffles an array randomly to prevent deterministic ordering starvation
- */
-function shuffleArray<T>(array: T[]): T[] {
-  return [...array].sort(() => Math.random() - 0.5);
 }
 
 export const autonomousGroupChatService = new AutonomousGroupChatService();

--- a/packages/agents/src/autonomous/AutonomousGroupChatService.ts
+++ b/packages/agents/src/autonomous/AutonomousGroupChatService.ts
@@ -43,11 +43,15 @@ export class AutonomousGroupChatService {
       with: {
         chat: true,
       },
+      limit: 20,
     });
 
     let messagesCreated = 0;
 
-    for (const chatParticipant of groupChatsRaw) {
+    // Shuffle to prevent starvation (deterministic order would always favor same chats)
+    const shuffledChats = shuffleArray(groupChatsRaw);
+
+    for (const chatParticipant of shuffledChats) {
       const chat = chatParticipant.chat;
       if (!chat || !chat.isGroup) continue; // Skip DMs
 
@@ -64,17 +68,21 @@ export class AutonomousGroupChatService {
 
       if (recentMessages.length === 0) continue;
 
-      // Check if agent was mentioned or should respond
+      // Check if agent was mentioned (exclude agent's own messages)
       const agentMentioned = recentMessages.some(
         (m: { content: string; senderId: string }) =>
+          m.senderId !== agentUserId &&
           m.content.toLowerCase().includes(agentDisplayName.toLowerCase())
       );
 
-      // Don't spam - only respond if mentioned or if it's been a while
+      // Don't spam - only respond if mentioned OR significant conversation activity
       const agentLastMessage = recentMessages.find(
         (m: { content: string; senderId: string }) => m.senderId === agentUserId
       );
-      if (!agentMentioned && agentLastMessage) {
+      const hasRecentConversation = recentMessages.length >= 3;
+      const shouldRespond =
+        agentMentioned || (!agentLastMessage && hasRecentConversation);
+      if (!shouldRespond) {
         continue;
       }
 
@@ -117,7 +125,11 @@ Generate ONLY the message text, or "SKIP" if you shouldn't respond.`;
 
       const cleanContent = responseContent.trim().replace(/^["']|["']$/g, '');
 
-      if (!cleanContent || cleanContent.length < 5 || cleanContent === 'SKIP') {
+      if (
+        !cleanContent ||
+        cleanContent.length < 5 ||
+        cleanContent.toUpperCase() === 'SKIP'
+      ) {
         continue;
       }
 
@@ -150,6 +162,13 @@ Generate ONLY the message text, or "SKIP" if you shouldn't respond.`;
 
     return messagesCreated;
   }
+}
+
+/**
+ * Shuffles an array randomly to prevent deterministic ordering starvation
+ */
+function shuffleArray<T>(array: T[]): T[] {
+  return [...array].sort(() => Math.random() - 0.5);
 }
 
 export const autonomousGroupChatService = new AutonomousGroupChatService();


### PR DESCRIPTION
## Summary

- **Fix spam logic that allowed uninvited responses**: Previously, agents would respond when not mentioned AND had no recent message in the chat, which is backwards. Now agents only respond if mentioned OR if there's significant conversation activity (>=3 messages) and the agent hasn't participated yet.
- **Exclude agent's own messages from mention detection**: Agent's own messages no longer count as "mentions" which could cause infinite loops.
- **Make SKIP check case-insensitive**: The LLM might return "Skip" or "skip" instead of "SKIP", all should be handled.
- **Add limit(20) to group chat query**: Prevents unbounded queries when an agent is in many group chats.
- **Shuffle group chats before iterating**: Prevents starvation where the same chats always get processed first due to deterministic ordering.

## Test Plan

- [ ] Verify agents only respond when explicitly mentioned or when there's meaningful conversation (>=3 messages) and they haven't participated
- [ ] Verify agents don't trigger on their own messages mentioning themselves
- [ ] Verify LLM returning "skip", "Skip", or "SKIP" all work correctly
- [ ] Verify agents in many group chats don't cause performance issues (limit of 20)
- [ ] Verify different group chats get attention over time (randomization)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed critical spam prevention bug where agents would respond when NOT mentioned AND had no recent message (backwards logic). Now agents only respond if explicitly mentioned OR there's significant conversation (≥3 messages) and they haven't participated yet.

**Key Changes:**
- Fixed inverted spam logic that allowed uninvited responses
- Excluded agent's own messages from mention detection to prevent self-triggering loops
- Made SKIP check case-insensitive (`toUpperCase()`)
- Added `limit(20)` to group chat query to prevent unbounded queries
- Shuffled group chats before iteration to prevent starvation

**Issue Found:**
- The new `shuffleArray()` implementation uses `.sort(() => Math.random() - 0.5)` which produces biased shuffles. The codebase already has a proper Fisher-Yates implementation at `packages/engine/src/utils/randomization.ts` that should be imported instead.

<h3>Confidence Score: 3/5</h3>


- Safe to merge after fixing the shuffle implementation
- The PR fixes critical spam prevention bugs and the logic changes are correct. However, the shuffle implementation uses a biased algorithm instead of the proper Fisher-Yates shuffle already available in the codebase. This is a quality issue but not a blocker since the shuffle is only for preventing starvation, not for security-critical randomization.
- The shuffle implementation at line 170-172 needs to use the proper Fisher-Yates algorithm from `@babylon/engine`

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agents/src/autonomous/AutonomousGroupChatService.ts | Fixed backwards spam logic, added agent self-mention filtering, case-insensitive SKIP check, query limit(20), and chat shuffling. Shuffle implementation uses suboptimal algorithm. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Coordinator as AutonomousCoordinator
    participant GroupChatSvc as AutonomousGroupChatService
    participant DB as Database
    participant LLM as Groq LLM
    participant Executor as DirectExecutor

    Coordinator->>GroupChatSvc: participateInGroupChats(agentUserId, runtime)
    GroupChatSvc->>DB: Query chatParticipants (limit 20)
    DB-->>GroupChatSvc: Return group chats
    GroupChatSvc->>GroupChatSvc: shuffleArray(groupChats)
    
    loop For each shuffled chat (break after 1 success)
        GroupChatSvc->>DB: Get recent messages (last hour, limit 10)
        DB-->>GroupChatSvc: Return messages
        
        alt No messages
            GroupChatSvc->>GroupChatSvc: continue to next chat
        else Has messages
            GroupChatSvc->>GroupChatSvc: Check agentMentioned (exclude agent's own messages)
            GroupChatSvc->>GroupChatSvc: Check hasRecentConversation (>=3 messages)
            GroupChatSvc->>GroupChatSvc: shouldRespond = mentioned OR (!agentLastMessage AND hasRecentConversation)
            
            alt !shouldRespond
                GroupChatSvc->>GroupChatSvc: continue to next chat
            else shouldRespond
                GroupChatSvc->>LLM: Generate response (large model, temp=0.8)
                LLM-->>GroupChatSvc: Return content
                GroupChatSvc->>GroupChatSvc: Check if content.toUpperCase() === 'SKIP'
                
                alt Content is valid
                    GroupChatSvc->>Executor: executeDirectMessage(agentUserId, chatId, content)
                    Executor-->>GroupChatSvc: Result
                    GroupChatSvc->>GroupChatSvc: messagesCreated++
                    GroupChatSvc->>GroupChatSvc: break (only 1 message per tick)
                end
            end
        end
    end
    
    GroupChatSvc-->>Coordinator: Return messagesCreated
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Agent now responds to group conversations when mentioned or during periods of recent significant activity.

## Bug Fixes
* Fixed mention detection to exclude the agent's own messages.
* Improved fairness in group conversation processing.
* Normalized skip condition handling for case-insensitive matching.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->