### PR TITLE
fix: remove @elizaos/core from webpack externals to fix ESM require error

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -96,8 +96,9 @@ const nextConfig: NextConfig = {
     'drizzle-orm',
     'drizzle-orm/postgres-js',
     'ioredis', // Node.js Redis client - requires tls/net modules not available in edge runtime
-    // Avoid bundling warnings from dynamic requires in @elizaos/core (server-only usage).
-    '@elizaos/core',
+    // NOTE: @elizaos/core was removed from externals because it's ESM-only ("type": "module").
+    // Externalizing ESM packages causes require() errors at Vercel runtime (ERR_REQUIRE_ESM).
+    // Webpack now bundles it directly which resolves the ESM compatibility issue.
   ],
   images: {
     qualities: [100, 75],
@@ -255,13 +256,13 @@ const nextConfig: NextConfig = {
       // to externalize them so they're resolved at runtime from node_modules
       // NOTE: Do NOT externalize @babylon/* packages - they are TypeScript source files
       // and must be transpiled by webpack via transpilePackages
+      // NOTE: @elizaos/core intentionally excluded - it's ESM-only and must be bundled
       const serverExternalPackagesList = [
         'postgres',
         'drizzle-orm',
         'drizzle-orm/postgres-js',
         'ioredis',
         'swagger-jsdoc',
-        '@elizaos/core',
       ];
 
       if (!Array.isArray(config.externals)) {

--- a/packages/agents/src/plugins/plugin-autonomy/src/routes.ts
+++ b/packages/agents/src/plugins/plugin-autonomy/src/routes.ts
@@ -1,9 +1,12 @@
-import type {
-  IAgentRuntime,
-  Route,
-  RouteRequest,
-  RouteResponse,
-} from '@elizaos/core';
+import type { IAgentRuntime, Route } from '@elizaos/core';
+
+// Route handler request/response types (elizaos/core uses any in v1.6.5+)
+type RouteRequest = { body?: unknown };
+type RouteResponse = {
+  status: (code: number) => RouteResponse;
+  json: (data: unknown) => void;
+};
+
 import type { AutonomyService } from './service';
 import { AutonomousServiceType } from './types';
 


### PR DESCRIPTION
## Summary
- Remove `@elizaos/core` from `serverExternalPackages` and webpack externals function
- Fix type imports for `RouteRequest`/`RouteResponse` removed in elizaos/core v1.6.5

## Problem
`@elizaos/core` is ESM-only (`"type": "module"`) but was being externalized with CommonJS prefix, causing Vercel runtime to emit `require()` calls which fail with `ERR_REQUIRE_ESM`.

## Solution
Let webpack bundle `@elizaos/core` directly instead of externalizing it. This resolves the ESM compatibility issue at Vercel runtime.

## Test plan
- [ ] Verify agent creation works on Vercel deployment
- [ ] Verify agent-templates endpoint works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a module bundling issue that was causing runtime errors, improving application stability.

* **Chores**
  * Refactored internal type definitions for improved code organization and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Removed `@elizaos/core` from webpack externals to fix ESM compatibility issue at Vercel runtime. The package is ESM-only (`"type": "module"`) but was being externalized with CommonJS prefix, causing `require()` calls that fail with `ERR_REQUIRE_ESM`. Webpack now bundles it directly instead.

Additionally, replaced removed `RouteRequest` and `RouteResponse` type imports from `@elizaos/core` v1.6.5+ with local type definitions that match the actual usage patterns in the autonomy routes handlers.

**Key changes:**
- Removed `@elizaos/core` from `serverExternalPackages` array in next.config.ts:99-101
- Removed `@elizaos/core` from webpack externals function in next.config.ts:260-266
- Added explanatory comments documenting the ESM-only nature and bundling approach
- Defined local `RouteRequest` and `RouteResponse` types in routes.ts:4-8 to replace removed exports from `@elizaos/core`

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes correctly address the ESM/CommonJS compatibility issue by allowing webpack to bundle `@elizaos/core` instead of externalizing it. The type definitions for `RouteRequest`/`RouteResponse` accurately match the usage patterns throughout the routes handlers. The solution is well-documented with clear comments explaining the reasoning.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/next.config.ts | Removed `@elizaos/core` from serverExternalPackages and webpack externals function to allow bundling instead of externalizing |
| packages/agents/src/plugins/plugin-autonomy/src/routes.ts | Replaced removed `RouteRequest`/`RouteResponse` imports with local type definitions matching the usage patterns |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Vercel as Vercel Runtime
    participant Next as Next.js/Webpack
    participant Core as @elizaos/core (ESM)
    participant Routes as Autonomy Routes
    
    Note over Vercel,Routes: Before: @elizaos/core externalized
    Vercel->>Next: Load server bundle
    Next->>Core: require('@elizaos/core')
    Core--xNext: ERR_REQUIRE_ESM (package is ESM-only)
    Note over Next,Core: Failure: CommonJS require() cannot load ESM module
    
    Note over Vercel,Routes: After: @elizaos/core bundled
    Vercel->>Next: Load server bundle
    Note over Next,Core: Webpack bundles @elizaos/core directly
    Next->>Routes: Import bundled code
    Routes->>Routes: Use local RouteRequest/RouteResponse types
    Routes-->>Vercel: Success: Routes work correctly
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->