### PR TITLE
Fix prediction markets: restore NPC trading + realtime broadcasts

### DIFF
--- a/packages/engine/src/MarketDecisionEngine.ts
+++ b/packages/engine/src/MarketDecisionEngine.ts
@@ -671,6 +671,7 @@ Current Focus: ${recentTopics || 'Market General'}
     let prompt = renderPrompt(npcMarketDecisions, {
       examples,
       marketTable,
+      npcCount: contexts.length.toString(),
       npcsList,
       validNpcIds,
       validTickers,

--- a/packages/engine/src/prompts/trading/npc-market-decisions.ts
+++ b/packages/engine/src/prompts/trading/npc-market-decisions.ts
@@ -234,6 +234,9 @@ export const npcMarketDecisions = definePrompt({
 === ONGOING NARRATIVES ===
 {{ongoingNarrativesContext}}
 
+=== MARKET SNAPSHOT (Perps + Predictions) ===
+{{marketTable}}
+
 EXAMPLES:
 {{examples}}
 

--- a/packages/engine/src/services/trade-execution-service.ts
+++ b/packages/engine/src/services/trade-execution-service.ts
@@ -20,6 +20,7 @@ import {
   eq,
   gte,
   isNull,
+  type JsonValue,
   npcTrades,
   organizationState,
   perpPositions,
@@ -43,6 +44,7 @@ import {
   type TradeImpactInput,
 } from './market-impact-service';
 import { createNpcWalletAdapter } from './npc-wallet-adapter';
+import { broadcastToChannel } from './realtime-broadcaster';
 import { StaticDataRegistry } from './static-data-registry';
 import { invalidateAfterPredictionTrade } from './trade-cache-invalidation';
 
@@ -323,11 +325,11 @@ export class TradeExecutionService {
 
   private createPredictionBroadcast() {
     return {
-      emit: async (_channel: string, payload: Record<string, unknown>) => {
+      emit: async (channel: string, payload: Record<string, unknown>) => {
         if (!isPredictionBroadcastPayload(payload)) return;
 
-        // Broadcast events are handled by the service's internal broadcast mechanism
-        // The payload is logged for debugging purposes
+        await broadcastToChannel(channel, payload as Record<string, JsonValue>);
+
         logger.debug('Prediction broadcast event', {
           type: payload.type,
           marketId: payload.marketId,


### PR DESCRIPTION
## Summary
- Restore NPC activity in prediction markets by exposing real market IDs/prices to the trading LLM prompt.
- Broadcast NPC prediction trade events to the realtime channel so UIs can react without polling.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Testers reported prediction market charts often render as a single point / no real series.
- Staging DB investigation showed **0 prediction trades** in the last 24h (only resolution snapshots), meaning there was no data to chart.
- Root cause: NPC trading prompt did not include a market snapshot section with prediction `marketId`s, so the LLM had no valid IDs to trade.

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

**Non-goals / follow-ups**
- If we still see low prediction volume, add an explicit heuristic fallback (small random/contrarian trades) independent of LLM output.
- Improve attribution: core prediction service currently emits/records `source: user_trade`; follow-up could allow `npc_trade` snapshots.

## Changes
- Add `{{marketTable}}` into the `npc-market-decisions` prompt so the LLM can reference valid prediction IDs.
- Always pass `npcCount` into `renderPrompt` to avoid leaving `{{npcCount}}` unresolved in the prompt.
- Wire NPC prediction trade broadcasts through engine realtime broadcaster (so `prediction_trade`/`prediction_resolution` can reach UIs).

## Review guide
**Start here**
- `packages/engine/src/prompts/trading/npc-market-decisions.ts`
- `packages/engine/src/MarketDecisionEngine.ts`
- `packages/engine/src/services/trade-execution-service.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- This PR doesn’t change market math; it only restores the ability for NPCs to generate valid prediction trades by providing market IDs.

## Test plan
**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification (after deploy)**
1. Let `npc-tick` run for a few minutes.
2. Verify `NPCTrade` has new rows with `marketType=prediction`.
3. Verify `PredictionPriceHistory` gains new `eventType=trade` rows for active markets.
4. Open a prediction market detail page and confirm the chart shows an actual series.

## Ops / Migration / Deployment
- [ ] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option B: No visual changes
- Reason: Backend-only change; expected UI impact is via increased prediction trade/historical data after ticks run.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * NPCs now receive expanded context information in their market decision prompts.
  * Market snapshot data (perpetuals and predictions) integrated into decision-making templates.
  * Enhanced prediction data broadcasting system implemented.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes NPC prediction market trading by providing the LLM with actual market IDs and enabling realtime UI updates.

**Key Changes:**
- Added `{{marketTable}}` to the `npc-market-decisions` prompt template, exposing prediction market IDs and prices to the LLM
- Added missing `npcCount` parameter to `renderPrompt` call to resolve template variable
- Wired NPC prediction trades to realtime broadcaster so UIs receive `prediction_trade` events via SSE

**Impact:**
The root cause was that the LLM had no valid prediction market IDs to reference in its trading decisions, resulting in 0 NPC prediction trades and empty chart data. This fix restores NPC market activity and enables reactive UI updates.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are surgical and well-scoped: (1) adding a template variable that was already being generated but not passed to the prompt, (2) adding a missing parameter that was already being used in the template, and (3) replacing a no-op comment with an actual broadcast call. All three changes restore intended behavior without modifying core trading logic or market math. The variables are already marked as optional in the prompt loader, and `broadcastToChannel` gracefully handles missing broadcast functions.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/engine/src/prompts/trading/npc-market-decisions.ts | Added `{{marketTable}}` template variable to expose market snapshot (perps + predictions) to the LLM trading prompt |
| packages/engine/src/MarketDecisionEngine.ts | Added `npcCount` parameter to `renderPrompt` call to resolve unsubstituted template variable |
| packages/engine/src/services/trade-execution-service.ts | Wired NPC prediction trades to realtime broadcaster by calling `broadcastToChannel` instead of no-op comment |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant NPC as NPC Trading System
    participant MDE as MarketDecisionEngine
    participant Prompt as npc-market-decisions
    participant LLM as LLM (Trading AI)
    participant TES as TradeExecutionService
    participant PMS as PredictionMarketService
    participant RTB as RealtimeBroadcaster
    participant UI as UI Clients

    Note over NPC,UI: NPC Prediction Market Fix Flow

    NPC->>MDE: generateDecisions(contexts)
    activate MDE
    
    MDE->>MDE: formatMarketTable(contexts)
    Note right of MDE: Includes both perp<br/>and prediction markets<br/>with IDs and prices
    
    MDE->>Prompt: renderPrompt(npcMarketDecisions, {<br/>  marketTable,<br/>  npcCount,<br/>  ...other vars<br/>})
    Note right of Prompt: FIX: marketTable now<br/>included in prompt<br/>FIX: npcCount resolves<br/>{{npcCount}} placeholder
    
    Prompt-->>MDE: Rendered prompt with<br/>prediction market IDs
    
    MDE->>LLM: Generate trading decisions<br/>with market snapshot
    
    LLM-->>MDE: Decisions including<br/>buy_yes/buy_no with<br/>valid marketId
    
    MDE-->>NPC: TradingDecision[]
    deactivate MDE
    
    NPC->>TES: executeDecisionBatch(decisions)
    activate TES
    
    loop For each prediction trade
        TES->>TES: executeSingleDecision(decision)
        TES->>PMS: buy({userId, marketId, side, amount})
        activate PMS
        
        PMS->>PMS: Execute trade logic<br/>(update shares, prices)
        
        PMS->>TES: emit(channel, payload)
        Note right of PMS: Broadcast callback
        
        TES->>RTB: broadcastToChannel(channel, payload)
        Note right of TES: FIX: Actually broadcast<br/>instead of no-op
        
        RTB->>UI: SSE: prediction_trade event
        Note right of UI: Chart updates<br/>without polling
        
        PMS-->>TES: Trade result
        deactivate PMS
    end
    
    TES-->>NPC: Execution results
    deactivate TES
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->