### PR TITLE
Fix narrative: apply story event market impacts to prices

### DIFF
--- a/packages/engine/src/__tests__/event-market-pipeline-applyEventToMarkets.test.ts
+++ b/packages/engine/src/__tests__/event-market-pipeline-applyEventToMarkets.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+const mockApplyUpdates = mock(() => Promise.resolve([]));
+
+mock.module('../services/price-update-service', () => ({
+  PriceUpdateService: {
+    applyUpdates: mockApplyUpdates,
+  },
+}));
+
+mock.module('../services/static-data-registry', () => ({
+  StaticDataRegistry: {
+    getAllOrganizations: () => [],
+    getOrganization: () => null,
+  },
+}));
+
+mock.module('@babylon/shared', () => ({
+  logger: {
+    debug: mock(() => {}),
+    error: mock(() => {}),
+    info: mock(() => {}),
+    warn: mock(() => {}),
+  },
+}));
+
+const now = new Date();
+const mockDb = {
+  select: mock(() => {
+    const builder = {
+      from: mock(() => builder),
+      where: mock(() => builder),
+      limit: mock(async () => [
+        {
+          activeModifiers: [],
+          updatedAt: now,
+        },
+      ]),
+      then: (resolve: (value: unknown) => void) =>
+        Promise.resolve([
+          {
+            id: 'org-1',
+            currentPrice: 100,
+            basePrice: 100,
+          },
+        ]).then(resolve),
+    };
+    return builder;
+  }),
+  update: mock(() => {
+    const builder = {
+      set: mock(() => builder),
+      where: mock(() => builder),
+      returning: mock(async () => [{ id: 'org-1' }]),
+    };
+    return builder;
+  }),
+};
+
+mock.module('@babylon/db', () => ({
+  and: (...args: unknown[]) => ({ and: args }),
+  db: mockDb,
+  eq: (...args: unknown[]) => ({ eq: args }),
+  inArray: (...args: unknown[]) => ({ inArray: args }),
+  organizationState: {
+    id: 'id',
+    activeModifiers: 'activeModifiers',
+    basePrice: 'basePrice',
+    currentPrice: 'currentPrice',
+    sentiment: 'sentiment',
+    updatedAt: 'updatedAt',
+  },
+  sql: (...args: unknown[]) => ({ sql: args }),
+}));
+
+import { applyEventToMarkets } from '../services/event-market-pipeline';
+
+describe('EventMarketPipeline.applyEventToMarkets', () => {
+  test('applies immediate price updates via PriceUpdateService', async () => {
+    await applyEventToMarkets({
+      arcId: 'arc-1',
+      type: 'rumor',
+      severity: 1,
+      affectedActors: [],
+      affectedStocks: ['org-1'],
+      affectedQuestions: [],
+      signalDirection: 'NEUTRAL',
+      signalStrength: 0,
+      marketImpacts: [
+        {
+          stockTicker: 'org-1',
+          direction: 'up',
+          magnitude: 'moderate',
+          duration: 'hours',
+        },
+      ],
+    });
+
+    expect(mockApplyUpdates).toHaveBeenCalledTimes(1);
+    const [updates] = mockApplyUpdates.mock.calls[0] ?? [];
+    expect(Array.isArray(updates)).toBe(true);
+    expect(updates).toHaveLength(1);
+    expect(updates?.[0]).toMatchObject({
+      organizationId: 'org-1',
+      source: 'event',
+    });
+    expect(updates?.[0]?.newPrice).toBeCloseTo(105, 8);
+  });
+});

--- a/packages/engine/src/services/event-market-pipeline.ts
+++ b/packages/engine/src/services/event-market-pipeline.ts
@@ -15,6 +15,7 @@ import {
   and,
   db,
   eq,
+  inArray,
   organizationState,
   type PriceModifier,
   type StructuredEventData,
@@ -23,6 +24,7 @@ import {
 import { logger } from '@babylon/shared';
 import { secureRandom } from '../utils/entropy';
 import { parseModifiersSafe, validatePriceModifier } from './jsonb-validators';
+import { PriceUpdateService } from './price-update-service';
 import { StaticDataRegistry } from './static-data-registry';
 
 /**
@@ -106,6 +108,10 @@ export async function applyEventToMarkets(
   event: StructuredEventData
 ): Promise<number> {
   let modifiersApplied = 0;
+  const multiplierByOrgId = new Map<
+    string,
+    { multiplier: number; tickers: Set<string> }
+  >();
 
   for (const impact of event.marketImpacts) {
     try {
@@ -166,6 +172,19 @@ export async function applyEventToMarkets(
       await addPriceModifier(impact.stockTicker, modifier);
       modifiersApplied++;
 
+      const orgId =
+        resolveTickerToOrgId(impact.stockTicker) ?? impact.stockTicker;
+      const existing = multiplierByOrgId.get(orgId);
+      if (existing) {
+        existing.multiplier *= effect;
+        existing.tickers.add(impact.stockTicker);
+      } else {
+        multiplierByOrgId.set(orgId, {
+          multiplier: effect,
+          tickers: new Set([impact.stockTicker]),
+        });
+      }
+
       logger.info(
         `Applied price modifier to ${impact.stockTicker}`,
         {
@@ -182,6 +201,89 @@ export async function applyEventToMarkets(
         { error: error instanceof Error ? error.message : String(error) },
         'EventMarketPipeline'
       );
+    }
+  }
+
+  // Apply immediate price impacts so narrative events visibly move markets.
+  // This keeps the "market modifiers" behavior but removes the user-facing
+  // impression that narrative has no effect.
+  if (multiplierByOrgId.size > 0) {
+    const orgIds = [...multiplierByOrgId.keys()];
+    const states = await db
+      .select({
+        id: organizationState.id,
+        currentPrice: organizationState.currentPrice,
+        basePrice: organizationState.basePrice,
+      })
+      .from(organizationState)
+      .where(inArray(organizationState.id, orgIds));
+
+    const stateByOrgId = new Map(states.map((s) => [s.id, s]));
+
+    const updates = orgIds
+      .map((orgId) => {
+        const entry = multiplierByOrgId.get(orgId);
+        if (!entry) return null;
+
+        // Clamp combined multiplier to avoid extreme compounding from multiple impacts.
+        const combinedMultiplier = Math.max(
+          MIN_PRICE_MULTIPLIER,
+          Math.min(MAX_PRICE_MULTIPLIER, entry.multiplier)
+        );
+
+        const state = stateByOrgId.get(orgId);
+        const currentPrice = Number(state?.currentPrice ?? state?.basePrice);
+        if (!Number.isFinite(currentPrice) || currentPrice <= 0) return null;
+
+        const newPrice = currentPrice * combinedMultiplier;
+        if (!Number.isFinite(newPrice) || newPrice <= 0) return null;
+
+        const canonicalTicker =
+          StaticDataRegistry.getOrganization(orgId)?.ticker;
+
+        return {
+          organizationId: orgId,
+          newPrice,
+          source: 'event' as const,
+          reason: `Narrative event (${event.type}) market impact`,
+          metadata: {
+            arcId: event.arcId,
+            ticker:
+              typeof canonicalTicker === 'string' && canonicalTicker.length > 0
+                ? canonicalTicker
+                : null,
+            tickers: [...entry.tickers],
+          },
+        };
+      })
+      .filter((u): u is NonNullable<typeof u> => u !== null);
+
+    if (updates.length > 0) {
+      try {
+        const applied = await PriceUpdateService.applyUpdates(updates);
+        logger.info(
+          'Applied narrative price updates',
+          {
+            arcId: event.arcId,
+            eventType: event.type,
+            count: applied.length,
+            sample: applied.slice(0, 3).map((u) => ({
+              organizationId: u.organizationId,
+              oldPrice: Number(u.oldPrice.toFixed(4)),
+              newPrice: Number(u.newPrice.toFixed(4)),
+              changePercent: Number(u.changePercent.toFixed(4)),
+            })),
+          },
+          'EventMarketPipeline'
+        );
+      } catch (error) {
+        // Price application is best-effort; modifiers are persisted regardless.
+        logger.warn(
+          'Failed to apply narrative price updates',
+          { error: error instanceof Error ? error.message : String(error) },
+          'EventMarketPipeline'
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Narrative market impacts now trigger **immediate** price updates via `PriceUpdateService`, so story events visibly move markets (price series + SSE updates).
- Keeps the existing modifier persistence (`OrganizationState.activeModifiers`) but removes the “narrative has no effect” user-facing behavior.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Tester feedback: narrative ↔ market linkage felt broken (events applied modifiers but prices didn’t change).

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [x] Tests (`packages/testing`)

**Non-goals / follow-ups**
- No retroactive backfill of *previously stored* modifiers into historical prices.
- A follow-up could implement a stronger “decay → price reversion” loop if we want `activeModifiers` to continuously shape prices over time (instead of event-time application only).

## Changes
- `packages/engine/src/services/event-market-pipeline.ts`: after persisting modifiers, batch-apply the resulting immediate price multipliers via `PriceUpdateService.applyUpdates()` (best-effort + logging).
- `packages/engine/src/__tests__/event-market-pipeline-applyEventToMarkets.test.ts`: unit test with mocked DB + `PriceUpdateService` to assert we emit the expected event price update.

## Review guide

**Start here**
- `packages/engine/src/services/event-market-pipeline.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- Price application is intentionally best-effort (modifiers are persisted regardless).

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Trigger/observe narrative event generation with `marketImpacts` (engine tick).
2. Confirm a `StockPrice` entry is recorded + `price_update` SSE emitted.
3. Confirm perps UI reflects the move (or check logs: `Applied narrative price updates`).

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend-only change (engine price update path), no direct UI changes.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markets now automatically apply narrative-driven price updates when affected by events with combined impact calculations.
  * Implemented bulk processing for price updates across organizations with automatic source and reason tracking.

* **Tests**
  * Added comprehensive test coverage for event-market pipeline processing, validating price update calculations and service integrations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed narrative events not visibly moving markets by adding immediate price updates via `PriceUpdateService` after modifiers are persisted.

- Accumulates multipliers for each affected organization during modifier application
- Fetches current prices and calculates new prices based on combined multipliers
- Applies price updates with SSE broadcast so UI reflects narrative impact immediately
- Maintains existing modifier persistence behavior (best-effort price application)
- Has one logical issue: multiplier accumulation happens before verifying `addPriceModifier` succeeded, which could cause price updates for modifiers that failed to persist

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with one logical issue that should be addressed
- The implementation correctly addresses the bug where narrative events didn't visibly affect markets. The logic is sound with proper error handling, bounds checking, and best-effort semantics. However, there's a logical flaw where multipliers are accumulated even if `addPriceModifier` fails, which could cause price updates for modifiers that weren't actually persisted. This is unlikely to occur in practice due to the retry mechanism, but it's a correctness issue that should be fixed.
- Pay close attention to `packages/engine/src/services/event-market-pipeline.ts` lines 172-186 where multiplier accumulation happens before verifying modifier persistence succeeded

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/engine/src/services/event-market-pipeline.ts | Added immediate price updates via PriceUpdateService when narrative events apply market impacts; has one logical issue with multiplier accumulation timing |
| packages/engine/src/__tests__/event-market-pipeline-applyEventToMarkets.test.ts | New test validates that narrative events trigger price updates via PriceUpdateService; good coverage with proper mocking |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Event as Narrative Event
    participant Pipeline as applyEventToMarkets
    participant DB as Database
    participant Modifier as addPriceModifier
    participant PriceUpdate as PriceUpdateService
    participant SSE as Realtime Broadcaster

    Event->>Pipeline: marketImpacts[]
    
    loop For each impact
        Pipeline->>Pipeline: Calculate effect multiplier
        Pipeline->>Modifier: addPriceModifier(ticker, modifier)
        Modifier->>DB: Persist modifier to activeModifiers
        Modifier-->>Pipeline: Success
        Pipeline->>Pipeline: Accumulate multiplier by orgId
    end
    
    Pipeline->>DB: Fetch current prices for affected orgs
    DB-->>Pipeline: Organization states
    
    Pipeline->>Pipeline: Calculate new prices<br/>(currentPrice × multiplier)
    
    Pipeline->>PriceUpdate: applyUpdates(priceUpdates[])
    PriceUpdate->>DB: Update Organization.currentPrice
    PriceUpdate->>DB: Update OrganizationState.currentPrice
    PriceUpdate->>DB: Record price history
    PriceUpdate->>SSE: Broadcast price_update event
    PriceUpdate-->>Pipeline: Applied updates
    
    Pipeline-->>Event: modifiersApplied count
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->