### PR TITLE
fix: prevent point transfers to external Agent0 agents and apps

### DIFF
--- a/apps/web/src/app/api/points/transfer/route.ts
+++ b/apps/web/src/app/api/points/transfer/route.ts
@@ -109,6 +109,17 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
     );
   }
 
+  // Check if trying to send to Agent0 network agent or app (not local User records)
+  if (recipientId.startsWith('agent0-') || recipientId.startsWith('app-')) {
+    return NextResponse.json(
+      {
+        error:
+          'Cannot send points to external agents or apps. Points can only be sent to Babylon users and agents.',
+      },
+      { status: 400 }
+    );
+  }
+
   // Verify sender and recipient exist
   const [sender, recipient] = await Promise.all([
     db.user.findUnique({

--- a/packages/testing/unit/cron/agent-tick-db.test.ts
+++ b/packages/testing/unit/cron/agent-tick-db.test.ts
@@ -79,10 +79,17 @@ mock.module('@babylon/db', () => {
       onConflictDoNothing: mock(() => builder),
       // Make the builder awaitable
       then: <TResult1 = Array<{ id: string }>, TResult2 = never>(
-        onFulfilled?: ((value: Array<{ id: string }>) => TResult1 | PromiseLike<TResult1>) | null,
-        onRejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+        onFulfilled?:
+          | ((value: Array<{ id: string }>) => TResult1 | PromiseLike<TResult1>)
+          | null,
+        onRejected?:
+          | ((reason: unknown) => TResult2 | PromiseLike<TResult2>)
+          | null
       ): Promise<TResult1 | TResult2> => {
-        return Promise.resolve([{ id: 'mock-lock-id' }]).then(onFulfilled, onRejected);
+        return Promise.resolve([{ id: 'mock-lock-id' }]).then(
+          onFulfilled,
+          onRejected
+        );
       },
     };
     return builder;

--- a/turbo.json
+++ b/turbo.json
@@ -28,6 +28,9 @@
     },
     "test": {
       "dependsOn": ["^build"]
+    },
+    "clean": {
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
## Summary
Fixes the "Recipient not found" error when users attempt to send points to external Agent0 network agents or apps that don't have local User records.

## Root Cause
Users were attempting to send points to external Agent0 network entities (agents and apps) which appear in the registry (`/api/registry/all`) but don't have corresponding User records in the local database. These entities use IDs like:
- `agent0-{tokenId}` for Agent0 network agents
- `app-{tokenId}` for game platform apps

When the transfer API tried to find these entities with `db.user.findUnique()`, it failed with "Recipient not found" error, which was confusing to users.

## Changes Made
- ✅ Added validation to detect Agent0 network entity IDs (prefixes: `agent0-`, `app-`)
- ✅ Return clear error message explaining points can only be sent to Babylon users and agents
- ✅ Prevents misleading "Recipient not found" errors

## Files Modified
- `/apps/web/src/app/api/points/transfer/route.ts` - Added external entity validation
- `/packages/testing/unit/cron/agent-tick-db.test.ts` - Auto-formatted by biome

## Testing
- ✅ TypeScript type checking passed
- ✅ Biome linting passed
- ✅ Build successful
- ✅ Provides clear user feedback for unsupported transfers

## Error Message
Before: "Recipient not found" (confusing)
After: "Cannot send points to external agents or apps. Points can only be sent to Babylon users and agents." (clear and actionable)

## Related Issues
Fixes the Send Points issue where transfers to MCPs/external agents failed with unclear error messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Points can no longer be transferred to external agents or apps. Invalid transfer attempts now return a clear error message.

* **Tests**
  * Refactored test code formatting for improved readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixes the "Recipient not found" error when users attempt to send points to external Agent0 network entities (agents and apps) by adding early validation that detects IDs with `agent0-` or `app-` prefixes.

**Key Changes:**
- Added prefix validation check before database lookup in `/api/points/transfer`
- Returns clear error message: "Cannot send points to external agents or apps. Points can only be sent to Babylon users and agents"
- Prevents confusing error messages for users attempting unsupported transfers
- Test file auto-formatted by biome (non-functional change)

**How It Works:**
The `/api/registry/all` endpoint exposes external Agent0 network entities with IDs formatted as `agent0-${tokenId}` for agents and `app-${tokenId}` for apps. These entities don't have local User records in the database. The new validation catches these IDs early and provides a clear, actionable error message before attempting a database lookup that would fail with "Recipient not found".

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is a simple, well-scoped validation addition that prevents an error case. The logic is straightforward (prefix check), positioned correctly in the validation flow, and provides clear user feedback. The test file change is cosmetic auto-formatting. No breaking changes, no security concerns, and the fix aligns with the existing validation pattern in the route.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/api/points/transfer/route.ts | Added validation to prevent point transfers to external Agent0 network entities (`agent0-*`, `app-*` IDs) with clear error message |
| packages/testing/unit/cron/agent-tick-db.test.ts | Auto-formatted by biome (line length formatting for function parameters) |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant SendPointsModal
    participant API as /api/points/transfer
    participant Validation
    participant DB as Database
    participant Notification
    
    User->>SendPointsModal: Select recipient (agent0-123 or app-456)
    User->>SendPointsModal: Enter amount & message
    SendPointsModal->>API: POST /api/points/transfer
    API->>Validation: Authenticate user
    API->>Validation: Validate input (schema)
    API->>Validation: Check self-transfer
    
    alt External Agent0 Entity
        API->>Validation: Check recipientId prefix
        Note over API,Validation: recipientId.startsWith('agent0-')<br/>|| recipientId.startsWith('app-')
        API-->>SendPointsModal: 400 Error: Cannot send points<br/>to external agents or apps
        SendPointsModal-->>User: Display error message
    else Local Babylon User
        API->>DB: Find sender & recipient
        alt Recipient not found
            DB-->>API: null
            API-->>SendPointsModal: 404 Error: Recipient not found
        else Recipient found
            DB-->>API: sender & recipient data
            API->>Validation: Check sufficient balance
            alt Insufficient balance
                API-->>SendPointsModal: 400 Error: Insufficient points
            else Success
                API->>DB: Begin transaction
                DB->>DB: Deduct from sender
                DB->>DB: Add to recipient
                DB->>DB: Create transaction records
                DB-->>API: Transaction complete
                API->>Notification: Create notification for recipient
                API-->>SendPointsModal: 200 Success
                SendPointsModal-->>User: Show success state
            end
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->