### PR TITLE
feat(training): BAB-76 Enhanced Reward Signals with Market Regime Awareness

### DIFF
--- a/packages/training/python/config/reward_weights.yaml
+++ b/packages/training/python/config/reward_weights.yaml
@@ -1,0 +1,100 @@
+# Reward Weight Configuration for Enhanced Training Signals
+#
+# This file defines the weight distribution for the enhanced composite reward
+# function. Adjust these to experiment with different training objectives.
+#
+# Each weight set must sum to 1.0 for proper normalization.
+#
+# Components:
+#   regime_pnl      - P&L adjusted for market conditions (bull/bear/sideways)
+#   skill_alpha     - Counterfactual alpha (actual vs expected performance)
+#   temporal_bonus  - Credit from delayed reward attribution
+#   format          - Response format quality (valid JSON, proper structure)
+#   reasoning       - Quality of LLM reasoning traces
+#   behavior        - Archetype-aligned behavior bonuses
+#
+# Design principles:
+# 1. skill_alpha rewards genuine trading skill over market luck
+# 2. regime_pnl provides market-adjusted performance signal
+# 3. format/reasoning ensure response quality baseline
+# 4. behavior drives archetype personality expression
+
+# Default weights (balanced, emphasizes skill)
+default:
+  regime_pnl: 0.35
+  skill_alpha: 0.20
+  temporal_bonus: 0.05
+  format: 0.15
+  reasoning: 0.10
+  behavior: 0.15
+
+# High-skill emphasis (for models with good format/reasoning already)
+skill_focused:
+  regime_pnl: 0.30
+  skill_alpha: 0.30
+  temporal_bonus: 0.10
+  format: 0.10
+  reasoning: 0.05
+  behavior: 0.15
+
+# Quality-focused (early training to establish good format habits)
+quality_focused:
+  regime_pnl: 0.25
+  skill_alpha: 0.15
+  temporal_bonus: 0.05
+  format: 0.25
+  reasoning: 0.15
+  behavior: 0.15
+
+# Behavior-focused (for archetype personality training)
+behavior_focused:
+  regime_pnl: 0.25
+  skill_alpha: 0.15
+  temporal_bonus: 0.05
+  format: 0.15
+  reasoning: 0.10
+  behavior: 0.30
+
+# Pure trading (minimal quality emphasis, for trading-only training)
+pure_trading:
+  regime_pnl: 0.40
+  skill_alpha: 0.30
+  temporal_bonus: 0.10
+  format: 0.10
+  reasoning: 0.05
+  behavior: 0.05
+
+# Legacy compatibility (matches old archetype_composite_reward distribution)
+# Use this when enhanced context (regime, alpha) is not available
+legacy:
+  pnl: 0.55
+  format: 0.20
+  reasoning: 0.15
+  behavior: 0.10
+  # Note: This profile omits skill_alpha and temporal_bonus
+  # The enhanced_composite_reward falls back to archetype_composite_reward
+  # when regime_overall is None
+
+# Market regime thresholds
+regime_thresholds:
+  bull: 0.05        # >5% avg increase = bull market
+  bear: -0.05       # <-5% avg decrease = bear market
+  # Between bear and bull = sideways
+
+# Expected returns by regime (for counterfactual calculation)
+regime_expected_returns:
+  bull: 0.05        # Expect +5% return in bull market
+  bear: -0.05       # Expect -5% loss in bear market
+  sideways: 0.0     # Expect flat in sideways market
+
+# Temporal credit decay
+temporal:
+  decay_rate: 0.9   # Credit weight decays by 10% per step
+  min_weight: 0.1   # Don't credit decisions below this weight
+
+# Volatility dampening
+volatility:
+  low: 2.0          # Standard deviation threshold for low volatility
+  high: 15.0        # Standard deviation threshold for high volatility
+  dampening_factor: 0.5  # Max dampening at high volatility (50% signal reduction)
+

--- a/packages/training/python/scripts/import_json_trajectories.py
+++ b/packages/training/python/scripts/import_json_trajectories.py
@@ -287,13 +287,18 @@ def import_trajectories(
     ground_truth = None
     ground_truth_path = source_dir / "ground-truth.json"
     if ground_truth_path.exists():
-        with open(ground_truth_path, "r", encoding="utf-8") as f:
-            ground_truth = json.load(f)
-        logger.info(f"Loaded ground truth from {ground_truth_path}")
-        if "priceHistory" in ground_truth:
-            logger.info(f"  - Price history for {len(ground_truth.get('priceHistory', {}))} tickers")
-        if "causalEvents" in ground_truth:
-            logger.info(f"  - {len(ground_truth.get('causalEvents', []))} causal events")
+        try:
+            with open(ground_truth_path, "r", encoding="utf-8") as f:
+                ground_truth = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.error(f"Failed to load ground truth from {ground_truth_path}: {e}")
+            ground_truth = None
+        else:
+            logger.info(f"Loaded ground truth from {ground_truth_path}")
+            if "priceHistory" in ground_truth:
+                logger.info(f"  - Price history for {len(ground_truth.get('priceHistory', {}))} tickers")
+            if "causalEvents" in ground_truth:
+                logger.info(f"  - {len(ground_truth.get('causalEvents', []))} causal events")
     
     # Get database connection (skip if dry run)
     conn = None
@@ -315,7 +320,13 @@ def import_trajectories(
             if ground_truth:
                 traj_metadata = traj_data.get("metadata", {})
                 if isinstance(traj_metadata, str):
-                    traj_metadata = json.loads(traj_metadata) if traj_metadata else {}
+                    try:
+                        traj_metadata = json.loads(traj_metadata) if traj_metadata else {}
+                    except (TypeError, json.JSONDecodeError) as e:
+                        logger.warning(
+                            f"Malformed metadata JSON for trajectory {trajectory_id}, ignoring metadata: {e}"
+                        )
+                        traj_metadata = {}
                 
                 # Build price context from ground truth
                 price_context = {}
@@ -452,4 +463,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/packages/training/python/scripts/import_json_trajectories.py
+++ b/packages/training/python/scripts/import_json_trajectories.py
@@ -283,6 +283,18 @@ def import_trajectories(
     
     logger.info(f"Found {stats.total_files} trajectory files in {traj_dir}")
     
+    # Load ground truth for enhanced rewards (if available)
+    ground_truth = None
+    ground_truth_path = source_dir / "ground-truth.json"
+    if ground_truth_path.exists():
+        with open(ground_truth_path, "r", encoding="utf-8") as f:
+            ground_truth = json.load(f)
+        logger.info(f"Loaded ground truth from {ground_truth_path}")
+        if "priceHistory" in ground_truth:
+            logger.info(f"  - Price history for {len(ground_truth.get('priceHistory', {}))} tickers")
+        if "causalEvents" in ground_truth:
+            logger.info(f"  - {len(ground_truth.get('causalEvents', []))} causal events")
+    
     # Get database connection (skip if dry run)
     conn = None
     if not dry_run:
@@ -298,6 +310,37 @@ def import_trajectories(
             # Handle wrapped format (trajectory key) vs direct format
             traj_data = data.get("trajectory", data)
             trajectory_id = traj_data.get("trajectoryId", file_path.stem)
+            
+            # Merge ground truth into metadata for enhanced rewards
+            if ground_truth:
+                traj_metadata = traj_data.get("metadata", {})
+                if isinstance(traj_metadata, str):
+                    traj_metadata = json.loads(traj_metadata) if traj_metadata else {}
+                
+                # Build price context from ground truth
+                price_context = {}
+                if "priceHistory" in ground_truth:
+                    # Extract initial and final prices from history
+                    initial_prices = {}
+                    final_prices = {}
+                    for ticker, history in ground_truth["priceHistory"].items():
+                        if history and len(history) > 0:
+                            initial_prices[ticker] = history[0]
+                            final_prices[ticker] = history[-1]
+                    price_context["initial_prices"] = initial_prices
+                    price_context["final_prices"] = final_prices
+                    price_context["price_history"] = ground_truth["priceHistory"]
+                
+                # Include causal events for reference
+                if "causalEvents" in ground_truth:
+                    price_context["causal_events"] = ground_truth["causalEvents"]
+                
+                traj_metadata["ground_truth"] = {
+                    "initialPrices": price_context.get("initial_prices", {}),
+                    "finalPrices": price_context.get("final_prices", {}),
+                    "priceHistory": ground_truth.get("priceHistory", {}),
+                }
+                traj_data["metadata"] = traj_metadata
             
             # Validate
             is_valid, issues = validate_trajectory(traj_data)

--- a/packages/training/python/src/data_bridge/reader.py
+++ b/packages/training/python/src/data_bridge/reader.py
@@ -232,8 +232,13 @@ class JsonTrajectoryReader:
             gt_path = self._directory.parent / "ground-truth.json"
         
         if gt_path.exists():
-            with open(gt_path, "r", encoding="utf-8") as f:
-                self._ground_truth = json.load(f)
+            try:
+                with open(gt_path, "r", encoding="utf-8") as f:
+                    self._ground_truth = json.load(f)
+            except (OSError, json.JSONDecodeError) as e:
+                logger.warning(f"Failed to load ground truth from {gt_path}: {e}")
+                self._ground_truth = None
+                return
             logger.info(f"Loaded ground truth from {gt_path}")
     
     def _build_price_context(self) -> Dict:
@@ -276,7 +281,13 @@ class JsonTrajectoryReader:
                 if price_context:
                     metadata = trajectory_data.get("metadata", {})
                     if isinstance(metadata, str):
-                        metadata = json.loads(metadata) if metadata else {}
+                        try:
+                            metadata = json.loads(metadata) if metadata else {}
+                        except json.JSONDecodeError as e:
+                            logger.warning(
+                                f"Malformed metadata JSON in {file_path}, ignoring metadata: {e}"
+                            )
+                            metadata = {}
                     metadata["ground_truth"] = price_context
                     trajectory_data["metadata"] = metadata
                 

--- a/packages/training/python/src/data_bridge/reader.py
+++ b/packages/training/python/src/data_bridge/reader.py
@@ -213,23 +213,73 @@ class JsonTrajectoryReader:
     def __init__(self, directory_path: str):
         self._directory = Path(directory_path)
         self._trajectories_by_window: Dict[str, List[Dict]] = {}
+        self._ground_truth: Optional[Dict] = None
 
         if not self._directory.is_dir():
             raise FileNotFoundError(
                 f"Source directory not found: {self._directory.resolve()}")
 
+        self._load_ground_truth()
         self._scan_files()
         logger.info(
             f"Found {len(self._trajectories_by_window)} windows in {self._directory}")
+    
+    def _load_ground_truth(self):
+        """Load ground truth for enhanced rewards if available."""
+        gt_path = self._directory / "ground-truth.json"
+        if not gt_path.exists():
+            # Check parent directory (trajectories may be in subdirectory)
+            gt_path = self._directory.parent / "ground-truth.json"
+        
+        if gt_path.exists():
+            with open(gt_path, "r", encoding="utf-8") as f:
+                self._ground_truth = json.load(f)
+            logger.info(f"Loaded ground truth from {gt_path}")
+    
+    def _build_price_context(self) -> Dict:
+        """Build price context from ground truth for enhanced rewards."""
+        if not self._ground_truth:
+            return {}
+        
+        price_context = {}
+        if "priceHistory" in self._ground_truth:
+            initial_prices = {}
+            final_prices = {}
+            for ticker, history in self._ground_truth["priceHistory"].items():
+                if history and len(history) > 0:
+                    initial_prices[ticker] = history[0]
+                    final_prices[ticker] = history[-1]
+            price_context = {
+                "initialPrices": initial_prices,
+                "finalPrices": final_prices,
+                "priceHistory": self._ground_truth["priceHistory"],
+            }
+        
+        return price_context
 
     def _scan_files(self):
         file_count = 0
+        price_context = self._build_price_context()
+        
         for file_path in self._directory.glob("*.json"):
+            # Skip ground-truth.json
+            if file_path.name == "ground-truth.json":
+                continue
+            
             file_count += 1
             try:
                 with file_path.open('r', encoding='utf-8') as f:
                     data = json.load(f)
                 trajectory_data = data.get('trajectory', data)
+                
+                # Merge ground truth into metadata for enhanced rewards
+                if price_context:
+                    metadata = trajectory_data.get("metadata", {})
+                    if isinstance(metadata, str):
+                        metadata = json.loads(metadata) if metadata else {}
+                    metadata["ground_truth"] = price_context
+                    trajectory_data["metadata"] = metadata
+                
                 window_id = trajectory_data.get("windowId", "default_window")
                 if window_id not in self._trajectories_by_window:
                     self._trajectories_by_window[window_id] = []

--- a/packages/training/python/src/training/babylon_env.py
+++ b/packages/training/python/src/training/babylon_env.py
@@ -43,7 +43,18 @@ from .rewards import (
     TrajectoryRewardInputs,
     BehaviorMetrics,
     archetype_composite_reward,
+    enhanced_composite_reward,
+    compute_counterfactual,
+    TemporalCredit,
 )
+from .market_regime import (
+    MarketRegime,
+    extract_regime_from_trajectory,
+    get_expected_return,
+    detect_regime_from_prices,
+)
+from .temporal_credit import attribute_temporal_credit
+from .reward_config import get_regime_expected_return
 from .rubric_loader import has_custom_rubric, normalize_archetype
 from .tokenization_utils import tokenize_for_trainer
 from .quality_scorer import score_response
@@ -370,6 +381,33 @@ class BabylonRLAIFEnv(BaseEnv):
             self.judge_scores_buffer = []
             self.judge_format_scores = []
             self.judge_reasoning_scores = []
+        
+        # Add enhanced reward metrics (regime, alpha, temporal)
+        if hasattr(self, 'enhanced_reward_metrics') and self.enhanced_reward_metrics:
+            metrics = self.enhanced_reward_metrics
+            total_regimes = metrics['regime_bulls'] + metrics['regime_bears'] + metrics['regime_sideways']
+            
+            if total_regimes > 0:
+                wandb_metrics["train/regime_bull_pct"] = metrics['regime_bulls'] / total_regimes
+                wandb_metrics["train/regime_bear_pct"] = metrics['regime_bears'] / total_regimes
+                wandb_metrics["train/regime_sideways_pct"] = metrics['regime_sideways'] / total_regimes
+            
+            if metrics['alphas']:
+                wandb_metrics["train/counterfactual_alpha_mean"] = sum(metrics['alphas']) / len(metrics['alphas'])
+                wandb_metrics["train/counterfactual_alpha_min"] = min(metrics['alphas'])
+                wandb_metrics["train/counterfactual_alpha_max"] = max(metrics['alphas'])
+            
+            if metrics['volatilities']:
+                wandb_metrics["train/market_volatility_mean"] = sum(metrics['volatilities']) / len(metrics['volatilities'])
+            
+            # Reset for next logging interval
+            self.enhanced_reward_metrics = {
+                'regime_bulls': 0,
+                'regime_bears': 0,
+                'regime_sideways': 0,
+                'alphas': [],
+                'volatilities': [],
+            }
 
         self.judgement_samples = []  # Clear after logging
         await super().wandb_log(wandb_metrics)
@@ -752,10 +790,11 @@ You receive market updates and must analyze, reason, and then act."""
 
             # 5. Build reward inputs
             final_pnl = traj.get("final_pnl", 0.0)
+            starting_balance = 10000.0
             reward_inputs = TrajectoryRewardInputs(
                 final_pnl=final_pnl,
-                starting_balance=10000.0,
-                end_balance=10000.0 + final_pnl,
+                starting_balance=starting_balance,
+                end_balance=starting_balance + final_pnl,
                 format_score=fmt_score,
                 reasoning_score=rsn_score,
                 risky_actions_count=0,
@@ -763,12 +802,67 @@ You receive market updates and must analyze, reason, and then act."""
                 total_actions=behavior_metrics.episode_length,
             )
 
-            # 6. Compute archetype-aware composite score
-            base_score = archetype_composite_reward(
-                inputs=reward_inputs,
-                archetype=archetype_norm,
-                behavior_metrics=behavior_metrics,
-            )
+            # 6. Compute enhanced reward with regime awareness
+            # Try to extract market regime from trajectory metadata
+            regime = extract_regime_from_trajectory(traj)
+            
+            if regime is not None:
+                # Enhanced path: use regime-adjusted counterfactual reward
+                regime_expected_return = get_regime_expected_return(regime.overall)
+                
+                # Compute counterfactual alpha
+                counterfactual = compute_counterfactual(
+                    actual_pnl=final_pnl,
+                    starting_balance=starting_balance,
+                    regime_overall=regime.overall,
+                    regime_expected_return=regime_expected_return,
+                )
+                
+                # Compute temporal credits from trajectory steps
+                steps = traj.get("steps", [])
+                outcome_data = traj.get("market_outcomes", None)
+                temporal_credits = attribute_temporal_credit(
+                    steps=steps,
+                    final_pnl=final_pnl,
+                    outcome_data=outcome_data,
+                )
+                
+                # Use enhanced composite reward
+                base_score = enhanced_composite_reward(
+                    inputs=reward_inputs,
+                    archetype=archetype_norm,
+                    behavior_metrics=behavior_metrics,
+                    regime_overall=regime.overall,
+                    regime_volatility=regime.volatility,
+                    regime_expected_return=regime_expected_return,
+                    counterfactual_alpha=counterfactual.alpha,
+                    temporal_credits=temporal_credits,
+                )
+                
+                # Track enhanced metrics for W&B
+                if not hasattr(self, 'enhanced_reward_metrics'):
+                    self.enhanced_reward_metrics = {
+                        'regime_bulls': 0,
+                        'regime_bears': 0,
+                        'regime_sideways': 0,
+                        'alphas': [],
+                        'volatilities': [],
+                    }
+                if regime.overall == 'bull':
+                    self.enhanced_reward_metrics['regime_bulls'] += 1
+                elif regime.overall == 'bear':
+                    self.enhanced_reward_metrics['regime_bears'] += 1
+                else:
+                    self.enhanced_reward_metrics['regime_sideways'] += 1
+                self.enhanced_reward_metrics['alphas'].append(counterfactual.alpha)
+                self.enhanced_reward_metrics['volatilities'].append(regime.volatility)
+            else:
+                # Fallback: standard archetype composite reward
+                base_score = archetype_composite_reward(
+                    inputs=reward_inputs,
+                    archetype=archetype_norm,
+                    behavior_metrics=behavior_metrics,
+                )
             
             # 7. GRPO adjustment: Blend base score with action quality
             # For multiple completions per prompt, action quality provides variance

--- a/packages/training/python/src/training/babylon_env.py
+++ b/packages/training/python/src/training/babylon_env.py
@@ -45,16 +45,12 @@ from .rewards import (
     archetype_composite_reward,
     enhanced_composite_reward,
     compute_counterfactual,
-    TemporalCredit,
 )
 from .market_regime import (
-    MarketRegime,
     extract_regime_from_trajectory,
-    get_expected_return,
-    detect_regime_from_prices,
 )
 from .temporal_credit import attribute_temporal_credit
-from .reward_config import get_regime_expected_return
+from .reward_config import get_regime_expected_return, get_temporal_decay_rate
 from .rubric_loader import has_custom_rubric, normalize_archetype
 from .tokenization_utils import tokenize_for_trainer
 from .quality_scorer import score_response
@@ -97,6 +93,11 @@ class BabylonEnvConfig(BaseEnvConfig):
     max_steps_per_trajectory: int = Field(
         default=20,
         description="Maximum steps to include from each trajectory"
+    )
+
+    reward_weight_profile: str = Field(
+        default_factory=lambda: os.getenv("REWARD_WEIGHT_PROFILE", "default"),
+        description="Reward weight profile name from packages/training/python/config/reward_weights.yaml",
     )
 
     # RLAIF Judge settings (Legacy - kept for config compatibility)
@@ -175,6 +176,11 @@ class BabylonRLAIFEnv(BaseEnv):
         self.judge_scores_buffer: List[float] = []
         self.judge_format_scores: List[float] = []
         self.judge_reasoning_scores: List[float] = []
+        self.enhanced_reward_metrics = {
+            "regime_counts": {"bull": 0, "bear": 0, "sideways": 0},
+            "alphas": [],
+            "volatilities": [],
+        }
 
         # Evaluation suite for tracking progress
         self.eval_suite: Optional[EvaluationSuite] = None
@@ -281,7 +287,9 @@ class BabylonRLAIFEnv(BaseEnv):
                     t."windowId",
                     t."scenarioId",
                     t."stepsJson",
+                    t."metadataJson",
                     t."finalPnL",
+                    t."finalBalance",
                     t."episodeLength",
                     t."totalReward",
                     t."archetype",
@@ -326,6 +334,30 @@ class BabylonRLAIFEnv(BaseEnv):
                 )
                 archetype = 'default'
 
+            metadata = row.get("metadataJson") or {}
+            if isinstance(metadata, str):
+                try:
+                    metadata = json.loads(metadata) if metadata else {}
+                except json.JSONDecodeError as e:
+                    logger.warning(
+                        f"Malformed metadataJson for trajectory {row['trajectoryId']}: {e}"
+                    )
+                    metadata = {}
+
+            final_pnl = float(row["finalPnL"] or 0.0)
+
+            final_balance: Optional[float] = None
+            starting_balance: Optional[float] = None
+            raw_final_balance = row.get("finalBalance")
+            if raw_final_balance is not None:
+                try:
+                    final_balance = float(raw_final_balance)
+                    starting_balance = final_balance - final_pnl
+                except (TypeError, ValueError) as e:
+                    logger.warning(
+                        f"Malformed finalBalance for trajectory {row['trajectoryId']}: {e}"
+                    )
+
             groups[group_key].append({
                 'trajectory_id': row['trajectoryId'],
                 'agent_id': row['agentId'],
@@ -333,8 +365,11 @@ class BabylonRLAIFEnv(BaseEnv):
                 'window_id': row['windowId'],
                 'scenario_id': row['scenarioId'],
                 'archetype': archetype,
+                'metadata': metadata,
                 'steps': steps,
-                'final_pnl': float(row['finalPnL'] or 0),
+                'final_pnl': final_pnl,
+                'final_balance': final_balance,
+                'starting_balance': starting_balance,
                 'episode_length': row['episodeLength'] or len(steps),
                 'total_reward': float(row['totalReward'] or 0),
             })
@@ -383,28 +418,29 @@ class BabylonRLAIFEnv(BaseEnv):
             self.judge_reasoning_scores = []
         
         # Add enhanced reward metrics (regime, alpha, temporal)
-        if hasattr(self, 'enhanced_reward_metrics') and self.enhanced_reward_metrics:
-            m = self.enhanced_reward_metrics
-            counts = m['regime_counts']
-            total = sum(counts.values())
-            
+        m = self.enhanced_reward_metrics
+        counts = m["regime_counts"]
+        total = sum(counts.values())
+        has_enhanced_metrics = total > 0 or bool(m["alphas"]) or bool(m["volatilities"])
+
+        if has_enhanced_metrics:
             if total > 0:
-                for regime in ('bull', 'bear', 'sideways'):
+                for regime in ("bull", "bear", "sideways"):
                     wandb_metrics[f"train/regime_{regime}_pct"] = counts[regime] / total
-            
-            if m['alphas']:
-                wandb_metrics["train/counterfactual_alpha_mean"] = sum(m['alphas']) / len(m['alphas'])
-                wandb_metrics["train/counterfactual_alpha_min"] = min(m['alphas'])
-                wandb_metrics["train/counterfactual_alpha_max"] = max(m['alphas'])
-            
-            if m['volatilities']:
-                wandb_metrics["train/market_volatility_mean"] = sum(m['volatilities']) / len(m['volatilities'])
-            
+
+            if m["alphas"]:
+                wandb_metrics["train/counterfactual_alpha_mean"] = sum(m["alphas"]) / len(m["alphas"])
+                wandb_metrics["train/counterfactual_alpha_min"] = min(m["alphas"])
+                wandb_metrics["train/counterfactual_alpha_max"] = max(m["alphas"])
+
+            if m["volatilities"]:
+                wandb_metrics["train/market_volatility_mean"] = sum(m["volatilities"]) / len(m["volatilities"])
+
             # Reset for next logging interval
             self.enhanced_reward_metrics = {
-                'regime_counts': {'bull': 0, 'bear': 0, 'sideways': 0},
-                'alphas': [],
-                'volatilities': [],
+                "regime_counts": {"bull": 0, "bear": 0, "sideways": 0},
+                "alphas": [],
+                "volatilities": [],
             }
 
         self.judgement_samples = []  # Clear after logging
@@ -737,6 +773,8 @@ You receive market updates and must analyze, reason, and then act."""
         """
         logger.debug(f"Scoring {len(rollout_data)} rollouts with deterministic judge")
         scores = []
+        weight_profile = self.config.reward_weight_profile
+        temporal_decay_rate = get_temporal_decay_rate()
 
         for item in rollout_data:
             traj = item["trajectory"]
@@ -787,12 +825,28 @@ You receive market updates and must analyze, reason, and then act."""
             behavior_metrics = self._extract_behavior_metrics(traj)
 
             # 5. Build reward inputs
-            final_pnl = traj.get("final_pnl", 0.0)
-            starting_balance = 10000.0
+            final_pnl = float(traj.get("final_pnl", 0.0) or 0.0)
+
+            starting_balance = traj.get("starting_balance")
+            if starting_balance is None:
+                final_balance = traj.get("final_balance")
+                if final_balance is not None:
+                    try:
+                        starting_balance = float(final_balance) - final_pnl
+                    except (TypeError, ValueError):
+                        starting_balance = None
+            starting_balance = float(starting_balance) if starting_balance is not None else 10000.0
+
+            end_balance = traj.get("final_balance")
+            try:
+                end_balance = float(end_balance) if end_balance is not None else starting_balance + final_pnl
+            except (TypeError, ValueError):
+                end_balance = starting_balance + final_pnl
+
             reward_inputs = TrajectoryRewardInputs(
                 final_pnl=final_pnl,
                 starting_balance=starting_balance,
-                end_balance=starting_balance + final_pnl,
+                end_balance=end_balance,
                 format_score=fmt_score,
                 reasoning_score=rsn_score,
                 risky_actions_count=0,
@@ -823,6 +877,7 @@ You receive market updates and must analyze, reason, and then act."""
                     steps=steps,
                     final_pnl=final_pnl,
                     outcome_data=outcome_data,
+                    decay_rate=temporal_decay_rate,
                 )
                 
                 # Use enhanced composite reward
@@ -835,18 +890,13 @@ You receive market updates and must analyze, reason, and then act."""
                     regime_expected_return=regime_expected_return,
                     counterfactual_alpha=counterfactual.alpha,
                     temporal_credits=temporal_credits,
+                    weight_profile=weight_profile,
                 )
                 
                 # Track enhanced metrics for W&B
-                if not hasattr(self, 'enhanced_reward_metrics'):
-                    self.enhanced_reward_metrics = {
-                        'regime_counts': {'bull': 0, 'bear': 0, 'sideways': 0},
-                        'alphas': [],
-                        'volatilities': [],
-                    }
-                self.enhanced_reward_metrics['regime_counts'][regime.overall] += 1
-                self.enhanced_reward_metrics['alphas'].append(counterfactual.alpha)
-                self.enhanced_reward_metrics['volatilities'].append(regime.volatility)
+                self.enhanced_reward_metrics["regime_counts"][regime.overall] += 1
+                self.enhanced_reward_metrics["alphas"].append(counterfactual.alpha)
+                self.enhanced_reward_metrics["volatilities"].append(regime.volatility)
             else:
                 # Fallback: standard archetype composite reward
                 base_score = archetype_composite_reward(

--- a/packages/training/python/src/training/babylon_env.py
+++ b/packages/training/python/src/training/babylon_env.py
@@ -384,27 +384,25 @@ class BabylonRLAIFEnv(BaseEnv):
         
         # Add enhanced reward metrics (regime, alpha, temporal)
         if hasattr(self, 'enhanced_reward_metrics') and self.enhanced_reward_metrics:
-            metrics = self.enhanced_reward_metrics
-            total_regimes = metrics['regime_bulls'] + metrics['regime_bears'] + metrics['regime_sideways']
+            m = self.enhanced_reward_metrics
+            counts = m['regime_counts']
+            total = sum(counts.values())
             
-            if total_regimes > 0:
-                wandb_metrics["train/regime_bull_pct"] = metrics['regime_bulls'] / total_regimes
-                wandb_metrics["train/regime_bear_pct"] = metrics['regime_bears'] / total_regimes
-                wandb_metrics["train/regime_sideways_pct"] = metrics['regime_sideways'] / total_regimes
+            if total > 0:
+                for regime in ('bull', 'bear', 'sideways'):
+                    wandb_metrics[f"train/regime_{regime}_pct"] = counts[regime] / total
             
-            if metrics['alphas']:
-                wandb_metrics["train/counterfactual_alpha_mean"] = sum(metrics['alphas']) / len(metrics['alphas'])
-                wandb_metrics["train/counterfactual_alpha_min"] = min(metrics['alphas'])
-                wandb_metrics["train/counterfactual_alpha_max"] = max(metrics['alphas'])
+            if m['alphas']:
+                wandb_metrics["train/counterfactual_alpha_mean"] = sum(m['alphas']) / len(m['alphas'])
+                wandb_metrics["train/counterfactual_alpha_min"] = min(m['alphas'])
+                wandb_metrics["train/counterfactual_alpha_max"] = max(m['alphas'])
             
-            if metrics['volatilities']:
-                wandb_metrics["train/market_volatility_mean"] = sum(metrics['volatilities']) / len(metrics['volatilities'])
+            if m['volatilities']:
+                wandb_metrics["train/market_volatility_mean"] = sum(m['volatilities']) / len(m['volatilities'])
             
             # Reset for next logging interval
             self.enhanced_reward_metrics = {
-                'regime_bulls': 0,
-                'regime_bears': 0,
-                'regime_sideways': 0,
+                'regime_counts': {'bull': 0, 'bear': 0, 'sideways': 0},
                 'alphas': [],
                 'volatilities': [],
             }
@@ -842,18 +840,11 @@ You receive market updates and must analyze, reason, and then act."""
                 # Track enhanced metrics for W&B
                 if not hasattr(self, 'enhanced_reward_metrics'):
                     self.enhanced_reward_metrics = {
-                        'regime_bulls': 0,
-                        'regime_bears': 0,
-                        'regime_sideways': 0,
+                        'regime_counts': {'bull': 0, 'bear': 0, 'sideways': 0},
                         'alphas': [],
                         'volatilities': [],
                     }
-                if regime.overall == 'bull':
-                    self.enhanced_reward_metrics['regime_bulls'] += 1
-                elif regime.overall == 'bear':
-                    self.enhanced_reward_metrics['regime_bears'] += 1
-                else:
-                    self.enhanced_reward_metrics['regime_sideways'] += 1
+                self.enhanced_reward_metrics['regime_counts'][regime.overall] += 1
                 self.enhanced_reward_metrics['alphas'].append(counterfactual.alpha)
                 self.enhanced_reward_metrics['volatilities'].append(regime.volatility)
             else:

--- a/packages/training/python/src/training/market_regime.py
+++ b/packages/training/python/src/training/market_regime.py
@@ -1,0 +1,379 @@
+"""
+Market Regime Detection for Enhanced Reward Signals
+
+Detects market conditions (bull/bear/sideways) from price data to provide
+context-aware reward signals. This enables the training system to distinguish
+between skill and luck - a profitable trade in a crashing market is more
+impressive than one in a bull run.
+
+Key concepts:
+- Regime: Overall market direction (bull/bear/sideways)
+- Volatility: Price variance, used to dampen reward signals in noisy markets
+- Per-ticker trends: Individual asset movements for granular analysis
+"""
+
+import math
+from dataclasses import dataclass, field
+from typing import Dict, List, Literal, Optional
+
+
+# =============================================================================
+# Regime Detection Thresholds
+# =============================================================================
+
+# Overall regime thresholds (percentage change)
+BULL_THRESHOLD = 5.0    # >5% avg increase = bull market
+BEAR_THRESHOLD = -5.0   # <-5% avg decrease = bear market
+
+# Per-ticker trend thresholds
+TICKER_UP_THRESHOLD = 5.0
+TICKER_DOWN_THRESHOLD = -5.0
+
+# Volatility normalization (expected std dev range)
+VOLATILITY_LOW = 2.0    # Low volatility market
+VOLATILITY_HIGH = 15.0  # High volatility market
+
+# Regime-based expected returns for counterfactual calculation
+REGIME_EXPECTED_RETURNS: Dict[str, float] = {
+    "bull": 0.05,      # Expect +5% return in bull market
+    "bear": -0.05,     # Expect -5% loss in bear market
+    "sideways": 0.0,   # Expect flat in sideways market
+}
+
+
+# =============================================================================
+# Data Structures
+# =============================================================================
+
+@dataclass
+class MarketRegime:
+    """
+    Market condition during a trajectory's time window.
+    
+    Attributes:
+        overall: Aggregate market direction across all tracked assets
+        volatility: Normalized volatility score (0.0 = calm, 1.0 = extreme)
+        per_ticker: Individual asset trends for granular analysis
+        avg_change_pct: Average percentage change across all tickers
+        window_id: Time window this regime applies to (for caching)
+    """
+    overall: Literal["bull", "bear", "sideways"]
+    volatility: float
+    per_ticker: Dict[str, Literal["up", "down", "flat"]]
+    avg_change_pct: float = 0.0
+    window_id: Optional[str] = None
+    
+    def to_dict(self) -> Dict:
+        """Serialize for logging/storage."""
+        return {
+            "overall": self.overall,
+            "volatility": self.volatility,
+            "per_ticker": self.per_ticker,
+            "avg_change_pct": self.avg_change_pct,
+            "window_id": self.window_id,
+        }
+    
+    @classmethod
+    def from_dict(cls, data: Dict) -> "MarketRegime":
+        """Deserialize from storage."""
+        return cls(
+            overall=data["overall"],
+            volatility=data["volatility"],
+            per_ticker=data.get("per_ticker", {}),
+            avg_change_pct=data.get("avg_change_pct", 0.0),
+            window_id=data.get("window_id"),
+        )
+    
+    @classmethod
+    def default_sideways(cls) -> "MarketRegime":
+        """Create a neutral/unknown regime for fallback."""
+        return cls(
+            overall="sideways",
+            volatility=0.5,
+            per_ticker={},
+            avg_change_pct=0.0,
+            window_id=None,
+        )
+
+
+@dataclass
+class PriceContext:
+    """
+    Price data context embedded in trajectory metadata.
+    
+    This is captured at trajectory generation time to make trajectories
+    self-contained for training (no DB lookup needed).
+    """
+    initial_prices: Dict[str, float]
+    final_prices: Dict[str, float]
+    price_history: Dict[str, List[float]] = field(default_factory=dict)
+    regime: Optional[MarketRegime] = None
+    window_id: Optional[str] = None
+    
+    def to_dict(self) -> Dict:
+        """Serialize for trajectory metadata storage."""
+        return {
+            "initial_prices": self.initial_prices,
+            "final_prices": self.final_prices,
+            "price_history": self.price_history,
+            "regime": self.regime.to_dict() if self.regime else None,
+            "window_id": self.window_id,
+        }
+    
+    @classmethod
+    def from_dict(cls, data: Dict) -> "PriceContext":
+        """Deserialize from trajectory metadata."""
+        regime_data = data.get("regime")
+        return cls(
+            initial_prices=data.get("initial_prices", {}),
+            final_prices=data.get("final_prices", {}),
+            price_history=data.get("price_history", {}),
+            regime=MarketRegime.from_dict(regime_data) if regime_data else None,
+            window_id=data.get("window_id"),
+        )
+
+
+# =============================================================================
+# Regime Detection Functions
+# =============================================================================
+
+def calculate_volatility(changes: List[float]) -> float:
+    """
+    Calculate normalized volatility from a list of percentage changes.
+    
+    Uses standard deviation normalized to [0, 1] range based on expected
+    market volatility bounds.
+    
+    Args:
+        changes: List of percentage changes (e.g., [2.5, -1.0, 3.2])
+    
+    Returns:
+        Volatility score in [0, 1] range
+    """
+    if len(changes) < 2:
+        return 0.5  # Default to moderate volatility with insufficient data
+    
+    # Calculate mean
+    mean = sum(changes) / len(changes)
+    
+    # Calculate variance
+    variance = sum((x - mean) ** 2 for x in changes) / len(changes)
+    
+    # Standard deviation
+    std_dev = math.sqrt(variance)
+    
+    # Normalize to [0, 1] based on expected volatility range
+    normalized = (std_dev - VOLATILITY_LOW) / (VOLATILITY_HIGH - VOLATILITY_LOW)
+    
+    return max(0.0, min(1.0, normalized))
+
+
+def calculate_price_change_pct(initial: float, final: float) -> float:
+    """
+    Calculate percentage change between two prices.
+    
+    Args:
+        initial: Starting price
+        final: Ending price
+    
+    Returns:
+        Percentage change (e.g., 5.0 for +5%)
+    """
+    if initial <= 0:
+        return 0.0
+    return ((final - initial) / initial) * 100
+
+
+def detect_ticker_trend(change_pct: float) -> Literal["up", "down", "flat"]:
+    """
+    Classify a single ticker's trend based on percentage change.
+    
+    Args:
+        change_pct: Percentage change for the ticker
+    
+    Returns:
+        Trend classification
+    """
+    if change_pct > TICKER_UP_THRESHOLD:
+        return "up"
+    elif change_pct < TICKER_DOWN_THRESHOLD:
+        return "down"
+    return "flat"
+
+
+def detect_overall_regime(avg_change: float) -> Literal["bull", "bear", "sideways"]:
+    """
+    Classify overall market regime based on average change.
+    
+    Args:
+        avg_change: Average percentage change across all tickers
+    
+    Returns:
+        Regime classification
+    """
+    if avg_change > BULL_THRESHOLD:
+        return "bull"
+    elif avg_change < BEAR_THRESHOLD:
+        return "bear"
+    return "sideways"
+
+
+def detect_market_regime(
+    price_data: Dict[str, List[float]],
+    window_id: Optional[str] = None,
+) -> MarketRegime:
+    """
+    Detect market regime from price history data.
+    
+    This is the main entry point for regime detection. It analyzes price
+    movements across multiple tickers to determine:
+    1. Overall market direction (bull/bear/sideways)
+    2. Market volatility
+    3. Per-ticker trends
+    
+    Args:
+        price_data: Dictionary mapping ticker symbols to price history lists.
+                   Each list should be chronologically ordered (oldest first).
+                   Example: {"BTC": [100000, 105000, 110000], "ETH": [4000, 3900, 4100]}
+        window_id: Optional time window identifier for caching
+    
+    Returns:
+        MarketRegime with overall trend, volatility, and per-ticker breakdowns
+    """
+    if not price_data:
+        return MarketRegime.default_sideways()
+    
+    per_ticker: Dict[str, Literal["up", "down", "flat"]] = {}
+    changes: List[float] = []
+    
+    for ticker, prices in price_data.items():
+        if len(prices) < 2:
+            per_ticker[ticker] = "flat"
+            continue
+        
+        # Calculate change from first to last price
+        initial_price = prices[0]
+        final_price = prices[-1]
+        change_pct = calculate_price_change_pct(initial_price, final_price)
+        
+        changes.append(change_pct)
+        per_ticker[ticker] = detect_ticker_trend(change_pct)
+    
+    # Calculate aggregate metrics
+    if not changes:
+        return MarketRegime(
+            overall="sideways",
+            volatility=0.5,
+            per_ticker=per_ticker,
+            avg_change_pct=0.0,
+            window_id=window_id,
+        )
+    
+    avg_change = sum(changes) / len(changes)
+    volatility = calculate_volatility(changes)
+    overall = detect_overall_regime(avg_change)
+    
+    return MarketRegime(
+        overall=overall,
+        volatility=volatility,
+        per_ticker=per_ticker,
+        avg_change_pct=avg_change,
+        window_id=window_id,
+    )
+
+
+def detect_regime_from_prices(
+    initial_prices: Dict[str, float],
+    final_prices: Dict[str, float],
+    window_id: Optional[str] = None,
+) -> MarketRegime:
+    """
+    Detect market regime from initial/final price snapshots.
+    
+    Convenience function when only start/end prices are available
+    (no full history). This is common for trajectory metadata.
+    
+    Args:
+        initial_prices: Prices at start of window {"BTC": 100000, "ETH": 4000}
+        final_prices: Prices at end of window {"BTC": 110000, "ETH": 3800}
+        window_id: Optional time window identifier
+    
+    Returns:
+        MarketRegime based on start-to-end changes
+    """
+    # Convert to price_data format (2-element lists)
+    price_data: Dict[str, List[float]] = {}
+    
+    all_tickers = set(initial_prices.keys()) | set(final_prices.keys())
+    
+    for ticker in all_tickers:
+        initial = initial_prices.get(ticker, 0.0)
+        final = final_prices.get(ticker, initial)
+        
+        if initial > 0:
+            price_data[ticker] = [initial, final]
+    
+    return detect_market_regime(price_data, window_id)
+
+
+def extract_regime_from_trajectory(trajectory: Dict) -> Optional[MarketRegime]:
+    """
+    Extract market regime from trajectory metadata if available.
+    
+    Trajectories generated with enhanced metadata will include price context.
+    This function extracts or computes the regime from that context.
+    
+    Args:
+        trajectory: Trajectory dictionary with optional metadata.price_context
+    
+    Returns:
+        MarketRegime if extractable, None otherwise
+    """
+    metadata = trajectory.get("metadata", {})
+    
+    # Check for pre-computed regime
+    price_context = metadata.get("price_context", {})
+    if price_context:
+        regime_data = price_context.get("regime")
+        if regime_data:
+            return MarketRegime.from_dict(regime_data)
+        
+        # Compute from price snapshots if available
+        initial_prices = price_context.get("initial_prices", {})
+        final_prices = price_context.get("final_prices", {})
+        
+        if initial_prices and final_prices:
+            return detect_regime_from_prices(
+                initial_prices,
+                final_prices,
+                trajectory.get("window_id"),
+            )
+    
+    # Check for legacy ground_truth format (from causal simulation)
+    ground_truth = metadata.get("ground_truth", {})
+    if ground_truth:
+        initial_prices = ground_truth.get("initialPrices", {})
+        final_prices = ground_truth.get("finalPrices", {})
+        
+        if initial_prices and final_prices:
+            return detect_regime_from_prices(
+                initial_prices,
+                final_prices,
+                trajectory.get("window_id"),
+            )
+    
+    return None
+
+
+def get_expected_return(regime: MarketRegime) -> float:
+    """
+    Get expected return for a market regime (for counterfactual calculation).
+    
+    Args:
+        regime: Market regime
+    
+    Returns:
+        Expected return as decimal (e.g., 0.05 for +5%)
+    """
+    return REGIME_EXPECTED_RETURNS.get(regime.overall, 0.0)
+

--- a/packages/training/python/src/training/market_regime.py
+++ b/packages/training/python/src/training/market_regime.py
@@ -13,7 +13,7 @@ Key concepts:
 """
 
 import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Dict, List, Literal, Optional
 
 
@@ -93,43 +93,6 @@ class MarketRegime:
             per_ticker={},
             avg_change_pct=0.0,
             window_id=None,
-        )
-
-
-@dataclass
-class PriceContext:
-    """
-    Price data context embedded in trajectory metadata.
-    
-    This is captured at trajectory generation time to make trajectories
-    self-contained for training (no DB lookup needed).
-    """
-    initial_prices: Dict[str, float]
-    final_prices: Dict[str, float]
-    price_history: Dict[str, List[float]] = field(default_factory=dict)
-    regime: Optional[MarketRegime] = None
-    window_id: Optional[str] = None
-    
-    def to_dict(self) -> Dict:
-        """Serialize for trajectory metadata storage."""
-        return {
-            "initial_prices": self.initial_prices,
-            "final_prices": self.final_prices,
-            "price_history": self.price_history,
-            "regime": self.regime.to_dict() if self.regime else None,
-            "window_id": self.window_id,
-        }
-    
-    @classmethod
-    def from_dict(cls, data: Dict) -> "PriceContext":
-        """Deserialize from trajectory metadata."""
-        regime_data = data.get("regime")
-        return cls(
-            initial_prices=data.get("initial_prices", {}),
-            final_prices=data.get("final_prices", {}),
-            price_history=data.get("price_history", {}),
-            regime=MarketRegime.from_dict(regime_data) if regime_data else None,
-            window_id=data.get("window_id"),
         )
 
 

--- a/packages/training/python/src/training/market_regime.py
+++ b/packages/training/python/src/training/market_regime.py
@@ -12,9 +12,12 @@ Key concepts:
 - Per-ticker trends: Individual asset movements for granular analysis
 """
 
+import logging
 import math
 from dataclasses import dataclass
 from typing import Dict, List, Literal, Optional
+
+logger = logging.getLogger(__name__)
 
 
 # =============================================================================
@@ -143,6 +146,11 @@ def calculate_price_change_pct(initial: float, final: float) -> float:
         Percentage change (e.g., 5.0 for +5%)
     """
     if initial <= 0:
+        logger.debug(
+            "Invalid initial price for pct change calculation (initial=%s, final=%s)",
+            initial,
+            final,
+        )
         return 0.0
     return ((final - initial) / initial) * 100
 
@@ -339,4 +347,3 @@ def get_expected_return(regime: MarketRegime) -> float:
         Expected return as decimal (e.g., 0.05 for +5%)
     """
     return REGIME_EXPECTED_RETURNS.get(regime.overall, 0.0)
-

--- a/packages/training/python/src/training/online_env.py
+++ b/packages/training/python/src/training/online_env.py
@@ -499,7 +499,7 @@ class BabylonOnlineEnv(BaseEnv):
                 base_url="http://localhost:9001/v1",
                 api_key="x",
                 num_requests_for_eval=64,
-                server_type="vllm",  # vLLM required for tokens_and_logprobs
+                server_type="openai",  # vLLM provides OpenAI-compatible API
             ),
         ]
         

--- a/packages/training/python/src/training/reward_config.py
+++ b/packages/training/python/src/training/reward_config.py
@@ -11,9 +11,6 @@ from typing import Dict, Optional
 import yaml
 
 
-# Config version for cache invalidation
-REWARD_CONFIG_VERSION = "1.0.0"
-
 # Find the config directory relative to this file
 _CURRENT_DIR = Path(__file__).parent
 _CONFIG_DIR = _CURRENT_DIR.parent.parent.parent / "config"
@@ -80,7 +77,7 @@ class RewardWeightConfig:
             # Skip non-profile sections
             if key in ("regime_thresholds", "regime_expected_returns", "temporal", "volatility"):
                 continue
-            if isinstance(value, dict) and "regime_pnl" in value or "pnl" in value:
+            if isinstance(value, dict) and ("regime_pnl" in value or "pnl" in value):
                 self._weights_profiles[key] = value
         
         if not self._weights_profiles:

--- a/packages/training/python/src/training/reward_config.py
+++ b/packages/training/python/src/training/reward_config.py
@@ -1,0 +1,190 @@
+"""
+Reward Configuration Loader
+
+Loads reward weight configurations from YAML config file.
+This allows experimentation with different weight distributions
+without code changes.
+"""
+
+from pathlib import Path
+from typing import Dict, Optional
+import yaml
+
+
+# Config version for cache invalidation
+REWARD_CONFIG_VERSION = "1.0.0"
+
+# Find the config directory relative to this file
+_CURRENT_DIR = Path(__file__).parent
+_CONFIG_DIR = _CURRENT_DIR.parent.parent.parent / "config"
+_WEIGHTS_FILE = _CONFIG_DIR / "reward_weights.yaml"
+
+
+# Default weights if config file not found
+DEFAULT_WEIGHTS: Dict[str, float] = {
+    "regime_pnl": 0.35,
+    "skill_alpha": 0.20,
+    "temporal_bonus": 0.05,
+    "format": 0.15,
+    "reasoning": 0.10,
+    "behavior": 0.15,
+}
+
+DEFAULT_LEGACY_WEIGHTS: Dict[str, float] = {
+    "pnl": 0.55,
+    "format": 0.20,
+    "reasoning": 0.15,
+    "behavior": 0.10,
+}
+
+DEFAULT_REGIME_EXPECTED_RETURNS: Dict[str, float] = {
+    "bull": 0.05,
+    "bear": -0.05,
+    "sideways": 0.0,
+}
+
+DEFAULT_TEMPORAL_CONFIG: Dict[str, float] = {
+    "decay_rate": 0.9,
+    "min_weight": 0.1,
+}
+
+
+class RewardWeightConfig:
+    """Singleton for reward weight configuration loaded from YAML."""
+    
+    _instance: Optional['RewardWeightConfig'] = None
+    _weights_profiles: Dict[str, Dict[str, float]]
+    _regime_expected_returns: Dict[str, float]
+    _regime_thresholds: Dict[str, float]
+    _temporal_config: Dict[str, float]
+    _volatility_config: Dict[str, float]
+    
+    def __new__(cls) -> 'RewardWeightConfig':
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._load_config()
+        return cls._instance
+    
+    def _load_config(self) -> None:
+        """Load reward weights from YAML config file."""
+        if not _WEIGHTS_FILE.exists():
+            self._set_defaults()
+            return
+        
+        with open(_WEIGHTS_FILE, 'r', encoding='utf-8') as f:
+            config = yaml.safe_load(f) or {}
+        
+        # Load weight profiles
+        self._weights_profiles = {}
+        for key, value in config.items():
+            # Skip non-profile sections
+            if key in ("regime_thresholds", "regime_expected_returns", "temporal", "volatility"):
+                continue
+            if isinstance(value, dict) and "regime_pnl" in value or "pnl" in value:
+                self._weights_profiles[key] = value
+        
+        if not self._weights_profiles:
+            self._weights_profiles = {"default": DEFAULT_WEIGHTS}
+        
+        # Load regime configuration
+        self._regime_expected_returns = config.get(
+            "regime_expected_returns",
+            DEFAULT_REGIME_EXPECTED_RETURNS
+        )
+        self._regime_thresholds = config.get(
+            "regime_thresholds",
+            {"bull": 0.05, "bear": -0.05}
+        )
+        
+        # Load temporal configuration
+        self._temporal_config = config.get("temporal", DEFAULT_TEMPORAL_CONFIG)
+        
+        # Load volatility configuration
+        self._volatility_config = config.get("volatility", {
+            "low": 2.0,
+            "high": 15.0,
+            "dampening_factor": 0.5,
+        })
+    
+    def _set_defaults(self) -> None:
+        """Set default values when config file is not found."""
+        self._weights_profiles = {
+            "default": DEFAULT_WEIGHTS,
+            "legacy": DEFAULT_LEGACY_WEIGHTS,
+        }
+        self._regime_expected_returns = DEFAULT_REGIME_EXPECTED_RETURNS
+        self._regime_thresholds = {"bull": 0.05, "bear": -0.05}
+        self._temporal_config = DEFAULT_TEMPORAL_CONFIG
+        self._volatility_config = {
+            "low": 2.0,
+            "high": 15.0,
+            "dampening_factor": 0.5,
+        }
+    
+    def get_weights(self, profile: str = "default") -> Dict[str, float]:
+        """
+        Get reward weights for a profile.
+        
+        Args:
+            profile: Name of the weight profile (e.g., "default", "skill_focused")
+        
+        Returns:
+            Dictionary mapping component names to weights
+        """
+        return self._weights_profiles.get(profile, self._weights_profiles.get("default", DEFAULT_WEIGHTS))
+    
+    def get_regime_expected_return(self, regime: str) -> float:
+        """
+        Get expected return for a market regime.
+        
+        Args:
+            regime: Market regime ("bull", "bear", "sideways")
+        
+        Returns:
+            Expected return as decimal (e.g., 0.05 for +5%)
+        """
+        return self._regime_expected_returns.get(regime.lower(), 0.0)
+    
+    def get_regime_thresholds(self) -> Dict[str, float]:
+        """Get regime classification thresholds."""
+        return self._regime_thresholds.copy()
+    
+    def get_temporal_decay_rate(self) -> float:
+        """Get temporal credit decay rate."""
+        return self._temporal_config.get("decay_rate", 0.9)
+    
+    def get_temporal_min_weight(self) -> float:
+        """Get minimum temporal credit weight."""
+        return self._temporal_config.get("min_weight", 0.1)
+    
+    def get_volatility_config(self) -> Dict[str, float]:
+        """Get volatility configuration."""
+        return self._volatility_config.copy()
+    
+    @property
+    def available_profiles(self) -> list:
+        """List available weight profiles."""
+        return list(self._weights_profiles.keys())
+
+
+# Module-level convenience functions
+
+def get_reward_weights(profile: str = "default") -> Dict[str, float]:
+    """Get reward weights for a profile."""
+    return RewardWeightConfig().get_weights(profile)
+
+
+def get_regime_expected_return(regime: str) -> float:
+    """Get expected return for a market regime."""
+    return RewardWeightConfig().get_regime_expected_return(regime)
+
+
+def get_temporal_decay_rate() -> float:
+    """Get temporal credit decay rate."""
+    return RewardWeightConfig().get_temporal_decay_rate()
+
+
+def list_weight_profiles() -> list:
+    """List available weight profiles."""
+    return RewardWeightConfig().available_profiles
+

--- a/packages/training/python/src/training/rewards.py
+++ b/packages/training/python/src/training/rewards.py
@@ -1600,6 +1600,7 @@ def enhanced_composite_reward(
     regime_expected_return: float = 0.0,
     counterfactual_alpha: Optional[float] = None,
     temporal_credits: Optional[List[TemporalCredit]] = None,
+    weight_profile: str = "default",
 ) -> float:
     """
     Enhanced archetype-aware reward with regime adjustment and counterfactual.
@@ -1631,6 +1632,7 @@ def enhanced_composite_reward(
         regime_expected_return: Expected return for this regime
         counterfactual_alpha: Pre-computed alpha (actual - benchmark)
         temporal_credits: List of temporal credit assignments
+        weight_profile: Reward weight profile name from reward_weights.yaml
     
     Returns:
         Composite reward score in [-1.0, 1.0]
@@ -1712,23 +1714,41 @@ def enhanced_composite_reward(
     # ==========================================================================
     # Weights designed to emphasize skill (alpha) over luck (raw PnL)
     
-    ENHANCED_WEIGHTS = {
-        "regime_pnl": 0.35,      # Regime-adjusted P&L
-        "alpha": 0.20,           # Skill signal (counterfactual)
-        "temporal": 0.05,        # Delayed reward attribution
-        "format": 0.15,          # Response format quality
-        "reasoning": 0.10,       # Reasoning quality
-        "behavior": 0.15,        # Archetype-aligned behavior
+    from .reward_config import get_reward_weights
+
+    profile_weights = get_reward_weights(weight_profile)
+    weights = {
+        "regime_pnl": float(profile_weights.get("regime_pnl", profile_weights.get("pnl", 0.0))),
+        "skill_alpha": float(profile_weights.get("skill_alpha", profile_weights.get("alpha", 0.0))),
+        "temporal_bonus": float(profile_weights.get("temporal_bonus", profile_weights.get("temporal", 0.0))),
+        "format": float(profile_weights.get("format", 0.0)),
+        "reasoning": float(profile_weights.get("reasoning", 0.0)),
+        "behavior": float(profile_weights.get("behavior", 0.0)),
     }
+
+    total_weight = sum(weights.values())
+    if total_weight <= 0:
+        weights = {
+            "regime_pnl": 0.35,
+            "skill_alpha": 0.20,
+            "temporal_bonus": 0.05,
+            "format": 0.15,
+            "reasoning": 0.10,
+            "behavior": 0.15,
+        }
+        total_weight = 1.0
+
+    if abs(total_weight - 1.0) > 1e-6:
+        weights = {k: v / total_weight for k, v in weights.items()}
     
     # Compute weighted composite
     composite = (
-        (pnl_score - risk_penalty) * ENHANCED_WEIGHTS["regime_pnl"]
-        + alpha_score * ENHANCED_WEIGHTS["alpha"]
-        + temporal_bonus * ENHANCED_WEIGHTS["temporal"]
-        + format_score * ENHANCED_WEIGHTS["format"]
-        + reasoning_score * ENHANCED_WEIGHTS["reasoning"]
-        + behavior_bonus * ENHANCED_WEIGHTS["behavior"]
+        (pnl_score - risk_penalty) * weights["regime_pnl"]
+        + alpha_score * weights["skill_alpha"]
+        + temporal_bonus * weights["temporal_bonus"]
+        + format_score * weights["format"]
+        + reasoning_score * weights["reasoning"]
+        + behavior_bonus * weights["behavior"]
     )
     
     return max(-1.0, min(1.0, composite))

--- a/packages/training/python/src/training/rewards.py
+++ b/packages/training/python/src/training/rewards.py
@@ -241,6 +241,129 @@ class TrajectoryRewardInputs:
     successful_actions: int = 0
 
 
+# =============================================================================
+# Enhanced Reward Signals: Counterfactual & Temporal Credit
+# =============================================================================
+
+@dataclass
+class CounterfactualResult:
+    """
+    Result of counterfactual analysis: what would have happened without action?
+    
+    Alpha = Actual P&L - Benchmark P&L
+    - Positive alpha: Agent added value through trading (skill)
+    - Negative alpha: Agent would have been better off holding (luck or error)
+    
+    Attributes:
+        hold_pnl: P&L if agent held cash (always 0)
+        benchmark_pnl: Expected P&L based on market regime
+        alpha: Actual - Benchmark (the skill signal)
+        actual_pnl: The agent's actual P&L
+    """
+    hold_pnl: float = 0.0
+    benchmark_pnl: float = 0.0
+    alpha: float = 0.0
+    actual_pnl: float = 0.0
+    
+    def to_dict(self) -> Dict:
+        """Serialize for logging."""
+        return {
+            "hold_pnl": self.hold_pnl,
+            "benchmark_pnl": self.benchmark_pnl,
+            "alpha": self.alpha,
+            "actual_pnl": self.actual_pnl,
+        }
+
+
+@dataclass
+class TemporalCredit:
+    """
+    Credit assignment for a decision with delayed outcome.
+    
+    When a trade is made, the actual P&L may not be known until later
+    (e.g., position closed, market resolved). This tracks the credit
+    weight based on temporal distance from outcome.
+    
+    Attributes:
+        decision_step: Step index where decision was made
+        outcome_step: Step index where outcome was observed
+        credit_weight: Weight for this credit (decays with distance)
+        outcome_pnl: The P&L attributed to this decision
+        market_id: Market/ticker affected by the decision
+    """
+    decision_step: int = 0
+    outcome_step: int = 0
+    credit_weight: float = 1.0
+    outcome_pnl: float = 0.0
+    market_id: Optional[str] = None
+    
+    def to_dict(self) -> Dict:
+        """Serialize for logging."""
+        return {
+            "decision_step": self.decision_step,
+            "outcome_step": self.outcome_step,
+            "credit_weight": self.credit_weight,
+            "outcome_pnl": self.outcome_pnl,
+            "market_id": self.market_id,
+        }
+
+
+# Temporal credit decay rate (per step)
+TEMPORAL_CREDIT_DECAY = 0.9
+
+
+def compute_counterfactual(
+    actual_pnl: float,
+    starting_balance: float,
+    regime_overall: str,
+    regime_expected_return: float = 0.0,
+) -> CounterfactualResult:
+    """
+    Compute counterfactual: what would have happened without action?
+    
+    This answers the question: "Did the agent's actions add value, or was
+    the P&L just due to market conditions?"
+    
+    In a bull market, everyone makes money. In a bear market, not losing
+    is an achievement. The counterfactual adjusts for this.
+    
+    Args:
+        actual_pnl: The agent's actual P&L
+        starting_balance: Initial balance for computing expected returns
+        regime_overall: Market regime ("bull", "bear", "sideways")
+        regime_expected_return: Expected return for this regime (0.05 = +5%)
+    
+    Returns:
+        CounterfactualResult with alpha (skill signal)
+    
+    Examples:
+        Bull market (+5% expected), agent made +3%:
+            alpha = 3% - 5% = -2% (underperformed)
+        
+        Bear market (-5% expected), agent lost -2%:
+            alpha = -2% - (-5%) = +3% (outperformed)
+        
+        Sideways (0% expected), agent made +1%:
+            alpha = 1% - 0% = +1% (added value)
+    """
+    # Hold cash benchmark (always 0)
+    hold_pnl = 0.0
+    
+    # Regime-adjusted benchmark
+    # In bull market, expect positive return; in bear, expect negative
+    benchmark_pnl = starting_balance * regime_expected_return
+    
+    # Alpha: skill signal (did actions add value vs benchmark?)
+    alpha = actual_pnl - benchmark_pnl
+    
+    return CounterfactualResult(
+        hold_pnl=hold_pnl,
+        benchmark_pnl=benchmark_pnl,
+        alpha=alpha,
+        actual_pnl=actual_pnl,
+    )
+
+
 def calculate_pnl_reward(start_balance: float, end_balance: float) -> float:
     """
     Calculate PnL Reward.
@@ -414,6 +537,122 @@ def composite_reward(
     ) / total_weight
 
     return max(-1.0, min(1.0, composite))
+
+
+# =============================================================================
+# Regime-Adjusted Reward Functions
+# =============================================================================
+
+def regime_adjusted_pnl_reward(
+    actual_pnl: float,
+    starting_balance: float,
+    regime_overall: str,
+    regime_volatility: float = 0.5,
+    regime_expected_return: float = 0.0,
+) -> float:
+    """
+    Calculate P&L reward adjusted for market conditions.
+    
+    This adjusts raw P&L to account for market regime:
+    - Bull market: Everyone makes money, so we subtract expected bull return
+    - Bear market: Not losing is winning, so we add expected bear loss
+    - Sideways: Neutral adjustment
+    
+    High volatility dampens the signal (more noise = less reliable P&L).
+    
+    Args:
+        actual_pnl: Agent's actual P&L
+        starting_balance: Initial balance
+        regime_overall: "bull", "bear", or "sideways"
+        regime_volatility: Normalized volatility (0.0 = calm, 1.0 = extreme)
+        regime_expected_return: Expected return for this regime (e.g., 0.05 for bull)
+    
+    Returns:
+        Adjusted reward in [-1.0, 1.0] range
+    """
+    if starting_balance <= 0:
+        return 0.0
+    
+    # Normalize to return percentage
+    actual_return = actual_pnl / starting_balance
+    
+    # Subtract expected return to isolate skill
+    # Bull: subtract +5% expectation
+    # Bear: subtract -5% expectation (effectively adding credit for preservation)
+    # Sideways: no adjustment
+    adjusted_return = actual_return - regime_expected_return
+    
+    # Apply volatility dampening
+    # High volatility = more noise, dampen the signal
+    # volatility 0.0 -> factor 1.0 (no dampening)
+    # volatility 1.0 -> factor 0.5 (50% dampening)
+    volatility_factor = 1.0 - (regime_volatility * 0.5)
+    adjusted_return *= volatility_factor
+    
+    # Scale to reward range: 10% adjusted return = 1.0 reward
+    scaled_reward = adjusted_return * 10.0
+    
+    return max(-1.0, min(1.0, scaled_reward))
+
+
+def calculate_alpha_reward(
+    alpha: float,
+    starting_balance: float,
+) -> float:
+    """
+    Convert alpha (skill signal) to a normalized reward.
+    
+    Alpha is the difference between actual P&L and benchmark P&L.
+    Positive alpha = added value, negative alpha = destroyed value.
+    
+    Args:
+        alpha: Counterfactual alpha (actual_pnl - benchmark_pnl)
+        starting_balance: For normalization
+    
+    Returns:
+        Normalized reward in [-1.0, 1.0]
+    """
+    if starting_balance <= 0:
+        return 0.0
+    
+    # Normalize alpha as percentage of starting balance
+    alpha_pct = alpha / starting_balance
+    
+    # Scale: 5% alpha = 1.0 reward (more sensitive than raw PnL)
+    scaled = alpha_pct * 20.0
+    
+    return max(-1.0, min(1.0, scaled))
+
+
+def calculate_temporal_credit_bonus(
+    credits: List[TemporalCredit],
+    starting_balance: float,
+) -> float:
+    """
+    Calculate bonus from temporal credit assignment.
+    
+    Aggregates credit-weighted outcomes from delayed rewards.
+    
+    Args:
+        credits: List of temporal credits from decisions
+        starting_balance: For normalization
+    
+    Returns:
+        Bonus in [-0.5, 0.5] range
+    """
+    if not credits or starting_balance <= 0:
+        return 0.0
+    
+    # Sum credit-weighted outcomes
+    total_credited_pnl = sum(c.outcome_pnl * c.credit_weight for c in credits)
+    
+    # Normalize as percentage of starting balance
+    credited_pct = total_credited_pnl / starting_balance
+    
+    # Scale: 5% credited = 0.5 bonus
+    scaled = credited_pct * 10.0
+    
+    return max(-0.5, min(0.5, scaled))
 
 
 def relative_scores(rewards: list[float]) -> list[float]:
@@ -1341,4 +1580,155 @@ def archetype_composite_reward(
         + behavior_bonus * weights["behavior"]
     ) / total_weight
 
+    return max(-1.0, min(1.0, composite))
+
+
+# =============================================================================
+# Enhanced Composite Reward (with Regime & Counterfactual)
+# =============================================================================
+
+# Import MarketRegime here to avoid circular imports at module load
+# The actual import happens in the function to ensure market_regime module is loaded
+
+
+def enhanced_composite_reward(
+    inputs: TrajectoryRewardInputs,
+    archetype: str,
+    behavior_metrics: Optional[BehaviorMetrics] = None,
+    regime_overall: Optional[str] = None,
+    regime_volatility: float = 0.5,
+    regime_expected_return: float = 0.0,
+    counterfactual_alpha: Optional[float] = None,
+    temporal_credits: Optional[List[TemporalCredit]] = None,
+) -> float:
+    """
+    Enhanced archetype-aware reward with regime adjustment and counterfactual.
+    
+    This is the full-featured reward function that accounts for:
+    1. Market regime (bull/bear/sideways adjustment)
+    2. Counterfactual alpha (skill vs luck)
+    3. Temporal credit (delayed reward attribution)
+    4. Archetype-specific behavior bonuses
+    5. Format and reasoning quality
+    
+    Backward compatible: if regime args are None, falls back to original
+    archetype_composite_reward logic.
+    
+    Weight distribution (when enhanced mode active):
+        - regime_adjusted_pnl: 35%
+        - skill_alpha: 20%
+        - temporal_bonus: 5%
+        - format: 15%
+        - reasoning: 10%
+        - behavior: 15%
+    
+    Args:
+        inputs: Standard trajectory reward inputs
+        archetype: Agent archetype for behavior weighting
+        behavior_metrics: Optional behavior metrics for archetype bonus
+        regime_overall: Market regime ("bull", "bear", "sideways") or None
+        regime_volatility: Normalized volatility (0.0-1.0)
+        regime_expected_return: Expected return for this regime
+        counterfactual_alpha: Pre-computed alpha (actual - benchmark)
+        temporal_credits: List of temporal credit assignments
+    
+    Returns:
+        Composite reward score in [-1.0, 1.0]
+    """
+    archetype_norm = normalize_archetype(archetype)
+    
+    # Check if we have enhanced context
+    has_enhanced_context = regime_overall is not None or counterfactual_alpha is not None
+    
+    if not has_enhanced_context:
+        # Fallback to original archetype_composite_reward
+        return archetype_composite_reward(inputs, archetype, behavior_metrics)
+    
+    # ==========================================================================
+    # Enhanced Mode: Full reward computation with regime awareness
+    # ==========================================================================
+    
+    # 1. Regime-Adjusted PnL Score
+    if regime_overall is not None:
+        pnl_score = regime_adjusted_pnl_reward(
+            actual_pnl=inputs.final_pnl,
+            starting_balance=inputs.starting_balance,
+            regime_overall=regime_overall,
+            regime_volatility=regime_volatility,
+            regime_expected_return=regime_expected_return,
+        )
+    else:
+        # No regime info, use standard PnL reward
+        pnl_score = calculate_pnl_reward(inputs.starting_balance, inputs.end_balance)
+    
+    # Archetype-specific PnL adjustments (carried over from original)
+    if archetype_norm == "degen" and pnl_score < 0:
+        pnl_score = pnl_score * 0.3  # Degens not penalized hard for losses
+    if archetype_norm == "social-butterfly" and pnl_score < 0:
+        pnl_score = pnl_score * 0.5  # Social butterflies don't care about trading
+    
+    # Bankruptcy check (even for degens)
+    if inputs.end_balance <= 0 and archetype_norm not in ("degen", "social-butterfly"):
+        return -1.0  # Hard penalty for bankruptcy
+    
+    # 2. Skill Alpha Score (Counterfactual)
+    alpha_score = 0.0
+    if counterfactual_alpha is not None:
+        alpha_score = calculate_alpha_reward(
+            alpha=counterfactual_alpha,
+            starting_balance=inputs.starting_balance,
+        )
+    
+    # 3. Temporal Credit Bonus
+    temporal_bonus = 0.0
+    if temporal_credits:
+        temporal_bonus = calculate_temporal_credit_bonus(
+            credits=temporal_credits,
+            starting_balance=inputs.starting_balance,
+        )
+    
+    # 4. Risk penalty for risky actions (except degens)
+    risk_penalty = 0.0
+    if inputs.risky_actions_count > 0 and archetype_norm != "degen":
+        risk_penalty = inputs.risky_actions_count * ARCHETYPE_RISK_PENALTY_MULTIPLIER
+    
+    # 5. Format and Reasoning scores
+    format_score = inputs.format_score
+    reasoning_score = inputs.reasoning_score
+    
+    # 6. Behavior bonus from archetype-specific behaviors
+    behavior_bonus = 0.0
+    if behavior_metrics is not None:
+        behavior_bonus = calculate_archetype_behavior_bonus(archetype_norm, behavior_metrics)
+        
+        # Incorporate priority metrics from rubrics.json
+        priority_score = calculate_priority_weighted_score(archetype_norm, behavior_metrics)
+        
+        # Blend: 70% behavior bonus, 30% priority metrics
+        behavior_bonus = behavior_bonus * 0.7 + (priority_score - 0.5) * 0.3
+    
+    # ==========================================================================
+    # Enhanced Weight Distribution
+    # ==========================================================================
+    # Weights designed to emphasize skill (alpha) over luck (raw PnL)
+    
+    ENHANCED_WEIGHTS = {
+        "regime_pnl": 0.35,      # Regime-adjusted P&L
+        "alpha": 0.20,           # Skill signal (counterfactual)
+        "temporal": 0.05,        # Delayed reward attribution
+        "format": 0.15,          # Response format quality
+        "reasoning": 0.10,       # Reasoning quality
+        "behavior": 0.15,        # Archetype-aligned behavior
+    }
+    
+    # Compute weighted composite
+    composite = (
+        (pnl_score - risk_penalty) * ENHANCED_WEIGHTS["regime_pnl"]
+        + alpha_score * ENHANCED_WEIGHTS["alpha"]
+        + temporal_bonus * ENHANCED_WEIGHTS["temporal"]
+        + format_score * ENHANCED_WEIGHTS["format"]
+        + reasoning_score * ENHANCED_WEIGHTS["reasoning"]
+        + behavior_bonus * ENHANCED_WEIGHTS["behavior"]
+    )
+    
     return max(-1.0, min(1.0, composite))

--- a/packages/training/python/src/training/temporal_credit.py
+++ b/packages/training/python/src/training/temporal_credit.py
@@ -1,0 +1,375 @@
+"""
+Temporal Credit Assignment for Delayed Rewards
+
+When an agent makes a trading decision, the actual outcome (P&L) may not be
+known until later - when the position is closed, the market resolves, or the
+trading window ends. This module handles assigning credit back to the
+decisions that caused eventual outcomes.
+
+Key concepts:
+- Decision: A trade action (buy, sell, open position, close position)
+- Outcome: The eventual P&L realization
+- Credit: Weight assigned to a decision based on temporal distance from outcome
+- Decay: Credit weight decreases exponentially with distance from outcome
+
+This implements a form of temporal difference credit assignment common in RL,
+adapted for the trading domain where outcomes are delayed.
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+import math
+
+from .rewards import TemporalCredit, TEMPORAL_CREDIT_DECAY
+
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+# Action types considered as trading decisions for credit assignment
+TRADING_ACTION_TYPES = frozenset([
+    "buy", "sell",
+    "buy_prediction", "sell_prediction",
+    "open_perp", "close_perp",
+    "open_long", "open_short", "close_long", "close_short",
+    "trade", "trading",
+])
+
+# Default decay rate (can be overridden)
+DEFAULT_DECAY_RATE = TEMPORAL_CREDIT_DECAY  # 0.9
+
+
+# =============================================================================
+# Core Functions
+# =============================================================================
+
+def is_trading_action(action_type: str) -> bool:
+    """
+    Check if an action type is a trading decision.
+    
+    Args:
+        action_type: Action type string from trajectory step
+    
+    Returns:
+        True if this is a trading action that should receive credit
+    """
+    normalized = action_type.lower().strip()
+    return normalized in TRADING_ACTION_TYPES or any(
+        t in normalized for t in ("buy", "sell", "trade", "open", "close")
+    )
+
+
+def extract_market_id(step: Dict) -> Optional[str]:
+    """
+    Extract market identifier from a trajectory step.
+    
+    Checks multiple possible parameter names for the market/ticker.
+    
+    Args:
+        step: Trajectory step dictionary
+    
+    Returns:
+        Market ID string if found, None otherwise
+    """
+    action = step.get("action", {})
+    params = action.get("parameters", {})
+    
+    # Check common parameter names
+    for key in ("marketId", "market_id", "ticker", "market", "symbol"):
+        value = params.get(key)
+        if value:
+            return str(value)
+    
+    # Check result for market info
+    result = action.get("result", {})
+    for key in ("market", "ticker", "marketId"):
+        value = result.get(key)
+        if value:
+            return str(value)
+    
+    return None
+
+
+def extract_action_pnl(step: Dict) -> Optional[float]:
+    """
+    Extract P&L from a trajectory step if available.
+    
+    Some actions (especially closes) have immediate P&L in the result.
+    
+    Args:
+        step: Trajectory step dictionary
+    
+    Returns:
+        P&L value if present, None otherwise
+    """
+    action = step.get("action", {})
+    result = action.get("result", {})
+    
+    # Check for P&L in result
+    pnl = result.get("pnl")
+    if pnl is not None:
+        return float(pnl)
+    
+    # Check for realized P&L
+    realized = result.get("realizedPnL") or result.get("realized_pnl")
+    if realized is not None:
+        return float(realized)
+    
+    return None
+
+
+def calculate_credit_weight(
+    decision_step: int,
+    outcome_step: int,
+    decay_rate: float = DEFAULT_DECAY_RATE,
+) -> float:
+    """
+    Calculate credit weight based on temporal distance.
+    
+    Uses exponential decay: weight = decay_rate ^ (distance)
+    
+    The idea is that decisions closer to the outcome should receive more
+    credit, while distant decisions receive less (but still some).
+    
+    Args:
+        decision_step: Step index where decision was made
+        outcome_step: Step index where outcome was observed
+        decay_rate: Decay rate per step (default 0.9)
+    
+    Returns:
+        Credit weight in (0, 1]
+    """
+    distance = max(0, outcome_step - decision_step)
+    return decay_rate ** distance
+
+
+def attribute_temporal_credit(
+    steps: List[Dict],
+    final_pnl: float,
+    outcome_data: Optional[Dict[str, float]] = None,
+    decay_rate: float = DEFAULT_DECAY_RATE,
+) -> List[TemporalCredit]:
+    """
+    Assign credit to trading decisions based on eventual outcomes.
+    
+    This is the main entry point for temporal credit assignment. It:
+    1. Identifies trading decisions in the trajectory
+    2. Matches them to outcomes (per-market or overall)
+    3. Assigns credit weights based on temporal distance
+    
+    Credit assignment strategies:
+    - If outcome_data has per-market P&L, use that for specific trades
+    - Otherwise, distribute final_pnl across all trading decisions
+    
+    Args:
+        steps: List of trajectory step dictionaries
+        final_pnl: Final P&L for the entire trajectory
+        outcome_data: Optional dict mapping market_id to P&L
+                     Example: {"BTC": 150.0, "ETH": -50.0}
+        decay_rate: Decay rate for credit weighting
+    
+    Returns:
+        List of TemporalCredit assignments
+    """
+    if not steps:
+        return []
+    
+    credits: List[TemporalCredit] = []
+    
+    # Collect all trading decisions with their indices
+    trading_decisions: List[Tuple[int, str, Dict]] = []  # (step_idx, market_id, step)
+    
+    for i, step in enumerate(steps):
+        action = step.get("action", {})
+        action_type = action.get("actionType", action.get("action_type", ""))
+        
+        if is_trading_action(action_type):
+            market_id = extract_market_id(step)
+            if market_id:
+                trading_decisions.append((i, market_id, step))
+    
+    if not trading_decisions:
+        return []
+    
+    # Group decisions by market for per-market credit assignment
+    decisions_by_market: Dict[str, List[Tuple[int, Dict]]] = {}
+    for step_idx, market_id, step in trading_decisions:
+        if market_id not in decisions_by_market:
+            decisions_by_market[market_id] = []
+        decisions_by_market[market_id].append((step_idx, step))
+    
+    outcome_step = len(steps) - 1  # Assume outcome at end of trajectory
+    
+    # Assign credit based on available outcome data
+    if outcome_data:
+        # Per-market credit assignment
+        for market_id, market_pnl in outcome_data.items():
+            market_decisions = decisions_by_market.get(market_id, [])
+            
+            if not market_decisions:
+                continue
+            
+            # Distribute P&L across decisions for this market
+            # Weight by temporal proximity to outcome
+            total_weight = sum(
+                calculate_credit_weight(idx, outcome_step, decay_rate)
+                for idx, _ in market_decisions
+            )
+            
+            for step_idx, step in market_decisions:
+                weight = calculate_credit_weight(step_idx, outcome_step, decay_rate)
+                
+                # Normalize weight to distribute P&L proportionally
+                normalized_weight = weight / total_weight if total_weight > 0 else 0
+                credited_pnl = market_pnl * normalized_weight
+                
+                credits.append(TemporalCredit(
+                    decision_step=step_idx,
+                    outcome_step=outcome_step,
+                    credit_weight=weight,
+                    outcome_pnl=credited_pnl,
+                    market_id=market_id,
+                ))
+    else:
+        # No per-market data, distribute final_pnl across all decisions
+        all_decisions = [(idx, market, step) for idx, market, step in trading_decisions]
+        
+        # Calculate total weight for normalization
+        total_weight = sum(
+            calculate_credit_weight(idx, outcome_step, decay_rate)
+            for idx, _, _ in all_decisions
+        )
+        
+        for step_idx, market_id, step in all_decisions:
+            weight = calculate_credit_weight(step_idx, outcome_step, decay_rate)
+            
+            # Distribute final P&L proportionally by weight
+            normalized_weight = weight / total_weight if total_weight > 0 else 0
+            credited_pnl = final_pnl * normalized_weight
+            
+            credits.append(TemporalCredit(
+                decision_step=step_idx,
+                outcome_step=outcome_step,
+                credit_weight=weight,
+                outcome_pnl=credited_pnl,
+                market_id=market_id,
+            ))
+    
+    return credits
+
+
+def attribute_credit_with_intermediate_outcomes(
+    steps: List[Dict],
+    decay_rate: float = DEFAULT_DECAY_RATE,
+) -> List[TemporalCredit]:
+    """
+    Assign credit using intermediate outcomes from step results.
+    
+    Some steps have immediate P&L (e.g., closing a position). This function
+    uses those intermediate outcomes for more accurate credit assignment.
+    
+    Args:
+        steps: List of trajectory step dictionaries
+        decay_rate: Decay rate for credit weighting
+    
+    Returns:
+        List of TemporalCredit assignments
+    """
+    credits: List[TemporalCredit] = []
+    
+    # Track open positions and their opening step
+    open_positions: Dict[str, List[int]] = {}  # market_id -> [opening step indices]
+    
+    for i, step in enumerate(steps):
+        action = step.get("action", {})
+        action_type = action.get("actionType", action.get("action_type", "")).lower()
+        market_id = extract_market_id(step)
+        
+        if not market_id:
+            continue
+        
+        # Track opening positions
+        if any(t in action_type for t in ("buy", "open", "long")):
+            if market_id not in open_positions:
+                open_positions[market_id] = []
+            open_positions[market_id].append(i)
+        
+        # Process closing positions with P&L
+        elif any(t in action_type for t in ("sell", "close")):
+            pnl = extract_action_pnl(step)
+            
+            if pnl is not None:
+                # Find opening decisions to credit
+                opening_steps = open_positions.get(market_id, [])
+                
+                if opening_steps:
+                    # Credit to most recent opening (LIFO)
+                    opening_step = opening_steps.pop()
+                    weight = calculate_credit_weight(opening_step, i, decay_rate)
+                    
+                    credits.append(TemporalCredit(
+                        decision_step=opening_step,
+                        outcome_step=i,
+                        credit_weight=weight,
+                        outcome_pnl=pnl * weight,
+                        market_id=market_id,
+                    ))
+                
+                # Also credit the closing decision (it realized the P&L)
+                credits.append(TemporalCredit(
+                    decision_step=i,
+                    outcome_step=i,
+                    credit_weight=1.0,
+                    outcome_pnl=pnl,
+                    market_id=market_id,
+                ))
+    
+    return credits
+
+
+def aggregate_credits_by_step(credits: List[TemporalCredit]) -> Dict[int, float]:
+    """
+    Aggregate temporal credits by decision step.
+    
+    Useful for understanding which decisions contributed most to outcomes.
+    
+    Args:
+        credits: List of temporal credits
+    
+    Returns:
+        Dict mapping step index to total credited P&L
+    """
+    aggregated: Dict[int, float] = {}
+    
+    for credit in credits:
+        step = credit.decision_step
+        if step not in aggregated:
+            aggregated[step] = 0.0
+        aggregated[step] += credit.outcome_pnl
+    
+    return aggregated
+
+
+def aggregate_credits_by_market(credits: List[TemporalCredit]) -> Dict[str, float]:
+    """
+    Aggregate temporal credits by market.
+    
+    Useful for understanding which markets contributed most to outcomes.
+    
+    Args:
+        credits: List of temporal credits
+    
+    Returns:
+        Dict mapping market_id to total credited P&L
+    """
+    aggregated: Dict[str, float] = {}
+    
+    for credit in credits:
+        market = credit.market_id or "unknown"
+        if market not in aggregated:
+            aggregated[market] = 0.0
+        aggregated[market] += credit.outcome_pnl
+    
+    return aggregated
+

--- a/packages/training/python/src/training/temporal_credit.py
+++ b/packages/training/python/src/training/temporal_credit.py
@@ -16,9 +16,8 @@ This implements a form of temporal difference credit assignment common in RL,
 adapted for the trading domain where outcomes are delayed.
 """
 
-from dataclasses import dataclass, field
+from collections import defaultdict
 from typing import Dict, List, Optional, Tuple
-import math
 
 from .rewards import TemporalCredit, TEMPORAL_CREDIT_DECAY
 
@@ -193,10 +192,8 @@ def attribute_temporal_credit(
         return []
     
     # Group decisions by market for per-market credit assignment
-    decisions_by_market: Dict[str, List[Tuple[int, Dict]]] = {}
+    decisions_by_market: Dict[str, List[Tuple[int, Dict]]] = defaultdict(list)
     for step_idx, market_id, step in trading_decisions:
-        if market_id not in decisions_by_market:
-            decisions_by_market[market_id] = []
         decisions_by_market[market_id].append((step_idx, step))
     
     outcome_step = len(steps) - 1  # Assume outcome at end of trajectory
@@ -279,7 +276,7 @@ def attribute_credit_with_intermediate_outcomes(
     credits: List[TemporalCredit] = []
     
     # Track open positions and their opening step
-    open_positions: Dict[str, List[int]] = {}  # market_id -> [opening step indices]
+    open_positions: Dict[str, List[int]] = defaultdict(list)
     
     for i, step in enumerate(steps):
         action = step.get("action", {})
@@ -291,8 +288,6 @@ def attribute_credit_with_intermediate_outcomes(
         
         # Track opening positions
         if any(t in action_type for t in ("buy", "open", "long")):
-            if market_id not in open_positions:
-                open_positions[market_id] = []
             open_positions[market_id].append(i)
         
         # Process closing positions with P&L
@@ -329,47 +324,17 @@ def attribute_credit_with_intermediate_outcomes(
 
 
 def aggregate_credits_by_step(credits: List[TemporalCredit]) -> Dict[int, float]:
-    """
-    Aggregate temporal credits by decision step.
-    
-    Useful for understanding which decisions contributed most to outcomes.
-    
-    Args:
-        credits: List of temporal credits
-    
-    Returns:
-        Dict mapping step index to total credited P&L
-    """
-    aggregated: Dict[int, float] = {}
-    
+    """Aggregate temporal credits by decision step."""
+    aggregated: Dict[int, float] = defaultdict(float)
     for credit in credits:
-        step = credit.decision_step
-        if step not in aggregated:
-            aggregated[step] = 0.0
-        aggregated[step] += credit.outcome_pnl
-    
-    return aggregated
+        aggregated[credit.decision_step] += credit.outcome_pnl
+    return dict(aggregated)
 
 
 def aggregate_credits_by_market(credits: List[TemporalCredit]) -> Dict[str, float]:
-    """
-    Aggregate temporal credits by market.
-    
-    Useful for understanding which markets contributed most to outcomes.
-    
-    Args:
-        credits: List of temporal credits
-    
-    Returns:
-        Dict mapping market_id to total credited P&L
-    """
-    aggregated: Dict[str, float] = {}
-    
+    """Aggregate temporal credits by market."""
+    aggregated: Dict[str, float] = defaultdict(float)
     for credit in credits:
-        market = credit.market_id or "unknown"
-        if market not in aggregated:
-            aggregated[market] = 0.0
-        aggregated[market] += credit.outcome_pnl
-    
-    return aggregated
+        aggregated[credit.market_id or "unknown"] += credit.outcome_pnl
+    return dict(aggregated)
 

--- a/packages/training/python/tests/test_enhanced_rewards.py
+++ b/packages/training/python/tests/test_enhanced_rewards.py
@@ -10,14 +10,10 @@ from typing import Dict, List
 
 from src.training.market_regime import (
     MarketRegime,
-    PriceContext,
     detect_market_regime,
     detect_regime_from_prices,
     extract_regime_from_trajectory,
     calculate_volatility,
-    calculate_price_change_pct,
-    detect_ticker_trend,
-    detect_overall_regime,
     get_expected_return,
     BULL_THRESHOLD,
     BEAR_THRESHOLD,
@@ -146,8 +142,8 @@ class TestMarketRegimeDetection:
         assert regime.overall == "bull"
         assert regime.avg_change_pct == 10.0
     
-    def test_price_context_serialization(self):
-        """PriceContext can be serialized and deserialized."""
+    def test_market_regime_serialization(self):
+        """MarketRegime can be serialized and deserialized."""
         regime = MarketRegime(
             overall="bull",
             volatility=0.3,
@@ -155,18 +151,12 @@ class TestMarketRegimeDetection:
             avg_change_pct=7.5,
         )
         
-        context = PriceContext(
-            initial_prices={"BTC": 100000},
-            final_prices={"BTC": 110000},
-            regime=regime,
-        )
+        data = regime.to_dict()
+        restored = MarketRegime.from_dict(data)
         
-        data = context.to_dict()
-        restored = PriceContext.from_dict(data)
-        
-        assert restored.initial_prices == context.initial_prices
-        assert restored.final_prices == context.final_prices
-        assert restored.regime.overall == "bull"
+        assert restored.overall == regime.overall
+        assert restored.volatility == regime.volatility
+        assert restored.per_ticker == regime.per_ticker
     
     def test_extract_regime_from_trajectory_metadata(self):
         """Extract regime from trajectory price_context metadata."""

--- a/packages/training/python/tests/test_enhanced_rewards.py
+++ b/packages/training/python/tests/test_enhanced_rewards.py
@@ -1,0 +1,689 @@
+"""
+Tests for Enhanced Reward Signals
+
+Tests market regime detection, counterfactual rewards, temporal credit,
+and the enhanced composite reward function.
+"""
+
+import pytest
+from typing import Dict, List
+
+from src.training.market_regime import (
+    MarketRegime,
+    PriceContext,
+    detect_market_regime,
+    detect_regime_from_prices,
+    extract_regime_from_trajectory,
+    calculate_volatility,
+    calculate_price_change_pct,
+    detect_ticker_trend,
+    detect_overall_regime,
+    get_expected_return,
+    BULL_THRESHOLD,
+    BEAR_THRESHOLD,
+)
+
+from src.training.rewards import (
+    CounterfactualResult,
+    TemporalCredit,
+    compute_counterfactual,
+    regime_adjusted_pnl_reward,
+    calculate_alpha_reward,
+    calculate_temporal_credit_bonus,
+    enhanced_composite_reward,
+    archetype_composite_reward,
+    TrajectoryRewardInputs,
+    BehaviorMetrics,
+)
+
+from src.training.temporal_credit import (
+    is_trading_action,
+    extract_market_id,
+    extract_action_pnl,
+    calculate_credit_weight,
+    attribute_temporal_credit,
+    attribute_credit_with_intermediate_outcomes,
+    aggregate_credits_by_step,
+    aggregate_credits_by_market,
+    DEFAULT_DECAY_RATE,
+)
+
+from src.training.reward_config import (
+    RewardWeightConfig,
+    get_reward_weights,
+    get_regime_expected_return,
+    get_temporal_decay_rate,
+    list_weight_profiles,
+)
+
+
+# =============================================================================
+# Market Regime Tests
+# =============================================================================
+
+class TestMarketRegimeDetection:
+    """Tests for market regime detection from price data."""
+    
+    def test_detect_bull_market(self):
+        """Bull market: >5% average increase."""
+        price_data = {
+            "BTC": [100000, 110000],  # +10%
+            "ETH": [4000, 4400],       # +10%
+        }
+        regime = detect_market_regime(price_data)
+        
+        assert regime.overall == "bull"
+        assert regime.avg_change_pct > BULL_THRESHOLD
+    
+    def test_detect_bear_market(self):
+        """Bear market: <-5% average decrease."""
+        price_data = {
+            "BTC": [100000, 90000],   # -10%
+            "ETH": [4000, 3600],      # -10%
+        }
+        regime = detect_market_regime(price_data)
+        
+        assert regime.overall == "bear"
+        assert regime.avg_change_pct < BEAR_THRESHOLD
+    
+    def test_detect_sideways_market(self):
+        """Sideways market: between -5% and +5%."""
+        price_data = {
+            "BTC": [100000, 102000],  # +2%
+            "ETH": [4000, 3920],      # -2%
+        }
+        regime = detect_market_regime(price_data)
+        
+        assert regime.overall == "sideways"
+        assert BEAR_THRESHOLD <= regime.avg_change_pct <= BULL_THRESHOLD
+    
+    def test_per_ticker_trends(self):
+        """Per-ticker trends are correctly classified."""
+        price_data = {
+            "BTC": [100000, 110000],  # +10% -> up
+            "ETH": [4000, 3600],      # -10% -> down
+            "SOL": [100, 102],        # +2% -> flat
+        }
+        regime = detect_market_regime(price_data)
+        
+        assert regime.per_ticker["BTC"] == "up"
+        assert regime.per_ticker["ETH"] == "down"
+        assert regime.per_ticker["SOL"] == "flat"
+    
+    def test_volatility_calculation(self):
+        """Volatility is normalized to [0, 1] range."""
+        low_vol_changes = [1.0, 1.5, 1.0, 1.5]
+        high_vol_changes = [10.0, -15.0, 20.0, -25.0]
+        
+        low_vol = calculate_volatility(low_vol_changes)
+        high_vol = calculate_volatility(high_vol_changes)
+        
+        assert 0.0 <= low_vol <= 1.0
+        assert 0.0 <= high_vol <= 1.0
+        assert low_vol < high_vol
+    
+    def test_empty_price_data(self):
+        """Empty price data returns sideways default."""
+        regime = detect_market_regime({})
+        
+        assert regime.overall == "sideways"
+        assert regime.volatility == 0.5
+    
+    def test_single_price_list(self):
+        """Single-element price list is treated as flat."""
+        price_data = {"BTC": [100000]}
+        regime = detect_market_regime(price_data)
+        
+        assert regime.per_ticker.get("BTC") == "flat"
+    
+    def test_regime_from_initial_final_prices(self):
+        """Regime detection from initial/final price snapshots."""
+        initial = {"BTC": 100000, "ETH": 4000}
+        final = {"BTC": 110000, "ETH": 4400}  # +10% each
+        
+        regime = detect_regime_from_prices(initial, final)
+        
+        assert regime.overall == "bull"
+        assert regime.avg_change_pct == 10.0
+    
+    def test_price_context_serialization(self):
+        """PriceContext can be serialized and deserialized."""
+        regime = MarketRegime(
+            overall="bull",
+            volatility=0.3,
+            per_ticker={"BTC": "up"},
+            avg_change_pct=7.5,
+        )
+        
+        context = PriceContext(
+            initial_prices={"BTC": 100000},
+            final_prices={"BTC": 110000},
+            regime=regime,
+        )
+        
+        data = context.to_dict()
+        restored = PriceContext.from_dict(data)
+        
+        assert restored.initial_prices == context.initial_prices
+        assert restored.final_prices == context.final_prices
+        assert restored.regime.overall == "bull"
+    
+    def test_extract_regime_from_trajectory_metadata(self):
+        """Extract regime from trajectory price_context metadata."""
+        trajectory = {
+            "metadata": {
+                "price_context": {
+                    "initial_prices": {"BTC": 100000},
+                    "final_prices": {"BTC": 90000},  # -10%
+                    "regime": None,  # Should compute from prices
+                }
+            }
+        }
+        
+        regime = extract_regime_from_trajectory(trajectory)
+        
+        assert regime is not None
+        assert regime.overall == "bear"
+    
+    def test_extract_regime_from_ground_truth(self):
+        """Extract regime from legacy ground_truth metadata."""
+        trajectory = {
+            "metadata": {
+                "ground_truth": {
+                    "initialPrices": {"BTC": 100000},
+                    "finalPrices": {"BTC": 110000},  # +10%
+                }
+            }
+        }
+        
+        regime = extract_regime_from_trajectory(trajectory)
+        
+        assert regime is not None
+        assert regime.overall == "bull"
+    
+    def test_expected_return_by_regime(self):
+        """Expected returns differ by regime."""
+        bull = MarketRegime(overall="bull", volatility=0.3, per_ticker={})
+        bear = MarketRegime(overall="bear", volatility=0.3, per_ticker={})
+        sideways = MarketRegime(overall="sideways", volatility=0.3, per_ticker={})
+        
+        assert get_expected_return(bull) == 0.05
+        assert get_expected_return(bear) == -0.05
+        assert get_expected_return(sideways) == 0.0
+
+
+# =============================================================================
+# Counterfactual Reward Tests
+# =============================================================================
+
+class TestCounterfactualRewards:
+    """Tests for counterfactual reward computation."""
+    
+    def test_counterfactual_bull_market_underperformance(self):
+        """In bull market, underperforming has negative alpha."""
+        # Bull market: expected +5% = +500 on 10k starting balance
+        # Agent made +3% = +300
+        result = compute_counterfactual(
+            actual_pnl=300,
+            starting_balance=10000,
+            regime_overall="bull",
+            regime_expected_return=0.05,
+        )
+        
+        assert result.benchmark_pnl == 500  # 5% of 10k
+        assert result.alpha == -200  # 300 - 500
+        assert result.actual_pnl == 300
+    
+    def test_counterfactual_bear_market_outperformance(self):
+        """In bear market, losing less than expected has positive alpha."""
+        # Bear market: expected -5% = -500
+        # Agent lost -2% = -200
+        result = compute_counterfactual(
+            actual_pnl=-200,
+            starting_balance=10000,
+            regime_overall="bear",
+            regime_expected_return=-0.05,
+        )
+        
+        assert result.benchmark_pnl == -500  # -5% of 10k
+        assert result.alpha == 300  # -200 - (-500) = +300
+    
+    def test_counterfactual_sideways_market(self):
+        """In sideways market, any profit is positive alpha."""
+        result = compute_counterfactual(
+            actual_pnl=100,
+            starting_balance=10000,
+            regime_overall="sideways",
+            regime_expected_return=0.0,
+        )
+        
+        assert result.benchmark_pnl == 0
+        assert result.alpha == 100
+    
+    def test_regime_adjusted_pnl_reward_scaling(self):
+        """Regime-adjusted reward scales correctly."""
+        # 10% adjusted return = 1.0 reward
+        reward = regime_adjusted_pnl_reward(
+            actual_pnl=1000,
+            starting_balance=10000,
+            regime_overall="sideways",
+            regime_volatility=0.0,
+            regime_expected_return=0.0,
+        )
+        
+        assert reward == 1.0  # 10% return, no adjustment, no dampening
+    
+    def test_regime_adjusted_pnl_volatility_dampening(self):
+        """High volatility dampens reward signal."""
+        # Same P&L, different volatility
+        low_vol_reward = regime_adjusted_pnl_reward(
+            actual_pnl=500,
+            starting_balance=10000,
+            regime_overall="sideways",
+            regime_volatility=0.0,
+            regime_expected_return=0.0,
+        )
+        
+        high_vol_reward = regime_adjusted_pnl_reward(
+            actual_pnl=500,
+            starting_balance=10000,
+            regime_overall="sideways",
+            regime_volatility=1.0,
+            regime_expected_return=0.0,
+        )
+        
+        assert low_vol_reward > high_vol_reward
+    
+    def test_alpha_reward_scaling(self):
+        """Alpha reward scales appropriately."""
+        # 5% alpha = 1.0 reward
+        reward = calculate_alpha_reward(
+            alpha=500,
+            starting_balance=10000,
+        )
+        
+        assert reward == 1.0  # 5% alpha = max reward
+
+
+# =============================================================================
+# Temporal Credit Tests
+# =============================================================================
+
+class TestTemporalCredit:
+    """Tests for temporal credit assignment."""
+    
+    def test_is_trading_action(self):
+        """Trading actions are correctly identified."""
+        assert is_trading_action("buy") == True
+        assert is_trading_action("sell") == True
+        assert is_trading_action("open_perp") == True
+        assert is_trading_action("close_perp") == True
+        assert is_trading_action("BUY_PREDICTION") == True  # Case insensitive
+        
+        assert is_trading_action("social") == False
+        assert is_trading_action("research") == False
+        assert is_trading_action("chat") == False
+    
+    def test_credit_weight_decay(self):
+        """Credit weight decays exponentially with distance."""
+        # Same step = full weight
+        assert calculate_credit_weight(10, 10) == 1.0
+        
+        # 1 step away
+        weight_1 = calculate_credit_weight(9, 10)
+        assert weight_1 == DEFAULT_DECAY_RATE  # 0.9
+        
+        # 2 steps away
+        weight_2 = calculate_credit_weight(8, 10)
+        assert weight_2 == DEFAULT_DECAY_RATE ** 2
+        
+        # Weight decreases with distance
+        assert weight_2 < weight_1
+    
+    def test_attribute_temporal_credit_basic(self):
+        """Basic temporal credit attribution."""
+        steps = [
+            {"action": {"actionType": "buy", "parameters": {"marketId": "BTC"}}},
+            {"action": {"actionType": "research", "parameters": {}}},
+            {"action": {"actionType": "sell", "parameters": {"marketId": "BTC"}}},
+        ]
+        
+        credits = attribute_temporal_credit(steps, final_pnl=100)
+        
+        # Should have credits for buy and sell actions
+        assert len(credits) == 2
+        
+        # Later decisions get more weight
+        buy_credit = next(c for c in credits if c.decision_step == 0)
+        sell_credit = next(c for c in credits if c.decision_step == 2)
+        
+        assert sell_credit.credit_weight > buy_credit.credit_weight
+    
+    def test_attribute_credit_per_market(self):
+        """Credit attribution with per-market outcome data."""
+        steps = [
+            {"action": {"actionType": "buy", "parameters": {"marketId": "BTC"}}},
+            {"action": {"actionType": "buy", "parameters": {"marketId": "ETH"}}},
+        ]
+        
+        outcome_data = {"BTC": 100, "ETH": -50}
+        credits = attribute_temporal_credit(steps, final_pnl=50, outcome_data=outcome_data)
+        
+        btc_credit = next(c for c in credits if c.market_id == "BTC")
+        eth_credit = next(c for c in credits if c.market_id == "ETH")
+        
+        assert btc_credit.outcome_pnl > 0
+        assert eth_credit.outcome_pnl < 0
+    
+    def test_aggregate_credits_by_market(self):
+        """Credits can be aggregated by market."""
+        credits = [
+            TemporalCredit(decision_step=0, outcome_step=5, credit_weight=0.9, outcome_pnl=50, market_id="BTC"),
+            TemporalCredit(decision_step=2, outcome_step=5, credit_weight=0.8, outcome_pnl=50, market_id="BTC"),
+            TemporalCredit(decision_step=1, outcome_step=5, credit_weight=0.85, outcome_pnl=-30, market_id="ETH"),
+        ]
+        
+        by_market = aggregate_credits_by_market(credits)
+        
+        assert by_market["BTC"] == 100
+        assert by_market["ETH"] == -30
+    
+    def test_temporal_credit_bonus_calculation(self):
+        """Temporal credit bonus scales correctly."""
+        credits = [
+            TemporalCredit(decision_step=0, outcome_step=5, credit_weight=0.9, outcome_pnl=500),
+        ]
+        
+        bonus = calculate_temporal_credit_bonus(credits, starting_balance=10000)
+        
+        # 500 * 0.9 = 450 credited, 4.5% of starting = 0.45 bonus
+        assert 0.4 < bonus < 0.5
+
+
+# =============================================================================
+# Enhanced Composite Reward Tests
+# =============================================================================
+
+class TestEnhancedCompositeReward:
+    """Tests for the enhanced composite reward function."""
+    
+    def test_fallback_to_archetype_reward_without_regime(self):
+        """Without regime context, falls back to archetype_composite_reward."""
+        inputs = TrajectoryRewardInputs(
+            final_pnl=500,
+            starting_balance=10000,
+            end_balance=10500,
+            format_score=0.8,
+            reasoning_score=0.7,
+        )
+        
+        enhanced = enhanced_composite_reward(
+            inputs=inputs,
+            archetype="trader",
+            behavior_metrics=None,
+            regime_overall=None,
+        )
+        
+        archetype = archetype_composite_reward(
+            inputs=inputs,
+            archetype="trader",
+            behavior_metrics=None,
+        )
+        
+        assert enhanced == archetype
+    
+    def test_enhanced_reward_with_regime(self):
+        """Enhanced reward uses regime adjustment when available."""
+        inputs = TrajectoryRewardInputs(
+            final_pnl=500,
+            starting_balance=10000,
+            end_balance=10500,
+            format_score=0.8,
+            reasoning_score=0.7,
+        )
+        
+        # Bull market: +500 is only +5% (expected), so alpha = 0
+        bull_reward = enhanced_composite_reward(
+            inputs=inputs,
+            archetype="trader",
+            regime_overall="bull",
+            regime_volatility=0.3,
+            regime_expected_return=0.05,
+            counterfactual_alpha=0,
+        )
+        
+        # Bear market: +500 is +5% vs -5% expected, so alpha = +1000
+        bear_reward = enhanced_composite_reward(
+            inputs=inputs,
+            archetype="trader",
+            regime_overall="bear",
+            regime_volatility=0.3,
+            regime_expected_return=-0.05,
+            counterfactual_alpha=1000,
+        )
+        
+        # Bear market performance should be rewarded more
+        assert bear_reward > bull_reward
+    
+    def test_enhanced_reward_bounded(self):
+        """Enhanced reward stays in [-1.0, 1.0] range."""
+        inputs = TrajectoryRewardInputs(
+            final_pnl=5000,  # Huge profit
+            starting_balance=10000,
+            end_balance=15000,
+            format_score=1.0,
+            reasoning_score=1.0,
+        )
+        
+        reward = enhanced_composite_reward(
+            inputs=inputs,
+            archetype="trader",
+            regime_overall="sideways",
+            regime_volatility=0.1,
+            regime_expected_return=0.0,
+            counterfactual_alpha=5000,
+        )
+        
+        assert -1.0 <= reward <= 1.0
+    
+    def test_temporal_credits_integrated(self):
+        """Temporal credits are included in enhanced reward."""
+        inputs = TrajectoryRewardInputs(
+            final_pnl=0,  # No raw P&L
+            starting_balance=10000,
+            end_balance=10000,
+            format_score=0.5,
+            reasoning_score=0.5,
+        )
+        
+        credits = [
+            TemporalCredit(decision_step=0, outcome_step=5, credit_weight=1.0, outcome_pnl=500),
+        ]
+        
+        with_credits = enhanced_composite_reward(
+            inputs=inputs,
+            archetype="trader",
+            regime_overall="sideways",
+            regime_expected_return=0.0,
+            temporal_credits=credits,
+        )
+        
+        without_credits = enhanced_composite_reward(
+            inputs=inputs,
+            archetype="trader",
+            regime_overall="sideways",
+            regime_expected_return=0.0,
+            temporal_credits=[],
+        )
+        
+        assert with_credits > without_credits
+
+
+# =============================================================================
+# Reward Config Tests
+# =============================================================================
+
+class TestRewardConfig:
+    """Tests for reward weight configuration loading."""
+    
+    def test_default_weights_available(self):
+        """Default weight profile is always available."""
+        weights = get_reward_weights("default")
+        
+        assert "regime_pnl" in weights
+        assert "skill_alpha" in weights
+        assert "temporal_bonus" in weights
+        assert "format" in weights
+        assert "reasoning" in weights
+        assert "behavior" in weights
+    
+    def test_weights_sum_to_one(self):
+        """Weight profiles sum to 1.0."""
+        for profile in list_weight_profiles():
+            weights = get_reward_weights(profile)
+            total = sum(weights.values())
+            # Allow small floating point error
+            assert abs(total - 1.0) < 0.01, f"Profile {profile} sums to {total}"
+    
+    def test_regime_expected_returns(self):
+        """Regime expected returns are configured."""
+        assert get_regime_expected_return("bull") == 0.05
+        assert get_regime_expected_return("bear") == -0.05
+        assert get_regime_expected_return("sideways") == 0.0
+        
+        # Unknown regime defaults to 0
+        assert get_regime_expected_return("unknown") == 0.0
+    
+    def test_temporal_decay_rate(self):
+        """Temporal decay rate is configured."""
+        decay = get_temporal_decay_rate()
+        assert 0.0 < decay <= 1.0
+
+
+# =============================================================================
+# Integration Tests
+# =============================================================================
+
+class TestEnhancedRewardsIntegration:
+    """Integration tests for the complete enhanced reward pipeline."""
+    
+    def test_full_pipeline_bull_market(self):
+        """Full pipeline test in bull market."""
+        # Simulate bull market trajectory
+        trajectory = {
+            "final_pnl": 300,
+            "metadata": {
+                "price_context": {
+                    "initial_prices": {"BTC": 100000, "ETH": 4000},
+                    "final_prices": {"BTC": 110000, "ETH": 4400},  # +10% each
+                }
+            },
+            "steps": [
+                {"action": {"actionType": "buy", "parameters": {"marketId": "BTC"}}},
+                {"action": {"actionType": "sell", "parameters": {"marketId": "BTC"}}},
+            ],
+        }
+        
+        # Extract regime
+        regime = extract_regime_from_trajectory(trajectory)
+        assert regime is not None
+        assert regime.overall == "bull"
+        
+        # Compute counterfactual
+        expected_return = get_regime_expected_return(regime.overall)
+        counterfactual = compute_counterfactual(
+            actual_pnl=trajectory["final_pnl"],
+            starting_balance=10000,
+            regime_overall=regime.overall,
+            regime_expected_return=expected_return,
+        )
+        
+        # In bull market with +5% expected, +3% actual = negative alpha
+        assert counterfactual.alpha < 0
+        
+        # Compute temporal credits
+        credits = attribute_temporal_credit(
+            trajectory["steps"],
+            trajectory["final_pnl"],
+        )
+        assert len(credits) == 2
+        
+        # Compute enhanced reward
+        inputs = TrajectoryRewardInputs(
+            final_pnl=trajectory["final_pnl"],
+            starting_balance=10000,
+            end_balance=10300,
+            format_score=0.8,
+            reasoning_score=0.7,
+        )
+        
+        reward = enhanced_composite_reward(
+            inputs=inputs,
+            archetype="trader",
+            regime_overall=regime.overall,
+            regime_volatility=regime.volatility,
+            regime_expected_return=expected_return,
+            counterfactual_alpha=counterfactual.alpha,
+            temporal_credits=credits,
+        )
+        
+        # Should still be positive (profitable) but not max due to underperformance
+        assert -1.0 <= reward <= 1.0
+    
+    def test_full_pipeline_bear_market_outperformance(self):
+        """Full pipeline test: outperforming in bear market."""
+        # Simulate bear market trajectory
+        trajectory = {
+            "final_pnl": -200,  # Lost 2%
+            "metadata": {
+                "price_context": {
+                    "initial_prices": {"BTC": 100000, "ETH": 4000},
+                    "final_prices": {"BTC": 90000, "ETH": 3600},  # -10% each
+                }
+            },
+            "steps": [
+                {"action": {"actionType": "sell", "parameters": {"marketId": "BTC"}}},
+            ],
+        }
+        
+        # Extract regime
+        regime = extract_regime_from_trajectory(trajectory)
+        assert regime.overall == "bear"
+        
+        # Compute counterfactual
+        expected_return = get_regime_expected_return(regime.overall)  # -5%
+        counterfactual = compute_counterfactual(
+            actual_pnl=trajectory["final_pnl"],
+            starting_balance=10000,
+            regime_overall=regime.overall,
+            regime_expected_return=expected_return,
+        )
+        
+        # Lost -2% vs expected -5% = positive alpha (+3% = +300)
+        assert counterfactual.alpha > 0
+        
+        # Enhanced reward should recognize the outperformance
+        inputs = TrajectoryRewardInputs(
+            final_pnl=trajectory["final_pnl"],
+            starting_balance=10000,
+            end_balance=9800,
+            format_score=0.8,
+            reasoning_score=0.7,
+        )
+        
+        reward = enhanced_composite_reward(
+            inputs=inputs,
+            archetype="trader",
+            regime_overall=regime.overall,
+            regime_volatility=regime.volatility,
+            regime_expected_return=expected_return,
+            counterfactual_alpha=counterfactual.alpha,
+        )
+        
+        # Should be positive despite negative P&L due to outperformance
+        assert reward > 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])
+

--- a/packages/training/python/tests/test_enhanced_rewards_extended.py
+++ b/packages/training/python/tests/test_enhanced_rewards_extended.py
@@ -1,0 +1,1130 @@
+"""
+Extended Tests for Enhanced Reward Signals
+
+Comprehensive coverage for:
+- Boundary conditions and edge cases
+- Error handling and invalid inputs
+- All code paths and branches
+- Real function calls (no mocks of code under test)
+"""
+
+import pytest
+import math
+from typing import Dict
+
+from src.training.market_regime import (
+    MarketRegime,
+    detect_market_regime,
+    detect_regime_from_prices,
+    extract_regime_from_trajectory,
+    calculate_volatility,
+    calculate_price_change_pct,
+    detect_ticker_trend,
+    detect_overall_regime,
+    get_expected_return,
+    BULL_THRESHOLD,
+    BEAR_THRESHOLD,
+    TICKER_UP_THRESHOLD,
+    TICKER_DOWN_THRESHOLD,
+)
+
+from src.training.rewards import (
+    CounterfactualResult,
+    TemporalCredit,
+    compute_counterfactual,
+    regime_adjusted_pnl_reward,
+    calculate_alpha_reward,
+    calculate_temporal_credit_bonus,
+    enhanced_composite_reward,
+    archetype_composite_reward,
+    TrajectoryRewardInputs,
+    BehaviorMetrics,
+    clamp_bonus,
+    ARCHETYPE_REWARD_WEIGHTS,
+)
+
+from src.training.temporal_credit import (
+    is_trading_action,
+    extract_market_id,
+    extract_action_pnl,
+    calculate_credit_weight,
+    attribute_temporal_credit,
+    attribute_credit_with_intermediate_outcomes,
+    aggregate_credits_by_step,
+    aggregate_credits_by_market,
+    DEFAULT_DECAY_RATE,
+    TRADING_ACTION_TYPES,
+)
+
+from src.training.reward_config import (
+    RewardWeightConfig,
+    get_reward_weights,
+    get_regime_expected_return,
+    get_temporal_decay_rate,
+    list_weight_profiles,
+)
+
+
+# =============================================================================
+# Market Regime: Boundary Conditions
+# =============================================================================
+
+class TestMarketRegimeBoundaries:
+    """Boundary condition tests for market regime detection."""
+    
+    def test_exactly_at_bull_threshold(self):
+        """Price change exactly at bull threshold."""
+        price_data = {"BTC": [100000, 105000]}  # Exactly +5%
+        regime = detect_market_regime(price_data)
+        # At threshold, should be sideways (not strictly greater)
+        assert regime.overall == "sideways"
+        assert regime.avg_change_pct == 5.0
+    
+    def test_just_above_bull_threshold(self):
+        """Price change just above bull threshold."""
+        price_data = {"BTC": [100000, 105001]}  # +5.001%
+        regime = detect_market_regime(price_data)
+        assert regime.overall == "bull"
+    
+    def test_exactly_at_bear_threshold(self):
+        """Price change exactly at bear threshold."""
+        price_data = {"BTC": [100000, 95000]}  # Exactly -5%
+        regime = detect_market_regime(price_data)
+        assert regime.overall == "sideways"
+        assert regime.avg_change_pct == -5.0
+    
+    def test_just_below_bear_threshold(self):
+        """Price change just below bear threshold."""
+        price_data = {"BTC": [100000, 94999]}  # -5.001%
+        regime = detect_market_regime(price_data)
+        assert regime.overall == "bear"
+    
+    def test_zero_price_change(self):
+        """No price change at all."""
+        price_data = {"BTC": [100000, 100000]}
+        regime = detect_market_regime(price_data)
+        assert regime.overall == "sideways"
+        assert regime.avg_change_pct == 0.0
+    
+    def test_very_large_positive_change(self):
+        """Extreme bull market (+1000%)."""
+        price_data = {"BTC": [100000, 1100000]}  # +1000%
+        regime = detect_market_regime(price_data)
+        assert regime.overall == "bull"
+        assert regime.avg_change_pct == 1000.0
+    
+    def test_very_large_negative_change(self):
+        """Extreme bear market (-99%)."""
+        price_data = {"BTC": [100000, 1000]}  # -99%
+        regime = detect_market_regime(price_data)
+        assert regime.overall == "bear"
+        assert regime.avg_change_pct == -99.0
+    
+    def test_mixed_tickers_averaging_to_sideways(self):
+        """Mixed up/down tickers averaging to sideways."""
+        price_data = {
+            "BTC": [100000, 110000],  # +10%
+            "ETH": [100, 90],          # -10%
+        }
+        regime = detect_market_regime(price_data)
+        assert regime.overall == "sideways"
+        assert abs(regime.avg_change_pct) < 0.01
+        assert regime.per_ticker["BTC"] == "up"
+        assert regime.per_ticker["ETH"] == "down"
+
+
+class TestMarketRegimeEdgeCases:
+    """Edge case tests for market regime detection."""
+    
+    def test_zero_initial_price(self):
+        """Zero initial price should not cause division by zero."""
+        price_data = {"BTC": [0, 100000]}
+        regime = detect_market_regime(price_data)
+        # Should handle gracefully - 0% change
+        assert regime.per_ticker["BTC"] == "flat"
+    
+    def test_negative_prices(self):
+        """Negative prices (invalid but should not crash)."""
+        price_data = {"BTC": [-100, -50]}
+        regime = detect_market_regime(price_data)
+        # Should still compute (50% decrease in absolute terms)
+        assert regime is not None
+    
+    def test_single_ticker_single_price(self):
+        """Single ticker with single price point."""
+        price_data = {"BTC": [100000]}
+        regime = detect_market_regime(price_data)
+        assert regime.per_ticker["BTC"] == "flat"
+    
+    def test_many_tickers(self):
+        """Large number of tickers."""
+        price_data = {f"TICKER{i}": [100, 110] for i in range(100)}
+        regime = detect_market_regime(price_data)
+        assert regime.overall == "bull"
+        assert len(regime.per_ticker) == 100
+    
+    def test_empty_price_list(self):
+        """Ticker with empty price list."""
+        price_data = {"BTC": []}
+        regime = detect_market_regime(price_data)
+        # Empty list means no change data
+        assert regime is not None
+
+
+class TestVolatilityCalculation:
+    """Tests for volatility calculation edge cases."""
+    
+    def test_single_change(self):
+        """Single change returns default volatility."""
+        vol = calculate_volatility([5.0])
+        assert vol == 0.5  # Default for insufficient data
+    
+    def test_empty_changes(self):
+        """Empty list returns default volatility."""
+        vol = calculate_volatility([])
+        assert vol == 0.5
+    
+    def test_identical_changes(self):
+        """All identical changes = zero variance."""
+        vol = calculate_volatility([5.0, 5.0, 5.0, 5.0])
+        # Zero variance means below low threshold
+        assert vol == 0.0
+    
+    def test_extreme_volatility(self):
+        """Very high volatility is clamped to 1.0."""
+        vol = calculate_volatility([100.0, -100.0, 100.0, -100.0])
+        assert vol == 1.0
+    
+    def test_negative_volatility_clamping(self):
+        """Very low std dev doesn't go below 0."""
+        vol = calculate_volatility([0.1, 0.1, 0.11, 0.1])
+        assert vol >= 0.0
+
+
+class TestPriceChangeCalculation:
+    """Tests for price change percentage calculation."""
+    
+    def test_positive_change(self):
+        pct = calculate_price_change_pct(100, 110)
+        assert pct == 10.0
+    
+    def test_negative_change(self):
+        pct = calculate_price_change_pct(100, 90)
+        assert pct == -10.0
+    
+    def test_zero_initial(self):
+        """Zero initial price returns 0 to avoid division by zero."""
+        pct = calculate_price_change_pct(0, 100)
+        assert pct == 0.0
+    
+    def test_negative_initial(self):
+        """Negative initial price returns 0."""
+        pct = calculate_price_change_pct(-100, 100)
+        assert pct == 0.0
+    
+    def test_double_price(self):
+        pct = calculate_price_change_pct(100, 200)
+        assert pct == 100.0
+
+
+class TestTickerTrendDetection:
+    """Tests for ticker trend classification."""
+    
+    def test_up_exactly_at_threshold(self):
+        trend = detect_ticker_trend(TICKER_UP_THRESHOLD)
+        # At threshold, should be flat
+        assert trend == "flat"
+    
+    def test_down_exactly_at_threshold(self):
+        trend = detect_ticker_trend(TICKER_DOWN_THRESHOLD)
+        assert trend == "flat"
+    
+    def test_up_above_threshold(self):
+        trend = detect_ticker_trend(TICKER_UP_THRESHOLD + 0.01)
+        assert trend == "up"
+    
+    def test_down_below_threshold(self):
+        trend = detect_ticker_trend(TICKER_DOWN_THRESHOLD - 0.01)
+        assert trend == "down"
+
+
+class TestRegimeFromTrajectoryExtraction:
+    """Tests for extracting regime from trajectory metadata."""
+    
+    def test_empty_trajectory(self):
+        """Empty trajectory returns None."""
+        regime = extract_regime_from_trajectory({})
+        assert regime is None
+    
+    def test_trajectory_without_metadata(self):
+        """Trajectory without metadata returns None."""
+        regime = extract_regime_from_trajectory({"steps": []})
+        assert regime is None
+    
+    def test_trajectory_with_empty_metadata(self):
+        """Trajectory with empty metadata returns None."""
+        regime = extract_regime_from_trajectory({"metadata": {}})
+        assert regime is None
+    
+    def test_trajectory_with_precomputed_regime(self):
+        """Trajectory with pre-computed regime in price_context."""
+        trajectory = {
+            "metadata": {
+                "price_context": {
+                    "regime": {
+                        "overall": "bear",
+                        "volatility": 0.8,
+                        "per_ticker": {"BTC": "down"},
+                        "avg_change_pct": -10.0,
+                    }
+                }
+            }
+        }
+        regime = extract_regime_from_trajectory(trajectory)
+        assert regime is not None
+        assert regime.overall == "bear"
+        assert regime.volatility == 0.8
+    
+    def test_trajectory_with_only_initial_prices(self):
+        """Trajectory with only initial prices, no final."""
+        trajectory = {
+            "metadata": {
+                "price_context": {
+                    "initial_prices": {"BTC": 100000},
+                }
+            }
+        }
+        regime = extract_regime_from_trajectory(trajectory)
+        assert regime is None
+    
+    def test_trajectory_with_mixed_camelcase_keys(self):
+        """Legacy ground_truth with camelCase keys."""
+        trajectory = {
+            "metadata": {
+                "ground_truth": {
+                    "initialPrices": {"BTC": 100000},
+                    "finalPrices": {"BTC": 80000},  # -20%
+                }
+            }
+        }
+        regime = extract_regime_from_trajectory(trajectory)
+        assert regime is not None
+        assert regime.overall == "bear"
+
+
+class TestMarketRegimeSerialization:
+    """Tests for MarketRegime to_dict/from_dict."""
+    
+    def test_roundtrip_all_fields(self):
+        """Full roundtrip preserves all fields."""
+        original = MarketRegime(
+            overall="bull",
+            volatility=0.75,
+            per_ticker={"BTC": "up", "ETH": "down", "SOL": "flat"},
+            avg_change_pct=7.5,
+            window_id="2025-01-14-10",
+        )
+        
+        data = original.to_dict()
+        restored = MarketRegime.from_dict(data)
+        
+        assert restored.overall == original.overall
+        assert restored.volatility == original.volatility
+        assert restored.per_ticker == original.per_ticker
+        assert restored.avg_change_pct == original.avg_change_pct
+        assert restored.window_id == original.window_id
+    
+    def test_from_dict_missing_optional_fields(self):
+        """from_dict handles missing optional fields."""
+        data = {
+            "overall": "sideways",
+            "volatility": 0.5,
+        }
+        regime = MarketRegime.from_dict(data)
+        assert regime.per_ticker == {}
+        assert regime.avg_change_pct == 0.0
+        assert regime.window_id is None
+    
+    def test_default_sideways_values(self):
+        """default_sideways() creates neutral regime."""
+        regime = MarketRegime.default_sideways()
+        assert regime.overall == "sideways"
+        assert regime.volatility == 0.5
+        assert regime.per_ticker == {}
+        assert regime.avg_change_pct == 0.0
+
+
+# =============================================================================
+# Temporal Credit: Edge Cases and Boundaries
+# =============================================================================
+
+class TestIsTradingActionComprehensive:
+    """Comprehensive tests for is_trading_action."""
+    
+    def test_all_known_trading_actions(self):
+        """All explicitly listed trading actions."""
+        for action in TRADING_ACTION_TYPES:
+            assert is_trading_action(action), f"{action} should be trading"
+    
+    def test_case_variations(self):
+        """Case insensitivity."""
+        assert is_trading_action("BUY") == True
+        assert is_trading_action("Buy") == True
+        assert is_trading_action("SELL") == True
+        assert is_trading_action("OpenPerp") == True
+    
+    def test_whitespace_handling(self):
+        """Whitespace is stripped."""
+        assert is_trading_action("  buy  ") == True
+        assert is_trading_action("\tsell\n") == True
+    
+    def test_partial_matches(self):
+        """Partial string matches for flexibility."""
+        assert is_trading_action("buy_btc") == True
+        assert is_trading_action("market_sell") == True
+        assert is_trading_action("open_position") == True
+        assert is_trading_action("close_all") == True
+    
+    def test_non_trading_actions(self):
+        """Non-trading actions."""
+        assert is_trading_action("chat") == False
+        assert is_trading_action("message") == False
+        assert is_trading_action("research") == False
+        assert is_trading_action("wait") == False
+        assert is_trading_action("observe") == False
+        assert is_trading_action("analyze") == False
+    
+    def test_empty_string(self):
+        """Empty string is not a trading action."""
+        assert is_trading_action("") == False
+    
+    def test_special_characters(self):
+        """Actions with special characters."""
+        assert is_trading_action("buy!") == True
+        assert is_trading_action("sell@market") == True
+
+
+class TestExtractMarketId:
+    """Tests for extract_market_id from step data."""
+    
+    def test_marketId_in_parameters(self):
+        step = {"action": {"parameters": {"marketId": "BTC"}}}
+        assert extract_market_id(step) == "BTC"
+    
+    def test_market_id_snake_case(self):
+        step = {"action": {"parameters": {"market_id": "ETH"}}}
+        assert extract_market_id(step) == "ETH"
+    
+    def test_ticker_parameter(self):
+        step = {"action": {"parameters": {"ticker": "SOL"}}}
+        assert extract_market_id(step) == "SOL"
+    
+    def test_market_parameter(self):
+        step = {"action": {"parameters": {"market": "DOGE"}}}
+        assert extract_market_id(step) == "DOGE"
+    
+    def test_symbol_parameter(self):
+        step = {"action": {"parameters": {"symbol": "AVAX"}}}
+        assert extract_market_id(step) == "AVAX"
+    
+    def test_market_in_result(self):
+        step = {"action": {"result": {"market": "BNB"}}}
+        assert extract_market_id(step) == "BNB"
+    
+    def test_empty_step(self):
+        assert extract_market_id({}) is None
+    
+    def test_no_action(self):
+        step = {"result": {"market": "XRP"}}
+        assert extract_market_id(step) is None
+    
+    def test_no_parameters_or_result(self):
+        step = {"action": {"actionType": "buy"}}
+        assert extract_market_id(step) is None
+    
+    def test_numeric_market_id(self):
+        """Numeric market IDs are converted to string."""
+        step = {"action": {"parameters": {"marketId": 12345}}}
+        assert extract_market_id(step) == "12345"
+
+
+class TestExtractActionPnl:
+    """Tests for extract_action_pnl from step data."""
+    
+    def test_pnl_in_result(self):
+        step = {"action": {"result": {"pnl": 150.50}}}
+        assert extract_action_pnl(step) == 150.50
+    
+    def test_realized_pnl_camelcase(self):
+        step = {"action": {"result": {"realizedPnL": -50.0}}}
+        assert extract_action_pnl(step) == -50.0
+    
+    def test_realized_pnl_snake_case(self):
+        step = {"action": {"result": {"realized_pnl": 200}}}
+        assert extract_action_pnl(step) == 200.0
+    
+    def test_pnl_zero(self):
+        step = {"action": {"result": {"pnl": 0}}}
+        assert extract_action_pnl(step) == 0.0
+    
+    def test_no_pnl(self):
+        step = {"action": {"result": {"success": True}}}
+        assert extract_action_pnl(step) is None
+    
+    def test_empty_step(self):
+        assert extract_action_pnl({}) is None
+    
+    def test_string_pnl(self):
+        """String P&L is converted to float."""
+        step = {"action": {"result": {"pnl": "100.5"}}}
+        assert extract_action_pnl(step) == 100.5
+
+
+class TestCreditWeightCalculation:
+    """Tests for calculate_credit_weight."""
+    
+    def test_same_step_full_weight(self):
+        """Decision at outcome step gets full weight."""
+        assert calculate_credit_weight(5, 5) == 1.0
+    
+    def test_one_step_away(self):
+        """One step before outcome."""
+        weight = calculate_credit_weight(4, 5, decay_rate=0.9)
+        assert weight == 0.9
+    
+    def test_many_steps_away(self):
+        """Many steps before outcome (exponential decay)."""
+        weight = calculate_credit_weight(0, 10, decay_rate=0.9)
+        expected = 0.9 ** 10
+        assert abs(weight - expected) < 1e-9
+    
+    def test_future_decision_clamped(self):
+        """Decision after outcome (invalid) clamps to 0 distance."""
+        weight = calculate_credit_weight(10, 5)
+        assert weight == 1.0  # max(0, -5) = 0, decay^0 = 1
+    
+    def test_zero_decay_rate(self):
+        """Zero decay rate = only same-step credit."""
+        assert calculate_credit_weight(0, 10, decay_rate=0.0) == 0.0
+        assert calculate_credit_weight(10, 10, decay_rate=0.0) == 1.0
+    
+    def test_decay_rate_one(self):
+        """Decay rate 1.0 = uniform credit."""
+        assert calculate_credit_weight(0, 100, decay_rate=1.0) == 1.0
+    
+    def test_custom_decay_rate(self):
+        """Custom decay rate."""
+        weight = calculate_credit_weight(0, 5, decay_rate=0.5)
+        assert weight == 0.5 ** 5
+
+
+class TestAttributeTemporalCreditEdgeCases:
+    """Edge case tests for attribute_temporal_credit."""
+    
+    def test_empty_steps(self):
+        """Empty step list returns empty credits."""
+        credits = attribute_temporal_credit([], final_pnl=1000)
+        assert credits == []
+    
+    def test_no_trading_actions(self):
+        """Steps with no trading actions return empty credits."""
+        steps = [
+            {"action": {"actionType": "research"}},
+            {"action": {"actionType": "chat"}},
+        ]
+        credits = attribute_temporal_credit(steps, final_pnl=1000)
+        assert credits == []
+    
+    def test_trading_action_without_market_id(self):
+        """Trading action without market ID is skipped."""
+        steps = [
+            {"action": {"actionType": "buy", "parameters": {}}},  # No market
+        ]
+        credits = attribute_temporal_credit(steps, final_pnl=1000)
+        assert credits == []
+    
+    def test_single_trading_action(self):
+        """Single trading action gets full credit."""
+        steps = [
+            {"action": {"actionType": "buy", "parameters": {"marketId": "BTC"}}},
+        ]
+        credits = attribute_temporal_credit(steps, final_pnl=500)
+        assert len(credits) == 1
+        assert credits[0].outcome_pnl == 500  # Full P&L
+    
+    def test_zero_final_pnl(self):
+        """Zero final P&L distributes zero credit."""
+        steps = [
+            {"action": {"actionType": "buy", "parameters": {"marketId": "BTC"}}},
+            {"action": {"actionType": "sell", "parameters": {"marketId": "BTC"}}},
+        ]
+        credits = attribute_temporal_credit(steps, final_pnl=0)
+        assert all(c.outcome_pnl == 0 for c in credits)
+    
+    def test_negative_final_pnl(self):
+        """Negative final P&L distributes negative credit."""
+        steps = [
+            {"action": {"actionType": "buy", "parameters": {"marketId": "BTC"}}},
+        ]
+        credits = attribute_temporal_credit(steps, final_pnl=-500)
+        assert credits[0].outcome_pnl == -500
+    
+    def test_per_market_outcome_data(self):
+        """Per-market outcome data is used correctly."""
+        steps = [
+            {"action": {"actionType": "buy", "parameters": {"marketId": "BTC"}}},
+            {"action": {"actionType": "buy", "parameters": {"marketId": "ETH"}}},
+        ]
+        outcome_data = {"BTC": 300, "ETH": -100}
+        credits = attribute_temporal_credit(steps, final_pnl=200, outcome_data=outcome_data)
+        
+        btc_credits = [c for c in credits if c.market_id == "BTC"]
+        eth_credits = [c for c in credits if c.market_id == "ETH"]
+        
+        assert len(btc_credits) == 1
+        assert len(eth_credits) == 1
+        assert btc_credits[0].outcome_pnl == 300  # Only BTC trade for BTC
+        assert eth_credits[0].outcome_pnl == -100
+    
+    def test_outcome_data_with_missing_market(self):
+        """Outcome data for market not in steps is ignored."""
+        steps = [
+            {"action": {"actionType": "buy", "parameters": {"marketId": "BTC"}}},
+        ]
+        outcome_data = {"BTC": 100, "ETH": 200}  # ETH not in steps
+        credits = attribute_temporal_credit(steps, final_pnl=100, outcome_data=outcome_data)
+        
+        assert len(credits) == 1
+        assert credits[0].market_id == "BTC"
+
+
+class TestAttributeCreditWithIntermediateOutcomes:
+    """Tests for intermediate outcome credit assignment."""
+    
+    def test_open_and_close_with_pnl(self):
+        """Open position followed by close with P&L."""
+        steps = [
+            {"action": {"actionType": "buy", "parameters": {"marketId": "BTC"}}},
+            {"action": {"actionType": "sell", "parameters": {"marketId": "BTC"}, "result": {"pnl": 150}}},
+        ]
+        credits = attribute_credit_with_intermediate_outcomes(steps)
+        
+        # Should have credit for buy (opening) and sell (closing)
+        assert len(credits) == 2
+        
+        # Closing decision gets full credit
+        close_credit = next(c for c in credits if c.decision_step == 1)
+        assert close_credit.outcome_pnl == 150
+        assert close_credit.credit_weight == 1.0
+    
+    def test_no_closes_no_credits(self):
+        """Only opens without closes = no credits."""
+        steps = [
+            {"action": {"actionType": "open_long", "parameters": {"marketId": "BTC"}}},
+            {"action": {"actionType": "open_long", "parameters": {"marketId": "ETH"}}},
+        ]
+        credits = attribute_credit_with_intermediate_outcomes(steps)
+        assert credits == []
+    
+    def test_close_without_pnl(self):
+        """Close without P&L in result = no credit."""
+        steps = [
+            {"action": {"actionType": "buy", "parameters": {"marketId": "BTC"}}},
+            {"action": {"actionType": "sell", "parameters": {"marketId": "BTC"}, "result": {"success": True}}},
+        ]
+        credits = attribute_credit_with_intermediate_outcomes(steps)
+        assert credits == []
+    
+    def test_lifo_matching(self):
+        """Multiple opens: LIFO matching for closes."""
+        steps = [
+            {"action": {"actionType": "buy", "parameters": {"marketId": "BTC"}}},  # 0
+            {"action": {"actionType": "buy", "parameters": {"marketId": "BTC"}}},  # 1
+            {"action": {"actionType": "sell", "parameters": {"marketId": "BTC"}, "result": {"pnl": 100}}},  # 2
+        ]
+        credits = attribute_credit_with_intermediate_outcomes(steps)
+        
+        # Should credit step 1 (most recent open) not step 0
+        open_credit = next((c for c in credits if c.decision_step < 2), None)
+        assert open_credit is not None
+        assert open_credit.decision_step == 1
+
+
+class TestAggregateCredits:
+    """Tests for credit aggregation functions."""
+    
+    def test_aggregate_by_step_empty(self):
+        result = aggregate_credits_by_step([])
+        assert result == {}
+    
+    def test_aggregate_by_step_single(self):
+        credits = [TemporalCredit(decision_step=0, outcome_step=5, credit_weight=0.9, outcome_pnl=100)]
+        result = aggregate_credits_by_step(credits)
+        assert result == {0: 100}
+    
+    def test_aggregate_by_step_multiple_same_step(self):
+        credits = [
+            TemporalCredit(decision_step=0, outcome_step=5, credit_weight=0.9, outcome_pnl=100),
+            TemporalCredit(decision_step=0, outcome_step=5, credit_weight=0.8, outcome_pnl=50),
+        ]
+        result = aggregate_credits_by_step(credits)
+        assert result == {0: 150}
+    
+    def test_aggregate_by_market_empty(self):
+        result = aggregate_credits_by_market([])
+        assert result == {}
+    
+    def test_aggregate_by_market_none_market(self):
+        credits = [TemporalCredit(decision_step=0, outcome_step=5, credit_weight=0.9, outcome_pnl=100, market_id=None)]
+        result = aggregate_credits_by_market(credits)
+        assert result == {"unknown": 100}
+
+
+# =============================================================================
+# Counterfactual Rewards: Edge Cases
+# =============================================================================
+
+class TestCounterfactualEdgeCases:
+    """Edge case tests for counterfactual computation."""
+    
+    def test_zero_starting_balance(self):
+        """Zero starting balance should not cause division by zero."""
+        result = compute_counterfactual(
+            actual_pnl=100,
+            starting_balance=0,
+            regime_overall="bull",
+            regime_expected_return=0.05,
+        )
+        # Benchmark should be 0
+        assert result.benchmark_pnl == 0
+        assert result.alpha == 100
+    
+    def test_negative_starting_balance(self):
+        """Negative starting balance (invalid but should not crash)."""
+        result = compute_counterfactual(
+            actual_pnl=100,
+            starting_balance=-10000,
+            regime_overall="bull",
+            regime_expected_return=0.05,
+        )
+        # Negative expected return
+        assert result.benchmark_pnl == -500
+    
+    def test_very_large_pnl(self):
+        """Very large P&L values."""
+        result = compute_counterfactual(
+            actual_pnl=1_000_000,
+            starting_balance=10000,
+            regime_overall="sideways",
+            regime_expected_return=0.0,
+        )
+        assert result.alpha == 1_000_000
+    
+    def test_matching_benchmark(self):
+        """Actual P&L exactly matches benchmark."""
+        result = compute_counterfactual(
+            actual_pnl=500,
+            starting_balance=10000,
+            regime_overall="bull",
+            regime_expected_return=0.05,
+        )
+        assert result.benchmark_pnl == 500
+        assert result.alpha == 0
+    
+    def test_unknown_regime(self):
+        """Unknown regime type defaults to sideways behavior."""
+        result = compute_counterfactual(
+            actual_pnl=100,
+            starting_balance=10000,
+            regime_overall="unknown_regime",
+            regime_expected_return=0.0,  # Would need to pass 0 for unknown
+        )
+        assert result.benchmark_pnl == 0
+        assert result.alpha == 100
+
+
+class TestRegimeAdjustedPnlReward:
+    """Tests for regime_adjusted_pnl_reward edge cases."""
+    
+    def test_zero_starting_balance(self):
+        """Zero starting balance returns 0 reward."""
+        reward = regime_adjusted_pnl_reward(
+            actual_pnl=1000,
+            starting_balance=0,
+            regime_overall="bull",
+            regime_volatility=0.5,
+            regime_expected_return=0.05,
+        )
+        # Should handle gracefully
+        assert reward == 0.0 or math.isnan(reward) == False
+    
+    def test_extreme_pnl_bounded(self):
+        """Extreme P&L is bounded to [-1, 1]."""
+        reward = regime_adjusted_pnl_reward(
+            actual_pnl=100000,  # 1000% gain
+            starting_balance=10000,
+            regime_overall="sideways",
+            regime_volatility=0.0,
+            regime_expected_return=0.0,
+        )
+        assert -1.0 <= reward <= 1.0
+    
+    def test_volatility_dampening_range(self):
+        """Volatility dampening works across full range."""
+        for vol in [0.0, 0.25, 0.5, 0.75, 1.0]:
+            reward = regime_adjusted_pnl_reward(
+                actual_pnl=500,
+                starting_balance=10000,
+                regime_overall="sideways",
+                regime_volatility=vol,
+                regime_expected_return=0.0,
+            )
+            assert -1.0 <= reward <= 1.0
+
+
+class TestAlphaReward:
+    """Tests for calculate_alpha_reward edge cases."""
+    
+    def test_zero_alpha(self):
+        reward = calculate_alpha_reward(alpha=0, starting_balance=10000)
+        assert reward == 0.0
+    
+    def test_positive_alpha(self):
+        # 5% alpha = max reward
+        reward = calculate_alpha_reward(alpha=500, starting_balance=10000)
+        assert reward == 1.0
+    
+    def test_negative_alpha(self):
+        # -5% alpha = min reward
+        reward = calculate_alpha_reward(alpha=-500, starting_balance=10000)
+        assert reward == -1.0
+    
+    def test_extreme_alpha_bounded(self):
+        reward = calculate_alpha_reward(alpha=100000, starting_balance=10000)
+        assert -1.0 <= reward <= 1.0
+    
+    def test_zero_starting_balance(self):
+        reward = calculate_alpha_reward(alpha=100, starting_balance=0)
+        # Should handle gracefully
+        assert isinstance(reward, float)
+
+
+class TestTemporalCreditBonus:
+    """Tests for calculate_temporal_credit_bonus."""
+    
+    def test_empty_credits(self):
+        bonus = calculate_temporal_credit_bonus([], starting_balance=10000)
+        assert bonus == 0.0
+    
+    def test_positive_credits(self):
+        credits = [
+            TemporalCredit(decision_step=0, outcome_step=5, credit_weight=1.0, outcome_pnl=500),
+        ]
+        bonus = calculate_temporal_credit_bonus(credits, starting_balance=10000)
+        assert bonus > 0
+    
+    def test_negative_credits(self):
+        credits = [
+            TemporalCredit(decision_step=0, outcome_step=5, credit_weight=1.0, outcome_pnl=-500),
+        ]
+        bonus = calculate_temporal_credit_bonus(credits, starting_balance=10000)
+        assert bonus < 0
+    
+    def test_mixed_credits(self):
+        credits = [
+            TemporalCredit(decision_step=0, outcome_step=5, credit_weight=1.0, outcome_pnl=500),
+            TemporalCredit(decision_step=1, outcome_step=5, credit_weight=0.9, outcome_pnl=-200),
+        ]
+        bonus = calculate_temporal_credit_bonus(credits, starting_balance=10000)
+        # Net positive, but partial
+        assert isinstance(bonus, float)
+
+
+# =============================================================================
+# Enhanced Composite Reward: All Code Paths
+# =============================================================================
+
+class TestEnhancedCompositeRewardCodePaths:
+    """Tests covering all code paths in enhanced_composite_reward."""
+    
+    def _make_inputs(self, final_pnl=500) -> TrajectoryRewardInputs:
+        return TrajectoryRewardInputs(
+            final_pnl=final_pnl,
+            starting_balance=10000,
+            end_balance=10000 + final_pnl,
+            format_score=0.8,
+            reasoning_score=0.7,
+        )
+    
+    def test_all_weight_profiles(self):
+        """Test with all available weight profiles."""
+        inputs = self._make_inputs()
+        
+        # Test that enhanced_composite_reward works with the default profile
+        # (profile selection happens at a higher level in babylon_env)
+        reward = enhanced_composite_reward(
+            inputs=inputs,
+            archetype="trader",
+            regime_overall="sideways",
+        )
+        assert -1.0 <= reward <= 1.0
+        
+        # Verify profiles are loadable
+        for profile in list_weight_profiles():
+            weights = get_reward_weights(profile)
+            assert sum(weights.values()) > 0, f"Profile {profile} has no weights"
+    
+    def test_all_archetypes(self):
+        """Test with all archetypes."""
+        inputs = self._make_inputs()
+        
+        for archetype in ARCHETYPE_REWARD_WEIGHTS.keys():
+            reward = enhanced_composite_reward(
+                inputs=inputs,
+                archetype=archetype,
+                regime_overall="sideways",
+            )
+            assert -1.0 <= reward <= 1.0, f"Archetype {archetype} gave out of range reward"
+    
+    def test_with_behavior_metrics(self):
+        """Test with behavior metrics provided."""
+        inputs = self._make_inputs()
+        metrics = BehaviorMetrics(
+            trades_executed=10,
+            profitable_trades=6,
+            win_rate=0.6,
+            total_pnl=500,
+        )
+        
+        reward = enhanced_composite_reward(
+            inputs=inputs,
+            archetype="trader",
+            behavior_metrics=metrics,
+            regime_overall="bull",
+            regime_expected_return=0.05,
+        )
+        assert -1.0 <= reward <= 1.0
+    
+    def test_all_components_zero(self):
+        """Test with all components being zero."""
+        inputs = TrajectoryRewardInputs(
+            final_pnl=0,
+            starting_balance=10000,
+            end_balance=10000,
+            format_score=0.0,
+            reasoning_score=0.0,
+        )
+        
+        reward = enhanced_composite_reward(
+            inputs=inputs,
+            archetype="trader",
+            regime_overall="sideways",
+            counterfactual_alpha=0,
+            temporal_credits=[],
+        )
+        # Should be 0 or very small
+        assert -0.1 <= reward <= 0.1
+    
+    def test_negative_scores(self):
+        """Format and reasoning scores can't be negative by design, but test robustness."""
+        inputs = TrajectoryRewardInputs(
+            final_pnl=-1000,
+            starting_balance=10000,
+            end_balance=9000,
+            format_score=0.0,  # Min valid
+            reasoning_score=0.0,  # Min valid
+        )
+        
+        reward = enhanced_composite_reward(
+            inputs=inputs,
+            archetype="trader",
+            regime_overall="bear",
+            regime_expected_return=-0.05,
+            counterfactual_alpha=-500,  # Underperformed
+        )
+        assert -1.0 <= reward <= 1.0
+    
+    def test_unknown_archetype_fallback(self):
+        """Unknown archetype should use default weights."""
+        inputs = self._make_inputs()
+        
+        reward = enhanced_composite_reward(
+            inputs=inputs,
+            archetype="unknown_archetype_xyz",
+            regime_overall="sideways",
+        )
+        assert -1.0 <= reward <= 1.0
+
+
+class TestEnhancedVsArchetypeReward:
+    """Compare enhanced and archetype rewards."""
+    
+    def test_regime_awareness_changes_score(self):
+        """Regime awareness should change score vs vanilla archetype."""
+        inputs = TrajectoryRewardInputs(
+            final_pnl=300,
+            starting_balance=10000,
+            end_balance=10300,
+            format_score=0.7,
+            reasoning_score=0.6,
+        )
+        
+        # Vanilla archetype reward
+        archetype = archetype_composite_reward(inputs=inputs, archetype="trader")
+        
+        # Enhanced with bull market (underperformance)
+        enhanced_bull = enhanced_composite_reward(
+            inputs=inputs,
+            archetype="trader",
+            regime_overall="bull",
+            regime_volatility=0.3,
+            regime_expected_return=0.05,
+            counterfactual_alpha=-200,  # Made 3%, expected 5%
+        )
+        
+        # Enhanced with bear market (outperformance)
+        enhanced_bear = enhanced_composite_reward(
+            inputs=inputs,
+            archetype="trader",
+            regime_overall="bear",
+            regime_volatility=0.3,
+            regime_expected_return=-0.05,
+            counterfactual_alpha=800,  # Made +3%, expected -5%
+        )
+        
+        # Bear market profit should be rewarded more
+        assert enhanced_bear > enhanced_bull
+
+
+# =============================================================================
+# Reward Config: Singleton and Edge Cases
+# =============================================================================
+
+class TestRewardConfigSingleton:
+    """Tests for RewardWeightConfig singleton behavior."""
+    
+    def test_singleton_same_instance(self):
+        """Multiple calls return same instance."""
+        config1 = RewardWeightConfig()
+        config2 = RewardWeightConfig()
+        assert config1 is config2
+    
+    def test_get_weights_for_unknown_profile(self):
+        """Unknown profile returns default weights."""
+        weights = get_reward_weights("nonexistent_profile_xyz")
+        default = get_reward_weights("default")
+        assert weights == default
+    
+    def test_get_regime_expected_return_unknown(self):
+        """Unknown regime returns 0."""
+        ret = get_regime_expected_return("unknown_regime_xyz")
+        assert ret == 0.0
+    
+    def test_get_temporal_decay_rate_valid(self):
+        """Decay rate is valid."""
+        rate = get_temporal_decay_rate()
+        assert 0.0 < rate <= 1.0
+    
+    def test_get_volatility_config_has_keys(self):
+        """Volatility config has expected keys."""
+        config = RewardWeightConfig().get_volatility_config()
+        assert "low" in config
+        assert "high" in config
+        assert "dampening_factor" in config
+
+
+# =============================================================================
+# Integration: Full Pipeline Tests
+# =============================================================================
+
+class TestFullPipelineEdgeCases:
+    """Integration tests for edge cases in the full pipeline."""
+    
+    def test_empty_trajectory_pipeline(self):
+        """Empty trajectory should not crash pipeline."""
+        trajectory = {}
+        
+        regime = extract_regime_from_trajectory(trajectory)
+        assert regime is None
+        
+        credits = attribute_temporal_credit([], final_pnl=0)
+        assert credits == []
+        
+        inputs = TrajectoryRewardInputs(
+            final_pnl=0,
+            starting_balance=10000,
+            end_balance=10000,
+            format_score=0.5,
+            reasoning_score=0.5,
+        )
+        
+        # Should fall back to archetype reward
+        reward = enhanced_composite_reward(
+            inputs=inputs,
+            archetype="trader",
+            regime_overall=None,
+        )
+        
+        archetype_reward = archetype_composite_reward(
+            inputs=inputs,
+            archetype="trader",
+        )
+        
+        assert reward == archetype_reward
+    
+    def test_minimal_valid_trajectory(self):
+        """Minimal valid trajectory with all components."""
+        trajectory = {
+            "final_pnl": 100,
+            "metadata": {
+                "price_context": {
+                    "initial_prices": {"BTC": 100000},
+                    "final_prices": {"BTC": 101000},  # +1%
+                }
+            },
+            "steps": [
+                {"action": {"actionType": "buy", "parameters": {"marketId": "BTC"}}},
+            ],
+        }
+        
+        regime = extract_regime_from_trajectory(trajectory)
+        assert regime is not None
+        assert regime.overall == "sideways"  # +1% < 5%
+        
+        credits = attribute_temporal_credit(
+            trajectory["steps"],
+            trajectory["final_pnl"],
+        )
+        assert len(credits) == 1
+        
+        inputs = TrajectoryRewardInputs(
+            final_pnl=trajectory["final_pnl"],
+            starting_balance=10000,
+            end_balance=10100,
+            format_score=0.7,
+            reasoning_score=0.6,
+        )
+        
+        counterfactual = compute_counterfactual(
+            actual_pnl=100,
+            starting_balance=10000,
+            regime_overall=regime.overall,
+            regime_expected_return=get_regime_expected_return(regime.overall),
+        )
+        
+        reward = enhanced_composite_reward(
+            inputs=inputs,
+            archetype="trader",
+            regime_overall=regime.overall,
+            regime_volatility=regime.volatility,
+            regime_expected_return=get_regime_expected_return(regime.overall),
+            counterfactual_alpha=counterfactual.alpha,
+            temporal_credits=credits,
+        )
+        
+        assert -1.0 <= reward <= 1.0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])
+

--- a/packages/training/python/tests/test_online_env.py
+++ b/packages/training/python/tests/test_online_env.py
@@ -16,10 +16,10 @@ from src.training.online_env import (
     build_observation_prompt,
     parse_action_from_response,
     extract_thinking,
-    score_response,
     BabylonOnlineEnv,
     BabylonOnlineEnvConfig,
 )
+from src.training.quality_scorer import score_response
 from src.training.scenario_pool import (
     Scenario,
     ScenarioPoolConfig,
@@ -284,7 +284,7 @@ Line 3
 
 
 class TestScoreResponse:
-    """Tests for score_response"""
+    """Tests for score_response - returns QualityScore object"""
 
     def test_well_formatted_response(self):
         scenario = Scenario(id="test", source="synthetic")
@@ -296,42 +296,43 @@ Looking at the risk, a small position of 0.1 BTC seems reasonable.
 
 {"action": "open_perp", "ticker": "BTC", "size": 0.1, "direction": "long"}"""
         
-        score, metrics = score_response(response, scenario, "trader")
+        result = score_response(response, scenario, "trader")
         
-        assert metrics["has_thinking"] is True
-        assert metrics["has_valid_action"] is True
-        assert metrics["action_type"] == "open_perp"
-        assert metrics["format_score"] > 0.5
-        assert metrics["reasoning_score"] > 0.3
+        assert result.has_thinking is True
+        assert result.has_valid_action is True
+        assert result.action_type == "open_perp"
+        assert result.format_score > 0.5
+        assert result.reasoning_score > 0.3
 
     def test_no_thinking_tags(self):
         scenario = Scenario(id="test", source="synthetic")
         response = '{"action": "wait", "reason": "unclear"}'
         
-        score, metrics = score_response(response, scenario, "trader")
+        result = score_response(response, scenario, "trader")
         
-        assert metrics["has_thinking"] is False
-        assert metrics["has_valid_action"] is True
-        assert metrics["format_score"] < 0.5
+        assert result.has_thinking is False
+        assert result.has_valid_action is True
+        assert result.format_score < 0.5
 
     def test_invalid_action(self):
         scenario = Scenario(id="test", source="synthetic")
         response = "<think>Analysis here</think>\nI'll wait for now."
         
-        score, metrics = score_response(response, scenario, "trader")
+        result = score_response(response, scenario, "trader")
         
-        assert metrics["has_thinking"] is True
-        assert metrics["has_valid_action"] is False
-        assert metrics["action_type"] is None
+        assert result.has_thinking is True
+        assert result.has_valid_action is False
+        assert result.action_type is None
 
     def test_very_short_response_penalized(self):
         scenario = Scenario(id="test", source="synthetic")
         response = '{"action": "wait"}'
         
-        score, metrics = score_response(response, scenario, "trader")
+        result = score_response(response, scenario, "trader")
         
-        # Short responses should have lower format scores
-        assert metrics["format_score"] <= 0.3
+        # Short responses should have lower format scores and length penalties
+        assert result.format_score < 0.5
+        assert result.length_penalty < 0
 
     def test_reasoning_with_analysis_terms(self):
         scenario = Scenario(id="test", source="synthetic")
@@ -343,10 +344,10 @@ Given the probability of success and managing risk, I'll proceed.
 
 {"action": "buy", "market": "m1", "amount": 100, "side": "yes"}"""
         
-        score, metrics = score_response(response, scenario, "trader")
+        result = score_response(response, scenario, "trader")
         
         # Should have high reasoning score due to analysis terms
-        assert metrics["reasoning_score"] > 0.4
+        assert result.reasoning_score > 0.4
 
     def test_different_archetypes_affect_score(self):
         scenario = Scenario(id="test", source="synthetic")
@@ -354,12 +355,12 @@ Given the probability of success and managing risk, I'll proceed.
         response = """<think>Quick analysis - buying now.</think>
 {"action": "buy", "market": "m1", "amount": 1000, "side": "yes"}"""
         
-        trader_score, _ = score_response(response, scenario, "trader")
-        degen_score, _ = score_response(response, scenario, "degen")
+        trader_result = score_response(response, scenario, "trader")
+        degen_result = score_response(response, scenario, "degen")
         
         # Both should be scored (actual values depend on reward weights)
-        assert trader_score is not None
-        assert degen_score is not None
+        assert trader_result is not None
+        assert degen_result is not None
 
 
 # =============================================================================
@@ -508,12 +509,12 @@ I'll take a small long position because the risk/reward is favorable.
             '{"action": "wait"}',
         ]
         
-        scores = []
+        results = []
         for resp in responses:
-            score, _ = score_response(resp, scenario, "trader")
-            scores.append(score)
+            result = score_response(resp, scenario, "trader")
+            results.append(result)
         
-        # Higher quality responses should generally score higher
-        # (Though exact ordering depends on reward weights)
-        assert all(isinstance(s, float) for s in scores)
+        # All responses should produce valid QualityScore objects
+        assert all(result is not None for result in results)
+        assert all(0.0 <= result.format_score <= 1.0 for result in results)
 


### PR DESCRIPTION
# PR: 
## Summary

- **Implement context-aware reward system (BAB-76)** that distinguishes skill from luck by comparing agent performance against market conditions
- **Add market regime detection** (bull/bear/sideways) from price data to provide counterfactual benchmarks for reward calculation
- **Implement temporal credit assignment** to attribute delayed outcomes (P&L) back to the trading decisions that caused them

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: BAB-76 (Enhanced Reward Signals)
- Related: Part of the RL training pipeline improvements
- Prior work: Builds on archetype scoring system in `rewards.py`

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [x] Other: `packages/training` (Python RL training pipeline)

**Non-goals / follow-ups**
- W&B dashboard visualization of new metrics (separate PR)
- Hyperparameter tuning for reward weights (after validation)
- Production deployment (needs staging testing first)

## Changes

### New Files
| File | Purpose |
|------|---------|
| `src/training/market_regime.py` | Market regime detection (bull/bear/sideways) from price data |
| `src/training/temporal_credit.py` | Temporal credit assignment for delayed rewards |
| `src/training/reward_config.py` | YAML-based reward weight configuration singleton |
| `config/reward_weights.yaml` | Configurable weight profiles (default, skill-focused, risk-averse, etc.) |
| `tests/test_enhanced_rewards.py` | 34 core tests for enhanced rewards |
| `tests/test_enhanced_rewards_extended.py` | 115 edge case and boundary tests |

### Modified Files
| File | Changes |
|------|---------|
| `src/training/rewards.py` | Added `enhanced_composite_reward()`, `compute_counterfactual()`, `regime_adjusted_pnl_reward()`, `calculate_alpha_reward()`, `calculate_temporal_credit_bonus()` |
| `src/training/babylon_env.py` | Integration: extracts regime from trajectory, computes counterfactual, applies enhanced reward when regime available |
| `src/data_bridge/reader.py` | `JsonTrajectoryReader` now loads `ground-truth.json` and injects price context |
| `scripts/import_json_trajectories.py` | Injects ground truth price data into trajectory metadata on DB import |
| `src/training/online_env.py` | Fixed `server_type` from `'vllm'` to `'openai'` (vLLM is OpenAI-compatible) |
| `tests/test_online_env.py` | Fixed `score_response` import, updated tests for `QualityScore` object API |

### Key Concepts Introduced

1. **Market Regime Detection**: Classifies market conditions based on price changes
   - Bull: >5% average increase
   - Bear: <-5% average decrease
   - Sideways: between -5% and +5%

2. **Counterfactual Alpha**: Measures skill by comparing actual P&L against expected P&L for the regime
   - `alpha = actual_pnl - (starting_balance × expected_return)`
   - Positive alpha in bear market = agent outperformed despite adverse conditions

3. **Temporal Credit Assignment**: Distributes credit for final P&L back to trading decisions
   - Exponential decay: decisions closer to outcome get more credit
   - Per-market attribution when outcome data available

4. **Enhanced Composite Reward**: Combines regime-adjusted P&L, skill alpha, temporal bonus with existing format/reasoning/behavior scores

## Review guide

**Start here**
- `src/training/market_regime.py` - Core regime detection logic
- `src/training/rewards.py` lines 1594-1680 - `enhanced_composite_reward()` function
- `src/training/babylon_env.py` lines ~350-420 - Integration in `_score_trajectory_group()`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

Medium risk because:
- Changes reward calculation which directly affects training signal
- Falls back to existing `archetype_composite_reward` when no regime data available (safe default)
- Extensive test coverage (149 tests) mitigates regression risk

**Notes for reviewers**
- The enhanced reward is **additive**, not replacing existing logic - it activates only when `price_context` metadata is present
- Trajectories generated with `--causal` flag will have the required metadata
- Default weight profile maintains similar behavior to existing rewards
- All reward component weights are configurable via YAML without code changes

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)
- [x] Python tests: `python -m pytest tests/ --ignore=tests/integration --ignore=tests/e2e`

**Test Results**
```
====================== 686 passed, 25 warnings =======================
```

**Test Coverage Added**
| Category | Tests | Description |
|----------|-------|-------------|
| Market Regime | 36 | Boundary conditions, edge cases, serialization |
| Temporal Credit | 31 | All action types, credit weights, attribution |
| Counterfactual | 17 | Zero balance, extreme values, alpha clamping |
| Enhanced Reward | 19 | All archetypes, all profiles, integration |
| Full Pipeline | 12 | End-to-end, empty inputs, minimal valid |

**Manual verification**
1. Generated trajectories with `make tier4-generate` using `--causal` flag
2. Imported to DB with `make tier4-import` and verified `metadataJson` contains `price_context`
3. Ran training with `make train-12gb` and confirmed W&B logs show `regime_*` metrics

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Notes**
- No new env vars required
- No DB schema changes (uses existing `metadataJson` column)
- New config file `config/reward_weights.yaml` is included in repo
- Backward compatible: existing trajectories without price_context will use fallback reward

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

The enhanced reward system is fully backward compatible:
- Falls back to `archetype_composite_reward` when no regime data
- Existing trajectories work unchanged
- New functionality only activates with new data format

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

No new external APIs, no PII handling, no auth changes.

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- No new APIs
- Internal trajectory metadata format extended with optional `price_context`

### Database
- No schema changes
- Existing `metadataJson` column now may contain additional `price_context` field
- Query patterns unchanged

### Contracts / on-chain
- N/A

### Docs
- Code is self-documenting with comprehensive docstrings
- Book documentation for these changes exists in  #773

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend-only change to Python training pipeline. No UI components affected. Training metrics visible in W&B dashboard (external tool).

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed) — _follow-up PR_
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Market-regime detection (bull/bear/sideways) for regime-aware rewards.
  * Configurable reward weight profiles with a shipped weights file.
  * Enhanced reward pipeline: counterfactual alpha, temporal credit assignment, and regime-aware composite scoring.
  * Ground-truth integration to enrich trajectory metadata and scoring.
  * Improved trajectory balance handling and enhanced training metrics logging.

* **Tests**
  * Large, comprehensive test suites covering regime detection, temporal credits, counterfactuals, and end-to-end reward behavior.

* **Other**
  * Online API default changed to an OpenAI-compatible server.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Implements context-aware reward system that distinguishes skill from luck by comparing agent performance against market regime benchmarks. Adds market regime detection (bull/bear/sideways) from price data, temporal credit assignment for delayed P&L attribution, and YAML-based configurable reward weights.

## Key Implementation Details

- **Market regime detection** (`market_regime.py`): Classifies market conditions using ±5% thresholds, calculates volatility, tracks per-ticker trends
- **Counterfactual alpha** (`rewards.py:315-380`): Computes skill signal by subtracting regime-expected return from actual P&L
- **Temporal credit assignment** (`temporal_credit.py`): Distributes final P&L credit back to trading decisions with exponential decay (0.9 per step)
- **Enhanced composite reward** (`rewards.py:1594-1730`): Combines regime-adjusted P&L (35%), skill alpha (20%), temporal bonus (5%), format/reasoning (25%), behavior (15%)
- **Backward compatibility**: Falls back to `archetype_composite_reward` when regime data unavailable (`babylon_env.py:805-838`)

## Data Flow

1. Trajectories generated with `--causal` flag include `ground-truth.json` with price history
2. `JsonTrajectoryReader` loads ground truth and injects `price_context` into trajectory metadata
3. Training pipeline extracts regime from metadata, computes counterfactual, applies enhanced reward
4. W&B tracking includes `regime_bull/bear/sideways_pct`, `counterfactual_alpha_mean/min/max`, `market_volatility_mean`

## Test Coverage

149 total tests (34 core + 115 extended) covering:
- Market regime detection with boundary conditions
- Temporal credit attribution for all action types
- Counterfactual calculation with zero balance and extreme values
- Enhanced reward integration with all archetypes and weight profiles
- End-to-end pipeline with empty/minimal inputs

## Code Quality

- Comprehensive docstrings with examples throughout
- Proper error handling for edge cases (empty data, zero balance, insufficient prices)
- Type hints and dataclasses for clear interfaces
- Singleton pattern for configuration with safe defaults
- No breaking changes - fully backward compatible

<h3>Confidence Score: 5/5</h3>


- Safe to merge - well-tested, backward compatible, no runtime risks
- Score of 5 reflects exceptional code quality: 149 comprehensive tests (including extensive edge cases), full backward compatibility with automatic fallback, additive changes that don't modify existing behavior, extensive documentation, proper error handling throughout, and successful test run (686 passed). The enhanced reward system only activates when new metadata is present, ensuring zero risk to existing trajectories.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/training/python/config/reward_weights.yaml | Clean configuration file with well-documented reward weight profiles (default, skill-focused, quality-focused, etc.) and sensible default values |
| packages/training/python/src/training/market_regime.py | Well-structured market regime detection with clear thresholds, proper error handling for edge cases, and comprehensive docstrings |
| packages/training/python/src/training/temporal_credit.py | Solid temporal credit assignment implementation with exponential decay, per-market attribution, and intermediate outcome handling |
| packages/training/python/src/training/reward_config.py | Singleton configuration loader with proper defaults, safe YAML loading, and graceful fallback when config file missing |
| packages/training/python/src/training/rewards.py | Enhanced reward computation with regime awareness and counterfactual alpha - integrates smoothly with existing archetype system, backward compatible fallback |
| packages/training/python/src/training/babylon_env.py | Integration of enhanced rewards into training pipeline - extracts regime from metadata, computes counterfactual, tracks W&B metrics properly |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GEN as Trajectory Generation<br/>(TypeScript)
    participant GT as ground-truth.json
    participant DB as PostgreSQL
    participant READER as JsonTrajectoryReader
    participant ENV as BabylonRLAIFEnv
    participant REGIME as MarketRegime
    participant REWARDS as Enhanced Rewards
    participant TRAINER as GRPO Trainer
    participant WANDB as Weights & Biases

    Note over GEN,GT: 1. Data Generation with --causal Flag
    GEN->>GT: Generate price history (initialPrices, finalPrices, priceHistory)
    GEN->>DB: Save trajectories with metadata
    
    Note over READER,ENV: 2. Training Data Pipeline
    READER->>GT: Load ground-truth.json
    READER->>READER: Build price_context from ground truth
    READER->>DB: Load trajectories
    READER->>READER: Inject price_context into trajectory metadata
    
    Note over ENV,REWARDS: 3. Training Loop - Enhanced Reward Calculation
    TRAINER->>ENV: get_next_item()
    ENV->>READER: Get trajectory group
    READER-->>ENV: Trajectories with price_context in metadata
    
    loop For each trajectory
        ENV->>REGIME: extract_regime_from_trajectory(metadata)
        REGIME->>REGIME: detect_regime_from_prices(initialPrices, finalPrices)
        REGIME-->>ENV: MarketRegime(overall, volatility, per_ticker)
        
        alt Regime data available
            ENV->>REWARDS: compute_counterfactual(actual_pnl, regime, expected_return)
            REWARDS-->>ENV: CounterfactualResult(alpha, benchmark_pnl)
            
            ENV->>REWARDS: attribute_temporal_credit(steps, final_pnl)
            REWARDS-->>ENV: List[TemporalCredit]
            
            ENV->>REWARDS: enhanced_composite_reward(inputs, regime, alpha, credits)
            REWARDS->>REWARDS: regime_adjusted_pnl_reward (35%)
            REWARDS->>REWARDS: calculate_alpha_reward (20%)
            REWARDS->>REWARDS: calculate_temporal_credit_bonus (5%)
            REWARDS->>REWARDS: format + reasoning scores (25%)
            REWARDS->>REWARDS: archetype behavior bonus (15%)
            REWARDS-->>ENV: Enhanced composite score [0, 1]
        else No regime data
            ENV->>REWARDS: archetype_composite_reward(inputs)
            REWARDS-->>ENV: Legacy composite score [0, 1]
        end
        
        ENV->>ENV: Track regime_counts, alphas, volatilities
    end
    
    ENV-->>TRAINER: ScoredDataGroup with enhanced scores
    
    Note over TRAINER,WANDB: 4. Training & Metrics
    TRAINER->>TRAINER: Calculate GRPO loss from score variance
    TRAINER->>TRAINER: Backward pass + optimizer step
    TRAINER->>WANDB: Log training metrics
    ENV->>WANDB: Log enhanced metrics (regime_bull/bear/sideways_pct, alpha_mean/min/max, volatility_mean)
    
    Note over TRAINER: Every N steps
    TRAINER->>TRAINER: Save checkpoint
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->