### PR TITLE
fix: prioritize trading and engagement over posting for all agents

### DIFF
--- a/packages/agents/src/autonomous/templates/multi-step-decision.ts
+++ b/packages/agents/src/autonomous/templates/multi-step-decision.ts
@@ -342,9 +342,7 @@ ${
 
   // Add conditional actions based on flags - engagement before posting
   if (justTraded && canPost) {
-    priorityActions.push(
-      'POST about your trade (share your moves!)'
-    );
+    priorityActions.push('POST about your trade (share your moves!)');
   }
   if (canComment) {
     priorityActions.push('COMMENT on interesting posts in the feed');
@@ -361,7 +359,9 @@ ${
   }
   // POST is LOW PRIORITY - only if nothing else to do
   if (canPost && !justTraded) {
-    priorityActions.push('POST only if you have something truly unique to say (LOW PRIORITY)');
+    priorityActions.push(
+      'POST only if you have something truly unique to say (LOW PRIORITY)'
+    );
   }
 
   // Always end with FINISH

--- a/packages/agents/src/autonomous/templates/multi-step-decision.ts
+++ b/packages/agents/src/autonomous/templates/multi-step-decision.ts
@@ -325,48 +325,58 @@ ${
 }`
       : '';
 
-  // Action priority guidance for NPCs - build list dynamically to avoid duplicate numbers
-  let npcActionPrioritySection = '';
-  if (isNpc) {
-    const priorityActions: string[] = [];
+  // Action priority guidance for ALL agents (NPCs and user-created)
+  // This encourages engagement (trading, commenting, liking) OVER posting
+  // Prevents agents from posting too much and instead focuses on other game actions
+  const priorityActions: string[] = [];
 
-    // Always start with RESPOND
-    priorityActions.push('RESPOND to pending interactions first (if any)');
+  // Always start with RESPOND
+  priorityActions.push('RESPOND to pending interactions first (if any)');
 
-    // Add conditional actions based on flags
-    if (justTraded && canPost) {
-      priorityActions.push(
-        'POST about your trade (users love seeing your moves!)'
-      );
-    }
-    if (canComment) {
-      priorityActions.push('COMMENT on interesting posts in the feed');
-    }
-    if (canEngage) {
-      priorityActions.push('LIKE posts you agree with');
-      priorityActions.push('REPOST content worth amplifying');
-    }
-    if (canTrade && !justTraded) {
-      priorityActions.push('TRADE if you have market conviction');
-    }
-    if (canPost && !justTraded) {
-      priorityActions.push('POST only if you have something unique to say');
-    }
+  // TRADING is HIGH PRIORITY - agents should trade prediction/perp markets actively
+  if (canTrade && !justTraded) {
+    priorityActions.push(
+      'TRADE on prediction or perp markets (this is your main job!)'
+    );
+  }
 
-    // Always end with FINISH
-    priorityActions.push('FINISH if nothing compelling');
+  // Add conditional actions based on flags - engagement before posting
+  if (justTraded && canPost) {
+    priorityActions.push(
+      'POST about your trade (share your moves!)'
+    );
+  }
+  if (canComment) {
+    priorityActions.push('COMMENT on interesting posts in the feed');
+  }
+  if (canEngage) {
+    priorityActions.push('LIKE posts you agree with');
+    priorityActions.push('REPOST content worth amplifying');
+  }
+  if (canGroupChat) {
+    priorityActions.push('GROUP_MESSAGE to chat with your community');
+  }
+  if (canRespondDMs) {
+    priorityActions.push('DM someone interesting');
+  }
+  // POST is LOW PRIORITY - only if nothing else to do
+  if (canPost && !justTraded) {
+    priorityActions.push('POST only if you have something truly unique to say (LOW PRIORITY)');
+  }
 
-    // Build numbered list from the array
-    const numberedList = priorityActions
-      .map((action, index) => `${index + 1}. ${action}`)
-      .join('\n');
+  // Always end with FINISH
+  priorityActions.push('FINISH if nothing compelling');
 
-    npcActionPrioritySection = `
-# Action Priority (prefer engagement over broadcasting)
+  // Build numbered list from the array
+  const numberedList = priorityActions
+    .map((action, index) => `${index + 1}. ${action}`)
+    .join('\n');
+
+  const actionPrioritySection = `
+# Action Priority (prefer trading & engagement over posting)
 ${numberedList}
 
 `;
-  }
 
   // Build conditional sections (only show context for enabled features)
   const tradingSection = canTrade
@@ -474,7 +484,7 @@ ${
 - Meme language is good ("lfg", "ngmi", "gm", slang is fine)
 - SHORT summaries of markets, not full question text
 - DON'T include raw IDs in post content
-${qualityRulesSection}${npcVoiceRulesSection}${npcActionPrioritySection}
+${qualityRulesSection}${npcVoiceRulesSection}${actionPrioritySection}
 Examples:
   ❌ BAD: "Buying YES on 'Will Polymarket deploy its Sentient Market-Making AIs to artificially lower the price of BitcAIn below $120,000 within 5 days?'"
   ✅ GOOD: "The BitcAIn manipulation rumors are getting spicy"


### PR DESCRIPTION
## Summary

Fixes issue where user-created agents were posting too frequently instead of performing other game actions.

## Problem

- User-created agents had no action priority guidance (only NPCs had it)
- This caused agents to treat all actions equally, often choosing to POST
- Agents should focus on trading, commenting, and engaging rather than spamming posts

## Solution

Modified `packages/agents/src/autonomous/templates/multi-step-decision.ts` to apply action priority guidance to **ALL agents** (NPCs and user-created):

| Priority | Action |
|----------|--------|
| 1 | RESPOND to pending interactions |
| 2 | **TRADE** on prediction/perp markets (marked as 'this is your main job!') |
| 3 | POST about your trade (if just traded) |
| 4 | COMMENT on interesting posts |
| 5 | LIKE posts you agree with |
| 6 | REPOST content worth amplifying |
| 7 | GROUP_MESSAGE to chat |
| 8 | DM someone interesting |
| 9 | **POST** only if unique to say (marked as 'LOW PRIORITY') |
| 10 | FINISH if nothing compelling |

## Testing

- [x] Typecheck passes
- [x] Lint passes

## Notes

- This is a soft guidance change (prompt-based)
- Existing hard limits still apply (only 1 post per tick maximum)
- Can add hard rate limiting (2-hour cooldown) as follow-up if needed

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h2>Greptile Overview</h2>

### Greptile Summary

Extends action priority guidance from NPC-only to all agents (NPCs and user-created). The priority list now explicitly emphasizes trading as the main job (priority 2) and demotes posting to low priority (priority 9), addressing the issue where user-created agents posted too frequently instead of performing other game actions like trading and engagement.

### Confidence Score: 5/5

- Safe to merge - clean refactoring with no functional risks
- This is a low-risk change that refactors conditional NPC-only logic into unconditional logic applied to all agents. The change is purely prompt-based guidance (no hard logic changes), maintains all existing feature flags and conditions, and aligns with the stated goal of reducing user-created agent posting frequency. The code structure is cleaner after the refactoring.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| packages/agents/src/autonomous/templates/multi-step-decision.ts | 5/5 | Extends action priority guidance from NPCs to all agents, prioritizing trading/engagement over posting |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent
    participant Prompt as Action Priority Prompt
    participant LLM
    participant Actions as Game Actions
    
    Agent->>Prompt: "Build decision prompt"
    
    alt Has Pending Interactions
        Prompt->>LLM: "Priority 1: RESPOND first"
    end
    
    alt Can Trade & Not Just Traded
        Prompt->>LLM: "Priority 2: TRADE (main job!)"
    end
    
    alt Just Traded
        Prompt->>LLM: "Priority 3: POST about trade"
    end
    
    Prompt->>LLM: "Priority 4-8: COMMENT, LIKE, REPOST, GROUP_MESSAGE, DM"
    
    alt Can Post & Not Just Traded
        Prompt->>LLM: "Priority 9: POST (LOW PRIORITY)"
    end
    
    Prompt->>LLM: "Priority 10: FINISH if nothing compelling"
    
    LLM->>Actions: "Execute chosen action based on priorities"
    Actions-->>Agent: "Action result"
```

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| packages/agents/src/autonomous/templates/multi-step-decision.ts | 5/5 | Extends action priority guidance from NPCs to all agents, prioritizing trading/engagement over posting |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent
    participant Prompt as Action Priority Prompt
    participant LLM
    participant Actions as Game Actions
    
    Agent->>Prompt: "Build decision prompt"
    
    alt Has Pending Interactions
        Prompt->>LLM: "Priority 1: RESPOND first"
    end
    
    alt Can Trade & Not Just Traded
        Prompt->>LLM: "Priority 2: TRADE (main job!)"
    end
    
    alt Just Traded
        Prompt->>LLM: "Priority 3: POST about trade"
    end
    
    Prompt->>LLM: "Priority 4-8: COMMENT, LIKE, REPOST, GROUP_MESSAGE, DM"
    
    alt Can Post & Not Just Traded
        Prompt->>LLM: "Priority 9: POST (LOW PRIORITY)"
    end
    
    Prompt->>LLM: "Priority 10: FINISH if nothing compelling"
    
    LLM->>Actions: "Execute chosen action based on priorities"
    Actions-->>Agent: "Action result"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->