### PR TITLE
fix(engine): add simulation mode guards to MarketContextService methods

### DIFF
--- a/packages/engine/src/services/market-context-service.ts
+++ b/packages/engine/src/services/market-context-service.ts
@@ -693,6 +693,11 @@ export class MarketContextService {
     npcId: string,
     npcName: string
   ): Promise<EventContext[]> {
+    // In simulation mode, events are not persisted to DB - return empty
+    if (isSimulationMode()) {
+      return [];
+    }
+
     const now = new Date();
     const threeDaysAgo = new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000);
 
@@ -754,6 +759,11 @@ export class MarketContextService {
    * @returns Array of the NPC's recent posts
    */
   async getRecentPostsByNPC(npcId: string): Promise<FeedPostContext[]> {
+    // In simulation mode, posts are not persisted to DB - return empty
+    if (isSimulationMode()) {
+      return [];
+    }
+
     const now = new Date();
     const threeDaysAgo = new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000);
 

--- a/packages/engine/src/utils/context-builder.ts
+++ b/packages/engine/src/utils/context-builder.ts
@@ -15,6 +15,7 @@
 import { and, db, desc, gte, lte, worldEvents } from '@babylon/db';
 import { RelationshipEvolutionEngine } from '../RelationshipEvolutionEngine';
 import { MarketContextService } from '../services/market-context-service';
+import { isSimulationMode } from '../storage-bridge';
 import type { Actor, FeedPost, Question, WorldEvent } from '../types/shared';
 import { CONTEXT_LIMITS, truncateArray, truncateText } from './context-limits';
 import { extractDayFromTimestamp } from './date-utils';
@@ -87,6 +88,7 @@ export async function buildComprehensiveNPCContext(
   questions?: Question[]
 ): Promise<ComprehensiveNPCContext> {
   const marketContextService = new MarketContextService();
+  const simulationMode = isSimulationMode();
 
   const personalEventsRaw = await marketContextService.getEventsForNPC(
     actor.id,
@@ -104,7 +106,7 @@ export async function buildComprehensiveNPCContext(
     ),
   }));
 
-  let recentEvents;
+  let recentEvents: ComprehensiveNPCContext['recentEvents'] = [];
   if (allPreviousEvents && allPreviousEvents.length > 0) {
     const filteredEvents = allPreviousEvents
       .filter((e) => e.day < currentDay)
@@ -127,6 +129,9 @@ export async function buildComprehensiveNPCContext(
       ),
       pointsToward: e.pointsToward || undefined,
     }));
+  } else if (simulationMode) {
+    // In simulation mode, events are not persisted to the DB.
+    recentEvents = [];
   } else {
     const now = new Date();
     const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
@@ -215,38 +220,40 @@ export async function buildComprehensiveNPCContext(
     resolvedOutcome: q.resolvedOutcome ?? undefined,
   }));
 
-  const relationshipContext =
-    await RelationshipEvolutionEngine.getActorRelationships(actor.id);
-  const relationships = shuffleArray(relationshipContext)
-    .slice(0, 10)
-    .map((rel) => {
-      const isActor1 = rel.actor1Id === actor.id;
-      const otherActorId = isActor1 ? rel.actor2Id : rel.actor1Id;
-      const sentimentDesc: 'respect' | 'beef' | 'neutral' =
-        rel.sentiment > 0.3
-          ? 'respect'
-          : rel.sentiment < -0.3
-            ? 'beef'
-            : 'neutral';
-      const strengthDesc: 'strong' | 'moderate' | 'weak' =
-        rel.strength > 0.7
-          ? 'strong'
-          : rel.strength > 0.4
-            ? 'moderate'
-            : 'weak';
+  const relationships = simulationMode
+    ? []
+    : shuffleArray(await RelationshipEvolutionEngine.getActorRelationships(actor.id))
+        .slice(0, 10)
+        .map((rel) => {
+          const isActor1 = rel.actor1Id === actor.id;
+          const otherActorId = isActor1 ? rel.actor2Id : rel.actor1Id;
+          const sentimentDesc: 'respect' | 'beef' | 'neutral' =
+            rel.sentiment > 0.3
+              ? 'respect'
+              : rel.sentiment < -0.3
+                ? 'beef'
+                : 'neutral';
+          const strengthDesc: 'strong' | 'moderate' | 'weak' =
+            rel.strength > 0.7
+              ? 'strong'
+              : rel.strength > 0.4
+                ? 'moderate'
+                : 'weak';
 
-      return {
-        otherActorName: otherActorId,
-        type: rel.relationshipType,
-        sentiment: sentimentDesc,
-        strength: strengthDesc,
-        history: rel.history ? truncateText(rel.history, 100) : undefined,
-      };
-    });
+          return {
+            otherActorName: otherActorId,
+            type: rel.relationshipType,
+            sentiment: sentimentDesc,
+            strength: strengthDesc,
+            history: rel.history ? truncateText(rel.history, 100) : undefined,
+          };
+        });
 
-  const npcContext = await marketContextService.buildContextForNPC(actor.id);
-  const marketPositions: Array<{ market: string; side: string; pnl?: number }> =
-    npcContext?.currentPositions
+  let marketPositions: Array<{ market: string; side: string; pnl?: number }> =
+    [];
+  if (!simulationMode) {
+    const npcContext = await marketContextService.buildContextForNPC(actor.id);
+    marketPositions = npcContext?.currentPositions
       ? shuffleArray(npcContext.currentPositions)
           .slice(0, 5)
           .map((pos) => ({
@@ -256,6 +263,7 @@ export async function buildComprehensiveNPCContext(
               'pnl' in pos && typeof pos.pnl === 'number' ? pos.pnl : undefined,
           }))
       : [];
+  }
 
   const shuffledPersonalEvents = shuffleArray(personalEvents);
 


### PR DESCRIPTION
## Summary

- Fix crash when running `generate-training-data.ts` due to missing simulation mode checks
- `getEventsForNPC()` and `getRecentPostsByNPC()` were calling DB directly in JSON mode, causing "This method is not supported in JSON mode" error
- Guards now return empty arrays in simulation mode, consistent with `buildContextForAllNPCs()`

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Error trace pointed to `market-context-service.ts:701` calling `db.select()` in JSON mode
- Root cause: `getEventsForNPC()` added in `b0aac30b6` before simulation mode support (`3a3855b98`)
- The simulation mode guard was only added to `buildContextForAllNPCs()`, not to these public methods

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- `packages/engine/src/services/market-context-service.ts`:
  - Added `isSimulationMode()` guard to `getEventsForNPC()` (returns `[]` in simulation mode)
  - Added `isSimulationMode()` guard to `getRecentPostsByNPC()` (returns `[]` in simulation mode)

## Review guide

**Start here**
- `packages/engine/src/services/market-context-service.ts` - lines 696-700 and 762-766

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- Simple guard additions, same pattern used in `buildContextForAllNPCs()` at line 84
- In simulation mode, events/posts are not persisted to DB, so returning empty is correct behavior
- The `context-builder.ts` calls these methods directly, bypassing the guarded `buildContextForAllNPCs()`

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [ ] `bun run lint`
- [x] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Run `bun run packages/engine/examples/generate-training-data.ts --hours 1`
2. Verify no "This method is not supported in JSON mode" error
3. Trajectories are generated successfully

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend-only fix for simulation mode, no UI impact

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Simulations now run faster by skipping database lookups for recent events, posts, relationships and market positions.
* **Bug Fixes**
  * Simulation mode consistently returns empty results for events/posts/relationships/market positions and avoids persisting those items, preventing unexpected DB interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed crash in `generate-training-data.ts` by adding simulation mode guards to `getEventsForNPC()` and `getRecentPostsByNPC()` methods. These methods were calling `db.select()` directly in JSON mode, causing "This method is not supported in JSON mode" errors.

**Key Changes:**
- Added `isSimulationMode()` check at the start of both methods
- Returns empty arrays `[]` in simulation mode, matching the pattern used in `buildContextForAllNPCs()`
- Guards prevent database access when storage mode is JSON or memory

**Why This Works:**
- In simulation mode, events and posts are not persisted to DB, so returning empty arrays is semantically correct
- `context-builder.ts` calls these methods directly, bypassing the already-guarded `buildContextForAllNPCs()`
- The fix ensures consistent behavior across all context-building code paths

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no risk
- Simple, defensive guards that follow established patterns in the codebase. The fix addresses the exact error mentioned in the PR description, and returning empty arrays is correct behavior since simulation mode doesn't persist data to DB. No logic changes, no side effects, and matches the existing pattern from buildContextForAllNPCs() at line 84.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/engine/src/services/market-context-service.ts | Added simulation mode guards to getEventsForNPC() and getRecentPostsByNPC() to prevent database calls in JSON mode |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Script as generate-training-data.ts
    participant Bridge as storage-bridge
    participant ContextBuilder as context-builder.ts
    participant MCS as MarketContextService
    participant DB as Database

    Script->>Bridge: initializeSimulationMode()
    Bridge->>Bridge: Set mode to JSON
    
    Script->>ContextBuilder: buildComprehensiveNPCContext()
    ContextBuilder->>MCS: getEventsForNPC(npcId, npcName)
    
    alt Simulation Mode (After Fix)
        MCS->>Bridge: isSimulationMode()
        Bridge-->>MCS: true
        MCS-->>ContextBuilder: return []
    else Database Mode
        MCS->>Bridge: isSimulationMode()
        Bridge-->>MCS: false
        MCS->>DB: db.select().from(worldEvents)
        DB-->>MCS: events
        MCS-->>ContextBuilder: return events
    end
    
    ContextBuilder->>MCS: getRecentPostsByNPC(npcId)
    
    alt Simulation Mode (After Fix)
        MCS->>Bridge: isSimulationMode()
        Bridge-->>MCS: true
        MCS-->>ContextBuilder: return []
    else Database Mode
        MCS->>Bridge: isSimulationMode()
        Bridge-->>MCS: false
        MCS->>DB: db.select().from(posts)
        DB-->>MCS: posts
        MCS-->>ContextBuilder: return posts
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->