### PR TITLE
feat(BAB-84): add arc pulse events for market activity

### DIFF
--- a/packages/engine/src/game-tick.ts
+++ b/packages/engine/src/game-tick.ts
@@ -68,7 +68,10 @@ import {
 } from './services/article-image-service';
 import { characterMappingService } from './services/character-mapping-service';
 // Content generation helpers
-import { generateEvents } from './services/event-generation-helpers';
+import {
+  generateArcPulseEventsIfNeeded,
+  generateEvents,
+} from './services/event-generation-helpers';
 import { bootstrapGameIfNeeded } from './services/game-bootstrap-service';
 import { MarketContextService } from './services/market-context-service';
 import { NPCGroupDynamicsService } from './services/npc-group-dynamics-service';
@@ -541,7 +544,12 @@ export async function executeGameTick(
       timestamp,
       dayNumberForTimestamp(timestamp)
     );
-    result.eventsCreated = eventsGenerated;
+    const pulseEventsGenerated = await generateArcPulseEventsIfNeeded(
+      currentActiveQuestions.slice(0, 3),
+      timestamp,
+      dayNumberForTimestamp(timestamp)
+    );
+    result.eventsCreated = eventsGenerated + pulseEventsGenerated;
 
     // NPC posts and replies are now handled by /api/cron/npc-tick
     // This removes the old generateMixedPosts and generateNPCRepliesFromPreviousTicks calls

--- a/packages/engine/src/services/event-generation-helpers.ts
+++ b/packages/engine/src/services/event-generation-helpers.ts
@@ -1,4 +1,13 @@
-import { db, posts, type Question, worldEvents } from '@babylon/db';
+import {
+  and,
+  db,
+  desc,
+  gte,
+  inArray,
+  posts,
+  type Question,
+  worldEvents,
+} from '@babylon/db';
 import type { BabylonLLMClient } from '@babylon/engine';
 import { generateSnowflakeId, logger } from '@babylon/shared';
 import { ArticleGenerator } from '../ArticleGenerator';
@@ -337,6 +346,115 @@ export async function generateEvents(
   }
 
   return eventsCreated;
+}
+
+const ARC_PULSE_LOOKBACK_MS = 24 * 60 * 60 * 1000; // 24h
+const ARC_PULSE_MAX_EVENTS_PER_TICK = 2;
+const ARC_PULSE_INTERVAL_MS_BY_PHASE: Record<
+  'early' | 'middle' | 'late' | 'climax',
+  number
+> = {
+  early: 6 * 60 * 60 * 1000, // 6h
+  middle: 4 * 60 * 60 * 1000, // 4h
+  late: 2 * 60 * 60 * 1000, // 2h
+  climax: 60 * 60 * 1000, // 1h
+};
+
+/**
+ * Generate additional "arc pulse" events to keep narratives (and markets) active.
+ *
+ * @description
+ * This is a lightweight approximation of "sub-arc events": for each active question,
+ * if we haven't emitted a `WorldEvent` recently, emit a new one using the same
+ * generation logic as `generateEvents()` (signal direction is still derived from the arc plan).
+ *
+ * This helps keep the feed and market context refreshed without relying on purely
+ * synthetic volatility.
+ */
+export async function generateArcPulseEventsIfNeeded(
+  questions: QuestionForEvent[],
+  timestamp: Date,
+  currentDay?: number
+): Promise<number> {
+  if (questions.length === 0) return 0;
+
+  const questionNumbers = questions
+    .map((q) =>
+      typeof q.questionNumber === 'number' &&
+      Number.isFinite(q.questionNumber) &&
+      q.questionNumber >= 0 &&
+      q.questionNumber <= 2147483647
+        ? q.questionNumber
+        : null
+    )
+    .filter((n): n is number => n !== null);
+
+  if (questionNumbers.length === 0) return 0;
+
+  const lookbackDate = new Date(timestamp.getTime() - ARC_PULSE_LOOKBACK_MS);
+  const recent = await db
+    .select({
+      relatedQuestion: worldEvents.relatedQuestion,
+      timestamp: worldEvents.timestamp,
+    })
+    .from(worldEvents)
+    .where(
+      and(
+        inArray(worldEvents.relatedQuestion, questionNumbers),
+        gte(worldEvents.timestamp, lookbackDate)
+      )
+    )
+    .orderBy(desc(worldEvents.timestamp));
+
+  const lastEventByQuestion = new Map<number, Date>();
+  for (const row of recent) {
+    const q = row.relatedQuestion;
+    if (typeof q !== 'number') continue;
+    if (!lastEventByQuestion.has(q)) {
+      lastEventByQuestion.set(q, row.timestamp);
+    }
+  }
+
+  let created = 0;
+
+  for (const question of questions) {
+    if (created >= ARC_PULSE_MAX_EVENTS_PER_TICK) break;
+
+    const questionNum =
+      typeof question.questionNumber === 'number' &&
+      Number.isFinite(question.questionNumber) &&
+      question.questionNumber >= 0 &&
+      question.questionNumber <= 2147483647
+        ? question.questionNumber
+        : null;
+
+    if (questionNum === null) continue;
+
+    let intervalMs = ARC_PULSE_INTERVAL_MS_BY_PHASE.early;
+    if (currentDay !== undefined) {
+      const arcPlan = await getArcPlan(question.id);
+      if (arcPlan) {
+        const phase = getPhaseForDay(currentDay, arcPlan);
+        intervalMs = ARC_PULSE_INTERVAL_MS_BY_PHASE[phase];
+      }
+    }
+
+    const lastEventAt = lastEventByQuestion.get(questionNum) ?? null;
+    if (
+      lastEventAt &&
+      timestamp.getTime() - lastEventAt.getTime() < intervalMs
+    ) {
+      continue;
+    }
+
+    const generated = await generateEvents([question], timestamp, currentDay);
+    if (generated > 0) {
+      created += generated;
+      lastEventByQuestion.set(questionNum, timestamp);
+    }
+  }
+
+  return created;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds lightweight “arc pulse” events to keep active questions generating narrative signals regularly.
- Uses arc-plan phase to adjust cadence, improving feed freshness and market context without relying purely on synthetic volatility.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Linear: https://linear.app/eliza-labs/issue/BAB-84/create-comprehensive-economic-system-for-active-market-dynamics

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- Add `generateArcPulseEventsIfNeeded()` in `packages/engine/src/services/event-generation-helpers.ts`:
  - Emits additional `WorldEvent` entries if a question hasn’t had recent activity.
  - Cadence is phase-aware (early=6h, middle=4h, late=2h, climax=1h).
  - Caps to 2 extra events per tick.
- Call this helper from `packages/engine/src/game-tick.ts` right after the existing `generateEvents()`.

## Review guide
**Start here**
- `packages/engine/src/services/event-generation-helpers.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- This is intentionally an incremental step toward the broader economic system; it focuses only on narrative/event cadence.

## Test plan
**Commands run**
- [ ] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)

**Manual verification**
1. Observe `WorldEvent` inserts over time for active questions and confirm cadence increases as resolution approaches.

## Ops / Migration / Deployment
- [x] No deploy impact

## Breaking changes
- [x] None

## Security / privacy
- [x] No security impact

## Screenshots / recordings (UI)

### Option B: No visual changes
- Reason: Engine-only behavior change.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Adds phase-aware "arc pulse" event generation to maintain narrative momentum for active questions. The new `generateArcPulseEventsIfNeeded()` function checks if questions haven't had events recently (within 24h lookback) and generates additional events based on arc phase intervals: 6h (early), 4h (middle), 2h (late), and 1h (climax). Both regular and pulse events are capped at 2 per tick, providing controlled event cadence.

## Key Changes
- New `generateArcPulseEventsIfNeeded()` function queries recent events and generates pulse events when phase-specific intervals are exceeded
- Integrated into game tick flow after regular event generation
- Uses same event generation logic with arc plan-based signal direction
- Lookback query runs once per tick, with local map tracking preventing duplicate pulse events within the same call

## Implementation Notes
- The arc pulse logic reuses `generateEvents()`, ensuring consistent event quality and signal direction
- Phase-based cadence acceleration (6h → 1h) aligns with narrative arc timing as resolution approaches
- Both regular and pulse event generation operate on the same question set (`currentActiveQuestions.slice(0, 3)`), which could theoretically generate up to 4 events per tick total (2 regular + 2 pulse)

<h3>Confidence Score: 4/5</h3>


- Safe to merge with minor consideration about event generation volume
- Implementation is clean and follows existing patterns. The arc pulse logic correctly checks intervals and respects caps. One minor consideration: both `generateEvents()` and `generateArcPulseEventsIfNeeded()` can generate up to 2 events each per tick for potentially overlapping questions, which could produce 4 total events instead of the intended 2-3. However, this is bounded behavior and the 24h lookback in arc pulse should prevent excessive event spam in practice.
- No files require special attention - implementation is straightforward and well-integrated

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/engine/src/services/event-generation-helpers.ts | New `generateArcPulseEventsIfNeeded()` function added to generate additional events for active questions based on arc phase timing. Lookback mechanism checks for recent events within 24h window and generates new events if phase-specific intervals are exceeded. |
| packages/engine/src/game-tick.ts | Imports and calls `generateArcPulseEventsIfNeeded()` after regular event generation, aggregating both counts into `result.eventsCreated`. Clean integration with existing event generation flow. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GT as game-tick.ts
    participant GE as generateEvents()
    participant AP as generateArcPulseEventsIfNeeded()
    participant DB as Database (worldEvents)
    participant NS as narrative-state-service

    Note over GT: executeGameTick()
    GT->>GE: Call with currentActiveQuestions.slice(0, 3)
    GE->>NS: getArcPlan(question.id)
    NS-->>GE: Return arc plan
    GE->>NS: getPhaseForDay(currentDay, arcPlan)
    NS-->>GE: Return phase (early/middle/late/climax)
    GE->>NS: getSignalDirection(arcPlan, phase, '', outcome)
    NS-->>GE: Return signal direction
    GE->>DB: Insert world events (max 2)
    GE-->>GT: Return eventsGenerated count

    GT->>AP: Call with same currentActiveQuestions.slice(0, 3)
    AP->>DB: Query recent events (24h lookback)
    DB-->>AP: Return recent events by question
    
    loop For each question (max 2 events)
        AP->>NS: getArcPlan(question.id)
        NS-->>AP: Return arc plan
        AP->>NS: getPhaseForDay(currentDay, arcPlan)
        NS-->>AP: Return phase
        
        alt Event needed (interval exceeded)
            AP->>GE: Call generateEvents([question])
            GE->>NS: Get arc plan & phase
            GE->>DB: Insert world event
            GE-->>AP: Return 1
        else Too recent
            Note over AP: Skip this question
        end
    end
    
    AP-->>GT: Return pulseEventsGenerated count
    Note over GT: result.eventsCreated = eventsGenerated + pulseEventsGenerated
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->