### PR TITLE
feat(agents): reduce hold bias and increase trading action diversity

### DIFF
--- a/packages/agents/src/autonomous/templates/multi-step-decision.ts
+++ b/packages/agents/src/autonomous/templates/multi-step-decision.ts
@@ -150,13 +150,13 @@ export type ShareBehavior = 'public_only' | 'group_only' | 'both' | 'quiet';
  * Determine share behavior based on a random roll.
  * Pure function for testability - call Math.random() only at the edge.
  *
- * Probability distribution (non-overlapping ranges) - HEAVILY BIASED AGAINST POSTING:
- * - 10% (0.00 - 0.10): public_only - Share publicly via POST (rare!)
- * - 5% (0.10 - 0.15): both - Share both publicly AND in group chat (very rare!)
- * - 25% (0.15 - 0.40): group_only - Share in group chat only
- * - 60% (0.40 - 1.00): quiet - Stay quiet, no sharing (most common!)
+ * Probability distribution (non-overlapping ranges) - MORE BALANCED FOR ACTION DIVERSITY:
+ * - 25% (0.00 - 0.25): public_only - Share publicly via POST
+ * - 10% (0.25 - 0.35): both - Share both publicly AND in group chat
+ * - 25% (0.35 - 0.60): group_only - Share in group chat only
+ * - 40% (0.60 - 1.00): quiet - Stay quiet, no sharing
  *
- * Player agents should focus on TRADING, ENGAGING, and COMMENTING - not posting.
+ * This balanced distribution encourages more varied post-trade behavior.
  *
  * @param roll - Random value between 0 and 1 (clamped if out of range)
  * @returns ShareBehavior indicating how to share the trade
@@ -165,10 +165,10 @@ export function determineShareBehavior(roll: number): ShareBehavior {
   // Defensively clamp roll to [0, 1] range
   const clampedRoll = Math.max(0, Math.min(1, roll));
 
-  if (clampedRoll < 0.1) return 'public_only'; // 10% - rare
-  if (clampedRoll < 0.15) return 'both'; // 5% - very rare
-  if (clampedRoll < 0.4) return 'group_only'; // 25%
-  return 'quiet'; // 60% - most common
+  if (clampedRoll < 0.25) return 'public_only'; // 25%
+  if (clampedRoll < 0.35) return 'both'; // 10%
+  if (clampedRoll < 0.6) return 'group_only'; // 25%
+  return 'quiet'; // 40%
 }
 
 // =============================================================================
@@ -328,17 +328,24 @@ ${
       : '';
 
   // Action priority guidance for player-created agents
-  // STRONGLY discourages posting - agents should focus on game mechanics
+  // Emphasizes TRADING as the primary activity - agents exist to trade!
   const priorityActions: string[] = [];
 
   // Always start with RESPOND
   priorityActions.push('RESPOND to pending interactions first (if any)');
 
   // TRADING is THE HIGHEST PRIORITY - this is why agents exist
-  if (canTrade && !justTraded) {
-    priorityActions.push(
-      '🔥 TRADE on prediction or perp markets - THIS IS YOUR #1 JOB!'
-    );
+  // Even if you just traded, consider trading AGAIN on different markets
+  if (canTrade) {
+    if (!justTraded) {
+      priorityActions.push(
+        '🔥🔥🔥 TRADE NOW - You have NOT traded this tick! Trading is your PRIMARY purpose!'
+      );
+    } else {
+      priorityActions.push(
+        '🔥 TRADE AGAIN - Consider another position on a DIFFERENT market!'
+      );
+    }
   }
 
   // Engagement actions are HIGH priority


### PR DESCRIPTION
## Summary
- Rebalances share behavior probabilities to reduce "quiet" bias
- Emphasizes trading as primary agent activity

## Problem
Agents heavily biased toward "hold" action (60% quiet after trades). Limits market activity.

## Changes
- `packages/agents/src/autonomous/templates/multi-step-decision.ts`:
  - `determineShareBehavior()`: quiet 60%→40%, public_only 10%→25%, both 5%→10%
  - Trading priority now encourages trading even after first trade per tick

## Test plan
- [ ] Observe agents sharing trades publicly more often
- [ ] Verify agents attempt multiple trades per tick on different markets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Rebalanced autonomous agent behavior to prioritize trading activities and reduce posting emphasis
  * Updated decision-making logic to encourage more diversified trading patterns across different markets
  * Modified action prioritization to emphasize trading as the primary activity while maintaining existing constraints on other interactions

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR rebalances agent trading behavior probabilities in `determineShareBehavior()` to reduce excessive quietness and increase market engagement. The changes shift from a heavily conservative distribution (60% quiet, 10% public posts) to a more balanced approach (40% quiet, 25% public posts) that encourages agents to share their trades more frequently.

Key changes:
- **Share behavior probabilities adjusted**: `public_only` increased from 10% to 25%, `both` doubled from 5% to 10%, `quiet` reduced from 60% to 40%
- **Multiple trades per tick now encouraged**: Modified priority guidance to suggest trading again on different markets even after completing a trade
- **Comment updates**: Documentation now describes distribution as "MORE BALANCED FOR ACTION DIVERSITY" instead of "HEAVILY BIASED AGAINST POSTING"

The mathematical implementation in `determineShareBehavior()` is correct with non-overlapping probability ranges. The changes align with the stated goal of reducing hold bias and increasing visible market activity without introducing logical errors.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are well-isolated to probability distributions and text guidance, with correct mathematical implementation. The function remains a pure, deterministic function with proper clamping, and the probability ranges are non-overlapping and sum to 100%. No breaking changes to function signatures or behavior patterns.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agents/src/autonomous/templates/multi-step-decision.ts | Rebalanced share behavior probabilities (quiet: 60%→40%, public_only: 10%→25%, both: 5%→10%) and encouraged multiple trades per tick to increase agent market activity |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent
    participant MultiStepDecision
    participant ShareBehavior
    participant Market

    Agent->>MultiStepDecision: Execute tick with context
    
    alt Trading enabled & no trade yet
        MultiStepDecision->>Agent: 🔥🔥🔥 TRADE NOW (PRIMARY purpose!)
        Agent->>Market: Execute trade
        Market-->>Agent: Trade successful
    else Already traded this tick
        MultiStepDecision->>Agent: 🔥 TRADE AGAIN (different market)
        Agent->>Market: Execute another trade
        Market-->>Agent: Trade successful
    end
    
    MultiStepDecision->>ShareBehavior: determineShareBehavior(random())
    
    alt 25% - public_only (was 10%)
        ShareBehavior-->>MultiStepDecision: Share publicly via POST
        MultiStepDecision->>Agent: Encourage public post about trade
        Agent->>Market: Create public post
    else 10% - both (was 5%)
        ShareBehavior-->>MultiStepDecision: Share publicly AND in group
        MultiStepDecision->>Agent: Encourage public post + group message
        Agent->>Market: Create post + group message
    else 25% - group_only
        ShareBehavior-->>MultiStepDecision: Share in group only
        MultiStepDecision->>Agent: Encourage group chat message
        Agent->>Market: Send group message
    else 40% - quiet (was 60%)
        ShareBehavior-->>MultiStepDecision: Stay quiet
        MultiStepDecision->>Agent: No sharing needed, consider other actions
    end
    
    Agent->>MultiStepDecision: Continue or FINISH
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->