### PR TITLE
fix(db): use absolute paths in drizzle config for CI compatibility

### DIFF
--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -1,4 +1,8 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'drizzle-kit';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Determine if we're in local development mode
 const isLocalDev =
@@ -18,9 +22,8 @@ const databaseUrl = isLocalDev
     LOCAL_DATABASE_URL);
 
 export default defineConfig({
-  // Use relative paths (drizzle-kit has issues with absolute paths)
-  schema: './src/schema/index.ts',
-  out: './drizzle/migrations',
+  schema: path.join(__dirname, 'src/schema/index.ts'),
+  out: path.join(__dirname, 'drizzle/migrations'),
   dialect: 'postgresql',
   dbCredentials: {
     url: databaseUrl,


### PR DESCRIPTION
## Summary
- Fixed drizzle-kit path resolution error in CI by using absolute paths computed from `import.meta.url`
- drizzle-kit resolves paths relative to CWD, not config file location, causing CI failures when running from repo root

## Test plan
- [x] Verified `bunx drizzle-kit push --config=packages/db/drizzle.config.ts` from repo root reads config correctly
- [x] Verified `bun run db:push` from `packages/db/` reads config correctly
- [x] Typecheck passes
- [x] Lint passes

Fixes: https://github.com/BabylonSocial/babylon/actions/runs/21022201150

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal path configuration handling to improve system compatibility and stability across different environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed drizzle-kit configuration to use absolute paths instead of relative paths, resolving CI failures when running from repository root.

- Converted `schema` and `out` paths from relative to absolute using `import.meta.url` and `path.join()`
- Added necessary imports (`node:path` and `node:url`)
- Ensures drizzle-kit correctly locates schema and migration files regardless of CWD

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is a straightforward fix using standard Node.js path resolution patterns. The implementation correctly converts relative paths to absolute paths using `import.meta.url`, which is the proper approach for ESM modules. Both target directories exist and the fix addresses a real CI failure without introducing new dependencies or breaking changes.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/db/drizzle.config.ts | Converted relative paths to absolute paths using `import.meta.url` to fix CI path resolution |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CI as CI Environment
    participant Drizzle as drizzle-kit
    participant Config as drizzle.config.ts
    participant FS as File System

    CI->>Drizzle: bunx drizzle-kit push --config=packages/db/drizzle.config.ts
    Note over CI,Drizzle: CWD: /repo/root
    Drizzle->>Config: Load config from packages/db/drizzle.config.ts
    Config->>Config: Compute __dirname from import.meta.url
    Note over Config: __dirname = /repo/root/packages/db
    Config->>Config: Build absolute paths
    Note over Config: schema = /repo/root/packages/db/src/schema/index.ts<br/>out = /repo/root/packages/db/drizzle/migrations
    Config-->>Drizzle: Return config with absolute paths
    Drizzle->>FS: Access schema at absolute path
    FS-->>Drizzle: Schema loaded successfully
    Drizzle->>FS: Write migrations to absolute path
    FS-->>Drizzle: Migrations written successfully
    Drizzle-->>CI: Success
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->