### PR TITLE
fix: agent onboarding and chat failures due to missing A2A operations and provider null checks

### DIFF
--- a/apps/web/src/app/api/agents/[agentId]/chat/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/chat/route.ts
@@ -287,11 +287,13 @@ export const POST = withErrorHandling(
       );
 
       // Compose state with providers
-      const state: State = await runtime.composeState(elizaMessage, [
-        'RECENT_MESSAGES',
-        'ACTION_STATE',
-        'ACTIONS',
-      ]);
+      // Use strict filtering (3rd param = true) to ONLY run the specified providers
+      // This prevents all Babylon A2A providers from running unnecessarily
+      const state: State = await runtime.composeState(
+        elizaMessage,
+        ['RECENT_MESSAGES', 'ACTION_STATE', 'ACTIONS'],
+        true
+      );
 
       // Add custom values to state
       state.values = {
@@ -500,10 +502,11 @@ export const POST = withErrorHandling(
 
     // Generate summary/response - always run to get proper user-facing message
     {
-      const state = await runtime.composeState(elizaMessage, [
-        'RECENT_MESSAGES',
-        'ACTION_STATE',
-      ]);
+      const state = await runtime.composeState(
+        elizaMessage,
+        ['RECENT_MESSAGES', 'ACTION_STATE'],
+        true
+      );
       state.values = {
         ...state.values,
         agentId, // Pass agentId for actions that need it

--- a/apps/web/src/app/api/agents/[agentId]/onboarding/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/onboarding/route.ts
@@ -108,7 +108,9 @@ export const POST = withErrorHandling(
     };
 
     // Compose state with ACTIONS provider to get actionsWithDescriptions
-    const state = await runtime.composeState(onboardingMessage, ['ACTIONS']);
+    // Use strict filtering (3rd param = true) to ONLY run the specified providers
+    // This prevents all Babylon A2A providers from running unnecessarily
+    const state = await runtime.composeState(onboardingMessage, ['ACTIONS'], true);
 
     // Add custom values to state
     state.values = {

--- a/apps/web/src/app/api/agents/[agentId]/onboarding/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/onboarding/route.ts
@@ -110,7 +110,11 @@ export const POST = withErrorHandling(
     // Compose state with ACTIONS provider to get actionsWithDescriptions
     // Use strict filtering (3rd param = true) to ONLY run the specified providers
     // This prevents all Babylon A2A providers from running unnecessarily
-    const state = await runtime.composeState(onboardingMessage, ['ACTIONS'], true);
+    const state = await runtime.composeState(
+      onboardingMessage,
+      ['ACTIONS'],
+      true
+    );
 
     // Add custom values to state
     state.values = {

--- a/packages/a2a/src/executors/babylon-executor.ts
+++ b/packages/a2a/src/executors/babylon-executor.ts
@@ -986,10 +986,7 @@ export class BabylonAgentExecutor implements AgentExecutor {
       (sum, p) => sum + p.unrealizedPnL,
       0
     );
-    const perpPnL = perpPositions.reduce(
-      (sum, p) => sum + p.unrealizedPnL,
-      0
-    );
+    const perpPnL = perpPositions.reduce((sum, p) => sum + p.unrealizedPnL, 0);
 
     return {
       marketPositions,

--- a/packages/a2a/src/executors/babylon-executor.ts
+++ b/packages/a2a/src/executors/babylon-executor.ts
@@ -237,6 +237,41 @@ type ExecutorOperationResult =
   | JsonValue;
 
 export class BabylonAgentExecutor implements AgentExecutor {
+  // Singleton instance for direct execution (bypasses HTTP)
+  private static instance: BabylonAgentExecutor | null = null;
+
+  /**
+   * Execute an operation directly without HTTP.
+   * Use this for server-side calls to avoid Vercel serverless self-call issues.
+   */
+  static async executeDirectly(
+    operation: string,
+    params: Record<string, JsonValue>,
+    userId?: string
+  ): Promise<JsonValue> {
+    if (!BabylonAgentExecutor.instance) {
+      BabylonAgentExecutor.instance = new BabylonAgentExecutor();
+    }
+
+    const context: RequestContext = {
+      taskId: `direct-${Date.now()}`,
+      contextId: userId || 'system',
+      userMessage: {
+        kind: 'message',
+        messageId: `msg-${Date.now()}`,
+        role: 'user',
+        parts: [],
+      },
+      task: null as unknown as Task,
+    };
+
+    const result = await BabylonAgentExecutor.instance.executeOperation(
+      { operation, params },
+      context
+    );
+    return result as JsonValue;
+  }
+
   async execute(
     requestContext: RequestContext,
     eventBus: ExecutionEventBus
@@ -315,7 +350,7 @@ export class BabylonAgentExecutor implements AgentExecutor {
     eventBus.finished();
   }
 
-  private async executeOperation(
+  async executeOperation(
     command: BabylonCommand,
     context: RequestContext
   ): Promise<ExecutorOperationResult> {

--- a/packages/a2a/src/executors/babylon-executor.ts
+++ b/packages/a2a/src/executors/babylon-executor.ts
@@ -18,7 +18,8 @@ import type {
   ExecutionEventBus,
   RequestContext,
 } from '@a2a-js/sdk/server';
-import { db } from '@babylon/db';
+import { db, getRawDrizzle } from '@babylon/db';
+import { perpMarketSnapshots } from '@babylon/db/schema';
 import type { JsonValue } from '@babylon/shared';
 import { generateSnowflakeId, logger } from '@babylon/shared';
 import { v4 as uuidv4 } from 'uuid';
@@ -551,23 +552,36 @@ export class BabylonAgentExecutor implements AgentExecutor {
 
   private async listPerpetualMarkets(params: Record<string, JsonValue>) {
     const limit = this.parsePositiveInt(params.limit, 20, 50);
-    // Get organization states for perpetual markets
-    const orgStates = await db.organizationState.findMany({
-      take: limit,
-      orderBy: { currentPrice: 'desc' },
-      select: {
-        id: true,
-        currentPrice: true,
-      },
-    });
+
+    const drizzle = getRawDrizzle();
+    const snapshots = await drizzle
+      .select({
+        ticker: perpMarketSnapshots.ticker,
+        name: perpMarketSnapshots.name,
+        organizationId: perpMarketSnapshots.organizationId,
+        currentPrice: perpMarketSnapshots.currentPrice,
+        change24h: perpMarketSnapshots.change24h,
+        changePercent24h: perpMarketSnapshots.changePercent24h,
+        volume24h: perpMarketSnapshots.volume24h,
+        openInterest: perpMarketSnapshots.openInterest,
+        fundingRate: perpMarketSnapshots.fundingRate,
+      })
+      .from(perpMarketSnapshots)
+      .limit(limit);
+
     return {
-      perpetuals: orgStates.map(
-        (o: { id: string; currentPrice: number | null }) => ({
-          id: o.id,
-          ticker: o.id,
-          currentPrice: Number(o.currentPrice) || 0,
-        })
-      ),
+      perpetuals: snapshots.map((s) => ({
+        name: s.name || s.ticker,
+        ticker: s.ticker,
+        currentPrice: Number(s.currentPrice) || 0,
+        priceChange24h: Number(s.change24h) || 0,
+        volume24h: Number(s.volume24h) || 0,
+        openInterest: Number(s.openInterest) || 0,
+        fundingRate:
+          typeof s.fundingRate === 'object' && s.fundingRate !== null
+            ? (s.fundingRate as { rate?: number }).rate || 0
+            : 0,
+      })),
     };
   }
 
@@ -885,7 +899,6 @@ export class BabylonAgentExecutor implements AgentExecutor {
       },
     });
 
-    // Get markets for positions to include question text
     const marketIds = [
       ...new Set(marketPositionsRaw.map((p) => p.marketId).filter(Boolean)),
     ];
@@ -893,43 +906,82 @@ export class BabylonAgentExecutor implements AgentExecutor {
       marketIds.length > 0
         ? await db.market.findMany({
             where: { id: { in: marketIds } },
-            select: { id: true, question: true, resolved: true },
+            select: {
+              id: true,
+              question: true,
+              resolved: true,
+              yesShares: true,
+              noShares: true,
+            },
           })
         : [];
     const marketMap = new Map(markets.map((m) => [m.id, m]));
 
-    // Get perpetual positions (closedAt is null means position is open)
-    const perpPositions = await db.perpPosition.findMany({
+    const perpPositionsRaw = await db.perpPosition.findMany({
       where: {
         userId,
         closedAt: null,
       },
     });
 
+    const orgIds = [
+      ...new Set(perpPositionsRaw.map((p) => p.organizationId).filter(Boolean)),
+    ];
+    const orgStates =
+      orgIds.length > 0
+        ? await db.organizationState.findMany({
+            where: { id: { in: orgIds } },
+            select: { id: true, currentPrice: true },
+          })
+        : [];
+    const orgStateMap = new Map(orgStates.map((o) => [o.id, o]));
+
     return {
       marketPositions: marketPositionsRaw.map((p) => {
         const market = marketMap.get(p.marketId);
+        const side: 'YES' | 'NO' = p.outcome === true ? 'YES' : 'NO';
+
+        // CPMM price: yesPrice = noShares / total, noPrice = yesShares / total
+        const yesShares = Number(market?.yesShares ?? 0);
+        const noShares = Number(market?.noShares ?? 0);
+        const totalShares = yesShares + noShares;
+        const currentPrice =
+          totalShares > 0
+            ? side === 'YES'
+              ? noShares / totalShares
+              : yesShares / totalShares
+            : 0.5;
+
+        const avgPrice = Number(p.avgPrice);
+        const shares = Number(p.shares);
+        const unrealizedPnL = (currentPrice - avgPrice) * shares;
+
         return {
           id: p.id,
           marketId: String(p.marketId),
-          marketQuestion: market?.question || 'Unknown',
-          outcome: p.outcome,
-          shares: Number(p.shares),
-          avgPrice: Number(p.avgPrice),
-          unrealizedPnL: 0, // Would need current price to calculate
+          question: market?.question || 'Unknown',
+          side,
+          shares,
+          avgPrice,
+          currentPrice,
+          unrealizedPnL,
         };
       }),
-      perpPositions: perpPositions.map((p) => ({
-        id: p.id,
-        ticker: p.ticker,
-        organizationId: p.organizationId,
-        side: p.side,
-        size: Number(p.size),
-        entryPrice: Number(p.entryPrice),
-        leverage: Number(p.leverage),
-        unrealizedPnL: Number(p.unrealizedPnL) || 0,
-      })),
-      totalPnL: perpPositions.reduce(
+      perpPositions: perpPositionsRaw.map((p) => {
+        const orgState = orgStateMap.get(p.organizationId);
+        const currentPrice = Number(orgState?.currentPrice ?? p.entryPrice);
+        return {
+          id: p.id,
+          ticker: p.ticker,
+          side: p.side as 'long' | 'short',
+          size: Number(p.size),
+          entryPrice: Number(p.entryPrice),
+          currentPrice,
+          leverage: Number(p.leverage),
+          unrealizedPnL: Number(p.unrealizedPnL) || 0,
+        };
+      }),
+      totalPnL: perpPositionsRaw.reduce(
         (sum, p) => sum + (Number(p.unrealizedPnL) || 0),
         0
       ),

--- a/packages/a2a/src/executors/babylon-executor.ts
+++ b/packages/a2a/src/executors/babylon-executor.ts
@@ -936,55 +936,65 @@ export class BabylonAgentExecutor implements AgentExecutor {
         : [];
     const orgStateMap = new Map(orgStates.map((o) => [o.id, o]));
 
+    const marketPositions = marketPositionsRaw.map((p) => {
+      const market = marketMap.get(p.marketId);
+      const side: 'YES' | 'NO' = p.outcome === true ? 'YES' : 'NO';
+
+      // CPMM price: yesPrice = noShares / total, noPrice = yesShares / total
+      const yesShares = Number(market?.yesShares ?? 0);
+      const noShares = Number(market?.noShares ?? 0);
+      const totalShares = yesShares + noShares;
+      const currentPrice =
+        totalShares > 0
+          ? side === 'YES'
+            ? noShares / totalShares
+            : yesShares / totalShares
+          : 0.5;
+
+      const avgPrice = Number(p.avgPrice);
+      const shares = Number(p.shares);
+      const unrealizedPnL = (currentPrice - avgPrice) * shares;
+
+      return {
+        id: p.id,
+        marketId: String(p.marketId),
+        question: market?.question || 'Unknown',
+        side,
+        shares,
+        avgPrice,
+        currentPrice,
+        unrealizedPnL,
+      };
+    });
+
+    const perpPositions = perpPositionsRaw.map((p) => {
+      const orgState = orgStateMap.get(p.organizationId);
+      const currentPrice = Number(orgState?.currentPrice ?? p.entryPrice);
+      return {
+        id: p.id,
+        ticker: p.ticker,
+        side: p.side as 'long' | 'short',
+        size: Number(p.size),
+        entryPrice: Number(p.entryPrice),
+        currentPrice,
+        leverage: Number(p.leverage),
+        unrealizedPnL: Number(p.unrealizedPnL) || 0,
+      };
+    });
+
+    const marketPnL = marketPositions.reduce(
+      (sum, p) => sum + p.unrealizedPnL,
+      0
+    );
+    const perpPnL = perpPositions.reduce(
+      (sum, p) => sum + p.unrealizedPnL,
+      0
+    );
+
     return {
-      marketPositions: marketPositionsRaw.map((p) => {
-        const market = marketMap.get(p.marketId);
-        const side: 'YES' | 'NO' = p.outcome === true ? 'YES' : 'NO';
-
-        // CPMM price: yesPrice = noShares / total, noPrice = yesShares / total
-        const yesShares = Number(market?.yesShares ?? 0);
-        const noShares = Number(market?.noShares ?? 0);
-        const totalShares = yesShares + noShares;
-        const currentPrice =
-          totalShares > 0
-            ? side === 'YES'
-              ? noShares / totalShares
-              : yesShares / totalShares
-            : 0.5;
-
-        const avgPrice = Number(p.avgPrice);
-        const shares = Number(p.shares);
-        const unrealizedPnL = (currentPrice - avgPrice) * shares;
-
-        return {
-          id: p.id,
-          marketId: String(p.marketId),
-          question: market?.question || 'Unknown',
-          side,
-          shares,
-          avgPrice,
-          currentPrice,
-          unrealizedPnL,
-        };
-      }),
-      perpPositions: perpPositionsRaw.map((p) => {
-        const orgState = orgStateMap.get(p.organizationId);
-        const currentPrice = Number(orgState?.currentPrice ?? p.entryPrice);
-        return {
-          id: p.id,
-          ticker: p.ticker,
-          side: p.side as 'long' | 'short',
-          size: Number(p.size),
-          entryPrice: Number(p.entryPrice),
-          currentPrice,
-          leverage: Number(p.leverage),
-          unrealizedPnL: Number(p.unrealizedPnL) || 0,
-        };
-      }),
-      totalPnL: perpPositionsRaw.reduce(
-        (sum, p) => sum + (Number(p.unrealizedPnL) || 0),
-        0
-      ),
+      marketPositions,
+      perpPositions,
+      totalPnL: marketPnL + perpPnL,
     };
   }
 

--- a/packages/a2a/src/executors/babylon-executor.ts
+++ b/packages/a2a/src/executors/babylon-executor.ts
@@ -553,25 +553,52 @@ export class BabylonAgentExecutor implements AgentExecutor {
   private async listPerpetualMarkets(params: Record<string, JsonValue>) {
     const limit = this.parsePositiveInt(params.limit, 20, 50);
 
-    const drizzle = getRawDrizzle();
-    const snapshots = await drizzle
-      .select({
-        ticker: perpMarketSnapshots.ticker,
-        name: perpMarketSnapshots.name,
-        organizationId: perpMarketSnapshots.organizationId,
-        currentPrice: perpMarketSnapshots.currentPrice,
-        change24h: perpMarketSnapshots.change24h,
-        changePercent24h: perpMarketSnapshots.changePercent24h,
-        volume24h: perpMarketSnapshots.volume24h,
-        openInterest: perpMarketSnapshots.openInterest,
-        fundingRate: perpMarketSnapshots.fundingRate,
-      })
-      .from(perpMarketSnapshots)
-      .limit(limit);
+    let snapshots: Array<{
+      ticker: string;
+      name: string | null;
+      organizationId: string;
+      currentPrice: number;
+      change24h: number | null;
+      changePercent24h: number | null;
+      volume24h: number | null;
+      openInterest: number | null;
+      fundingRate: unknown;
+    }>;
+
+    try {
+      const drizzle = getRawDrizzle();
+      snapshots = await drizzle
+        .select({
+          ticker: perpMarketSnapshots.ticker,
+          name: perpMarketSnapshots.name,
+          organizationId: perpMarketSnapshots.organizationId,
+          currentPrice: perpMarketSnapshots.currentPrice,
+          change24h: perpMarketSnapshots.change24h,
+          changePercent24h: perpMarketSnapshots.changePercent24h,
+          volume24h: perpMarketSnapshots.volume24h,
+          openInterest: perpMarketSnapshots.openInterest,
+          fundingRate: perpMarketSnapshots.fundingRate,
+        })
+        .from(perpMarketSnapshots)
+        .limit(limit);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (
+        message.includes('getRawDrizzle() is only available in PostgreSQL mode') ||
+        message.includes('Database not initialized')
+      ) {
+        logger.debug('Perpetual markets unavailable, returning empty', {
+          message,
+        });
+        return { perpetuals: [] };
+      }
+      throw error;
+    }
 
     return {
       perpetuals: snapshots.map((s) => ({
         name: s.name || s.ticker,
+        type: 'perpetual',
         ticker: s.ticker,
         currentPrice: Number(s.currentPrice) || 0,
         priceChange24h: Number(s.change24h) || 0,
@@ -586,9 +613,10 @@ export class BabylonAgentExecutor implements AgentExecutor {
   }
 
   private async getUserProfile(params: Record<string, JsonValue>) {
-    const userId = typeof params.userId === 'string' ? params.userId : '';
+    const userId =
+      typeof params.userId === 'string' ? params.userId.trim() : '';
     if (!userId) {
-      return { profile: null };
+      throw new Error('userId is required');
     }
 
     const user = await db.user.findUnique({
@@ -601,25 +629,38 @@ export class BabylonAgentExecutor implements AgentExecutor {
         profileImageUrl: true,
         reputationPoints: true,
         virtualBalance: true,
+        walletAddress: true,
         isAgent: true,
       },
     });
 
     if (!user) {
-      return { profile: null };
+      logger.debug('User not found for getUserProfile, returning defaults', {
+        userId,
+      });
+      return {
+        id: userId,
+        username: null,
+        displayName: null,
+        bio: null,
+        profileImageUrl: null,
+        reputationPoints: 0,
+        virtualBalance: 0,
+        walletAddress: null,
+        isAgent: false,
+      };
     }
 
     return {
-      profile: {
-        id: user.id,
-        username: user.username,
-        displayName: user.displayName,
-        bio: user.bio,
-        profileImageUrl: user.profileImageUrl,
-        reputationPoints: user.reputationPoints,
-        balance: Number(user.virtualBalance) || 0,
-        isAgent: user.isAgent,
-      },
+      id: user.id,
+      username: user.username,
+      displayName: user.displayName,
+      bio: user.bio,
+      profileImageUrl: user.profileImageUrl,
+      reputationPoints: user.reputationPoints || 0,
+      virtualBalance: Number(user.virtualBalance) || 0,
+      walletAddress: user.walletAddress,
+      isAgent: user.isAgent,
     };
   }
 
@@ -632,6 +673,7 @@ export class BabylonAgentExecutor implements AgentExecutor {
       select: {
         id: true,
         currentPrice: true,
+        basePrice: true,
       },
     });
     return {
@@ -640,6 +682,13 @@ export class BabylonAgentExecutor implements AgentExecutor {
         name: o.id,
         ticker: o.id,
         currentPrice: Number(o.currentPrice) || 0,
+        initialPrice: Number(o.basePrice) || 0,
+        priceChangePercentage:
+          Number(o.basePrice) > 0
+            ? ((Number(o.currentPrice) - Number(o.basePrice)) /
+                Number(o.basePrice)) *
+              100
+            : 0,
       })),
     };
   }
@@ -1004,34 +1053,14 @@ export class BabylonAgentExecutor implements AgentExecutor {
         ? params.userId
         : context.contextId || context.taskId;
 
-    const user = await db.user.findUnique({
-      where: { id: userId },
-      select: {
-        id: true,
-        walletAddress: true,
-        virtualBalance: true,
-        reputationPoints: true,
-      },
-    });
-
-    // Return default values if user not found (graceful degradation for onboarding)
-    if (!user) {
-      logger.debug('User not found for getUserWallet, returning defaults', {
-        userId,
-      });
-      return {
-        userId,
-        walletAddress: null,
-        balance: 0,
-        reputationPoints: 0,
-      };
-    }
+    const [balance, positions] = await Promise.all([
+      this.getBalance({ userId }, context),
+      this.getPositions({ userId }, context),
+    ]);
 
     return {
-      userId: user.id,
-      walletAddress: user.walletAddress,
-      balance: Number(user.virtualBalance) || 0,
-      reputationPoints: user.reputationPoints || 0,
+      balance: balance as JsonValue,
+      positions: positions as JsonValue,
     };
   }
 

--- a/packages/a2a/src/executors/babylon-executor.ts
+++ b/packages/a2a/src/executors/babylon-executor.ts
@@ -561,11 +561,13 @@ export class BabylonAgentExecutor implements AgentExecutor {
       },
     });
     return {
-      perpetuals: orgStates.map((o: { id: string; currentPrice: number | null }) => ({
-        id: o.id,
-        ticker: o.id,
-        currentPrice: Number(o.currentPrice) || 0,
-      })),
+      perpetuals: orgStates.map(
+        (o: { id: string; currentPrice: number | null }) => ({
+          id: o.id,
+          ticker: o.id,
+          currentPrice: Number(o.currentPrice) || 0,
+        })
+      ),
     };
   }
 

--- a/packages/a2a/src/executors/babylon-executor.ts
+++ b/packages/a2a/src/executors/babylon-executor.ts
@@ -237,39 +237,46 @@ type ExecutorOperationResult =
   | JsonValue;
 
 export class BabylonAgentExecutor implements AgentExecutor {
-  // Singleton instance for direct execution (bypasses HTTP)
-  private static instance: BabylonAgentExecutor | null = null;
-
   /**
-   * Execute an operation directly without HTTP.
-   * Use this for server-side calls to avoid Vercel serverless self-call issues.
+   * Execute operation directly without A2A HTTP protocol
+   * Used for server-side internal calls to bypass Vercel serverless HTTP limitations
+   *
+   * @param operation - The operation name (e.g., 'portfolio.get_balance')
+   * @param params - Operation parameters
+   * @param agentUserId - The agent's user ID for context
+   * @returns Operation result as JsonValue
    */
-  static async executeDirectly(
+  public static async executeDirectly(
     operation: string,
     params: Record<string, JsonValue>,
-    userId?: string
+    agentUserId: string
   ): Promise<JsonValue> {
-    if (!BabylonAgentExecutor.instance) {
-      BabylonAgentExecutor.instance = new BabylonAgentExecutor();
-    }
+    const executor = new BabylonAgentExecutor();
+    const command: BabylonCommand = { operation, params };
+    const taskId = `direct-${Date.now()}`;
 
+    // Create minimal RequestContext for the operation
     const context: RequestContext = {
-      taskId: `direct-${Date.now()}`,
-      contextId: userId || 'system',
+      taskId,
+      contextId: agentUserId,
       userMessage: {
         kind: 'message',
-        messageId: `msg-${Date.now()}`,
+        messageId: `direct-msg-${Date.now()}`,
         role: 'user',
-        parts: [],
+        parts: [{ kind: 'text', text: `Direct call: ${operation}` }],
       },
-      task: null as unknown as Task,
+      task: {
+        kind: 'task',
+        id: taskId,
+        contextId: agentUserId,
+        status: { state: 'working', timestamp: new Date().toISOString() },
+        artifacts: [],
+      },
     };
 
-    const result = await BabylonAgentExecutor.instance.executeOperation(
-      { operation, params },
-      context
-    );
-    return result as JsonValue;
+    const result = await executor.executeOperation(command, context);
+    // Cast to JsonValue since ExecutorOperationResult is compatible at runtime
+    return result as unknown as JsonValue;
   }
 
   async execute(
@@ -350,7 +357,7 @@ export class BabylonAgentExecutor implements AgentExecutor {
     eventBus.finished();
   }
 
-  async executeOperation(
+  private async executeOperation(
     command: BabylonCommand,
     context: RequestContext
   ): Promise<ExecutorOperationResult> {
@@ -588,43 +595,36 @@ export class BabylonAgentExecutor implements AgentExecutor {
   private async listPerpetualMarkets(params: Record<string, JsonValue>) {
     const limit = this.parsePositiveInt(params.limit, 20, 50);
 
-    try {
-      const drizzle = getRawDrizzle();
-      const snapshots = await drizzle
-        .select({
-          ticker: perpMarketSnapshots.ticker,
-          name: perpMarketSnapshots.name,
-          organizationId: perpMarketSnapshots.organizationId,
-          currentPrice: perpMarketSnapshots.currentPrice,
-          change24h: perpMarketSnapshots.change24h,
-          changePercent24h: perpMarketSnapshots.changePercent24h,
-          volume24h: perpMarketSnapshots.volume24h,
-          openInterest: perpMarketSnapshots.openInterest,
-          fundingRate: perpMarketSnapshots.fundingRate,
-        })
-        .from(perpMarketSnapshots)
-        .limit(limit);
+    const drizzle = getRawDrizzle();
+    const snapshots = await drizzle
+      .select({
+        ticker: perpMarketSnapshots.ticker,
+        name: perpMarketSnapshots.name,
+        organizationId: perpMarketSnapshots.organizationId,
+        currentPrice: perpMarketSnapshots.currentPrice,
+        change24h: perpMarketSnapshots.change24h,
+        changePercent24h: perpMarketSnapshots.changePercent24h,
+        volume24h: perpMarketSnapshots.volume24h,
+        openInterest: perpMarketSnapshots.openInterest,
+        fundingRate: perpMarketSnapshots.fundingRate,
+      })
+      .from(perpMarketSnapshots)
+      .limit(limit);
 
-      return {
-        perpetuals: snapshots.map((s) => ({
-          name: s.name || s.ticker,
-          ticker: s.ticker,
-          currentPrice: Number(s.currentPrice) || 0,
-          priceChange24h: Number(s.change24h) || 0,
-          volume24h: Number(s.volume24h) || 0,
-          openInterest: Number(s.openInterest) || 0,
-          fundingRate:
-            typeof s.fundingRate === 'object' && s.fundingRate !== null
-              ? (s.fundingRate as { rate?: number }).rate || 0
-              : 0,
-        })),
-      };
-    } catch (error) {
-      logger.warn('Failed to fetch perpMarketSnapshots, returning empty', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return { perpetuals: [] };
-    }
+    return {
+      perpetuals: snapshots.map((s) => ({
+        name: s.name || s.ticker,
+        ticker: s.ticker,
+        currentPrice: Number(s.currentPrice) || 0,
+        priceChange24h: Number(s.change24h) || 0,
+        volume24h: Number(s.volume24h) || 0,
+        openInterest: Number(s.openInterest) || 0,
+        fundingRate:
+          typeof s.fundingRate === 'object' && s.fundingRate !== null
+            ? (s.fundingRate as { rate?: number }).rate || 0
+            : 0,
+      })),
+    };
   }
 
   private async getUserProfile(params: Record<string, JsonValue>) {

--- a/packages/a2a/src/executors/babylon-executor.ts
+++ b/packages/a2a/src/executors/babylon-executor.ts
@@ -553,36 +553,43 @@ export class BabylonAgentExecutor implements AgentExecutor {
   private async listPerpetualMarkets(params: Record<string, JsonValue>) {
     const limit = this.parsePositiveInt(params.limit, 20, 50);
 
-    const drizzle = getRawDrizzle();
-    const snapshots = await drizzle
-      .select({
-        ticker: perpMarketSnapshots.ticker,
-        name: perpMarketSnapshots.name,
-        organizationId: perpMarketSnapshots.organizationId,
-        currentPrice: perpMarketSnapshots.currentPrice,
-        change24h: perpMarketSnapshots.change24h,
-        changePercent24h: perpMarketSnapshots.changePercent24h,
-        volume24h: perpMarketSnapshots.volume24h,
-        openInterest: perpMarketSnapshots.openInterest,
-        fundingRate: perpMarketSnapshots.fundingRate,
-      })
-      .from(perpMarketSnapshots)
-      .limit(limit);
+    try {
+      const drizzle = getRawDrizzle();
+      const snapshots = await drizzle
+        .select({
+          ticker: perpMarketSnapshots.ticker,
+          name: perpMarketSnapshots.name,
+          organizationId: perpMarketSnapshots.organizationId,
+          currentPrice: perpMarketSnapshots.currentPrice,
+          change24h: perpMarketSnapshots.change24h,
+          changePercent24h: perpMarketSnapshots.changePercent24h,
+          volume24h: perpMarketSnapshots.volume24h,
+          openInterest: perpMarketSnapshots.openInterest,
+          fundingRate: perpMarketSnapshots.fundingRate,
+        })
+        .from(perpMarketSnapshots)
+        .limit(limit);
 
-    return {
-      perpetuals: snapshots.map((s) => ({
-        name: s.name || s.ticker,
-        ticker: s.ticker,
-        currentPrice: Number(s.currentPrice) || 0,
-        priceChange24h: Number(s.change24h) || 0,
-        volume24h: Number(s.volume24h) || 0,
-        openInterest: Number(s.openInterest) || 0,
-        fundingRate:
-          typeof s.fundingRate === 'object' && s.fundingRate !== null
-            ? (s.fundingRate as { rate?: number }).rate || 0
-            : 0,
-      })),
-    };
+      return {
+        perpetuals: snapshots.map((s) => ({
+          name: s.name || s.ticker,
+          ticker: s.ticker,
+          currentPrice: Number(s.currentPrice) || 0,
+          priceChange24h: Number(s.change24h) || 0,
+          volume24h: Number(s.volume24h) || 0,
+          openInterest: Number(s.openInterest) || 0,
+          fundingRate:
+            typeof s.fundingRate === 'object' && s.fundingRate !== null
+              ? (s.fundingRate as { rate?: number }).rate || 0
+              : 0,
+        })),
+      };
+    } catch (error) {
+      logger.warn('Failed to fetch perpMarketSnapshots, returning empty', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return { perpetuals: [] };
+    }
   }
 
   private async getUserProfile(params: Record<string, JsonValue>) {

--- a/packages/a2a/src/executors/babylon-executor.ts
+++ b/packages/a2a/src/executors/babylon-executor.ts
@@ -319,6 +319,13 @@ export class BabylonAgentExecutor implements AgentExecutor {
     context: RequestContext
   ): Promise<ExecutorOperationResult> {
     switch (command.operation) {
+      // Portfolio operations
+      case 'portfolio.get_balance':
+        return this.getBalance(command.params, context);
+      case 'portfolio.get_positions':
+        return this.getPositions(command.params, context);
+      case 'portfolio.get_user_wallet':
+        return this.getUserWallet(command.params, context);
       case 'social.create_post':
         return this.createPost(command.params, context);
       case 'social.get_feed':
@@ -327,8 +334,12 @@ export class BabylonAgentExecutor implements AgentExecutor {
         return this.likePost(command.params, context);
       case 'markets.list_prediction':
         return this.listPredictionMarkets(command.params);
+      case 'markets.list_perpetuals':
+        return this.listPerpetualMarkets(command.params);
       case 'users.search':
         return this.searchUsers(command.params);
+      case 'users.get_profile':
+        return this.getUserProfile(command.params);
       case 'stats.system':
         return this.getSystemStats();
       case 'stats.leaderboard':
@@ -337,6 +348,15 @@ export class BabylonAgentExecutor implements AgentExecutor {
         return this.getTrendingTags(command.params);
       case 'stats.posts_by_tag':
         return this.getPostsByTag(command.params);
+      case 'stats.get_organizations':
+        return this.getOrganizations(command.params);
+      // Messaging operations
+      case 'messaging.get_chats':
+        return this.getChatsHandler(command.params, context);
+      case 'messaging.get_unread_count':
+        return this.getUnreadCountHandler(command.params, context);
+      case 'messaging.get_notifications':
+        return this.getNotificationsHandler(command.params, context);
       case 'moderation.create_escrow_payment':
         return this.createEscrowPayment(command.params, context);
       case 'moderation.verify_escrow_payment':
@@ -529,6 +549,109 @@ export class BabylonAgentExecutor implements AgentExecutor {
     };
   }
 
+  private async listPerpetualMarkets(params: Record<string, JsonValue>) {
+    const limit = this.parsePositiveInt(params.limit, 20, 50);
+    // Get organization states for perpetual markets
+    const orgStates = await db.organizationState.findMany({
+      take: limit,
+      orderBy: { currentPrice: 'desc' },
+      select: {
+        id: true,
+        currentPrice: true,
+      },
+    });
+    return {
+      perpetuals: orgStates.map((o: { id: string; currentPrice: number | null }) => ({
+        id: o.id,
+        ticker: o.id,
+        currentPrice: Number(o.currentPrice) || 0,
+      })),
+    };
+  }
+
+  private async getUserProfile(params: Record<string, JsonValue>) {
+    const userId = typeof params.userId === 'string' ? params.userId : '';
+    if (!userId) {
+      return { profile: null };
+    }
+
+    const user = await db.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        username: true,
+        displayName: true,
+        bio: true,
+        profileImageUrl: true,
+        reputationPoints: true,
+        virtualBalance: true,
+        isAgent: true,
+      },
+    });
+
+    if (!user) {
+      return { profile: null };
+    }
+
+    return {
+      profile: {
+        id: user.id,
+        username: user.username,
+        displayName: user.displayName,
+        bio: user.bio,
+        profileImageUrl: user.profileImageUrl,
+        reputationPoints: user.reputationPoints,
+        balance: Number(user.virtualBalance) || 0,
+        isAgent: user.isAgent,
+      },
+    };
+  }
+
+  private async getOrganizations(params: Record<string, JsonValue>) {
+    const limit = this.parsePositiveInt(params.limit, 20, 100);
+    // Get organization states
+    const orgStates = await db.organizationState.findMany({
+      take: limit,
+      orderBy: { currentPrice: 'desc' },
+      select: {
+        id: true,
+        currentPrice: true,
+      },
+    });
+    return {
+      organizations: orgStates.map((o) => ({
+        id: o.id,
+        name: o.id,
+        ticker: o.id,
+        currentPrice: Number(o.currentPrice) || 0,
+      })),
+    };
+  }
+
+  private async getChatsHandler(
+    _params: Record<string, JsonValue>,
+    _context: RequestContext
+  ) {
+    // Return empty chats - actual chat data requires more complex queries
+    return { chats: [] };
+  }
+
+  private async getUnreadCountHandler(
+    _params: Record<string, JsonValue>,
+    _context: RequestContext
+  ) {
+    // Return 0 unread count as default
+    return { unreadCount: 0 };
+  }
+
+  private async getNotificationsHandler(
+    _params: Record<string, JsonValue>,
+    _context: RequestContext
+  ) {
+    // Return empty notifications as default
+    return { notifications: [] };
+  }
+
   private async searchUsers(params: Record<string, JsonValue>) {
     const query = typeof params.query === 'string' ? params.query.trim() : '';
     if (!query) {
@@ -685,6 +808,170 @@ export class BabylonAgentExecutor implements AgentExecutor {
       return fallback;
     }
     return Math.min(parsed, max);
+  }
+
+  // Portfolio operations
+  private async getBalance(
+    params: Record<string, JsonValue>,
+    context: RequestContext
+  ): Promise<ExecutorOperationResult> {
+    // Try to get userId from params, then from x-agent-id header (via contextId), then taskId
+    const userId =
+      typeof params.userId === 'string' && params.userId
+        ? params.userId
+        : context.contextId || context.taskId;
+
+    const user = await db.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        virtualBalance: true,
+        reputationPoints: true,
+      },
+    });
+
+    // Return default values if user not found (graceful degradation for onboarding)
+    if (!user) {
+      logger.debug('User not found for getBalance, returning defaults', {
+        userId,
+      });
+      return {
+        balance: 0,
+        reputationPoints: 0,
+      };
+    }
+
+    return {
+      balance: Number(user.virtualBalance) || 0,
+      reputationPoints: user.reputationPoints || 0,
+    };
+  }
+
+  private async getPositions(
+    params: Record<string, JsonValue>,
+    context: RequestContext
+  ): Promise<ExecutorOperationResult> {
+    const userId =
+      typeof params.userId === 'string' && params.userId
+        ? params.userId
+        : context.contextId || context.taskId;
+
+    // Check if user exists first (for graceful handling)
+    const userExists = await db.user.findUnique({
+      where: { id: userId },
+      select: { id: true },
+    });
+
+    // Return empty positions if user not found (graceful degradation for onboarding)
+    if (!userExists) {
+      logger.debug('User not found for getPositions, returning empty', {
+        userId,
+      });
+      return {
+        marketPositions: [],
+        perpPositions: [],
+        totalPnL: 0,
+      };
+    }
+
+    // Get prediction market positions
+    const marketPositionsRaw = await db.position.findMany({
+      where: {
+        userId,
+        shares: { gt: '0' },
+        status: 'active',
+      },
+    });
+
+    // Get markets for positions to include question text
+    const marketIds = [
+      ...new Set(marketPositionsRaw.map((p) => p.marketId).filter(Boolean)),
+    ];
+    const markets =
+      marketIds.length > 0
+        ? await db.market.findMany({
+            where: { id: { in: marketIds } },
+            select: { id: true, question: true, resolved: true },
+          })
+        : [];
+    const marketMap = new Map(markets.map((m) => [m.id, m]));
+
+    // Get perpetual positions (closedAt is null means position is open)
+    const perpPositions = await db.perpPosition.findMany({
+      where: {
+        userId,
+        closedAt: null,
+      },
+    });
+
+    return {
+      marketPositions: marketPositionsRaw.map((p) => {
+        const market = marketMap.get(p.marketId);
+        return {
+          id: p.id,
+          marketId: String(p.marketId),
+          marketQuestion: market?.question || 'Unknown',
+          outcome: p.outcome,
+          shares: Number(p.shares),
+          avgPrice: Number(p.avgPrice),
+          unrealizedPnL: 0, // Would need current price to calculate
+        };
+      }),
+      perpPositions: perpPositions.map((p) => ({
+        id: p.id,
+        ticker: p.ticker,
+        organizationId: p.organizationId,
+        side: p.side,
+        size: Number(p.size),
+        entryPrice: Number(p.entryPrice),
+        leverage: Number(p.leverage),
+        unrealizedPnL: Number(p.unrealizedPnL) || 0,
+      })),
+      totalPnL: perpPositions.reduce(
+        (sum, p) => sum + (Number(p.unrealizedPnL) || 0),
+        0
+      ),
+    };
+  }
+
+  private async getUserWallet(
+    params: Record<string, JsonValue>,
+    context: RequestContext
+  ): Promise<ExecutorOperationResult> {
+    const userId =
+      typeof params.userId === 'string' && params.userId
+        ? params.userId
+        : context.contextId || context.taskId;
+
+    const user = await db.user.findUnique({
+      where: { id: userId },
+      select: {
+        id: true,
+        walletAddress: true,
+        virtualBalance: true,
+        reputationPoints: true,
+      },
+    });
+
+    // Return default values if user not found (graceful degradation for onboarding)
+    if (!user) {
+      logger.debug('User not found for getUserWallet, returning defaults', {
+        userId,
+      });
+      return {
+        userId,
+        walletAddress: null,
+        balance: 0,
+        reputationPoints: 0,
+      };
+    }
+
+    return {
+      userId: user.id,
+      walletAddress: user.walletAddress,
+      balance: Number(user.virtualBalance) || 0,
+      reputationPoints: user.reputationPoints || 0,
+    };
   }
 
   async cancelTask(taskId: string, eventBus: ExecutionEventBus): Promise<void> {

--- a/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts
+++ b/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts
@@ -545,6 +545,10 @@ export class BabylonA2AClient {
     // Map camelCase actions to category.snake_case operation names
     // This follows the executor's convention (e.g., 'social.create_post', 'stats.leaderboard')
     const operationMap: Record<string, string> = {
+      // Portfolio operations
+      getBalance: 'portfolio.get_balance',
+      getPositions: 'portfolio.get_positions',
+      getUserWallet: 'portfolio.get_user_wallet',
       // Social operations
       createPost: 'social.create_post',
       getFeed: 'social.get_feed',
@@ -554,10 +558,17 @@ export class BabylonA2AClient {
       getLeaderboard: 'stats.leaderboard',
       getTrendingTags: 'stats.trending_tags',
       getPostsByTag: 'stats.posts_by_tag',
+      getOrganizations: 'stats.get_organizations',
       // Markets operations
       getPredictions: 'markets.list_prediction',
+      getPerpetuals: 'markets.list_perpetuals',
       // Users operations
       searchUsers: 'users.search',
+      getUserProfile: 'users.get_profile',
+      // Messaging operations
+      getChats: 'messaging.get_chats',
+      getUnreadCount: 'messaging.get_unread_count',
+      getNotifications: 'messaging.get_notifications',
     };
 
     // Use mapped operation name if available, otherwise use original action

--- a/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts
+++ b/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts
@@ -441,8 +441,9 @@ export class BabylonA2AClient {
   }
 
   /**
-   * Execute via direct executor (bypasses HTTP for server-side calls)
-   * Maps a2a.* methods to executor operations
+   * Execute via A2A protocol or direct executor
+   * Uses direct executor on server-side to avoid Vercel serverless 503 errors
+   * Falls back to A2A SDK for external/client-side calls
    */
   private async executeViaA2A(
     action: string,
@@ -478,15 +479,103 @@ export class BabylonA2AClient {
 
     const operationName = operationMap[action] || action;
 
-    // Use direct executor to bypass HTTP (fixes Vercel serverless 503 errors)
-    const { BabylonAgentExecutor } = await import('@babylon/a2a');
-    const result = await BabylonAgentExecutor.executeDirectly(
-      operationName,
-      params,
-      this.agentId
-    );
+    // On server-side (Next.js API routes), use direct executor to avoid HTTP self-call
+    // This fixes Vercel serverless 503 errors
+    const isServerSide = typeof window === 'undefined';
+    if (isServerSide) {
+      const { BabylonAgentExecutor } = await import('@babylon/a2a');
+      return BabylonAgentExecutor.executeDirectly(
+        operationName,
+        params,
+        this.agentId
+      );
+    }
 
-    return result;
+    // Client-side or when SDK client is needed: use A2A protocol
+    if (!this.sdkClient) {
+      throw new Error('A2A client not available');
+    }
+
+    // Map action to skill ID for A2A protocol
+    const skillMap: Record<string, string> = {
+      getBalance: 'portfolio-balance',
+      getPositions: 'portfolio-balance',
+      getUserWallet: 'portfolio-balance',
+      getPredictions: 'prediction-markets',
+      getPerpetuals: 'perpetual-futures',
+      getFeed: 'social-feed',
+      createPost: 'social-feed',
+      likePost: 'social-feed',
+      getUserProfile: 'user-social-graph',
+      searchUsers: 'user-social-graph',
+      getLeaderboard: 'stats-discovery',
+      getSystemStats: 'stats-discovery',
+      getTrendingTags: 'stats-discovery',
+      getOrganizations: 'stats-discovery',
+      getChats: 'messaging-chats',
+      getUnreadCount: 'messaging-chats',
+      getNotifications: 'messaging-chats',
+    };
+    const skillId = skillMap[action] || 'portfolio-balance';
+
+    const response = await this.sdkClient.sendMessage({
+      message: {
+        kind: 'message',
+        messageId: crypto.randomUUID(),
+        role: 'user',
+        parts: [
+          {
+            kind: 'data',
+            data: { operation: operationName, params },
+            metadata: { skillId },
+          },
+        ],
+      },
+    });
+
+    // Handle A2A response
+    type DataPart = { kind: 'data'; data: JsonValue };
+    const isDataPart = (part: { kind: string }): part is DataPart =>
+      part.kind === 'data' && 'data' in part;
+
+    if ('result' in response && response.result) {
+      const result = response.result;
+      if (typeof result === 'object' && result !== null && 'kind' in result) {
+        if (result.kind === 'message') {
+          const msg = result as { parts: Array<{ kind: string }> };
+          const dataPart = msg.parts.find((p) => isDataPart(p));
+          return dataPart && isDataPart(dataPart) ? dataPart.data : {};
+        }
+        if (result.kind === 'task') {
+          // For tasks, poll for completion
+          const task = result as { id: string; status?: { state: string }; artifacts?: Array<{ parts: Array<{ kind: string }> }> };
+          const maxWaitMs = 30000;
+          const startTime = Date.now();
+          
+          while (Date.now() - startTime < maxWaitMs) {
+            const taskResponse = await this.sdkClient.getTask({ id: task.id });
+            if ('result' in taskResponse && taskResponse.result) {
+              const taskResult = taskResponse.result as { task?: typeof task };
+              if (taskResult.task?.status?.state === 'completed') {
+                const artifact = taskResult.task.artifacts?.[0];
+                if (artifact) {
+                  const dataPart = artifact.parts.find((p) => isDataPart(p));
+                  return dataPart && isDataPart(dataPart) ? dataPart.data : {};
+                }
+                return {};
+              }
+              if (['failed', 'canceled', 'rejected'].includes(taskResult.task?.status?.state || '')) {
+                throw new Error(`Task ${taskResult.task?.status?.state}`);
+              }
+            }
+            await new Promise((r) => setTimeout(r, 500));
+          }
+          throw new Error('Task timeout');
+        }
+      }
+    }
+
+    return {};
   }
 
   /**

--- a/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts
+++ b/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts
@@ -9,7 +9,7 @@
  * - Lazy header injection per-request (not per-client initialization)
  */
 
-import type { AgentCard } from '@a2a-js/sdk';
+import type { AgentCard, Message, Task } from '@a2a-js/sdk';
 import { A2AClient } from '@a2a-js/sdk/client';
 import { db } from '@babylon/db';
 import { StaticDataRegistry } from '@babylon/engine';
@@ -441,15 +441,18 @@ export class BabylonA2AClient {
   }
 
   /**
-   * Execute via A2A protocol or direct executor
-   * Uses direct executor on server-side to avoid Vercel serverless 503 errors
-   * Falls back to A2A SDK for external/client-side calls
+   * Execute via A2A message/send with skills
+   * Maps a2a.* methods to A2A protocol
+   *
+   * On server-side (Vercel serverless), uses direct executor to avoid HTTP self-call issues.
+   * On client-side or when A2A protocol is explicitly needed, uses SDK client with HTTP.
    */
   private async executeViaA2A(
     action: string,
     params: Record<string, JsonValue>
   ): Promise<JsonValue> {
     // Map camelCase actions to category.snake_case operation names
+    // This follows the executor's convention (e.g., 'social.create_post', 'stats.leaderboard')
     const operationMap: Record<string, string> = {
       // Portfolio operations
       getBalance: 'portfolio.get_balance',
@@ -479,8 +482,8 @@ export class BabylonA2AClient {
 
     const operationName = operationMap[action] || action;
 
-    // On server-side (Next.js API routes), use direct executor to avoid HTTP self-call
-    // This fixes Vercel serverless 503 errors
+    // On server-side (Next.js API routes), use direct executor to bypass HTTP
+    // This fixes Vercel serverless 503 errors from self-calls
     const isServerSide = typeof window === 'undefined';
     if (isServerSide) {
       const { BabylonAgentExecutor } = await import('@babylon/a2a');
@@ -491,31 +494,100 @@ export class BabylonA2AClient {
       );
     }
 
-    // Client-side or when SDK client is needed: use A2A protocol
+    // Client-side: use A2A SDK with HTTP (for true agent-to-agent communication)
     if (!this.sdkClient) {
       throw new Error('A2A client not available');
     }
 
-    // Map action to skill ID for A2A protocol
+    // Map action to skill ID - comprehensive mapping for all 69+ A2A methods
     const skillMap: Record<string, string> = {
+      // Portfolio & Balance
       getBalance: 'portfolio-balance',
       getPositions: 'portfolio-balance',
       getUserWallet: 'portfolio-balance',
+      transferPoints: 'portfolio-balance',
+      // Prediction Markets
       getPredictions: 'prediction-markets',
+      buyShares: 'prediction-markets',
+      sellShares: 'prediction-markets',
+      getTrades: 'prediction-markets',
+      getTradeHistory: 'prediction-markets',
+      // Perpetual Futures
       getPerpetuals: 'perpetual-futures',
+      openPosition: 'perpetual-futures',
+      closePosition: 'perpetual-futures',
+      // Market Data
+      getMarketData: 'prediction-markets',
+      getMarketPrices: 'prediction-markets',
+      subscribeMarket: 'prediction-markets',
+      // Social Feed
       getFeed: 'social-feed',
+      getPost: 'social-feed',
       createPost: 'social-feed',
+      deletePost: 'social-feed',
       likePost: 'social-feed',
+      unlikePost: 'social-feed',
+      sharePost: 'social-feed',
+      getComments: 'social-feed',
+      createComment: 'social-feed',
+      deleteComment: 'social-feed',
+      likeComment: 'social-feed',
+      // User Management
       getUserProfile: 'user-social-graph',
+      updateProfile: 'user-social-graph',
+      followUser: 'user-social-graph',
+      unfollowUser: 'user-social-graph',
+      getFollowers: 'user-social-graph',
+      getFollowing: 'user-social-graph',
       searchUsers: 'user-social-graph',
-      getLeaderboard: 'stats-discovery',
-      getSystemStats: 'stats-discovery',
-      getTrendingTags: 'stats-discovery',
-      getOrganizations: 'stats-discovery',
+      favoriteProfile: 'user-social-graph',
+      unfavoriteProfile: 'user-social-graph',
+      getFavorites: 'user-social-graph',
+      getFavoritePosts: 'user-social-graph',
+      // Messaging
       getChats: 'messaging-chats',
+      getChatMessages: 'messaging-chats',
+      sendMessage: 'messaging-chats',
+      createGroup: 'messaging-chats',
+      leaveChat: 'messaging-chats',
       getUnreadCount: 'messaging-chats',
+      // Notifications
       getNotifications: 'messaging-chats',
+      markNotificationsRead: 'messaging-chats',
+      getGroupInvites: 'messaging-chats',
+      acceptGroupInvite: 'messaging-chats',
+      declineGroupInvite: 'messaging-chats',
+      // Stats & Discovery
+      getLeaderboard: 'stats-discovery',
+      getUserStats: 'stats-discovery',
+      getSystemStats: 'stats-discovery',
+      getReferrals: 'stats-discovery',
+      getReferralStats: 'stats-discovery',
+      getReferralCode: 'stats-discovery',
+      getReputation: 'stats-discovery',
+      getReputationBreakdown: 'stats-discovery',
+      getTrendingTags: 'stats-discovery',
+      getPostsByTag: 'stats-discovery',
+      getOrganizations: 'stats-discovery',
+      // Agent Discovery
+      discoverAgents: 'stats-discovery',
+      getAgentInfo: 'stats-discovery',
+      // Payments
+      paymentRequest: 'portfolio-balance',
+      paymentReceipt: 'portfolio-balance',
+      // Moderation
+      blockUser: 'user-social-graph',
+      unblockUser: 'user-social-graph',
+      muteUser: 'user-social-graph',
+      unmuteUser: 'user-social-graph',
+      reportUser: 'user-social-graph',
+      reportPost: 'social-feed',
+      getBlocks: 'user-social-graph',
+      getMutes: 'user-social-graph',
+      checkBlockStatus: 'user-social-graph',
+      checkMuteStatus: 'user-social-graph',
     };
+
     const skillId = skillMap[action] || 'portfolio-balance';
 
     const response = await this.sdkClient.sendMessage({
@@ -527,55 +599,82 @@ export class BabylonA2AClient {
           {
             kind: 'data',
             data: { operation: operationName, params },
-            metadata: { skillId },
+            metadata: {
+              skillId,
+            },
           },
         ],
       },
     });
 
-    // Handle A2A response
-    type DataPart = { kind: 'data'; data: JsonValue };
-    const isDataPart = (part: { kind: string }): part is DataPart =>
-      part.kind === 'data' && 'data' in part;
+    // Type for data part in A2A messages
+    interface DataPart {
+      kind: 'data';
+      data: JsonValue;
+    }
 
+    function isDataPart(part: { kind: string }): part is DataPart {
+      return part.kind === 'data' && 'data' in part;
+    }
+
+    // Handle response - extract Task or Message
+    let task: Task | undefined;
     if ('result' in response && response.result) {
       const result = response.result;
       if (typeof result === 'object' && result !== null && 'kind' in result) {
-        if (result.kind === 'message') {
-          const msg = result as { parts: Array<{ kind: string }> };
+        if (result.kind === 'task') {
+          task = result as Task;
+        } else if (result.kind === 'message') {
+          // Direct message response
+          const msg = result as Message;
           const dataPart = msg.parts.find((p) => isDataPart(p));
           return dataPart && isDataPart(dataPart) ? dataPart.data : {};
-        }
-        if (result.kind === 'task') {
-          // For tasks, poll for completion
-          const task = result as { id: string; status?: { state: string }; artifacts?: Array<{ parts: Array<{ kind: string }> }> };
-          const maxWaitMs = 30000;
-          const startTime = Date.now();
-          
-          while (Date.now() - startTime < maxWaitMs) {
-            const taskResponse = await this.sdkClient.getTask({ id: task.id });
-            if ('result' in taskResponse && taskResponse.result) {
-              const taskResult = taskResponse.result as { task?: typeof task };
-              if (taskResult.task?.status?.state === 'completed') {
-                const artifact = taskResult.task.artifacts?.[0];
-                if (artifact) {
-                  const dataPart = artifact.parts.find((p) => isDataPart(p));
-                  return dataPart && isDataPart(dataPart) ? dataPart.data : {};
-                }
-                return {};
-              }
-              if (['failed', 'canceled', 'rejected'].includes(taskResult.task?.status?.state || '')) {
-                throw new Error(`Task ${taskResult.task?.status?.state}`);
-              }
-            }
-            await new Promise((r) => setTimeout(r, 500));
-          }
-          throw new Error('Task timeout');
         }
       }
     }
 
-    return {};
+    if (!task) {
+      throw new Error('Expected task response from A2A');
+    }
+
+    // Poll for completion
+    const maxWaitMs = 30000;
+    const startTime = Date.now();
+    while (Date.now() - startTime < maxWaitMs) {
+      const taskResponse = await this.sdkClient.getTask({ id: task.id });
+
+      if ('result' in taskResponse && taskResponse.result) {
+        const result = taskResponse.result as { task?: Task };
+        if (result.task) {
+          task = result.task;
+        }
+      }
+
+      const state = task.status?.state;
+      if (state === 'completed') {
+        if (task.artifacts && task.artifacts.length > 0) {
+          const artifact = task.artifacts[0];
+          if (artifact) {
+            const dataPart = artifact.parts.find((p) => isDataPart(p));
+            return dataPart && isDataPart(dataPart) ? dataPart.data : {};
+          }
+        }
+        return {};
+      }
+
+      if (state === 'failed' || state === 'canceled' || state === 'rejected') {
+        const messagePart = task.status?.message?.parts?.[0];
+        const errorText =
+          messagePart && 'text' in messagePart
+            ? messagePart.text
+            : 'Unknown error';
+        throw new Error(`Task ${state}: ${errorText}`);
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+
+    throw new Error('Task did not complete within timeout');
   }
 
   /**

--- a/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts
+++ b/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts
@@ -9,7 +9,7 @@
  * - Lazy header injection per-request (not per-client initialization)
  */
 
-import type { AgentCard, Message, Task } from '@a2a-js/sdk';
+import type { AgentCard } from '@a2a-js/sdk';
 import { A2AClient } from '@a2a-js/sdk/client';
 import { db } from '@babylon/db';
 import { StaticDataRegistry } from '@babylon/engine';
@@ -441,109 +441,14 @@ export class BabylonA2AClient {
   }
 
   /**
-   * Execute via A2A message/send with skills
-   * Maps a2a.* methods to A2A protocol
+   * Execute via direct executor (bypasses HTTP for server-side calls)
+   * Maps a2a.* methods to executor operations
    */
   private async executeViaA2A(
     action: string,
     params: Record<string, JsonValue>
   ): Promise<JsonValue> {
-    if (!this.sdkClient) {
-      throw new Error('A2A client not available - use database fallback');
-    }
-    // Map action to skill ID - comprehensive mapping for all 69+ A2A methods
-    const skillMap: Record<string, string> = {
-      // Portfolio & Balance
-      getBalance: 'portfolio-balance',
-      getPositions: 'portfolio-balance',
-      getUserWallet: 'portfolio-balance',
-      transferPoints: 'portfolio-balance',
-      // Prediction Markets
-      getPredictions: 'prediction-markets',
-      buyShares: 'prediction-markets',
-      sellShares: 'prediction-markets',
-      getTrades: 'prediction-markets',
-      getTradeHistory: 'prediction-markets',
-      // Perpetual Futures
-      getPerpetuals: 'perpetual-futures',
-      openPosition: 'perpetual-futures',
-      closePosition: 'perpetual-futures',
-      // Market Data
-      getMarketData: 'prediction-markets',
-      getMarketPrices: 'prediction-markets',
-      subscribeMarket: 'prediction-markets',
-      // Social Feed
-      getFeed: 'social-feed',
-      getPost: 'social-feed',
-      createPost: 'social-feed',
-      deletePost: 'social-feed',
-      likePost: 'social-feed',
-      unlikePost: 'social-feed',
-      sharePost: 'social-feed',
-      getComments: 'social-feed',
-      createComment: 'social-feed',
-      deleteComment: 'social-feed',
-      likeComment: 'social-feed',
-      // User Management
-      getUserProfile: 'user-social-graph',
-      updateProfile: 'user-social-graph',
-      followUser: 'user-social-graph',
-      unfollowUser: 'user-social-graph',
-      getFollowers: 'user-social-graph',
-      getFollowing: 'user-social-graph',
-      searchUsers: 'user-social-graph',
-      favoriteProfile: 'user-social-graph',
-      unfavoriteProfile: 'user-social-graph',
-      getFavorites: 'user-social-graph',
-      getFavoritePosts: 'user-social-graph',
-      // Messaging
-      getChats: 'messaging-chats',
-      getChatMessages: 'messaging-chats',
-      sendMessage: 'messaging-chats',
-      createGroup: 'messaging-chats',
-      leaveChat: 'messaging-chats',
-      getUnreadCount: 'messaging-chats',
-      // Notifications
-      getNotifications: 'messaging-chats',
-      markNotificationsRead: 'messaging-chats',
-      getGroupInvites: 'messaging-chats',
-      acceptGroupInvite: 'messaging-chats',
-      declineGroupInvite: 'messaging-chats',
-      // Stats & Discovery
-      getLeaderboard: 'stats-discovery',
-      getUserStats: 'stats-discovery',
-      getSystemStats: 'stats-discovery',
-      getReferrals: 'stats-discovery',
-      getReferralStats: 'stats-discovery',
-      getReferralCode: 'stats-discovery',
-      getReputation: 'stats-discovery',
-      getReputationBreakdown: 'stats-discovery',
-      getTrendingTags: 'stats-discovery',
-      getPostsByTag: 'stats-discovery',
-      getOrganizations: 'stats-discovery',
-      // Agent Discovery
-      discoverAgents: 'stats-discovery',
-      getAgentInfo: 'stats-discovery',
-      // Payments
-      paymentRequest: 'portfolio-balance',
-      paymentReceipt: 'portfolio-balance',
-      // Moderation
-      blockUser: 'user-social-graph',
-      unblockUser: 'user-social-graph',
-      muteUser: 'user-social-graph',
-      unmuteUser: 'user-social-graph',
-      reportUser: 'user-social-graph',
-      reportPost: 'social-feed',
-      getBlocks: 'user-social-graph',
-      getMutes: 'user-social-graph',
-      checkBlockStatus: 'user-social-graph',
-      checkMuteStatus: 'user-social-graph',
-    };
-
-    const skillId = skillMap[action] || 'portfolio-balance';
-
     // Map camelCase actions to category.snake_case operation names
-    // This follows the executor's convention (e.g., 'social.create_post', 'stats.leaderboard')
     const operationMap: Record<string, string> = {
       // Portfolio operations
       getBalance: 'portfolio.get_balance',
@@ -571,94 +476,17 @@ export class BabylonA2AClient {
       getNotifications: 'messaging.get_notifications',
     };
 
-    // Use mapped operation name if available, otherwise use original action
     const operationName = operationMap[action] || action;
 
-    const response = await this.sdkClient.sendMessage({
-      message: {
-        kind: 'message',
-        messageId: crypto.randomUUID(),
-        role: 'user',
-        parts: [
-          {
-            kind: 'data',
-            data: { operation: operationName, params },
-            metadata: {
-              skillId,
-            },
-          },
-        ],
-      },
-    });
+    // Use direct executor to bypass HTTP (fixes Vercel serverless 503 errors)
+    const { BabylonAgentExecutor } = await import('@babylon/a2a');
+    const result = await BabylonAgentExecutor.executeDirectly(
+      operationName,
+      params,
+      this.agentId
+    );
 
-    // Type for data part in A2A messages
-    interface DataPart {
-      kind: 'data';
-      data: JsonValue;
-    }
-
-    function isDataPart(part: { kind: string }): part is DataPart {
-      return part.kind === 'data' && 'data' in part;
-    }
-
-    // Handle response - extract Task or Message
-    let task: Task | undefined;
-    if ('result' in response && response.result) {
-      const result = response.result;
-      if (typeof result === 'object' && result !== null && 'kind' in result) {
-        if (result.kind === 'task') {
-          task = result as Task;
-        } else if (result.kind === 'message') {
-          // Direct message response
-          const msg = result as Message;
-          const dataPart = msg.parts.find((p) => isDataPart(p));
-          return dataPart && isDataPart(dataPart) ? dataPart.data : {};
-        }
-      }
-    }
-
-    if (!task) {
-      throw new Error('Expected task response from A2A');
-    }
-
-    // Poll for completion
-    const maxWaitMs = 30000;
-    const startTime = Date.now();
-    while (Date.now() - startTime < maxWaitMs) {
-      const taskResponse = await this.sdkClient.getTask({ id: task.id });
-
-      if ('result' in taskResponse && taskResponse.result) {
-        const result = taskResponse.result as { task?: Task };
-        if (result.task) {
-          task = result.task;
-        }
-      }
-
-      const state = task.status?.state;
-      if (state === 'completed') {
-        if (task.artifacts && task.artifacts.length > 0) {
-          const artifact = task.artifacts[0];
-          if (artifact) {
-            const dataPart = artifact.parts.find((p) => isDataPart(p));
-            return dataPart && isDataPart(dataPart) ? dataPart.data : {};
-          }
-        }
-        return {};
-      }
-
-      if (state === 'failed' || state === 'canceled' || state === 'rejected') {
-        const messagePart = task.status?.message?.parts?.[0];
-        const errorText =
-          messagePart && 'text' in messagePart
-            ? messagePart.text
-            : 'Unknown error';
-        throw new Error(`Task ${state}: ${errorText}`);
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, 500));
-    }
-
-    throw new Error('Task did not complete within timeout');
+    return result;
   }
 
   /**

--- a/packages/agents/src/plugins/babylon/providers/agent-wallet.ts
+++ b/packages/agents/src/plugins/babylon/providers/agent-wallet.ts
@@ -63,7 +63,7 @@ export const agentWalletProvider: Provider = {
 
     // Get balance and positions via A2A
     const [balanceData, positionsData] = await Promise.all([
-      babylonRuntime.a2aClient.getBalance(),
+      babylonRuntime.a2aClient.getBalance(agentUserId),
       babylonRuntime.a2aClient.getPositions(agentUserId),
     ]);
 

--- a/packages/agents/src/plugins/babylon/providers/agent-wallet.ts
+++ b/packages/agents/src/plugins/babylon/providers/agent-wallet.ts
@@ -109,9 +109,9 @@ export const agentWalletProvider: Provider = {
       output += `📊 PREDICTION MARKET POSITIONS (${positions.marketPositions.length}):
 ${positions.marketPositions
   .map((p) => {
-    return `• ${p.question.substring(0, 60)}...
-  Side: ${p.side.toUpperCase()} | Shares: ${p.shares.toFixed(2)} @ avg $${p.avgPrice.toFixed(2)}
-  Current: $${p.currentPrice.toFixed(2)} | Value: $${(p.shares * p.currentPrice).toFixed(2)}
+    return `• ${(p.question || 'Unknown Market').substring(0, 60)}...
+  Side: ${(p.side || 'UNKNOWN').toUpperCase()} | Shares: ${(p.shares || 0).toFixed(2)} @ avg $${(p.avgPrice || 0).toFixed(2)}
+  Current: $${(p.currentPrice || 0).toFixed(2)} | Value: $${((p.shares || 0) * (p.currentPrice || 0)).toFixed(2)}
   P&L: ${(p.unrealizedPnL || 0) >= 0 ? '+' : ''}$${(p.unrealizedPnL || 0).toFixed(2)}`;
   })
   .join('\n\n')}

--- a/packages/agents/src/plugins/babylon/providers/dashboard.ts
+++ b/packages/agents/src/plugins/babylon/providers/dashboard.ts
@@ -67,7 +67,9 @@ export const dashboardProvider: Provider = {
     // Fetch ALL dashboard data via A2A protocol
     const [balance, positions, predictions, feed, chats, notifications] =
       await Promise.all([
-        babylonRuntime.a2aClient.sendRequest('a2a.getBalance', {}),
+        babylonRuntime.a2aClient.sendRequest('a2a.getBalance', {
+          userId: agentUserId,
+        }),
         babylonRuntime.a2aClient.sendRequest('a2a.getPositions', {
           userId: agentUserId,
         }),

--- a/packages/agents/src/plugins/babylon/providers/dashboard.ts
+++ b/packages/agents/src/plugins/babylon/providers/dashboard.ts
@@ -159,7 +159,9 @@ ${
 🔔 NOTIFICATIONS
 Unread: ${unreadNotifications}
 ${
-  notificationsData.notifications && notificationsData.notifications.length > 0 && notificationsData.notifications[0]?.message
+  notificationsData.notifications &&
+  notificationsData.notifications.length > 0 &&
+  notificationsData.notifications[0]?.message
     ? `Latest: ${notificationsData.notifications[0].message.substring(0, 80)}...`
     : 'No notifications'
 }

--- a/packages/agents/src/plugins/babylon/providers/dashboard.ts
+++ b/packages/agents/src/plugins/babylon/providers/dashboard.ts
@@ -132,7 +132,7 @@ ${
   predictionsData.predictions && predictionsData.predictions.length > 0
     ? `Recent: ${predictionsData.predictions
         .slice(0, 3)
-        .map((p) => p.question.substring(0, 50))
+        .map((p) => (p.question || 'Unknown').substring(0, 50))
         .join(', ')}`
     : 'No active markets'
 }
@@ -140,8 +140,8 @@ ${
 📱 SOCIAL FEED
 Recent Posts: ${recentPosts}
 ${
-  feedData.posts && feedData.posts.length > 0
-    ? `Latest: ${feedData.posts[0]?.content.substring(0, 100)}...`
+  feedData.posts && feedData.posts.length > 0 && feedData.posts[0]?.content
+    ? `Latest: ${feedData.posts[0].content.substring(0, 100)}...`
     : 'No recent posts'
 }
 
@@ -159,8 +159,8 @@ ${
 🔔 NOTIFICATIONS
 Unread: ${unreadNotifications}
 ${
-  notificationsData.notifications && notificationsData.notifications.length > 0
-    ? `Latest: ${notificationsData.notifications[0]?.message.substring(0, 80)}...`
+  notificationsData.notifications && notificationsData.notifications.length > 0 && notificationsData.notifications[0]?.message
+    ? `Latest: ${notificationsData.notifications[0].message.substring(0, 80)}...`
     : 'No notifications'
 }
 

--- a/packages/agents/src/plugins/babylon/providers/portfolio.ts
+++ b/packages/agents/src/plugins/babylon/providers/portfolio.ts
@@ -60,7 +60,9 @@ export const portfolioProvider: Provider = {
     }
 
     const [balanceData, positionsData] = await Promise.all([
-      babylonRuntime.a2aClient.sendRequest('a2a.getBalance', {}),
+      babylonRuntime.a2aClient.sendRequest('a2a.getBalance', {
+        userId: agentUserId,
+      }),
       babylonRuntime.a2aClient.sendRequest('a2a.getPositions', {
         userId: agentUserId,
       }),


### PR DESCRIPTION
## Problem
Agent onboarding and chat were failing with "Unsupported operation: getPositions" errors, followed by "Cannot read properties of undefined (reading 'substring')" crashes.

## Root Cause
Both onboarding and chat call `runtime.composeState()` which triggers providers. These providers make A2A calls (`getBalance`, `getPositions`, `getPerpetuals`, etc.) that were not implemented in the executor, causing both flows to fail.

## Changes
- Added portfolio, market, user, and messaging operation handlers to `BabylonAgentExecutor`
- Updated `operationMap` to route A2A operations correctly
- Fixed providers to pass `userId` parameter to A2A calls
- Added null checks for `.substring()` calls in provider templates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Portfolio: balance, positions, and wallet info available.
  * Markets: perpetual markets listing with pricing and volume.
  * Users & Organizations: user profiles and organization listings.
  * Messaging: chats, unread counts, and notifications (safe defaults).

* **Improvements**
  * Faster server-side handling of agent requests for lower latency.
  * Safer data handling and fallbacks to avoid missing-field errors.
  * Dashboard and onboarding/chat state composition now strictly use only requested providers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes agent onboarding and chat failures caused by missing A2A operation handlers. When agents call `runtime.composeState()`, providers trigger A2A operations like `getBalance`, `getPositions`, `getPerpetuals`, etc. These operations were not implemented in the executor, causing "Unsupported operation" errors and subsequent crashes.

**Key Changes:**
- Added 12 missing operation handlers in `BabylonAgentExecutor`: portfolio operations (`getBalance`, `getPositions`, `getUserWallet`), market operations (`listPerpetualMarkets`), user operations (`getUserProfile`, `getOrganizations`), and messaging stubs (`getChats`, `getUnreadCount`, `getNotifications`)
- Updated `operationMap` in `BabylonA2AClient` to route these operations correctly between client and executor
- Fixed providers to pass `userId` parameter to A2A calls (was missing in `getBalance()` calls)
- Added null safety checks before `.substring()` calls on `question`, `content`, `message`, `side` fields to prevent "Cannot read properties of undefined" crashes
- Implemented graceful degradation: returns default values (balance: 0, empty positions) for users not found during onboarding

The changes follow the existing A2A architecture and include appropriate error handling for database availability issues.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor risk around field naming inconsistencies.
- The implementation correctly addresses the root cause by adding missing operation handlers and fixing null safety issues. The graceful degradation approach is appropriate for onboarding scenarios. However, there's a field naming mismatch in the `getPositions` response that could cause runtime issues in providers expecting the `A2AMarketPosition` interface.
- Pay close attention to `packages/a2a/src/executors/babylon-executor.ts` - verify the field naming in the `marketPositions` response matches the interface expected by providers.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/a2a/src/executors/babylon-executor.ts | Added portfolio, market, user, and messaging operation handlers to fix A2A operation failures. Includes safe defaults for missing users and graceful error handling. |
| packages/agents/src/plugins/babylon/integration-a2a-sdk.ts | Added operation mappings in `operationMap` to route portfolio, market, user, and messaging operations correctly between client and executor. |
| packages/agents/src/plugins/babylon/providers/agent-wallet.ts | Fixed missing `userId` parameter in `getBalance()` call and added null safety checks for position fields to prevent substring errors. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent as Agent Runtime
    participant Provider as Provider (agent-wallet/dashboard/portfolio)
    participant A2AClient as BabylonA2AClient
    participant Executor as BabylonAgentExecutor
    participant DB as Database

    Note over Agent,DB: Agent Onboarding/Chat Flow

    Agent->>Provider: composeState() triggers providers
    Provider->>A2AClient: getBalance(userId)
    A2AClient->>A2AClient: Map to 'portfolio.get_balance'
    A2AClient->>Executor: A2A message with operation + userId
    Executor->>Executor: executeOperation('portfolio.get_balance')
    Executor->>DB: Find user by userId
    alt User found
        DB-->>Executor: User data
        Executor-->>A2AClient: {balance, reputationPoints}
    else User not found (onboarding)
        Executor-->>A2AClient: {balance: 0, reputationPoints: 0}
    end
    A2AClient-->>Provider: Balance data
    
    Provider->>A2AClient: getPositions(userId)
    A2AClient->>A2AClient: Map to 'portfolio.get_positions'
    A2AClient->>Executor: A2A message with operation + userId
    Executor->>Executor: executeOperation('portfolio.get_positions')
    Executor->>DB: Check user exists
    alt User exists
        Executor->>DB: Query positions + markets
        DB-->>Executor: Position data
        Executor-->>A2AClient: {marketPositions[], perpPositions[], totalPnL}
    else User not found
        Executor-->>A2AClient: {marketPositions: [], perpPositions: [], totalPnL: 0}
    end
    A2AClient-->>Provider: Positions data
    
    Provider->>Provider: Apply null checks on response fields
    Provider-->>Agent: Safe provider text with defaults
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->