### PR TITLE
fix(chat): improve chat page scrolling, input, and dropdown

### DIFF
--- a/apps/web/src/app/chats/page.tsx
+++ b/apps/web/src/app/chats/page.tsx
@@ -124,13 +124,16 @@ export default function ChatsPage() {
 
   return (
     <>
-      <PageContainer noPadding className="flex flex-col">
+      {/* Use fixed viewport heights to ensure proper scroll containment */}
+      {/* Mobile: 100dvh - 56px header - 56px bottom nav = calc(100dvh - 112px) */}
+      {/* Desktop: full viewport height */}
+      <div className="flex h-[calc(100dvh-112px)] flex-col overflow-hidden md:h-dvh">
         {/* Desktop: Two Column Layout */}
-        <div className="hidden flex-1 flex-col overflow-hidden xl:flex">
-          <div className="flex-1 overflow-hidden">
-            <div className="flex h-full">
+        <div className="hidden min-h-0 flex-1 flex-col overflow-hidden xl:flex">
+          <div className="min-h-0 flex-1 overflow-hidden">
+            <div className="flex h-full min-h-0">
               {/* Left Column: Chat List with Filters */}
-              <div className="flex h-full w-96 flex-col bg-background">
+              <div className="flex h-full min-h-0 w-96 flex-col bg-background">
                 <ChatHeader
                   isConnected={globalSSEConnected}
                   activeFilter={activeFilter}
@@ -141,7 +144,7 @@ export default function ChatsPage() {
                 <ChatSearchBar value={searchQuery} onChange={setSearchQuery} />
 
                 {/* Scrollable chat list */}
-                <div className="flex-1 overflow-y-auto">
+                <div className="min-h-0 flex-1 overflow-y-auto">
                   <ChatList
                     chats={filteredChats}
                     selectedChatId={selectedChatId}
@@ -157,7 +160,7 @@ export default function ChatsPage() {
               <Separator orientation="vertical" className="shrink-0" />
 
               {/* Right Column: Chat View */}
-              <div className="h-full flex-1 bg-background">
+              <div className="h-full min-h-0 flex-1 bg-background">
                 <ChatView
                   chatDetails={chatDetails}
                   currentUserId={user?.id}
@@ -187,13 +190,13 @@ export default function ChatsPage() {
         </div>
 
         {/* Mobile/Tablet: Responsive Layout */}
-        <div className="flex flex-1 flex-col overflow-hidden xl:hidden">
-          <div className="flex-1 overflow-hidden">
-            <div className="flex h-full">
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden xl:hidden">
+          <div className="min-h-0 flex-1 overflow-hidden">
+            <div className="flex h-full min-h-0">
               {/* Chat List (full screen on mobile, side panel on tablet when chat selected) */}
               <div
                 className={cn(
-                  'h-full w-full flex-col bg-background',
+                  'h-full min-h-0 w-full flex-col bg-background',
                   selectedChatId ? 'hidden lg:flex lg:w-96' : 'flex'
                 )}
               >
@@ -207,7 +210,7 @@ export default function ChatsPage() {
                 <ChatSearchBar value={searchQuery} onChange={setSearchQuery} />
 
                 {/* Scrollable chat list */}
-                <div className="flex-1 overflow-y-auto">
+                <div className="min-h-0 flex-1 overflow-y-auto">
                   <ChatList
                     chats={filteredChats}
                     selectedChatId={selectedChatId}
@@ -231,7 +234,7 @@ export default function ChatsPage() {
               {selectedChatId && chatDetails && (
                 <div
                   className={cn(
-                    'h-full flex-1 bg-background',
+                    'h-full min-h-0 flex-1 bg-background',
                     !selectedChatId ? 'hidden lg:block' : 'block'
                   )}
                 >
@@ -265,7 +268,7 @@ export default function ChatsPage() {
             </div>
           </div>
         </div>
-      </PageContainer>
+      </div>
 
       {/* Leave Chat Confirmation Dialog */}
       <AlertDialog open={isLeaveConfirmOpen} onOpenChange={setLeaveConfirmOpen}>

--- a/apps/web/src/app/chats/page.tsx
+++ b/apps/web/src/app/chats/page.tsx
@@ -125,8 +125,8 @@ export default function ChatsPage() {
   return (
     <>
       {/* Use fixed viewport heights to ensure proper scroll containment */}
-      {/* Mobile: 100dvh - 56px header - 56px bottom nav = calc(100dvh - 112px) */}
-      {/* Desktop: full viewport height */}
+      {/* Mobile: 100dvh - 56px (MobileHeader pt-14) - 56px (BottomNav pb-14) = 112px */}
+      {/* Desktop: full viewport height (no header/nav padding) */}
       <div className="flex h-[calc(100dvh-112px)] flex-col overflow-hidden md:h-dvh">
         {/* Desktop: Two Column Layout */}
         <div className="hidden min-h-0 flex-1 flex-col overflow-hidden xl:flex">
@@ -232,12 +232,7 @@ export default function ChatsPage() {
 
               {/* Chat View (full screen on mobile, shared on tablet) */}
               {selectedChatId && chatDetails && (
-                <div
-                  className={cn(
-                    'h-full min-h-0 flex-1 bg-background',
-                    !selectedChatId ? 'hidden lg:block' : 'block'
-                  )}
-                >
+                <div className="block h-full min-h-0 flex-1 bg-background">
                   <ChatView
                     chatDetails={chatDetails}
                     currentUserId={user?.id}

--- a/apps/web/src/components/chats/MessageInput.tsx
+++ b/apps/web/src/components/chats/MessageInput.tsx
@@ -77,7 +77,7 @@ export function MessageInput({
             'max-h-40 min-h-[44px] flex-1 resize-none overflow-y-auto rounded-lg px-4 py-3 text-sm',
             'message-input bg-sidebar-accent/50',
             'text-foreground placeholder:text-muted-foreground',
-            'outline-none',
+            'outline-none focus:ring-2 focus:ring-primary/50',
             'disabled:cursor-not-allowed disabled:opacity-50'
           )}
         />

--- a/apps/web/src/components/chats/MessageInput.tsx
+++ b/apps/web/src/components/chats/MessageInput.tsx
@@ -2,9 +2,11 @@
 
 import { cn } from '@babylon/shared';
 import { Send } from 'lucide-react';
-import React from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { LoginButton } from '@/components/auth/LoginButton';
 import { Skeleton } from '@/components/shared/Skeleton';
+
+const MAX_TEXTAREA_HEIGHT = 160;
 
 interface MessageInputProps {
   value: string;
@@ -21,11 +23,30 @@ export function MessageInput({
   sending,
   authenticated,
 }: MessageInputProps) {
-  const handleKeyPress = (e: React.KeyboardEvent) => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Resize textarea based on content
+  const resizeTextarea = useCallback(() => {
+    const textarea = textareaRef.current;
+    if (textarea) {
+      textarea.style.height = 'auto';
+      textarea.style.height =
+        Math.min(textarea.scrollHeight, MAX_TEXTAREA_HEIGHT) + 'px';
+    }
+  }, []);
+
+  // Resize textarea when value changes
+  // biome-ignore lint/correctness/useExhaustiveDependencies: value is intentionally included to trigger resize when content changes
+  useEffect(() => {
+    resizeTextarea();
+  }, [value, resizeTextarea]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       onSend();
     }
+    // Shift+Enter will insert a newline (default behavior)
   };
 
   if (!authenticated) {
@@ -43,16 +64,17 @@ export function MessageInput({
 
   return (
     <div className="bg-background px-4 py-3">
-      <div className="flex gap-2 md:gap-3">
-        <input
-          type="text"
+      <div className="flex items-end gap-2 md:gap-3">
+        <textarea
+          ref={textareaRef}
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          onKeyPress={handleKeyPress}
+          onKeyDown={handleKeyDown}
           placeholder="Type a message..."
           disabled={sending}
+          rows={1}
           className={cn(
-            'flex-1 rounded-lg px-4 py-3 text-sm',
+            'max-h-40 min-h-[44px] flex-1 resize-none overflow-y-auto rounded-lg px-4 py-3 text-sm',
             'message-input bg-sidebar-accent/50',
             'text-foreground placeholder:text-muted-foreground',
             'outline-none',
@@ -63,7 +85,7 @@ export function MessageInput({
           onClick={onSend}
           disabled={!value.trim() || sending}
           className={cn(
-            'flex items-center gap-2 rounded-lg px-4 py-3 font-semibold md:gap-3',
+            'flex h-[44px] items-center gap-2 rounded-lg px-4 py-3 font-semibold md:gap-3',
             'chat-button bg-sidebar-accent/50 text-primary',
             'transition-all duration-300',
             'disabled:cursor-not-allowed disabled:text-muted-foreground disabled:opacity-50'

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -1,66 +1,153 @@
-import type React from 'react';
+'use client';
+
+import { cn } from '@babylon/shared';
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import * as React from 'react';
 
 /**
- * Dropdown menu component (placeholder implementation).
- *
- * Placeholder dropdown menu component. Styling and functionality
- * are handled via className and props.
- *
- * @param props - DropdownMenu component props
- * @returns Dropdown menu element
+ * Root dropdown menu component.
  */
-export const DropdownMenu = ({
-  children,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement> & {
-  children: React.ReactNode;
-}) => <div {...props}>{children}</div>;
-
-/**
- * Dropdown menu content container component.
- *
- * Container for dropdown menu items.
- *
- * @param props - DropdownMenuContent component props
- * @returns Dropdown menu content element
- */
-export const DropdownMenuContent = ({
-  children,
-  align: _align,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement> & {
-  children: React.ReactNode;
-  align?: 'start' | 'center' | 'end';
-}) => <div {...props}>{children}</div>;
-
-/**
- * Dropdown menu item component.
- *
- * Individual clickable item within a dropdown menu.
- *
- * @param props - DropdownMenuItem component props
- * @returns Dropdown menu item element
- */
-export const DropdownMenuItem = ({
-  children,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement> & {
-  children: React.ReactNode;
-}) => <div {...props}>{children}</div>;
+const DropdownMenu = DropdownMenuPrimitive.Root;
 
 /**
  * Dropdown menu trigger component.
- *
- * Element that triggers the dropdown menu to open.
- *
- * @param props - DropdownMenuTrigger component props
- * @returns Dropdown menu trigger element
  */
-export const DropdownMenuTrigger = ({
-  children,
-  asChild: _asChild,
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+/**
+ * Dropdown menu group component.
+ */
+const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+
+/**
+ * Dropdown menu portal component.
+ */
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+
+/**
+ * Dropdown menu sub component.
+ */
+const DropdownMenuSub = DropdownMenuPrimitive.Sub;
+
+/**
+ * Dropdown menu radio group component.
+ */
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
+
+/**
+ * Dropdown menu content component.
+ */
+const DropdownMenuContent = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md',
+        'data-[state=closed]:animate-out data-[state=open]:animate-in',
+        'data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
+        'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2',
+        'data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        className
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+/**
+ * Dropdown menu item component.
+ */
+const DropdownMenuItem = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      'relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none',
+      'transition-colors focus:bg-accent focus:text-accent-foreground',
+      'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      inset && 'pl-8',
+      className
+    )}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+/**
+ * Dropdown menu label component.
+ */
+const DropdownMenuLabel = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & {
+    inset?: boolean;
+  }
+>(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn(
+      'px-2 py-1.5 font-semibold text-sm',
+      inset && 'pl-8',
+      className
+    )}
+    {...props}
+  />
+));
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+
+/**
+ * Dropdown menu separator component.
+ */
+const DropdownMenuSeparator = React.forwardRef<
+  React.ComponentRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn('-mx-1 my-1 h-px bg-muted', className)}
+    {...props}
+  />
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+
+/**
+ * Dropdown menu shortcut component.
+ */
+const DropdownMenuShortcut = ({
+  className,
   ...props
-}: React.HTMLAttributes<HTMLDivElement> & {
-  children: React.ReactNode;
-  asChild?: boolean;
-}) => <div {...props}>{children}</div>;
+}: React.HTMLAttributes<HTMLSpanElement>) => {
+  return (
+    <span
+      className={cn(
+        'ml-auto text-muted-foreground text-xs tracking-widest',
+        className
+      )}
+      {...props}
+    />
+  );
+};
+DropdownMenuShortcut.displayName = 'DropdownMenuShortcut';
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuRadioGroup,
+};


### PR DESCRIPTION
before:


https://github.com/user-attachments/assets/3ddcc8a3-103b-4a7f-a300-ff7cbad523fc

after:


https://github.com/user-attachments/assets/3c62a3f0-81a0-4516-b6f3-95378f749ebd

Fixed the chat page scroll behavior where the entire page (including header and input) would scroll instead of just the messages area. Also upgraded the message input from a single-line text field to an auto-resizing textarea that supports shift+enter for multi-line messages. Additionally, replaced the placeholder dropdown menu component with a proper Radix UI implementation so the "Leave Chat" option only appears when clicking the three-dot menu.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-line message input with automatic resizing (Shift+Enter for new lines)

* **Improvements**
  * More stable chat page layout and improved scroll containment across mobile and desktop
  * Enhanced dropdown menus with richer, more consistent behavior and styling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed chat page scroll behavior by replacing `PageContainer` with fixed viewport heights and proper flexbox containment using `min-h-0`. Upgraded message input from single-line text field to auto-resizing `textarea` with shift+enter support. Replaced placeholder dropdown with proper Radix UI implementation.

- **Scroll fix**: Removed `PageContainer` wrapper and used explicit viewport heights (`h-[calc(100dvh-112px)]` mobile, `h-dvh` desktop) with `min-h-0` on all flex containers to enable proper scroll containment
- **Textarea upgrade**: Changed `input` to `textarea` with auto-resize logic (max 160px height), shift+enter for newlines, and proper keyboard handling
- **Dropdown upgrade**: Replaced placeholder components with full `@radix-ui/react-dropdown-menu` implementation including portal rendering, animations, and proper accessibility

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- Well-structured UI improvements with proper flexbox containment patterns, standard Radix UI implementation, and correct textarea auto-resize logic. Changes are focused, well-tested patterns with no business logic modifications.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/chats/page.tsx | Fixed scroll containment by replacing PageContainer with fixed viewport heights and adding min-h-0 to flex containers |
| apps/web/src/components/chats/MessageInput.tsx | Upgraded from single-line input to auto-resizing textarea with shift+enter support for multi-line messages |
| apps/web/src/components/ui/dropdown-menu.tsx | Replaced placeholder implementation with full Radix UI dropdown menu with proper styling and animations |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Page as ChatsPage
    participant ChatView
    participant MessageInput
    participant Header as ChatViewHeader
    participant Dropdown as DropdownMenu

    User->>Page: Opens chat page
    Page->>Page: Apply fixed viewport heights<br/>(h-[calc(100dvh-112px)] mobile)
    Page->>ChatView: Render with min-h-0 flex containers
    ChatView->>Header: Render header (fixed)
    ChatView->>ChatView: Create scrollable message area<br/>(min-h-0 flex-1 overflow-y-auto)
    ChatView->>MessageInput: Render input (fixed)
    
    User->>MessageInput: Types message
    MessageInput->>MessageInput: Auto-resize textarea<br/>(up to MAX_TEXTAREA_HEIGHT)
    
    User->>MessageInput: Presses Enter
    MessageInput->>ChatView: onSend() callback
    
    User->>MessageInput: Presses Shift+Enter
    MessageInput->>MessageInput: Insert newline (default behavior)
    
    User->>Header: Clicks three-dot menu
    Header->>Dropdown: Open Radix UI dropdown
    Dropdown->>Dropdown: Portal content with animations
    User->>Dropdown: Clicks "Leave Chat"
    Dropdown->>Page: onLeaveChat() callback
    Page->>Page: Show confirmation dialog
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->