### PR TITLE
Fix prediction markets: attribute NPC trades correctly

### DIFF
--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -623,6 +623,8 @@ async function executePredictionTrade(params: {
         referrerShare: FEE_CONFIG.REFERRER_SHARE,
         minFeeAmount: FEE_CONFIG.MIN_FEE_AMOUNT,
       },
+      tradeSource: isNpc ? 'npc_trade' : 'user_trade',
+      tradeActorType: isNpc ? 'npc' : 'user',
       feeProcessor: isNpc
         ? undefined
         : {
@@ -727,6 +729,8 @@ async function executePredictionSell(params: {
         referrerShare: FEE_CONFIG.REFERRER_SHARE,
         minFeeAmount: FEE_CONFIG.MIN_FEE_AMOUNT,
       },
+      tradeSource: isNpc ? 'npc_trade' : 'user_trade',
+      tradeActorType: isNpc ? 'npc' : 'user',
       feeProcessor: isNpc
         ? undefined
         : {

--- a/packages/core/markets/prediction/PredictionMarketService.ts
+++ b/packages/core/markets/prediction/PredictionMarketService.ts
@@ -86,6 +86,9 @@ export class PredictionMarketService {
 
     this.assertMarketActiveForBuy(market);
 
+    const tradeSource = this.deps.tradeSource ?? 'user_trade';
+    const tradeActorType = this.deps.tradeActorType ?? 'user';
+
     // Calculate shares with fees (fee rate from deps)
     const calc = PredictionPricing.calculateBuyWithFees(
       market.yesShares,
@@ -151,7 +154,7 @@ export class PredictionMarketService {
       noShares: calc.newNoShares,
       liquidity: newLiquidity,
       eventType: 'trade',
-      source: 'user_trade',
+      source: tradeSource,
     });
 
     await this.emitTrade({
@@ -163,14 +166,14 @@ export class PredictionMarketService {
       noShares: calc.newNoShares,
       liquidity: newLiquidity,
       trade: {
-        actorType: 'user',
+        actorType: tradeActorType,
         actorId: userId,
         action: 'buy',
         side,
         shares: calc.sharesBought,
         amount,
         price: calc.avgPrice,
-        source: 'user_trade',
+        source: tradeSource,
         timestamp: this.now().toISOString(),
       },
     });
@@ -214,6 +217,9 @@ export class PredictionMarketService {
     const market = await this.ensureMarket(marketId);
 
     this.assertMarketActiveForSell(market);
+
+    const tradeSource = this.deps.tradeSource ?? 'user_trade';
+    const tradeActorType = this.deps.tradeActorType ?? 'user';
 
     const yesPos = await this.db.getPosition(userId, marketId, 'yes');
     const noPos = await this.db.getPosition(userId, marketId, 'no');
@@ -311,7 +317,7 @@ export class PredictionMarketService {
       noShares: calc.newNoShares,
       liquidity: newLiquidity,
       eventType: 'trade',
-      source: 'user_trade',
+      source: tradeSource,
     });
 
     await this.emitTrade({
@@ -323,14 +329,14 @@ export class PredictionMarketService {
       noShares: calc.newNoShares,
       liquidity: newLiquidity,
       trade: {
-        actorType: 'user',
+        actorType: tradeActorType,
         actorId: userId,
         action: 'sell',
         side,
         shares,
         amount: netProceeds,
         price: calc.avgPrice,
-        source: 'user_trade',
+        source: tradeSource,
         timestamp: this.now().toISOString(),
       },
     });

--- a/packages/core/markets/prediction/__tests__/PredictionMarketService.test.ts
+++ b/packages/core/markets/prediction/__tests__/PredictionMarketService.test.ts
@@ -243,6 +243,37 @@ describe('PredictionMarketService', () => {
     expect(cache.keys).toContain('prediction:m1:*');
   });
 
+  it('buy should allow overriding trade attribution', async () => {
+    service = new PredictionMarketService({
+      db,
+      wallet,
+      broadcast,
+      cache,
+      clock: { now: () => new Date() },
+      fees: feeConfig,
+      feeProcessor,
+      tradeSource: 'npc_trade',
+      tradeActorType: 'npc',
+    });
+
+    await service.buy({
+      userId: 'u1',
+      marketId: 'm1',
+      side: 'yes',
+      amount: 100,
+    });
+
+    expect(db.snapshots[0]?.source).toBe('npc_trade');
+
+    const event = broadcast.events[0]?.payload as unknown as {
+      type?: string;
+      trade?: { actorType?: string; source?: string };
+    };
+    expect(event.type).toBe('prediction_trade');
+    expect(event.trade?.actorType).toBe('npc');
+    expect(event.trade?.source).toBe('npc_trade');
+  });
+
   it('sell should decrease position, compute pnl, and close when remaining small', async () => {
     await service.buy({
       userId: 'u1',

--- a/packages/core/markets/prediction/types.ts
+++ b/packages/core/markets/prediction/types.ts
@@ -166,4 +166,6 @@ export interface PredictionServiceDeps {
   clock?: ClockPort;
   fees: FeeConfig;
   feeProcessor?: FeeProcessor;
+  tradeSource?: PredictionPriceSnapshotRecord['source'];
+  tradeActorType?: 'user' | 'npc';
 }

--- a/packages/engine/src/services/trade-execution-service.ts
+++ b/packages/engine/src/services/trade-execution-service.ts
@@ -517,6 +517,8 @@ export class TradeExecutionService {
         referrerShare: FEE_CONFIG.REFERRER_SHARE,
         minFeeAmount: FEE_CONFIG.MIN_FEE_AMOUNT,
       },
+      tradeSource: 'npc_trade',
+      tradeActorType: 'npc',
     });
 
     const result = await service.buy({
@@ -662,6 +664,8 @@ export class TradeExecutionService {
         referrerShare: FEE_CONFIG.REFERRER_SHARE,
         minFeeAmount: FEE_CONFIG.MIN_FEE_AMOUNT,
       },
+      tradeSource: 'npc_trade',
+      tradeActorType: 'npc',
     });
 
     const sellResult = await service.sell({


### PR DESCRIPTION
## Summary
- Allow core `PredictionMarketService` to attribute trades as `npc_trade` (history + SSE payloads), instead of always `user_trade`.
- Apply the attribution overrides for NPC prediction trades in engine tick + agent direct executors.
- Add unit test coverage for the attribution override behavior.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Follow-up to PR #772 (prediction markets: persist agent trade history + real trade counts).
- This PR incorporates the remaining “important” part from PR #778: distinguishing `npc_trade` vs `user_trade` attribution.

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [x] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- `packages/core/markets/prediction/types.ts`: add optional `tradeSource` + `tradeActorType` to `PredictionServiceDeps`.
- `packages/core/markets/prediction/PredictionMarketService.ts`: use the overrides when recording trade snapshots and emitting `prediction_trade`.
- `packages/engine/src/services/trade-execution-service.ts`: mark NPC prediction trades as `npc_trade`.
- `packages/agents/src/autonomous/DirectExecutors.ts`: mark NPC prediction trades as `npc_trade`.
- `packages/core/markets/prediction/__tests__/PredictionMarketService.test.ts`: add regression test for attribution override.

## Review guide

**Start here**
- `packages/core/markets/prediction/PredictionMarketService.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- Defaults are unchanged (`user_trade` / `user`) for all existing user flows.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [x] `bun run typecheck` (via pre-push)
- [x] `bun run lint` (via pre-push)
- [x] `bun run build` (via pre-push)
- [ ] `bun run test` (unit + integration)

**Manual verification**
1. Let `npc-tick` run and confirm prediction history snapshots have `source=npc_trade` (optional).

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option B: No visual changes
- Reason: backend-only change (history attribution + SSE payload fields), no UI layout changes.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`fix/prediction-agent-trades-history` for stacking)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Prediction market trades now feature explicit source and actor type attribution, clearly distinguishing between user-initiated and NPC-initiated transactions. This improvement enhances transaction tracking and provides better visibility into the origins of market trades, enabling more informed and transparent market participation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Adds trade source attribution to distinguish NPC trades (`npc_trade`) from user trades (`user_trade`) in prediction market history and SSE broadcasts
- Introduces optional `tradeSource` and `tradeActorType` parameters to `PredictionServiceDeps` interface with backward-compatible defaults
- Updates `TradeExecutionService` and `DirectExecutors` to properly attribute NPC prediction trades when initializing `PredictionMarketService`

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| packages/core/markets/prediction/PredictionMarketService.ts | Core service updated to use trade attribution overrides for history snapshots and SSE payloads |
| packages/core/markets/prediction/types.ts | Added optional tradeSource and tradeActorType fields to PredictionServiceDeps interface |
| packages/agents/src/autonomous/DirectExecutors.ts | Updated to pass NPC attribution when executing prediction trades through agents |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk and follows good engineering practices
- Score reflects well-structured implementation with proper defaults, comprehensive test coverage, and clear separation of concerns
- No files require special attention as the changes are straightforward and maintain backward compatibility

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as "NPC Agent"
    participant DE as "DirectExecutors"
    participant PMS as "PredictionMarketService"
    participant PDB as "PredictionDbAdapter"
    participant Wallet as "WalletAdapter"
    participant Broadcast as "BroadcastService"

    User->>DE: "executeDirectTrade(params)"
    DE->>DE: "Check if NPC actor"
    DE->>DE: "Validate balance and amount"
    DE->>DE: "Create prediction wallet adapter"
    DE->>PMS: "new PredictionMarketService(deps)"
    Note over PMS: "deps include tradeSource='npc_trade', tradeActorType='npc'"
    DE->>PMS: "buy(userId, marketId, side, amount)"
    PMS->>PDB: "ensureMarket(marketId)"
    PMS->>Wallet: "debit(userId, amount)"
    PMS->>PDB: "updateMarketState(marketId, newState)"
    PMS->>PDB: "upsertPosition(position)"
    PMS->>PDB: "insertPriceSnapshot(snapshot)"
    Note over PDB: "snapshot.source = 'npc_trade'"
    PMS->>Broadcast: "emit('markets', tradePayload)"
    Note over Broadcast: "trade.source = 'npc_trade', trade.actorType = 'npc'"
    PMS-->>DE: "return trade result"
    DE->>DE: "Record trade in AgentPnLService"
    DE-->>User: "return DirectTradeResult"
```

<!-- greptile_other_comments_section -->

<details><summary><h3>Context used (3)</h3></summary>

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=d07fd731-326a-4ea1-84d3-eec6a8044b74))
- Context from `dashboard` - .cursorrules ([source](https://app.greptile.com/review/custom-context?memory=d8da6060-b92a-430f-81d2-446cd9e51763))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=445626a4-e384-4d3b-99de-4ccf9a293a0d))
</details>


<!-- /greptile_comment -->