### PR TITLE
fix(db): use sql.raw() for JSONB default in gameOnboarding

### DIFF
--- a/packages/db/src/schema/users.ts
+++ b/packages/db/src/schema/users.ts
@@ -68,9 +68,10 @@ export const gameOnboarding = pgTable(
     // Full state as JSONB for flexibility
     // The default is generated from DEFAULT_GAME_ONBOARDING_STATE constant,
     // ensuring TypeScript validates the default against the GameOnboardingState interface.
+    // Note: sql.raw() is required because drizzle-kit doesn't support parameterized sql`` defaults
     state: jsonb('state')
       .$type<GameOnboardingState>()
-      .default(sql`${JSON.stringify(DEFAULT_GAME_ONBOARDING_STATE)}::jsonb`),
+      .default(sql.raw(`'${JSON.stringify(DEFAULT_GAME_ONBOARDING_STATE)}'::jsonb`)),
 
     // Quick access flags
     isComplete: boolean('isComplete').notNull().default(false),


### PR DESCRIPTION
<h2>Greptile Overview</h2>

### Greptile Summary

Fixed JSONB default value generation for the `gameOnboarding.state` column by switching from parameterized `sql` template literal to `sql.raw()` to ensure drizzle-kit can properly generate migration files.

- Changed `.default(sql\`${JSON.stringify(DEFAULT_GAME_ONBOARDING_STATE)}::jsonb\`)` to `.default(sql.raw(\`'${JSON.stringify(DEFAULT_GAME_ONBOARDING_STATE)}'::jsonb\`))`
- Added clarifying comment explaining why `sql.raw()` is required
- Ensures the default value is output as a literal SQL string in DDL during migration generation

### Confidence Score: 5/5

- This PR is safe to merge with minimal risk
- The change is a targeted fix for a known drizzle-kit limitation, properly converting parameterized SQL template to raw SQL literal. The fix maintains the same runtime behavior while enabling proper migration generation. The added comment provides clear context for future maintainers.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| packages/db/src/schema/users.ts | 5/5 | Fixed JSONB default value to use `sql.raw()` instead of parameterized `sql` template literal to ensure proper migration generation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Schema as users.ts Schema
    participant DrizzleKit as drizzle-kit
    participant Migration as SQL Migration
    participant DB as PostgreSQL

    Note over Dev,DB: Before Fix (Parameterized sql``)
    Dev->>Schema: Define default with sql`${value}::jsonb`
    Schema->>DrizzleKit: Generate migration
    DrizzleKit-->>Migration: ❌ Cannot process parameterized value
    Note over DrizzleKit,Migration: Migration generation fails

    Note over Dev,DB: After Fix (sql.raw())
    Dev->>Schema: Define default with sql.raw(`'${value}'::jsonb`)
    Schema->>DrizzleKit: Generate migration
    DrizzleKit->>Migration: ✅ Output literal SQL string
    Migration->>DB: CREATE TABLE with DEFAULT '{"completedSteps":[]...}'::jsonb
    DB-->>Dev: Table created successfully with proper default
```