### PR TITLE
feat(agents): enable all autonomous capabilities by default

### DIFF
--- a/packages/agents/src/services/AgentService.ts
+++ b/packages/agents/src/services/AgentService.ts
@@ -199,7 +199,7 @@ export class AgentServiceV2 {
 
       const newAgent = newAgentResult[0]!;
 
-      // Create the agent config record
+      // Create the agent config record with all autonomous capabilities enabled by default
       await tx.insert(userAgentConfigs).values({
         id: await generateSnowflakeId(),
         userId: agentUserId,
@@ -207,7 +207,12 @@ export class AgentServiceV2 {
         personality: personality ?? null,
         tradingStrategy: tradingStrategy ?? null,
         messageExamples: bio ? JSON.parse(JSON.stringify(bio)) : null,
-        a2aEnabled: true, // Enable A2A by default for all agents
+        a2aEnabled: true,
+        autonomousPosting: true,
+        autonomousCommenting: true,
+        autonomousTrading: true,
+        autonomousDMs: true,
+        autonomousGroupChats: true,
         updatedAt: new Date(),
       });
 


### PR DESCRIPTION
## Summary

- Enables all autonomous capabilities by default when users create an agent via UI
- Previously all autonomous flags (`autonomousPosting`, `autonomousCommenting`, `autonomousTrading`, `autonomousDMs`, `autonomousGroupChats`) defaulted to `false`
- Now they are all set to `true` during agent creation

## Changes

- Updated `AgentService.createAgent()` to explicitly set all autonomous capability flags to `true`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent autonomous capabilities expanded: posting, commenting, trading, direct messaging, and group chat functionality are now enabled by default, providing broader agent autonomy across multiple interaction types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Changed default behavior for newly created agents to have all autonomous capabilities enabled (`autonomousPosting`, `autonomousCommenting`, `autonomousTrading`, `autonomousDMs`, `autonomousGroupChats` all set to `true`).

- Previously, these flags defaulted to `false` (as defined in the database schema at `packages/db/src/schema/user-agent-configs.ts:45-53`)
- Now explicitly sets all autonomous flags to `true` during agent creation in `AgentService.createAgent()`
- This is a UX-focused change that enables agents to be fully autonomous by default without requiring manual configuration
- The API response already returns these flags to the frontend (`apps/web/src/app/api/agents/route.ts:213-217`), so UI can still display and manage them
- Users can still disable specific autonomous features via the `updateAgent()` method if needed

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor considerations
- The change is straightforward and well-scoped, only modifying default values for autonomous flags during agent creation. The implementation is consistent with existing patterns and doesn't introduce bugs. Score of 4 (not 5) because: (1) this is a significant behavioral change that enables autonomous trading/posting/DMs by default, which could have cost implications for users if they're not aware agents will start acting autonomously immediately; (2) there's no migration strategy mentioned for existing agents or communication plan for users about this default change
- No files require special attention - the change is isolated and straightforward

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agents/src/services/AgentService.ts | Added explicit enablement of all autonomous capabilities (posting, commenting, trading, DMs, group chats) by default during agent creation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API as POST /api/agents
    participant AgentService
    participant DB as Database
    participant Registry as AgentRegistry

    User->>API: Create agent request
    API->>AgentService: createAgent(params)
    
    Note over AgentService: Validate manager user<br/>Check balance for deposit
    
    AgentService->>DB: Begin transaction
    AgentService->>DB: Insert user record<br/>(isAgent=true)
    
    Note over AgentService,DB: NEW: All autonomous flags<br/>explicitly set to true
    AgentService->>DB: Insert userAgentConfig<br/>(autonomousPosting=true,<br/>autonomousCommenting=true,<br/>autonomousTrading=true,<br/>autonomousDMs=true,<br/>autonomousGroupChats=true)
    
    alt Initial deposit > 0
        AgentService->>DB: Transfer funds<br/>(manager → agent)
        AgentService->>DB: Record transactions
    end
    
    AgentService->>DB: Create agent log
    AgentService->>DB: Commit transaction
    
    AgentService->>Registry: registerUserAgent()
    
    opt Auto wallet setup enabled
        AgentService->>AgentService: setupAgentIdentity()
    end
    
    AgentService-->>API: Return agent user
    API->>DB: getAgentConfig()
    API-->>User: Return agent with config<br/>(all autonomous flags=true)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->