### PR TITLE
fix(BAB-79): keep perp prices moving after trades

### DIFF
--- a/apps/web/src/app/api/markets/perps/_adapters.ts
+++ b/apps/web/src/app/api/markets/perps/_adapters.ts
@@ -195,6 +195,8 @@ export function createPerpMarketService(
  */
 export async function applyUserTradePriceImpact(ticker: string): Promise<void> {
   try {
+    const normalizedTicker = ticker.toUpperCase();
+
     // 1. Get organizationId and 24h stats from perpMarketSnapshots
     const [snapshot] = await db
       .select({
@@ -204,13 +206,13 @@ export async function applyUserTradePriceImpact(ticker: string): Promise<void> {
         low24h: perpMarketSnapshots.low24h,
       })
       .from(perpMarketSnapshots)
-      .where(eq(perpMarketSnapshots.ticker, ticker))
+      .where(eq(perpMarketSnapshots.ticker, normalizedTicker))
       .limit(1);
 
     if (!snapshot) {
       logger.warn(
         'PerpMarketSnapshot not found for price impact',
-        { ticker },
+        { ticker: normalizedTicker },
         'PerpPriceImpact'
       );
       return;
@@ -232,7 +234,7 @@ export async function applyUserTradePriceImpact(ticker: string): Promise<void> {
     if (!org) {
       logger.warn(
         'Organization not found for price impact',
-        { ticker, organizationId },
+        { ticker: normalizedTicker, organizationId },
         'PerpPriceImpact'
       );
       return;
@@ -250,7 +252,10 @@ export async function applyUserTradePriceImpact(ticker: string): Promise<void> {
       })
       .from(perpPositions)
       .where(
-        and(eq(perpPositions.ticker, ticker), isNull(perpPositions.closedAt))
+        and(
+          eq(perpPositions.ticker, normalizedTicker),
+          isNull(perpPositions.closedAt)
+        )
       );
 
     // 4. Calculate net holdings (longs - shorts)
@@ -275,7 +280,7 @@ export async function applyUserTradePriceImpact(ticker: string): Promise<void> {
     logger.info(
       `Price impact calculation: netHoldings=${netHoldings}, newPrice=${newPrice.toFixed(4)}, change=${change.toFixed(4)}, effectiveSupply=${effectiveSupply}`,
       {
-        ticker,
+        ticker: normalizedTicker,
         netHoldings,
         newPrice,
         change,
@@ -298,8 +303,15 @@ export async function applyUserTradePriceImpact(ticker: string): Promise<void> {
     const changePercent = currentPrice > 0 ? (change / currentPrice) * 100 : 0;
 
     logger.info(
-      `User trade price impact: ${ticker} (${organizationId}) ${currentPrice.toFixed(2)} -> ${newPrice.toFixed(2)} (${changePercent > 0 ? '+' : ''}${changePercent.toFixed(2)}%)`,
-      { ticker, organizationId, currentPrice, newPrice, netHoldings, change },
+      `User trade price impact: ${normalizedTicker} (${organizationId}) ${currentPrice.toFixed(2)} -> ${newPrice.toFixed(2)} (${changePercent > 0 ? '+' : ''}${changePercent.toFixed(2)}%)`,
+      {
+        ticker: normalizedTicker,
+        organizationId,
+        currentPrice,
+        newPrice,
+        netHoldings,
+        change,
+      },
       'PerpPriceImpact'
     );
 
@@ -310,59 +322,17 @@ export async function applyUserTradePriceImpact(ticker: string): Promise<void> {
         newPrice,
         source: 'user_trade',
         reason: 'User trade price impact',
+        metadata: { ticker: normalizedTicker },
       },
     ]);
-
-    // 9. Broadcast with ticker explicitly for UI hooks (useMarketPrices)
-    // PriceUpdateService broadcasts with organizationId, but UI uses ticker
-    try {
-      await broadcastToChannel('markets', {
-        type: 'perp_price_update',
-        updates: [
-          {
-            ticker, // The ticker that UI hooks listen for (e.g., "AIPHB")
-            organizationId,
-            newPrice,
-            price: newPrice,
-            change,
-            changePercent,
-          },
-        ],
-      });
-    } catch {
-      // Non-critical, ignore broadcast errors
-    }
-
-    // 10. Also update perpMarketSnapshots for consistency
-    // Only update high24h/low24h if newPrice exceeds existing bounds
-    // Don't recalculate change24h here - it's properly computed by game-tick
-    // using the actual price24hAgo reference
-    const existingHigh = Number(snapshot.high24h ?? newPrice);
-    const existingLow = Number(snapshot.low24h ?? newPrice);
-
-    const updateData: Record<string, unknown> = {
-      currentPrice: newPrice,
-      updatedAt: new Date(),
-    };
-
-    // Only update high24h if new price is higher
-    if (newPrice > existingHigh) {
-      updateData.high24h = newPrice;
-    }
-    // Only update low24h if new price is lower
-    if (newPrice < existingLow) {
-      updateData.low24h = newPrice;
-    }
-
-    await db
-      .update(perpMarketSnapshots)
-      .set(updateData)
-      .where(eq(perpMarketSnapshots.ticker, ticker));
   } catch (error) {
     // Don't throw - price impact is enhancement, not critical path
     logger.error(
       'Failed to apply user trade price impact',
-      { ticker, error: error instanceof Error ? error.message : String(error) },
+      {
+        ticker: ticker.toUpperCase(),
+        error: error instanceof Error ? error.message : String(error),
+      },
       'PerpPriceImpact'
     );
   }

--- a/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts
+++ b/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts
@@ -251,8 +251,13 @@ function createAuthenticatedFetchForAgent(
     return fetch(url, { ...init, headers });
   };
 
-  // Bun's fetch has a preconnect property that must be preserved for type compatibility
-  (customFetch as unknown as typeof fetch).preconnect = fetch.preconnect;
+  // Bun may expose a non-standard `fetch.preconnect`; preserve it when present.
+  const maybePreconnect = (fetch as unknown as { preconnect?: unknown })
+    .preconnect;
+  if (maybePreconnect) {
+    (customFetch as unknown as { preconnect?: unknown }).preconnect =
+      maybePreconnect;
+  }
 
   return customFetch as typeof fetch;
 }

--- a/packages/engine/src/game-tick.ts
+++ b/packages/engine/src/game-tick.ts
@@ -23,15 +23,13 @@ import {
   games,
   gte,
   inArray,
-  isNotNull,
   isNull,
   type JsonValue,
   lte,
   markets as marketsSchema,
-  organizationState,
   organizations,
   perpMarketSnapshots,
-  poolPositions,
+  perpPositions,
   pools,
   positions,
   posts,
@@ -2301,158 +2299,111 @@ async function updateMarketPricesFromTrades(
   _timestamp: Date,
   executionResult: TradingExecutionResult
 ): Promise<number> {
-  if (!executionResult.executedTrades.length) {
-    return 0;
-  }
+  if (!executionResult.executedTrades.length) return 0;
 
-  // Get all companies with current holdings (static + dynamic data)
-  const orgStates = await dbService().getAllOrganizationStates();
-  const priceMap = new Map(orgStates.map((s) => [s.id, s.currentPrice]));
+  const hasPerpTrades = executionResult.executedTrades.some(
+    (t) => t.marketType === 'perp'
+  );
+  if (!hasPerpTrades) return 0;
 
-  const companiesList = StaticDataRegistry.getAllOrganizations()
-    .filter((org) => org.type === 'company')
-    .map((org) => ({
-      id: org.id,
-      name: org.name,
-      currentPrice: priceMap.get(org.id) ?? org.initialPrice,
-      initialPrice: org.initialPrice,
-    }));
+  // Recompute perp prices from open PerpPosition rows.
+  // NPC perps now trade via PerpMarketService (perpPositions table), so using
+  // legacy poolPositions would keep prices effectively static.
+  const snapshots = await db
+    .select({
+      ticker: perpMarketSnapshots.ticker,
+      organizationId: perpMarketSnapshots.organizationId,
+      currentPrice: perpMarketSnapshots.currentPrice,
+    })
+    .from(perpMarketSnapshots);
 
-  type CompanyData = (typeof companiesList)[0];
-  // Use raw org IDs as keys since positions now store raw IDs
-  const companyMap = new Map<string, CompanyData>(
-    companiesList.map((c: CompanyData) => [c.id, c])
+  if (snapshots.length === 0) return 0;
+
+  // Scope recomputation to tickers actually traded this tick (when available).
+  const tradedTickers = new Set(
+    executionResult.executedTrades
+      .filter(
+        (t): t is (typeof executionResult.executedTrades)[number] & {
+          ticker: string;
+        } => t.marketType === 'perp' && typeof t.ticker === 'string'
+      )
+      .map((t) => t.ticker.toUpperCase())
   );
 
-  // Calculate total holdings for each company from ALL positions
-  const holdingsByTicker = new Map<string, number>();
+  const selected =
+    tradedTickers.size > 0
+      ? snapshots.filter((s) => tradedTickers.has(s.ticker.toUpperCase()))
+      : snapshots;
 
-  const allPositions = await db
+  if (selected.length === 0) return 0;
+
+  const orgIds = [...new Set(selected.map((s) => s.organizationId))];
+  const orgs = await db
     .select({
-      ticker: poolPositions.ticker,
-      side: poolPositions.side,
-      size: poolPositions.size,
+      id: organizations.id,
+      initialPrice: organizations.initialPrice,
     })
-    .from(poolPositions)
+    .from(organizations)
+    .where(inArray(organizations.id, orgIds));
+  const initialByOrgId = new Map(
+    orgs.map((o) => [o.id, Number(o.initialPrice ?? 100)])
+  );
+
+  const tickers = selected.map((s) => s.ticker);
+  const positionsOpen = await db
+    .select({
+      ticker: perpPositions.ticker,
+      side: perpPositions.side,
+      size: perpPositions.size,
+    })
+    .from(perpPositions)
     .where(
-      and(
-        eq(poolPositions.marketType, 'perp'),
-        isNull(poolPositions.closedAt),
-        isNotNull(poolPositions.ticker)
-      )
+      and(inArray(perpPositions.ticker, tickers), isNull(perpPositions.closedAt))
     );
 
-  for (const pos of allPositions) {
-    if (!pos.ticker) continue;
-
-    const current = holdingsByTicker.get(pos.ticker) || 0;
-    // Long positions add to holdings, short positions subtract
-    const delta = pos.side === 'long' ? pos.size : -pos.size;
+  const holdingsByTicker = new Map<string, number>();
+  for (const pos of positionsOpen) {
+    const current = holdingsByTicker.get(pos.ticker) ?? 0;
+    const delta = pos.side === 'long' ? Number(pos.size) : -Number(pos.size);
     holdingsByTicker.set(pos.ticker, current + delta);
   }
 
-  let updates = 0;
-  const priceUpdatesForChain: Array<{
-    organizationId: string;
-    newPrice: number;
-  }> = [];
+  const updates = selected
+    .map((snap) => {
+      const initialPrice = initialByOrgId.get(snap.organizationId) ?? 100;
+      const currentPrice = Number(snap.currentPrice ?? initialPrice);
+      const netHoldings = holdingsByTicker.get(snap.ticker) ?? 0;
 
-  // Update prices based on total capital deployed
-  // Market cap = initialPrice × syntheticSupply + totalDeployed
-  // ticker is now a raw org ID, not a transformed ticker
-  for (const [ticker, netHoldings] of holdingsByTicker) {
-    const company = companyMap.get(ticker);
-    if (!company) continue;
-
-    const initialPrice = company.initialPrice ?? 100;
-    const currentPrice = company.currentPrice ?? initialPrice;
-
-    // Use centralized vAMM formula with liquidity factor
-    // This applies the same pricing logic as real-time user trade impacts
-    // @see PERP_MARKET_CONFIG in @babylon/shared
-    const newPrice = calculatePriceFromHoldings(
-      initialPrice,
-      currentPrice,
-      netHoldings,
-      PERP_MARKET_CONFIG
-    );
-
-    // Calculate market cap for logging (same formula as calculatePriceFromHoldings)
-    const effectiveSupply =
-      PERP_MARKET_CONFIG.SYNTHETIC_SUPPLY / PERP_MARKET_CONFIG.LIQUIDITY_FACTOR;
-    const newMarketCap = initialPrice * effectiveSupply + netHoldings;
-
-    const change = newPrice - currentPrice;
-    const changePercent = currentPrice > 0 ? (change / currentPrice) * 100 : 0;
-
-    // Only update if price actually changed
-    if (Math.abs(change) < 0.01) continue;
-
-    await db
-      .update(organizationState)
-      .set({ currentPrice: newPrice, updatedAt: new Date() })
-      .where(eq(organizationState.id, company.id));
-
-    await dbService().recordPriceUpdate(
-      company.id,
-      newPrice,
-      change,
-      changePercent
-    );
-
-    logger.info(
-      `Price update for ${ticker}: ${currentPrice.toFixed(2)} -> ${newPrice.toFixed(2)} (${changePercent.toFixed(2)}%) [holdings: $${netHoldings.toFixed(0)}]`,
-      { ticker, currentPrice, newPrice, netHoldings, marketCap: newMarketCap },
-      'GameTick'
-    );
-
-    // Add to on-chain publish queue
-    priceUpdatesForChain.push({
-      organizationId: company.id,
-      newPrice,
-    });
-
-    updates++;
-  }
-
-  // Publish all price updates to blockchain in batch
-  if (priceUpdatesForChain.length > 0) {
-    try {
-      await PriceUpdateService.applyUpdates(
-        priceUpdatesForChain.map((u) => ({
-          ...u,
-          source: 'npc_trade',
-          reason: 'NPC trading price impact',
-        }))
-      );
-    } catch (error) {
-      // Log with special marker for monitoring/retry systems
-      logger.error(
-        'PRICE_SYNC_FAILED: Failed to publish prices to blockchain - queueing for retry',
-        {
-          error: error instanceof Error ? error.message : String(error),
-          count: priceUpdatesForChain.length,
-          retryable: true,
-        },
-        'GameTick'
+      const newPrice = calculatePriceFromHoldings(
+        initialPrice,
+        currentPrice,
+        netHoldings,
+        PERP_MARKET_CONFIG
       );
 
-      // Log each failed update for potential manual recovery
-      for (const update of priceUpdatesForChain) {
-        logger.warn(
-          'PRICE_SYNC_FAILED',
-          {
-            organizationId: update.organizationId,
-            newPrice: update.newPrice,
-            retryable: true,
-          },
-          'GameTick'
-        );
-      }
-    }
-  }
+      if (Math.abs(newPrice - currentPrice) < 0.001) return null;
 
-  return updates;
+      return {
+        organizationId: snap.organizationId,
+        newPrice,
+        source: 'npc_trade' as const,
+        reason: 'NPC trading price impact',
+        metadata: { ticker: snap.ticker },
+      };
+    })
+    .filter((u): u is NonNullable<typeof u> => u !== null);
+
+  if (updates.length === 0) return 0;
+
+  const applied = await PriceUpdateService.applyUpdates(updates);
+
+  logger.info(
+    `Perp price recomputation applied ${applied.length} updates`,
+    { count: applied.length },
+    'GameTick'
+  );
+
+  return applied.length;
 }
 
 /**
@@ -3334,6 +3285,7 @@ export async function simulateMarketVolatility(): Promise<number> {
           newPrice: u.newPrice,
           source: 'volatility_simulation',
           reason: 'Simulated market volatility',
+          metadata: { ticker: u.ticker },
         }))
       );
 

--- a/packages/engine/src/services/price-update-service.ts
+++ b/packages/engine/src/services/price-update-service.ts
@@ -1,5 +1,11 @@
 import { PerpDbAdapter, PerpMarketService } from '@babylon/core/markets/perps';
-import { db, eq, getDbInstance, organizations } from '@babylon/db';
+import {
+  db,
+  eq,
+  getDbInstance,
+  organizationState,
+  organizations,
+} from '@babylon/db';
 import { FEE_CONFIG, WalletService } from '@babylon/engine';
 import type { JsonValue } from '@babylon/shared';
 import { logger } from '@babylon/shared';
@@ -73,6 +79,7 @@ export class PriceUpdateService {
     });
     const appliedUpdates: AppliedPriceUpdate[] = [];
     const priceMap = new Map<string, number>();
+    const now = new Date();
 
     for (const update of updates) {
       if (!Number.isFinite(update.newPrice) || update.newPrice <= 0) {
@@ -108,8 +115,21 @@ export class PriceUpdateService {
 
       await db
         .update(organizations)
-        .set({ currentPrice: update.newPrice, updatedAt: new Date() })
+        .set({ currentPrice: update.newPrice, updatedAt: now })
         .where(eq(organizations.id, organization.id));
+
+      // Keep runtime price state in sync (used across engine + widgets)
+      await db
+        .insert(organizationState)
+        .values({
+          id: organization.id,
+          currentPrice: update.newPrice,
+          updatedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: organizationState.id,
+          set: { currentPrice: update.newPrice, updatedAt: now },
+        });
 
       await getDbInstance().recordPriceUpdate(
         organization.id,
@@ -143,6 +163,37 @@ export class PriceUpdateService {
           type: 'price_update',
           updates: JSON.parse(JSON.stringify(appliedUpdates)) as JsonValue,
         });
+
+        // If any updates include a canonical perp ticker, also broadcast a
+        // `perp_price_update` for real-time UI hooks/stores.
+        const perpUpdates = appliedUpdates
+          .map((u) => {
+            const tickerRaw =
+              u.metadata && typeof u.metadata === 'object'
+                ? (u.metadata as Record<string, unknown>).ticker
+                : undefined;
+            const ticker =
+              typeof tickerRaw === 'string' && tickerRaw.length > 0
+                ? tickerRaw.toUpperCase()
+                : null;
+            if (!ticker) return null;
+            return {
+              ticker,
+              organizationId: u.organizationId,
+              newPrice: u.newPrice,
+              price: u.newPrice,
+              change: u.change,
+              changePercent: u.changePercent,
+            };
+          })
+          .filter((u): u is NonNullable<typeof u> => u !== null);
+
+        if (perpUpdates.length > 0) {
+          await broadcastToChannel('markets', {
+            type: 'perp_price_update',
+            updates: perpUpdates as unknown as JsonValue,
+          });
+        }
       } catch {
         // Broadcast is optional - engine can work without it
       }

--- a/packages/engine/src/services/trade-execution-service.ts
+++ b/packages/engine/src/services/trade-execution-service.ts
@@ -452,7 +452,7 @@ export class TradeExecutionService {
       npcName: decision.npcName,
       poolId: actorId, // Using actorId for backward compatibility
       marketType: 'perp',
-      ticker: decision.ticker,
+      ticker: tradeTicker,
       action: decision.action,
       side,
       amount: cappedAmount,


### PR DESCRIPTION
## Summary
- Fixes perpetual markets staying at a fixed price by recomputing perp prices from the new `perpPositions` system and broadcasting the correct SSE events.
- Ensures perp price updates persist correctly by upserting `OrganizationState` and emitting `perp_price_update` with ticker metadata.
- Removes duplicate / conflicting client-side snapshot updates and normalizes ticker handling.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Linear: https://linear.app/eliza-labs/issue/BAB-79/perpetual-markets-not-moving-prices-remain-fixed-despite-trades

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [x] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- Recompute perp prices from `perpPositions` (instead of legacy `poolPositions`) during tick updates.
- Broadcast perp price updates via `PriceUpdateService` using `metadata.ticker` and persist to `OrganizationState`.
- Normalize ticker casing and avoid duplicate manual snapshot updates in the perps API adapter.
- Fix NPC trade executed ticker to match the actual traded ticker.
- Guard access to non-standard `fetch.preconnect` usage for TS compatibility.

## Review guide
**Start here**
- `packages/engine/src/game-tick.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- Main behavioral change is the source-of-truth switch to `perpPositions` for recomputing prices.

## Test plan
**Commands run**
- [ ] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [x] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Place perp trades and confirm the perp price stream (`perp_price_update`) changes the displayed price.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `…`
- Changed: `…`
- Removed: `…`

**DB / data migration**
- Migration(s): `…`
- Backfill/seed: `…` (command/script + expected runtime)

**Rollout / rollback plan**
- Rollout: ship normally
- Rollback: revert PR

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option B: No visual changes
- Reason: Behavior/SSE/data correctness fix; no static UI visuals to capture.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed trade execution to accurately report ticker information in trade records.
  * Improved price update synchronization to maintain consistent state across the system.

* **Improvements**
  * Enhanced market price calculations to focus on actively traded assets, improving efficiency.
  * Refined price tracking with better metadata and logging for debugging and tracing.
  * Optimized price update handling with improved state management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixes perpetual markets staying at fixed prices by switching the price recomputation source from legacy `poolPositions` to the current `perpPositions` table, ensuring NPC perp trades correctly impact market prices.

**Key Changes:**
- `game-tick.ts`: Rewrote `updateMarketPricesFromTrades` to query `perpPositions` (new system) instead of `poolPositions` (legacy system), scoped to traded tickers for efficiency
- `price-update-service.ts`: Added `organizationState` upsert for runtime price consistency and broadcasts `perp_price_update` SSE events when ticker metadata is present
- `_adapters.ts`: Removed duplicate snapshot updates and manual SSE broadcasts since `PriceUpdateService` now centralizes both
- `trade-execution-service.ts`: Fixed NPC trade execution ticker to use normalized `tradeTicker` value for consistency
- `integration-a2a-sdk.ts`: Guarded non-standard `fetch.preconnect` access to prevent TypeScript errors

**Impact:**
The root cause was that NPC perp trades now write to `perpPositions` (via `PerpMarketService`), but the tick-based price recalculation was still reading from `poolPositions`, causing prices to remain static despite trading activity. This PR correctly aligns the price computation with the actual data source.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with low risk - it fixes a critical data source mismatch
- Score reflects a well-reasoned fix for a clear bug (reading from wrong table), with proper delegation to centralized services. Minor concern about the threshold change from 0.01 to 0.001 in `game-tick.ts` potentially causing more frequent updates, though this appears intentional for more responsive pricing
- `packages/engine/src/game-tick.ts` warrants extra attention due to the core logic change and reduced price change threshold

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/engine/src/game-tick.ts | Refactored `updateMarketPricesFromTrades` to query `perpPositions` instead of `poolPositions`, scoping updates to traded tickers and delegating to `PriceUpdateService` with ticker metadata |
| packages/engine/src/services/price-update-service.ts | Added `organizationState` upsert and `perp_price_update` SSE broadcast when ticker metadata is present in price updates |
| apps/web/src/app/api/markets/perps/_adapters.ts | Normalized ticker casing, removed duplicate snapshot updates and manual SSE broadcasts since `PriceUpdateService` now handles both |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GT as GameTick
    participant DB as Database
    participant PUS as PriceUpdateService
    participant PMS as PerpMarketService
    participant SSE as SSE Broadcast

    Note over GT: NPC/User Perp Trades Execute
    
    GT->>DB: Query perpMarketSnapshots (ticker, orgId, currentPrice)
    DB-->>GT: Snapshot data
    
    GT->>DB: Query perpPositions (ticker, side, size WHERE closedAt IS NULL)
    DB-->>GT: Open positions
    
    GT->>GT: Calculate netHoldings = sum(long positions - short positions)
    GT->>GT: calculatePriceFromHoldings(initialPrice, currentPrice, netHoldings)
    
    GT->>PUS: applyUpdates([{organizationId, newPrice, metadata: {ticker}}])
    
    PUS->>DB: SELECT organizations WHERE id = organizationId
    DB-->>PUS: Organization (oldPrice)
    
    PUS->>DB: UPDATE organizations SET currentPrice, updatedAt
    PUS->>DB: UPSERT organizationState (currentPrice, updatedAt)
    PUS->>DB: recordPriceUpdate(orgId, newPrice, change, changePercent)
    
    PUS->>PMS: applyPriceUpdates(priceMap)
    PMS->>DB: Update perp positions & calculate unrealized PnL
    
    PUS->>SSE: broadcastToChannel('markets', {type: 'price_update'})
    
    Note over PUS: Extract ticker from metadata
    PUS->>PUS: Build perpUpdates from metadata.ticker
    PUS->>SSE: broadcastToChannel('markets', {type: 'perp_price_update', ticker})
    
    Note over SSE: UI receives perp_price_update and updates displays
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->