### PR TITLE
fix(BAB-120): add thousands separators to market numbers

### DIFF
--- a/apps/web/src/app/markets/_components/cards/PredictionMarketCard.tsx
+++ b/apps/web/src/app/markets/_components/cards/PredictionMarketCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { cn } from '@babylon/shared';
+import { cn, formatNumberWithSeparators } from '@babylon/shared';
 import { ArrowUpDown, Clock } from 'lucide-react';
 import { memo } from 'react';
 import type { PredictionMarketWithPosition } from '@/types/markets';
@@ -66,7 +66,7 @@ export const PredictionMarketCard = memo(function PredictionMarketCard({
             </div>
             <div className="flex items-center gap-1">
               <ArrowUpDown className="h-3 w-3" />
-              {totalShares > 0 ? totalShares.toFixed(0) : '0'}
+              {totalShares > 0 ? formatNumberWithSeparators(totalShares) : '0'}
             </div>
           </div>
           <div className="flex gap-2">
@@ -100,7 +100,12 @@ export const PredictionMarketCard = memo(function PredictionMarketCard({
               )}
             >
               {prediction.userPosition.unrealizedPnL >= 0 ? '+' : ''}$
-              {prediction.userPosition.unrealizedPnL.toFixed(2)}
+              {formatNumberWithSeparators(
+                prediction.userPosition.unrealizedPnL,
+                {
+                  decimals: 2,
+                }
+              )}
             </span>
           </div>
         )}

--- a/apps/web/src/app/markets/_components/cards/PredictionMarketCard.tsx
+++ b/apps/web/src/app/markets/_components/cards/PredictionMarketCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { cn, formatNumberWithSeparators } from '@babylon/shared';
+import { cn, formatCurrency, formatNumberWithSeparators } from '@babylon/shared';
 import { ArrowUpDown, Clock } from 'lucide-react';
 import { memo } from 'react';
 import type { PredictionMarketWithPosition } from '@/types/markets';
@@ -99,13 +99,10 @@ export const PredictionMarketCard = memo(function PredictionMarketCard({
                   : 'text-red-600'
               )}
             >
-              {prediction.userPosition.unrealizedPnL >= 0 ? '+' : ''}$
-              {formatNumberWithSeparators(
-                prediction.userPosition.unrealizedPnL,
-                {
-                  decimals: 2,
-                }
-              )}
+              {prediction.userPosition.unrealizedPnL >= 0 ? '+' : ''}
+              {formatCurrency(prediction.userPosition.unrealizedPnL, {
+                useThousandsSeparator: true,
+              })}
             </span>
           </div>
         )}

--- a/apps/web/src/app/markets/predictions/[id]/page.tsx
+++ b/apps/web/src/app/markets/predictions/[id]/page.tsx
@@ -499,9 +499,10 @@ export default function PredictionDetailPage() {
                   think it won&apos;t.
                 </p>
                 <p className="text-muted-foreground text-sm">
-                  If you&apos;re right, you&apos;ll receive {BABYLON_POINTS_SYMBOL}1 per share. The
-                  current price reflects the market&apos;s probability.
-                  current price reflects the market&apos;s probability.
+                  If you&apos;re right, you&apos;ll receive{' '}
+                  {BABYLON_POINTS_SYMBOL}1 per share. The current price reflects
+                  the market&apos;s probability. current price reflects the
+                  market&apos;s probability.
                 </p>
               </div>
             </div>

--- a/apps/web/src/components/markets/AssetTradesFeed.tsx
+++ b/apps/web/src/components/markets/AssetTradesFeed.tsx
@@ -352,7 +352,7 @@ export function AssetTradesFeed({
   /** Wrapper around shared formatCurrency to handle string input */
   const formatCurrency = (value: string | number) => {
     const num = typeof value === 'string' ? Number.parseFloat(value) : value;
-    return formatCurrencyShared(num);
+    return formatCurrencyShared(num, { useThousandsSeparator: true });
   };
 
   const formatTime = (timestamp: string) => {

--- a/apps/web/src/components/markets/CategoryPnLCard.tsx
+++ b/apps/web/src/components/markets/CategoryPnLCard.tsx
@@ -75,7 +75,7 @@ interface CategoryPnLCardProps {
 function formatCurrency(value: number | null | undefined) {
   const safeValue =
     typeof value === 'number' && Number.isFinite(value) ? value : 0;
-  return formatCurrencyShared(safeValue);
+  return formatCurrencyShared(safeValue, { useThousandsSeparator: true });
 }
 
 /**

--- a/apps/web/src/components/markets/CategoryPnLShareCard.tsx
+++ b/apps/web/src/components/markets/CategoryPnLShareCard.tsx
@@ -1,4 +1,4 @@
-import { BABYLON_POINTS_SYMBOL } from '@babylon/shared';
+import { formatCurrency as formatCurrencyShared } from '@babylon/shared';
 import type { User } from '@/stores/authStore';
 import type { MarketCategory } from '@/types/markets';
 
@@ -53,16 +53,14 @@ interface CategoryPnLShareCardProps {
  * Format currency value safely.
  *
  * Formats a number as Babylon points, defaulting to 0 if invalid.
+ * Uses shared formatCurrency utility for consistency across the codebase.
  *
  * @param value - Value to format
  * @returns Formatted currency string
  */
 function formatCurrency(value: number) {
   const safeValue = Number.isFinite(value) ? value : 0;
-  return `${BABYLON_POINTS_SYMBOL}${safeValue.toLocaleString('en-US', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })}`;
+  return formatCurrencyShared(safeValue, { useThousandsSeparator: true });
 }
 
 /**

--- a/apps/web/src/components/markets/CategoryPnLShareCard.tsx
+++ b/apps/web/src/components/markets/CategoryPnLShareCard.tsx
@@ -59,7 +59,10 @@ interface CategoryPnLShareCardProps {
  */
 function formatCurrency(value: number) {
   const safeValue = Number.isFinite(value) ? value : 0;
-  return `${BABYLON_POINTS_SYMBOL}${safeValue.toFixed(2)}`;
+  return `${BABYLON_POINTS_SYMBOL}${safeValue.toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
 }
 
 /**

--- a/apps/web/src/components/markets/MarketOverviewPanel.tsx
+++ b/apps/web/src/components/markets/MarketOverviewPanel.tsx
@@ -1,6 +1,10 @@
 'use client';
 
-import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
+import {
+  BABYLON_POINTS_SYMBOL,
+  cn,
+  formatNumberWithSeparators,
+} from '@babylon/shared';
 import {
   Activity,
   BarChart3,
@@ -217,7 +221,8 @@ export function MarketOverviewPanel() {
                 Total Volume
               </span>
               <span className="font-semibold text-foreground text-sm">
-                {predictionOverview.totalVolume.toFixed(0)} shares
+                {formatNumberWithSeparators(predictionOverview.totalVolume)}{' '}
+                shares
               </span>
             </div>
           </div>

--- a/apps/web/src/components/markets/PerpPositionsList.tsx
+++ b/apps/web/src/components/markets/PerpPositionsList.tsx
@@ -1,11 +1,6 @@
 'use client';
 
-import {
-  BABYLON_POINTS_SYMBOL,
-  calculateUnrealizedPnL,
-  cn,
-  formatCurrency,
-} from '@babylon/shared';
+import { calculateUnrealizedPnL, cn, formatCurrency } from '@babylon/shared';
 import { AlertTriangle, TrendingDown, TrendingUp } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
@@ -135,7 +130,10 @@ export function PerpPositionsList({
 
     const pnlSign = pnl >= 0 ? '+' : '-';
     toast.success('Position closed!', {
-      description: `${pendingClose.position.ticker}: ${pnlSign}${BABYLON_POINTS_SYMBOL}${Math.abs(pnl).toFixed(2)} PnL`,
+      description: `${pendingClose.position.ticker}: ${pnlSign}${formatCurrency(
+        Math.abs(pnl),
+        { useThousandsSeparator: true }
+      )} PnL`,
     });
 
     // Invalidate cache to ensure fresh data on next fetch
@@ -146,7 +144,8 @@ export function PerpPositionsList({
   }, [closePerpPosition, onPositionClosed, pendingClose]);
 
   /** Use shared formatCurrency for price formatting */
-  const formatPrice = formatCurrency;
+  const formatPrice = (amount: number) =>
+    formatCurrency(amount, { useThousandsSeparator: true });
 
   const formatDate = (dateStr: string) => {
     const date = new Date(dateStr);

--- a/apps/web/src/components/markets/PortfolioPnLCard.tsx
+++ b/apps/web/src/components/markets/PortfolioPnLCard.tsx
@@ -1,4 +1,4 @@
-import { BABYLON_POINTS_SYMBOL } from '@babylon/shared';
+import { formatCurrency as formatCurrencyShared } from '@babylon/shared';
 import { Share2, Sparkles } from 'lucide-react';
 import type { PortfolioPnLSnapshot } from '@/hooks/usePortfolioPnL';
 
@@ -42,6 +42,7 @@ interface PortfolioPnLCardProps {
  * Format currency value safely.
  *
  * Formats a number as Babylon points, defaulting to 0 if invalid.
+ * Uses shared formatCurrency utility for consistency across the codebase.
  *
  * @param value - Value to format
  * @returns Formatted currency string
@@ -49,10 +50,7 @@ interface PortfolioPnLCardProps {
 function formatCurrency(value: number | null | undefined) {
   const safeValue =
     typeof value === 'number' && Number.isFinite(value) ? value : 0;
-  return `${BABYLON_POINTS_SYMBOL}${safeValue.toLocaleString('en-US', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })}`;
+  return formatCurrencyShared(safeValue, { useThousandsSeparator: true });
 }
 
 export function PortfolioPnLCard({

--- a/apps/web/src/components/markets/PortfolioPnLCard.tsx
+++ b/apps/web/src/components/markets/PortfolioPnLCard.tsx
@@ -49,7 +49,10 @@ interface PortfolioPnLCardProps {
 function formatCurrency(value: number | null | undefined) {
   const safeValue =
     typeof value === 'number' && Number.isFinite(value) ? value : 0;
-  return `${BABYLON_POINTS_SYMBOL}${safeValue.toFixed(2)}`;
+  return `${BABYLON_POINTS_SYMBOL}${safeValue.toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
 }
 
 export function PortfolioPnLCard({

--- a/apps/web/src/components/markets/PortfolioPnLShareCard.tsx
+++ b/apps/web/src/components/markets/PortfolioPnLShareCard.tsx
@@ -1,4 +1,4 @@
-import { BABYLON_POINTS_SYMBOL } from '@babylon/shared';
+import { formatCurrency as formatCurrencyShared } from '@babylon/shared';
 import type { PortfolioPnLSnapshot } from '@/hooks/usePortfolioPnL';
 import type { User } from '@/stores/authStore';
 
@@ -37,16 +37,14 @@ interface PortfolioPnLShareCardProps {
  * Format currency value safely.
  *
  * Formats a number as Babylon points, defaulting to 0 if invalid.
+ * Uses shared formatCurrency utility for consistency across the codebase.
  *
  * @param value - Value to format
  * @returns Formatted currency string
  */
 function formatCurrency(value: number) {
   const safeValue = Number.isFinite(value) ? value : 0;
-  return `${BABYLON_POINTS_SYMBOL}${safeValue.toLocaleString('en-US', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })}`;
+  return formatCurrencyShared(safeValue, { useThousandsSeparator: true });
 }
 
 export function PortfolioPnLShareCard({

--- a/apps/web/src/components/markets/PortfolioPnLShareCard.tsx
+++ b/apps/web/src/components/markets/PortfolioPnLShareCard.tsx
@@ -43,7 +43,10 @@ interface PortfolioPnLShareCardProps {
  */
 function formatCurrency(value: number) {
   const safeValue = Number.isFinite(value) ? value : 0;
-  return `${BABYLON_POINTS_SYMBOL}${safeValue.toFixed(2)}`;
+  return `${BABYLON_POINTS_SYMBOL}${safeValue.toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
 }
 
 export function PortfolioPnLShareCard({

--- a/apps/web/src/components/markets/PredictionPositionsList.tsx
+++ b/apps/web/src/components/markets/PredictionPositionsList.tsx
@@ -1,12 +1,7 @@
 'use client';
 
 import type { UserPredictionPosition } from '@babylon/shared';
-import {
-  BABYLON_POINTS_SYMBOL,
-  cn,
-  formatCurrency,
-  logger,
-} from '@babylon/shared';
+import { cn, formatCurrency, logger } from '@babylon/shared';
 import { usePrivy } from '@privy-io/react-auth';
 import { CheckCircle, XCircle } from 'lucide-react';
 import { useState } from 'react';
@@ -130,7 +125,10 @@ export function PredictionPositionsList({
       const pnl = data.pnl;
       const pnlSign = pnl >= 0 ? '+' : '-';
       toast.success('Shares sold!', {
-        description: `Sold ${position.shares.toFixed(2)} ${position.side} shares for ${pnlSign}${BABYLON_POINTS_SYMBOL}${Math.abs(pnl).toFixed(2)} PnL`,
+        description: `Sold ${position.shares.toFixed(2)} ${position.side} shares for ${pnlSign}${formatCurrency(
+          Math.abs(pnl),
+          { useThousandsSeparator: true }
+        )} PnL`,
       });
 
       onPositionSold?.();
@@ -150,7 +148,8 @@ export function PredictionPositionsList({
   };
 
   /** Use shared formatCurrency with 3 decimals for prediction prices */
-  const formatPrice = (price: number) => formatCurrency(price, 3);
+  const formatPrice = (price: number) =>
+    formatCurrency(price, { decimals: 3, useThousandsSeparator: true });
 
   if (positions.length === 0) {
     return (

--- a/apps/web/src/components/markets/PredictionTrendingPanel.tsx
+++ b/apps/web/src/components/markets/PredictionTrendingPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { cn } from '@babylon/shared';
+import { cn, formatNumberWithSeparators } from '@babylon/shared';
 import { Flame } from 'lucide-react';
 import { useMemo } from 'react';
 import { Skeleton } from '@/components/shared/Skeleton';
@@ -100,7 +100,10 @@ export function PredictionTrendingPanel({
               </div>
               <div className="flex items-center justify-between pt-1 text-muted-foreground text-xs">
                 <span>
-                  Volume: {(market.yesShares + market.noShares).toFixed(0)}{' '}
+                  Volume:{' '}
+                  {formatNumberWithSeparators(
+                    market.yesShares + market.noShares
+                  )}{' '}
                   shares
                 </span>
                 <span className="font-semibold text-green-600">

--- a/apps/web/src/components/markets/TradeConfirmationDialog.tsx
+++ b/apps/web/src/components/markets/TradeConfirmationDialog.tsx
@@ -155,7 +155,8 @@ export function TradeConfirmationDialog({
   if (!tradeDetails) return null;
 
   /** Use shared formatCurrency for price formatting */
-  const formatPrice = formatCurrency;
+  const formatPrice = (amount: number) =>
+    formatCurrency(amount, { useThousandsSeparator: true });
 
   const getTitle = () => {
     switch (tradeDetails.type) {

--- a/packages/agents/src/autonomous/AutonomousBatchResponseService.ts
+++ b/packages/agents/src/autonomous/AutonomousBatchResponseService.ts
@@ -985,21 +985,21 @@ LEAVE EMPTY IF:
 
             // Log skipped interaction if there was reasoning
             if (thought) {
-               agentService
-              .createLog(agentUserId, {
-                type: 'system',
-                level: 'debug',
-                message: `Skipped automated response to ${interaction.type}`,
-                prompt: currentPrompt,
-                completion: responseContent,
-                thinking: thought,
-                metadata: {
-                  interactionId: interaction.id,
-                  interactionType: interaction.type,
-                  skipped: true
-                },
-              })
-              .catch(() => {});
+              agentService
+                .createLog(agentUserId, {
+                  type: 'system',
+                  level: 'debug',
+                  message: `Skipped automated response to ${interaction.type}`,
+                  prompt: currentPrompt,
+                  completion: responseContent,
+                  thinking: thought,
+                  metadata: {
+                    interactionId: interaction.id,
+                    interactionType: interaction.type,
+                    skipped: true,
+                  },
+                })
+                .catch(() => {});
             }
 
             cleanContent = null; // Mark as skipped

--- a/packages/agents/src/autonomous/AutonomousTradingService.ts
+++ b/packages/agents/src/autonomous/AutonomousTradingService.ts
@@ -155,7 +155,10 @@ export class AutonomousTradingService {
     const suggestedTradeSize =
       balance.balance > 0
         ? Math.min(
-            Math.max(balance.balance * SUGGESTED_TRADE_PERCENT, MIN_SUGGESTED_TRADE_SIZE),
+            Math.max(
+              balance.balance * SUGGESTED_TRADE_PERCENT,
+              MIN_SUGGESTED_TRADE_SIZE
+            ),
             balance.balance
           )
         : 0;
@@ -291,8 +294,7 @@ If holding:
     }
 
     const trade = tradeDecision.trade;
-    const rawAmount =
-      trade.amount_in_points ?? trade.amount;
+    const rawAmount = trade.amount_in_points ?? trade.amount;
     const normalizedAmount =
       typeof rawAmount === 'string' ? Number(rawAmount) : rawAmount;
 

--- a/packages/shared/src/utils/format.ts
+++ b/packages/shared/src/utils/format.ts
@@ -320,3 +320,35 @@ export function sanitizeId(id: string | undefined | null): string {
 export function formatNumber(num: number): string {
   return formatCompactNumber(num);
 }
+
+/**
+ * Format number with thousands separators (e.g., 10,000)
+ *
+ * @description Formats a number using locale thousands separators and a fixed
+ * number of decimals. Useful for readability when you want commas instead of
+ * compact K/M suffixes.
+ *
+ * @example
+ * ```typescript
+ * formatNumberWithSeparators(10000) // "10,000"
+ * formatNumberWithSeparators(1234.56, { decimals: 2 }) // "1,234.56"
+ * ```
+ */
+export function formatNumberWithSeparators(
+  value: number,
+  options: { decimals?: number; locale?: string } = {}
+): string {
+  const { decimals = 0, locale = 'en-US' } = options;
+
+  if (!Number.isFinite(value)) {
+    return (0).toLocaleString(locale, {
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
+    });
+  }
+
+  return value.toLocaleString(locale, {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+}


### PR DESCRIPTION
## Summary
- Adds a shared thousands-separator formatter and applies it across market UIs for readability (e.g., `10,000` instead of `10000`).
- Uses the shared `formatCurrency(..., { useThousandsSeparator: true })` where appropriate for Babylon points amounts.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Linear: https://linear.app/eliza-labs/issue/BAB-120/add-commas-to-numbers-1000-for-better-readability

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [x] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- Add `formatNumberWithSeparators()` in `packages/shared/src/utils/format.ts`.
- Apply separators in key market surfaces (cards, overview totals, positions, PnL cards, confirmation dialogs).

## Review guide
**Start here**
- `packages/shared/src/utils/format.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

## Test plan
**Commands run**
- [ ] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)

**Manual verification**
1. Open markets pages/cards with values > 1000 and confirm commas appear.

## Ops / Migration / Deployment
- [x] No deploy impact

## Breaking changes
- [x] None

## Security / privacy
- [x] No security impact

## Screenshots / recordings (UI)

### Option B: No visual changes
- Reason: No layout/styling changes; only numeric formatting.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable number-formatting utility with configurable decimals and thousands separators.

* **UI Improvements**
  * Market volumes, share counts, prices, and P&L values now display with thousands separators across the app (including dialogs and toasts) for clearer, locale-aware numeric presentation.
  * Minor text spacing/line-break adjustment in one explanatory paragraph.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added thousands separators (commas) to market numbers across UI components for better readability. Introduced `formatNumberWithSeparators()` utility and leveraged existing `formatCurrency(..., { useThousandsSeparator: true })` option.

## Key Changes
- Created new `formatNumberWithSeparators()` function in `packages/shared/src/utils/format.ts` for non-currency numbers
- Applied separators to market cards, positions lists, PnL displays, trade confirmations, and overview panels
- Updated 12 UI components across the markets interface

## Issues Found
- **Inconsistent implementation**: Three files (`PortfolioPnLCard.tsx`, `CategoryPnLShareCard.tsx`, `PortfolioPnLShareCard.tsx`) use inline `toLocaleString()` instead of the shared `formatCurrency()` utility that other files use
- **Missing tests**: No unit tests added for the new `formatNumberWithSeparators()` function

<h3>Confidence Score: 4/5</h3>


- Safe to merge with minor style inconsistencies that should be addressed
- The implementation is functionally correct and improves readability. However, inconsistent formatting approaches across components reduce maintainability. Three files implement inline `toLocaleString()` while others use the shared utility, creating unnecessary code duplication.
- `PortfolioPnLCard.tsx`, `CategoryPnLShareCard.tsx`, and `PortfolioPnLShareCard.tsx` should use shared utilities for consistency

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/shared/src/utils/format.ts | Added `formatNumberWithSeparators()` utility function with proper null/non-finite handling |
| apps/web/src/components/markets/PortfolioPnLCard.tsx | Implemented inline `toLocaleString` for thousands separators instead of using shared utility |
| apps/web/src/components/markets/CategoryPnLShareCard.tsx | Implemented inline `toLocaleString` for thousands separators instead of using shared utility |
| apps/web/src/components/markets/PortfolioPnLShareCard.tsx | Implemented inline `toLocaleString` for thousands separators instead of using shared utility |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as Market UI Components
    participant Format as format.ts
    participant Locale as Browser Intl API

    Note over UI,Locale: Number Formatting Flow

    UI->>Format: formatNumberWithSeparators(10000)
    Format->>Locale: toLocaleString('en-US', options)
    Locale-->>Format: "10,000"
    Format-->>UI: "10,000"

    UI->>Format: formatCurrency(1234.56, { useThousandsSeparator: true })
    Format->>Locale: toLocaleString('en-US', options)
    Locale-->>Format: "1,234.56"
    Format-->>UI: "Ƀ1,234.56"

    Note over UI: Alternative (inline implementation)
    UI->>Locale: value.toLocaleString('en-US', {...})
    Locale-->>UI: "1,234.56"
    Note over UI: Manual symbol: "Ƀ1,234.56"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->