### PR TITLE
fix(BAB-111): close position dialog cancel

### DIFF
--- a/apps/web/src/app/api/admin/feedback/route.ts
+++ b/apps/web/src/app/api/admin/feedback/route.ts
@@ -10,9 +10,19 @@ import {
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
-import { db, desc, eq, feedbacks, ilike, sql, users } from '@babylon/db';
+import {
+  and,
+  db,
+  desc,
+  eq,
+  feedbacks,
+  gte,
+  ilike,
+  lte,
+  sql,
+  users,
+} from '@babylon/db';
 import { FeedbackTypeSchema } from '@babylon/shared';
-import { and, gte, lte } from 'drizzle-orm';
 import type { NextRequest } from 'next/server';
 
 /** Valid feedback types for SQL filter validation */

--- a/apps/web/src/app/api/markets/perps/[ticker]/history/route.ts
+++ b/apps/web/src/app/api/markets/perps/[ticker]/history/route.ts
@@ -44,8 +44,7 @@
  */
 
 import { successResponse, withErrorHandling } from '@babylon/api';
-import { db, perpMarketSnapshots, stockPrices } from '@babylon/db';
-import { desc, eq } from 'drizzle-orm';
+import { db, desc, eq, perpMarketSnapshots, stockPrices } from '@babylon/db';
 import type { NextRequest } from 'next/server';
 import { z } from 'zod';
 

--- a/apps/web/src/app/api/users/by-username/[username]/route.ts
+++ b/apps/web/src/app/api/users/by-username/[username]/route.ts
@@ -83,10 +83,10 @@ import {
   follows,
   positions,
   reactions,
+  sql,
   users,
 } from '@babylon/db';
 import { logger, UsernameParamSchema } from '@babylon/shared';
-import { sql } from 'drizzle-orm';
 import type { NextRequest } from 'next/server';
 
 /**

--- a/apps/web/src/components/markets/TradeConfirmationDialog.tsx
+++ b/apps/web/src/components/markets/TradeConfirmationDialog.tsx
@@ -493,7 +493,16 @@ export function TradeConfirmationDialog({
         {renderDetails()}
 
         <AlertDialogFooter>
-          <AlertDialogCancel disabled={isSubmitting}>Cancel</AlertDialogCancel>
+          <AlertDialogCancel
+            disabled={isSubmitting}
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onOpenChange(false);
+            }}
+          >
+            Cancel
+          </AlertDialogCancel>
           <AlertDialogAction
             onClick={(e) => {
               e.preventDefault();


### PR DESCRIPTION
## Summary
- Fixes the close-position confirmation dialog so `Cancel` reliably closes the dialog and does not trigger the close action.
- Removes a Bun/TypeScript typecheck footgun by standardizing Drizzle helpers imports in a few web route handlers.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Linear: https://linear.app/eliza-labs/issue/BAB-111/fix-close-position-dialog-cancel-button
- Depends on: https://github.com/BabylonSocial/babylon/pull/757

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [ ] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- `apps/web/src/components/markets/TradeConfirmationDialog.tsx`: wire `AlertDialogCancel` to close the dialog (prevent default + stop propagation, then `onOpenChange(false)`).
- `apps/web/src/app/api/*/route.ts`: standardize Drizzle helpers imports to come from `@babylon/db`.

## Review guide

**Start here**
- `apps/web/src/components/markets/TradeConfirmationDialog.tsx`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- The Drizzle import change is to avoid mixed `drizzle-orm` copies under Bun causing incompatible SQL expression types.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Open an existing position.
2. Click `Close` to open the confirmation dialog.
3. Click `Cancel`.
4. Verify the dialog closes and the position remains open.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: behavior-only fix (dialog interaction), no meaningful visual diff.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [ ] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR fixes a dialog interaction bug and standardizes Drizzle ORM imports.

**Main Fix**: The Cancel button in `TradeConfirmationDialog` now properly closes the dialog without triggering the trade action. Previously, clicking Cancel did not reliably dismiss the dialog. The fix adds an explicit `onClick` handler that prevents default behavior, stops event propagation, and calls `onOpenChange(false)` to close the dialog.

**Import Standardization**: Three API route handlers now import Drizzle query operators (`and`, `desc`, `eq`, `gte`, `lte`, `sql`) from `@babylon/db` instead of directly from `drizzle-orm`. This prevents type incompatibilities when Bun resolves multiple copies of the `drizzle-orm` package. The `@babylon/db` package already re-exports all these operators (lines 521-549 in `packages/db/src/index.ts`), making this a safe refactor.

**Technical Details**: The AlertDialog component from the UI library already supports closing via backdrop clicks (line 40 in `alert-dialog.tsx`), but the Cancel button needed explicit handling to ensure consistent behavior across all dismiss paths.

### Confidence Score: 5/5

- Safe to merge - fixes a user-facing bug with a straightforward solution and standardizes imports to prevent type system issues
- The changes are minimal, well-scoped, and correct. The Cancel button fix uses standard React event handling patterns (preventDefault + stopPropagation + state update). The import changes are purely organizational since @babylon/db already re-exports all the needed operators from drizzle-orm. No logic changes, no breaking changes, and the fix directly addresses the reported issue.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/web/src/components/markets/TradeConfirmationDialog.tsx | 5/5 | Added onClick handler to Cancel button that prevents default behavior and explicitly closes dialog via onOpenChange(false) |
| apps/web/src/app/api/admin/feedback/route.ts | 5/5 | Standardized imports by moving and, gte, lte from drizzle-orm to @babylon/db package |
| apps/web/src/app/api/markets/perps/[ticker]/history/route.ts | 5/5 | Standardized imports by moving desc, eq from drizzle-orm to @babylon/db package |
| apps/web/src/app/api/users/by-username/[username]/route.ts | 5/5 | Standardized imports by moving sql from drizzle-orm to @babylon/db package |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant TradeDialog as TradeConfirmationDialog
    participant Parent as Parent Component
    participant API as Trading API

    User->>Parent: Click "Close Position"
    Parent->>TradeDialog: Open dialog (open=true)
    TradeDialog->>User: Display confirmation dialog
    
    alt User clicks Cancel
        User->>TradeDialog: Click Cancel button
        TradeDialog->>TradeDialog: e.preventDefault()
        TradeDialog->>TradeDialog: e.stopPropagation()
        TradeDialog->>Parent: onOpenChange(false)
        Parent->>TradeDialog: Update open=false
        TradeDialog->>User: Dialog closes
        Note over User,TradeDialog: Position remains open
    else User clicks Confirm
        User->>TradeDialog: Click Confirm button
        TradeDialog->>TradeDialog: e.preventDefault()
        TradeDialog->>Parent: onConfirm()
        Parent->>API: Close position request
        API->>Parent: Position closed
        Parent->>TradeDialog: Update open=false
        TradeDialog->>User: Dialog closes
        Note over User,API: Position successfully closed
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->