### PR TITLE
fix(BAB-136): chats scroll to bottom on initial load

### DIFF
--- a/apps/web/src/components/agents/AgentChat.tsx
+++ b/apps/web/src/components/agents/AgentChat.tsx
@@ -102,10 +102,10 @@ export function AgentChat({
   const usePro = agent.modelTier === 'pro';
 
   // Scroll to newest messages (scrollTop = 0 due to flex-col-reverse)
-  const scrollToBottom = useCallback((_behavior: ScrollBehavior = 'smooth') => {
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
     const container = chatContainerRef.current;
     if (container) {
-      container.scrollTop = 0;
+      container.scrollTo({ top: 0, behavior });
     }
   }, []);
 
@@ -411,7 +411,7 @@ export function AgentChat({
       {/* Messages - Scrollable, starts at bottom via flex-col-reverse */}
       <div
         ref={chatContainerRef}
-        className="relative min-h-0 flex-1 flex flex-col-reverse overflow-y-auto px-4 py-3"
+        className="relative flex min-h-0 flex-1 flex-col-reverse overflow-y-auto px-4 py-3"
       >
         <div className="flex flex-col space-y-4">
           <MessageList

--- a/apps/web/src/components/agents/AgentChat.tsx
+++ b/apps/web/src/components/agents/AgentChat.tsx
@@ -101,11 +101,12 @@ export function AgentChat({
   // Use pro mode based on agent's model tier
   const usePro = agent.modelTier === 'pro';
 
-  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
-    // Use setTimeout to ensure DOM is fully rendered after state update
-    setTimeout(() => {
-      messagesEndRef.current?.scrollIntoView({ behavior, block: 'end' });
-    }, 0);
+  // Scroll to newest messages (scrollTop = 0 due to flex-col-reverse)
+  const scrollToBottom = useCallback((_behavior: ScrollBehavior = 'smooth') => {
+    const container = chatContainerRef.current;
+    if (container) {
+      container.scrollTop = 0;
+    }
   }, []);
 
   // Create ChatDetails for the header component
@@ -247,21 +248,15 @@ export function AgentChat({
     fetchMessages();
   }, [fetchMessages]);
 
-  // Scroll to bottom on initial load and when switching agents
+  // Track last message for change detection
   useEffect(() => {
     const lastId =
       messages.length > 0 ? messages[messages.length - 1]?.id : null;
     if (!lastId || loading) return;
-
-    const shouldForce = lastMessageIdRef.current === null;
     lastMessageIdRef.current = lastId;
+  }, [messages, loading]);
 
-    if (shouldForce) {
-      scrollToBottom('auto');
-    }
-  }, [messages, loading, scrollToBottom]);
-
-  // Intersection observer for infinite scroll
+  // Load older messages when scrolling up
   useEffect(() => {
     const container = chatContainerRef.current;
     const sentinel = topSentinelRef.current;
@@ -272,12 +267,9 @@ export function AgentChat({
       (entries) => {
         const entry = entries[0];
         if (!entry) return;
-        if (
-          entry.isIntersecting &&
-          container.scrollTop < 200 &&
-          hasMore &&
-          !isLoadingMore
-        ) {
+        const maxScrollTop = container.scrollHeight - container.clientHeight;
+        const nearTop = container.scrollTop >= maxScrollTop - 200;
+        if (entry.isIntersecting && nearTop && hasMore && !isLoadingMore) {
           pendingScrollAdjustRef.current = {
             previousHeight: container.scrollHeight,
             previousTop: container.scrollTop,
@@ -416,23 +408,25 @@ export function AgentChat({
         </div>
       </div>
 
-      {/* Messages - Scrollable using shared MessageList */}
+      {/* Messages - Scrollable, starts at bottom via flex-col-reverse */}
       <div
         ref={chatContainerRef}
-        className="relative min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-3"
+        className="relative min-h-0 flex-1 flex flex-col-reverse overflow-y-auto px-4 py-3"
       >
-        <MessageList
-          messages={chatMessages}
-          participants={participants}
-          currentUserId={user?.id}
-          loading={loading}
-          isLoadingMore={isLoadingMore}
-          hasMore={hasMore}
-          pullDistance={0}
-          authenticated={!!user}
-          topSentinelRef={topSentinelRef}
-          messagesEndRef={messagesEndRef}
-        />
+        <div className="flex flex-col space-y-4">
+          <MessageList
+            messages={chatMessages}
+            participants={participants}
+            currentUserId={user?.id}
+            loading={loading}
+            isLoadingMore={isLoadingMore}
+            hasMore={hasMore}
+            pullDistance={0}
+            authenticated={!!user}
+            topSentinelRef={topSentinelRef}
+            messagesEndRef={messagesEndRef}
+          />
+        </div>
       </div>
 
       {/* Footer - Fixed */}

--- a/apps/web/src/components/chats/ChatView.tsx
+++ b/apps/web/src/components/chats/ChatView.tsx
@@ -103,23 +103,25 @@ export function ChatView({
         )}
       </div>
 
-      {/* Messages - Scrollable */}
+      {/* Messages - Scrollable, starts at bottom via flex-col-reverse */}
       <div
         ref={containerRef}
-        className="relative min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-3"
+        className="relative min-h-0 flex-1 flex flex-col-reverse overflow-y-auto px-4 py-3"
       >
-        <MessageList
-          messages={chatDetails.messages || []}
-          participants={chatDetails.participants || []}
-          currentUserId={currentUserId}
-          loading={loading}
-          isLoadingMore={isLoadingMore}
-          hasMore={hasMore}
-          pullDistance={pullDistance}
-          authenticated={authenticated}
-          topSentinelRef={topSentinelRef}
-          messagesEndRef={messagesEndRef}
-        />
+        <div className="flex flex-col space-y-4">
+          <MessageList
+            messages={chatDetails.messages || []}
+            participants={chatDetails.participants || []}
+            currentUserId={currentUserId}
+            loading={loading}
+            isLoadingMore={isLoadingMore}
+            hasMore={hasMore}
+            pullDistance={pullDistance}
+            authenticated={authenticated}
+            topSentinelRef={topSentinelRef}
+            messagesEndRef={messagesEndRef}
+          />
+        </div>
       </div>
 
       {/* Footer - Fixed */}

--- a/apps/web/src/components/chats/ChatView.tsx
+++ b/apps/web/src/components/chats/ChatView.tsx
@@ -106,7 +106,7 @@ export function ChatView({
       {/* Messages - Scrollable, starts at bottom via flex-col-reverse */}
       <div
         ref={containerRef}
-        className="relative min-h-0 flex-1 flex flex-col-reverse overflow-y-auto px-4 py-3"
+        className="relative flex min-h-0 flex-1 flex-col-reverse overflow-y-auto px-4 py-3"
       >
         <div className="flex flex-col space-y-4">
           <MessageList

--- a/apps/web/src/components/chats/hooks/useChatPage.ts
+++ b/apps/web/src/components/chats/hooks/useChatPage.ts
@@ -410,10 +410,10 @@ export function useChatPage() {
   );
 
   // Scroll to newest messages (scrollTop = 0 due to flex-col-reverse)
-  const scrollToBottom = useCallback((_behavior: ScrollBehavior = 'auto') => {
+  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'auto') => {
     const container = chatContainerRef.current;
     if (container) {
-      container.scrollTop = 0;
+      container.scrollTo({ top: 0, behavior });
     }
   }, []);
 
@@ -489,6 +489,7 @@ export function useChatPage() {
 
     if (wasEmpty) {
       setIsAtBottom(true);
+      scrollToBottom('auto');
       return;
     }
 
@@ -549,7 +550,7 @@ export function useChatPage() {
       setIsAtBottom(atBottom);
     };
 
-    container.addEventListener('scroll', handleScroll);
+    container.addEventListener('scroll', handleScroll, { passive: true });
     handleScroll();
     return () => container.removeEventListener('scroll', handleScroll);
   }, []);

--- a/apps/web/src/components/chats/hooks/useChatPage.ts
+++ b/apps/web/src/components/chats/hooks/useChatPage.ts
@@ -409,15 +409,11 @@ export function useChatPage() {
     [getAccessToken, user]
   );
 
-  // Scroll to bottom
-  const scrollToBottom = useCallback((behavior: ScrollBehavior = 'auto') => {
+  // Scroll to newest messages (scrollTop = 0 due to flex-col-reverse)
+  const scrollToBottom = useCallback((_behavior: ScrollBehavior = 'auto') => {
     const container = chatContainerRef.current;
     if (container) {
-      requestAnimationFrame(() => {
-        container.scrollTop = container.scrollHeight;
-      });
-    } else {
-      messagesEndRef.current?.scrollIntoView({ behavior, block: 'end' });
+      container.scrollTop = 0;
     }
   }, []);
 
@@ -479,29 +475,29 @@ export function useChatPage() {
     }
   }, [realtimeMessages]);
 
-  // Scroll to bottom on new messages
+  // Handle new messages and auto-scroll
   useEffect(() => {
+    if (loadingChat) return;
+
     const msgs = chatDetails?.messages || [];
     const lastId = msgs.length > 0 ? msgs[msgs.length - 1]?.id : null;
     if (!lastId) return;
 
     const isNewMessage = lastId !== lastMessageIdRef.current;
-    const shouldForce = lastMessageIdRef.current === null;
+    const wasEmpty = lastMessageIdRef.current === null;
     lastMessageIdRef.current = lastId;
 
-    if (shouldForce) {
-      scrollToBottom('auto');
+    if (wasEmpty) {
       setIsAtBottom(true);
       return;
     }
 
     if (isNewMessage && isAtBottom) {
       scrollToBottom('smooth');
-      setIsAtBottom(true);
     }
-  }, [chatDetails?.messages, isAtBottom, scrollToBottom]);
+  }, [chatDetails?.messages, isAtBottom, scrollToBottom, loadingChat]);
 
-  // Intersection observer for infinite scroll
+  // Load older messages when scrolling up
   useEffect(() => {
     const container = chatContainerRef.current;
     const sentinel = topSentinelRef.current;
@@ -512,12 +508,9 @@ export function useChatPage() {
       (entries) => {
         const entry = entries[0];
         if (!entry) return;
-        if (
-          entry.isIntersecting &&
-          container.scrollTop < 200 &&
-          hasMore &&
-          !isLoadingMore
-        ) {
+        const maxScrollTop = container.scrollHeight - container.clientHeight;
+        const nearTop = container.scrollTop >= maxScrollTop - 200;
+        if (entry.isIntersecting && nearTop && hasMore && !isLoadingMore) {
           pendingScrollAdjustRef.current = {
             previousHeight: container.scrollHeight,
             previousTop: container.scrollTop,
@@ -545,16 +538,14 @@ export function useChatPage() {
     pendingScrollAdjustRef.current = null;
   }, [isLoadingMore]);
 
-  // Track scroll position
+  // Track scroll position for auto-scroll behavior
   useEffect(() => {
     const container = chatContainerRef.current;
     if (!container) return;
 
     const handleScroll = () => {
       const threshold = 50;
-      const atBottom =
-        container.scrollTop + container.clientHeight >=
-        container.scrollHeight - threshold;
+      const atBottom = container.scrollTop <= threshold;
       setIsAtBottom(atBottom);
     };
 


### PR DESCRIPTION
## Summary

- Fix chat messages always scrolling to top (oldest messages) when loading a chat
- Now correctly displays newest messages at the bottom on initial load
- Uses CSS `flex-col-reverse` pattern for reliable scroll positioning without timing issues

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- User reported chats always showing oldest messages first on load
- Affected both regular chats (ChatView) and agent chats (AgentChat)

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑aDdll)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- `ChatView.tsx`: Add `flex-col-reverse` to scroll container with inner wrapper
- `AgentChat.tsx`: Add `flex-col-reverse` to scroll container with inner wrapper
- `useChatPage.ts`: Update scroll logic for reversed container (scrollTop=0 is now "bottom")

## Review guide

**Start here**
- `apps/web/src/components/chats/ChatView.tsx` - see the flex-col-reverse pattern
- `apps/web/src/components/chats/hooks/useChatPage.ts` - updated scroll tracking logic

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- The `flex-col-reverse` CSS pattern inverts scroll behavior: `scrollTop=0` shows the end of content (newest messages)
- This eliminates JavaScript timing issues where scroll would fire before React rendered messages
- Both ChatView and AgentChat now use identical patterns

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Navigate to /chats
2. Select any chat with messages
3. Verify newest messages are visible at the bottom on initial load
4. Scroll up to verify older messages load correctly
5. Send a message and verify it appears at the bottom

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option A: Visual demo

| Feature | Before | After |
|---------|--------|-------|
| Chat scroll position | Scrolled to top, showing oldest messages | Scrolled to bottom, showing newest messages |

Before:
[chat-scroll-before.webm](https://github.com/user-attachments/assets/2796d451-5506-4d60-b571-8065da08e40a)



After:
[chat-scroll-after.webm](https://github.com/user-attachments/assets/57dfb160-69c8-42fa-8061-bd835de4791c)



## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR fixes a chat scrolling bug where messages would show oldest messages first instead of the newest messages on initial load.

## Implementation

The fix implements the CSS `flex-col-reverse` pattern, which inverts the visual order of flex children while maintaining DOM order. This approach eliminates JavaScript timing issues that occurred when trying to scroll to bottom before React finished rendering messages.

**Key changes:**
- **Layout**: Wrapped message lists in a `flex-col-reverse` container with an inner `flex-col` wrapper to maintain proper message spacing
- **Scroll behavior**: Updated `scrollToBottom()` to set `scrollTop = 0` (which shows newest messages in a reversed container)
- **Infinite scroll**: Updated intersection observer logic to detect "near top" as `scrollTop >= maxScrollTop - 200` (reversed from `scrollTop < 200`)
- **Scroll tracking**: Updated `isAtBottom` detection to check `scrollTop <= threshold` instead of `scrollTop + clientHeight >= scrollHeight - threshold`

## How flex-col-reverse works

With `flex-col-reverse`:
- Messages are still rendered oldest-to-newest in DOM order
- Visual display is reversed: newest messages appear at the bottom
- `scrollTop = 0` positions the viewport at the "start" of the scroll area, which is visually the bottom (newest messages)
- `scrollTop = max` positions at the top (oldest messages)

This pattern provides reliable scroll positioning without race conditions between React rendering and scroll commands.

## Consistency

Both `ChatView` and `AgentChat` components now use identical patterns for scroll handling, ensuring consistent behavior across regular chats and agent chats.

### Confidence Score: 5/5

- Safe to merge - bug fix with sound implementation and no breaking changes
- The implementation correctly uses the flex-col-reverse pattern to fix the scroll positioning bug. All scroll-related logic has been properly updated to account for the inverted scroll behavior. The changes are isolated to chat UI components with no impact on business logic or data handling. Only minor style issues exist around unused scroll behavior parameters.
- No files require special attention - all changes follow consistent patterns and correct logic

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/web/src/components/agents/AgentChat.tsx | 5/5 | Added flex-col-reverse pattern with wrapper div, updated scroll logic to use scrollTop=0 for bottom, removed forced scroll on initial load |
| apps/web/src/components/chats/ChatView.tsx | 5/5 | Added flex-col-reverse pattern with wrapper div to enable scroll-to-bottom without JS timing issues |
| apps/web/src/components/chats/hooks/useChatPage.ts | 5/5 | Updated scrollToBottom to set scrollTop=0, updated isAtBottom detection logic to match reversed scroll behavior, updated infinite scroll trigger logic |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ChatView/AgentChat
    participant Container as flex-col-reverse Container
    participant MessageList
    participant IntersectionObserver

    User->>ChatView/AgentChat: Open chat
    ChatView/AgentChat->>ChatView/AgentChat: Load messages
    ChatView/AgentChat->>MessageList: Render messages (oldest to newest)
    MessageList->>Container: Display in flex-col-reverse
    Note over Container: scrollTop=0 shows newest messages at bottom
    
    User->>Container: Scroll up to view older messages
    Container->>IntersectionObserver: Sentinel becomes visible
    IntersectionObserver->>IntersectionObserver: Check scrollTop >= maxScrollTop - 200
    IntersectionObserver->>ChatView/AgentChat: Trigger loadMore()
    ChatView/AgentChat->>ChatView/AgentChat: Save scroll position
    ChatView/AgentChat->>MessageList: Prepend older messages
    ChatView/AgentChat->>Container: Adjust scrollTop to maintain position
    
    User->>ChatView/AgentChat: Send new message
    ChatView/AgentChat->>MessageList: Append message
    ChatView/AgentChat->>Container: scrollToBottom() sets scrollTop=0
    Note over Container: Smooth scroll to newest messages
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat message scrolling and infinite-scroll behavior for loading older messages
  * Refined auto-scroll handling when switching between conversations and loading new messages

* **Refactor**
  * Restructured chat message container layout and scroll mechanics for better performance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->