### PR TITLE
fix(BAB-109): soft-close prediction positions

### DIFF
--- a/packages/core/markets/prediction/PredictionMarketService.ts
+++ b/packages/core/markets/prediction/PredictionMarketService.ts
@@ -116,6 +116,7 @@ export class PredictionMarketService {
               (existingPos.avgPrice * existingPos.shares +
                 calc.avgPrice * calc.sharesBought) /
               (existingPos.shares + calc.sharesBought),
+            status: 'active',
             updatedAt: this.now(),
           }
         : {
@@ -208,9 +209,10 @@ export class PredictionMarketService {
 
     const yesPos = await this.db.getPosition(userId, marketId, 'yes');
     const noPos = await this.db.getPosition(userId, marketId, 'no');
-    const positions = [yesPos, noPos].filter(
-      (p): p is NonNullable<typeof p> => !!p
-    );
+    const positions = [yesPos, noPos]
+      .filter((p): p is NonNullable<typeof p> => !!p)
+      // Exclude closed/empty positions from sell selection (we keep them for history)
+      .filter((p) => p.status !== 'closed' && p.shares > MIN_SHARES);
 
     let pos: NonNullable<typeof yesPos> | NonNullable<typeof noPos> | null =
       null;
@@ -251,10 +253,19 @@ export class PredictionMarketService {
       liquidity: newLiquidity,
     });
 
+    const costBasis = pos.avgPrice * shares;
+    const netProceeds = calc.netProceeds ?? 0;
+    const profitLoss = netProceeds - costBasis;
+
     const remaining = pos.shares - shares;
     const positionClosed = remaining <= MIN_SHARES;
     if (positionClosed) {
-      await this.db.deletePosition(pos.id);
+      await this.db.upsertPosition({
+        ...pos,
+        shares: 0,
+        status: 'closed',
+        updatedAt: this.now(),
+      });
     } else {
       await this.db.upsertPosition({
         ...pos,
@@ -262,10 +273,6 @@ export class PredictionMarketService {
         updatedAt: this.now(),
       });
     }
-
-    const costBasis = pos.avgPrice * shares;
-    const netProceeds = calc.netProceeds ?? 0;
-    const profitLoss = netProceeds - costBasis;
 
     await this.deps.wallet.credit({
       userId,

--- a/packages/core/markets/prediction/__tests__/PredictionMarketService.test.ts
+++ b/packages/core/markets/prediction/__tests__/PredictionMarketService.test.ts
@@ -267,7 +267,39 @@ describe('PredictionMarketService', () => {
       shares: pos!.shares - sellShares,
     });
     expect(result2.positionClosed).toBe(true);
-    expect(await db.getPosition('u1', 'm1', 'yes')).toBeNull();
+    const closed = await db.getPosition('u1', 'm1', 'yes');
+    expect(closed).not.toBeNull();
+    expect(closed?.status).toBe('closed');
+    expect(closed?.shares).toBe(0);
+  });
+
+  it('should ignore closed positions when selecting a position to sell', async () => {
+    await service.buy({
+      userId: 'u1',
+      marketId: 'm1',
+      side: 'yes',
+      amount: 50,
+    });
+    await service.buy({ userId: 'u1', marketId: 'm1', side: 'no', amount: 50 });
+
+    const yesPos = await db.getPosition('u1', 'm1', 'yes');
+    const noPos = await db.getPosition('u1', 'm1', 'no');
+    expect(yesPos).not.toBeNull();
+    expect(noPos).not.toBeNull();
+
+    await service.sell({
+      userId: 'u1',
+      marketId: 'm1',
+      positionId: yesPos!.id,
+      shares: yesPos!.shares,
+    });
+
+    const sellNo = await service.sell({
+      userId: 'u1',
+      marketId: 'm1',
+      shares: noPos!.shares,
+    });
+    expect(sellNo.positionClosed).toBe(true);
   });
 
   it('should require positionId when both sides exist', async () => {

--- a/packages/core/markets/prediction/adapters/drizzle/PredictionDbAdapter.ts
+++ b/packages/core/markets/prediction/adapters/drizzle/PredictionDbAdapter.ts
@@ -8,7 +8,7 @@ import {
 } from '@babylon/db';
 import { generateSnowflakeId } from '@babylon/shared';
 import type { InferInsertModel } from 'drizzle-orm';
-import { and, eq, inArray, ne } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 import type {
   PredictionDbPort,
   PredictionMarketRecord,
@@ -100,8 +100,8 @@ export class PredictionDbAdapter implements PredictionDbPort {
       .where(
         and(
           eq(positions.userId, userId),
-          // Only return active positions with sellable shares
-          ne(positions.status, 'resolved')
+          // Only return active (open) positions with sellable shares
+          eq(positions.status, 'active')
         )
       );
     // Filter out positions with negligible shares (closed but not marked resolved)

--- a/packages/core/markets/prediction/types.ts
+++ b/packages/core/markets/prediction/types.ts
@@ -48,7 +48,7 @@ export interface PredictionPositionRecord {
   side: PredictionSide;
   shares: number;
   avgPrice: number;
-  status?: 'active' | 'resolved';
+  status?: 'active' | 'closed' | 'resolved';
   outcome?: boolean | null;
   pnl?: number;
   resolvedAt?: Date | null;


### PR DESCRIPTION
## Summary
- Stops hard-deleting prediction positions on full sell; instead marks them as `closed` with `shares=0` (keeps history for stats/audit).
- Ensures closed/empty positions don’t interfere with sell selection (no more false “multiple positions” when only one side is actually open).

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Linear: https://linear.app/eliza-labs/issue/BAB-109/fix-position-tracking-ensure-soft-deletion-and-trade-history-logging
- Depends on: https://github.com/BabylonSocial/babylon/pull/757

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [ ] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [x] Other: core prediction market (`packages/core`)

## Changes
- `packages/core/markets/prediction/PredictionMarketService.ts`: on full sell, upserts position as `status='closed'` + `shares=0` (no hard delete); filters closed/empty positions out of sell selection; reactivates position on buy.
- `packages/core/markets/prediction/adapters/drizzle/PredictionDbAdapter.ts`: `listUserPositions()` now returns only `status='active'` rows.
- `packages/core/markets/prediction/types.ts`: extend position status union to include `closed`.
- `packages/core/markets/prediction/__tests__/PredictionMarketService.test.ts`: update assertions + add regression test.

## Review guide

**Start here**
- `packages/core/markets/prediction/PredictionMarketService.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- We keep closed positions for history/stats, but exclude them from active position flows via status + share threshold.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Unit test: `bun test packages/core/markets/prediction/__tests__/PredictionMarketService.test.ts`

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: core market logic + unit tests only.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [ ] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

## Overview
This PR implements soft-deletion for prediction market positions. When users fully sell their positions, instead of hard-deleting the row, positions are now marked as `status='closed'` with `shares=0`. This preserves trade history for statistics and auditing while ensuring closed positions don't interfere with trading operations.

## Key Changes
- **Soft-close on full sell**: Position rows are preserved with `status='closed'` and `shares=0` instead of being deleted
- **Position reactivation**: When buying shares on a previously closed position, it's reactivated with `status='active'`
- **Sell filtering**: Closed positions are excluded from sell position selection to prevent "multiple positions" errors
- **List filtering**: `listUserPositions()` now returns only `status='active'` positions

## Architecture Context
The changes maintain consistency with the existing prediction market service architecture where:
- Position state is managed through the `PredictionDbPort` interface
- The service layer handles business logic while the adapter handles data persistence
- Position lifecycle follows: active → closed (on full sell) → resolved (on market resolution)

## Integration Points
- The changes integrate properly with the wallet service for credits/debits
- Fee processing continues to work with position IDs
- Price snapshots and trade events are correctly emitted
- The filtering logic ensures closed positions don't affect active trading flows

### Confidence Score: 3/5

- This PR is functional but has a logic issue in the resolve() method that should be addressed before merging
- Score reflects that the core soft-close functionality works correctly and is well-tested, but there's a logic issue where closed positions are incorrectly changed to 'resolved' status during market resolution. This won't cause data corruption or user-facing bugs (since closed positions have shares=0), but it's semantically incorrect and could cause confusion in future feature development. The issue is straightforward to fix by filtering out closed positions in the resolve() method.
- Pay close attention to PredictionMarketService.ts - specifically the resolve() method which processes closed positions incorrectly

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| packages/core/markets/prediction/types.ts | 5/5 | Added 'closed' to position status union type - straightforward type extension with no issues |
| packages/core/markets/prediction/adapters/drizzle/PredictionDbAdapter.ts | 4/5 | Changed listUserPositions to filter only 'active' status; minor: outdated comment at line 107 |
| packages/core/markets/prediction/PredictionMarketService.ts | 3/5 | Implements soft-close logic and position reactivation; issue: resolve() method incorrectly changes closed positions to 'resolved' status |
| packages/core/markets/prediction/__tests__/PredictionMarketService.test.ts | 4/5 | Updated tests to verify soft-close behavior and closed position filtering; good coverage but missing test for position reactivation scenario |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Service as PredictionMarketService
    participant DB as PredictionDbAdapter
    participant Wallet

    Note over User,Wallet: Scenario: Full Sell (Soft-Close)
    
    User->>Service: sell(userId, marketId, shares)
    Service->>DB: getPosition(userId, marketId, 'yes')
    DB-->>Service: position (status='active', shares=100)
    Service->>DB: getPosition(userId, marketId, 'no')
    DB-->>Service: null
    
    Note over Service: Filter positions<br/>Exclude status='closed'<br/>and shares <= MIN_SHARES
    
    Service->>Service: Calculate sell with fees
    Service->>DB: updateMarketState(newShares, newLiquidity)
    DB-->>Service: updated market
    
    Note over Service: remaining = 0 (position fully closed)
    
    Service->>DB: upsertPosition({...pos, shares: 0, status: 'closed'})
    DB-->>Service: closed position
    
    Service->>Wallet: credit(userId, netProceeds)
    Wallet-->>Service: success
    Service->>Wallet: recordPnL(userId, pnl)
    Wallet-->>Service: success
    
    Service-->>User: TradeResult(positionClosed=true)
    
    Note over User,Wallet: Scenario: Buy on Closed Position (Reactivation)
    
    User->>Service: buy(userId, marketId, side='yes', amount)
    Service->>Wallet: debit(userId, amount)
    Wallet-->>Service: success
    
    Service->>DB: getPosition(userId, marketId, 'yes')
    DB-->>Service: position (status='closed', shares=0)
    
    Note over Service: Merge with closed position<br/>New avgPrice = calc.avgPrice<br/>New shares = calc.sharesBought
    
    Service->>DB: upsertPosition({...pos, shares: Y, status: 'active'})
    DB-->>Service: reactivated position
    
    Service-->>User: TradeResult(positionId, shares)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->