### PR TITLE
Fix markets: price history pipeline + range-aware charts

### DIFF
--- a/apps/web/src/app/api/markets/perps/[ticker]/history/route.ts
+++ b/apps/web/src/app/api/markets/perps/[ticker]/history/route.ts
@@ -27,9 +27,15 @@
  *         schema:
  *           type: integer
  *           minimum: 1
- *           maximum: 1000
+ *           maximum: 2000
  *           default: 200
  *         description: Number of history points to return
+ *       - in: query
+ *         name: range
+ *         schema:
+ *           type: string
+ *           enum: [1H, 4H, 1D, 1W, ALL]
+ *         description: Optional server-side time range filter/downsampling
  *     responses:
  *       200:
  *         description: Price history retrieved successfully
@@ -38,15 +44,25 @@
  *
  * @example
  * ```typescript
- * const response = await fetch(`/api/markets/perps/${ticker}/history?limit=100`);
+ * const response = await fetch(`/api/markets/perps/${ticker}/history?limit=100&range=1W`);
  * const { history } = await response.json();
  * ```
  */
 
 import { successResponse, withErrorHandling } from '@babylon/api';
-import { db, desc, eq, perpMarketSnapshots, stockPrices } from '@babylon/db';
+import {
+  and,
+  db,
+  desc,
+  eq,
+  gte,
+  perpMarketSnapshots,
+  stockPrices,
+} from '@babylon/db';
 import type { NextRequest } from 'next/server';
 import { z } from 'zod';
+
+type TimeRange = '1H' | '4H' | '1D' | '1W' | 'ALL';
 
 const ParamsSchema = z.object({
   ticker: z.string().min(1).max(20),
@@ -56,11 +72,137 @@ const QuerySchema = z.object({
   limit: z
     .preprocess(
       (value) => (value === null ? undefined : value),
-      z.coerce.number().min(1).max(1000)
+      z.coerce.number().min(1).max(2000)
     )
     .optional()
     .default(200),
+  range: z.enum(['1H', '4H', '1D', '1W', 'ALL']).optional(),
 });
+
+const RANGE_MS: Record<TimeRange, number> = {
+  '1H': 60 * 60 * 1000,
+  '4H': 4 * 60 * 60 * 1000,
+  '1D': 24 * 60 * 60 * 1000,
+  '1W': 7 * 24 * 60 * 60 * 1000,
+  ALL: 0,
+};
+
+const BUCKET_CANDIDATES_MS = [
+  60_000, // 1m
+  2 * 60_000, // 2m
+  5 * 60_000, // 5m
+  10 * 60_000, // 10m
+  15 * 60_000, // 15m
+  30 * 60_000, // 30m
+  60 * 60_000, // 1h
+  2 * 60 * 60_000, // 2h
+  4 * 60 * 60_000, // 4h
+  6 * 60 * 60_000, // 6h
+  12 * 60 * 60_000, // 12h
+  24 * 60 * 60_000, // 1d
+];
+
+function chooseBucketMs(spanMs: number, maxPoints: number): number {
+  if (!Number.isFinite(spanMs) || spanMs <= 0) return BUCKET_CANDIDATES_MS[0]!;
+  if (!Number.isFinite(maxPoints) || maxPoints <= 1)
+    return BUCKET_CANDIDATES_MS.at(-1)!;
+
+  for (const candidate of BUCKET_CANDIDATES_MS) {
+    if (Math.ceil(spanMs / candidate) <= maxPoints) return candidate;
+  }
+  return BUCKET_CANDIDATES_MS.at(-1)!;
+}
+
+function downsampleStockPrices(
+  points: Array<{
+    price: number;
+    timestamp: Date;
+    volume: number | null;
+  }>,
+  maxPoints: number
+): Array<{
+  price: number;
+  timestamp: Date;
+  openPrice: number;
+  highPrice: number;
+  lowPrice: number;
+  volume: number;
+  change: number;
+  changePercent: number;
+}> {
+  if (points.length <= maxPoints) {
+    return points.map((p) => ({
+      price: p.price,
+      timestamp: p.timestamp,
+      openPrice: p.price,
+      highPrice: p.price,
+      lowPrice: p.price,
+      volume: Number(p.volume ?? 0),
+      change: 0,
+      changePercent: 0,
+    }));
+  }
+
+  const first = points[0];
+  const last = points[points.length - 1];
+  if (!first || !last) return [];
+
+  const spanMs = last.timestamp.getTime() - first.timestamp.getTime();
+  const bucketMs = chooseBucketMs(spanMs, maxPoints);
+
+  const buckets = new Map<
+    number,
+    {
+      open: number;
+      high: number;
+      low: number;
+      close: number;
+      volume: number;
+    }
+  >();
+
+  for (const point of points) {
+    const t = point.timestamp.getTime();
+    const bucketStart = Math.floor(t / bucketMs) * bucketMs;
+    const existing = buckets.get(bucketStart);
+    const price = point.price;
+    const volume = Number(point.volume ?? 0);
+
+    if (!existing) {
+      buckets.set(bucketStart, {
+        open: price,
+        high: price,
+        low: price,
+        close: price,
+        volume,
+      });
+      continue;
+    }
+
+    existing.high = Math.max(existing.high, price);
+    existing.low = Math.min(existing.low, price);
+    existing.close = price;
+    existing.volume += volume;
+  }
+
+  return [...buckets.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([bucketStart, bucket]) => {
+      const change = bucket.close - bucket.open;
+      const changePercent =
+        bucket.open === 0 ? 0 : (change / bucket.open) * 100;
+      return {
+        price: bucket.close,
+        timestamp: new Date(bucketStart),
+        openPrice: bucket.open,
+        highPrice: bucket.high,
+        lowPrice: bucket.low,
+        volume: bucket.volume,
+        change,
+        changePercent,
+      };
+    });
+}
 
 export const GET = withErrorHandling(
   async (
@@ -69,7 +211,10 @@ export const GET = withErrorHandling(
   ) => {
     const { ticker } = ParamsSchema.parse(await context.params);
     const { searchParams } = new URL(request.url);
-    const { limit } = QuerySchema.parse({ limit: searchParams.get('limit') });
+    const { limit, range } = QuerySchema.parse({
+      limit: searchParams.get('limit'),
+      range: searchParams.get('range'),
+    });
 
     // Look up the organizationId from the perp market snapshot
     const [marketSnapshot] = await db
@@ -86,8 +231,15 @@ export const GET = withErrorHandling(
       });
     }
 
-    // Get price history from stockPrices table
-    const history = await db
+    const now = new Date();
+    const selectedRange = (range ?? 'ALL') as TimeRange;
+    const since =
+      selectedRange === 'ALL'
+        ? null
+        : new Date(now.getTime() - RANGE_MS[selectedRange]);
+
+    // Get price history from stockPrices table (raw points)
+    const rawHistory = await db
       .select({
         id: stockPrices.id,
         price: stockPrices.price,
@@ -100,51 +252,45 @@ export const GET = withErrorHandling(
         volume: stockPrices.volume,
       })
       .from(stockPrices)
-      .where(eq(stockPrices.organizationId, marketSnapshot.organizationId))
+      .where(
+        since
+          ? and(
+              eq(stockPrices.organizationId, marketSnapshot.organizationId),
+              gte(stockPrices.timestamp, since)
+            )
+          : eq(stockPrices.organizationId, marketSnapshot.organizationId)
+      )
       .orderBy(desc(stockPrices.timestamp))
-      .limit(limit);
+      // When a range is selected, fetch more raw points so downsampling has enough signal.
+      .limit(range ? Math.max(limit * 10, 5000) : limit);
 
-    // If we don't have enough recent data, also check older data
-    if (history.length < 10) {
-      const allHistory = await db
-        .select({
-          id: stockPrices.id,
-          price: stockPrices.price,
-          change: stockPrices.change,
-          changePercent: stockPrices.changePercent,
-          timestamp: stockPrices.timestamp,
-          openPrice: stockPrices.openPrice,
-          highPrice: stockPrices.highPrice,
-          lowPrice: stockPrices.lowPrice,
-          volume: stockPrices.volume,
-        })
-        .from(stockPrices)
-        .where(eq(stockPrices.organizationId, marketSnapshot.organizationId))
-        .orderBy(desc(stockPrices.timestamp))
-        .limit(limit);
-
-      return successResponse({
-        ticker,
-        organizationId: marketSnapshot.organizationId,
-        history: allHistory.reverse().map((point) => ({
-          id: point.id,
-          price: point.price,
-          change: point.change,
-          changePercent: point.changePercent,
-          timestamp: point.timestamp.toISOString(),
-          openPrice: point.openPrice,
-          highPrice: point.highPrice,
-          lowPrice: point.lowPrice,
-          volume: point.volume,
-        })),
-      });
-    }
+    const ascending = rawHistory.reverse();
+    const history = range
+      ? downsampleStockPrices(
+          ascending.map((p) => ({
+            price: Number(p.price),
+            timestamp: p.timestamp,
+            volume: p.volume,
+          })),
+          limit
+        ).map((p) => ({
+          id: null as string | null,
+          price: p.price,
+          change: p.change,
+          changePercent: p.changePercent,
+          timestamp: p.timestamp,
+          openPrice: p.openPrice,
+          highPrice: p.highPrice,
+          lowPrice: p.lowPrice,
+          volume: p.volume,
+        }))
+      : ascending;
 
     return successResponse({
       ticker,
       organizationId: marketSnapshot.organizationId,
-      history: history.reverse().map((point) => ({
-        id: point.id,
+      history: history.map((point) => ({
+        id: point.id ?? undefined,
         price: point.price,
         change: point.change,
         changePercent: point.changePercent,

--- a/apps/web/src/app/api/markets/perps/_adapters.ts
+++ b/apps/web/src/app/api/markets/perps/_adapters.ts
@@ -25,7 +25,7 @@ import {
   db,
   eq,
   isNull,
-  organizations,
+  organizationState,
   perpMarketSnapshots,
   perpPositions,
 } from '@babylon/db';
@@ -220,28 +220,33 @@ export async function applyUserTradePriceImpact(ticker: string): Promise<void> {
 
     const organizationId = snapshot.organizationId;
 
-    // 2. Get organization data (initialPrice, currentPrice)
-    const [org] = await db
+    // 2. Get dynamic org pricing state (basePrice/currentPrice)
+    // Do not depend on the legacy `Organization` table which may not be seeded in some envs.
+    const [state] = await db
       .select({
-        id: organizations.id,
-        currentPrice: organizations.currentPrice,
-        initialPrice: organizations.initialPrice,
+        id: organizationState.id,
+        currentPrice: organizationState.currentPrice,
+        basePrice: organizationState.basePrice,
       })
-      .from(organizations)
-      .where(eq(organizations.id, organizationId))
+      .from(organizationState)
+      .where(eq(organizationState.id, organizationId))
       .limit(1);
 
-    if (!org) {
+    if (!state) {
       logger.warn(
-        'Organization not found for price impact',
+        'OrganizationState not found for price impact',
         { ticker: normalizedTicker, organizationId },
         'PerpPriceImpact'
       );
       return;
     }
 
-    const initialPrice = Number(org.initialPrice ?? 100);
-    const currentPrice = Number(org.currentPrice ?? initialPrice);
+    const initialPrice = Number(
+      state.basePrice ?? snapshot.currentPrice ?? 100
+    );
+    const currentPrice = Number(
+      snapshot.currentPrice ?? state.currentPrice ?? initialPrice
+    );
 
     // 3. Get all open positions for this ticker
     // Note: positions use ticker (e.g., "AIPHB"), not organizationId

--- a/apps/web/src/app/api/markets/predictions/[id]/history/route.ts
+++ b/apps/web/src/app/api/markets/predictions/[id]/history/route.ts
@@ -1,18 +1,103 @@
 import { successResponse, withErrorHandling } from '@babylon/api';
-import { db, desc, eq, predictionPriceHistories } from '@babylon/db';
+import { and, db, desc, eq, gte, predictionPriceHistories } from '@babylon/db';
 import { PredictionMarketIdSchema } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 import { z } from 'zod';
+
+type TimeRange = '1H' | '4H' | '1D' | '1W' | 'ALL';
 
 const QuerySchema = z.object({
   limit: z
     .preprocess(
       (value) => (value === null ? undefined : value),
-      z.coerce.number().min(1).max(1000)
+      z.coerce.number().min(1).max(2000)
     )
     .optional()
     .default(200),
+  range: z.enum(['1H', '4H', '1D', '1W', 'ALL']).optional(),
 });
+
+const RANGE_MS: Record<TimeRange, number> = {
+  '1H': 60 * 60 * 1000,
+  '4H': 4 * 60 * 60 * 1000,
+  '1D': 24 * 60 * 60 * 1000,
+  '1W': 7 * 24 * 60 * 60 * 1000,
+  ALL: 0,
+};
+
+const BUCKET_CANDIDATES_MS = [
+  60_000, // 1m
+  2 * 60_000, // 2m
+  5 * 60_000, // 5m
+  10 * 60_000, // 10m
+  15 * 60_000, // 15m
+  30 * 60_000, // 30m
+  60 * 60_000, // 1h
+  2 * 60 * 60_000, // 2h
+  4 * 60 * 60_000, // 4h
+  6 * 60 * 60_000, // 6h
+  12 * 60 * 60_000, // 12h
+  24 * 60 * 60_000, // 1d
+];
+
+function chooseBucketMs(spanMs: number, maxPoints: number): number {
+  if (!Number.isFinite(spanMs) || spanMs <= 0) return BUCKET_CANDIDATES_MS[0]!;
+  if (!Number.isFinite(maxPoints) || maxPoints <= 1)
+    return BUCKET_CANDIDATES_MS.at(-1)!;
+
+  for (const candidate of BUCKET_CANDIDATES_MS) {
+    if (Math.ceil(spanMs / candidate) <= maxPoints) return candidate;
+  }
+  return BUCKET_CANDIDATES_MS.at(-1)!;
+}
+
+function downsamplePredictionHistory(
+  points: Array<{
+    id: string;
+    yesPrice: number;
+    noPrice: number;
+    yesShares: number;
+    noShares: number;
+    liquidity: number;
+    eventType: string;
+    source: string;
+    createdAt: Date;
+  }>,
+  maxPoints: number
+): Array<{
+  id: string;
+  yesPrice: number;
+  noPrice: number;
+  yesShares: number;
+  noShares: number;
+  liquidity: number;
+  eventType: string;
+  source: string;
+  createdAt: Date;
+}> {
+  if (points.length <= maxPoints) return points;
+  const first = points[0];
+  const last = points[points.length - 1];
+  if (!first || !last) return [];
+
+  const spanMs = last.createdAt.getTime() - first.createdAt.getTime();
+  const bucketMs = chooseBucketMs(spanMs, maxPoints);
+
+  const buckets = new Map<number, (typeof points)[number]>();
+  for (const point of points) {
+    const t = point.createdAt.getTime();
+    const bucketStart = Math.floor(t / bucketMs) * bucketMs;
+    // Keep the most recent point in each bucket (points are expected ascending).
+    buckets.set(bucketStart, point);
+  }
+
+  return [...buckets.entries()]
+    .sort((a, b) => a[0] - b[0])
+    .map(([bucketStart, point]) => ({
+      ...point,
+      createdAt: new Date(bucketStart),
+    }));
+}
 
 export const GET = withErrorHandling(
   async (
@@ -23,24 +108,54 @@ export const GET = withErrorHandling(
       await context.params
     );
     const { searchParams } = new URL(request.url);
-    const { limit } = QuerySchema.parse({ limit: searchParams.get('limit') });
+    const { limit, range } = QuerySchema.parse({
+      limit: searchParams.get('limit'),
+      range: searchParams.get('range'),
+    });
 
-    const history = await db
+    const now = new Date();
+    const selectedRange = (range ?? 'ALL') as TimeRange;
+    const since =
+      selectedRange === 'ALL'
+        ? null
+        : new Date(now.getTime() - RANGE_MS[selectedRange]);
+
+    const rawHistory = await db
       .select()
       .from(predictionPriceHistories)
-      .where(eq(predictionPriceHistories.marketId, marketId))
+      .where(
+        since
+          ? and(
+              eq(predictionPriceHistories.marketId, marketId),
+              gte(predictionPriceHistories.createdAt, since)
+            )
+          : eq(predictionPriceHistories.marketId, marketId)
+      )
       .orderBy(desc(predictionPriceHistories.createdAt))
-      .limit(limit);
+      .limit(range ? Math.max(limit * 10, 5000) : limit);
+
+    const ascending = rawHistory.reverse().map((point) => ({
+      ...point,
+      yesPrice: Number(point.yesPrice),
+      noPrice: Number(point.noPrice),
+      yesShares: Number(point.yesShares),
+      noShares: Number(point.noShares),
+      liquidity: Number(point.liquidity),
+    }));
+
+    const history = range
+      ? downsamplePredictionHistory(ascending, limit)
+      : ascending;
 
     return successResponse({
       marketId,
-      history: history.reverse().map((point) => ({
+      history: history.map((point) => ({
         id: point.id,
-        yesPrice: Number(point.yesPrice),
-        noPrice: Number(point.noPrice),
-        yesShares: Number(point.yesShares),
-        noShares: Number(point.noShares),
-        liquidity: Number(point.liquidity),
+        yesPrice: point.yesPrice,
+        noPrice: point.noPrice,
+        yesShares: point.yesShares,
+        noShares: point.noShares,
+        liquidity: point.liquidity,
         eventType: point.eventType,
         source: point.source,
         timestamp: point.createdAt.toISOString(),

--- a/apps/web/src/app/markets/perps/[ticker]/page.tsx
+++ b/apps/web/src/app/markets/perps/[ticker]/page.tsx
@@ -46,6 +46,7 @@ import {
   invalidateWalletBalance,
   useWalletBalance,
 } from '@/stores/walletBalanceStore';
+import type { MarketTimeRange } from '@/types/markets';
 
 export default function PerpDetailPage() {
   const params = useParams();
@@ -65,6 +66,7 @@ export default function PerpDetailPage() {
   const [leverage, setLeverage] = useState(10);
   const [submitting, setSubmitting] = useState(false);
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
+  const [timeRange, setTimeRange] = useState<MarketTimeRange>('ALL');
   const pageContainerRef = useRef<HTMLDivElement | null>(null);
 
   // Use centralized positions store for better caching and performance
@@ -95,7 +97,9 @@ export default function PerpDetailPage() {
   // Fetch real price history from API
   const { history: priceHistory, refresh: refreshPriceHistory } =
     usePerpHistory(ticker, {
+      limit: 1000,
       seed: market ? { currentPrice: market.currentPrice } : undefined,
+      range: timeRange,
     });
 
   // Subscribe to real-time trade and price updates for all perp markets
@@ -419,6 +423,8 @@ export default function PerpDetailPage() {
               data={priceHistory}
               currentPrice={displayPrice}
               ticker={ticker}
+              timeRange={timeRange}
+              onTimeRangeChange={setTimeRange}
             />
           </div>
 

--- a/apps/web/src/app/markets/predictions/[id]/page.tsx
+++ b/apps/web/src/app/markets/predictions/[id]/page.tsx
@@ -36,7 +36,7 @@ import type {
   PredictionTradeSSE,
 } from '@/hooks/usePredictionMarketStream';
 import { usePredictionMarketStream } from '@/hooks/usePredictionMarketStream';
-import type { PredictionMarket } from '@/types/markets';
+import type { MarketTimeRange, PredictionMarket } from '@/types/markets';
 
 /**
  * Extended prediction market with detail page specific fields.
@@ -71,6 +71,7 @@ export default function PredictionDetailPage() {
     []
   );
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
+  const [timeRange, setTimeRange] = useState<MarketTimeRange>('ALL');
   const pageContainerRef = useRef<HTMLDivElement | null>(null);
 
   const recalculatePositionMetrics = useCallback(
@@ -149,7 +150,9 @@ export default function PredictionDetailPage() {
   );
   const { history: priceHistory, refresh: refreshPriceHistory } =
     usePredictionHistory(marketId ?? null, {
+      limit: 1000,
       seed: historySeed,
+      range: timeRange,
     });
   const amountNum = Number.parseFloat(amount) || 0;
   const calculation =
@@ -484,6 +487,8 @@ export default function PredictionDetailPage() {
             <PredictionProbabilityChart
               data={priceHistory}
               marketId={marketId}
+              timeRange={timeRange}
+              onTimeRangeChange={setTimeRange}
               showBrush={true}
             />
           </div>

--- a/apps/web/src/components/markets/PerpPriceChart.tsx
+++ b/apps/web/src/components/markets/PerpPriceChart.tsx
@@ -9,6 +9,7 @@ import {
   formatChartTime,
   useLightweightChart,
 } from '@/components/charts/LightweightChartBase';
+import { MARKET_TIME_RANGES, type MarketTimeRange } from '@/types/markets';
 
 /**
  * Price point structure for chart data.
@@ -38,16 +39,13 @@ interface PerpPriceChartProps {
   currentPrice: number;
   /** Market ticker symbol */
   ticker: string;
+  /** Selected time range */
+  timeRange: MarketTimeRange;
+  /** Time range selection handler */
+  onTimeRangeChange: (range: MarketTimeRange) => void;
   /** Whether to show brush selector (unused, for future) */
   showBrush?: boolean;
 }
-
-/**
- * Time range options for chart filtering.
- */
-type TimeRange = '1H' | '4H' | '1D' | '1W' | 'ALL';
-
-const TIME_RANGES: TimeRange[] = ['1H', '4H', '1D', '1W', 'ALL'];
 
 /**
  * Perpetual price chart using TradingView Lightweight Charts.
@@ -71,8 +69,9 @@ export function PerpPriceChart({
   data,
   currentPrice,
   ticker,
+  timeRange,
+  onTimeRangeChange,
 }: PerpPriceChartProps) {
-  const [timeRange, setTimeRange] = useState<TimeRange>('ALL');
   const [chartInitError, setChartInitError] = useState<string | null>(null);
   const priceSeries = useRef<ISeriesApi<'Area'> | null>(null);
   const lastPriceLineRef = useRef<ReturnType<
@@ -107,7 +106,7 @@ export function PerpPriceChart({
     let filtered = validData;
     if (timeRange !== 'ALL') {
       const now = Date.now();
-      const ranges: Record<TimeRange, number> = {
+      const ranges: Record<MarketTimeRange, number> = {
         '1H': 60 * 60 * 1000,
         '4H': 4 * 60 * 60 * 1000,
         '1D': 24 * 60 * 60 * 1000,
@@ -316,10 +315,10 @@ export function PerpPriceChart({
 
         {/* Time range selector */}
         <div className="flex items-center gap-1 rounded-md bg-muted/30 p-1">
-          {TIME_RANGES.map((range) => (
+          {MARKET_TIME_RANGES.map((range) => (
             <button
               key={range}
-              onClick={() => setTimeRange(range)}
+              onClick={() => onTimeRangeChange(range)}
               className={`cursor-pointer rounded px-2 py-1 text-xs transition-colors ${
                 timeRange === range
                   ? 'bg-primary text-primary-foreground'

--- a/apps/web/src/components/markets/PredictionProbabilityChart.tsx
+++ b/apps/web/src/components/markets/PredictionProbabilityChart.tsx
@@ -9,6 +9,7 @@ import {
   LINE_STYLES,
   useLightweightChart,
 } from '@/components/charts/LightweightChartBase';
+import { MARKET_TIME_RANGES, type MarketTimeRange } from '@/types/markets';
 
 /**
  * Price point structure for prediction chart data.
@@ -40,16 +41,13 @@ interface PredictionProbabilityChartProps {
   data: PricePoint[];
   /** Market identifier for keying */
   marketId: string;
+  /** Selected time range */
+  timeRange: MarketTimeRange;
+  /** Time range selection handler */
+  onTimeRangeChange: (range: MarketTimeRange) => void;
   /** Whether to show brush selector (unused, for future) */
   showBrush?: boolean;
 }
-
-/**
- * Time range options for chart filtering.
- */
-type TimeRange = '1H' | '4H' | '1D' | '1W' | 'ALL';
-
-const TIME_RANGES: TimeRange[] = ['1H', '4H', '1D', '1W', 'ALL'];
 
 /**
  * Prediction probability chart using TradingView Lightweight Charts.
@@ -72,8 +70,9 @@ const TIME_RANGES: TimeRange[] = ['1H', '4H', '1D', '1W', 'ALL'];
 export function PredictionProbabilityChart({
   data,
   marketId,
+  timeRange,
+  onTimeRangeChange,
 }: PredictionProbabilityChartProps) {
-  const [timeRange, setTimeRange] = useState<TimeRange>('ALL');
   const [chartInitError, setChartInitError] = useState<string | null>(null);
   const yesSeries = useRef<ISeriesApi<'Area'> | null>(null);
   const noSeries = useRef<ISeriesApi<'Line'> | null>(null);
@@ -109,7 +108,7 @@ export function PredictionProbabilityChart({
     let filtered = validData;
     if (timeRange !== 'ALL') {
       const now = Date.now();
-      const ranges: Record<TimeRange, number> = {
+      const ranges: Record<MarketTimeRange, number> = {
         '1H': 60 * 60 * 1000,
         '4H': 4 * 60 * 60 * 1000,
         '1D': 24 * 60 * 60 * 1000,
@@ -300,10 +299,10 @@ export function PredictionProbabilityChart({
 
         {/* Time range selector */}
         <div className="flex items-center gap-1 rounded-md bg-muted/30 p-1">
-          {TIME_RANGES.map((range) => (
+          {MARKET_TIME_RANGES.map((range) => (
             <button
               key={range}
-              onClick={() => setTimeRange(range)}
+              onClick={() => onTimeRangeChange(range)}
               className={`cursor-pointer rounded px-2 py-1 text-xs transition-colors ${
                 timeRange === range
                   ? 'bg-primary text-primary-foreground'

--- a/apps/web/src/hooks/usePerpHistory.ts
+++ b/apps/web/src/hooks/usePerpHistory.ts
@@ -6,6 +6,7 @@ import {
   type PerpTradeSSE,
   usePerpMarketStream,
 } from '@/hooks/usePerpMarketStream';
+import type { MarketTimeRange } from '@/types/markets';
 
 /**
  * Represents a single point in perpetual market price history.
@@ -37,6 +38,8 @@ interface SeedSnapshot {
 interface UsePerpHistoryOptions {
   /** Maximum number of history points to keep (default: 200) */
   limit?: number;
+  /** Optional server-side time range filter/downsampling */
+  range?: MarketTimeRange;
   /** Seed data to use if API fails or returns no data */
   seed?: SeedSnapshot;
 }
@@ -73,6 +76,7 @@ export function usePerpHistory(
   options?: UsePerpHistoryOptions
 ) {
   const limit = options?.limit ?? 200;
+  const range = options?.range;
   const seedRef = useRef<SeedSnapshot | undefined>(options?.seed);
   const [history, setHistory] = useState<PerpHistoryPoint[]>([]);
   const [loading, setLoading] = useState(false);
@@ -262,8 +266,12 @@ export function usePerpHistory(
     setError(null);
 
     try {
+      const params = new URLSearchParams({ limit: String(limit) });
+      if (range) {
+        params.set('range', range);
+      }
       const response = await fetch(
-        `/api/markets/perps/${encodeURIComponent(ticker)}/history?limit=${limit}`
+        `/api/markets/perps/${encodeURIComponent(ticker)}/history?${params.toString()}`
       );
 
       let data: unknown = null;
@@ -317,7 +325,7 @@ export function usePerpHistory(
     } finally {
       setLoading(false);
     }
-  }, [ticker, limit, formatHistory, fallbackFromSeed]);
+  }, [ticker, limit, range, formatHistory, fallbackFromSeed]);
 
   useEffect(() => {
     void fetchHistory();

--- a/apps/web/src/hooks/usePredictionHistory.ts
+++ b/apps/web/src/hooks/usePredictionHistory.ts
@@ -2,6 +2,7 @@ import { logger } from '@babylon/shared';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { usePredictionMarketStream } from '@/hooks/usePredictionMarketStream';
+import type { MarketTimeRange } from '@/types/markets';
 
 /**
  * Represents a single point in prediction market price history.
@@ -37,6 +38,8 @@ interface SeedSnapshot {
 interface UsePredictionHistoryOptions {
   /** Maximum number of history points to keep (default: 200) */
   limit?: number;
+  /** Optional server-side time range filter/downsampling */
+  range?: MarketTimeRange;
   /** Seed data to use if API fails or returns no data */
   seed?: SeedSnapshot;
 }
@@ -73,6 +76,7 @@ export function usePredictionHistory(
   options?: UsePredictionHistoryOptions
 ) {
   const limit = options?.limit ?? 100;
+  const range = options?.range;
   const seedRef = useRef<SeedSnapshot | undefined>(options?.seed);
   const [history, setHistory] = useState<PredictionHistoryPoint[]>([]);
   const [loading, setLoading] = useState(false);
@@ -192,8 +196,12 @@ export function usePredictionHistory(
     setError(null);
 
     try {
+      const params = new URLSearchParams({ limit: String(limit) });
+      if (range) {
+        params.set('range', range);
+      }
       const response = await fetch(
-        `/api/markets/predictions/${encodeURIComponent(marketId)}/history?limit=${limit}`
+        `/api/markets/predictions/${encodeURIComponent(marketId)}/history?${params.toString()}`
       );
 
       let data: unknown = null;
@@ -244,7 +252,7 @@ export function usePredictionHistory(
     } finally {
       setLoading(false);
     }
-  }, [marketId, limit, formatHistory, fallbackFromSeed]);
+  }, [marketId, limit, range, formatHistory, fallbackFromSeed]);
 
   // Fetch history on mount and when marketId changes
   useEffect(() => {

--- a/apps/web/src/types/markets.ts
+++ b/apps/web/src/types/markets.ts
@@ -209,6 +209,19 @@ export interface DisplayPerpPosition {
 // =============================================================================
 
 /**
+ * Supported time ranges for market charts and history queries.
+ */
+export type MarketTimeRange = '1H' | '4H' | '1D' | '1W' | 'ALL';
+
+export const MARKET_TIME_RANGES: MarketTimeRange[] = [
+  '1H',
+  '4H',
+  '1D',
+  '1W',
+  'ALL',
+];
+
+/**
  * Price point for perp price charts.
  */
 export interface PerpHistoryPoint {

--- a/packages/engine/src/game-tick.ts
+++ b/packages/engine/src/game-tick.ts
@@ -24,7 +24,7 @@ import {
   type JsonValue,
   lte,
   markets as marketsSchema,
-  organizations,
+  organizationState,
   perpMarketSnapshots,
   perpPositions,
   pools,
@@ -2859,15 +2859,15 @@ export async function updateMarketPricesFromTrades(
   if (selected.length === 0) return 0;
 
   const orgIds = [...new Set(selected.map((s) => s.organizationId))];
-  const orgs = await db
+  const orgStates = await db
     .select({
-      id: organizations.id,
-      initialPrice: organizations.initialPrice,
+      id: organizationState.id,
+      basePrice: organizationState.basePrice,
     })
-    .from(organizations)
-    .where(inArray(organizations.id, orgIds));
+    .from(organizationState)
+    .where(inArray(organizationState.id, orgIds));
   const initialByOrgId = new Map(
-    orgs.map((o) => [o.id, Number(o.initialPrice ?? 100)])
+    orgStates.map((o) => [o.id, Number(o.basePrice ?? 100)])
   );
 
   const tickers = selected.map((s) => s.ticker);
@@ -2894,7 +2894,13 @@ export async function updateMarketPricesFromTrades(
 
   const updates = selected
     .map((snap) => {
-      const initialPrice = initialByOrgId.get(snap.organizationId) ?? 100;
+      const basePrice = initialByOrgId.get(snap.organizationId);
+      const initialPrice =
+        typeof basePrice === 'number' &&
+        Number.isFinite(basePrice) &&
+        basePrice > 0
+          ? basePrice
+          : Number(snap.currentPrice ?? 100);
       const currentPrice = Number(snap.currentPrice ?? initialPrice);
       const netHoldings = holdingsByTicker.get(snap.ticker) ?? 0;
 
@@ -3717,18 +3723,19 @@ export async function simulateMarketVolatility(): Promise<number> {
       return 0;
     }
 
-    // Get organization initial prices for bounds
+    // Get organization base prices for bounds (do not depend on the legacy Organization table)
     const orgIds = [...new Set(markets.map((m) => m.organizationId))];
-    const orgs = await db
+    const orgStates = await db
       .select({
-        id: organizations.id,
-        initialPrice: organizations.initialPrice,
-        currentPrice: organizations.currentPrice,
+        id: organizationState.id,
+        basePrice: organizationState.basePrice,
       })
-      .from(organizations)
-      .where(inArray(organizations.id, orgIds));
+      .from(organizationState)
+      .where(inArray(organizationState.id, orgIds));
 
-    const orgMap = new Map(orgs.map((o) => [o.id, o]));
+    const basePriceByOrgId = new Map(
+      orgStates.map((o) => [o.id, Number(o.basePrice ?? 100)])
+    );
 
     let updatedCount = 0;
     const priceUpdates: Array<{
@@ -3738,11 +3745,14 @@ export async function simulateMarketVolatility(): Promise<number> {
     }> = [];
 
     for (const market of markets) {
-      const org = orgMap.get(market.organizationId);
-      if (!org) continue;
-
       const currentPrice = Number(market.currentPrice);
-      const initialPrice = Number(org.initialPrice ?? 100);
+      const basePrice = basePriceByOrgId.get(market.organizationId);
+      const initialPrice =
+        typeof basePrice === 'number' &&
+        Number.isFinite(basePrice) &&
+        basePrice > 0
+          ? basePrice
+          : currentPrice;
 
       // Get or initialize volatility state for this market
       let state = marketVolatilityState.get(market.ticker);

--- a/packages/engine/src/services/price-update-service.ts
+++ b/packages/engine/src/services/price-update-service.ts
@@ -93,38 +93,51 @@ export class PriceUpdateService {
         continue;
       }
 
+      const orgId = update.organizationId;
+
+      // Prefer OrganizationState as the source of truth for dynamic pricing.
+      // The `Organization` table is not guaranteed to be seeded in all envs.
+      const [state] = await db
+        .select({
+          id: organizationState.id,
+          currentPrice: organizationState.currentPrice,
+          basePrice: organizationState.basePrice,
+        })
+        .from(organizationState)
+        .where(eq(organizationState.id, orgId))
+        .limit(1);
+
+      // Best-effort: keep `Organization.currentPrice` in sync if the row exists.
       const [organization] = await db
         .select({
           id: organizations.id,
           currentPrice: organizations.currentPrice,
         })
         .from(organizations)
-        .where(eq(organizations.id, update.organizationId))
+        .where(eq(organizations.id, orgId))
         .limit(1);
 
-      if (!organization) {
-        logger.warn(
-          'Organization not found for price update',
-          { organizationId: update.organizationId },
-          'PriceUpdateService'
-        );
-        continue;
-      }
-
-      const oldPrice = Number(organization.currentPrice ?? update.newPrice);
+      const oldPriceCandidate =
+        organization?.currentPrice ??
+        state?.currentPrice ??
+        state?.basePrice ??
+        update.newPrice;
+      const oldPrice = Number(oldPriceCandidate ?? update.newPrice);
       const change = update.newPrice - oldPrice;
       const changePercent = oldPrice === 0 ? 0 : (change / oldPrice) * 100;
 
-      await db
-        .update(organizations)
-        .set({ currentPrice: update.newPrice, updatedAt: now })
-        .where(eq(organizations.id, organization.id));
+      if (organization) {
+        await db
+          .update(organizations)
+          .set({ currentPrice: update.newPrice, updatedAt: now })
+          .where(eq(organizations.id, organization.id));
+      }
 
       // Keep runtime price state in sync (used across engine + widgets)
       await db
         .insert(organizationState)
         .values({
-          id: organization.id,
+          id: orgId,
           currentPrice: update.newPrice,
           updatedAt: now,
         })
@@ -134,16 +147,16 @@ export class PriceUpdateService {
         });
 
       await getDbInstance().recordPriceUpdate(
-        organization.id,
+        orgId,
         update.newPrice,
         change,
         changePercent
       );
 
-      priceMap.set(organization.id, update.newPrice);
+      priceMap.set(orgId, update.newPrice);
 
       appliedUpdates.push({
-        organizationId: organization.id,
+        organizationId: orgId,
         oldPrice,
         newPrice: update.newPrice,
         change,


### PR DESCRIPTION
## Summary
- Fix perp price updates + `StockPrice` history recording when the legacy `Organization` table isn’t seeded (staging was effectively running with `organizations` empty).
- Make market history endpoints time-range aware (`range=1H|4H|1D|1W|ALL`) and add lightweight server-side downsampling so charts show meaningful series instead of “minutes”.
- Wire chart time-range selector to refetch history (perps + predictions), so switching ranges actually updates the displayed data.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Tester feedback: markets looked static (~0% change), charts appeared to span only minutes even when selecting 1W, and prediction history sometimes rendered as a single point.

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

**Non-goals / follow-ups**
- NPC prediction trading volume + ensuring prediction history is continuously generated for new markets.
- Trade count accuracy / presentation (possible aggregation/definition mismatch in UI endpoints).
- Narrative → market coupling (events producing modifiers is not yet fully materialized into price history).

## Changes
- Engine: `PriceUpdateService` no longer requires an `organizations` row to persist updates; it uses `organizationState` as source of truth and always records `StockPrice`.
- Engine: perps trade-driven recomputation + volatility simulation now use `organizationState.basePrice` (with safe fallbacks) instead of querying `organizations`.
- Web API: perps + predictions history endpoints accept `range` and can downsample to a reasonable number of points.
- Web UI: charts are controlled by a shared `MarketTimeRange` and trigger a refetch when the user selects a new range.

## Review guide
**Start here**
- `packages/engine/src/services/price-update-service.ts`
- `packages/engine/src/game-tick.ts`
- `apps/web/src/app/api/markets/perps/[ticker]/history/route.ts`
- `apps/web/src/app/api/markets/predictions/[id]/history/route.ts`
- `apps/web/src/hooks/usePerpHistory.ts` / `apps/web/src/hooks/usePredictionHistory.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- `OrganizationState` is treated as the pricing source of truth; `Organization.currentPrice` is updated best-effort when present.
- History APIs keep response shape stable; only adds optional `range` query param and downsampling behavior.

## Test plan
**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Open a perp market detail page and switch ranges (1H/4H/1D/1W/ALL). Confirm the network request includes `range=` and the chart span changes.
2. Wait for a few ticks and confirm `StockPrice` history accumulates (chart gains points) and prices move (via volatility simulation and/or trades).
3. Open a prediction market detail page and switch ranges; confirm it refetches `/api/markets/predictions/:id/history?range=...` and the chart updates.

## Ops / Migration / Deployment
- [ ] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**DB / data migration**
- None (behavioral change only). Note: `StockPrice` will start accumulating in envs where it was previously empty due to the missing `Organization` rows.

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- Adds optional `range` query param to:
  - `/api/markets/perps/:ticker/history`
  - `/api/markets/predictions/:id/history`

### Database
- Relies on `organizationState` for pricing state; `Organization` row is now optional.
- Ensures `StockPrice` writes happen consistently when prices change.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes
- Reason: No layout/style changes; the UX improvement is data-driven (range selection now refetches + history is no longer “minutes”). Please verify via the manual steps above on staging where the history series is non-empty.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed perp price history pipeline and made market charts time-range aware by decoupling pricing state from the legacy `Organization` table and implementing server-side downsampling.

**Key changes:**
- **Engine**: `PriceUpdateService` and `game-tick.ts` now query `organizationState` as the source of truth for pricing, with the `Organization` table updated best-effort when present. This fixes the issue where `StockPrice` history wasn't being recorded in staging environments where the `organizations` table was empty.
- **API**: History endpoints (`/api/markets/perps/[ticker]/history` and `/api/markets/predictions/[id]/history`) now accept an optional `range` query parameter (`1H|4H|1D|1W|ALL`) and implement server-side downsampling using time-bucketing to reduce payload size while maintaining visual fidelity.
- **Frontend**: Chart time-range state was lifted from chart components to parent pages, enabling range selection to trigger refetch with the new range parameter. This connects user interaction to server-side filtering/downsampling.

The changes maintain backward compatibility (range is optional, defaults to `ALL`), preserve response shape, and include defensive validation for price fallbacks throughout the pricing pipeline.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with careful post-deployment monitoring of price history accumulation
- Score reflects well-structured changes that solve the stated problem (static markets, missing history) with proper defensive coding. The architectural shift from `Organization` to `organizationState` as source of truth is sound and includes appropriate fallbacks. Downsampling implementation is straightforward with clear bucketing logic. Deducted one point due to: (1) medium risk from changing pricing pipeline's data source without migration path for existing `Organization`-dependent code, and (2) the downsampling logic hasn't been tested under high-volume scenarios where bucketing edge cases might emerge
- Monitor `packages/engine/src/services/price-update-service.ts` and `packages/engine/src/game-tick.ts` post-deploy to ensure `StockPrice` history accumulates correctly and prices remain stable across ticks

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/engine/src/services/price-update-service.ts | Removed hard dependency on `Organization` table, now queries `organizationState` first with fallback chain for price determination |
| packages/engine/src/game-tick.ts | Replaced `organizations` queries with `organizationState` for perp price calculations, added defensive checks for basePrice validity |
| apps/web/src/app/api/markets/perps/[ticker]/history/route.ts | Added time-range query param, downsampling logic with bucketing, and increased max limit to 2000 for fetching raw data |
| apps/web/src/app/api/markets/predictions/[id]/history/route.ts | Added time-range filtering and downsampling similar to perps endpoint, using most recent point per bucket |
| apps/web/src/app/api/markets/perps/_adapters.ts | Updated `applyUserTradePriceImpact` to query `organizationState` instead of `organizations`, matching engine changes |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Page as Market Detail Page
    participant Hook as useHistory Hook
    participant API as History API Route
    participant DB as Database
    participant Engine as PriceUpdateService

    Note over User,Engine: Time-Range Aware Chart Flow

    User->>Page: Select time range (1H/4H/1D/1W/ALL)
    Page->>Page: Update timeRange state
    Page->>Hook: Trigger refetch with new range
    Hook->>API: GET /api/markets/.../history?range=1W&limit=1000
    
    API->>DB: Query stockPrices/predictionPriceHistories
    Note over API,DB: Fetch 10x points when range specified<br/>(e.g., 5000 raw points for downsampling)
    DB-->>API: Raw price history data
    
    API->>API: downsampleStockPrices(rawData, limit)
    Note over API: Bucket data by time intervals<br/>(1m, 5m, 15m, 1h, etc.)<br/>Select optimal bucket size
    API-->>Hook: Downsampled history points
    
    Hook->>Page: Update history state
    Page->>User: Render updated chart with new range

    Note over User,Engine: Price Update Pipeline (Fixed)

    Engine->>DB: Query organizationState for basePrice
    Note over Engine,DB: No longer requires Organization table<br/>Uses organizationState as source of truth
    DB-->>Engine: basePrice + currentPrice
    
    Engine->>DB: Calculate new price from trades/volatility
    Engine->>DB: Update organizationState.currentPrice
    Engine->>DB: recordPriceUpdate() → stockPrices
    Note over Engine,DB: StockPrice history now accumulates<br/>even when Organization table is empty
    
    Engine->>API: Broadcast price update via SSE
    API->>Page: Real-time price update
    Page->>Page: Append new point to chart
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interactive time-range filters (1H, 4H, 1D, 1W, ALL) to market and prediction history charts with server-side downsampling for improved performance.
  * Increased maximum history data points from 1,000 to 2,000.
  * Charts now display OHLCV-style price metrics when time ranges are applied.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->