### PR TITLE
fix(agents): prevent agents from posting DM replies to public feed

### DIFF
--- a/packages/agents/src/autonomous/templates/multi-step-decision.ts
+++ b/packages/agents/src/autonomous/templates/multi-step-decision.ts
@@ -221,7 +221,8 @@ ${context.assignedMarketId && canTrade ? `# YOUR FOCUS MARKET: ${context.assigne
 2. **One Action**: Choose ONE action per iteration
 3. **No Duplicates**: Don't repeat the same action on the same target
 4. **Know When to Stop**: Set isFinish=true after 2-3 meaningful actions or when done
-${canComment ? '5. **COMMENT on the feed**: Look at Recent Posts above - reply to something interesting!' : ''}
+5. **PRIVACY**: NEVER use POST to reply to a private message (DM). Use RESPOND for all DMs.
+${canComment ? '6. **COMMENT on the feed**: Look at Recent Posts above - reply to something interesting!' : ''}
 
 # Action Ideas
 ${canTrade ? '- **TRADE**: Take a position on a market' : ''}
@@ -291,7 +292,7 @@ ${
     ? `
 POST:
 {
-  "content": "Short post (1-2 sentences). NO full market questions! Use summaries like 'the TeslAI bet' or 'BitcAIn drop prediction'"
+  "content": "Short post (1-2 sentences). NO full market questions! NO replies to DMs! Use summaries like 'the TeslAI bet' or 'BitcAIn drop prediction'"
 }`
     : ''
 }


### PR DESCRIPTION
## Summary
- Updated `multi-step-decision.ts` prompt template to explicitly forbid agents from using the `POST` action to reply to private messages (DMs).
- Added a strict "PRIVACY" rule to the decision rules section.
- Updated the `POST` parameter schema description to warn against replying to DMs.

## Test plan
- Verified prompt instructions now include privacy warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced privacy safeguards in the autonomous agent's decision-making process to prevent replies to direct messages, with improved messaging to clarify allowed post and comment behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed a privacy vulnerability where agents could use the `POST` action to reply to private messages (DMs), causing DM content to be posted publicly to the feed.

The fix adds explicit instructions in the multi-step decision prompt template:
- Added new Decision Rule #5 "PRIVACY" that explicitly forbids using `POST` to reply to DMs
- Updated the `POST` parameter schema description to warn against replying to DMs
- Directs agents to use the `RESPOND` action for all DM interactions, which correctly routes messages to private chats

This is a prompt-level safeguard that prevents the LLM from choosing the wrong action when handling private messages. The technical infrastructure for both actions (`POST` for public feed, `RESPOND` for private messages) was already correct - the issue was that the agent's decision-making prompt didn't make the privacy boundary clear enough.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- The changes are minimal, well-targeted, and fix a critical privacy issue. Only adds clarifying text to an LLM prompt template without modifying any code logic, database queries, or API endpoints. The fix is straightforward - adding explicit instructions to prevent agents from using the wrong action type for DM replies.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agents/src/autonomous/templates/multi-step-decision.ts | Added privacy rule to prevent agents from using POST action to reply to DMs, instructing use of RESPOND instead |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent as Agent (LLM)
    participant Executor as MultiStepExecutor
    participant Template as DecisionPrompt
    participant PostService as executeDirectPost
    participant ResponseService as AutonomousBatchResponseService
    participant Feed as Public Feed
    participant DM as Private Chat

    Note over Agent,DM: Before: Agent could use POST for DM replies

    Agent->>Executor: Execute tick
    Executor->>Template: Build decision prompt
    Template-->>Agent: Context with available actions
    
    Note over Template: NEW: Rule #5 PRIVACY added
    Note over Template: "NEVER use POST to reply to DMs"
    
    Agent->>Executor: Decision: POST action
    Note over Agent: Sees DM content in pending interactions
    
    alt Agent chooses POST (Wrong - prevented by new rule)
        Executor->>PostService: Create public post
        PostService->>Feed: DM reply posted publicly ❌
        Note over Feed: Privacy violation!
    end
    
    alt Agent chooses RESPOND (Correct - enforced by new rule)
        Executor->>ResponseService: Process batch response
        ResponseService->>DM: Reply sent privately ✅
        Note over DM: Privacy maintained
    end
    
    Note over Agent,DM: After: Explicit instruction prevents POST for DMs
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->