### PR TITLE
fix(engine): add simulation mode guards to RelationshipEvolutionEngine

### DIFF
--- a/packages/engine/src/RelationshipEvolutionEngine.ts
+++ b/packages/engine/src/RelationshipEvolutionEngine.ts
@@ -24,6 +24,7 @@ import {
 import { generateSnowflakeId, logger } from '@babylon/shared';
 import type { BabylonLLMClient } from './llm/openai-client';
 import { StaticDataRegistry } from './services/static-data-registry';
+import { isSimulationMode } from './storage-bridge';
 import type { Actor, ActorRelationship, Organization } from './types/shared';
 
 export interface RelationshipChange {
@@ -57,6 +58,16 @@ export class RelationshipEvolutionEngine {
     actors: Actor[],
     organizations: Organization[]
   ): Promise<number> {
+    // In simulation mode, relationships are not persisted to DB
+    if (isSimulationMode()) {
+      logger.debug(
+        'Skipping initial relationships in simulation mode',
+        undefined,
+        'RelationshipEvolutionEngine'
+      );
+      return 0;
+    }
+
     logger.info(
       'Generating initial NPC relationships...',
       undefined,
@@ -262,6 +273,11 @@ Return JSON: { "description": "...", "type": "...", "sentiment": 0.0 }`;
   async trackInteraction(
     interaction: Omit<Interaction, 'timestamp'>
   ): Promise<void> {
+    // In simulation mode, interactions are not persisted to DB
+    if (isSimulationMode()) {
+      return;
+    }
+
     // Sort IDs to ensure consistency
     const sorted = [interaction.actor1Id, interaction.actor2Id].sort();
     const id1 = sorted[0]!;
@@ -283,6 +299,11 @@ Return JSON: { "description": "...", "type": "...", "sentiment": 0.0 }`;
    * This is the KEY method - uses LLM to generate natural text descriptions
    */
   async analyzeAndUpdateRelationships(): Promise<number> {
+    // In simulation mode, relationships are not persisted to DB
+    if (isSimulationMode()) {
+      return 0;
+    }
+
     if (!this.llm) {
       logger.warn(
         'No LLM client available, skipping relationship analysis',
@@ -510,6 +531,11 @@ Return JSON: { "description": "...", "type": "...", "sentiment": 0.0 }`;
    * Just the text descriptions, nothing else
    */
   async getRelationshipContextForActor(actorId: string): Promise<string> {
+    // In simulation mode, relationships are not persisted to DB
+    if (isSimulationMode()) {
+      return '';
+    }
+
     // Get relationships for this actor
     const relationships = await db
       .select()
@@ -563,6 +589,11 @@ Return JSON: { "description": "...", "type": "...", "sentiment": 0.0 }`;
   static async getActorRelationships(
     actorId: string
   ): Promise<ActorRelationship[]> {
+    // In simulation mode, relationships are not persisted to DB
+    if (isSimulationMode()) {
+      return [];
+    }
+
     const relationships = await db
       .select()
       .from(actorRelationships)
@@ -596,6 +627,11 @@ Return JSON: { "description": "...", "type": "...", "sentiment": 0.0 }`;
     actor1Id: string,
     actor2Id: string
   ): Promise<ActorRelationship | null> {
+    // In simulation mode, relationships are not persisted to DB
+    if (isSimulationMode()) {
+      return null;
+    }
+
     const [relationship] = await db
       .select()
       .from(actorRelationships)

--- a/packages/engine/src/__tests__/relationship-evolution-simulation.test.ts
+++ b/packages/engine/src/__tests__/relationship-evolution-simulation.test.ts
@@ -1,0 +1,177 @@
+/**
+ * RelationshipEvolutionEngine Simulation Mode Tests
+ *
+ * Tests that RelationshipEvolutionEngine methods correctly return early
+ * in simulation mode to avoid raw Drizzle DB calls that would fail in JSON mode.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// Mock the simulation mode check BEFORE importing the engine
+const mockIsSimulationMode = mock(() => true);
+mock.module('../storage-bridge', () => ({
+  isSimulationMode: mockIsSimulationMode,
+}));
+
+// Mock DB to verify no calls are made
+const mockDbSelect = mock(() => ({
+  from: mock(() => ({
+    where: mock(() => ({
+      orderBy: mock(() => ({
+        limit: mock(() => Promise.resolve([])),
+      })),
+      limit: mock(() => Promise.resolve([])),
+    })),
+  })),
+}));
+
+const mockDbInsert = mock(() => ({
+  values: mock(() => Promise.resolve()),
+}));
+
+const mockDbUpdate = mock(() => ({
+  set: mock(() => ({
+    where: mock(() => Promise.resolve()),
+  })),
+}));
+
+mock.module('@babylon/db', () => ({
+  db: {
+    select: mockDbSelect,
+    insert: mockDbInsert,
+    update: mockDbUpdate,
+  },
+  actorRelationships: {},
+  npcInteractions: {},
+  and: () => {},
+  or: () => {},
+  eq: () => {},
+  gte: () => {},
+  desc: () => {},
+}));
+
+mock.module('@babylon/shared', () => ({
+  generateSnowflakeId: mock(() => Promise.resolve('test-id-123')),
+  logger: {
+    info: mock(() => {}),
+    warn: mock(() => {}),
+    debug: mock(() => {}),
+    error: mock(() => {}),
+  },
+}));
+
+// Now import the engine
+import { RelationshipEvolutionEngine } from '../RelationshipEvolutionEngine';
+
+describe('RelationshipEvolutionEngine - Simulation Mode', () => {
+  beforeEach(() => {
+    // Reset mocks before each test
+    mockDbSelect.mockClear();
+    mockDbInsert.mockClear();
+    mockDbUpdate.mockClear();
+    mockIsSimulationMode.mockImplementation(() => true);
+  });
+
+  describe('generateInitialRelationships', () => {
+    test('returns 0 in simulation mode without DB calls', async () => {
+      const engine = new RelationshipEvolutionEngine();
+      const result = await engine.generateInitialRelationships([], []);
+
+      expect(result).toBe(0);
+      expect(mockDbSelect).not.toHaveBeenCalled();
+      expect(mockDbInsert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('trackInteraction', () => {
+    test('returns early in simulation mode without DB calls', async () => {
+      const engine = new RelationshipEvolutionEngine();
+      await engine.trackInteraction({
+        actor1Id: 'actor1',
+        actor2Id: 'actor2',
+        type: 'mention',
+        sentiment: 0.5,
+        context: 'test interaction',
+      });
+
+      expect(mockDbInsert).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('analyzeAndUpdateRelationships', () => {
+    test('returns 0 in simulation mode without DB calls', async () => {
+      const engine = new RelationshipEvolutionEngine();
+      const result = await engine.analyzeAndUpdateRelationships();
+
+      expect(result).toBe(0);
+      expect(mockDbSelect).not.toHaveBeenCalled();
+      expect(mockDbUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getRelationshipContextForActor', () => {
+    test('returns empty string in simulation mode without DB calls', async () => {
+      const engine = new RelationshipEvolutionEngine();
+      const result = await engine.getRelationshipContextForActor('actor1');
+
+      expect(result).toBe('');
+      expect(mockDbSelect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getActorRelationships (static)', () => {
+    test('returns empty array in simulation mode without DB calls', async () => {
+      const result =
+        await RelationshipEvolutionEngine.getActorRelationships('actor1');
+
+      expect(result).toEqual([]);
+      expect(mockDbSelect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getRelationship (static)', () => {
+    test('returns null in simulation mode without DB calls', async () => {
+      const result = await RelationshipEvolutionEngine.getRelationship(
+        'actor1',
+        'actor2'
+      );
+
+      expect(result).toBeNull();
+      expect(mockDbSelect).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('RelationshipEvolutionEngine - Non-Simulation Mode', () => {
+  beforeEach(() => {
+    // Reset mocks before each test
+    mockDbSelect.mockClear();
+    mockDbInsert.mockClear();
+    mockDbUpdate.mockClear();
+    mockIsSimulationMode.mockImplementation(() => false);
+  });
+
+  describe('getActorRelationships (static)', () => {
+    test('calls DB in non-simulation mode', async () => {
+      // This will throw because our mock doesn't return a proper array,
+      // but the important thing is that the DB SELECT was called
+      try {
+        await RelationshipEvolutionEngine.getActorRelationships('actor1');
+      } catch {
+        // Expected - mock doesn't return proper array
+      }
+
+      // DB should be called when not in simulation mode
+      expect(mockDbSelect).toHaveBeenCalled();
+    });
+  });
+
+  describe('getRelationship (static)', () => {
+    test('calls DB in non-simulation mode', async () => {
+      await RelationshipEvolutionEngine.getRelationship('actor1', 'actor2');
+
+      // DB should be called when not in simulation mode
+      expect(mockDbSelect).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `isSimulationMode()` guards to `RelationshipEvolutionEngine` to prevent raw Drizzle DB calls in JSON mode
- Fixes crash when running `generate-training-data.ts` for extended periods (24+ hours)
- Enables RL training data pipeline to run end-to-end without database dependency

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- PR review feedback: "RelationshipEvolutionEngine.analyzeAndUpdateRelationships() uses db.select()/db.insert(), which will throw in JSON/memory mode"
- Error: `This method is not supported in JSON mode. Use table repositories instead.`

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- `packages/engine/src/RelationshipEvolutionEngine.ts`: Added `isSimulationMode()` guards to 6 methods:
  - `generateInitialRelationships()` → returns `0`
  - `trackInteraction()` → returns early
  - `analyzeAndUpdateRelationships()` → returns `0`
  - `getRelationshipContextForActor()` → returns `''`
  - `getActorRelationships()` (static) → returns `[]`
  - `getRelationship()` (static) → returns `null`
- `packages/engine/src/__tests__/relationship-evolution-simulation.test.ts`: Added 8 unit tests

## Review guide

**Start here**
- `packages/engine/src/RelationshipEvolutionEngine.ts` - 6 simple early-return guards

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- Pattern matches existing guards in `MarketContextService` and `context-builder.ts`
- `analyzeAndUpdateRelationships()` is called at hour 23 in `GameLoop.tick()`

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Run `bun run packages/engine/examples/generate-training-data.ts --hours 24`
2. Verify no JSON mode errors at hour 23

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: N/A
- Changed: N/A
- Removed: N/A

**DB / data migration**
- Migration(s): N/A
- Backfill/seed: N/A

**Rollout / rollback plan**
- Rollout: Standard deploy
- Rollback: Revert commit

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- N/A

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- N/A

### Database
- N/A

### Contracts / on-chain
- N/A

### Docs
- N/A

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend-only fix for simulation mode guards. No UI impact.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added extensive test coverage validating simulation mode behavior for all relationship engine operations, including both simulation and standard operation modes.

* **Chores**
  * Enhanced the relationship engine with simulation mode support, allowing operations to execute without database persistence during testing scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Adds `isSimulationMode()` guards to `RelationshipEvolutionEngine` to prevent raw Drizzle DB calls when running in JSON/memory mode, fixing a crash that occurred when running the training data generation script for extended periods (24+ hours).

- Guards added to 6 methods: `generateInitialRelationships()`, `trackInteraction()`, `analyzeAndUpdateRelationships()`, `getRelationshipContextForActor()`, `getActorRelationships()`, and `getRelationship()`
- Each guard returns an appropriate empty value (`0`, `''`, `[]`, or `null`) when in simulation mode
- Pattern matches existing guards in `MarketContextService`, `MarketDecisionEngine`, and other engine components
- 8 unit tests added to verify the guards work correctly and DB is called in non-simulation mode

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge - it adds early-return guards that have no impact on production (postgres) mode behavior.
- Score reflects the simplicity of the changes (early-return guards with well-defined return values), comprehensive test coverage (8 tests), and the pattern being well-established across the codebase.
- No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/engine/src/RelationshipEvolutionEngine.ts | Added isSimulationMode() guards to 6 methods to prevent raw Drizzle DB calls in JSON/memory mode. Returns appropriate empty values (0, '', [], null) when in simulation mode. Pattern matches existing guards in other engine files. |
| packages/engine/src/__tests__/relationship-evolution-simulation.test.ts | New test file with 8 unit tests validating simulation mode guards work correctly and that DB is still called in non-simulation mode. Tests use proper bun:test mocking patterns. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GL as GameLoop
    participant REE as RelationshipEvolutionEngine
    participant SB as storage-bridge
    participant DB as Database

    GL->>REE: analyzeAndUpdateRelationships()
    REE->>SB: isSimulationMode()
    
    alt Simulation Mode (JSON/Memory)
        SB-->>REE: true
        REE-->>GL: return 0 (skip DB calls)
    else Production Mode (Postgres)
        SB-->>REE: false
        REE->>DB: db.select() / db.update() / db.insert()
        DB-->>REE: relationships data
        REE-->>GL: return updated count
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->