### PR TITLE
fix(api): remove nested transaction in group invite accept

### DIFF
--- a/apps/web/src/app/api/groups/invites/[inviteId]/accept/route.ts
+++ b/apps/web/src/app/api/groups/invites/[inviteId]/accept/route.ts
@@ -51,32 +51,42 @@ export const POST = withErrorHandling(
         throw new ApiError('This invite has already been processed', 400);
       }
 
-      // Check if user is at the NPC group limit (only NPC groups count toward the limit)
-      const activeMemberships = await db.groupMember.findMany({
-        where: {
-          userId: user.userId,
-          isActive: true,
-        },
+      // Check if the invited group is an NPC group
+      const invitedGroup = await db.group.findUnique({
+        where: { id: invite.groupId },
+        select: { type: true },
       });
 
-      // Fetch all groups in one query to avoid N+1
-      const groupIds = activeMemberships.map((m) => m.groupId);
-      const memberGroups =
-        groupIds.length > 0
-          ? await db.group.findMany({
-              where: { id: { in: groupIds } },
-              select: { id: true, type: true },
-            })
-          : [];
+      // Only check NPC group limit if the invited group is an NPC group
+      if (invitedGroup?.type === 'npc') {
+        const activeMemberships = await db.groupMember.findMany({
+          where: {
+            userId: user.userId,
+            isActive: true,
+          },
+        });
 
-      // Count NPC groups
-      const npcGroupCount = memberGroups.filter((g) => g.type === 'npc').length;
+        // Fetch all groups in one query to avoid N+1
+        const groupIds = activeMemberships.map((m) => m.groupId);
+        const memberGroups =
+          groupIds.length > 0
+            ? await db.group.findMany({
+                where: { id: { in: groupIds } },
+                select: { id: true, type: true },
+              })
+            : [];
 
-      if (npcGroupCount >= GROUP_CONFIG.MAX_ACTIVE_USER_GROUPS) {
-        throw new ApiError(
-          `You can only be in ${GROUP_CONFIG.MAX_ACTIVE_USER_GROUPS} NPC groups at a time. Leave a group first.`,
-          400
-        );
+        // Count NPC groups
+        const npcGroupCount = memberGroups.filter(
+          (g) => g.type === 'npc'
+        ).length;
+
+        if (npcGroupCount >= GROUP_CONFIG.MAX_ACTIVE_USER_GROUPS) {
+          throw new ApiError(
+            `You can only be in ${GROUP_CONFIG.MAX_ACTIVE_USER_GROUPS} NPC groups at a time. Leave a group first.`,
+            400
+          );
+        }
       }
 
       // Check if user is already an active member (fail fast, no race condition here)

--- a/apps/web/src/app/api/groups/invites/[inviteId]/accept/route.ts
+++ b/apps/web/src/app/api/groups/invites/[inviteId]/accept/route.ts
@@ -51,14 +51,18 @@ export const POST = withErrorHandling(
         throw new ApiError('This invite has already been processed', 400);
       }
 
-      // Check if the invited group is an NPC group
+      // Check if the invited group exists and get its type
       const invitedGroup = await db.group.findUnique({
         where: { id: invite.groupId },
         select: { type: true },
       });
 
+      if (!invitedGroup) {
+        throw new ApiError('Group not found', 404);
+      }
+
       // Only check NPC group limit if the invited group is an NPC group
-      if (invitedGroup?.type === 'npc') {
+      if (invitedGroup.type === 'npc') {
         const activeMemberships = await db.groupMember.findMany({
           where: {
             userId: user.userId,

--- a/apps/web/src/app/api/groups/invites/[inviteId]/accept/route.ts
+++ b/apps/web/src/app/api/groups/invites/[inviteId]/accept/route.ts
@@ -101,55 +101,53 @@ export const POST = withErrorHandling(
       const now = new Date();
       const memberId = await generateSnowflakeId();
 
-      // Use transaction with atomic upserts to prevent race conditions
-      await db.transaction(async (tx) => {
-        // Upsert GroupMember - use drizzle's onConflictDoUpdate
-        await tx
-          .insert(groupMembers)
-          .values({
-            id: memberId,
-            groupId: invite.groupId,
-            userId: user.userId,
+      // Upsert GroupMember - use drizzle's onConflictDoUpdate
+      // Note: asUser already wraps this in a transaction, so no need for nested transaction
+      await db
+        .insert(groupMembers)
+        .values({
+          id: memberId,
+          groupId: invite.groupId,
+          userId: user.userId,
+          role: 'member',
+          addedBy: invite.invitedBy,
+          joinedAt: now,
+          isActive: true,
+          messageCount: 0,
+          qualityScore: 1.0,
+        })
+        .onConflictDoUpdate({
+          target: [groupMembers.groupId, groupMembers.userId],
+          set: {
+            isActive: true,
             role: 'member',
             addedBy: invite.invitedBy,
             joinedAt: now,
+            kickedAt: sql`NULL`,
+            kickReason: sql`NULL`,
+          },
+        });
+
+      // Upsert ChatParticipant if chat exists
+      if (groupChat) {
+        const participantId = await generateSnowflakeId();
+        await db
+          .insert(chatParticipants)
+          .values({
+            id: participantId,
+            chatId: groupChat.id,
+            userId: user.userId,
+            joinedAt: now,
             isActive: true,
-            messageCount: 0,
-            qualityScore: 1.0,
           })
           .onConflictDoUpdate({
-            target: [groupMembers.groupId, groupMembers.userId],
+            target: [chatParticipants.chatId, chatParticipants.userId],
             set: {
               isActive: true,
-              role: 'member',
-              addedBy: invite.invitedBy,
               joinedAt: now,
-              kickedAt: sql`NULL`,
-              kickReason: sql`NULL`,
             },
           });
-
-        // Upsert ChatParticipant if chat exists
-        if (groupChat) {
-          const participantId = await generateSnowflakeId();
-          await tx
-            .insert(chatParticipants)
-            .values({
-              id: participantId,
-              chatId: groupChat.id,
-              userId: user.userId,
-              joinedAt: now,
-              isActive: true,
-            })
-            .onConflictDoUpdate({
-              target: [chatParticipants.chatId, chatParticipants.userId],
-              set: {
-                isActive: true,
-                joinedAt: now,
-              },
-            });
-        }
-      });
+      }
 
       // Get user's display name for system message
       const joiningUser = await db.user.findUnique({


### PR DESCRIPTION
<h2>Greptile Overview</h2>

### Greptile Summary

Removes nested transaction wrapper in group invite acceptance endpoint that was causing "An unexpected error occurred". The `asUser()` helper already provides transaction semantics by wrapping operations in `instance.transaction()`, making the explicit `db.transaction()` call redundant and problematic. All database operations (member upsert, chat participant upsert, system message creation, invite status update, notification update) remain atomic within the single transaction provided by `asUser()`.

### Confidence Score: 2/5

- Fix resolves nested transaction issue but introduces logic bug with NPC group limit enforcement
- The transaction fix correctly removes the nested `db.transaction()` wrapper since `asUser()` already provides transaction semantics. However, the NPC group limit check (lines 75-80) doesn't verify whether the invited group is actually an NPC type before blocking the user. This means users at their NPC group limit would be incorrectly prevented from joining 'user' or 'agent' type groups. The limit should only apply when the invited group is of type 'npc'.
- apps/web/src/app/api/groups/invites/[inviteId]/accept/route.ts - NPC group limit logic needs to check invited group type

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/web/src/app/api/groups/invites/[inviteId]/accept/route.ts | 2/5 | Removes nested transaction wrapper; NPC group limit check doesn't verify invited group type |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API as Accept Invite API
    participant Auth as authenticate()
    participant DB as asUser(tx)
    participant Validation as Validation Logic

    Client->>API: POST /api/groups/invites/:inviteId/accept
    API->>Auth: Verify user authentication
    Auth-->>API: User object
    
    API->>DB: Start transaction via asUser()
    activate DB
    
    DB->>Validation: Fetch invite details
    Validation-->>DB: Invite data
    
    DB->>Validation: Check invite ownership & status
    
    DB->>Validation: Count user's active NPC groups
    Validation-->>DB: NPC group count
    
    DB->>Validation: Check if already member
    
    DB->>DB: Upsert GroupMember (atomic)
    DB->>DB: Upsert ChatParticipant (atomic)
    DB->>DB: Create system join message
    DB->>DB: Update invite status to 'accepted'
    DB->>DB: Mark notification as read
    
    DB-->>API: Commit transaction
    deactivate DB
    
    API-->>Client: Success response
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable invite acceptance flow with consistent member activation and status updates.
  * Improved handling of chat participants for group chats to avoid duplicates and ensure proper activation.
  * Refined conflict resolution so join timestamps and activation flags are updated predictably.
  * Limit checks for special (NPC) groups are now gated and only run when applicable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->