### PR TITLE
Fix perp trade ticker resolution (BAB-77)

### DIFF
--- a/packages/agents/src/autonomous/AutonomousTradingService.ts
+++ b/packages/agents/src/autonomous/AutonomousTradingService.ts
@@ -28,6 +28,7 @@ import { callGroqDirect } from '../llm/direct-groq';
 import { getAgentConfig } from '../shared/agent-config';
 import { logger } from '../shared/logger';
 import { executeDirectTrade } from './DirectExecutors';
+import { resolvePerpTicker } from './utils/resolvePerpTicker';
 
 export class AutonomousTradingService {
   /**
@@ -300,19 +301,13 @@ If holding:
       marketType = 'prediction';
       side = trade.action as 'buy_yes' | 'buy_no';
     } else if (trade.type === 'perp') {
-      // Find matching perp market
-      const org = perpCompanies.find((o) => {
-        const staticOrg = StaticDataRegistry.getOrganization(o.id);
-        return (
-          staticOrg?.name === trade.market ||
-          o.id === trade.market ||
-          staticOrg?.ticker === trade.market
-        );
-      });
-      if (!org) {
+      const perpIdentifier = trade.market;
+      const resolvedPerp = resolvePerpTicker(perpIdentifier);
+
+      if (!resolvedPerp) {
         logger.info(
-          `[AutonomousTrading] Perp market not found: ${trade.market}`,
-          undefined,
+          `[AutonomousTrading] Perp market not recognized: ${perpIdentifier}`,
+          { agentUserId },
           'AutonomousTrading'
         );
         return {
@@ -323,8 +318,26 @@ If holding:
           marketType: undefined,
         };
       }
-      const staticOrg = StaticDataRegistry.getOrganization(org.id);
-      marketId = staticOrg?.ticker || org.id;
+
+      const org = perpCompanies.find(
+        (o) => o.id === resolvedPerp.organizationId
+      );
+      if (!org) {
+        logger.info(
+          `[AutonomousTrading] Perp market not in prompt list: ${resolvedPerp.ticker}`,
+          { agentUserId },
+          'AutonomousTrading'
+        );
+        return {
+          tradesExecuted: 0,
+          marketId: undefined,
+          ticker: undefined,
+          side: undefined,
+          marketType: undefined,
+        };
+      }
+
+      marketId = resolvedPerp.ticker;
       marketType = 'perp';
       side = trade.action as 'open_long' | 'open_short';
     }

--- a/packages/agents/src/autonomous/AutonomousTradingService.ts
+++ b/packages/agents/src/autonomous/AutonomousTradingService.ts
@@ -319,24 +319,6 @@ If holding:
         };
       }
 
-      const org = perpCompanies.find(
-        (o) => o.id === resolvedPerp.organizationId
-      );
-      if (!org) {
-        logger.info(
-          `[AutonomousTrading] Perp market not in prompt list: ${resolvedPerp.ticker}`,
-          { agentUserId },
-          'AutonomousTrading'
-        );
-        return {
-          tradesExecuted: 0,
-          marketId: undefined,
-          ticker: undefined,
-          side: undefined,
-          marketType: undefined,
-        };
-      }
-
       marketId = resolvedPerp.ticker;
       marketType = 'perp';
       side = trade.action as 'open_long' | 'open_short';
@@ -360,6 +342,7 @@ If holding:
       side,
       amount: trade.amount,
       reasoning: trade.reasoning,
+      skipPerpResolution: marketType === 'perp',
     });
 
     if (!result.success) {

--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -45,10 +45,15 @@ import { resolvePerpTicker } from './utils/resolvePerpTicker';
 export interface DirectTradeParams {
   agentUserId: string;
   marketType: 'prediction' | 'perp';
-  marketId: string; // Market ID for prediction, ticker for perp
+  marketId: string; // Market ID for prediction, ticker/name/id for perp
   side: 'buy_yes' | 'buy_no' | 'open_long' | 'open_short';
   amount: number;
   reasoning?: string;
+  /**
+   * Skip resolving the perp ticker when the caller already passed the canonical ticker.
+   * Useful for services that call resolvePerpTicker upstream.
+   */
+  skipPerpResolution?: boolean;
 }
 
 export interface DirectTradeResult {
@@ -167,14 +172,17 @@ export async function executeDirectTrade(
     });
   }
 
-  const resolvedPerp = resolvePerpTicker(marketId);
-  if (!resolvedPerp) {
+  const perpTicker = params.skipPerpResolution
+    ? marketId
+    : resolvePerpTicker(marketId)?.ticker;
+
+  if (!perpTicker) {
     return { success: false, error: `Perp market not found: ${marketId}` };
   }
 
   return executePerpTrade({
     agentUserId,
-    ticker: resolvedPerp.ticker,
+    ticker: perpTicker,
     side: side as 'open_long' | 'open_short',
     amount,
     reasoning,

--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -36,6 +36,7 @@ import { agentPnLService } from '../services/AgentPnLService';
 import { logger } from '../shared/logger';
 import { generateSnowflakeId } from '../shared/snowflake';
 import { topicDiversityService } from './TopicDiversityService';
+import { resolvePerpTicker } from './utils/resolvePerpTicker';
 
 // =============================================================================
 // Types
@@ -165,9 +166,15 @@ export async function executeDirectTrade(
       agentManagedBy,
     });
   }
+
+  const resolvedPerp = resolvePerpTicker(marketId);
+  if (!resolvedPerp) {
+    return { success: false, error: `Perp market not found: ${marketId}` };
+  }
+
   return executePerpTrade({
     agentUserId,
-    ticker: marketId,
+    ticker: resolvedPerp.ticker,
     side: side as 'open_long' | 'open_short',
     amount,
     reasoning,

--- a/packages/agents/src/autonomous/__tests__/resolvePerpTicker.test.ts
+++ b/packages/agents/src/autonomous/__tests__/resolvePerpTicker.test.ts
@@ -23,6 +23,24 @@ describe('resolvePerpTicker', () => {
     expect(result?.ticker).toBe('TSLAI');
   });
 
+  test('handles empty-like inputs gracefully', () => {
+    expect(resolvePerpTicker('')).toBeNull();
+    expect(resolvePerpTicker('   ')).toBeNull();
+    expect(resolvePerpTicker(undefined)).toBeNull();
+    expect(resolvePerpTicker(null)).toBeNull();
+  });
+
+  test('handles special characters in identifier', () => {
+    const result = resolvePerpTicker('$TSLAI!!');
+    expect(result?.ticker).toBe('TSLAI');
+  });
+
+  test('supports prefix partial matches but avoids mid-string matches', () => {
+    expect(resolvePerpTicker('tes')).not.toBeNull();
+    expect(resolvePerpTicker('tes')?.ticker).toBe('TSLAI');
+    expect(resolvePerpTicker('sla')).toBeNull();
+  });
+
   test('returns null for unknown identifiers', () => {
     expect(resolvePerpTicker('not-real')).toBeNull();
   });

--- a/packages/agents/src/autonomous/__tests__/resolvePerpTicker.test.ts
+++ b/packages/agents/src/autonomous/__tests__/resolvePerpTicker.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test';
+import { resolvePerpTicker } from '../utils/resolvePerpTicker';
+
+describe('resolvePerpTicker', () => {
+  test('matches canonical ticker regardless of casing', () => {
+    const result = resolvePerpTicker('tslai');
+    expect(result).not.toBeNull();
+    expect(result?.ticker).toBe('TSLAI');
+  });
+
+  test('matches by organization id', () => {
+    const result = resolvePerpTicker('teslai');
+    expect(result?.ticker).toBe('TSLAI');
+  });
+
+  test('matches by parody name', () => {
+    const result = resolvePerpTicker('TeslAI');
+    expect(result?.ticker).toBe('TSLAI');
+  });
+
+  test('matches by original name', () => {
+    const result = resolvePerpTicker('Tesla');
+    expect(result?.ticker).toBe('TSLAI');
+  });
+
+  test('returns null for unknown identifiers', () => {
+    expect(resolvePerpTicker('not-real')).toBeNull();
+  });
+});

--- a/packages/agents/src/autonomous/utils/resolvePerpTicker.ts
+++ b/packages/agents/src/autonomous/utils/resolvePerpTicker.ts
@@ -60,15 +60,21 @@ export function resolvePerpTicker(
 
   // Partial match fallback for longer identifiers (e.g., "tesla stock")
   if (normalized.length >= 3) {
-    const partial = allOrgs.find((org) => {
-      const normalizedTicker = normalize(org.ticker ?? '');
-      const normalizedName = normalize(org.name);
-      const normalizedOriginal = normalize(org.originalName ?? '');
-
+    const matchesPrefix = (candidate: string | null | undefined) => {
+      if (!candidate) return false;
+      const normalizedCandidate = normalize(candidate);
+      if (!normalizedCandidate) return false;
       return (
-        normalizedTicker.includes(normalized) ||
-        normalizedName.includes(normalized) ||
-        normalizedOriginal.includes(normalized)
+        normalizedCandidate.startsWith(normalized) ||
+        normalized.startsWith(normalizedCandidate)
+      );
+    };
+
+    const partial = allOrgs.find((org) => {
+      return (
+        matchesPrefix(org.ticker) ||
+        matchesPrefix(org.name) ||
+        matchesPrefix(org.originalName)
       );
     });
 

--- a/packages/agents/src/autonomous/utils/resolvePerpTicker.ts
+++ b/packages/agents/src/autonomous/utils/resolvePerpTicker.ts
@@ -1,0 +1,85 @@
+import { StaticDataRegistry } from '@babylon/engine';
+
+export interface ResolvedPerpMarket {
+  ticker: string;
+  organizationId: string;
+  name: string;
+}
+
+const normalize = (value: string) =>
+  value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]/g, '');
+
+/**
+ * Resolve a user-provided perp identifier (ticker/name/id) to a canonical ticker.
+ * Accepts case-insensitive ticker symbols, organization IDs, parody names,
+ * original names, and common handles.
+ */
+export function resolvePerpTicker(
+  identifier?: string | null
+): ResolvedPerpMarket | null {
+  if (!identifier) return null;
+
+  const trimmed = identifier.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const allOrgs = StaticDataRegistry.getAllOrganizations().filter(
+    (org) => org.ticker && org.type === 'company'
+  );
+
+  const lower = trimmed.toLowerCase();
+  const normalized = normalize(trimmed);
+
+  const matchers: Array<(org: (typeof allOrgs)[number]) => boolean> = [
+    (org) => org.ticker?.toLowerCase() === lower,
+    (org) => org.id.toLowerCase() === lower,
+    (org) => org.name.toLowerCase() === lower,
+    (org) => org.originalName?.toLowerCase() === lower,
+    (org) => org.originalHandle?.toLowerCase() === lower,
+    (org) => normalize(org.ticker ?? '') === normalized,
+    (org) => normalize(org.id) === normalized,
+    (org) => normalize(org.name) === normalized,
+    (org) => normalize(org.originalName ?? '') === normalized,
+    (org) => normalize(org.originalHandle ?? '') === normalized,
+  ];
+
+  for (const matcher of matchers) {
+    const found = allOrgs.find(matcher);
+    if (found?.ticker) {
+      return {
+        ticker: found.ticker,
+        organizationId: found.id,
+        name: found.name,
+      };
+    }
+  }
+
+  // Partial match fallback for longer identifiers (e.g., "tesla stock")
+  if (normalized.length >= 3) {
+    const partial = allOrgs.find((org) => {
+      const normalizedTicker = normalize(org.ticker ?? '');
+      const normalizedName = normalize(org.name);
+      const normalizedOriginal = normalize(org.originalName ?? '');
+
+      return (
+        normalizedTicker.includes(normalized) ||
+        normalizedName.includes(normalized) ||
+        normalizedOriginal.includes(normalized)
+      );
+    });
+
+    if (partial?.ticker) {
+      return {
+        ticker: partial.ticker,
+        organizationId: partial.id,
+        name: partial.name,
+      };
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a resolver that maps any user-provided perp identifier to the canonical ticker
- wire resolver into direct executor + autonomous trading so perps execute even when LLM uses free-form names
- add focused unit tests covering ticker, id, parody-name, and original-name lookups

## Testing
- bun test packages/agents/src/autonomous/__tests__/resolvePerpTicker.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced perp market identification with multiple matching methods and partial fuzzy matching
  * Option to bypass perp resolution when desired, allowing direct ticker usage

* **Bug Fixes**
  * Safer handling when perp markets are unrecognized; prevents execution with unresolved identifiers
  * Improved logging and guards around perp resolution outcomes

* **Tests**
  * Added coverage for perp resolution (canonicalization, ID/name matching, unknown inputs)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR centralizes perp ticker resolution logic to handle free-form LLM-generated identifiers. Previously, `AutonomousTradingService` had inline matching logic that only checked exact ticker/id/name matches. The new `resolvePerpTicker` utility provides:

- **Exact matching**: Case-insensitive checks for ticker, organization ID, parody name, original name, and original handle
- **Normalized matching**: Strips special characters and whitespace for fuzzy matching (e.g., "TSLA-I" → "tslai")
- **Partial matching fallback**: Uses `includes()` for longer inputs (≥3 chars) to match substrings like "tesla stock"

**Key Changes:**
- Extracted resolver utility in `packages/agents/src/autonomous/utils/resolvePerpTicker.ts`
- Integrated resolver into `DirectExecutors.ts:170-172` before perp trade execution
- Replaced inline matching in `AutonomousTradingService.ts:304-305` with resolver call
- Added unit tests covering basic matching scenarios

**Observations:**
- The partial matching fallback (lines 62-82) returns the first match found, which could be ambiguous when multiple companies contain the search term
- Test suite covers happy paths but missing edge cases (whitespace, special chars, multiple matches)
- Integration properly handles null returns with error messages

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk - the changes improve code organization and robustness
- The implementation is solid with proper error handling and integration. Score of 4 (not 5) due to partial matching ambiguity that could return unexpected results in edge cases, and limited test coverage for those edge cases. The core functionality is sound and well-integrated.
- Pay attention to `packages/agents/src/autonomous/utils/resolvePerpTicker.ts` - the partial matching logic may need refinement if ambiguous matches become an issue in production

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agents/src/autonomous/utils/resolvePerpTicker.ts | New utility that maps user-provided perp identifiers to canonical tickers using multiple matching strategies (exact, normalized, partial) |
| packages/agents/src/autonomous/__tests__/resolvePerpTicker.test.ts | Test suite covering ticker, id, parody name, and original name lookups with basic edge cases |
| packages/agents/src/autonomous/DirectExecutors.ts | Integrated ticker resolver before perp trade execution with proper error handling |
| packages/agents/src/autonomous/AutonomousTradingService.ts | Replaced inline matching logic with centralized resolver, improving maintainability and robustness |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant LLM as LLM/User Input
    participant ATS as AutonomousTradingService
    participant DE as DirectExecutors
    participant RPT as resolvePerpTicker
    participant SDR as StaticDataRegistry
    participant PMS as PerpMarketService
    
    LLM->>ATS: trade.market = "tesla"
    ATS->>RPT: resolvePerpTicker("tesla")
    RPT->>SDR: getAllOrganizations()
    SDR-->>RPT: List of organizations
    RPT->>RPT: Filter by type === 'company'
    RPT->>RPT: Exact match (ticker/id/name/handle)
    RPT->>RPT: Normalized match
    RPT->>RPT: Partial match fallback
    RPT-->>ATS: {ticker: "TSLAI", organizationId: "teslai", name: "TeslAI"}
    ATS->>DE: executeDirectTrade(marketId: "TSLAI")
    DE->>RPT: resolvePerpTicker("TSLAI")
    RPT-->>DE: {ticker: "TSLAI", ...}
    DE->>PMS: openPosition(ticker: "TSLAI")
    PMS-->>DE: Position created
    DE-->>ATS: {success: true, ticker: "TSLAI"}
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->