### PR TITLE
fix: optimize agent chat/onboarding with strict provider filtering + A2A direct executor

### DIFF
--- a/apps/web/src/app/api/agents/[agentId]/chat/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/chat/route.ts
@@ -287,11 +287,13 @@ export const POST = withErrorHandling(
       );
 
       // Compose state with providers
-      const state: State = await runtime.composeState(elizaMessage, [
-        'RECENT_MESSAGES',
-        'ACTION_STATE',
-        'ACTIONS',
-      ]);
+      // Use strict filtering (3rd param = true) to ONLY run the specified providers
+      // This prevents all Babylon A2A providers from running unnecessarily
+      const state: State = await runtime.composeState(
+        elizaMessage,
+        ['RECENT_MESSAGES', 'ACTION_STATE', 'ACTIONS'],
+        true
+      );
 
       // Add custom values to state
       state.values = {
@@ -500,10 +502,11 @@ export const POST = withErrorHandling(
 
     // Generate summary/response - always run to get proper user-facing message
     {
-      const state = await runtime.composeState(elizaMessage, [
-        'RECENT_MESSAGES',
-        'ACTION_STATE',
-      ]);
+      const state = await runtime.composeState(
+        elizaMessage,
+        ['RECENT_MESSAGES', 'ACTION_STATE'],
+        true
+      );
       state.values = {
         ...state.values,
         agentId, // Pass agentId for actions that need it

--- a/apps/web/src/app/api/agents/[agentId]/onboarding/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/onboarding/route.ts
@@ -108,7 +108,9 @@ export const POST = withErrorHandling(
     };
 
     // Compose state with ACTIONS provider to get actionsWithDescriptions
-    const state = await runtime.composeState(onboardingMessage, ['ACTIONS']);
+    // Use strict filtering (3rd param = true) to ONLY run the specified providers
+    // This prevents all Babylon A2A providers from running unnecessarily
+    const state = await runtime.composeState(onboardingMessage, ['ACTIONS'], true);
 
     // Add custom values to state
     state.values = {

--- a/apps/web/src/app/api/agents/[agentId]/onboarding/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/onboarding/route.ts
@@ -110,7 +110,11 @@ export const POST = withErrorHandling(
     // Compose state with ACTIONS provider to get actionsWithDescriptions
     // Use strict filtering (3rd param = true) to ONLY run the specified providers
     // This prevents all Babylon A2A providers from running unnecessarily
-    const state = await runtime.composeState(onboardingMessage, ['ACTIONS'], true);
+    const state = await runtime.composeState(
+      onboardingMessage,
+      ['ACTIONS'],
+      true
+    );
 
     // Add custom values to state
     state.values = {

--- a/packages/a2a/src/executors/babylon-executor.ts
+++ b/packages/a2a/src/executors/babylon-executor.ts
@@ -237,6 +237,41 @@ type ExecutorOperationResult =
   | JsonValue;
 
 export class BabylonAgentExecutor implements AgentExecutor {
+  // Singleton instance for direct execution (bypasses HTTP)
+  private static instance: BabylonAgentExecutor | null = null;
+
+  /**
+   * Execute an operation directly without HTTP.
+   * Use this for server-side calls to avoid Vercel serverless self-call issues.
+   */
+  static async executeDirectly(
+    operation: string,
+    params: Record<string, JsonValue>,
+    userId?: string
+  ): Promise<JsonValue> {
+    if (!BabylonAgentExecutor.instance) {
+      BabylonAgentExecutor.instance = new BabylonAgentExecutor();
+    }
+
+    const context: RequestContext = {
+      taskId: `direct-${Date.now()}`,
+      contextId: userId || 'system',
+      userMessage: {
+        kind: 'message',
+        messageId: `msg-${Date.now()}`,
+        role: 'user',
+        parts: [],
+      },
+      task: null as unknown as Task,
+    };
+
+    const result = await BabylonAgentExecutor.instance.executeOperation(
+      { operation, params },
+      context
+    );
+    return result as JsonValue;
+  }
+
   async execute(
     requestContext: RequestContext,
     eventBus: ExecutionEventBus
@@ -315,7 +350,7 @@ export class BabylonAgentExecutor implements AgentExecutor {
     eventBus.finished();
   }
 
-  private async executeOperation(
+  async executeOperation(
     command: BabylonCommand,
     context: RequestContext
   ): Promise<ExecutorOperationResult> {

--- a/packages/a2a/src/executors/babylon-executor.ts
+++ b/packages/a2a/src/executors/babylon-executor.ts
@@ -237,39 +237,46 @@ type ExecutorOperationResult =
   | JsonValue;
 
 export class BabylonAgentExecutor implements AgentExecutor {
-  // Singleton instance for direct execution (bypasses HTTP)
-  private static instance: BabylonAgentExecutor | null = null;
-
   /**
-   * Execute an operation directly without HTTP.
-   * Use this for server-side calls to avoid Vercel serverless self-call issues.
+   * Execute operation directly without A2A HTTP protocol
+   * Used for server-side internal calls to bypass Vercel serverless HTTP limitations
+   *
+   * @param operation - The operation name (e.g., 'portfolio.get_balance')
+   * @param params - Operation parameters
+   * @param agentUserId - The agent's user ID for context
+   * @returns Operation result as JsonValue
    */
-  static async executeDirectly(
+  public static async executeDirectly(
     operation: string,
     params: Record<string, JsonValue>,
-    userId?: string
+    agentUserId: string
   ): Promise<JsonValue> {
-    if (!BabylonAgentExecutor.instance) {
-      BabylonAgentExecutor.instance = new BabylonAgentExecutor();
-    }
+    const executor = new BabylonAgentExecutor();
+    const command: BabylonCommand = { operation, params };
+    const taskId = `direct-${Date.now()}`;
 
+    // Create minimal RequestContext for the operation
     const context: RequestContext = {
-      taskId: `direct-${Date.now()}`,
-      contextId: userId || 'system',
+      taskId,
+      contextId: agentUserId,
       userMessage: {
         kind: 'message',
-        messageId: `msg-${Date.now()}`,
+        messageId: `direct-msg-${Date.now()}`,
         role: 'user',
-        parts: [],
+        parts: [{ kind: 'text', text: `Direct call: ${operation}` }],
       },
-      task: null as unknown as Task,
+      task: {
+        kind: 'task',
+        id: taskId,
+        contextId: agentUserId,
+        status: { state: 'working', timestamp: new Date().toISOString() },
+        artifacts: [],
+      },
     };
 
-    const result = await BabylonAgentExecutor.instance.executeOperation(
-      { operation, params },
-      context
-    );
-    return result as JsonValue;
+    const result = await executor.executeOperation(command, context);
+    // Cast to JsonValue since ExecutorOperationResult is compatible at runtime
+    return result as unknown as JsonValue;
   }
 
   async execute(
@@ -350,7 +357,7 @@ export class BabylonAgentExecutor implements AgentExecutor {
     eventBus.finished();
   }
 
-  async executeOperation(
+  private async executeOperation(
     command: BabylonCommand,
     context: RequestContext
   ): Promise<ExecutorOperationResult> {
@@ -588,43 +595,36 @@ export class BabylonAgentExecutor implements AgentExecutor {
   private async listPerpetualMarkets(params: Record<string, JsonValue>) {
     const limit = this.parsePositiveInt(params.limit, 20, 50);
 
-    try {
-      const drizzle = getRawDrizzle();
-      const snapshots = await drizzle
-        .select({
-          ticker: perpMarketSnapshots.ticker,
-          name: perpMarketSnapshots.name,
-          organizationId: perpMarketSnapshots.organizationId,
-          currentPrice: perpMarketSnapshots.currentPrice,
-          change24h: perpMarketSnapshots.change24h,
-          changePercent24h: perpMarketSnapshots.changePercent24h,
-          volume24h: perpMarketSnapshots.volume24h,
-          openInterest: perpMarketSnapshots.openInterest,
-          fundingRate: perpMarketSnapshots.fundingRate,
-        })
-        .from(perpMarketSnapshots)
-        .limit(limit);
+    const drizzle = getRawDrizzle();
+    const snapshots = await drizzle
+      .select({
+        ticker: perpMarketSnapshots.ticker,
+        name: perpMarketSnapshots.name,
+        organizationId: perpMarketSnapshots.organizationId,
+        currentPrice: perpMarketSnapshots.currentPrice,
+        change24h: perpMarketSnapshots.change24h,
+        changePercent24h: perpMarketSnapshots.changePercent24h,
+        volume24h: perpMarketSnapshots.volume24h,
+        openInterest: perpMarketSnapshots.openInterest,
+        fundingRate: perpMarketSnapshots.fundingRate,
+      })
+      .from(perpMarketSnapshots)
+      .limit(limit);
 
-      return {
-        perpetuals: snapshots.map((s) => ({
-          name: s.name || s.ticker,
-          ticker: s.ticker,
-          currentPrice: Number(s.currentPrice) || 0,
-          priceChange24h: Number(s.change24h) || 0,
-          volume24h: Number(s.volume24h) || 0,
-          openInterest: Number(s.openInterest) || 0,
-          fundingRate:
-            typeof s.fundingRate === 'object' && s.fundingRate !== null
-              ? (s.fundingRate as { rate?: number }).rate || 0
-              : 0,
-        })),
-      };
-    } catch (error) {
-      logger.warn('Failed to fetch perpMarketSnapshots, returning empty', {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return { perpetuals: [] };
-    }
+    return {
+      perpetuals: snapshots.map((s) => ({
+        name: s.name || s.ticker,
+        ticker: s.ticker,
+        currentPrice: Number(s.currentPrice) || 0,
+        priceChange24h: Number(s.change24h) || 0,
+        volume24h: Number(s.volume24h) || 0,
+        openInterest: Number(s.openInterest) || 0,
+        fundingRate:
+          typeof s.fundingRate === 'object' && s.fundingRate !== null
+            ? (s.fundingRate as { rate?: number }).rate || 0
+            : 0,
+      })),
+    };
   }
 
   private async getUserProfile(params: Record<string, JsonValue>) {

--- a/packages/a2a/src/executors/babylon-executor.ts
+++ b/packages/a2a/src/executors/babylon-executor.ts
@@ -553,36 +553,43 @@ export class BabylonAgentExecutor implements AgentExecutor {
   private async listPerpetualMarkets(params: Record<string, JsonValue>) {
     const limit = this.parsePositiveInt(params.limit, 20, 50);
 
-    const drizzle = getRawDrizzle();
-    const snapshots = await drizzle
-      .select({
-        ticker: perpMarketSnapshots.ticker,
-        name: perpMarketSnapshots.name,
-        organizationId: perpMarketSnapshots.organizationId,
-        currentPrice: perpMarketSnapshots.currentPrice,
-        change24h: perpMarketSnapshots.change24h,
-        changePercent24h: perpMarketSnapshots.changePercent24h,
-        volume24h: perpMarketSnapshots.volume24h,
-        openInterest: perpMarketSnapshots.openInterest,
-        fundingRate: perpMarketSnapshots.fundingRate,
-      })
-      .from(perpMarketSnapshots)
-      .limit(limit);
+    try {
+      const drizzle = getRawDrizzle();
+      const snapshots = await drizzle
+        .select({
+          ticker: perpMarketSnapshots.ticker,
+          name: perpMarketSnapshots.name,
+          organizationId: perpMarketSnapshots.organizationId,
+          currentPrice: perpMarketSnapshots.currentPrice,
+          change24h: perpMarketSnapshots.change24h,
+          changePercent24h: perpMarketSnapshots.changePercent24h,
+          volume24h: perpMarketSnapshots.volume24h,
+          openInterest: perpMarketSnapshots.openInterest,
+          fundingRate: perpMarketSnapshots.fundingRate,
+        })
+        .from(perpMarketSnapshots)
+        .limit(limit);
 
-    return {
-      perpetuals: snapshots.map((s) => ({
-        name: s.name || s.ticker,
-        ticker: s.ticker,
-        currentPrice: Number(s.currentPrice) || 0,
-        priceChange24h: Number(s.change24h) || 0,
-        volume24h: Number(s.volume24h) || 0,
-        openInterest: Number(s.openInterest) || 0,
-        fundingRate:
-          typeof s.fundingRate === 'object' && s.fundingRate !== null
-            ? (s.fundingRate as { rate?: number }).rate || 0
-            : 0,
-      })),
-    };
+      return {
+        perpetuals: snapshots.map((s) => ({
+          name: s.name || s.ticker,
+          ticker: s.ticker,
+          currentPrice: Number(s.currentPrice) || 0,
+          priceChange24h: Number(s.change24h) || 0,
+          volume24h: Number(s.volume24h) || 0,
+          openInterest: Number(s.openInterest) || 0,
+          fundingRate:
+            typeof s.fundingRate === 'object' && s.fundingRate !== null
+              ? (s.fundingRate as { rate?: number }).rate || 0
+              : 0,
+        })),
+      };
+    } catch (error) {
+      logger.warn('Failed to fetch perpMarketSnapshots, returning empty', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return { perpetuals: [] };
+    }
   }
 
   private async getUserProfile(params: Record<string, JsonValue>) {

--- a/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts
+++ b/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts
@@ -441,8 +441,9 @@ export class BabylonA2AClient {
   }
 
   /**
-   * Execute via direct executor (bypasses HTTP for server-side calls)
-   * Maps a2a.* methods to executor operations
+   * Execute via A2A protocol or direct executor
+   * Uses direct executor on server-side to avoid Vercel serverless 503 errors
+   * Falls back to A2A SDK for external/client-side calls
    */
   private async executeViaA2A(
     action: string,
@@ -478,15 +479,103 @@ export class BabylonA2AClient {
 
     const operationName = operationMap[action] || action;
 
-    // Use direct executor to bypass HTTP (fixes Vercel serverless 503 errors)
-    const { BabylonAgentExecutor } = await import('@babylon/a2a');
-    const result = await BabylonAgentExecutor.executeDirectly(
-      operationName,
-      params,
-      this.agentId
-    );
+    // On server-side (Next.js API routes), use direct executor to avoid HTTP self-call
+    // This fixes Vercel serverless 503 errors
+    const isServerSide = typeof window === 'undefined';
+    if (isServerSide) {
+      const { BabylonAgentExecutor } = await import('@babylon/a2a');
+      return BabylonAgentExecutor.executeDirectly(
+        operationName,
+        params,
+        this.agentId
+      );
+    }
 
-    return result;
+    // Client-side or when SDK client is needed: use A2A protocol
+    if (!this.sdkClient) {
+      throw new Error('A2A client not available');
+    }
+
+    // Map action to skill ID for A2A protocol
+    const skillMap: Record<string, string> = {
+      getBalance: 'portfolio-balance',
+      getPositions: 'portfolio-balance',
+      getUserWallet: 'portfolio-balance',
+      getPredictions: 'prediction-markets',
+      getPerpetuals: 'perpetual-futures',
+      getFeed: 'social-feed',
+      createPost: 'social-feed',
+      likePost: 'social-feed',
+      getUserProfile: 'user-social-graph',
+      searchUsers: 'user-social-graph',
+      getLeaderboard: 'stats-discovery',
+      getSystemStats: 'stats-discovery',
+      getTrendingTags: 'stats-discovery',
+      getOrganizations: 'stats-discovery',
+      getChats: 'messaging-chats',
+      getUnreadCount: 'messaging-chats',
+      getNotifications: 'messaging-chats',
+    };
+    const skillId = skillMap[action] || 'portfolio-balance';
+
+    const response = await this.sdkClient.sendMessage({
+      message: {
+        kind: 'message',
+        messageId: crypto.randomUUID(),
+        role: 'user',
+        parts: [
+          {
+            kind: 'data',
+            data: { operation: operationName, params },
+            metadata: { skillId },
+          },
+        ],
+      },
+    });
+
+    // Handle A2A response
+    type DataPart = { kind: 'data'; data: JsonValue };
+    const isDataPart = (part: { kind: string }): part is DataPart =>
+      part.kind === 'data' && 'data' in part;
+
+    if ('result' in response && response.result) {
+      const result = response.result;
+      if (typeof result === 'object' && result !== null && 'kind' in result) {
+        if (result.kind === 'message') {
+          const msg = result as { parts: Array<{ kind: string }> };
+          const dataPart = msg.parts.find((p) => isDataPart(p));
+          return dataPart && isDataPart(dataPart) ? dataPart.data : {};
+        }
+        if (result.kind === 'task') {
+          // For tasks, poll for completion
+          const task = result as { id: string; status?: { state: string }; artifacts?: Array<{ parts: Array<{ kind: string }> }> };
+          const maxWaitMs = 30000;
+          const startTime = Date.now();
+          
+          while (Date.now() - startTime < maxWaitMs) {
+            const taskResponse = await this.sdkClient.getTask({ id: task.id });
+            if ('result' in taskResponse && taskResponse.result) {
+              const taskResult = taskResponse.result as { task?: typeof task };
+              if (taskResult.task?.status?.state === 'completed') {
+                const artifact = taskResult.task.artifacts?.[0];
+                if (artifact) {
+                  const dataPart = artifact.parts.find((p) => isDataPart(p));
+                  return dataPart && isDataPart(dataPart) ? dataPart.data : {};
+                }
+                return {};
+              }
+              if (['failed', 'canceled', 'rejected'].includes(taskResult.task?.status?.state || '')) {
+                throw new Error(`Task ${taskResult.task?.status?.state}`);
+              }
+            }
+            await new Promise((r) => setTimeout(r, 500));
+          }
+          throw new Error('Task timeout');
+        }
+      }
+    }
+
+    return {};
   }
 
   /**

--- a/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts
+++ b/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts
@@ -9,7 +9,7 @@
  * - Lazy header injection per-request (not per-client initialization)
  */
 
-import type { AgentCard } from '@a2a-js/sdk';
+import type { AgentCard, Message, Task } from '@a2a-js/sdk';
 import { A2AClient } from '@a2a-js/sdk/client';
 import { db } from '@babylon/db';
 import { StaticDataRegistry } from '@babylon/engine';
@@ -441,15 +441,18 @@ export class BabylonA2AClient {
   }
 
   /**
-   * Execute via A2A protocol or direct executor
-   * Uses direct executor on server-side to avoid Vercel serverless 503 errors
-   * Falls back to A2A SDK for external/client-side calls
+   * Execute via A2A message/send with skills
+   * Maps a2a.* methods to A2A protocol
+   *
+   * On server-side (Vercel serverless), uses direct executor to avoid HTTP self-call issues.
+   * On client-side or when A2A protocol is explicitly needed, uses SDK client with HTTP.
    */
   private async executeViaA2A(
     action: string,
     params: Record<string, JsonValue>
   ): Promise<JsonValue> {
     // Map camelCase actions to category.snake_case operation names
+    // This follows the executor's convention (e.g., 'social.create_post', 'stats.leaderboard')
     const operationMap: Record<string, string> = {
       // Portfolio operations
       getBalance: 'portfolio.get_balance',
@@ -479,8 +482,8 @@ export class BabylonA2AClient {
 
     const operationName = operationMap[action] || action;
 
-    // On server-side (Next.js API routes), use direct executor to avoid HTTP self-call
-    // This fixes Vercel serverless 503 errors
+    // On server-side (Next.js API routes), use direct executor to bypass HTTP
+    // This fixes Vercel serverless 503 errors from self-calls
     const isServerSide = typeof window === 'undefined';
     if (isServerSide) {
       const { BabylonAgentExecutor } = await import('@babylon/a2a');
@@ -491,31 +494,100 @@ export class BabylonA2AClient {
       );
     }
 
-    // Client-side or when SDK client is needed: use A2A protocol
+    // Client-side: use A2A SDK with HTTP (for true agent-to-agent communication)
     if (!this.sdkClient) {
       throw new Error('A2A client not available');
     }
 
-    // Map action to skill ID for A2A protocol
+    // Map action to skill ID - comprehensive mapping for all 69+ A2A methods
     const skillMap: Record<string, string> = {
+      // Portfolio & Balance
       getBalance: 'portfolio-balance',
       getPositions: 'portfolio-balance',
       getUserWallet: 'portfolio-balance',
+      transferPoints: 'portfolio-balance',
+      // Prediction Markets
       getPredictions: 'prediction-markets',
+      buyShares: 'prediction-markets',
+      sellShares: 'prediction-markets',
+      getTrades: 'prediction-markets',
+      getTradeHistory: 'prediction-markets',
+      // Perpetual Futures
       getPerpetuals: 'perpetual-futures',
+      openPosition: 'perpetual-futures',
+      closePosition: 'perpetual-futures',
+      // Market Data
+      getMarketData: 'prediction-markets',
+      getMarketPrices: 'prediction-markets',
+      subscribeMarket: 'prediction-markets',
+      // Social Feed
       getFeed: 'social-feed',
+      getPost: 'social-feed',
       createPost: 'social-feed',
+      deletePost: 'social-feed',
       likePost: 'social-feed',
+      unlikePost: 'social-feed',
+      sharePost: 'social-feed',
+      getComments: 'social-feed',
+      createComment: 'social-feed',
+      deleteComment: 'social-feed',
+      likeComment: 'social-feed',
+      // User Management
       getUserProfile: 'user-social-graph',
+      updateProfile: 'user-social-graph',
+      followUser: 'user-social-graph',
+      unfollowUser: 'user-social-graph',
+      getFollowers: 'user-social-graph',
+      getFollowing: 'user-social-graph',
       searchUsers: 'user-social-graph',
-      getLeaderboard: 'stats-discovery',
-      getSystemStats: 'stats-discovery',
-      getTrendingTags: 'stats-discovery',
-      getOrganizations: 'stats-discovery',
+      favoriteProfile: 'user-social-graph',
+      unfavoriteProfile: 'user-social-graph',
+      getFavorites: 'user-social-graph',
+      getFavoritePosts: 'user-social-graph',
+      // Messaging
       getChats: 'messaging-chats',
+      getChatMessages: 'messaging-chats',
+      sendMessage: 'messaging-chats',
+      createGroup: 'messaging-chats',
+      leaveChat: 'messaging-chats',
       getUnreadCount: 'messaging-chats',
+      // Notifications
       getNotifications: 'messaging-chats',
+      markNotificationsRead: 'messaging-chats',
+      getGroupInvites: 'messaging-chats',
+      acceptGroupInvite: 'messaging-chats',
+      declineGroupInvite: 'messaging-chats',
+      // Stats & Discovery
+      getLeaderboard: 'stats-discovery',
+      getUserStats: 'stats-discovery',
+      getSystemStats: 'stats-discovery',
+      getReferrals: 'stats-discovery',
+      getReferralStats: 'stats-discovery',
+      getReferralCode: 'stats-discovery',
+      getReputation: 'stats-discovery',
+      getReputationBreakdown: 'stats-discovery',
+      getTrendingTags: 'stats-discovery',
+      getPostsByTag: 'stats-discovery',
+      getOrganizations: 'stats-discovery',
+      // Agent Discovery
+      discoverAgents: 'stats-discovery',
+      getAgentInfo: 'stats-discovery',
+      // Payments
+      paymentRequest: 'portfolio-balance',
+      paymentReceipt: 'portfolio-balance',
+      // Moderation
+      blockUser: 'user-social-graph',
+      unblockUser: 'user-social-graph',
+      muteUser: 'user-social-graph',
+      unmuteUser: 'user-social-graph',
+      reportUser: 'user-social-graph',
+      reportPost: 'social-feed',
+      getBlocks: 'user-social-graph',
+      getMutes: 'user-social-graph',
+      checkBlockStatus: 'user-social-graph',
+      checkMuteStatus: 'user-social-graph',
     };
+
     const skillId = skillMap[action] || 'portfolio-balance';
 
     const response = await this.sdkClient.sendMessage({
@@ -527,55 +599,82 @@ export class BabylonA2AClient {
           {
             kind: 'data',
             data: { operation: operationName, params },
-            metadata: { skillId },
+            metadata: {
+              skillId,
+            },
           },
         ],
       },
     });
 
-    // Handle A2A response
-    type DataPart = { kind: 'data'; data: JsonValue };
-    const isDataPart = (part: { kind: string }): part is DataPart =>
-      part.kind === 'data' && 'data' in part;
+    // Type for data part in A2A messages
+    interface DataPart {
+      kind: 'data';
+      data: JsonValue;
+    }
 
+    function isDataPart(part: { kind: string }): part is DataPart {
+      return part.kind === 'data' && 'data' in part;
+    }
+
+    // Handle response - extract Task or Message
+    let task: Task | undefined;
     if ('result' in response && response.result) {
       const result = response.result;
       if (typeof result === 'object' && result !== null && 'kind' in result) {
-        if (result.kind === 'message') {
-          const msg = result as { parts: Array<{ kind: string }> };
+        if (result.kind === 'task') {
+          task = result as Task;
+        } else if (result.kind === 'message') {
+          // Direct message response
+          const msg = result as Message;
           const dataPart = msg.parts.find((p) => isDataPart(p));
           return dataPart && isDataPart(dataPart) ? dataPart.data : {};
-        }
-        if (result.kind === 'task') {
-          // For tasks, poll for completion
-          const task = result as { id: string; status?: { state: string }; artifacts?: Array<{ parts: Array<{ kind: string }> }> };
-          const maxWaitMs = 30000;
-          const startTime = Date.now();
-          
-          while (Date.now() - startTime < maxWaitMs) {
-            const taskResponse = await this.sdkClient.getTask({ id: task.id });
-            if ('result' in taskResponse && taskResponse.result) {
-              const taskResult = taskResponse.result as { task?: typeof task };
-              if (taskResult.task?.status?.state === 'completed') {
-                const artifact = taskResult.task.artifacts?.[0];
-                if (artifact) {
-                  const dataPart = artifact.parts.find((p) => isDataPart(p));
-                  return dataPart && isDataPart(dataPart) ? dataPart.data : {};
-                }
-                return {};
-              }
-              if (['failed', 'canceled', 'rejected'].includes(taskResult.task?.status?.state || '')) {
-                throw new Error(`Task ${taskResult.task?.status?.state}`);
-              }
-            }
-            await new Promise((r) => setTimeout(r, 500));
-          }
-          throw new Error('Task timeout');
         }
       }
     }
 
-    return {};
+    if (!task) {
+      throw new Error('Expected task response from A2A');
+    }
+
+    // Poll for completion
+    const maxWaitMs = 30000;
+    const startTime = Date.now();
+    while (Date.now() - startTime < maxWaitMs) {
+      const taskResponse = await this.sdkClient.getTask({ id: task.id });
+
+      if ('result' in taskResponse && taskResponse.result) {
+        const result = taskResponse.result as { task?: Task };
+        if (result.task) {
+          task = result.task;
+        }
+      }
+
+      const state = task.status?.state;
+      if (state === 'completed') {
+        if (task.artifacts && task.artifacts.length > 0) {
+          const artifact = task.artifacts[0];
+          if (artifact) {
+            const dataPart = artifact.parts.find((p) => isDataPart(p));
+            return dataPart && isDataPart(dataPart) ? dataPart.data : {};
+          }
+        }
+        return {};
+      }
+
+      if (state === 'failed' || state === 'canceled' || state === 'rejected') {
+        const messagePart = task.status?.message?.parts?.[0];
+        const errorText =
+          messagePart && 'text' in messagePart
+            ? messagePart.text
+            : 'Unknown error';
+        throw new Error(`Task ${state}: ${errorText}`);
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+
+    throw new Error('Task did not complete within timeout');
   }
 
   /**

--- a/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts
+++ b/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts
@@ -9,7 +9,7 @@
  * - Lazy header injection per-request (not per-client initialization)
  */
 
-import type { AgentCard, Message, Task } from '@a2a-js/sdk';
+import type { AgentCard } from '@a2a-js/sdk';
 import { A2AClient } from '@a2a-js/sdk/client';
 import { db } from '@babylon/db';
 import { StaticDataRegistry } from '@babylon/engine';
@@ -441,109 +441,14 @@ export class BabylonA2AClient {
   }
 
   /**
-   * Execute via A2A message/send with skills
-   * Maps a2a.* methods to A2A protocol
+   * Execute via direct executor (bypasses HTTP for server-side calls)
+   * Maps a2a.* methods to executor operations
    */
   private async executeViaA2A(
     action: string,
     params: Record<string, JsonValue>
   ): Promise<JsonValue> {
-    if (!this.sdkClient) {
-      throw new Error('A2A client not available - use database fallback');
-    }
-    // Map action to skill ID - comprehensive mapping for all 69+ A2A methods
-    const skillMap: Record<string, string> = {
-      // Portfolio & Balance
-      getBalance: 'portfolio-balance',
-      getPositions: 'portfolio-balance',
-      getUserWallet: 'portfolio-balance',
-      transferPoints: 'portfolio-balance',
-      // Prediction Markets
-      getPredictions: 'prediction-markets',
-      buyShares: 'prediction-markets',
-      sellShares: 'prediction-markets',
-      getTrades: 'prediction-markets',
-      getTradeHistory: 'prediction-markets',
-      // Perpetual Futures
-      getPerpetuals: 'perpetual-futures',
-      openPosition: 'perpetual-futures',
-      closePosition: 'perpetual-futures',
-      // Market Data
-      getMarketData: 'prediction-markets',
-      getMarketPrices: 'prediction-markets',
-      subscribeMarket: 'prediction-markets',
-      // Social Feed
-      getFeed: 'social-feed',
-      getPost: 'social-feed',
-      createPost: 'social-feed',
-      deletePost: 'social-feed',
-      likePost: 'social-feed',
-      unlikePost: 'social-feed',
-      sharePost: 'social-feed',
-      getComments: 'social-feed',
-      createComment: 'social-feed',
-      deleteComment: 'social-feed',
-      likeComment: 'social-feed',
-      // User Management
-      getUserProfile: 'user-social-graph',
-      updateProfile: 'user-social-graph',
-      followUser: 'user-social-graph',
-      unfollowUser: 'user-social-graph',
-      getFollowers: 'user-social-graph',
-      getFollowing: 'user-social-graph',
-      searchUsers: 'user-social-graph',
-      favoriteProfile: 'user-social-graph',
-      unfavoriteProfile: 'user-social-graph',
-      getFavorites: 'user-social-graph',
-      getFavoritePosts: 'user-social-graph',
-      // Messaging
-      getChats: 'messaging-chats',
-      getChatMessages: 'messaging-chats',
-      sendMessage: 'messaging-chats',
-      createGroup: 'messaging-chats',
-      leaveChat: 'messaging-chats',
-      getUnreadCount: 'messaging-chats',
-      // Notifications
-      getNotifications: 'messaging-chats',
-      markNotificationsRead: 'messaging-chats',
-      getGroupInvites: 'messaging-chats',
-      acceptGroupInvite: 'messaging-chats',
-      declineGroupInvite: 'messaging-chats',
-      // Stats & Discovery
-      getLeaderboard: 'stats-discovery',
-      getUserStats: 'stats-discovery',
-      getSystemStats: 'stats-discovery',
-      getReferrals: 'stats-discovery',
-      getReferralStats: 'stats-discovery',
-      getReferralCode: 'stats-discovery',
-      getReputation: 'stats-discovery',
-      getReputationBreakdown: 'stats-discovery',
-      getTrendingTags: 'stats-discovery',
-      getPostsByTag: 'stats-discovery',
-      getOrganizations: 'stats-discovery',
-      // Agent Discovery
-      discoverAgents: 'stats-discovery',
-      getAgentInfo: 'stats-discovery',
-      // Payments
-      paymentRequest: 'portfolio-balance',
-      paymentReceipt: 'portfolio-balance',
-      // Moderation
-      blockUser: 'user-social-graph',
-      unblockUser: 'user-social-graph',
-      muteUser: 'user-social-graph',
-      unmuteUser: 'user-social-graph',
-      reportUser: 'user-social-graph',
-      reportPost: 'social-feed',
-      getBlocks: 'user-social-graph',
-      getMutes: 'user-social-graph',
-      checkBlockStatus: 'user-social-graph',
-      checkMuteStatus: 'user-social-graph',
-    };
-
-    const skillId = skillMap[action] || 'portfolio-balance';
-
     // Map camelCase actions to category.snake_case operation names
-    // This follows the executor's convention (e.g., 'social.create_post', 'stats.leaderboard')
     const operationMap: Record<string, string> = {
       // Portfolio operations
       getBalance: 'portfolio.get_balance',
@@ -571,94 +476,17 @@ export class BabylonA2AClient {
       getNotifications: 'messaging.get_notifications',
     };
 
-    // Use mapped operation name if available, otherwise use original action
     const operationName = operationMap[action] || action;
 
-    const response = await this.sdkClient.sendMessage({
-      message: {
-        kind: 'message',
-        messageId: crypto.randomUUID(),
-        role: 'user',
-        parts: [
-          {
-            kind: 'data',
-            data: { operation: operationName, params },
-            metadata: {
-              skillId,
-            },
-          },
-        ],
-      },
-    });
+    // Use direct executor to bypass HTTP (fixes Vercel serverless 503 errors)
+    const { BabylonAgentExecutor } = await import('@babylon/a2a');
+    const result = await BabylonAgentExecutor.executeDirectly(
+      operationName,
+      params,
+      this.agentId
+    );
 
-    // Type for data part in A2A messages
-    interface DataPart {
-      kind: 'data';
-      data: JsonValue;
-    }
-
-    function isDataPart(part: { kind: string }): part is DataPart {
-      return part.kind === 'data' && 'data' in part;
-    }
-
-    // Handle response - extract Task or Message
-    let task: Task | undefined;
-    if ('result' in response && response.result) {
-      const result = response.result;
-      if (typeof result === 'object' && result !== null && 'kind' in result) {
-        if (result.kind === 'task') {
-          task = result as Task;
-        } else if (result.kind === 'message') {
-          // Direct message response
-          const msg = result as Message;
-          const dataPart = msg.parts.find((p) => isDataPart(p));
-          return dataPart && isDataPart(dataPart) ? dataPart.data : {};
-        }
-      }
-    }
-
-    if (!task) {
-      throw new Error('Expected task response from A2A');
-    }
-
-    // Poll for completion
-    const maxWaitMs = 30000;
-    const startTime = Date.now();
-    while (Date.now() - startTime < maxWaitMs) {
-      const taskResponse = await this.sdkClient.getTask({ id: task.id });
-
-      if ('result' in taskResponse && taskResponse.result) {
-        const result = taskResponse.result as { task?: Task };
-        if (result.task) {
-          task = result.task;
-        }
-      }
-
-      const state = task.status?.state;
-      if (state === 'completed') {
-        if (task.artifacts && task.artifacts.length > 0) {
-          const artifact = task.artifacts[0];
-          if (artifact) {
-            const dataPart = artifact.parts.find((p) => isDataPart(p));
-            return dataPart && isDataPart(dataPart) ? dataPart.data : {};
-          }
-        }
-        return {};
-      }
-
-      if (state === 'failed' || state === 'canceled' || state === 'rejected') {
-        const messagePart = task.status?.message?.parts?.[0];
-        const errorText =
-          messagePart && 'text' in messagePart
-            ? messagePart.text
-            : 'Unknown error';
-        throw new Error(`Task ${state}: ${errorText}`);
-      }
-
-      await new Promise((resolve) => setTimeout(resolve, 500));
-    }
-
-    throw new Error('Task did not complete within timeout');
+    return result;
   }
 
   /**


### PR DESCRIPTION
## Summary
Fixes agent onboarding and chat 500 errors on Vercel by:
1. Using strict provider filtering to skip unnecessary A2A calls
2. Adding direct A2A executor for server-side calls (for future use)

## Problem
When creating an agent and navigating to chats, onboarding/chat routes were failing with:
- `500 Internal Server Error: Unsupported operation: getPositions`
- `503 RPC error for message/send` on Vercel

**Root cause:** `composeState()` was running ALL 16 Babylon providers (dashboard, portfolio, markets, etc.) even though the routes only needed `ACTIONS`, `RECENT_MESSAGES`, and `ACTION_STATE`. This triggered A2A HTTP calls that failed on Vercel serverless.

## Solution

### 1. Strict Provider Filtering (Primary Fix)
Added `true` as the 3rd parameter to `composeState()` to enable strict filtering:
// Before (runs ALL providers):
runtime.composeState(message, ['ACTIONS'])

// After (runs ONLY 'ACTIONS'):
runtime.composeState(message, ['ACTIONS'], true)**Benefits:**
- Eliminates unnecessary A2A calls during onboarding/chat
- Significantly faster response times (skips 16 providers)
- Fixes Vercel 500/503 errors

### 2. A2A Direct Executor (Kept for Future Use)
Added `BabylonAgentExecutor.executeDirectly()` for when A2A providers are actually needed:
- Bypasses HTTP on server-side (fixes Vercel serverless self-call issues)
- Preserves full A2A protocol for client-side/external agent communication


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled server-side direct execution for blockchain operations, bypassing HTTP protocol overhead.

* **Refactor**
  * Optimized state composition with strict provider filtering in agent chat and onboarding flows.
  * Enhanced blockchain operation mapping and server-side request handling for improved efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR fixes critical 500/503 errors in agent onboarding and chat routes on Vercel by implementing strict provider filtering and adding a direct A2A executor for server-side calls.

**Key Changes:**
- Added third parameter (`true`) to `composeState()` calls to enable strict provider filtering, preventing unnecessary execution of all 16 Babylon A2A providers when only specific providers are needed
- Introduced `BabylonAgentExecutor.executeDirectly()` static method to bypass HTTP protocol for server-side A2A calls, resolving Vercel serverless self-call limitations
- Modified `BabylonA2AClient.executeViaA2A()` to detect server-side vs client-side execution and route accordingly

**Impact:**
- Eliminates unnecessary A2A HTTP calls during onboarding/chat (previously triggered all 16 providers)
- Fixes Vercel 503 RPC errors caused by serverless functions calling themselves via HTTP
- Significantly improves response times by skipping irrelevant provider execution
- Maintains full A2A protocol compatibility for client-side and external agent communication

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no identified issues
- The changes are well-architected, properly documented, and directly address the root cause of the production errors. The strict filtering approach is a clean optimization, and the direct executor pattern is a standard solution for serverless self-call issues. All changes are additive (no breaking changes), maintain backward compatibility, and include clear inline documentation explaining the rationale.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/api/agents/[agentId]/chat/route.ts | Added strict provider filtering (third parameter `true`) to two `composeState()` calls to prevent unnecessary A2A provider execution during chat interactions |
| apps/web/src/app/api/agents/[agentId]/onboarding/route.ts | Added strict provider filtering to `composeState()` call to prevent unnecessary A2A provider execution during agent onboarding |
| packages/a2a/src/executors/babylon-executor.ts | Added `executeDirectly()` static method to bypass A2A HTTP protocol for server-side internal calls, addressing Vercel serverless limitations |
| packages/agents/src/plugins/babylon/integration-a2a-sdk.ts | Added server-side detection to use direct executor instead of HTTP for A2A calls, fixing Vercel 503 errors while preserving SDK client for client-side usage |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Client/Browser
    participant API as Next.js API Route<br/>(chat/onboarding)
    participant Runtime as Agent Runtime
    participant A2AClient as BabylonA2AClient
    participant Executor as BabylonAgentExecutor
    participant DB as Database

    Note over Client,DB: BEFORE: All providers executed (16 A2A calls)
    
    Client->>API: POST /api/agents/[agentId]/chat
    API->>Runtime: composeState(message, ['ACTIONS'])
    Runtime->>A2AClient: Execute ALL 16 providers
    A2AClient->>API: HTTP A2A call (self-call)
    Note over API,A2AClient: ❌ 503 Error on Vercel serverless

    Note over Client,DB: AFTER: Strict filtering + direct executor
    
    Client->>API: POST /api/agents/[agentId]/chat
    API->>Runtime: composeState(message, ['ACTIONS'], true)
    Note over Runtime: Strict filtering: ONLY 'ACTIONS' provider runs
    
    alt Server-side (Vercel)
        Runtime->>A2AClient: executeViaA2A() detects server-side
        A2AClient->>Executor: BabylonAgentExecutor.executeDirectly()
        Note over Executor: Bypass HTTP, call executeOperation()
        Executor->>DB: Direct database query
        DB-->>Executor: Data
        Executor-->>A2AClient: Result
        A2AClient-->>Runtime: Result
    else Client-side
        Runtime->>A2AClient: executeViaA2A() detects client-side
        A2AClient->>API: HTTP A2A call via SDK
        API->>Executor: Process via A2A protocol
        Executor->>DB: Database query
        DB-->>Executor: Data
        Executor-->>API: Result
        API-->>A2AClient: Result
        A2AClient-->>Runtime: Result
    end
    
    Runtime-->>API: State with action results
    API-->>Client: 200 OK
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->