### PR TITLE
fix(engine): guard against undefined content in FeedGenerator.postProcessContent

### DIFF
--- a/packages/engine/src/FeedGenerator.ts
+++ b/packages/engine/src/FeedGenerator.ts
@@ -153,6 +153,16 @@ export class FeedGenerator extends EventEmitter {
 
   /** Strips hashtags/emojis, normalizes whitespace, replaces real names with parody names. */
   private async postProcessContent(content: string): Promise<string> {
+    // Guard against undefined/null content from malformed LLM responses
+    if (!content || typeof content !== 'string') {
+      logger.warn(
+        'postProcessContent received invalid content, returning fallback',
+        { contentType: typeof content, content },
+        'FeedGenerator'
+      );
+      return 'No comment.';
+    }
+
     let processed = content;
 
     // 1. Strip hashtags (LLMs love to add them despite instructions)
@@ -2605,11 +2615,21 @@ ${voiceContext}
       return 'Interesting point.'; // Fallback
     }
 
-    // Handle XML structure
+    // Handle XML structure - response may be wrapped in 'response' key or be direct
     const response =
       'response' in rawResponse && rawResponse.response
         ? rawResponse.response
-        : (rawResponse as { post: string });
+        : (rawResponse as { post?: string });
+
+    // Guard against missing 'post' field in response
+    if (!response.post) {
+      logger.warn(
+        'LLM response missing post field',
+        { response },
+        'FeedGenerator'
+      );
+      return 'Interesting point.';
+    }
 
     return await this.postProcessContent(response.post);
   }


### PR DESCRIPTION
## Summary

- **Fixed crash in long-running simulator** caused by LLM responses missing the `post` field, resulting in `undefined.match()` error in `postProcessContent`
- Added defensive guards at both the method level and call site to return safe fallbacks instead of crashing
- Protects all 19 call sites of `postProcessContent` throughout the FeedGenerator

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Discovered during 24-hour training data generation run
- Error: `TypeError: undefined is not an object (evaluating 'processed.match')` at `FeedGenerator.ts:159`

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- `packages/engine/src/FeedGenerator.ts`:
  - Added null/undefined guard at start of `postProcessContent()` method
  - Added guard in `generateReplyContent()` to check for missing `post` field before calling `postProcessContent()`
  - Both guards log warnings and return safe fallback strings

## Review guide

**Start here**
- `packages/engine/src/FeedGenerator.ts` lines 155-167 (main guard)
- `packages/engine/src/FeedGenerator.ts` lines 2626-2634 (call site guard)

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- The guard in `postProcessContent` protects all 19 call sites throughout the file
- Fallback strings ("No comment." and "Interesting point.") are intentionally generic/safe
- Warning logs added to help diagnose when LLM returns malformed responses

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Run `generate-training-data.ts` for extended period - should no longer crash on malformed LLM responses

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend-only fix in game engine. No UI components affected.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced feed generation stability with improved handling of malformed or incomplete data, ensuring consistent feed delivery.
  * Added safeguards to prevent generation errors from invalid content structures, maintaining reliable operation across all feed types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR adds defensive guards to prevent crashes when LLM responses are malformed or missing the expected `post` field. The fix addresses a production issue discovered during long-running simulation where `undefined.match()` caused crashes.

**Key changes:**
- Added guard in `postProcessContent()` (lines 156-164) to handle undefined/null/non-string content
- Added guard in `generateReplyContent()` (lines 2624-2632) to check for missing `post` field before calling `postProcessContent()`
- Both guards log warnings and return safe fallback strings

**Issues found:**
- Three other call sites remain unprotected: lines 3721, 3989, and 4067. These directly call `postProcessContent(response.post)` without checking if `response.post` exists first, which could still cause crashes if the LLM returns malformed responses.

<h3>Confidence Score: 3/5</h3>


- This PR is partially safe but has incomplete protection
- The fix correctly addresses the reported issue and adds valuable defensive guards, but leaves three unprotected call sites (lines 3721, 3989, 4067) that could still crash with the same error. The PR claims to protect "all 19 call sites" but only guards one explicitly.
- FeedGenerator.ts needs additional guards at lines 3721, 3989, and 4067 to fully resolve the issue

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/engine/src/FeedGenerator.ts | Added defensive guards for undefined LLM responses, but some call sites remain unprotected |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant LLM as LLM Service
    participant FG as FeedGenerator
    participant PPM as postProcessContent()
    participant Logger as Logger
    
    FG->>LLM: generateJSON() for reply content
    LLM-->>FG: rawResponse (may be malformed)
    
    alt rawResponse is null/undefined/invalid
        FG->>Logger: warn "LLM returned null/undefined/invalid"
        FG-->>FG: return "Interesting point."
    else response missing 'post' field
        FG->>Logger: warn "LLM response missing post field"
        FG-->>FG: return "Interesting point."
    else response.post exists
        FG->>PPM: postProcessContent(response.post)
        
        alt content is undefined/null/non-string
            PPM->>Logger: warn "postProcessContent received invalid content"
            PPM-->>FG: return "No comment."
        else content is valid string
            PPM->>PPM: Strip hashtags, emojis, normalize whitespace
            PPM->>PPM: Replace real names with parody names
            PPM-->>FG: return processed content
        end
        
        FG-->>FG: return processed content
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->