### PR TITLE
fix(BAB-78): ensure at least one prediction market is open

### DIFF
--- a/packages/engine/src/game-tick.ts
+++ b/packages/engine/src/game-tick.ts
@@ -662,13 +662,26 @@ export async function executeGameTick(
   const currentActiveCount =
     currentActiveQuestions.length - result.questionsResolved;
   if (currentActiveCount < 10) {
-    if (Date.now() < deadline) {
+    const shouldForceGeneration = currentActiveCount <= 0;
+    if (Date.now() < deadline || shouldForceGeneration) {
+      if (shouldForceGeneration && Date.now() >= deadline) {
+        logger.warn(
+          'No active prediction questions – forcing generation past tick budget',
+          { budgetMs, currentActiveCount },
+          'GameTick'
+        );
+      }
+
+      // If we've exceeded the tick budget, still allow a small window to avoid
+      // periods with zero active prediction markets.
+      const generationDeadline =
+        Date.now() < deadline ? deadline : Date.now() + 30_000;
       const questionsGenerated = await generateNewQuestions(
         Math.min(3, 15 - currentActiveCount),
         llmClient,
-        deadline
+        generationDeadline
       );
-      result.questionsCreated = questionsGenerated;
+      result.questionsCreated += questionsGenerated;
     } else {
       logger.warn(
         'Skipping question generation – tick budget exceeded',


### PR DESCRIPTION
## Summary
- Prevents periods with 0 active prediction markets by forcing question generation when none are available.
- Adds a small “critical window” to still generate a question even if the tick budget is tight.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Linear: https://linear.app/eliza-labs/issue/BAB-78/ensure-at-least-one-prediction-market-is-open-at-all-times

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- `packages/engine/src/game-tick.ts`: if `currentActiveCount <= 0`, generate at least one question, even under tight tick budget.

## Review guide
**Start here**
- `packages/engine/src/game-tick.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

## Test plan
**Commands run**
- [ ] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)

**Manual verification**
1. Let the system run until active predictions drop to 0 and confirm a new question is generated.

## Ops / Migration / Deployment
- [x] No deploy impact

## Breaking changes
- [x] None

## Security / privacy
- [x] No security impact

## Screenshots / recordings (UI)

### Option B: No visual changes
- Reason: Engine-only behavior change.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Prevented periods with zero active prediction markets by forcing question generation even when the tick budget is exceeded. The fix adds a `shouldForceGeneration` flag that bypasses the deadline check when `currentActiveCount <= 0`, allowing up to 30 seconds of additional time for question generation.

**Key changes:**
- Added conditional logic to force generation when no active markets exist
- Changed `result.questionsCreated` from assignment (`=`) to addition (`+=`) operator to correctly accumulate questions created across multiple generation blocks in the same tick
- Added warning log when forcing generation past tick budget
- Created a `generationDeadline` that extends 30 seconds past `Date.now()` when forcing generation

The operator change from `=` to `+=` is necessary because both the initial question generation block (line 271-304) and this replenishment block (line 662-692) can execute in the same tick, especially when questions are resolved between the two blocks.

<h3>Confidence Score: 4/5</h3>


- Safe to merge - focused bug fix with appropriate safeguards
- The logic is sound and solves the stated problem. The += operator change is correct and necessary. The 30-second extension is a reasonable safeguard. Only minor concern is that question generation could still fail, leaving zero markets, but this is handled by retrying on the next tick.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/engine/src/game-tick.ts | Added logic to force question generation when no active markets exist, even if tick budget is exceeded. Uses a 30-second critical window and changes operator from = to += for questionsCreated counter. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GT as GameTick
    participant QM as QuestionManager
    participant DB as Database
    
    Note over GT: Check current active count
    GT->>GT: currentActiveCount = activeQuestions.length - questionsResolved
    
    alt currentActiveCount < 10
        GT->>GT: shouldForceGeneration = currentActiveCount <= 0
        
        alt Date.now() < deadline OR shouldForceGeneration
            alt shouldForceGeneration AND past deadline
                GT->>GT: Log warning: forcing past budget
                GT->>GT: generationDeadline = Date.now() + 30_000
            else within deadline
                GT->>GT: generationDeadline = deadline
            end
            
            GT->>QM: generateNewQuestions(count, llm, generationDeadline)
            QM->>DB: Create new questions
            DB-->>QM: Questions created
            QM-->>GT: questionsGenerated count
            GT->>GT: result.questionsCreated += questionsGenerated
        else past deadline AND not forcing
            GT->>GT: Log warning: skipping generation
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->