### PR TITLE
BAB-96 fix agents treat amount as shares

### DIFF
--- a/packages/agents/src/autonomous/AutonomousTradingService.ts
+++ b/packages/agents/src/autonomous/AutonomousTradingService.ts
@@ -147,6 +147,12 @@ export class AutonomousTradingService {
       })
       .join('\n');
 
+    const suggestedTradeSize =
+      balance.balance > 0
+        ? Math.min(Math.max(balance.balance * 0.1, 5), balance.balance)
+        : 0;
+    const suggestedTradeSizeText = suggestedTradeSize.toFixed(2);
+
     // Build trading prompt
     const prompt = `${config?.systemPrompt ?? 'You are an AI trading agent on Babylon.'}
 
@@ -167,6 +173,9 @@ ${contextString}
 
 Strategy: ${config?.tradingStrategy || 'Balanced risk/reward seeking alpha'}
 
+Suggested Trade Size (10% of balance): $${suggestedTradeSizeText}
+Recommended range: invest roughly 5-20% of your balance per trade.
+
 Task: Decide on ONE trade to make, or hold if nothing looks good.
 
 Output JSON only:
@@ -176,10 +185,12 @@ Output JSON only:
     "type": "prediction" | "perp",
     "market": "market_id or ticker",
     "action": "buy_yes" | "buy_no" | "open_long" | "open_short",
-    "amount": 50,
+    "amount_in_points": 50,
     "reasoning": "Brief reason"
   }
 }
+
+IMPORTANT: "amount_in_points" is the number of Babylon Points (1 pt = $1 USD) you want to invest, NOT a share count.
 
 If holding:
 {
@@ -231,7 +242,8 @@ If holding:
         type: 'prediction' | 'perp';
         market: string;
         action: string;
-        amount: number;
+        amount?: number | string;
+        amount_in_points?: number | string;
         reasoning?: string;
       };
       reasoning?: string;
@@ -271,6 +283,29 @@ If holding:
     }
 
     const trade = tradeDecision.trade;
+    const rawAmount =
+      trade.amount_in_points ?? trade.amount;
+    const normalizedAmount =
+      typeof rawAmount === 'string' ? Number(rawAmount) : rawAmount;
+
+    if (
+      typeof normalizedAmount !== 'number' ||
+      Number.isNaN(normalizedAmount) ||
+      normalizedAmount <= 0
+    ) {
+      logger.warn(
+        `[AutonomousTrading] Invalid trade amount provided`,
+        { agentUserId, rawAmount },
+        'AutonomousTrading'
+      );
+      return {
+        tradesExecuted: 0,
+        marketId: undefined,
+        ticker: undefined,
+        side: undefined,
+        marketType: undefined,
+      };
+    }
 
     // Map LLM decision to DirectExecutor parameters
     let marketId: string | undefined;
@@ -345,7 +380,7 @@ If holding:
       marketType,
       marketId,
       side,
-      amount: trade.amount,
+      amount: normalizedAmount,
       reasoning: trade.reasoning,
     });
 

--- a/packages/agents/src/autonomous/AutonomousTradingService.ts
+++ b/packages/agents/src/autonomous/AutonomousTradingService.ts
@@ -29,6 +29,10 @@ import { getAgentConfig } from '../shared/agent-config';
 import { logger } from '../shared/logger';
 import { executeDirectTrade } from './DirectExecutors';
 
+const SUGGESTED_TRADE_PERCENT = 0.1;
+const MIN_SUGGESTED_TRADE_SIZE = 10;
+const MIN_SUGGESTED_TRADE_SIZE_LABEL = MIN_SUGGESTED_TRADE_SIZE.toFixed(0);
+
 export class AutonomousTradingService {
   /**
    * Evaluate and execute trades for an agent
@@ -149,7 +153,10 @@ export class AutonomousTradingService {
 
     const suggestedTradeSize =
       balance.balance > 0
-        ? Math.min(Math.max(balance.balance * 0.1, 5), balance.balance)
+        ? Math.min(
+            Math.max(balance.balance * SUGGESTED_TRADE_PERCENT, MIN_SUGGESTED_TRADE_SIZE),
+            balance.balance
+          )
         : 0;
     const suggestedTradeSizeText = suggestedTradeSize.toFixed(2);
 
@@ -173,7 +180,7 @@ ${contextString}
 
 Strategy: ${config?.tradingStrategy || 'Balanced risk/reward seeking alpha'}
 
-Suggested Trade Size (10% of balance): $${suggestedTradeSizeText}
+Suggested Trade Size (10% of balance, min $${MIN_SUGGESTED_TRADE_SIZE_LABEL}): $${suggestedTradeSizeText}
 Recommended range: invest roughly 5-20% of your balance per trade.
 
 Task: Decide on ONE trade to make, or hold if nothing looks good.

--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -109,6 +109,16 @@ export async function executeDirectTrade(
   const { agentUserId, marketType, marketId, side, reasoning } = params;
   let { amount } = params;
 
+  const looksLikeShareCount =
+    Number.isInteger(amount) && amount >= 1 && amount <= 10;
+  if (looksLikeShareCount) {
+    logger.warn(
+      `[DirectExecutor] Trade amount ${amount} looks like a share count. Expected Babylon Points.`,
+      { agentUserId, marketType, side },
+      'DirectExecutors'
+    );
+  }
+
   // Check if this is an NPC
   const npcActor = StaticDataRegistry.getActor(agentUserId);
   const isNpc = !!npcActor;

--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -37,6 +37,9 @@ import { logger } from '../shared/logger';
 import { generateSnowflakeId } from '../shared/snowflake';
 import { topicDiversityService } from './TopicDiversityService';
 
+const SHARE_LIKE_MAX_INTEGER = 10;
+const SHARE_LIKE_RATIO_THRESHOLD = 0.01;
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -109,16 +112,6 @@ export async function executeDirectTrade(
   const { agentUserId, marketType, marketId, side, reasoning } = params;
   let { amount } = params;
 
-  const looksLikeShareCount =
-    Number.isInteger(amount) && amount >= 1 && amount <= 10;
-  if (looksLikeShareCount) {
-    logger.warn(
-      `[DirectExecutor] Trade amount ${amount} looks like a share count. Expected Babylon Points.`,
-      { agentUserId, marketType, side },
-      'DirectExecutors'
-    );
-  }
-
   // Check if this is an NPC
   const npcActor = StaticDataRegistry.getActor(agentUserId);
   const isNpc = !!npcActor;
@@ -135,6 +128,24 @@ export async function executeDirectTrade(
   } else {
     const walletBalance = await WalletService.getBalance(agentUserId);
     balance = walletBalance.balance;
+  }
+
+  const looksLikeShareCount =
+    Number.isInteger(amount) &&
+    amount >= 1 &&
+    amount <= SHARE_LIKE_MAX_INTEGER &&
+    balance > 0 &&
+    amount / balance < SHARE_LIKE_RATIO_THRESHOLD;
+  if (looksLikeShareCount) {
+    logger.warn(
+      `[DirectExecutor] Trade amount $${amount.toFixed(
+        2
+      )} looks like a share count relative to $${balance.toFixed(
+        2
+      )} balance. Expected Babylon Points.`,
+      { agentUserId, marketType, side, balance },
+      'DirectExecutors'
+    );
   }
 
   // Cannot trade more than balance


### PR DESCRIPTION
## Type
- [x] Bug fix
- [ ] Feature
- [ ] Chore

## Context / Links
- [BAB-96](https://linear.app/eliza-labs/issue/BAB-96/fix-agents-trading-whole-shares-instead-of-dollar-amounts)
- Agents were outputting `amount` as share counts. We now require `amount_in_points`, provide balance context, and validate executor inputs.

## Scope
- `packages/agents/src/autonomous/AutonomousTradingService.ts`
- `packages/agents/src/autonomous/DirectExecutors.ts`

## Changes
1. Add balance-aware suggested trade size (10% of balance with $10 floor) and prompt copy so LLMs size positions in Babylon Points.
2. Normalize/validate `amount_in_points` vs the legacy `amount` field before executing trades.
3. Enhance executor warnings so “share-like” values only trigger when they are tiny relative to the user’s balance, reducing false alarms.

## Review Guide
- Start in `AutonomousTradingService` to review the prompt changes and parsing guard rails.
- Then check `DirectExecutors` for the refined heuristics that log suspicious share-sized trades.

## Test Plan
- [x] `turbo typecheck`
- [x] `turbo lint`
- [x] `turbo build`
- [x] `bunx biome lint packages/agents/src/autonomous/AutonomousTradingService.ts packages/agents/src/autonomous/DirectExecutors.ts`

## Ops / Migration
- [x] Not required

## Breaking Changes
- [x] None

## Security
- [x] No new surface area

## Screenshots / Recordings
- Backend-only change; no UI to capture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added recommended trade size calculation (10% of balance, bounded by $10 minimum and total balance) for autonomous trading.
  * Trade amounts now processed using Babylon Points as the primary indicator.

* **Improvements**
  * Enhanced trade amount validation with detection and warning for anomalous input patterns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->