### PR TITLE
feat(BAB-118): add manual resolution review

### DIFF
--- a/apps/web/src/app/admin/resolutions/page.tsx
+++ b/apps/web/src/app/admin/resolutions/page.tsx
@@ -7,10 +7,24 @@
 'use client';
 
 import { cn } from '@babylon/shared';
-import { ExternalLink, ShieldAlert } from 'lucide-react';
+import { ExternalLink, Loader2, ShieldAlert } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return 'n/a';
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    }).format(new Date(dateStr));
+  } catch {
+    return dateStr;
+  }
+}
 
 type PendingResolution = {
   id: string;
@@ -119,7 +133,7 @@ export default function AdminResolutionsPage() {
                 <div className="flex items-start justify-between gap-4">
                   <div className="min-w-0">
                     <div className="text-muted-foreground text-xs">
-                      Q{q.questionNumber} • {q.resolutionDate ?? 'n/a'} •{' '}
+                      Q{q.questionNumber} • {formatDate(q.resolutionDate)} •{' '}
                       {q.resolutionReviewStatus}
                       {q.resolutionConfidence !== null
                         ? ` • confidence ${(q.resolutionConfidence * 100).toFixed(0)}%`
@@ -159,13 +173,19 @@ export default function AdminResolutionsPage() {
                     disabled={submittingId === q.id}
                     onClick={() => act(q.id, 'approve')}
                   >
+                    {submittingId === q.id ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : null}
                     Approve
                   </Button>
                   <Button
-                    variant="secondary"
+                    variant="outline"
                     disabled={submittingId === q.id}
                     onClick={() => act(q.id, 'reject')}
                   >
+                    {submittingId === q.id ? (
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    ) : null}
                     Reject
                   </Button>
                 </div>

--- a/apps/web/src/app/admin/resolutions/page.tsx
+++ b/apps/web/src/app/admin/resolutions/page.tsx
@@ -6,25 +6,21 @@
 
 'use client';
 
-import { cn } from '@babylon/shared';
-import { ExternalLink, Loader2, RefreshCw, ShieldAlert } from 'lucide-react';
+import { cn, formatDateTime } from '@babylon/shared';
+import {
+  ExternalLink,
+  Loader2,
+  RefreshCw,
+  Shield,
+  ShieldAlert,
+} from 'lucide-react';
+import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
+import { PageContainer } from '@/components/shared/PageContainer';
+import { Skeleton } from '@/components/shared/Skeleton';
 import { Button } from '@/components/ui/button';
-
-/** Format date with time for resolution display */
-function formatDateTime(dateStr: string): string {
-  try {
-    return new Intl.DateTimeFormat('en-US', {
-      month: 'short',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-    }).format(new Date(dateStr));
-  } catch {
-    return dateStr;
-  }
-}
+import { useAuth } from '@/hooks/useAuth';
 
 type PendingResolution = {
   id: string;
@@ -35,17 +31,70 @@ type PendingResolution = {
   resolutionProofUrl: string | null;
   resolutionDescription: string | null;
   resolutionConfidence: number | null;
-  resolutionReviewStatus: 'pending' | 'approved' | 'rejected' | string;
+  resolutionReviewStatus: 'pending' | 'approved' | 'rejected' | null;
   requiresManualReview: boolean;
   updatedAt: string | null;
 };
 
+/** Runtime type guard for PendingResolution */
+function isPendingResolution(value: unknown): value is PendingResolution {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.id === 'string' &&
+    typeof obj.questionNumber === 'number' &&
+    typeof obj.text === 'string' &&
+    typeof obj.outcome === 'boolean' &&
+    typeof obj.requiresManualReview === 'boolean'
+  );
+}
+
+/** Extract error message from API response with runtime validation */
+function extractErrorMessage(data: unknown, fallback: string): string {
+  if (typeof data !== 'object' || data === null) return fallback;
+  const obj = data as Record<string, unknown>;
+  if (typeof obj.error !== 'object' || obj.error === null) return fallback;
+  const err = obj.error as Record<string, unknown>;
+  return typeof err.message === 'string' ? err.message : fallback;
+}
+
 export default function AdminResolutionsPage() {
+  const router = useRouter();
+  const { authenticated, ready } = useAuth();
   const [items, setItems] = useState<PendingResolution[]>([]);
   const [loading, setLoading] = useState(true);
   const [submittingId, setSubmittingId] = useState<string | null>(null);
+  const [isAuthorized, setIsAuthorized] = useState<boolean | null>(null);
+
+  const checkAdminAccess = useCallback(async () => {
+    if (!ready) return;
+
+    if (!authenticated) {
+      router.push('/');
+      return;
+    }
+
+    // Check admin access by attempting to fetch the resolution queue
+    try {
+      const res = await fetch('/api/admin/resolutions');
+      if (!res.ok) {
+        setIsAuthorized(false);
+        setLoading(false);
+        return;
+      }
+      setIsAuthorized(true);
+    } catch {
+      setIsAuthorized(false);
+      setLoading(false);
+    }
+  }, [authenticated, ready, router]);
+
+  useEffect(() => {
+    checkAdminAccess();
+  }, [checkAdminAccess]);
 
   const fetchQueue = useCallback(async () => {
+    if (!isAuthorized) return;
     setLoading(true);
     try {
       const res = await fetch('/api/admin/resolutions');
@@ -56,28 +105,28 @@ export default function AdminResolutionsPage() {
         throw new Error('Invalid response from server');
       }
       if (!res.ok) {
-        const err = data as { error?: { message?: string } };
         throw new Error(
-          err?.error?.message ?? 'Failed to load resolution queue'
+          extractErrorMessage(data, 'Failed to load resolution queue')
         );
       }
       const payload = data as { items?: unknown[] };
-      setItems(
-        Array.isArray(payload?.items)
-          ? (payload.items as PendingResolution[])
-          : []
-      );
+      const validItems = Array.isArray(payload?.items)
+        ? payload.items.filter(isPendingResolution)
+        : [];
+      setItems(validItems);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to load queue');
       setItems([]);
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [isAuthorized]);
 
   useEffect(() => {
-    fetchQueue();
-  }, [fetchQueue]);
+    if (isAuthorized) {
+      fetchQueue();
+    }
+  }, [isAuthorized, fetchQueue]);
 
   const pendingCount = useMemo(
     () => items.filter((i) => i.resolutionReviewStatus === 'pending').length,
@@ -100,8 +149,7 @@ export default function AdminResolutionsPage() {
           throw new Error(`Invalid response for ${action} on question ${id}`);
         }
         if (!res.ok) {
-          const err = data as { error?: { message?: string } };
-          throw new Error(err?.error?.message ?? 'Action failed');
+          throw new Error(extractErrorMessage(data, 'Action failed'));
         }
         toast.success(action === 'approve' ? 'Approved' : 'Rejected');
         await fetchQueue();
@@ -113,6 +161,34 @@ export default function AdminResolutionsPage() {
     },
     [fetchQueue]
   );
+
+  // Show loading skeleton while checking auth
+  if (!ready || isAuthorized === null) {
+    return (
+      <PageContainer>
+        <div className="mx-auto w-full max-w-5xl p-6">
+          <Skeleton className="mb-4 h-8 w-64" />
+          <Skeleton className="h-4 w-96" />
+        </div>
+      </PageContainer>
+    );
+  }
+
+  // Show access denied for non-admins
+  if (!isAuthorized) {
+    return (
+      <PageContainer>
+        <div className="flex h-full flex-col items-center justify-center">
+          <Shield className="mb-4 h-16 w-16 text-muted-foreground" />
+          <h1 className="mb-2 font-bold text-2xl">Access Denied</h1>
+          <p className="text-muted-foreground">
+            You don&apos;t have permission to access the resolution review
+            queue.
+          </p>
+        </div>
+      </PageContainer>
+    );
+  }
 
   return (
     <div className="mx-auto w-full max-w-5xl p-6">

--- a/apps/web/src/app/admin/resolutions/page.tsx
+++ b/apps/web/src/app/admin/resolutions/page.tsx
@@ -1,0 +1,179 @@
+/**
+ * Admin Resolution Review Queue
+ *
+ * Lists low-confidence prediction question resolutions that require manual review.
+ */
+
+'use client';
+
+import { cn } from '@babylon/shared';
+import { ExternalLink, ShieldAlert } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+
+type PendingResolution = {
+  id: string;
+  questionNumber: number;
+  text: string;
+  outcome: boolean;
+  resolutionDate: string | null;
+  resolutionProofUrl: string | null;
+  resolutionDescription: string | null;
+  resolutionConfidence: number | null;
+  resolutionReviewStatus: 'pending' | 'approved' | 'rejected' | string;
+  requiresManualReview: boolean;
+  updatedAt: string | null;
+};
+
+export default function AdminResolutionsPage() {
+  const [items, setItems] = useState<PendingResolution[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [submittingId, setSubmittingId] = useState<string | null>(null);
+
+  const fetchQueue = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/admin/resolutions');
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        throw new Error(data?.error ?? 'Failed to load resolution queue');
+      }
+      setItems(Array.isArray(data?.items) ? data.items : []);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to load queue');
+      setItems([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchQueue();
+  }, [fetchQueue]);
+
+  const pendingCount = useMemo(
+    () => items.filter((i) => i.resolutionReviewStatus === 'pending').length,
+    [items]
+  );
+
+  const act = useCallback(
+    async (id: string, action: 'approve' | 'reject') => {
+      setSubmittingId(id);
+      try {
+        const res = await fetch(`/api/admin/resolutions/${id}`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ action }),
+        });
+        const data = await res.json().catch(() => null);
+        if (!res.ok) {
+          throw new Error(data?.error ?? 'Action failed');
+        }
+        toast.success(action === 'approve' ? 'Approved' : 'Rejected');
+        await fetchQueue();
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : 'Action failed');
+      } finally {
+        setSubmittingId(null);
+      }
+    },
+    [fetchQueue]
+  );
+
+  return (
+    <div className="mx-auto w-full max-w-5xl p-6">
+      <div className="mb-6 flex items-start justify-between gap-4">
+        <div>
+          <h1 className="font-bold text-2xl">Resolution Review Queue</h1>
+          <p className="text-muted-foreground">
+            Low-confidence resolutions requiring manual approval before markets
+            resolve.
+          </p>
+        </div>
+        <div
+          className={cn(
+            'inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm',
+            pendingCount > 0 ? 'border-yellow-500/30 bg-yellow-500/10' : ''
+          )}
+        >
+          <ShieldAlert className="h-4 w-4" />
+          <span>{pendingCount} pending</span>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="text-muted-foreground">Loading…</div>
+      ) : items.length === 0 ? (
+        <div className="rounded-lg border border-border bg-card p-6 text-muted-foreground">
+          No pending resolution reviews.
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {items.map((q) => (
+            <div
+              key={q.id}
+              className="rounded-lg border border-border bg-card p-5"
+            >
+              <div className="flex flex-col gap-3">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="min-w-0">
+                    <div className="text-muted-foreground text-xs">
+                      Q{q.questionNumber} • {q.resolutionDate ?? 'n/a'} •{' '}
+                      {q.resolutionReviewStatus}
+                      {q.resolutionConfidence !== null
+                        ? ` • confidence ${(q.resolutionConfidence * 100).toFixed(0)}%`
+                        : ''}
+                    </div>
+                    <div className="mt-1 line-clamp-2 font-medium">
+                      {q.text}
+                    </div>
+                  </div>
+
+                  <div className="flex shrink-0 items-center gap-2">
+                    {q.resolutionProofUrl ? (
+                      <a
+                        href={q.resolutionProofUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center gap-1 text-primary text-sm hover:underline"
+                      >
+                        Proof <ExternalLink className="h-4 w-4" />
+                      </a>
+                    ) : null}
+                  </div>
+                </div>
+
+                {q.resolutionDescription ? (
+                  <div className="rounded-md bg-muted/30 p-3 text-sm">
+                    {q.resolutionDescription}
+                  </div>
+                ) : (
+                  <div className="rounded-md bg-muted/30 p-3 text-muted-foreground text-sm">
+                    No proof/description stored yet.
+                  </div>
+                )}
+
+                <div className="flex items-center gap-2">
+                  <Button
+                    disabled={submittingId === q.id}
+                    onClick={() => act(q.id, 'approve')}
+                  >
+                    Approve
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    disabled={submittingId === q.id}
+                    onClick={() => act(q.id, 'reject')}
+                  >
+                    Reject
+                  </Button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/resolutions/page.tsx
+++ b/apps/web/src/app/admin/resolutions/page.tsx
@@ -7,13 +7,13 @@
 'use client';
 
 import { cn } from '@babylon/shared';
-import { ExternalLink, Loader2, ShieldAlert } from 'lucide-react';
+import { ExternalLink, Loader2, RefreshCw, ShieldAlert } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 
-function formatDate(dateStr: string | null): string {
-  if (!dateStr) return 'n/a';
+/** Format date with time for resolution display */
+function formatDateTime(dateStr: string): string {
   try {
     return new Intl.DateTimeFormat('en-US', {
       month: 'short',
@@ -49,11 +49,20 @@ export default function AdminResolutionsPage() {
     setLoading(true);
     try {
       const res = await fetch('/api/admin/resolutions');
-      const data = await res.json().catch(() => null);
-      if (!res.ok) {
-        throw new Error(data?.error ?? 'Failed to load resolution queue');
+      let data: unknown;
+      try {
+        data = await res.json();
+      } catch {
+        throw new Error('Invalid response from server');
       }
-      setItems(Array.isArray(data?.items) ? data.items : []);
+      if (!res.ok) {
+        const err = data as { error?: { message?: string } };
+        throw new Error(
+          err?.error?.message ?? 'Failed to load resolution queue'
+        );
+      }
+      const payload = data as { items?: unknown[] };
+      setItems(Array.isArray(payload?.items) ? (payload.items as PendingResolution[]) : []);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to load queue');
       setItems([]);
@@ -105,14 +114,25 @@ export default function AdminResolutionsPage() {
             resolve.
           </p>
         </div>
-        <div
-          className={cn(
-            'inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm',
-            pendingCount > 0 ? 'border-yellow-500/30 bg-yellow-500/10' : ''
-          )}
-        >
-          <ShieldAlert className="h-4 w-4" />
-          <span>{pendingCount} pending</span>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => fetchQueue()}
+            disabled={loading}
+            title="Refresh queue"
+          >
+            <RefreshCw className={cn('h-4 w-4', loading && 'animate-spin')} />
+          </Button>
+          <div
+            className={cn(
+              'inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm',
+              pendingCount > 0 ? 'border-yellow-500/30 bg-yellow-500/10' : ''
+            )}
+          >
+            <ShieldAlert className="h-4 w-4" />
+            <span>{pendingCount} pending</span>
+          </div>
         </div>
       </div>
 
@@ -132,12 +152,27 @@ export default function AdminResolutionsPage() {
               <div className="flex flex-col gap-3">
                 <div className="flex items-start justify-between gap-4">
                   <div className="min-w-0">
-                    <div className="text-muted-foreground text-xs">
-                      Q{q.questionNumber} • {formatDate(q.resolutionDate)} •{' '}
-                      {q.resolutionReviewStatus}
-                      {q.resolutionConfidence !== null
-                        ? ` • confidence ${(q.resolutionConfidence * 100).toFixed(0)}%`
-                        : ''}
+                    <div className="flex items-center gap-2 text-muted-foreground text-xs">
+                      <span>Q{q.questionNumber}</span>
+                      <span>•</span>
+                      <span
+                        className={cn(
+                          'rounded px-1.5 py-0.5 font-medium',
+                          q.outcome
+                            ? 'bg-green-500/10 text-green-600'
+                            : 'bg-red-500/10 text-red-600'
+                        )}
+                      >
+                        {q.outcome ? 'YES' : 'NO'}
+                      </span>
+                      <span>•</span>
+                      <span>{q.resolutionDate ? formatDateTime(q.resolutionDate) : 'n/a'}</span>
+                      {q.resolutionConfidence !== null ? (
+                        <>
+                          <span>•</span>
+                          <span>{(q.resolutionConfidence * 100).toFixed(0)}% confidence</span>
+                        </>
+                      ) : null}
                     </div>
                     <div className="mt-1 line-clamp-2 font-medium">
                       {q.text}
@@ -180,6 +215,7 @@ export default function AdminResolutionsPage() {
                   </Button>
                   <Button
                     variant="outline"
+                    className="border-red-500/30 text-red-600 hover:bg-red-500/10"
                     disabled={submittingId === q.id}
                     onClick={() => act(q.id, 'reject')}
                   >

--- a/apps/web/src/app/admin/resolutions/page.tsx
+++ b/apps/web/src/app/admin/resolutions/page.tsx
@@ -62,7 +62,11 @@ export default function AdminResolutionsPage() {
         );
       }
       const payload = data as { items?: unknown[] };
-      setItems(Array.isArray(payload?.items) ? (payload.items as PendingResolution[]) : []);
+      setItems(
+        Array.isArray(payload?.items)
+          ? (payload.items as PendingResolution[])
+          : []
+      );
     } catch (err) {
       toast.error(err instanceof Error ? err.message : 'Failed to load queue');
       setItems([]);
@@ -89,9 +93,15 @@ export default function AdminResolutionsPage() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ action }),
         });
-        const data = await res.json().catch(() => null);
+        let data: unknown;
+        try {
+          data = await res.json();
+        } catch {
+          throw new Error(`Invalid response for ${action} on question ${id}`);
+        }
         if (!res.ok) {
-          throw new Error(data?.error ?? 'Action failed');
+          const err = data as { error?: { message?: string } };
+          throw new Error(err?.error?.message ?? 'Action failed');
         }
         toast.success(action === 'approve' ? 'Approved' : 'Rejected');
         await fetchQueue();
@@ -166,11 +176,18 @@ export default function AdminResolutionsPage() {
                         {q.outcome ? 'YES' : 'NO'}
                       </span>
                       <span>•</span>
-                      <span>{q.resolutionDate ? formatDateTime(q.resolutionDate) : 'n/a'}</span>
+                      <span>
+                        {q.resolutionDate
+                          ? formatDateTime(q.resolutionDate)
+                          : 'n/a'}
+                      </span>
                       {q.resolutionConfidence !== null ? (
                         <>
                           <span>•</span>
-                          <span>{(q.resolutionConfidence * 100).toFixed(0)}% confidence</span>
+                          <span>
+                            {(q.resolutionConfidence * 100).toFixed(0)}%
+                            confidence
+                          </span>
                         </>
                       ) : null}
                     </div>

--- a/apps/web/src/app/admin/resolutions/page.tsx
+++ b/apps/web/src/app/admin/resolutions/page.tsx
@@ -19,6 +19,16 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { PageContainer } from '@/components/shared/PageContainer';
 import { Skeleton } from '@/components/shared/Skeleton';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/hooks/useAuth';
 
@@ -65,6 +75,9 @@ export default function AdminResolutionsPage() {
   const [loading, setLoading] = useState(true);
   const [submittingId, setSubmittingId] = useState<string | null>(null);
   const [isAuthorized, setIsAuthorized] = useState<boolean | null>(null);
+  const [rejectConfirm, setRejectConfirm] = useState<PendingResolution | null>(
+    null
+  );
 
   const checkAdminAccess = useCallback(async () => {
     if (!ready) return;
@@ -310,11 +323,8 @@ export default function AdminResolutionsPage() {
                     variant="outline"
                     className="border-red-500/30 text-red-600 hover:bg-red-500/10"
                     disabled={submittingId === q.id}
-                    onClick={() => act(q.id, 'reject')}
+                    onClick={() => setRejectConfirm(q)}
                   >
-                    {submittingId === q.id ? (
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                    ) : null}
                     Reject
                   </Button>
                 </div>
@@ -323,6 +333,44 @@ export default function AdminResolutionsPage() {
           ))}
         </div>
       )}
+
+      {/* Reject Confirmation Dialog */}
+      <AlertDialog
+        open={rejectConfirm !== null}
+        onOpenChange={(open) => !open && setRejectConfirm(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Reject Resolution?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will clear the stored proof and postpone the resolution by 24
+              hours. The question will need to be re-evaluated.
+              {rejectConfirm && (
+                <div className="mt-2 rounded-md bg-muted/50 p-2 text-foreground">
+                  Q{rejectConfirm.questionNumber}: {rejectConfirm.text}
+                </div>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-red-600 hover:bg-red-700"
+              onClick={() => {
+                if (rejectConfirm) {
+                  act(rejectConfirm.id, 'reject');
+                  setRejectConfirm(null);
+                }
+              }}
+            >
+              {submittingId === rejectConfirm?.id ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : null}
+              Reject
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/apps/web/src/app/api/admin/resolutions/[id]/route.ts
+++ b/apps/web/src/app/api/admin/resolutions/[id]/route.ts
@@ -79,11 +79,15 @@ export const POST = withErrorHandling(
         })
         .where(eq(questions.id, id));
 
-      logger.info('Resolution approved', {
-        questionId: id,
-        questionNumber: existing.questionNumber,
-        reviewedBy: admin.userId,
-      }, 'AdminResolutions');
+      logger.info(
+        'Resolution approved',
+        {
+          questionId: id,
+          questionNumber: existing.questionNumber,
+          reviewedBy: admin.userId,
+        },
+        'AdminResolutions'
+      );
 
       return successResponse({ success: true });
     }
@@ -106,12 +110,16 @@ export const POST = withErrorHandling(
       })
       .where(eq(questions.id, id));
 
-    logger.info('Resolution rejected', {
-      questionId: id,
-      questionNumber: existing.questionNumber,
-      reviewedBy: admin.userId,
-      postponedUntil: postponed.toISOString(),
-    }, 'AdminResolutions');
+    logger.info(
+      'Resolution rejected',
+      {
+        questionId: id,
+        questionNumber: existing.questionNumber,
+        reviewedBy: admin.userId,
+        postponedUntil: postponed.toISOString(),
+      },
+      'AdminResolutions'
+    );
 
     return successResponse({
       success: true,

--- a/apps/web/src/app/api/admin/resolutions/[id]/route.ts
+++ b/apps/web/src/app/api/admin/resolutions/[id]/route.ts
@@ -6,7 +6,9 @@
  */
 
 import {
+  checkRateLimitAndDuplicates,
   errorResponse,
+  RATE_LIMIT_CONFIGS,
   requireAdmin,
   successResponse,
   withErrorHandling,
@@ -36,6 +38,15 @@ export const POST = withErrorHandling(
     context: { params: Promise<{ id: string }> }
   ) => {
     const admin = await requireAdmin(request);
+
+    // Rate limit admin actions to prevent accidental rapid-fire approvals/rejections
+    const rateLimitResponse = checkRateLimitAndDuplicates(
+      admin.userId,
+      null,
+      RATE_LIMIT_CONFIGS.ADMIN_ACTION
+    );
+    if (rateLimitResponse) return rateLimitResponse;
+
     const { id } = ParamsSchema.parse(await context.params);
     const { action } = BodySchema.parse(await request.json());
 
@@ -73,7 +84,11 @@ export const POST = withErrorHandling(
     }
 
     if (existing.resolutionReviewStatus === 'approved') {
-      return errorResponse('Question already approved', 'ALREADY_APPROVED', 400);
+      return errorResponse(
+        'Question already approved',
+        'ALREADY_APPROVED',
+        400
+      );
     }
 
     const now = new Date();

--- a/apps/web/src/app/api/admin/resolutions/[id]/route.ts
+++ b/apps/web/src/app/api/admin/resolutions/[id]/route.ts
@@ -1,0 +1,84 @@
+/**
+ * Admin Resolution Review Action API
+ *
+ * @route POST /api/admin/resolutions/[id] - Approve or reject a pending resolution
+ * @access Admin
+ */
+
+import { requireAdmin, successResponse, withErrorHandling } from '@babylon/api';
+import { db, eq, questions } from '@babylon/db';
+import type { NextRequest } from 'next/server';
+import { z } from 'zod';
+
+const ParamsSchema = z.object({
+  id: z.string().min(1),
+});
+
+const BodySchema = z.object({
+  action: z.enum(['approve', 'reject']),
+});
+
+export const POST = withErrorHandling(
+  async (
+    request: NextRequest,
+    context: { params: Promise<{ id: string }> }
+  ) => {
+    const admin = await requireAdmin(request);
+    const { id } = ParamsSchema.parse(await context.params);
+    const { action } = BodySchema.parse(await request.json());
+
+    const [existing] = await db
+      .select({
+        id: questions.id,
+        questionNumber: questions.questionNumber,
+        requiresManualReview: questions.requiresManualReview,
+        resolutionReviewStatus: questions.resolutionReviewStatus,
+      })
+      .from(questions)
+      .where(eq(questions.id, id))
+      .limit(1);
+
+    if (!existing) {
+      return successResponse({ error: 'Question not found' }, 404);
+    }
+
+    const now = new Date();
+
+    if (action === 'approve') {
+      await db
+        .update(questions)
+        .set({
+          resolutionReviewStatus: 'approved',
+          resolutionReviewedAt: now,
+          resolutionReviewedBy: admin.userId,
+          updatedAt: now,
+        })
+        .where(eq(questions.id, id));
+
+      return successResponse({ success: true });
+    }
+
+    // Reject: clear the review flag and postpone resolution to avoid immediate retry loops.
+    const postponed = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+
+    await db
+      .update(questions)
+      .set({
+        requiresManualReview: false,
+        resolutionReviewStatus: null,
+        resolutionReviewedAt: now,
+        resolutionReviewedBy: admin.userId,
+        resolutionConfidence: null,
+        resolutionProofUrl: null,
+        resolutionDescription: null,
+        resolutionDate: postponed,
+        updatedAt: now,
+      })
+      .where(eq(questions.id, id));
+
+    return successResponse({
+      success: true,
+      postponedUntil: postponed.toISOString(),
+    });
+  }
+);

--- a/apps/web/src/app/api/admin/resolutions/[id]/route.ts
+++ b/apps/web/src/app/api/admin/resolutions/[id]/route.ts
@@ -7,8 +7,12 @@
 
 import { requireAdmin, successResponse, withErrorHandling } from '@babylon/api';
 import { db, eq, questions } from '@babylon/db';
+import { logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 import { z } from 'zod';
+
+/** Hours to postpone resolution after rejection (default: 24h) */
+const POSTPONE_HOURS = Number(process.env.RESOLUTION_POSTPONE_HOURS) || 24;
 
 const ParamsSchema = z.object({
   id: z.string().min(1),
@@ -31,6 +35,7 @@ export const POST = withErrorHandling(
       .select({
         id: questions.id,
         questionNumber: questions.questionNumber,
+        status: questions.status,
         requiresManualReview: questions.requiresManualReview,
         resolutionReviewStatus: questions.resolutionReviewStatus,
       })
@@ -40,6 +45,25 @@ export const POST = withErrorHandling(
 
     if (!existing) {
       return successResponse({ error: 'Question not found' }, 404);
+    }
+
+    // Validate the question is in a valid state for review
+    if (existing.status !== 'active') {
+      return successResponse(
+        { error: 'Question is not active and cannot be reviewed' },
+        400
+      );
+    }
+
+    if (!existing.requiresManualReview) {
+      return successResponse(
+        { error: 'Question does not require manual review' },
+        400
+      );
+    }
+
+    if (existing.resolutionReviewStatus === 'approved') {
+      return successResponse({ error: 'Question already approved' }, 400);
     }
 
     const now = new Date();
@@ -55,17 +79,23 @@ export const POST = withErrorHandling(
         })
         .where(eq(questions.id, id));
 
+      logger.info('Resolution approved', {
+        questionId: id,
+        questionNumber: existing.questionNumber,
+        reviewedBy: admin.userId,
+      }, 'AdminResolutions');
+
       return successResponse({ success: true });
     }
 
     // Reject: clear the review flag and postpone resolution to avoid immediate retry loops.
-    const postponed = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+    const postponed = new Date(now.getTime() + POSTPONE_HOURS * 60 * 60 * 1000);
 
     await db
       .update(questions)
       .set({
         requiresManualReview: false,
-        resolutionReviewStatus: null,
+        resolutionReviewStatus: 'rejected',
         resolutionReviewedAt: now,
         resolutionReviewedBy: admin.userId,
         resolutionConfidence: null,
@@ -75,6 +105,13 @@ export const POST = withErrorHandling(
         updatedAt: now,
       })
       .where(eq(questions.id, id));
+
+    logger.info('Resolution rejected', {
+      questionId: id,
+      questionNumber: existing.questionNumber,
+      reviewedBy: admin.userId,
+      postponedUntil: postponed.toISOString(),
+    }, 'AdminResolutions');
 
     return successResponse({
       success: true,

--- a/apps/web/src/app/api/admin/resolutions/[id]/route.ts
+++ b/apps/web/src/app/api/admin/resolutions/[id]/route.ts
@@ -5,14 +5,22 @@
  * @access Admin
  */
 
-import { requireAdmin, successResponse, withErrorHandling } from '@babylon/api';
+import {
+  errorResponse,
+  requireAdmin,
+  successResponse,
+  withErrorHandling,
+} from '@babylon/api';
 import { db, eq, questions } from '@babylon/db';
 import { logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 import { z } from 'zod';
 
 /** Hours to postpone resolution after rejection (default: 24h) */
-const POSTPONE_HOURS = Number(process.env.RESOLUTION_POSTPONE_HOURS) || 24;
+const POSTPONE_HOURS = (() => {
+  const val = Number(process.env.RESOLUTION_POSTPONE_HOURS);
+  return Number.isFinite(val) && val > 0 ? val : 24;
+})();
 
 const ParamsSchema = z.object({
   id: z.string().min(1),
@@ -44,26 +52,28 @@ export const POST = withErrorHandling(
       .limit(1);
 
     if (!existing) {
-      return successResponse({ error: 'Question not found' }, 404);
+      return errorResponse('Question not found', 'NOT_FOUND', 404);
     }
 
     // Validate the question is in a valid state for review
     if (existing.status !== 'active') {
-      return successResponse(
-        { error: 'Question is not active and cannot be reviewed' },
+      return errorResponse(
+        'Question is not active and cannot be reviewed',
+        'INVALID_STATE',
         400
       );
     }
 
     if (!existing.requiresManualReview) {
-      return successResponse(
-        { error: 'Question does not require manual review' },
+      return errorResponse(
+        'Question does not require manual review',
+        'NOT_REVIEWABLE',
         400
       );
     }
 
     if (existing.resolutionReviewStatus === 'approved') {
-      return successResponse({ error: 'Question already approved' }, 400);
+      return errorResponse('Question already approved', 'ALREADY_APPROVED', 400);
     }
 
     const now = new Date();

--- a/apps/web/src/app/api/admin/resolutions/route.ts
+++ b/apps/web/src/app/api/admin/resolutions/route.ts
@@ -1,0 +1,66 @@
+/**
+ * Admin Resolution Review Queue API
+ *
+ * @route GET /api/admin/resolutions - List pending resolution reviews
+ * @access Admin
+ *
+ * Returns prediction questions that were flagged as low-confidence and require
+ * manual review before the market can be resolved.
+ */
+
+import { requireAdmin, successResponse, withErrorHandling } from '@babylon/api';
+import { and, asc, db, eq, isNull, or, questions } from '@babylon/db';
+import type { NextRequest } from 'next/server';
+
+export const GET = withErrorHandling(async (request: NextRequest) => {
+  await requireAdmin(request);
+
+  const pending = await db
+    .select({
+      id: questions.id,
+      questionNumber: questions.questionNumber,
+      text: questions.text,
+      outcome: questions.outcome,
+      resolutionDate: questions.resolutionDate,
+      resolutionProofUrl: questions.resolutionProofUrl,
+      resolutionDescription: questions.resolutionDescription,
+      resolutionConfidence: questions.resolutionConfidence,
+      resolutionReviewStatus: questions.resolutionReviewStatus,
+      requiresManualReview: questions.requiresManualReview,
+      updatedAt: questions.updatedAt,
+    })
+    .from(questions)
+    .where(
+      and(
+        eq(questions.status, 'active'),
+        eq(questions.requiresManualReview, true),
+        or(
+          isNull(questions.resolutionReviewStatus),
+          eq(questions.resolutionReviewStatus, 'pending')
+        )
+      )
+    )
+    .orderBy(asc(questions.resolutionDate))
+    .limit(200);
+
+  return successResponse({
+    success: true,
+    items: pending.map((q) => ({
+      id: q.id,
+      questionNumber: q.questionNumber,
+      text: q.text,
+      outcome: q.outcome,
+      resolutionDate: q.resolutionDate?.toISOString() ?? null,
+      resolutionProofUrl: q.resolutionProofUrl ?? null,
+      resolutionDescription: q.resolutionDescription ?? null,
+      resolutionConfidence:
+        typeof q.resolutionConfidence === 'number'
+          ? q.resolutionConfidence
+          : null,
+      resolutionReviewStatus: q.resolutionReviewStatus ?? 'pending',
+      requiresManualReview: Boolean(q.requiresManualReview),
+      updatedAt: q.updatedAt?.toISOString() ?? null,
+    })),
+    count: pending.length,
+  });
+});

--- a/apps/web/src/app/markets/predictions/[id]/page.tsx
+++ b/apps/web/src/app/markets/predictions/[id]/page.tsx
@@ -499,9 +499,10 @@ export default function PredictionDetailPage() {
                   think it won&apos;t.
                 </p>
                 <p className="text-muted-foreground text-sm">
-                  If you&apos;re right, you&apos;ll receive {BABYLON_POINTS_SYMBOL}1 per share. The
-                  current price reflects the market&apos;s probability.
-                  current price reflects the market&apos;s probability.
+                  If you&apos;re right, you&apos;ll receive{' '}
+                  {BABYLON_POINTS_SYMBOL}1 per share. The current price reflects
+                  the market&apos;s probability. current price reflects the
+                  market&apos;s probability.
                 </p>
               </div>
             </div>

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -11,6 +11,22 @@ export interface ButtonProps extends React.ComponentPropsWithoutRef<'button'> {
   size?: 'default' | 'sm' | 'lg' | 'icon';
 }
 
+const variantStyles: Record<NonNullable<ButtonProps['variant']>, string> = {
+  default:
+    'bg-primary text-primary-foreground hover:bg-primary/90 border border-transparent',
+  outline:
+    'border border-border bg-transparent hover:bg-accent hover:text-accent-foreground',
+  ghost: 'hover:bg-accent hover:text-accent-foreground',
+  link: 'text-primary underline-offset-4 hover:underline',
+};
+
+const sizeStyles: Record<NonNullable<ButtonProps['size']>, string> = {
+  default: 'h-10 px-4 py-2',
+  sm: 'h-9 rounded-md px-3',
+  lg: 'h-11 rounded-md px-8',
+  icon: 'h-10 w-10',
+};
+
 /**
  * Button component for user interactions.
  *
@@ -29,15 +45,32 @@ export interface ButtonProps extends React.ComponentPropsWithoutRef<'button'> {
  */
 export const Button = ({
   children,
-  variant: _variant,
-  size: _size,
+  variant = 'default',
+  size = 'default',
   className,
   ...props
 }: ButtonProps) => {
   return (
-    <button className={cn(className)} {...props}>
+    <button
+      className={cn(
+        'inline-flex items-center justify-center whitespace-nowrap rounded-md font-medium text-sm ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+        variantStyles[variant],
+        sizeStyles[size],
+        className
+      )}
+      {...props}
+    >
       {children}
     </button>
   );
 };
-export const buttonVariants = () => '';
+
+export const buttonVariants = (
+  variant: ButtonProps['variant'] = 'default',
+  size: ButtonProps['size'] = 'default'
+) =>
+  cn(
+    'inline-flex items-center justify-center whitespace-nowrap rounded-md font-medium text-sm ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+    variantStyles[variant],
+    sizeStyles[size]
+  );

--- a/apps/web/src/hooks/usePerpHistory.ts
+++ b/apps/web/src/hooks/usePerpHistory.ts
@@ -2,7 +2,10 @@ import { logger } from '@babylon/shared';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useMarketPrices } from '@/hooks/useMarketPrices';
-import { usePerpMarketStream } from '@/hooks/usePerpMarketStream';
+import {
+  type PerpTradeSSE,
+  usePerpMarketStream,
+} from '@/hooks/usePerpMarketStream';
 
 /**
  * Represents a single point in perpetual market price history.
@@ -374,7 +377,7 @@ export function usePerpHistory(
   // (e.g., when price change is too small to trigger a broadcast)
   usePerpMarketStream(ticker, {
     onTrade: useCallback(
-      (event) => {
+      (event: PerpTradeSSE) => {
         // Use exitPrice for close events, entryPrice for open events
         const tradePrice = event.exitPrice ?? event.entryPrice;
         if (tradePrice && Number.isFinite(tradePrice) && tradePrice > 0) {

--- a/packages/agents/src/autonomous/AutonomousBatchResponseService.ts
+++ b/packages/agents/src/autonomous/AutonomousBatchResponseService.ts
@@ -985,21 +985,21 @@ LEAVE EMPTY IF:
 
             // Log skipped interaction if there was reasoning
             if (thought) {
-               agentService
-              .createLog(agentUserId, {
-                type: 'system',
-                level: 'debug',
-                message: `Skipped automated response to ${interaction.type}`,
-                prompt: currentPrompt,
-                completion: responseContent,
-                thinking: thought,
-                metadata: {
-                  interactionId: interaction.id,
-                  interactionType: interaction.type,
-                  skipped: true
-                },
-              })
-              .catch(() => {});
+              agentService
+                .createLog(agentUserId, {
+                  type: 'system',
+                  level: 'debug',
+                  message: `Skipped automated response to ${interaction.type}`,
+                  prompt: currentPrompt,
+                  completion: responseContent,
+                  thinking: thought,
+                  metadata: {
+                    interactionId: interaction.id,
+                    interactionType: interaction.type,
+                    skipped: true,
+                  },
+                })
+                .catch(() => {});
             }
 
             cleanContent = null; // Mark as skipped

--- a/packages/agents/src/autonomous/AutonomousTradingService.ts
+++ b/packages/agents/src/autonomous/AutonomousTradingService.ts
@@ -155,7 +155,10 @@ export class AutonomousTradingService {
     const suggestedTradeSize =
       balance.balance > 0
         ? Math.min(
-            Math.max(balance.balance * SUGGESTED_TRADE_PERCENT, MIN_SUGGESTED_TRADE_SIZE),
+            Math.max(
+              balance.balance * SUGGESTED_TRADE_PERCENT,
+              MIN_SUGGESTED_TRADE_SIZE
+            ),
             balance.balance
           )
         : 0;
@@ -291,8 +294,7 @@ If holding:
     }
 
     const trade = tradeDecision.trade;
-    const rawAmount =
-      trade.amount_in_points ?? trade.amount;
+    const rawAmount = trade.amount_in_points ?? trade.amount;
     const normalizedAmount =
       typeof rawAmount === 'string' ? Number(rawAmount) : rawAmount;
 

--- a/packages/db/drizzle/migrations/0017_add_question_resolution_review.sql
+++ b/packages/db/drizzle/migrations/0017_add_question_resolution_review.sql
@@ -1,0 +1,9 @@
+ALTER TABLE "Question" ADD COLUMN "resolutionConfidence" double precision;
+ALTER TABLE "Question" ADD COLUMN "requiresManualReview" boolean NOT NULL DEFAULT false;
+ALTER TABLE "Question" ADD COLUMN "resolutionReviewStatus" text;
+ALTER TABLE "Question" ADD COLUMN "resolutionReviewedAt" timestamp;
+ALTER TABLE "Question" ADD COLUMN "resolutionReviewedBy" text;
+
+CREATE INDEX IF NOT EXISTS "Question_requiresManualReview_status_idx"
+ON "Question" ("requiresManualReview", "resolutionReviewStatus", "status");
+

--- a/packages/db/drizzle/migrations/0017_add_question_resolution_review.sql
+++ b/packages/db/drizzle/migrations/0017_add_question_resolution_review.sql
@@ -5,5 +5,5 @@ ALTER TABLE "Question" ADD COLUMN "resolutionReviewedAt" timestamp;
 ALTER TABLE "Question" ADD COLUMN "resolutionReviewedBy" text;
 
 CREATE INDEX IF NOT EXISTS "Question_requiresManualReview_status_idx"
-ON "Question" ("requiresManualReview", "resolutionReviewStatus", "status");
+ON "Question" ("status", "requiresManualReview", "resolutionReviewStatus");
 

--- a/packages/db/drizzle/migrations/0017_add_question_resolution_review.sql
+++ b/packages/db/drizzle/migrations/0017_add_question_resolution_review.sql
@@ -4,6 +4,10 @@ ALTER TABLE "Question" ADD COLUMN "resolutionReviewStatus" text;
 ALTER TABLE "Question" ADD COLUMN "resolutionReviewedAt" timestamp;
 ALTER TABLE "Question" ADD COLUMN "resolutionReviewedBy" text;
 
+-- Composite index optimized for admin resolution queue query:
+-- SELECT ... WHERE status = 'active' AND requiresManualReview = true
+--   AND (resolutionReviewStatus IS NULL OR resolutionReviewStatus = 'pending')
+-- Column order matches query filter selectivity: status (most selective) first
 CREATE INDEX IF NOT EXISTS "Question_requiresManualReview_status_idx"
 ON "Question" ("status", "requiresManualReview", "resolutionReviewStatus");
 

--- a/packages/db/drizzle/migrations/0017_rollback_add_question_resolution_review.sql
+++ b/packages/db/drizzle/migrations/0017_rollback_add_question_resolution_review.sql
@@ -1,0 +1,8 @@
+DROP INDEX IF EXISTS "Question_requiresManualReview_status_idx";
+
+ALTER TABLE "Question" DROP COLUMN IF EXISTS "resolutionReviewedBy";
+ALTER TABLE "Question" DROP COLUMN IF EXISTS "resolutionReviewedAt";
+ALTER TABLE "Question" DROP COLUMN IF EXISTS "resolutionReviewStatus";
+ALTER TABLE "Question" DROP COLUMN IF EXISTS "requiresManualReview";
+ALTER TABLE "Question" DROP COLUMN IF EXISTS "resolutionConfidence";
+

--- a/packages/db/src/schema/markets.ts
+++ b/packages/db/src/schema/markets.ts
@@ -93,6 +93,11 @@ export const questions = pgTable(
       table.status,
       table.resolutionDate
     ),
+    index('Question_requiresManualReview_status_idx').on(
+      table.requiresManualReview,
+      table.resolutionReviewStatus,
+      table.status
+    ),
   ]
 );
 

--- a/packages/db/src/schema/markets.ts
+++ b/packages/db/src/schema/markets.ts
@@ -94,9 +94,9 @@ export const questions = pgTable(
       table.resolutionDate
     ),
     index('Question_requiresManualReview_status_idx').on(
+      table.status,
       table.requiresManualReview,
-      table.resolutionReviewStatus,
-      table.status
+      table.resolutionReviewStatus
     ),
   ]
 );

--- a/packages/db/src/schema/markets.ts
+++ b/packages/db/src/schema/markets.ts
@@ -77,6 +77,13 @@ export const questions = pgTable(
     oracleSessionId: text('oracleSessionId').unique(),
     resolutionProofUrl: text('resolutionProofUrl'),
     resolutionDescription: text('resolutionDescription'),
+    resolutionConfidence: doublePrecision('resolutionConfidence'),
+    requiresManualReview: boolean('requiresManualReview')
+      .notNull()
+      .default(false),
+    resolutionReviewStatus: text('resolutionReviewStatus'),
+    resolutionReviewedAt: timestamp('resolutionReviewedAt', { mode: 'date' }),
+    resolutionReviewedBy: text('resolutionReviewedBy'),
   },
   (table) => [
     index('Question_createdDate_idx').on(table.createdDate),

--- a/packages/engine/src/QuestionManager.ts
+++ b/packages/engine/src/QuestionManager.ts
@@ -131,6 +131,25 @@ export interface QuestionCreationParams {
 }
 
 /**
+ * Resolution with proof and confidence assessment
+ *
+ * Returned by generateResolutionWithProof containing the resolution description,
+ * optional proof article, and confidence metrics for manual review flagging.
+ */
+export interface ResolutionWithProof {
+  /** Natural language description of why/how the question resolved */
+  description: string;
+  /** Optional proof article with URL */
+  proof?: { type: 'article'; article: Article; url: string };
+  /** Confidence score (0-1) based on speculative signal detection */
+  confidence: number;
+  /** Whether this resolution requires manual admin review */
+  requiresManualReview: boolean;
+  /** Detected speculative signals that reduced confidence */
+  confidenceSignals: string[];
+}
+
+/**
  * Question Manager - Handles question lifecycle
  *
  * @class QuestionManager
@@ -563,13 +582,7 @@ ${s.involvedOrganizations?.length ? `Organizations: ${s.involvedOrganizations.jo
     actors: SelectedActor[],
     organizations: Organization[],
     recentEvents: DayTimeline[]
-  ): Promise<{
-    description: string;
-    proof?: { type: 'article'; article: Article; url: string };
-    confidence: number;
-    requiresManualReview: boolean;
-    confidenceSignals: string[];
-  }> {
+  ): Promise<ResolutionWithProof> {
     const description = await this.generateResolutionEvent(
       question,
       actors,

--- a/packages/engine/src/QuestionManager.ts
+++ b/packages/engine/src/QuestionManager.ts
@@ -636,6 +636,7 @@ ${s.involvedOrganizations?.length ? `Organizations: ${s.involvedOrganizations.jo
     const signals: string[] = [];
 
     // Speculative signals with weights (higher = more speculative)
+    // Patterns are designed to minimize false positives from common phrases
     const speculativeSignals: Array<[RegExp, string, number]> = [
       // High-weight: strong speculation indicators
       [/\brumou?r(s|ed)?\b/i, 'rumor', 0.25],
@@ -645,11 +646,13 @@ ${s.involvedOrganizations?.length ? `Organizations: ${s.involvedOrganizations.jo
       // Medium-weight: conditional language (stricter patterns to avoid false positives)
       [/\b(might|could)\s+(be|have|become|lead|cause)\b/i, 'conditional', 0.15],
       [/\bexpected\s+to\b/i, 'expected_to', 0.15],
-      [/\blikely\s+(to|that)\b/i, 'likely', 0.12],
+      // More specific: "likely to be/happen" vs "the likely winner" (definitive)
+      [/\blikely\s+to\s+(be|happen|occur|result)\b/i, 'likely', 0.12],
       // Low-weight: common but still speculative
       [/\breportedly\b/i, 'reportedly', 0.1],
       [/\bpossibly\b/i, 'possibly', 0.1],
-      [/\bapparently\b/i, 'apparently', 0.08],
+      // More specific: "apparently uncertain" vs "apparently successful" (confirming)
+      [/\bapparently\s+(not|uncertain|unclear|unconfirmed)\b/i, 'apparently', 0.08],
     ];
 
     let totalWeight = 0;

--- a/packages/engine/src/QuestionManager.ts
+++ b/packages/engine/src/QuestionManager.ts
@@ -73,7 +73,11 @@ import {
   trendingTags,
   worldEvents,
 } from '@babylon/db';
-import { generateSnowflakeId, logger } from '@babylon/shared';
+import {
+  generateSnowflakeId,
+  logger,
+  RESOLUTION_CONFIDENCE_CONFIG,
+} from '@babylon/shared';
 import { type Article, ArticleGenerator } from './ArticleGenerator';
 import type { BabylonLLMClient } from './llm/openai-client';
 import { BabylonLLMClient as BabylonLLMClientValue } from './llm/openai-client';
@@ -632,9 +636,10 @@ ${s.involvedOrganizations?.length ? `Organizations: ${s.involvedOrganizations.jo
       }
     }
 
-    // Graduated confidence: start at 0.95, subtract accumulated weight, floor at 0.2
-    const confidence = Math.max(0.2, 0.95 - totalWeight);
-    const MANUAL_REVIEW_THRESHOLD = 0.7;
+    // Graduated confidence: start at base, subtract accumulated weight, floor at min
+    const { BASE_CONFIDENCE, MIN_CONFIDENCE, MANUAL_REVIEW_THRESHOLD } =
+      RESOLUTION_CONFIDENCE_CONFIG;
+    const confidence = Math.max(MIN_CONFIDENCE, BASE_CONFIDENCE - totalWeight);
 
     return {
       confidence,

--- a/packages/engine/src/QuestionManager.ts
+++ b/packages/engine/src/QuestionManager.ts
@@ -593,6 +593,17 @@ ${s.involvedOrganizations?.length ? `Organizations: ${s.involvedOrganizations.jo
       .filter((s): s is string => typeof s === 'string' && s.trim().length > 0)
       .join('\n');
 
+    // Guard: empty evidence should always trigger manual review
+    if (!evidenceText.trim()) {
+      return {
+        description,
+        proof: proof || undefined,
+        confidence: RESOLUTION_CONFIDENCE_CONFIG.MIN_CONFIDENCE,
+        requiresManualReview: true,
+        confidenceSignals: ['no_evidence'],
+      };
+    }
+
     const assessment = this.assessResolutionConfidence(evidenceText);
 
     return {

--- a/packages/engine/src/QuestionManager.ts
+++ b/packages/engine/src/QuestionManager.ts
@@ -562,6 +562,9 @@ ${s.involvedOrganizations?.length ? `Organizations: ${s.involvedOrganizations.jo
   ): Promise<{
     description: string;
     proof?: { type: 'article'; article: Article; url: string };
+    confidence: number;
+    requiresManualReview: boolean;
+    confidenceSignals: string[];
   }> {
     const description = await this.generateResolutionEvent(
       question,
@@ -578,7 +581,59 @@ ${s.involvedOrganizations?.length ? `Organizations: ${s.involvedOrganizations.jo
       organizations
     );
 
-    return { description, proof: proof || undefined };
+    const evidenceText = [
+      description,
+      proof?.type === 'article' ? proof.article.title : null,
+      proof?.type === 'article' ? proof.article.summary : null,
+    ]
+      .filter((s): s is string => typeof s === 'string' && s.trim().length > 0)
+      .join('\n');
+
+    const assessment = this.assessResolutionConfidence(evidenceText);
+
+    return {
+      description,
+      proof: proof || undefined,
+      confidence: assessment.confidence,
+      requiresManualReview: assessment.requiresManualReview,
+      confidenceSignals: assessment.signals,
+    };
+  }
+
+  private assessResolutionConfidence(text: string): {
+    confidence: number;
+    requiresManualReview: boolean;
+    signals: string[];
+  } {
+    const signals: string[] = [];
+    const lower = text.toLowerCase();
+
+    const speculativeSignals: Array<[RegExp, string]> = [
+      [/\brumou?r(s|ed)?\b/i, 'rumor'],
+      [/\balleged(ly)?\b/i, 'alleged'],
+      [/\breported(ly)?\b/i, 'reported'],
+      [/\bsources?\s+say\b/i, 'sources_say'],
+      [/\bmay\b/i, 'may'],
+      [/\bmight\b/i, 'might'],
+      [/\bcould\b/i, 'could'],
+      [/\bexpected\s+to\b/i, 'expected_to'],
+      [/\blikely\b/i, 'likely'],
+      [/\bunconfirmed\b/i, 'unconfirmed'],
+    ];
+
+    for (const [regex, label] of speculativeSignals) {
+      if (regex.test(lower)) {
+        signals.push(label);
+      }
+    }
+
+    // Default to high confidence; downgrade when evidence looks speculative.
+    const confidence = signals.length > 0 ? 0.35 : 0.9;
+    return {
+      confidence,
+      requiresManualReview: confidence < 0.7,
+      signals,
+    };
   }
 
   /**

--- a/packages/engine/src/QuestionManager.ts
+++ b/packages/engine/src/QuestionManager.ts
@@ -606,32 +606,39 @@ ${s.involvedOrganizations?.length ? `Organizations: ${s.involvedOrganizations.jo
     signals: string[];
   } {
     const signals: string[] = [];
-    const lower = text.toLowerCase();
 
-    const speculativeSignals: Array<[RegExp, string]> = [
-      [/\brumou?r(s|ed)?\b/i, 'rumor'],
-      [/\balleged(ly)?\b/i, 'alleged'],
-      [/\breported(ly)?\b/i, 'reported'],
-      [/\bsources?\s+say\b/i, 'sources_say'],
-      [/\bmay\b/i, 'may'],
-      [/\bmight\b/i, 'might'],
-      [/\bcould\b/i, 'could'],
-      [/\bexpected\s+to\b/i, 'expected_to'],
-      [/\blikely\b/i, 'likely'],
-      [/\bunconfirmed\b/i, 'unconfirmed'],
+    // Speculative signals with weights (higher = more speculative)
+    const speculativeSignals: Array<[RegExp, string, number]> = [
+      // High-weight: strong speculation indicators
+      [/\brumou?r(s|ed)?\b/i, 'rumor', 0.25],
+      [/\bunconfirmed\b/i, 'unconfirmed', 0.25],
+      [/\balleged(ly)?\b/i, 'alleged', 0.2],
+      [/\bsources?\s+(say|claim|suggest)\b/i, 'sources_say', 0.2],
+      // Medium-weight: conditional language (stricter patterns to avoid false positives)
+      [/\b(might|could)\s+(be|have|become|lead|cause)\b/i, 'conditional', 0.15],
+      [/\bexpected\s+to\b/i, 'expected_to', 0.15],
+      [/\blikely\s+(to|that)\b/i, 'likely', 0.12],
+      // Low-weight: common but still speculative
+      [/\breportedly\b/i, 'reportedly', 0.1],
+      [/\bpossibly\b/i, 'possibly', 0.1],
+      [/\bapparently\b/i, 'apparently', 0.08],
     ];
 
-    for (const [regex, label] of speculativeSignals) {
-      if (regex.test(lower)) {
+    let totalWeight = 0;
+    for (const [regex, label, weight] of speculativeSignals) {
+      if (regex.test(text)) {
         signals.push(label);
+        totalWeight += weight;
       }
     }
 
-    // Default to high confidence; downgrade when evidence looks speculative.
-    const confidence = signals.length > 0 ? 0.35 : 0.9;
+    // Graduated confidence: start at 0.95, subtract accumulated weight, floor at 0.2
+    const confidence = Math.max(0.2, 0.95 - totalWeight);
+    const MANUAL_REVIEW_THRESHOLD = 0.7;
+
     return {
       confidence,
-      requiresManualReview: confidence < 0.7,
+      requiresManualReview: confidence < MANUAL_REVIEW_THRESHOLD,
       signals,
     };
   }

--- a/packages/engine/src/game-tick.ts
+++ b/packages/engine/src/game-tick.ts
@@ -422,12 +422,34 @@ export async function executeGameTick(
     ];
 
     const questionManager = new QuestionManager(llmClient);
+    const questionsToReveal: Array<{ id: string; outcome: boolean }> = [];
 
     // Resolve payouts
     // Each question resolution is wrapped in try/catch to prevent partial failures
     // from breaking the entire tick. Failed resolutions will be retried next tick.
     for (const question of questionsToResolve) {
       try {
+        const isApproved = question.resolutionReviewStatus === 'approved';
+        const isPendingManualReview =
+          question.requiresManualReview && !isApproved;
+        const hasStoredProof =
+          Boolean(question.resolutionProofUrl) &&
+          Boolean(question.resolutionDescription);
+
+        if (isPendingManualReview && hasStoredProof) {
+          logger.info(
+            'Skipping question resolution (pending manual review)',
+            {
+              questionId: question.id,
+              questionNumber: question.questionNumber,
+              confidence: question.resolutionConfidence ?? null,
+              reviewStatus: question.resolutionReviewStatus ?? 'pending',
+            },
+            'GameTick'
+          );
+          continue;
+        }
+
         // Generate resolution proof content
         // We cast question to Question type - database question fields are compatible
         const questionForManager: Question = {
@@ -439,58 +461,104 @@ export async function executeGameTick(
           status: 'active',
         };
 
-        const { description, proof } =
-          await questionManager.generateResolutionWithProof(
+        const shouldGenerateProof =
+          !hasStoredProof ||
+          question.resolutionConfidence === null ||
+          question.resolutionConfidence === undefined;
+
+        let generatedProof: Awaited<
+          ReturnType<QuestionManager['generateResolutionWithProof']>
+        > | null = null;
+
+        if (shouldGenerateProof) {
+          const proofResult = await questionManager.generateResolutionWithProof(
             questionForManager,
             allActors,
             organizations,
             recentTimelines
           );
 
-        // Save proof article and update question atomically if proof exists
-        if (proof && proof.type === 'article') {
-          await db.transaction(async (tx) => {
-            // Create article in database
-            await tx.insert(posts).values({
-              id: proof.article.id,
-              type: 'article',
-              content: proof.article.summary, // Use summary for content preview
-              fullContent: proof.article.content,
-              articleTitle: proof.article.title,
-              authorId: proof.article.authorOrgId,
-              gameId: 'continuous',
-              timestamp: new Date(),
-              category: proof.article.category,
-              sentiment: proof.article.sentiment,
-              slant: proof.article.slant,
-              biasScore: proof.article.biasScore,
-            });
+          generatedProof = proofResult;
 
-            // Update question with proof URL
+          const reviewStatus = proofResult.requiresManualReview
+            ? 'pending'
+            : null;
+
+          // Save proof article (if any) and update question atomically.
+          await db.transaction(async (tx) => {
+            if (proofResult.proof?.type === 'article') {
+              await tx.insert(posts).values({
+                id: proofResult.proof.article.id,
+                type: 'article',
+                content: proofResult.proof.article.summary,
+                fullContent: proofResult.proof.article.content,
+                articleTitle: proofResult.proof.article.title,
+                authorId: proofResult.proof.article.authorOrgId,
+                gameId: 'continuous',
+                timestamp: new Date(),
+                category: proofResult.proof.article.category,
+                sentiment: proofResult.proof.article.sentiment,
+                slant: proofResult.proof.article.slant,
+                biasScore: proofResult.proof.article.biasScore,
+              });
+            }
+
             await tx
               .update(questionsSchema)
               .set({
-                resolutionDescription: description,
-                resolutionProofUrl: proof.url,
+                resolutionDescription: proofResult.description,
+                resolutionProofUrl: proofResult.proof?.url ?? null,
+                resolutionConfidence: proofResult.confidence,
+                requiresManualReview: proofResult.requiresManualReview,
+                resolutionReviewStatus: reviewStatus,
                 updatedAt: new Date(),
               })
               .where(eq(questionsSchema.id, question.id));
           });
 
-          logger.info(
-            `Generated resolution proof for Q${question.questionNumber}`,
+          if (proofResult.proof?.type === 'article') {
+            logger.info(
+              `Generated resolution proof for Q${question.questionNumber}`,
+              {
+                proofUrl: proofResult.proof.url,
+                articleId: proofResult.proof.article.id,
+                confidence: proofResult.confidence,
+                requiresManualReview: proofResult.requiresManualReview,
+                confidenceSignals: proofResult.confidenceSignals,
+              },
+              'GameTick'
+            );
+          }
+        }
+
+        const requiresManualReview =
+          generatedProof?.requiresManualReview ?? question.requiresManualReview;
+        const reviewStatus =
+          generatedProof?.requiresManualReview === true
+            ? 'pending'
+            : question.resolutionReviewStatus;
+
+        // If low-confidence, queue for manual review instead of resolving now.
+        if (requiresManualReview && reviewStatus !== 'approved') {
+          logger.warn(
+            'Queued question for manual resolution review',
             {
-              proofUrl: proof.url,
-              articleId: proof.article.id,
+              questionId: question.id,
+              questionNumber: question.questionNumber,
+              confidence:
+                generatedProof?.confidence ?? question.resolutionConfidence,
+              reviewStatus: reviewStatus ?? 'pending',
             },
             'GameTick'
           );
+          continue;
         }
 
         // resolveQuestionPayouts has its own internal transaction for payout operations
         // and updates question status to 'resolved' atomically
         await resolveQuestionPayouts(question.questionNumber);
         result.questionsResolved++;
+        questionsToReveal.push({ id: question.id, outcome: question.outcome });
       } catch (error) {
         // Log error but continue with other questions
         // Failed question will remain in 'active' status and be retried next tick
@@ -507,7 +575,7 @@ export async function executeGameTick(
     }
 
     // Publish reveals to blockchain oracle
-    const oracleResult = await publishOracleReveals(questionsToResolve);
+    const oracleResult = await publishOracleReveals(questionsToReveal);
     result.oracleReveals += oracleResult.revealed;
     result.oracleErrors += oracleResult.errors;
   }

--- a/packages/engine/src/game-tick.ts
+++ b/packages/engine/src/game-tick.ts
@@ -461,10 +461,9 @@ export async function executeGameTick(
           status: 'active',
         };
 
-        const shouldGenerateProof =
-          !hasStoredProof ||
-          question.resolutionConfidence === null ||
-          question.resolutionConfidence === undefined;
+        // Only generate proof if we don't have one stored
+        // Avoids regenerating existing proofs when only confidence is missing
+        const shouldGenerateProof = !hasStoredProof;
 
         let generatedProof: Awaited<
           ReturnType<QuestionManager['generateResolutionWithProof']>

--- a/packages/shared/src/constants/markets.ts
+++ b/packages/shared/src/constants/markets.ts
@@ -60,8 +60,13 @@ export const PERP_MARKET_CONFIG = {
 
 /**
  * Type for the perp market configuration.
+ * Uses widened number types to allow overrides in tests.
  */
-export type PerpMarketConfig = typeof PERP_MARKET_CONFIG;
+export type PerpMarketConfig = {
+  [K in keyof typeof PERP_MARKET_CONFIG]: (typeof PERP_MARKET_CONFIG)[K] extends number
+    ? number
+    : (typeof PERP_MARKET_CONFIG)[K];
+};
 
 /**
  * Calculates the effective supply based on liquidity factor.

--- a/packages/shared/src/constants/markets.ts
+++ b/packages/shared/src/constants/markets.ts
@@ -6,6 +6,29 @@
  */
 
 /**
+ * Resolution Confidence Configuration
+ *
+ * Thresholds for the manual resolution review system.
+ */
+export const RESOLUTION_CONFIDENCE_CONFIG = {
+  /**
+   * Confidence threshold below which resolutions require manual review.
+   * Resolutions with confidence < this value are flagged for admin approval.
+   */
+  MANUAL_REVIEW_THRESHOLD: 0.7,
+
+  /**
+   * Base confidence score when no speculative signals are detected.
+   */
+  BASE_CONFIDENCE: 0.95,
+
+  /**
+   * Minimum confidence score (floor).
+   */
+  MIN_CONFIDENCE: 0.2,
+} as const;
+
+/**
  * vAMM (Virtual Automated Market Maker) configuration for perp markets.
  *
  * The effective supply determines price sensitivity:

--- a/packages/shared/src/utils/format.ts
+++ b/packages/shared/src/utils/format.ts
@@ -74,6 +74,36 @@ export function formatTime(date: Date | string): string {
 }
 
 /**
+ * Format date/timestamp to readable date and time string
+ *
+ * Supports both Date objects and ISO timestamp strings.
+ * Returns the original string on parse failure for graceful degradation.
+ *
+ * @param date - Date object or ISO timestamp string
+ * @returns Formatted date-time string (e.g., "Jan 16, 3:45 PM")
+ *
+ * @example
+ * ```typescript
+ * formatDateTime(new Date()); // "Jan 16, 3:45 PM"
+ * formatDateTime("2025-01-16T15:45:00Z"); // "Jan 16, 3:45 PM"
+ * formatDateTime("invalid"); // "invalid"
+ * ```
+ */
+export function formatDateTime(date: Date | string): string {
+  try {
+    const d = typeof date === 'string' ? new Date(date) : date;
+    return new Intl.DateTimeFormat('en-US', {
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+    }).format(d);
+  } catch {
+    return typeof date === 'string' ? date : String(date);
+  }
+}
+
+/**
  * Calculate sentiment score from text (simple heuristic)
  *
  * Uses keyword matching to determine sentiment. Returns value between


### PR DESCRIPTION
## Summary
- Adds a resolution confidence score and a manual review queue to prevent premature market resolutions from speculative sources.
- Stores confidence + review metadata on `Question` and blocks auto-resolution until approved.
- Provides an admin review API + UI to approve/reject low-confidence resolutions.

## Type
- [x] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Linear: https://linear.app/eliza-labs/issue/BAB-118/add-resolution-confidence-score-and-manual-review-queue

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [x] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- DB: add `Question.resolutionConfidence`, `requiresManualReview`, `resolutionReviewStatus`, `resolutionReviewedAt`, `resolutionReviewedBy` + migrations.
- Engine: generate resolution proof + confidence, mark low-confidence resolutions as `pending` manual review, and skip auto-resolve until approved.
- Web: add admin endpoints and `/admin/resolutions` UI to approve/reject.

## Review guide
**Start here**
- `packages/engine/src/game-tick.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- Reject action clears stored proof/confidence and postpones `resolutionDate` to avoid immediate retry loops.

## Test plan
**Commands run**
- [ ] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [x] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Let a question reach resolution time with speculative proof → verify it enters the manual review queue and does not resolve.
2. Approve in `/admin/resolutions` → verify it resolves on the next tick.

## Ops / Migration / Deployment
- [ ] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [x] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**DB / data migration**
- Migration(s): `packages/db/drizzle/migrations/0017_add_question_resolution_review.sql`

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy
- [ ] No security impact
- [x] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### Database
- Adds columns to `Question` used by the resolution pipeline.

</details>

## Screenshots / recordings (UI)

### Option A: Visual demo

| Feature | Before | After |
|---------|--------|-------|
| Admin resolution review queue | N/A | `/admin/resolutions` shows pending items with approve/reject |

*Demo script (for recording):*
1. Open `/admin/resolutions`.
2. Approve a pending item.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin resolution review UI: queue listing, refresh, pending badge, loading/empty states, per-item approve/reject with inline feedback and toasts.
  * Admin review APIs to fetch queue and submit approve/reject actions (reject can postpone resolution).

* **Automations**
  * Automated resolution generation with confidence scoring, signals for manual review, and orchestration to defer payout until review completes.

* **Database**
  * Added columns and index to track confidence, manual-review flags, review status, reviewer, and timestamps.

* **UX**
  * Improved button styling and added combined date/time formatting utility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR introduces a manual resolution review system to prevent premature market resolutions from low-confidence sources. When the engine generates resolution proof, it analyzes the text for speculative language (rumor, alleged, may, might, etc.) and assigns a confidence score. Resolutions below 0.7 confidence are flagged for manual review and blocked from auto-resolving until an admin approves them via `/admin/resolutions`.

**Key changes:**
- DB: added 5 new columns (`resolutionConfidence`, `requiresManualReview`, `resolutionReviewStatus`, `resolutionReviewedAt`, `resolutionReviewedBy`) with migration
- Engine: `QuestionManager.assessResolutionConfidence()` scans for 10 speculative patterns and returns confidence + signals
- Engine: `game-tick.ts` checks review status and skips resolution for pending items, stores metadata in transaction
- Web: admin API endpoints (GET list, POST approve/reject) and React UI for review queue
- Reject action clears stored proof/confidence and postpones `resolutionDate` by 24h to avoid retry loops

**Issues found:**
- Missing index definition in `packages/db/src/schema/markets.ts` - migration creates `Question_requiresManualReview_status_idx` but schema doesn't declare it

<h3>Confidence Score: 4/5</h3>


- Safe to merge after fixing schema/migration index mismatch
- Implementation is solid with proper transaction handling and retry prevention, but the schema-migration mismatch could cause issues with Drizzle ORM's schema validation or future migrations
- Fix `packages/db/src/schema/markets.ts` to add the missing composite index before deploying

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/db/src/schema/markets.ts | adds 5 new columns to questions table but missing index definition from migration |
| packages/engine/src/QuestionManager.ts | adds `assessResolutionConfidence` and `generateResolutionWithProof` methods; clean implementation |
| packages/engine/src/game-tick.ts | integrates manual review queue logic; skips pending resolutions and stores confidence metadata |
| apps/web/src/app/api/admin/resolutions/[id]/route.ts | POST endpoint handles approve/reject actions; reject clears metadata and postpones 24h |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GT as GameTick
    participant QM as QuestionManager
    participant DB as Database
    participant Admin as Admin UI
    participant API as Admin API

    Note over GT,DB: Question Resolution Flow with Manual Review

    GT->>DB: Query questions ready to resolve
    DB-->>GT: Return questions to resolve
    
    GT->>GT: Check if requiresManualReview && !approved
    alt Already has proof and pending review
        GT->>GT: Skip resolution (log + continue)
    else Needs proof generation
        GT->>QM: generateResolutionWithProof()
        QM->>QM: generateResolutionEvent()
        QM->>QM: generateProofContent() (creates Article)
        QM->>QM: assessResolutionConfidence(text)
        Note over QM: Check speculative signals:<br/>rumor, alleged, may, might, etc.
        QM-->>GT: Return {description, proof, confidence, requiresManualReview}
        
        GT->>DB: Save proof + metadata (transaction)
        Note over DB: Store resolutionDescription,<br/>resolutionProofUrl,<br/>resolutionConfidence,<br/>requiresManualReview,<br/>resolutionReviewStatus
    end
    
    alt Low confidence (< 0.7)
        GT->>GT: Queue for manual review (skip resolution)
        Note over GT: Question remains active
    else High confidence OR approved
        GT->>DB: Resolve question
        GT->>DB: Settle positions
        Note over GT,DB: Market resolves normally
    end

    Note over Admin,API: Manual Review Process

    Admin->>API: GET /api/admin/resolutions
    API->>DB: Query requiresManualReview=true, status=pending
    DB-->>API: Return pending resolutions
    API-->>Admin: Display review queue

    Admin->>Admin: Review proof + confidence
    alt Approve
        Admin->>API: POST /api/admin/resolutions/{id} {action: approve}
        API->>DB: Set resolutionReviewStatus=approved
        Note over DB: Next tick will resolve
    else Reject
        Admin->>API: POST /api/admin/resolutions/{id} {action: reject}
        API->>DB: Clear proof metadata<br/>Set requiresManualReview=false<br/>Postpone resolutionDate +24h
        Note over DB: Prevents immediate retry loop
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->