### PR TITLE
feat(profile): add followers/following list modal

### DIFF
--- a/apps/web/src/app/api/users/[userId]/followers/route.ts
+++ b/apps/web/src/app/api/users/[userId]/followers/route.ts
@@ -82,8 +82,9 @@
  */
 
 import {
+  findUserByIdentifier,
+  NotFoundError,
   optionalAuth,
-  requireUserByIdentifier,
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
@@ -116,6 +117,7 @@ interface FollowerResponse {
   followedAt: string;
   isActor: boolean;
   tier?: string;
+  isMutualFollow?: boolean;
 }
 
 /**
@@ -127,7 +129,7 @@ export const GET = withErrorHandling(
     request: NextRequest,
     context: { params: Promise<{ userId: string }> }
   ) => {
-    await optionalAuth(request);
+    const authUser = await optionalAuth(request);
     const params = await context.params;
     const { userId: targetIdentifier } = UserIdParamSchema.parse(params);
 
@@ -140,18 +142,20 @@ export const GET = withErrorHandling(
     };
     UserFollowersQuerySchema.parse(queryParams);
 
-    const targetUser = await requireUserByIdentifier(targetIdentifier, {
-      id: true,
-    });
-    const targetId = targetUser.id;
+    // Try to find as user first
+    const targetUser = await findUserByIdentifier(targetIdentifier);
 
-    logger.debug(
-      'Target not found as user, checking if actor',
-      { targetIdentifier },
-      'GET /api/users/[userId]/followers'
-    );
+    // Check if it's an actor (NPC)
+    const targetActor = StaticDataRegistry.getActor(targetIdentifier);
 
-    const targetActor = StaticDataRegistry.getActor(targetId);
+    // If neither user nor actor found, throw not found
+    if (!targetUser && !targetActor) {
+      throw new NotFoundError('User', undefined, {
+        identifier: targetIdentifier,
+      });
+    }
+
+    const targetId = targetUser?.id || targetIdentifier;
 
     let followersList: FollowerResponse[] = [];
 
@@ -177,6 +181,7 @@ export const GET = withErrorHandling(
             followerId: rel.followerId,
             createdAt: rel.createdAt,
             followerName: followerActor.name,
+            followerUsername: followerActor.username,
             followerTier: followerActor.tier,
             followerProfileImageUrl: followerActor.profileImageUrl,
             followerDescription: followerActor.description,
@@ -204,7 +209,7 @@ export const GET = withErrorHandling(
         ...actorFollowersList.map((f) => ({
           id: f.followerId,
           displayName: f.followerName,
-          username: f.followerId,
+          username: f.followerUsername || null,
           profileImageUrl: f.followerProfileImageUrl || null,
           bio: f.followerDescription || '',
           followedAt: f.createdAt.toISOString(),
@@ -276,7 +281,7 @@ export const GET = withErrorHandling(
           return {
             id: f.npcId,
             displayName: actor?.name || f.npcId,
-            username: actor?.id || null,
+            username: actor?.username || null,
             profileImageUrl: actor?.profileImageUrl || null,
             bio: actor?.description || '',
             followedAt: f.followedAt.toISOString(),
@@ -288,6 +293,53 @@ export const GET = withErrorHandling(
         (a, b) =>
           new Date(b.followedAt).getTime() - new Date(a.followedAt).getTime()
       );
+    }
+
+    // Check if authenticated user follows each follower (for showing follow/unfollow button state)
+    if (authUser?.userId) {
+      const followerIds = followersList
+        .filter((f) => !f.isActor)
+        .map((f) => f.id);
+      const actorFollowerIds = followersList
+        .filter((f) => f.isActor)
+        .map((f) => f.id);
+
+      // Check which followers the authenticated user follows
+      const followedUserIds = new Set<string>();
+      if (followerIds.length > 0) {
+        const allUserFollows = await db
+          .select({ followingId: follows.followingId })
+          .from(follows)
+          .where(eq(follows.followerId, authUser.userId));
+        for (const f of allUserFollows) {
+          if (followerIds.includes(f.followingId)) {
+            followedUserIds.add(f.followingId);
+          }
+        }
+      }
+
+      // Check actor follows
+      const followedActorIds = new Set<string>();
+      if (actorFollowerIds.length > 0) {
+        const allActorFollows = await db
+          .select({ actorId: userActorFollows.actorId })
+          .from(userActorFollows)
+          .where(eq(userActorFollows.userId, authUser.userId));
+        for (const f of allActorFollows) {
+          if (actorFollowerIds.includes(f.actorId)) {
+            followedActorIds.add(f.actorId);
+          }
+        }
+      }
+
+      // Add isMutualFollow to each follower (true if auth user follows them)
+      for (const follower of followersList) {
+        (
+          follower as FollowerResponse & { isMutualFollow?: boolean }
+        ).isMutualFollow = follower.isActor
+          ? followedActorIds.has(follower.id)
+          : followedUserIds.has(follower.id);
+      }
     }
 
     logger.info(

--- a/apps/web/src/app/api/users/[userId]/followers/route.ts
+++ b/apps/web/src/app/api/users/[userId]/followers/route.ts
@@ -96,6 +96,7 @@ import {
   eq,
   followStatuses,
   follows,
+  inArray,
   not,
   userActorFollows,
   users,
@@ -304,31 +305,37 @@ export const GET = withErrorHandling(
         .filter((f) => f.isActor)
         .map((f) => f.id);
 
-      // Check which followers the authenticated user follows
+      // Check which followers the authenticated user follows (using inArray for efficiency)
       const followedUserIds = new Set<string>();
       if (followerIds.length > 0) {
-        const allUserFollows = await db
+        const userFollowResults = await db
           .select({ followingId: follows.followingId })
           .from(follows)
-          .where(eq(follows.followerId, authUser.userId));
-        for (const f of allUserFollows) {
-          if (followerIds.includes(f.followingId)) {
-            followedUserIds.add(f.followingId);
-          }
+          .where(
+            and(
+              eq(follows.followerId, authUser.userId),
+              inArray(follows.followingId, followerIds)
+            )
+          );
+        for (const f of userFollowResults) {
+          followedUserIds.add(f.followingId);
         }
       }
 
-      // Check actor follows
+      // Check actor follows (using inArray for efficiency)
       const followedActorIds = new Set<string>();
       if (actorFollowerIds.length > 0) {
-        const allActorFollows = await db
+        const actorFollowResults = await db
           .select({ actorId: userActorFollows.actorId })
           .from(userActorFollows)
-          .where(eq(userActorFollows.userId, authUser.userId));
-        for (const f of allActorFollows) {
-          if (actorFollowerIds.includes(f.actorId)) {
-            followedActorIds.add(f.actorId);
-          }
+          .where(
+            and(
+              eq(userActorFollows.userId, authUser.userId),
+              inArray(userActorFollows.actorId, actorFollowerIds)
+            )
+          );
+        for (const f of actorFollowResults) {
+          followedActorIds.add(f.actorId);
         }
       }
 

--- a/apps/web/src/app/api/users/[userId]/followers/route.ts
+++ b/apps/web/src/app/api/users/[userId]/followers/route.ts
@@ -82,9 +82,8 @@
  */
 
 import {
-  findUserByIdentifier,
-  NotFoundError,
   optionalAuth,
+  requireTargetByIdentifier,
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
@@ -143,20 +142,9 @@ export const GET = withErrorHandling(
     };
     UserFollowersQuerySchema.parse(queryParams);
 
-    // Try to find as user first
-    const targetUser = await findUserByIdentifier(targetIdentifier);
-
-    // Check if it's an actor (NPC)
-    const targetActor = StaticDataRegistry.getActor(targetIdentifier);
-
-    // If neither user nor actor found, throw not found
-    if (!targetUser && !targetActor) {
-      throw new NotFoundError('User', undefined, {
-        identifier: targetIdentifier,
-      });
-    }
-
-    const targetId = targetUser?.id || targetIdentifier;
+    // Find target (user or actor) - throws NotFoundError if neither exists
+    const { actor: targetActor, targetId } =
+      await requireTargetByIdentifier(targetIdentifier);
 
     let followersList: FollowerResponse[] = [];
 

--- a/apps/web/src/app/api/users/[userId]/followers/route.ts
+++ b/apps/web/src/app/api/users/[userId]/followers/route.ts
@@ -341,9 +341,7 @@ export const GET = withErrorHandling(
 
       // Add isMutualFollow to each follower (true if auth user follows them)
       for (const follower of followersList) {
-        (
-          follower as FollowerResponse & { isMutualFollow?: boolean }
-        ).isMutualFollow = follower.isActor
+        follower.isMutualFollow = follower.isActor
           ? followedActorIds.has(follower.id)
           : followedUserIds.has(follower.id);
       }

--- a/apps/web/src/app/api/users/[userId]/following/route.ts
+++ b/apps/web/src/app/api/users/[userId]/following/route.ts
@@ -90,9 +90,8 @@
  */
 
 import {
-  findUserByIdentifier,
-  NotFoundError,
   optionalAuth,
+  requireTargetByIdentifier,
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
@@ -151,20 +150,9 @@ export const GET = withErrorHandling(
     };
     UserFollowersQuerySchema.parse(queryParams);
 
-    // Try to find as user first
-    const targetUser = await findUserByIdentifier(targetIdentifier);
-
-    // Check if it's an actor (NPC)
-    const targetActor = StaticDataRegistry.getActor(targetIdentifier);
-
-    // If neither user nor actor found, throw not found
-    if (!targetUser && !targetActor) {
-      throw new NotFoundError('User', undefined, {
-        identifier: targetIdentifier,
-      });
-    }
-
-    const targetId = targetUser?.id || targetIdentifier;
+    // Find target (user or actor) - throws NotFoundError if neither exists
+    const { actor: targetActor, targetId } =
+      await requireTargetByIdentifier(targetIdentifier);
 
     let followingList: FollowingResponse[] = [];
 

--- a/apps/web/src/app/api/users/[userId]/following/route.ts
+++ b/apps/web/src/app/api/users/[userId]/following/route.ts
@@ -103,6 +103,7 @@ import {
   desc,
   eq,
   follows,
+  inArray,
   userActorFollows,
   users,
 } from '@babylon/db';
@@ -252,29 +253,44 @@ export const GET = withErrorHandling(
         };
       });
 
-      // Check mutual follows if authenticated user is viewing their own following list
-      const mutualFollowChecks =
-        authUser && authUser.userId === targetId
-          ? await Promise.all(
-              userFollowsList.map(async (f) => {
-                const [mutualFollow] = await db
-                  .select({ id: follows.id })
-                  .from(follows)
-                  .where(
-                    and(
-                      eq(follows.followerId, f.followingId),
-                      eq(follows.followingId, authUser.userId)
-                    )
-                  )
-                  .limit(1);
-                return { userId: f.followingId, isMutual: !!mutualFollow };
-              })
-            )
-          : [];
+      // Check mutual follows for authenticated users (using batched query for efficiency)
+      const mutualFollowMap = new Map<string, boolean>();
+      if (authUser?.userId) {
+        const followingUserIds = userFollowsList.map((f) => f.followingId);
+        const followingActorIds = actorFollowsList.map((f) => f.actorId);
 
-      const mutualFollowMap = new Map(
-        mutualFollowChecks.map((check) => [check.userId, check.isMutual])
-      );
+        // Batch query for user mutual follows
+        if (followingUserIds.length > 0) {
+          const userMutualFollows = await db
+            .select({ followingId: follows.followingId })
+            .from(follows)
+            .where(
+              and(
+                eq(follows.followerId, authUser.userId),
+                inArray(follows.followingId, followingUserIds)
+              )
+            );
+          for (const f of userMutualFollows) {
+            mutualFollowMap.set(f.followingId, true);
+          }
+        }
+
+        // Batch query for actor mutual follows
+        if (followingActorIds.length > 0) {
+          const actorMutualFollows = await db
+            .select({ actorId: userActorFollows.actorId })
+            .from(userActorFollows)
+            .where(
+              and(
+                eq(userActorFollows.userId, authUser.userId),
+                inArray(userActorFollows.actorId, followingActorIds)
+              )
+            );
+          for (const f of actorMutualFollows) {
+            mutualFollowMap.set(f.actorId, true);
+          }
+        }
+      }
 
       followingList = [
         ...userFollowsList.map((f) => ({
@@ -301,6 +317,7 @@ export const GET = withErrorHandling(
               followedAt: f.createdAt.toISOString(),
               type: 'actor' as const,
               tier: null,
+              isMutualFollow: mutualFollowMap.get(f.actorId) || false,
             };
           }
 
@@ -314,6 +331,7 @@ export const GET = withErrorHandling(
             followedAt: f.createdAt.toISOString(),
             type: 'actor' as const,
             tier: f.actorTier || null,
+            isMutualFollow: mutualFollowMap.get(f.actorId) || false,
           };
         }),
       ].sort(

--- a/apps/web/src/app/api/users/[userId]/following/route.ts
+++ b/apps/web/src/app/api/users/[userId]/following/route.ts
@@ -90,8 +90,9 @@
  */
 
 import {
+  findUserByIdentifier,
+  NotFoundError,
   optionalAuth,
-  requireUserByIdentifier,
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
@@ -149,18 +150,20 @@ export const GET = withErrorHandling(
     };
     UserFollowersQuerySchema.parse(queryParams);
 
-    const targetUser = await requireUserByIdentifier(targetIdentifier, {
-      id: true,
-    });
-    const targetId = targetUser.id;
+    // Try to find as user first
+    const targetUser = await findUserByIdentifier(targetIdentifier);
 
-    logger.debug(
-      'Target not found as user, checking if actor',
-      { targetIdentifier },
-      'GET /api/users/[userId]/following'
-    );
+    // Check if it's an actor (NPC)
+    const targetActor = StaticDataRegistry.getActor(targetIdentifier);
 
-    const targetActor = StaticDataRegistry.getActor(targetId);
+    // If neither user nor actor found, throw not found
+    if (!targetUser && !targetActor) {
+      throw new NotFoundError('User', undefined, {
+        identifier: targetIdentifier,
+      });
+    }
+
+    const targetId = targetUser?.id || targetIdentifier;
 
     let followingList: FollowingResponse[] = [];
 
@@ -186,6 +189,7 @@ export const GET = withErrorHandling(
             followingId: rel.followingId,
             createdAt: rel.createdAt,
             followingName: followingActor.name,
+            followingUsername: followingActor.username,
             followingTier: followingActor.tier,
             followingProfileImageUrl: followingActor.profileImageUrl,
             followingDescription: followingActor.description,
@@ -196,7 +200,7 @@ export const GET = withErrorHandling(
       followingList = actorFollowsList.map((f) => ({
         id: f.followingId,
         displayName: f.followingName,
-        username: f.followingId,
+        username: f.followingUsername || null,
         profileImageUrl: f.followingProfileImageUrl || null,
         bio: f.followingDescription || '',
         followedAt: f.createdAt.toISOString(),
@@ -241,6 +245,7 @@ export const GET = withErrorHandling(
           actorId: rel.actorId,
           createdAt: rel.createdAt,
           actorName: actor?.name ?? null,
+          actorUsername: actor?.username ?? null,
           actorDescription: actor?.description ?? null,
           actorProfileImageUrl: actor?.profileImageUrl ?? null,
           actorTier: actor?.tier ?? null,
@@ -302,7 +307,7 @@ export const GET = withErrorHandling(
           return {
             id: f.actorId,
             displayName: f.actorName || f.actorId,
-            username: null,
+            username: f.actorUsername || null,
             profileImageUrl: f.actorProfileImageUrl || null,
             bio: f.actorDescription || null,
             isActor: true,

--- a/apps/web/src/app/profile/[id]/page.tsx
+++ b/apps/web/src/app/profile/[id]/page.tsx
@@ -1302,11 +1302,6 @@ export default function ActorProfilePage() {
           }
           userId={actorInfo.id}
           type={followListModal.type}
-          initialCount={
-            followListModal.type === 'followers'
-              ? (optimisticFollowerCount ?? actorInfo.stats?.followers ?? 0)
-              : (actorInfo.stats?.following ?? 0)
-          }
         />
       )}
     </PageContainer>

--- a/apps/web/src/app/profile/[id]/page.tsx
+++ b/apps/web/src/app/profile/[id]/page.tsx
@@ -26,6 +26,7 @@ import { FollowButton } from '@/components/interactions/FollowButton';
 import { ModerationMenu } from '@/components/moderation/ModerationMenu';
 import { SendPointsModal } from '@/components/points/SendPointsModal';
 import { PostCard } from '@/components/posts/PostCard';
+import { FollowListModal } from '@/components/profile/FollowListModal';
 import { OnChainBadge } from '@/components/profile/OnChainBadge';
 import { ProfileWidget } from '@/components/profile/ProfileWidget';
 import { Avatar } from '@/components/shared/Avatar';
@@ -53,6 +54,10 @@ export default function ActorProfilePage() {
   const [optimisticFollowerCount, setOptimisticFollowerCount] = useState<
     number | null
   >(null);
+  const [followListModal, setFollowListModal] = useState<{
+    isOpen: boolean;
+    type: 'followers' | 'following';
+  }>({ isOpen: false, type: 'followers' });
 
   // Check if viewing own profile - compare with both actorId and identifier (for ID-based URLs)
   const isOwnProfile =
@@ -272,8 +277,13 @@ export default function ActorProfilePage() {
       organizations?: Organization[];
     };
 
-    // Find actor
+    // Find actor by id, username, or name
     let actor = actorsDb.actors?.find((a) => a.id === actorId);
+    if (!actor) {
+      actor = actorsDb.actors?.find(
+        (a) => 'username' in a && a.username === actorId
+      );
+    }
     if (!actor) {
       actor = actorsDb.actors?.find((a) => a.name === actorId);
     }
@@ -804,15 +814,25 @@ export default function ActorProfilePage() {
 
                 {/* Stats */}
                 <div className="flex gap-4 text-[15px]">
-                  <Link href="#" className="hover:underline">
+                  <button
+                    onClick={() =>
+                      setFollowListModal({ isOpen: true, type: 'following' })
+                    }
+                    className="hover:underline"
+                  >
                     <span className="font-bold text-foreground">
                       {actorInfo.stats?.following || 0}
                     </span>
                     <span className="ml-1 text-muted-foreground">
                       Following
                     </span>
-                  </Link>
-                  <Link href="#" className="hover:underline">
+                  </button>
+                  <button
+                    onClick={() =>
+                      setFollowListModal({ isOpen: true, type: 'followers' })
+                    }
+                    className="hover:underline"
+                  >
                     <span className="font-bold text-foreground">
                       {optimisticFollowerCount !== null
                         ? optimisticFollowerCount
@@ -821,7 +841,7 @@ export default function ActorProfilePage() {
                     <span className="ml-1 text-muted-foreground">
                       Followers
                     </span>
-                  </Link>
+                  </button>
                 </div>
               </div>
             </div>
@@ -1126,20 +1146,30 @@ export default function ActorProfilePage() {
 
               {/* Stats */}
               <div className="flex gap-4 text-[15px]">
-                <Link href="#" className="hover:underline">
+                <button
+                  onClick={() =>
+                    setFollowListModal({ isOpen: true, type: 'following' })
+                  }
+                  className="hover:underline"
+                >
                   <span className="font-bold text-foreground">
                     {actorInfo.stats?.following || 0}
                   </span>
                   <span className="ml-1 text-muted-foreground">Following</span>
-                </Link>
-                <Link href="#" className="hover:underline">
+                </button>
+                <button
+                  onClick={() =>
+                    setFollowListModal({ isOpen: true, type: 'followers' })
+                  }
+                  className="hover:underline"
+                >
                   <span className="font-bold text-foreground">
                     {optimisticFollowerCount !== null
                       ? optimisticFollowerCount
                       : actorInfo.stats?.followers || 0}
                   </span>
                   <span className="ml-1 text-muted-foreground">Followers</span>
-                </Link>
+                </button>
               </div>
             </div>
           </div>
@@ -1260,6 +1290,23 @@ export default function ActorProfilePage() {
             // Refresh profile data after successful transfer
             loadActorInfo();
           }}
+        />
+      )}
+
+      {/* Follow List Modal */}
+      {actorInfo && (
+        <FollowListModal
+          isOpen={followListModal.isOpen}
+          onClose={() =>
+            setFollowListModal({ ...followListModal, isOpen: false })
+          }
+          userId={actorInfo.id}
+          type={followListModal.type}
+          initialCount={
+            followListModal.type === 'followers'
+              ? (optimisticFollowerCount ?? actorInfo.stats?.followers ?? 0)
+              : (actorInfo.stats?.following ?? 0)
+          }
         />
       )}
     </PageContainer>

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -19,6 +19,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { ArticleCard } from '@/components/articles/ArticleCard';
 import { LoginButton } from '@/components/auth/LoginButton';
 import { PostCard } from '@/components/posts/PostCard';
+import { FollowListModal } from '@/components/profile/FollowListModal';
 import { LinkSocialAccountsModal } from '@/components/profile/LinkSocialAccountsModal';
 import { OnChainBadge } from '@/components/profile/OnChainBadge';
 import { ProfileWidget } from '@/components/profile/ProfileWidget';
@@ -91,6 +92,10 @@ export default function ProfilePage() {
   });
   const [tab, setTab] = useState<'posts' | 'replies' | 'trades'>('posts');
   const [showLinkAccountsModal, setShowLinkAccountsModal] = useState(false);
+  const [followListModal, setFollowListModal] = useState<{
+    isOpen: boolean;
+    type: 'followers' | 'following';
+  }>({ isOpen: false, type: 'followers' });
   const [posts, setPosts] = useState<
     Array<{
       id: string;
@@ -719,20 +724,30 @@ export default function ProfilePage() {
 
         {/* Stats */}
         <div className="flex gap-4 text-[15px]">
-          <Link href="#" className="hover:underline">
+          <button
+            onClick={() =>
+              setFollowListModal({ isOpen: true, type: 'following' })
+            }
+            className="hover:underline"
+          >
             <span className="font-bold text-foreground">
               {optimisticFollowingCount !== null
                 ? optimisticFollowingCount
                 : user?.stats?.following || 0}
             </span>
             <span className="ml-1 text-muted-foreground">Following</span>
-          </Link>
-          <Link href="#" className="hover:underline">
+          </button>
+          <button
+            onClick={() =>
+              setFollowListModal({ isOpen: true, type: 'followers' })
+            }
+            className="hover:underline"
+          >
             <span className="font-bold text-foreground">
               {user?.stats?.followers || 0}
             </span>
             <span className="ml-1 text-muted-foreground">Followers</span>
-          </Link>
+          </button>
         </div>
       </div>
     </div>
@@ -1304,6 +1319,23 @@ export default function ProfilePage() {
             </div>
           </div>
         </div>
+      )}
+
+      {/* Follow List Modal */}
+      {user && (
+        <FollowListModal
+          isOpen={followListModal.isOpen}
+          onClose={() =>
+            setFollowListModal({ ...followListModal, isOpen: false })
+          }
+          userId={user.id}
+          type={followListModal.type}
+          initialCount={
+            followListModal.type === 'followers'
+              ? (user.stats?.followers ?? 0)
+              : (optimisticFollowingCount ?? user.stats?.following ?? 0)
+          }
+        />
       )}
     </PageContainer>
   );

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -1330,11 +1330,6 @@ export default function ProfilePage() {
           }
           userId={user.id}
           type={followListModal.type}
-          initialCount={
-            followListModal.type === 'followers'
-              ? (user.stats?.followers ?? 0)
-              : (optimisticFollowingCount ?? user.stats?.following ?? 0)
-          }
         />
       )}
     </PageContainer>

--- a/apps/web/src/components/profile/FollowListModal.tsx
+++ b/apps/web/src/components/profile/FollowListModal.tsx
@@ -1,0 +1,362 @@
+'use client';
+
+import { cn, getProfileUrl } from '@babylon/shared';
+import { Loader2, Users, X } from 'lucide-react';
+import Link from 'next/link';
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+import { Avatar } from '@/components/shared/Avatar';
+import { VerifiedBadge } from '@/components/shared/VerifiedBadge';
+import { useAuth } from '@/hooks/useAuth';
+
+/**
+ * FollowListModal component for displaying followers or following lists.
+ *
+ * Shows a scrollable list of users with their avatars, names, and follow/unfollow
+ * buttons. Supports infinite scroll for large lists and provides mutual follow
+ * indicators.
+ *
+ * @param props - FollowListModal component props
+ * @returns Follow list modal element or null if not open
+ *
+ * @example
+ * ```tsx
+ * <FollowListModal
+ *   isOpen={showModal}
+ *   onClose={() => setShowModal(false)}
+ *   userId="user-123"
+ *   type="followers"
+ *   title="Followers"
+ * />
+ * ```
+ */
+
+interface FollowUser {
+  id: string;
+  displayName: string;
+  username: string | null;
+  profileImageUrl: string | null;
+  bio: string | null;
+  isActor: boolean;
+  followedAt: string;
+  type: 'user' | 'actor';
+  tier?: string | null;
+  isMutualFollow?: boolean;
+}
+
+interface FollowListModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  userId: string;
+  type: 'followers' | 'following';
+  title?: string;
+  initialCount?: number;
+}
+
+export function FollowListModal({
+  isOpen,
+  onClose,
+  userId,
+  type,
+  title,
+  initialCount = 0,
+}: FollowListModalProps) {
+  const { authenticated, user, getAccessToken } = useAuth();
+  const [users, setUsers] = useState<FollowUser[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [followingStatus, setFollowingStatus] = useState<
+    Record<string, boolean>
+  >({});
+  const [loadingFollow, setLoadingFollow] = useState<Record<string, boolean>>(
+    {}
+  );
+
+  const displayTitle =
+    title || (type === 'followers' ? 'Followers' : 'Following');
+
+  // Fetch the list when modal opens
+  const fetchList = useCallback(async () => {
+    if (!isOpen || !userId) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    const token = await getAccessToken();
+    const headers: HeadersInit = {
+      'Content-Type': 'application/json',
+    };
+    if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    const response = await fetch(
+      `/api/users/${encodeURIComponent(userId)}/${type}?page=1&limit=100&includeMutual=true`,
+      { headers }
+    );
+
+    if (!response.ok) {
+      setError('Failed to load list');
+      setIsLoading(false);
+      return;
+    }
+
+    const data = await response.json();
+    const list = type === 'followers' ? data.followers : data.following;
+    setUsers(list || []);
+
+    // Initialize following status for each user
+    if (authenticated && user) {
+      const statusMap: Record<string, boolean> = {};
+      for (const u of list || []) {
+        if (type === 'following' && userId === user.id) {
+          // Viewing own following list - current user follows everyone in this list
+          statusMap[u.id] = true;
+        } else if (type === 'followers') {
+          // Viewing followers list - use isMutualFollow which indicates if current user follows them
+          statusMap[u.id] = u.isMutualFollow || false;
+        } else {
+          // Viewing someone else's following list - use isMutualFollow
+          statusMap[u.id] = u.isMutualFollow || false;
+        }
+      }
+      setFollowingStatus(statusMap);
+    }
+
+    setIsLoading(false);
+  }, [isOpen, userId, type, authenticated, user, getAccessToken]);
+
+  useEffect(() => {
+    fetchList();
+  }, [fetchList]);
+
+  // Handle body scroll lock
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
+  // Handle escape key
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      window.addEventListener('keydown', handleEscape);
+    }
+    return () => {
+      window.removeEventListener('keydown', handleEscape);
+    };
+  }, [isOpen, onClose]);
+
+  const handleFollow = async (targetUserId: string) => {
+    if (!authenticated || !user) {
+      toast.error('Please sign in to follow users');
+      return;
+    }
+
+    if (targetUserId === user.id) {
+      return;
+    }
+
+    setLoadingFollow((prev) => ({ ...prev, [targetUserId]: true }));
+
+    const token = await getAccessToken();
+    if (!token) {
+      toast.error('Authentication required');
+      setLoadingFollow((prev) => ({ ...prev, [targetUserId]: false }));
+      return;
+    }
+
+    const isCurrentlyFollowing = followingStatus[targetUserId];
+    const method = isCurrentlyFollowing ? 'DELETE' : 'POST';
+
+    // Optimistic update
+    setFollowingStatus((prev) => ({
+      ...prev,
+      [targetUserId]: !isCurrentlyFollowing,
+    }));
+
+    const response = await fetch(
+      `/api/users/${encodeURIComponent(targetUserId)}/follow`,
+      {
+        method,
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      // Revert optimistic update
+      setFollowingStatus((prev) => ({
+        ...prev,
+        [targetUserId]: isCurrentlyFollowing,
+      }));
+      toast.error('Failed to update follow status');
+    } else {
+      // Dispatch event to update profile stats
+      window.dispatchEvent(
+        new CustomEvent('profile-updated', {
+          detail: { type: isCurrentlyFollowing ? 'unfollow' : 'follow' },
+        })
+      );
+    }
+
+    setLoadingFollow((prev) => ({ ...prev, [targetUserId]: false }));
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* Modal */}
+      <div className="relative flex max-h-[80vh] w-full max-w-md flex-col rounded-2xl border border-border bg-background shadow-xl">
+        {/* Header */}
+        <div className="flex items-center justify-between border-border border-b px-6 py-4">
+          <div className="flex items-center gap-2">
+            <Users className="h-5 w-5 text-muted-foreground" />
+            <h2 className="font-bold text-foreground text-xl">
+              {displayTitle}
+            </h2>
+            {!isLoading && (
+              <span className="text-muted-foreground text-sm">
+                ({users.length})
+              </span>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            className="rounded-full p-2 transition-colors hover:bg-muted/50"
+            aria-label="Close"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+            </div>
+          ) : error ? (
+            <div className="flex flex-col items-center justify-center py-12 text-center">
+              <p className="text-muted-foreground">{error}</p>
+              <button
+                onClick={fetchList}
+                className="mt-4 rounded-lg bg-primary px-4 py-2 text-primary-foreground transition-colors hover:bg-primary/90"
+              >
+                Try again
+              </button>
+            </div>
+          ) : users.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-12 text-center">
+              <Users className="mb-4 h-12 w-12 text-muted-foreground opacity-50" />
+              <p className="text-muted-foreground">
+                {type === 'followers'
+                  ? 'No followers yet'
+                  : 'Not following anyone yet'}
+              </p>
+            </div>
+          ) : (
+            <div className="divide-y divide-border">
+              {users.map((followUser) => {
+                const isOwnProfile = user?.id === followUser.id;
+                const isFollowing = followingStatus[followUser.id] || false;
+                const isLoadingThis = loadingFollow[followUser.id] || false;
+                const profileUrl = getProfileUrl(
+                  followUser.id,
+                  followUser.username
+                );
+
+                return (
+                  <div
+                    key={followUser.id}
+                    className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/30"
+                  >
+                    {/* Avatar */}
+                    <Link href={profileUrl} onClick={onClose}>
+                      <Avatar
+                        id={followUser.id}
+                        name={followUser.displayName}
+                        type={followUser.isActor ? 'actor' : 'user'}
+                        src={followUser.profileImageUrl || undefined}
+                        size="md"
+                        className="flex-shrink-0"
+                      />
+                    </Link>
+
+                    {/* User Info */}
+                    <div className="min-w-0 flex-1">
+                      <Link
+                        href={profileUrl}
+                        onClick={onClose}
+                        className="group flex items-center gap-1"
+                      >
+                        <span className="truncate font-semibold text-foreground group-hover:underline">
+                          {followUser.displayName}
+                        </span>
+                        {followUser.isActor && <VerifiedBadge size="sm" />}
+                      </Link>
+                      {followUser.username && (
+                        <p className="truncate text-muted-foreground text-sm">
+                          @{followUser.username}
+                        </p>
+                      )}
+                    </div>
+
+                    {/* Follow Button */}
+                    {authenticated && !isOwnProfile && (
+                      <button
+                        onClick={() => handleFollow(followUser.id)}
+                        disabled={isLoadingThis}
+                        className={cn(
+                          'group relative flex shrink-0 items-center justify-center gap-1.5 rounded-full border px-3 py-1.5 font-bold text-sm transition-all duration-200',
+                          isFollowing
+                            ? 'border-border bg-background text-foreground hover:border-red-500/50 hover:bg-red-500/10 hover:text-red-500'
+                            : 'border-[#0066FF] bg-[#0066FF] text-primary-foreground hover:bg-[#0052CC]',
+                          isLoadingThis && 'cursor-not-allowed opacity-50'
+                        )}
+                      >
+                        {isLoadingThis ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : isFollowing ? (
+                          <>
+                            <span className="group-hover:hidden">
+                              Following
+                            </span>
+                            <span className="hidden group-hover:inline">
+                              Unfollow
+                            </span>
+                          </>
+                        ) : (
+                          <span>Follow</span>
+                        )}
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/profile/FollowListModal.tsx
+++ b/apps/web/src/components/profile/FollowListModal.tsx
@@ -38,7 +38,6 @@ interface FollowUser {
   bio: string | null;
   isActor: boolean;
   followedAt: string;
-  type: 'user' | 'actor';
   tier?: string | null;
   isMutualFollow?: boolean;
 }
@@ -179,7 +178,7 @@ export function FollowListModal({
       return;
     }
 
-    const isCurrentlyFollowing = followingStatus[targetUserId];
+    const isCurrentlyFollowing = followingStatus[targetUserId] ?? false;
     const method = isCurrentlyFollowing ? 'DELETE' : 'POST';
 
     // Optimistic update
@@ -229,11 +228,17 @@ export function FollowListModal({
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="follow-list-modal-title"
+    >
       {/* Backdrop */}
       <div
         className="absolute inset-0 bg-black/50 backdrop-blur-sm"
         onClick={onClose}
+        aria-hidden="true"
       />
 
       {/* Modal */}
@@ -242,7 +247,10 @@ export function FollowListModal({
         <div className="flex items-center justify-between border-border border-b px-6 py-4">
           <div className="flex items-center gap-2">
             <Users className="h-5 w-5 text-muted-foreground" />
-            <h2 className="font-bold text-foreground text-xl">
+            <h2
+              id="follow-list-modal-title"
+              className="font-bold text-foreground text-xl"
+            >
               {displayTitle}
             </h2>
             {!isLoading && (

--- a/apps/web/src/components/profile/FollowListModal.tsx
+++ b/apps/web/src/components/profile/FollowListModal.tsx
@@ -13,8 +13,7 @@ import { useAuth } from '@/hooks/useAuth';
  * FollowListModal component for displaying followers or following lists.
  *
  * Shows a scrollable list of users with their avatars, names, and follow/unfollow
- * buttons. Supports infinite scroll for large lists and provides mutual follow
- * indicators.
+ * buttons. Displays up to 100 users per list.
  *
  * @param props - FollowListModal component props
  * @returns Follow list modal element or null if not open
@@ -50,7 +49,6 @@ interface FollowListModalProps {
   userId: string;
   type: 'followers' | 'following';
   title?: string;
-  initialCount?: number;
 }
 
 export function FollowListModal({
@@ -59,7 +57,6 @@ export function FollowListModal({
   userId,
   type,
   title,
-  initialCount = 0,
 }: FollowListModalProps) {
   const { authenticated, user, getAccessToken } = useAuth();
   const [users, setUsers] = useState<FollowUser[]>([]);
@@ -82,48 +79,53 @@ export function FollowListModal({
     setIsLoading(true);
     setError(null);
 
-    const token = await getAccessToken();
-    const headers: HeadersInit = {
-      'Content-Type': 'application/json',
-    };
-    if (token) {
-      headers['Authorization'] = `Bearer ${token}`;
-    }
-
-    const response = await fetch(
-      `/api/users/${encodeURIComponent(userId)}/${type}?page=1&limit=100&includeMutual=true`,
-      { headers }
-    );
-
-    if (!response.ok) {
-      setError('Failed to load list');
-      setIsLoading(false);
-      return;
-    }
-
-    const data = await response.json();
-    const list = type === 'followers' ? data.followers : data.following;
-    setUsers(list || []);
-
-    // Initialize following status for each user
-    if (authenticated && user) {
-      const statusMap: Record<string, boolean> = {};
-      for (const u of list || []) {
-        if (type === 'following' && userId === user.id) {
-          // Viewing own following list - current user follows everyone in this list
-          statusMap[u.id] = true;
-        } else if (type === 'followers') {
-          // Viewing followers list - use isMutualFollow which indicates if current user follows them
-          statusMap[u.id] = u.isMutualFollow || false;
-        } else {
-          // Viewing someone else's following list - use isMutualFollow
-          statusMap[u.id] = u.isMutualFollow || false;
-        }
+    try {
+      const token = await getAccessToken();
+      const headers: HeadersInit = {
+        'Content-Type': 'application/json',
+      };
+      if (token) {
+        headers['Authorization'] = `Bearer ${token}`;
       }
-      setFollowingStatus(statusMap);
-    }
 
-    setIsLoading(false);
+      const response = await fetch(
+        `/api/users/${encodeURIComponent(userId)}/${type}?page=1&limit=100&includeMutual=true`,
+        { headers }
+      );
+
+      if (!response.ok) {
+        setError('Failed to load list');
+        setIsLoading(false);
+        return;
+      }
+
+      const data = await response.json();
+      const list = type === 'followers' ? data.followers : data.following;
+      setUsers(list || []);
+
+      // Initialize following status for each user
+      if (authenticated && user) {
+        const statusMap: Record<string, boolean> = {};
+        for (const u of list || []) {
+          if (type === 'following' && userId === user.id) {
+            // Viewing own following list - current user follows everyone in this list
+            statusMap[u.id] = true;
+          } else if (type === 'followers') {
+            // Viewing followers list - use isMutualFollow which indicates if current user follows them
+            statusMap[u.id] = u.isMutualFollow || false;
+          } else {
+            // Viewing someone else's following list - use isMutualFollow
+            statusMap[u.id] = u.isMutualFollow || false;
+          }
+        }
+        setFollowingStatus(statusMap);
+      }
+
+      setIsLoading(false);
+    } catch {
+      setError('Network error. Please try again.');
+      setIsLoading(false);
+    }
   }, [isOpen, userId, type, authenticated, user, getAccessToken]);
 
   useEffect(() => {
@@ -186,30 +188,39 @@ export function FollowListModal({
       [targetUserId]: !isCurrentlyFollowing,
     }));
 
-    const response = await fetch(
-      `/api/users/${encodeURIComponent(targetUserId)}/follow`,
-      {
-        method,
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    );
+    try {
+      const response = await fetch(
+        `/api/users/${encodeURIComponent(targetUserId)}/follow`,
+        {
+          method,
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
 
-    if (!response.ok) {
-      // Revert optimistic update
+      if (!response.ok) {
+        // Revert optimistic update
+        setFollowingStatus((prev) => ({
+          ...prev,
+          [targetUserId]: isCurrentlyFollowing,
+        }));
+        toast.error('Failed to update follow status');
+      } else {
+        // Dispatch event to update profile stats
+        window.dispatchEvent(
+          new CustomEvent('profile-updated', {
+            detail: { type: isCurrentlyFollowing ? 'unfollow' : 'follow' },
+          })
+        );
+      }
+    } catch {
+      // Revert optimistic update on network error
       setFollowingStatus((prev) => ({
         ...prev,
         [targetUserId]: isCurrentlyFollowing,
       }));
-      toast.error('Failed to update follow status');
-    } else {
-      // Dispatch event to update profile stats
-      window.dispatchEvent(
-        new CustomEvent('profile-updated', {
-          detail: { type: isCurrentlyFollowing ? 'unfollow' : 'follow' },
-        })
-      );
+      toast.error('Network error. Please try again.');
     }
 
     setLoadingFollow((prev) => ({ ...prev, [targetUserId]: false }));

--- a/apps/web/src/components/profile/FollowListModal.tsx
+++ b/apps/web/src/components/profile/FollowListModal.tsx
@@ -3,7 +3,7 @@
 import { cn, getProfileUrl } from '@babylon/shared';
 import { Loader2, Users, X } from 'lucide-react';
 import Link from 'next/link';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { Avatar } from '@/components/shared/Avatar';
 import { VerifiedBadge } from '@/components/shared/VerifiedBadge';
@@ -68,12 +68,24 @@ export function FollowListModal({
     {}
   );
 
+  // AbortController ref for cancelling pending requests
+  const abortControllerRef = useRef<AbortController | null>(null);
+
   const displayTitle =
     title || (type === 'followers' ? 'Followers' : 'Following');
 
   // Fetch the list when modal opens
   const fetchList = useCallback(async () => {
     if (!isOpen || !userId) return;
+
+    // Cancel any pending request
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+    }
+
+    // Create new AbortController for this request
+    const abortController = new AbortController();
+    abortControllerRef.current = abortController;
 
     setIsLoading(true);
     setError(null);
@@ -88,8 +100,8 @@ export function FollowListModal({
       }
 
       const response = await fetch(
-        `/api/users/${encodeURIComponent(userId)}/${type}?page=1&limit=100&includeMutual=true`,
-        { headers }
+        `/api/users/${encodeURIComponent(userId)}/${type}?page=1&limit=100`,
+        { headers, signal: abortController.signal }
       );
 
       if (!response.ok) {
@@ -103,17 +115,16 @@ export function FollowListModal({
       setUsers(list || []);
 
       // Initialize following status for each user
+      // isFollowedByCurrentUser indicates if the current user follows each person in the list
       if (authenticated && user) {
         const statusMap: Record<string, boolean> = {};
         for (const u of list || []) {
           if (type === 'following' && userId === user.id) {
             // Viewing own following list - current user follows everyone in this list
             statusMap[u.id] = true;
-          } else if (type === 'followers') {
-            // Viewing followers list - use isMutualFollow which indicates if current user follows them
-            statusMap[u.id] = u.isMutualFollow || false;
           } else {
-            // Viewing someone else's following list - use isMutualFollow
+            // Viewing followers or someone else's following list
+            // isMutualFollow indicates if the current user follows this person
             statusMap[u.id] = u.isMutualFollow || false;
           }
         }
@@ -121,11 +132,24 @@ export function FollowListModal({
       }
 
       setIsLoading(false);
-    } catch {
+    } catch (err) {
+      // Ignore abort errors - they're expected when cancelling requests
+      if (err instanceof Error && err.name === 'AbortError') {
+        return;
+      }
       setError('Network error. Please try again.');
       setIsLoading(false);
     }
   }, [isOpen, userId, type, authenticated, user, getAccessToken]);
+
+  // Cleanup abort controller on unmount
+  useEffect(() => {
+    return () => {
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+    };
+  }, []);
 
   useEffect(() => {
     fetchList();

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -227,10 +227,13 @@ export type { ErrorLike, JsonValue, StringRecord } from './types';
 export {
   type CanonicalUser,
   type EnsureUserOptions,
+  type TargetLookupResult,
   ensureUserForAuth,
+  findTargetByIdentifier,
   findUserByIdentifier,
   findUserByIdentifierWithSelect,
   getCanonicalUserId,
+  requireTargetByIdentifier,
   requireUserByIdentifier,
 } from './users';
 // Server-side utilities (require Node.js crypto)

--- a/packages/api/src/users/index.ts
+++ b/packages/api/src/users/index.ts
@@ -12,7 +12,10 @@ export {
 } from './ensure-user';
 
 export {
+  findTargetByIdentifier,
   findUserByIdentifier,
   findUserByIdentifierWithSelect,
+  requireTargetByIdentifier,
   requireUserByIdentifier,
+  type TargetLookupResult,
 } from './user-lookup';

--- a/packages/api/src/users/user-lookup.ts
+++ b/packages/api/src/users/user-lookup.ts
@@ -5,6 +5,7 @@
  */
 
 import { db, eq, or, users } from '@babylon/db';
+import { StaticDataRegistry, type StaticActor } from '@babylon/engine';
 import type { InferSelectModel } from 'drizzle-orm';
 import type { SelectedFields } from 'drizzle-orm/pg-core';
 import { NotFoundError } from '../errors';
@@ -115,4 +116,98 @@ export async function requireUserByIdentifier(
     throw new NotFoundError('User', undefined, { identifier });
   }
   return user;
+}
+
+/**
+ * Result of finding a target by identifier
+ */
+export interface TargetLookupResult {
+  /** The user if found, null otherwise */
+  user: User | null;
+  /** The actor if found, null otherwise */
+  actor: StaticActor | null;
+  /** The resolved target ID (user.id or actor.id) */
+  targetId: string | null;
+  /** Whether the target is an actor (NPC) */
+  isActor: boolean;
+}
+
+/**
+ * Find target (user or actor) by identifier
+ *
+ * @description Searches for a user first, then falls back to actor lookup.
+ * This is useful for API routes that need to handle both users and actors.
+ *
+ * @param {string} identifier - The user ID, privyId, username, or actor ID
+ * @returns {Promise<TargetLookupResult>} Result containing user, actor, and resolved targetId
+ *
+ * @example
+ * ```typescript
+ * const { user, actor, targetId, isActor } = await findTargetByIdentifier('elon-usk');
+ * if (!targetId) {
+ *   throw new NotFoundError('User', undefined, { identifier });
+ * }
+ * ```
+ */
+export async function findTargetByIdentifier(
+  identifier: string
+): Promise<TargetLookupResult> {
+  // Try to find as user first
+  const user = await findUserByIdentifier(identifier);
+
+  if (user) {
+    return {
+      user,
+      actor: null,
+      targetId: user.id,
+      isActor: false,
+    };
+  }
+
+  // Check if it's an actor (NPC) - now also searches by username
+  const actor = StaticDataRegistry.getActor(identifier);
+
+  if (actor) {
+    return {
+      user: null,
+      actor,
+      targetId: actor.id,
+      isActor: true,
+    };
+  }
+
+  // Neither found
+  return {
+    user: null,
+    actor: null,
+    targetId: null,
+    isActor: false,
+  };
+}
+
+/**
+ * Require target (user or actor) by identifier (throws if not found)
+ *
+ * @description Searches for a user or actor and throws NotFoundError if neither is found.
+ *
+ * @param {string} identifier - The user ID, privyId, username, or actor ID
+ * @returns {Promise<TargetLookupResult>} Result containing user, actor, and resolved targetId
+ * @throws {NotFoundError} If neither user nor actor is found
+ *
+ * @example
+ * ```typescript
+ * const { user, actor, targetId, isActor } = await requireTargetByIdentifier('elon-usk');
+ * // targetId is guaranteed to be non-null here
+ * ```
+ */
+export async function requireTargetByIdentifier(
+  identifier: string
+): Promise<TargetLookupResult & { targetId: string }> {
+  const result = await findTargetByIdentifier(identifier);
+
+  if (!result.targetId) {
+    throw new NotFoundError('User', undefined, { identifier });
+  }
+
+  return result as TargetLookupResult & { targetId: string };
 }

--- a/packages/engine/src/services/static-data-registry.ts
+++ b/packages/engine/src/services/static-data-registry.ts
@@ -47,6 +47,7 @@ import { organizations as organizationsData } from '../data/organizations';
 export interface StaticActor {
   id: string;
   name: string;
+  username?: string;
   realName?: string;
   description?: string;
   domain: string[];
@@ -149,6 +150,7 @@ export class StaticDataRegistry {
       const actorAny = actor as {
         id: string;
         name: string;
+        username?: string;
         realName?: string;
         description?: string;
         domain?: string[];
@@ -165,6 +167,7 @@ export class StaticDataRegistry {
       const staticActor: StaticActor = {
         id: actorAny.id,
         name: actorAny.name,
+        username: actorAny.username,
         realName: actorAny.realName,
         description: actorAny.description,
         domain: actorAny.domain ?? [],

--- a/packages/engine/src/services/static-data-registry.ts
+++ b/packages/engine/src/services/static-data-registry.ts
@@ -117,6 +117,7 @@ export interface OrganizationMapping {
 export class StaticDataRegistry {
   // In-memory caches
   private static actorMap: Map<string, StaticActor> | null = null;
+  private static actorByUsername: Map<string, StaticActor> | null = null;
   private static actorList: StaticActor[] | null = null;
   private static orgMap: Map<string, StaticOrganization> | null = null;
   private static orgList: StaticOrganization[] | null = null;
@@ -134,6 +135,7 @@ export class StaticDataRegistry {
     if (this.actorMap !== null) return;
 
     this.actorMap = new Map();
+    this.actorByUsername = new Map();
     this.actorList = [];
     this.actorsByTier = new Map([
       ['S_TIER', []],
@@ -185,6 +187,14 @@ export class StaticDataRegistry {
 
       this.actorMap.set(actor.id, staticActor);
       this.actorList.push(staticActor);
+
+      // Index by username for lookup by username
+      if (staticActor.username) {
+        this.actorByUsername.set(
+          staticActor.username.toLowerCase(),
+          staticActor
+        );
+      }
 
       // Index by tier
       const tierKey = (staticActor.tier ?? 'NONE') as ActorTier | 'NONE';
@@ -270,11 +280,16 @@ export class StaticDataRegistry {
   // ==========================================================================
 
   /**
-   * Get a static actor by ID - NO DATABASE CALL
+   * Get a static actor by ID or username - NO DATABASE CALL
+   * @param identifier - Actor ID or username (case-insensitive for username)
    */
-  static getActor(id: string): StaticActor | null {
+  static getActor(identifier: string): StaticActor | null {
     this.initialize();
-    return this.actorMap?.get(id) ?? null;
+    // First try exact ID match
+    const byId = this.actorMap?.get(identifier);
+    if (byId) return byId;
+    // Then try username match (case-insensitive)
+    return this.actorByUsername?.get(identifier.toLowerCase()) ?? null;
   }
 
   /**
@@ -478,6 +493,7 @@ export class StaticDataRegistry {
    */
   static clearCache(): void {
     this.actorMap = null;
+    this.actorByUsername = null;
     this.actorList = null;
     this.orgMap = null;
     this.orgList = null;

--- a/packages/testing/unit/cron/agent-tick-db.test.ts
+++ b/packages/testing/unit/cron/agent-tick-db.test.ts
@@ -79,10 +79,17 @@ mock.module('@babylon/db', () => {
       onConflictDoNothing: mock(() => builder),
       // Make the builder awaitable
       then: <TResult1 = Array<{ id: string }>, TResult2 = never>(
-        onFulfilled?: ((value: Array<{ id: string }>) => TResult1 | PromiseLike<TResult1>) | null,
-        onRejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
+        onFulfilled?:
+          | ((value: Array<{ id: string }>) => TResult1 | PromiseLike<TResult1>)
+          | null,
+        onRejected?:
+          | ((reason: unknown) => TResult2 | PromiseLike<TResult2>)
+          | null
       ): Promise<TResult1 | TResult2> => {
-        return Promise.resolve([{ id: 'mock-lock-id' }]).then(onFulfilled, onRejected);
+        return Promise.resolve([{ id: 'mock-lock-id' }]).then(
+          onFulfilled,
+          onRejected
+        );
       },
     };
     return builder;


### PR DESCRIPTION
https://github.com/user-attachments/assets/4f641f4c-d857-4bdd-ab08-29f0863ffbf5

Previously, clicking on the followers/following counts on profile pages did nothing (linked to #). This PR implements a followers/following list modal that displays users and actors with their avatars, display names, and usernames, with functional follow/unfollow buttons showing correct states. Also adds username lookup support for actors so they can be accessed via their username URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Follow List modal for Followers/Following with per-item follow/unfollow and optimistic updates.
  * Mutual-follow indicator on list items when viewing as an authenticated user.
  * NPC/actor entries included and visually distinguished in lists.

* **Enhancements**
  * Improved username/display consistency across follower and following entries.
  * More reliable target resolution with explicit not-found behavior when loading lists.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR implements interactive followers/following lists by replacing placeholder links with a functional modal component. The modal displays users and NPC actors with their avatars, display names, usernames, and working follow/unfollow buttons. 

**Key changes:**
- Created `FollowListModal` component with optimistic UI updates and proper error handling
- Updated followers/following API endpoints to support actor username lookup and return mutual follow indicators for authenticated users
- Modified profile pages to open the modal when clicking follower/following counts
- Added username field to `StaticActor` interface and registry
- Enabled actor profile lookup by username in addition to ID

The implementation properly handles both regular users and NPC actors across all endpoints, with the backend routing follow operations to the appropriate database tables (`follows` for users, `userActorFollows` for actors).

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The implementation is clean, well-structured, and properly handles both user and actor entities throughout. The code follows existing patterns, includes proper error handling with optimistic UI updates and rollback, and integrates seamlessly with the existing follow/unfollow API infrastructure. The changes are additive (new modal component) with minimal modifications to existing code.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/components/profile/FollowListModal.tsx | new modal component for displaying followers/following lists with functional follow/unfollow buttons |
| apps/web/src/app/api/users/[userId]/followers/route.ts | adds username support for actors and mutual follow indicators, enables actor username lookup |
| apps/web/src/app/api/users/[userId]/following/route.ts | adds username support for actors, enables actor username lookup |
| apps/web/src/app/profile/[id]/page.tsx | replaces static links with interactive buttons that open follower/following modal, adds username lookup |
| apps/web/src/app/profile/page.tsx | replaces static links with interactive buttons that open follower/following modal |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    actor User
    participant ProfilePage
    participant FollowListModal
    participant FollowersAPI
    participant FollowingAPI
    participant FollowAPI
    participant Database
    participant StaticDataRegistry

    User->>ProfilePage: Click on Followers/Following count
    ProfilePage->>FollowListModal: Open modal (type, userId)
    
    alt Type is "followers"
        FollowListModal->>FollowersAPI: GET /api/users/{userId}/followers
        FollowersAPI->>Database: Query user followers
        FollowersAPI->>Database: Query actor followers
        FollowersAPI->>StaticDataRegistry: Enrich actor data (username, profile)
        alt Authenticated
            FollowersAPI->>Database: Check mutual follow status
        end
        FollowersAPI-->>FollowListModal: Return followers list with isMutualFollow
    else Type is "following"
        FollowListModal->>FollowingAPI: GET /api/users/{userId}/following
        FollowingAPI->>Database: Query user following
        FollowingAPI->>Database: Query actor following
        FollowingAPI->>StaticDataRegistry: Enrich actor data (username, profile)
        alt Viewing own list & authenticated
            FollowingAPI->>Database: Check mutual follow status
        end
        FollowingAPI-->>FollowListModal: Return following list
    end
    
    FollowListModal->>FollowListModal: Initialize follow button states
    FollowListModal-->>User: Display list with avatars and buttons
    
    User->>FollowListModal: Click Follow/Unfollow button
    FollowListModal->>FollowListModal: Optimistic UI update
    alt Follow action
        FollowListModal->>FollowAPI: POST /api/users/{targetId}/follow
    else Unfollow action
        FollowListModal->>FollowAPI: DELETE /api/users/{targetId}/follow
    end
    
    alt Target is user
        FollowAPI->>Database: Insert/Delete follows record
    else Target is actor
        FollowAPI->>Database: Insert/Delete userActorFollows record
    end
    
    alt Success
        FollowAPI-->>FollowListModal: Success response
        FollowListModal->>ProfilePage: Dispatch profile-updated event
        ProfilePage->>ProfilePage: Update follower counts
    else Error
        FollowAPI-->>FollowListModal: Error response
        FollowListModal->>FollowListModal: Revert optimistic update
        FollowListModal-->>User: Show error toast
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->