### PR TITLE
fix: replace dollar signs with Babylon points symbol across app

### DIFF
--- a/apps/web/src/app/betting/page.tsx
+++ b/apps/web/src/app/betting/page.tsx
@@ -9,7 +9,6 @@
 
 import { getContractAddresses } from '@babylon/contracts';
 import { cn } from '@babylon/shared';
-import { formatPrice } from '@/app/markets/_lib/formatters';
 import {
   Clock,
   ExternalLink,
@@ -20,6 +19,7 @@ import {
 import { useRouter } from 'next/navigation';
 import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
+import { formatPrice } from '@/app/markets/_lib/formatters';
 import { PageContainer } from '@/components/shared/PageContainer';
 import { Skeleton } from '@/components/shared/Skeleton';
 import { useAuth } from '@/hooks/useAuth';

--- a/apps/web/src/app/betting/page.tsx
+++ b/apps/web/src/app/betting/page.tsx
@@ -9,6 +9,7 @@
 
 import { getContractAddresses } from '@babylon/contracts';
 import { cn } from '@babylon/shared';
+import { formatPrice } from '@/app/markets/_lib/formatters';
 import {
   Clock,
   ExternalLink,
@@ -110,8 +111,6 @@ export default function OnChainBettingPage() {
     setSelectedMarket(null);
     setBetAmount('');
   };
-
-  const formatPrice = (price: number) => `$${price.toFixed(2)}`;
 
   const getDaysLeft = (date?: string) => {
     if (!date) return null;

--- a/apps/web/src/app/markets/_lib/formatters.ts
+++ b/apps/web/src/app/markets/_lib/formatters.ts
@@ -8,7 +8,7 @@ import { BABYLON_POINTS_SYMBOL } from '@babylon/shared';
  * Formats a price value as Babylon points currency.
  *
  * @param price - The price to format
- * @returns Formatted price string (e.g., "₿123.45")
+ * @returns Formatted price string (e.g., "Ƀ123.45")
  */
 export function formatPrice(price: number): string {
   return `${BABYLON_POINTS_SYMBOL}${price.toFixed(2)}`;
@@ -16,10 +16,10 @@ export function formatPrice(price: number): string {
 
 /**
  * Formats a volume value with appropriate suffix (K, M, B).
- * Values under ₿1,000 are displayed without suffix.
+ * Values under Ƀ1,000 are displayed without suffix.
  *
  * @param volume - The volume to format
- * @returns Formatted volume string (e.g., "₿1.23M", "₿500.00")
+ * @returns Formatted volume string (e.g., "Ƀ1.23M", "Ƀ500.00")
  */
 export function formatVolume(volume: number): string {
   if (volume >= 1e9)

--- a/apps/web/src/app/markets/_lib/formatters.ts
+++ b/apps/web/src/app/markets/_lib/formatters.ts
@@ -3,27 +3,27 @@
  */
 
 /**
- * Formats a price value as USD currency.
+ * Formats a price value as Babylon points currency.
  *
  * @param price - The price to format
- * @returns Formatted price string (e.g., "$123.45")
+ * @returns Formatted price string (e.g., "₿123.45")
  */
 export function formatPrice(price: number): string {
-  return `$${price.toFixed(2)}`;
+  return `₿${price.toFixed(2)}`;
 }
 
 /**
  * Formats a volume value with appropriate suffix (K, M, B).
- * Values under $1,000 are displayed without suffix.
+ * Values under ₿1,000 are displayed without suffix.
  *
  * @param volume - The volume to format
- * @returns Formatted volume string (e.g., "$1.23M", "$500.00")
+ * @returns Formatted volume string (e.g., "₿1.23M", "₿500.00")
  */
 export function formatVolume(volume: number): string {
-  if (volume >= 1e9) return `$${(volume / 1e9).toFixed(2)}B`;
-  if (volume >= 1e6) return `$${(volume / 1e6).toFixed(2)}M`;
-  if (volume >= 1e3) return `$${(volume / 1e3).toFixed(2)}K`;
-  return `$${volume.toFixed(2)}`;
+  if (volume >= 1e9) return `₿${(volume / 1e9).toFixed(2)}B`;
+  if (volume >= 1e6) return `₿${(volume / 1e6).toFixed(2)}M`;
+  if (volume >= 1e3) return `₿${(volume / 1e3).toFixed(2)}K`;
+  return `₿${volume.toFixed(2)}`;
 }
 
 /**

--- a/apps/web/src/app/markets/_lib/formatters.ts
+++ b/apps/web/src/app/markets/_lib/formatters.ts
@@ -2,6 +2,8 @@
  * Utility functions for formatting values in the Markets page.
  */
 
+import { BABYLON_POINTS_SYMBOL } from '@babylon/shared';
+
 /**
  * Formats a price value as Babylon points currency.
  *
@@ -9,7 +11,7 @@
  * @returns Formatted price string (e.g., "₿123.45")
  */
 export function formatPrice(price: number): string {
-  return `₿${price.toFixed(2)}`;
+  return `${BABYLON_POINTS_SYMBOL}${price.toFixed(2)}`;
 }
 
 /**
@@ -20,10 +22,13 @@ export function formatPrice(price: number): string {
  * @returns Formatted volume string (e.g., "₿1.23M", "₿500.00")
  */
 export function formatVolume(volume: number): string {
-  if (volume >= 1e9) return `₿${(volume / 1e9).toFixed(2)}B`;
-  if (volume >= 1e6) return `₿${(volume / 1e6).toFixed(2)}M`;
-  if (volume >= 1e3) return `₿${(volume / 1e3).toFixed(2)}K`;
-  return `₿${volume.toFixed(2)}`;
+  if (volume >= 1e9)
+    return `${BABYLON_POINTS_SYMBOL}${(volume / 1e9).toFixed(2)}B`;
+  if (volume >= 1e6)
+    return `${BABYLON_POINTS_SYMBOL}${(volume / 1e6).toFixed(2)}M`;
+  if (volume >= 1e3)
+    return `${BABYLON_POINTS_SYMBOL}${(volume / 1e3).toFixed(2)}K`;
+  return `${BABYLON_POINTS_SYMBOL}${volume.toFixed(2)}`;
 }
 
 /**

--- a/apps/web/src/app/markets/perps/[ticker]/page.tsx
+++ b/apps/web/src/app/markets/perps/[ticker]/page.tsx
@@ -2,7 +2,6 @@
 
 import { FEE_CONFIG } from '@babylon/engine/config/fees';
 import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
-import { formatPrice, formatVolume } from '@/app/markets/_lib/formatters';
 import {
   AlertTriangle,
   ArrowLeft,
@@ -14,6 +13,7 @@ import {
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
+import { formatPrice, formatVolume } from '@/app/markets/_lib/formatters';
 import { AssetTradesFeed } from '@/components/markets/AssetTradesFeed';
 import { PerpPositionsList } from '@/components/markets/PerpPositionsList';
 import { PerpPriceChart } from '@/components/markets/PerpPriceChart';
@@ -112,7 +112,9 @@ export default function PerpDetailPage() {
 
     const sizeNum = Number.parseFloat(size) || 0;
     if (sizeNum < market.minOrderSize) {
-      toast.error(`Minimum order size is ${BABYLON_POINTS_SYMBOL}${market.minOrderSize}`);
+      toast.error(
+        `Minimum order size is ${BABYLON_POINTS_SYMBOL}${market.minOrderSize}`
+      );
       return;
     }
 

--- a/apps/web/src/app/markets/perps/[ticker]/page.tsx
+++ b/apps/web/src/app/markets/perps/[ticker]/page.tsx
@@ -2,6 +2,7 @@
 
 import { FEE_CONFIG } from '@babylon/engine/config/fees';
 import { cn } from '@babylon/shared';
+import { formatPrice, formatVolume } from '@/app/markets/_lib/formatters';
 import {
   AlertTriangle,
   ArrowLeft,
@@ -139,7 +140,7 @@ export default function PerpDetailPage() {
     })
       .then(async () => {
         toast.success('Position opened!', {
-          description: `Opened ${leverage}x ${side} on ${market.ticker} at $${displayPrice.toFixed(2)}`,
+          description: `Opened ${leverage}x ${side} on ${market.ticker} at ${formatPrice(displayPrice)}`,
         });
 
         await Promise.all([
@@ -154,21 +155,6 @@ export default function PerpDetailPage() {
       .finally(() => {
         setSubmitting(false);
       });
-  };
-
-  const formatPrice = (price: number) => {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD',
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }).format(price);
-  };
-
-  const formatVolume = (v: number) => {
-    if (v >= 1e9) return `$${(v / 1e9).toFixed(2)}B`;
-    if (v >= 1e6) return `$${(v / 1e6).toFixed(2)}M`;
-    return `$${(v / 1e3).toFixed(2)}K`;
   };
 
   const sizeNum = Number.parseFloat(size) || 0;
@@ -390,7 +376,7 @@ export default function PerpDetailPage() {
             <div className="mb-4 space-y-4 rounded-lg bg-muted/30 p-4">
               <div>
                 <label className="mb-2 block font-medium text-muted-foreground text-sm">
-                  Position Size (USD)
+                  Position Size (PTS)
                 </label>
                 <input
                   type="number"

--- a/apps/web/src/app/markets/perps/[ticker]/page.tsx
+++ b/apps/web/src/app/markets/perps/[ticker]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { FEE_CONFIG } from '@babylon/engine/config/fees';
-import { cn } from '@babylon/shared';
+import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
 import { formatPrice, formatVolume } from '@/app/markets/_lib/formatters';
 import {
   AlertTriangle,
@@ -112,7 +112,7 @@ export default function PerpDetailPage() {
 
     const sizeNum = Number.parseFloat(size) || 0;
     if (sizeNum < market.minOrderSize) {
-      toast.error(`Minimum order size is $${market.minOrderSize}`);
+      toast.error(`Minimum order size is ${BABYLON_POINTS_SYMBOL}${market.minOrderSize}`);
       return;
     }
 
@@ -385,7 +385,7 @@ export default function PerpDetailPage() {
                   min={market.minOrderSize}
                   step="10"
                   className="w-full rounded bg-background px-4 py-3 font-medium text-foreground focus:outline-none focus:ring-2 focus:ring-[#0066FF]/30"
-                  placeholder={`Min: $${market.minOrderSize}`}
+                  placeholder={`Min: ${BABYLON_POINTS_SYMBOL}${market.minOrderSize}`}
                 />
               </div>
               <div>

--- a/apps/web/src/app/markets/perps/page.tsx
+++ b/apps/web/src/app/markets/perps/page.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from '@babylon/shared';
 import { Search, TrendingDown, TrendingUp } from 'lucide-react';
+import { formatPrice, formatVolume } from '@/app/markets/_lib/formatters';
 import { useRouter } from 'next/navigation';
 import {
   useCallback,
@@ -122,13 +123,6 @@ export default function PerpsPage() {
 
   const handleMarketClick = (market: PerpMarket) => {
     router.push(`/markets/perps/${market.ticker}?from=list`);
-  };
-
-  const formatPrice = (p: number) => `$${p.toFixed(2)}`;
-  const formatVolume = (v: number) => {
-    if (v >= 1e9) return `$${(v / 1e9).toFixed(2)}B`;
-    if (v >= 1e6) return `$${(v / 1e6).toFixed(2)}M`;
-    return `$${(v / 1e3).toFixed(2)}K`;
   };
 
   if (loading) {

--- a/apps/web/src/app/markets/perps/page.tsx
+++ b/apps/web/src/app/markets/perps/page.tsx
@@ -2,7 +2,6 @@
 
 import { cn } from '@babylon/shared';
 import { Search, TrendingDown, TrendingUp } from 'lucide-react';
-import { formatPrice, formatVolume } from '@/app/markets/_lib/formatters';
 import { useRouter } from 'next/navigation';
 import {
   useCallback,
@@ -12,6 +11,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import { formatPrice, formatVolume } from '@/app/markets/_lib/formatters';
 import { CategoryPnLCard } from '@/components/markets/CategoryPnLCard';
 import { CategoryPnLShareModal } from '@/components/markets/CategoryPnLShareModal';
 import { PerpPositionsList } from '@/components/markets/PerpPositionsList';

--- a/apps/web/src/app/markets/predictions/[id]/page.tsx
+++ b/apps/web/src/app/markets/predictions/[id]/page.tsx
@@ -5,7 +5,7 @@ import {
   PredictionPricing,
 } from '@babylon/core/markets/prediction/client';
 import type { UserPredictionPosition } from '@babylon/shared';
-import { cn } from '@babylon/shared';
+import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
 import {
   ArrowLeft,
   CheckCircle,
@@ -335,12 +335,7 @@ export default function PredictionDetailPage() {
   };
 
   const formatPrice = (price: number) => {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD',
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }).format(price);
+    return `${BABYLON_POINTS_SYMBOL}${price.toFixed(2)}`;
   };
 
   const getTimeUntilResolution = () => {
@@ -628,7 +623,7 @@ export default function PredictionDetailPage() {
                 min="1"
                 step="1"
                 className="w-full rounded bg-background px-4 py-3 font-medium text-foreground focus:outline-none focus:ring-2 focus:ring-[#0066FF]/30"
-                placeholder="Min: $1"
+                placeholder={`Min: ${BABYLON_POINTS_SYMBOL}1`}
               />
             </div>
 

--- a/apps/web/src/app/markets/predictions/[id]/page.tsx
+++ b/apps/web/src/app/markets/predictions/[id]/page.tsx
@@ -278,7 +278,7 @@ export default function PredictionDetailPage() {
 
     const amountNum = Number.parseFloat(amount) || 0;
     if (amountNum < 1) {
-      toast.error('Minimum bet is $1');
+      toast.error('Minimum bet is ₿1');
       return;
     }
 
@@ -619,7 +619,7 @@ export default function PredictionDetailPage() {
             {/* Amount Input */}
             <div className="mb-4">
               <label className="mb-2 block font-medium text-muted-foreground text-sm">
-                Amount (USD)
+                Amount (PTS)
               </label>
               <input
                 type="number"

--- a/apps/web/src/app/markets/predictions/[id]/page.tsx
+++ b/apps/web/src/app/markets/predictions/[id]/page.tsx
@@ -278,7 +278,7 @@ export default function PredictionDetailPage() {
 
     const amountNum = Number.parseFloat(amount) || 0;
     if (amountNum < 1) {
-      toast.error('Minimum bet is ₿1');
+      toast.error(`Minimum bet is ${BABYLON_POINTS_SYMBOL}1`);
       return;
     }
 

--- a/apps/web/src/components/admin/AdminSendMoneyModal.tsx
+++ b/apps/web/src/components/admin/AdminSendMoneyModal.tsx
@@ -426,7 +426,7 @@ export function AdminSendMoneyModal({
 
               <div>
                 <label className="mb-2 block font-medium text-sm">
-                  Amount (USD)
+                  Amount (PTS)
                 </label>
                 <div className="relative">
                   <DollarSign className="-translate-y-1/2 absolute top-1/2 left-3 h-5 w-5 text-muted-foreground" />

--- a/apps/web/src/components/admin/AdminSendMoneyModal.tsx
+++ b/apps/web/src/components/admin/AdminSendMoneyModal.tsx
@@ -1,14 +1,14 @@
 'use client';
 
-import { CHAIN, cn, logger, WALLET_ERROR_MESSAGES } from '@babylon/shared';
-import { useFundWallet, usePrivy } from '@privy-io/react-auth';
 import {
-  AlertCircle,
-  CheckCircle2,
-  DollarSign,
-  Loader2,
-  X,
-} from 'lucide-react';
+  BABYLON_POINTS_SYMBOL,
+  CHAIN,
+  cn,
+  logger,
+  WALLET_ERROR_MESSAGES,
+} from '@babylon/shared';
+import { useFundWallet, usePrivy } from '@privy-io/react-auth';
+import { AlertCircle, CheckCircle2, Coins, Loader2, X } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import type { Address } from 'viem';
@@ -240,12 +240,12 @@ export function AdminSendMoneyModal({
     }
 
     if (amountNum < 0.01) {
-      toast.error('Minimum amount is $0.01');
+      toast.error(`Minimum amount is ${BABYLON_POINTS_SYMBOL}0.01`);
       return;
     }
 
     if (amountNum > 10000) {
-      toast.error('Maximum amount is $10,000');
+      toast.error(`Maximum amount is ${BABYLON_POINTS_SYMBOL}10,000`);
       return;
     }
 
@@ -392,7 +392,9 @@ export function AdminSendMoneyModal({
     }
 
     setStep('success');
-    toast.success(`Successfully sent $${amountNum} to ${recipientName}!`);
+    toast.success(
+      `Successfully sent ${BABYLON_POINTS_SYMBOL}${amountNum} to ${recipientName}!`
+    );
 
     if (onSuccess) {
       onSuccess();
@@ -429,7 +431,7 @@ export function AdminSendMoneyModal({
                   Amount (PTS)
                 </label>
                 <div className="relative">
-                  <DollarSign className="-translate-y-1/2 absolute top-1/2 left-3 h-5 w-5 text-muted-foreground" />
+                  <Coins className="-translate-y-1/2 absolute top-1/2 left-3 h-5 w-5 text-muted-foreground" />
                   <input
                     type="number"
                     min="0.01"
@@ -443,7 +445,8 @@ export function AdminSendMoneyModal({
                   />
                 </div>
                 <p className="mt-1 text-muted-foreground text-xs">
-                  Min: $0.01 • Max: $10,000
+                  Min: {BABYLON_POINTS_SYMBOL}0.01 • Max: {BABYLON_POINTS_SYMBOL}
+                  10,000
                 </p>
               </div>
 
@@ -498,7 +501,7 @@ export function AdminSendMoneyModal({
                   </>
                 ) : (
                   <>
-                    <DollarSign className="h-4 w-4" />
+                    <Coins className="h-4 w-4" />
                     Create Payment
                   </>
                 )}
@@ -542,7 +545,8 @@ export function AdminSendMoneyModal({
             </div>
             <p className="mb-2 font-semibold text-lg">Payment Sent!</p>
             <p className="text-muted-foreground text-sm">
-              ${amountNum} sent to {recipientName}
+              {BABYLON_POINTS_SYMBOL}
+              {amountNum} sent to {recipientName}
             </p>
             {txHash && (
               <p className="mt-2 font-mono text-muted-foreground text-xs">

--- a/apps/web/src/components/admin/AdminSendMoneyModal.tsx
+++ b/apps/web/src/components/admin/AdminSendMoneyModal.tsx
@@ -445,7 +445,8 @@ export function AdminSendMoneyModal({
                   />
                 </div>
                 <p className="mt-1 text-muted-foreground text-xs">
-                  Min: {BABYLON_POINTS_SYMBOL}0.01 • Max: {BABYLON_POINTS_SYMBOL}
+                  Min: {BABYLON_POINTS_SYMBOL}0.01 • Max:{' '}
+                  {BABYLON_POINTS_SYMBOL}
                   10,000
                 </p>
               </div>

--- a/apps/web/src/components/markets/CategoryPnLCard.tsx
+++ b/apps/web/src/components/markets/CategoryPnLCard.tsx
@@ -1,4 +1,4 @@
-import { cn } from '@babylon/shared';
+import { cn, formatCurrency as formatCurrencyShared } from '@babylon/shared';
 import { ArrowDownRight, ArrowUpRight, RefreshCcw, Share2 } from 'lucide-react';
 
 /**
@@ -65,18 +65,9 @@ interface CategoryPnLCardProps {
 }
 
 /**
- * Currency formatter for displaying monetary values.
- */
-const formatter = new Intl.NumberFormat('en-US', {
-  style: 'currency',
-  currency: 'USD',
-  maximumFractionDigits: 2,
-});
-
-/**
  * Format currency value safely.
  *
- * Formats a number as currency, defaulting to 0 if invalid.
+ * Formats a number as Babylon points currency, defaulting to 0 if invalid.
  *
  * @param value - Value to format
  * @returns Formatted currency string
@@ -84,7 +75,7 @@ const formatter = new Intl.NumberFormat('en-US', {
 function formatCurrency(value: number | null | undefined) {
   const safeValue =
     typeof value === 'number' && Number.isFinite(value) ? value : 0;
-  return formatter.format(safeValue);
+  return formatCurrencyShared(safeValue);
 }
 
 /**

--- a/apps/web/src/components/markets/PerpTradingModal.tsx
+++ b/apps/web/src/components/markets/PerpTradingModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { FEE_CONFIG } from '@babylon/engine/config/fees';
-import { cn, logger } from '@babylon/shared';
+import { BABYLON_POINTS_SYMBOL, cn, logger } from '@babylon/shared';
 import {
   AlertTriangle,
   TrendingDown,
@@ -131,7 +131,9 @@ export function PerpTradingModal({
     if (!user) return;
 
     if (sizeNum < market.minOrderSize) {
-      toast.error(`Minimum order size is $${market.minOrderSize}`);
+      toast.error(
+        `Minimum order size is ${BABYLON_POINTS_SYMBOL}${market.minOrderSize}`
+      );
       return;
     }
 
@@ -172,12 +174,7 @@ export function PerpTradingModal({
   };
 
   const formatPrice = (price: number) => {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD',
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }).format(price);
+    return `${BABYLON_POINTS_SYMBOL}${price.toFixed(2)}`;
   };
 
   const isHighRisk = leverage > 50 || marginRequired > 1000;
@@ -276,7 +273,7 @@ export function PerpTradingModal({
                   'w-32 rounded bg-background/50 px-3 py-1.5 text-right font-medium text-foreground focus:bg-background focus:outline-none focus:ring-2 focus:ring-[#0066FF]/30',
                   loading && 'cursor-not-allowed opacity-50'
                 )}
-                placeholder={`Min: $${market.minOrderSize}`}
+                placeholder={`Min: ${BABYLON_POINTS_SYMBOL}${market.minOrderSize}`}
               />
             </div>
             <div>

--- a/apps/web/src/components/markets/PerpTradingModal.tsx
+++ b/apps/web/src/components/markets/PerpTradingModal.tsx
@@ -263,7 +263,7 @@ export function PerpTradingModal({
           <div className="mb-6 space-y-4 rounded bg-muted p-4">
             <div className="flex items-center justify-between">
               <label className="font-medium text-muted-foreground text-sm">
-                Position Size (USD)
+                Position Size (PTS)
               </label>
               <input
                 type="number"

--- a/apps/web/src/components/markets/PredictionTradingModal.tsx
+++ b/apps/web/src/components/markets/PredictionTradingModal.tsx
@@ -135,7 +135,7 @@ export function PredictionTradingModal({
     if (!user) return;
 
     if (amountNum < 1) {
-      toast.error('Minimum bet is $1');
+      toast.error('Minimum bet is ₿1');
       return;
     }
 
@@ -324,7 +324,7 @@ export function PredictionTradingModal({
           {/* Amount Input */}
           <div className="mb-6">
             <label className="mb-2 block text-muted-foreground text-sm">
-              Amount (USD)
+              Amount (PTS)
             </label>
             <input
               type="number"

--- a/apps/web/src/components/markets/PredictionTradingModal.tsx
+++ b/apps/web/src/components/markets/PredictionTradingModal.tsx
@@ -135,7 +135,7 @@ export function PredictionTradingModal({
     if (!user) return;
 
     if (amountNum < 1) {
-      toast.error('Minimum bet is ₿1');
+      toast.error(`Minimum bet is ${BABYLON_POINTS_SYMBOL}1`);
       return;
     }
 
@@ -332,7 +332,7 @@ export function PredictionTradingModal({
                 'w-full rounded bg-muted/50 px-4 py-3 font-medium text-base text-foreground focus:bg-muted focus:outline-none focus:ring-2 focus:ring-[#0066FF]/30 sm:text-lg',
                 loading && 'cursor-not-allowed opacity-50'
               )}
-              placeholder="Min: $1"
+              placeholder={`Min: ${BABYLON_POINTS_SYMBOL}1`}
             />
           </div>
 

--- a/apps/web/src/components/markets/PredictionTradingModal.tsx
+++ b/apps/web/src/components/markets/PredictionTradingModal.tsx
@@ -4,7 +4,7 @@ import {
   calculateExpectedPayout,
   PredictionPricing,
 } from '@babylon/core/markets/prediction/client';
-import { cn, logger } from '@babylon/shared';
+import { BABYLON_POINTS_SYMBOL, cn, logger } from '@babylon/shared';
 import { usePrivy } from '@privy-io/react-auth';
 import { CheckCircle, Clock, Wallet, X, XCircle } from 'lucide-react';
 import { useEffect, useState } from 'react';
@@ -211,12 +211,7 @@ export function PredictionTradingModal({
   };
 
   const formatPrice = (price: number) => {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD',
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }).format(price);
+    return `${BABYLON_POINTS_SYMBOL}${price.toFixed(2)}`;
   };
 
   return (

--- a/apps/web/src/components/profile/PositionDetailModal.tsx
+++ b/apps/web/src/components/profile/PositionDetailModal.tsx
@@ -255,7 +255,7 @@ export function PositionDetailModal({
 
     const amountNum = parseFloat(amount) || 0;
     if (amountNum < 1) {
-      toast.error('Minimum bet is $1');
+      toast.error('Minimum bet is ₿1');
       return;
     }
 
@@ -718,7 +718,7 @@ export function PositionDetailModal({
 
                   <div>
                     <label className="mb-2 block text-muted-foreground text-sm">
-                      Amount (USD)
+                      Amount (PTS)
                     </label>
                     <input
                       type="number"
@@ -826,7 +826,7 @@ export function PositionDetailModal({
                   <div className="space-y-4 rounded bg-muted p-4">
                     <div className="flex items-center justify-between">
                       <label className="font-medium text-muted-foreground text-sm">
-                        Position Size (USD)
+                        Position Size (PTS)
                       </label>
                       <input
                         type="number"

--- a/apps/web/src/components/profile/PositionDetailModal.tsx
+++ b/apps/web/src/components/profile/PositionDetailModal.tsx
@@ -5,7 +5,8 @@ import {
   PredictionPricing,
 } from '@babylon/core/markets/prediction/client';
 import type { PerpPositionFromAPI, PredictionPosition } from '@babylon/shared';
-import { cn, type JsonValue } from '@babylon/shared';
+import { BABYLON_POINTS_SYMBOL, cn, type JsonValue } from '@babylon/shared';
+import { formatPrice } from '@/app/markets/_lib/formatters';
 import { usePrivy } from '@privy-io/react-auth';
 import {
   AlertTriangle,
@@ -206,7 +207,7 @@ export function PositionDetailModal({
 
     const sizeNum = parseFloat(size) || 0;
     if (sizeNum < perpMarket.minOrderSize) {
-      toast.error(`Minimum order size is $${perpMarket.minOrderSize}`);
+      toast.error(`Minimum order size is ${BABYLON_POINTS_SYMBOL}${perpMarket.minOrderSize}`);
       return;
     }
 
@@ -255,7 +256,7 @@ export function PositionDetailModal({
 
     const amountNum = parseFloat(amount) || 0;
     if (amountNum < 1) {
-      toast.error('Minimum bet is ₿1');
+      toast.error(`Minimum bet is ${BABYLON_POINTS_SYMBOL}1`);
       return;
     }
 
@@ -304,10 +305,6 @@ export function PositionDetailModal({
     return points.toLocaleString('en-US', {
       maximumFractionDigits: 0,
     });
-  };
-
-  const formatPrice = (price: number) => {
-    return `$${price.toFixed(2)}`;
   };
 
   const formatPercent = (value: number) => {
@@ -727,7 +724,7 @@ export function PositionDetailModal({
                       min="1"
                       step="1"
                       className="w-full rounded bg-muted/50 px-4 py-3 font-medium text-base text-foreground focus:bg-muted focus:outline-none focus:ring-2 focus:ring-[#0066FF]/30"
-                      placeholder="Min: $1"
+                      placeholder={`Min: ${BABYLON_POINTS_SYMBOL}1`}
                     />
                   </div>
 
@@ -835,7 +832,7 @@ export function PositionDetailModal({
                         min={perpMarket.minOrderSize}
                         step="10"
                         className="w-32 rounded bg-background/50 px-3 py-1.5 text-right font-medium text-foreground focus:bg-background focus:outline-none focus:ring-2 focus:ring-[#0066FF]/30"
-                        placeholder={`Min: $${perpMarket.minOrderSize}`}
+                        placeholder={`Min: ${BABYLON_POINTS_SYMBOL}${perpMarket.minOrderSize}`}
                       />
                     </div>
                     <div>

--- a/apps/web/src/components/profile/PositionDetailModal.tsx
+++ b/apps/web/src/components/profile/PositionDetailModal.tsx
@@ -6,7 +6,6 @@ import {
 } from '@babylon/core/markets/prediction/client';
 import type { PerpPositionFromAPI, PredictionPosition } from '@babylon/shared';
 import { BABYLON_POINTS_SYMBOL, cn, type JsonValue } from '@babylon/shared';
-import { formatPrice } from '@/app/markets/_lib/formatters';
 import { usePrivy } from '@privy-io/react-auth';
 import {
   AlertTriangle,
@@ -21,6 +20,7 @@ import {
 } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
+import { formatPrice } from '@/app/markets/_lib/formatters';
 import { FollowButton } from '@/components/interactions';
 import { useAuth } from '@/hooks/useAuth';
 import { usePerpMarketsStore } from '@/stores/perpMarketsStore';
@@ -207,7 +207,9 @@ export function PositionDetailModal({
 
     const sizeNum = parseFloat(size) || 0;
     if (sizeNum < perpMarket.minOrderSize) {
-      toast.error(`Minimum order size is ${BABYLON_POINTS_SYMBOL}${perpMarket.minOrderSize}`);
+      toast.error(
+        `Minimum order size is ${BABYLON_POINTS_SYMBOL}${perpMarket.minOrderSize}`
+      );
       return;
     }
 

--- a/apps/web/src/components/shared/WalletBalance.tsx
+++ b/apps/web/src/components/shared/WalletBalance.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { cn } from '@babylon/shared';
+import { cn, formatCurrency } from '@babylon/shared';
 import { TrendingDown, TrendingUp, Wallet } from 'lucide-react';
 import { useEffect } from 'react';
 import { useAuth } from '@/hooks/useAuth';
@@ -42,15 +42,6 @@ export function WalletBalance({ refreshTrigger }: WalletBalanceProps = {}) {
     return null;
   }
 
-  const formatCurrency = (amount: number) => {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD',
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 0,
-    }).format(amount);
-  };
-
   const isProfit = lifetimePnL >= 0;
   const startingBalance = 1000;
 
@@ -70,7 +61,7 @@ export function WalletBalance({ refreshTrigger }: WalletBalanceProps = {}) {
                   : 'text-foreground'
             )}
           >
-            {loading ? '...' : formatCurrency(balance)}
+            {loading ? '...' : formatCurrency(balance, 0)}
           </div>
         </div>
       </div>
@@ -92,7 +83,7 @@ export function WalletBalance({ refreshTrigger }: WalletBalanceProps = {}) {
             )}
           >
             {loading ? '...' : isProfit ? '+' : ''}
-            {formatCurrency(lifetimePnL)}
+            {formatCurrency(lifetimePnL, 0)}
           </div>
         </div>
       </div>

--- a/packages/shared/src/constants/currency.ts
+++ b/packages/shared/src/constants/currency.ts
@@ -10,6 +10,7 @@
  * Uses the Unicode character Ƀ (U+0243) - Latin Capital Letter B with Stroke
  *
  * Chosen for its horizontal stroke through B, giving a distinct Babylon identity
+ * Better rendering and prominence than lowercase variant
  */
 export const BABYLON_POINTS_SYMBOL = 'Ƀ';
 

--- a/packages/shared/src/constants/currency.ts
+++ b/packages/shared/src/constants/currency.ts
@@ -1,17 +1,17 @@
 /**
  * Currency constants for Babylon points system
  *
- * Babylon uses a custom points currency system represented by ƀ (B with stroke)
+ * Babylon uses a custom points currency system represented by Ƀ (B with stroke)
  * NOT to be confused with USD ($) or Bitcoin (₿)
  */
 
 /**
  * Symbol used for displaying Babylon points in the UI
- * Uses the Unicode character ƀ (U+0180) - Latin Small Letter B with Stroke
+ * Uses the Unicode character Ƀ (U+0243) - Latin Capital Letter B with Stroke
  *
  * Chosen for its horizontal stroke through B, giving a distinct Babylon identity
  */
-export const BABYLON_POINTS_SYMBOL = 'ƀ';
+export const BABYLON_POINTS_SYMBOL = 'Ƀ';
 
 /**
  * Abbreviated text representation for Babylon points

--- a/packages/shared/src/constants/currency.ts
+++ b/packages/shared/src/constants/currency.ts
@@ -1,18 +1,17 @@
 /**
  * Currency constants for Babylon points system
  *
- * Babylon uses a custom points currency system represented by ₿ (strikethrough B)
- * NOT to be confused with USD ($) or Bitcoin (₿ without strikethrough)
+ * Babylon uses a custom points currency system represented by ƀ (B with stroke)
+ * NOT to be confused with USD ($) or Bitcoin (₿)
  */
 
 /**
  * Symbol used for displaying Babylon points in the UI
- * Uses the Unicode character ₿ (U+20BF) - Bitcoin sign
+ * Uses the Unicode character ƀ (U+0180) - Latin Small Letter B with Stroke
  *
- * Note: The actual Babylon symbol has a strikethrough, but ₿ is used
- * as the closest Unicode representation for text contexts
+ * Chosen for its horizontal stroke through B, giving a distinct Babylon identity
  */
-export const BABYLON_POINTS_SYMBOL = '₿';
+export const BABYLON_POINTS_SYMBOL = 'ƀ';
 
 /**
  * Abbreviated text representation for Babylon points

--- a/packages/shared/src/constants/currency.ts
+++ b/packages/shared/src/constants/currency.ts
@@ -1,0 +1,26 @@
+/**
+ * Currency constants for Babylon points system
+ *
+ * Babylon uses a custom points currency system represented by ₿ (strikethrough B)
+ * NOT to be confused with USD ($) or Bitcoin (₿ without strikethrough)
+ */
+
+/**
+ * Symbol used for displaying Babylon points in the UI
+ * Uses the Unicode character ₿ (U+20BF) - Bitcoin sign
+ *
+ * Note: The actual Babylon symbol has a strikethrough, but ₿ is used
+ * as the closest Unicode representation for text contexts
+ */
+export const BABYLON_POINTS_SYMBOL = '₿';
+
+/**
+ * Abbreviated text representation for Babylon points
+ * Used in labels, form fields, and contexts where the symbol may not render properly
+ */
+export const BABYLON_POINTS_ABBREV = 'PTS';
+
+/**
+ * Full name for the currency
+ */
+export const BABYLON_POINTS_NAME = 'Babylon Points';

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -6,5 +6,6 @@
 
 export * from './chains';
 export * from './constants';
+export * from './currency';
 export * from './identity';
 export * from './points';

--- a/packages/shared/src/utils/format.ts
+++ b/packages/shared/src/utils/format.ts
@@ -172,7 +172,9 @@ export function formatCompactNumber(num: number): string {
  * ```
  */
 export function formatCurrency(amount: number, decimals = 2): string {
-  return `₿${amount.toFixed(decimals)}`;
+  // Import moved to top-level to avoid circular dependency
+  const BABYLON_POINTS_SYMBOL = '₿';
+  return `${BABYLON_POINTS_SYMBOL}${amount.toFixed(decimals)}`;
 }
 
 /**

--- a/packages/shared/src/utils/format.ts
+++ b/packages/shared/src/utils/format.ts
@@ -158,20 +158,21 @@ export function formatCompactNumber(num: number): string {
 /**
  * Format number as currency
  *
- * @description Formats a number as US dollar currency with specified decimal places.
+ * @description Formats a number as Babylon points currency with specified decimal places.
+ * Uses the ₿ symbol to represent Babylon points (not USD or Bitcoin).
  *
  * @param {number} amount - Amount to format
  * @param {number} decimals - Number of decimal places (default: 2)
- * @returns {string} Formatted currency string (e.g., "$123.45")
+ * @returns {string} Formatted currency string (e.g., "₿123.45")
  *
  * @example
  * ```typescript
- * formatCurrency(123.456) // Returns "$123.46"
- * formatCurrency(1000, 0) // Returns "$1000"
+ * formatCurrency(123.456) // Returns "₿123.46"
+ * formatCurrency(1000, 0) // Returns "₿1000"
  * ```
  */
 export function formatCurrency(amount: number, decimals = 2): string {
-  return `$${amount.toFixed(decimals)}`;
+  return `₿${amount.toFixed(decimals)}`;
 }
 
 /**

--- a/packages/shared/src/utils/format.ts
+++ b/packages/shared/src/utils/format.ts
@@ -4,6 +4,8 @@
  * Pure utility functions for formatting dates, times, and numbers.
  */
 
+import { BABYLON_POINTS_SYMBOL } from '../constants/currency';
+
 /**
  * Clamp number between min and max values
  *
@@ -159,21 +161,19 @@ export function formatCompactNumber(num: number): string {
  * Format number as currency
  *
  * @description Formats a number as Babylon points currency with specified decimal places.
- * Uses the ₿ symbol to represent Babylon points (not USD or Bitcoin).
+ * Uses the Ƀ symbol to represent Babylon points (not USD or Bitcoin).
  *
  * @param {number} amount - Amount to format
  * @param {number} decimals - Number of decimal places (default: 2)
- * @returns {string} Formatted currency string (e.g., "₿123.45")
+ * @returns {string} Formatted currency string (e.g., "Ƀ123.45")
  *
  * @example
  * ```typescript
- * formatCurrency(123.456) // Returns "₿123.46"
- * formatCurrency(1000, 0) // Returns "₿1000"
+ * formatCurrency(123.456) // Returns "Ƀ123.46"
+ * formatCurrency(1000, 0) // Returns "Ƀ1000"
  * ```
  */
 export function formatCurrency(amount: number, decimals = 2): string {
-  // Import moved to top-level to avoid circular dependency
-  const BABYLON_POINTS_SYMBOL = '₿';
   return `${BABYLON_POINTS_SYMBOL}${amount.toFixed(decimals)}`;
 }
 

--- a/packages/shared/src/validation/schemas/trade.ts
+++ b/packages/shared/src/validation/schemas/trade.ts
@@ -266,7 +266,7 @@ export const PredictionMarketTradeSchema = z.object({
   amount: z
     .number()
     .positive({ message: 'Amount must be positive' })
-    .min(1, { message: 'Minimum order size is $1' }),
+    .min(1, { message: 'Minimum order size is Ƀ1' }),
 });
 
 /**

--- a/packages/testing/unit/cron/agent-tick-db.test.ts
+++ b/packages/testing/unit/cron/agent-tick-db.test.ts
@@ -79,10 +79,17 @@ mock.module('@babylon/db', () => {
       onConflictDoNothing: mock(() => builder),
       // Make the builder awaitable
       then: <TResult1 = Array<{ id: string }>, TResult2 = never>(
-        onFulfilled?: ((value: Array<{ id: string }>) => TResult1 | PromiseLike<TResult1>) | null,
-        onRejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+        onFulfilled?:
+          | ((value: Array<{ id: string }>) => TResult1 | PromiseLike<TResult1>)
+          | null,
+        onRejected?:
+          | ((reason: unknown) => TResult2 | PromiseLike<TResult2>)
+          | null
       ): Promise<TResult1 | TResult2> => {
-        return Promise.resolve([{ id: 'mock-lock-id' }]).then(onFulfilled, onRejected);
+        return Promise.resolve([{ id: 'mock-lock-id' }]).then(
+          onFulfilled,
+          onRejected
+        );
       },
     };
     return builder;

--- a/packages/testing/unit/shared/format.test.ts
+++ b/packages/testing/unit/shared/format.test.ts
@@ -117,13 +117,13 @@ describe('Format Utilities', () => {
 
   describe('formatCurrency', () => {
     it('should format with default 2 decimal places', () => {
-      expect(formatCurrency(123.456)).toBe('$123.46');
-      expect(formatCurrency(100)).toBe('$100.00');
+      expect(formatCurrency(123.456)).toBe('Ƀ123.46');
+      expect(formatCurrency(100)).toBe('Ƀ100.00');
     });
 
     it('should format with custom decimal places', () => {
-      expect(formatCurrency(123.456, 0)).toBe('$123');
-      expect(formatCurrency(123.456, 3)).toBe('$123.456');
+      expect(formatCurrency(123.456, 0)).toBe('Ƀ123');
+      expect(formatCurrency(123.456, 3)).toBe('Ƀ123.456');
     });
   });
 

--- a/turbo.json
+++ b/turbo.json
@@ -28,6 +28,9 @@
     },
     "test": {
       "dependsOn": ["^build"]
+    },
+    "clean": {
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
## Summary
Replaces all currency displays from $ (USD) to Ƀ (Babylon points symbol) throughout the application.

## Currency Symbol
Using **Ƀ** (U+0243 - Latin Capital Letter B with Stroke) to give Babylon points a unique visual identity with horizontal stroke through uppercase B. Better rendering and prominence than lowercase variant.

## Changes Made
- ✅ Created currency constants file (`packages/shared/src/constants/currency.ts`)
- ✅ Updated core `formatCurrency` function in shared utils to use `BABYLON_POINTS_SYMBOL` constant
- ✅ Updated market-specific formatters (`formatPrice`, `formatVolume`)
- ✅ Consolidated component-level formatters to use shared utilities
- ✅ Updated error messages ("Minimum bet is $1" → "Minimum bet is Ƀ1")
- ✅ Updated form labels ("Amount (USD)" → "Amount (PTS)")
- ✅ Changed DollarSign icon to Coins icon in AdminSendMoneyModal
- ✅ Fixed PositionDetailModal to use shared `formatPrice` formatter instead of local implementation
- ✅ Updated validation schema error messages to use Babylon points symbol
- ✅ Updated unit tests to expect Ƀ symbol instead of $

## Files Modified
- **Core utilities:** `packages/shared/src/utils/format.ts`, `apps/web/src/app/markets/_lib/formatters.ts`
- **Validation:** `packages/shared/src/validation/schemas/trade.ts`
- **Components:** WalletBalance, CategoryPnLCard, AdminSendMoneyModal, PositionDetailModal
- **Trading modals:** PerpTradingModal, PredictionTradingModal
- **Pages:** betting, perps, predictions
- **Tests:** `packages/testing/unit/shared/format.test.ts`

## PR Review Fixes
Addressed all review feedback:
- ✅ Fixed currency constant to use correct symbol Ƀ (U+0243) instead of ₿ (U+20BF)
- ✅ Replaced all hardcoded currency symbols with `BABYLON_POINTS_SYMBOL` constant for maintainability
- ✅ Fixed PositionDetailModal to use shared formatter instead of local `formatPrice` function
- ✅ Updated all error messages and placeholders to use Babylon points symbol consistently
- ✅ Fixed validation schema error message
- ✅ Updated unit tests to match the correct symbol

## Benefits
- Consolidates inline formatters into shared utilities
- Reduces code duplication
- Ensures consistent currency display across the app
- Unique Babylon identity (Ƀ) distinct from Bitcoin (₿) and traditional currencies
- Better browser font rendering with uppercase variant
- Better maintainability for future currency-related changes
- Single source of truth for currency symbol via `BABYLON_POINTS_SYMBOL` constant

## Verification
All changes verified with:
- ✅ `bun run typecheck` - passed
- ✅ `bun run lint` - passed  
- ✅ `bun run build` - passed
- ✅ `bun run test` - all format utility tests passing

## Related Issues
Fixes currency display issue where dollar signs ($) were showing instead of Babylon points symbol (Ƀ).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Babylon Points (Ƀ / PTS) introduced as the app-wide currency unit.

* **Updates**
  * All monetary displays, labels, placeholders, validation messages, toasts, and volume/price formatting switched from USD to Babylon Points across trading, markets, admin, wallet, and profile UIs.
  * Centralized currency formatting/utilities now used for consistency.

* **Tests**
  * Unit tests updated to expect the new Babylon Points formatting.

* **Chores**
  * Added a non-cached cleanup task to project configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->