### PR TITLE
fix(markets): migrate currency symbol from $ to Ƀ [Stack 1/2]

### DIFF
--- a/apps/web/src/app/markets/predictions/[id]/page.tsx
+++ b/apps/web/src/app/markets/predictions/[id]/page.tsx
@@ -616,7 +616,7 @@ export default function PredictionDetailPage() {
             {/* Amount Input */}
             <div className="mb-4">
               <label className="mb-2 block font-medium text-muted-foreground text-sm">
-                Amount (PTS)
+                Amount ({BABYLON_POINTS_SYMBOL})
               </label>
               <input
                 type="number"

--- a/apps/web/src/app/markets/predictions/[id]/page.tsx
+++ b/apps/web/src/app/markets/predictions/[id]/page.tsx
@@ -498,7 +498,7 @@ export default function PredictionDetailPage() {
                   think it won&apos;t.
                 </p>
                 <p className="text-muted-foreground text-sm">
-                  If you&apos;re right, you&apos;ll receive $1 per share. The
+                  If you&apos;re right, you&apos;ll receive Ƀ1 per share. The
                   current price reflects the market&apos;s probability.
                 </p>
               </div>

--- a/apps/web/src/components/charts/LightweightChartBase.tsx
+++ b/apps/web/src/components/charts/LightweightChartBase.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { logger } from '@babylon/shared';
+import { BABYLON_POINTS_SYMBOL, logger } from '@babylon/shared';
 import type {
   AreaSeriesOptions,
   ChartOptions,
@@ -245,7 +245,7 @@ export function formatChartTime(timestamp: number): Time {
  * Format price for display.
  */
 export function formatChartPrice(value: number, includeSymbol = false): string {
-  const prefix = includeSymbol ? '$' : '';
+  const prefix = includeSymbol ? BABYLON_POINTS_SYMBOL : '';
 
   if (value === 0) return `${prefix}0`;
   if (value >= 1_000_000_000)

--- a/apps/web/src/components/markets/AssetTradesFeed.tsx
+++ b/apps/web/src/components/markets/AssetTradesFeed.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { cn, logger } from '@babylon/shared';
+import { BABYLON_POINTS_SYMBOL, cn, logger } from '@babylon/shared';
 import {
   AlertCircle,
   ArrowUpDown,
@@ -347,12 +347,7 @@ export function AssetTradesFeed({
 
   const formatCurrency = (value: string | number) => {
     const num = typeof value === 'string' ? Number.parseFloat(value) : value;
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD',
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }).format(num);
+    return `${BABYLON_POINTS_SYMBOL}${num.toFixed(2)}`;
   };
 
   const formatTime = (timestamp: string) => {

--- a/apps/web/src/components/markets/AssetTradesFeed.tsx
+++ b/apps/web/src/components/markets/AssetTradesFeed.tsx
@@ -1,6 +1,10 @@
 'use client';
 
-import { BABYLON_POINTS_SYMBOL, cn, logger } from '@babylon/shared';
+import {
+  cn,
+  formatCurrency as formatCurrencyShared,
+  logger,
+} from '@babylon/shared';
 import {
   AlertCircle,
   ArrowUpDown,
@@ -345,9 +349,10 @@ export function AssetTradesFeed({
     },
   });
 
+  /** Wrapper around shared formatCurrency to handle string input */
   const formatCurrency = (value: string | number) => {
     const num = typeof value === 'string' ? Number.parseFloat(value) : value;
-    return `${BABYLON_POINTS_SYMBOL}${num.toFixed(2)}`;
+    return formatCurrencyShared(num);
   };
 
   const formatTime = (timestamp: string) => {

--- a/apps/web/src/components/markets/CategoryPnLShareCard.tsx
+++ b/apps/web/src/components/markets/CategoryPnLShareCard.tsx
@@ -1,3 +1,4 @@
+import { BABYLON_POINTS_SYMBOL } from '@babylon/shared';
 import type { User } from '@/stores/authStore';
 import type { MarketCategory } from '@/types/markets';
 
@@ -49,24 +50,16 @@ interface CategoryPnLShareCardProps {
 }
 
 /**
- * Currency formatter for displaying monetary values.
- */
-const formatter = new Intl.NumberFormat('en-US', {
-  style: 'currency',
-  currency: 'USD',
-  maximumFractionDigits: 2,
-});
-
-/**
  * Format currency value safely.
  *
- * Formats a number as currency, defaulting to 0 if invalid.
+ * Formats a number as Babylon points, defaulting to 0 if invalid.
  *
  * @param value - Value to format
  * @returns Formatted currency string
  */
 function formatCurrency(value: number) {
-  return formatter.format(Number.isFinite(value) ? value : 0);
+  const safeValue = Number.isFinite(value) ? value : 0;
+  return `${BABYLON_POINTS_SYMBOL}${safeValue.toFixed(2)}`;
 }
 
 /**

--- a/apps/web/src/components/markets/MarketOverviewPanel.tsx
+++ b/apps/web/src/components/markets/MarketOverviewPanel.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { cn } from '@babylon/shared';
+import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
 import {
   Activity,
   BarChart3,
-  DollarSign,
+  Coins,
   TrendingDown,
   TrendingUp,
 } from 'lucide-react';
@@ -116,9 +116,9 @@ export function MarketOverviewPanel() {
   }, [predictionMarkets]);
 
   const formatVolume = (v: number) => {
-    if (v >= 1e9) return `$${(v / 1e9).toFixed(2)}B`;
-    if (v >= 1e6) return `$${(v / 1e6).toFixed(2)}M`;
-    return `$${(v / 1e3).toFixed(2)}K`;
+    if (v >= 1e9) return `${BABYLON_POINTS_SYMBOL}${(v / 1e9).toFixed(2)}B`;
+    if (v >= 1e6) return `${BABYLON_POINTS_SYMBOL}${(v / 1e6).toFixed(2)}M`;
+    return `${BABYLON_POINTS_SYMBOL}${(v / 1e3).toFixed(2)}K`;
   };
 
   return (
@@ -145,7 +145,7 @@ export function MarketOverviewPanel() {
             </div>
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-1.5">
-                <DollarSign className="h-3.5 w-3.5 text-muted-foreground" />
+                <Coins className="h-3.5 w-3.5 text-muted-foreground" />
                 <span className="text-muted-foreground text-sm">
                   24h Volume
                 </span>

--- a/apps/web/src/components/markets/PerpPositionsList.tsx
+++ b/apps/web/src/components/markets/PerpPositionsList.tsx
@@ -4,6 +4,7 @@ import {
   BABYLON_POINTS_SYMBOL,
   calculateUnrealizedPnL,
   cn,
+  formatCurrency,
 } from '@babylon/shared';
 import { AlertTriangle, TrendingDown, TrendingUp } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
@@ -143,9 +144,8 @@ export function PerpPositionsList({
     setPendingClose(null);
   }, [closePerpPosition, onPositionClosed, pendingClose]);
 
-  const formatPrice = (price: number) => {
-    return `${BABYLON_POINTS_SYMBOL}${price.toFixed(2)}`;
-  };
+  /** Use shared formatCurrency for price formatting */
+  const formatPrice = formatCurrency;
 
   const formatDate = (dateStr: string) => {
     const date = new Date(dateStr);

--- a/apps/web/src/components/markets/PerpPositionsList.tsx
+++ b/apps/web/src/components/markets/PerpPositionsList.tsx
@@ -1,6 +1,10 @@
 'use client';
 
-import { calculateUnrealizedPnL, cn } from '@babylon/shared';
+import {
+  BABYLON_POINTS_SYMBOL,
+  calculateUnrealizedPnL,
+  cn,
+} from '@babylon/shared';
 import { AlertTriangle, TrendingDown, TrendingUp } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
@@ -129,7 +133,7 @@ export function PerpPositionsList({
           : 0;
 
     toast.success('Position closed!', {
-      description: `${pendingClose.position.ticker}: ${pnl >= 0 ? '+' : ''}$${pnl.toFixed(2)} PnL`,
+      description: `${pendingClose.position.ticker}: ${pnl >= 0 ? '+' : ''}${BABYLON_POINTS_SYMBOL}${pnl.toFixed(2)} PnL`,
     });
 
     // Invalidate cache to ensure fresh data on next fetch
@@ -140,12 +144,7 @@ export function PerpPositionsList({
   }, [closePerpPosition, onPositionClosed, pendingClose]);
 
   const formatPrice = (price: number) => {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD',
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }).format(price);
+    return `${BABYLON_POINTS_SYMBOL}${price.toFixed(2)}`;
   };
 
   const formatDate = (dateStr: string) => {

--- a/apps/web/src/components/markets/PerpPositionsList.tsx
+++ b/apps/web/src/components/markets/PerpPositionsList.tsx
@@ -133,8 +133,9 @@ export function PerpPositionsList({
           ? data.realizedPnL
           : 0;
 
+    const pnlSign = pnl >= 0 ? '+' : '-';
     toast.success('Position closed!', {
-      description: `${pendingClose.position.ticker}: ${pnl >= 0 ? '+' : ''}${BABYLON_POINTS_SYMBOL}${pnl.toFixed(2)} PnL`,
+      description: `${pendingClose.position.ticker}: ${pnlSign}${BABYLON_POINTS_SYMBOL}${Math.abs(pnl).toFixed(2)} PnL`,
     });
 
     // Invalidate cache to ensure fresh data on next fetch

--- a/apps/web/src/components/markets/PerpPriceChart.test.tsx
+++ b/apps/web/src/components/markets/PerpPriceChart.test.tsx
@@ -8,6 +8,7 @@
  * - Edge cases
  */
 
+import { BABYLON_POINTS_SYMBOL } from '@babylon/shared';
 import { describe, expect, it } from 'bun:test';
 
 // Mock data generator
@@ -102,49 +103,49 @@ describe('PerpPriceChart - Data Processing', () => {
   describe('Price Formatting Logic', () => {
     it('should format billions correctly', () => {
       const price = 1500000000;
-      const formatted = `$${(price / 1000000000).toFixed(2)}B`;
+      const formatted = `${BABYLON_POINTS_SYMBOL}${(price / 1000000000).toFixed(2)}B`;
 
-      expect(formatted).toBe('$1.50B');
+      expect(formatted).toBe(`${BABYLON_POINTS_SYMBOL}1.50B`);
     });
 
     it('should format millions correctly', () => {
       const price = 1500000;
-      const formatted = `$${(price / 1000000).toFixed(2)}M`;
+      const formatted = `${BABYLON_POINTS_SYMBOL}${(price / 1000000).toFixed(2)}M`;
 
-      expect(formatted).toBe('$1.50M');
+      expect(formatted).toBe(`${BABYLON_POINTS_SYMBOL}1.50M`);
     });
 
     it('should format thousands correctly', () => {
       const price = 1500;
-      const formatted = `$${(price / 1000).toFixed(2)}K`;
+      const formatted = `${BABYLON_POINTS_SYMBOL}${(price / 1000).toFixed(2)}K`;
 
-      expect(formatted).toBe('$1.50K');
+      expect(formatted).toBe(`${BABYLON_POINTS_SYMBOL}1.50K`);
     });
 
     it('should format regular prices correctly', () => {
       const price = 123.456;
-      const formatted = `$${price.toFixed(2)}`;
+      const formatted = `${BABYLON_POINTS_SYMBOL}${price.toFixed(2)}`;
 
-      expect(formatted).toBe('$123.46');
+      expect(formatted).toBe(`${BABYLON_POINTS_SYMBOL}123.46`);
     });
 
     it('should format small decimals correctly', () => {
       const price = 0.001234;
-      const formatted = `$${price.toFixed(6)}`;
+      const formatted = `${BABYLON_POINTS_SYMBOL}${price.toFixed(6)}`;
 
-      expect(formatted).toBe('$0.001234');
+      expect(formatted).toBe(`${BABYLON_POINTS_SYMBOL}0.001234`);
     });
 
     it('should format very small decimals correctly', () => {
       const price = 0.00000123;
-      const formatted = `$${price.toFixed(8)}`;
+      const formatted = `${BABYLON_POINTS_SYMBOL}${price.toFixed(8)}`;
 
-      expect(formatted).toBe('$0.00000123');
+      expect(formatted).toBe(`${BABYLON_POINTS_SYMBOL}0.00000123`);
     });
 
     it('should handle zero price', () => {
       const price = 0;
-      const formatted = price === 0 ? '' : `$${price}`;
+      const formatted = price === 0 ? '' : `${BABYLON_POINTS_SYMBOL}${price}`;
 
       expect(formatted).toBe('');
     });

--- a/apps/web/src/components/markets/PerpTradingModal.tsx
+++ b/apps/web/src/components/markets/PerpTradingModal.tsx
@@ -157,7 +157,7 @@ export function PerpTradingModal({
       });
 
       toast.success('Position opened!', {
-        description: `Opened ${leverage}x ${side} on ${market.ticker} at $${result.position.entryPrice.toFixed(2)}`,
+        description: `Opened ${leverage}x ${side} on ${market.ticker} at ${BABYLON_POINTS_SYMBOL}${result.position.entryPrice.toFixed(2)}`,
       });
 
       // Invalidate caches to ensure fresh data on next fetch

--- a/apps/web/src/components/markets/PnLShareModal.test.tsx
+++ b/apps/web/src/components/markets/PnLShareModal.test.tsx
@@ -1,0 +1,74 @@
+import { BABYLON_POINTS_SYMBOL } from '@babylon/shared';
+import { describe, expect, it } from 'bun:test';
+
+/**
+ * Tests for PnL formatting logic used in PnLShareModal.
+ *
+ * These tests verify that the P&L sign is correctly displayed
+ * for both positive and negative values in share messages.
+ */
+describe('PnLShareModal - P&L Sign Formatting', () => {
+  /**
+   * Helper function that replicates the shareText formatting logic.
+   * This is extracted from PnLShareModal to enable unit testing.
+   */
+  const formatPnLForShare = (pnl: number): string => {
+    const sign = pnl >= 0 ? '+' : '-';
+    return `${sign}${BABYLON_POINTS_SYMBOL}${Math.abs(pnl).toFixed(2)}`;
+  };
+
+  describe('formatPnLForShare', () => {
+    it('should format positive P&L with plus sign', () => {
+      expect(formatPnLForShare(100)).toBe(`+${BABYLON_POINTS_SYMBOL}100.00`);
+      expect(formatPnLForShare(0.01)).toBe(`+${BABYLON_POINTS_SYMBOL}0.01`);
+      expect(formatPnLForShare(1234.56)).toBe(
+        `+${BABYLON_POINTS_SYMBOL}1234.56`
+      );
+    });
+
+    it('should format zero P&L with plus sign', () => {
+      expect(formatPnLForShare(0)).toBe(`+${BABYLON_POINTS_SYMBOL}0.00`);
+    });
+
+    it('should format negative P&L with minus sign', () => {
+      expect(formatPnLForShare(-100)).toBe(`-${BABYLON_POINTS_SYMBOL}100.00`);
+      expect(formatPnLForShare(-0.01)).toBe(`-${BABYLON_POINTS_SYMBOL}0.01`);
+      expect(formatPnLForShare(-1234.56)).toBe(
+        `-${BABYLON_POINTS_SYMBOL}1234.56`
+      );
+    });
+
+    it('should handle edge cases correctly', () => {
+      // Very small negative number
+      expect(formatPnLForShare(-0.001)).toBe(`-${BABYLON_POINTS_SYMBOL}0.00`);
+      // Large positive number
+      expect(formatPnLForShare(999999.99)).toBe(
+        `+${BABYLON_POINTS_SYMBOL}999999.99`
+      );
+      // Large negative number
+      expect(formatPnLForShare(-999999.99)).toBe(
+        `-${BABYLON_POINTS_SYMBOL}999999.99`
+      );
+    });
+  });
+
+  describe('Share text generation', () => {
+    it('should include correct sign in portfolio share text', () => {
+      const portfolioPnL = -50.25;
+      const sign = portfolioPnL >= 0 ? '+' : '-';
+      const shareText = `My Babylon P&L is ${sign}${BABYLON_POINTS_SYMBOL}${Math.abs(portfolioPnL).toFixed(2)}. Trading narratives, sharing the upside.`;
+
+      expect(shareText).toContain('-Ƀ50.25');
+      expect(shareText).not.toContain('+Ƀ50.25');
+    });
+
+    it('should include correct sign in category share text', () => {
+      const categoryPnL = 150.75;
+      const sign = categoryPnL >= 0 ? '+' : '-';
+      const shareText = `My Perps P&L on Babylon is ${sign}${BABYLON_POINTS_SYMBOL}${Math.abs(categoryPnL).toFixed(2)}. Trading narratives, sharing the upside.`;
+
+      expect(shareText).toContain('+Ƀ150.75');
+      expect(shareText).not.toContain('-Ƀ150.75');
+    });
+  });
+});

--- a/apps/web/src/components/markets/PnLShareModal.tsx
+++ b/apps/web/src/components/markets/PnLShareModal.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import { getReferralUrl, logger, trackExternalShare } from '@babylon/shared';
+import {
+  BABYLON_POINTS_SYMBOL,
+  getReferralUrl,
+  logger,
+  trackExternalShare,
+} from '@babylon/shared';
 import { usePrivy } from '@privy-io/react-auth';
 import { Download, LogOut, Twitter, X } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -152,10 +157,10 @@ export function PnLShareModal({
       'Join me in Babylon, a real-time simulation where humans and AI agents battle across prediction markets, form alliances, and shape outcomes—together.';
 
     if (type === 'portfolio' && portfolioData) {
-      return `My Babylon P&L is ${portfolioData.totalPnL >= 0 ? '+' : ''}$${Math.abs(portfolioData.totalPnL).toFixed(2)}. Trading narratives, sharing the upside.\n\n${standardMessage}\n\n${link}`;
+      return `My Babylon P&L is ${portfolioData.totalPnL >= 0 ? '+' : ''}${BABYLON_POINTS_SYMBOL}${Math.abs(portfolioData.totalPnL).toFixed(2)}. Trading narratives, sharing the upside.\n\n${standardMessage}\n\n${link}`;
     }
     if (type === 'category' && categoryData) {
-      return `My ${categoryLabel} P&L on Babylon is ${categoryData.unrealizedPnL >= 0 ? '+' : ''}$${Math.abs(categoryData.unrealizedPnL).toFixed(2)}. Trading narratives, sharing the upside.\n\n${standardMessage}\n\n${link}`;
+      return `My ${categoryLabel} P&L on Babylon is ${categoryData.unrealizedPnL >= 0 ? '+' : ''}${BABYLON_POINTS_SYMBOL}${Math.abs(categoryData.unrealizedPnL).toFixed(2)}. Trading narratives, sharing the upside.\n\n${standardMessage}\n\n${link}`;
     }
     return `${standardMessage}\n\n${link}`;
   }, [

--- a/apps/web/src/components/markets/PnLShareModal.tsx
+++ b/apps/web/src/components/markets/PnLShareModal.tsx
@@ -157,10 +157,12 @@ export function PnLShareModal({
       'Join me in Babylon, a real-time simulation where humans and AI agents battle across prediction markets, form alliances, and shape outcomes—together.';
 
     if (type === 'portfolio' && portfolioData) {
-      return `My Babylon P&L is ${portfolioData.totalPnL >= 0 ? '+' : ''}${BABYLON_POINTS_SYMBOL}${Math.abs(portfolioData.totalPnL).toFixed(2)}. Trading narratives, sharing the upside.\n\n${standardMessage}\n\n${link}`;
+      const sign = portfolioData.totalPnL >= 0 ? '+' : '-';
+      return `My Babylon P&L is ${sign}${BABYLON_POINTS_SYMBOL}${Math.abs(portfolioData.totalPnL).toFixed(2)}. Trading narratives, sharing the upside.\n\n${standardMessage}\n\n${link}`;
     }
     if (type === 'category' && categoryData) {
-      return `My ${categoryLabel} P&L on Babylon is ${categoryData.unrealizedPnL >= 0 ? '+' : ''}${BABYLON_POINTS_SYMBOL}${Math.abs(categoryData.unrealizedPnL).toFixed(2)}. Trading narratives, sharing the upside.\n\n${standardMessage}\n\n${link}`;
+      const sign = categoryData.unrealizedPnL >= 0 ? '+' : '-';
+      return `My ${categoryLabel} P&L on Babylon is ${sign}${BABYLON_POINTS_SYMBOL}${Math.abs(categoryData.unrealizedPnL).toFixed(2)}. Trading narratives, sharing the upside.\n\n${standardMessage}\n\n${link}`;
     }
     return `${standardMessage}\n\n${link}`;
   }, [

--- a/apps/web/src/components/markets/PortfolioPnLCard.tsx
+++ b/apps/web/src/components/markets/PortfolioPnLCard.tsx
@@ -1,3 +1,4 @@
+import { BABYLON_POINTS_SYMBOL } from '@babylon/shared';
 import { Share2, Sparkles } from 'lucide-react';
 import type { PortfolioPnLSnapshot } from '@/hooks/usePortfolioPnL';
 
@@ -38,18 +39,9 @@ interface PortfolioPnLCardProps {
 }
 
 /**
- * Currency formatter for displaying monetary values.
- */
-const formatter = new Intl.NumberFormat('en-US', {
-  style: 'currency',
-  currency: 'USD',
-  maximumFractionDigits: 2,
-});
-
-/**
  * Format currency value safely.
  *
- * Formats a number as currency, defaulting to 0 if invalid.
+ * Formats a number as Babylon points, defaulting to 0 if invalid.
  *
  * @param value - Value to format
  * @returns Formatted currency string
@@ -57,7 +49,7 @@ const formatter = new Intl.NumberFormat('en-US', {
 function formatCurrency(value: number | null | undefined) {
   const safeValue =
     typeof value === 'number' && Number.isFinite(value) ? value : 0;
-  return formatter.format(safeValue);
+  return `${BABYLON_POINTS_SYMBOL}${safeValue.toFixed(2)}`;
 }
 
 export function PortfolioPnLCard({

--- a/apps/web/src/components/markets/PortfolioPnLShareCard.tsx
+++ b/apps/web/src/components/markets/PortfolioPnLShareCard.tsx
@@ -1,3 +1,4 @@
+import { BABYLON_POINTS_SYMBOL } from '@babylon/shared';
 import type { PortfolioPnLSnapshot } from '@/hooks/usePortfolioPnL';
 import type { User } from '@/stores/authStore';
 
@@ -33,24 +34,16 @@ interface PortfolioPnLShareCardProps {
 }
 
 /**
- * Currency formatter for displaying monetary values.
- */
-const formatter = new Intl.NumberFormat('en-US', {
-  style: 'currency',
-  currency: 'USD',
-  maximumFractionDigits: 2,
-});
-
-/**
  * Format currency value safely.
  *
- * Formats a number as currency, defaulting to 0 if invalid.
+ * Formats a number as Babylon points, defaulting to 0 if invalid.
  *
  * @param value - Value to format
  * @returns Formatted currency string
  */
 function formatCurrency(value: number) {
-  return formatter.format(Number.isFinite(value) ? value : 0);
+  const safeValue = Number.isFinite(value) ? value : 0;
+  return `${BABYLON_POINTS_SYMBOL}${safeValue.toFixed(2)}`;
 }
 
 export function PortfolioPnLShareCard({

--- a/apps/web/src/components/markets/PredictionPositionsList.tsx
+++ b/apps/web/src/components/markets/PredictionPositionsList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { UserPredictionPosition } from '@babylon/shared';
-import { cn, logger } from '@babylon/shared';
+import { BABYLON_POINTS_SYMBOL, cn, logger } from '@babylon/shared';
 import { usePrivy } from '@privy-io/react-auth';
 import { CheckCircle, XCircle } from 'lucide-react';
 import { useState } from 'react';
@@ -124,7 +124,7 @@ export function PredictionPositionsList({
       const data: SellSharesSuccessResponse = await response.json();
       const pnl = data.pnl;
       toast.success('Shares sold!', {
-        description: `Sold ${position.shares.toFixed(2)} ${position.side} shares for ${pnl >= 0 ? '+' : ''}$${pnl.toFixed(2)} PnL`,
+        description: `Sold ${position.shares.toFixed(2)} ${position.side} shares for ${pnl >= 0 ? '+' : ''}${BABYLON_POINTS_SYMBOL}${pnl.toFixed(2)} PnL`,
       });
 
       onPositionSold?.();
@@ -143,7 +143,7 @@ export function PredictionPositionsList({
     }
   };
 
-  const formatPrice = (price: number) => `$${price.toFixed(3)}`;
+  const formatPrice = (price: number) => `${BABYLON_POINTS_SYMBOL}${price.toFixed(3)}`;
 
   if (positions.length === 0) {
     return (

--- a/apps/web/src/components/markets/PredictionPositionsList.tsx
+++ b/apps/web/src/components/markets/PredictionPositionsList.tsx
@@ -128,8 +128,9 @@ export function PredictionPositionsList({
 
       const data: SellSharesSuccessResponse = await response.json();
       const pnl = data.pnl;
+      const pnlSign = pnl >= 0 ? '+' : '-';
       toast.success('Shares sold!', {
-        description: `Sold ${position.shares.toFixed(2)} ${position.side} shares for ${pnl >= 0 ? '+' : ''}${BABYLON_POINTS_SYMBOL}${pnl.toFixed(2)} PnL`,
+        description: `Sold ${position.shares.toFixed(2)} ${position.side} shares for ${pnlSign}${BABYLON_POINTS_SYMBOL}${Math.abs(pnl).toFixed(2)} PnL`,
       });
 
       onPositionSold?.();

--- a/apps/web/src/components/markets/PredictionPositionsList.tsx
+++ b/apps/web/src/components/markets/PredictionPositionsList.tsx
@@ -1,7 +1,12 @@
 'use client';
 
 import type { UserPredictionPosition } from '@babylon/shared';
-import { BABYLON_POINTS_SYMBOL, cn, logger } from '@babylon/shared';
+import {
+  BABYLON_POINTS_SYMBOL,
+  cn,
+  formatCurrency,
+  logger,
+} from '@babylon/shared';
 import { usePrivy } from '@privy-io/react-auth';
 import { CheckCircle, XCircle } from 'lucide-react';
 import { useState } from 'react';
@@ -143,7 +148,8 @@ export function PredictionPositionsList({
     }
   };
 
-  const formatPrice = (price: number) => `${BABYLON_POINTS_SYMBOL}${price.toFixed(3)}`;
+  /** Use shared formatCurrency with 3 decimals for prediction prices */
+  const formatPrice = (price: number) => formatCurrency(price, 3);
 
   if (positions.length === 0) {
     return (

--- a/apps/web/src/components/markets/TopMoversPanel.tsx
+++ b/apps/web/src/components/markets/TopMoversPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { cn } from '@babylon/shared';
+import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
 import { TrendingDown, TrendingUp } from 'lucide-react';
 import { Skeleton } from '@/components/shared/Skeleton';
 import {
@@ -35,7 +35,7 @@ export function TopMoversPanel({ onMarketClick }: TopMoversPanelProps) {
   const { topGainers, topLosers, loading } = usePerpTopMovers(4);
   usePerpMarketsPolling(30000); // Enable 30s polling
 
-  const formatPrice = (p: number) => `$${p.toFixed(2)}`;
+  const formatPrice = (p: number) => `${BABYLON_POINTS_SYMBOL}${p.toFixed(2)}`;
 
   return (
     <div className="flex flex-1 flex-col rounded-2xl bg-sidebar px-4 py-3">

--- a/apps/web/src/components/markets/TopMoversPanel.tsx
+++ b/apps/web/src/components/markets/TopMoversPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
+import { cn, formatCurrency } from '@babylon/shared';
 import { TrendingDown, TrendingUp } from 'lucide-react';
 import { Skeleton } from '@/components/shared/Skeleton';
 import {
@@ -35,7 +35,8 @@ export function TopMoversPanel({ onMarketClick }: TopMoversPanelProps) {
   const { topGainers, topLosers, loading } = usePerpTopMovers(4);
   usePerpMarketsPolling(30000); // Enable 30s polling
 
-  const formatPrice = (p: number) => `${BABYLON_POINTS_SYMBOL}${p.toFixed(2)}`;
+  /** Use shared formatCurrency for price formatting */
+  const formatPrice = formatCurrency;
 
   return (
     <div className="flex flex-1 flex-col rounded-2xl bg-sidebar px-4 py-3">

--- a/apps/web/src/components/markets/TradeConfirmationDialog.tsx
+++ b/apps/web/src/components/markets/TradeConfirmationDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { cn } from '@babylon/shared';
+import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
 import {
   AlertTriangle,
   CheckCircle,
@@ -155,12 +155,7 @@ export function TradeConfirmationDialog({
   if (!tradeDetails) return null;
 
   const formatPrice = (price: number) => {
-    return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD',
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }).format(price);
+    return `${BABYLON_POINTS_SYMBOL}${price.toFixed(2)}`;
   };
 
   const getTitle = () => {

--- a/apps/web/src/components/markets/TradeConfirmationDialog.tsx
+++ b/apps/web/src/components/markets/TradeConfirmationDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
+import { cn, formatCurrency } from '@babylon/shared';
 import {
   AlertTriangle,
   CheckCircle,
@@ -154,9 +154,8 @@ export function TradeConfirmationDialog({
 }: TradeConfirmationDialogProps) {
   if (!tradeDetails) return null;
 
-  const formatPrice = (price: number) => {
-    return `${BABYLON_POINTS_SYMBOL}${price.toFixed(2)}`;
-  };
+  /** Use shared formatCurrency for price formatting */
+  const formatPrice = formatCurrency;
 
   const getTitle = () => {
     switch (tradeDetails.type) {

--- a/apps/web/src/components/profile/TradingProfile.tsx
+++ b/apps/web/src/components/profile/TradingProfile.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
+import { cn, formatCompactCurrency } from '@babylon/shared';
 import {
   Activity,
   AlertCircle,
@@ -311,15 +311,8 @@ export function TradingProfile({
     };
   }, [fetchTradingData]);
 
-  const formatCurrency = (value: number) => {
-    if (!Number.isFinite(value)) return `${BABYLON_POINTS_SYMBOL}0.00`;
-    const abs = Math.abs(value);
-    if (abs >= 1000000)
-      return `${BABYLON_POINTS_SYMBOL}${(value / 1000000).toFixed(2)}M`;
-    if (abs >= 1000)
-      return `${BABYLON_POINTS_SYMBOL}${(value / 1000).toFixed(2)}K`;
-    return `${BABYLON_POINTS_SYMBOL}${value.toFixed(2)}`;
-  };
+  /** Use shared formatCompactCurrency for K/M/B suffix formatting */
+  const formatCurrency = formatCompactCurrency;
 
   const calculateCurrentPrice = (market: PredictionPosition['Market']) => {
     const yesShares = toNumber(market.yesShares);

--- a/apps/web/src/components/profile/TradingProfile.tsx
+++ b/apps/web/src/components/profile/TradingProfile.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { cn } from '@babylon/shared';
+import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
 import {
   Activity,
   AlertCircle,
   BarChart3,
   Clock,
-  DollarSign,
+  Coins,
   Target,
   TrendingDown,
   TrendingUp,
@@ -312,11 +312,13 @@ export function TradingProfile({
   }, [fetchTradingData]);
 
   const formatCurrency = (value: number) => {
-    if (!Number.isFinite(value)) return '$0.00';
+    if (!Number.isFinite(value)) return `${BABYLON_POINTS_SYMBOL}0.00`;
     const abs = Math.abs(value);
-    if (abs >= 1000000) return `$${(value / 1000000).toFixed(2)}M`;
-    if (abs >= 1000) return `$${(value / 1000).toFixed(2)}K`;
-    return `$${value.toFixed(2)}`;
+    if (abs >= 1000000)
+      return `${BABYLON_POINTS_SYMBOL}${(value / 1000000).toFixed(2)}M`;
+    if (abs >= 1000)
+      return `${BABYLON_POINTS_SYMBOL}${(value / 1000).toFixed(2)}K`;
+    return `${BABYLON_POINTS_SYMBOL}${value.toFixed(2)}`;
   };
 
   const calculateCurrentPrice = (market: PredictionPosition['Market']) => {
@@ -363,7 +365,7 @@ export function TradingProfile({
       <div className="grid grid-cols-2 gap-4 p-4 lg:grid-cols-4">
         <div className="rounded-lg border border-border bg-card p-4">
           <div className="mb-2 flex items-center gap-2">
-            <DollarSign className="h-4 w-4 text-green-500" />
+            <Coins className="h-4 w-4 text-green-500" />
             <span className="font-medium text-muted-foreground text-xs">
               Balance
             </span>

--- a/packages/shared/src/utils/format.ts
+++ b/packages/shared/src/utils/format.ts
@@ -212,6 +212,50 @@ export function formatCurrency(
 }
 
 /**
+ * Format number as compact currency with K/M/B suffixes
+ *
+ * @description Formats a number as Babylon points currency with K/M/B suffixes
+ * for large values. Uses the Ƀ symbol. Handles non-finite values gracefully.
+ *
+ * @param {number} value - Amount to format
+ * @param {number} decimals - Number of decimal places (default: 2)
+ * @returns {string} Formatted currency string with suffix (e.g., "Ƀ1.50K", "Ƀ2.30M")
+ *
+ * @example
+ * ```typescript
+ * formatCompactCurrency(1500) // Returns "Ƀ1.50K"
+ * formatCompactCurrency(2300000) // Returns "Ƀ2.30M"
+ * formatCompactCurrency(1500000000) // Returns "Ƀ1.50B"
+ * formatCompactCurrency(500) // Returns "Ƀ500.00"
+ * formatCompactCurrency(-1500) // Returns "-Ƀ1.50K"
+ * formatCompactCurrency(NaN) // Returns "Ƀ0.00"
+ * ```
+ */
+export function formatCompactCurrency(value: number, decimals = 2): string {
+  // Handle non-finite values
+  if (!Number.isFinite(value)) {
+    return `${BABYLON_POINTS_SYMBOL}0.${'0'.repeat(decimals)}`;
+  }
+
+  // Handle negative numbers: sign should come before the symbol
+  const isNegative = value < 0;
+  const abs = Math.abs(value);
+  const sign = isNegative ? '-' : '';
+
+  if (abs >= 1_000_000_000) {
+    return `${sign}${BABYLON_POINTS_SYMBOL}${(abs / 1_000_000_000).toFixed(decimals)}B`;
+  }
+  if (abs >= 1_000_000) {
+    return `${sign}${BABYLON_POINTS_SYMBOL}${(abs / 1_000_000).toFixed(decimals)}M`;
+  }
+  if (abs >= 1_000) {
+    return `${sign}${BABYLON_POINTS_SYMBOL}${(abs / 1_000).toFixed(decimals)}K`;
+  }
+
+  return `${sign}${BABYLON_POINTS_SYMBOL}${abs.toFixed(decimals)}`;
+}
+
+/**
  * Format number as percentage
  *
  * @description Converts a number to a percentage string, rounded to nearest integer.

--- a/packages/shared/src/utils/format.ts
+++ b/packages/shared/src/utils/format.ts
@@ -158,23 +158,57 @@ export function formatCompactNumber(num: number): string {
 }
 
 /**
+ * Options for formatCurrency function.
+ */
+interface FormatCurrencyOptions {
+  /** Number of decimal places (default: 2) */
+  decimals?: number;
+  /** Whether to use thousands separators (default: false for backwards compat) */
+  useThousandsSeparator?: boolean;
+}
+
+/**
  * Format number as currency
  *
  * @description Formats a number as Babylon points currency with specified decimal places.
  * Uses the Ƀ symbol to represent Babylon points (not USD or Bitcoin).
+ * Optionally includes thousands separators for better readability of large values.
  *
  * @param {number} amount - Amount to format
- * @param {number} decimals - Number of decimal places (default: 2)
- * @returns {string} Formatted currency string (e.g., "Ƀ123.45")
+ * @param {number | FormatCurrencyOptions} options - Decimal places or options object
+ * @returns {string} Formatted currency string (e.g., "Ƀ123.45" or "Ƀ1,234.56")
  *
  * @example
  * ```typescript
  * formatCurrency(123.456) // Returns "Ƀ123.46"
  * formatCurrency(1000, 0) // Returns "Ƀ1000"
+ * formatCurrency(1234.56, { useThousandsSeparator: true }) // Returns "Ƀ1,234.56"
+ * formatCurrency(1234567.89, { decimals: 2, useThousandsSeparator: true }) // Returns "Ƀ1,234,567.89"
  * ```
  */
-export function formatCurrency(amount: number, decimals = 2): string {
-  return `${BABYLON_POINTS_SYMBOL}${amount.toFixed(decimals)}`;
+export function formatCurrency(
+  amount: number,
+  options: number | FormatCurrencyOptions = 2
+): string {
+  const decimals =
+    typeof options === 'number' ? options : (options.decimals ?? 2);
+  const useThousandsSeparator =
+    typeof options === 'object' && options.useThousandsSeparator;
+
+  // Handle negative numbers: sign should come before the symbol
+  const isNegative = amount < 0;
+  const absoluteAmount = Math.abs(amount);
+  const sign = isNegative ? '-' : '';
+
+  if (useThousandsSeparator) {
+    const formatted = absoluteAmount.toLocaleString('en-US', {
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
+    });
+    return `${sign}${BABYLON_POINTS_SYMBOL}${formatted}`;
+  }
+
+  return `${sign}${BABYLON_POINTS_SYMBOL}${absoluteAmount.toFixed(decimals)}`;
 }
 
 /**

--- a/packages/shared/src/utils/format.ts
+++ b/packages/shared/src/utils/format.ts
@@ -232,9 +232,9 @@ export function formatCurrency(
  * ```
  */
 export function formatCompactCurrency(value: number, decimals = 2): string {
-  // Handle non-finite values
+  // Handle non-finite values (uses toFixed to avoid trailing dot when decimals=0)
   if (!Number.isFinite(value)) {
-    return `${BABYLON_POINTS_SYMBOL}0.${'0'.repeat(decimals)}`;
+    return `${BABYLON_POINTS_SYMBOL}${(0).toFixed(decimals)}`;
   }
 
   // Handle negative numbers: sign should come before the symbol

--- a/packages/testing/unit/shared/format.test.ts
+++ b/packages/testing/unit/shared/format.test.ts
@@ -121,9 +121,47 @@ describe('Format Utilities', () => {
       expect(formatCurrency(100)).toBe('Ƀ100.00');
     });
 
-    it('should format with custom decimal places', () => {
+    it('should format with custom decimal places (number param)', () => {
       expect(formatCurrency(123.456, 0)).toBe('Ƀ123');
       expect(formatCurrency(123.456, 3)).toBe('Ƀ123.456');
+    });
+
+    it('should format with options object', () => {
+      expect(formatCurrency(123.456, { decimals: 1 })).toBe('Ƀ123.5');
+      expect(formatCurrency(100, { decimals: 0 })).toBe('Ƀ100');
+    });
+
+    it('should format with thousands separators when enabled', () => {
+      expect(formatCurrency(1234.56, { useThousandsSeparator: true })).toBe(
+        'Ƀ1,234.56'
+      );
+      expect(
+        formatCurrency(1234567.89, { decimals: 2, useThousandsSeparator: true })
+      ).toBe('Ƀ1,234,567.89');
+      expect(
+        formatCurrency(1000000, { decimals: 0, useThousandsSeparator: true })
+      ).toBe('Ƀ1,000,000');
+    });
+
+    it('should not use thousands separators by default', () => {
+      expect(formatCurrency(1234.56)).toBe('Ƀ1234.56');
+      expect(formatCurrency(1234567.89)).toBe('Ƀ1234567.89');
+    });
+
+    it('should handle negative numbers correctly', () => {
+      // Sign should come before the symbol
+      expect(formatCurrency(-100)).toBe('-Ƀ100.00');
+      expect(formatCurrency(-1234.56)).toBe('-Ƀ1234.56');
+    });
+
+    it('should handle edge cases with thousands separators', () => {
+      expect(formatCurrency(0, { useThousandsSeparator: true })).toBe('Ƀ0.00');
+      expect(formatCurrency(999, { useThousandsSeparator: true })).toBe(
+        'Ƀ999.00'
+      );
+      expect(formatCurrency(-1234.56, { useThousandsSeparator: true })).toBe(
+        '-Ƀ1,234.56'
+      );
     });
   });
 

--- a/packages/testing/unit/shared/format.test.ts
+++ b/packages/testing/unit/shared/format.test.ts
@@ -202,6 +202,11 @@ describe('Format Utilities', () => {
       expect(formatCompactCurrency(-Infinity)).toBe('Ƀ0.00');
     });
 
+    it('should handle non-finite values with decimals=0 (no trailing dot)', () => {
+      expect(formatCompactCurrency(NaN, 0)).toBe('Ƀ0');
+      expect(formatCompactCurrency(Infinity, 0)).toBe('Ƀ0');
+    });
+
     it('should respect custom decimals', () => {
       expect(formatCompactCurrency(1500, 1)).toBe('Ƀ1.5K');
       expect(formatCompactCurrency(1500, 0)).toBe('Ƀ2K');

--- a/packages/testing/unit/shared/format.test.ts
+++ b/packages/testing/unit/shared/format.test.ts
@@ -6,6 +6,7 @@
 import { describe, expect, it } from 'bun:test';
 import {
   clamp,
+  formatCompactCurrency,
   formatCompactNumber,
   formatCurrency,
   formatDate,
@@ -162,6 +163,49 @@ describe('Format Utilities', () => {
       expect(formatCurrency(-1234.56, { useThousandsSeparator: true })).toBe(
         '-Ƀ1,234.56'
       );
+    });
+  });
+
+  describe('formatCompactCurrency', () => {
+    it('should format small values without suffix', () => {
+      expect(formatCompactCurrency(500)).toBe('Ƀ500.00');
+      expect(formatCompactCurrency(0)).toBe('Ƀ0.00');
+      expect(formatCompactCurrency(999.99)).toBe('Ƀ999.99');
+    });
+
+    it('should format thousands with K suffix', () => {
+      expect(formatCompactCurrency(1000)).toBe('Ƀ1.00K');
+      expect(formatCompactCurrency(1500)).toBe('Ƀ1.50K');
+      expect(formatCompactCurrency(999999)).toBe('Ƀ1000.00K');
+    });
+
+    it('should format millions with M suffix', () => {
+      expect(formatCompactCurrency(1000000)).toBe('Ƀ1.00M');
+      expect(formatCompactCurrency(2300000)).toBe('Ƀ2.30M');
+      expect(formatCompactCurrency(999999999)).toBe('Ƀ1000.00M');
+    });
+
+    it('should format billions with B suffix', () => {
+      expect(formatCompactCurrency(1000000000)).toBe('Ƀ1.00B');
+      expect(formatCompactCurrency(1500000000)).toBe('Ƀ1.50B');
+    });
+
+    it('should handle negative values correctly', () => {
+      expect(formatCompactCurrency(-1500)).toBe('-Ƀ1.50K');
+      expect(formatCompactCurrency(-2300000)).toBe('-Ƀ2.30M');
+      expect(formatCompactCurrency(-500)).toBe('-Ƀ500.00');
+    });
+
+    it('should handle non-finite values', () => {
+      expect(formatCompactCurrency(NaN)).toBe('Ƀ0.00');
+      expect(formatCompactCurrency(Infinity)).toBe('Ƀ0.00');
+      expect(formatCompactCurrency(-Infinity)).toBe('Ƀ0.00');
+    });
+
+    it('should respect custom decimals', () => {
+      expect(formatCompactCurrency(1500, 1)).toBe('Ƀ1.5K');
+      expect(formatCompactCurrency(1500, 0)).toBe('Ƀ2K');
+      expect(formatCompactCurrency(500, 3)).toBe('Ƀ500.000');
     });
   });
 


### PR DESCRIPTION
## Summary
<!-- 1–3 bullets: what changed + why (user impact / business goal). -->

- **Migrate all currency displays from `$` to `Ƀ` (Babylon Points symbol)** across market components
- Replace `DollarSign` icons with `Coins` icons for visual consistency
- Ensure ticker names (e.g., `$BTC`, `$ETH`) retain the `$` prefix as intended

> ⚠️ **Stacked PR (1/2)** - This is the first PR in a stack. Merge this before [Stack 2/2].

## Type
<!-- Helps triage + release notes. -->

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
<!-- Link issues, Linear tickets, docs, prior PRs. -->

- Part of BAB-69 market improvements
- Currency symbol migration from USD (`$`) to Babylon Points (`Ƀ`)

## Scope (keep it focused)
<!-- If you had to touch multiple areas, explain why and what you intentionally left out. -->

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
<!-- List the notable changes (what is new/removed/modified). Link key files if it helps. -->

### Icon Changes
- `MarketOverviewPanel.tsx`: `DollarSign` → `Coins`
- `TradingProfile.tsx`: `DollarSign` → `Coins`

### Currency Formatting Updates
| File | Change |
|------|--------|
| `MarketOverviewPanel.tsx` | `formatVolume` uses `BABYLON_POINTS_SYMBOL` |
| `PerpPositionsList.tsx` | `formatPrice` + toast messages |
| `PredictionPositionsList.tsx` | `formatPrice` + toast messages |
| `TopMoversPanel.tsx` | `formatPrice` |
| `PnLShareModal.tsx` | Share text messages |
| `TradeConfirmationDialog.tsx` | `formatPrice` |
| `AssetTradesFeed.tsx` | `formatCurrency` |
| `CategoryPnLShareCard.tsx` | `formatCurrency` |
| `PortfolioPnLShareCard.tsx` | `formatCurrency` |
| `PortfolioPnLCard.tsx` | `formatCurrency` |
| `PerpTradingModal.tsx` | Toast messages |
| `LightweightChartBase.tsx` | `formatChartPrice` |
| `TradingProfile.tsx` | `formatCurrency` |
| `predictions/[id]/page.tsx` | Text: "$1 per share" → "Ƀ1 per share" |
| `PerpPriceChart.test.tsx` | Test expectations |

## Review guide
<!-- Help reviewers go fast: where to start, what to ignore, tricky bits, key decisions. -->

**Start here**
- `apps/web/src/components/markets/MarketOverviewPanel.tsx` - typical example of the pattern

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- All changes follow the same pattern: import `BABYLON_POINTS_SYMBOL` from `@babylon/shared` and use it in format functions
- Ticker names like `$BTC` intentionally keep the `$` prefix (these are stock ticker symbols, not currency)
- The constant `BABYLON_POINTS_SYMBOL = "Ƀ"` is already defined in `@babylon/shared`

## Test plan
<!-- Tick what you ran. Add manual steps for anything user-facing. -->

**Commands run**
- [x] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Navigate to `/markets` and verify all prices show `Ƀ` instead of `$`
2. Open a perp market detail page, verify chart prices show `Ƀ`
3. Open a prediction market, verify prices show `Ƀ`
4. Open a position and verify toast messages show `Ƀ`
5. Verify ticker names still show `$BTC`, `$ETH`, etc.

## Ops / Migration / Deployment
<!-- Anything that impacts deploys, data, cron, config, or rollouts. -->

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy
<!-- Authn/authz, secrets handling, PII, prompt injection surfaces, etc. -->

- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: This is a text/symbol replacement only. The UI layout and behavior remain identical. The only visible change is `$` → `Ƀ` in currency displays (not ticker names).

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`feat/bab-69-market-volatility-simulation`)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Switched currency displays and UI labels to use the Babylon Points symbol (Ƀ) and updated related icons (coin icons replacing dollar icons).
* **New Features**
  * Added unified, configurable currency formatting with compact K/M/B suffixes and sign-aware output.
* **Tests**
  * Added comprehensive tests covering currency, compact-formatting, and share-text PnL formatting.
* **Documentation**
  * Updated help and formatting text (e.g., "If you're right, you'll receive Ƀ1 per share.").

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR successfully migrates all currency displays from USD (`$`) to Babylon Points (`Ƀ`) across the markets UI. The changes are focused and systematic:

- Replaces hardcoded `$` and `Intl.NumberFormat` USD formatters with `BABYLON_POINTS_SYMBOL` constant from `@babylon/shared`
- Updates icons from `DollarSign` to `Coins` in two components for visual consistency
- Correctly preserves `$` prefix for ticker symbols (e.g., `$BTC`, `$ETH`) as intended
- Updates test expectations to reflect new symbol
- Covers all market-related components: positions lists, trading modals, charts, PnL cards, and share functionality

The implementation is clean and maintains backward compatibility for ticker symbol display. All changes follow the same pattern: import the constant and use string interpolation for formatting.

<h3>Confidence Score: 5/5</h3>


- Safe to merge - straightforward symbol replacement with consistent pattern
- All changes follow a uniform pattern of replacing hardcoded `$` with `BABYLON_POINTS_SYMBOL` constant. The implementation is consistent across all 15 files, correctly distinguishes between currency symbols (changed) and ticker prefixes (preserved), and includes updated test expectations.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/components/markets/MarketOverviewPanel.tsx | Replaced `$` with `BABYLON_POINTS_SYMBOL` in volume formatting and changed `DollarSign` icon to `Coins` |
| apps/web/src/components/markets/PerpPositionsList.tsx | Replaced `Intl.NumberFormat` with `BABYLON_POINTS_SYMBOL` formatting, correctly preserves `$` prefix for ticker display |
| apps/web/src/components/markets/TradeConfirmationDialog.tsx | Updated price formatting to use `BABYLON_POINTS_SYMBOL`, correctly preserves `$` prefix for ticker names in descriptions |
| apps/web/src/components/markets/AssetTradesFeed.tsx | Replaced `Intl.NumberFormat` USD currency formatter with simple `BABYLON_POINTS_SYMBOL` concatenation |
| apps/web/src/components/charts/LightweightChartBase.tsx | Replaced hardcoded `$` with `BABYLON_POINTS_SYMBOL` in chart price formatting |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Component as UI Component
    participant Shared as @babylon/shared
    participant Format as Formatter Function
    
    Note over User,Format: Currency Symbol Migration Flow
    
    User->>Component: Views market data
    Component->>Shared: Import BABYLON_POINTS_SYMBOL
    Shared-->>Component: Returns 'Ƀ' constant
    
    Component->>Format: Call formatPrice(123.45)
    Format->>Shared: Use BABYLON_POINTS_SYMBOL
    Shared-->>Format: 'Ƀ'
    Format-->>Component: 'Ƀ123.45'
    Component-->>User: Display 'Ƀ123.45'
    
    Note over Component,Format: Ticker symbols preserved
    Component->>User: Display '$BTC' (unchanged)
    
    Note over User,Format: Toast Notifications
    User->>Component: Execute trade
    Component->>Format: Format PnL with BABYLON_POINTS_SYMBOL
    Format-->>Component: 'Ƀ50.00'
    Component->>User: Toast: '+Ƀ50.00 PnL'
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->