### PR TITLE
feat(agents): reduce posting frequency and add self-awareness for NPCs and agents

### DIFF
--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -54,6 +54,7 @@ import { topicDiversityService } from './TopicDiversityService';
 
 import {
   type ActionTraceResult,
+  type AgentOwnPostContext,
   type AgentTickContext,
   buildMultiStepDecisionPrompt,
   type MultiStepDecision,
@@ -327,6 +328,7 @@ export class MultiStepExecutor {
     const canComment = enabledFeatures.includes('commenting');
     const canRespondDMs = enabledFeatures.includes('DMs');
     const canGroupChat = enabledFeatures.includes('groupChats');
+    const canPost = enabledFeatures.includes('posting');
 
     // Gather context in parallel - all these queries are independent
     const [
@@ -336,6 +338,7 @@ export class MultiStepExecutor {
       recentPosts,
       pendingInteractions,
       agentGroupChats,
+      agentOwnPosts,
     ] = await Promise.all([
       // Get prediction markets (only if trading enabled)
       canTrade ? this.getPredictionMarkets() : Promise.resolve([]),
@@ -353,6 +356,8 @@ export class MultiStepExecutor {
         : Promise.resolve([]),
       // Get agent's group chats (only if group chats enabled)
       canGroupChat ? this.getAgentGroupChats(agentUserId) : Promise.resolve([]),
+      // Get agent's own recent posts (for posting frequency awareness)
+      canPost ? this.getAgentOwnPosts(agentUserId) : Promise.resolve([]),
     ]);
 
     // Get topic diversity guidance for this agent
@@ -385,6 +390,8 @@ export class MultiStepExecutor {
       // NPC's actual character data for personalized guidance
       personality: assignment?.personality,
       postStyle: assignment?.postStyle,
+      // Agent's own recent posts for self-awareness
+      agentOwnPosts,
     };
   }
 
@@ -483,6 +490,82 @@ export class MultiStepExecutor {
       // Log the error before returning empty fallback
       logger.warn(
         'Failed to fetch agent group chats',
+        {
+          agentUserId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        'MultiStepExecutor'
+      );
+      return [];
+    }
+  }
+
+  /**
+   * Get agent's own recent posts for self-awareness
+   * Shows what the agent has posted recently with engagement metrics
+   */
+  private async getAgentOwnPosts(
+    agentUserId: string
+  ): Promise<AgentOwnPostContext[]> {
+    try {
+      const recentOwnPosts = await db
+        .select({
+          id: posts.id,
+          content: posts.content,
+          createdAt: posts.createdAt,
+        })
+        .from(posts)
+        .where(and(eq(posts.authorId, agentUserId), isNull(posts.deletedAt)))
+        .orderBy(desc(posts.createdAt))
+        .limit(5);
+
+      if (recentOwnPosts.length === 0) {
+        return [];
+      }
+
+      // Get engagement counts for these posts
+      const postIds = recentOwnPosts.map((p) => p.id);
+      const [likeCounts, commentCounts] = await Promise.all([
+        db
+          .select({
+            postId: reactions.postId,
+            count: sql<number>`count(*)`,
+          })
+          .from(reactions)
+          .where(
+            and(inArray(reactions.postId, postIds), eq(reactions.type, 'like'))
+          )
+          .groupBy(reactions.postId),
+        db
+          .select({
+            postId: comments.postId,
+            count: sql<number>`count(*)`,
+          })
+          .from(comments)
+          .where(
+            and(inArray(comments.postId, postIds), isNull(comments.deletedAt))
+          )
+          .groupBy(comments.postId),
+      ]);
+
+      const likeCountMap = new Map<string, number>();
+      const commentCountMap = new Map<string, number>();
+      for (const row of likeCounts) {
+        if (row.postId) likeCountMap.set(row.postId, Number(row.count));
+      }
+      for (const row of commentCounts) {
+        if (row.postId) commentCountMap.set(row.postId, Number(row.count));
+      }
+
+      return recentOwnPosts.map((p) => ({
+        content: p.content,
+        timeAgo: getTimeAgo(p.createdAt),
+        likeCount: likeCountMap.get(p.id) ?? 0,
+        commentCount: commentCountMap.get(p.id) ?? 0,
+      }));
+    } catch (error) {
+      logger.warn(
+        'Failed to fetch agent own posts',
         {
           agentUserId,
           error: error instanceof Error ? error.message : String(error),

--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -508,15 +508,16 @@ export class MultiStepExecutor {
     agentUserId: string
   ): Promise<AgentOwnPostContext[]> {
     try {
+      // Use posts.timestamp for ordering to leverage Post_authorId_timestamp_idx index
       const recentOwnPosts = await db
         .select({
           id: posts.id,
           content: posts.content,
-          createdAt: posts.createdAt,
+          timestamp: posts.timestamp,
         })
         .from(posts)
         .where(and(eq(posts.authorId, agentUserId), isNull(posts.deletedAt)))
-        .orderBy(desc(posts.createdAt))
+        .orderBy(desc(posts.timestamp))
         .limit(5);
 
       if (recentOwnPosts.length === 0) {
@@ -559,7 +560,7 @@ export class MultiStepExecutor {
 
       return recentOwnPosts.map((p) => ({
         content: p.content,
-        timeAgo: getTimeAgo(p.createdAt),
+        timeAgo: getTimeAgo(p.timestamp),
         likeCount: likeCountMap.get(p.id) ?? 0,
         commentCount: commentCountMap.get(p.id) ?? 0,
       }));

--- a/packages/agents/src/autonomous/templates/multi-step-decision.ts
+++ b/packages/agents/src/autonomous/templates/multi-step-decision.ts
@@ -95,6 +95,13 @@ export interface GroupChatContext {
   memberCount?: number;
 }
 
+export interface AgentOwnPostContext {
+  content: string;
+  timeAgo: string;
+  likeCount: number;
+  commentCount: number;
+}
+
 export interface AgentTickContext {
   balance: number;
   pnl: number;
@@ -118,6 +125,8 @@ export interface AgentTickContext {
   // NPC's actual character data for personalized guidance
   personality?: string;
   postStyle?: string;
+  // Agent's own recent posts for self-awareness
+  agentOwnPosts?: AgentOwnPostContext[];
 }
 
 export interface MultiStepDecision {
@@ -408,7 +417,10 @@ ${npcContextSection}${tradePostEncouragement}# Current Execution Context
 # Your Open Positions
 ${formatAgentPositions(context.agentPositions)}
 ${formatPositionManagementGuidance(context.agentPositions)}
-${tradingSection}
+${canPost ? `
+# Your Recent Posts (AVOID REPEATING - check how long ago you posted!)
+${formatAgentOwnPosts(context.agentOwnPosts)}
+` : ''}${tradingSection}
 ${commentingSection}
 ${dmsSection}
 ${groupChatsSection}
@@ -777,6 +789,22 @@ function formatPendingInteractions(interactions: PendingInteraction[]): string {
       (i) =>
         `- [${i.type}] @${i.author}: "${i.content.substring(0, 60)}${i.content.length > 60 ? '...' : ''}"`
     )
+    .join('\n');
+}
+
+function formatAgentOwnPosts(
+  ownPosts: AgentOwnPostContext[] | undefined
+): string {
+  if (!ownPosts || ownPosts.length === 0)
+    return 'You have not posted recently.';
+
+  return ownPosts
+    .map((p, i) => {
+      const engagement = `❤️${p.likeCount} 💬${p.commentCount}`;
+      const truncatedContent =
+        p.content.length > 80 ? `${p.content.substring(0, 80)}...` : p.content;
+      return `[${i + 1}] "${truncatedContent}" (${p.timeAgo}) [${engagement}]`;
+    })
     .join('\n');
 }
 

--- a/packages/engine/src/__tests__/posting-probability-service.test.ts
+++ b/packages/engine/src/__tests__/posting-probability-service.test.ts
@@ -76,18 +76,18 @@ describe('Posting Probability Service - Base Probability', () => {
     const bProb = calculatePostingProbability(bActor, null, context);
     const cProb = calculatePostingProbability(cActor, null, context);
 
-    // Simplified: equal probability for all tiers (0.25 base)
-    expect(sProb).toBe(0.25);
-    expect(bProb).toBe(0.25);
-    expect(cProb).toBe(0.25);
+    // Simplified: equal probability for all tiers (0.15 base)
+    expect(sProb).toBe(0.15);
+    expect(bProb).toBe(0.15);
+    expect(cProb).toBe(0.15);
   });
 
-  test('base probability is 0.25', () => {
+  test('base probability is 0.15', () => {
     const actor = createMockActor();
     const context = createMockContext();
     const prob = calculatePostingProbability(actor, null, context);
 
-    expect(prob).toBe(0.25);
+    expect(prob).toBe(0.15);
   });
 
   test('probability is capped at 1.0', () => {
@@ -110,12 +110,12 @@ describe('Posting Probability Service - Base Probability', () => {
 });
 
 describe('Posting Probability Service - Daily Cap', () => {
-  test('returns 0 when daily post cap (3) is reached', () => {
+  test('returns 0 when daily post cap (2) is reached', () => {
     const actor = createMockActor();
-    // MAX_POSTS_PER_DAY is 3
+    // MAX_POSTS_PER_DAY is 2
     const state = createMockState({
       id: actor.id,
-      postsToday: 3,
+      postsToday: 2,
       lastPostAt: new Date(),
     });
     const context = createMockContext();
@@ -129,9 +129,9 @@ describe('Posting Probability Service - Daily Cap', () => {
     const contextTime = new Date('2026-01-05T14:00:00Z');
     const state = createMockState({
       id: actor.id,
-      postsToday: 2,
-      // Set lastPostAt to 3 hours before context time to pass the recency check
-      lastPostAt: new Date(contextTime.getTime() - 3 * 60 * 60 * 1000),
+      postsToday: 1,
+      // Set lastPostAt to 5 hours before context time to pass the recency check (MIN_HOURS_BETWEEN_POSTS is 4)
+      lastPostAt: new Date(contextTime.getTime() - 5 * 60 * 60 * 1000),
     });
     const context = createMockContext({ currentTime: contextTime });
 
@@ -141,14 +141,14 @@ describe('Posting Probability Service - Daily Cap', () => {
 });
 
 describe('Posting Probability Service - Recency Check', () => {
-  test('returns 0 if posted within MIN_HOURS_BETWEEN_POSTS (2 hours)', () => {
+  test('returns 0 if posted within MIN_HOURS_BETWEEN_POSTS (4 hours)', () => {
     const actor = createMockActor();
     const contextTime = new Date('2026-01-05T14:00:00Z');
     const state = createMockState({
       id: actor.id,
       postsToday: 1,
-      // 30 minutes before context.currentTime
-      lastPostAt: new Date(contextTime.getTime() - 30 * 60 * 1000),
+      // 2 hours before context.currentTime (less than 4 hour minimum)
+      lastPostAt: new Date(contextTime.getTime() - 2 * 60 * 60 * 1000),
     });
     const context = createMockContext({ currentTime: contextTime });
 
@@ -162,8 +162,8 @@ describe('Posting Probability Service - Recency Check', () => {
     const state = createMockState({
       id: actor.id,
       postsToday: 1,
-      // 3 hours before context.currentTime
-      lastPostAt: new Date(contextTime.getTime() - 3 * 60 * 60 * 1000),
+      // 5 hours before context.currentTime (more than 4 hour minimum)
+      lastPostAt: new Date(contextTime.getTime() - 5 * 60 * 60 * 1000),
     });
     const context = createMockContext({ currentTime: contextTime });
 
@@ -211,7 +211,7 @@ describe('Posting Probability Service - Mention Boost', () => {
     });
 
     const prob = calculatePostingProbability(actor, null, context);
-    expect(prob).toBe(0.25); // Base probability only
+    expect(prob).toBe(0.15); // Base probability only
   });
 });
 
@@ -242,8 +242,8 @@ describe('Posting Probability Service - Affiliation Boost', () => {
     });
 
     const prob = calculatePostingProbability(actor, null, bothContext);
-    // 0.25 * 1.5 (mention) * 1.5 (affiliation) = 0.5625
-    expect(prob).toBeCloseTo(0.5625, 4);
+    // 0.15 * 1.5 (mention) * 1.5 (affiliation) = 0.3375
+    expect(prob).toBeCloseTo(0.3375, 4);
   });
 });
 

--- a/packages/engine/src/services/posting-probability-service.ts
+++ b/packages/engine/src/services/posting-probability-service.ts
@@ -56,23 +56,23 @@ export interface PostingContext {
 /**
  * SIMPLIFIED: Equal base probability for all tiers.
  * All NPCs have equal chance to post - creates natural entropy.
- * Reduced from 0.5 to encourage more action variety.
+ * Reduced from 0.25 to dial down posting frequency.
  */
-const BASE_PROBABILITY = 0.25;
+const BASE_PROBABILITY = 0.15;
 
 /**
  * Maximum posts per day per NPC to prevent spam.
  * Same for all tiers - fair rotation.
- * Reduced from 4 to limit feed saturation.
+ * Reduced from 3 to limit feed saturation.
  */
-const MAX_POSTS_PER_DAY = 3;
+const MAX_POSTS_PER_DAY = 2;
 
 /**
  * Minimum hours between posts for same NPC.
  * Prevents same NPC posting multiple times per tick.
- * Increased from 1 to spread posts out more.
+ * Increased from 2 to spread posts out more.
  */
-const MIN_HOURS_BETWEEN_POSTS = 2;
+const MIN_HOURS_BETWEEN_POSTS = 4;
 
 /**
  * Boost when actor was mentioned by player (keeps engagement reactive)


### PR DESCRIPTION
## Summary
- Reduced posting frequency by lowering `BASE_PROBABILITY` from 0.25 to 0.15 (40% reduction)
- Reduced `MAX_POSTS_PER_DAY` from 3 to 2
- Increased `MIN_HOURS_BETWEEN_POSTS` from 2 to 4 hours
- Added agent's own recent posts to decision context so **both NPCs and user-controlled agents** are aware of what they've posted recently and when

## What's affected

| Change | NPCs | User Agents |
|--------|------|-------------|
| Posting probability reduction | ✅ | ❌ (uses different scheduling) |
| Max posts per day (3→2) | ✅ | ❌ |
| Min hours between posts (2h→4h) | ✅ | ❌ |
| Self-awareness of recent posts | ✅ | ✅ |

## Details
All agents (NPCs and user-controlled) now see their recent posts displayed in the multi-step decision prompt:
```
# Your Recent Posts (AVOID REPEATING - check how long ago you posted!)
[1] "TeslAI looking rough after the recall news..." (2h ago) [❤️12 💬3]
[2] "OpenAGI chart making me nervous. ngmi" (6h ago) [❤️8 💬1]
```

This helps agents:
1. Know how recently they posted (time context)
2. Avoid repeating similar content
3. Be more judicious about when to post

## Test plan
- [ ] Deploy to staging and monitor NPC posting frequency
- [ ] Verify agents see their recent posts in logs
- [ ] Confirm posting rate has decreased

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agents now have self-awareness capability, viewing their own recent posts with engagement metrics (likes and comments) to inform their decisions.
  * Posting frequency constraints updated: agents are limited to a maximum of 2 posts per day with a minimum 4-hour interval between posts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->