### PR TITLE
Fix prediction markets: record agent trade price history

### DIFF
--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -9,6 +9,7 @@
 import {
   broadcastAgentActivity,
   broadcastChatMessage,
+  broadcastToChannel,
   type CommentActivityData,
   type MessageActivityData,
   type PostActivityData,
@@ -33,6 +34,7 @@ import {
   perpPositions,
   positions,
   posts,
+  predictionPriceHistories,
   reactions,
   shares,
   sql,
@@ -42,6 +44,7 @@ import {
   FEE_CONFIG,
   type GeneratedTag,
   generateTagsFromPost,
+  invalidateAfterPredictionTrade,
   PredictionPricing,
   StaticDataRegistry,
   storeTagsForPost,
@@ -576,6 +579,19 @@ async function executePredictionTrade(params: {
       });
     }
 
+    await txDb.insert(predictionPriceHistories).values({
+      id: await generateSnowflakeId(),
+      marketId: market.id,
+      yesPrice: calculation.newYesPrice,
+      noPrice: calculation.newNoPrice,
+      yesShares: String(calculation.newYesShares),
+      noShares: String(calculation.newNoShares),
+      liquidity: String(Number(market.liquidity) + calculation.netAmount),
+      eventType: 'trade',
+      source: isNpc ? 'npc_trade' : 'user_trade',
+      createdAt: new Date(),
+    });
+
     return { calculation };
   };
 
@@ -604,6 +620,44 @@ async function executePredictionTrade(params: {
     { shares: sharesRounded },
     'DirectExecutors'
   );
+
+  await invalidateAfterPredictionTrade(market.id).catch((error) => {
+    logger.debug(
+      'Failed to invalidate prediction trades cache after direct trade',
+      {
+        marketId: market.id,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      'DirectExecutors'
+    );
+  });
+
+  broadcastToChannel('markets', {
+    type: 'prediction_trade',
+    marketId: market.id,
+    yesPrice: result.calculation.newYesPrice,
+    noPrice: result.calculation.newNoPrice,
+    yesShares: result.calculation.newYesShares,
+    noShares: result.calculation.newNoShares,
+    liquidity: Number(market.liquidity) + result.calculation.netAmount,
+    trade: {
+      actorType: isNpc ? 'npc' : 'user',
+      actorId: agentUserId,
+      action: 'buy',
+      side: isBuyYes ? 'yes' : 'no',
+      shares: result.calculation.sharesBought,
+      amount,
+      price: result.calculation.avgPrice,
+      source: isNpc ? 'npc_trade' : 'user_trade',
+      timestamp: new Date().toISOString(),
+    },
+  }).catch((error: Error) => {
+    logger.debug(
+      'Failed to broadcast prediction trade update',
+      { marketId: market.id, error: error.message },
+      'DirectExecutors'
+    );
+  });
 
   return {
     success: true,
@@ -777,6 +831,19 @@ async function executePredictionSell(params: {
         .where(eq(positions.id, existingPosition.id));
     }
 
+    await txDb.insert(predictionPriceHistories).values({
+      id: await generateSnowflakeId(),
+      marketId: market.id,
+      yesPrice: calculation.newYesPrice,
+      noPrice: calculation.newNoPrice,
+      yesShares: String(calculation.newYesShares),
+      noShares: String(calculation.newNoShares),
+      liquidity: String(Number(market.liquidity) - calculation.totalCost),
+      eventType: 'trade',
+      source: isNpc ? 'npc_trade' : 'user_trade',
+      createdAt: new Date(),
+    });
+
     return { calculation, sharesToSell, remainingShares, netProceeds };
   };
 
@@ -823,6 +890,46 @@ async function executePredictionSell(params: {
     { sharesSold: result.sharesToSell, remaining: result.remainingShares },
     'DirectExecutors'
   );
+
+  await invalidateAfterPredictionTrade(market.id).catch((error) => {
+    logger.debug(
+      'Failed to invalidate prediction trades cache after direct sell',
+      {
+        marketId: market.id,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      'DirectExecutors'
+    );
+  });
+
+  const tradeAction =
+    Math.abs(result.remainingShares) < MIN_SHARES_THRESHOLD ? 'close' : 'sell';
+  broadcastToChannel('markets', {
+    type: 'prediction_trade',
+    marketId: market.id,
+    yesPrice: result.calculation.newYesPrice,
+    noPrice: result.calculation.newNoPrice,
+    yesShares: result.calculation.newYesShares,
+    noShares: result.calculation.newNoShares,
+    liquidity: Number(market.liquidity) - result.calculation.totalCost,
+    trade: {
+      actorType: isNpc ? 'npc' : 'user',
+      actorId: agentUserId,
+      action: tradeAction,
+      side: isSellYes ? 'yes' : 'no',
+      shares: result.sharesToSell,
+      amount: result.netProceeds,
+      price: result.calculation.avgPrice,
+      source: isNpc ? 'npc_trade' : 'user_trade',
+      timestamp: new Date().toISOString(),
+    },
+  }).catch((error: Error) => {
+    logger.debug(
+      'Failed to broadcast prediction trade update',
+      { marketId: market.id, error: error.message },
+      'DirectExecutors'
+    );
+  });
 
   return {
     success: true,

--- a/packages/agents/src/autonomous/__tests__/prediction-price-history.test.ts
+++ b/packages/agents/src/autonomous/__tests__/prediction-price-history.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const predictionPriceHistories = { table: 'PredictionPriceHistory' };
+const markets = { table: 'Market', id: 'id' };
+const positions = {
+  table: 'Position',
+  userId: 'userId',
+  marketId: 'marketId',
+  side: 'side',
+  status: 'status',
+  amount: 'amount',
+  id: 'id',
+};
+const users = { table: 'User', id: 'id', displayName: 'displayName' };
+const agentTrades = { table: 'AgentTrade' };
+const agentLogs = { table: 'AgentLog' };
+
+const marketRow = {
+  id: '260717599719948288',
+  yesShares: '100',
+  noShares: '100',
+  liquidity: '10000',
+  question: 'Will something happen?',
+};
+
+const userRow = { displayName: 'Test Agent' };
+
+const insertedPredictionHistory: Array<Record<string, unknown>> = [];
+
+const mockTxDb = {
+  update: mock(() => ({
+    set: mock(() => ({
+      where: mock(async () => []),
+      returning: mock(async () => []),
+    })),
+  })),
+  select: mock(() => ({
+    from: mock(() => ({
+      where: mock(() => ({
+        limit: mock(async () => []),
+      })),
+    })),
+  })),
+  insert: mock((table: unknown) => ({
+    values: mock(async (values: Record<string, unknown>) => {
+      if (table === predictionPriceHistories) {
+        insertedPredictionHistory.push(values);
+      }
+      return [];
+    }),
+    returning: mock(async () => []),
+  })),
+  delete: mock(() => ({
+    where: mock(async () => []),
+  })),
+};
+
+const mockDb = {
+  select: mock(() => ({
+    from: mock((table: unknown) => ({
+      where: mock(() => ({
+        limit: mock(async () => {
+          if (table === markets) return [marketRow];
+          if (table === users) return [userRow];
+          return [];
+        }),
+      })),
+    })),
+  })),
+};
+
+mock.module('@babylon/api', () => ({
+  broadcastAgentActivity: mock(async () => undefined),
+  broadcastChatMessage: mock(async () => undefined),
+  broadcastToChannel: mock(async () => undefined),
+}));
+
+mock.module('@babylon/core/markets/perps', () => ({
+  PerpDbAdapter: class {},
+  PerpMarketService: class {},
+}));
+
+mock.module('@babylon/engine', () => ({
+  FEE_CONFIG: { TRADING_FEE_RATE: 0.001 },
+  invalidateAfterPredictionTrade: mock(async () => undefined),
+  PredictionPricing: {
+    calculateBuyWithFees: mock(() => ({
+      sharesBought: 10,
+      avgPrice: 0.75,
+      netAmount: 9.99,
+      newYesShares: 110,
+      newNoShares: 90,
+      newYesPrice: 0.55,
+      newNoPrice: 0.45,
+    })),
+    calculateSellWithFees: mock(() => ({
+      avgPrice: 0.5,
+      netProceeds: 5,
+      netAmount: 5,
+      totalCost: 5,
+      newYesShares: 100,
+      newNoShares: 100,
+      newYesPrice: 0.5,
+      newNoPrice: 0.5,
+    })),
+  },
+  StaticDataRegistry: {
+    getActor: () => null,
+    getAllOrganizations: () => [],
+  },
+  WalletService: {
+    getBalance: mock(async () => ({ balance: 10000 })),
+    debit: mock(async () => undefined),
+    credit: mock(async () => undefined),
+    recordPnL: mock(async () => undefined),
+  },
+  generateTagsFromPost: mock(async () => []),
+  storeTagsForPost: mock(async () => undefined),
+}));
+
+mock.module('@babylon/db', () => ({
+  actorState: { id: 'id', tradingBalance: 'tradingBalance' },
+  agentLogs,
+  agentTrades,
+  aliasedTable: (table: unknown) => table,
+  and: (...args: unknown[]) => args,
+  asSystem: async (
+    operation: (database: typeof mockTxDb) => Promise<unknown>
+  ) => operation(mockTxDb),
+  asUser: async (
+    _user: { userId: string },
+    operation: (database: typeof mockTxDb) => Promise<unknown>
+  ) => operation(mockTxDb),
+  chatParticipants: {},
+  chats: {},
+  comments: {},
+  db: mockDb,
+  dmAcceptances: {},
+  eq: (a: unknown, b: unknown) => ({ a, b }),
+  gte: (a: unknown, b: unknown) => ({ a, b }),
+  isNull: (a: unknown) => ({ a }),
+  markets,
+  messages: {},
+  perpPositions: {},
+  positions,
+  posts: {},
+  predictionPriceHistories,
+  reactions: {},
+  shares: {},
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings,
+    values,
+  }),
+  users,
+  withTransaction: async (
+    operation: (database: typeof mockTxDb) => Promise<unknown>
+  ) => operation(mockTxDb),
+  desc: (a: unknown) => a,
+}));
+
+describe('DirectExecutors prediction price history', () => {
+  beforeEach(() => {
+    insertedPredictionHistory.length = 0;
+  });
+
+  test('records PredictionPriceHistory for agent prediction buys', async () => {
+    const { executeDirectTrade } = await import('../DirectExecutors');
+
+    const result = await executeDirectTrade({
+      agentUserId: '123456789012345678',
+      marketType: 'prediction',
+      marketId: marketRow.id,
+      side: 'buy_yes',
+      amount: 10,
+      reasoning: 'test',
+    });
+
+    expect(result.success).toBe(true);
+    expect(insertedPredictionHistory).toHaveLength(1);
+
+    const snapshot = insertedPredictionHistory[0]!;
+    expect(snapshot.marketId).toBe(marketRow.id);
+    expect(snapshot.eventType).toBe('trade');
+    expect(snapshot.source).toBe('user_trade');
+    expect(snapshot.yesPrice).toBe(0.55);
+    expect(snapshot.noPrice).toBe(0.45);
+    expect(snapshot.yesShares).toBe('110');
+    expect(snapshot.noShares).toBe('90');
+    expect(snapshot.liquidity).toBe('10009.99');
+    expect(typeof snapshot.id).toBe('string');
+  });
+});

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/buy-prediction.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/buy-prediction.ts
@@ -4,8 +4,24 @@
  * (Same pattern as AutonomousTradingService)
  */
 
-import { and, asUser, db, eq, gte, markets, positions, sql } from '@babylon/db';
-import { FEE_CONFIG, PredictionPricing, WalletService } from '@babylon/engine';
+import { broadcastToChannel } from '@babylon/api';
+import {
+  and,
+  asUser,
+  db,
+  eq,
+  gte,
+  markets,
+  positions,
+  predictionPriceHistories,
+  sql,
+} from '@babylon/db';
+import {
+  FEE_CONFIG,
+  invalidateAfterPredictionTrade,
+  PredictionPricing,
+  WalletService,
+} from '@babylon/engine';
 import type {
   Action,
   ActionResult,
@@ -179,6 +195,19 @@ export const buyPredictionAction: Action = {
           })
           .where(eq(markets.id, market.id));
 
+        await txDb.insert(predictionPriceHistories).values({
+          id: await generateSnowflakeId(),
+          marketId: market.id,
+          yesPrice: calculation.newYesPrice,
+          noPrice: calculation.newNoPrice,
+          yesShares: String(calculation.newYesShares),
+          noShares: String(calculation.newNoShares),
+          liquidity: String(nextLiquidity),
+          eventType: 'trade',
+          source: 'user_trade',
+          createdAt: new Date(),
+        });
+
         // Check for existing position
         const [existingPosition] = await txDb
           .select()
@@ -260,6 +289,44 @@ export const buyPredictionAction: Action = {
         shares: result.calculation.sharesBought,
         avgPrice: result.calculation.avgPrice,
         cost: amount,
+      });
+
+      await invalidateAfterPredictionTrade(market.id).catch((error) => {
+        logger.debug(
+          'Failed to invalidate prediction trades cache after agent buy',
+          {
+            marketId: market.id,
+            error: error instanceof Error ? error.message : String(error),
+          }
+        );
+      });
+
+      const nextLiquidity =
+        Number(market.liquidity) + result.calculation.netAmount;
+      broadcastToChannel('markets', {
+        type: 'prediction_trade',
+        marketId: market.id,
+        yesPrice: result.calculation.newYesPrice,
+        noPrice: result.calculation.newNoPrice,
+        yesShares: result.calculation.newYesShares,
+        noShares: result.calculation.newNoShares,
+        liquidity: nextLiquidity,
+        trade: {
+          actorType: 'user',
+          actorId: agentUserId,
+          action: 'buy',
+          side: isBuyYes ? 'yes' : 'no',
+          shares: result.calculation.sharesBought,
+          amount,
+          price: result.calculation.avgPrice,
+          source: 'user_trade',
+          timestamp: new Date().toISOString(),
+        },
+      }).catch((error: Error) => {
+        logger.debug('Failed to broadcast prediction trade update', {
+          marketId: market.id,
+          error: error.message,
+        });
       });
 
       return {

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/sell-prediction.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/sell-prediction.ts
@@ -4,8 +4,22 @@
  * (Same pattern as AutonomousTradingService)
  */
 
-import { and, asUser, db, eq, markets, positions } from '@babylon/db';
-import { FEE_CONFIG, PredictionPricing, WalletService } from '@babylon/engine';
+import { broadcastToChannel } from '@babylon/api';
+import {
+  and,
+  asUser,
+  db,
+  eq,
+  markets,
+  positions,
+  predictionPriceHistories,
+} from '@babylon/db';
+import {
+  FEE_CONFIG,
+  invalidateAfterPredictionTrade,
+  PredictionPricing,
+  WalletService,
+} from '@babylon/engine';
 import type {
   Action,
   ActionResult,
@@ -16,6 +30,7 @@ import type {
 } from '@elizaos/core';
 import { AgentPnLService } from '../../../../services/AgentPnLService';
 import { logger } from '../../../../shared/logger';
+import { generateSnowflakeId } from '../../../../shared/snowflake';
 
 const agentPnLService = new AgentPnLService();
 
@@ -180,6 +195,19 @@ export const sellPredictionAction: Action = {
           })
           .where(eq(markets.id, market.id));
 
+        await txDb.insert(predictionPriceHistories).values({
+          id: await generateSnowflakeId(),
+          marketId: market.id,
+          yesPrice: calculation.newYesPrice,
+          noPrice: calculation.newNoPrice,
+          yesShares: String(calculation.newYesShares),
+          noShares: String(calculation.newNoShares),
+          liquidity: String(nextLiquidity),
+          eventType: 'trade',
+          source: 'user_trade',
+          createdAt: new Date(),
+        });
+
         // Update or close position
         const remainingShares = currentShares - sharesToSell;
         if (remainingShares <= 0) {
@@ -249,6 +277,45 @@ export const sellPredictionAction: Action = {
         sharesSold: sharesToSell,
         proceeds,
         remainingShares: result.remainingShares,
+      });
+
+      await invalidateAfterPredictionTrade(market.id).catch((error) => {
+        logger.debug(
+          'Failed to invalidate prediction trades cache after agent sell',
+          {
+            marketId: market.id,
+            error: error instanceof Error ? error.message : String(error),
+          }
+        );
+      });
+
+      const nextLiquidity =
+        Number(market.liquidity) - result.calculation.totalCost;
+      const tradeAction = result.remainingShares <= 0 ? 'close' : 'sell';
+      broadcastToChannel('markets', {
+        type: 'prediction_trade',
+        marketId: market.id,
+        yesPrice: result.calculation.newYesPrice,
+        noPrice: result.calculation.newNoPrice,
+        yesShares: result.calculation.newYesShares,
+        noShares: result.calculation.newNoShares,
+        liquidity: nextLiquidity,
+        trade: {
+          actorType: 'user',
+          actorId: agentUserId,
+          action: tradeAction,
+          side: isSellYes ? 'yes' : 'no',
+          shares: sharesToSell,
+          amount: proceeds,
+          price: result.calculation.avgPrice ?? proceeds / sharesToSell,
+          source: 'user_trade',
+          timestamp: new Date().toISOString(),
+        },
+      }).catch((error: Error) => {
+        logger.debug('Failed to broadcast prediction trade update', {
+          marketId: market.id,
+          error: error.message,
+        });
       });
 
       return {


### PR DESCRIPTION
## Summary
- Record agent-driven prediction market trades into `PredictionPriceHistory` so charts reflect real agent activity.
- Emit `prediction_trade` SSE events + invalidate prediction trade caches after agent trades.
- Add a unit test to prevent regressions.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Tester feedback: prediction markets show movement, but 1W/ALL history looks like a single point; agents appear to trade but history/series doesn’t build.

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [x] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- `packages/agents/src/autonomous/DirectExecutors.ts`: after successful prediction buy/sell, insert a `PredictionPriceHistory` snapshot, invalidate prediction-trade caches, and broadcast `prediction_trade` SSE.
- `packages/agents/src/plugins/plugin-agent-core/src/actions/buy-prediction.ts`: same snapshot + cache invalidation + SSE broadcast for chat-initiated buys.
- `packages/agents/src/plugins/plugin-agent-core/src/actions/sell-prediction.ts`: same snapshot + cache invalidation + SSE broadcast for chat-initiated sells.
- `packages/agents/src/autonomous/__tests__/prediction-price-history.test.ts`: unit test asserts prediction buys record `PredictionPriceHistory`.

**Non-goals / follow-ups**
- Backfilling historical `PredictionPriceHistory` for already-executed agent trades (could be done via a one-off script if needed).

## Review guide
**Start here**
- `packages/agents/src/autonomous/DirectExecutors.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- This increases `PredictionPriceHistory` write volume to match actual agent trade activity (expected/desired for charting).
- `source` is set to `user_trade` for user-agents and `npc_trade` for NPC actors.

## Test plan
**Commands run**
- [ ] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Trigger an agent prediction buy/sell.
2. Verify `PredictionPriceHistory` grows for that market and the chart shows a real series for 1W.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option B: No visual changes
- Reason: Backend/agent runtime change only (history persistence + SSE), no UI layout/visual changes.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Real-time market updates now broadcast when prediction trades execute
  * Price history is automatically recorded for all prediction buy and sell transactions
  * Market state refreshes include updated pricing, shares, and liquidity data

* **Tests**
  * Added comprehensive test coverage for price history tracking in prediction trades

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixes a critical gap where agent-driven prediction market trades weren't being recorded in `PredictionPriceHistory`, causing charts to display incomplete or single-point data despite active agent trading.

**Changes made:**
- Records price history snapshots for all agent prediction trades (buy/sell) in `DirectExecutors.ts` and the `buy-prediction`/`sell-prediction` action handlers
- Emits `prediction_trade` SSE events after agent trades to notify clients of market updates in real-time
- Invalidates prediction trade caches to ensure fresh data is served to clients
- Added unit test to prevent regression of price history recording

**Integration points:**
- Matches the existing pattern used in `PredictionMarketService.recordSnapshot()` for regular user trades
- Uses the same `PredictionPriceHistory` schema (eventType='trade', source='user_trade'/'npc_trade')
- Consistent with trade broadcasting patterns defined in `trade-execution-service.ts`
- Cache invalidation follows established error handling (soft failures with debug logging)

<h3>Confidence Score: 4/5</h3>


- Safe to merge with minor considerations about duplicate logic and test coverage
- The implementation correctly addresses the bug by recording price history for agent trades. The pattern is consistent with existing user trade flows, proper error handling is in place (soft failures for cache/SSE), and a unit test prevents regression. Score reduced from 5 to 4 due to code duplication across three files (DirectExecutors, buy-prediction, sell-prediction) that could potentially be refactored into shared utilities, and test coverage only validates the buy path.
- No files require special attention - the changes follow established patterns and include appropriate error handling

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agents/src/autonomous/DirectExecutors.ts | Added price history recording, cache invalidation, and SSE broadcasting for both buy and sell agent trades |
| packages/agents/src/plugins/plugin-agent-core/src/actions/buy-prediction.ts | Added price history recording, cache invalidation, and SSE broadcasting for chat-initiated buy actions |
| packages/agents/src/plugins/plugin-agent-core/src/actions/sell-prediction.ts | Added price history recording, cache invalidation, and SSE broadcasting for chat-initiated sell actions |
| packages/agents/src/autonomous/__tests__/prediction-price-history.test.ts | Comprehensive unit test verifying price history recording for agent prediction trades with proper mocking |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent
    participant DirectExecutors
    participant DB
    participant PredictionPricing
    participant WalletService
    participant Cache
    participant SSE
    
    Agent->>DirectExecutors: executeDirectTrade(prediction buy/sell)
    DirectExecutors->>DB: Fetch market by ID
    DB-->>DirectExecutors: Market data
    DirectExecutors->>PredictionPricing: calculateBuyWithFees() / calculateSellWithFees()
    PredictionPricing-->>DirectExecutors: calculation (newYesPrice, newNoPrice, shares)
    
    DirectExecutors->>DB: Begin transaction
    DirectExecutors->>WalletService: debit() / credit()
    DirectExecutors->>DB: Update market shares & liquidity
    DirectExecutors->>DB: Insert PredictionPriceHistory
    Note over DirectExecutors,DB: NEW: Records price snapshot with<br/>eventType='trade', source='npc_trade'/'user_trade'
    DirectExecutors->>DB: Upsert/update Position
    DirectExecutors->>DB: Commit transaction
    
    DirectExecutors->>Cache: invalidateAfterPredictionTrade(marketId)
    Note over Cache: Invalidates prediction trades cache<br/>(soft error handling)
    
    DirectExecutors->>SSE: broadcastToChannel('markets', prediction_trade event)
    Note over SSE: Broadcasts trade to clients with<br/>updated prices, shares, liquidity<br/>(soft error handling)
    
    DirectExecutors-->>Agent: Trade result (success, shares, prices)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->