### PR TITLE
fix(BAB-102): baseline NPC trades use actor balances

### DIFF
--- a/packages/engine/src/npc/npc-investment-manager.ts
+++ b/packages/engine/src/npc/npc-investment-manager.ts
@@ -80,7 +80,7 @@ export class NPCInvestmentManager {
 
     const actorBalance = actorStateResult[0];
     if (!actorBalance) {
-      throw new Error(`Actor state not found for pool: ${poolId}`);
+      throw new Error(`Actor state not found: ${poolId} (poolId = actorId)`);
     }
 
     // Get open positions (closedAt is null)
@@ -309,6 +309,11 @@ export class NPCInvestmentManager {
     //
     // Baseline allocations should therefore be computed from actorState + open positions,
     // rather than the (often stale) pools.availableBalance field.
+    //
+    // Note: We fetch all actor states here intentionally. Filtering happens downstream:
+    // - Actors not in StaticDataRegistry are skipped (actorMap lookup)
+    // - Actors with zero/negative balance are skipped
+    // - Actors with open positions (prediction or perp) are skipped
     const npcStates = await db
       .select({
         id: actorState.id,

--- a/packages/engine/src/npc/npc-investment-manager.ts
+++ b/packages/engine/src/npc/npc-investment-manager.ts
@@ -10,6 +10,7 @@
 
 import {
   actorRelationships,
+  actorState,
   and,
   db,
   isNull,
@@ -301,44 +302,36 @@ export class NPCInvestmentManager {
    * Build baseline allocation decisions for NPC pools lacking exposure
    */
   private static async buildBaselineDecisions(): Promise<TradingDecision[]> {
-    // Get active pools
-    const activePoolsResult = await db
-      .select()
-      .from(pools)
-      .where(eq(pools.isActive, true));
-
-    if (activePoolsResult.length === 0) {
-      return [];
-    }
-
-    // Get open positions for these pools
-    const poolIds = activePoolsResult.map((p) => p.id);
-    const allPositions = await db
+    // The trading system has moved away from pool balances and uses actorState.tradingBalance
+    // directly. We keep poolPositions as "back-compat" storage keyed by poolId=actorId.
+    //
+    // Baseline allocations should therefore be computed from actorState + open positions,
+    // rather than the (often stale) pools.availableBalance field.
+    const npcStates = await db
       .select({
-        id: poolPositions.id,
-        poolId: poolPositions.poolId,
-        closedAt: poolPositions.closedAt,
+        id: actorState.id,
+        tradingBalance: actorState.tradingBalance,
       })
+      .from(actorState);
+
+    if (npcStates.length === 0) return [];
+
+    const actorIds = npcStates.map((npc) => npc.id);
+
+    // Open prediction positions are stored in poolPositions with poolId = actorId.
+    const openPredictionPositions = await db
+      .select({ poolId: poolPositions.poolId })
       .from(poolPositions)
-      .where(inArray(poolPositions.poolId, poolIds));
-
-    const openPositionsByPool = new Map<string, { id: string }[]>();
-    allPositions.forEach((pos) => {
-      if (pos.closedAt === null) {
-        const existing = openPositionsByPool.get(pos.poolId) ?? [];
-        existing.push({ id: pos.id });
-        openPositionsByPool.set(pos.poolId, existing);
-      }
-    });
-
-    // Add position info to pools
-    const activePools = activePoolsResult.map((pool) => ({
-      ...pool,
-      PoolPosition: openPositionsByPool.get(pool.id) ?? [],
-    }));
-
-    const actorIds = Array.from(
-      new Set(activePools.map((pool) => pool.npcActorId))
+      .where(
+        and(
+          inArray(poolPositions.poolId, actorIds),
+          isNull(poolPositions.closedAt)
+        )
+      );
+    const actorIdsWithOpenPredictionPositions = new Set(
+      openPredictionPositions
+        .map((p) => p.poolId)
+        .filter((id): id is string => Boolean(id))
     );
 
     // Get existing OPEN perp positions for these actors (userId = actorId for NPCs)
@@ -346,7 +339,6 @@ export class NPCInvestmentManager {
     const existingPerpPositions = await db
       .select({
         userId: perpPositions.userId,
-        ticker: perpPositions.ticker,
         organizationId: perpPositions.organizationId,
       })
       .from(perpPositions)
@@ -357,13 +349,16 @@ export class NPCInvestmentManager {
         )
       );
 
-    // Build set of "actorId:orgId" combinations that already have positions
-    // We use organizationId for matching since that's more reliable than ticker
+    // Build set of "actorId:orgId" combinations that already have positions.
+    // We use organizationId for matching since decision tickers are frequently org IDs.
     const existingPerpPositionKeys = new Set(
       existingPerpPositions.map(
         (p: { userId: string; organizationId: string }) =>
           `${p.userId}:${p.organizationId.toLowerCase()}`
       )
+    );
+    const actorIdsWithOpenPerpPositions = new Set(
+      existingPerpPositions.map((p) => p.userId)
     );
 
     // Get organizations from static registry with dynamic prices
@@ -461,20 +456,29 @@ export class NPCInvestmentManager {
 
     const baselineDecisions: TradingDecision[] = [];
 
-    for (const pool of activePools) {
-      // Skip pools that already hold positions
-      if (pool.PoolPosition.length > 0) {
+    const balanceByActorId = new Map(
+      npcStates.map((npc) => [
+        npc.id,
+        Number.parseFloat(npc.tradingBalance?.toString() ?? '0'),
+      ])
+    );
+
+    for (const actorId of actorIds) {
+      // Only run baseline allocation for NPCs with *no* open positions at all.
+      // Once an NPC has started trading, MarketDecisionEngine should take over.
+      if (
+        actorIdsWithOpenPredictionPositions.has(actorId) ||
+        actorIdsWithOpenPerpPositions.has(actorId)
+      ) {
         continue;
       }
 
-      const actor = actorMap.get(pool.npcActorId);
+      const actor = actorMap.get(actorId);
       if (!actor) {
         continue;
       }
 
-      const availableBalance = Number.parseFloat(
-        pool.availableBalance.toString()
-      );
+      const availableBalance = balanceByActorId.get(actor.id) ?? 0;
       if (availableBalance <= 0) {
         continue;
       }

--- a/packages/engine/src/npc/npc-investment-manager.ts
+++ b/packages/engine/src/npc/npc-investment-manager.ts
@@ -70,15 +70,17 @@ export class NPCInvestmentManager {
    * Get portfolio metrics for an NPC pool
    */
   static async getPortfolioMetrics(poolId: string): Promise<PortfolioMetrics> {
-    const poolResult = await db
-      .select()
-      .from(pools)
-      .where(eq(pools.id, poolId))
+    // The trading system now uses actorState.tradingBalance as the source of truth.
+    // poolId = actorId for NPC pools, so we query actorState directly.
+    const actorStateResult = await db
+      .select({ tradingBalance: actorState.tradingBalance })
+      .from(actorState)
+      .where(eq(actorState.id, poolId))
       .limit(1);
 
-    const pool = poolResult[0];
-    if (!pool) {
-      throw new Error(`Pool not found: ${poolId}`);
+    const actorBalance = actorStateResult[0];
+    if (!actorBalance) {
+      throw new Error(`Actor state not found for pool: ${poolId}`);
     }
 
     // Get open positions (closedAt is null)
@@ -106,7 +108,7 @@ export class NPCInvestmentManager {
       leverage: p.leverage ?? undefined,
     }));
     const availableBalance = Number.parseFloat(
-      pool.availableBalance?.toString() ?? '0'
+      actorBalance.tradingBalance?.toString() ?? '0'
     );
 
     // Calculate total invested capital (sum of all open position entry values)


### PR DESCRIPTION
## Summary
- Fixes baseline NPC trading allocations using the real balance source-of-truth (`actorState.tradingBalance`) instead of stale `pools.availableBalance`.
- Prevents baseline allocation from re-running once an NPC already has any open positions (perp or prediction), letting MarketDecisionEngine take over.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Linear: https://linear.app/eliza-labs/issue/BAB-102/markets-critical-trading-issues-market-updates-position-tracking-and

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- `NPCInvestmentManager.buildBaselineDecisions()` now:
  - Reads balances from `actorState.tradingBalance`.
  - Detects existing open positions via `perpPositions` + `poolPositions` (prediction back-compat).
  - Only emits baseline trades for NPCs with no open positions.

## Review guide
**Start here**
- `packages/engine/src/npc/npc-investment-manager.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- This is intentionally scoped to baseline allocation only; MarketDecisionEngine remains the driver for ongoing NPC trading.

## Test plan
**Commands run**
- [ ] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [x] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Run a tick and confirm baseline NPC trades actually execute with non-zero actor balances.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option B: No visual changes
- Reason: Engine-only behavior change.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes baseline NPC trading allocations to use the authoritative `actorState.tradingBalance` instead of stale `pools.availableBalance`. The change refactors `buildBaselineDecisions()` to query `actorState` directly and implements dual position detection (both prediction and perp) to prevent re-running baseline allocation once NPCs have any open positions, allowing `MarketDecisionEngine` to take over.

**Key improvements:**
- Uses `actorState.tradingBalance` as single source of truth for available balance
- Detects existing positions across both market types (`poolPositions` for prediction, `perpPositions` for perp)
- Prevents baseline allocation re-runs for NPCs with any open positions
- Adds comprehensive comments explaining the architecture shift from pool-based to actor-based balance tracking
- Maintains backward compatibility with prediction market storage via `poolId=actorId` convention

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with high confidence. The changes are focused, well-tested, and fix a critical data consistency issue without introducing new risks.
- Score of 5 reflects: (1) Focused, single-purpose change addressing data consistency; (2) Correct logic using authoritative `actorState.tradingBalance` instead of stale pool data; (3) Improved position detection with dual checks for both market types; (4) No breaking changes or database migrations required; (5) Existing unit tests cover the allocation logic and demonstrate understanding of the change; (6) Clear comments explaining the architectural shift from pool-based to actor-based balance tracking; (7) Proper handling of edge cases (no balance, minimal budget, existing positions).
- No files require special attention. The change is isolated to a single file with clear intent and proper implementation.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/engine/src/npc/npc-investment-manager.ts | Refactored `buildBaselineDecisions()` to use `actorState.tradingBalance` (source of truth) instead of stale `pools.availableBalance`. Added dual position detection (prediction + perp) to prevent baseline re-allocation once NPCs have any open positions. Change is focused, well-commented, and correctly implements the intended behavior. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GameTick as Game Tick
    participant BLI as buildBaselineDecisions()
    participant DB as Database
    participant TE as TradeExecutionService

    GameTick->>BLI: executeBaselineInvestments()
    BLI->>DB: SELECT actorState.tradingBalance
    DB-->>BLI: npcStates[]
    
    BLI->>DB: Query poolPositions (predictions)
    DB-->>BLI: openPredictionPositions[]
    
    BLI->>DB: Query perpPositions (perps)
    DB-->>BLI: existingPerpPositions[]
    
    alt NPC has ANY open position
        BLI-->>GameTick: SKIP (continue to next NPC)
    else NPC has NO positions
        BLI->>BLI: Get actor affiliations & relationships
        BLI->>BLI: Build target organizations
        BLI->>BLI: Create TradingDecisions (80% of balance)
        BLI-->>GameTick: decisions[]
        GameTick->>TE: executeDecisionBatch(decisions)
        TE->>DB: Execute trades
        DB-->>TE: result
        TE-->>GameTick: TradingExecutionResult
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched investment logic from pool-centric to actor-centric balances and decisioning.
  * Baseline allocation now iterates per actor, using actor state and affiliations to choose targets and falling back to top-priced organizations.
  * Added awareness of open positions to skip actors with active exposure during baseline allocation.

* **Chores**
  * Preserved public APIs/backward compatibility and added safety checks for missing actor balances.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->