### PR TITLE
fix(BAB-119): align hot prediction % with AMM price

### DIFF
--- a/apps/web/src/app/api/markets/predictions/[id]/route.ts
+++ b/apps/web/src/app/api/markets/predictions/[id]/route.ts
@@ -103,9 +103,13 @@ export const GET = withErrorHandling(
 
     const yesShares = market.yesShares;
     const noShares = market.noShares;
-    const total = yesShares + noShares;
-    const yesProb = total > 0 ? yesShares / total : 0.5;
-    const noProb = total > 0 ? noShares / total : 0.5;
+    // Probability should reflect the CPMM price, not the raw share ratio.
+    const yesProb = PredictionPricing.getCurrentPrice(
+      yesShares,
+      noShares,
+      'yes'
+    );
+    const noProb = PredictionPricing.getCurrentPrice(yesShares, noShares, 'no');
 
     let userPositions: UserPositionSnapshot[] = [];
     let primaryPosition: UserPositionSnapshot | null = null;

--- a/apps/web/src/app/api/markets/predictions/route.ts
+++ b/apps/web/src/app/api/markets/predictions/route.ts
@@ -150,9 +150,13 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   const questionsData = markets.map((m) => {
     const yesShares = m.yesShares;
     const noShares = m.noShares;
-    const total = yesShares + noShares;
-    const yesProb = total > 0 ? yesShares / total : 0.5;
-    const noProb = total > 0 ? noShares / total : 0.5;
+    // Probability should reflect the CPMM price, not the raw share ratio.
+    const yesProb = PredictionPricing.getCurrentPrice(
+      yesShares,
+      noShares,
+      'yes'
+    );
+    const noProb = PredictionPricing.getCurrentPrice(yesShares, noShares, 'no');
     const userPositions = userPositionsMap.get(m.id) ?? [];
     const primaryPosition = userPositions[0] ?? null;
 

--- a/apps/web/src/app/markets/_lib/formatters.ts
+++ b/apps/web/src/app/markets/_lib/formatters.ts
@@ -2,6 +2,7 @@
  * Utility functions for formatting values in the Markets page.
  */
 
+import { PredictionPricing } from '@babylon/core/markets/prediction/client';
 import { BABYLON_POINTS_SYMBOL } from '@babylon/shared';
 
 /**
@@ -48,6 +49,10 @@ export function getDaysLeft(date?: string): number | null {
 /**
  * Calculates YES/NO percentages from share counts.
  *
+ * Note: In our CPMM-style YES/NO markets, the displayed "probability" should
+ * match the AMM price (not the raw share ratio). We therefore use
+ * `PredictionPricing.getCurrentPrice()` as the source of truth.
+ *
  * @param yesShares - Number of YES shares
  * @param noShares - Number of NO shares
  * @returns Object with yesPercent and noPercent
@@ -64,9 +69,12 @@ export function calculateSharePercentages(
     return { yesPercent: 50, noPercent: 50, totalShares: 0 };
   }
 
+  const yesPrice = PredictionPricing.getCurrentPrice(yes, no, 'yes');
+  const noPrice = PredictionPricing.getCurrentPrice(yes, no, 'no');
+
   return {
-    yesPercent: (yes / total) * 100,
-    noPercent: (no / total) * 100,
+    yesPercent: yesPrice * 100,
+    noPercent: noPrice * 100,
     totalShares: total,
   };
 }


### PR DESCRIPTION
## Summary
- Fixes inverted YES/NO percentages by aligning UI + API probabilities with CPMM pricing (`PredictionPricing.getCurrentPrice`).
- Ensures hot list and API endpoints return probabilities consistent with the market model and chart/SSE behavior.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Linear: https://linear.app/eliza-labs/issue/BAB-119/fix-hot-predictions-percentage-inversion-bug

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- Use CPMM price (`PredictionPricing.getCurrentPrice`) for probability/percent calculations in:
  - `apps/web/src/app/markets/_lib/formatters.ts`
  - `apps/web/src/app/api/markets/predictions/route.ts`
  - `apps/web/src/app/api/markets/predictions/[id]/route.ts`

## Review guide
**Start here**
- `apps/web/src/app/markets/_lib/formatters.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

## Test plan
**Commands run**
- [ ] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)

**Manual verification**
1. Compare “Hot Predictions” YES/NO percentages against the market page for the same question.

## Ops / Migration / Deployment
- [x] No deploy impact

## Breaking changes
- [x] None

## Security / privacy
- [x] No security impact

## Screenshots / recordings (UI)

### Option B: No visual changes
- Reason: UI values change, but no visual layout/styling changes.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated prediction probability calculations to use market pricing model instead of raw share ratios for more accurate probability display across all prediction markets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed inverted YES/NO probability calculations by replacing raw share ratios with CPMM pricing model (`PredictionPricing.getCurrentPrice()`). This ensures UI displays and API responses match the actual market price model used for trading.

**Key Changes:**
- Updated `calculateSharePercentages()` in `formatters.ts` to use CPMM price calculation
- Fixed probability calculations in both `/api/markets/predictions` endpoints
- Added clear documentation explaining CPMM pricing vs raw share ratios

**Issue Found:**
- `apps/web/src/app/api/feed/widgets/markets/route.ts` still uses the old inverted calculation (lines 157-158 and 303-304) and needs the same fix applied

<h3>Confidence Score: 4/5</h3>


- Safe to merge after fixing the widgets API endpoint that still has inverted probabilities
- The fix correctly addresses the probability inversion bug in the hot predictions UI and main API endpoints by using the proper CPMM pricing model. However, the same bug exists in `/api/feed/widgets/markets/route.ts` which wasn't included in this PR scope, creating an inconsistency where widget markets will still show inverted probabilities.
- Pay close attention to `apps/web/src/app/api/feed/widgets/markets/route.ts` - it needs the same fix applied to maintain consistency

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/markets/_lib/formatters.ts | Replaced raw share ratio with CPMM price calculation using `PredictionPricing.getCurrentPrice()`, correctly aligning UI percentages with market pricing model |
| apps/web/src/app/api/markets/predictions/route.ts | Updated probability calculation to use CPMM pricing instead of raw share ratio, ensuring API returns consistent probabilities with the AMM model |
| apps/web/src/app/api/markets/predictions/[id]/route.ts | Applied CPMM price calculation for single market endpoint, maintaining consistency with list endpoint and market pricing model |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as Hot Predictions UI
    participant Formatter as formatters.ts
    participant API as /api/markets/predictions
    participant Pricing as PredictionPricing
    participant DB as Database

    Note over UI,DB: Before Fix: Raw Share Ratios (Inverted)
    
    UI->>Formatter: calculateSharePercentages(yesShares, noShares)
    Formatter->>Formatter: yesPercent = (yes/total)*100
    Formatter->>Formatter: noPercent = (no/total)*100
    Formatter-->>UI: { yesPercent, noPercent } ❌ Inverted
    
    UI->>API: GET /api/markets/predictions
    API->>DB: Fetch markets
    DB-->>API: yesShares, noShares
    API->>API: yesProb = yesShares/total
    API->>API: noProb = noShares/total
    API-->>UI: { yesProbability, noProbability } ❌ Inverted

    Note over UI,DB: After Fix: CPMM Price Model (Correct)
    
    UI->>Formatter: calculateSharePercentages(yesShares, noShares)
    Formatter->>Pricing: getCurrentPrice(yes, no, 'yes')
    Pricing-->>Formatter: noShares/total ✓
    Formatter->>Pricing: getCurrentPrice(yes, no, 'no')
    Pricing-->>Formatter: yesShares/total ✓
    Formatter-->>UI: { yesPercent, noPercent } ✓ Aligned with AMM
    
    UI->>API: GET /api/markets/predictions
    API->>DB: Fetch markets
    DB-->>API: yesShares, noShares
    API->>Pricing: getCurrentPrice(yesShares, noShares, 'yes')
    Pricing-->>API: noShares/total ✓
    API->>Pricing: getCurrentPrice(yesShares, noShares, 'no')
    Pricing-->>API: yesShares/total ✓
    API-->>UI: { yesProbability, noProbability } ✓ Aligned with AMM
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->