### PR TITLE
fix(BAB-108): diversify NPC trading strategies

### DIFF
--- a/packages/engine/src/MarketDecisionEngine.ts
+++ b/packages/engine/src/MarketDecisionEngine.ts
@@ -82,6 +82,11 @@ import {
 import type { BabylonLLMClient } from './llm/openai-client';
 import { parseXML } from './llm/xml-parser';
 import {
+  formatTradingStrategyBias,
+  getNpcTradingStrategy,
+  TRADING_STRATEGIES,
+} from './npc/trading-strategies';
+import {
   generateWorldContext,
   getShuffledExamplesText,
   npcMarketDecisions,
@@ -551,6 +556,8 @@ export class MarketDecisionEngine {
     return contexts
       .map((ctx, i) => {
         const archetype = this.mapPersonalityToArchetype(ctx.personality);
+        const strategyKey = getNpcTradingStrategy(ctx.npcId);
+        const strategy = TRADING_STRATEGIES[strategyKey];
         const exposure = this.calculateExposure(
           ctx.availableBalance,
           ctx.currentPositions
@@ -605,7 +612,8 @@ export class MarketDecisionEngine {
 
         return `[${i + 1}] TRADER DASHBOARD
 ID: ${ctx.npcId} | Name: ${ctx.npcName}
-Archetype: ${archetype} | Cash: $${ctx.availableBalance.toLocaleString()}
+Archetype: ${archetype} | Strategy: ${strategy.label} (${strategyKey})
+Bias: ${formatTradingStrategyBias(strategy)} | Cash: $${ctx.availableBalance.toLocaleString()}
 Total PnL: ${pnlSign}$${totalPnL.toFixed(0)} | Exposure: ${exposure.toFixed(1)}%
 Network: ${relationships}
 Positions: ${topPositions || 'None'}

--- a/packages/engine/src/__tests__/trading-strategies.test.ts
+++ b/packages/engine/src/__tests__/trading-strategies.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  getNpcTradingStrategy,
+  TRADING_STRATEGIES,
+} from '../npc/trading-strategies';
+
+describe('NPC trading strategies', () => {
+  test('assigns deterministically per npcId', () => {
+    const npcId = 'npc-test-123';
+    const strategy1 = getNpcTradingStrategy(npcId);
+    const strategy2 = getNpcTradingStrategy(npcId);
+    expect(strategy1).toBe(strategy2);
+  });
+
+  test('returns a known strategy key', () => {
+    const knownKeys = new Set(Object.keys(TRADING_STRATEGIES));
+    const strategy = getNpcTradingStrategy('npc-test-abc');
+    expect(knownKeys.has(strategy)).toBe(true);
+  });
+
+  test('spreads strategies across many npcIds', () => {
+    const strategies = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      strategies.add(getNpcTradingStrategy(`npc-${i}`));
+    }
+    expect(strategies.size).toBeGreaterThan(1);
+  });
+
+  test('bias weights are normalized (sum to ~1)', () => {
+    for (const strategy of Object.values(TRADING_STRATEGIES)) {
+      const sum = strategy.followTrend + strategy.contrarian + strategy.random;
+      expect(sum).toBeCloseTo(1, 5);
+    }
+  });
+});

--- a/packages/engine/src/npc/trading-strategies.ts
+++ b/packages/engine/src/npc/trading-strategies.ts
@@ -1,0 +1,73 @@
+export interface TradingStrategyBias {
+  followTrend: number;
+  contrarian: number;
+  random: number;
+}
+
+export interface TradingStrategyConfig extends TradingStrategyBias {
+  label: string;
+  description: string;
+}
+
+export const TRADING_STRATEGIES = {
+  momentum: {
+    label: 'Momentum',
+    description:
+      'Prefers trading with the trend; will sometimes fade extremes or wait.',
+    followTrend: 0.7,
+    contrarian: 0.2,
+    random: 0.1,
+  },
+  contrarian: {
+    label: 'Contrarian',
+    description:
+      'Prefers fading crowded trades and betting against extremes; rarely follows the trend.',
+    followTrend: 0.2,
+    contrarian: 0.7,
+    random: 0.1,
+  },
+  value: {
+    label: 'Value',
+    description:
+      'Looks for mispricing/value and is more selective; mixes trend-following and contrarian entries.',
+    followTrend: 0.3,
+    contrarian: 0.4,
+    random: 0.3,
+  },
+  random: {
+    label: 'Random',
+    description:
+      'Acts with higher entropy and less consistency; often holds or makes small opportunistic trades.',
+    followTrend: 0.33,
+    contrarian: 0.33,
+    random: 0.34,
+  },
+} as const satisfies Record<string, TradingStrategyConfig>;
+
+export type NPCTradingStrategyKey = keyof typeof TRADING_STRATEGIES;
+
+function hashStringToUint32(value: string): number {
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) {
+    hash = (hash << 5) - hash + value.charCodeAt(i);
+    hash |= 0;
+  }
+  return hash >>> 0;
+}
+
+export function getNpcTradingStrategy(npcId: string): NPCTradingStrategyKey {
+  const keys = Object.keys(TRADING_STRATEGIES) as NPCTradingStrategyKey[];
+  if (keys.length === 0) {
+    throw new Error('TRADING_STRATEGIES must not be empty');
+  }
+
+  const hash = hashStringToUint32(npcId);
+  return keys[hash % keys.length]!;
+}
+
+export function formatTradingStrategyBias(bias: TradingStrategyBias): string {
+  const toPct = (value: number) => `${Math.round(value * 100)}%`;
+  return `Follow trend: ${toPct(bias.followTrend)} | Contrarian: ${toPct(
+    bias.contrarian
+  )} | Random: ${toPct(bias.random)}`;
+}

--- a/packages/engine/src/prompts/trading/npc-market-decisions.ts
+++ b/packages/engine/src/prompts/trading/npc-market-decisions.ts
@@ -205,7 +205,7 @@ export function getShuffledExamplesText(): string {
  */
 export const npcMarketDecisions = definePrompt({
   id: 'npc-market-decisions',
-  version: '6.0.0',
+  version: '6.1.0',
   category: 'trading',
   description: 'Generate trading decisions with full character context',
   temperature: 0.8,
@@ -261,6 +261,11 @@ CONTRARIAN BEHAVIOR (CRITICAL - avoid herding):
 - When YES price is high (>0.7), contrarians should bet NO for value
 - When NO price is low (<0.3), contrarians see opportunity
 - Skeptics, bears, and pessimists often trade against the crowd
+
+INDIVIDUAL STRATEGY BIAS (CRITICAL - avoid copy trading):
+- Each TRADER DASHBOARD includes a "Strategy" and "Bias" line (Follow trend / Contrarian / Random).
+- Apply the bias when choosing direction and sizing. Even allies should not blindly copy each other.
+- "Follow trend" aligns with market momentum/signals. "Contrarian" fades crowded/extreme prices. "Random" increases entropy (often hold/smaller size).
 
 MARKET TYPE BALANCE (IMPORTANT):
 - Use BOTH perpetuals (perp) AND prediction markets


### PR DESCRIPTION
## Summary
- Adds deterministic per-NPC trading strategy biases to reduce NPC herding/copy-trading.
- Surfaces each NPC's strategy + bias weights in the trading prompt ("TRADER DASHBOARD") and updates prompt rules to respect it.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Linear: https://linear.app/eliza-labs/issue/BAB-108/diversify-npc-trading-strategies-to-prevent-herding
- Stacked on: PR #757 (base)

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Non-goals / follow-ups**
- Verify behavior in a multi-NPC sim tick once #757 is merged (no deterministic runtime test here).

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- Adds `TRADING_STRATEGIES` + `getNpcTradingStrategy()` for deterministic per-NPC strategy assignment.
- Includes strategy + bias weights in the NPC dashboards injected into the LLM prompt.
- Updates the prompt rules to enforce individual strategy bias (avoid herd behavior).

## Review guide

**Start here**
- `packages/engine/src/npc/trading-strategies.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- This is purely prompt-context shaping; the execution layer is unchanged.

## Test plan

**Commands run**
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [ ] `bun run test` (unit + integration)

**Manual verification**
1. (Optional) Run a sim tick with multiple NPCs and confirm decisions diversify across long/short/yes/no.

## Ops / Migration / Deployment

- [x] No deploy impact

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Prompt-only change in `packages/engine`, no UI impact.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR adds deterministic per-NPC trading strategy biases to prevent NPC herding behavior in trading decisions. The implementation introduces four strategy types (momentum, contrarian, value, random) with different bias weights for trend-following, contrarian, and random behavior.

**Key Changes:**
- **New module** `trading-strategies.ts` defines strategy configs with normalized bias weights (sum to 1.0) and provides `getNpcTradingStrategy()` for deterministic strategy assignment via hash-based selection
- **Dashboard enhancement** in `MarketDecisionEngine.ts` now displays each NPC's strategy label and bias percentages in the TRADER DASHBOARD injected into prompts
- **Prompt update** adds INDIVIDUAL STRATEGY BIAS rules instructing the LLM to apply biases when choosing trade direction and sizing to avoid copy-trading behavior
- **Test coverage** verifies deterministic assignment, known strategy keys, distribution across NPCs, and normalized weights

**Implementation Quality:**
- Uses deterministic hashing to ensure same NPC always gets same strategy across ticks
- Bias weights are properly normalized and validated in tests
- Clean separation of concerns with strategy logic in dedicated module
- Prompt-only change with no execution layer modifications (low risk)

**Minor Issue:**
- Dashboard line formatting could be improved for better visual balance (style issue, non-blocking)

### Confidence Score: 5/5

- Safe to merge - prompt-only changes with clean implementation and test coverage
- The PR introduces well-structured trading strategy diversification with deterministic assignment, normalized bias weights validated by tests, and no execution layer changes. The only finding is a minor style issue with dashboard formatting that doesn't affect functionality. All bias weights sum to 1.0 as verified by tests, the hash function is deterministic, and the implementation follows clean code principles with proper separation of concerns.
- No files require special attention

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| packages/engine/src/npc/trading-strategies.ts | 5/5 | New file defining trading strategy biases and assignment logic - clean implementation with deterministic hashing |
| packages/engine/src/__tests__/trading-strategies.test.ts | 5/5 | Test file verifying deterministic strategy assignment and normalized bias weights - good coverage |
| packages/engine/src/MarketDecisionEngine.ts | 4/5 | Integrates trading strategies into NPC dashboards with strategy label and bias display, minor formatting issue found |
| packages/engine/src/prompts/trading/npc-market-decisions.ts | 5/5 | Prompt updated to include individual strategy bias rules - version bumped appropriately |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Engine as MarketDecisionEngine
    participant Strategies as trading-strategies.ts
    participant Prompt as npc-market-decisions.ts
    participant LLM as BabylonLLMClient
    
    Engine->>Engine: generateBatchDecisions()
    Engine->>Engine: formatNPCsList(contexts)
    
    loop For each NPC context
        Engine->>Strategies: getNpcTradingStrategy(npcId)
        Strategies->>Strategies: hashStringToUint32(npcId)
        Strategies-->>Engine: strategyKey (momentum/contrarian/value/random)
        Engine->>Strategies: TRADING_STRATEGIES[strategyKey]
        Strategies-->>Engine: strategy config (label, bias weights)
        Engine->>Strategies: formatTradingStrategyBias(strategy)
        Strategies-->>Engine: formatted bias string
        Engine->>Engine: Include strategy + bias in TRADER DASHBOARD
    end
    
    Engine->>Prompt: renderPrompt(npcMarketDecisions, {...})
    Note over Prompt: Includes INDIVIDUAL STRATEGY BIAS rules
    Prompt-->>Engine: Full prompt with strategy context
    
    Engine->>LLM: generateJSON(prompt)
    Note over LLM: LLM sees each NPC's strategy bias<br/>in TRADER DASHBOARD and applies<br/>diversified trading decisions
    LLM-->>Engine: Trading decisions (diversified)
    
    Engine->>Engine: validateDecisions()
    Engine-->>Engine: Return validated decisions
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->