### PR TITLE
fix(linear): Remove Bearer prefix from API key auth header

### DIFF
--- a/packages/api/src/linear/client.ts
+++ b/packages/api/src/linear/client.ts
@@ -43,7 +43,9 @@ export async function createLinearIssue(
 
   const client = new GraphQLClient(LINEAR_API_URL, {
     headers: {
-      Authorization: `Bearer ${apiKey}`,
+      // Personal API keys (lin_api_*) don't use Bearer prefix
+      // OAuth tokens would use: `Bearer ${token}`
+      Authorization: apiKey,
       'Content-Type': 'application/json',
     },
     signal: controller.signal,


### PR DESCRIPTION
## Summary

Fixes the Linear integration not syncing feedback issues.

## The Problem

The Authorization header was incorrectly using `Bearer ${apiKey}` format:

```typescript
Authorization: `Bearer ${apiKey}`,
```

## The Fix

Per Linear's API documentation:
- **OAuth tokens** use: `Authorization: Bearer <ACCESS_TOKEN>`
- **Personal API keys** (`lin_api_*`) use: `Authorization: <API_KEY>` (no Bearer prefix)

Since we use personal API keys, the correct format is:

```typescript
Authorization: apiKey,
```

## Verification

Reviewed against Context7's Linear API documentation which states:
> Use `Authorization: Bearer <ACCESS_TOKEN>` for OAuth or `Authorization: <API_KEY>` for personal keys.

## Testing

After deploying, submit a test feedback and verify it appears in Linear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Linear API authentication configuration to properly handle personal API key authorization headers, ensuring correct integration with the Linear service.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed Linear integration authentication by removing the Bearer prefix from the Authorization header when using personal API keys (`lin_api_*`).

- Corrected the authentication header from `Bearer ${apiKey}` to just `apiKey` in `packages/api/src/linear/client.ts:48`
- Added clear inline comments explaining the difference between personal API keys and OAuth tokens
- The fix aligns with Linear's API documentation which specifies that personal API keys should be sent directly in the Authorization header without the Bearer prefix, while OAuth tokens require the Bearer scheme

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The change is a simple, focused bug fix that corrects the authentication header format for Linear's API. The code change is minimal (removing Bearer prefix), well-documented with inline comments, and matches Linear's official API documentation for personal API keys. The fix has validation built into the codebase (key format check on line 85), and the change only affects the Linear integration - no risk to other systems.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/api/src/linear/client.ts | Fixed Authorization header to use API key directly without Bearer prefix, matching Linear API requirements for personal keys |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API as Feedback API
    participant LinearClient as Linear Client
    participant LinearAPI as Linear GraphQL API
    
    User->>API: Submit feedback
    API->>API: Save to database
    API-->>User: Return success
    API->>LinearClient: syncFeedbackToLinear()
    LinearClient->>LinearClient: Check if already synced
    LinearClient->>LinearClient: Format feedback
    LinearClient->>LinearAPI: POST /graphql<br/>Authorization: lin_api_xxxxx
    Note over LinearAPI: Personal API keys require<br/>direct key without Bearer prefix
    LinearAPI-->>LinearClient: Issue created
    LinearClient->>API: Update metadata with issue ID
    LinearClient->>API: Log success
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->