### PR TITLE
feat(agents): enable autonomous DM responses for all agents

### DIFF
--- a/packages/agents/src/autonomous/AutonomousCoordinator.ts
+++ b/packages/agents/src/autonomous/AutonomousCoordinator.ts
@@ -33,6 +33,7 @@ import { getAgentConfig } from '../shared/agent-config';
 import { logger } from '../shared/logger';
 
 // Import services
+import { autonomousDMService } from './AutonomousDMService';
 import { autonomousGroupChatService } from './AutonomousGroupChatService';
 import { autonomousPlanningCoordinator } from './AutonomousPlanningCoordinator';
 import { multiStepExecutor } from './MultiStepExecutor';
@@ -256,6 +257,15 @@ export class AutonomousCoordinator {
             runtime
           );
         result.actionsExecuted.groupMessages += groupMessages;
+      }
+
+      // Handle DMs separately (reactive to incoming messages)
+      if (config?.autonomousDMs) {
+        const dmResponses = await autonomousDMService.respondToDMs(
+          agentUserId,
+          runtime
+        );
+        result.actionsExecuted.messages += dmResponses;
       }
 
       logger.info(


### PR DESCRIPTION
## Summary

Fixes agents not responding to DMs by implementing automatic DM handling in the AutonomousCoordinator.

## Problem

Agents with `autonomousDMs: true` were not responding to direct messages because:
- The feature was incomplete - `AutonomousDMService` existed but was never called for most agents
- Only agents with goals + `planningHorizon='multi'` had working DM responses (via planning coordinator)
- The default execution path (MultiStepExecutor) had no DM handling

## Solution

Added automatic DM handling in `AutonomousCoordinator.executeAutonomousTick()` that mirrors the proven pattern for group chats:

```typescript
// Handle DMs separately (reactive to incoming messages)
if (config?.autonomousDMs) {
  const dmResponses = await autonomousDMService.respondToDMs(
    agentUserId,
    runtime
  );
  result.actionsExecuted.messages += dmResponses;
}
```

## How It Works

1. User sends DM to agent → message is created and stored
2. On next agent tick (every minute), if `autonomousDMs` is enabled:
   - Automatically checks for unread DMs from last hour
   - Generates and sends responses (max 1 per tick to prevent spam)
   - Updates message count in tick results

No LLM decision needed - DMs are handled automatically when the config flag is enabled.

## Changes

- Import `autonomousDMService` in AutonomousCoordinator
- Add automatic DM handling after group chat handling (line 262-269)
- Pattern matches existing group chat implementation

## Testing

- TypeScript compilation: ✅ Passes
- Lint: ✅ Passes  
- Build: ✅ Passes

Will work immediately once deployed for all agents with `autonomousDMs: true`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Agents can now automatically respond to direct messages when autonomous DM handling is enabled, improving responsiveness to user interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR adds automatic DM response handling to `AutonomousCoordinator.executeAutonomousTick()` by calling `autonomousDMService.respondToDMs()` when `autonomousDMs` is enabled. The implementation mirrors the existing pattern for group chats.

**Key Changes:**
- Imports `autonomousDMService` from `./AutonomousDMService`
- Adds DM response handling after group chat handling (lines 262-269)
- Increments `result.actionsExecuted.messages` with DM response count

**Critical Issue Found:**
The implementation creates duplicate DM handling in the default execution path. When agents use `MultiStepExecutor` (the default for most agents), DMs are already handled through `autonomousBatchResponseService.gatherPendingInteractions()`, which includes both DMs and group chats. Adding `autonomousDMService.respondToDMs()` after the MultiStepExecutor completes means agents could respond twice to the same DMs.

The planning coordinator path (agents with goals + `planningHorizon='multi'`) correctly returns early before this new code runs, so it avoids the duplication issue.

**Why Group Chats Don't Have This Problem:**
Group chat handling is correctly separated because `AutonomousBatchResponseService.gatherPendingChatMessages()` gathers messages from all chats but doesn't implement the group-specific participation logic (mention detection, activity threshold). That logic only exists in `AutonomousGroupChatService`, so there's no overlap.

<h3>Confidence Score: 2/5</h3>


- This PR introduces a logical bug that will cause duplicate DM responses for most agents
- The implementation creates duplicate DM handling in the default execution path (MultiStepExecutor), which already processes DMs via AutonomousBatchResponseService. This will result in agents sending two responses to the same DM. Only agents using the planning coordinator path avoid this issue, but they represent a small subset of all agents.
- `packages/agents/src/autonomous/AutonomousCoordinator.ts` requires immediate attention to prevent duplicate DM responses

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agents/src/autonomous/AutonomousCoordinator.ts | Adds automatic DM response handling that mirrors group chat pattern, but may create duplicate DM responses when used with MultiStepExecutor |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Cron as Agent Tick Cron
    participant AC as AutonomousCoordinator
    participant MSE as MultiStepExecutor
    participant ABRS as AutonomousBatchResponseService
    participant DMS as AutonomousDMService
    participant AGCS as AutonomousGroupChatService
    participant DB as Database

    Cron->>AC: executeAutonomousTick(agentUserId, runtime)
    
    alt Has Goals + PlanningHorizon='multi'
        AC->>AC: Use Planning Coordinator
        Note over AC: Planning path already handles DMs correctly
    else Default Path (MultiStepExecutor)
        AC->>MSE: execute(agentUserId, runtime, isNpc)
        MSE->>ABRS: gatherPendingInteractions(agentUserId)
        ABRS->>DB: Query chat_participants, messages
        DB-->>ABRS: All chats (DMs + Groups)
        ABRS-->>MSE: Pending interactions (includes DMs)
        MSE->>MSE: LLM decides actions
        MSE->>DB: Execute responses (including DMs)
        MSE-->>AC: MultiStepResult
        
        Note over AC: After MultiStepExecutor completes...
        
        AC->>AGCS: participateInGroupChats(agentUserId, runtime)
        AGCS->>DB: Query group chats only (isGroup=true)
        AGCS->>DB: Create group messages
        AGCS-->>AC: groupMessages count
        
        AC->>DMS: respondToDMs(agentUserId, runtime)
        Note over AC,DMS: ⚠️ DUPLICATE: DMs already handled by MultiStepExecutor
        DMS->>DB: Query DM chats only (isGroup=false)
        DMS->>DB: Create DM responses
        DMS-->>AC: dmResponses count
        
        Note over AC: Result may double-count DM responses
    end
    
    AC-->>Cron: AutonomousTickResult
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->