### PR TITLE
fix: Default Name Generation & Field Regeneration Fix

### DIFF
--- a/apps/web/src/app/agents/create/hooks/useAgentForm.ts
+++ b/apps/web/src/app/agents/create/hooks/useAgentForm.ts
@@ -2,7 +2,10 @@ import type { AgentTemplate } from '@babylon/agents/client';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
-import { escapeRegex, generateAgentName } from '@/utils/nameGenerator';
+import {
+  createNameMatchRegex,
+  generateAgentName,
+} from '@/utils/nameGenerator';
 
 const STORAGE_KEY = 'babylon_agent_draft';
 
@@ -179,11 +182,8 @@ export function useAgentForm(): UseAgentFormResult {
 
           // Only replace if there's a previous name and it's different
           if (oldName && oldName !== value) {
-            // Use word boundaries to avoid replacing substrings (e.g., "Nova" in "Innovative")
-            const oldNameRegex = new RegExp(
-              `\\b${escapeRegex(oldName)}\\b`,
-              'g'
-            );
+            // Use flexible boundaries that handle punctuation/unicode better than \b
+            const oldNameRegex = createNameMatchRegex(oldName);
 
             setAgentData((prevAgent) => ({
               ...prevAgent,

--- a/apps/web/src/app/agents/create/hooks/useAgentForm.ts
+++ b/apps/web/src/app/agents/create/hooks/useAgentForm.ts
@@ -1,9 +1,52 @@
 import type { AgentTemplate } from '@babylon/agents/client';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
 
 const STORAGE_KEY = 'babylon_agent_draft';
+
+// Agent name generation
+const NAME_PREFIXES = [
+  // Greek letters
+  'Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon', 'Zeta', 'Eta', 'Theta',
+  'Iota', 'Kappa', 'Lambda', 'Mu', 'Nu', 'Xi', 'Omicron', 'Pi',
+  'Rho', 'Sigma', 'Tau', 'Upsilon', 'Phi', 'Chi', 'Psi', 'Omega',
+  // Tech/Cyber
+  'Quantum', 'Neo', 'Cyber', 'Nexus', 'Apex', 'Vertex', 'Pulse', 'Flux',
+  'Vector', 'Helix', 'Prism', 'Matrix', 'Cipher', 'Binary', 'Neural',
+  // Nature/Elements
+  'Nova', 'Solar', 'Lunar', 'Stellar', 'Cosmic', 'Astral', 'Phoenix', 'Storm',
+  'Thunder', 'Frost', 'Ember', 'Shadow', 'Dawn', 'Dusk',
+  // Power/Status
+  'Iron', 'Steel', 'Titan', 'Atlas', 'Orion', 'Vortex', 'Blaze', 'Spark',
+  'Echo', 'Phantom', 'Specter', 'Raven', 'Falcon', 'Hawk', 'Eagle',
+  // Abstract
+  'Zen', 'Aura', 'Axiom', 'Lumen', 'Photon', 'Quark', 'Volt', 'Arc',
+];
+
+const NAME_SUFFIXES = [
+  // Role-based
+  'Trader', 'Agent', 'Bot', 'AI', 'Mind', 'Brain', 'Sage', 'Oracle',
+  // Technical
+  'Core', 'Node', 'Edge', 'Prime', 'Pro', 'Max', 'Ultra', 'Plus',
+  'X', 'Zero', 'One', 'Protocol', 'System', 'Engine', 'Logic',
+  // Abstract
+  'Flow', 'Wave', 'Sync', 'Link', 'Net', 'Hub', 'Lab', 'Works',
+  'Force', 'Drive', 'Pulse', 'Signal', 'Stream', 'Grid', 'Mesh',
+];
+
+const generateAgentName = (): { username: string; displayName: string } => {
+  const prefix = NAME_PREFIXES[Math.floor(Math.random() * NAME_PREFIXES.length)]!;
+  const suffix = NAME_SUFFIXES[Math.floor(Math.random() * NAME_SUFFIXES.length)]!;
+
+  // Use simple 4-digit number (looks natural, e.g., "novatrader42" or "alphabot7291")
+  const number = Math.floor(Math.random() * 9000) + 1000; // 1000-9999
+
+  const displayName = `${prefix} ${suffix}`;
+  const username = `${prefix.toLowerCase()}${suffix.toLowerCase()}${number}`;
+
+  return { username, displayName };
+};
 
 export interface ProfileFormData {
   username: string;
@@ -48,9 +91,12 @@ const TOTAL_PROFILE_PICTURES = 100;
 export function useAgentForm(): UseAgentFormResult {
   const { getAccessToken } = useAuth();
 
+  // Generate default agent name on mount
+  const [initialName] = useState(() => generateAgentName());
+
   const [profileData, setProfileData] = useState<ProfileFormData>({
-    username: '',
-    displayName: '',
+    username: initialName.username,
+    displayName: initialName.displayName,
     bio: '',
     profileImageUrl: '',
     coverImageUrl: '',
@@ -65,6 +111,9 @@ export function useAgentForm(): UseAgentFormResult {
 
   const [isInitialized, setIsInitialized] = useState(false);
   const [generatingField, setGeneratingField] = useState<string | null>(null);
+
+  // Track the name currently used in prompts (for replacement when user changes it)
+  const nameInPromptsRef = useRef<string>(initialName.displayName);
 
   // Load template on mount
   useEffect(() => {
@@ -104,10 +153,10 @@ export function useAgentForm(): UseAgentFormResult {
       const randomBanner =
         Math.floor(Math.random() * TOTAL_PROFILE_PICTURES) + 1;
 
-      // Update profile data
+      // Update profile data (preserve generated name)
       setProfileData((prev) => ({
-        username: prev.username || '',
-        displayName: prev.displayName || '',
+        username: prev.username,
+        displayName: prev.displayName,
         bio: template.description,
         profileImageUrl:
           prev.profileImageUrl ||
@@ -117,23 +166,23 @@ export function useAgentForm(): UseAgentFormResult {
           `/assets/user-banners/banner-${randomBanner}.jpg`,
       }));
 
-      // Keep {{agentName}} placeholder - will be replaced when user sets their name
-      setAgentData({
-        system: template.system,
-        personality: template.bio,
-        tradingStrategy: template.tradingStrategy,
-        initialDeposit: 100,
-      });
+      // Replace {{agentName}} placeholder with generated display name
+      const displayName = initialName.displayName;
+      setAgentData((prev) => ({
+        system: template.system.replace(/\{\{agentName\}\}/g, displayName),
+        personality: template.bio.replace(/\{\{agentName\}\}/g, displayName),
+        tradingStrategy: template.tradingStrategy.replace(/\{\{agentName\}\}/g, displayName),
+        initialDeposit: prev.initialDeposit,
+      }));
 
       setIsInitialized(true);
     };
 
     loadTemplate();
-  }, []);
+  }, [initialName]);
 
-  // Note: {{agentName}} placeholder replacement is handled in updateProfileField
-  // when displayName is first set. Once replaced, subsequent displayName changes
-  // do not update the system prompt (it's user-editable at that point).
+  // Note: When displayName changes, we find and replace the old name with the new name
+  // in the system prompt, personality, and trading strategy fields.
 
   // Auto-save to localStorage
   useEffect(() => {
@@ -148,24 +197,25 @@ export function useAgentForm(): UseAgentFormResult {
     (field: keyof ProfileFormData, value: string) => {
       setProfileData((prev) => ({ ...prev, [field]: value }));
 
-      // When displayName is set, replace {{agentName}} placeholder
+      // When displayName changes, replace the old name with new name in prompts
       if (field === 'displayName' && value) {
-        setAgentData((prevAgent) => {
-          if (!prevAgent.system.includes('{{agentName}}')) return prevAgent;
-
-          return {
+        const oldName = nameInPromptsRef.current;
+        
+        // Only replace if there's a previous name and it's different
+        if (oldName && oldName !== value) {
+          const escapeRegex = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+          const oldNameRegex = new RegExp(escapeRegex(oldName), 'g');
+          
+          setAgentData((prevAgent) => ({
             ...prevAgent,
-            system: prevAgent.system.replace(/\{\{agentName\}\}/g, value),
-            personality: prevAgent.personality.replace(
-              /\{\{agentName\}\}/g,
-              value
-            ),
-            tradingStrategy: prevAgent.tradingStrategy.replace(
-              /\{\{agentName\}\}/g,
-              value
-            ),
-          };
-        });
+            system: prevAgent.system.replace(oldNameRegex, value),
+            personality: prevAgent.personality.replace(oldNameRegex, value),
+            tradingStrategy: prevAgent.tradingStrategy.replace(oldNameRegex, value),
+          }));
+        }
+        
+        // Update the tracked name
+        nameInPromptsRef.current = value;
       }
     },
     []

--- a/apps/web/src/app/agents/create/hooks/useAgentForm.ts
+++ b/apps/web/src/app/agents/create/hooks/useAgentForm.ts
@@ -140,8 +140,10 @@ const generateAgentName = (): { username: string; displayName: string } => {
   const suffix =
     NAME_SUFFIXES[Math.floor(Math.random() * NAME_SUFFIXES.length)]!;
 
-  // Use simple 4-digit number (looks natural, e.g., "novatrader42" or "alphabot7291")
-  const number = Math.floor(Math.random() * 9000) + 1000; // 1000-9999
+  // Use 6-digit number for better uniqueness at scale
+  // Range: 100000-999999 = 900,000 possible numbers
+  // Combined with ~2,275 name combos = ~2 billion unique usernames
+  const number = Math.floor(Math.random() * 900000) + 100000;
 
   const displayName = `${prefix} ${suffix}`;
   const username = `${prefix.toLowerCase()}${suffix.toLowerCase()}${number}`;
@@ -283,7 +285,8 @@ export function useAgentForm(): UseAgentFormResult {
     };
 
     loadTemplate();
-  }, [initialName]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- initialName is stable (from useState initializer), runs once on mount
+  }, []);
 
   // Note: When displayName changes, we find and replace the old name with the new name
   // in the system prompt, personality, and trading strategy fields.
@@ -309,7 +312,8 @@ export function useAgentForm(): UseAgentFormResult {
         if (oldName && oldName !== value) {
           const escapeRegex = (str: string) =>
             str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-          const oldNameRegex = new RegExp(escapeRegex(oldName), 'g');
+          // Use word boundaries to avoid replacing substrings (e.g., "Nova" in "Innovative")
+          const oldNameRegex = new RegExp(`\\b${escapeRegex(oldName)}\\b`, 'g');
 
           setAgentData((prevAgent) => ({
             ...prevAgent,
@@ -374,12 +378,10 @@ export function useAgentForm(): UseAgentFormResult {
       }
 
       const result = await response.json();
-      const strippedValue = (result.value as string)
-        .replace(/<think>[\s\S]*?<\/think>/gi, '')
-        .trim();
+      const value = (result.value as string).trim();
 
       if (field === 'personality') {
-        const personalityLines = strippedValue
+        const personalityLines = value
           .split('|')
           .map((s: string) => s.trim())
           .filter((s: string) => s);
@@ -387,7 +389,7 @@ export function useAgentForm(): UseAgentFormResult {
       } else {
         updateAgentField(
           field as keyof AgentFormData,
-          strippedValue.replace(/\n\n+/g, '\n')
+          value.replace(/\n\n+/g, '\n')
         );
       }
 

--- a/apps/web/src/app/agents/create/hooks/useAgentForm.ts
+++ b/apps/web/src/app/agents/create/hooks/useAgentForm.ts
@@ -8,36 +8,137 @@ const STORAGE_KEY = 'babylon_agent_draft';
 // Agent name generation
 const NAME_PREFIXES = [
   // Greek letters
-  'Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon', 'Zeta', 'Eta', 'Theta',
-  'Iota', 'Kappa', 'Lambda', 'Mu', 'Nu', 'Xi', 'Omicron', 'Pi',
-  'Rho', 'Sigma', 'Tau', 'Upsilon', 'Phi', 'Chi', 'Psi', 'Omega',
+  'Alpha',
+  'Beta',
+  'Gamma',
+  'Delta',
+  'Epsilon',
+  'Zeta',
+  'Eta',
+  'Theta',
+  'Iota',
+  'Kappa',
+  'Lambda',
+  'Mu',
+  'Nu',
+  'Xi',
+  'Omicron',
+  'Pi',
+  'Rho',
+  'Sigma',
+  'Tau',
+  'Upsilon',
+  'Phi',
+  'Chi',
+  'Psi',
+  'Omega',
   // Tech/Cyber
-  'Quantum', 'Neo', 'Cyber', 'Nexus', 'Apex', 'Vertex', 'Pulse', 'Flux',
-  'Vector', 'Helix', 'Prism', 'Matrix', 'Cipher', 'Binary', 'Neural',
+  'Quantum',
+  'Neo',
+  'Cyber',
+  'Nexus',
+  'Apex',
+  'Vertex',
+  'Pulse',
+  'Flux',
+  'Vector',
+  'Helix',
+  'Prism',
+  'Matrix',
+  'Cipher',
+  'Binary',
+  'Neural',
   // Nature/Elements
-  'Nova', 'Solar', 'Lunar', 'Stellar', 'Cosmic', 'Astral', 'Phoenix', 'Storm',
-  'Thunder', 'Frost', 'Ember', 'Shadow', 'Dawn', 'Dusk',
+  'Nova',
+  'Solar',
+  'Lunar',
+  'Stellar',
+  'Cosmic',
+  'Astral',
+  'Phoenix',
+  'Storm',
+  'Thunder',
+  'Frost',
+  'Ember',
+  'Shadow',
+  'Dawn',
+  'Dusk',
   // Power/Status
-  'Iron', 'Steel', 'Titan', 'Atlas', 'Orion', 'Vortex', 'Blaze', 'Spark',
-  'Echo', 'Phantom', 'Specter', 'Raven', 'Falcon', 'Hawk', 'Eagle',
+  'Iron',
+  'Steel',
+  'Titan',
+  'Atlas',
+  'Orion',
+  'Vortex',
+  'Blaze',
+  'Spark',
+  'Echo',
+  'Phantom',
+  'Specter',
+  'Raven',
+  'Falcon',
+  'Hawk',
+  'Eagle',
   // Abstract
-  'Zen', 'Aura', 'Axiom', 'Lumen', 'Photon', 'Quark', 'Volt', 'Arc',
+  'Zen',
+  'Aura',
+  'Axiom',
+  'Lumen',
+  'Photon',
+  'Quark',
+  'Volt',
+  'Arc',
 ];
 
 const NAME_SUFFIXES = [
   // Role-based
-  'Trader', 'Agent', 'Bot', 'AI', 'Mind', 'Brain', 'Sage', 'Oracle',
+  'Trader',
+  'Agent',
+  'Bot',
+  'AI',
+  'Mind',
+  'Brain',
+  'Sage',
+  'Oracle',
   // Technical
-  'Core', 'Node', 'Edge', 'Prime', 'Pro', 'Max', 'Ultra', 'Plus',
-  'X', 'Zero', 'One', 'Protocol', 'System', 'Engine', 'Logic',
+  'Core',
+  'Node',
+  'Edge',
+  'Prime',
+  'Pro',
+  'Max',
+  'Ultra',
+  'Plus',
+  'X',
+  'Zero',
+  'One',
+  'Protocol',
+  'System',
+  'Engine',
+  'Logic',
   // Abstract
-  'Flow', 'Wave', 'Sync', 'Link', 'Net', 'Hub', 'Lab', 'Works',
-  'Force', 'Drive', 'Pulse', 'Signal', 'Stream', 'Grid', 'Mesh',
+  'Flow',
+  'Wave',
+  'Sync',
+  'Link',
+  'Net',
+  'Hub',
+  'Lab',
+  'Works',
+  'Force',
+  'Drive',
+  'Pulse',
+  'Signal',
+  'Stream',
+  'Grid',
+  'Mesh',
 ];
 
 const generateAgentName = (): { username: string; displayName: string } => {
-  const prefix = NAME_PREFIXES[Math.floor(Math.random() * NAME_PREFIXES.length)]!;
-  const suffix = NAME_SUFFIXES[Math.floor(Math.random() * NAME_SUFFIXES.length)]!;
+  const prefix =
+    NAME_PREFIXES[Math.floor(Math.random() * NAME_PREFIXES.length)]!;
+  const suffix =
+    NAME_SUFFIXES[Math.floor(Math.random() * NAME_SUFFIXES.length)]!;
 
   // Use simple 4-digit number (looks natural, e.g., "novatrader42" or "alphabot7291")
   const number = Math.floor(Math.random() * 9000) + 1000; // 1000-9999
@@ -171,7 +272,10 @@ export function useAgentForm(): UseAgentFormResult {
       setAgentData((prev) => ({
         system: template.system.replace(/\{\{agentName\}\}/g, displayName),
         personality: template.bio.replace(/\{\{agentName\}\}/g, displayName),
-        tradingStrategy: template.tradingStrategy.replace(/\{\{agentName\}\}/g, displayName),
+        tradingStrategy: template.tradingStrategy.replace(
+          /\{\{agentName\}\}/g,
+          displayName
+        ),
         initialDeposit: prev.initialDeposit,
       }));
 
@@ -200,20 +304,24 @@ export function useAgentForm(): UseAgentFormResult {
       // When displayName changes, replace the old name with new name in prompts
       if (field === 'displayName' && value) {
         const oldName = nameInPromptsRef.current;
-        
+
         // Only replace if there's a previous name and it's different
         if (oldName && oldName !== value) {
-          const escapeRegex = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+          const escapeRegex = (str: string) =>
+            str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
           const oldNameRegex = new RegExp(escapeRegex(oldName), 'g');
-          
+
           setAgentData((prevAgent) => ({
             ...prevAgent,
             system: prevAgent.system.replace(oldNameRegex, value),
             personality: prevAgent.personality.replace(oldNameRegex, value),
-            tradingStrategy: prevAgent.tradingStrategy.replace(oldNameRegex, value),
+            tradingStrategy: prevAgent.tradingStrategy.replace(
+              oldNameRegex,
+              value
+            ),
           }));
         }
-        
+
         // Update the tracked name
         nameInPromptsRef.current = value;
       }

--- a/apps/web/src/app/agents/create/hooks/useAgentForm.ts
+++ b/apps/web/src/app/agents/create/hooks/useAgentForm.ts
@@ -2,154 +2,12 @@ import type { AgentTemplate } from '@babylon/agents/client';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
+import { escapeRegex, generateAgentName } from '@/utils/nameGenerator';
 
 const STORAGE_KEY = 'babylon_agent_draft';
 
-// Agent name generation
-const NAME_PREFIXES = [
-  // Greek letters
-  'Alpha',
-  'Beta',
-  'Gamma',
-  'Delta',
-  'Epsilon',
-  'Zeta',
-  'Eta',
-  'Theta',
-  'Iota',
-  'Kappa',
-  'Lambda',
-  'Mu',
-  'Nu',
-  'Xi',
-  'Omicron',
-  'Pi',
-  'Rho',
-  'Sigma',
-  'Tau',
-  'Upsilon',
-  'Phi',
-  'Chi',
-  'Psi',
-  'Omega',
-  // Tech/Cyber
-  'Quantum',
-  'Neo',
-  'Cyber',
-  'Nexus',
-  'Apex',
-  'Vertex',
-  'Pulse',
-  'Flux',
-  'Vector',
-  'Helix',
-  'Prism',
-  'Matrix',
-  'Cipher',
-  'Binary',
-  'Neural',
-  // Nature/Elements
-  'Nova',
-  'Solar',
-  'Lunar',
-  'Stellar',
-  'Cosmic',
-  'Astral',
-  'Phoenix',
-  'Storm',
-  'Thunder',
-  'Frost',
-  'Ember',
-  'Shadow',
-  'Dawn',
-  'Dusk',
-  // Power/Status
-  'Iron',
-  'Steel',
-  'Titan',
-  'Atlas',
-  'Orion',
-  'Vortex',
-  'Blaze',
-  'Spark',
-  'Echo',
-  'Phantom',
-  'Specter',
-  'Raven',
-  'Falcon',
-  'Hawk',
-  'Eagle',
-  // Abstract
-  'Zen',
-  'Aura',
-  'Axiom',
-  'Lumen',
-  'Photon',
-  'Quark',
-  'Volt',
-  'Arc',
-];
-
-const NAME_SUFFIXES = [
-  // Role-based
-  'Trader',
-  'Agent',
-  'Bot',
-  'AI',
-  'Mind',
-  'Brain',
-  'Sage',
-  'Oracle',
-  // Technical
-  'Core',
-  'Node',
-  'Edge',
-  'Prime',
-  'Pro',
-  'Max',
-  'Ultra',
-  'Plus',
-  'X',
-  'Zero',
-  'One',
-  'Protocol',
-  'System',
-  'Engine',
-  'Logic',
-  // Abstract
-  'Flow',
-  'Wave',
-  'Sync',
-  'Link',
-  'Net',
-  'Hub',
-  'Lab',
-  'Works',
-  'Force',
-  'Drive',
-  'Pulse',
-  'Signal',
-  'Stream',
-  'Grid',
-  'Mesh',
-];
-
-const generateAgentName = (): { username: string; displayName: string } => {
-  const prefix =
-    NAME_PREFIXES[Math.floor(Math.random() * NAME_PREFIXES.length)]!;
-  const suffix =
-    NAME_SUFFIXES[Math.floor(Math.random() * NAME_SUFFIXES.length)]!;
-
-  // Use 6-digit number for better uniqueness at scale
-  // Range: 100000-999999 = 900,000 possible numbers
-  // Combined with ~2,275 name combos = ~2 billion unique usernames
-  const number = Math.floor(Math.random() * 900000) + 100000;
-
-  const displayName = `${prefix} ${suffix}`;
-  const username = `${prefix.toLowerCase()}${suffix.toLowerCase()}${number}`;
-
-  return { username, displayName };
-};
+// Debounce delay for name replacement in prompts (ms)
+const NAME_REPLACEMENT_DEBOUNCE_MS = 300;
 
 export interface ProfileFormData {
   username: string;
@@ -217,6 +75,10 @@ export function useAgentForm(): UseAgentFormResult {
 
   // Track the name currently used in prompts (for replacement when user changes it)
   const nameInPromptsRef = useRef<string>(initialName.displayName);
+  // Debounce timer for name replacement to handle rapid typing
+  const nameReplacementTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
 
   // Load template on mount
   useEffect(() => {
@@ -305,29 +167,38 @@ export function useAgentForm(): UseAgentFormResult {
       setProfileData((prev) => ({ ...prev, [field]: value }));
 
       // When displayName changes, replace the old name with new name in prompts
+      // Debounced to handle rapid typing and prevent race conditions
       if (field === 'displayName' && value) {
-        const oldName = nameInPromptsRef.current;
-
-        // Only replace if there's a previous name and it's different
-        if (oldName && oldName !== value) {
-          const escapeRegex = (str: string) =>
-            str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-          // Use word boundaries to avoid replacing substrings (e.g., "Nova" in "Innovative")
-          const oldNameRegex = new RegExp(`\\b${escapeRegex(oldName)}\\b`, 'g');
-
-          setAgentData((prevAgent) => ({
-            ...prevAgent,
-            system: prevAgent.system.replace(oldNameRegex, value),
-            personality: prevAgent.personality.replace(oldNameRegex, value),
-            tradingStrategy: prevAgent.tradingStrategy.replace(
-              oldNameRegex,
-              value
-            ),
-          }));
+        // Clear any pending replacement
+        if (nameReplacementTimerRef.current) {
+          clearTimeout(nameReplacementTimerRef.current);
         }
 
-        // Update the tracked name
-        nameInPromptsRef.current = value;
+        nameReplacementTimerRef.current = setTimeout(() => {
+          const oldName = nameInPromptsRef.current;
+
+          // Only replace if there's a previous name and it's different
+          if (oldName && oldName !== value) {
+            // Use word boundaries to avoid replacing substrings (e.g., "Nova" in "Innovative")
+            const oldNameRegex = new RegExp(
+              `\\b${escapeRegex(oldName)}\\b`,
+              'g'
+            );
+
+            setAgentData((prevAgent) => ({
+              ...prevAgent,
+              system: prevAgent.system.replace(oldNameRegex, value),
+              personality: prevAgent.personality.replace(oldNameRegex, value),
+              tradingStrategy: prevAgent.tradingStrategy.replace(
+                oldNameRegex,
+                value
+              ),
+            }));
+          }
+
+          // Update the tracked name after replacement
+          nameInPromptsRef.current = value;
+        }, NAME_REPLACEMENT_DEBOUNCE_MS);
       }
     },
     []

--- a/apps/web/src/app/agents/create/hooks/useAgentForm.ts
+++ b/apps/web/src/app/agents/create/hooks/useAgentForm.ts
@@ -2,10 +2,7 @@ import type { AgentTemplate } from '@babylon/agents/client';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
-import {
-  createNameMatchRegex,
-  generateAgentName,
-} from '@/utils/nameGenerator';
+import { createNameMatchRegex, generateAgentName } from '@/utils/nameGenerator';
 
 const STORAGE_KEY = 'babylon_agent_draft';
 

--- a/apps/web/src/app/api/agents/generate-field/route.ts
+++ b/apps/web/src/app/api/agents/generate-field/route.ts
@@ -111,6 +111,7 @@ import { NextResponse } from 'next/server';
 
 const MAX_TOKENS = 500;
 const MAX_ATTEMPTS = 3;
+const MIN_CONTENT_LENGTH = 10;
 
 /**
  * XML output format instructions appended to all prompts
@@ -136,10 +137,20 @@ function extractContent(raw: string): string | null {
     return null;
   }
 
-  // Parse the XML response
-  const parsed = parseKeyValueXml(responseMatch[0]) as {
-    content?: string;
-  } | null;
+  // Parse the XML response with error handling
+  let parsed: { content?: string } | null;
+  try {
+    parsed = parseKeyValueXml(responseMatch[0]) as {
+      content?: string;
+    } | null;
+  } catch (error) {
+    logger.warn(
+      'Failed to parse XML response',
+      { error: error instanceof Error ? error.message : String(error) },
+      'GenerateField'
+    );
+    return null;
+  }
 
   if (!parsed?.content) {
     return null;
@@ -181,6 +192,18 @@ export async function POST(req: NextRequest) {
   const systemPrompt =
     'You are a helpful assistant that generates agent configurations. Be concise, professional, and authentic. Always output your response in the required XML format.';
 
+  // Validate API keys are configured before attempting generation
+  if (!process.env.GROQ_API_KEY && !process.env.ANTHROPIC_API_KEY) {
+    return NextResponse.json(
+      {
+        success: false,
+        error:
+          'No LLM API key configured. Set GROQ_API_KEY or ANTHROPIC_API_KEY.',
+      },
+      { status: 503 }
+    );
+  }
+
   let cleanedValue: string | null = null;
 
   // Retry loop for robust generation
@@ -192,97 +215,119 @@ export async function POST(req: NextRequest) {
       ? `CRITICAL: You have ${MAX_TOKENS} tokens max. Your response MUST start with <response> immediately. No <think> tags. No reasoning. Output valid XML only.\n\n${basePrompt}${XML_FORMAT_INSTRUCTIONS}`
       : `${basePrompt}${XML_FORMAT_INSTRUCTIONS}`;
 
-    let generatedValue: string;
+    let generatedValue: string | undefined;
 
-    // Use Groq qwen/qwen3-32b if available, otherwise fall back to Claude
-    if (process.env.GROQ_API_KEY) {
-      const groq = createGroq({
-        apiKey: process.env.GROQ_API_KEY,
-        baseURL: 'https://api.groq.com/openai/v1',
-      });
-
-      const result = await generateText({
-        model: groq.languageModel('qwen/qwen3-32b'),
-        prompt,
-        system: systemPrompt,
-        temperature: isRetry ? 0.6 : 0.8, // Lower temperature on retry for more predictable output
-        maxOutputTokens: MAX_TOKENS,
-      });
-
-      generatedValue = result.text.trim();
-      logger.info(
-        'Generated agent field with Groq',
-        { fieldName, provider: 'groq', attempt },
-        'GenerateField'
-      );
-
-      if (isPromptLoggingEnabled()) {
-        await logPrompt({
-          promptType: `generate_field_${fieldName}`,
-          input: `System: ${systemPrompt}\n\nUser: ${prompt}`,
-          output: generatedValue,
-          metadata: {
-            provider: 'groq',
-            model: 'qwen/qwen3-32b',
-            temperature: isRetry ? 0.6 : 0.8,
-            maxTokens: MAX_TOKENS,
-          },
+    try {
+      // Use Groq qwen/qwen3-32b if available, otherwise fall back to Claude
+      if (process.env.GROQ_API_KEY) {
+        const groq = createGroq({
+          apiKey: process.env.GROQ_API_KEY,
+          baseURL: 'https://api.groq.com/openai/v1',
         });
-      }
-    } else if (process.env.ANTHROPIC_API_KEY) {
-      const anthropic = new Anthropic({
-        apiKey: process.env.ANTHROPIC_API_KEY,
-      });
 
-      const message = await anthropic.messages.create({
-        model: 'claude-sonnet-4-5',
-        max_tokens: MAX_TOKENS,
-        temperature: isRetry ? 0.6 : 0.8,
-        system: systemPrompt,
-        messages: [
-          {
-            role: 'user',
-            content: prompt,
-          },
-        ],
-      });
-
-      const firstContent = message.content[0]!;
-      generatedValue = (firstContent as { text: string }).text.trim();
-      logger.info(
-        'Generated agent field with Claude',
-        { fieldName, provider: 'claude', attempt },
-        'GenerateField'
-      );
-
-      if (isPromptLoggingEnabled()) {
-        await logPrompt({
-          promptType: `generate_field_${fieldName}`,
-          input: `System: ${systemPrompt}\n\nUser: ${prompt}`,
-          output: generatedValue,
-          metadata: {
-            provider: 'claude',
-            model: 'claude-sonnet-4-5',
-            temperature: isRetry ? 0.6 : 0.8,
-            maxTokens: MAX_TOKENS,
-          },
+        const result = await generateText({
+          model: groq.languageModel('qwen/qwen3-32b'),
+          prompt,
+          system: systemPrompt,
+          temperature: isRetry ? 0.6 : 0.8, // Lower temperature on retry for more predictable output
+          maxOutputTokens: MAX_TOKENS,
         });
+
+        generatedValue = result.text.trim();
+        logger.info(
+          'Generated agent field with Groq',
+          { fieldName, provider: 'groq', attempt },
+          'GenerateField'
+        );
+
+        if (isPromptLoggingEnabled()) {
+          await logPrompt({
+            promptType: `generate_field_${fieldName}`,
+            input: `System: ${systemPrompt}\n\nUser: ${prompt}`,
+            output: generatedValue,
+            metadata: {
+              provider: 'groq',
+              model: 'qwen/qwen3-32b',
+              temperature: isRetry ? 0.6 : 0.8,
+              maxTokens: MAX_TOKENS,
+            },
+          });
+        }
+      } else {
+        // Anthropic path (we know key exists from validation above)
+        const anthropic = new Anthropic({
+          apiKey: process.env.ANTHROPIC_API_KEY,
+        });
+
+        const message = await anthropic.messages.create({
+          model: 'claude-sonnet-4-5',
+          max_tokens: MAX_TOKENS,
+          temperature: isRetry ? 0.6 : 0.8,
+          system: systemPrompt,
+          messages: [
+            {
+              role: 'user',
+              content: prompt,
+            },
+          ],
+        });
+
+        // Defensive check for Anthropic response content
+        const firstContent = message.content[0];
+        if (!firstContent || firstContent.type !== 'text') {
+          logger.warn(
+            'Unexpected Anthropic response format',
+            { fieldName, contentType: firstContent?.type, attempt },
+            'GenerateField'
+          );
+          continue; // Retry
+        }
+        generatedValue = firstContent.text.trim();
+        logger.info(
+          'Generated agent field with Claude',
+          { fieldName, provider: 'claude', attempt },
+          'GenerateField'
+        );
+
+        if (isPromptLoggingEnabled()) {
+          await logPrompt({
+            promptType: `generate_field_${fieldName}`,
+            input: `System: ${systemPrompt}\n\nUser: ${prompt}`,
+            output: generatedValue,
+            metadata: {
+              provider: 'claude',
+              model: 'claude-sonnet-4-5',
+              temperature: isRetry ? 0.6 : 0.8,
+              maxTokens: MAX_TOKENS,
+            },
+          });
+        }
       }
-    } else {
-      return NextResponse.json(
+    } catch (apiError) {
+      logger.warn(
+        `LLM API error on attempt ${attempt}`,
         {
-          success: false,
-          error:
-            'No LLM API key configured. Set GROQ_API_KEY or ANTHROPIC_API_KEY.',
+          fieldName,
+          error: apiError instanceof Error ? apiError.message : 'Unknown',
         },
-        { status: 503 }
+        'GenerateField'
       );
+      if (attempt === MAX_ATTEMPTS) {
+        return NextResponse.json(
+          {
+            success: false,
+            error: 'LLM API error. Please try again.',
+          },
+          { status: 500 }
+        );
+      }
+      continue; // Retry on earlier attempts
     }
 
     // Try to extract clean content
     cleanedValue = extractContent(generatedValue);
 
-    if (cleanedValue && cleanedValue.length >= 10) {
+    if (cleanedValue && cleanedValue.length >= MIN_CONTENT_LENGTH) {
       // Success! We got valid content
       break;
     }
@@ -301,7 +346,7 @@ export async function POST(req: NextRequest) {
   }
 
   // If all attempts failed, return error
-  if (!cleanedValue || cleanedValue.length < 10) {
+  if (!cleanedValue || cleanedValue.length < MIN_CONTENT_LENGTH) {
     logger.error(
       `Failed to generate valid content after ${MAX_ATTEMPTS} attempts`,
       { fieldName },

--- a/apps/web/src/app/api/agents/generate-field/route.ts
+++ b/apps/web/src/app/api/agents/generate-field/route.ts
@@ -112,6 +112,7 @@ import { NextResponse } from 'next/server';
 const MAX_TOKENS = 500;
 const MAX_ATTEMPTS = 3;
 const MIN_CONTENT_LENGTH = 10;
+const RETRY_BASE_DELAY_MS = 500; // Base delay for exponential backoff
 
 /**
  * XML output format instructions appended to all prompts
@@ -321,6 +322,8 @@ export async function POST(req: NextRequest) {
           { status: 500 }
         );
       }
+      // Exponential backoff before retry
+      await new Promise((r) => setTimeout(r, RETRY_BASE_DELAY_MS * attempt));
       continue; // Retry on earlier attempts
     }
 
@@ -332,17 +335,26 @@ export async function POST(req: NextRequest) {
       break;
     }
 
-    // Log warning and retry
+    // Log warning and retry with exponential backoff
     logger.warn(
       `No valid <response> block found on attempt ${attempt}`,
       {
         fieldName,
         rawLength: generatedValue.length,
         hasResponseTag: generatedValue.includes('<response>'),
-        raw: generatedValue.substring(0, 300),
+        // Truncate to 100 chars to avoid logging sensitive content in production
+        rawPreview:
+          process.env.NODE_ENV === 'development'
+            ? generatedValue.substring(0, 100)
+            : '[redacted]',
       },
       'GenerateField'
     );
+
+    // Exponential backoff before retry (500ms, 1000ms, etc.)
+    if (attempt < MAX_ATTEMPTS) {
+      await new Promise((r) => setTimeout(r, RETRY_BASE_DELAY_MS * attempt));
+    }
   }
 
   // If all attempts failed, return error

--- a/apps/web/src/app/api/agents/generate-field/route.ts
+++ b/apps/web/src/app/api/agents/generate-field/route.ts
@@ -104,9 +104,52 @@ import {
 } from '@babylon/api';
 import { isPromptLoggingEnabled, logPrompt } from '@babylon/engine';
 import { logger } from '@babylon/shared';
+import { parseKeyValueXml } from '@elizaos/core';
 import { generateText } from 'ai';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+
+const MAX_TOKENS = 500;
+const MAX_ATTEMPTS = 3;
+
+/**
+ * XML output format instructions appended to all prompts
+ */
+const XML_FORMAT_INSTRUCTIONS = `
+
+# Required Output Format (use exactly this structure)
+
+Your response MUST start with <response> immediately. No <think> tags. No reasoning.
+
+<response>
+<content>your generated content here</content>
+</response>`;
+
+/**
+ * Extract content from XML response using parseKeyValueXml
+ * The response MUST be wrapped in <response> tags - anything outside (like <think>) is ignored
+ */
+function extractContent(raw: string): string | null {
+  // Extract <response>...</response> block (ignores anything outside like <think> tags)
+  const responseMatch = raw.match(/<response>([\s\S]*?)<\/response>/i);
+  if (!responseMatch) {
+    return null;
+  }
+
+  // Parse the XML response
+  const parsed = parseKeyValueXml(responseMatch[0]) as {
+    content?: string;
+  } | null;
+
+  if (!parsed?.content) {
+    return null;
+  }
+
+  // Clean up the content
+  return parsed.content
+    .trim()
+    .replace(/^["']|["']$/g, ''); // Remove leading/trailing quotes
+}
 
 export async function POST(req: NextRequest) {
   const user = await authenticateUser(req);
@@ -129,109 +172,151 @@ export async function POST(req: NextRequest) {
 
   const { fieldName, currentValue, context } = await req.json();
 
-  const prompt = buildPromptForField(fieldName, currentValue, context);
-  const systemPrompt =
-    'You are a helpful assistant that generates agent configurations. Be concise, professional, and authentic.';
-
-  let generatedValue: string;
-
-  // Use Groq qwen/qwen3-32b if available, otherwise fall back to Claude
-  if (process.env.GROQ_API_KEY) {
-    const groq = createGroq({
-      apiKey: process.env.GROQ_API_KEY,
-      baseURL: 'https://api.groq.com/openai/v1',
-    });
-
-    const result = await generateText({
-      model: groq.languageModel('qwen/qwen3-32b'),
-      prompt,
-      system: systemPrompt,
-      temperature: 0.8,
-      maxOutputTokens: 300,
-      // providerOptions: {
-      //   groq: {
-      //     // Hide <think>...</think> reasoning tags from Qwen model output
-      //     reasoningFormat: 'hidden',
-      //   },
-      // },
-    });
-
-    generatedValue = result.text.trim();
-    logger.info(
-      'Generated agent field with Groq',
-      { fieldName, provider: 'groq' },
-      'GenerateField'
-    );
-
-    if (isPromptLoggingEnabled()) {
-      await logPrompt({
-        promptType: `generate_field_${fieldName}`,
-        input: `System: ${systemPrompt}\n\nUser: ${prompt}`,
-        output: generatedValue,
-        metadata: {
-          provider: 'groq',
-          model: 'qwen/qwen3-32b',
-          temperature: 0.8,
-          maxTokens: 300,
-        },
-      });
-    }
-  } else if (process.env.ANTHROPIC_API_KEY) {
-    const anthropic = new Anthropic({
-      apiKey: process.env.ANTHROPIC_API_KEY,
-    });
-
-    const message = await anthropic.messages.create({
-      model: 'claude-sonnet-4-5',
-      max_tokens: 300,
-      temperature: 0.8,
-      system: systemPrompt,
-      messages: [
-        {
-          role: 'user',
-          content: prompt,
-        },
-      ],
-    });
-
-    const firstContent = message.content[0]!;
-    generatedValue = (firstContent as { text: string }).text.trim();
-    logger.info(
-      'Generated agent field with Claude',
-      { fieldName, provider: 'claude' },
-      'GenerateField'
-    );
-
-    if (isPromptLoggingEnabled()) {
-      await logPrompt({
-        promptType: `generate_field_${fieldName}`,
-        input: `System: ${systemPrompt}\n\nUser: ${prompt}`,
-        output: generatedValue,
-        metadata: {
-          provider: 'claude',
-          model: 'claude-sonnet-4-5',
-          temperature: 0.8,
-          maxTokens: 300,
-        },
-      });
-    }
-  } else {
+  if (!fieldName) {
     return NextResponse.json(
-      {
-        success: false,
-        error:
-          'No LLM API key configured. Set GROQ_API_KEY or ANTHROPIC_API_KEY.',
-      },
-      { status: 503 }
+      { success: false, error: 'Missing fieldName' },
+      { status: 400 }
     );
   }
 
-  // Strip any <think>...</think> tags and their content (from reasoning models like Qwen)
-  // Also remove leading/trailing quotes
-  const cleanedValue = generatedValue
-    .replace(/<think>[\s\S]*?<\/think>/gi, '')
-    .replace(/^["']|["']$/g, '')
-    .trim();
+  const basePrompt = buildPromptForField(fieldName, currentValue, context);
+  const systemPrompt =
+    'You are a helpful assistant that generates agent configurations. Be concise, professional, and authentic. Always output your response in the required XML format.';
+
+  let cleanedValue: string | null = null;
+
+  // Retry loop for robust generation
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const isRetry = attempt > 1;
+
+    // Add XML format instructions, with stronger reminder on retry
+    const prompt = isRetry
+      ? `CRITICAL: You have ${MAX_TOKENS} tokens max. Your response MUST start with <response> immediately. No <think> tags. No reasoning. Output valid XML only.\n\n${basePrompt}${XML_FORMAT_INSTRUCTIONS}`
+      : `${basePrompt}${XML_FORMAT_INSTRUCTIONS}`;
+
+    let generatedValue: string;
+
+    // Use Groq qwen/qwen3-32b if available, otherwise fall back to Claude
+    if (process.env.GROQ_API_KEY) {
+      const groq = createGroq({
+        apiKey: process.env.GROQ_API_KEY,
+        baseURL: 'https://api.groq.com/openai/v1',
+      });
+
+      const result = await generateText({
+        model: groq.languageModel('qwen/qwen3-32b'),
+        prompt,
+        system: systemPrompt,
+        temperature: isRetry ? 0.6 : 0.8, // Lower temperature on retry for more predictable output
+        maxOutputTokens: MAX_TOKENS,
+      });
+
+      generatedValue = result.text.trim();
+      logger.info(
+        'Generated agent field with Groq',
+        { fieldName, provider: 'groq', attempt },
+        'GenerateField'
+      );
+
+      if (isPromptLoggingEnabled()) {
+        await logPrompt({
+          promptType: `generate_field_${fieldName}`,
+          input: `System: ${systemPrompt}\n\nUser: ${prompt}`,
+          output: generatedValue,
+          metadata: {
+            provider: 'groq',
+            model: 'qwen/qwen3-32b',
+            temperature: isRetry ? 0.6 : 0.8,
+            maxTokens: MAX_TOKENS,
+          },
+        });
+      }
+    } else if (process.env.ANTHROPIC_API_KEY) {
+      const anthropic = new Anthropic({
+        apiKey: process.env.ANTHROPIC_API_KEY,
+      });
+
+      const message = await anthropic.messages.create({
+        model: 'claude-sonnet-4-5',
+        max_tokens: MAX_TOKENS,
+        temperature: isRetry ? 0.6 : 0.8,
+        system: systemPrompt,
+        messages: [
+          {
+            role: 'user',
+            content: prompt,
+          },
+        ],
+      });
+
+      const firstContent = message.content[0]!;
+      generatedValue = (firstContent as { text: string }).text.trim();
+      logger.info(
+        'Generated agent field with Claude',
+        { fieldName, provider: 'claude', attempt },
+        'GenerateField'
+      );
+
+      if (isPromptLoggingEnabled()) {
+        await logPrompt({
+          promptType: `generate_field_${fieldName}`,
+          input: `System: ${systemPrompt}\n\nUser: ${prompt}`,
+          output: generatedValue,
+          metadata: {
+            provider: 'claude',
+            model: 'claude-sonnet-4-5',
+            temperature: isRetry ? 0.6 : 0.8,
+            maxTokens: MAX_TOKENS,
+          },
+        });
+      }
+    } else {
+      return NextResponse.json(
+        {
+          success: false,
+          error:
+            'No LLM API key configured. Set GROQ_API_KEY or ANTHROPIC_API_KEY.',
+        },
+        { status: 503 }
+      );
+    }
+
+    // Try to extract clean content
+    cleanedValue = extractContent(generatedValue);
+
+    if (cleanedValue && cleanedValue.length >= 10) {
+      // Success! We got valid content
+      break;
+    }
+
+    // Log warning and retry
+    logger.warn(
+      `No valid <response> block found on attempt ${attempt}`,
+      {
+        fieldName,
+        rawLength: generatedValue.length,
+        hasResponseTag: generatedValue.includes('<response>'),
+        raw: generatedValue.substring(0, 300),
+      },
+      'GenerateField'
+    );
+  }
+
+  // If all attempts failed, return error
+  if (!cleanedValue || cleanedValue.length < 10) {
+    logger.error(
+      `Failed to generate valid content after ${MAX_ATTEMPTS} attempts`,
+      { fieldName },
+      'GenerateField'
+    );
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Failed to generate valid content. Please try again.',
+      },
+      { status: 500 }
+    );
+  }
 
   return NextResponse.json({
     success: true,

--- a/apps/web/src/app/api/agents/generate-field/route.ts
+++ b/apps/web/src/app/api/agents/generate-field/route.ts
@@ -146,9 +146,7 @@ function extractContent(raw: string): string | null {
   }
 
   // Clean up the content
-  return parsed.content
-    .trim()
-    .replace(/^["']|["']$/g, ''); // Remove leading/trailing quotes
+  return parsed.content.trim().replace(/^["']|["']$/g, ''); // Remove leading/trailing quotes
 }
 
 export async function POST(req: NextRequest) {

--- a/apps/web/src/app/api/agents/generate-field/route.ts
+++ b/apps/web/src/app/api/agents/generate-field/route.ts
@@ -327,6 +327,20 @@ export async function POST(req: NextRequest) {
       continue; // Retry on earlier attempts
     }
 
+    // Guard against undefined (shouldn't happen, but TypeScript requires it)
+    // This can occur if the Anthropic path continues without setting generatedValue
+    if (!generatedValue) {
+      logger.warn(
+        `No response generated on attempt ${attempt}`,
+        { fieldName, attempt },
+        'GenerateField'
+      );
+      if (attempt < MAX_ATTEMPTS) {
+        await new Promise((r) => setTimeout(r, RETRY_BASE_DELAY_MS * attempt));
+      }
+      continue;
+    }
+
     // Try to extract clean content
     cleanedValue = extractContent(generatedValue);
 
@@ -336,17 +350,13 @@ export async function POST(req: NextRequest) {
     }
 
     // Log warning and retry with exponential backoff
+    // Avoid logging raw model output - only log safe metadata
     logger.warn(
       `No valid <response> block found on attempt ${attempt}`,
       {
         fieldName,
         rawLength: generatedValue.length,
         hasResponseTag: generatedValue.includes('<response>'),
-        // Truncate to 100 chars to avoid logging sensitive content in production
-        rawPreview:
-          process.env.NODE_ENV === 'development'
-            ? generatedValue.substring(0, 100)
-            : '[redacted]',
       },
       'GenerateField'
     );

--- a/apps/web/src/utils/nameGenerator.ts
+++ b/apps/web/src/utils/nameGenerator.ts
@@ -1,0 +1,176 @@
+/**
+ * Agent Name Generator
+ *
+ * Generates random, memorable names for AI trading agents.
+ * Uses curated word lists organized by theme for variety.
+ */
+
+// Agent name generation word lists
+const NAME_PREFIXES = [
+  // Greek letters
+  'Alpha',
+  'Beta',
+  'Gamma',
+  'Delta',
+  'Epsilon',
+  'Zeta',
+  'Eta',
+  'Theta',
+  'Iota',
+  'Kappa',
+  'Lambda',
+  'Mu',
+  'Nu',
+  'Xi',
+  'Omicron',
+  'Pi',
+  'Rho',
+  'Sigma',
+  'Tau',
+  'Upsilon',
+  'Phi',
+  'Chi',
+  'Psi',
+  'Omega',
+  // Tech/Cyber
+  'Quantum',
+  'Neo',
+  'Cyber',
+  'Nexus',
+  'Apex',
+  'Vertex',
+  'Pulse',
+  'Flux',
+  'Vector',
+  'Helix',
+  'Prism',
+  'Matrix',
+  'Cipher',
+  'Binary',
+  'Neural',
+  // Nature/Elements
+  'Nova',
+  'Solar',
+  'Lunar',
+  'Stellar',
+  'Cosmic',
+  'Astral',
+  'Phoenix',
+  'Storm',
+  'Thunder',
+  'Frost',
+  'Ember',
+  'Shadow',
+  'Dawn',
+  'Dusk',
+  // Power/Status
+  'Iron',
+  'Steel',
+  'Titan',
+  'Atlas',
+  'Orion',
+  'Vortex',
+  'Blaze',
+  'Spark',
+  'Echo',
+  'Phantom',
+  'Specter',
+  'Raven',
+  'Falcon',
+  'Hawk',
+  'Eagle',
+  // Abstract
+  'Zen',
+  'Aura',
+  'Axiom',
+  'Lumen',
+  'Photon',
+  'Quark',
+  'Volt',
+  'Arc',
+] as const;
+
+const NAME_SUFFIXES = [
+  // Role-based
+  'Trader',
+  'Agent',
+  'Bot',
+  'AI',
+  'Mind',
+  'Brain',
+  'Sage',
+  'Oracle',
+  // Technical
+  'Core',
+  'Node',
+  'Edge',
+  'Prime',
+  'Pro',
+  'Max',
+  'Ultra',
+  'Plus',
+  'X',
+  'Zero',
+  'One',
+  'Protocol',
+  'System',
+  'Engine',
+  'Logic',
+  // Abstract
+  'Flow',
+  'Wave',
+  'Sync',
+  'Link',
+  'Net',
+  'Hub',
+  'Lab',
+  'Works',
+  'Force',
+  'Drive',
+  'Pulse',
+  'Signal',
+  'Stream',
+  'Grid',
+  'Mesh',
+] as const;
+
+export interface GeneratedAgentName {
+  username: string;
+  displayName: string;
+}
+
+/**
+ * Generates a random agent name with display name and username.
+ *
+ * @returns Object with displayName (e.g., "Nova Trader") and username (e.g., "novatrader123456")
+ *
+ * @example
+ * const { username, displayName } = generateAgentName();
+ * // displayName: "Quantum Oracle"
+ * // username: "quantumoracle847291"
+ */
+export function generateAgentName(): GeneratedAgentName {
+  // Arrays are non-empty (defined above), so these are guaranteed to exist
+  const prefix =
+    NAME_PREFIXES[Math.floor(Math.random() * NAME_PREFIXES.length)]!;
+  const suffix =
+    NAME_SUFFIXES[Math.floor(Math.random() * NAME_SUFFIXES.length)]!;
+
+  // Use 6-digit number for better uniqueness at scale
+  // Range: 100000-999999 = 900,000 possible numbers
+  // Combined with ~2,275 name combos = ~2 billion unique usernames
+  const number = Math.floor(Math.random() * 900000) + 100000;
+
+  const displayName = `${prefix} ${suffix}`;
+  const username = `${prefix.toLowerCase()}${suffix.toLowerCase()}${number}`;
+
+  return { username, displayName };
+}
+
+/**
+ * Escapes special regex characters in a string.
+ * Used for safe string replacement in prompts.
+ */
+export function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/apps/web/src/utils/nameGenerator.ts
+++ b/apps/web/src/utils/nameGenerator.ts
@@ -174,3 +174,20 @@ export function generateAgentName(): GeneratedAgentName {
 export function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
+
+/**
+ * Creates a regex pattern for matching a name with flexible boundaries.
+ * Handles punctuation, unicode, and edge cases better than \b word boundaries.
+ *
+ * Uses negative lookbehind/lookahead for alphanumeric chars to avoid
+ * matching substrings while allowing punctuation/emoji at boundaries.
+ *
+ * @param name - The name to create a pattern for (will be escaped)
+ * @returns RegExp that matches the name with proper boundaries
+ */
+export function createNameMatchRegex(name: string): RegExp {
+  const escaped = escapeRegex(name);
+  // Match name that is not preceded or followed by alphanumeric chars
+  // This handles cases like "Nova!" or emoji names better than \b
+  return new RegExp(`(?<![a-zA-Z0-9])${escaped}(?![a-zA-Z0-9])`, 'g');
+}

--- a/packages/db/src/schema/users.ts
+++ b/packages/db/src/schema/users.ts
@@ -1,5 +1,5 @@
 import type { GameOnboardingStep } from '@babylon/shared';
-import { relations, sql } from 'drizzle-orm';
+import { relations } from 'drizzle-orm';
 import {
   bigint,
   boolean,
@@ -68,12 +68,9 @@ export const gameOnboarding = pgTable(
     // Full state as JSONB for flexibility
     // The default is generated from DEFAULT_GAME_ONBOARDING_STATE constant,
     // ensuring TypeScript validates the default against the GameOnboardingState interface.
-    // Note: sql.raw() is required because drizzle-kit doesn't support parameterized sql`` defaults
     state: jsonb('state')
       .$type<GameOnboardingState>()
-      .default(
-        sql.raw(`'${JSON.stringify(DEFAULT_GAME_ONBOARDING_STATE)}'::jsonb`)
-      ),
+      .default(DEFAULT_GAME_ONBOARDING_STATE),
 
     // Quick access flags
     isComplete: boolean('isComplete').notNull().default(false),

--- a/packages/db/src/schema/users.ts
+++ b/packages/db/src/schema/users.ts
@@ -71,7 +71,9 @@ export const gameOnboarding = pgTable(
     // Note: sql.raw() is required because drizzle-kit doesn't support parameterized sql`` defaults
     state: jsonb('state')
       .$type<GameOnboardingState>()
-      .default(sql.raw(`'${JSON.stringify(DEFAULT_GAME_ONBOARDING_STATE)}'::jsonb`)),
+      .default(
+        sql.raw(`'${JSON.stringify(DEFAULT_GAME_ONBOARDING_STATE)}'::jsonb`)
+      ),
 
     // Quick access flags
     isComplete: boolean('isComplete').notNull().default(false),

--- a/packages/db/src/schema/users.ts
+++ b/packages/db/src/schema/users.ts
@@ -68,9 +68,10 @@ export const gameOnboarding = pgTable(
     // Full state as JSONB for flexibility
     // The default is generated from DEFAULT_GAME_ONBOARDING_STATE constant,
     // ensuring TypeScript validates the default against the GameOnboardingState interface.
+    // Note: sql.raw() is required because drizzle-kit doesn't support parameterized sql`` defaults
     state: jsonb('state')
       .$type<GameOnboardingState>()
-      .default(sql`${JSON.stringify(DEFAULT_GAME_ONBOARDING_STATE)}::jsonb`),
+      .default(sql.raw(`'${JSON.stringify(DEFAULT_GAME_ONBOARDING_STATE)}'::jsonb`)),
 
     // Quick access flags
     isComplete: boolean('isComplete').notNull().default(false),


### PR DESCRIPTION
<h2>Greptile Overview</h2>

### Greptile Summary

This PR adds auto-generated default agent names and fixes the field regeneration issue where `<think>` tags were appearing in LLM responses.

## Key Changes

- **Default Name Generation**: On agent creation, `username` and `displayName` fields are now pre-populated with randomly generated values (e.g., "Nova Trader" / "novatrader4238") from curated word lists
- **Name Sync**: When users edit the display name, the old name is automatically replaced across all prompt fields (`system`, `personality`, `tradingStrategy`)
- **XML Response Parsing**: The API now requires LLM responses in XML format (`<response><content>...</content></response>`), uses `parseKeyValueXml` from `@elizaos/core` to extract clean content, and includes a retry loop (up to 3 attempts) with lower temperature on failure
- **Database Fix**: Changed `sql` to `sql.raw()` for drizzle-kit compatibility

## Issues Found

- Redundant `<think>` tag stripping in client code (line 377-379) - API now returns clean content
- Potential username collision at scale (only 9000 possible numbers)
- Missing error handling for `parseKeyValueXml` if it throws exceptions

### Confidence Score: 4/5

- This PR is safe to merge with minor cleanup opportunities
- The implementation is solid with well-structured code and good retry logic for robustness. The issues found are minor style improvements (redundant `<think>` tag stripping, missing try-catch) rather than critical bugs. The username collision concern is a scalability consideration but not an immediate blocker.
- No files require special attention - all issues are minor style improvements

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/web/src/app/agents/create/hooks/useAgentForm.ts | 4/5 | Added default name generation and name sync logic. Redundant `<think>` tag stripping still present in client (should be removed since API now handles it). |
| apps/web/src/app/api/agents/generate-field/route.ts | 4/5 | Added XML response parsing with retry loop. Potential error handling gap if `parseKeyValueXml` throws exceptions. |
| packages/db/src/schema/users.ts | 5/5 | Fixed `sql.raw()` usage for drizzle-kit compatibility. Minor but correct fix. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant useAgentForm
    participant API as /api/agents/generate-field
    participant LLM as Groq/Claude

    Note over useAgentForm: On mount
    useAgentForm->>useAgentForm: generateAgentName()
    useAgentForm->>useAgentForm: setState(username, displayName)
    useAgentForm->>useAgentForm: Load random template
    useAgentForm->>useAgentForm: Replace {{agentName}} in prompts
    useAgentForm->>User: Display pre-populated form

    Note over User,useAgentForm: User edits display name
    User->>useAgentForm: updateProfileField('displayName', newName)
    useAgentForm->>useAgentForm: Replace oldName with newName in prompts
    useAgentForm->>useAgentForm: Update nameInPromptsRef

    Note over User,LLM: User regenerates field
    User->>useAgentForm: regenerateField('system')
    useAgentForm->>API: POST with field + context
    
    loop Retry up to 3 attempts
        API->>API: Build prompt + XML instructions
        API->>LLM: Generate text with XML format
        LLM-->>API: Response (may include <think> tags)
        API->>API: extractContent() - parse XML
        alt Valid <response> block found
            API-->>useAgentForm: Return cleaned content
        else No valid response
            API->>API: Retry with lower temp
        end
    end
    
    alt All retries failed
        API-->>useAgentForm: Error 500
        useAgentForm->>User: Show error toast
    else Success
        useAgentForm->>useAgentForm: Strip <think> tags (redundant)
        useAgentForm->>useAgentForm: Update field state
        useAgentForm->>User: Show success toast
    end
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agents now get autogenerated human-friendly names that sync into profile fields and placeholders, with debounced updates when renamed.
  * Added a name-generation utility for consistent display and username creation.

* **Improvements**
  * Field-generation backend now enforces XML output, includes retries, provider selection, rate checks, and better parsing/logging for more reliable content.
  * Onboarding state default handling improved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->