### PR TITLE
feat: NFT-gated group chats with ownership verification and auto-revalidation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -440,6 +440,8 @@ PHALA_ENDPOINT=
 
 # Cron job security token (generate with: openssl rand -hex 32)
 CRON_SECRET=your_random_secret_here_replace_with_actual_secret
+# NFT revalidation cron job timeout in milliseconds (default: 50000 = 50s, allows 10s buffer for Vercel 60s limit)
+NFT_REVALIDATE_TIMEOUT_MS=50000
 
 # NPC Tick Configuration
 # Number of NPCs to process per tick (rotates through all)

--- a/apps/web/src/app/api/admin/groups/[id]/revalidate-nft/route.ts
+++ b/apps/web/src/app/api/admin/groups/[id]/revalidate-nft/route.ts
@@ -10,21 +10,22 @@
  */
 
 import {
+  BusinessLogicError,
   getClientIp,
   logAdminView,
   NFTVerificationService,
+  NotFoundError,
+  removeUserFromNftChat,
   requireAdmin,
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
 import {
-  and,
   asSystem,
   chatParticipants,
   chats,
   db,
   eq,
-  groupMembers,
   inArray,
   users,
 } from '@babylon/db';
@@ -58,11 +59,11 @@ export const POST = withErrorHandling(
     });
 
     if (!chat) {
-      return successResponse({ error: 'Chat not found' }, 404);
+      throw new NotFoundError('Chat', chatId);
     }
 
     if (!chat.nftGated || !chat.requiredNftContractAddress) {
-      return successResponse({ error: 'Chat is not NFT-gated' }, 400);
+      throw new BusinessLogicError('Chat is not NFT-gated', 'NOT_NFT_GATED');
     }
 
     // Get all participants with their wallet addresses
@@ -106,7 +107,7 @@ export const POST = withErrorHandling(
     };
 
     for (const participant of participants) {
-      // Skip admin user (don't remove the owner)
+      // Skip the requesting admin (admins don't need NFT to stay in chats they manage)
       if (participant.userId === admin.userId) {
         results.validated++;
         continue;
@@ -114,7 +115,7 @@ export const POST = withErrorHandling(
 
       if (!participant.walletAddress) {
         // No wallet - remove from chat
-        await removeUserFromChat(
+        await removeUserFromNftChat(
           chatId,
           chat.groupId,
           participant.userId,
@@ -143,7 +144,7 @@ export const POST = withErrorHandling(
 
         if (!verification.canAccess) {
           // Remove user from chat
-          await removeUserFromChat(
+          await removeUserFromNftChat(
             chatId,
             chat.groupId,
             participant.userId,
@@ -192,43 +193,3 @@ export const POST = withErrorHandling(
     });
   }
 );
-
-/**
- * Helper to remove a user from an NFT-gated chat
- */
-async function removeUserFromChat(
-  chatId: string,
-  groupId: string | null,
-  userId: string,
-  reason: string
-): Promise<void> {
-  await db.transaction(async (tx) => {
-    // Remove from chat participants
-    await tx
-      .delete(chatParticipants)
-      .where(
-        and(
-          eq(chatParticipants.chatId, chatId),
-          eq(chatParticipants.userId, userId)
-        )
-      );
-
-    // If there's a linked group, update group membership
-    if (groupId) {
-      await tx
-        .update(groupMembers)
-        .set({
-          isActive: false,
-          kickedAt: new Date(),
-          kickReason: reason,
-        })
-        .where(
-          and(
-            eq(groupMembers.groupId, groupId),
-            eq(groupMembers.userId, userId),
-            eq(groupMembers.isActive, true)
-          )
-        );
-    }
-  });
-}

--- a/apps/web/src/app/api/admin/groups/[id]/revalidate-nft/route.ts
+++ b/apps/web/src/app/api/admin/groups/[id]/revalidate-nft/route.ts
@@ -21,6 +21,7 @@ import {
   withErrorHandling,
 } from '@babylon/api';
 import {
+  and,
   asSystem,
   chatParticipants,
   chats,
@@ -66,7 +67,7 @@ export const POST = withErrorHandling(
       throw new BusinessLogicError('Chat is not NFT-gated', 'NOT_NFT_GATED');
     }
 
-    // Get all participants with their wallet addresses
+    // Get all active participants with their wallet addresses
     const participants = await asSystem(async (database) => {
       const participantList = await database
         .select({
@@ -74,7 +75,12 @@ export const POST = withErrorHandling(
           userId: chatParticipants.userId,
         })
         .from(chatParticipants)
-        .where(eq(chatParticipants.chatId, chatId));
+        .where(
+          and(
+            eq(chatParticipants.chatId, chatId),
+            eq(chatParticipants.isActive, true)
+          )
+        );
 
       if (participantList.length === 0) return [];
 

--- a/apps/web/src/app/api/admin/groups/[id]/revalidate-nft/route.ts
+++ b/apps/web/src/app/api/admin/groups/[id]/revalidate-nft/route.ts
@@ -1,0 +1,234 @@
+/**
+ * Admin NFT Revalidation API
+ *
+ * @route POST /api/admin/groups/[id]/revalidate-nft - Revalidate NFT access for all members
+ * @access Admin
+ *
+ * @description
+ * Triggers a revalidation of NFT ownership for all members in an NFT-gated chat.
+ * Members who no longer own the required NFT will be removed from the chat.
+ */
+
+import {
+  getClientIp,
+  logAdminView,
+  NFTVerificationService,
+  requireAdmin,
+  successResponse,
+  withErrorHandling,
+} from '@babylon/api';
+import {
+  and,
+  asSystem,
+  chatParticipants,
+  chats,
+  db,
+  eq,
+  groupMembers,
+  inArray,
+  users,
+} from '@babylon/db';
+import { logger } from '@babylon/shared';
+import type { NextRequest } from 'next/server';
+
+/**
+ * POST /api/admin/groups/[id]/revalidate-nft
+ * Revalidate NFT access for all members of an NFT-gated chat
+ * Removes members who no longer own the required NFT
+ */
+export const POST = withErrorHandling(
+  async (
+    request: NextRequest,
+    context: { params: Promise<{ id: string }> }
+  ) => {
+    const admin = await requireAdmin(request);
+    const { id: chatId } = await context.params;
+
+    logAdminView({
+      adminId: admin.userId,
+      ipAddress: getClientIp(request.headers) ?? undefined,
+      resourceType: 'nft-groups',
+      resourceId: chatId,
+      metadata: { action: 'revalidate_nft_access' },
+    });
+
+    // Get the chat and verify it's NFT-gated
+    const chat = await db.query.chats.findFirst({
+      where: eq(chats.id, chatId),
+    });
+
+    if (!chat) {
+      return successResponse({ error: 'Chat not found' }, 404);
+    }
+
+    if (!chat.nftGated || !chat.requiredNftContractAddress) {
+      return successResponse({ error: 'Chat is not NFT-gated' }, 400);
+    }
+
+    // Get all participants with their wallet addresses
+    const participants = await asSystem(async (database) => {
+      const participantList = await database
+        .select({
+          participantId: chatParticipants.id,
+          userId: chatParticipants.userId,
+        })
+        .from(chatParticipants)
+        .where(eq(chatParticipants.chatId, chatId));
+
+      if (participantList.length === 0) return [];
+
+      const userIds = participantList.map((p) => p.userId);
+      const usersList = await database
+        .select({
+          id: users.id,
+          walletAddress: users.walletAddress,
+        })
+        .from(users)
+        .where(inArray(users.id, userIds));
+
+      const usersMap = new Map(usersList.map((u) => [u.id, u]));
+
+      return participantList.map((p) => ({
+        participantId: p.participantId,
+        userId: p.userId,
+        walletAddress: usersMap.get(p.userId)?.walletAddress ?? null,
+      }));
+    }, 'admin-revalidate-nft');
+
+    // Check each participant's NFT ownership
+    const results = {
+      total: participants.length,
+      validated: 0,
+      removed: 0,
+      noWallet: 0,
+      errors: 0,
+      removedUsers: [] as string[],
+    };
+
+    for (const participant of participants) {
+      // Skip admin user (don't remove the owner)
+      if (participant.userId === admin.userId) {
+        results.validated++;
+        continue;
+      }
+
+      if (!participant.walletAddress) {
+        // No wallet - remove from chat
+        await removeUserFromChat(
+          chatId,
+          chat.groupId,
+          participant.userId,
+          'No wallet connected'
+        );
+        results.noWallet++;
+        results.removedUsers.push(participant.userId);
+        continue;
+      }
+
+      try {
+        // Invalidate cache first to ensure fresh check
+        await NFTVerificationService.invalidateOwnershipCache(
+          participant.walletAddress,
+          chat.requiredNftContractAddress,
+          chat.requiredNftChainId ?? undefined
+        );
+
+        // Check NFT ownership
+        const verification = await NFTVerificationService.verifyChatAccess(
+          participant.walletAddress,
+          chat.requiredNftContractAddress,
+          chat.requiredNftTokenId ?? null,
+          chat.requiredNftChainId ?? undefined
+        );
+
+        if (!verification.canAccess) {
+          // Remove user from chat
+          await removeUserFromChat(
+            chatId,
+            chat.groupId,
+            participant.userId,
+            verification.reason ?? 'No longer owns required NFT'
+          );
+          results.removed++;
+          results.removedUsers.push(participant.userId);
+        } else {
+          results.validated++;
+        }
+      } catch (error) {
+        logger.error(
+          'Error validating NFT ownership',
+          {
+            userId: participant.userId,
+            chatId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          'POST /api/admin/groups/[id]/revalidate-nft'
+        );
+        results.errors++;
+      }
+    }
+
+    logger.info(
+      'NFT revalidation completed',
+      {
+        adminId: admin.userId,
+        chatId,
+        results,
+      },
+      'POST /api/admin/groups/[id]/revalidate-nft'
+    );
+
+    return successResponse({
+      revalidation: {
+        chatId,
+        contractAddress: chat.requiredNftContractAddress,
+        total: results.total,
+        stillValid: results.validated,
+        removed: results.removed,
+        noWallet: results.noWallet,
+        errors: results.errors,
+        removedUserIds: results.removedUsers,
+      },
+    });
+  }
+);
+
+/**
+ * Helper to remove a user from an NFT-gated chat
+ */
+async function removeUserFromChat(
+  chatId: string,
+  groupId: string | null,
+  userId: string,
+  reason: string
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    // Remove from chat participants
+    await tx
+      .delete(chatParticipants)
+      .where(
+        and(
+          eq(chatParticipants.chatId, chatId),
+          eq(chatParticipants.userId, userId)
+        )
+      );
+
+    // If there's a linked group, update group membership
+    if (groupId) {
+      await tx
+        .update(groupMembers)
+        .set({
+          isActive: false,
+          kickedAt: new Date(),
+          kickReason: reason,
+        })
+        .where(
+          and(
+            eq(groupMembers.groupId, groupId),
+            eq(groupMembers.userId, userId),
+            eq(groupMembers.isActive, true)
+          )
+        );
+    }
+  });
+}

--- a/apps/web/src/app/api/admin/groups/nft-collection/route.ts
+++ b/apps/web/src/app/api/admin/groups/nft-collection/route.ts
@@ -19,6 +19,7 @@ import {
   withErrorHandling,
 } from '@babylon/api';
 import {
+  and,
   asSystem,
   chatParticipants,
   chats,
@@ -84,7 +85,12 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
           count: sql<number>`count(*)::int`,
         })
         .from(chatParticipants)
-        .where(inArray(chatParticipants.chatId, chatIds))
+        .where(
+          and(
+            inArray(chatParticipants.chatId, chatIds),
+            eq(chatParticipants.isActive, true)
+          )
+        )
         .groupBy(chatParticipants.chatId);
 
       for (const row of memberCountsResult) {

--- a/apps/web/src/app/api/admin/groups/nft-collection/route.ts
+++ b/apps/web/src/app/api/admin/groups/nft-collection/route.ts
@@ -20,9 +20,9 @@ import {
 } from '@babylon/api';
 import {
   and,
-  asSystem,
   chatParticipants,
   chats,
+  db,
   eq,
   groupMembers,
   groups,
@@ -58,51 +58,49 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     metadata: { action: 'list_nft_gated_groups' },
   });
 
-  const nftGatedChats = await asSystem(async (database) => {
-    const chatsList = await database
+  const chatsList = await db
+    .select({
+      id: chats.id,
+      name: chats.name,
+      groupId: chats.groupId,
+      nftGated: chats.nftGated,
+      requiredNftContractAddress: chats.requiredNftContractAddress,
+      requiredNftTokenId: chats.requiredNftTokenId,
+      requiredNftChainId: chats.requiredNftChainId,
+      createdAt: chats.createdAt,
+      updatedAt: chats.updatedAt,
+    })
+    .from(chats)
+    .where(eq(chats.nftGated, true));
+
+  // Get member counts for all chats in a single query using GROUP BY
+  const chatIds = chatsList.map((c) => c.id);
+  const memberCountMap = new Map<string, number>();
+
+  if (chatIds.length > 0) {
+    const memberCountsResult = await db
       .select({
-        id: chats.id,
-        name: chats.name,
-        groupId: chats.groupId,
-        nftGated: chats.nftGated,
-        requiredNftContractAddress: chats.requiredNftContractAddress,
-        requiredNftTokenId: chats.requiredNftTokenId,
-        requiredNftChainId: chats.requiredNftChainId,
-        createdAt: chats.createdAt,
-        updatedAt: chats.updatedAt,
+        chatId: chatParticipants.chatId,
+        count: sql<number>`count(*)::int`,
       })
-      .from(chats)
-      .where(eq(chats.nftGated, true));
-
-    // Get member counts for all chats in a single query using GROUP BY
-    const chatIds = chatsList.map((c) => c.id);
-    const memberCountMap = new Map<string, number>();
-
-    if (chatIds.length > 0) {
-      const memberCountsResult = await database
-        .select({
-          chatId: chatParticipants.chatId,
-          count: sql<number>`count(*)::int`,
-        })
-        .from(chatParticipants)
-        .where(
-          and(
-            inArray(chatParticipants.chatId, chatIds),
-            eq(chatParticipants.isActive, true)
-          )
+      .from(chatParticipants)
+      .where(
+        and(
+          inArray(chatParticipants.chatId, chatIds),
+          eq(chatParticipants.isActive, true)
         )
-        .groupBy(chatParticipants.chatId);
+      )
+      .groupBy(chatParticipants.chatId);
 
-      for (const row of memberCountsResult) {
-        memberCountMap.set(row.chatId, row.count);
-      }
+    for (const row of memberCountsResult) {
+      memberCountMap.set(row.chatId, row.count);
     }
+  }
 
-    return chatsList.map((chat) => ({
-      ...chat,
-      memberCount: memberCountMap.get(chat.id) ?? 0,
-    }));
-  }, 'admin-nft-groups');
+  const nftGatedChats = chatsList.map((chat) => ({
+    ...chat,
+    memberCount: memberCountMap.get(chat.id) ?? 0,
+  }));
 
   return successResponse({
     groups: nftGatedChats,
@@ -131,15 +129,19 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
     },
   });
 
-  const result = await asSystem(async (database) => {
-    const [groupId, chatId] = await Promise.all([
-      generateSnowflakeId(),
-      generateSnowflakeId(),
-    ]);
-    const now = new Date();
+  // Generate all IDs upfront before transaction
+  const [groupId, chatId, memberId, participantId] = await Promise.all([
+    generateSnowflakeId(),
+    generateSnowflakeId(),
+    generateSnowflakeId(),
+    generateSnowflakeId(),
+  ]);
+  const now = new Date();
 
+  // Use transaction to ensure atomicity - if any insert fails, all are rolled back
+  const result = await db.transaction(async (tx) => {
     // Create the group
-    await database.insert(groups).values({
+    await tx.insert(groups).values({
       id: groupId,
       name: data.name,
       description: data.description ?? null,
@@ -151,7 +153,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
     });
 
     // Create the NFT-gated chat linked to the group
-    await database.insert(chats).values({
+    await tx.insert(chats).values({
       id: chatId,
       name: data.name,
       description: data.description ?? null,
@@ -166,15 +168,9 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
       updatedAt: now,
     });
 
-    // Generate IDs upfront for parallel inserts
-    const [memberId, participantId] = await Promise.all([
-      generateSnowflakeId(),
-      generateSnowflakeId(),
-    ]);
-
     // Add admin as owner of the group and chat participant in parallel
     await Promise.all([
-      database.insert(groupMembers).values({
+      tx.insert(groupMembers).values({
         id: memberId,
         groupId,
         userId: admin.userId,
@@ -183,7 +179,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
         joinedAt: now,
         isActive: true,
       }),
-      database.insert(chatParticipants).values({
+      tx.insert(chatParticipants).values({
         id: participantId,
         chatId,
         userId: admin.userId,
@@ -193,7 +189,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
     ]);
 
     return { groupId, chatId };
-  }, 'admin-create-nft-group');
+  });
 
   logger.info(
     'NFT-gated group created by admin',

--- a/apps/web/src/app/api/admin/groups/nft-collection/route.ts
+++ b/apps/web/src/app/api/admin/groups/nft-collection/route.ts
@@ -37,7 +37,8 @@ const CreateNftCollectionGroupSchema = z.object({
   description: z.string().max(500).optional(),
   contractAddress: z
     .string()
-    .regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid contract address format'),
+    .regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid contract address format')
+    .transform((addr) => addr.toLowerCase()),
   chainId: z.number().int().positive(),
   tokenId: z.number().int().min(0).nullable().optional(),
 });
@@ -150,7 +151,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
       groupId,
       createdBy: admin.userId,
       nftGated: true,
-      requiredNftContractAddress: data.contractAddress.toLowerCase(),
+      requiredNftContractAddress: data.contractAddress,
       requiredNftTokenId: data.tokenId ?? null,
       requiredNftChainId: data.chainId,
       createdAt: now,
@@ -199,7 +200,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
         name: data.name,
         chatId: result.chatId,
         nftGated: true,
-        contractAddress: data.contractAddress.toLowerCase(),
+        contractAddress: data.contractAddress,
         tokenId: data.tokenId ?? null,
         chainId: data.chainId,
       },

--- a/apps/web/src/app/api/admin/groups/nft-collection/route.ts
+++ b/apps/web/src/app/api/admin/groups/nft-collection/route.ts
@@ -132,8 +132,10 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
   });
 
   const result = await asSystem(async (database) => {
-    const groupId = await generateSnowflakeId();
-    const chatId = await generateSnowflakeId();
+    const [groupId, chatId] = await Promise.all([
+      generateSnowflakeId(),
+      generateSnowflakeId(),
+    ]);
     const now = new Date();
 
     // Create the group
@@ -164,25 +166,31 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
       updatedAt: now,
     });
 
-    // Add admin as owner of the group
-    await database.insert(groupMembers).values({
-      id: await generateSnowflakeId(),
-      groupId,
-      userId: admin.userId,
-      role: 'owner',
-      addedBy: admin.userId,
-      joinedAt: now,
-      isActive: true,
-    });
+    // Generate IDs upfront for parallel inserts
+    const [memberId, participantId] = await Promise.all([
+      generateSnowflakeId(),
+      generateSnowflakeId(),
+    ]);
 
-    // Add admin to chat participants
-    await database.insert(chatParticipants).values({
-      id: await generateSnowflakeId(),
-      chatId,
-      userId: admin.userId,
-      joinedAt: now,
-      isActive: true,
-    });
+    // Add admin as owner of the group and chat participant in parallel
+    await Promise.all([
+      database.insert(groupMembers).values({
+        id: memberId,
+        groupId,
+        userId: admin.userId,
+        role: 'owner',
+        addedBy: admin.userId,
+        joinedAt: now,
+        isActive: true,
+      }),
+      database.insert(chatParticipants).values({
+        id: participantId,
+        chatId,
+        userId: admin.userId,
+        joinedAt: now,
+        isActive: true,
+      }),
+    ]);
 
     return { groupId, chatId };
   }, 'admin-create-nft-group');

--- a/apps/web/src/app/api/admin/groups/nft-collection/route.ts
+++ b/apps/web/src/app/api/admin/groups/nft-collection/route.ts
@@ -25,6 +25,8 @@ import {
   eq,
   groupMembers,
   groups,
+  inArray,
+  sql,
 } from '@babylon/db';
 import { generateSnowflakeId, logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
@@ -70,20 +72,24 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       .from(chats)
       .where(eq(chats.nftGated, true));
 
-    // Get member counts for each chat
+    // Get member counts for all chats in a single query using GROUP BY
     const chatIds = chatsList.map((c) => c.id);
-    const memberCountsResult = await Promise.all(
-      chatIds.map(async (chatId) => {
-        const count = await database
-          .select({ chatId: chatParticipants.chatId })
-          .from(chatParticipants)
-          .where(eq(chatParticipants.chatId, chatId));
-        return { chatId, count: count.length };
-      })
-    );
-    const memberCountMap = new Map(
-      memberCountsResult.map((r) => [r.chatId, r.count])
-    );
+    const memberCountMap = new Map<string, number>();
+
+    if (chatIds.length > 0) {
+      const memberCountsResult = await database
+        .select({
+          chatId: chatParticipants.chatId,
+          count: sql<number>`count(*)::int`,
+        })
+        .from(chatParticipants)
+        .where(inArray(chatParticipants.chatId, chatIds))
+        .groupBy(chatParticipants.chatId);
+
+      for (const row of memberCountsResult) {
+        memberCountMap.set(row.chatId, row.count);
+      }
+    }
 
     return chatsList.map((chat) => ({
       ...chat,

--- a/apps/web/src/app/api/admin/groups/nft-collection/route.ts
+++ b/apps/web/src/app/api/admin/groups/nft-collection/route.ts
@@ -1,0 +1,203 @@
+/**
+ * Admin NFT Collection Group API
+ *
+ * @route POST /api/admin/groups/nft-collection - Create NFT-gated group
+ * @route GET /api/admin/groups/nft-collection - List NFT-gated groups
+ * @access Admin
+ *
+ * @description
+ * Admin-only endpoints for creating and managing NFT-gated group chats.
+ * These are groups where access is restricted to holders of specific NFT collections.
+ * Users automatically lose access if they transfer or sell their NFT.
+ */
+
+import {
+  getClientIp,
+  logAdminView,
+  requireAdmin,
+  successResponse,
+  withErrorHandling,
+} from '@babylon/api';
+import {
+  asSystem,
+  chatParticipants,
+  chats,
+  eq,
+  groupMembers,
+  groups,
+} from '@babylon/db';
+import { generateSnowflakeId, logger } from '@babylon/shared';
+import type { NextRequest } from 'next/server';
+import { z } from 'zod';
+
+const CreateNftCollectionGroupSchema = z.object({
+  name: z.string().min(1).max(100),
+  description: z.string().max(500).optional(),
+  contractAddress: z
+    .string()
+    .regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid contract address format'),
+  chainId: z.number().int().positive(),
+  tokenId: z.number().int().min(0).nullable().optional(),
+});
+
+/**
+ * GET /api/admin/groups/nft-collection
+ * List all NFT-gated group chats
+ */
+export const GET = withErrorHandling(async (request: NextRequest) => {
+  const admin = await requireAdmin(request);
+
+  logAdminView({
+    adminId: admin.userId,
+    ipAddress: getClientIp(request.headers) ?? undefined,
+    resourceType: 'nft-groups',
+    metadata: { action: 'list_nft_gated_groups' },
+  });
+
+  const nftGatedChats = await asSystem(async (database) => {
+    const chatsList = await database
+      .select({
+        id: chats.id,
+        name: chats.name,
+        groupId: chats.groupId,
+        nftGated: chats.nftGated,
+        requiredNftContractAddress: chats.requiredNftContractAddress,
+        requiredNftTokenId: chats.requiredNftTokenId,
+        requiredNftChainId: chats.requiredNftChainId,
+        createdAt: chats.createdAt,
+        updatedAt: chats.updatedAt,
+      })
+      .from(chats)
+      .where(eq(chats.nftGated, true));
+
+    // Get member counts for each chat
+    const chatIds = chatsList.map((c) => c.id);
+    const memberCountsResult = await Promise.all(
+      chatIds.map(async (chatId) => {
+        const count = await database
+          .select({ chatId: chatParticipants.chatId })
+          .from(chatParticipants)
+          .where(eq(chatParticipants.chatId, chatId));
+        return { chatId, count: count.length };
+      })
+    );
+    const memberCountMap = new Map(
+      memberCountsResult.map((r) => [r.chatId, r.count])
+    );
+
+    return chatsList.map((chat) => ({
+      ...chat,
+      memberCount: memberCountMap.get(chat.id) ?? 0,
+    }));
+  }, 'admin-nft-groups');
+
+  return successResponse({
+    groups: nftGatedChats,
+    total: nftGatedChats.length,
+  });
+});
+
+/**
+ * POST /api/admin/groups/nft-collection
+ * Create a new NFT-gated group chat for an NFT collection
+ * Only admins can create these collection-based groups
+ */
+export const POST = withErrorHandling(async (request: NextRequest) => {
+  const admin = await requireAdmin(request);
+  const body = await request.json();
+  const data = CreateNftCollectionGroupSchema.parse(body);
+
+  logAdminView({
+    adminId: admin.userId,
+    ipAddress: getClientIp(request.headers) ?? undefined,
+    resourceType: 'nft-groups',
+    metadata: {
+      action: 'create_nft_gated_group',
+      contractAddress: data.contractAddress,
+      chainId: data.chainId,
+    },
+  });
+
+  const result = await asSystem(async (database) => {
+    const groupId = await generateSnowflakeId();
+    const chatId = await generateSnowflakeId();
+    const now = new Date();
+
+    // Create the group
+    await database.insert(groups).values({
+      id: groupId,
+      name: data.name,
+      description: data.description ?? null,
+      type: 'user',
+      ownerId: admin.userId,
+      createdById: admin.userId,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // Create the NFT-gated chat linked to the group
+    await database.insert(chats).values({
+      id: chatId,
+      name: data.name,
+      description: data.description ?? null,
+      isGroup: true,
+      groupId,
+      createdBy: admin.userId,
+      nftGated: true,
+      requiredNftContractAddress: data.contractAddress.toLowerCase(),
+      requiredNftTokenId: data.tokenId ?? null,
+      requiredNftChainId: data.chainId,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    // Add admin as owner of the group
+    await database.insert(groupMembers).values({
+      id: await generateSnowflakeId(),
+      groupId,
+      userId: admin.userId,
+      role: 'owner',
+      addedBy: admin.userId,
+      joinedAt: now,
+      isActive: true,
+    });
+
+    // Add admin to chat participants
+    await database.insert(chatParticipants).values({
+      id: await generateSnowflakeId(),
+      chatId,
+      userId: admin.userId,
+      joinedAt: now,
+      isActive: true,
+    });
+
+    return { groupId, chatId };
+  }, 'admin-create-nft-group');
+
+  logger.info(
+    'NFT-gated group created by admin',
+    {
+      adminId: admin.userId,
+      groupId: result.groupId,
+      chatId: result.chatId,
+      contractAddress: data.contractAddress,
+      chainId: data.chainId,
+    },
+    'POST /api/admin/groups/nft-collection'
+  );
+
+  return successResponse(
+    {
+      group: {
+        id: result.groupId,
+        name: data.name,
+        chatId: result.chatId,
+        nftGated: true,
+        contractAddress: data.contractAddress.toLowerCase(),
+        tokenId: data.tokenId ?? null,
+        chainId: data.chainId,
+      },
+    },
+    201
+  );
+});

--- a/apps/web/src/app/api/chats/[id]/join-nft/route.ts
+++ b/apps/web/src/app/api/chats/[id]/join-nft/route.ts
@@ -19,11 +19,11 @@ import {
 } from '@babylon/api';
 import {
   and,
-  asUser,
   chatParticipants,
   chats,
   db,
   eq,
+  groupMembers,
   users,
 } from '@babylon/db';
 import { generateSnowflakeId, logger } from '@babylon/shared';
@@ -113,36 +113,71 @@ export const POST = withErrorHandling(
       );
     }
 
-    // Add user to chat
-    await asUser(user, async (database) => {
-      const now = new Date();
-      const participantId = await generateSnowflakeId();
+    // Add user to chat using transaction for atomicity
+    const now = new Date();
+    const participantId = await generateSnowflakeId();
 
-      // Add to chat participants
-      await database.chatParticipant.create({
-        data: {
+    try {
+      await db.transaction(async (tx) => {
+        // Add to chat participants
+        await tx.insert(chatParticipants).values({
           id: participantId,
           chatId,
           userId: user.userId,
           joinedAt: now,
-        },
-      });
+          isActive: true,
+        });
 
-      // If there's a linked group, add to group members
-      if (chat.groupId) {
-        const memberId = await generateSnowflakeId();
-        await database.groupMember.create({
-          data: {
-            id: memberId,
-            groupId: chat.groupId,
-            userId: user.userId,
-            role: 'member',
-            joinedAt: now,
-            isActive: true,
-          },
+        // If there's a linked group, add to group members
+        if (chat.groupId) {
+          const memberId = await generateSnowflakeId();
+          // Check for existing inactive membership and reactivate
+          const existingMember = await tx.query.groupMembers.findFirst({
+            where: and(
+              eq(groupMembers.groupId, chat.groupId),
+              eq(groupMembers.userId, user.userId)
+            ),
+          });
+
+          if (existingMember) {
+            // Reactivate existing membership
+            await tx
+              .update(groupMembers)
+              .set({
+                isActive: true,
+                joinedAt: now,
+                kickedAt: null,
+                kickReason: null,
+              })
+              .where(eq(groupMembers.id, existingMember.id));
+          } else {
+            // Create new membership
+            await tx.insert(groupMembers).values({
+              id: memberId,
+              groupId: chat.groupId,
+              userId: user.userId,
+              role: 'member',
+              addedBy: user.userId,
+              joinedAt: now,
+              isActive: true,
+            });
+          }
+        }
+      });
+    } catch (error) {
+      // Handle race condition - if user was already added by concurrent request
+      if (
+        error instanceof Error &&
+        error.message.includes('unique constraint')
+      ) {
+        return successResponse({
+          success: true,
+          message: 'Already a member of this chat',
+          alreadyMember: true,
         });
       }
-    });
+      throw error;
+    }
 
     logger.info(
       'User joined NFT-gated chat',

--- a/apps/web/src/app/api/chats/[id]/join-nft/route.ts
+++ b/apps/web/src/app/api/chats/[id]/join-nft/route.ts
@@ -1,0 +1,170 @@
+/**
+ * Join NFT-Gated Chat API
+ *
+ * @route POST /api/chats/[id]/join-nft - Join an NFT-gated chat
+ * @access Authenticated
+ *
+ * @description
+ * Allows users to join an NFT-gated chat if they hold the required NFT.
+ * Verifies NFT ownership before adding the user as a participant.
+ */
+
+import {
+  authenticate,
+  BusinessLogicError,
+  NFTVerificationService,
+  NotFoundError,
+  successResponse,
+  withErrorHandling,
+} from '@babylon/api';
+import {
+  and,
+  asUser,
+  chatParticipants,
+  chats,
+  db,
+  eq,
+  users,
+} from '@babylon/db';
+import { generateSnowflakeId, logger } from '@babylon/shared';
+import type { NextRequest } from 'next/server';
+
+/**
+ * POST /api/chats/[id]/join-nft
+ * Join an NFT-gated chat by verifying NFT ownership
+ */
+export const POST = withErrorHandling(
+  async (
+    request: NextRequest,
+    context: { params: Promise<{ id: string }> }
+  ) => {
+    const user = await authenticate(request);
+    const { id: chatId } = await context.params;
+
+    if (!chatId) {
+      throw new BusinessLogicError('Chat ID is required', 'CHAT_ID_REQUIRED');
+    }
+
+    // Get the chat
+    const chat = await db.query.chats.findFirst({
+      where: eq(chats.id, chatId),
+    });
+
+    if (!chat) {
+      throw new NotFoundError('Chat', chatId);
+    }
+
+    if (!chat.nftGated || !chat.requiredNftContractAddress) {
+      throw new BusinessLogicError(
+        'This chat is not NFT-gated',
+        'NOT_NFT_GATED'
+      );
+    }
+
+    // Check if user is already a participant
+    const existingParticipant = await db.query.chatParticipants.findFirst({
+      where: and(
+        eq(chatParticipants.chatId, chatId),
+        eq(chatParticipants.userId, user.userId)
+      ),
+    });
+
+    if (existingParticipant) {
+      return successResponse({
+        success: true,
+        message: 'Already a member of this chat',
+        alreadyMember: true,
+      });
+    }
+
+    // Get user's wallet address
+    const [userData] = await db
+      .select({ walletAddress: users.walletAddress })
+      .from(users)
+      .where(eq(users.id, user.userId))
+      .limit(1);
+
+    if (!userData?.walletAddress) {
+      throw new BusinessLogicError(
+        'You need to connect a wallet to join NFT-gated chats',
+        'WALLET_REQUIRED'
+      );
+    }
+
+    // Invalidate cache and verify NFT ownership with fresh check
+    await NFTVerificationService.invalidateOwnershipCache(
+      userData.walletAddress,
+      chat.requiredNftContractAddress,
+      chat.requiredNftChainId ?? undefined
+    );
+
+    const verification = await NFTVerificationService.verifyChatAccess(
+      userData.walletAddress,
+      chat.requiredNftContractAddress,
+      chat.requiredNftTokenId ?? null,
+      chat.requiredNftChainId ?? undefined
+    );
+
+    if (!verification.canAccess) {
+      throw new BusinessLogicError(
+        verification.reason ??
+          'You do not own the required NFT to join this chat',
+        'NFT_REQUIRED'
+      );
+    }
+
+    // Add user to chat
+    await asUser(user, async (database) => {
+      const now = new Date();
+      const participantId = await generateSnowflakeId();
+
+      // Add to chat participants
+      await database.chatParticipant.create({
+        data: {
+          id: participantId,
+          chatId,
+          userId: user.userId,
+          joinedAt: now,
+        },
+      });
+
+      // If there's a linked group, add to group members
+      if (chat.groupId) {
+        const memberId = await generateSnowflakeId();
+        await database.groupMember.create({
+          data: {
+            id: memberId,
+            groupId: chat.groupId,
+            userId: user.userId,
+            role: 'member',
+            joinedAt: now,
+            isActive: true,
+          },
+        });
+      }
+    });
+
+    logger.info(
+      'User joined NFT-gated chat',
+      {
+        userId: user.userId,
+        chatId,
+        contractAddress: chat.requiredNftContractAddress,
+      },
+      'POST /api/chats/[id]/join-nft'
+    );
+
+    return successResponse({
+      success: true,
+      message: 'Successfully joined the chat',
+      chat: {
+        id: chat.id,
+        name: chat.name,
+        nftGated: true,
+        contractAddress: chat.requiredNftContractAddress,
+        tokenId: chat.requiredNftTokenId,
+        chainId: chat.requiredNftChainId,
+      },
+    });
+  }
+);

--- a/apps/web/src/app/api/chats/[id]/join-nft/route.ts
+++ b/apps/web/src/app/api/chats/[id]/join-nft/route.ts
@@ -24,6 +24,8 @@ import {
   db,
   eq,
   groupMembers,
+  isUniqueConstraintError,
+  toDatabaseErrorType,
   users,
 } from '@babylon/db';
 import { generateSnowflakeId, logger } from '@babylon/shared';
@@ -61,11 +63,12 @@ export const POST = withErrorHandling(
       );
     }
 
-    // Check if user is already a participant
+    // Check if user is already an active participant
     const existingParticipant = await db.query.chatParticipants.findFirst({
       where: and(
         eq(chatParticipants.chatId, chatId),
-        eq(chatParticipants.userId, user.userId)
+        eq(chatParticipants.userId, user.userId),
+        eq(chatParticipants.isActive, true)
       ),
     });
 
@@ -115,23 +118,42 @@ export const POST = withErrorHandling(
 
     // Add user to chat using transaction for atomicity
     const now = new Date();
-    const participantId = await generateSnowflakeId();
 
     try {
       await db.transaction(async (tx) => {
-        // Add to chat participants
-        await tx.insert(chatParticipants).values({
-          id: participantId,
-          chatId,
-          userId: user.userId,
-          joinedAt: now,
-          isActive: true,
+        // Check for existing inactive participant and reactivate
+        const inactiveParticipant = await tx.query.chatParticipants.findFirst({
+          where: and(
+            eq(chatParticipants.chatId, chatId),
+            eq(chatParticipants.userId, user.userId),
+            eq(chatParticipants.isActive, false)
+          ),
         });
+
+        if (inactiveParticipant) {
+          // Reactivate existing participant
+          await tx
+            .update(chatParticipants)
+            .set({
+              isActive: true,
+              joinedAt: now,
+            })
+            .where(eq(chatParticipants.id, inactiveParticipant.id));
+        } else {
+          // Create new participant
+          const participantId = await generateSnowflakeId();
+          await tx.insert(chatParticipants).values({
+            id: participantId,
+            chatId,
+            userId: user.userId,
+            joinedAt: now,
+            isActive: true,
+          });
+        }
 
         // If there's a linked group, add to group members
         if (chat.groupId) {
-          const memberId = await generateSnowflakeId();
-          // Check for existing inactive membership and reactivate
+          // Check for existing membership (active or inactive) and reactivate
           const existingMember = await tx.query.groupMembers.findFirst({
             where: and(
               eq(groupMembers.groupId, chat.groupId),
@@ -152,6 +174,7 @@ export const POST = withErrorHandling(
               .where(eq(groupMembers.id, existingMember.id));
           } else {
             // Create new membership
+            const memberId = await generateSnowflakeId();
             await tx.insert(groupMembers).values({
               id: memberId,
               groupId: chat.groupId,
@@ -166,10 +189,8 @@ export const POST = withErrorHandling(
       });
     } catch (error) {
       // Handle race condition - if user was already added by concurrent request
-      if (
-        error instanceof Error &&
-        error.message.includes('unique constraint')
-      ) {
+      // Check for PostgreSQL unique constraint violation (code 23505)
+      if (isUniqueConstraintError(toDatabaseErrorType(error))) {
         return successResponse({
           success: true,
           message: 'Already a member of this chat',

--- a/apps/web/src/app/api/chats/nft-gated/route.ts
+++ b/apps/web/src/app/api/chats/nft-gated/route.ts
@@ -134,7 +134,12 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
         count: sql<number>`count(*)::int`,
       })
       .from(chatParticipants)
-      .where(inArray(chatParticipants.chatId, chatIds))
+      .where(
+        and(
+          inArray(chatParticipants.chatId, chatIds),
+          eq(chatParticipants.isActive, true)
+        )
+      )
       .groupBy(chatParticipants.chatId);
 
     for (const row of memberCountsResult) {

--- a/apps/web/src/app/api/chats/nft-gated/route.ts
+++ b/apps/web/src/app/api/chats/nft-gated/route.ts
@@ -78,74 +78,105 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     );
   const memberOfSet = new Set(userMemberships.map((m) => m.chatId));
 
-  // Get member counts for each chat
-  const memberCounts = await Promise.all(
-    nftGatedChats.map(async (chat) => {
-      const [result] = await db
-        .select({ count: sql<number>`count(*)::int` })
-        .from(chatParticipants)
-        .where(eq(chatParticipants.chatId, chat.id));
-      return { chatId: chat.id, count: result?.count ?? 0 };
-    })
-  );
-  const memberCountMap = new Map(memberCounts.map((m) => [m.chatId, m.count]));
+  // Get member counts for all chats in a single query using GROUP BY
+  const chatIds = nftGatedChats.map((c) => c.id);
+  const memberCountMap = new Map<string, number>();
+
+  if (chatIds.length > 0) {
+    const memberCountsResult = await db
+      .select({
+        chatId: chatParticipants.chatId,
+        count: sql<number>`count(*)::int`,
+      })
+      .from(chatParticipants)
+      .where(inArray(chatParticipants.chatId, chatIds))
+      .groupBy(chatParticipants.chatId);
+
+    for (const row of memberCountsResult) {
+      memberCountMap.set(row.chatId, row.count);
+    }
+  }
 
   // Check NFT access for each chat if user has wallet
-  const chatResults = await Promise.all(
-    nftGatedChats.map(async (chat) => {
-      const isMember = memberOfSet.has(chat.id);
-      let hasAccess = false;
-      let tokenIds: number[] = [];
+  // Process in batches to avoid overwhelming RPC endpoints
+  const BATCH_SIZE = 5;
+  const chatResults: Array<{
+    id: string;
+    name: string | null;
+    description: string | null;
+    memberCount: number;
+    nftRequirement: {
+      contractAddress: string | null;
+      tokenId: number | null;
+      chainId: number | null;
+    };
+    isMember: boolean;
+    hasAccess: boolean;
+    ownedTokenIds: number[];
+    createdAt: Date;
+  }> = [];
 
-      if (userData?.walletAddress && chat.requiredNftContractAddress) {
-        try {
-          const verification = await NFTVerificationService.verifyChatAccess(
-            userData.walletAddress,
-            chat.requiredNftContractAddress,
-            chat.requiredNftTokenId ?? null,
-            chat.requiredNftChainId ?? undefined
-          );
-          hasAccess = verification.canAccess;
+  for (let i = 0; i < nftGatedChats.length; i += BATCH_SIZE) {
+    const batch = nftGatedChats.slice(i, i + BATCH_SIZE);
 
-          // Get owned token IDs if has access
-          if (hasAccess && chat.requiredNftTokenId === null) {
-            tokenIds = await NFTVerificationService.getUserTokenIds(
+    const batchResults = await Promise.all(
+      batch.map(async (chat) => {
+        const isMember = memberOfSet.has(chat.id);
+        let hasAccess = false;
+        let tokenIds: number[] = [];
+
+        if (userData?.walletAddress && chat.requiredNftContractAddress) {
+          try {
+            const verification = await NFTVerificationService.verifyChatAccess(
               userData.walletAddress,
               chat.requiredNftContractAddress,
+              chat.requiredNftTokenId ?? null,
               chat.requiredNftChainId ?? undefined
-            ).catch(() => []);
-          } else if (hasAccess && chat.requiredNftTokenId !== null) {
-            tokenIds = [chat.requiredNftTokenId];
-          }
-        } catch (error) {
-          logger.warn(
-            'Error checking NFT access for chat',
-            {
-              chatId: chat.id,
-              error: error instanceof Error ? error.message : String(error),
-            },
-            'GET /api/chats/nft-gated'
-          );
-        }
-      }
+            );
+            hasAccess = verification.canAccess;
 
-      return {
-        id: chat.id,
-        name: chat.name,
-        description: chat.description,
-        memberCount: memberCountMap.get(chat.id) ?? 0,
-        nftRequirement: {
-          contractAddress: chat.requiredNftContractAddress,
-          tokenId: chat.requiredNftTokenId,
-          chainId: chat.requiredNftChainId,
-        },
-        isMember,
-        hasAccess,
-        ownedTokenIds: tokenIds,
-        createdAt: chat.createdAt,
-      };
-    })
-  );
+            // Get owned token IDs if has access
+            if (hasAccess && chat.requiredNftTokenId === null) {
+              tokenIds = await NFTVerificationService.getUserTokenIds(
+                userData.walletAddress,
+                chat.requiredNftContractAddress,
+                chat.requiredNftChainId ?? undefined
+              ).catch(() => []);
+            } else if (hasAccess && chat.requiredNftTokenId !== null) {
+              tokenIds = [chat.requiredNftTokenId];
+            }
+          } catch (error) {
+            logger.warn(
+              'Error checking NFT access for chat',
+              {
+                chatId: chat.id,
+                error: error instanceof Error ? error.message : String(error),
+              },
+              'GET /api/chats/nft-gated'
+            );
+          }
+        }
+
+        return {
+          id: chat.id,
+          name: chat.name,
+          description: chat.description,
+          memberCount: memberCountMap.get(chat.id) ?? 0,
+          nftRequirement: {
+            contractAddress: chat.requiredNftContractAddress,
+            tokenId: chat.requiredNftTokenId,
+            chainId: chat.requiredNftChainId,
+          },
+          isMember,
+          hasAccess,
+          ownedTokenIds: tokenIds,
+          createdAt: chat.createdAt,
+        };
+      })
+    );
+
+    chatResults.push(...batchResults);
+  }
 
   // Sort: accessible non-member chats first, then by member count
   chatResults.sort((a, b) => {

--- a/apps/web/src/app/api/chats/nft-gated/route.ts
+++ b/apps/web/src/app/api/chats/nft-gated/route.ts
@@ -228,21 +228,9 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     chatResults.push(...batchResults);
   }
 
-  // Sort: accessible non-member chats first, then by member count
-  chatResults.sort((a, b) => {
-    // Chats user can join but hasn't joined yet come first
-    const aCanJoin = a.hasAccess && !a.isMember;
-    const bCanJoin = b.hasAccess && !b.isMember;
-    if (aCanJoin && !bCanJoin) return -1;
-    if (!aCanJoin && bCanJoin) return 1;
-
-    // Then member chats
-    if (a.isMember && !b.isMember) return -1;
-    if (!a.isMember && b.isMember) return 1;
-
-    // Then by member count
-    return b.memberCount - a.memberCount;
-  });
+  // Note: Results are ordered by createdAt DESC from the database query.
+  // Client-side sorting by access/membership is left to the frontend since
+  // in-memory sorting after pagination would break pagination consistency.
 
   return successResponse({
     chats: chatResults,

--- a/apps/web/src/app/api/chats/nft-gated/route.ts
+++ b/apps/web/src/app/api/chats/nft-gated/route.ts
@@ -108,13 +108,14 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     });
   }
 
-  // Get user's current memberships
+  // Get user's current active memberships
   const userMemberships = await db
     .select({ chatId: chatParticipants.chatId })
     .from(chatParticipants)
     .where(
       and(
         eq(chatParticipants.userId, user.userId),
+        eq(chatParticipants.isActive, true),
         inArray(
           chatParticipants.chatId,
           nftGatedChats.map((c) => c.id)

--- a/apps/web/src/app/api/chats/nft-gated/route.ts
+++ b/apps/web/src/app/api/chats/nft-gated/route.ts
@@ -17,9 +17,11 @@ import {
 } from '@babylon/api';
 import {
   and,
+  asc,
   chatParticipants,
   chats,
   db,
+  desc,
   eq,
   inArray,
   sql,
@@ -28,12 +30,39 @@ import {
 import { logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 
+// Pagination constants
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 50;
+
 /**
  * GET /api/chats/nft-gated
  * List NFT-gated chats the user can potentially join
  */
 export const GET = withErrorHandling(async (request: NextRequest) => {
   const user = await authenticate(request);
+
+  // Parse pagination parameters from query string
+  const { searchParams } = new URL(request.url);
+  const limitParam = searchParams.get('limit');
+  const offsetParam = searchParams.get('offset');
+
+  // Validate and apply pagination with sensible defaults and hard max
+  let limit = DEFAULT_LIMIT;
+  let offset = 0;
+
+  if (limitParam) {
+    const parsedLimit = parseInt(limitParam, 10);
+    if (!isNaN(parsedLimit) && parsedLimit > 0) {
+      limit = Math.min(parsedLimit, MAX_LIMIT);
+    }
+  }
+
+  if (offsetParam) {
+    const parsedOffset = parseInt(offsetParam, 10);
+    if (!isNaN(parsedOffset) && parsedOffset >= 0) {
+      offset = parsedOffset;
+    }
+  }
 
   // Get user's wallet address
   const [userData] = await db
@@ -42,7 +71,14 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     .where(eq(users.id, user.userId))
     .limit(1);
 
-  // Get all NFT-gated chats
+  // Get total count of NFT-gated chats for pagination metadata
+  const [totalCountResult] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(chats)
+    .where(eq(chats.nftGated, true));
+  const totalCount = totalCountResult?.count ?? 0;
+
+  // Get paginated NFT-gated chats ordered by createdAt (newest first)
   const nftGatedChats = await db
     .select({
       id: chats.id,
@@ -54,12 +90,21 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       createdAt: chats.createdAt,
     })
     .from(chats)
-    .where(eq(chats.nftGated, true));
+    .where(eq(chats.nftGated, true))
+    .orderBy(desc(chats.createdAt), asc(chats.id))
+    .limit(limit)
+    .offset(offset);
 
   if (nftGatedChats.length === 0) {
     return successResponse({
       chats: [],
       hasWallet: !!userData?.walletAddress,
+      pagination: {
+        total: totalCount,
+        limit,
+        offset,
+        hasMore: false,
+      },
     });
   }
 
@@ -198,5 +243,11 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     chats: chatResults,
     hasWallet: !!userData?.walletAddress,
     walletAddress: userData?.walletAddress ?? null,
+    pagination: {
+      total: totalCount,
+      limit,
+      offset,
+      hasMore: offset + nftGatedChats.length < totalCount,
+    },
   });
 });

--- a/apps/web/src/app/api/chats/nft-gated/route.ts
+++ b/apps/web/src/app/api/chats/nft-gated/route.ts
@@ -29,10 +29,24 @@ import {
 } from '@babylon/db';
 import { logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
+import { z } from 'zod';
 
 // Pagination constants
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 50;
+
+// Pagination schema with type coercion and validation
+// Uses preprocess to handle empty strings gracefully (treat as undefined)
+const PaginationSchema = z.object({
+  limit: z.preprocess(
+    (val) => (val === '' || val === null ? undefined : val),
+    z.coerce.number().int().positive().max(MAX_LIMIT).default(DEFAULT_LIMIT)
+  ),
+  offset: z.preprocess(
+    (val) => (val === '' || val === null ? undefined : val),
+    z.coerce.number().int().nonnegative().default(0)
+  ),
+});
 
 /**
  * GET /api/chats/nft-gated
@@ -41,28 +55,12 @@ const MAX_LIMIT = 50;
 export const GET = withErrorHandling(async (request: NextRequest) => {
   const user = await authenticate(request);
 
-  // Parse pagination parameters from query string
+  // Parse and validate pagination parameters using Zod
   const { searchParams } = new URL(request.url);
-  const limitParam = searchParams.get('limit');
-  const offsetParam = searchParams.get('offset');
-
-  // Validate and apply pagination with sensible defaults and hard max
-  let limit = DEFAULT_LIMIT;
-  let offset = 0;
-
-  if (limitParam) {
-    const parsedLimit = parseInt(limitParam, 10);
-    if (!isNaN(parsedLimit) && parsedLimit > 0) {
-      limit = Math.min(parsedLimit, MAX_LIMIT);
-    }
-  }
-
-  if (offsetParam) {
-    const parsedOffset = parseInt(offsetParam, 10);
-    if (!isNaN(parsedOffset) && parsedOffset >= 0) {
-      offset = parsedOffset;
-    }
-  }
+  const { limit, offset } = PaginationSchema.parse({
+    limit: searchParams.get('limit') ?? undefined,
+    offset: searchParams.get('offset') ?? undefined,
+  });
 
   // Get user's wallet address
   const [userData] = await db

--- a/apps/web/src/app/api/chats/nft-gated/route.ts
+++ b/apps/web/src/app/api/chats/nft-gated/route.ts
@@ -1,0 +1,171 @@
+/**
+ * NFT-Gated Chats Discovery API
+ *
+ * @route GET /api/chats/nft-gated - List available NFT-gated chats
+ * @access Authenticated
+ *
+ * @description
+ * Returns a list of NFT-gated chats that the user could potentially join.
+ * Shows which chats the user has access to based on their NFT holdings.
+ */
+
+import {
+  authenticate,
+  NFTVerificationService,
+  successResponse,
+  withErrorHandling,
+} from '@babylon/api';
+import {
+  and,
+  chatParticipants,
+  chats,
+  db,
+  eq,
+  inArray,
+  sql,
+  users,
+} from '@babylon/db';
+import { logger } from '@babylon/shared';
+import type { NextRequest } from 'next/server';
+
+/**
+ * GET /api/chats/nft-gated
+ * List NFT-gated chats the user can potentially join
+ */
+export const GET = withErrorHandling(async (request: NextRequest) => {
+  const user = await authenticate(request);
+
+  // Get user's wallet address
+  const [userData] = await db
+    .select({ walletAddress: users.walletAddress })
+    .from(users)
+    .where(eq(users.id, user.userId))
+    .limit(1);
+
+  // Get all NFT-gated chats
+  const nftGatedChats = await db
+    .select({
+      id: chats.id,
+      name: chats.name,
+      description: chats.description,
+      requiredNftContractAddress: chats.requiredNftContractAddress,
+      requiredNftTokenId: chats.requiredNftTokenId,
+      requiredNftChainId: chats.requiredNftChainId,
+      createdAt: chats.createdAt,
+    })
+    .from(chats)
+    .where(eq(chats.nftGated, true));
+
+  if (nftGatedChats.length === 0) {
+    return successResponse({
+      chats: [],
+      hasWallet: !!userData?.walletAddress,
+    });
+  }
+
+  // Get user's current memberships
+  const userMemberships = await db
+    .select({ chatId: chatParticipants.chatId })
+    .from(chatParticipants)
+    .where(
+      and(
+        eq(chatParticipants.userId, user.userId),
+        inArray(
+          chatParticipants.chatId,
+          nftGatedChats.map((c) => c.id)
+        )
+      )
+    );
+  const memberOfSet = new Set(userMemberships.map((m) => m.chatId));
+
+  // Get member counts for each chat
+  const memberCounts = await Promise.all(
+    nftGatedChats.map(async (chat) => {
+      const [result] = await db
+        .select({ count: sql<number>`count(*)::int` })
+        .from(chatParticipants)
+        .where(eq(chatParticipants.chatId, chat.id));
+      return { chatId: chat.id, count: result?.count ?? 0 };
+    })
+  );
+  const memberCountMap = new Map(memberCounts.map((m) => [m.chatId, m.count]));
+
+  // Check NFT access for each chat if user has wallet
+  const chatResults = await Promise.all(
+    nftGatedChats.map(async (chat) => {
+      const isMember = memberOfSet.has(chat.id);
+      let hasAccess = false;
+      let tokenIds: number[] = [];
+
+      if (userData?.walletAddress && chat.requiredNftContractAddress) {
+        try {
+          const verification = await NFTVerificationService.verifyChatAccess(
+            userData.walletAddress,
+            chat.requiredNftContractAddress,
+            chat.requiredNftTokenId ?? null,
+            chat.requiredNftChainId ?? undefined
+          );
+          hasAccess = verification.canAccess;
+
+          // Get owned token IDs if has access
+          if (hasAccess && chat.requiredNftTokenId === null) {
+            tokenIds = await NFTVerificationService.getUserTokenIds(
+              userData.walletAddress,
+              chat.requiredNftContractAddress,
+              chat.requiredNftChainId ?? undefined
+            ).catch(() => []);
+          } else if (hasAccess && chat.requiredNftTokenId !== null) {
+            tokenIds = [chat.requiredNftTokenId];
+          }
+        } catch (error) {
+          logger.warn(
+            'Error checking NFT access for chat',
+            {
+              chatId: chat.id,
+              error: error instanceof Error ? error.message : String(error),
+            },
+            'GET /api/chats/nft-gated'
+          );
+        }
+      }
+
+      return {
+        id: chat.id,
+        name: chat.name,
+        description: chat.description,
+        memberCount: memberCountMap.get(chat.id) ?? 0,
+        nftRequirement: {
+          contractAddress: chat.requiredNftContractAddress,
+          tokenId: chat.requiredNftTokenId,
+          chainId: chat.requiredNftChainId,
+        },
+        isMember,
+        hasAccess,
+        ownedTokenIds: tokenIds,
+        createdAt: chat.createdAt,
+      };
+    })
+  );
+
+  // Sort: accessible non-member chats first, then by member count
+  chatResults.sort((a, b) => {
+    // Chats user can join but hasn't joined yet come first
+    const aCanJoin = a.hasAccess && !a.isMember;
+    const bCanJoin = b.hasAccess && !b.isMember;
+    if (aCanJoin && !bCanJoin) return -1;
+    if (!aCanJoin && bCanJoin) return 1;
+
+    // Then member chats
+    if (a.isMember && !b.isMember) return -1;
+    if (!a.isMember && b.isMember) return 1;
+
+    // Then by member count
+    return b.memberCount - a.memberCount;
+  });
+
+  return successResponse({
+    chats: chatResults,
+    hasWallet: !!userData?.walletAddress,
+    walletAddress: userData?.walletAddress ?? null,
+  });
+});

--- a/apps/web/src/app/api/cron/nft-revalidate/route.ts
+++ b/apps/web/src/app/api/cron/nft-revalidate/route.ts
@@ -27,6 +27,7 @@ import {
   db,
   eq,
   inArray,
+  sql,
   users,
 } from '@babylon/db';
 import { logger } from '@babylon/shared';
@@ -64,7 +65,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   logger.info('Starting NFT revalidation cron job', {}, 'nft-revalidate');
 
   try {
-    // Get all NFT-gated chats (ordered by createdAt for deterministic round-robin processing)
+    // Get NFT-gated chats ordered by lastNftRevalidatedAt for true round-robin processing.
+    // NULLS FIRST ensures newly created chats (never revalidated) are processed first.
+    // Falls back to createdAt for deterministic ordering when timestamps are equal.
     const nftGatedChats = await db
       .select({
         id: chats.id,
@@ -75,7 +78,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       })
       .from(chats)
       .where(eq(chats.nftGated, true))
-      .orderBy(asc(chats.createdAt))
+      .orderBy(
+        sql`${chats.lastNftRevalidatedAt} ASC NULLS FIRST`,
+        asc(chats.createdAt)
+      )
       .limit(MAX_CHATS_PER_RUN);
 
     if (nftGatedChats.length === 0) {
@@ -116,6 +122,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
           chat.requiredNftTokenId,
           chat.requiredNftChainId
         );
+
+        // Update lastNftRevalidatedAt to mark this chat as recently processed
+        // This ensures round-robin processing across all NFT-gated chats
+        await db
+          .update(chats)
+          .set({ lastNftRevalidatedAt: new Date() })
+          .where(eq(chats.id, chat.id));
 
         results.chatsProcessed++;
         results.usersChecked += chatResult.checked;

--- a/apps/web/src/app/api/cron/nft-revalidate/route.ts
+++ b/apps/web/src/app/api/cron/nft-revalidate/route.ts
@@ -1,0 +1,315 @@
+/**
+ * NFT Revalidation Cron Job
+ *
+ * @route POST /api/cron/nft-revalidate
+ * @access Cron only (via CRON_SECRET)
+ *
+ * @description
+ * Periodically revalidates NFT ownership for all members in NFT-gated chats.
+ * This ensures users who have sold or transferred their NFTs are automatically
+ * removed from gated chats.
+ *
+ * Recommended schedule: Every 5-15 minutes
+ * Vercel cron: "* /5 * * * *" or similar
+ */
+
+import { NFTVerificationService } from '@babylon/api';
+import {
+  and,
+  asSystem,
+  chatParticipants,
+  chats,
+  db,
+  eq,
+  groupMembers,
+  inArray,
+  users,
+} from '@babylon/db';
+import { logger } from '@babylon/shared';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+// Maximum time for a single run (Vercel function timeout - 10s buffer)
+const MAX_RUN_TIME_MS = 50_000;
+// Max users to check per chat per run (avoid overloading RPC)
+const MAX_USERS_PER_CHAT = 20;
+// Max chats to process per run
+const MAX_CHATS_PER_RUN = 5;
+
+/**
+ * POST /api/cron/nft-revalidate
+ * Revalidate NFT access for all NFT-gated chats
+ */
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  const startTime = Date.now();
+
+  // Verify cron secret (Vercel cron protection)
+  const authHeader = request.headers.get('authorization');
+  const cronSecret = process.env.CRON_SECRET;
+
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  logger.info('Starting NFT revalidation cron job', {}, 'nft-revalidate');
+
+  try {
+    // Get all NFT-gated chats
+    const nftGatedChats = await db
+      .select({
+        id: chats.id,
+        groupId: chats.groupId,
+        requiredNftContractAddress: chats.requiredNftContractAddress,
+        requiredNftTokenId: chats.requiredNftTokenId,
+        requiredNftChainId: chats.requiredNftChainId,
+      })
+      .from(chats)
+      .where(eq(chats.nftGated, true))
+      .limit(MAX_CHATS_PER_RUN);
+
+    if (nftGatedChats.length === 0) {
+      logger.info('No NFT-gated chats found', {}, 'nft-revalidate');
+      return NextResponse.json({
+        success: true,
+        message: 'No NFT-gated chats to process',
+      });
+    }
+
+    const results = {
+      chatsProcessed: 0,
+      usersChecked: 0,
+      usersRemoved: 0,
+      errors: 0,
+    };
+
+    for (const chat of nftGatedChats) {
+      // Check if we're running out of time
+      if (Date.now() - startTime > MAX_RUN_TIME_MS) {
+        logger.warn(
+          'NFT revalidation timed out',
+          { processed: results.chatsProcessed },
+          'nft-revalidate'
+        );
+        break;
+      }
+
+      if (!chat.requiredNftContractAddress) {
+        continue;
+      }
+
+      try {
+        const chatResult = await revalidateChatAccess(
+          chat.id,
+          chat.groupId,
+          chat.requiredNftContractAddress,
+          chat.requiredNftTokenId,
+          chat.requiredNftChainId
+        );
+
+        results.chatsProcessed++;
+        results.usersChecked += chatResult.checked;
+        results.usersRemoved += chatResult.removed;
+        results.errors += chatResult.errors;
+      } catch (error) {
+        logger.error(
+          'Error processing chat for NFT revalidation',
+          {
+            chatId: chat.id,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          'nft-revalidate'
+        );
+        results.errors++;
+      }
+    }
+
+    logger.info(
+      'NFT revalidation cron job completed',
+      {
+        duration: Date.now() - startTime,
+        ...results,
+      },
+      'nft-revalidate'
+    );
+
+    return NextResponse.json({
+      success: true,
+      results,
+    });
+  } catch (error) {
+    logger.error(
+      'NFT revalidation cron job failed',
+      { error: error instanceof Error ? error.message : String(error) },
+      'nft-revalidate'
+    );
+    return NextResponse.json(
+      {
+        error: 'NFT revalidation failed',
+        details: error instanceof Error ? error.message : String(error),
+      },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * Revalidate NFT access for a single chat
+ */
+async function revalidateChatAccess(
+  chatId: string,
+  groupId: string | null,
+  contractAddress: string,
+  tokenId: number | null,
+  chainId: number | null
+): Promise<{ checked: number; removed: number; errors: number }> {
+  const results = { checked: 0, removed: 0, errors: 0 };
+
+  // Get participants with wallet addresses
+  const participants = await asSystem(async (database) => {
+    const participantList = await database
+      .select({
+        participantId: chatParticipants.id,
+        userId: chatParticipants.userId,
+      })
+      .from(chatParticipants)
+      .where(eq(chatParticipants.chatId, chatId))
+      .limit(MAX_USERS_PER_CHAT);
+
+    if (participantList.length === 0) return [];
+
+    const userIds = participantList.map((p) => p.userId);
+    const usersList = await database
+      .select({
+        id: users.id,
+        walletAddress: users.walletAddress,
+      })
+      .from(users)
+      .where(inArray(users.id, userIds));
+
+    const usersMap = new Map(usersList.map((u) => [u.id, u]));
+
+    return participantList.map((p) => ({
+      userId: p.userId,
+      walletAddress: usersMap.get(p.userId)?.walletAddress ?? null,
+    }));
+  }, 'nft-revalidate-cron');
+
+  for (const participant of participants) {
+    results.checked++;
+
+    // Skip users without wallet - they can't own NFTs
+    if (!participant.walletAddress) {
+      // Remove user without wallet from NFT-gated chat
+      try {
+        await removeUserFromChat(
+          chatId,
+          groupId,
+          participant.userId,
+          'No wallet connected'
+        );
+        results.removed++;
+      } catch {
+        results.errors++;
+      }
+      continue;
+    }
+
+    try {
+      // Check NFT ownership (uses cache, so generally fast)
+      const verification = await NFTVerificationService.verifyChatAccess(
+        participant.walletAddress,
+        contractAddress,
+        tokenId,
+        chainId ?? undefined
+      );
+
+      if (!verification.canAccess) {
+        // Invalidate cache and recheck to be sure
+        await NFTVerificationService.invalidateOwnershipCache(
+          participant.walletAddress,
+          contractAddress,
+          chainId ?? undefined
+        );
+
+        const freshCheck = await NFTVerificationService.verifyChatAccess(
+          participant.walletAddress,
+          contractAddress,
+          tokenId,
+          chainId ?? undefined
+        );
+
+        if (!freshCheck.canAccess) {
+          await removeUserFromChat(
+            chatId,
+            groupId,
+            participant.userId,
+            freshCheck.reason ?? 'No longer owns required NFT'
+          );
+          results.removed++;
+
+          logger.info(
+            'User removed from NFT-gated chat',
+            {
+              chatId,
+              userId: participant.userId,
+              reason: freshCheck.reason,
+            },
+            'nft-revalidate'
+          );
+        }
+      }
+    } catch (error) {
+      // Log but don't fail the whole job for one user
+      logger.warn(
+        'Error checking NFT ownership for user',
+        {
+          chatId,
+          userId: participant.userId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        'nft-revalidate'
+      );
+      results.errors++;
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Helper to remove a user from an NFT-gated chat
+ */
+async function removeUserFromChat(
+  chatId: string,
+  groupId: string | null,
+  userId: string,
+  reason: string
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    await tx
+      .delete(chatParticipants)
+      .where(
+        and(
+          eq(chatParticipants.chatId, chatId),
+          eq(chatParticipants.userId, userId)
+        )
+      );
+
+    if (groupId) {
+      await tx
+        .update(groupMembers)
+        .set({
+          isActive: false,
+          kickedAt: new Date(),
+          kickReason: reason,
+        })
+        .where(
+          and(
+            eq(groupMembers.groupId, groupId),
+            eq(groupMembers.userId, userId),
+            eq(groupMembers.isActive, true)
+          )
+        );
+    }
+  });
+}

--- a/apps/web/src/app/api/cron/nft-revalidate/route.ts
+++ b/apps/web/src/app/api/cron/nft-revalidate/route.ts
@@ -13,15 +13,18 @@
  * Vercel cron: "* /5 * * * *" or similar
  */
 
-import { NFTVerificationService } from '@babylon/api';
 import {
-  and,
+  NFTVerificationService,
+  removeUserFromNftChat,
+  verifyCronAuth,
+} from '@babylon/api';
+import {
+  asc,
   asSystem,
   chatParticipants,
   chats,
   db,
   eq,
-  groupMembers,
   inArray,
   users,
 } from '@babylon/db';
@@ -43,18 +46,20 @@ const MAX_CHATS_PER_RUN = 5;
 export async function POST(request: NextRequest): Promise<NextResponse> {
   const startTime = Date.now();
 
-  // Verify cron secret (Vercel cron protection)
-  const authHeader = request.headers.get('authorization');
-  const cronSecret = process.env.CRON_SECRET;
-
-  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+  // Verify cron authorization using centralized auth (fail-closed in production)
+  if (!verifyCronAuth(request, { jobName: 'NftRevalidate' })) {
+    logger.warn(
+      'Unauthorized nft-revalidate request attempt',
+      undefined,
+      'nft-revalidate'
+    );
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   logger.info('Starting NFT revalidation cron job', {}, 'nft-revalidate');
 
   try {
-    // Get all NFT-gated chats
+    // Get all NFT-gated chats (ordered by createdAt for deterministic round-robin processing)
     const nftGatedChats = await db
       .select({
         id: chats.id,
@@ -65,6 +70,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       })
       .from(chats)
       .where(eq(chats.nftGated, true))
+      .orderBy(asc(chats.createdAt))
       .limit(MAX_CHATS_PER_RUN);
 
     if (nftGatedChats.length === 0) {
@@ -201,7 +207,7 @@ async function revalidateChatAccess(
     if (!participant.walletAddress) {
       // Remove user without wallet from NFT-gated chat
       try {
-        await removeUserFromChat(
+        await removeUserFromNftChat(
           chatId,
           groupId,
           participant.userId,
@@ -239,7 +245,7 @@ async function revalidateChatAccess(
         );
 
         if (!freshCheck.canAccess) {
-          await removeUserFromChat(
+          await removeUserFromNftChat(
             chatId,
             groupId,
             participant.userId,
@@ -274,42 +280,4 @@ async function revalidateChatAccess(
   }
 
   return results;
-}
-
-/**
- * Helper to remove a user from an NFT-gated chat
- */
-async function removeUserFromChat(
-  chatId: string,
-  groupId: string | null,
-  userId: string,
-  reason: string
-): Promise<void> {
-  await db.transaction(async (tx) => {
-    await tx
-      .delete(chatParticipants)
-      .where(
-        and(
-          eq(chatParticipants.chatId, chatId),
-          eq(chatParticipants.userId, userId)
-        )
-      );
-
-    if (groupId) {
-      await tx
-        .update(groupMembers)
-        .set({
-          isActive: false,
-          kickedAt: new Date(),
-          kickReason: reason,
-        })
-        .where(
-          and(
-            eq(groupMembers.groupId, groupId),
-            eq(groupMembers.userId, userId),
-            eq(groupMembers.isActive, true)
-          )
-        );
-    }
-  });
 }

--- a/apps/web/src/app/api/cron/nft-revalidate/route.ts
+++ b/apps/web/src/app/api/cron/nft-revalidate/route.ts
@@ -19,6 +19,7 @@ import {
   verifyCronAuth,
 } from '@babylon/api';
 import {
+  and,
   asc,
   asSystem,
   chatParticipants,
@@ -182,7 +183,12 @@ async function revalidateChatAccess(
         userId: chatParticipants.userId,
       })
       .from(chatParticipants)
-      .where(eq(chatParticipants.chatId, chatId))
+      .where(
+        and(
+          eq(chatParticipants.chatId, chatId),
+          eq(chatParticipants.isActive, true)
+        )
+      )
       .limit(MAX_USERS_PER_CHAT);
 
     if (participantList.length === 0) return [];

--- a/apps/web/src/app/api/cron/nft-revalidate/route.ts
+++ b/apps/web/src/app/api/cron/nft-revalidate/route.ts
@@ -125,9 +125,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
         // Update lastNftRevalidatedAt to mark this chat as recently processed
         // This ensures round-robin processing across all NFT-gated chats
+        // Also update updatedAt for consistent audit/cache semantics
+        const now = new Date();
         await db
           .update(chats)
-          .set({ lastNftRevalidatedAt: new Date() })
+          .set({ lastNftRevalidatedAt: now, updatedAt: now })
           .where(eq(chats.id, chat.id));
 
         results.chatsProcessed++;

--- a/apps/web/src/app/api/cron/nft-revalidate/route.ts
+++ b/apps/web/src/app/api/cron/nft-revalidate/route.ts
@@ -33,7 +33,11 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
 // Maximum time for a single run (Vercel function timeout - 10s buffer)
-const MAX_RUN_TIME_MS = 50_000;
+// Configurable via environment variable for different deployment environments
+const MAX_RUN_TIME_MS = parseInt(
+  process.env.NFT_REVALIDATE_TIMEOUT_MS ?? '50000',
+  10
+);
 // Max users to check per chat per run (avoid overloading RPC)
 const MAX_USERS_PER_CHAT = 20;
 // Max chats to process per run
@@ -221,7 +225,16 @@ async function revalidateChatAccess(
     }
 
     try {
-      // Check NFT ownership (uses cache, so generally fast)
+      // Invalidate cache first to ensure fresh ownership check
+      // This prevents race conditions where stale cache data could be re-cached
+      // between checks by concurrent requests
+      await NFTVerificationService.invalidateOwnershipCache(
+        participant.walletAddress,
+        contractAddress,
+        chainId ?? undefined
+      );
+
+      // Check NFT ownership with fresh data
       const verification = await NFTVerificationService.verifyChatAccess(
         participant.walletAddress,
         contractAddress,
@@ -230,39 +243,23 @@ async function revalidateChatAccess(
       );
 
       if (!verification.canAccess) {
-        // Invalidate cache and recheck to be sure
-        await NFTVerificationService.invalidateOwnershipCache(
-          participant.walletAddress,
-          contractAddress,
-          chainId ?? undefined
+        await removeUserFromNftChat(
+          chatId,
+          groupId,
+          participant.userId,
+          verification.reason ?? 'No longer owns required NFT'
         );
+        results.removed++;
 
-        const freshCheck = await NFTVerificationService.verifyChatAccess(
-          participant.walletAddress,
-          contractAddress,
-          tokenId,
-          chainId ?? undefined
-        );
-
-        if (!freshCheck.canAccess) {
-          await removeUserFromNftChat(
+        logger.info(
+          'User removed from NFT-gated chat',
+          {
             chatId,
-            groupId,
-            participant.userId,
-            freshCheck.reason ?? 'No longer owns required NFT'
-          );
-          results.removed++;
-
-          logger.info(
-            'User removed from NFT-gated chat',
-            {
-              chatId,
-              userId: participant.userId,
-              reason: freshCheck.reason,
-            },
-            'nft-revalidate'
-          );
-        }
+            userId: participant.userId,
+            reason: verification.reason,
+          },
+          'nft-revalidate'
+        );
       }
     } catch (error) {
       // Log but don't fail the whole job for one user

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -227,7 +227,6 @@ export type { ErrorLike, JsonValue, StringRecord } from './types';
 export {
   type CanonicalUser,
   type EnsureUserOptions,
-  type TargetLookupResult,
   ensureUserForAuth,
   findTargetByIdentifier,
   findUserByIdentifier,
@@ -235,6 +234,7 @@ export {
   getCanonicalUserId,
   requireTargetByIdentifier,
   requireUserByIdentifier,
+  type TargetLookupResult,
 } from './users';
 // Server-side utilities (require Node.js crypto)
 export {

--- a/packages/api/src/services/index.ts
+++ b/packages/api/src/services/index.ts
@@ -21,6 +21,7 @@ export * from './feedback-service';
 export * from './generation-lock-service';
 // Moderation Services
 export * from './moderation';
+export * from './nft-group-service';
 export * from './nft-verification-service';
 export * from './notification-service';
 // Onchain Service

--- a/packages/api/src/services/nft-group-service.ts
+++ b/packages/api/src/services/nft-group-service.ts
@@ -52,13 +52,16 @@ export async function removeUserFromNftChat(
   }
 
   await db.transaction(async (tx) => {
-    // Remove from chat participants
+    // Soft delete from chat participants (set isActive: false)
+    // This allows reactivation if user re-acquires the NFT and rejoins
     await tx
-      .delete(chatParticipants)
+      .update(chatParticipants)
+      .set({ isActive: false })
       .where(
         and(
           eq(chatParticipants.chatId, chatId),
-          eq(chatParticipants.userId, userId)
+          eq(chatParticipants.userId, userId),
+          eq(chatParticipants.isActive, true)
         )
       );
 

--- a/packages/api/src/services/nft-group-service.ts
+++ b/packages/api/src/services/nft-group-service.ts
@@ -1,0 +1,99 @@
+/**
+ * NFT Group Service
+ *
+ * @module api/services/nft-group-service
+ *
+ * @description
+ * Shared utilities for managing NFT-gated group chats, including user removal
+ * and membership management.
+ */
+
+import {
+  and,
+  chatParticipants,
+  chats,
+  db,
+  eq,
+  groupMembers,
+} from '@babylon/db';
+import { logger } from '@babylon/shared';
+
+import { notifyNftAccessRevoked } from './notification-service';
+
+/**
+ * Remove a user from an NFT-gated chat and optionally mark their group membership as inactive.
+ * Uses a transaction to ensure atomicity of the operation.
+ * Also sends a notification to the user about their removal.
+ *
+ * @param chatId - The ID of the chat to remove the user from
+ * @param groupId - The ID of the linked group (null if no group)
+ * @param userId - The ID of the user to remove
+ * @param reason - The reason for removal (e.g., "No longer owns required NFT")
+ */
+export async function removeUserFromNftChat(
+  chatId: string,
+  groupId: string | null,
+  userId: string,
+  reason: string
+): Promise<void> {
+  // Get chat name for notification before removal
+  let chatName = 'NFT-gated chat';
+  try {
+    const [chat] = await db
+      .select({ name: chats.name })
+      .from(chats)
+      .where(eq(chats.id, chatId))
+      .limit(1);
+    if (chat?.name) {
+      chatName = chat.name;
+    }
+  } catch {
+    // Continue with default name if lookup fails
+  }
+
+  await db.transaction(async (tx) => {
+    // Remove from chat participants
+    await tx
+      .delete(chatParticipants)
+      .where(
+        and(
+          eq(chatParticipants.chatId, chatId),
+          eq(chatParticipants.userId, userId)
+        )
+      );
+
+    // If there's a linked group, mark group membership as inactive with kick reason
+    if (groupId) {
+      await tx
+        .update(groupMembers)
+        .set({
+          isActive: false,
+          kickedAt: new Date(),
+          kickReason: reason,
+        })
+        .where(
+          and(
+            eq(groupMembers.groupId, groupId),
+            eq(groupMembers.userId, userId),
+            eq(groupMembers.isActive, true)
+          )
+        );
+    }
+  });
+
+  // Send notification to user about their removal (non-blocking)
+  try {
+    await notifyNftAccessRevoked(userId, chatId, chatName, reason);
+  } catch (error) {
+    // Log but don't fail the removal if notification fails
+    logger.warn(
+      'Failed to send NFT access revoked notification',
+      {
+        userId,
+        chatId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      'NFTGroupService'
+    );
+  }
+}

--- a/packages/api/src/services/notification-service.ts
+++ b/packages/api/src/services/notification-service.ts
@@ -27,7 +27,8 @@ export type NotificationType =
   | 'report_evaluated'
   | 'appeal_status'
   | 'points_received'
-  | 'group_invite';
+  | 'group_invite'
+  | 'nft_access_revoked';
 
 interface CreateNotificationParams {
   userId: string; // Who receives the notification
@@ -643,4 +644,28 @@ export async function notifyGroupChatMessage(
     );
 
   await Promise.all(notificationPromises);
+}
+
+/**
+ * Create notification when user is removed from an NFT-gated chat
+ * This happens when the user no longer owns the required NFT
+ */
+export async function notifyNftAccessRevoked(
+  userId: string,
+  chatId: string,
+  chatName: string,
+  reason: string
+): Promise<void> {
+  const message =
+    reason === 'No wallet connected'
+      ? `You were removed from "${chatName}" because your wallet was disconnected`
+      : `You were removed from "${chatName}" because you no longer own the required NFT`;
+
+  await createNotification({
+    userId,
+    type: 'nft_access_revoked',
+    chatId,
+    title: 'NFT Access Revoked',
+    message,
+  });
 }

--- a/packages/api/src/users/user-lookup.ts
+++ b/packages/api/src/users/user-lookup.ts
@@ -5,7 +5,7 @@
  */
 
 import { db, eq, or, users } from '@babylon/db';
-import { StaticDataRegistry, type StaticActor } from '@babylon/engine';
+import { type StaticActor, StaticDataRegistry } from '@babylon/engine';
 import type { InferSelectModel } from 'drizzle-orm';
 import type { SelectedFields } from 'drizzle-orm/pg-core';
 import { NotFoundError } from '../errors';

--- a/packages/db/drizzle/migrations/0016_add_nft_revalidation_timestamp.sql
+++ b/packages/db/drizzle/migrations/0016_add_nft_revalidation_timestamp.sql
@@ -1,0 +1,21 @@
+-- Add lastNftRevalidatedAt timestamp to Chat table
+-- Used by the NFT revalidation cron job to track which chats have been
+-- processed recently, enabling true round-robin processing instead of
+-- always processing the same oldest chats.
+
+DO $$
+BEGIN
+    -- Add lastNftRevalidatedAt if it doesn't exist
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns 
+        WHERE table_name = 'Chat' AND column_name = 'lastNftRevalidatedAt'
+    ) THEN
+        ALTER TABLE "Chat" ADD COLUMN "lastNftRevalidatedAt" timestamp;
+    END IF;
+END $$;
+
+-- Create index for efficient ordering in the cron job query
+CREATE INDEX IF NOT EXISTS "Chat_lastNftRevalidatedAt_idx" ON "Chat" USING btree ("lastNftRevalidatedAt");
+
+-- Create composite index for NFT-gated chat revalidation queries
+CREATE INDEX IF NOT EXISTS "Chat_nftGated_lastNftRevalidatedAt_idx" ON "Chat" USING btree ("nftGated", "lastNftRevalidatedAt");

--- a/packages/db/src/schema/messaging.ts
+++ b/packages/db/src/schema/messaging.ts
@@ -33,6 +33,7 @@ export const chats = pgTable(
     requiredNftTokenId: integer('requiredNftTokenId'),
     requiredNftChainId: integer('requiredNftChainId'),
     nftGated: boolean('nftGated').notNull().default(false),
+    lastNftRevalidatedAt: timestamp('lastNftRevalidatedAt', { mode: 'date' }),
   },
   (table) => [
     index('Chat_gameId_dayNumber_idx').on(table.gameId, table.dayNumber),

--- a/packages/shared/src/auth/privy-email-utils.ts
+++ b/packages/shared/src/auth/privy-email-utils.ts
@@ -125,7 +125,11 @@ export function getAllVerifiedEmails(
   // Check linkedAccounts for additional email-type accounts
   if (Array.isArray(user.linkedAccounts)) {
     for (const account of user.linkedAccounts) {
-      if (account?.type === 'email' && 'address' in account && account.address) {
+      if (
+        account?.type === 'email' &&
+        'address' in account &&
+        account.address
+      ) {
         const emailAccount = account as PrivyEmailAccount;
         // Only include verified emails
         if (isEmailVerified(emailAccount)) {
@@ -185,7 +189,9 @@ export function findEmailByDomain(
  *   // User has admin access
  * }
  */
-export function checkForAdminEmail(user: PrivyUserWithEmails | null | undefined): {
+export function checkForAdminEmail(
+  user: PrivyUserWithEmails | null | undefined
+): {
   adminEmail: string | null;
   allVerifiedEmails: string[];
 } {

--- a/packages/testing/integration/nft-gated-chats.integration.test.ts
+++ b/packages/testing/integration/nft-gated-chats.integration.test.ts
@@ -11,14 +11,7 @@
  */
 
 import { afterEach, beforeAll, describe, expect, test } from 'bun:test';
-import {
-  chatParticipants,
-  chats,
-  db,
-  eq,
-  inArray,
-  users,
-} from '@babylon/db';
+import { chatParticipants, chats, db, eq, inArray, users } from '@babylon/db';
 import { generateSnowflakeId, getCurrentChainId } from '@babylon/shared';
 
 const BASE_URL =

--- a/packages/testing/unit/nft-verification-service.test.ts
+++ b/packages/testing/unit/nft-verification-service.test.ts
@@ -18,7 +18,8 @@
  */
 
 import { beforeEach, describe, expect, test } from 'bun:test';
-import { NFTVerificationService, ValidationError } from '@babylon/api';
+import { NFTVerificationService } from '@babylon/api';
+import { ValidationError } from '@babylon/shared';
 import type { Address } from 'viem';
 
 describe('NFTVerificationService', () => {

--- a/packages/testing/unit/shared/privy-email-utils.test.ts
+++ b/packages/testing/unit/shared/privy-email-utils.test.ts
@@ -3,13 +3,13 @@
  * Tests for email extraction and admin domain checking from Privy user objects
  */
 
-import { describe, expect, it, beforeAll, afterAll } from 'bun:test';
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 import {
-  getAllVerifiedEmails,
-  findEmailByDomain,
   checkForAdminEmail,
-  type PrivyUserWithEmails,
+  findEmailByDomain,
+  getAllVerifiedEmails,
   type PrivyEmailAccount,
+  type PrivyUserWithEmails,
 } from '@babylon/shared';
 
 describe('Privy Email Utilities', () => {
@@ -223,12 +223,16 @@ describe('Privy Email Utilities', () => {
       // Note: findEmailByDomain returns the email as-is from the input array
       // Normalization happens in getAllVerifiedEmails before calling this function
       const emails = ['user@ELIZALABS.AI'];
-      expect(findEmailByDomain(emails, 'elizalabs.ai')).toBe('user@ELIZALABS.AI');
+      expect(findEmailByDomain(emails, 'elizalabs.ai')).toBe(
+        'user@ELIZALABS.AI'
+      );
     });
 
     it('should match domain case-insensitively (admin domain uppercase)', () => {
       const emails = ['user@elizalabs.ai'];
-      expect(findEmailByDomain(emails, 'ELIZALABS.AI')).toBe('user@elizalabs.ai');
+      expect(findEmailByDomain(emails, 'ELIZALABS.AI')).toBe(
+        'user@elizalabs.ai'
+      );
     });
 
     it('should trim whitespace from domain', () => {


### PR DESCRIPTION
## Summary
This PR adds comprehensive NFT-gated group chat functionality, allowing admins to create group chats restricted to holders of specific NFT collections.

## Features

### Admin Endpoints
- `POST /api/admin/groups/nft-collection` - Create NFT-gated groups for specific contract addresses
- `GET /api/admin/groups/nft-collection` - List all NFT-gated groups
- `POST /api/admin/groups/[id]/revalidate-nft` - Manually trigger NFT ownership revalidation

### User Endpoints
- `GET /api/chats/nft-gated` - Discover available NFT-gated chats based on wallet holdings
- `POST /api/chats/[id]/join-nft` - Join an NFT-gated chat by proving ownership

### Automated Revalidation
- `POST /api/cron/nft-revalidate` - Cron job for periodic NFT ownership checks
- Automatically removes users who no longer own required NFTs
- Rate-limited to avoid RPC overload (5 chats/run, 20 users/chat)

### Access Control
- 1-minute cache TTL for NFT ownership with on-demand invalidation
- Automatic removal when user fails verification during message send
- Support for collection-wide or token-specific requirements
- Multi-chain support (Base, Ethereum, testnets)

## Test Fixes
- Fix `ValidationError` import in `nft-verification-service.test.ts` (was importing from `@babylon/api` but service uses `@babylon/shared`)

## Testing
- All NFT verification unit tests pass (10/10)
- All unit tests pass (932/932)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NFT-gated chat discovery, join flow, and per-chat access checks with on-chain verification.
  * Admin endpoints to list/create NFT-gated groups and manually revalidate group membership.
  * Background cron to periodically revalidate NFT access and remove ineligible users.
  * New "NFT Access Revoked" notification sent when users are removed.

* **Chores**
  * DB schema/migration and env var added to track last NFT revalidation timing.

* **Tests**
  * Minor test/import refinements and formatting updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Comprehensive NFT-gated group chat system with ownership verification, auto-revalidation, and discovery endpoints. Integrates with blockchain RPCs to verify ERC721 ownership before granting chat access.

**Key changes:**
- Admin endpoints for creating NFT-gated groups and triggering manual revalidation
- User endpoints for discovering and joining NFT-gated chats based on wallet holdings
- Automated cron job for periodic ownership revalidation (removes users who no longer own NFTs)
- 1-minute cache TTL with on-demand invalidation for fresh checks
- Multi-chain support (Base, Ethereum, testnets) with rate limiting

**Critical issue:**
- `join-nft/route.ts` uses Prisma-style API (`database.chatParticipant.create()`) but codebase uses Drizzle ORM. This will cause runtime errors and prevent users from joining NFT-gated chats.

<h3>Confidence Score: 1/5</h3>


- Not safe to merge - contains critical syntax errors that will break NFT chat join functionality
- The join-nft endpoint uses incorrect database API (Prisma instead of Drizzle), causing guaranteed runtime failures when users attempt to join NFT-gated chats. This breaks core functionality.
- `apps/web/src/app/api/chats/[id]/join-nft/route.ts` requires immediate attention - contains critical database API mismatch

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/api/chats/[id]/join-nft/route.ts | NFT-gated chat join endpoint with critical database API mismatch - uses Prisma syntax instead of Drizzle |
| apps/web/src/app/api/admin/groups/[id]/revalidate-nft/route.ts | Admin endpoint to revalidate NFT ownership for chat members, correctly uses Drizzle API |
| apps/web/src/app/api/cron/nft-revalidate/route.ts | Cron job for periodic NFT ownership revalidation with rate limiting and timeout handling |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Frontend
    participant JoinAPI as /api/chats/[id]/join-nft
    participant DiscoveryAPI as /api/chats/nft-gated
    participant NFTService as NFTVerificationService
    participant RPC as Blockchain RPC
    participant DB as Database
    participant Cron as /api/cron/nft-revalidate

    Note over User,Cron: NFT-Gated Chat Access Flow

    User->>DiscoveryAPI: GET /api/chats/nft-gated
    DiscoveryAPI->>DB: Fetch all NFT-gated chats
    DB-->>DiscoveryAPI: Return chats list
    DiscoveryAPI->>DB: Get user wallet address
    DB-->>DiscoveryAPI: Return wallet
    loop For each chat
        DiscoveryAPI->>NFTService: verifyChatAccess()
        NFTService->>RPC: Check NFT ownership (cached)
        RPC-->>NFTService: Ownership result
        NFTService-->>DiscoveryAPI: Access verification
    end
    DiscoveryAPI-->>Frontend: Available chats + access status

    User->>JoinAPI: POST /api/chats/[id]/join-nft
    JoinAPI->>DB: Fetch chat details
    DB-->>JoinAPI: Chat + NFT requirements
    JoinAPI->>DB: Check existing membership
    JoinAPI->>DB: Get user wallet address
    DB-->>JoinAPI: Wallet address
    JoinAPI->>NFTService: invalidateOwnershipCache()
    JoinAPI->>NFTService: verifyChatAccess()
    NFTService->>RPC: Check NFT ownership (fresh)
    RPC-->>NFTService: Ownership verified
    NFTService-->>JoinAPI: canAccess=true
    JoinAPI->>DB: Insert chatParticipants + groupMembers
    JoinAPI-->>Frontend: Success

    Note over Cron: Automated Revalidation (every 5-15 min)

    Cron->>DB: Get NFT-gated chats (max 5)
    DB-->>Cron: Chats list
    loop For each chat (max 20 users)
        Cron->>DB: Get participants + wallets
        DB-->>Cron: Participants list
        loop For each participant
            Cron->>NFTService: verifyChatAccess()
            NFTService->>RPC: Check ownership (cached)
            RPC-->>NFTService: Ownership result
            alt No longer owns NFT
                Cron->>NFTService: invalidateOwnershipCache()
                Cron->>NFTService: verifyChatAccess() (fresh)
                NFTService->>RPC: Recheck ownership
                RPC-->>NFTService: Still doesn't own
                Cron->>DB: Delete from chatParticipants
                Cron->>DB: Update groupMembers (kicked)
            end
        end
    end
    Cron-->>Cron: Return results
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->