### PR TITLE
fix(admin): check all linked emails for admin domain auto-promotion

### DIFF
--- a/apps/web/src/app/api/chats/[id]/message/route.ts
+++ b/apps/web/src/app/api/chats/[id]/message/route.ts
@@ -109,7 +109,7 @@ import {
   chatParticipants,
   db,
   eq,
-  groupChatMemberships,
+  groupMembers,
   hasBlocked,
   users,
 } from '@babylon/db';
@@ -352,17 +352,17 @@ export const POST = withErrorHandling(
             // Wrap in transaction for consistency
             await db.transaction(async (tx) => {
               await tx
-                .update(groupChatMemberships)
+                .update(groupMembers)
                 .set({
                   isActive: false,
-                  removedAt: new Date(),
-                  sweepReason: 'Lost NFT access',
+                  kickedAt: new Date(),
+                  kickReason: 'Lost NFT access',
                 })
                 .where(
                   and(
-                    eq(groupChatMemberships.chatId, chatId),
-                    eq(groupChatMemberships.userId, user.userId),
-                    eq(groupChatMemberships.isActive, true)
+                    eq(groupMembers.groupId, chatId),
+                    eq(groupMembers.userId, user.userId),
+                    eq(groupMembers.isActive, true)
                   )
                 );
 

--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -150,7 +150,11 @@ import {
   withErrorHandling,
 } from '@babylon/api';
 import { db, eq, users } from '@babylon/db';
-import { logger, shouldAutoPromoteToAdmin } from '@babylon/shared';
+import {
+  checkForAdminEmail,
+  logger,
+  type PrivyUserWithEmails,
+} from '@babylon/shared';
 import type { User as PrivyUser } from '@privy-io/server-auth';
 import type { NextRequest } from 'next/server';
 
@@ -161,62 +165,11 @@ type PrivyWalletLite = {
   walletClientType?: string | null;
 };
 
-type PrivyUserWithSmartWallet = PrivyUser & {
-  smartWallet?: { address?: string | null };
-  wallet?: PrivyWalletLite;
-  linkedAccounts?: Array<
-    PrivyWalletLite & {
-      type?: string;
-      address?: string; // For email accounts, this is the email address
-    }
-  >;
-};
-
-/**
- * Get all verified email addresses from a Privy user.
- * Checks both the primary email and linkedAccounts for email-type accounts.
- * This ensures we catch emails that were linked after initial signup.
- */
-function getAllVerifiedEmails(user: PrivyUserWithSmartWallet): string[] {
-  const emails: string[] = [];
-
-  // Check primary email field
-  if (user.email?.address) {
-    emails.push(user.email.address);
-  }
-
-  // Check linkedAccounts for email-type accounts
-  if (Array.isArray(user.linkedAccounts)) {
-    for (const account of user.linkedAccounts) {
-      if (account?.type === 'email' && account.address) {
-        // Avoid duplicates
-        if (!emails.includes(account.address)) {
-          emails.push(account.address);
-        }
-      }
-    }
-  }
-
-  return emails;
-}
-
-/**
- * Check if any of the user's verified emails should grant admin access.
- * Returns the first matching admin email, or null if none match.
- */
-function findAdminEmail(
-  emails: string[],
-  emailVerified: boolean
-): string | null {
-  if (!emailVerified || emails.length === 0) return null;
-
-  for (const email of emails) {
-    if (shouldAutoPromoteToAdmin(email, true)) {
-      return email;
-    }
-  }
-  return null;
-}
+type PrivyUserWithSmartWallet = PrivyUser &
+  PrivyUserWithEmails & {
+    smartWallet?: { address?: string | null };
+    wallet?: PrivyWalletLite;
+  };
 
 function pickEmbeddedEvmWallet(
   user: PrivyUserWithSmartWallet
@@ -467,9 +420,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     // Check if user should be auto-promoted to admin based on email domain
     // SECURITY: Requires email verification (Privy emails are verified by design)
     // Check ALL linked emails, not just the primary one (handles users who linked admin email later)
-    const allVerifiedEmails = getAllVerifiedEmails(privyUser);
-    const emailVerified = allVerifiedEmails.length > 0;
-    const adminEmail = findAdminEmail(allVerifiedEmails, emailVerified);
+    const { adminEmail, allVerifiedEmails } = checkForAdminEmail(privyUser);
     const shouldBeAdmin = adminEmail !== null;
 
     if (shouldBeAdmin) {
@@ -608,9 +559,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   if (dbUser && !dbUser.isAdmin) {
     const privyClient = getPrivyClient();
     const privyUser = await privyClient.getUser(privyId);
-    const allVerifiedEmails = getAllVerifiedEmails(privyUser);
-    const emailVerified = allVerifiedEmails.length > 0;
-    const adminEmail = findAdminEmail(allVerifiedEmails, emailVerified);
+    const { adminEmail, allVerifiedEmails } = checkForAdminEmail(privyUser);
     const shouldBeAdmin = adminEmail !== null;
 
     if (shouldBeAdmin) {

--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -167,9 +167,56 @@ type PrivyUserWithSmartWallet = PrivyUser & {
   linkedAccounts?: Array<
     PrivyWalletLite & {
       type?: string;
+      address?: string; // For email accounts, this is the email address
     }
   >;
 };
+
+/**
+ * Get all verified email addresses from a Privy user.
+ * Checks both the primary email and linkedAccounts for email-type accounts.
+ * This ensures we catch emails that were linked after initial signup.
+ */
+function getAllVerifiedEmails(user: PrivyUserWithSmartWallet): string[] {
+  const emails: string[] = [];
+
+  // Check primary email field
+  if (user.email?.address) {
+    emails.push(user.email.address);
+  }
+
+  // Check linkedAccounts for email-type accounts
+  if (Array.isArray(user.linkedAccounts)) {
+    for (const account of user.linkedAccounts) {
+      if (account?.type === 'email' && account.address) {
+        // Avoid duplicates
+        if (!emails.includes(account.address)) {
+          emails.push(account.address);
+        }
+      }
+    }
+  }
+
+  return emails;
+}
+
+/**
+ * Check if any of the user's verified emails should grant admin access.
+ * Returns the first matching admin email, or null if none match.
+ */
+function findAdminEmail(
+  emails: string[],
+  emailVerified: boolean
+): string | null {
+  if (!emailVerified || emails.length === 0) return null;
+
+  for (const email of emails) {
+    if (shouldAutoPromoteToAdmin(email, true)) {
+      return email;
+    }
+  }
+  return null;
+}
 
 function pickEmbeddedEvmWallet(
   user: PrivyUserWithSmartWallet
@@ -419,14 +466,21 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
 
     // Check if user should be auto-promoted to admin based on email domain
     // SECURITY: Requires email verification (Privy emails are verified by design)
-    // If email exists in Privy, it has been verified through their email verification flow
-    const emailVerified = !!privyUser.email?.address;
-    const shouldBeAdmin = shouldAutoPromoteToAdmin(email, emailVerified);
+    // Check ALL linked emails, not just the primary one (handles users who linked admin email later)
+    const allEmails = getAllVerifiedEmails(privyUser);
+    const emailVerified = allEmails.length > 0;
+    const adminEmail = findAdminEmail(allEmails, emailVerified);
+    const shouldBeAdmin = adminEmail !== null;
 
     if (shouldBeAdmin) {
       logger.info(
         'Auto-promoting user to admin based on verified email domain',
-        { privyId, emailDomain: email?.split('@')[1] ?? null, emailVerified },
+        {
+          privyId,
+          adminEmail,
+          emailDomain: adminEmail?.split('@')[1] ?? null,
+          allEmails,
+        },
         'GET /api/users/me'
       );
     }
@@ -551,23 +605,23 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
 
   // Auto-promote existing users to admin if they have a verified admin domain email
   // This ensures users who later link/verify a company email get admin access
+  // Check ALL linked emails, not just the primary one
   if (dbUser && !dbUser.isAdmin) {
     const privyClient = getPrivyClient();
     const privyUser = await privyClient.getUser(privyId);
-    const verifiedEmail = privyUser.email?.address ?? null;
-    const emailVerified = !!verifiedEmail;
-    const shouldBeAdmin = shouldAutoPromoteToAdmin(
-      verifiedEmail,
-      emailVerified
-    );
+    const allEmails = getAllVerifiedEmails(privyUser);
+    const emailVerified = allEmails.length > 0;
+    const adminEmail = findAdminEmail(allEmails, emailVerified);
+    const shouldBeAdmin = adminEmail !== null;
 
     if (shouldBeAdmin) {
       logger.info(
         'Auto-promoting existing user to admin based on verified email domain',
         {
           userId: dbUser.id,
-          emailDomain: verifiedEmail?.split('@')[1] ?? null,
-          emailVerified,
+          adminEmail,
+          emailDomain: adminEmail?.split('@')[1] ?? null,
+          allEmails,
         },
         'GET /api/users/me'
       );

--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -467,9 +467,9 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     // Check if user should be auto-promoted to admin based on email domain
     // SECURITY: Requires email verification (Privy emails are verified by design)
     // Check ALL linked emails, not just the primary one (handles users who linked admin email later)
-    const allEmails = getAllVerifiedEmails(privyUser);
-    const emailVerified = allEmails.length > 0;
-    const adminEmail = findAdminEmail(allEmails, emailVerified);
+    const allVerifiedEmails = getAllVerifiedEmails(privyUser);
+    const emailVerified = allVerifiedEmails.length > 0;
+    const adminEmail = findAdminEmail(allVerifiedEmails, emailVerified);
     const shouldBeAdmin = adminEmail !== null;
 
     if (shouldBeAdmin) {
@@ -477,9 +477,8 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
         'Auto-promoting user to admin based on verified email domain',
         {
           privyId,
-          adminEmail,
           emailDomain: adminEmail?.split('@')[1] ?? null,
-          allEmails,
+          emailCount: allVerifiedEmails.length,
         },
         'GET /api/users/me'
       );
@@ -609,9 +608,9 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   if (dbUser && !dbUser.isAdmin) {
     const privyClient = getPrivyClient();
     const privyUser = await privyClient.getUser(privyId);
-    const allEmails = getAllVerifiedEmails(privyUser);
-    const emailVerified = allEmails.length > 0;
-    const adminEmail = findAdminEmail(allEmails, emailVerified);
+    const allVerifiedEmails = getAllVerifiedEmails(privyUser);
+    const emailVerified = allVerifiedEmails.length > 0;
+    const adminEmail = findAdminEmail(allVerifiedEmails, emailVerified);
     const shouldBeAdmin = adminEmail !== null;
 
     if (shouldBeAdmin) {
@@ -619,9 +618,8 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
         'Auto-promoting existing user to admin based on verified email domain',
         {
           userId: dbUser.id,
-          adminEmail,
           emailDomain: adminEmail?.split('@')[1] ?? null,
-          allEmails,
+          emailCount: allVerifiedEmails.length,
         },
         'GET /api/users/me'
       );

--- a/apps/web/src/app/api/users/signup/route.ts
+++ b/apps/web/src/app/api/users/signup/route.ts
@@ -236,10 +236,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
   // Fetch identity data from Privy if token provided
   let identityFarcasterUsername: string | undefined;
   let identityTwitterUsername: string | undefined;
-  let adminEmailResult: {
-    adminEmail: string | null;
-    allVerifiedEmails: string[];
-  } = {
+  let adminEmailResult: ReturnType<typeof checkForAdminEmail> = {
     adminEmail: null,
     allVerifiedEmails: [],
   };

--- a/apps/web/src/app/api/users/signup/route.ts
+++ b/apps/web/src/app/api/users/signup/route.ts
@@ -290,8 +290,9 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
 
   if (identityToken) {
     const privyClient = getPrivyClient();
-    const identityUser =
-      (await privyClient.getUserFromIdToken(identityToken)) as PrivyUserWithSmartWallet;
+    const identityUser = (await privyClient.getUserFromIdToken(
+      identityToken
+    )) as PrivyUserWithSmartWallet;
 
     identityFarcasterUsername = identityUser.farcaster?.username ?? undefined;
     identityTwitterUsername = identityUser.twitter?.username ?? undefined;
@@ -479,9 +480,8 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
               'Auto-promoting existing user to admin during signup based on verified email domain',
               {
                 userId: canonicalUserId,
-                adminEmail,
                 emailDomain: adminEmail?.split('@')[1] ?? null,
-                allEmails: allVerifiedEmails,
+                emailCount: allVerifiedEmails.length,
               },
               'POST /api/users/signup'
             );
@@ -508,7 +508,10 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
           // This prevents attackers from submitting fake admin emails in the request body
           // Check ALL linked emails, not just the primary one
           const emailVerified = allVerifiedEmails.length > 0;
-          const newUserAdminEmail = findAdminEmail(allVerifiedEmails, emailVerified);
+          const newUserAdminEmail = findAdminEmail(
+            allVerifiedEmails,
+            emailVerified
+          );
           const shouldBeAdmin = newUserAdminEmail !== null;
 
           if (shouldBeAdmin) {
@@ -516,9 +519,8 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
               'Auto-promoting new signup user to admin based on verified email domain',
               {
                 userId: canonicalUserId,
-                adminEmail: newUserAdminEmail,
                 emailDomain: newUserAdminEmail?.split('@')[1] ?? null,
-                allEmails: allVerifiedEmails,
+                emailCount: allVerifiedEmails.length,
               },
               'POST /api/users/signup'
             );

--- a/apps/web/src/app/api/users/signup/route.ts
+++ b/apps/web/src/app/api/users/signup/route.ts
@@ -150,9 +150,56 @@ type PrivyUserWithSmartWallet = PrivyUser & {
   linkedAccounts?: Array<
     PrivyWalletLite & {
       type?: string;
+      address?: string; // For email accounts, this is the email address
     }
   >;
 };
+
+/**
+ * Get all verified email addresses from a Privy user.
+ * Checks both the primary email and linkedAccounts for email-type accounts.
+ * This ensures we catch emails that were linked after initial signup.
+ */
+function getAllVerifiedEmails(user: PrivyUserWithSmartWallet): string[] {
+  const emails: string[] = [];
+
+  // Check primary email field
+  if (user.email?.address) {
+    emails.push(user.email.address);
+  }
+
+  // Check linkedAccounts for email-type accounts
+  if (Array.isArray(user.linkedAccounts)) {
+    for (const account of user.linkedAccounts) {
+      if (account?.type === 'email' && account.address) {
+        // Avoid duplicates
+        if (!emails.includes(account.address)) {
+          emails.push(account.address);
+        }
+      }
+    }
+  }
+
+  return emails;
+}
+
+/**
+ * Check if any of the user's verified emails should grant admin access.
+ * Returns the first matching admin email, or null if none match.
+ */
+function findAdminEmail(
+  emails: string[],
+  emailVerified: boolean
+): string | null {
+  if (!emailVerified || emails.length === 0) return null;
+
+  for (const email of emails) {
+    if (shouldAutoPromoteToAdmin(email, true)) {
+      return email;
+    }
+  }
+  return null;
+}
 
 function pickEmbeddedEvmWallet(
   user: PrivyUserWithSmartWallet
@@ -239,17 +286,18 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
   // Fetch identity data from Privy if token provided
   let identityFarcasterUsername: string | undefined;
   let identityTwitterUsername: string | undefined;
-  let verifiedEmail: string | null = null;
+  let allVerifiedEmails: string[] = [];
 
   if (identityToken) {
     const privyClient = getPrivyClient();
-    const identityUser: PrivyUser =
-      await privyClient.getUserFromIdToken(identityToken);
+    const identityUser =
+      (await privyClient.getUserFromIdToken(identityToken)) as PrivyUserWithSmartWallet;
 
     identityFarcasterUsername = identityUser.farcaster?.username ?? undefined;
     identityTwitterUsername = identityUser.twitter?.username ?? undefined;
-    // SECURITY: Get verified email from Privy, not from user input
-    verifiedEmail = identityUser.email?.address ?? null;
+    // SECURITY: Get verified emails from Privy, not from user input
+    // Check ALL linked emails to support users who linked admin email after initial signup
+    allVerifiedEmails = getAllVerifiedEmails(identityUser);
   } else {
     logger.info(
       'Signup received no identity token; proceeding with provided payload only',
@@ -420,18 +468,20 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
         if (existingUserRecord) {
           // Update existing user
           // Also check if user should be auto-promoted to admin (for existing users with new verified email)
-          const emailVerified = !!verifiedEmail;
+          // Check ALL linked emails, not just the primary one
+          const emailVerified = allVerifiedEmails.length > 0;
+          const adminEmail = findAdminEmail(allVerifiedEmails, emailVerified);
           const shouldPromoteToAdmin =
-            !existingUserRecord.isAdmin &&
-            shouldAutoPromoteToAdmin(verifiedEmail, emailVerified);
+            !existingUserRecord.isAdmin && adminEmail !== null;
 
           if (shouldPromoteToAdmin) {
             logger.info(
               'Auto-promoting existing user to admin during signup based on verified email domain',
               {
                 userId: canonicalUserId,
-                emailDomain: verifiedEmail?.split('@')[1] ?? null,
-                emailVerified,
+                adminEmail,
+                emailDomain: adminEmail?.split('@')[1] ?? null,
+                allEmails: allVerifiedEmails,
               },
               'POST /api/users/signup'
             );
@@ -456,19 +506,19 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
           // Check if user should be auto-promoted to admin based on email domain
           // SECURITY: Use Privy-verified email, not user-supplied email from parsedProfile
           // This prevents attackers from submitting fake admin emails in the request body
-          const emailVerified = !!verifiedEmail;
-          const shouldBeAdmin = shouldAutoPromoteToAdmin(
-            verifiedEmail,
-            emailVerified
-          );
+          // Check ALL linked emails, not just the primary one
+          const emailVerified = allVerifiedEmails.length > 0;
+          const newUserAdminEmail = findAdminEmail(allVerifiedEmails, emailVerified);
+          const shouldBeAdmin = newUserAdminEmail !== null;
 
           if (shouldBeAdmin) {
             logger.info(
               'Auto-promoting new signup user to admin based on verified email domain',
               {
                 userId: canonicalUserId,
-                emailDomain: verifiedEmail?.split('@')[1] ?? null,
-                emailVerified,
+                adminEmail: newUserAdminEmail,
+                emailDomain: newUserAdminEmail?.split('@')[1] ?? null,
+                allEmails: allVerifiedEmails,
               },
               'POST /api/users/signup'
             );

--- a/apps/web/src/app/api/users/signup/route.ts
+++ b/apps/web/src/app/api/users/signup/route.ts
@@ -113,11 +113,12 @@ import {
 } from '@babylon/db';
 import type { OnboardingProfilePayload } from '@babylon/shared';
 import {
+  checkForAdminEmail,
   generateSnowflakeId,
   logger,
   OnboardingProfileSchema,
   POINTS,
-  shouldAutoPromoteToAdmin,
+  type PrivyUserWithEmails,
 } from '@babylon/shared';
 import type { User as PrivyUser } from '@privy-io/server-auth';
 import type { NextRequest } from 'next/server';
@@ -144,62 +145,11 @@ type PrivyWalletLite = {
   walletClientType?: string | null;
 };
 
-type PrivyUserWithSmartWallet = PrivyUser & {
-  smartWallet?: { address?: string | null };
-  wallet?: PrivyWalletLite;
-  linkedAccounts?: Array<
-    PrivyWalletLite & {
-      type?: string;
-      address?: string; // For email accounts, this is the email address
-    }
-  >;
-};
-
-/**
- * Get all verified email addresses from a Privy user.
- * Checks both the primary email and linkedAccounts for email-type accounts.
- * This ensures we catch emails that were linked after initial signup.
- */
-function getAllVerifiedEmails(user: PrivyUserWithSmartWallet): string[] {
-  const emails: string[] = [];
-
-  // Check primary email field
-  if (user.email?.address) {
-    emails.push(user.email.address);
-  }
-
-  // Check linkedAccounts for email-type accounts
-  if (Array.isArray(user.linkedAccounts)) {
-    for (const account of user.linkedAccounts) {
-      if (account?.type === 'email' && account.address) {
-        // Avoid duplicates
-        if (!emails.includes(account.address)) {
-          emails.push(account.address);
-        }
-      }
-    }
-  }
-
-  return emails;
-}
-
-/**
- * Check if any of the user's verified emails should grant admin access.
- * Returns the first matching admin email, or null if none match.
- */
-function findAdminEmail(
-  emails: string[],
-  emailVerified: boolean
-): string | null {
-  if (!emailVerified || emails.length === 0) return null;
-
-  for (const email of emails) {
-    if (shouldAutoPromoteToAdmin(email, true)) {
-      return email;
-    }
-  }
-  return null;
-}
+type PrivyUserWithSmartWallet = PrivyUser &
+  PrivyUserWithEmails & {
+    smartWallet?: { address?: string | null };
+    wallet?: PrivyWalletLite;
+  };
 
 function pickEmbeddedEvmWallet(
   user: PrivyUserWithSmartWallet
@@ -286,7 +236,10 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
   // Fetch identity data from Privy if token provided
   let identityFarcasterUsername: string | undefined;
   let identityTwitterUsername: string | undefined;
-  let allVerifiedEmails: string[] = [];
+  let adminEmailResult: { adminEmail: string | null; allVerifiedEmails: string[] } = {
+    adminEmail: null,
+    allVerifiedEmails: [],
+  };
 
   if (identityToken) {
     const privyClient = getPrivyClient();
@@ -298,7 +251,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
     identityTwitterUsername = identityUser.twitter?.username ?? undefined;
     // SECURITY: Get verified emails from Privy, not from user input
     // Check ALL linked emails to support users who linked admin email after initial signup
-    allVerifiedEmails = getAllVerifiedEmails(identityUser);
+    adminEmailResult = checkForAdminEmail(identityUser);
   } else {
     logger.info(
       'Signup received no identity token; proceeding with provided payload only',
@@ -470,8 +423,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
           // Update existing user
           // Also check if user should be auto-promoted to admin (for existing users with new verified email)
           // Check ALL linked emails, not just the primary one
-          const emailVerified = allVerifiedEmails.length > 0;
-          const adminEmail = findAdminEmail(allVerifiedEmails, emailVerified);
+          const { adminEmail, allVerifiedEmails } = adminEmailResult;
           const shouldPromoteToAdmin =
             !existingUserRecord.isAdmin && adminEmail !== null;
 
@@ -507,11 +459,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
           // SECURITY: Use Privy-verified email, not user-supplied email from parsedProfile
           // This prevents attackers from submitting fake admin emails in the request body
           // Check ALL linked emails, not just the primary one
-          const emailVerified = allVerifiedEmails.length > 0;
-          const newUserAdminEmail = findAdminEmail(
-            allVerifiedEmails,
-            emailVerified
-          );
+          const { adminEmail: newUserAdminEmail, allVerifiedEmails } = adminEmailResult;
           const shouldBeAdmin = newUserAdminEmail !== null;
 
           if (shouldBeAdmin) {

--- a/apps/web/src/app/api/users/signup/route.ts
+++ b/apps/web/src/app/api/users/signup/route.ts
@@ -236,7 +236,10 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
   // Fetch identity data from Privy if token provided
   let identityFarcasterUsername: string | undefined;
   let identityTwitterUsername: string | undefined;
-  let adminEmailResult: { adminEmail: string | null; allVerifiedEmails: string[] } = {
+  let adminEmailResult: {
+    adminEmail: string | null;
+    allVerifiedEmails: string[];
+  } = {
     adminEmail: null,
     allVerifiedEmails: [],
   };
@@ -459,7 +462,8 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
           // SECURITY: Use Privy-verified email, not user-supplied email from parsedProfile
           // This prevents attackers from submitting fake admin emails in the request body
           // Check ALL linked emails, not just the primary one
-          const { adminEmail: newUserAdminEmail, allVerifiedEmails } = adminEmailResult;
+          const { adminEmail: newUserAdminEmail, allVerifiedEmails } =
+            adminEmailResult;
           const shouldBeAdmin = newUserAdminEmail !== null;
 
           if (shouldBeAdmin) {

--- a/packages/api/src/admin-middleware.ts
+++ b/packages/api/src/admin-middleware.ts
@@ -29,7 +29,7 @@ import {
   ROLE_PERMISSIONS,
   users,
 } from '@babylon/db';
-import { logger } from '@babylon/shared';
+import { checkForAdminEmail, logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 import type { AuthenticatedUser } from './auth-middleware';
 import { authenticate, getPrivyClient } from './auth-middleware';
@@ -37,75 +37,6 @@ import { getDevAdminUser, isValidDevAdminToken } from './dev-credentials';
 import { AuthorizationError } from './errors';
 
 const isDevelopment = process.env.NODE_ENV !== 'production';
-
-/**
- * Privy user type with linked accounts
- */
-type PrivyUserWithLinkedAccounts = {
-  email?: { address?: string };
-  linkedAccounts?: Array<{
-    type?: string;
-    address?: string;
-  }>;
-};
-
-/**
- * Get all verified email addresses from a Privy user.
- * Checks both the primary email and linkedAccounts for email-type accounts.
- * This ensures we catch emails that were linked after initial signup.
- */
-function getAllVerifiedEmails(user: PrivyUserWithLinkedAccounts): string[] {
-  const emails: string[] = [];
-
-  // Check primary email field
-  if (user.email?.address) {
-    emails.push(user.email.address);
-  }
-
-  // Check linkedAccounts for email-type accounts
-  if (Array.isArray(user.linkedAccounts)) {
-    for (const account of user.linkedAccounts) {
-      if (account?.type === 'email' && account.address) {
-        // Avoid duplicates
-        if (!emails.includes(account.address)) {
-          emails.push(account.address);
-        }
-      }
-    }
-  }
-
-  return emails;
-}
-
-/**
- * Check if a user should be auto-promoted to SUPER_ADMIN based on their email domain.
- * Uses ADMIN_EMAIL_DOMAIN env variable (e.g., 'elizalabs.ai').
- * Requires email to be verified to prevent unverified email attacks.
- */
-function shouldAutoPromoteToSuperAdmin(
-  email: string | null | undefined,
-  emailVerified: boolean
-): boolean {
-  if (!emailVerified || !email) return false;
-
-  const adminDomain = process.env.ADMIN_EMAIL_DOMAIN?.trim();
-  if (!adminDomain) return false;
-
-  return email.toLowerCase().endsWith(`@${adminDomain.toLowerCase()}`);
-}
-
-/**
- * Find an admin email from a list of verified emails.
- * Returns the first email that matches the admin domain, or null if none match.
- */
-function findAdminEmailFromList(emails: string[]): string | null {
-  for (const email of emails) {
-    if (shouldAutoPromoteToSuperAdmin(email, true)) {
-      return email;
-    }
-  }
-  return null;
-}
 
 /**
  * Authenticated admin user with role information
@@ -168,8 +99,7 @@ export async function getAdminRole(
     const privyUser = await privyClient.getUser(effectivePrivyId);
 
     // Check all verified emails including linkedAccounts
-    const allVerifiedEmails = getAllVerifiedEmails(privyUser);
-    const adminEmail = findAdminEmailFromList(allVerifiedEmails);
+    const { adminEmail, allVerifiedEmails } = checkForAdminEmail(privyUser);
 
     if (adminEmail) {
       logger.info(

--- a/packages/api/src/admin-middleware.ts
+++ b/packages/api/src/admin-middleware.ts
@@ -39,6 +39,45 @@ import { AuthorizationError } from './errors';
 const isDevelopment = process.env.NODE_ENV !== 'production';
 
 /**
+ * Privy user type with linked accounts
+ */
+type PrivyUserWithLinkedAccounts = {
+  email?: { address?: string };
+  linkedAccounts?: Array<{
+    type?: string;
+    address?: string;
+  }>;
+};
+
+/**
+ * Get all verified email addresses from a Privy user.
+ * Checks both the primary email and linkedAccounts for email-type accounts.
+ * This ensures we catch emails that were linked after initial signup.
+ */
+function getAllVerifiedEmails(user: PrivyUserWithLinkedAccounts): string[] {
+  const emails: string[] = [];
+
+  // Check primary email field
+  if (user.email?.address) {
+    emails.push(user.email.address);
+  }
+
+  // Check linkedAccounts for email-type accounts
+  if (Array.isArray(user.linkedAccounts)) {
+    for (const account of user.linkedAccounts) {
+      if (account?.type === 'email' && account.address) {
+        // Avoid duplicates
+        if (!emails.includes(account.address)) {
+          emails.push(account.address);
+        }
+      }
+    }
+  }
+
+  return emails;
+}
+
+/**
  * Check if a user should be auto-promoted to SUPER_ADMIN based on their email domain.
  * Uses ADMIN_EMAIL_DOMAIN env variable (e.g., 'elizalabs.ai').
  * Requires email to be verified to prevent unverified email attacks.
@@ -53,6 +92,19 @@ function shouldAutoPromoteToSuperAdmin(
   if (!adminDomain) return false;
 
   return email.toLowerCase().endsWith(`@${adminDomain.toLowerCase()}`);
+}
+
+/**
+ * Find an admin email from a list of verified emails.
+ * Returns the first email that matches the admin domain, or null if none match.
+ */
+function findAdminEmailFromList(emails: string[]): string | null {
+  for (const email of emails) {
+    if (shouldAutoPromoteToSuperAdmin(email, true)) {
+      return email;
+    }
+  }
+  return null;
 }
 
 /**
@@ -107,6 +159,7 @@ export async function getAdminRole(
 
   // Check admin email domain - fetch verified email directly from Privy for security
   // This ensures we're using Privy's verified email, not a potentially tampered database value
+  // Check ALL linked emails, not just the primary one (handles users who linked admin email later)
   const adminDomain = process.env.ADMIN_EMAIL_DOMAIN?.trim();
   const effectivePrivyId = privyId ?? user?.privyId;
 
@@ -114,14 +167,14 @@ export async function getAdminRole(
     const privyClient = getPrivyClient();
     const privyUser = await privyClient.getUser(effectivePrivyId);
 
-    // Privy's email object indicates verification status
-    // The email.address is only present if the email has been verified
-    const verifiedEmail = privyUser?.email?.address;
+    // Check all verified emails including linkedAccounts
+    const allEmails = getAllVerifiedEmails(privyUser);
+    const adminEmail = findAdminEmailFromList(allEmails);
 
-    if (verifiedEmail && shouldAutoPromoteToSuperAdmin(verifiedEmail, true)) {
+    if (adminEmail) {
       logger.info(
         'Auto-promoting user to SUPER_ADMIN via verified Privy email domain',
-        { userId, email: verifiedEmail, privyId: effectivePrivyId },
+        { userId, adminEmail, allEmails, privyId: effectivePrivyId },
         'getAdminRole'
       );
       return { role: 'SUPER_ADMIN', permissions: ROLE_PERMISSIONS.SUPER_ADMIN };

--- a/packages/api/src/admin-middleware.ts
+++ b/packages/api/src/admin-middleware.ts
@@ -168,13 +168,18 @@ export async function getAdminRole(
     const privyUser = await privyClient.getUser(effectivePrivyId);
 
     // Check all verified emails including linkedAccounts
-    const allEmails = getAllVerifiedEmails(privyUser);
-    const adminEmail = findAdminEmailFromList(allEmails);
+    const allVerifiedEmails = getAllVerifiedEmails(privyUser);
+    const adminEmail = findAdminEmailFromList(allVerifiedEmails);
 
     if (adminEmail) {
       logger.info(
         'Auto-promoting user to SUPER_ADMIN via verified Privy email domain',
-        { userId, adminEmail, allEmails, privyId: effectivePrivyId },
+        {
+          userId,
+          emailDomain: adminEmail.split('@')[1] ?? null,
+          emailCount: allVerifiedEmails.length,
+          privyId: effectivePrivyId,
+        },
         'getAdminRole'
       );
       return { role: 'SUPER_ADMIN', permissions: ROLE_PERMISSIONS.SUPER_ADMIN };

--- a/packages/shared/src/auth/admin.ts
+++ b/packages/shared/src/auth/admin.ts
@@ -26,8 +26,9 @@ export function getAdminEmailDomain(): string | null {
  * Check if an email address matches the admin domain pattern.
  * This is a low-level check that only validates the email format.
  *
- * NOTE: For auto-admin promotion, use `shouldAutoPromoteToAdmin` instead,
- * which also requires email verification.
+ * NOTE: For auto-admin promotion, use `checkForAdminEmail` from
+ * `./privy-email-utils` instead, which checks all linked emails and
+ * uses Privy's verification timestamps.
  *
  * @param email - The email address to check
  * @returns True if the email domain matches the admin domain
@@ -47,6 +48,10 @@ export function isAdminEmail(email: string | null | undefined): boolean {
 
 /**
  * Check if a user should be auto-promoted to admin based on their email.
+ *
+ * @deprecated Use `checkForAdminEmail` from `./privy-email-utils` instead.
+ * That function properly checks all linked emails and uses Privy's verification
+ * timestamps rather than requiring a separate emailVerified boolean.
  *
  * SECURITY: Requires both:
  * 1. Email matches the admin domain (ADMIN_EMAIL_DOMAIN env var)

--- a/packages/shared/src/auth/index.ts
+++ b/packages/shared/src/auth/index.ts
@@ -8,4 +8,5 @@ export * from './admin';
 export * from './farcaster-auth-client';
 export * from './farcaster-onboarding';
 export * from './privy-config';
+export * from './privy-email-utils';
 export * from './wallet-utils';

--- a/packages/shared/src/auth/privy-email-utils.ts
+++ b/packages/shared/src/auth/privy-email-utils.ts
@@ -7,27 +7,88 @@
  *
  * These utilities work with both primary email (user.email) and linked email
  * accounts (user.linkedAccounts) to ensure complete email coverage.
+ *
+ * @security Only verified emails are returned. Privy includes verification
+ * timestamps (verified_at, first_verified_at, latest_verified_at) on email
+ * accounts - we only include emails that have been verified.
  */
+
+/**
+ * Privy email account with verification timestamps.
+ * Matches Privy's LinkedAccountEmail structure.
+ */
+export interface PrivyEmailAccount {
+  type: 'email';
+  address: string;
+  /** UNIX timestamp when email was last verified */
+  verified_at?: number;
+  /** UNIX timestamp when email was first verified */
+  first_verified_at?: number;
+  /** UNIX timestamp when email was last verified */
+  latest_verified_at?: number;
+}
+
+/**
+ * Privy linked account types for type discrimination.
+ */
+export type PrivyLinkedAccount =
+  | PrivyEmailAccount
+  | { type: 'wallet'; address?: string; walletClient?: string }
+  | { type: 'farcaster'; fid?: number; username?: string }
+  | { type: 'twitter'; username?: string }
+  | { type: 'google_oauth'; email?: string }
+  | { type: 'apple_oauth'; email?: string }
+  | { type: 'discord_oauth'; username?: string }
+  | { type: 'passkey'; credential_id?: string }
+  | { type: 'phone'; number?: string }
+  | { type: 'custom_auth'; custom_user_id?: string }
+  | { type?: string; address?: string }; // Fallback for unknown types
 
 /**
  * Minimal Privy user type for email extraction.
  * Compatible with both server SDK User type and client-side user objects.
  */
 export interface PrivyUserWithEmails {
-  email?: { address?: string };
-  linkedAccounts?: Array<{
-    type?: string;
+  /** Primary email (convenience property from Privy SDK) */
+  email?: {
     address?: string;
-  }>;
+    verified_at?: number;
+    first_verified_at?: number;
+    latest_verified_at?: number;
+  };
+  /** All linked accounts including emails, wallets, social accounts */
+  linkedAccounts?: PrivyLinkedAccount[];
+}
+
+/**
+ * Check if an email account is verified.
+ * Privy includes verification timestamps only for verified emails.
+ *
+ * @param account - The email account to check
+ * @returns true if the email has verification timestamps
+ */
+function isEmailVerified(account: {
+  verified_at?: number;
+  first_verified_at?: number;
+  latest_verified_at?: number;
+}): boolean {
+  // An email is verified if it has any verification timestamp
+  return !!(
+    account.verified_at ||
+    account.first_verified_at ||
+    account.latest_verified_at
+  );
 }
 
 /**
  * Get all verified email addresses from a Privy user.
  *
- * Checks both the primary email (`user.email?.address`) and the `linkedAccounts`
- * array for email-type accounts. This ensures we catch emails that were linked
- * after initial signup (e.g., user logged in with Farcaster first, then linked
- * their company email later).
+ * Checks both the primary email (`user.email`) and the `linkedAccounts`
+ * array for email-type accounts. Only returns emails that have been
+ * verified (have verification timestamps).
+ *
+ * @security Only verified emails are returned. Emails without verification
+ * timestamps are excluded to prevent unverified email attacks.
  *
  * @param user - The Privy user object (or null/undefined)
  * @returns Array of all verified email addresses (deduplicated, lowercase)
@@ -37,36 +98,44 @@ export interface PrivyUserWithEmails {
  * // Returns: ['user@gmail.com', 'user@company.com']
  *
  * @example
- * // User logged in with Farcaster, later linked email
+ * // User logged in with Farcaster, later linked and verified email
  * const emails = getAllVerifiedEmails(privyUser);
- * // Returns email from linkedAccounts even if user.email is undefined
+ * // Returns email from linkedAccounts if verified
  */
 export function getAllVerifiedEmails(
   user: PrivyUserWithEmails | null | undefined
 ): string[] {
   if (!user) return [];
 
-  const emails: string[] = [];
+  const emails = new Set<string>();
 
-  // Check primary email field (convenience property)
+  // Check primary email field (convenience property from Privy SDK)
+  // The primary email in user.email is always verified if present
+  // (Privy only populates this field for verified emails)
   if (user.email?.address) {
-    emails.push(user.email.address.toLowerCase());
+    // For the primary email, Privy only includes it if verified
+    // But we also check timestamps for extra safety
+    const hasTimestamps = isEmailVerified(user.email);
+    // Accept if verified or if no timestamps available (Privy SDK behavior)
+    if (hasTimestamps || user.email.verified_at === undefined) {
+      emails.add(user.email.address.toLowerCase());
+    }
   }
 
   // Check linkedAccounts for additional email-type accounts
   if (Array.isArray(user.linkedAccounts)) {
     for (const account of user.linkedAccounts) {
-      if (account?.type === 'email' && account.address) {
-        const normalizedEmail = account.address.toLowerCase();
-        // Avoid duplicates (primary email may also be in linkedAccounts)
-        if (!emails.includes(normalizedEmail)) {
-          emails.push(normalizedEmail);
+      if (account?.type === 'email' && 'address' in account && account.address) {
+        const emailAccount = account as PrivyEmailAccount;
+        // Only include verified emails
+        if (isEmailVerified(emailAccount)) {
+          emails.add(emailAccount.address.toLowerCase());
         }
       }
     }
   }
 
-  return emails;
+  return [...emails];
 }
 
 /**
@@ -108,17 +177,18 @@ export function findEmailByDomain(
  * Uses ADMIN_EMAIL_DOMAIN environment variable.
  *
  * @param user - The Privy user object
- * @returns Object with adminEmail (if found) and allEmails array
+ * @returns Object with adminEmail (if found) and allVerifiedEmails array
  *
  * @example
- * const { adminEmail, allEmails } = checkForAdminEmail(privyUser);
+ * const { adminEmail, allVerifiedEmails } = checkForAdminEmail(privyUser);
  * if (adminEmail) {
  *   // User has admin access
  * }
  */
-export function checkForAdminEmail(
-  user: PrivyUserWithEmails | null | undefined
-): { adminEmail: string | null; allVerifiedEmails: string[] } {
+export function checkForAdminEmail(user: PrivyUserWithEmails | null | undefined): {
+  adminEmail: string | null;
+  allVerifiedEmails: string[];
+} {
   const adminDomain = process.env.ADMIN_EMAIL_DOMAIN?.trim() ?? null;
   const allVerifiedEmails = getAllVerifiedEmails(user);
   const adminEmail = findEmailByDomain(allVerifiedEmails, adminDomain);

--- a/packages/shared/src/auth/privy-email-utils.ts
+++ b/packages/shared/src/auth/privy-email-utils.ts
@@ -1,0 +1,127 @@
+/**
+ * Privy Email Utility Functions
+ *
+ * @description Shared utilities for extracting and processing email addresses
+ * from Privy user objects. Used for admin email domain checks and other
+ * email-related functionality.
+ *
+ * These utilities work with both primary email (user.email) and linked email
+ * accounts (user.linkedAccounts) to ensure complete email coverage.
+ */
+
+/**
+ * Minimal Privy user type for email extraction.
+ * Compatible with both server SDK User type and client-side user objects.
+ */
+export interface PrivyUserWithEmails {
+  email?: { address?: string };
+  linkedAccounts?: Array<{
+    type?: string;
+    address?: string;
+  }>;
+}
+
+/**
+ * Get all verified email addresses from a Privy user.
+ *
+ * Checks both the primary email (`user.email?.address`) and the `linkedAccounts`
+ * array for email-type accounts. This ensures we catch emails that were linked
+ * after initial signup (e.g., user logged in with Farcaster first, then linked
+ * their company email later).
+ *
+ * @param user - The Privy user object (or null/undefined)
+ * @returns Array of all verified email addresses (deduplicated, lowercase)
+ *
+ * @example
+ * const emails = getAllVerifiedEmails(privyUser);
+ * // Returns: ['user@gmail.com', 'user@company.com']
+ *
+ * @example
+ * // User logged in with Farcaster, later linked email
+ * const emails = getAllVerifiedEmails(privyUser);
+ * // Returns email from linkedAccounts even if user.email is undefined
+ */
+export function getAllVerifiedEmails(
+  user: PrivyUserWithEmails | null | undefined
+): string[] {
+  if (!user) return [];
+
+  const emails: string[] = [];
+
+  // Check primary email field (convenience property)
+  if (user.email?.address) {
+    emails.push(user.email.address.toLowerCase());
+  }
+
+  // Check linkedAccounts for additional email-type accounts
+  if (Array.isArray(user.linkedAccounts)) {
+    for (const account of user.linkedAccounts) {
+      if (account?.type === 'email' && account.address) {
+        const normalizedEmail = account.address.toLowerCase();
+        // Avoid duplicates (primary email may also be in linkedAccounts)
+        if (!emails.includes(normalizedEmail)) {
+          emails.push(normalizedEmail);
+        }
+      }
+    }
+  }
+
+  return emails;
+}
+
+/**
+ * Find an email matching the admin domain from a list of verified emails.
+ *
+ * @param emails - Array of verified email addresses
+ * @param adminDomain - The admin domain to match (e.g., 'elizalabs.ai')
+ * @returns The first matching admin email, or null if none match
+ *
+ * @example
+ * const adminEmail = findEmailByDomain(['user@gmail.com', 'user@elizalabs.ai'], 'elizalabs.ai');
+ * // Returns: 'user@elizalabs.ai'
+ *
+ * @example
+ * const adminEmail = findEmailByDomain([], 'elizalabs.ai');
+ * // Returns: null (empty array)
+ */
+export function findEmailByDomain(
+  emails: string[],
+  adminDomain: string | null | undefined
+): string | null {
+  if (!adminDomain || emails.length === 0) return null;
+
+  const domainLower = `@${adminDomain.toLowerCase().trim()}`;
+
+  for (const email of emails) {
+    if (email.toLowerCase().endsWith(domainLower)) {
+      return email;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Check if any of the user's verified emails matches the admin domain.
+ *
+ * Convenience function that combines getAllVerifiedEmails and findEmailByDomain.
+ * Uses ADMIN_EMAIL_DOMAIN environment variable.
+ *
+ * @param user - The Privy user object
+ * @returns Object with adminEmail (if found) and allEmails array
+ *
+ * @example
+ * const { adminEmail, allEmails } = checkForAdminEmail(privyUser);
+ * if (adminEmail) {
+ *   // User has admin access
+ * }
+ */
+export function checkForAdminEmail(
+  user: PrivyUserWithEmails | null | undefined
+): { adminEmail: string | null; allVerifiedEmails: string[] } {
+  const adminDomain = process.env.ADMIN_EMAIL_DOMAIN?.trim() ?? null;
+  const allVerifiedEmails = getAllVerifiedEmails(user);
+  const adminEmail = findEmailByDomain(allVerifiedEmails, adminDomain);
+
+  return { adminEmail, allVerifiedEmails };
+}

--- a/packages/testing/unit/shared/privy-email-utils.test.ts
+++ b/packages/testing/unit/shared/privy-email-utils.test.ts
@@ -1,0 +1,333 @@
+/**
+ * Privy Email Utilities Unit Tests
+ * Tests for email extraction and admin domain checking from Privy user objects
+ */
+
+import { describe, expect, it, beforeAll, afterAll } from 'bun:test';
+import {
+  getAllVerifiedEmails,
+  findEmailByDomain,
+  checkForAdminEmail,
+  type PrivyUserWithEmails,
+  type PrivyEmailAccount,
+} from '@babylon/shared';
+
+describe('Privy Email Utilities', () => {
+  describe('getAllVerifiedEmails', () => {
+    it('should return empty array for null user', () => {
+      expect(getAllVerifiedEmails(null)).toEqual([]);
+    });
+
+    it('should return empty array for undefined user', () => {
+      expect(getAllVerifiedEmails(undefined)).toEqual([]);
+    });
+
+    it('should return empty array for user with no emails', () => {
+      const user: PrivyUserWithEmails = {};
+      expect(getAllVerifiedEmails(user)).toEqual([]);
+    });
+
+    it('should return primary email when present and verified', () => {
+      const user: PrivyUserWithEmails = {
+        email: {
+          address: 'user@example.com',
+          verified_at: Date.now(),
+        },
+      };
+      expect(getAllVerifiedEmails(user)).toEqual(['user@example.com']);
+    });
+
+    it('should return primary email when no verification timestamps (Privy SDK behavior)', () => {
+      // Privy SDK only includes email if verified, so trust it even without timestamps
+      const user: PrivyUserWithEmails = {
+        email: {
+          address: 'user@example.com',
+        },
+      };
+      expect(getAllVerifiedEmails(user)).toEqual(['user@example.com']);
+    });
+
+    it('should return emails from linkedAccounts when verified', () => {
+      const user: PrivyUserWithEmails = {
+        linkedAccounts: [
+          {
+            type: 'email',
+            address: 'linked@example.com',
+            verified_at: Date.now(),
+          } as PrivyEmailAccount,
+        ],
+      };
+      expect(getAllVerifiedEmails(user)).toEqual(['linked@example.com']);
+    });
+
+    it('should NOT return unverified emails from linkedAccounts', () => {
+      const user: PrivyUserWithEmails = {
+        linkedAccounts: [
+          {
+            type: 'email',
+            address: 'unverified@example.com',
+            // No verification timestamps
+          } as PrivyEmailAccount,
+        ],
+      };
+      expect(getAllVerifiedEmails(user)).toEqual([]);
+    });
+
+    it('should return both primary and linkedAccounts emails', () => {
+      const user: PrivyUserWithEmails = {
+        email: {
+          address: 'primary@example.com',
+          verified_at: Date.now(),
+        },
+        linkedAccounts: [
+          {
+            type: 'email',
+            address: 'linked@company.com',
+            verified_at: Date.now(),
+          } as PrivyEmailAccount,
+        ],
+      };
+      const emails = getAllVerifiedEmails(user);
+      expect(emails).toContain('primary@example.com');
+      expect(emails).toContain('linked@company.com');
+      expect(emails).toHaveLength(2);
+    });
+
+    it('should deduplicate emails when primary appears in linkedAccounts', () => {
+      const user: PrivyUserWithEmails = {
+        email: {
+          address: 'user@example.com',
+          verified_at: Date.now(),
+        },
+        linkedAccounts: [
+          {
+            type: 'email',
+            address: 'user@example.com',
+            verified_at: Date.now(),
+          } as PrivyEmailAccount,
+        ],
+      };
+      expect(getAllVerifiedEmails(user)).toEqual(['user@example.com']);
+    });
+
+    it('should normalize emails to lowercase', () => {
+      const user: PrivyUserWithEmails = {
+        email: {
+          address: 'User@Example.COM',
+          verified_at: Date.now(),
+        },
+        linkedAccounts: [
+          {
+            type: 'email',
+            address: 'LINKED@Company.org',
+            verified_at: Date.now(),
+          } as PrivyEmailAccount,
+        ],
+      };
+      const emails = getAllVerifiedEmails(user);
+      expect(emails).toContain('user@example.com');
+      expect(emails).toContain('linked@company.org');
+    });
+
+    it('should handle mixed account types in linkedAccounts', () => {
+      const user: PrivyUserWithEmails = {
+        linkedAccounts: [
+          { type: 'wallet', address: '0x123' },
+          {
+            type: 'email',
+            address: 'verified@example.com',
+            verified_at: Date.now(),
+          } as PrivyEmailAccount,
+          { type: 'farcaster', fid: 12345 },
+          {
+            type: 'email',
+            address: 'another@example.com',
+            verified_at: Date.now(),
+          } as PrivyEmailAccount,
+        ],
+      };
+      const emails = getAllVerifiedEmails(user);
+      expect(emails).toContain('verified@example.com');
+      expect(emails).toContain('another@example.com');
+      expect(emails).toHaveLength(2);
+    });
+
+    it('should handle first_verified_at timestamp', () => {
+      const user: PrivyUserWithEmails = {
+        linkedAccounts: [
+          {
+            type: 'email',
+            address: 'first@example.com',
+            first_verified_at: Date.now(),
+          } as PrivyEmailAccount,
+        ],
+      };
+      expect(getAllVerifiedEmails(user)).toEqual(['first@example.com']);
+    });
+
+    it('should handle latest_verified_at timestamp', () => {
+      const user: PrivyUserWithEmails = {
+        linkedAccounts: [
+          {
+            type: 'email',
+            address: 'latest@example.com',
+            latest_verified_at: Date.now(),
+          } as PrivyEmailAccount,
+        ],
+      };
+      expect(getAllVerifiedEmails(user)).toEqual(['latest@example.com']);
+    });
+  });
+
+  describe('findEmailByDomain', () => {
+    it('should return null for empty emails array', () => {
+      expect(findEmailByDomain([], 'example.com')).toBeNull();
+    });
+
+    it('should return null when adminDomain is null', () => {
+      expect(findEmailByDomain(['user@example.com'], null)).toBeNull();
+    });
+
+    it('should return null when adminDomain is undefined', () => {
+      expect(findEmailByDomain(['user@example.com'], undefined)).toBeNull();
+    });
+
+    it('should return null when adminDomain is empty string', () => {
+      expect(findEmailByDomain(['user@example.com'], '')).toBeNull();
+    });
+
+    it('should return null when no domain matches', () => {
+      const emails = ['user@gmail.com', 'admin@company.org'];
+      expect(findEmailByDomain(emails, 'elizalabs.ai')).toBeNull();
+    });
+
+    it('should return matching email', () => {
+      const emails = ['user@gmail.com', 'admin@elizalabs.ai'];
+      expect(findEmailByDomain(emails, 'elizalabs.ai')).toBe(
+        'admin@elizalabs.ai'
+      );
+    });
+
+    it('should return first matching email when multiple match', () => {
+      const emails = [
+        'first@elizalabs.ai',
+        'second@elizalabs.ai',
+        'other@gmail.com',
+      ];
+      expect(findEmailByDomain(emails, 'elizalabs.ai')).toBe(
+        'first@elizalabs.ai'
+      );
+    });
+
+    it('should match domain case-insensitively', () => {
+      // Note: findEmailByDomain returns the email as-is from the input array
+      // Normalization happens in getAllVerifiedEmails before calling this function
+      const emails = ['user@ELIZALABS.AI'];
+      expect(findEmailByDomain(emails, 'elizalabs.ai')).toBe('user@ELIZALABS.AI');
+    });
+
+    it('should match domain case-insensitively (admin domain uppercase)', () => {
+      const emails = ['user@elizalabs.ai'];
+      expect(findEmailByDomain(emails, 'ELIZALABS.AI')).toBe('user@elizalabs.ai');
+    });
+
+    it('should trim whitespace from domain', () => {
+      const emails = ['user@elizalabs.ai'];
+      expect(findEmailByDomain(emails, '  elizalabs.ai  ')).toBe(
+        'user@elizalabs.ai'
+      );
+    });
+
+    it('should not match partial domains', () => {
+      const emails = ['user@notelizalabs.ai'];
+      expect(findEmailByDomain(emails, 'elizalabs.ai')).toBeNull();
+    });
+
+    it('should not match subdomains', () => {
+      const emails = ['user@sub.elizalabs.ai'];
+      expect(findEmailByDomain(emails, 'elizalabs.ai')).toBeNull();
+    });
+  });
+
+  describe('checkForAdminEmail', () => {
+    const originalEnv = process.env.ADMIN_EMAIL_DOMAIN;
+
+    beforeAll(() => {
+      process.env.ADMIN_EMAIL_DOMAIN = 'elizalabs.ai';
+    });
+
+    afterAll(() => {
+      if (originalEnv) {
+        process.env.ADMIN_EMAIL_DOMAIN = originalEnv;
+      } else {
+        delete process.env.ADMIN_EMAIL_DOMAIN;
+      }
+    });
+
+    it('should return null adminEmail and empty array for null user', () => {
+      const result = checkForAdminEmail(null);
+      expect(result.adminEmail).toBeNull();
+      expect(result.allVerifiedEmails).toEqual([]);
+    });
+
+    it('should return null adminEmail when no emails match admin domain', () => {
+      const user: PrivyUserWithEmails = {
+        email: {
+          address: 'user@gmail.com',
+          verified_at: Date.now(),
+        },
+      };
+      const result = checkForAdminEmail(user);
+      expect(result.adminEmail).toBeNull();
+      expect(result.allVerifiedEmails).toEqual(['user@gmail.com']);
+    });
+
+    it('should return admin email from primary email', () => {
+      const user: PrivyUserWithEmails = {
+        email: {
+          address: 'admin@elizalabs.ai',
+          verified_at: Date.now(),
+        },
+      };
+      const result = checkForAdminEmail(user);
+      expect(result.adminEmail).toBe('admin@elizalabs.ai');
+      expect(result.allVerifiedEmails).toEqual(['admin@elizalabs.ai']);
+    });
+
+    it('should return admin email from linkedAccounts', () => {
+      const user: PrivyUserWithEmails = {
+        email: {
+          address: 'personal@gmail.com',
+          verified_at: Date.now(),
+        },
+        linkedAccounts: [
+          {
+            type: 'email',
+            address: 'work@elizalabs.ai',
+            verified_at: Date.now(),
+          } as PrivyEmailAccount,
+        ],
+      };
+      const result = checkForAdminEmail(user);
+      expect(result.adminEmail).toBe('work@elizalabs.ai');
+      expect(result.allVerifiedEmails).toContain('personal@gmail.com');
+      expect(result.allVerifiedEmails).toContain('work@elizalabs.ai');
+    });
+
+    it('should find admin email even when primary is not admin domain', () => {
+      const user: PrivyUserWithEmails = {
+        linkedAccounts: [
+          { type: 'wallet', address: '0x123' },
+          { type: 'farcaster', fid: 12345 },
+          {
+            type: 'email',
+            address: 'hidden@elizalabs.ai',
+            verified_at: Date.now(),
+          } as PrivyEmailAccount,
+        ],
+      };
+      const result = checkForAdminEmail(user);
+      expect(result.adminEmail).toBe('hidden@elizalabs.ai');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Previously, the admin email domain check only looked at the primary email (`privyUser.email?.address`). This missed users who:
- Logged in with Farcaster/Twitter/wallet first
- Later linked their `@elizalabs.ai` email

Now checks all emails in `linkedAccounts` array in addition to the primary email, ensuring admin access is granted regardless of login method.

## Changes

### Admin Email Detection Fix
- **`apps/web/src/app/api/users/me/route.ts`**: Added `getAllVerifiedEmails()` and `findAdminEmail()` helpers, updated new user and existing user promotion logic
- **`apps/web/src/app/api/users/signup/route.ts`**: Same helpers and updates for signup flow
- **`packages/api/src/admin-middleware.ts`**: Same pattern for runtime admin check in `getAdminRole()`

### Bonus Fix
- **`apps/web/src/app/api/chats/[id]/message/route.ts`**: Fixed incorrect import (`groupChatMemberships` → `groupMembers`) and field names (`chatId` → `groupId`, `removedAt` → `kickedAt`)

## Technical Details

The fix was verified against [Privy documentation](https://docs.privy.io) via Context7:
- Email accounts in `linkedAccounts` have `type='email'` and `address` field
- This matches Privy's documented User object structure

## Environment Variable

Reminder: `ADMIN_EMAIL_DOMAIN` should be set to `elizalabs.ai` (without the `@` prefix) in Vercel.

## Testing

After deployment, users with a linked and verified `@elizalabs.ai` email should:
1. Refresh the page (triggers `/api/users/me`)
2. See the Admin link appear in the sidebar
3. Have access to admin functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-email admin detection now considers all verified emails and records the chosen admin email.
  * New email utilities exported to collect, normalize, and evaluate verified/linked emails for admin checks.

* **Bug Fixes**
  * Admin-promotion and profile/signup logging improved to include admin email domain and verified-email count.
  * Member removal consistently records a kick timestamp and reason.

* **Tests**
  * Added unit tests covering email utilities and edge cases.

* **Documentation**
  * JSDoc updated to reference the new admin-email helper.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed admin auto-promotion to check all verified emails in Privy's `linkedAccounts` array, not just the primary email. Previously, users who logged in with Farcaster/Twitter/wallet first and later linked an `@elizalabs.ai` email were not granted admin access.

**Key Changes:**
- Added `getAllVerifiedEmails()` helper that checks both `user.email?.address` and `linkedAccounts` array for `type='email'` entries
- Added `findAdminEmail()` helper that iterates through all emails to find the first admin domain match
- Updated admin promotion logic in `/api/users/me`, `/api/users/signup`, and `admin-middleware.ts` to use these helpers
- Ensured all three auth flows (new user creation, existing user check, runtime admin check) consistently check all linked emails

**Bonus Fix:**
- Corrected database schema references in `chats/[id]/message/route.ts`: `groupChatMemberships` → `groupMembers`, `chatId` → `groupId`, `removedAt` → `kickedAt`, `sweepReason` → `kickReason`

**Security:**
- All emails checked are Privy-verified by design (Privy only includes verified emails in the user object)
- Maintains existing email verification requirement via `shouldAutoPromoteToAdmin()` function

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are well-structured with clear helper functions, maintain security by relying on Privy's verified emails, fix a legitimate bug in admin promotion logic, and include a bonus fix for incorrect schema references. All changes follow consistent patterns across the codebase.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/api/users/me/route.ts | Added `getAllVerifiedEmails()` and `findAdminEmail()` helpers to check all linked email accounts for admin domain matching, fixing admin promotion for users who linked admin emails after initial signup |
| apps/web/src/app/api/users/signup/route.ts | Applied same admin email checking pattern using `getAllVerifiedEmails()` and `findAdminEmail()` helpers for consistency across signup flow |
| packages/api/src/admin-middleware.ts | Extended `getAdminRole()` to check all verified emails including `linkedAccounts` for runtime admin privilege checks |
| apps/web/src/app/api/chats/[id]/message/route.ts | Fixed incorrect schema references: changed `groupChatMemberships` to `groupMembers`, `chatId` to `groupId`, and `removedAt`/`sweepReason` to `kickedAt`/`kickReason` to match current database schema |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API as API Route<br/>(me/signup)
    participant Privy as Privy Client
    participant Helper as getAllVerifiedEmails()<br/>findAdminEmail()
    participant DB as Database

    User->>API: Authenticate with Privy
    API->>Privy: getUser(privyId)
    Privy-->>API: Return user with linkedAccounts
    
    API->>Helper: getAllVerifiedEmails(privyUser)
    Helper->>Helper: Check user.email?.address
    Helper->>Helper: Check linkedAccounts for type='email'
    Helper-->>API: Return all verified emails []
    
    API->>Helper: findAdminEmail(emails, emailVerified)
    loop For each email
        Helper->>Helper: shouldAutoPromoteToAdmin(email)
        alt Email matches ADMIN_EMAIL_DOMAIN
            Helper-->>API: Return matching admin email
        end
    end
    
    alt Admin email found
        API->>DB: Set isAdmin=true
        DB-->>API: User updated
        API-->>User: Admin access granted
    else No admin email
        API-->>User: Regular user access
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->