### PR TITLE
feat(linear): Improve feedback sync with username, timestamp, and duplicate prevention

### DIFF
--- a/apps/web/src/app/api/admin/feedback/[feedbackId]/retry-sync/route.ts
+++ b/apps/web/src/app/api/admin/feedback/[feedbackId]/retry-sync/route.ts
@@ -9,6 +9,7 @@ import {
   getLinearConfig,
   requireAdmin,
   successResponse,
+  SYNC_LOCK_TTL_MS,
   syncFeedbackToLinear,
   withErrorHandling,
 } from '@babylon/api';
@@ -27,9 +28,6 @@ const LinearSyncedMetadataSchema = z.object({
   linearIssueUrl: z.string().optional().catch(undefined),
   linearSyncStartedAt: z.string().optional().catch(undefined),
 });
-
-/** How long a sync lock is valid before it's considered stale (5 minutes) */
-const SYNC_LOCK_TTL_MS = 5 * 60 * 1000;
 
 type LinearSyncedMetadata = z.infer<typeof LinearSyncedMetadataSchema>;
 
@@ -100,25 +98,34 @@ export const POST = withErrorHandling(
     // Check if sync is already in progress (prevents duplicate issues)
     if (metadata.linearSyncStartedAt) {
       const syncStarted = new Date(metadata.linearSyncStartedAt).getTime();
-      const now = Date.now();
-      const lockAgeMs = now - syncStarted;
 
-      if (lockAgeMs < SYNC_LOCK_TTL_MS) {
-        const remainingSeconds = Math.ceil(
-          (SYNC_LOCK_TTL_MS - lockAgeMs) / 1000
-        );
-        return successResponse({
-          success: false,
-          syncInProgress: true,
+      // Handle invalid date strings (NaN) by treating as stale lock
+      if (!Number.isNaN(syncStarted)) {
+        const now = Date.now();
+        const lockAgeMs = now - syncStarted;
+
+        if (lockAgeMs < SYNC_LOCK_TTL_MS) {
+          const remainingSeconds = Math.ceil(
+            (SYNC_LOCK_TTL_MS - lockAgeMs) / 1000
+          );
+          return successResponse({
+            success: false,
+            syncInProgress: true,
+            syncStartedAt: metadata.linearSyncStartedAt,
+            message: `Sync already in progress. Try again in ${remainingSeconds} seconds or wait for completion.`,
+          });
+        }
+        // Lock is stale, proceed with sync
+        logger.warn('Stale sync lock detected during manual retry', {
+          feedbackId,
           syncStartedAt: metadata.linearSyncStartedAt,
-          message: `Sync already in progress. Try again in ${remainingSeconds} seconds or wait for completion.`,
+        });
+      } else {
+        logger.warn('Invalid linearSyncStartedAt timestamp during manual retry', {
+          feedbackId,
+          syncStartedAt: metadata.linearSyncStartedAt,
         });
       }
-      // Lock is stale, proceed with sync
-      logger.warn('Stale sync lock detected during manual retry', {
-        feedbackId,
-        syncStartedAt: metadata.linearSyncStartedAt,
-      });
     }
 
     // Get user info for the sync - distinguish between orphaned feedback and deleted user

--- a/apps/web/src/app/api/admin/feedback/[feedbackId]/retry-sync/route.ts
+++ b/apps/web/src/app/api/admin/feedback/[feedbackId]/retry-sync/route.ts
@@ -108,12 +108,12 @@ export const POST = withErrorHandling(
           const remainingSeconds = Math.ceil(
             (SYNC_LOCK_TTL_MS - lockAgeMs) / 1000
           );
-          return successResponse({
-            success: false,
-            syncInProgress: true,
-            syncStartedAt: metadata.linearSyncStartedAt,
-            message: `Sync already in progress. Try again in ${remainingSeconds} seconds or wait for completion.`,
-          });
+          // Return 409 Conflict to distinguish from success states
+          return errorResponse(
+            `Sync already in progress. Try again in ${remainingSeconds} seconds or wait for completion.`,
+            'SYNC_IN_PROGRESS',
+            409
+          );
         }
         // Lock is stale, proceed with sync
         logger.warn('Stale sync lock detected during manual retry', {

--- a/apps/web/src/app/api/admin/feedback/[feedbackId]/retry-sync/route.ts
+++ b/apps/web/src/app/api/admin/feedback/[feedbackId]/retry-sync/route.ts
@@ -2,6 +2,7 @@
  * Admin Feedback Retry Sync API
  *
  * Allows admins to manually retry Linear sync for failed feedback items.
+ * Uses pure Drizzle ORM for all database operations.
  */
 
 import {
@@ -13,7 +14,8 @@ import {
   syncFeedbackToLinear,
   withErrorHandling,
 } from '@babylon/api';
-import { db } from '@babylon/db';
+import { eq, feedbacks, users } from '@babylon/db';
+import { getRawDrizzle, type JsonValue } from '@babylon/db';
 import { logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 import { z } from 'zod';
@@ -35,9 +37,13 @@ type LinearSyncedMetadata = z.infer<typeof LinearSyncedMetadataSchema>;
  * Safely parse feedback metadata from DB, returning validated Linear sync fields.
  * Returns a safe default object if parsing fails.
  */
-function parseLinearSyncedMetadata(rawMetadata: unknown): LinearSyncedMetadata {
+function parseLinearSyncedMetadata(
+  rawMetadata: JsonValue | null | undefined
+): LinearSyncedMetadata {
   const normalizedMetadata =
-    rawMetadata && typeof rawMetadata === 'object' ? rawMetadata : {};
+    rawMetadata && typeof rawMetadata === 'object' && !Array.isArray(rawMetadata)
+      ? rawMetadata
+      : {};
   return LinearSyncedMetadataSchema.parse(normalizedMetadata);
 }
 
@@ -55,6 +61,7 @@ export const POST = withErrorHandling(
     await requireAdmin(request);
 
     const { feedbackId } = await context.params;
+    const db = getRawDrizzle();
 
     // Check Linear configuration
     const linearConfig = getLinearConfig();
@@ -66,15 +73,16 @@ export const POST = withErrorHandling(
       );
     }
 
-    // Fetch feedback to verify it exists and get user info
-    const feedback = await db.feedback.findUnique({
-      where: { id: feedbackId },
-      select: {
-        id: true,
-        fromUserId: true,
-        metadata: true,
-      },
-    });
+    // Fetch feedback to verify it exists and get user info using Drizzle
+    const [feedback] = await db
+      .select({
+        id: feedbacks.id,
+        fromUserId: feedbacks.fromUserId,
+        metadata: feedbacks.metadata,
+      })
+      .from(feedbacks)
+      .where(eq(feedbacks.id, feedbackId))
+      .limit(1);
 
     if (!feedback) {
       return errorResponse('Feedback not found', 'FEEDBACK_NOT_FOUND', 404);
@@ -96,6 +104,7 @@ export const POST = withErrorHandling(
     }
 
     // Check if sync is already in progress (prevents duplicate issues)
+    // This provides immediate 409 feedback to admin instead of silent skip
     if (metadata.linearSyncStartedAt) {
       const syncStarted = new Date(metadata.linearSyncStartedAt).getTime();
 
@@ -137,10 +146,17 @@ export const POST = withErrorHandling(
       );
     }
 
-    const user = await db.user.findUnique({
-      where: { id: feedback.fromUserId },
-      select: { id: true, email: true, username: true, displayName: true },
-    });
+    // Fetch user using Drizzle
+    const [user] = await db
+      .select({
+        id: users.id,
+        email: users.email,
+        username: users.username,
+        displayName: users.displayName,
+      })
+      .from(users)
+      .where(eq(users.id, feedback.fromUserId))
+      .limit(1);
 
     if (!user) {
       return errorResponse(
@@ -155,16 +171,15 @@ export const POST = withErrorHandling(
     // syncFeedbackToLinear updates metadata as a side effect, so we refetch.
     await syncFeedbackToLinear(linearConfig, feedbackId, user);
 
-    // Refetch to get canonical metadata after sync (avoids returning stale data)
-    const updatedFeedback = await db.feedback.findUnique({
-      where: { id: feedbackId },
-      select: { metadata: true },
-    });
+    // Refetch to get canonical metadata after sync using Drizzle
+    const [updatedFeedback] = await db
+      .select({ metadata: feedbacks.metadata })
+      .from(feedbacks)
+      .where(eq(feedbacks.id, feedbackId))
+      .limit(1);
 
     // Validate updated metadata at runtime
-    const updatedMetadata = parseLinearSyncedMetadata(
-      updatedFeedback?.metadata
-    );
+    const updatedMetadata = parseLinearSyncedMetadata(updatedFeedback?.metadata);
 
     logger.info('Manual Linear sync completed', {
       feedbackId,

--- a/apps/web/src/app/api/admin/feedback/[feedbackId]/retry-sync/route.ts
+++ b/apps/web/src/app/api/admin/feedback/[feedbackId]/retry-sync/route.ts
@@ -104,7 +104,7 @@ export const POST = withErrorHandling(
 
     const user = await db.user.findUnique({
       where: { id: feedback.fromUserId },
-      select: { id: true, email: true },
+      select: { id: true, email: true, username: true, displayName: true },
     });
 
     if (!user) {

--- a/apps/web/src/app/api/admin/feedback/[feedbackId]/retry-sync/route.ts
+++ b/apps/web/src/app/api/admin/feedback/[feedbackId]/retry-sync/route.ts
@@ -25,7 +25,11 @@ const LinearSyncedMetadataSchema = z.object({
   linearIssueId: z.string().optional().catch(undefined),
   linearIssueIdentifier: z.string().optional().catch(undefined),
   linearIssueUrl: z.string().optional().catch(undefined),
+  linearSyncStartedAt: z.string().optional().catch(undefined),
 });
+
+/** How long a sync lock is valid before it's considered stale (5 minutes) */
+const SYNC_LOCK_TTL_MS = 5 * 60 * 1000;
 
 type LinearSyncedMetadata = z.infer<typeof LinearSyncedMetadataSchema>;
 
@@ -90,6 +94,30 @@ export const POST = withErrorHandling(
           url: metadata.linearIssueUrl,
         },
         message: 'Feedback already synced to Linear',
+      });
+    }
+
+    // Check if sync is already in progress (prevents duplicate issues)
+    if (metadata.linearSyncStartedAt) {
+      const syncStarted = new Date(metadata.linearSyncStartedAt).getTime();
+      const now = Date.now();
+      const lockAgeMs = now - syncStarted;
+
+      if (lockAgeMs < SYNC_LOCK_TTL_MS) {
+        const remainingSeconds = Math.ceil(
+          (SYNC_LOCK_TTL_MS - lockAgeMs) / 1000
+        );
+        return successResponse({
+          success: false,
+          syncInProgress: true,
+          syncStartedAt: metadata.linearSyncStartedAt,
+          message: `Sync already in progress. Try again in ${remainingSeconds} seconds or wait for completion.`,
+        });
+      }
+      // Lock is stale, proceed with sync
+      logger.warn('Stale sync lock detected during manual retry', {
+        feedbackId,
+        syncStartedAt: metadata.linearSyncStartedAt,
       });
     }
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -129,6 +129,7 @@ export {
   type LinearConfig,
   type LinearFeedbackData,
   type LinearIssue,
+  SYNC_LOCK_TTL_MS,
   syncFeedbackToLinear,
 } from './linear';
 // Monitoring
@@ -227,7 +228,6 @@ export type { ErrorLike, JsonValue, StringRecord } from './types';
 export {
   type CanonicalUser,
   type EnsureUserOptions,
-  type TargetLookupResult,
   ensureUserForAuth,
   findTargetByIdentifier,
   findUserByIdentifier,
@@ -235,6 +235,7 @@ export {
   getCanonicalUserId,
   requireTargetByIdentifier,
   requireUserByIdentifier,
+  type TargetLookupResult,
 } from './users';
 // Server-side utilities (require Node.js crypto)
 export {

--- a/packages/api/src/linear/format-feedback.ts
+++ b/packages/api/src/linear/format-feedback.ts
@@ -94,7 +94,8 @@ export function formatFeedbackForLinear(feedback: FeedbackData): {
     const safeDisplayName = feedback.displayName
       ? escapeHtml(feedback.displayName)
       : safeUsername;
-    const profileUrl = `${APP_BASE_URL}/profile/${safeUsername}`;
+    // URL-encode the raw username for safe profile links (handles spaces, @, etc.)
+    const profileUrl = `${APP_BASE_URL}/profile/${encodeURIComponent(feedback.username)}`;
     submittedBy = `[${safeDisplayName}](${profileUrl}) (@${safeUsername})`;
   } else {
     submittedBy = safeEmail ?? 'Unknown';

--- a/packages/api/src/linear/format-feedback.ts
+++ b/packages/api/src/linear/format-feedback.ts
@@ -94,8 +94,7 @@ export function formatFeedbackForLinear(feedback: FeedbackData): {
     const safeDisplayName = feedback.displayName
       ? escapeHtml(feedback.displayName)
       : safeUsername;
-    // URL-encode username for safe profile links (handles %, #, ? etc.)
-    const profileUrl = `${APP_BASE_URL}/profile/${encodeURIComponent(feedback.username)}`;
+    const profileUrl = `${APP_BASE_URL}/profile/${safeUsername}`;
     submittedBy = `[${safeDisplayName}](${profileUrl}) (@${safeUsername})`;
   } else {
     submittedBy = safeEmail ?? 'Unknown';

--- a/packages/api/src/linear/format-feedback.ts
+++ b/packages/api/src/linear/format-feedback.ts
@@ -21,6 +21,27 @@ export interface FeedbackData {
 }
 
 /**
+ * Format a timestamp using Intl.DateTimeFormat for clarity and robustness.
+ * Returns a UTC timestamp string like "31/12/2025 15:30:00 UTC".
+ */
+function formatTimestamp(date: Date): string {
+  return (
+    new Intl.DateTimeFormat('en-GB', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+      timeZone: 'UTC',
+    })
+      .format(date)
+      .replace(',', '') + ' UTC'
+  );
+}
+
+/**
  * Get formatted label with emoji for Linear issue titles.
  * Uses shared FEEDBACK_TYPE_CONFIG for DRY compliance.
  */
@@ -101,10 +122,9 @@ export function formatFeedbackForLinear(feedback: FeedbackData): {
     submittedBy = safeEmail ?? 'Unknown';
   }
 
-  // Format timestamp
+  // Format timestamp using Intl.DateTimeFormat for clarity and robustness
   const timestamp = feedback.createdAt
-    ? feedback.createdAt.toISOString().replace('T', ' ').substring(0, 19) +
-      ' UTC'
+    ? formatTimestamp(feedback.createdAt)
     : 'Unknown';
 
   lines.push(

--- a/packages/api/src/linear/format-feedback.ts
+++ b/packages/api/src/linear/format-feedback.ts
@@ -94,7 +94,8 @@ export function formatFeedbackForLinear(feedback: FeedbackData): {
     const safeDisplayName = feedback.displayName
       ? escapeHtml(feedback.displayName)
       : safeUsername;
-    const profileUrl = `${APP_BASE_URL}/profile/${safeUsername}`;
+    // URL-encode username for safe profile links (handles %, #, ? etc.)
+    const profileUrl = `${APP_BASE_URL}/profile/${encodeURIComponent(feedback.username)}`;
     submittedBy = `[${safeDisplayName}](${profileUrl}) (@${safeUsername})`;
   } else {
     submittedBy = safeEmail ?? 'Unknown';

--- a/packages/api/src/linear/format-feedback.ts
+++ b/packages/api/src/linear/format-feedback.ts
@@ -2,6 +2,10 @@ import { FEEDBACK_TYPE_CONFIG, type FeedbackType } from '@babylon/shared';
 
 export type { FeedbackType };
 
+/** Base URL for user profile links */
+const APP_BASE_URL =
+  process.env.NEXT_PUBLIC_APP_URL || 'https://babylon.game';
+
 export interface FeedbackData {
   id: string;
   feedbackType: FeedbackType;
@@ -11,6 +15,9 @@ export interface FeedbackData {
   rating?: number | null;
   userId: string;
   userEmail?: string | null;
+  username?: string | null;
+  displayName?: string | null;
+  createdAt?: Date;
 }
 
 /**
@@ -80,12 +87,32 @@ export function formatFeedbackForLinear(feedback: FeedbackData): {
     );
   }
 
+  // Build "Submitted by" with profile link if username available
+  let submittedBy: string;
+  if (feedback.username) {
+    const safeUsername = escapeHtml(feedback.username);
+    const safeDisplayName = feedback.displayName
+      ? escapeHtml(feedback.displayName)
+      : safeUsername;
+    const profileUrl = `${APP_BASE_URL}/profile/${safeUsername}`;
+    submittedBy = `[${safeDisplayName}](${profileUrl}) (@${safeUsername})`;
+  } else {
+    submittedBy = safeEmail ?? 'Unknown';
+  }
+
+  // Format timestamp
+  const timestamp = feedback.createdAt
+    ? feedback.createdAt.toISOString().replace('T', ' ').substring(0, 19) +
+      ' UTC'
+    : 'Unknown';
+
   lines.push(
     '---',
     '',
     '### Submission Details',
     '',
-    `- **Submitted by:** ${safeEmail ?? 'Unknown'}`,
+    `- **Submitted by:** ${submittedBy}`,
+    `- **Submitted at:** ${timestamp}`,
     `- **User ID:** \`${escapeHtml(feedback.userId)}\``,
     `- **Feedback ID:** \`${escapeHtml(feedback.id)}\``,
     `- **Type:** ${config.heading}`

--- a/packages/api/src/linear/index.ts
+++ b/packages/api/src/linear/index.ts
@@ -6,4 +6,4 @@ export type {
 } from './format-feedback';
 export { formatFeedbackForLinear } from './format-feedback';
 export type { FeedbackUser, LinearConfig } from './sync-feedback';
-export { syncFeedbackToLinear } from './sync-feedback';
+export { SYNC_LOCK_TTL_MS, syncFeedbackToLinear } from './sync-feedback';

--- a/packages/api/src/linear/sync-feedback.ts
+++ b/packages/api/src/linear/sync-feedback.ts
@@ -96,9 +96,82 @@ const LinearSyncMetadataSchema = z.object({
 export const SYNC_LOCK_TTL_MS = 5 * 60 * 1000;
 
 /**
+ * Atomically acquire a sync lock for Linear issue creation.
+ * Uses a single SQL UPDATE with conditional WHERE clause to prevent TOCTOU race conditions.
+ *
+ * @returns Object with lockAcquired flag and metadata/createdAt if successful
+ */
+async function acquireSyncLock(
+  feedbackId: string,
+  syncStartedAt: string,
+  ttlMs: number
+): Promise<{
+  lockAcquired: boolean;
+  metadata: JsonObject | null;
+  createdAt: Date | null;
+  reason?: 'not_found' | 'already_synced' | 'lock_held';
+}> {
+  // Calculate the stale threshold timestamp
+  const staleThreshold = new Date(Date.now() - ttlMs).toISOString();
+
+  // Atomic lock acquisition using raw SQL:
+  // - Only acquires lock if linearIssueId is NULL (not already synced)
+  // - Only acquires lock if linearSyncStartedAt is NULL OR older than TTL
+  // This eliminates the TOCTOU gap between check and set
+  type LockResult = { id: string; metadata: JsonObject | null; createdAt: Date };
+  const result: LockResult[] = await db.$queryRaw<LockResult>`
+    UPDATE "Feedback"
+    SET metadata = jsonb_set(
+      COALESCE(metadata, '{}'::jsonb),
+      '{linearSyncStartedAt}',
+      to_jsonb(${syncStartedAt}::text)
+    )
+    WHERE id = ${feedbackId}
+      AND (metadata->>'linearIssueId' IS NULL)
+      AND (
+        metadata->>'linearSyncStartedAt' IS NULL
+        OR metadata->>'linearSyncStartedAt' < ${staleThreshold}
+      )
+    RETURNING id, metadata, "createdAt"
+  `;
+
+  const firstRow = result[0];
+  if (firstRow) {
+    return {
+      lockAcquired: true,
+      metadata: firstRow.metadata,
+      createdAt: firstRow.createdAt,
+    };
+  }
+
+  // Lock not acquired - determine why for logging
+  const feedback = await db.feedback.findUnique({
+    where: { id: feedbackId },
+    select: { metadata: true },
+  });
+
+  if (!feedback) {
+    return { lockAcquired: false, metadata: null, createdAt: null, reason: 'not_found' };
+  }
+
+  const syncMetadata = LinearSyncMetadataSchema.parse(
+    feedback.metadata && typeof feedback.metadata === 'object'
+      ? feedback.metadata
+      : {}
+  );
+
+  if (syncMetadata.linearIssueId) {
+    return { lockAcquired: false, metadata: null, createdAt: null, reason: 'already_synced' };
+  }
+
+  return { lockAcquired: false, metadata: null, createdAt: null, reason: 'lock_held' };
+}
+
+/**
  * Syncs a feedback record to Linear by creating an issue.
  * Updates the feedback metadata with the Linear issue reference.
  *
+ * Uses atomic lock acquisition to prevent duplicate issues from concurrent requests.
  * Idempotent: If feedback already has a linearIssueId, skips creation.
  */
 export async function syncFeedbackToLinear(
@@ -106,70 +179,41 @@ export async function syncFeedbackToLinear(
   feedbackId: string,
   user: FeedbackUser
 ): Promise<void> {
-  // Fetch feedback from DB to get current state (ensures consistency)
+  // Atomically acquire sync lock - this eliminates TOCTOU race conditions
+  const syncStartedAt = new Date().toISOString();
+  const lockResult = await acquireSyncLock(feedbackId, syncStartedAt, SYNC_LOCK_TTL_MS);
+
+  if (!lockResult.lockAcquired) {
+    switch (lockResult.reason) {
+      case 'not_found':
+        logger.warn('Feedback not found for Linear sync', { feedbackId });
+        break;
+      case 'already_synced':
+        logger.info('Feedback already synced to Linear, skipping', { feedbackId });
+        break;
+      case 'lock_held':
+        logger.info('Linear sync already in progress, skipping', { feedbackId });
+        break;
+    }
+    return;
+  }
+
+  // Fetch full feedback data now that we have the lock
   const feedback = await db.feedback.findUnique({
     where: { id: feedbackId },
     select: { comment: true, metadata: true, createdAt: true },
   });
 
   if (!feedback) {
-    logger.warn('Feedback not found for Linear sync', { feedbackId });
+    logger.warn('Feedback not found after lock acquisition', { feedbackId });
     return;
   }
 
-  // Safely parse metadata using Zod schema
+  // Parse metadata from the locked record
   const rawMetadata =
     feedback.metadata && typeof feedback.metadata === 'object'
       ? (feedback.metadata as JsonObject)
       : {};
-
-  // Idempotency check: skip if already synced to Linear
-  const syncMetadata = LinearSyncMetadataSchema.parse(rawMetadata);
-  if (syncMetadata.linearIssueId) {
-    logger.info('Feedback already synced to Linear, skipping', {
-      feedbackId,
-      linearIssueId: syncMetadata.linearIssueId,
-    });
-    return;
-  }
-
-  // Check for concurrent sync (prevents duplicate issues from race conditions)
-  if (syncMetadata.linearSyncStartedAt) {
-    const syncStarted = new Date(syncMetadata.linearSyncStartedAt).getTime();
-    // Handle invalid date strings (NaN) by treating as stale lock
-    if (Number.isNaN(syncStarted)) {
-      logger.warn('Invalid linearSyncStartedAt timestamp, proceeding with sync', {
-        feedbackId,
-        syncStartedAt: syncMetadata.linearSyncStartedAt,
-      });
-    } else {
-      const now = Date.now();
-      if (now - syncStarted < SYNC_LOCK_TTL_MS) {
-        logger.info('Linear sync already in progress, skipping', {
-          feedbackId,
-          syncStartedAt: syncMetadata.linearSyncStartedAt,
-        });
-        return;
-      }
-      // Lock is stale, proceed with sync (previous sync likely failed)
-      logger.warn('Stale Linear sync lock detected, proceeding with sync', {
-        feedbackId,
-        syncStartedAt: syncMetadata.linearSyncStartedAt,
-      });
-    }
-  }
-
-  // Set sync lock BEFORE creating Linear issue to prevent race conditions
-  const syncStartedAt = new Date().toISOString();
-  await db.feedback.update({
-    where: { id: feedbackId },
-    data: {
-      metadata: {
-        ...rawMetadata,
-        linearSyncStartedAt: syncStartedAt,
-      },
-    },
-  });
 
   // Helper to clear the sync lock (called on failure to allow immediate retry)
   const clearSyncLock = async () => {

--- a/packages/api/src/linear/sync-feedback.ts
+++ b/packages/api/src/linear/sync-feedback.ts
@@ -4,7 +4,7 @@
  * Includes retry logic with exponential backoff for transient failures.
  */
 
-import { db } from '@babylon/db';
+import { db, type JsonObject } from '@babylon/db';
 import { FeedbackTypeSchema, logger } from '@babylon/shared';
 import { z } from 'zod';
 import { createLinearIssue } from './client';
@@ -163,6 +163,23 @@ export async function syncFeedbackToLinear(
     },
   });
 
+  // Helper to clear the sync lock (used on success and failure)
+  const clearSyncLock = async () => {
+    const current = await db.feedback.findUnique({
+      where: { id: feedbackId },
+      select: { metadata: true },
+    });
+    const currentMetadata =
+      current?.metadata && typeof current.metadata === 'object'
+        ? (current.metadata as JsonObject)
+        : {};
+    const { linearSyncStartedAt: _, ...withoutLock } = currentMetadata;
+    await db.feedback.update({
+      where: { id: feedbackId },
+      data: { metadata: withoutLock },
+    });
+  };
+
   const metadata: FeedbackMetadata = FeedbackMetadataSchema.parse(rawMetadata);
 
   const formatted = formatFeedbackForLinear({
@@ -179,19 +196,26 @@ export async function syncFeedbackToLinear(
     createdAt: feedback.createdAt,
   });
 
-  // Create Linear issue with retry logic for transient failures
-  const issue = await withRetry(
-    () =>
-      createLinearIssue(config.apiKey, {
-        teamId: config.teamId,
-        title: formatted.title,
-        description: formatted.description,
-        labelIds: config.gameFeedbackLabelId
-          ? [config.gameFeedbackLabelId]
-          : undefined,
-      }),
-    { feedbackId }
-  );
+  let issue;
+  try {
+    // Create Linear issue with retry logic for transient failures
+    issue = await withRetry(
+      () =>
+        createLinearIssue(config.apiKey, {
+          teamId: config.teamId,
+          title: formatted.title,
+          description: formatted.description,
+          labelIds: config.gameFeedbackLabelId
+            ? [config.gameFeedbackLabelId]
+            : undefined,
+        }),
+      { feedbackId }
+    );
+  } catch (error) {
+    // Clear the sync lock on failure so retry can work
+    await clearSyncLock();
+    throw error;
+  }
 
   // Merge update: fetch fresh metadata to preserve concurrent updates.
   // The linearSyncStartedAt lock set earlier prevents duplicate Linear issues
@@ -207,7 +231,7 @@ export async function syncFeedbackToLinear(
       : {};
 
   // Remove the sync lock and store the issue info
-  const { linearSyncStartedAt: _, ...metadataWithoutLock } = freshMetadata;
+  const { linearSyncStartedAt: __, ...metadataWithoutLock } = freshMetadata;
   await db.feedback.update({
     where: { id: feedbackId },
     data: {

--- a/packages/api/src/linear/sync-feedback.ts
+++ b/packages/api/src/linear/sync-feedback.ts
@@ -79,6 +79,8 @@ export interface LinearConfig {
 export interface FeedbackUser {
   id: string;
   email: string | null;
+  username: string | null;
+  displayName: string | null;
 }
 
 /**
@@ -87,7 +89,11 @@ export interface FeedbackUser {
  */
 const LinearSyncMetadataSchema = z.object({
   linearIssueId: z.string().optional().catch(undefined),
+  linearSyncStartedAt: z.string().optional().catch(undefined),
 });
+
+/** How long a sync lock is valid before it's considered stale (5 minutes) */
+const SYNC_LOCK_TTL_MS = 5 * 60 * 1000;
 
 /**
  * Syncs a feedback record to Linear by creating an issue.
@@ -103,7 +109,7 @@ export async function syncFeedbackToLinear(
   // Fetch feedback from DB to get current state (ensures consistency)
   const feedback = await db.feedback.findUnique({
     where: { id: feedbackId },
-    select: { comment: true, metadata: true },
+    select: { comment: true, metadata: true, createdAt: true },
   });
 
   if (!feedback) {
@@ -127,6 +133,36 @@ export async function syncFeedbackToLinear(
     return;
   }
 
+  // Check for concurrent sync (prevents duplicate issues from race conditions)
+  if (syncMetadata.linearSyncStartedAt) {
+    const syncStarted = new Date(syncMetadata.linearSyncStartedAt).getTime();
+    const now = Date.now();
+    if (now - syncStarted < SYNC_LOCK_TTL_MS) {
+      logger.info('Linear sync already in progress, skipping', {
+        feedbackId,
+        syncStartedAt: syncMetadata.linearSyncStartedAt,
+      });
+      return;
+    }
+    // Lock is stale, proceed with sync (previous sync likely failed)
+    logger.warn('Stale Linear sync lock detected, proceeding with sync', {
+      feedbackId,
+      syncStartedAt: syncMetadata.linearSyncStartedAt,
+    });
+  }
+
+  // Set sync lock BEFORE creating Linear issue to prevent race conditions
+  const syncStartedAt = new Date().toISOString();
+  await db.feedback.update({
+    where: { id: feedbackId },
+    data: {
+      metadata: {
+        ...(rawMetadata as Record<string, unknown>),
+        linearSyncStartedAt: syncStartedAt,
+      },
+    },
+  });
+
   const metadata: FeedbackMetadata = FeedbackMetadataSchema.parse(rawMetadata);
 
   const formatted = formatFeedbackForLinear({
@@ -138,6 +174,9 @@ export async function syncFeedbackToLinear(
     rating: metadata.rating,
     userId: user.id,
     userEmail: user.email,
+    username: user.username,
+    displayName: user.displayName,
+    createdAt: feedback.createdAt,
   });
 
   // Create Linear issue with retry logic for transient failures
@@ -155,9 +194,8 @@ export async function syncFeedbackToLinear(
   );
 
   // Merge update: fetch fresh metadata to preserve concurrent updates.
-  // Note: This is not truly atomic (TOCTOU gap exists), but the idempotency
-  // check above prevents duplicate Linear issues, and metadata merge is
-  // additive only. Risk is acceptable for fire-and-forget background sync.
+  // The linearSyncStartedAt lock set earlier prevents duplicate Linear issues
+  // from race conditions. This update clears the lock and stores the issue info.
   const freshFeedback = await db.feedback.findUnique({
     where: { id: feedbackId },
     select: { metadata: true },
@@ -168,11 +206,13 @@ export async function syncFeedbackToLinear(
       ? (freshFeedback.metadata as Record<string, unknown>)
       : {};
 
+  // Remove the sync lock and store the issue info
+  const { linearSyncStartedAt: _, ...metadataWithoutLock } = freshMetadata;
   await db.feedback.update({
     where: { id: feedbackId },
     data: {
       metadata: {
-        ...freshMetadata,
+        ...metadataWithoutLock,
         linearIssueId: issue.id,
         linearIssueIdentifier: issue.identifier,
         linearIssueUrl: issue.url,

--- a/packages/api/src/linear/sync-feedback.ts
+++ b/packages/api/src/linear/sync-feedback.ts
@@ -4,7 +4,8 @@
  * Includes retry logic with exponential backoff for transient failures.
  */
 
-import { db, type JsonObject } from '@babylon/db';
+import { db, feedbacks, type JsonObject } from '@babylon/db';
+import { and, eq, or, sql } from 'drizzle-orm';
 import { FeedbackTypeSchema, logger } from '@babylon/shared';
 import { z } from 'zod';
 import { createLinearIssue } from './client';
@@ -97,9 +98,10 @@ export const SYNC_LOCK_TTL_MS = 5 * 60 * 1000;
 
 /**
  * Atomically acquire a sync lock for Linear issue creation.
- * Uses a single SQL UPDATE with conditional WHERE clause to prevent TOCTOU race conditions.
+ * Uses Drizzle's update().set().where().returning() for atomic conditional updates.
+ * This eliminates TOCTOU race conditions by checking and setting in one operation.
  *
- * @returns Object with lockAcquired flag and metadata/createdAt if successful
+ * @returns Object with lockAcquired flag and feedback data if successful
  */
 async function acquireSyncLock(
   feedbackId: string,
@@ -114,32 +116,43 @@ async function acquireSyncLock(
   // Calculate the stale threshold timestamp
   const staleThreshold = new Date(Date.now() - ttlMs).toISOString();
 
-  // Atomic lock acquisition using raw SQL:
+  // Atomic lock acquisition using Drizzle's query builder with sql templates:
   // - Only acquires lock if linearIssueId is NULL (not already synced)
   // - Only acquires lock if linearSyncStartedAt is NULL OR older than TTL
-  // This eliminates the TOCTOU gap between check and set
-  type LockResult = { id: string; metadata: JsonObject | null; createdAt: Date };
-  const result: LockResult[] = await db.$queryRaw<LockResult>`
-    UPDATE "Feedback"
-    SET metadata = jsonb_set(
-      COALESCE(metadata, '{}'::jsonb),
-      '{linearSyncStartedAt}',
-      to_jsonb(${syncStartedAt}::text)
-    )
-    WHERE id = ${feedbackId}
-      AND (metadata->>'linearIssueId' IS NULL)
-      AND (
-        metadata->>'linearSyncStartedAt' IS NULL
-        OR metadata->>'linearSyncStartedAt' < ${staleThreshold}
+  // - Uses RETURNING to get updated row in single round-trip
+  const result = await db
+    .update(feedbacks)
+    .set({
+      // Use jsonb_set to atomically update the lock timestamp in metadata
+      metadata: sql`jsonb_set(
+        COALESCE(${feedbacks.metadata}, '{}'::jsonb),
+        '{linearSyncStartedAt}',
+        to_jsonb(${syncStartedAt}::text)
+      )`,
+    })
+    .where(
+      and(
+        eq(feedbacks.id, feedbackId),
+        // Not already synced to Linear
+        sql`${feedbacks.metadata}->>'linearIssueId' IS NULL`,
+        // No active lock OR lock is stale
+        or(
+          sql`${feedbacks.metadata}->>'linearSyncStartedAt' IS NULL`,
+          sql`${feedbacks.metadata}->>'linearSyncStartedAt' < ${staleThreshold}`
+        )
       )
-    RETURNING id, metadata, "createdAt"
-  `;
+    )
+    .returning({
+      id: feedbacks.id,
+      metadata: feedbacks.metadata,
+      createdAt: feedbacks.createdAt,
+    });
 
   const firstRow = result[0];
   if (firstRow) {
     return {
       lockAcquired: true,
-      metadata: firstRow.metadata,
+      metadata: firstRow.metadata as JsonObject | null,
       createdAt: firstRow.createdAt,
     };
   }

--- a/packages/api/src/linear/sync-feedback.ts
+++ b/packages/api/src/linear/sync-feedback.ts
@@ -120,7 +120,7 @@ export async function syncFeedbackToLinear(
   // Safely parse metadata using Zod schema
   const rawMetadata =
     feedback.metadata && typeof feedback.metadata === 'object'
-      ? feedback.metadata
+      ? (feedback.metadata as JsonObject)
       : {};
 
   // Idempotency check: skip if already synced to Linear
@@ -165,7 +165,7 @@ export async function syncFeedbackToLinear(
     where: { id: feedbackId },
     data: {
       metadata: {
-        ...(rawMetadata as Record<string, unknown>),
+        ...rawMetadata,
         linearSyncStartedAt: syncStartedAt,
       },
     },
@@ -239,7 +239,7 @@ export async function syncFeedbackToLinear(
 
   const freshMetadata =
     freshFeedback?.metadata && typeof freshFeedback.metadata === 'object'
-      ? (freshFeedback.metadata as Record<string, unknown>)
+      ? (freshFeedback.metadata as JsonObject)
       : {};
 
   // Remove the sync lock and store the issue info

--- a/packages/api/src/linear/sync-feedback.ts
+++ b/packages/api/src/linear/sync-feedback.ts
@@ -2,9 +2,11 @@
  * Sync feedback to Linear by creating an issue.
  * This function is designed to be fire-and-forget from the API route.
  * Includes retry logic with exponential backoff for transient failures.
+ *
+ * Uses pure Drizzle ORM throughout for consistency.
  */
 
-import { db, feedbacks, type JsonObject } from '@babylon/db';
+import { db, feedbacks, type JsonObject, type JsonValue } from '@babylon/db';
 import { and, eq, or, sql } from 'drizzle-orm';
 import { FeedbackTypeSchema, logger } from '@babylon/shared';
 import { z } from 'zod';
@@ -97,6 +99,15 @@ const LinearSyncMetadataSchema = z.object({
 export const SYNC_LOCK_TTL_MS = 5 * 60 * 1000;
 
 /**
+ * Helper to safely parse JSON metadata from database result.
+ */
+function parseJsonMetadata(raw: JsonValue | null | undefined): JsonObject {
+  return raw && typeof raw === 'object' && !Array.isArray(raw)
+    ? (raw as JsonObject)
+    : {};
+}
+
+/**
  * Atomically acquire a sync lock for Linear issue creation.
  * Uses Drizzle's update().set().where().returning() for atomic conditional updates.
  * This eliminates TOCTOU race conditions by checking and setting in one operation.
@@ -109,8 +120,9 @@ async function acquireSyncLock(
   ttlMs: number
 ): Promise<{
   lockAcquired: boolean;
-  metadata: JsonObject | null;
-  createdAt: Date | null;
+  comment: string | null;
+  metadata: JsonObject;
+  createdAt: Date;
   reason?: 'not_found' | 'already_synced' | 'lock_held';
 }> {
   // Calculate the stale threshold timestamp
@@ -144,6 +156,7 @@ async function acquireSyncLock(
     )
     .returning({
       id: feedbacks.id,
+      comment: feedbacks.comment,
       metadata: feedbacks.metadata,
       createdAt: feedbacks.createdAt,
     });
@@ -152,32 +165,69 @@ async function acquireSyncLock(
   if (firstRow) {
     return {
       lockAcquired: true,
-      metadata: firstRow.metadata as JsonObject | null,
+      comment: firstRow.comment,
+      metadata: parseJsonMetadata(firstRow.metadata),
       createdAt: firstRow.createdAt,
     };
   }
 
-  // Lock not acquired - determine why for logging
-  const feedback = await db.feedback.findUnique({
-    where: { id: feedbackId },
-    select: { metadata: true },
-  });
+  // Lock not acquired - determine why for logging using Drizzle select
+  const [feedback] = await db
+    .select({ metadata: feedbacks.metadata })
+    .from(feedbacks)
+    .where(eq(feedbacks.id, feedbackId))
+    .limit(1);
 
   if (!feedback) {
-    return { lockAcquired: false, metadata: null, createdAt: null, reason: 'not_found' };
+    return {
+      lockAcquired: false,
+      comment: null,
+      metadata: {},
+      createdAt: new Date(),
+      reason: 'not_found',
+    };
   }
 
   const syncMetadata = LinearSyncMetadataSchema.parse(
-    feedback.metadata && typeof feedback.metadata === 'object'
-      ? feedback.metadata
-      : {}
+    parseJsonMetadata(feedback.metadata)
   );
 
   if (syncMetadata.linearIssueId) {
-    return { lockAcquired: false, metadata: null, createdAt: null, reason: 'already_synced' };
+    return {
+      lockAcquired: false,
+      comment: null,
+      metadata: {},
+      createdAt: new Date(),
+      reason: 'already_synced',
+    };
   }
 
-  return { lockAcquired: false, metadata: null, createdAt: null, reason: 'lock_held' };
+  return {
+    lockAcquired: false,
+    comment: null,
+    metadata: {},
+    createdAt: new Date(),
+    reason: 'lock_held',
+  };
+}
+
+/**
+ * Atomically clear the sync lock using Drizzle's jsonb_set with path removal.
+ * Called on failure to allow immediate retry.
+ */
+async function clearSyncLock(feedbackId: string): Promise<void> {
+  try {
+    // Use Drizzle's update with sql template to atomically remove the lock key
+    await db
+      .update(feedbacks)
+      .set({
+        metadata: sql`${feedbacks.metadata} - 'linearSyncStartedAt'`,
+      })
+      .where(eq(feedbacks.id, feedbackId));
+  } catch (cleanupError) {
+    // Log but don't throw - lock will expire naturally after TTL
+    logger.warn('Failed to clear sync lock', { feedbackId, cleanupError });
+  }
 }
 
 /**
@@ -186,6 +236,8 @@ async function acquireSyncLock(
  *
  * Uses atomic lock acquisition to prevent duplicate issues from concurrent requests.
  * Idempotent: If feedback already has a linearIssueId, skips creation.
+ *
+ * All database operations use Drizzle ORM for consistency.
  */
 export async function syncFeedbackToLinear(
   config: LinearConfig,
@@ -193,8 +245,13 @@ export async function syncFeedbackToLinear(
   user: FeedbackUser
 ): Promise<void> {
   // Atomically acquire sync lock - this eliminates TOCTOU race conditions
+  // Also returns the feedback data in the same round-trip
   const syncStartedAt = new Date().toISOString();
-  const lockResult = await acquireSyncLock(feedbackId, syncStartedAt, SYNC_LOCK_TTL_MS);
+  const lockResult = await acquireSyncLock(
+    feedbackId,
+    syncStartedAt,
+    SYNC_LOCK_TTL_MS
+  );
 
   if (!lockResult.lockAcquired) {
     switch (lockResult.reason) {
@@ -202,7 +259,9 @@ export async function syncFeedbackToLinear(
         logger.warn('Feedback not found for Linear sync', { feedbackId });
         break;
       case 'already_synced':
-        logger.info('Feedback already synced to Linear, skipping', { feedbackId });
+        logger.info('Feedback already synced to Linear, skipping', {
+          feedbackId,
+        });
         break;
       case 'lock_held':
         logger.info('Linear sync already in progress, skipping', { feedbackId });
@@ -211,50 +270,15 @@ export async function syncFeedbackToLinear(
     return;
   }
 
-  // Fetch full feedback data now that we have the lock
-  const feedback = await db.feedback.findUnique({
-    where: { id: feedbackId },
-    select: { comment: true, metadata: true, createdAt: true },
-  });
-
-  if (!feedback) {
-    logger.warn('Feedback not found after lock acquisition', { feedbackId });
-    return;
-  }
-
-  // Parse metadata from the locked record
-  const rawMetadata =
-    feedback.metadata && typeof feedback.metadata === 'object'
-      ? (feedback.metadata as JsonObject)
-      : {};
-
-  // Helper to clear the sync lock (called on failure to allow immediate retry)
-  const clearSyncLock = async () => {
-    try {
-      const current = await db.feedback.findUnique({
-        where: { id: feedbackId },
-        select: { metadata: true },
-      });
-      if (!current?.metadata || typeof current.metadata !== 'object') return;
-
-      const currentMetadata = current.metadata as JsonObject;
-      const { linearSyncStartedAt: _, ...withoutLock } = currentMetadata;
-      await db.feedback.update({
-        where: { id: feedbackId },
-        data: { metadata: withoutLock },
-      });
-    } catch (cleanupError) {
-      // Log but don't throw - lock will expire naturally after TTL
-      logger.warn('Failed to clear sync lock', { feedbackId, cleanupError });
-    }
-  };
-
-  const metadata: FeedbackMetadata = FeedbackMetadataSchema.parse(rawMetadata);
+  // Use metadata from lock acquisition result (no extra DB call needed)
+  const metadata: FeedbackMetadata = FeedbackMetadataSchema.parse(
+    lockResult.metadata
+  );
 
   const formatted = formatFeedbackForLinear({
     id: feedbackId,
     feedbackType: metadata.feedbackType,
-    description: feedback.comment ?? '',
+    description: lockResult.comment ?? '',
     stepsToReproduce: metadata.stepsToReproduce,
     screenshotUrl: metadata.screenshotUrl,
     rating: metadata.rating,
@@ -262,7 +286,7 @@ export async function syncFeedbackToLinear(
     userEmail: user.email,
     username: user.username,
     displayName: user.displayName,
-    createdAt: feedback.createdAt,
+    createdAt: lockResult.createdAt,
   });
 
   // Create Linear issue with retry logic for transient failures
@@ -282,36 +306,22 @@ export async function syncFeedbackToLinear(
     );
   } catch (error) {
     // Clear the sync lock on failure so immediate retry is possible
-    await clearSyncLock();
+    await clearSyncLock(feedbackId);
     throw error;
   }
 
-  // Merge update: fetch fresh metadata to preserve concurrent updates.
-  // The linearSyncStartedAt lock set earlier prevents duplicate Linear issues
-  // from race conditions. This update clears the lock and stores the issue info.
-  const freshFeedback = await db.feedback.findUnique({
-    where: { id: feedbackId },
-    select: { metadata: true },
-  });
-
-  const freshMetadata =
-    freshFeedback?.metadata && typeof freshFeedback.metadata === 'object'
-      ? (freshFeedback.metadata as JsonObject)
-      : {};
-
-  // Remove the sync lock and store the issue info
-  const { linearSyncStartedAt: _, ...metadataWithoutLock } = freshMetadata;
-  await db.feedback.update({
-    where: { id: feedbackId },
-    data: {
-      metadata: {
-        ...metadataWithoutLock,
-        linearIssueId: issue.id,
-        linearIssueIdentifier: issue.identifier,
-        linearIssueUrl: issue.url,
-      },
-    },
-  });
+  // Atomically update metadata: remove lock and add issue info in one operation
+  // Uses Drizzle's sql template with jsonb operators for atomic update
+  await db
+    .update(feedbacks)
+    .set({
+      metadata: sql`(${feedbacks.metadata} - 'linearSyncStartedAt') || jsonb_build_object(
+        'linearIssueId', ${issue.id}::text,
+        'linearIssueIdentifier', ${issue.identifier}::text,
+        'linearIssueUrl', ${issue.url}::text
+      )`,
+    })
+    .where(eq(feedbacks.id, feedbackId));
 
   logger.info('Linear issue created for feedback', {
     feedbackId,

--- a/packages/api/src/linear/sync-feedback.ts
+++ b/packages/api/src/linear/sync-feedback.ts
@@ -93,7 +93,7 @@ const LinearSyncMetadataSchema = z.object({
 });
 
 /** How long a sync lock is valid before it's considered stale (5 minutes) */
-const SYNC_LOCK_TTL_MS = 5 * 60 * 1000;
+export const SYNC_LOCK_TTL_MS = 5 * 60 * 1000;
 
 /**
  * Syncs a feedback record to Linear by creating an issue.
@@ -136,19 +136,27 @@ export async function syncFeedbackToLinear(
   // Check for concurrent sync (prevents duplicate issues from race conditions)
   if (syncMetadata.linearSyncStartedAt) {
     const syncStarted = new Date(syncMetadata.linearSyncStartedAt).getTime();
-    const now = Date.now();
-    if (now - syncStarted < SYNC_LOCK_TTL_MS) {
-      logger.info('Linear sync already in progress, skipping', {
+    // Handle invalid date strings (NaN) by treating as stale lock
+    if (Number.isNaN(syncStarted)) {
+      logger.warn('Invalid linearSyncStartedAt timestamp, proceeding with sync', {
         feedbackId,
         syncStartedAt: syncMetadata.linearSyncStartedAt,
       });
-      return;
+    } else {
+      const now = Date.now();
+      if (now - syncStarted < SYNC_LOCK_TTL_MS) {
+        logger.info('Linear sync already in progress, skipping', {
+          feedbackId,
+          syncStartedAt: syncMetadata.linearSyncStartedAt,
+        });
+        return;
+      }
+      // Lock is stale, proceed with sync (previous sync likely failed)
+      logger.warn('Stale Linear sync lock detected, proceeding with sync', {
+        feedbackId,
+        syncStartedAt: syncMetadata.linearSyncStartedAt,
+      });
     }
-    // Lock is stale, proceed with sync (previous sync likely failed)
-    logger.warn('Stale Linear sync lock detected, proceeding with sync', {
-      feedbackId,
-      syncStartedAt: syncMetadata.linearSyncStartedAt,
-    });
   }
 
   // Set sync lock BEFORE creating Linear issue to prevent race conditions

--- a/packages/api/src/linear/sync-feedback.ts
+++ b/packages/api/src/linear/sync-feedback.ts
@@ -163,21 +163,25 @@ export async function syncFeedbackToLinear(
     },
   });
 
-  // Helper to clear the sync lock (used on success and failure)
+  // Helper to clear the sync lock (called on failure to allow immediate retry)
   const clearSyncLock = async () => {
-    const current = await db.feedback.findUnique({
-      where: { id: feedbackId },
-      select: { metadata: true },
-    });
-    const currentMetadata =
-      current?.metadata && typeof current.metadata === 'object'
-        ? (current.metadata as JsonObject)
-        : {};
-    const { linearSyncStartedAt: _, ...withoutLock } = currentMetadata;
-    await db.feedback.update({
-      where: { id: feedbackId },
-      data: { metadata: withoutLock },
-    });
+    try {
+      const current = await db.feedback.findUnique({
+        where: { id: feedbackId },
+        select: { metadata: true },
+      });
+      if (!current?.metadata || typeof current.metadata !== 'object') return;
+
+      const currentMetadata = current.metadata as JsonObject;
+      const { linearSyncStartedAt: _, ...withoutLock } = currentMetadata;
+      await db.feedback.update({
+        where: { id: feedbackId },
+        data: { metadata: withoutLock },
+      });
+    } catch (cleanupError) {
+      // Log but don't throw - lock will expire naturally after TTL
+      logger.warn('Failed to clear sync lock', { feedbackId, cleanupError });
+    }
   };
 
   const metadata: FeedbackMetadata = FeedbackMetadataSchema.parse(rawMetadata);
@@ -196,9 +200,9 @@ export async function syncFeedbackToLinear(
     createdAt: feedback.createdAt,
   });
 
+  // Create Linear issue with retry logic for transient failures
   let issue;
   try {
-    // Create Linear issue with retry logic for transient failures
     issue = await withRetry(
       () =>
         createLinearIssue(config.apiKey, {
@@ -212,7 +216,7 @@ export async function syncFeedbackToLinear(
       { feedbackId }
     );
   } catch (error) {
-    // Clear the sync lock on failure so retry can work
+    // Clear the sync lock on failure so immediate retry is possible
     await clearSyncLock();
     throw error;
   }
@@ -231,7 +235,7 @@ export async function syncFeedbackToLinear(
       : {};
 
   // Remove the sync lock and store the issue info
-  const { linearSyncStartedAt: __, ...metadataWithoutLock } = freshMetadata;
+  const { linearSyncStartedAt: _, ...metadataWithoutLock } = freshMetadata;
   await db.feedback.update({
     where: { id: feedbackId },
     data: {

--- a/packages/testing/unit/linear-integration.test.ts
+++ b/packages/testing/unit/linear-integration.test.ts
@@ -4,6 +4,7 @@ import {
   type FeedbackType,
   formatFeedbackForLinear,
 } from '../../api/src/linear/format-feedback';
+import { SYNC_LOCK_TTL_MS } from '../../api/src/linear/sync-feedback';
 
 describe('formatFeedbackForLinear', () => {
   test('bug report with all fields', () => {
@@ -147,6 +148,125 @@ describe('formatFeedbackForLinear', () => {
       ).not.toThrow();
     }
   });
+
+  // New tests for username/profile link functionality
+  test('formats username with profile link', () => {
+    const result = formatFeedbackForLinear({
+      id: 'test',
+      feedbackType: 'bug',
+      description: 'test description',
+      userId: 'user-1',
+      username: 'gold_roach',
+      displayName: 'Golden Roach',
+    });
+    // Check for markdown link format with display name and profile path
+    expect(result.description).toContain('[Golden Roach]');
+    expect(result.description).toContain('/profile/gold_roach)');
+    expect(result.description).toContain('(@gold_roach)');
+  });
+
+  test('uses username as display name when displayName is null', () => {
+    const result = formatFeedbackForLinear({
+      id: 'test',
+      feedbackType: 'bug',
+      description: 'test description',
+      userId: 'user-1',
+      username: 'gold_roach',
+      displayName: null,
+    });
+    // When displayName is null, username should be used as display name
+    expect(result.description).toContain('[gold_roach]');
+    expect(result.description).toContain('/profile/gold_roach)');
+    expect(result.description).toContain('(@gold_roach)');
+  });
+
+  test('falls back to email when username is null', () => {
+    const result = formatFeedbackForLinear({
+      id: 'test',
+      feedbackType: 'bug',
+      description: 'test description',
+      userId: 'user-1',
+      username: null,
+      displayName: null,
+      userEmail: 'test@example.com',
+    });
+    expect(result.description).toContain('**Submitted by:** test@example.com');
+    expect(result.description).not.toContain('https://babylon.game/profile/');
+  });
+
+  test('URL-encodes special characters in username', () => {
+    const result = formatFeedbackForLinear({
+      id: 'test',
+      feedbackType: 'bug',
+      description: 'test description',
+      userId: 'user-1',
+      username: 'user with spaces',
+      displayName: 'User With Spaces',
+    });
+    expect(result.description).toContain('/profile/user%20with%20spaces');
+  });
+
+  test('URL-encodes @ symbol in username', () => {
+    const result = formatFeedbackForLinear({
+      id: 'test',
+      feedbackType: 'bug',
+      description: 'test description',
+      userId: 'user-1',
+      username: '@special_user',
+      displayName: 'Special User',
+    });
+    expect(result.description).toContain('/profile/%40special_user');
+  });
+
+  test('formats timestamp correctly with Intl.DateTimeFormat', () => {
+    const result = formatFeedbackForLinear({
+      id: 'test',
+      feedbackType: 'bug',
+      description: 'test description',
+      userId: 'user-1',
+      createdAt: new Date('2025-12-31T15:30:00Z'),
+    });
+    // en-GB format: DD/MM/YYYY HH:MM:SS UTC
+    expect(result.description).toContain('31/12/2025');
+    expect(result.description).toContain('15:30:00');
+    expect(result.description).toContain('UTC');
+  });
+
+  test('shows Unknown timestamp when createdAt is undefined', () => {
+    const result = formatFeedbackForLinear({
+      id: 'test',
+      feedbackType: 'bug',
+      description: 'test description',
+      userId: 'user-1',
+    });
+    expect(result.description).toContain('**Submitted at:** Unknown');
+  });
+
+  test('escapes HTML in username and displayName', () => {
+    const result = formatFeedbackForLinear({
+      id: 'test',
+      feedbackType: 'bug',
+      description: 'test',
+      userId: 'user-1',
+      username: '<script>xss</script>',
+      displayName: '<b>Bold Name</b>',
+    });
+    expect(result.description).toContain('&lt;script&gt;xss&lt;/script&gt;');
+    expect(result.description).toContain('&lt;b&gt;Bold Name&lt;/b&gt;');
+    expect(result.description).not.toContain('<script>');
+    expect(result.description).not.toContain('<b>');
+  });
+
+  test('includes Submitted at field in output', () => {
+    const result = formatFeedbackForLinear({
+      id: 'test',
+      feedbackType: 'bug',
+      description: 'test',
+      userId: 'user-1',
+      createdAt: new Date('2025-01-15T10:00:00Z'),
+    });
+    expect(result.description).toContain('**Submitted at:**');
+  });
 });
 
 describe('getLinearConfig', () => {
@@ -174,5 +294,19 @@ describe('getLinearConfig', () => {
     expect(config?.teamId).toBe('team-123');
     process.env.LINEAR_API_KEY = orig.api;
     process.env.LINEAR_TEAM_ID = orig.team;
+  });
+});
+
+describe('SYNC_LOCK_TTL_MS', () => {
+  test('is 5 minutes in milliseconds', () => {
+    expect(SYNC_LOCK_TTL_MS).toBe(5 * 60 * 1000);
+    expect(SYNC_LOCK_TTL_MS).toBe(300000);
+  });
+
+  test('is a reasonable TTL for sync operations', () => {
+    // Should be at least 1 minute (enough for retries)
+    expect(SYNC_LOCK_TTL_MS).toBeGreaterThanOrEqual(60 * 1000);
+    // Should be at most 10 minutes (don't block too long)
+    expect(SYNC_LOCK_TTL_MS).toBeLessThanOrEqual(10 * 60 * 1000);
   });
 });


### PR DESCRIPTION
## Summary

Improvements to the Linear feedback integration to provide better context in issues and prevent duplicate issue creation.

## Changes

### 1. Username with Profile Link
- Shows the user's display name linked to their Babylon profile
- Format: `[Golden Roach](https://babylon.game/profile/gold_roach_mode) (@gold_roach_mode)`
- Falls back to email or 'Unknown' if username not available

### 2. Submission Timestamp
- Adds `Submitted at` field with UTC timestamp
- Format: `2025-12-31 20:47:31 UTC`

### 3. Duplicate Prevention (Race Condition Fix)
- **Problem**: Concurrent requests could create duplicate Linear issues (e.g., BF-4, BF-5, BF-6 all for the same feedback)
- **Solution**: Adds a `linearSyncStartedAt` lock before creating the Linear issue
- Subsequent concurrent requests see the lock and skip
- Lock expires after 5 minutes to handle failed syncs

## Linear Issue Preview

```markdown
### Submission Details
- **Submitted by:** [Golden Roach](https://babylon.game/profile/gold_roach_mode) (@gold_roach_mode)
- **Submitted at:** 2025-12-31 20:47:31 UTC
- **User ID:** \`did:privy:xxx\`
- **Feedback ID:** \`264857091317956608\`
- **Type:** Bug Report
```

## Files Changed
- `packages/api/src/linear/format-feedback.ts` - Username link + timestamp formatting
- `packages/api/src/linear/sync-feedback.ts` - Pass new fields + duplicate prevention lock
- `apps/web/src/app/api/admin/feedback/[feedbackId]/retry-sync/route.ts` - Include username in query

## Testing
1. Submit feedback and verify Linear issue shows username with profile link
2. Verify timestamp is displayed
3. Rapid-fire submit same feedback and verify only one issue is created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual feedback retry now detects active syncs, returns a wait indication to prevent duplicate submissions, and exposes a short lock TTL.
  * Feedback items include submitter profile links, display names, and readable "Submitted at" timestamps.
  * User lookups return richer profile info for clearer attribution; a sync TTL constant is now exposed for monitoring.
* **Bug Fixes**
  * Improved logging and handling for stale or invalid sync locks during manual retries.
* **Tests**
  * Added coverage for profile links, timestamp formatting, escaping, and lock TTL.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Adds username with profile links, timestamps, and a lock-based duplicate prevention mechanism to the Linear feedback sync. The implementation prevents race conditions when multiple concurrent requests try to sync the same feedback by using a `linearSyncStartedAt` lock with a 5-minute TTL.

**Key Changes:**
- Username formatting with profile links and proper HTML escaping
- Timestamp display in Linear issues (UTC format)
- Lock mechanism prevents duplicate issue creation from concurrent requests
- Lock expires after 5 minutes to handle failed syncs

**Issues Found:**
- Username in profile URLs needs URL encoding for special characters
- Manual retry-sync endpoint may fail silently when lock is active (< 5 min old)

<h3>Confidence Score: 3/5</h3>


- Safe to merge with two critical bugs that should be fixed
- The duplicate prevention mechanism is solid, but two logic errors need fixing: username URL encoding and retry-sync lock handling. Both could cause broken links or silent failures in production
- Pay close attention to `packages/api/src/linear/format-feedback.ts` (URL encoding) and `apps/web/src/app/api/admin/feedback/[feedbackId]/retry-sync/route.ts` (lock handling)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/api/src/linear/sync-feedback.ts | Added duplicate prevention lock mechanism and passes username/timestamp to formatter |
| packages/api/src/linear/format-feedback.ts | Formats username with profile link and timestamp, proper HTML escaping applied |
| apps/web/src/app/api/admin/feedback/[feedbackId]/retry-sync/route.ts | Added username and displayName to user query for retry-sync endpoint |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API as Feedback API
    participant DB as Database
    participant Sync as syncFeedbackToLinear
    participant Linear as Linear API
    
    User->>API: POST /api/feedback/game-feedback
    API->>DB: Create feedback record
    DB-->>API: Feedback created
    
    API->>Sync: Fire-and-forget sync
    Note over API,Sync: Async - doesn't block response
    API-->>User: 201 Success
    
    Sync->>DB: Fetch feedback + metadata
    DB-->>Sync: Feedback data
    
    alt Already has linearIssueId
        Sync->>Sync: Skip (idempotent)
    else Has linearSyncStartedAt < 5min
        Sync->>Sync: Skip (lock active)
    else Stale lock or no lock
        Sync->>DB: Set linearSyncStartedAt lock
        DB-->>Sync: Lock set
        
        Sync->>Linear: Create issue (with retries)
        Linear-->>Sync: Issue created
        
        Sync->>DB: Clear lock + store issue info
        DB-->>Sync: Updated
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->