### PR TITLE
feat(BAB-100-6): Add banner upload endpoint for agents and users

### DIFF
--- a/apps/web/src/app/api/upload/banner/route.ts
+++ b/apps/web/src/app/api/upload/banner/route.ts
@@ -100,7 +100,9 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
   // Validate targetType against allowed values
   if (!VALID_TARGET_TYPES.includes(rawTargetType as TargetType)) {
     return NextResponse.json(
-      { error: `Invalid targetType. Allowed: ${VALID_TARGET_TYPES.join(', ')}` },
+      {
+        error: `Invalid targetType. Allowed: ${VALID_TARGET_TYPES.join(', ')}`,
+      },
       { status: 400 }
     );
   }

--- a/apps/web/src/app/api/upload/banner/route.ts
+++ b/apps/web/src/app/api/upload/banner/route.ts
@@ -22,6 +22,58 @@ import { NextResponse } from 'next/server';
 
 const MAX_BANNER_SIZE = 5 * 1024 * 1024; // 5MB
 const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+const VALID_TARGET_TYPES = ['user', 'agent'] as const;
+type TargetType = (typeof VALID_TARGET_TYPES)[number];
+
+// Map MIME types to file extensions (safer than splitting MIME type)
+const MIME_TO_EXT: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+};
+
+/**
+ * Magic byte signatures for image validation.
+ * Prevents uploading executables disguised as images.
+ */
+const IMAGE_MAGIC_BYTES: Record<string, number[][]> = {
+  'image/jpeg': [[0xff, 0xd8, 0xff]],
+  'image/png': [[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]],
+  'image/gif': [
+    [0x47, 0x49, 0x46, 0x38, 0x37, 0x61], // GIF87a
+    [0x47, 0x49, 0x46, 0x38, 0x39, 0x61], // GIF89a
+  ],
+};
+
+/** WebP magic bytes: RIFF at bytes 0-3, WEBP at bytes 8-11 */
+const WEBP_RIFF_HEADER = [0x52, 0x49, 0x46, 0x46]; // "RIFF"
+const WEBP_FORMAT_MARKER = [0x57, 0x45, 0x42, 0x50]; // "WEBP"
+
+/**
+ * Validates that file bytes match the declared MIME type.
+ * Prevents uploading executables disguised as images.
+ */
+function validateImageMagicBytes(buffer: Buffer, mimeType: string): boolean {
+  if (mimeType === 'image/webp') {
+    if (buffer.length < 12) return false;
+    const hasRiffHeader = WEBP_RIFF_HEADER.every(
+      (byte, i) => buffer[i] === byte
+    );
+    const hasWebpMarker = WEBP_FORMAT_MARKER.every(
+      (byte, i) => buffer[8 + i] === byte
+    );
+    return hasRiffHeader && hasWebpMarker;
+  }
+
+  const signatures = IMAGE_MAGIC_BYTES[mimeType];
+  if (!signatures) return false;
+
+  return signatures.some((signature) => {
+    if (buffer.length < signature.length) return false;
+    return signature.every((byte, i) => buffer[i] === byte);
+  });
+}
 
 /**
  * POST /api/upload/banner
@@ -42,11 +94,28 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
 
   const formData = await request.formData();
   const file = formData.get('file') as File;
-  const targetId = formData.get('targetId') as string; // user or agent ID
-  const targetType = (formData.get('targetType') as string) || 'user'; // 'user' or 'agent'
+  const targetId = formData.get('targetId') as string | null;
+  const rawTargetType = (formData.get('targetType') as string) || 'user';
+
+  // Validate targetType against allowed values
+  if (!VALID_TARGET_TYPES.includes(rawTargetType as TargetType)) {
+    return NextResponse.json(
+      { error: `Invalid targetType. Allowed: ${VALID_TARGET_TYPES.join(', ')}` },
+      { status: 400 }
+    );
+  }
+  const targetType = rawTargetType as TargetType;
 
   if (!file) {
     return NextResponse.json({ error: 'No file provided' }, { status: 400 });
+  }
+
+  // Require targetId when uploading for an agent
+  if (targetType === 'agent' && !targetId) {
+    return NextResponse.json(
+      { error: 'targetId is required when uploading a banner for an agent' },
+      { status: 400 }
+    );
   }
 
   if (!ALLOWED_TYPES.includes(file.type)) {
@@ -65,8 +134,8 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
     );
   }
 
-  // Verify ownership
-  const effectiveTargetId = targetId || user.userId;
+  // Verify ownership - targetId is required for agents (validated above), optional for users
+  const effectiveTargetId = targetId ?? user.userId;
   if (targetType === 'agent') {
     // Verify user owns/manages the agent
     const [agent] = await db
@@ -88,14 +157,26 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
     );
   }
 
+  // Convert file to buffer for validation
+  const arrayBuffer = await file.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+
+  // Validate magic bytes match declared MIME type (prevents fake file uploads)
+  if (!validateImageMagicBytes(buffer, file.type)) {
+    return NextResponse.json(
+      {
+        error:
+          'File content does not match declared type. Ensure you are uploading a valid image.',
+      },
+      { status: 400 }
+    );
+  }
+
   // Upload to storage
   const storage = getStorageClient();
   const timestamp = Date.now();
-  const extension = file.type.split('/')[1];
+  const extension = MIME_TO_EXT[file.type] || 'jpg';
   const filename = `${effectiveTargetId}_${timestamp}.${extension}`;
-
-  const arrayBuffer = await file.arrayBuffer();
-  const buffer = Buffer.from(arrayBuffer);
 
   const folder = targetType === 'agent' ? 'actor-banners' : 'user-banners';
   const result = await storage.uploadImage({

--- a/apps/web/src/app/api/upload/banner/route.ts
+++ b/apps/web/src/app/api/upload/banner/route.ts
@@ -1,0 +1,125 @@
+/**
+ * Banner Upload API
+ *
+ * @description Handles banner/cover image uploads for agent and user profiles.
+ *
+ * @route POST /api/upload/banner
+ * @access Authenticated
+ */
+
+import {
+  authenticate,
+  checkRateLimitAndDuplicates,
+  getStorageClient,
+  RATE_LIMIT_CONFIGS,
+  successResponse,
+  withErrorHandling,
+} from '@babylon/api';
+import { db, eq, users } from '@babylon/db';
+import { logger } from '@babylon/shared';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+const MAX_BANNER_SIZE = 5 * 1024 * 1024; // 5MB
+const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+
+/**
+ * POST /api/upload/banner
+ * Upload banner image for user or agent profile
+ */
+export const POST = withErrorHandling(async (request: NextRequest) => {
+  const user = await authenticate(request);
+
+  // Rate limiting
+  const rateLimitError = checkRateLimitAndDuplicates(
+    user.userId,
+    null,
+    RATE_LIMIT_CONFIGS.UPLOAD_IMAGE
+  );
+  if (rateLimitError) {
+    return rateLimitError;
+  }
+
+  const formData = await request.formData();
+  const file = formData.get('file') as File;
+  const targetId = formData.get('targetId') as string; // user or agent ID
+  const targetType = (formData.get('targetType') as string) || 'user'; // 'user' or 'agent'
+
+  if (!file) {
+    return NextResponse.json({ error: 'No file provided' }, { status: 400 });
+  }
+
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    return NextResponse.json(
+      {
+        error: `Invalid file type. Allowed: ${ALLOWED_TYPES.join(', ')}`,
+      },
+      { status: 400 }
+    );
+  }
+
+  if (file.size > MAX_BANNER_SIZE) {
+    return NextResponse.json(
+      { error: `File too large. Max size: ${MAX_BANNER_SIZE / 1024 / 1024}MB` },
+      { status: 400 }
+    );
+  }
+
+  // Verify ownership
+  const effectiveTargetId = targetId || user.userId;
+  if (targetType === 'agent') {
+    // Verify user owns/manages the agent
+    const [agent] = await db
+      .select({ managedBy: users.managedBy, isAgent: users.isAgent })
+      .from(users)
+      .where(eq(users.id, effectiveTargetId))
+      .limit(1);
+
+    if (!agent || !agent.isAgent || agent.managedBy !== user.userId) {
+      return NextResponse.json(
+        { error: 'You can only upload banners for your own agents' },
+        { status: 403 }
+      );
+    }
+  } else if (effectiveTargetId !== user.userId) {
+    return NextResponse.json(
+      { error: 'You can only upload banners for your own profile' },
+      { status: 403 }
+    );
+  }
+
+  // Upload to storage
+  const storage = getStorageClient();
+  const timestamp = Date.now();
+  const extension = file.type.split('/')[1];
+  const filename = `${effectiveTargetId}_${timestamp}.${extension}`;
+
+  const arrayBuffer = await file.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+
+  const folder = targetType === 'agent' ? 'actor-banners' : 'user-banners';
+  const result = await storage.uploadImage({
+    file: buffer,
+    filename,
+    contentType: file.type,
+    folder,
+  });
+
+  // Update database - both agents and users use the User table with coverImageUrl
+  await db
+    .update(users)
+    .set({ coverImageUrl: result.url })
+    .where(eq(users.id, effectiveTargetId));
+
+  logger.info(
+    `Banner uploaded for ${targetType}`,
+    { targetId: effectiveTargetId, url: result.url },
+    'BannerUpload'
+  );
+
+  return successResponse({
+    url: result.url,
+    filename,
+    size: result.size,
+  });
+});

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -227,7 +227,6 @@ export type { ErrorLike, JsonValue, StringRecord } from './types';
 export {
   type CanonicalUser,
   type EnsureUserOptions,
-  type TargetLookupResult,
   ensureUserForAuth,
   findTargetByIdentifier,
   findUserByIdentifier,
@@ -235,6 +234,7 @@ export {
   getCanonicalUserId,
   requireTargetByIdentifier,
   requireUserByIdentifier,
+  type TargetLookupResult,
 } from './users';
 // Server-side utilities (require Node.js crypto)
 export {

--- a/packages/api/src/users/user-lookup.ts
+++ b/packages/api/src/users/user-lookup.ts
@@ -5,7 +5,7 @@
  */
 
 import { db, eq, or, users } from '@babylon/db';
-import { StaticDataRegistry, type StaticActor } from '@babylon/engine';
+import { type StaticActor, StaticDataRegistry } from '@babylon/engine';
 import type { InferSelectModel } from 'drizzle-orm';
 import type { SelectedFields } from 'drizzle-orm/pg-core';
 import { NotFoundError } from '../errors';

--- a/packages/shared/src/auth/privy-email-utils.ts
+++ b/packages/shared/src/auth/privy-email-utils.ts
@@ -125,7 +125,11 @@ export function getAllVerifiedEmails(
   // Check linkedAccounts for additional email-type accounts
   if (Array.isArray(user.linkedAccounts)) {
     for (const account of user.linkedAccounts) {
-      if (account?.type === 'email' && 'address' in account && account.address) {
+      if (
+        account?.type === 'email' &&
+        'address' in account &&
+        account.address
+      ) {
         const emailAccount = account as PrivyEmailAccount;
         // Only include verified emails
         if (isEmailVerified(emailAccount)) {
@@ -185,7 +189,9 @@ export function findEmailByDomain(
  *   // User has admin access
  * }
  */
-export function checkForAdminEmail(user: PrivyUserWithEmails | null | undefined): {
+export function checkForAdminEmail(
+  user: PrivyUserWithEmails | null | undefined
+): {
   adminEmail: string | null;
   allVerifiedEmails: string[];
 } {

--- a/packages/testing/integration/nft-gated-chats.integration.test.ts
+++ b/packages/testing/integration/nft-gated-chats.integration.test.ts
@@ -11,14 +11,7 @@
  */
 
 import { afterEach, beforeAll, describe, expect, test } from 'bun:test';
-import {
-  chatParticipants,
-  chats,
-  db,
-  eq,
-  inArray,
-  users,
-} from '@babylon/db';
+import { chatParticipants, chats, db, eq, inArray, users } from '@babylon/db';
 import { generateSnowflakeId, getCurrentChainId } from '@babylon/shared';
 
 const BASE_URL =

--- a/packages/testing/unit/shared/privy-email-utils.test.ts
+++ b/packages/testing/unit/shared/privy-email-utils.test.ts
@@ -3,13 +3,13 @@
  * Tests for email extraction and admin domain checking from Privy user objects
  */
 
-import { describe, expect, it, beforeAll, afterAll } from 'bun:test';
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 import {
-  getAllVerifiedEmails,
-  findEmailByDomain,
   checkForAdminEmail,
-  type PrivyUserWithEmails,
+  findEmailByDomain,
+  getAllVerifiedEmails,
   type PrivyEmailAccount,
+  type PrivyUserWithEmails,
 } from '@babylon/shared';
 
 describe('Privy Email Utilities', () => {
@@ -223,12 +223,16 @@ describe('Privy Email Utilities', () => {
       // Note: findEmailByDomain returns the email as-is from the input array
       // Normalization happens in getAllVerifiedEmails before calling this function
       const emails = ['user@ELIZALABS.AI'];
-      expect(findEmailByDomain(emails, 'elizalabs.ai')).toBe('user@ELIZALABS.AI');
+      expect(findEmailByDomain(emails, 'elizalabs.ai')).toBe(
+        'user@ELIZALABS.AI'
+      );
     });
 
     it('should match domain case-insensitively (admin domain uppercase)', () => {
       const emails = ['user@elizalabs.ai'];
-      expect(findEmailByDomain(emails, 'ELIZALABS.AI')).toBe('user@elizalabs.ai');
+      expect(findEmailByDomain(emails, 'ELIZALABS.AI')).toBe(
+        'user@elizalabs.ai'
+      );
     });
 
     it('should trim whitespace from domain', () => {


### PR DESCRIPTION
## Summary
- Adds POST /api/upload/banner endpoint for uploading banner/cover images
- Supports both agents and users via targetType parameter
- Verifies ownership before allowing uploads
- Stores images in S3-compatible storage (actor-banners or user-banners folder)
- Updates User.coverImageUrl in database (agents use User table with isAgent flag)

## Changes
- Created `apps/web/src/app/api/upload/banner/route.ts`
- Validates file size (max 5MB) and type (JPEG, PNG, GIF, WebP)
- Agent ownership verified via User.managedBy field
- Rate limiting applied via RATE_LIMIT_CONFIGS.UPLOAD_IMAGE

## Fixes
- Resolves BAB-100 Issue #6: Agent banner upload fails with 405 error

## Test Plan
- [ ] Upload banner for user profile
- [ ] Upload banner for agent (managed by authenticated user)
- [ ] Verify 403 error when trying to upload banner for non-owned agent
- [ ] Verify 400 error for invalid file types/sizes
- [ ] Check database User.coverImageUrl is updated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Banner upload for profiles (users and agents) with ownership verification, rate limiting, and immediate update of the profile cover image. Supports JPEG, PNG, GIF, WebP; max 5MB. Uploads return the image URL, filename, and size.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


added POST `/api/upload/banner` endpoint enabling banner/cover image uploads for user profiles and agents

- authenticates users and verifies ownership before allowing uploads
- validates file type (JPEG, PNG, GIF, WebP) and size (max 5MB)  
- for agents, checks `User.managedBy` field matches authenticated user
- stores images in S3-compatible storage (`actor-banners` or `user-banners` folder)
- updates `User.coverImageUrl` in database (agents use User table with `isAgent` flag)
- remaining files contain only formatting changes (import reordering, line breaks)

<h3>Confidence Score: 2/5</h3>


- this PR has a critical security issue that must be fixed before merging
- the banner upload endpoint is missing magic byte validation, which exists in the `/api/upload/image` endpoint - this allows clients to upload executables disguised as images by spoofing the `file.type` field, creating a security vulnerability
- `apps/web/src/app/api/upload/banner/route.ts` requires magic byte validation before merge

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/api/upload/banner/route.ts | new banner upload endpoint for agents/users - missing magic byte validation that could allow malicious file uploads |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API as /api/upload/banner
    participant Auth as authenticate()
    participant RateLimit as checkRateLimitAndDuplicates()
    participant DB as Database
    participant Storage as S3 Storage

    Client->>API: POST /api/upload/banner
    Note over Client,API: FormData: file, targetId, targetType

    API->>Auth: Verify user token
    Auth-->>API: AuthenticatedUser

    API->>RateLimit: Check rate limit
    RateLimit-->>API: OK / Error 429

    API->>API: Validate file (type, size)
    
    alt targetType === 'agent'
        API->>DB: SELECT managedBy, isAgent FROM User WHERE id = targetId
        DB-->>API: Agent record
        
        alt agent.managedBy !== user.userId
            API-->>Client: 403 Forbidden
        end
    else targetType === 'user'
        alt targetId !== user.userId
            API-->>Client: 403 Forbidden
        end
    end

    API->>Storage: uploadImage(buffer, filename, folder)
    Storage-->>API: { url, size }

    API->>DB: UPDATE User SET coverImageUrl = url WHERE id = targetId
    DB-->>API: Success

    API-->>Client: 200 { url, filename, size }
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->