### PR TITLE
feat: enforce rate limiting for external agent APIs

### DIFF
--- a/apps/web/src/app/api/agents/external/discover/route.ts
+++ b/apps/web/src/app/api/agents/external/discover/route.ts
@@ -9,8 +9,10 @@
  * @see src/lib/services/agent-registry.service.ts
  */
 
-import type { TrustLevel } from '@babylon/agents';
+import type { AgentRegistration, TrustLevel } from '@babylon/agents';
 import { AgentStatus, AgentType, agentRegistry } from '@babylon/agents';
+import { checkRateLimitAsync, RATE_LIMIT_CONFIGS } from '@babylon/api';
+import { logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
@@ -42,18 +44,20 @@ const DiscoveryQuerySchema = z.object({
 
 /**
  * Authenticate the request using API key from Authorization header
+ * Returns the agent registration if authenticated, null otherwise
  */
-async function authenticateRequest(req: NextRequest): Promise<boolean> {
+async function authenticateRequest(
+  req: NextRequest
+): Promise<AgentRegistration | null> {
   const authHeader = req.headers.get('Authorization');
 
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    return false;
+    return null;
   }
 
   const apiKey = authHeader.substring(7); // Remove 'Bearer ' prefix
 
-  const agent = await agentRegistry.verifyExternalAgentApiKey(apiKey);
-  return !!agent;
+  return agentRegistry.verifyExternalAgentApiKey(apiKey);
 }
 
 /**
@@ -63,9 +67,9 @@ async function authenticateRequest(req: NextRequest): Promise<boolean> {
  */
 export async function GET(req: NextRequest) {
   // Authenticate the request
-  const isAuthenticated = await authenticateRequest(req);
+  const agent = await authenticateRequest(req);
 
-  if (!isAuthenticated) {
+  if (!agent) {
     return NextResponse.json(
       {
         success: false,
@@ -73,6 +77,47 @@ export async function GET(req: NextRequest) {
         message: 'Invalid or missing API key',
       },
       { status: 401 }
+    );
+  }
+
+  // Rate limit check - use agent's discoveryRateLimit or default to 60/min
+  const agentRateLimit = agent.discoveryMetadata?.limits?.rateLimit ?? 60;
+  const rateLimitConfig = {
+    ...RATE_LIMIT_CONFIGS.EXTERNAL_AGENT_DISCOVER,
+    maxRequests: agentRateLimit,
+  };
+
+  const rateLimitResult = await checkRateLimitAsync(
+    agent.agentId,
+    rateLimitConfig
+  );
+
+  if (!rateLimitResult.allowed) {
+    logger.warn(
+      'External agent discovery rate limit exceeded',
+      {
+        agentId: agent.agentId,
+        retryAfter: rateLimitResult.retryAfter,
+        limit: agentRateLimit,
+      },
+      'ExternalAgentDiscovery'
+    );
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Too Many Requests',
+        message: 'Rate limit exceeded for discovery requests',
+        retryAfter: rateLimitResult.retryAfter,
+      },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(rateLimitResult.retryAfter ?? 60),
+          'X-RateLimit-Limit': String(agentRateLimit),
+          'X-RateLimit-Remaining': String(rateLimitResult.remaining ?? 0),
+        },
+      }
     );
   }
 
@@ -171,9 +216,9 @@ export async function GET(req: NextRequest) {
  */
 export async function POST(req: NextRequest) {
   // Authenticate the request
-  const isAuthenticated = await authenticateRequest(req);
+  const agent = await authenticateRequest(req);
 
-  if (!isAuthenticated) {
+  if (!agent) {
     return NextResponse.json(
       {
         success: false,
@@ -181,6 +226,47 @@ export async function POST(req: NextRequest) {
         message: 'Invalid or missing API key',
       },
       { status: 401 }
+    );
+  }
+
+  // Rate limit check - use agent's discoveryRateLimit or default to 60/min
+  const agentRateLimit = agent.discoveryMetadata?.limits?.rateLimit ?? 60;
+  const rateLimitConfig = {
+    ...RATE_LIMIT_CONFIGS.EXTERNAL_AGENT_DISCOVER,
+    maxRequests: agentRateLimit,
+  };
+
+  const rateLimitResult = await checkRateLimitAsync(
+    agent.agentId,
+    rateLimitConfig
+  );
+
+  if (!rateLimitResult.allowed) {
+    logger.warn(
+      'External agent discovery rate limit exceeded',
+      {
+        agentId: agent.agentId,
+        retryAfter: rateLimitResult.retryAfter,
+        limit: agentRateLimit,
+      },
+      'ExternalAgentDiscovery'
+    );
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Too Many Requests',
+        message: 'Rate limit exceeded for discovery requests',
+        retryAfter: rateLimitResult.retryAfter,
+      },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(rateLimitResult.retryAfter ?? 60),
+          'X-RateLimit-Limit': String(agentRateLimit),
+          'X-RateLimit-Remaining': String(rateLimitResult.remaining ?? 0),
+        },
+      }
     );
   }
 

--- a/apps/web/src/app/api/agents/external/discover/route.ts
+++ b/apps/web/src/app/api/agents/external/discover/route.ts
@@ -95,7 +95,9 @@ export async function GET(req: NextRequest) {
   }
 
   // Rate limit check - use agent's discoveryRateLimit or default to 60/min
-  const agentRateLimit = agent.discoveryMetadata?.limits?.rateLimit ?? 60;
+  // Clamp to valid bounds: min 1, max 1000 requests per minute
+  const rawRateLimit = agent.discoveryMetadata?.limits?.rateLimit ?? 60;
+  const agentRateLimit = Math.min(Math.max(rawRateLimit, 1), 1000);
   const rateLimitConfig = {
     ...RATE_LIMIT_CONFIGS.EXTERNAL_AGENT_DISCOVER,
     maxRequests: agentRateLimit,
@@ -256,7 +258,9 @@ export async function POST(req: NextRequest) {
   }
 
   // Rate limit check - use agent's discoveryRateLimit or default to 60/min
-  const agentRateLimit = agent.discoveryMetadata?.limits?.rateLimit ?? 60;
+  // Clamp to valid bounds: min 1, max 1000 requests per minute
+  const rawRateLimit = agent.discoveryMetadata?.limits?.rateLimit ?? 60;
+  const agentRateLimit = Math.min(Math.max(rawRateLimit, 1), 1000);
   const rateLimitConfig = {
     ...RATE_LIMIT_CONFIGS.EXTERNAL_AGENT_DISCOVER,
     maxRequests: agentRateLimit,

--- a/apps/web/src/app/api/agents/external/discover/route.ts
+++ b/apps/web/src/app/api/agents/external/discover/route.ts
@@ -42,6 +42,20 @@ const DiscoveryQuerySchema = z.object({
   offset: z.coerce.number().min(0).optional().default(0),
 });
 
+// Body validation for POST-based discovery
+const DiscoveryBodySchema = z.object({
+  types: z.array(z.nativeEnum(AgentType)).optional(),
+  statuses: z.array(z.nativeEnum(AgentStatus)).optional(),
+  minTrustLevel: z.coerce.number().min(0).max(4).optional(),
+  requiredCapabilities: z.array(z.string()).optional(),
+  requiredSkills: z.array(z.string()).optional(),
+  requiredDomains: z.array(z.string()).optional(),
+  matchMode: z.enum(['all', 'any']).optional(),
+  search: z.string().optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional().default(20),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+});
+
 /**
  * Authenticate the request using API key from Authorization header
  * Returns the agent registration if authenticated, null otherwise
@@ -134,7 +148,19 @@ export async function GET(req: NextRequest) {
     offset: searchParams.get('offset') || undefined,
   };
 
-  const validated = DiscoveryQuerySchema.parse(query);
+  const validatedResult = DiscoveryQuerySchema.safeParse(query);
+  if (!validatedResult.success) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Validation error',
+        details: validatedResult.error.issues,
+      },
+      { status: 400 }
+    );
+  }
+
+  const validated = validatedResult.data;
 
   // Build discovery filter
   const filter: DiscoveryFilter = {};
@@ -185,16 +211,16 @@ export async function GET(req: NextRequest) {
   const agents = await agentRegistry.discoverAgents(filter);
 
   // Transform agents for external API response
-  const results = agents.map((agent) => ({
-    agentId: agent.agentId,
-    name: agent.name,
-    type: agent.type,
-    status: agent.status,
-    trustLevel: agent.trustLevel,
-    capabilities: agent.capabilities,
-    discoveryMetadata: agent.discoveryMetadata,
-    endpoints: agent.discoveryMetadata?.endpoints,
-    lastActiveAt: agent.lastActiveAt,
+  const results = agents.map((discoveredAgent) => ({
+    agentId: discoveredAgent.agentId,
+    name: discoveredAgent.name,
+    type: discoveredAgent.type,
+    status: discoveredAgent.status,
+    trustLevel: discoveredAgent.trustLevel,
+    capabilities: discoveredAgent.capabilities,
+    discoveryMetadata: discoveredAgent.discoveryMetadata,
+    endpoints: discoveredAgent.discoveryMetadata?.endpoints,
+    lastActiveAt: discoveredAgent.lastActiveAt,
   }));
 
   return NextResponse.json({
@@ -271,32 +297,58 @@ export async function POST(req: NextRequest) {
   }
 
   // Parse request body
-  const body = await req.json();
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Validation error',
+        message: 'Invalid JSON body',
+      },
+      { status: 400 }
+    );
+  }
+
+  const validatedBodyResult = DiscoveryBodySchema.safeParse(body);
+  if (!validatedBodyResult.success) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Validation error',
+        details: validatedBodyResult.error.issues,
+      },
+      { status: 400 }
+    );
+  }
+
+  const validatedBody = validatedBodyResult.data;
 
   // Discover agents using agent registry
-  const agents = await agentRegistry.discoverAgents(body);
+  const agents = await agentRegistry.discoverAgents(validatedBody);
 
   // Transform agents for external API response
-  const results = agents.map((agent) => ({
-    agentId: agent.agentId,
-    name: agent.name,
-    type: agent.type,
-    status: agent.status,
-    trustLevel: agent.trustLevel,
-    capabilities: agent.capabilities,
-    discoveryMetadata: agent.discoveryMetadata,
-    endpoints: agent.discoveryMetadata?.endpoints,
-    lastActiveAt: agent.lastActiveAt,
+  const results = agents.map((discoveredAgent) => ({
+    agentId: discoveredAgent.agentId,
+    name: discoveredAgent.name,
+    type: discoveredAgent.type,
+    status: discoveredAgent.status,
+    trustLevel: discoveredAgent.trustLevel,
+    capabilities: discoveredAgent.capabilities,
+    discoveryMetadata: discoveredAgent.discoveryMetadata,
+    endpoints: discoveredAgent.discoveryMetadata?.endpoints,
+    lastActiveAt: discoveredAgent.lastActiveAt,
   }));
 
   return NextResponse.json({
     success: true,
     agents: results,
     pagination: {
-      limit: body.limit || 20,
-      offset: body.offset || 0,
+      limit: validatedBody.limit,
+      offset: validatedBody.offset,
       total: results.length,
     },
-    filters: body,
+    filters: validatedBody,
   });
 }

--- a/apps/web/src/app/api/agents/external/register/route.ts
+++ b/apps/web/src/app/api/agents/external/register/route.ts
@@ -124,8 +124,32 @@ export async function POST(req: NextRequest) {
   }
 
   // Parse and validate request body
-  const body = await req.json();
-  const validated = ExternalAgentRegisterSchema.parse(body);
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Validation error',
+        message: 'Invalid JSON body',
+      },
+      { status: 400 }
+    );
+  }
+
+  const validatedResult = ExternalAgentRegisterSchema.safeParse(body);
+  if (!validatedResult.success) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Validation error',
+        details: validatedResult.error.issues,
+      },
+      { status: 400 }
+    );
+  }
+  const validated = validatedResult.data;
 
   // Generate API key for this external agent
   const apiKey = generateApiKey();

--- a/apps/web/src/app/api/agents/external/register/route.ts
+++ b/apps/web/src/app/api/agents/external/register/route.ts
@@ -11,7 +11,14 @@
 
 import type { ExternalAgentConnectionParams } from '@babylon/agents';
 import { agentRegistry } from '@babylon/agents';
-import { authenticate, generateApiKey, hashApiKey } from '@babylon/api';
+import {
+  authenticate,
+  checkRateLimitAsync,
+  generateApiKey,
+  hashApiKey,
+  RATE_LIMIT_CONFIGS,
+} from '@babylon/api';
+import { logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
@@ -79,6 +86,42 @@ const ExternalAgentRegisterSchema = z.object({
 export async function POST(req: NextRequest) {
   // Authenticate the request (requires valid Privy session)
   const authUser = await authenticate(req);
+
+  // Rate limit check - 5 registrations per hour per user
+  const rateLimitResult = await checkRateLimitAsync(
+    authUser.userId,
+    RATE_LIMIT_CONFIGS.EXTERNAL_AGENT_REGISTER
+  );
+
+  if (!rateLimitResult.allowed) {
+    logger.warn(
+      'External agent registration rate limit exceeded',
+      {
+        userId: authUser.userId,
+        retryAfter: rateLimitResult.retryAfter,
+      },
+      'ExternalAgentRegister'
+    );
+
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Too Many Requests',
+        message: 'Rate limit exceeded for agent registration',
+        retryAfter: rateLimitResult.retryAfter,
+      },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(rateLimitResult.retryAfter ?? 3600),
+          'X-RateLimit-Limit': String(
+            RATE_LIMIT_CONFIGS.EXTERNAL_AGENT_REGISTER.maxRequests
+          ),
+          'X-RateLimit-Remaining': String(rateLimitResult.remaining ?? 0),
+        },
+      }
+    );
+  }
 
   // Parse and validate request body
   const body = await req.json();

--- a/packages/a2a/src/executors/babylon-executor.ts
+++ b/packages/a2a/src/executors/babylon-executor.ts
@@ -626,7 +626,9 @@ export class BabylonAgentExecutor implements AgentExecutor {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       if (
-        message.includes('getRawDrizzle() is only available in PostgreSQL mode') ||
+        message.includes(
+          'getRawDrizzle() is only available in PostgreSQL mode'
+        ) ||
         message.includes('Database not initialized')
       ) {
         logger.debug('Perpetual markets unavailable, returning empty', {

--- a/packages/api/src/rate-limiting/user-rate-limiter.ts
+++ b/packages/api/src/rate-limiting/user-rate-limiter.ts
@@ -161,6 +161,18 @@ export const RATE_LIMIT_CONFIGS = {
     actionType: 'public_nft_image_anonymous',
   }, // 10 fetches per minute for anonymous bucket
 
+  // External agent endpoints
+  EXTERNAL_AGENT_DISCOVER: {
+    maxRequests: 60,
+    windowMs: 60000,
+    actionType: 'external_agent_discover',
+  }, // 60 discovery requests per minute (default, can be overridden by agent's discoveryRateLimit)
+  EXTERNAL_AGENT_REGISTER: {
+    maxRequests: 5,
+    windowMs: 3600000,
+    actionType: 'external_agent_register',
+  }, // 5 registrations per hour per user
+
   // Default fallback
   DEFAULT: { maxRequests: 30, windowMs: 60000, actionType: 'default' }, // 30 requests per minute
 } as const;

--- a/packages/engine/src/utils/context-builder.ts
+++ b/packages/engine/src/utils/context-builder.ts
@@ -222,7 +222,9 @@ export async function buildComprehensiveNPCContext(
 
   const relationships = simulationMode
     ? []
-    : shuffleArray(await RelationshipEvolutionEngine.getActorRelationships(actor.id))
+    : shuffleArray(
+        await RelationshipEvolutionEngine.getActorRelationships(actor.id)
+      )
         .slice(0, 10)
         .map((rel) => {
           const isActor1 = rel.actor1Id === actor.id;


### PR DESCRIPTION
## Summary
- Add rate limiting to external agent discovery and registration endpoints
- Enforce agent's `discoveryRateLimit` field (stored but previously unused)
- Return 429 with proper headers when rate limit exceeded

## Changes
- `packages/api/src/rate-limiting/user-rate-limiter.ts`: Added `EXTERNAL_AGENT_DISCOVER` (60/min) and `EXTERNAL_AGENT_REGISTER` (5/hour) configs
- `apps/web/src/app/api/agents/external/discover/route.ts`: Added rate limiting after auth, uses agent's `discoveryRateLimit`
- `apps/web/src/app/api/agents/external/register/route.ts`: Added rate limiting (5 registrations/hour per user)

## Test plan
- [ ] Register external agent, verify rate limit headers in response
- [ ] Make >5 registration attempts in 1 hour, verify 429 response
- [ ] Make >60 discovery requests in 1 min, verify 429 response
- [ ] Verify `Retry-After` header is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rate limiting enforced for external agent discovery (60 req/min) and registration (5 req/hr); exceeding limits returns 429 with Retry-After and rate-limit headers.

* **Improvements**
  * Request body and query validation for discovery and registration endpoints; invalid requests return 400 with validation details.
  * Authentication handling tightened: missing/invalid credentials yield unauthorized responses.
  * Enhanced logging for rate-limit and authorization events.

* **Style**
  * Minor formatting cleanups with no behavior changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added rate limiting enforcement to external agent discovery and registration API endpoints. The implementation uses Redis-backed sliding window rate limiting with proper 429 responses and `Retry-After` headers.

Key changes:
- Added `EXTERNAL_AGENT_DISCOVER` (60 requests/min, customizable per agent) and `EXTERNAL_AGENT_REGISTER` (5 requests/hour per user) rate limit configs
- Implemented rate limiting in both GET and POST discovery endpoints after authentication, respecting agent's custom `discoveryRateLimit` field
- Added rate limiting to registration endpoint (5/hour per user) after authentication
- All rate-limited endpoints return proper 429 responses with `Retry-After`, `X-RateLimit-Limit`, and `X-RateLimit-Remaining` headers

The implementation correctly stores and retrieves agent-specific rate limits from the database via `discoveryMetadata.limits.rateLimit`.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk - implements standard rate limiting using existing infrastructure
- Implementation correctly uses existing Redis-backed rate limiting infrastructure with proper error responses and headers. Minor improvement possible by adding rate limit headers to successful responses for better client visibility
- No files require special attention - all changes follow established patterns

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/api/src/rate-limiting/user-rate-limiter.ts | Added two new rate limit configurations for external agent endpoints (60/min for discovery with agent override support, 5/hour for registration) |
| apps/web/src/app/api/agents/external/discover/route.ts | Added rate limiting to both GET and POST discover endpoints after auth, uses agent's custom rate limit from discoveryMetadata, returns proper 429 with headers |
| apps/web/src/app/api/agents/external/register/route.ts | Added rate limiting to registration endpoint after auth (5/hour per user), returns 429 with proper headers when exceeded |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API
    participant RateLimiter
    participant Redis
    participant Database

    Note over Client,Database: Discovery Endpoint
    Client->>API: Request with bearer token
    API->>Database: Verify token
    Database-->>API: Return agent data
    
    API->>RateLimiter: Check rate limit
    RateLimiter->>Redis: Sliding window check
    Redis-->>RateLimiter: Usage status
    
    alt Rate limit exceeded
        RateLimiter-->>API: Deny request
        API-->>Client: 429 Too Many Requests
    else Within limits
        RateLimiter-->>API: Allow request
        API->>Database: Query agents
        Database-->>API: Agent results
        API-->>Client: 200 Success
    end

    Note over Client,Database: Registration Endpoint
    Client->>API: Submit registration
    API->>RateLimiter: Check limit (5 per hour)
    RateLimiter->>Redis: Query usage
    Redis-->>RateLimiter: Usage count
    
    alt Rate limit exceeded
        API-->>Client: 429 with retry header
    else Within limits
        API->>Database: Create registration
        Database-->>API: Success
        API-->>Client: 201 Created
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->