### PR TITLE
fix(BAB-121): keep prediction chart colors distinct

### DIFF
--- a/apps/web/src/components/markets/PredictionProbabilityChart.test.tsx
+++ b/apps/web/src/components/markets/PredictionProbabilityChart.test.tsx
@@ -92,20 +92,14 @@ describe('PredictionProbabilityChart - Data Processing', () => {
   });
 
   describe('Color Assignment Logic', () => {
-    it('should assign green color when YES is favored', () => {
-      const probability = 60;
-      const isYesFavored = probability >= 50;
-      const lineColor = isYesFavored ? '#16a34a' : '#dc2626';
+    it('should keep YES/NO series colors distinct', () => {
+      // YES should remain green and NO should remain red, regardless of which side is favored.
+      const yesLineColor = '#22c55e';
+      const noLineColor = '#ef4444';
 
-      expect(lineColor).toBe('#16a34a');
-    });
-
-    it('should assign red color when NO is favored', () => {
-      const probability = 40;
-      const isYesFavored = probability >= 50;
-      const lineColor = isYesFavored ? '#16a34a' : '#dc2626';
-
-      expect(lineColor).toBe('#dc2626');
+      expect(yesLineColor).toBe('#22c55e');
+      expect(noLineColor).toBe('#ef4444');
+      expect(yesLineColor).not.toBe(noLineColor);
     });
   });
 

--- a/apps/web/src/components/markets/PredictionProbabilityChart.tsx
+++ b/apps/web/src/components/markets/PredictionProbabilityChart.tsx
@@ -150,8 +150,6 @@ export function PredictionProbabilityChart({
     return latest ? latest.yesPrice * 100 : 50;
   }, [data]);
 
-  const isYesFavored = currentProbability >= 50;
-
   // Initialize series when chart is ready
   useEffect(() => {
     if (!chart || seriesInitialized.current) return;
@@ -258,13 +256,6 @@ export function PredictionProbabilityChart({
       setChartInitError(message);
     }
   }, [chart, chartData]);
-
-  // Update series colors based on YES/NO favorability
-  useEffect(() => {
-    if (!yesSeries.current) return;
-    const style = isYesFavored ? AREA_STYLES.green : AREA_STYLES.red;
-    yesSeries.current.applyOptions(style);
-  }, [isYesFavored]);
 
   // Loading state when no data
   if (!data.length) {


### PR DESCRIPTION
## Summary
- Fixes prediction charts where YES/NO become indistinguishable by keeping series colors stable (YES green, NO red).
- Removes favorability-based recoloring that was turning the YES series red when YES < 50%.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Linear: https://linear.app/eliza-labs/issue/BAB-121/fix-light-mode-chart-colors-distinguish-yesno

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- `apps/web/src/components/markets/PredictionProbabilityChart.tsx`: remove YES-series recolor-on-favorability so YES remains green and NO remains red.
- Update unit test expectations.

## Review guide
**Start here**
- `apps/web/src/components/markets/PredictionProbabilityChart.tsx`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

## Test plan
**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [x] `bun run test` (unit + integration)

**Manual verification**
1. Open a prediction market chart where YES < 50% and confirm YES (green) and NO (red) remain distinct.

## Ops / Migration / Deployment
- [x] No deploy impact

## Breaking changes
- [x] None

## Security / privacy
- [x] No security impact

## Screenshots / recordings (UI)

### Option B: No visual changes
- Reason: Visual output changes (colors remain distinct), but no layout/styling assets beyond chart rendering.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified chart color system: YES and NO prediction lines now display with fixed colors (green and red respectively) instead of dynamically updating based on probability changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed prediction charts where YES and NO series became indistinguishable by removing the favorability-based color switching logic. Previously, when YES probability fell below 50%, the YES series would turn red, making both YES and NO series appear red and confusing users.

**Key changes:**
- Removed `isYesFavored` calculation and the `useEffect` that dynamically recolored the YES series
- YES series now permanently uses green (`#22c55e` from `AREA_STYLES.green`)
- NO series now permanently uses red (`#ef4444` from `LINE_STYLES.red`)
- Updated unit tests to verify color stability instead of favorability-based recoloring
- Aligns with `PredictionSparkline` component which already uses fixed colors

The fix ensures users can always distinguish YES from NO regardless of which outcome is favored.

<h3>Confidence Score: 5/5</h3>


- Safe to merge - focused bug fix with clear intent and proper test coverage
- This is a straightforward visual bug fix that removes problematic color-switching logic without introducing new functionality or complexity. The changes are minimal, well-tested, and align with existing patterns in the codebase (PredictionSparkline). No breaking changes, security concerns, or edge cases introduced.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/components/markets/PredictionProbabilityChart.tsx | Removed favorability-based color switching logic to keep YES green and NO red consistently |
| apps/web/src/components/markets/PredictionProbabilityChart.test.tsx | Updated tests to verify colors remain distinct instead of testing favorability-based recoloring |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Component as PredictionProbabilityChart
    participant Hook as useLightweightChart
    participant Chart as Lightweight Charts API
    participant Series as Chart Series (YES/NO)

    User->>Component: View prediction market chart
    Component->>Hook: Initialize chart with options
    Hook->>Chart: createChart(container, options)
    Chart-->>Hook: return chart instance
    Hook-->>Component: return {chart, chartContainerRef}
    
    Note over Component: Data processing
    Component->>Component: Process data (filter, sort, dedupe)
    Component->>Component: Calculate currentProbability
    
    Note over Component: Series initialization (once)
    Component->>Chart: addSeries(AreaSeries, AREA_STYLES.green)
    Chart-->>Component: return yesSeries
    Component->>Chart: addSeries(LineSeries, LINE_STYLES.red)
    Chart-->>Component: return noSeries
    
    Note over Component: Data update
    Component->>Series: yesSeries.setData(chartData.yes)
    Component->>Series: noSeries.setData(chartData.no)
    Component->>Chart: timeScale().fitContent()
    
    Note over Component: Color remains stable
    Note over Series: YES: always green (#22c55e)<br/>NO: always red (#ef4444)
    
    Series-->>User: Display chart with distinct colors
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->