### PR TITLE
fix(agents): add reasoning logs for trades and responses

### DIFF
--- a/packages/agents/src/autonomous/AutonomousBatchResponseService.ts
+++ b/packages/agents/src/autonomous/AutonomousBatchResponseService.ts
@@ -33,6 +33,7 @@ import { parseKeyValueXml } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
 import { getAgentConfig } from '../shared/agent-config';
 import { logger } from '../shared/logger';
+import { agentService } from '../services/AgentService';
 import { type AgentContext, getAgentContext } from './agent-context';
 import { executeDirectComment, executeDirectMessage } from './DirectExecutors';
 
@@ -891,6 +892,7 @@ LEAVE EMPTY IF:
 
 # Required Output Format
 <response>
+<thought>Brief reasoning for your response</thought>
 <text>your response here (or leave empty to skip)</text>
 </response>`;
 
@@ -912,7 +914,7 @@ LEAVE EMPTY IF:
         try {
           const isRetry = attempt > 1;
           const currentPrompt = isRetry
-            ? `${finalRespPrompt}\n\nREMINDER: You MUST output valid XML. Start with <response> and include <text> with your response.`
+            ? `${finalRespPrompt}\n\nREMINDER: You MUST output valid XML. Start with <response> and include <thought> and <text> tags.`
             : finalRespPrompt;
 
           const responseContent = await Promise.race([
@@ -953,6 +955,7 @@ LEAVE EMPTY IF:
           // Parse the extracted XML response
           const parsed = parseKeyValueXml(responseMatch[0]) as {
             text?: string;
+            thought?: string;
           } | null;
 
           if (!parsed?.text || parsed.text.trim().length === 0) {
@@ -970,15 +973,44 @@ LEAVE EMPTY IF:
 
           // Success!
           cleanContent = parsed.text.trim().replace(/^["']|["']$/g, '');
+          const thought = parsed.thought?.trim();
 
           // Check if LLM decided to skip (empty response)
           if (!cleanContent || cleanContent.length === 0) {
             logger.info(
               `LLM chose to skip interaction ${interaction.id} (empty response)`,
-              undefined,
+              { thought },
               'AutonomousBatchResponse'
             );
             cleanContent = null; // Mark as skipped
+          }
+
+          // Log the response generation context including reasoning
+          if (cleanContent) {
+            // We use setTimeout to not block the main loop, but here we want to ensure it's logged
+            // No await needed if we don't care about the result
+            agentService
+              .createLog(agentUserId, {
+                type:
+                  interaction.type === 'comment_reply' ? 'comment' : 'chat',
+                level: 'info',
+                message: `Generated automated response to ${interaction.type}`,
+                prompt: currentPrompt,
+                completion: responseContent,
+                thinking: thought,
+                metadata: {
+                  interactionId: interaction.id,
+                  interactionType: interaction.type,
+                  content: cleanContent,
+                },
+              })
+              .catch((err) => {
+                logger.error(
+                  'Failed to create log for automated response',
+                  { error: err },
+                  'AutonomousBatchResponse'
+                );
+              });
           }
           break;
         } catch (error) {

--- a/packages/agents/src/autonomous/AutonomousBatchResponseService.ts
+++ b/packages/agents/src/autonomous/AutonomousBatchResponseService.ts
@@ -31,9 +31,9 @@ import {
 import type { IAgentRuntime } from '@elizaos/core';
 import { parseKeyValueXml } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
+import { agentService } from '../services/AgentService';
 import { getAgentConfig } from '../shared/agent-config';
 import { logger } from '../shared/logger';
-import { agentService } from '../services/AgentService';
 import { type AgentContext, getAgentContext } from './agent-context';
 import { executeDirectComment, executeDirectMessage } from './DirectExecutors';
 
@@ -982,6 +982,26 @@ LEAVE EMPTY IF:
               { thought },
               'AutonomousBatchResponse'
             );
+
+            // Log skipped interaction if there was reasoning
+            if (thought) {
+               agentService
+              .createLog(agentUserId, {
+                type: 'system',
+                level: 'debug',
+                message: `Skipped automated response to ${interaction.type}`,
+                prompt: currentPrompt,
+                completion: responseContent,
+                thinking: thought,
+                metadata: {
+                  interactionId: interaction.id,
+                  interactionType: interaction.type,
+                  skipped: true
+                },
+              })
+              .catch(() => {});
+            }
+
             cleanContent = null; // Mark as skipped
           }
 
@@ -991,8 +1011,7 @@ LEAVE EMPTY IF:
             // No await needed if we don't care about the result
             agentService
               .createLog(agentUserId, {
-                type:
-                  interaction.type === 'comment_reply' ? 'comment' : 'chat',
+                type: interaction.type === 'comment_reply' ? 'comment' : 'chat',
                 level: 'info',
                 message: `Generated automated response to ${interaction.type}`,
                 prompt: currentPrompt,

--- a/packages/agents/src/services/AgentPnLService.ts
+++ b/packages/agents/src/services/AgentPnLService.ts
@@ -111,6 +111,7 @@ export class AgentPnLService {
         type: 'trade',
         level: 'info',
         message: `Trade executed: ${action} ${side || ''} ${amount} @ ${price}`,
+        thinking: reasoning ?? null,
         metadata: {
           marketType,
           marketId,

--- a/packages/agents/src/services/AgentPnLService.ts
+++ b/packages/agents/src/services/AgentPnLService.ts
@@ -117,7 +117,6 @@ export class AgentPnLService {
           marketId,
           ticker,
           pnl,
-          reasoning,
         } as JsonValue,
       });
     });


### PR DESCRIPTION
## Summary
- Added visible reasoning logs for Agent Trades and Autonomous Responses.
- Updated LLM prompts to output structured XML with `<thought>` tags logic.
- Connected `AutonomousBatchResponseService` to `agentLog` system.

## Technical Details
- `AgentPnLService.recordTrade` now populates the `thinking` column in `agent_logs` using the provided reasoning.
- `AutonomousBatchResponseService.executeResponses` now prompts for `<thought>` and logs it via `agentService.createLog`.

## Test Plan
- Types checked via `tsc`.
- Verified logic flow for logging integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent responses now include and preserve a "thought" (reasoning) field alongside generated text.
  * Trade logs can include agent reasoning when available.

* **Bug Fixes / Reliability**
  * Logging operations made non-blocking with improved error handling to avoid impacting core flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added reasoning/thinking logs to agent trades and autonomous responses by populating the `thinking` column in `agent_logs`.

## Key Changes
- **`AgentPnLService`**: Trade logs now include reasoning via the `thinking` field (line 114)
- **`AutonomousBatchResponseService`**: Updated LLM prompts to request structured XML with `<thought>` tags, extracted the reasoning, and logged it via `agentService.createLog` (lines 895, 917, 976, 992-1014)
- The `thinking` column already exists in the database schema (`packages/db/src/schema/agents.ts:27`)

## Implementation Quality
- Clean integration with existing log infrastructure
- Proper XML parsing and error handling for malformed responses
- Non-blocking async log creation with error catch handlers

<h3>Confidence Score: 4/5</h3>


- Safe to merge with minor observability consideration
- The implementation correctly integrates reasoning logs into both trade recording and autonomous response generation. The changes are well-structured and leverage existing infrastructure. Score reflects one style consideration around silent error handling in logging (non-critical).
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agents/src/services/AgentPnLService.ts | Added `thinking` field to trade logs, populated from the `reasoning` parameter |
| packages/agents/src/autonomous/AutonomousBatchResponseService.ts | Added `<thought>` tag to prompts and integrated reasoning logs via `agentService.createLog` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant LLM as LLM (Groq)
    participant ABS as AutonomousBatchResponseService
    participant AS as AgentService
    participant APNL as AgentPnLService
    participant DB as Database (agent_logs)

    Note over ABS,LLM: Autonomous Response Flow
    ABS->>LLM: Generate response with <thought> tag prompt
    LLM-->>ABS: Returns XML with <thought> and <text>
    ABS->>ABS: Parse <thought> and <text> from XML
    ABS->>AS: createLog(agentUserId, {thinking: thought, ...})
    AS->>DB: INSERT into agent_logs (thinking column)
    DB-->>AS: Log created
    AS-->>ABS: Log confirmation

    Note over APNL,DB: Trade Recording Flow
    APNL->>APNL: recordTrade(reasoning param)
    APNL->>DB: INSERT into agent_logs (thinking: reasoning)
    DB-->>APNL: Trade log created
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->