### PR TITLE
fix: wrap follow operations in transaction

### DIFF
--- a/apps/web/src/app/api/users/[userId]/follow/route.ts
+++ b/apps/web/src/app/api/users/[userId]/follow/route.ts
@@ -97,7 +97,15 @@ import {
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
-import { and, db, eq, follows, userActorFollows, users } from '@babylon/db';
+import {
+  and,
+  db,
+  eq,
+  follows,
+  userActorFollows,
+  users,
+  withTransaction,
+} from '@babylon/db';
 import { StaticDataRegistry } from '@babylon/engine';
 import {
   generateSnowflakeId,
@@ -170,35 +178,43 @@ export const POST = withErrorHandling(
     // Also check if targetActor exists (could be actor ID that doesn't match a user)
     if (targetUser && !targetUser.isActor) {
       // Target is a regular user - use Follow model
-      // Check if already following
-      const [existingFollow] = await db
-        .select({ id: follows.id })
-        .from(follows)
-        .where(
-          and(
-            eq(follows.followerId, user.userId),
-            eq(follows.followingId, targetId)
+      // Check if already following and create follow inside transaction
+      const newFollow = await withTransaction(async (tx) => {
+        const [existingFollow] = await tx
+          .select({ id: follows.id })
+          .from(follows)
+          .where(
+            and(
+              eq(follows.followerId, user.userId),
+              eq(follows.followingId, targetId)
+            )
           )
-        )
-        .limit(1);
+          .limit(1)
+          .for('update');
 
-      if (existingFollow) {
-        throw new BusinessLogicError(
-          'Already following this user',
-          'ALREADY_FOLLOWING'
-        );
-      }
+        if (existingFollow) {
+          throw new BusinessLogicError(
+            'Already following this user',
+            'ALREADY_FOLLOWING'
+          );
+        }
 
-      // Create follow relationship and get target user details
-      const followId = await generateSnowflakeId();
-      const [newFollow] = await db
-        .insert(follows)
-        .values({
-          id: followId,
-          followerId: user.userId,
-          followingId: targetId,
-        })
-        .returning();
+        const followId = await generateSnowflakeId();
+        const [createdFollow] = await tx
+          .insert(follows)
+          .values({
+            id: followId,
+            followerId: user.userId,
+            followingId: targetId,
+          })
+          .returning();
+
+        if (!createdFollow) {
+          throw new InternalServerError('Failed to create follow record');
+        }
+
+        return createdFollow;
+      });
 
       // Get target user details
       const [targetUserDetails] = await db


### PR DESCRIPTION
## Summary
- wrap user follow create flow in a DB transaction using withTransaction
- add FOR UPDATE locking on existing follow check to prevent races
- maintain existing cache invalidation and notifications after atomic insert

## Testing
- bun run typecheck
- bun run lint (note: existing info in apps/web/src/app/agents/create/hooks/useAgentForm.ts)
- bun run build (existing warnings from contracts forge deps and eliza core)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR wraps the user follow creation flow in a database transaction with FOR UPDATE locking to prevent race conditions. However, **the implementation is incomplete**:

## What Changed
- User follow operations (lines 182-217) now use `withTransaction` with FOR UPDATE locking on the existing follow check
- This prevents concurrent requests from creating duplicate follow records for regular users
- Cache invalidation and notifications remain outside the transaction (correct approach)

## Critical Issue
**The actor follow path (lines 274-301) was not updated** and still has the same race condition this PR aims to fix:
1. Check for existing follow (lines 274-283) 
2. Insert new follow (line 297)

These are separate operations without transaction protection, allowing two concurrent requests to both pass the check and attempt insertion, causing a unique constraint violation.

## Other Issues
- Redundant null check at lines 260-262 (already checked inside transaction)
- Actor follow uses insert-then-fetch pattern (lines 297-308) instead of `.returning()` like user follows
- Missing defensive null check for `targetUserDetails` after query (line 230)

## Recommendation
Apply the same transaction pattern to actor follows for consistency and to fully resolve race conditions across both code paths.

### Confidence Score: 2/5

- This PR fixes race conditions for user follows but leaves the same vulnerability in actor follows, creating inconsistent behavior
- Score reflects a critical incomplete fix - the PR successfully adds transaction protection to user follows but completely misses the actor follow path (lines 274-301), which has the identical race condition. This inconsistency means the stated goal of "wrap follow operations in transaction" is only half-achieved. The logic bug is critical because it will still allow duplicate actor follows under concurrent requests, defeating the purpose of this PR.
- The actor follow path (lines 274-301) in apps/web/src/app/api/users/[userId]/follow/route.ts needs immediate attention to add the same transaction protection as user follows

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/web/src/app/api/users/[userId]/follow/route.ts | 2/5 | Adds transaction with FOR UPDATE to user follows, but actor follows still have race condition. Also has redundant null checks. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API
    participant Database
    participant Transaction
    participant Cache

    Client->>API: Follow request
    API->>API: Authenticate and validate
    
    alt User Follow Path (Fixed)
        API->>Transaction: Begin transaction
        Transaction->>Database: SELECT with FOR UPDATE lock
        Database-->>Transaction: No existing follow
        Transaction->>Database: INSERT follow record
        Database-->>Transaction: Created
        Transaction-->>API: Commit success
        API->>Cache: Invalidate caches
        API-->>Client: Success
        
    else Actor Follow Path (Issue)
        API->>Database: SELECT existing follow
        Database-->>API: No existing follow
        Note over API,Database: Race window exists here
        API->>Database: INSERT follow record
        Database-->>API: Created
        API->>Cache: Invalidate cache
        API-->>Client: Success
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->