### PR TITLE
fix: change AgentPointsTransaction balanceBefore/balanceAfter to decimal

### DIFF
--- a/packages/agents/src/services/AgentService.ts
+++ b/packages/agents/src/services/AgentService.ts
@@ -847,8 +847,8 @@ export class AgentServiceV2 {
             ? 'spend_post'
             : 'spend_tick',
         amount: -amount,
-        balanceBefore: currentBalance,
-        balanceAfter: currentBalance - amount,
+        balanceBefore: String(currentBalance),
+        balanceAfter: String(currentBalance - amount),
         description: reason,
         relatedId: relatedId ?? null,
         agentUserId: agentUserId,

--- a/packages/db/drizzle/migrations/0015_fix_agent_points_transaction_decimal_balance.sql
+++ b/packages/db/drizzle/migrations/0015_fix_agent_points_transaction_decimal_balance.sql
@@ -1,0 +1,11 @@
+-- Migration: Fix AgentPointsTransaction balanceBefore/balanceAfter to decimal
+-- Fixes type mismatch where virtualBalance (decimal) was being inserted into integer columns
+-- causing PostgreSQL error 22P02 for values like 199.08
+
+-- Alter balanceBefore column from integer to decimal(18,2)
+ALTER TABLE "AgentPointsTransaction" 
+  ALTER COLUMN "balanceBefore" SET DATA TYPE numeric(18, 2);
+
+-- Alter balanceAfter column from integer to decimal(18,2)
+ALTER TABLE "AgentPointsTransaction" 
+  ALTER COLUMN "balanceAfter" SET DATA TYPE numeric(18, 2);

--- a/packages/db/drizzle/migrations/0015_rollback_fix_agent_points_transaction_decimal_balance.sql
+++ b/packages/db/drizzle/migrations/0015_rollback_fix_agent_points_transaction_decimal_balance.sql
@@ -1,5 +1,18 @@
 -- Rollback: Revert AgentPointsTransaction balanceBefore/balanceAfter to integer
--- Warning: This may cause data loss if decimal values have been stored
+--
+-- WARNING: DATA LOSS - This migration will TRUNCATE fractional values!
+-- Rows where balanceBefore or balanceAfter have non-zero fractional parts
+-- (e.g., 123.45) will be truncated to integers (e.g., 123).
+--
+-- RECOMMENDED: Before running this migration:
+-- 1. Take a backup of the AgentPointsTransaction table
+-- 2. Export affected rows using the query below
+--
+-- Query to detect rows with fractional cents that will lose precision:
+-- SELECT id, "balanceBefore", "balanceAfter"
+-- FROM "AgentPointsTransaction"
+-- WHERE "balanceBefore" != FLOOR("balanceBefore")
+--    OR "balanceAfter" != FLOOR("balanceAfter");
 
 ALTER TABLE "AgentPointsTransaction" 
   ALTER COLUMN "balanceBefore" SET DATA TYPE integer USING "balanceBefore"::integer;

--- a/packages/db/drizzle/migrations/0015_rollback_fix_agent_points_transaction_decimal_balance.sql
+++ b/packages/db/drizzle/migrations/0015_rollback_fix_agent_points_transaction_decimal_balance.sql
@@ -1,0 +1,8 @@
+-- Rollback: Revert AgentPointsTransaction balanceBefore/balanceAfter to integer
+-- Warning: This may cause data loss if decimal values have been stored
+
+ALTER TABLE "AgentPointsTransaction" 
+  ALTER COLUMN "balanceBefore" SET DATA TYPE integer USING "balanceBefore"::integer;
+
+ALTER TABLE "AgentPointsTransaction" 
+  ALTER COLUMN "balanceAfter" SET DATA TYPE integer USING "balanceAfter"::integer;

--- a/packages/db/src/schema/agents.ts
+++ b/packages/db/src/schema/agents.ts
@@ -174,8 +174,14 @@ export const agentPointsTransactions = pgTable(
     id: text('id').primaryKey(),
     type: text('type').notNull(),
     amount: integer('amount').notNull(),
-    balanceBefore: decimal('balanceBefore', { precision: 18, scale: 2 }).notNull(),
-    balanceAfter: decimal('balanceAfter', { precision: 18, scale: 2 }).notNull(),
+    balanceBefore: decimal('balanceBefore', {
+      precision: 18,
+      scale: 2,
+    }).notNull(),
+    balanceAfter: decimal('balanceAfter', {
+      precision: 18,
+      scale: 2,
+    }).notNull(),
     description: text('description').notNull(),
     relatedId: text('relatedId'),
     createdAt: timestamp('createdAt', { mode: 'date' }).notNull().defaultNow(),

--- a/packages/db/src/schema/agents.ts
+++ b/packages/db/src/schema/agents.ts
@@ -1,6 +1,7 @@
 import { relations } from 'drizzle-orm';
 import {
   boolean,
+  decimal,
   doublePrecision,
   index,
   integer,
@@ -173,8 +174,8 @@ export const agentPointsTransactions = pgTable(
     id: text('id').primaryKey(),
     type: text('type').notNull(),
     amount: integer('amount').notNull(),
-    balanceBefore: integer('balanceBefore').notNull(),
-    balanceAfter: integer('balanceAfter').notNull(),
+    balanceBefore: decimal('balanceBefore', { precision: 18, scale: 2 }).notNull(),
+    balanceAfter: decimal('balanceAfter', { precision: 18, scale: 2 }).notNull(),
     description: text('description').notNull(),
     relatedId: text('relatedId'),
     createdAt: timestamp('createdAt', { mode: 'date' }).notNull().defaultNow(),

--- a/packages/testing/integration/agent-autonomous-tick.integration.test.ts
+++ b/packages/testing/integration/agent-autonomous-tick.integration.test.ts
@@ -472,7 +472,7 @@ describe('Agent Autonomous Tick Integration', () => {
       where: { id: testAgentId },
       select: { virtualBalance: true },
     });
-    const beforeBalance = Number(beforeUser?.virtualBalance || 0);
+    const beforeBalance = Number(beforeUser?.virtualBalance ?? 0);
 
     const cronSecret = process.env.CRON_SECRET || 'development';
     const response = await fetch(`${BASE_URL}/api/cron/agent-tick`, {
@@ -528,7 +528,7 @@ describe('Agent Autonomous Tick Integration', () => {
       where: { id: testAgentId },
       select: { virtualBalance: true },
     });
-    const afterBalance = Number(afterUser?.virtualBalance || 0);
+    const afterBalance = Number(afterUser?.virtualBalance ?? 0);
 
     // Balance should be deducted (1 point per tick) - even if processing had errors
     // Balance is deducted before executeAutonomousTick, so it should always be deducted

--- a/packages/testing/integration/agent-autonomous-tick.integration.test.ts
+++ b/packages/testing/integration/agent-autonomous-tick.integration.test.ts
@@ -369,9 +369,7 @@ describe('Agent Autonomous Tick Integration', () => {
     expect(agentBefore).toBeTruthy();
     expect(agentBefore?.isAgent).toBe(true);
     // Balance check uses virtualBalance from user record
-    expect(
-      Number(agentBefore?.virtualBalance ?? 0)
-    ).toBeGreaterThanOrEqual(1);
+    expect(Number(agentBefore?.virtualBalance ?? 0)).toBeGreaterThanOrEqual(1);
 
     const cronSecret = process.env.CRON_SECRET || 'development';
     const response = await fetch(`${BASE_URL}/api/cron/agent-tick`, {


### PR DESCRIPTION
Agent ticks were failing silently due to a type mismatch when inserting into AgentPointsTransaction. The balanceBefore and balanceAfter columns were defined as integer, but virtualBalance (which is decimal) values like 199.08 were being inserted, causing PostgreSQL error 22P02. This resulted in stale locks accumulating as ticks would crash mid-execution without releasing their locks. Fixed by changing the columns to decimal(18,2) to match the virtualBalance type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Balance tracking in agent transaction records now uses decimal precision (18,2) to preserve cents and avoid conversion errors.
  * Database migration applied to convert existing transaction balances safely, with a rollback path prepared.

* **Tests**
  * Improved integration tests to handle null/undefined balances more robustly and cleaned up related assertions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Fixes a critical database type mismatch in `AgentPointsTransaction` table where `balanceBefore`/`balanceAfter` columns were defined as integer but receiving decimal values from `virtualBalance`, causing PostgreSQL error 22P02
- Updates the database schema to use `decimal(18,2)` precision for balance tracking columns and converts numeric values to strings in the service layer to ensure type compatibility
- Resolves silent agent tick failures that were causing stale locks to accumulate when transactions crashed mid-execution without releasing their locks

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| packages/db/src/schema/agents.ts | Updated AgentPointsTransaction table columns balanceBefore/balanceAfter from integer to decimal(18,2) to match virtualBalance precision |
| packages/agents/src/services/AgentService.ts | Added String() conversion for balance values before database insertion to ensure compatibility with decimal column types |

<h3>Confidence score: 5/5</h3>


- This PR is extremely safe to merge with minimal risk as it fixes a critical runtime bug
- Score reflects a straightforward type compatibility fix that directly addresses the root cause of silent failures described in the PR
- Pay attention to the database schema migration impact in `packages/db/src/schema/agents.ts` to ensure proper deployment

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as "User/System"
    participant AS as "AgentService"
    participant DB as "Database"
    participant TX as "Transaction"

    User->>AS: "deductPoints(agentUserId, amount, reason)"
    AS->>DB: "SELECT virtualBalance, managedBy FROM users WHERE id = agentUserId"
    DB->>AS: "Return agent data"
    AS->>AS: "Validate balance >= amount"
    AS->>TX: "Begin transaction"
    TX->>DB: "UPDATE users SET virtualBalance = currentBalance - amount"
    TX->>DB: "INSERT agentPointsTransactions with decimal balances"
    TX->>DB: "INSERT balanceTransactions for unified history"
    TX->>AS: "Commit transaction"
    AS->>User: "Return new balance"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->