### PR TITLE
fix(BAB-131): Group chat hybrid member addition (invite flow for humans, direct add for agents)

### DIFF
--- a/apps/web/src/app/api/admin/group-invite/route.ts
+++ b/apps/web/src/app/api/admin/group-invite/route.ts
@@ -286,42 +286,32 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
           },
         });
 
-      // Step 4: Upsert GroupMember - use raw SQL for partial index compatibility
-      // The partial unique index only applies to active members, so we use
-      // INSERT ... ON CONFLICT DO UPDATE for the active case
+      // Step 4: Upsert GroupMember using full unique constraint
       const memberId = await generateSnowflakeId();
-      await tx.execute(sql`
-        INSERT INTO "GroupMember" (
-          "id", "groupId", "userId", "role", "addedBy", "joinedAt", "isActive",
-          "messageCount", "qualityScore"
-        ) VALUES (
-          ${memberId}, ${deterministicGrpId}, ${userId}, 'member', ${npcId}, ${now}, true,
-          0, 1.0
-        )
-        ON CONFLICT ("groupId", "userId") WHERE "isActive" = true
-        DO UPDATE SET
-          "role" = 'member',
-          "addedBy" = ${npcId},
-          "joinedAt" = ${now},
-          "kickedAt" = NULL,
-          "kickReason" = NULL
-      `);
-
-      // Also handle the case where there's an inactive record (not covered by partial index)
-      // Update any inactive records to active
       await tx
-        .update(groupMembers)
-        .set({
-          isActive: true,
+        .insert(groupMembers)
+        .values({
+          id: memberId,
+          groupId: deterministicGrpId,
+          userId,
           role: 'member',
           addedBy: npcId,
           joinedAt: now,
-          kickedAt: sql`NULL`,
-          kickReason: sql`NULL`,
+          isActive: true,
+          messageCount: 0,
+          qualityScore: 1.0,
         })
-        .where(
-          sql`${groupMembers.groupId} = ${deterministicGrpId} AND ${groupMembers.userId} = ${userId} AND ${groupMembers.isActive} = false`
-        );
+        .onConflictDoUpdate({
+          target: [groupMembers.groupId, groupMembers.userId],
+          set: {
+            isActive: true,
+            role: 'member',
+            addedBy: npcId,
+            joinedAt: now,
+            kickedAt: sql`NULL`,
+            kickReason: sql`NULL`,
+          },
+        });
 
       return deterministicGrpId;
     });

--- a/apps/web/src/app/api/admin/group-invite/route.ts
+++ b/apps/web/src/app/api/admin/group-invite/route.ts
@@ -316,8 +316,8 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
           role: 'member',
           addedBy: npcId,
           joinedAt: now,
-          kickedAt: null,
-          kickReason: null,
+          kickedAt: sql`NULL`,
+          kickReason: sql`NULL`,
         })
         .where(
           sql`${groupMembers.groupId} = ${deterministicGrpId} AND ${groupMembers.userId} = ${userId} AND ${groupMembers.isActive} = false`

--- a/apps/web/src/app/api/agents/search/route.ts
+++ b/apps/web/src/app/api/agents/search/route.ts
@@ -150,12 +150,10 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
               not: user.userId, // Exclude current user
             },
           },
-          {
-            id: {
-              notIn:
-                excludedUserIds.length > 0 ? excludedUserIds : ['__none__'],
-            },
-          },
+          // Only add notIn clause if there are users to exclude
+          ...(excludedUserIds.length > 0
+            ? [{ id: { notIn: excludedUserIds } }]
+            : []),
           {
             // Include agents OR NPCs (non-human participants)
             OR: [{ isAgent: true }, { isActor: true }],

--- a/apps/web/src/app/api/agents/search/route.ts
+++ b/apps/web/src/app/api/agents/search/route.ts
@@ -1,0 +1,206 @@
+/**
+ * Agent/NPC Search API
+ *
+ * @description
+ * Search for agents and NPCs by username or display name with fuzzy matching.
+ * Returns AI agents (isAgent=true) and NPC actors (isActor=true).
+ * Designed for group chat member addition and social discovery.
+ *
+ * **Features:**
+ * - Case-insensitive search
+ * - Matches username OR display name
+ * - Excludes current user
+ * - Excludes banned users
+ * - Limits to 20 results (performance)
+ * - Alphabetically sorted results
+ * - Returns type indicator (agent vs npc)
+ *
+ * **Search Behavior:**
+ * - Minimum 2 characters required
+ * - Substring matching (contains)
+ * - Searches both username and display name fields
+ * - Returns empty array if query too short
+ *
+ * **Use Cases:**
+ * - Group chat member addition (agents/NPCs tab)
+ * - Agent discovery
+ * - NPC search for interaction
+ *
+ * @openapi
+ * /api/agents/search:
+ *   get:
+ *     tags:
+ *       - Agents
+ *     summary: Search for agents and NPCs
+ *     description: Search for agents/NPCs by username or display name (min 2 chars, max 20 results)
+ *     security:
+ *       - PrivyAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: q
+ *         required: true
+ *         schema:
+ *           type: string
+ *           minLength: 2
+ *         description: Search query (username or display name)
+ *         example: trading
+ *     responses:
+ *       200:
+ *         description: Search results
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 agents:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: string
+ *                       username:
+ *                         type: string
+ *                       displayName:
+ *                         type: string
+ *                       profileImageUrl:
+ *                         type: string
+ *                       bio:
+ *                         type: string
+ *                       type:
+ *                         type: string
+ *                         enum: [agent, npc]
+ *       401:
+ *         description: Unauthorized
+ *
+ * @example
+ * ```typescript
+ * // Search for agents/NPCs
+ * const response = await fetch('/api/agents/search?q=trading', {
+ *   headers: { 'Authorization': `Bearer ${token}` }
+ * });
+ * const { agents } = await response.json();
+ *
+ * // Display in search results
+ * agents.forEach(agent => {
+ *   console.log(`${agent.displayName} (${agent.type})`);
+ * });
+ * ```
+ */
+
+import { authenticate, successResponse, withErrorHandling } from '@babylon/api';
+import {
+  asUser,
+  getBlockedByUserIds,
+  getBlockedUserIds,
+  getMutedUserIds,
+} from '@babylon/db';
+import { logger } from '@babylon/shared';
+import type { NextRequest } from 'next/server';
+
+/**
+ * GET /api/agents/search
+ * Search for agents and NPCs by username or display name
+ */
+export const GET = withErrorHandling(async (request: NextRequest) => {
+  const user = await authenticate(request);
+
+  // Get query parameter
+  const { searchParams } = new URL(request.url);
+  const query = searchParams.get('q');
+
+  if (!query || query.trim().length < 2) {
+    return successResponse({ agents: [] });
+  }
+
+  const searchTerm = query.trim().toLowerCase();
+
+  // Get blocked/muted users to exclude from search
+  const [blockedIds, mutedIds, blockedByIds] = await Promise.all([
+    getBlockedUserIds(user.userId),
+    getMutedUserIds(user.userId),
+    getBlockedByUserIds(user.userId),
+  ]);
+
+  const excludedUserIds = [...blockedIds, ...mutedIds, ...blockedByIds];
+
+  // Search for agents (isAgent=true) and NPCs (isActor=true)
+  const agents = await asUser(user, async (db) => {
+    const results = await db.user.findMany({
+      where: {
+        AND: [
+          {
+            OR: [
+              {
+                username: {
+                  contains: searchTerm,
+                  mode: 'insensitive',
+                },
+              },
+              {
+                displayName: {
+                  contains: searchTerm,
+                  mode: 'insensitive',
+                },
+              },
+            ],
+          },
+          {
+            id: {
+              not: user.userId, // Exclude current user
+            },
+          },
+          {
+            id: {
+              notIn:
+                excludedUserIds.length > 0 ? excludedUserIds : ['__none__'],
+            },
+          },
+          {
+            // Include agents OR NPCs (non-human participants)
+            OR: [{ isAgent: true }, { isActor: true }],
+          },
+          {
+            isBanned: false, // Exclude banned users
+          },
+        ],
+      },
+      select: {
+        id: true,
+        displayName: true,
+        username: true,
+        profileImageUrl: true,
+        bio: true,
+        isAgent: true,
+        isActor: true,
+      },
+      take: 20, // Limit results
+      orderBy: [
+        {
+          username: 'asc',
+        },
+      ],
+    });
+
+    // Add type indicator for each result
+    return results.map((result) => ({
+      id: result.id,
+      displayName: result.displayName,
+      username: result.username,
+      profileImageUrl: result.profileImageUrl,
+      bio: result.bio,
+      // Determine type: prefer 'npc' if isActor, otherwise 'agent'
+      type: result.isActor ? 'npc' : 'agent',
+    }));
+  });
+
+  logger.info(
+    'Agent/NPC search completed',
+    { userId: user.userId, query: searchTerm, results: agents.length },
+    'GET /api/agents/search'
+  );
+
+  return successResponse({
+    agents,
+  });
+});

--- a/apps/web/src/app/api/agents/search/route.ts
+++ b/apps/web/src/app/api/agents/search/route.ts
@@ -98,6 +98,12 @@ import {
 import { logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 
+/** Maximum number of search results to return */
+const AGENT_SEARCH_LIMIT = 20;
+
+/** Maximum length for search query input */
+const MAX_QUERY_LENGTH = 100;
+
 /**
  * GET /api/agents/search
  * Search for agents and NPCs by username or display name
@@ -113,7 +119,8 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     return successResponse({ agents: [] });
   }
 
-  const searchTerm = query.trim().toLowerCase();
+  // Cap query length to prevent abuse
+  const searchTerm = query.trim().toLowerCase().slice(0, MAX_QUERY_LENGTH);
 
   // Get blocked/muted users to exclude from search
   const [blockedIds, mutedIds, blockedByIds] = await Promise.all([
@@ -172,7 +179,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
         isAgent: true,
         isActor: true,
       },
-      take: 20, // Limit results
+      take: AGENT_SEARCH_LIMIT,
       orderBy: [
         {
           username: 'asc',

--- a/apps/web/src/app/api/groups/[groupId]/members/route.ts
+++ b/apps/web/src/app/api/groups/[groupId]/members/route.ts
@@ -20,8 +20,10 @@ import {
   withErrorHandling,
 } from '@babylon/api';
 import {
+  and,
   asUser,
   chatParticipants,
+  eq,
   generateSnowflakeId,
   groupInvites,
   groupMembers,
@@ -126,13 +128,13 @@ export const POST = withErrorHandling(
         throw new ApiError('User is already a member of this group', 400);
       }
 
-      // Check if there's already a pending invite for this user
+      // Check if there's already an invite for this user
       const existingInvite = await db.groupInvite.findFirst({
         where: {
           groupId,
           invitedUserId: data.userId,
         },
-        select: { status: true },
+        select: { id: true, status: true },
       });
 
       if (existingInvite && existingInvite.status === 'pending') {
@@ -141,7 +143,7 @@ export const POST = withErrorHandling(
           400
         );
       }
-      // Note: If status is 'declined', we allow re-inviting via onConflictDoUpdate below
+      // Note: If status is 'declined' or 'accepted', we allow re-inviting by updating the existing invite
 
       // Find the chat for this group
       const groupChat = await db.chat.findFirst({
@@ -227,28 +229,36 @@ export const POST = withErrorHandling(
         return { added: true, invited: false, adderName, inviteId: null };
       } else {
         // HUMAN: Send invite (they need to accept)
-        // Use generateSnowflakeId for consistency with other IDs
-        const inviteId = await generateSnowflakeId();
+        // Reuse existing invite ID if re-inviting, otherwise generate new one
+        const inviteId = existingInvite?.id ?? (await generateSnowflakeId());
 
-        // Use onConflictDoUpdate to allow re-inviting users who previously declined
-        await db
-          .insert(groupInvites)
-          .values({
+        if (existingInvite) {
+          // Re-invite: update existing invite back to pending
+          await db
+            .update(groupInvites)
+            .set({
+              invitedBy: user.userId,
+              status: 'pending',
+              invitedAt: now,
+              respondedAt: sql`NULL`,
+            })
+            .where(
+              and(
+                eq(groupInvites.groupId, groupId),
+                eq(groupInvites.invitedUserId, data.userId)
+              )
+            );
+        } else {
+          // New invite
+          await db.insert(groupInvites).values({
             id: inviteId,
             groupId,
             invitedUserId: data.userId,
             invitedBy: user.userId,
             status: 'pending',
             invitedAt: now,
-          })
-          .onConflictDoUpdate({
-            target: [groupInvites.groupId, groupInvites.invitedUserId],
-            set: {
-              invitedBy: user.userId,
-              status: 'pending',
-              invitedAt: now,
-            },
           });
+        }
 
         // System message for invite
         if (groupChat) {
@@ -293,7 +303,8 @@ export const POST = withErrorHandling(
         user.userId,
         groupId,
         groupName,
-        result.inviteId || undefined
+        result.inviteId || undefined,
+        result.adderName // Pass pre-fetched name to avoid N+1
       );
 
       logger.info(

--- a/apps/web/src/app/api/groups/[groupId]/members/route.ts
+++ b/apps/web/src/app/api/groups/[groupId]/members/route.ts
@@ -1,18 +1,21 @@
 /**
  * Group Members API
  *
- * @route POST /api/groups/[groupId]/members - Add member to group directly
+ * @route POST /api/groups/[groupId]/members - Add member to group
  * @route DELETE /api/groups/[groupId]/members - Remove member from group
  * @access Authenticated (admins can add/remove, members can self-remove)
  *
- * NOTE: For MVP, members are added directly without invite flow.
- * NPC groups (type: 'npc') use the tiered system and cannot have members added via this API.
+ * Member addition behavior:
+ * - Agents/NPCs are added directly (no invite needed)
+ * - Human users receive an invite they can accept/decline
+ * - NPC groups (type: 'npc') use the tiered system and cannot have members added via this API
  */
 
 import {
   ApiError,
   authenticate,
   notifyGroupMemberAdded,
+  notifyUserGroupInvite,
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
@@ -20,10 +23,12 @@ import {
   asUser,
   chatParticipants,
   generateSnowflakeId,
+  groupInvites,
   groupMembers,
   sql,
 } from '@babylon/db';
 import { logger } from '@babylon/shared';
+import { nanoid } from 'nanoid';
 import type { NextRequest } from 'next/server';
 import { z } from 'zod';
 
@@ -33,10 +38,11 @@ const AddMemberSchema = z.object({
 
 /**
  * POST /api/groups/[groupId]/members
- * Add a member to the group directly (admin only)
+ * Add a member to the group (admin only)
  *
- * For MVP: All members (human and agent) are added directly without invite flow.
- * NPC groups use the tiered system and cannot be modified via this API.
+ * - Agents/NPCs are added directly (no invite needed)
+ * - Human users receive an invite they can accept/decline
+ * - NPC groups use the tiered system and cannot be modified via this API
  */
 export const POST = withErrorHandling(
   async (
@@ -51,7 +57,7 @@ export const POST = withErrorHandling(
     let groupName = 'Unknown';
     let chatId: string | null = null;
 
-    const { adderName } = await asUser(user, async (db) => {
+    const result = await asUser(user, async (db) => {
       // Get group details first to check type
       const group = await db.group.findUnique({
         where: { id: groupId },
@@ -85,10 +91,17 @@ export const POST = withErrorHandling(
         throw new ApiError('Only group admins can add members', 403);
       }
 
-      // Verify the user to add exists and is not banned
+      // Verify the user to add exists and is not banned, get type info
       const userToAdd = await db.user.findUnique({
         where: { id: data.userId },
-        select: { id: true, isBanned: true, displayName: true, username: true },
+        select: {
+          id: true,
+          isBanned: true,
+          displayName: true,
+          username: true,
+          isAgent: true,
+          isActor: true,
+        },
       });
 
       if (!userToAdd) {
@@ -112,6 +125,19 @@ export const POST = withErrorHandling(
         throw new ApiError('User is already a member of this group', 400);
       }
 
+      // Check if there's already a pending invite for this user
+      const existingInvite = await db.groupInvite.findFirst({
+        where: {
+          groupId,
+          invitedUserId: data.userId,
+          status: 'pending',
+        },
+      });
+
+      if (existingInvite) {
+        throw new ApiError('User already has a pending invite to this group', 400);
+      }
+
       // Find the chat for this group
       const groupChat = await db.chat.findFirst({
         where: { groupId },
@@ -120,57 +146,7 @@ export const POST = withErrorHandling(
 
       chatId = groupChat?.id || null;
 
-      // Add member directly using Drizzle upsert
-      const now = new Date();
-      const memberId = await generateSnowflakeId();
-
-      await db
-        .insert(groupMembers)
-        .values({
-          id: memberId,
-          groupId,
-          userId: data.userId,
-          role: 'member',
-          addedBy: user.userId,
-          joinedAt: now,
-          isActive: true,
-          messageCount: 0,
-          qualityScore: 1.0,
-        })
-        .onConflictDoUpdate({
-          target: [groupMembers.groupId, groupMembers.userId],
-          set: {
-            isActive: true,
-            role: 'member',
-            addedBy: user.userId,
-            joinedAt: now,
-            kickedAt: sql`NULL`,
-            kickReason: sql`NULL`,
-          },
-        });
-
-      // Upsert ChatParticipant if chat exists
-      if (groupChat) {
-        const participantId = await generateSnowflakeId();
-        await db
-          .insert(chatParticipants)
-          .values({
-            id: participantId,
-            chatId: groupChat.id,
-            userId: data.userId,
-            joinedAt: now,
-            isActive: true,
-          })
-          .onConflictDoUpdate({
-            target: [chatParticipants.chatId, chatParticipants.userId],
-            set: {
-              isActive: true,
-              joinedAt: now,
-            },
-          });
-      }
-
-      // Get adder's name for system message
+      // Get adder's name for messages
       const adder = await db.user.findUnique({
         where: { id: user.userId },
         select: { displayName: true, username: true },
@@ -179,39 +155,141 @@ export const POST = withErrorHandling(
       const addedUserName =
         userToAdd.displayName || userToAdd.username || 'Someone';
 
-      // Create system message announcing the new member
-      if (groupChat) {
-        await db.message.create({
-          data: {
-            id: await generateSnowflakeId(),
-            chatId: groupChat.id,
-            senderId: 'system',
-            content: `${adderName} added ${addedUserName} to the group`,
-            createdAt: now,
-          },
-        });
-      }
+      const now = new Date();
+      const isAgentOrNpc = userToAdd.isAgent || userToAdd.isActor;
 
-      return { adderName };
+      if (isAgentOrNpc) {
+        // AGENT/NPC: Add directly (no invite needed)
+        const memberId = await generateSnowflakeId();
+
+        await db
+          .insert(groupMembers)
+          .values({
+            id: memberId,
+            groupId,
+            userId: data.userId,
+            role: 'member',
+            addedBy: user.userId,
+            joinedAt: now,
+            isActive: true,
+            messageCount: 0,
+            qualityScore: 1.0,
+          })
+          .onConflictDoUpdate({
+            target: [groupMembers.groupId, groupMembers.userId],
+            set: {
+              isActive: true,
+              role: 'member',
+              addedBy: user.userId,
+              joinedAt: now,
+              kickedAt: sql`NULL`,
+              kickReason: sql`NULL`,
+            },
+          });
+
+        // Add to chat participants
+        if (groupChat) {
+          const participantId = await generateSnowflakeId();
+          await db
+            .insert(chatParticipants)
+            .values({
+              id: participantId,
+              chatId: groupChat.id,
+              userId: data.userId,
+              joinedAt: now,
+              isActive: true,
+            })
+            .onConflictDoUpdate({
+              target: [chatParticipants.chatId, chatParticipants.userId],
+              set: {
+                isActive: true,
+                joinedAt: now,
+              },
+            });
+
+          // System message for direct add
+          await db.message.create({
+            data: {
+              id: await generateSnowflakeId(),
+              chatId: groupChat.id,
+              senderId: 'system',
+              content: `${adderName} added ${addedUserName} to the group`,
+              createdAt: now,
+            },
+          });
+        }
+
+        return { added: true, invited: false, adderName, inviteId: null };
+      } else {
+        // HUMAN: Send invite (they need to accept)
+        const inviteId = nanoid();
+
+        await db
+          .insert(groupInvites)
+          .values({
+            id: inviteId,
+            groupId,
+            invitedUserId: data.userId,
+            invitedBy: user.userId,
+            status: 'pending',
+            invitedAt: now,
+          })
+          .onConflictDoNothing();
+
+        // System message for invite
+        if (groupChat) {
+          await db.message.create({
+            data: {
+              id: await generateSnowflakeId(),
+              chatId: groupChat.id,
+              senderId: 'system',
+              content: `${adderName} invited ${addedUserName} to the group`,
+              createdAt: now,
+            },
+          });
+        }
+
+        return { added: false, invited: true, adderName, inviteId };
+      }
     });
 
-    // Send notification to the added user (pass adderName to avoid extra query)
-    await notifyGroupMemberAdded(
-      data.userId,
-      user.userId,
-      groupId,
-      groupName,
-      chatId || undefined,
-      adderName
-    );
+    // Send appropriate notification
+    if (result.added) {
+      // Agent/NPC was directly added
+      await notifyGroupMemberAdded(
+        data.userId,
+        user.userId,
+        groupId,
+        groupName,
+        chatId || undefined,
+        result.adderName
+      );
 
-    logger.info(
-      'Member added to group',
-      { userId: user.userId, groupId, addedUserId: data.userId },
-      'POST /api/groups/:groupId/members'
-    );
+      logger.info(
+        'Agent/NPC added to group',
+        { userId: user.userId, groupId, addedUserId: data.userId },
+        'POST /api/groups/:groupId/members'
+      );
 
-    return successResponse({ success: true, added: true });
+      return successResponse({ success: true, added: true, invited: false });
+    } else {
+      // Human was invited
+      await notifyUserGroupInvite(
+        data.userId,
+        user.userId,
+        groupId,
+        groupName,
+        result.inviteId || undefined
+      );
+
+      logger.info(
+        'User invited to group',
+        { userId: user.userId, groupId, invitedUserId: data.userId },
+        'POST /api/groups/:groupId/members'
+      );
+
+      return successResponse({ success: true, added: false, invited: true });
+    }
   }
 );
 

--- a/apps/web/src/app/api/groups/[groupId]/members/route.ts
+++ b/apps/web/src/app/api/groups/[groupId]/members/route.ts
@@ -28,7 +28,6 @@ import {
   sql,
 } from '@babylon/db';
 import { logger } from '@babylon/shared';
-import { nanoid } from 'nanoid';
 import type { NextRequest } from 'next/server';
 import { z } from 'zod';
 
@@ -132,16 +131,17 @@ export const POST = withErrorHandling(
         where: {
           groupId,
           invitedUserId: data.userId,
-          status: 'pending',
         },
+        select: { status: true },
       });
 
-      if (existingInvite) {
+      if (existingInvite && existingInvite.status === 'pending') {
         throw new ApiError(
           'User already has a pending invite to this group',
           400
         );
       }
+      // Note: If status is 'declined', we allow re-inviting via onConflictDoUpdate below
 
       // Find the chat for this group
       const groupChat = await db.chat.findFirst({
@@ -227,8 +227,10 @@ export const POST = withErrorHandling(
         return { added: true, invited: false, adderName, inviteId: null };
       } else {
         // HUMAN: Send invite (they need to accept)
-        const inviteId = nanoid();
+        // Use generateSnowflakeId for consistency with other IDs
+        const inviteId = await generateSnowflakeId();
 
+        // Use onConflictDoUpdate to allow re-inviting users who previously declined
         await db
           .insert(groupInvites)
           .values({
@@ -239,7 +241,14 @@ export const POST = withErrorHandling(
             status: 'pending',
             invitedAt: now,
           })
-          .onConflictDoNothing();
+          .onConflictDoUpdate({
+            target: [groupInvites.groupId, groupInvites.invitedUserId],
+            set: {
+              invitedBy: user.userId,
+              status: 'pending',
+              invitedAt: now,
+            },
+          });
 
         // System message for invite
         if (groupChat) {

--- a/apps/web/src/app/api/groups/[groupId]/members/route.ts
+++ b/apps/web/src/app/api/groups/[groupId]/members/route.ts
@@ -51,7 +51,7 @@ export const POST = withErrorHandling(
     let groupName = 'Unknown';
     let chatId: string | null = null;
 
-    await asUser(user, async (db) => {
+    const { adderName } = await asUser(user, async (db) => {
       // Get group details first to check type
       const group = await db.group.findUnique({
         where: { id: groupId },
@@ -191,15 +191,18 @@ export const POST = withErrorHandling(
           },
         });
       }
+
+      return { adderName };
     });
 
-    // Send notification to the added user
+    // Send notification to the added user (pass adderName to avoid extra query)
     await notifyGroupMemberAdded(
       data.userId,
       user.userId,
       groupId,
       groupName,
-      chatId || undefined
+      chatId || undefined,
+      adderName
     );
 
     logger.info(

--- a/apps/web/src/app/api/groups/[groupId]/members/route.ts
+++ b/apps/web/src/app/api/groups/[groupId]/members/route.ts
@@ -57,6 +57,8 @@ export const POST = withErrorHandling(
     let groupName = 'Unknown';
     let chatId: string | null = null;
 
+    // Note: asUser wraps all operations in a database transaction,
+    // ensuring atomicity for member addition + chat participant + notifications
     const result = await asUser(user, async (db) => {
       // Get group details first to check type
       const group = await db.group.findUnique({
@@ -135,7 +137,10 @@ export const POST = withErrorHandling(
       });
 
       if (existingInvite) {
-        throw new ApiError('User already has a pending invite to this group', 400);
+        throw new ApiError(
+          'User already has a pending invite to this group',
+          400
+        );
       }
 
       // Find the chat for this group

--- a/apps/web/src/app/api/groups/[groupId]/members/route.ts
+++ b/apps/web/src/app/api/groups/[groupId]/members/route.ts
@@ -277,17 +277,25 @@ export const POST = withErrorHandling(
       }
     });
 
-    // Send appropriate notification
+    // Send appropriate notification (don't fail request if notification fails)
     if (result.added) {
       // Agent/NPC was directly added
-      await notifyGroupMemberAdded(
-        data.userId,
-        user.userId,
-        groupId,
-        groupName,
-        chatId || undefined,
-        result.adderName
-      );
+      try {
+        await notifyGroupMemberAdded(
+          data.userId,
+          user.userId,
+          groupId,
+          groupName,
+          chatId || undefined,
+          result.adderName
+        );
+      } catch (notifyError) {
+        logger.error(
+          'Failed to send group member added notification',
+          { userId: data.userId, groupId, error: notifyError },
+          'POST /api/groups/:groupId/members'
+        );
+      }
 
       logger.info(
         'Agent/NPC added to group',
@@ -298,14 +306,22 @@ export const POST = withErrorHandling(
       return successResponse({ success: true, added: true, invited: false });
     } else {
       // Human was invited
-      await notifyUserGroupInvite(
-        data.userId,
-        user.userId,
-        groupId,
-        groupName,
-        result.inviteId || undefined,
-        result.adderName // Pass pre-fetched name to avoid N+1
-      );
+      try {
+        await notifyUserGroupInvite(
+          data.userId,
+          user.userId,
+          groupId,
+          groupName,
+          result.inviteId || undefined,
+          result.adderName // Pass pre-fetched name to avoid N+1
+        );
+      } catch (notifyError) {
+        logger.error(
+          'Failed to send group invite notification',
+          { userId: data.userId, groupId, error: notifyError },
+          'POST /api/groups/:groupId/members'
+        );
+      }
 
       logger.info(
         'User invited to group',

--- a/apps/web/src/app/api/groups/[groupId]/members/route.ts
+++ b/apps/web/src/app/api/groups/[groupId]/members/route.ts
@@ -1,15 +1,18 @@
 /**
  * Group Members API
  *
- * @route POST /api/groups/[groupId]/members - Add member to group (sends invite)
+ * @route POST /api/groups/[groupId]/members - Add member to group directly
  * @route DELETE /api/groups/[groupId]/members - Remove member from group
  * @access Authenticated (admins can add/remove, members can self-remove)
+ *
+ * NOTE: For MVP, members are added directly without invite flow.
+ * NPC groups (type: 'npc') use the tiered system and cannot have members added via this API.
  */
 
 import {
   ApiError,
   authenticate,
-  notifyUserGroupInvite,
+  notifyGroupMemberAdded,
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
@@ -30,7 +33,10 @@ const AddMemberSchema = z.object({
 
 /**
  * POST /api/groups/[groupId]/members
- * Add a member to the group via invite (admin only)
+ * Add a member to the group directly (admin only)
+ *
+ * For MVP: All members (human and agent) are added directly without invite flow.
+ * NPC groups use the tiered system and cannot be modified via this API.
  */
 export const POST = withErrorHandling(
   async (
@@ -43,10 +49,29 @@ export const POST = withErrorHandling(
     const data = AddMemberSchema.parse(body);
 
     let groupName = 'Unknown';
-    let inviteId = '';
-    let isAgent = false;
+    let chatId: string | null = null;
 
     await asUser(user, async (db) => {
+      // Get group details first to check type
+      const group = await db.group.findUnique({
+        where: { id: groupId },
+        select: { name: true, type: true },
+      });
+
+      if (!group) {
+        throw new ApiError('Group not found', 404);
+      }
+
+      groupName = group.name || 'Unknown';
+
+      // NPC groups use the tiered system, cannot add members directly
+      if (group.type === 'npc') {
+        throw new ApiError(
+          'Cannot directly add members to NPC groups. NPC groups use the tiered invitation system.',
+          403
+        );
+      }
+
       // Check if user is admin or owner
       const membership = await db.groupMember.findFirst({
         where: {
@@ -60,12 +85,19 @@ export const POST = withErrorHandling(
         throw new ApiError('Only group admins can add members', 403);
       }
 
-      // Check if invitee is an agent (auto-accept, agents can't manually accept invites)
-      const invitee = await db.user.findUnique({
+      // Verify the user to add exists and is not banned
+      const userToAdd = await db.user.findUnique({
         where: { id: data.userId },
-        select: { isAgent: true },
+        select: { id: true, isBanned: true, displayName: true, username: true },
       });
-      isAgent = invitee?.isAgent === true;
+
+      if (!userToAdd) {
+        throw new ApiError('User not found', 404);
+      }
+
+      if (userToAdd.isBanned) {
+        throw new ApiError('Cannot add banned users to groups', 400);
+      }
 
       // Check if user is already a member
       const existingMember = await db.groupMember.findFirst({
@@ -80,136 +112,103 @@ export const POST = withErrorHandling(
         throw new ApiError('User is already a member of this group', 400);
       }
 
-      // Get group details for notification
-      const group = await db.group.findUnique({
-        where: { id: groupId },
-        select: { name: true },
-      });
-      groupName = group?.name || 'Unknown';
-
       // Find the chat for this group
       const groupChat = await db.chat.findFirst({
         where: { groupId },
         select: { id: true },
       });
 
-      if (isAgent) {
-        // Agents are auto-accepted - add them directly using atomic upserts
-        const now = new Date();
+      chatId = groupChat?.id || null;
 
-        await db.transaction(async (tx) => {
-          // Upsert GroupMember - use raw SQL for partial index compatibility
-          const memberId = await generateSnowflakeId();
-          await tx.execute(sql`
-            INSERT INTO "GroupMember" (
-              "id", "groupId", "userId", "role", "addedBy", "joinedAt", "isActive",
-              "messageCount", "qualityScore"
-            ) VALUES (
-              ${memberId}, ${groupId}, ${data.userId}, 'member', ${user.userId}, ${now}, true,
-              0, 1.0
-            )
-            ON CONFLICT ("groupId", "userId") WHERE "isActive" = true
-            DO NOTHING
-          `);
+      // Add member directly using Drizzle upsert
+      const now = new Date();
+      const memberId = await generateSnowflakeId();
 
-          // Update any inactive records to active
-          await tx
-            .update(groupMembers)
-            .set({
-              isActive: true,
-              role: 'member',
-              addedBy: user.userId,
-              joinedAt: now,
-              kickedAt: null,
-              kickReason: null,
-            })
-            .where(
-              sql`${groupMembers.groupId} = ${groupId} AND ${groupMembers.userId} = ${data.userId} AND ${groupMembers.isActive} = false`
-            );
-
-          // Upsert ChatParticipant if chat exists
-          if (groupChat) {
-            const participantId = await generateSnowflakeId();
-            await tx
-              .insert(chatParticipants)
-              .values({
-                id: participantId,
-                chatId: groupChat.id,
-                userId: data.userId,
-                joinedAt: now,
-                isActive: true,
-              })
-              .onConflictDoUpdate({
-                target: [chatParticipants.chatId, chatParticipants.userId],
-                set: {
-                  isActive: true,
-                  joinedAt: now,
-                },
-              });
-          }
-        });
-      } else {
-        // Regular users get an invite
-
-        // Check if there's already an existing invite (unique constraint on groupId + invitedUserId)
-        const existingInvite = await db.groupInvite.findFirst({
-          where: {
-            groupId,
-            invitedUserId: data.userId,
+      await db
+        .insert(groupMembers)
+        .values({
+          id: memberId,
+          groupId,
+          userId: data.userId,
+          role: 'member',
+          addedBy: user.userId,
+          joinedAt: now,
+          isActive: true,
+          messageCount: 0,
+          qualityScore: 1.0,
+        })
+        .onConflictDoUpdate({
+          target: [groupMembers.groupId, groupMembers.userId],
+          set: {
+            isActive: true,
+            role: 'member',
+            addedBy: user.userId,
+            joinedAt: now,
+            kickedAt: sql`NULL`,
+            kickReason: sql`NULL`,
           },
         });
 
-        if (existingInvite) {
-          if (existingInvite.status === 'pending') {
-            throw new ApiError('User already has a pending invite', 400);
-          }
-          // For declined or accepted (user left) invites, reset to pending (re-invite flow)
-          await db.groupInvite.update({
-            where: { id: existingInvite.id },
-            data: {
-              status: 'pending',
-              invitedBy: user.userId,
-              invitedAt: new Date(),
-              respondedAt: null,
+      // Upsert ChatParticipant if chat exists
+      if (groupChat) {
+        const participantId = await generateSnowflakeId();
+        await db
+          .insert(chatParticipants)
+          .values({
+            id: participantId,
+            chatId: groupChat.id,
+            userId: data.userId,
+            joinedAt: now,
+            isActive: true,
+          })
+          .onConflictDoUpdate({
+            target: [chatParticipants.chatId, chatParticipants.userId],
+            set: {
+              isActive: true,
+              joinedAt: now,
             },
           });
-          inviteId = existingInvite.id;
-        }
+      }
 
-        // Create new invite only if no existing invite was found
-        if (!inviteId) {
-          inviteId = await generateSnowflakeId();
-          await db.groupInvite.create({
-            data: {
-              id: inviteId,
-              groupId,
-              invitedUserId: data.userId,
-              invitedBy: user.userId,
-              status: 'pending',
-            },
-          });
-        }
+      // Get adder's name for system message
+      const adder = await db.user.findUnique({
+        where: { id: user.userId },
+        select: { displayName: true, username: true },
+      });
+      const adderName = adder?.displayName || adder?.username || 'Someone';
+      const addedUserName =
+        userToAdd.displayName || userToAdd.username || 'Someone';
+
+      // Create system message announcing the new member
+      if (groupChat) {
+        await db.message.create({
+          data: {
+            id: await generateSnowflakeId(),
+            chatId: groupChat.id,
+            senderId: 'system',
+            content: `${adderName} added ${addedUserName} to the group`,
+            createdAt: now,
+          },
+        });
       }
     });
 
-    // Send notification to the invited user (only for non-agents)
-    if (!isAgent && inviteId) {
-      await notifyUserGroupInvite(
-        data.userId,
-        user.userId,
-        groupId,
-        groupName,
-        inviteId
-      );
-    }
+    // Send notification to the added user
+    await notifyGroupMemberAdded(
+      data.userId,
+      user.userId,
+      groupId,
+      groupName,
+      chatId || undefined
+    );
 
     logger.info(
-      'Member invited to group',
-      { userId: user.userId, groupId, invitedUserId: data.userId },
+      'Member added to group',
+      { userId: user.userId, groupId, addedUserId: data.userId },
       'POST /api/groups/:groupId/members'
     );
 
-    return successResponse({ success: true, inviteId });
+    return successResponse({ success: true, added: true });
   }
 );
 
@@ -283,7 +282,7 @@ export const DELETE = withErrorHandling(
         select: { id: true },
       });
 
-      // Remove from associated chat
+      // Remove from associated chat and add system message
       if (groupChat) {
         await db.chatParticipant.deleteMany({
           where: {
@@ -291,6 +290,44 @@ export const DELETE = withErrorHandling(
             userId: userIdToRemove,
           },
         });
+
+        // Get names for system message
+        const removedUser = await db.user.findUnique({
+          where: { id: userIdToRemove },
+          select: { displayName: true, username: true },
+        });
+        const removedName =
+          removedUser?.displayName || removedUser?.username || 'Someone';
+
+        if (isSelf) {
+          // User left on their own
+          await db.message.create({
+            data: {
+              id: await generateSnowflakeId(),
+              chatId: groupChat.id,
+              senderId: 'system',
+              content: `${removedName} left the group`,
+              createdAt: new Date(),
+            },
+          });
+        } else {
+          // User was removed by admin
+          const admin = await db.user.findUnique({
+            where: { id: user.userId },
+            select: { displayName: true, username: true },
+          });
+          const adminName = admin?.displayName || admin?.username || 'Someone';
+
+          await db.message.create({
+            data: {
+              id: await generateSnowflakeId(),
+              chatId: groupChat.id,
+              senderId: 'system',
+              content: `${adminName} removed ${removedName} from the group`,
+              createdAt: new Date(),
+            },
+          });
+        }
       }
     });
 

--- a/apps/web/src/app/api/groups/invites/[inviteId]/accept/route.ts
+++ b/apps/web/src/app/api/groups/invites/[inviteId]/accept/route.ts
@@ -99,39 +99,35 @@ export const POST = withErrorHandling(
       });
 
       const now = new Date();
+      const memberId = await generateSnowflakeId();
 
       // Use transaction with atomic upserts to prevent race conditions
       await db.transaction(async (tx) => {
-        // Upsert GroupMember - use raw SQL for partial index compatibility
-        // INSERT new member OR update inactive member to active
-        const memberId = await generateSnowflakeId();
-        await tx.execute(sql`
-          INSERT INTO "GroupMember" (
-            "id", "groupId", "userId", "role", "addedBy", "joinedAt", "isActive",
-            "messageCount", "qualityScore"
-          ) VALUES (
-            ${memberId}, ${invite.groupId}, ${user.userId}, 'member', ${invite.invitedBy}, ${now}, true,
-            0, 1.0
-          )
-          ON CONFLICT ("groupId", "userId") WHERE "isActive" = true
-          DO NOTHING
-        `);
-
-        // Also handle the case where there's an inactive record (not covered by partial index)
-        // Update any inactive records to active
+        // Upsert GroupMember - use drizzle's onConflictDoUpdate
         await tx
-          .update(groupMembers)
-          .set({
-            isActive: true,
+          .insert(groupMembers)
+          .values({
+            id: memberId,
+            groupId: invite.groupId,
+            userId: user.userId,
             role: 'member',
             addedBy: invite.invitedBy,
             joinedAt: now,
-            kickedAt: null,
-            kickReason: null,
+            isActive: true,
+            messageCount: 0,
+            qualityScore: 1.0,
           })
-          .where(
-            sql`${groupMembers.groupId} = ${invite.groupId} AND ${groupMembers.userId} = ${user.userId} AND ${groupMembers.isActive} = false`
-          );
+          .onConflictDoUpdate({
+            target: [groupMembers.groupId, groupMembers.userId],
+            set: {
+              isActive: true,
+              role: 'member',
+              addedBy: invite.invitedBy,
+              joinedAt: now,
+              kickedAt: sql`NULL`,
+              kickReason: sql`NULL`,
+            },
+          });
 
         // Upsert ChatParticipant if chat exists
         if (groupChat) {

--- a/apps/web/src/app/api/groups/route.ts
+++ b/apps/web/src/app/api/groups/route.ts
@@ -152,7 +152,7 @@ import {
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
-import { asUser, groupInvites } from '@babylon/db';
+import { asUser, generateSnowflakeId, groupInvites } from '@babylon/db';
 import { logger } from '@babylon/shared';
 import { nanoid } from 'nanoid';
 import type { NextRequest } from 'next/server';
@@ -390,7 +390,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
 
             await db.message.create({
               data: {
-                id: nanoid(),
+                id: await generateSnowflakeId(),
                 chatId,
                 senderId: 'system',
                 content: `${creatorName} added ${agentNamesText} to the group`,
@@ -398,8 +398,8 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
               },
             });
 
-            // Notify agents directly added
-            await Promise.all(
+            // Notify agents directly added (use allSettled so notification failures don't break group creation)
+            await Promise.allSettled(
               agentIds.map((memberId) =>
                 notifyGroupMemberAdded(
                   memberId,
@@ -416,33 +416,53 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
           // HUMANS: Send invites (they need to accept/decline)
           if (humans.length > 0) {
             const humanIds = humans.map((u) => u.id);
+            const invitedAt = new Date();
 
-            // Create group invites for humans
-            for (const humanId of humanIds) {
-              const inviteId = nanoid();
-              await db
-                .insert(groupInvites)
-                .values({
-                  id: inviteId,
+            // Create group invites for humans in parallel
+            // Use onConflictDoUpdate to allow re-inviting users who previously declined
+            const inviteResults = await Promise.allSettled(
+              humanIds.map(async (humanId) => {
+                const inviteId = await generateSnowflakeId();
+                await db
+                  .insert(groupInvites)
+                  .values({
+                    id: inviteId,
+                    groupId,
+                    invitedUserId: humanId,
+                    invitedBy: user.userId,
+                    status: 'pending',
+                    invitedAt,
+                  })
+                  .onConflictDoUpdate({
+                    target: [groupInvites.groupId, groupInvites.invitedUserId],
+                    set: {
+                      invitedBy: user.userId,
+                      status: 'pending',
+                      invitedAt,
+                    },
+                  });
+
+                // Send invite notification (use allSettled so failures don't break group creation)
+                await notifyUserGroupInvite(
+                  humanId,
+                  user.userId,
                   groupId,
-                  invitedUserId: humanId,
-                  invitedBy: user.userId,
-                  status: 'pending',
-                  invitedAt: new Date(),
-                })
-                .onConflictDoNothing(); // Skip if already invited
+                  data.name,
+                  inviteId
+                );
+                return humanId;
+              })
+            );
 
-              invitedMemberIds.push(humanId);
-
-              // Send invite notification
-              await notifyUserGroupInvite(
-                humanId,
-                user.userId,
-                groupId,
-                data.name,
-                inviteId
-              );
-            }
+            // Collect successfully invited members
+            invitedMemberIds.push(
+              ...inviteResults
+                .filter(
+                  (r): r is PromiseFulfilledResult<string> =>
+                    r.status === 'fulfilled'
+                )
+                .map((r) => r.value)
+            );
 
             // Create system message for invites sent
             const humanNames = humans.map(
@@ -455,7 +475,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
 
             await db.message.create({
               data: {
-                id: nanoid(),
+                id: await generateSnowflakeId(),
                 chatId,
                 senderId: 'system',
                 content: `${creatorName} invited ${humanNamesText} to the group`,

--- a/apps/web/src/app/api/groups/route.ts
+++ b/apps/web/src/app/api/groups/route.ts
@@ -321,6 +321,13 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
     // Process initial members: humans get invites, agents get direct add
     const addedMemberIds: string[] = [];
     const invitedMemberIds: string[] = [];
+    // Notification work list - sent AFTER transaction commits
+    const agentNotifications: string[] = [];
+    const humanInviteNotifications: Array<{
+      humanId: string;
+      inviteId: string;
+    }> = [];
+    let creatorName = 'Someone';
 
     if (data.memberIds.length > 0) {
       const otherMembers = data.memberIds.filter((id) => id !== user.userId);
@@ -347,8 +354,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
             where: { id: user.userId },
             select: { displayName: true, username: true },
           });
-          const creatorName =
-            creator?.displayName || creator?.username || 'Someone';
+          creatorName = creator?.displayName || creator?.username || 'Someone';
 
           // Separate humans from agents/NPCs
           const agents = validMembers.filter((m) => m.isAgent || m.isActor);
@@ -378,6 +384,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
             });
 
             addedMemberIds.push(...agentIds);
+            agentNotifications.push(...agentIds);
 
             // Create system message for agents added
             const agentNames = agents.map(
@@ -398,19 +405,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
               },
             });
 
-            // Notify agents directly added (use allSettled so notification failures don't break group creation)
-            await Promise.allSettled(
-              agentIds.map((memberId) =>
-                notifyGroupMemberAdded(
-                  memberId,
-                  user.userId,
-                  groupId,
-                  data.name,
-                  chatId,
-                  creatorName
-                )
-              )
-            );
+            // Note: Agent notifications are sent AFTER the transaction commits (see below)
           }
 
           // HUMANS: Send invites (they need to accept/decline)
@@ -418,51 +413,32 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
             const humanIds = humans.map((u) => u.id);
             const invitedAt = new Date();
 
-            // Create group invites for humans in parallel
+            // Create group invites for humans
             // Use onConflictDoUpdate to allow re-inviting users who previously declined
-            const inviteResults = await Promise.allSettled(
-              humanIds.map(async (humanId) => {
-                const inviteId = await generateSnowflakeId();
-                await db
-                  .insert(groupInvites)
-                  .values({
-                    id: inviteId,
-                    groupId,
-                    invitedUserId: humanId,
+            for (const humanId of humanIds) {
+              const inviteId = await generateSnowflakeId();
+              await db
+                .insert(groupInvites)
+                .values({
+                  id: inviteId,
+                  groupId,
+                  invitedUserId: humanId,
+                  invitedBy: user.userId,
+                  status: 'pending',
+                  invitedAt,
+                })
+                .onConflictDoUpdate({
+                  target: [groupInvites.groupId, groupInvites.invitedUserId],
+                  set: {
                     invitedBy: user.userId,
                     status: 'pending',
                     invitedAt,
-                  })
-                  .onConflictDoUpdate({
-                    target: [groupInvites.groupId, groupInvites.invitedUserId],
-                    set: {
-                      invitedBy: user.userId,
-                      status: 'pending',
-                      invitedAt,
-                    },
-                  });
-
-                // Send invite notification (use allSettled so failures don't break group creation)
-                await notifyUserGroupInvite(
-                  humanId,
-                  user.userId,
-                  groupId,
-                  data.name,
-                  inviteId
-                );
-                return humanId;
-              })
-            );
-
-            // Collect successfully invited members
-            invitedMemberIds.push(
-              ...inviteResults
-                .filter(
-                  (r): r is PromiseFulfilledResult<string> =>
-                    r.status === 'fulfilled'
-                )
-                .map((r) => r.value)
-            );
+                  },
+                });
+              humanInviteNotifications.push({ humanId, inviteId });
+              invitedMemberIds.push(humanId);
+            }
+            // Note: Human invite notifications are sent AFTER the transaction commits (see below)
 
             // Create system message for invites sent
             const humanNames = humans.map(
@@ -492,8 +468,45 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
       chatId,
       memberCount: 1 + addedMemberIds.length, // creator + direct-added members (not invites)
       invitedCount: invitedMemberIds.length,
+      // Notification work list for post-transaction dispatch
+      notifications: {
+        agents: agentNotifications,
+        humanInvites: humanInviteNotifications,
+        creatorName,
+      },
     };
   });
+
+  // Send notifications AFTER transaction commits (prevents orphan notifications on rollback)
+  if (result.notifications.agents.length > 0) {
+    await Promise.allSettled(
+      result.notifications.agents.map((memberId) =>
+        notifyGroupMemberAdded(
+          memberId,
+          user.userId,
+          result.group.id,
+          data.name,
+          result.chatId,
+          result.notifications.creatorName
+        )
+      )
+    );
+  }
+
+  if (result.notifications.humanInvites.length > 0) {
+    await Promise.allSettled(
+      result.notifications.humanInvites.map(({ humanId, inviteId }) =>
+        notifyUserGroupInvite(
+          humanId,
+          user.userId,
+          result.group.id,
+          data.name,
+          inviteId,
+          result.notifications.creatorName // Pass pre-fetched name to avoid N+1
+        )
+      )
+    );
+  }
 
   logger.info(
     'Group created',

--- a/apps/web/src/app/api/groups/route.ts
+++ b/apps/web/src/app/api/groups/route.ts
@@ -148,10 +148,11 @@
 import {
   authenticate,
   notifyGroupMemberAdded,
+  notifyUserGroupInvite,
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
-import { asUser } from '@babylon/db';
+import { asUser, groupInvites } from '@babylon/db';
 import { logger } from '@babylon/shared';
 import { nanoid } from 'nanoid';
 import type { NextRequest } from 'next/server';
@@ -315,49 +316,31 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
       },
     });
 
-    // Add initial members directly (no invite flow for MVP)
-    // All selected users are added immediately as members
+    // Process initial members: humans get invites, agents get direct add
     const addedMemberIds: string[] = [];
+    const invitedMemberIds: string[] = [];
+
     if (data.memberIds.length > 0) {
       const otherMembers = data.memberIds.filter((id) => id !== user.userId);
 
       if (otherMembers.length > 0) {
-        // Verify users exist and are not banned, get their names for system message
+        // Verify users exist and are not banned, get their details including type
         const validMembers = await db.user.findMany({
           where: {
             id: { in: otherMembers },
             isBanned: false,
           },
-          select: { id: true, displayName: true, username: true },
+          select: {
+            id: true,
+            displayName: true,
+            username: true,
+            isAgent: true,
+            isActor: true,
+          },
         });
 
         if (validMembers.length > 0) {
-          const validMemberIds = validMembers.map((u) => u.id);
-
-          // Add all members directly as GroupMembers
-          await db.groupMember.createMany({
-            data: validMemberIds.map((userId) => ({
-              id: nanoid(),
-              groupId,
-              userId,
-              role: 'member',
-              addedBy: user.userId,
-            })),
-          });
-
-          // Add all members to ChatParticipants
-          await db.chatParticipant.createMany({
-            data: validMemberIds.map((userId) => ({
-              id: nanoid(),
-              chatId,
-              userId,
-              joinedAt: new Date(),
-            })),
-          });
-
-          addedMemberIds.push(...validMemberIds);
-
-          // Get creator's name for the system message
+          // Get creator's name for messages
           const creator = await db.user.findUnique({
             where: { id: user.userId },
             select: { displayName: true, username: true },
@@ -365,39 +348,119 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
           const creatorName =
             creator?.displayName || creator?.username || 'Someone';
 
-          // Build member names list for system message
-          const memberNames = validMembers.map(
-            (m) => m.displayName || m.username || 'Unknown'
-          );
-          const memberNamesText =
-            memberNames.length <= 3
-              ? memberNames.join(', ')
-              : `${memberNames.slice(0, 2).join(', ')} and ${memberNames.length - 2} others`;
+          // Separate humans from agents/NPCs
+          const agents = validMembers.filter((m) => m.isAgent || m.isActor);
+          const humans = validMembers.filter((m) => !m.isAgent && !m.isActor);
 
-          // Create system message announcing members were added
-          await db.message.create({
-            data: {
-              id: nanoid(),
-              chatId,
-              senderId: 'system',
-              content: `${creatorName} added ${memberNamesText} to the group`,
-              createdAt: new Date(),
-            },
-          });
+          // AGENTS/NPCs: Direct add (they don't need to accept)
+          if (agents.length > 0) {
+            const agentIds = agents.map((u) => u.id);
 
-          // Send notifications to all added members (pass creatorName to avoid N+1 queries)
-          await Promise.all(
-            validMemberIds.map((memberId) =>
-              notifyGroupMemberAdded(
-                memberId,
+            await db.groupMember.createMany({
+              data: agentIds.map((uId) => ({
+                id: nanoid(),
+                groupId,
+                userId: uId,
+                role: 'member',
+                addedBy: user.userId,
+              })),
+            });
+
+            await db.chatParticipant.createMany({
+              data: agentIds.map((uId) => ({
+                id: nanoid(),
+                chatId,
+                userId: uId,
+                joinedAt: new Date(),
+              })),
+            });
+
+            addedMemberIds.push(...agentIds);
+
+            // Create system message for agents added
+            const agentNames = agents.map(
+              (m) => m.displayName || m.username || 'Unknown'
+            );
+            const agentNamesText =
+              agentNames.length <= 3
+                ? agentNames.join(', ')
+                : `${agentNames.slice(0, 2).join(', ')} and ${agentNames.length - 2} others`;
+
+            await db.message.create({
+              data: {
+                id: nanoid(),
+                chatId,
+                senderId: 'system',
+                content: `${creatorName} added ${agentNamesText} to the group`,
+                createdAt: new Date(),
+              },
+            });
+
+            // Notify agents directly added
+            await Promise.all(
+              agentIds.map((memberId) =>
+                notifyGroupMemberAdded(
+                  memberId,
+                  user.userId,
+                  groupId,
+                  data.name,
+                  chatId,
+                  creatorName
+                )
+              )
+            );
+          }
+
+          // HUMANS: Send invites (they need to accept/decline)
+          if (humans.length > 0) {
+            const humanIds = humans.map((u) => u.id);
+
+            // Create group invites for humans
+            for (const humanId of humanIds) {
+              const inviteId = nanoid();
+              await db
+                .insert(groupInvites)
+                .values({
+                  id: inviteId,
+                  groupId,
+                  invitedUserId: humanId,
+                  invitedBy: user.userId,
+                  status: 'pending',
+                  invitedAt: new Date(),
+                })
+                .onConflictDoNothing(); // Skip if already invited
+
+              invitedMemberIds.push(humanId);
+
+              // Send invite notification
+              await notifyUserGroupInvite(
+                humanId,
                 user.userId,
                 groupId,
                 data.name,
+                inviteId
+              );
+            }
+
+            // Create system message for invites sent
+            const humanNames = humans.map(
+              (m) => m.displayName || m.username || 'Unknown'
+            );
+            const humanNamesText =
+              humanNames.length <= 3
+                ? humanNames.join(', ')
+                : `${humanNames.slice(0, 2).join(', ')} and ${humanNames.length - 2} others`;
+
+            await db.message.create({
+              data: {
+                id: nanoid(),
                 chatId,
-                creatorName
-              )
-            )
-          );
+                senderId: 'system',
+                content: `${creatorName} invited ${humanNamesText} to the group`,
+                createdAt: new Date(),
+              },
+            });
+          }
         }
       }
     }
@@ -405,7 +468,8 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
     return {
       group: newGroup,
       chatId,
-      memberCount: 1 + addedMemberIds.length, // creator + added members
+      memberCount: 1 + addedMemberIds.length, // creator + direct-added members (not invites)
+      invitedCount: invitedMemberIds.length,
     };
   });
 
@@ -416,6 +480,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
       groupId: result.group.id,
       chatId: result.chatId,
       memberCount: result.memberCount,
+      invitedCount: result.invitedCount,
     },
     'POST /api/groups'
   );
@@ -428,6 +493,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
       createdAt: result.group.createdAt,
       chatId: result.chatId,
       memberCount: result.memberCount,
+      invitedCount: result.invitedCount,
     },
   });
 });

--- a/apps/web/src/app/api/groups/route.ts
+++ b/apps/web/src/app/api/groups/route.ts
@@ -416,11 +416,11 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
             // Create group invites for humans
             // Use onConflictDoUpdate to allow re-inviting users who previously declined
             for (const humanId of humanIds) {
-              const inviteId = await generateSnowflakeId();
-              await db
+              const newInviteId = await generateSnowflakeId();
+              const result = await db
                 .insert(groupInvites)
                 .values({
-                  id: inviteId,
+                  id: newInviteId,
                   groupId,
                   invitedUserId: humanId,
                   invitedBy: user.userId,
@@ -434,8 +434,12 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
                     status: 'pending',
                     invitedAt,
                   },
-                });
-              humanInviteNotifications.push({ humanId, inviteId });
+                })
+                .returning({ id: groupInvites.id });
+
+              // Use actual ID from DB (may be existing ID on conflict, or new ID on insert)
+              const actualInviteId = result[0]?.id ?? newInviteId;
+              humanInviteNotifications.push({ humanId, inviteId: actualInviteId });
               invitedMemberIds.push(humanId);
             }
             // Note: Human invite notifications are sent AFTER the transaction commits (see below)

--- a/apps/web/src/app/api/groups/route.ts
+++ b/apps/web/src/app/api/groups/route.ts
@@ -440,13 +440,20 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
               // Use actual ID from DB (may be existing ID on conflict, or new ID on insert)
               const actualInviteId = result[0]?.id ?? newInviteId;
               if (!result[0]?.id) {
-                logger.warn('Invite returning() returned empty result, using generated ID', {
-                  groupId,
-                  invitedUserId: humanId,
-                  generatedId: newInviteId,
-                }, 'POST /api/groups');
+                logger.warn(
+                  'Invite returning() returned empty result, using generated ID',
+                  {
+                    groupId,
+                    invitedUserId: humanId,
+                    generatedId: newInviteId,
+                  },
+                  'POST /api/groups'
+                );
               }
-              humanInviteNotifications.push({ humanId, inviteId: actualInviteId });
+              humanInviteNotifications.push({
+                humanId,
+                inviteId: actualInviteId,
+              });
               invitedMemberIds.push(humanId);
             }
             // Note: Human invite notifications are sent AFTER the transaction commits (see below)

--- a/apps/web/src/app/api/groups/route.ts
+++ b/apps/web/src/app/api/groups/route.ts
@@ -385,7 +385,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
             },
           });
 
-          // Send notifications to all added members
+          // Send notifications to all added members (pass creatorName to avoid N+1 queries)
           await Promise.all(
             validMemberIds.map((memberId) =>
               notifyGroupMemberAdded(
@@ -393,7 +393,8 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
                 user.userId,
                 groupId,
                 data.name,
-                chatId
+                chatId,
+                creatorName
               )
             )
           );

--- a/apps/web/src/app/api/groups/route.ts
+++ b/apps/web/src/app/api/groups/route.ts
@@ -263,6 +263,8 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
   const body = await request.json();
   const data = CreateGroupSchema.parse(body);
 
+  // Note: asUser wraps all operations in a database transaction,
+  // ensuring atomicity for group creation + member additions
   const result = await asUser(user, async (db) => {
     // Create the group
     const groupId = nanoid();

--- a/apps/web/src/app/api/groups/route.ts
+++ b/apps/web/src/app/api/groups/route.ts
@@ -439,6 +439,13 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
 
               // Use actual ID from DB (may be existing ID on conflict, or new ID on insert)
               const actualInviteId = result[0]?.id ?? newInviteId;
+              if (!result[0]?.id) {
+                logger.warn('Invite returning() returned empty result, using generated ID', {
+                  groupId,
+                  invitedUserId: humanId,
+                  generatedId: newInviteId,
+                }, 'POST /api/groups');
+              }
               humanInviteNotifications.push({ humanId, inviteId: actualInviteId });
               invitedMemberIds.push(humanId);
             }

--- a/apps/web/src/app/api/groups/route.ts
+++ b/apps/web/src/app/api/groups/route.ts
@@ -147,7 +147,7 @@
 
 import {
   authenticate,
-  notifyUserGroupInvite,
+  notifyGroupMemberAdded,
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
@@ -315,24 +315,28 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
       },
     });
 
-    // Send invitations to initial members (they must accept to join)
+    // Add initial members directly (no invite flow for MVP)
+    // All selected users are added immediately as members
+    const addedMemberIds: string[] = [];
     if (data.memberIds.length > 0) {
       const otherMembers = data.memberIds.filter((id) => id !== user.userId);
 
       if (otherMembers.length > 0) {
-        // Check which users are agents (agents get auto-added, users get invites)
-        const memberUsers = await db.user.findMany({
-          where: { id: { in: otherMembers } },
-          select: { id: true, isAgent: true },
+        // Verify users exist and are not banned, get their names for system message
+        const validMembers = await db.user.findMany({
+          where: {
+            id: { in: otherMembers },
+            isBanned: false,
+          },
+          select: { id: true, displayName: true, username: true },
         });
 
-        const agentIds = memberUsers.filter((u) => u.isAgent).map((u) => u.id);
-        const humanIds = memberUsers.filter((u) => !u.isAgent).map((u) => u.id);
+        if (validMembers.length > 0) {
+          const validMemberIds = validMembers.map((u) => u.id);
 
-        // Auto-add agents directly (they don't need to accept invites)
-        if (agentIds.length > 0) {
+          // Add all members directly as GroupMembers
           await db.groupMember.createMany({
-            data: agentIds.map((userId) => ({
+            data: validMemberIds.map((userId) => ({
               id: nanoid(),
               groupId,
               userId,
@@ -341,40 +345,55 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
             })),
           });
 
+          // Add all members to ChatParticipants
           await db.chatParticipant.createMany({
-            data: agentIds.map((userId) => ({
+            data: validMemberIds.map((userId) => ({
               id: nanoid(),
               chatId,
               userId,
               joinedAt: new Date(),
             })),
           });
-        }
 
-        // Send invitations to human users (they must accept)
-        if (humanIds.length > 0) {
-          const inviteData = humanIds.map((userId) => ({
-            id: nanoid(),
-            groupId,
-            invitedUserId: userId,
-            invitedBy: user.userId,
-            status: 'pending' as const,
-            message: `You've been invited to join "${data.name}"`,
-          }));
+          addedMemberIds.push(...validMemberIds);
 
-          await db.groupInvite.createMany({
-            data: inviteData,
+          // Get creator's name for the system message
+          const creator = await db.user.findUnique({
+            where: { id: user.userId },
+            select: { displayName: true, username: true },
+          });
+          const creatorName =
+            creator?.displayName || creator?.username || 'Someone';
+
+          // Build member names list for system message
+          const memberNames = validMembers.map(
+            (m) => m.displayName || m.username || 'Unknown'
+          );
+          const memberNamesText =
+            memberNames.length <= 3
+              ? memberNames.join(', ')
+              : `${memberNames.slice(0, 2).join(', ')} and ${memberNames.length - 2} others`;
+
+          // Create system message announcing members were added
+          await db.message.create({
+            data: {
+              id: nanoid(),
+              chatId,
+              senderId: 'system',
+              content: `${creatorName} added ${memberNamesText} to the group`,
+              createdAt: new Date(),
+            },
           });
 
-          // Send notifications to all invited users
+          // Send notifications to all added members
           await Promise.all(
-            inviteData.map((invite) =>
-              notifyUserGroupInvite(
-                invite.invitedUserId,
+            validMemberIds.map((memberId) =>
+              notifyGroupMemberAdded(
+                memberId,
                 user.userId,
                 groupId,
                 data.name,
-                invite.id
+                chatId
               )
             )
           );
@@ -385,12 +404,18 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
     return {
       group: newGroup,
       chatId,
+      memberCount: 1 + addedMemberIds.length, // creator + added members
     };
   });
 
   logger.info(
     'Group created',
-    { userId: user.userId, groupId: result.group.id, chatId: result.chatId },
+    {
+      userId: user.userId,
+      groupId: result.group.id,
+      chatId: result.chatId,
+      memberCount: result.memberCount,
+    },
     'POST /api/groups'
   );
 
@@ -401,6 +426,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
       type: result.group.type,
       createdAt: result.group.createdAt,
       chatId: result.chatId,
+      memberCount: result.memberCount,
     },
   });
 });

--- a/apps/web/src/app/api/users/search/route.ts
+++ b/apps/web/src/app/api/users/search/route.ts
@@ -169,12 +169,10 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
               not: user.userId, // Exclude current user
             },
           },
-          {
-            id: {
-              notIn:
-                excludedUserIds.length > 0 ? excludedUserIds : ['__none__'], // Exclude blocked/muted users
-            },
-          },
+          // Conditionally exclude blocked/muted users only if the array is not empty
+          ...(excludedUserIds.length > 0
+            ? [{ id: { notIn: excludedUserIds } }]
+            : []),
           {
             isActor: false, // Always exclude NPCs (use /api/agents/search for those)
           },

--- a/apps/web/src/app/api/users/search/route.ts
+++ b/apps/web/src/app/api/users/search/route.ts
@@ -3,14 +3,15 @@
  *
  * @description
  * Search for users by username or display name with fuzzy matching.
- * Returns real users only (excludes NPCs, banned users, and current user).
+ * Returns real users only by default (excludes NPCs, agents, banned users, and current user).
  * Designed for user mention autocomplete, friend finding, and social discovery.
  *
  * **Features:**
  * - Case-insensitive search
  * - Matches username OR display name
  * - Excludes current user (no self-mentions)
- * - Excludes NPCs/actors
+ * - Excludes NPCs/actors by default
+ * - Excludes agents by default (use includeAgents=true to include)
  * - Excludes banned users
  * - Limits to 20 results (performance)
  * - Alphabetically sorted results
@@ -46,6 +47,13 @@
  *           minLength: 2
  *         description: Search query (username or display name)
  *         example: alice
+ *       - in: query
+ *         name: includeAgents
+ *         required: false
+ *         schema:
+ *           type: boolean
+ *         description: Include AI agents in results (default false)
+ *         example: false
  *     responses:
  *       200:
  *         description: Search results
@@ -85,6 +93,9 @@
  *   console.log(`@${user.username} - ${user.displayName}`);
  * });
  *
+ * // Include agents in search
+ * const withAgents = await fetch('/api/users/search?q=alice&includeAgents=true');
+ *
  * // Too short query
  * const empty = await fetch('/api/users/search?q=a');
  * // Returns { users: [] }
@@ -111,9 +122,10 @@ import type { NextRequest } from 'next/server';
 export const GET = withErrorHandling(async (request: NextRequest) => {
   const user = await authenticate(request);
 
-  // Get query parameter
+  // Get query parameters
   const { searchParams } = new URL(request.url);
   const query = searchParams.get('q');
+  const includeAgents = searchParams.get('includeAgents') === 'true';
 
   if (!query || query.trim().length < 2) {
     return successResponse({ users: [] });
@@ -131,6 +143,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   const excludedUserIds = [...blockedIds, ...mutedIds, ...blockedByIds];
 
   // Search for users (excluding the current user, NPCs, and blocked/muted users)
+  // Optionally include AI agents if includeAgents=true
   const users = await asUser(user, async (db) => {
     return await db.user.findMany({
       where: {
@@ -158,12 +171,15 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
           },
           {
             id: {
-              notIn: excludedUserIds, // Exclude blocked/muted users
+              notIn:
+                excludedUserIds.length > 0 ? excludedUserIds : ['__none__'], // Exclude blocked/muted users
             },
           },
           {
-            isActor: false, // Exclude NPCs
+            isActor: false, // Always exclude NPCs (use /api/agents/search for those)
           },
+          // Exclude agents unless includeAgents is true
+          ...(includeAgents ? [] : [{ isAgent: false }]),
           {
             isBanned: false, // Exclude banned users
           },
@@ -187,7 +203,12 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
 
   logger.info(
     'User search completed',
-    { userId: user.userId, query: searchTerm, results: users.length },
+    {
+      userId: user.userId,
+      query: searchTerm,
+      results: users.length,
+      includeAgents,
+    },
     'GET /api/users/search'
   );
 

--- a/apps/web/src/app/markets/_components/cards/PredictionMarketCard.tsx
+++ b/apps/web/src/app/markets/_components/cards/PredictionMarketCard.tsx
@@ -1,6 +1,10 @@
 'use client';
 
-import { cn, formatCurrency, formatNumberWithSeparators } from '@babylon/shared';
+import {
+  cn,
+  formatCurrency,
+  formatNumberWithSeparators,
+} from '@babylon/shared';
 import { ArrowUpDown, Clock } from 'lucide-react';
 import { memo } from 'react';
 import type { PredictionMarketWithPosition } from '@/types/markets';

--- a/apps/web/src/components/groups/CreateGroupModal.tsx
+++ b/apps/web/src/components/groups/CreateGroupModal.tsx
@@ -634,7 +634,9 @@ export function CreateGroupModal({
             </button>
             <button
               onClick={handleCreateGroup}
-              disabled={creating || selectedMembers.length === 0}
+              disabled={
+                creating || (selectedMembers.length === 0 && !groupName.trim())
+              }
               className={cn(
                 'flex-1 rounded-lg px-4 py-3 font-medium transition-colors',
                 'bg-primary text-primary-foreground hover:bg-primary/90',

--- a/apps/web/src/components/groups/CreateGroupModal.tsx
+++ b/apps/web/src/components/groups/CreateGroupModal.tsx
@@ -151,7 +151,12 @@ export function CreateGroupModal({
                   })
                 );
           setSearchResults(results);
+        } else {
+          setSearchResults([]);
         }
+      } catch (error) {
+        console.error('Member search failed:', error);
+        setSearchResults([]);
       } finally {
         setSearching(false);
       }

--- a/apps/web/src/components/groups/CreateGroupModal.tsx
+++ b/apps/web/src/components/groups/CreateGroupModal.tsx
@@ -2,50 +2,56 @@
 
 import { cn, getCurrentChainId } from '@babylon/shared';
 import { usePrivy } from '@privy-io/react-auth';
-import { Check, Loader2, Search, Shield, Users, X } from 'lucide-react';
+import {
+  Bot,
+  Check,
+  Loader2,
+  Search,
+  Shield,
+  User,
+  Users,
+  X,
+} from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { Avatar } from '@/components/shared/Avatar';
 import { useAuthStore } from '@/stores/authStore';
 
 /**
- * User structure for group creation modal.
+ * Member structure for group creation modal.
+ * Includes type to distinguish between humans, agents, and NPCs.
  */
-interface User {
+interface Member {
   id: string;
   displayName: string | null;
   username: string | null;
   profileImageUrl: string | null;
+  type: 'user' | 'agent' | 'npc';
 }
+
+type SearchTab = 'users' | 'agents';
+
+// Soft cap for member warning (no hard enforcement for MVP)
+const MEMBER_WARNING_THRESHOLD = 100;
 
 /**
  * Create group modal component for creating new user groups.
  *
  * Provides a form interface for creating groups with name input and
- * member selection. Includes user search functionality and automatic
- * group name generation from members. Creates both group and associated
- * chat on creation.
+ * member selection. Includes tabbed search for users and agents/NPCs.
+ * Creates both group and associated chat on creation.
  *
  * Features:
  * - Group name input
- * - User search
- * - Member selection
+ * - Tabbed search (Users / Agents & NPCs)
+ * - Member selection with type badges
  * - Auto-generated group names
  * - Form validation
  * - Loading states
  * - Error handling
- * - Body scroll lock and escape key handling
+ * - Member limit warning
  *
  * @param props - CreateGroupModal component props
  * @returns Create group modal element or null if not open
- *
- * @example
- * ```tsx
- * <CreateGroupModal
- *   isOpen={showModal}
- *   onClose={() => setShowModal(false)}
- *   onGroupCreated={(groupId, chatId) => router.push(`/groups/${groupId}`)}
- * />
- * ```
  */
 interface CreateGroupModalProps {
   isOpen: boolean;
@@ -62,11 +68,12 @@ export function CreateGroupModal({
   const { user } = useAuthStore();
   const [groupName, setGroupName] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
-  const [searchResults, setSearchResults] = useState<User[]>([]);
-  const [selectedUsers, setSelectedUsers] = useState<User[]>([]);
+  const [searchResults, setSearchResults] = useState<Member[]>([]);
+  const [selectedMembers, setSelectedMembers] = useState<Member[]>([]);
   const [searching, setSearching] = useState(false);
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<SearchTab>('users');
   const [nftGated, setNftGated] = useState(false);
   const [nftContractAddress, setNftContractAddress] = useState('');
   const [nftTokenId, setNftTokenId] = useState<string>('');
@@ -78,8 +85,9 @@ export function CreateGroupModal({
       setGroupName('');
       setSearchQuery('');
       setSearchResults([]);
-      setSelectedUsers([]);
+      setSelectedMembers([]);
       setError(null);
+      setActiveTab('users');
       setNftGated(false);
       setNftContractAddress('');
       setNftTokenId('');
@@ -87,46 +95,106 @@ export function CreateGroupModal({
     }
   }, [isOpen]);
 
-  // Search for users
+  // Search for users or agents based on active tab
   useEffect(() => {
     if (!searchQuery.trim() || searchQuery.length < 2) {
       setSearchResults([]);
       return;
     }
 
-    const searchUsers = async () => {
+    const searchMembers = async () => {
       setSearching(true);
       const token = await getAccessToken();
-      const response = await fetch(
-        `/api/users/search?q=${encodeURIComponent(searchQuery)}`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      );
+
+      // Use different endpoint based on active tab
+      const endpoint =
+        activeTab === 'users'
+          ? `/api/users/search?q=${encodeURIComponent(searchQuery)}`
+          : `/api/agents/search?q=${encodeURIComponent(searchQuery)}`;
+
+      const response = await fetch(endpoint, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
 
       if (response.ok) {
         const data = await response.json();
-        setSearchResults(data.users || []);
+        const results: Member[] =
+          activeTab === 'users'
+            ? (data.users || []).map(
+                (u: {
+                  id: string;
+                  displayName: string | null;
+                  username: string | null;
+                  profileImageUrl: string | null;
+                }) => ({
+                  ...u,
+                  type: 'user' as const,
+                })
+              )
+            : (data.agents || []).map(
+                (a: {
+                  id: string;
+                  displayName: string | null;
+                  username: string | null;
+                  profileImageUrl: string | null;
+                  type: 'agent' | 'npc';
+                }) => ({
+                  id: a.id,
+                  displayName: a.displayName,
+                  username: a.username,
+                  profileImageUrl: a.profileImageUrl,
+                  type: a.type,
+                })
+              );
+        setSearchResults(results);
       }
       setSearching(false);
     };
 
-    const debounce = setTimeout(searchUsers, 300);
+    const debounce = setTimeout(searchMembers, 300);
     return () => clearTimeout(debounce);
-  }, [searchQuery, getAccessToken]);
+  }, [searchQuery, activeTab, getAccessToken]);
 
-  const handleAddUser = (user: User) => {
-    if (!selectedUsers.find((u) => u.id === user.id)) {
-      setSelectedUsers([...selectedUsers, user]);
+  // Clear search when switching tabs
+  const handleTabChange = (tab: SearchTab) => {
+    setActiveTab(tab);
+    setSearchQuery('');
+    setSearchResults([]);
+  };
+
+  const handleAddMember = (member: Member) => {
+    if (!selectedMembers.find((m) => m.id === member.id)) {
+      setSelectedMembers([...selectedMembers, member]);
     }
     setSearchQuery('');
     setSearchResults([]);
   };
 
-  const handleRemoveUser = (userId: string) => {
-    setSelectedUsers(selectedUsers.filter((u) => u.id !== userId));
+  const handleRemoveMember = (memberId: string) => {
+    setSelectedMembers(selectedMembers.filter((m) => m.id !== memberId));
+  };
+
+  const getMemberTypeBadge = (type: 'user' | 'agent' | 'npc') => {
+    switch (type) {
+      case 'agent':
+        return (
+          <span className="ml-1 inline-flex items-center rounded bg-blue-500/10 px-1.5 py-0.5 text-blue-600 text-xs dark:text-blue-400">
+            <Bot className="mr-0.5 h-3 w-3" />
+            Agent
+          </span>
+        );
+      case 'npc':
+        return (
+          <span className="ml-1 inline-flex items-center rounded bg-purple-500/10 px-1.5 py-0.5 text-purple-600 text-xs dark:text-purple-400">
+            <User className="mr-0.5 h-3 w-3" />
+            NPC
+          </span>
+        );
+      default:
+        return null;
+    }
   };
 
   const handleCreateGroup = async () => {
@@ -135,20 +203,20 @@ export function CreateGroupModal({
 
     if (!finalGroupName) {
       // Auto-generate from members
-      const memberNames = selectedUsers
+      const memberNames = selectedMembers
         .slice(0, 2)
-        .map((u) => u.displayName || u.username || 'User');
+        .map((m) => m.displayName || m.username || 'User');
       const currentUserName = user?.displayName || user?.username || 'You';
 
-      if (selectedUsers.length === 0) {
+      if (selectedMembers.length === 0) {
         setError('Please add at least one member or enter a group name');
         return;
-      } else if (selectedUsers.length === 1) {
+      } else if (selectedMembers.length === 1) {
         finalGroupName = `${currentUserName}, ${memberNames[0]}`;
-      } else if (selectedUsers.length === 2) {
+      } else if (selectedMembers.length === 2) {
         finalGroupName = `${currentUserName}, ${memberNames[0]}, ${memberNames[1]}`;
       } else {
-        finalGroupName = `${currentUserName}, ${memberNames[0]}, ${memberNames[1]} +${selectedUsers.length - 2}`;
+        finalGroupName = `${currentUserName}, ${memberNames[0]}, ${memberNames[1]} +${selectedMembers.length - 2}`;
       }
     }
 
@@ -164,7 +232,7 @@ export function CreateGroupModal({
     const token = await getAccessToken();
     const requestBody = {
       name: finalGroupName,
-      memberIds: selectedUsers.map((u) => u.id),
+      memberIds: selectedMembers.map((m) => m.id),
       ...(nftGated &&
         nftContractAddress.trim() && {
           requiredNftContractAddress: nftContractAddress.trim(),
@@ -186,8 +254,9 @@ export function CreateGroupModal({
 
     if (!response.ok) {
       const data = await response.json();
+      setError(data.error || 'Failed to create group');
       setCreating(false);
-      throw new Error(data.error || 'Failed to create group');
+      return;
     }
 
     const data = await response.json();
@@ -202,6 +271,8 @@ export function CreateGroupModal({
     onClose();
   };
 
+  const totalMemberCount = selectedMembers.length + 1; // +1 for creator
+
   return (
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
@@ -212,11 +283,11 @@ export function CreateGroupModal({
       }}
     >
       <div
-        className="w-full max-w-md rounded-xl border border-border bg-background shadow-2xl"
+        className="flex max-h-[90vh] w-full max-w-md flex-col rounded-xl border border-border bg-background shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-center justify-between border-border border-b p-6">
+        <div className="flex shrink-0 items-center justify-between border-border border-b p-6">
           <div className="flex items-center gap-2">
             <Users className="h-5 w-5 text-primary" />
             <h2 className="font-bold text-xl">Create New Group</h2>
@@ -231,7 +302,7 @@ export function CreateGroupModal({
         </div>
 
         {/* Content */}
-        <div className="p-6">
+        <div className="flex-1 overflow-y-auto p-6">
           {error && (
             <div className="mb-4 rounded-lg border border-red-500/20 bg-red-500/10 p-3">
               <p className="text-red-500 text-sm">{error}</p>
@@ -264,28 +335,36 @@ export function CreateGroupModal({
               )}
             </div>
 
-            {/* Selected Users */}
-            {selectedUsers.length > 0 && (
+            {/* Selected Members */}
+            {selectedMembers.length > 0 && (
               <div className="space-y-2">
-                <label className="block font-medium text-sm">
-                  Members ({selectedUsers.length})
-                </label>
-                <div className="flex flex-wrap gap-2 rounded-lg border border-border bg-sidebar p-3">
-                  {selectedUsers.map((user) => (
+                <div className="flex items-center justify-between">
+                  <label className="block font-medium text-sm">
+                    Members ({totalMemberCount})
+                  </label>
+                  {totalMemberCount > MEMBER_WARNING_THRESHOLD && (
+                    <span className="text-xs text-yellow-600 dark:text-yellow-500">
+                      Large group - performance may vary
+                    </span>
+                  )}
+                </div>
+                <div className="flex max-h-[120px] flex-wrap gap-2 overflow-y-auto rounded-lg border border-border bg-sidebar p-3">
+                  {selectedMembers.map((member) => (
                     <div
-                      key={user.id}
+                      key={member.id}
                       className="flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1.5"
                     >
                       <Avatar
-                        imageUrl={user.profileImageUrl || undefined}
-                        name={user.username || user.displayName || '?'}
+                        imageUrl={member.profileImageUrl || undefined}
+                        name={member.username || member.displayName || '?'}
                         size="sm"
                       />
                       <span className="text-sm">
-                        {user.displayName || user.username || 'Unknown'}
+                        {member.displayName || member.username || 'Unknown'}
                       </span>
+                      {getMemberTypeBadge(member.type)}
                       <button
-                        onClick={() => handleRemoveUser(user.id)}
+                        onClick={() => handleRemoveMember(member.id)}
                         className="ml-1 text-muted-foreground hover:text-foreground"
                       >
                         <X className="h-3 w-3" />
@@ -296,16 +375,48 @@ export function CreateGroupModal({
               </div>
             )}
 
-            {/* User Search */}
+            {/* Search Tabs */}
             <div>
               <label className="mb-2 block font-medium text-sm">
                 Add Members
               </label>
+              <div className="mb-3 flex rounded-lg border border-border bg-sidebar p-1">
+                <button
+                  onClick={() => handleTabChange('users')}
+                  className={cn(
+                    'flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-2 text-sm transition-colors',
+                    activeTab === 'users'
+                      ? 'bg-background font-medium text-foreground shadow-sm'
+                      : 'text-muted-foreground hover:text-foreground'
+                  )}
+                >
+                  <User className="h-4 w-4" />
+                  Users
+                </button>
+                <button
+                  onClick={() => handleTabChange('agents')}
+                  className={cn(
+                    'flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-2 text-sm transition-colors',
+                    activeTab === 'agents'
+                      ? 'bg-background font-medium text-foreground shadow-sm'
+                      : 'text-muted-foreground hover:text-foreground'
+                  )}
+                >
+                  <Bot className="h-4 w-4" />
+                  Agents & NPCs
+                </button>
+              </div>
+
+              {/* Search Input */}
               <div className="relative">
                 <Search className="-translate-y-1/2 absolute top-1/2 left-3 h-4 w-4 text-muted-foreground" />
                 <input
                   type="text"
-                  placeholder="Search by username or name..."
+                  placeholder={
+                    activeTab === 'users'
+                      ? 'Search users by name...'
+                      : 'Search agents and NPCs...'
+                  }
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   className="w-full rounded-lg border border-border bg-sidebar py-3 pr-10 pl-9 transition-colors focus:border-primary focus:outline-none"
@@ -319,14 +430,14 @@ export function CreateGroupModal({
             {/* Search Results */}
             {searchResults.length > 0 && (
               <div className="max-h-[200px] overflow-hidden overflow-y-auto rounded-lg border border-border">
-                {searchResults.map((user) => {
-                  const isSelected = selectedUsers.find(
-                    (u) => u.id === user.id
+                {searchResults.map((member) => {
+                  const isSelected = selectedMembers.find(
+                    (m) => m.id === member.id
                   );
                   return (
                     <button
-                      key={user.id}
-                      onClick={() => !isSelected && handleAddUser(user)}
+                      key={member.id}
+                      onClick={() => !isSelected && handleAddMember(member)}
                       className={cn(
                         'flex w-full items-center gap-3 p-3 text-left transition-colors',
                         isSelected
@@ -336,17 +447,18 @@ export function CreateGroupModal({
                       disabled={!!isSelected}
                     >
                       <Avatar
-                        imageUrl={user.profileImageUrl || undefined}
-                        name={user.username || user.displayName || '?'}
+                        imageUrl={member.profileImageUrl || undefined}
+                        name={member.username || member.displayName || '?'}
                         size="sm"
                       />
                       <div className="min-w-0 flex-1">
-                        <div className="truncate font-medium text-sm">
-                          {user.displayName || user.username || 'Unknown'}
+                        <div className="flex items-center truncate font-medium text-sm">
+                          {member.displayName || member.username || 'Unknown'}
+                          {getMemberTypeBadge(member.type)}
                         </div>
-                        {user.username && (
+                        {member.username && (
                           <div className="truncate text-muted-foreground text-xs">
-                            @{user.username}
+                            @{member.username}
                           </div>
                         )}
                       </div>
@@ -363,13 +475,17 @@ export function CreateGroupModal({
               searchResults.length === 0 &&
               !searching && (
                 <div className="py-4 text-center text-muted-foreground text-sm">
-                  No users found
+                  No {activeTab === 'users' ? 'users' : 'agents or NPCs'} found
                 </div>
               )}
 
-            {!searchQuery && selectedUsers.length === 0 && (
+            {!searchQuery && selectedMembers.length === 0 && (
               <div className="rounded-lg border border-border border-dashed bg-sidebar py-4 text-center text-muted-foreground text-sm">
-                <p>Search for users to add to your group</p>
+                <p>
+                  Search for{' '}
+                  {activeTab === 'users' ? 'users' : 'agents and NPCs'} to add
+                  to your group
+                </p>
                 <p className="mt-1 text-xs">
                   Group name will auto-generate if not specified
                 </p>
@@ -502,22 +618,22 @@ export function CreateGroupModal({
           </div>
 
           {/* Preview of auto-generated name */}
-          {!groupName && selectedUsers.length > 0 && (
+          {!groupName && selectedMembers.length > 0 && (
             <div className="mt-4 rounded-lg border border-blue-500/20 bg-blue-500/10 p-3">
               <p className="text-blue-700 text-xs dark:text-blue-300">
                 <strong>Auto-name preview:</strong> {(() => {
-                  const memberNames = selectedUsers
+                  const memberNames = selectedMembers
                     .slice(0, 2)
-                    .map((u) => u.displayName || u.username || 'User');
+                    .map((m) => m.displayName || m.username || 'User');
                   const currentUserName =
                     user?.displayName || user?.username || 'You';
 
-                  if (selectedUsers.length === 1) {
+                  if (selectedMembers.length === 1) {
                     return `${currentUserName}, ${memberNames[0]}`;
-                  } else if (selectedUsers.length === 2) {
+                  } else if (selectedMembers.length === 2) {
                     return `${currentUserName}, ${memberNames[0]}, ${memberNames[1]}`;
                   } else {
-                    return `${currentUserName}, ${memberNames[0]}, ${memberNames[1]} +${selectedUsers.length - 2}`;
+                    return `${currentUserName}, ${memberNames[0]}, ${memberNames[1]} +${selectedMembers.length - 2}`;
                   }
                 })()}
               </p>
@@ -535,7 +651,7 @@ export function CreateGroupModal({
             </button>
             <button
               onClick={handleCreateGroup}
-              disabled={creating || selectedUsers.length === 0}
+              disabled={creating || selectedMembers.length === 0}
               className={cn(
                 'flex-1 rounded-lg px-4 py-3 font-medium transition-colors',
                 'bg-primary text-primary-foreground hover:bg-primary/90',
@@ -548,7 +664,7 @@ export function CreateGroupModal({
                   Creating...
                 </>
               ) : (
-                `Create Group${selectedUsers.length > 0 ? ` (${selectedUsers.length + 1} members)` : ''}`
+                `Create Group (${totalMemberCount} members)`
               )}
             </button>
           </div>

--- a/apps/web/src/components/groups/CreateGroupModal.tsx
+++ b/apps/web/src/components/groups/CreateGroupModal.tsx
@@ -2,7 +2,16 @@
 
 import { cn, getCurrentChainId } from '@babylon/shared';
 import { usePrivy } from '@privy-io/react-auth';
-import { Bot, Check, Loader2, Search, Shield, User, Users, X } from 'lucide-react';
+import {
+  Bot,
+  Check,
+  Loader2,
+  Search,
+  Shield,
+  User,
+  Users,
+  X,
+} from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { Avatar } from '@/components/shared/Avatar';
 import { useAuthStore } from '@/stores/authStore';
@@ -96,53 +105,56 @@ export function CreateGroupModal({
 
     const searchMembers = async () => {
       setSearching(true);
-      const token = await getAccessToken();
+      try {
+        const token = await getAccessToken();
 
-      // Use different endpoint based on active tab
-      const endpoint =
-        activeTab === 'users'
-          ? `/api/users/search?q=${encodeURIComponent(searchQuery)}`
-          : `/api/agents/search?q=${encodeURIComponent(searchQuery)}`;
-
-      const response = await fetch(endpoint, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        const results: Member[] =
+        // Use different endpoint based on active tab
+        const endpoint =
           activeTab === 'users'
-            ? (data.users || []).map(
-                (u: {
-                  id: string;
-                  displayName: string | null;
-                  username: string | null;
-                  profileImageUrl: string | null;
-                }) => ({
-                  ...u,
-                  type: 'user' as const,
-                })
-              )
-            : (data.agents || []).map(
-                (a: {
-                  id: string;
-                  displayName: string | null;
-                  username: string | null;
-                  profileImageUrl: string | null;
-                  type: 'agent' | 'npc';
-                }) => ({
-                  id: a.id,
-                  displayName: a.displayName,
-                  username: a.username,
-                  profileImageUrl: a.profileImageUrl,
-                  type: a.type,
-                })
-              );
-        setSearchResults(results);
+            ? `/api/users/search?q=${encodeURIComponent(searchQuery)}`
+            : `/api/agents/search?q=${encodeURIComponent(searchQuery)}`;
+
+        const response = await fetch(endpoint, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+
+        if (response.ok) {
+          const data = await response.json();
+          const results: Member[] =
+            activeTab === 'users'
+              ? (data.users || []).map(
+                  (u: {
+                    id: string;
+                    displayName: string | null;
+                    username: string | null;
+                    profileImageUrl: string | null;
+                  }) => ({
+                    ...u,
+                    type: 'user' as const,
+                  })
+                )
+              : (data.agents || []).map(
+                  (a: {
+                    id: string;
+                    displayName: string | null;
+                    username: string | null;
+                    profileImageUrl: string | null;
+                    type: 'agent' | 'npc';
+                  }) => ({
+                    id: a.id,
+                    displayName: a.displayName,
+                    username: a.username,
+                    profileImageUrl: a.profileImageUrl,
+                    type: a.type,
+                  })
+                );
+          setSearchResults(results);
+        }
+      } finally {
+        setSearching(false);
       }
-      setSearching(false);
     };
 
     const debounce = setTimeout(searchMembers, 300);
@@ -167,7 +179,6 @@ export function CreateGroupModal({
   const handleRemoveMember = (memberId: string) => {
     setSelectedMembers(selectedMembers.filter((m) => m.id !== memberId));
   };
-
 
   const handleCreateGroup = async () => {
     // Generate group name if not provided

--- a/apps/web/src/components/groups/CreateGroupModal.tsx
+++ b/apps/web/src/components/groups/CreateGroupModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { cn, getCurrentChainId, GROUP_CONFIG } from '@babylon/shared';
+import { cn, GROUP_CONFIG, getCurrentChainId } from '@babylon/shared';
 import { usePrivy } from '@privy-io/react-auth';
 import {
   Bot,

--- a/apps/web/src/components/groups/CreateGroupModal.tsx
+++ b/apps/web/src/components/groups/CreateGroupModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { cn, getCurrentChainId } from '@babylon/shared';
+import { cn, getCurrentChainId, GROUP_CONFIG } from '@babylon/shared';
 import { usePrivy } from '@privy-io/react-auth';
 import {
   Bot,
@@ -30,9 +30,6 @@ interface Member {
 }
 
 type SearchTab = 'users' | 'agents';
-
-// Soft cap for member warning (no hard enforcement for MVP)
-const MEMBER_WARNING_THRESHOLD = 100;
 
 /**
  * Create group modal component for creating new user groups.
@@ -231,25 +228,31 @@ export function CreateGroupModal({
         }),
     };
 
-    const response = await fetch('/api/groups', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify(requestBody),
-    });
+    try {
+      const response = await fetch('/api/groups', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(requestBody),
+      });
 
-    if (!response.ok) {
+      if (!response.ok) {
+        const data = await response.json();
+        setError(data.error || 'Failed to create group');
+        return;
+      }
+
       const data = await response.json();
-      setError(data.error || 'Failed to create group');
+      onGroupCreated(data.group.id, data.group.chatId);
+      onClose();
+    } catch (err) {
+      console.error('Failed to create group:', err);
+      setError('Network error. Please try again.');
+    } finally {
       setCreating(false);
-      return;
     }
-
-    const data = await response.json();
-    onGroupCreated(data.group.id, data.group.chatId);
-    onClose();
   };
 
   if (!isOpen) return null;
@@ -330,7 +333,7 @@ export function CreateGroupModal({
                   <label className="block font-medium text-sm">
                     Members ({totalMemberCount})
                   </label>
-                  {totalMemberCount > MEMBER_WARNING_THRESHOLD && (
+                  {totalMemberCount > GROUP_CONFIG.MEMBER_WARNING_THRESHOLD && (
                     <span className="text-xs text-yellow-600 dark:text-yellow-500">
                       Large group - performance may vary
                     </span>

--- a/apps/web/src/components/groups/CreateGroupModal.tsx
+++ b/apps/web/src/components/groups/CreateGroupModal.tsx
@@ -2,19 +2,11 @@
 
 import { cn, getCurrentChainId } from '@babylon/shared';
 import { usePrivy } from '@privy-io/react-auth';
-import {
-  Bot,
-  Check,
-  Loader2,
-  Search,
-  Shield,
-  User,
-  Users,
-  X,
-} from 'lucide-react';
+import { Bot, Check, Loader2, Search, Shield, User, Users, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { Avatar } from '@/components/shared/Avatar';
 import { useAuthStore } from '@/stores/authStore';
+import { MemberTypeBadge } from './MemberTypeBadge';
 
 /**
  * Member structure for group creation modal.
@@ -176,26 +168,6 @@ export function CreateGroupModal({
     setSelectedMembers(selectedMembers.filter((m) => m.id !== memberId));
   };
 
-  const getMemberTypeBadge = (type: 'user' | 'agent' | 'npc') => {
-    switch (type) {
-      case 'agent':
-        return (
-          <span className="ml-1 inline-flex items-center rounded bg-blue-500/10 px-1.5 py-0.5 text-blue-600 text-xs dark:text-blue-400">
-            <Bot className="mr-0.5 h-3 w-3" />
-            Agent
-          </span>
-        );
-      case 'npc':
-        return (
-          <span className="ml-1 inline-flex items-center rounded bg-purple-500/10 px-1.5 py-0.5 text-purple-600 text-xs dark:text-purple-400">
-            <User className="mr-0.5 h-3 w-3" />
-            NPC
-          </span>
-        );
-      default:
-        return null;
-    }
-  };
 
   const handleCreateGroup = async () => {
     // Generate group name if not provided
@@ -362,7 +334,7 @@ export function CreateGroupModal({
                       <span className="text-sm">
                         {member.displayName || member.username || 'Unknown'}
                       </span>
-                      {getMemberTypeBadge(member.type)}
+                      <MemberTypeBadge type={member.type} />
                       <button
                         onClick={() => handleRemoveMember(member.id)}
                         className="ml-1 text-muted-foreground hover:text-foreground"
@@ -454,7 +426,7 @@ export function CreateGroupModal({
                       <div className="min-w-0 flex-1">
                         <div className="flex items-center truncate font-medium text-sm">
                           {member.displayName || member.username || 'Unknown'}
-                          {getMemberTypeBadge(member.type)}
+                          <MemberTypeBadge type={member.type} />
                         </div>
                         {member.username && (
                           <div className="truncate text-muted-foreground text-xs">

--- a/apps/web/src/components/groups/GroupManagementModal.tsx
+++ b/apps/web/src/components/groups/GroupManagementModal.tsx
@@ -19,6 +19,7 @@ import {
 import { useEffect, useState } from 'react';
 import { Avatar } from '@/components/shared/Avatar';
 import { useAuthStore } from '@/stores/authStore';
+import { GroupTypeBadge, MemberTypeBadge } from './MemberTypeBadge';
 
 /**
  * Member structure for group management modal.
@@ -226,45 +227,6 @@ export function GroupManagementModal({
     setSearchResults([]);
   };
 
-  const getTypeBadge = (type: 'user' | 'agent' | 'npc') => {
-    switch (type) {
-      case 'agent':
-        return (
-          <span className="ml-1 inline-flex items-center rounded bg-blue-500/10 px-1.5 py-0.5 text-blue-600 text-xs dark:text-blue-400">
-            <Bot className="mr-0.5 h-3 w-3" />
-            Agent
-          </span>
-        );
-      case 'npc':
-        return (
-          <span className="ml-1 inline-flex items-center rounded bg-purple-500/10 px-1.5 py-0.5 text-purple-600 text-xs dark:text-purple-400">
-            <User className="mr-0.5 h-3 w-3" />
-            NPC
-          </span>
-        );
-      default:
-        return null;
-    }
-  };
-
-  const getGroupTypeBadge = (type: 'user' | 'npc' | 'agent') => {
-    switch (type) {
-      case 'npc':
-        return (
-          <span className="rounded bg-purple-500/10 px-2 py-1 text-purple-600 text-xs dark:text-purple-400">
-            NPC Group
-          </span>
-        );
-      case 'agent':
-        return (
-          <span className="rounded bg-blue-500/10 px-2 py-1 text-blue-600 text-xs dark:text-blue-400">
-            Agent Group
-          </span>
-        );
-      default:
-        return null;
-    }
-  };
 
   const handleAddMember = async (userId: string) => {
     if (!groupId) return;
@@ -530,7 +492,7 @@ export function GroupManagementModal({
               <h2 className="font-bold text-xl">
                 {groupDetails?.name || 'Group Settings'}
               </h2>
-              {groupDetails && getGroupTypeBadge(groupDetails.type)}
+              {groupDetails && <GroupTypeBadge type={groupDetails.type} />}
             </div>
             <button
               onClick={handleClose}
@@ -690,7 +652,7 @@ export function GroupManagementModal({
                                   {result.displayName ||
                                     result.username ||
                                     'Unknown'}
-                                  {getTypeBadge(result.type)}
+                                  <MemberTypeBadge type={result.type} />
                                 </div>
                                 {result.username && (
                                   <div className="truncate text-muted-foreground text-xs">

--- a/apps/web/src/components/groups/GroupManagementModal.tsx
+++ b/apps/web/src/components/groups/GroupManagementModal.tsx
@@ -175,7 +175,8 @@ export function GroupManagementModal({
 
         if (response.ok) {
           const data = await response.json();
-          const existingMemberIds = groupDetails?.members.map((m) => m.id) || [];
+          const existingMemberIds =
+            groupDetails?.members.map((m) => m.id) || [];
 
           const results: SearchResult[] =
             activeTab === 'users'

--- a/apps/web/src/components/groups/GroupManagementModal.tsx
+++ b/apps/web/src/components/groups/GroupManagementModal.tsx
@@ -215,7 +215,12 @@ export function GroupManagementModal({
                     })
                   );
           setSearchResults(results);
+        } else {
+          setSearchResults([]);
         }
+      } catch (error) {
+        console.error('Member search failed:', error);
+        setSearchResults([]);
       } finally {
         setSearching(false);
       }

--- a/apps/web/src/components/groups/GroupManagementModal.tsx
+++ b/apps/web/src/components/groups/GroupManagementModal.tsx
@@ -158,63 +158,66 @@ export function GroupManagementModal({
 
     const searchMembers = async () => {
       setSearching(true);
-      const token = await getAccessToken();
+      try {
+        const token = await getAccessToken();
 
-      // Use different endpoint based on active tab
-      const endpoint =
-        activeTab === 'users'
-          ? `/api/users/search?q=${encodeURIComponent(searchQuery)}`
-          : `/api/agents/search?q=${encodeURIComponent(searchQuery)}`;
-
-      const response = await fetch(endpoint, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
-
-      if (response.ok) {
-        const data = await response.json();
-        const existingMemberIds = groupDetails?.members.map((m) => m.id) || [];
-
-        const results: SearchResult[] =
+        // Use different endpoint based on active tab
+        const endpoint =
           activeTab === 'users'
-            ? (data.users || [])
-                .filter(
-                  (u: { id: string }) => !existingMemberIds.includes(u.id)
-                )
-                .map(
-                  (u: {
-                    id: string;
-                    displayName: string | null;
-                    username: string | null;
-                    profileImageUrl: string | null;
-                  }) => ({
-                    ...u,
-                    type: 'user' as const,
-                  })
-                )
-            : (data.agents || [])
-                .filter(
-                  (a: { id: string }) => !existingMemberIds.includes(a.id)
-                )
-                .map(
-                  (a: {
-                    id: string;
-                    displayName: string | null;
-                    username: string | null;
-                    profileImageUrl: string | null;
-                    type: 'agent' | 'npc';
-                  }) => ({
-                    id: a.id,
-                    displayName: a.displayName,
-                    username: a.username,
-                    profileImageUrl: a.profileImageUrl,
-                    type: a.type,
-                  })
-                );
-        setSearchResults(results);
+            ? `/api/users/search?q=${encodeURIComponent(searchQuery)}`
+            : `/api/agents/search?q=${encodeURIComponent(searchQuery)}`;
+
+        const response = await fetch(endpoint, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+
+        if (response.ok) {
+          const data = await response.json();
+          const existingMemberIds = groupDetails?.members.map((m) => m.id) || [];
+
+          const results: SearchResult[] =
+            activeTab === 'users'
+              ? (data.users || [])
+                  .filter(
+                    (u: { id: string }) => !existingMemberIds.includes(u.id)
+                  )
+                  .map(
+                    (u: {
+                      id: string;
+                      displayName: string | null;
+                      username: string | null;
+                      profileImageUrl: string | null;
+                    }) => ({
+                      ...u,
+                      type: 'user' as const,
+                    })
+                  )
+              : (data.agents || [])
+                  .filter(
+                    (a: { id: string }) => !existingMemberIds.includes(a.id)
+                  )
+                  .map(
+                    (a: {
+                      id: string;
+                      displayName: string | null;
+                      username: string | null;
+                      profileImageUrl: string | null;
+                      type: 'agent' | 'npc';
+                    }) => ({
+                      id: a.id,
+                      displayName: a.displayName,
+                      username: a.username,
+                      profileImageUrl: a.profileImageUrl,
+                      type: a.type,
+                    })
+                  );
+          setSearchResults(results);
+        }
+      } finally {
+        setSearching(false);
       }
-      setSearching(false);
     };
 
     const debounce = setTimeout(searchMembers, 300);
@@ -227,7 +230,6 @@ export function GroupManagementModal({
     setSearchQuery('');
     setSearchResults([]);
   };
-
 
   const handleAddMember = async (userId: string) => {
     if (!groupId) return;

--- a/apps/web/src/components/groups/GroupManagementModal.tsx
+++ b/apps/web/src/components/groups/GroupManagementModal.tsx
@@ -242,47 +242,53 @@ export function GroupManagementModal({
 
     setActionLoading(userId);
     setError(null);
-    const token = await getAccessToken();
-    const response = await fetch(`/api/groups/${groupId}/members`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      },
-      body: JSON.stringify({ userId }),
-    });
 
-    if (!response.ok) {
-      const data = await response.json();
-      setError(data.error || 'Failed to add member');
+    try {
+      const token = await getAccessToken();
+      const response = await fetch(`/api/groups/${groupId}/members`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ userId }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        setError(data.error || 'Failed to add member');
+        return;
+      }
+
+      const result = await response.json();
+
+      // Show appropriate feedback based on whether user was added or invited
+      if (result.added) {
+        toast.success('Member added to group');
+      } else if (result.invited) {
+        toast.success('Invite sent - waiting for acceptance');
+      }
+
+      // Reload group details
+      const detailsResponse = await fetch(`/api/groups/${groupId}`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      if (detailsResponse.ok) {
+        const data = await detailsResponse.json();
+        setGroupDetails(data.group);
+      }
+
+      setSearchQuery('');
+      setSearchResults([]);
+      onGroupUpdated?.();
+    } catch (err) {
+      console.error('Failed to add member:', err);
+      setError('Network error. Please try again.');
+    } finally {
       setActionLoading(null);
-      return;
     }
-
-    const result = await response.json();
-
-    // Show appropriate feedback based on whether user was added or invited
-    if (result.added) {
-      toast.success('Member added to group');
-    } else if (result.invited) {
-      toast.success('Invite sent - waiting for acceptance');
-    }
-
-    // Reload group details
-    const detailsResponse = await fetch(`/api/groups/${groupId}`, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
-    if (detailsResponse.ok) {
-      const data = await detailsResponse.json();
-      setGroupDetails(data.group);
-    }
-
-    setSearchQuery('');
-    setSearchResults([]);
-    onGroupUpdated?.();
-    setActionLoading(null);
   };
 
   const handleRemoveMember = async (userId: string) => {

--- a/apps/web/src/components/groups/GroupManagementModal.tsx
+++ b/apps/web/src/components/groups/GroupManagementModal.tsx
@@ -3,6 +3,7 @@
 import { cn } from '@babylon/shared';
 import { usePrivy } from '@privy-io/react-auth';
 import {
+  Bot,
   Crown,
   Loader2,
   LogOut,
@@ -10,6 +11,7 @@ import {
   Settings,
   Shield,
   Trash2,
+  User,
   UserMinus,
   UserPlus,
   X,
@@ -37,6 +39,7 @@ interface GroupDetails {
   id: string;
   name: string;
   description: string | null;
+  type: 'user' | 'npc' | 'agent';
   members: Member[];
   isAdmin: boolean;
   isCreator: boolean;
@@ -44,48 +47,35 @@ interface GroupDetails {
 }
 
 /**
- * User structure for group management modal.
+ * Search result for adding members
  */
-interface User {
+interface SearchResult {
   id: string;
   displayName: string | null;
   username: string | null;
   profileImageUrl: string | null;
+  type: 'user' | 'agent' | 'npc';
 }
+
+type SearchTab = 'users' | 'agents';
 
 /**
  * Group management modal component for managing group members and settings.
  *
  * Provides comprehensive group management interface including member list,
- * adding/removing members, promoting/demoting admins, and deleting groups.
- * Includes user search for adding members and confirmation dialogs for
- * destructive actions.
+ * adding/removing members with tabbed search (users and agents/NPCs),
+ * promoting/demoting admins, and deleting groups.
  *
  * Features:
- * - Member list display
- * - Add member functionality
+ * - Member list display with type badges
+ * - Tabbed search for adding members (Users / Agents & NPCs)
  * - Remove member functionality
  * - Promote/demote admin functionality
  * - Delete group functionality
  * - Leave group functionality
- * - User search
  * - Confirmation dialogs
  * - Loading states
  * - Error handling
- * - Body scroll lock and escape key handling
- *
- * @param props - GroupManagementModal component props
- * @returns Group management modal element or null if not open
- *
- * @example
- * ```tsx
- * <GroupManagementModal
- *   isOpen={showModal}
- *   onClose={() => setShowModal(false)}
- *   groupId="group-123"
- *   onGroupUpdated={() => refreshGroups()}
- * />
- * ```
  */
 interface GroupManagementModalProps {
   isOpen: boolean;
@@ -110,8 +100,9 @@ export function GroupManagementModal({
   // Add member state
   const [showAddMember, setShowAddMember] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
-  const [searchResults, setSearchResults] = useState<User[]>([]);
+  const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
   const [searching, setSearching] = useState(false);
+  const [activeTab, setActiveTab] = useState<SearchTab>('users');
 
   // Confirm dialogs
   const [confirmAction, setConfirmAction] = useState<{
@@ -126,6 +117,9 @@ export function GroupManagementModal({
       setGroupDetails(null);
       setError(null);
       setShowAddMember(false);
+      setSearchQuery('');
+      setSearchResults([]);
+      setActiveTab('users');
       return;
     }
 
@@ -140,8 +134,9 @@ export function GroupManagementModal({
       });
 
       if (!response.ok) {
+        setError('Failed to load group details');
         setLoading(false);
-        throw new Error('Failed to load group details');
+        return;
       }
 
       const data = await response.json();
@@ -152,46 +147,130 @@ export function GroupManagementModal({
     loadGroupDetails();
   }, [isOpen, groupId, getAccessToken]);
 
-  // Search for users to add
+  // Search for users or agents based on active tab
   useEffect(() => {
     if (!searchQuery.trim() || searchQuery.length < 2) {
       setSearchResults([]);
       return;
     }
 
-    const searchUsers = async () => {
+    const searchMembers = async () => {
       setSearching(true);
       const token = await getAccessToken();
-      const response = await fetch(
-        `/api/users/search?q=${encodeURIComponent(searchQuery)}`,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      );
+
+      // Use different endpoint based on active tab
+      const endpoint =
+        activeTab === 'users'
+          ? `/api/users/search?q=${encodeURIComponent(searchQuery)}`
+          : `/api/agents/search?q=${encodeURIComponent(searchQuery)}`;
+
+      const response = await fetch(endpoint, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
 
       if (response.ok) {
         const data = await response.json();
-        // Filter out existing members
         const existingMemberIds = groupDetails?.members.map((m) => m.id) || [];
-        setSearchResults(
-          (data.users || []).filter(
-            (u: User) => !existingMemberIds.includes(u.id)
-          )
-        );
+
+        const results: SearchResult[] =
+          activeTab === 'users'
+            ? (data.users || [])
+                .filter(
+                  (u: { id: string }) => !existingMemberIds.includes(u.id)
+                )
+                .map(
+                  (u: {
+                    id: string;
+                    displayName: string | null;
+                    username: string | null;
+                    profileImageUrl: string | null;
+                  }) => ({
+                    ...u,
+                    type: 'user' as const,
+                  })
+                )
+            : (data.agents || [])
+                .filter(
+                  (a: { id: string }) => !existingMemberIds.includes(a.id)
+                )
+                .map(
+                  (a: {
+                    id: string;
+                    displayName: string | null;
+                    username: string | null;
+                    profileImageUrl: string | null;
+                    type: 'agent' | 'npc';
+                  }) => ({
+                    id: a.id,
+                    displayName: a.displayName,
+                    username: a.username,
+                    profileImageUrl: a.profileImageUrl,
+                    type: a.type,
+                  })
+                );
+        setSearchResults(results);
       }
       setSearching(false);
     };
 
-    const debounce = setTimeout(searchUsers, 300);
+    const debounce = setTimeout(searchMembers, 300);
     return () => clearTimeout(debounce);
-  }, [searchQuery, getAccessToken, groupDetails]);
+  }, [searchQuery, activeTab, getAccessToken, groupDetails]);
+
+  // Clear search when switching tabs
+  const handleTabChange = (tab: SearchTab) => {
+    setActiveTab(tab);
+    setSearchQuery('');
+    setSearchResults([]);
+  };
+
+  const getTypeBadge = (type: 'user' | 'agent' | 'npc') => {
+    switch (type) {
+      case 'agent':
+        return (
+          <span className="ml-1 inline-flex items-center rounded bg-blue-500/10 px-1.5 py-0.5 text-blue-600 text-xs dark:text-blue-400">
+            <Bot className="mr-0.5 h-3 w-3" />
+            Agent
+          </span>
+        );
+      case 'npc':
+        return (
+          <span className="ml-1 inline-flex items-center rounded bg-purple-500/10 px-1.5 py-0.5 text-purple-600 text-xs dark:text-purple-400">
+            <User className="mr-0.5 h-3 w-3" />
+            NPC
+          </span>
+        );
+      default:
+        return null;
+    }
+  };
+
+  const getGroupTypeBadge = (type: 'user' | 'npc' | 'agent') => {
+    switch (type) {
+      case 'npc':
+        return (
+          <span className="rounded bg-purple-500/10 px-2 py-1 text-purple-600 text-xs dark:text-purple-400">
+            NPC Group
+          </span>
+        );
+      case 'agent':
+        return (
+          <span className="rounded bg-blue-500/10 px-2 py-1 text-blue-600 text-xs dark:text-blue-400">
+            Agent Group
+          </span>
+        );
+      default:
+        return null;
+    }
+  };
 
   const handleAddMember = async (userId: string) => {
     if (!groupId) return;
 
     setActionLoading(userId);
+    setError(null);
     const token = await getAccessToken();
     const response = await fetch(`/api/groups/${groupId}/members`, {
       method: 'POST',
@@ -203,8 +282,10 @@ export function GroupManagementModal({
     });
 
     if (!response.ok) {
+      const data = await response.json();
+      setError(data.error || 'Failed to add member');
       setActionLoading(null);
-      throw new Error('Failed to add member');
+      return;
     }
 
     // Reload group details
@@ -228,6 +309,7 @@ export function GroupManagementModal({
     if (!groupId) return;
 
     setActionLoading(userId);
+    setError(null);
     const token = await getAccessToken();
     const response = await fetch(
       `/api/groups/${groupId}/members?userId=${userId}`,
@@ -240,9 +322,11 @@ export function GroupManagementModal({
     );
 
     if (!response.ok) {
+      const data = await response.json();
+      setError(data.error || 'Failed to remove member');
       setActionLoading(null);
       setConfirmAction(null);
-      throw new Error('Failed to remove member');
+      return;
     }
 
     // Reload group details
@@ -265,6 +349,7 @@ export function GroupManagementModal({
     if (!groupId) return;
 
     setActionLoading(userId);
+    setError(null);
     const token = await getAccessToken();
     const response = await fetch(`/api/groups/${groupId}/admins`, {
       method: 'POST',
@@ -276,9 +361,11 @@ export function GroupManagementModal({
     });
 
     if (!response.ok) {
+      const data = await response.json();
+      setError(data.error || 'Failed to promote member');
       setActionLoading(null);
       setConfirmAction(null);
-      throw new Error('Failed to promote member');
+      return;
     }
 
     // Reload group details
@@ -301,6 +388,7 @@ export function GroupManagementModal({
     if (!groupId) return;
 
     setActionLoading(userId);
+    setError(null);
     const token = await getAccessToken();
     const response = await fetch(
       `/api/groups/${groupId}/admins?userId=${userId}`,
@@ -313,9 +401,11 @@ export function GroupManagementModal({
     );
 
     if (!response.ok) {
+      const data = await response.json();
+      setError(data.error || 'Failed to remove admin status');
       setActionLoading(null);
       setConfirmAction(null);
-      throw new Error('Failed to remove admin status');
+      return;
     }
 
     // Reload group details
@@ -338,6 +428,7 @@ export function GroupManagementModal({
     if (!groupId) return;
 
     setActionLoading('delete');
+    setError(null);
     const token = await getAccessToken();
     const response = await fetch(`/api/groups/${groupId}`, {
       method: 'DELETE',
@@ -347,9 +438,11 @@ export function GroupManagementModal({
     });
 
     if (!response.ok) {
+      const data = await response.json();
+      setError(data.error || 'Failed to delete group');
       setActionLoading(null);
       setConfirmAction(null);
-      throw new Error('Failed to delete group');
+      return;
     }
 
     onGroupUpdated?.();
@@ -360,6 +453,7 @@ export function GroupManagementModal({
     if (!groupId || !user) return;
 
     setActionLoading('leave');
+    setError(null);
     const token = await getAccessToken();
     const response = await fetch(
       `/api/groups/${groupId}/members?userId=${user.id}`,
@@ -372,9 +466,11 @@ export function GroupManagementModal({
     );
 
     if (!response.ok) {
+      const data = await response.json();
+      setError(data.error || 'Failed to leave group');
       setActionLoading(null);
       setConfirmAction(null);
-      throw new Error('Failed to leave group');
+      return;
     }
 
     onGroupUpdated?.();
@@ -410,6 +506,9 @@ export function GroupManagementModal({
     onClose();
   };
 
+  // NPC groups cannot have members added via this modal
+  const isNpcGroup = groupDetails?.type === 'npc';
+
   return (
     <>
       <div
@@ -431,6 +530,7 @@ export function GroupManagementModal({
               <h2 className="font-bold text-xl">
                 {groupDetails?.name || 'Group Settings'}
               </h2>
+              {groupDetails && getGroupTypeBadge(groupDetails.type)}
             </div>
             <button
               onClick={handleClose}
@@ -469,8 +569,8 @@ export function GroupManagementModal({
                     </button>
                   )}
 
-                  {/* Delete Group (admins only) */}
-                  {groupDetails.isAdmin && (
+                  {/* Delete Group (admins only, not for NPC groups) */}
+                  {groupDetails.isAdmin && !isNpcGroup && (
                     <button
                       onClick={() => setConfirmAction({ type: 'delete' })}
                       disabled={!!actionLoading}
@@ -482,13 +582,23 @@ export function GroupManagementModal({
                   )}
                 </div>
 
+                {/* NPC Group Notice */}
+                {isNpcGroup && (
+                  <div className="rounded-lg border border-purple-500/20 bg-purple-500/10 p-3">
+                    <p className="text-purple-700 text-sm dark:text-purple-300">
+                      This is an NPC-controlled group. Member management is
+                      handled by the tiered invitation system.
+                    </p>
+                  </div>
+                )}
+
                 {/* Members Section */}
                 <div className="space-y-3">
                   <div className="flex items-center justify-between">
                     <label className="block font-semibold text-sm">
                       Members ({groupDetails.members.length})
                     </label>
-                    {groupDetails.isAdmin && (
+                    {groupDetails.isAdmin && !isNpcGroup && (
                       <button
                         onClick={() => setShowAddMember(!showAddMember)}
                         className="rounded-lg border border-border bg-sidebar px-3 py-1.5 font-medium text-sm transition-colors hover:bg-accent"
@@ -509,13 +619,46 @@ export function GroupManagementModal({
                   </div>
 
                   {/* Add Member Section */}
-                  {showAddMember && groupDetails.isAdmin && (
-                    <div className="space-y-2 rounded-lg border border-border bg-sidebar p-3">
+                  {showAddMember && groupDetails.isAdmin && !isNpcGroup && (
+                    <div className="space-y-3 rounded-lg border border-border bg-sidebar p-3">
+                      {/* Search Tabs */}
+                      <div className="flex rounded-lg border border-border bg-background p-1">
+                        <button
+                          onClick={() => handleTabChange('users')}
+                          className={cn(
+                            'flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-sm transition-colors',
+                            activeTab === 'users'
+                              ? 'bg-sidebar font-medium text-foreground shadow-sm'
+                              : 'text-muted-foreground hover:text-foreground'
+                          )}
+                        >
+                          <User className="h-3.5 w-3.5" />
+                          Users
+                        </button>
+                        <button
+                          onClick={() => handleTabChange('agents')}
+                          className={cn(
+                            'flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-sm transition-colors',
+                            activeTab === 'agents'
+                              ? 'bg-sidebar font-medium text-foreground shadow-sm'
+                              : 'text-muted-foreground hover:text-foreground'
+                          )}
+                        >
+                          <Bot className="h-3.5 w-3.5" />
+                          Agents & NPCs
+                        </button>
+                      </div>
+
+                      {/* Search Input */}
                       <div className="relative">
                         <Search className="-translate-y-1/2 absolute top-1/2 left-3 h-4 w-4 text-muted-foreground" />
                         <input
                           type="text"
-                          placeholder="Search users..."
+                          placeholder={
+                            activeTab === 'users'
+                              ? 'Search users...'
+                              : 'Search agents and NPCs...'
+                          }
                           value={searchQuery}
                           onChange={(e) => setSearchQuery(e.target.value)}
                           className="w-full rounded-lg border border-border bg-background py-2.5 pr-10 pl-9 transition-colors focus:border-primary focus:outline-none"
@@ -525,38 +668,57 @@ export function GroupManagementModal({
                         )}
                       </div>
 
+                      {/* Search Results */}
                       {searchResults.length > 0 && (
                         <div className="max-h-[150px] overflow-hidden overflow-y-auto rounded-lg border border-border bg-background">
-                          {searchResults.map((user) => (
+                          {searchResults.map((result) => (
                             <button
-                              key={user.id}
-                              onClick={() => handleAddMember(user.id)}
-                              disabled={actionLoading === user.id}
+                              key={result.id}
+                              onClick={() => handleAddMember(result.id)}
+                              disabled={actionLoading === result.id}
                               className="flex w-full items-center gap-2 p-2.5 text-left transition-colors hover:bg-sidebar disabled:opacity-50"
                             >
                               <Avatar
-                                imageUrl={user.profileImageUrl || undefined}
-                                name={user.username || user.displayName || '?'}
+                                imageUrl={result.profileImageUrl || undefined}
+                                name={
+                                  result.username || result.displayName || '?'
+                                }
                                 size="sm"
                               />
                               <div className="min-w-0 flex-1">
-                                <div className="truncate font-medium text-sm">
-                                  {user.displayName ||
-                                    user.username ||
+                                <div className="flex items-center truncate font-medium text-sm">
+                                  {result.displayName ||
+                                    result.username ||
                                     'Unknown'}
+                                  {getTypeBadge(result.type)}
                                 </div>
+                                {result.username && (
+                                  <div className="truncate text-muted-foreground text-xs">
+                                    @{result.username}
+                                  </div>
+                                )}
                               </div>
-                              {actionLoading === user.id && (
+                              {actionLoading === result.id && (
                                 <Loader2 className="h-4 w-4 animate-spin" />
                               )}
                             </button>
                           ))}
                         </div>
                       )}
+
+                      {searchQuery.length >= 2 &&
+                        searchResults.length === 0 &&
+                        !searching && (
+                          <div className="py-2 text-center text-muted-foreground text-sm">
+                            No{' '}
+                            {activeTab === 'users' ? 'users' : 'agents or NPCs'}{' '}
+                            found
+                          </div>
+                        )}
                     </div>
                   )}
 
-                  {/* Members */}
+                  {/* Members List */}
                   <div className="space-y-2">
                     {groupDetails.members.map((member) => {
                       const isCreator = member.id === groupDetails.createdById;
@@ -591,14 +753,52 @@ export function GroupManagementModal({
                             )}
                           </div>
 
-                          {/* Actions (only for admins, not for creator) */}
-                          {groupDetails.isAdmin && !isCreator && (
-                            <div className="flex items-center gap-1">
-                              {!member.isAdmin ? (
+                          {/* Actions (only for admins, not for creator, not for NPC groups) */}
+                          {groupDetails.isAdmin &&
+                            !isCreator &&
+                            !isNpcGroup && (
+                              <div className="flex items-center gap-1">
+                                {!member.isAdmin ? (
+                                  <button
+                                    onClick={() =>
+                                      setConfirmAction({
+                                        type: 'promote',
+                                        userId: member.id,
+                                        userName:
+                                          member.displayName ||
+                                          member.username ||
+                                          'this user',
+                                      })
+                                    }
+                                    disabled={!!actionLoading}
+                                    className="rounded-md p-2 transition-colors hover:bg-background disabled:opacity-50"
+                                    title="Make Admin"
+                                  >
+                                    <Shield className="h-4 w-4 text-primary" />
+                                  </button>
+                                ) : (
+                                  <button
+                                    onClick={() =>
+                                      setConfirmAction({
+                                        type: 'demote',
+                                        userId: member.id,
+                                        userName:
+                                          member.displayName ||
+                                          member.username ||
+                                          'this user',
+                                      })
+                                    }
+                                    disabled={!!actionLoading}
+                                    className="rounded-md p-2 transition-colors hover:bg-background disabled:opacity-50"
+                                    title="Remove Admin"
+                                  >
+                                    <Shield className="h-4 w-4 text-muted-foreground" />
+                                  </button>
+                                )}
                                 <button
                                   onClick={() =>
                                     setConfirmAction({
-                                      type: 'promote',
+                                      type: 'remove',
                                       userId: member.id,
                                       userName:
                                         member.displayName ||
@@ -608,48 +808,12 @@ export function GroupManagementModal({
                                   }
                                   disabled={!!actionLoading}
                                   className="rounded-md p-2 transition-colors hover:bg-background disabled:opacity-50"
-                                  title="Make Admin"
+                                  title="Remove Member"
                                 >
-                                  <Shield className="h-4 w-4 text-primary" />
+                                  <UserMinus className="h-4 w-4 text-red-500" />
                                 </button>
-                              ) : (
-                                <button
-                                  onClick={() =>
-                                    setConfirmAction({
-                                      type: 'demote',
-                                      userId: member.id,
-                                      userName:
-                                        member.displayName ||
-                                        member.username ||
-                                        'this user',
-                                    })
-                                  }
-                                  disabled={!!actionLoading}
-                                  className="rounded-md p-2 transition-colors hover:bg-background disabled:opacity-50"
-                                  title="Remove Admin"
-                                >
-                                  <Shield className="h-4 w-4 text-muted-foreground" />
-                                </button>
-                              )}
-                              <button
-                                onClick={() =>
-                                  setConfirmAction({
-                                    type: 'remove',
-                                    userId: member.id,
-                                    userName:
-                                      member.displayName ||
-                                      member.username ||
-                                      'this user',
-                                  })
-                                }
-                                disabled={!!actionLoading}
-                                className="rounded-md p-2 transition-colors hover:bg-background disabled:opacity-50"
-                                title="Remove Member"
-                              >
-                                <UserMinus className="h-4 w-4 text-red-500" />
-                              </button>
-                            </div>
-                          )}
+                              </div>
+                            )}
                         </div>
                       );
                     })}
@@ -687,13 +851,13 @@ export function GroupManagementModal({
                 {confirmAction.type === 'delete' &&
                   'This will permanently delete the group and all its data. This action cannot be undone.'}
                 {confirmAction.type === 'remove' &&
-                  `Remove ${confirmAction.userName} from this group? They can be re-invited later.`}
+                  `Remove ${confirmAction.userName} from this group? They can be re-added later.`}
                 {confirmAction.type === 'promote' &&
                   `Give ${confirmAction.userName} admin privileges? They will be able to manage members and settings.`}
                 {confirmAction.type === 'demote' &&
                   `Remove admin privileges from ${confirmAction.userName}? They will remain a regular member.`}
                 {confirmAction.type === 'leave' &&
-                  'Are you sure you want to leave this group? You will need to be re-invited to join again.'}
+                  'Are you sure you want to leave this group? You will need to be re-added to join again.'}
               </p>
 
               <div className="flex gap-3">

--- a/apps/web/src/components/groups/GroupManagementModal.tsx
+++ b/apps/web/src/components/groups/GroupManagementModal.tsx
@@ -17,6 +17,7 @@ import {
   X,
 } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
 import { Avatar } from '@/components/shared/Avatar';
 import { useAuthStore } from '@/stores/authStore';
 import { GroupTypeBadge, MemberTypeBadge } from './MemberTypeBadge';
@@ -248,6 +249,15 @@ export function GroupManagementModal({
       setError(data.error || 'Failed to add member');
       setActionLoading(null);
       return;
+    }
+
+    const result = await response.json();
+
+    // Show appropriate feedback based on whether user was added or invited
+    if (result.added) {
+      toast.success('Member added to group');
+    } else if (result.invited) {
+      toast.success('Invite sent - waiting for acceptance');
     }
 
     // Reload group details

--- a/apps/web/src/components/groups/MemberTypeBadge.tsx
+++ b/apps/web/src/components/groups/MemberTypeBadge.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { Bot, User } from 'lucide-react';
+
+export type MemberType = 'user' | 'agent' | 'npc';
+export type GroupType = 'user' | 'agent' | 'npc';
+
+/**
+ * Badge component for displaying member type (agent/NPC)
+ * Used in group member lists and search results
+ */
+export function MemberTypeBadge({ type }: { type: MemberType }) {
+  switch (type) {
+    case 'agent':
+      return (
+        <span className="ml-1 inline-flex items-center rounded bg-blue-500/10 px-1.5 py-0.5 text-blue-600 text-xs dark:text-blue-400">
+          <Bot className="mr-0.5 h-3 w-3" />
+          Agent
+        </span>
+      );
+    case 'npc':
+      return (
+        <span className="ml-1 inline-flex items-center rounded bg-purple-500/10 px-1.5 py-0.5 text-purple-600 text-xs dark:text-purple-400">
+          <User className="mr-0.5 h-3 w-3" />
+          NPC
+        </span>
+      );
+    default:
+      return null;
+  }
+}
+
+/**
+ * Badge component for displaying group type (NPC Group/Agent Group)
+ * Used in group management UI
+ */
+export function GroupTypeBadge({ type }: { type: GroupType }) {
+  switch (type) {
+    case 'npc':
+      return (
+        <span className="rounded bg-purple-500/10 px-2 py-1 text-purple-600 text-xs dark:text-purple-400">
+          NPC Group
+        </span>
+      );
+    case 'agent':
+      return (
+        <span className="rounded bg-blue-500/10 px-2 py-1 text-blue-600 text-xs dark:text-blue-400">
+          Agent Group
+        </span>
+      );
+    default:
+      return null;
+  }
+}
+

--- a/apps/web/src/components/groups/MemberTypeBadge.tsx
+++ b/apps/web/src/components/groups/MemberTypeBadge.tsx
@@ -52,4 +52,3 @@ export function GroupTypeBadge({ type }: { type: GroupType }) {
       return null;
   }
 }
-

--- a/apps/web/src/components/groups/MemberTypeBadge.tsx
+++ b/apps/web/src/components/groups/MemberTypeBadge.tsx
@@ -3,6 +3,9 @@
 import { Bot, User } from 'lucide-react';
 
 export type MemberType = 'user' | 'agent' | 'npc';
+
+// Note: Canonical GroupType is defined in packages/db/src/schema/messaging.ts (groupTypeEnum)
+// This local definition mirrors it for client-side usage without bundling DB schema
 export type GroupType = 'user' | 'agent' | 'npc';
 
 /**

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "build:staging": "NODE_ENV=production bun --env-file=.env.staging.local run build",
     "build:production": "NODE_ENV=production bun --env-file=.env.production.local run build",
     "start": "turbo start --filter=web",
+    "start:local": "NODE_ENV=production bun --env-file=.env run start",
     "start:staging": "NODE_ENV=production bun --env-file=.env.staging.local run start",
     "start:production": "NODE_ENV=production bun --env-file=.env.production.local run start",
     "check": "biome check --write .",

--- a/packages/api/src/services/notification-service.ts
+++ b/packages/api/src/services/notification-service.ts
@@ -555,6 +555,48 @@ export async function notifyUserGroupInvite(
 }
 
 /**
+ * Create notification when a user is directly added to a group
+ * (without requiring invite acceptance)
+ */
+export async function notifyGroupMemberAdded(
+  userId: string,
+  addedById: string,
+  groupId: string,
+  groupName: string,
+  chatId?: string
+): Promise<void> {
+  // Don't notify if user added themselves
+  if (userId === addedById) {
+    return;
+  }
+
+  const result = await db
+    .select({
+      displayName: users.displayName,
+      username: users.username,
+    })
+    .from(users)
+    .where(eq(users.id, addedById))
+    .limit(1);
+
+  const adder = result[0];
+  const adderName = adder?.displayName || adder?.username || 'Someone';
+  const message = `${adderName} added you to ${groupName}`;
+
+  // Create notification with groupId and chatId for proper linking
+  await db.insert(notifications).values({
+    id: await generateSnowflakeId(),
+    userId,
+    type: 'group_invite', // Reuse type for notification grouping in UI
+    actorId: addedById,
+    title: 'Added to Group',
+    message,
+    groupId,
+    chatId,
+  });
+}
+
+/**
  * Create notification for new DM message
  */
 export async function notifyDMMessage(

--- a/packages/api/src/services/notification-service.ts
+++ b/packages/api/src/services/notification-service.ts
@@ -36,6 +36,8 @@ interface CreateNotificationParams {
   postId?: string;
   commentId?: string;
   chatId?: string; // For DM/chat message notifications
+  groupId?: string; // For group-related notifications
+  inviteId?: string; // For invite-related notifications
   title: string;
   message: string;
 }
@@ -155,6 +157,8 @@ export async function createNotification(
     postId: params.postId,
     commentId: params.commentId,
     chatId: params.chatId,
+    groupId: params.groupId,
+    inviteId: params.inviteId,
     title: params.title,
     message: params.message,
   });
@@ -516,6 +520,8 @@ export async function notifyGroupChatInvite(
 /**
  * Create notification for user group invite
  *
+ * Uses createNotification for proper safety checks (user existence, blocked users, deduplication).
+ *
  * @param inviterName - Optional pre-fetched inviter name to avoid N+1 queries when called in bulk
  */
 export async function notifyUserGroupInvite(
@@ -548,9 +554,8 @@ export async function notifyUserGroupInvite(
 
   const message = `${finalInviterName} invited you to join ${groupName}`;
 
-  // Create notification with groupId and inviteId for proper linking
-  await db.insert(notifications).values({
-    id: await generateSnowflakeId(),
+  // Use createNotification for proper safety checks (user existence, blocked users)
+  await createNotification({
     userId,
     type: 'group_invite',
     actorId: inviterId,
@@ -564,6 +569,8 @@ export async function notifyUserGroupInvite(
 /**
  * Create notification when a user is directly added to a group
  * (without requiring invite acceptance)
+ *
+ * Uses createNotification for proper safety checks (user existence, blocked users, deduplication).
  *
  * @param adderName - Optional pre-fetched adder name to avoid N+1 queries when called in bulk
  */
@@ -598,9 +605,8 @@ export async function notifyGroupMemberAdded(
 
   const message = `${resolvedAdderName} added you to ${groupName}`;
 
-  // Create notification with groupId and chatId for proper linking
-  await db.insert(notifications).values({
-    id: await generateSnowflakeId(),
+  // Use createNotification for proper safety checks (user existence, blocked users)
+  await createNotification({
     userId,
     type: 'group_invite', // Reuse type for notification grouping in UI
     actorId: addedById,

--- a/packages/api/src/services/notification-service.ts
+++ b/packages/api/src/services/notification-service.ts
@@ -557,31 +557,39 @@ export async function notifyUserGroupInvite(
 /**
  * Create notification when a user is directly added to a group
  * (without requiring invite acceptance)
+ *
+ * @param adderName - Optional pre-fetched adder name to avoid N+1 queries when called in bulk
  */
 export async function notifyGroupMemberAdded(
   userId: string,
   addedById: string,
   groupId: string,
   groupName: string,
-  chatId?: string
+  chatId?: string,
+  adderName?: string
 ): Promise<void> {
   // Don't notify if user added themselves
   if (userId === addedById) {
     return;
   }
 
-  const result = await db
-    .select({
-      displayName: users.displayName,
-      username: users.username,
-    })
-    .from(users)
-    .where(eq(users.id, addedById))
-    .limit(1);
+  // Use provided adderName or fetch it (for backwards compatibility)
+  let resolvedAdderName = adderName;
+  if (!resolvedAdderName) {
+    const result = await db
+      .select({
+        displayName: users.displayName,
+        username: users.username,
+      })
+      .from(users)
+      .where(eq(users.id, addedById))
+      .limit(1);
 
-  const adder = result[0];
-  const adderName = adder?.displayName || adder?.username || 'Someone';
-  const message = `${adderName} added you to ${groupName}`;
+    const adder = result[0];
+    resolvedAdderName = adder?.displayName || adder?.username || 'Someone';
+  }
+
+  const message = `${resolvedAdderName} added you to ${groupName}`;
 
   // Create notification with groupId and chatId for proper linking
   await db.insert(notifications).values({

--- a/packages/api/src/services/notification-service.ts
+++ b/packages/api/src/services/notification-service.ts
@@ -515,31 +515,38 @@ export async function notifyGroupChatInvite(
 
 /**
  * Create notification for user group invite
+ *
+ * @param inviterName - Optional pre-fetched inviter name to avoid N+1 queries when called in bulk
  */
 export async function notifyUserGroupInvite(
   userId: string,
   inviterId: string,
   groupId: string,
   groupName: string,
-  inviteId?: string
+  inviteId?: string,
+  inviterName?: string
 ): Promise<void> {
   // Don't notify if user invited themselves
   if (userId === inviterId) {
     return;
   }
 
-  const result = await db
-    .select({
-      displayName: users.displayName,
-      username: users.username,
-    })
-    .from(users)
-    .where(eq(users.id, inviterId))
-    .limit(1);
+  let finalInviterName = inviterName;
+  if (!finalInviterName) {
+    const result = await db
+      .select({
+        displayName: users.displayName,
+        username: users.username,
+      })
+      .from(users)
+      .where(eq(users.id, inviterId))
+      .limit(1);
 
-  const inviter = result[0];
-  const inviterName = inviter?.displayName || inviter?.username || 'Someone';
-  const message = `${inviterName} invited you to join ${groupName}`;
+    const inviter = result[0];
+    finalInviterName = inviter?.displayName || inviter?.username || 'Someone';
+  }
+
+  const message = `${finalInviterName} invited you to join ${groupName}`;
 
   // Create notification with groupId and inviteId for proper linking
   await db.insert(notifications).values({

--- a/packages/db/drizzle/migrations/0018_add_missing_group_member_unique_constraint.sql
+++ b/packages/db/drizzle/migrations/0018_add_missing_group_member_unique_constraint.sql
@@ -1,0 +1,22 @@
+-- Add missing unique constraint on GroupMember(groupId, userId)
+-- This constraint was defined in migration 0005 but may not have been applied to all environments.
+-- Required for ON CONFLICT upsert operations in the group member addition flow.
+
+DO $$
+BEGIN
+    -- Add the unique constraint if it doesn't exist
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint 
+        WHERE conname = 'GroupMember_groupId_userId_key' 
+        AND conrelid = '"GroupMember"'::regclass
+    ) THEN
+        ALTER TABLE "GroupMember" 
+        ADD CONSTRAINT "GroupMember_groupId_userId_key" 
+        UNIQUE ("groupId", "userId");
+        
+        RAISE NOTICE 'Added GroupMember_groupId_userId_key constraint';
+    ELSE
+        RAISE NOTICE 'GroupMember_groupId_userId_key constraint already exists';
+    END IF;
+END $$;
+

--- a/packages/db/drizzle/migrations/0018_rollback_add_missing_group_member_unique_constraint.sql
+++ b/packages/db/drizzle/migrations/0018_rollback_add_missing_group_member_unique_constraint.sql
@@ -1,0 +1,6 @@
+-- Rollback: Remove GroupMember unique constraint
+-- WARNING: This will break ON CONFLICT upsert operations in group member addition flow
+
+ALTER TABLE "GroupMember" 
+DROP CONSTRAINT IF EXISTS "GroupMember_groupId_userId_key";
+

--- a/packages/db/scripts/post-push-indexes.ts
+++ b/packages/db/scripts/post-push-indexes.ts
@@ -1,9 +1,13 @@
 /**
- * Post db:push script to create partial indexes that Drizzle doesn't support natively.
+ * Post db:push script to create custom indexes that Drizzle doesn't support natively.
  *
  * Run this after `bun run db:push` to ensure custom indexes are created.
  *
  * Usage: DATABASE_URL="..." bun run packages/db/scripts/post-push-indexes.ts
+ *
+ * NOTE: GroupMember now uses a FULL unique constraint on (groupId, userId)
+ * managed via schema + migration 0018. The old partial index approach has been
+ * deprecated in favor of using isActive flag for soft deletes.
  */
 
 import postgres from 'postgres';
@@ -17,26 +21,21 @@ async function main() {
 
   const sql = postgres(databaseUrl);
 
-  console.log('Creating partial indexes...\n');
+  console.log('Checking post-push indexes...\n');
 
-  // GroupMember: Partial unique index for soft deletes
-  // Only one active member per (groupId, userId), but allows multiple inactive records
+  // GroupMember: Drop old partial index if it exists (replaced by full unique constraint)
+  // The full unique constraint is now managed in schema + migration 0018
   try {
     await sql`
-      CREATE UNIQUE INDEX IF NOT EXISTS "GroupMember_groupId_userId_active_key" 
-      ON "GroupMember" ("groupId", "userId") 
-      WHERE "isActive" = true
+      DROP INDEX IF EXISTS "GroupMember_groupId_userId_active_key"
     `;
     console.log(
-      '✓ GroupMember_groupId_userId_active_key (partial unique index)'
+      '✓ Dropped old GroupMember_groupId_userId_active_key partial index (replaced by full unique constraint)'
     );
-  } catch (e) {
-    const error = e as Error;
-    if (error.message?.includes('already exists')) {
-      console.log('✓ GroupMember_groupId_userId_active_key (already exists)');
-    } else {
-      console.error('✗ GroupMember_groupId_userId_active_key:', error.message);
-    }
+  } catch {
+    console.log(
+      '✓ GroupMember_groupId_userId_active_key: already removed or did not exist'
+    );
   }
 
   await sql.end();

--- a/packages/db/src/schema/messaging.ts
+++ b/packages/db/src/schema/messaging.ts
@@ -231,8 +231,9 @@ export const groupMembers = pgTable(
     previousTier: integer('previousTier'),
   },
   (table) => [
-    // Note: Partial unique index is managed via migration, not here
-    // See migration 0011_fix_group_member_partial_unique.sql
+    // Full unique constraint on (groupId, userId) required for onConflictDoUpdate upserts
+    // Note: This replaced the partial index approach - we now use isActive flag for soft deletes
+    unique('GroupMember_groupId_userId_key').on(table.groupId, table.userId),
     index('GroupMember_groupId_idx').on(table.groupId),
     index('GroupMember_userId_idx').on(table.userId),
     index('GroupMember_groupId_isActive_idx').on(table.groupId, table.isActive),

--- a/packages/db/src/schema/messaging.ts
+++ b/packages/db/src/schema/messaging.ts
@@ -197,12 +197,9 @@ export const groups = pgTable(
 /**
  * GroupMember - membership table with roles and quality tracking
  *
- * Note: Unique constraint is a PARTIAL INDEX created via migration:
- * CREATE UNIQUE INDEX "GroupMember_groupId_userId_active_key"
- *   ON "GroupMember" ("groupId", "userId") WHERE "isActive" = true;
- *
- * This allows multiple inactive records (history) but ensures only one
- * active member per (groupId, userId) pair.
+ * Unique constraint: Full unique constraint on (groupId, userId).
+ * This enables idempotent upserts via onConflictDoUpdate.
+ * Soft deletes use the isActive flag (no multiple inactive history rows).
  */
 export const groupMembers = pgTable(
   'GroupMember',

--- a/packages/engine/src/QuestionManager.ts
+++ b/packages/engine/src/QuestionManager.ts
@@ -652,7 +652,11 @@ ${s.involvedOrganizations?.length ? `Organizations: ${s.involvedOrganizations.jo
       [/\breportedly\b/i, 'reportedly', 0.1],
       [/\bpossibly\b/i, 'possibly', 0.1],
       // More specific: "apparently uncertain" vs "apparently successful" (confirming)
-      [/\bapparently\s+(not|uncertain|unclear|unconfirmed)\b/i, 'apparently', 0.08],
+      [
+        /\bapparently\s+(not|uncertain|unclear|unconfirmed)\b/i,
+        'apparently',
+        0.08,
+      ],
     ];
 
     let totalWeight = 0;

--- a/packages/engine/src/game-tick.ts
+++ b/packages/engine/src/game-tick.ts
@@ -2411,7 +2411,9 @@ async function updateMarketPricesFromTrades(
   const tradedTickers = new Set(
     executionResult.executedTrades
       .filter(
-        (t): t is (typeof executionResult.executedTrades)[number] & {
+        (
+          t
+        ): t is (typeof executionResult.executedTrades)[number] & {
           ticker: string;
         } => t.marketType === 'perp' && typeof t.ticker === 'string'
       )
@@ -2446,7 +2448,10 @@ async function updateMarketPricesFromTrades(
     })
     .from(perpPositions)
     .where(
-      and(inArray(perpPositions.ticker, tickers), isNull(perpPositions.closedAt))
+      and(
+        inArray(perpPositions.ticker, tickers),
+        isNull(perpPositions.closedAt)
+      )
     );
 
   const holdingsByTicker = new Map<string, number>();

--- a/packages/engine/src/services/npc-group-dynamics-service.ts
+++ b/packages/engine/src/services/npc-group-dynamics-service.ts
@@ -35,6 +35,7 @@ import {
   posts,
   reactions,
   shares,
+  sql,
   userInteractions,
   users,
 } from '@babylon/db';
@@ -398,8 +399,8 @@ export class NPCGroupDynamicsService {
                   .set({
                     isActive: true,
                     joinedAt: new Date(),
-                    kickedAt: null,
-                    kickReason: null,
+                    kickedAt: sql`NULL`,
+                    kickReason: sql`NULL`,
                   })
                   .where(eq(groupMembers.id, existingMember.id));
               }

--- a/packages/shared/src/constants/constants.ts
+++ b/packages/shared/src/constants/constants.ts
@@ -170,4 +170,6 @@ export const GROUP_CONFIG = {
   IDEAL_GROUP_SIZE: 7,
   /** Hours after joining before next invite eligible */
   INVITE_COOLDOWN_HOURS: 4,
+  /** UI warning threshold for group member count (soft cap, not enforced) */
+  MEMBER_WARNING_THRESHOLD: 100,
 } as const;

--- a/scripts/seed-test-users.ts
+++ b/scripts/seed-test-users.ts
@@ -39,7 +39,9 @@ async function main(): Promise<void> {
     });
 
     if (existing) {
-      console.log(`  ⏭️  ${config.username} already exists (id: ${existing.id})`);
+      console.log(
+        `  ⏭️  ${config.username} already exists (id: ${existing.id})`
+      );
       continue;
     }
 
@@ -90,4 +92,3 @@ main()
     console.error('Error:', error);
     process.exit(1);
   });
-

--- a/scripts/seed-test-users.ts
+++ b/scripts/seed-test-users.ts
@@ -1,0 +1,93 @@
+#!/usr/bin/env bun
+
+/**
+ * Seed Test Users
+ *
+ * Creates human test users for manual testing.
+ * These users can be logged into via Privy dev mode.
+ *
+ * Usage:
+ *   bun run scripts/seed-test-users.ts
+ */
+
+import { closeDatabase, db, generateSnowflakeId } from '@babylon/db';
+
+const TEST_USERS = [
+  {
+    username: 'testuser2',
+    displayName: 'Test User Two',
+    bio: 'Second test account for group testing',
+  },
+  {
+    username: 'testuser3',
+    displayName: 'Test User Three',
+    bio: 'Third test account for group testing',
+  },
+  {
+    username: 'testuser4',
+    displayName: 'Test User Four',
+    bio: 'Fourth test account for multi-member testing',
+  },
+];
+
+async function main(): Promise<void> {
+  console.log('🌱 Seeding test users...\n');
+
+  for (const config of TEST_USERS) {
+    const existing = await db.user.findFirst({
+      where: { username: config.username },
+    });
+
+    if (existing) {
+      console.log(`  ⏭️  ${config.username} already exists (id: ${existing.id})`);
+      continue;
+    }
+
+    const userId = await generateSnowflakeId();
+    const privyId = `dev_${userId}`;
+
+    await db.user.create({
+      data: {
+        id: userId,
+        privyId,
+        username: config.username,
+        displayName: config.displayName,
+        bio: config.bio,
+        isActor: false,
+        isAgent: false,
+        isBanned: false,
+        virtualBalance: '100.00',
+        totalDeposited: '100.00',
+        totalWithdrawn: '0.00',
+        lifetimePnL: '0.00',
+        profileComplete: true,
+        hasProfileImage: true,
+        hasUsername: true,
+        hasBio: true,
+        reputationPoints: 0,
+        bannerDismissCount: 0,
+        showFarcasterPublic: true,
+        showTwitterPublic: true,
+        showWalletPublic: true,
+        appealCount: 0,
+        referralCount: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+
+    console.log(`  ✅ Created ${config.username} (id: ${userId})`);
+  }
+
+  console.log('\n✨ Done! Test users created.\n');
+
+  await closeDatabase();
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error('Error:', error);
+    process.exit(1);
+  });
+


### PR DESCRIPTION
<!--
Babylon PR template

Goal: make PRs easy to review + easy to ship.
- Prefer small, focused PRs (one theme). Avoid catch‑all PRs.
- Keep app-layer thin and portable (validate → service → map errors).
- Put domain logic in packages (framework-agnostic), not in Next handlers/components.
- Before requesting review, run the relevant checks (see "Test plan").
-->

## Summary
<!-- 1–3 bullets: what changed + why (user impact / business goal). -->

- **Fix broken group member addition**: Users can now be added to groups during creation - humans receive invites while agents/NPCs are added directly
- **Add agent/NPC search**: New `/api/agents/search` endpoint + tabbed UI for searching users vs agents/NPCs when creating groups
- **Hybrid membership model**: Human users get invites (can accept/decline), agents/NPCs are added directly to `GroupMember` and `ChatParticipant` tables

## Type
<!-- Helps triage + release notes. -->

- [x] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
<!-- Link issues, Linear tickets, docs, prior PRs. -->

- Fixes: Group creation showing "3 members added" but only creator appearing
- Fixes: Agent search not working in group creation flow
- Preserves: NPC 3-tier group system (untouched)
- Preserves: Invite flow for human users (they can accept/decline)

## Scope (keep it focused)
<!-- If you had to touch multiple areas, explain why and what you intentionally left out. -->

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Non-goals / Follow-ups:**
- Phase 2: Activity tracking fields (`lastActiveAt`, `inactivityStrikes`)
- Separate: GroupInvite table cleanup for old/orphaned invites

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [x] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
<!-- List the notable changes (what is new/removed/modified). Link key files if it helps. -->

### Database
- Add `GroupMember_groupId_userId_key` unique constraint (required for upsert pattern)
- Migration 0018 with idempotent constraint creation

### API - New Endpoint
- `GET /api/agents/search` - Search for agents (`isAgent=true`) and NPCs (`isActor=true`)
  - Returns `type: 'agent' | 'npc'` for UI badges
  - Excludes blocked/muted/banned users

### API - Modified Endpoints
- `POST /api/groups` - Hybrid member addition
  - **Agents/NPCs**: Added directly to GroupMember + ChatParticipant immediately
  - **Human users**: GroupInvite created, pending acceptance
  - System messages: "[Creator] added [NPCs]" / "[Creator] invited [Humans]"
  - Notifications sent to all (direct add notification or invite notification)
  - Response includes `memberCount` (directly added) and `invitedCount` (pending invites)
  
- `POST /api/groups/[groupId]/members` - Hybrid add for existing groups
  - Check `isAgent`/`isActor` to determine flow
  - Human users → Create GroupInvite, return `{ invited: true }`
  - Agents/NPCs → Direct add, return `{ added: true }`
  - NPC groups (type='npc') protected with 403 error
  - Uses `onConflictDoUpdate` for idempotent upserts
  - Fix: Use `sql\`NULL\`` for Drizzle null handling

- `GET /api/users/search` - Add `?includeAgents=true` optional param

### Frontend
- `CreateGroupModal.tsx` - Complete overhaul
  - Tabbed search: Users / Agents & NPCs
  - Type badges on selected members
  - Member limit warning at 100 (soft cap)
  - Success toast shows both added count and invited count

- `GroupManagementModal.tsx` - Updated for hybrid flow
  - Toast: "Member added to group" (agents/NPCs)
  - Toast: "Invite sent - waiting for acceptance" (humans)

- `MemberTypeBadge.tsx` - New shared component
  - `MemberTypeBadge` for user/agent/npc badges
  - `GroupTypeBadge` for group type display

### Notification Service
- `notifyGroupMemberAdded()` - Notify users when directly added to group
  - Accepts optional `adderName` param to avoid N+1 queries
- `notifyUserGroupInvite()` - Notify users when invited to group
  - Accepts optional `inviterName` param to avoid N+1 queries

### Engine (Bug Fix)
- `npc-group-dynamics-service.ts` - Fix `sql\`NULL\`` for Drizzle null handling

## Review guide
<!-- Help reviewers go fast: where to start, ignore, tricky bits, key decisions. -->

**Start here**
- `apps/web/src/app/api/groups/route.ts` - Core group creation logic with hybrid flow
- `apps/web/src/app/api/groups/[groupId]/members/route.ts` - Member addition with hybrid flow
- `apps/web/src/components/groups/CreateGroupModal.tsx` - UI changes

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- NPC group logic is **untouched** - only guards added to prevent direct member addition
- The `sql\`NULL\`` pattern is required because Drizzle converts `null` to empty strings in `onConflictDoUpdate`
- Human users still get invites they can accept/decline - preserves original UX intent
- Agents/NPCs are added directly since they can't "accept" invites

## Test plan
<!-- Tick what you ran. Add manual steps for anything user-facing. -->

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run test` (unit + integration) - there are pre-existing failing tests
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [x] `bun run db:check` (if DB schema/queries changed)

**Manual verification**

### API Endpoints
1. Agent search: `GET /api/agents/search?q=test` → Returns NPCs with type badges
2. User search: `GET /api/users/search?q=hello` → Returns human users only
3. User search with agents: `GET /api/users/search?q=hello&includeAgents=true` → Includes agents

### Group Creation (Hybrid Flow)
1. Create group with only NPCs → All NPCs added directly, "added" system messages
2. Create group with only humans → All humans get invites, "invited" system messages
3. Create group with mix → NPCs added, humans invited, separate system messages

### Add Member to Existing Group
1. Add NPC to existing group → Toast: "Member added to group"
2. Add human to existing group → Toast: "Invite sent - waiting for acceptance"

### Invite Flow (Human Users)
1. Create group with human user → GroupInvite record created
2. Log in as invited user → See group invitation notification
3. Accept invite → User becomes member, appears in group
4. (Or) Decline invite → Invite removed, user not in group

**DB Verification Queries:**
```sql
-- Verify agents/NPCs are direct members
SELECT gm."groupId", gm."userId", u.username, u."isAgent", u."isActor", gm."isActive"
FROM "GroupMember" gm
JOIN "User" u ON u.id = gm."userId"
WHERE u."isAgent" = true OR u."isActor" = true
ORDER BY gm."joinedAt" DESC LIMIT 10;

-- Verify pending invites for human users
SELECT gi."groupId", gi."invitedUserId", u.username, gi.status
FROM "GroupInvite" gi
JOIN "User" u ON u.id = gi."invitedUserId"
WHERE gi.status = 'pending'
ORDER BY gi."invitedAt" DESC LIMIT 10;

-- Verify notifications (both types)
SELECT n."userId", n.type, n.title, n.message
FROM "Notification" n
WHERE n.type IN ('group_add', 'group_invite')
ORDER BY n."createdAt" DESC LIMIT 10;

-- Verify system messages
SELECT m."chatId", m."senderId", m.content
FROM "Message" m
WHERE m."senderId" = 'system' AND (m.content LIKE '%added%' OR m.content LIKE '%invited%')
ORDER BY m."createdAt" DESC LIMIT 10;
```

## Ops / Migration / Deployment
<!-- Anything that impacts deploys, data, cron, config, or rollouts. -->

- [ ] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [x] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- None

**DB / data migration**
- Migration(s): `0018_add_missing_group_member_unique_constraint.sql`
  - Adds `UNIQUE (groupId, userId)` constraint to GroupMember
  - Idempotent (checks if constraint exists before adding)
- Rollback: `0018_rollback_add_missing_group_member_unique_constraint.sql`
- Note: Schema change in `packages/db/src/schema/messaging.ts` will be applied via `drizzle-kit push`

**Rollout / rollback plan**
- Rollout: Apply migration, deploy, verify group creation works
- Rollback: Revert migration (constraint removal), redeploy previous version

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Notes:**
- GroupInvite table still exists and is used for human user invites
- Existing NPC invite flow is unchanged

## Security / privacy
<!-- Authn/authz, secrets handling, PII, prompt injection surfaces, etc. -->

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
<!-- New/changed endpoints, SSE event payloads, shared types. -->
- New: `GET /api/agents/search?q=<query>` - Returns agents/NPCs with type badges
- Changed: `GET /api/users/search` - New optional `?includeAgents=true` param
- Changed: `POST /api/groups` - Response includes `memberCount` (direct adds) and `invitedCount` (pending invites)
- Changed: `POST /api/groups/[groupId]/members` - Returns `{ success: true, added: true }` or `{ success: true, invited: true }`

### Database
<!-- Tables/columns/indexes, perf implications, how to verify. -->
- New constraint: `GroupMember_groupId_userId_key` UNIQUE on (groupId, userId)
- Required for `ON CONFLICT DO UPDATE` upsert pattern
- Verify: `SELECT conname FROM pg_constraint WHERE conrelid = '"GroupMember"'::regclass;`

### Contracts / on-chain
<!-- Network(s), addresses, upgrade/migration notes, how to verify. -->
- N/A

### Docs
<!-- If you touched generated vendor docs, regenerate via `bun run docs:generate`. -->
- N/A

</details>

## Screenshots / recordings (UI)

### Option A: Visual demo

| Feature | Before | After |
|---------|--------|-------|
| Group Creation | Only creator added, "invite sent" to others | Hybrid: Agents added directly, humans invited |
| Member Search | Single search, agents broken | Tabbed search (Users / Agents & NPCs) |
| Member Badges | None | "Agent" / "NPC" badges on non-human members |
| System Messages | None | "[User] added [Agents]" / "[User] invited [Humans]" |
| Toast Feedback | N/A | "Member added" vs "Invite sent - waiting for acceptance" |

[BAB-131.webm](https://github.com/user-attachments/assets/414431b4-da02-455d-8c92-91875bf04697)


## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

---

## Summary by CodeRabbit

* **New Features**
  * Agent/NPC search and optional inclusion in user search; tabbed member selection in group UIs; member and group type badges
  * **Hybrid add flow**: Agents/NPCs added directly with notification; human users receive invites they can accept/decline
  * Updated member/invite counts in group creation response

* **Bug Fixes**
  * Clearer add/remove semantics, improved system messages ("added" vs "invited"), chat participant updates

* **Chores**
  * DB uniqueness migration to support reliable upserts; test-user seeding script and local start script

---

## Greptile Summary

This PR implements a **hybrid member addition flow** for user-created groups:
- **Agents/NPCs** (isAgent=true OR isActor=true): Added directly to GroupMember + ChatParticipant
- **Human users**: Receive GroupInvite they can accept/decline

**Key Changes:**
- **Database**: Added unique constraint `GroupMember_groupId_userId_key` for upsert operations (idempotent migration)
- **API**: New `/api/agents/search` endpoint for agent/NPC discovery with type indicators
- **API**: Modified `/api/groups` to implement hybrid flow - separate handling for humans vs agents
- **API**: Updated `/api/groups/[groupId]/members` to check `isAgent`/`isActor` and route accordingly
- **Frontend**: Complete overhaul of `CreateGroupModal` with tabbed search and type badges
- **Frontend**: `GroupManagementModal` shows appropriate toast feedback
- **Frontend**: New shared `MemberTypeBadge` component to avoid duplication
- **Notifications**: Optimized with `adderName`/`inviterName` params to avoid N+1 queries

**Architecture:**
```
User selects members
       ↓
┌──────────────────────────────────────┐
│  POST /api/groups                    │
│  └─ Separate humans from agents/NPCs │
└──────────────────────────────────────┘
       ↓                    ↓
┌─────────────┐    ┌─────────────────────┐
│ Agents/NPCs │    │ Human Users         │
│ ─────────── │    │ ───────────────     │
│ Direct add  │    │ Create GroupInvite  │
│ to members  │    │ (pending status)    │
└─────────────┘    └─────────────────────┘
       ↓                    ↓
┌─────────────┐    ┌─────────────────────┐
│ Notification│    │ Invite Notification │
│ "added you" │    │ "invited you"       │
└─────────────┘    └─────────────────────┘
       ↓                    ↓
┌─────────────┐    ┌─────────────────────┐
│ System msg  │    │ System msg          │
│ "X added Y" │    │ "X invited Y"       │
└─────────────┘    └─────────────────────┘
```

**Testing Notes:**
- Migration is idempotent and safe to run multiple times
- NPC group logic is untouched (only guards added)
- The `sql\`NULL\`` pattern is required because Drizzle converts JavaScript `null` to empty strings in `onConflictDoUpdate`
- Human invite acceptance flow works through existing `/api/groups/invites/[inviteId]/accept` endpoint

**Confidence Score: 4/5**
- Solid implementation with proper error handling and clear separation of concerns
- Hybrid flow preserves original UX intent for humans while enabling direct agent integration
- N+1 query optimization addressed in notification service

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents/NPCs search endpoint; Member and Group type badges; includeAgents search option.

* **Improvements**
  * Clear add-vs-invite flows, contextual system messages, direct-add notifications, and post-commit notification delivery.
  * Group creation now returns memberCount and invitedCount; enhanced search tabs and member-management UI.

* **Chores**
  * DB migration enforcing unique group-member constraint (plus rollback/index cleanup); test-user seed script; new local start script; UI member-size warning constant.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->