### PR TITLE
fix(BAB-100-4): add cache invalidation after points transfer

### DIFF
--- a/apps/web/src/app/api/points/transfer/route.ts
+++ b/apps/web/src/app/api/points/transfer/route.ts
@@ -63,6 +63,7 @@
 
 import {
   authenticate,
+  cachedDb,
   createNotification,
   withErrorHandling,
 } from '@babylon/api';
@@ -223,6 +224,18 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
       sender: updatedSender,
       recipient: updatedRecipient,
     };
+  });
+
+  // Invalidate cache for both users to update UI immediately
+  await Promise.all([
+    cachedDb.invalidateUserCache(senderId),
+    cachedDb.invalidateUserCache(recipientId),
+  ]).catch((error) => {
+    logger.warn('Failed to invalidate user cache after points transfer', {
+      error,
+      senderId,
+      recipientId,
+    });
   });
 
   logger.info(


### PR DESCRIPTION
## Summary
- Adds cache invalidation for both sender and recipient after points transfer
- Ensures UI reflects updated point balances immediately
- Uses `cachedDb.invalidateUserCache()` to clear cached user data

## Changes
- Modified `apps/web/src/app/api/points/transfer/route.ts`
- Added `cachedDb` import from `@babylon/api`
- Invalidate cache for both sender and recipient after transaction completes
- Added error handling with graceful fallback (logs warning but doesn't fail transfer)

## Fixes
- Resolves BAB-100 Issue #4: Agent points not reflecting after transfer

## Test Plan
- [ ] Transfer points between two users
- [ ] Verify both sender and recipient balances update immediately in UI
- [ ] Check that cache invalidation doesn't fail the transfer if it errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed delayed UI updates following points transfers between users. The system now immediately refreshes account data for both the sender and recipient after each transfer completes, ensuring accurate balance displays and transaction confirmations appear instantly without delay. Includes error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR adds cache invalidation for both sender and recipient users after a points transfer completes, ensuring the UI immediately reflects updated point balances.

- Imported `cachedDb` from `@babylon/api`
- Added `Promise.all` call to invalidate cache for both `senderId` and `recipientId` after the database transaction completes
- Includes proper error handling with `.catch()` that logs warnings but doesn't fail the transfer operation
- Follows the same pattern used in the follow/unfollow routes (`apps/web/src/app/api/users/[userId]/follow/route.ts`)
- Cache invalidation clears multiple cache namespaces: `CACHE_KEYS.USER`, `CACHE_KEYS.USER_BALANCE`, and `user:profile:stats`

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The implementation follows established patterns in the codebase (identical to follow/unfollow routes), includes proper error handling that prevents cache failures from affecting the transfer operation, and the cache invalidation logic is already tested and proven in production. The change is minimal, focused, and addresses the exact issue described.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/api/points/transfer/route.ts | Added cache invalidation for sender and recipient after points transfer to ensure UI updates immediately. Implementation follows established patterns with proper error handling. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API as Points Transfer API
    participant Auth as Authentication
    participant DB as Database
    participant Cache as Cache Service
    participant Notify as Notifications
    
    Client->>API: POST transfer request
    API->>Auth: Verify user
    Auth-->>API: Sender verified
    
    API->>API: Validate inputs
    API->>DB: Get sender and recipient
    DB-->>API: User records
    
    API->>API: Check balance
    
    API->>DB: Start transaction
    DB->>DB: Deduct sender points
    DB->>DB: Add recipient points
    DB->>DB: Log transactions
    DB-->>API: Transaction committed
    
    API->>Cache: Invalidate sender cache
    API->>Cache: Invalidate recipient cache
    Cache-->>API: Caches cleared
    
    API->>Notify: Send notification
    Notify-->>API: Sent
    
    API-->>Client: Success response
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->