### PR TITLE
feat(training): (BAB-71) - add social narrative rewards for non-trader archetypes 

### DIFF
--- a/packages/training/README.md
+++ b/packages/training/README.md
@@ -98,6 +98,8 @@ python scripts/run_training.py --steps 100 --no-wandb
 | `train/aiJudgeReward` | Average AI Judge composite score |
 | `train/format_score` | Average format quality score |
 | `train/reasoning_score` | Average reasoning quality score |
+| `train/social_reward_mean` | Average social reward (for non-trading archetypes) |
+| `train/counterfactual_alpha_mean` | Skill signal (with causal scenarios) |
 
 ### Resume from Checkpoint
 

--- a/packages/training/book/src/appendix/glossary.md
+++ b/packages/training/book/src/appendix/glossary.md
@@ -99,6 +99,24 @@ Measures skill vs luck: `Alpha = Actual P&L - Expected P&L`
 
 Attribution of final P&L back to individual trading decisions. Decisions closer to the outcome receive more credit (exponential decay).
 
+### Social Reward
+
+PnL-independent scoring for non-trading archetypes (Social Butterfly, Ass-Kisser, etc.). Composed of:
+- **Engagement**: Volume/diversity of social actions (posts, DMs, comments)
+- **Spread**: How well content reaches others (reactions, shares)
+- **Network**: Connections built (unique users, groups, reputation)
+- **Narrative**: Alignment with ground truth events
+
+### Narrative Event
+
+A ground truth event in the simulation that agents can react to. Contains:
+- Tick when it occurred
+- Affected tickers/markets
+- Expected direction (up/down/volatile)
+- Whether publicly revealed
+
+Used to score how well agents align actions with real events.
+
 ### Rubric
 
 Detailed evaluation criteria for an archetype. Defines what makes excellent, good, average, and poor performance.

--- a/packages/training/book/src/architecture/archetype-system.md
+++ b/packages/training/book/src/architecture/archetype-system.md
@@ -257,7 +257,7 @@ Each social archetype weights these differently:
 | Ass-Kisser | 35% | 15% | **40%** | 10% |
 | Goody Two-Shoes | 25% | 20% | 30% | 25% |
 
-A Social Butterfly with 25+ unique connections and high reputation can outscore a passive trader with zero P&L.
+A Social Butterfly with 15+ unique connections and positive reputation can outscore a passive trader with zero P&L.
 
 See [Enhanced Rewards - Social & Narrative](../scoring/enhanced-rewards.md#social--narrative-rewards) for implementation details.
 

--- a/packages/training/book/src/architecture/archetype-system.md
+++ b/packages/training/book/src/architecture/archetype-system.md
@@ -238,6 +238,29 @@ def archetype_composite_reward(inputs, archetype, behavior_metrics):
     return clamp(composite, -1.0, 1.0)
 ```
 
+## Social Archetypes
+
+Some archetypes (Social Butterfly, Ass-Kisser, Goody Two-Shoes) succeed through social interaction rather than trading. These use a **social reward system** with different scoring components:
+
+| Component | Description |
+|-----------|-------------|
+| **Engagement** | Volume of posts, DMs, comments, group activity |
+| **Information Spread** | Content that gets reactions/shares |
+| **Network** | Unique connections, group memberships, reputation |
+| **Narrative Alignment** | Actions aligned with ground truth events |
+
+Each social archetype weights these differently:
+
+| Archetype | Engagement | Spread | Network | Narrative |
+|-----------|------------|--------|---------|-----------|
+| Social Butterfly | 30% | 20% | **40%** | 10% |
+| Ass-Kisser | 35% | 15% | **40%** | 10% |
+| Goody Two-Shoes | 25% | 20% | 30% | 25% |
+
+A Social Butterfly with 25+ unique connections and high reputation can outscore a passive trader with zero P&L.
+
+See [Enhanced Rewards - Social & Narrative](../scoring/enhanced-rewards.md#social--narrative-rewards) for implementation details.
+
 ## Adding a New Archetype
 
 See [Adding Archetypes](../development/adding-archetypes.md) for the step-by-step guide.
@@ -246,4 +269,5 @@ Key files to modify:
 1. `config/rubrics.json` - Add rubric and priority metrics
 2. `python/src/training/rewards.py` - Add weights and bonus function
 3. `src/archetypes/` - Add TypeScript definition
+4. (For social archetypes) Add to `SOCIAL_REWARD_WEIGHTS` in `rewards.py`
 

--- a/packages/training/book/src/development/adding-archetypes.md
+++ b/packages/training/book/src/development/adding-archetypes.md
@@ -301,6 +301,34 @@ elif archetype == "whale":
     return _calculate_whale_bonus(metrics)
 ```
 
+## Social Archetypes
+
+For archetypes where social interaction is primary (not trading), also add social reward weights:
+
+```python
+# In rewards.py - add to SOCIAL_REWARD_WEIGHTS
+"my-social-archetype": {
+    "engagement": 0.30,  # Posts, DMs, comments
+    "spread": 0.25,      # Reactions, shares
+    "network": 0.30,     # Connections, groups
+    "narrative": 0.15,   # Alignment with events
+}
+```
+
+And add composite weights:
+
+```python
+# In rewards.py - add to SOCIAL_COMPOSITE_WEIGHTS
+"my-social-archetype": {
+    "social": 0.50,      # Total social reward weight
+    "format": 0.25,
+    "reasoning": 0.15,
+    "pnl": 0.10,         # Minimal PnL weight
+}
+```
+
+See [Enhanced Rewards - Social & Narrative](../scoring/enhanced-rewards.md#social--narrative-rewards).
+
 ## Checklist
 
 - [ ] Rubric added to `config/rubrics.json`
@@ -311,4 +339,6 @@ elif archetype == "whale":
 - [ ] Bonus function registered in dispatcher
 - [ ] Unit tests pass (`make tier1`)
 - [ ] (Optional) TypeScript definition
+- [ ] (For social archetypes) `SOCIAL_REWARD_WEIGHTS` entry
+- [ ] (For social archetypes) `SOCIAL_COMPOSITE_WEIGHTS` entry
 

--- a/packages/training/book/src/operations/wandb.md
+++ b/packages/training/book/src/operations/wandb.md
@@ -91,6 +91,30 @@ python scripts/run_training.py --profile 12gb
 | `train/reasoning_score` | Reasoning quality |
 | `train/behavior_bonus` | Archetype alignment |
 
+### Social Metrics
+
+For non-trading archetypes (Social Butterfly, Information Trader, etc.):
+
+| Metric | Description |
+|--------|-------------|
+| `train/social_reward_mean` | Combined social reward |
+| `train/social_engagement_mean` | Posts, comments, DMs activity |
+| `train/social_spread_mean` | Content reach and reactions |
+| `train/social_network_mean` | Connections and reputation |
+| `train/social_narrative_mean` | Alignment with ground truth |
+
+### Enhanced Reward Metrics
+
+When training with causal scenarios (price context available):
+
+| Metric | Description |
+|--------|-------------|
+| `train/regime_bull_pct` | % of trajectories in bull market |
+| `train/regime_bear_pct` | % of trajectories in bear market |
+| `train/regime_sideways_pct` | % of trajectories in sideways market |
+| `train/counterfactual_alpha_mean` | Skill signal (actual vs expected) |
+| `train/market_volatility_mean` | Average market volatility |
+
 ### GRPO-Specific
 
 | Metric | Description |

--- a/packages/training/book/src/scoring/enhanced-rewards.md
+++ b/packages/training/book/src/scoring/enhanced-rewards.md
@@ -470,7 +470,7 @@ reward = social_only_composite_reward(
 
 ### Key Insight
 
-A Social Butterfly with no trading but 25+ unique connections, 6+ group chats, and high reputation can **outscore** a passive trader who just holds their balance. This enables training agents specialized in community building rather than trading.
+A Social Butterfly with no trading but 15+ unique connections, 5+ group chats, and positive reputation can **outscore** a passive trader who just holds their balance. This enables training agents specialized in community building rather than trading.
 
 ### W&B Metrics
 

--- a/packages/training/book/src/scoring/enhanced-rewards.md
+++ b/packages/training/book/src/scoring/enhanced-rewards.md
@@ -423,6 +423,65 @@ reward = enhanced_composite_reward(
 # reward > 0 (positive despite negative P&L due to outperformance)
 ```
 
+## Social & Narrative Rewards
+
+For non-trading archetypes like **Social Butterfly** and **Information Trader**, financial performance is not the primary success metric. The social reward system provides PnL-independent scoring based on:
+
+### Components
+
+| Component | Description | Key Metrics |
+|-----------|-------------|-------------|
+| **Engagement** | Volume and diversity of social activity | Posts, comments, DMs, group chats |
+| **Information Spread** | Content that reaches and engages others | Reactions, shares, spread count |
+| **Network** | Building connections and reputation | Unique users, follower gains, reputation |
+| **Narrative Alignment** | Actions aligned with ground truth events | Prediction accuracy, timing |
+
+### Archetype-Specific Weights
+
+Different archetypes weight these components differently:
+
+| Archetype | Engagement | Spread | Network | Narrative |
+|-----------|------------|--------|---------|-----------|
+| Social Butterfly | 30% | 20% | **40%** | 10% |
+| Information Trader | 15% | 25% | 20% | **40%** |
+| Scammer/Liar | 20% | **40%** | 25% | 15% |
+| Goody Two-Shoes | 25% | 20% | 30% | 25% |
+| Ass-Kisser | 35% | 15% | **40%** | 10% |
+
+### Usage
+
+```python
+from training.rewards import calculate_social_reward, social_only_composite_reward
+
+# Get component breakdown
+result = calculate_social_reward(metrics, "social-butterfly")
+print(result.engagement_score)      # 0.85
+print(result.network_score)         # 0.92
+print(result.total_score)           # 0.78
+
+# Use social-focused composite reward
+reward = social_only_composite_reward(
+    inputs=trajectory_inputs,
+    archetype="social-butterfly",
+    behavior_metrics=metrics,
+)
+# Social Butterfly with $0 PnL but great social metrics can score > 0.6
+```
+
+### Key Insight
+
+A Social Butterfly with no trading but 25+ unique connections, 6+ group chats, and high reputation can **outscore** a passive trader who just holds their balance. This enables training agents specialized in community building rather than trading.
+
+### W&B Metrics
+
+| Metric | Description |
+|--------|-------------|
+| `train/social_reward_mean` | Average total social reward |
+| `train/social_engagement_mean` | Average engagement score |
+| `train/social_spread_mean` | Average information spread score |
+| `train/social_network_mean` | Average network score |
+| `train/social_narrative_mean` | Average narrative alignment score |
+
 ## Next Steps
 
 - [Reward System](./reward-system.md) - Basic reward components

--- a/packages/training/book/src/scoring/reward-system.md
+++ b/packages/training/book/src/scoring/reward-system.md
@@ -270,6 +270,24 @@ logger.info(f"  Std:  {np.std(scores):.3f}")
 logger.info(f"  Components: pnl={pnl:.3f}, fmt={fmt:.3f}, rsn={rsn:.3f}")
 ```
 
+## Social Rewards
+
+For non-trading archetypes (Social Butterfly, Ass-Kisser, Goody Two-Shoes), financial performance is not the primary goal. These archetypes use **social reward scoring**:
+
+```python
+# Social archetypes weight social components heavily
+weights = {
+    "social": 0.55,    # From calculate_social_reward()
+    "format": 0.20,
+    "reasoning": 0.15,
+    "pnl": 0.10,       # Minimal PnL weight
+}
+```
+
+This allows a Social Butterfly with zero P&L but strong network building to score higher than a passive trader.
+
+See [Enhanced Rewards - Social & Narrative](./enhanced-rewards.md#social--narrative-rewards) for details.
+
 ## Enhanced Rewards
 
 For more sophisticated reward calculation that accounts for market conditions, see [Enhanced Rewards](./enhanced-rewards.md):
@@ -277,4 +295,5 @@ For more sophisticated reward calculation that accounts for market conditions, s
 - **Market Regime Detection** - Classify bull/bear/sideways conditions
 - **Counterfactual Alpha** - Measure skill vs luck
 - **Temporal Credit** - Attribute delayed outcomes to decisions
+- **Social & Narrative Rewards** - PnL-independent scoring for social archetypes
 - **Configurable Weights** - YAML-based weight profiles

--- a/packages/training/book/src/scoring/reward-system.md
+++ b/packages/training/book/src/scoring/reward-system.md
@@ -272,16 +272,15 @@ logger.info(f"  Components: pnl={pnl:.3f}, fmt={fmt:.3f}, rsn={rsn:.3f}")
 
 ## Social Rewards
 
-For non-trading archetypes (Social Butterfly, Ass-Kisser, Goody Two-Shoes), financial performance is not the primary goal. These archetypes use **social reward scoring**:
+For non-trading archetypes (Social Butterfly, Ass-Kisser, Goody Two-Shoes), financial performance is not the primary goal. These archetypes use **social reward scoring** via `SOCIAL_COMPOSITE_WEIGHTS` in `rewards.py`:
 
 ```python
-# Social archetypes weight social components heavily
-weights = {
-    "social": 0.55,    # From calculate_social_reward()
-    "format": 0.20,
-    "reasoning": 0.15,
-    "pnl": 0.10,       # Minimal PnL weight
-}
+# Social Butterfly (most social-focused)
+"social-butterfly": {"social": 0.55, "format": 0.20, "reasoning": 0.15, "pnl": 0.10}
+
+# Ass-Kisser and Goody Two-Shoes (slightly more balanced)
+"ass-kisser":       {"social": 0.50, "format": 0.25, "reasoning": 0.15, "pnl": 0.10}
+"goody-twoshoes":   {"social": 0.50, "format": 0.25, "reasoning": 0.15, "pnl": 0.10}
 ```
 
 This allows a Social Butterfly with zero P&L but strong network building to score higher than a passive trader.

--- a/packages/training/book/src/scoring/rubrics.md
+++ b/packages/training/book/src/scoring/rubrics.md
@@ -146,7 +146,7 @@ Social Butterfly uses the social reward system with:
 - Information Spread: 20%
 - Narrative Alignment: 10%
 
-A Social Butterfly can score 0.6+ with zero trading by building 25+ connections.
+A Social Butterfly can achieve excellent network scores (1.0) with 15+ unique connections.
 ```
 
 ## Priority Metrics

--- a/packages/training/book/src/scoring/rubrics.md
+++ b/packages/training/book/src/scoring/rubrics.md
@@ -137,6 +137,16 @@ HIGHER than one who made $20 with 3 conservative trades.
 ### Metrics to Deprioritize
 - Total P&L (not primary goal)
 - Win rate, Sharpe ratio (irrelevant)
+
+### Social Reward Weights
+
+Social Butterfly uses the social reward system with:
+- Network: 40% (highest priority)
+- Engagement: 30%
+- Information Spread: 20%
+- Narrative Alignment: 10%
+
+A Social Butterfly can score 0.6+ with zero trading by building 25+ connections.
 ```
 
 ## Priority Metrics

--- a/packages/training/python/src/training/babylon_env.py
+++ b/packages/training/python/src/training/babylon_env.py
@@ -180,6 +180,12 @@ class BabylonRLAIFEnv(BaseEnv):
             "regime_counts": {"bull": 0, "bear": 0, "sideways": 0},
             "alphas": [],
             "volatilities": [],
+            # Social reward metrics (BAB-71)
+            "social_engagement": [],
+            "social_spread": [],
+            "social_network": [],
+            "social_narrative": [],
+            "social_total": [],
         }
 
         # Evaluation suite for tracking progress
@@ -435,12 +441,25 @@ class BabylonRLAIFEnv(BaseEnv):
 
             if m["volatilities"]:
                 wandb_metrics["train/market_volatility_mean"] = sum(m["volatilities"]) / len(m["volatilities"])
+            
+            # Social reward metrics (BAB-71)
+            if m["social_total"]:
+                wandb_metrics["train/social_reward_mean"] = sum(m["social_total"]) / len(m["social_total"])
+                wandb_metrics["train/social_engagement_mean"] = sum(m["social_engagement"]) / len(m["social_engagement"])
+                wandb_metrics["train/social_spread_mean"] = sum(m["social_spread"]) / len(m["social_spread"])
+                wandb_metrics["train/social_network_mean"] = sum(m["social_network"]) / len(m["social_network"])
+                wandb_metrics["train/social_narrative_mean"] = sum(m["social_narrative"]) / len(m["social_narrative"])
 
             # Reset for next logging interval
             self.enhanced_reward_metrics = {
                 "regime_counts": {"bull": 0, "bear": 0, "sideways": 0},
                 "alphas": [],
                 "volatilities": [],
+                "social_engagement": [],
+                "social_spread": [],
+                "social_network": [],
+                "social_narrative": [],
+                "social_total": [],
             }
 
         self.judgement_samples = []  # Clear after logging
@@ -897,7 +916,22 @@ You receive market updates and must analyze, reason, and then act."""
                 self.enhanced_reward_metrics["regime_counts"][regime.overall] += 1
                 self.enhanced_reward_metrics["alphas"].append(counterfactual.alpha)
                 self.enhanced_reward_metrics["volatilities"].append(regime.volatility)
-            else:
+            
+            # Calculate and track social reward (BAB-71)
+            # This is done separately to provide visibility into social scoring
+            if behavior_metrics is not None:
+                from .rewards import calculate_social_reward
+                social_result = calculate_social_reward(
+                    metrics=behavior_metrics,
+                    archetype=archetype_norm,
+                )
+                self.enhanced_reward_metrics["social_engagement"].append(social_result.engagement_score)
+                self.enhanced_reward_metrics["social_spread"].append(social_result.information_spread_score)
+                self.enhanced_reward_metrics["social_network"].append(social_result.network_score)
+                self.enhanced_reward_metrics["social_narrative"].append(social_result.narrative_alignment_score)
+                self.enhanced_reward_metrics["social_total"].append(social_result.total_score)
+            
+            if not has_enhanced_context:
                 # Fallback: standard archetype composite reward
                 base_score = archetype_composite_reward(
                     inputs=reward_inputs,

--- a/packages/training/python/src/training/babylon_env.py
+++ b/packages/training/python/src/training/babylon_env.py
@@ -931,8 +931,8 @@ You receive market updates and must analyze, reason, and then act."""
                 self.enhanced_reward_metrics["social_narrative"].append(social_result.narrative_alignment_score)
                 self.enhanced_reward_metrics["social_total"].append(social_result.total_score)
             
-            if not has_enhanced_context:
-                # Fallback: standard archetype composite reward
+            if regime is None:
+                # Fallback: standard archetype composite reward (no market regime data)
                 base_score = archetype_composite_reward(
                     inputs=reward_inputs,
                     archetype=archetype_norm,

--- a/packages/training/python/src/training/rewards.py
+++ b/packages/training/python/src/training/rewards.py
@@ -2068,6 +2068,26 @@ SOCIAL_COMPOSITE_WEIGHTS: Dict[str, Dict[str, float]] = {
 }
 
 
+def _validate_social_weights() -> None:
+    """Validate that social weight dictionaries sum to 1.0 (called at module load)."""
+    TOLERANCE = 1e-9
+    for name, weights_dict in [
+        ("SOCIAL_REWARD_WEIGHTS", SOCIAL_REWARD_WEIGHTS),
+        ("SOCIAL_COMPOSITE_WEIGHTS", SOCIAL_COMPOSITE_WEIGHTS),
+    ]:
+        for archetype, weights in weights_dict.items():
+            total = sum(weights.values())
+            if abs(total - 1.0) > TOLERANCE:
+                raise ValueError(
+                    f"{name}['{archetype}'] weights sum to {total}, expected 1.0. "
+                    f"Weights: {weights}"
+                )
+
+
+# Validate social weights at module load (similar to _validate_archetype_weights)
+_validate_social_weights()
+
+
 def social_only_composite_reward(
     inputs: TrajectoryRewardInputs,
     archetype: str,

--- a/packages/training/python/src/training/rewards.py
+++ b/packages/training/python/src/training/rewards.py
@@ -1794,19 +1794,43 @@ SOCIAL_EXCELLENT_SPREAD = 15  # Content spread to 15+ users
 SOCIAL_GOOD_SPREAD = 5        # Content spread to 5+ users
 SOCIAL_EXCELLENT_ENGAGEMENT = 20  # 20+ social actions
 SOCIAL_GOOD_ENGAGEMENT = 10       # 10+ social actions
+SOCIAL_MIN_ENGAGEMENT = 3         # Minimum for base score
 SOCIAL_EXCELLENT_NETWORK = 15     # 15+ unique connections
 SOCIAL_GOOD_NETWORK = 8           # 8+ unique connections
+SOCIAL_MIN_NETWORK = 3            # Minimum for base score
+
+# Archetype-specific weight profiles for social rewards
+SOCIAL_REWARD_WEIGHTS: Dict[str, Dict[str, float]] = {
+    "social-butterfly": {"engagement": 0.30, "spread": 0.20, "network": 0.40, "narrative": 0.10},
+    "information-trader": {"engagement": 0.15, "spread": 0.25, "network": 0.20, "narrative": 0.40},
+    "scammer": {"engagement": 0.20, "spread": 0.40, "network": 0.25, "narrative": 0.15},
+    "liar": {"engagement": 0.20, "spread": 0.40, "network": 0.25, "narrative": 0.15},
+    "goody-twoshoes": {"engagement": 0.25, "spread": 0.20, "network": 0.30, "narrative": 0.25},
+    "ass-kisser": {"engagement": 0.35, "spread": 0.15, "network": 0.40, "narrative": 0.10},
+    "default": {"engagement": 0.25, "spread": 0.25, "network": 0.25, "narrative": 0.25},
+}
+
+
+def _interpolate_score(value: int, min_val: int, good_val: int, excellent_val: int) -> float:
+    """
+    Interpolate a score in [0, 1] based on value thresholds.
+    
+    Returns:
+        1.0 if value >= excellent, interpolated otherwise
+    """
+    if value >= excellent_val:
+        return 1.0
+    elif value >= good_val:
+        return 0.6 + (value - good_val) / (excellent_val - good_val) * 0.4
+    elif value >= min_val:
+        return 0.2 + (value - min_val) / (good_val - min_val) * 0.4
+    else:
+        return value / max(min_val, 1) * 0.2
 
 
 def calculate_engagement_score(metrics: BehaviorMetrics) -> float:
     """
     Calculate engagement score based on social activity volume and quality.
-    
-    Rewards agents for:
-    - Posting content
-    - Commenting on others' content
-    - Initiating DM conversations
-    - Responding to group chats
     
     Args:
         metrics: Behavior metrics containing social activity counts
@@ -1814,7 +1838,6 @@ def calculate_engagement_score(metrics: BehaviorMetrics) -> float:
     Returns:
         Engagement score in [0.0, 1.0]
     """
-    # Count total social actions
     total_social = (
         metrics.posts_created
         + metrics.comments_made
@@ -1823,24 +1846,15 @@ def calculate_engagement_score(metrics: BehaviorMetrics) -> float:
         + metrics.mentions_given
     )
     
-    # Base score from action volume
-    if total_social >= SOCIAL_EXCELLENT_ENGAGEMENT:
-        volume_score = 1.0
-    elif total_social >= SOCIAL_GOOD_ENGAGEMENT:
-        volume_score = 0.7 + (total_social - SOCIAL_GOOD_ENGAGEMENT) / (SOCIAL_EXCELLENT_ENGAGEMENT - SOCIAL_GOOD_ENGAGEMENT) * 0.3
-    elif total_social >= 3:
-        volume_score = 0.3 + (total_social - 3) / (SOCIAL_GOOD_ENGAGEMENT - 3) * 0.4
-    else:
-        volume_score = total_social * 0.1
+    volume_score = _interpolate_score(
+        total_social, SOCIAL_MIN_ENGAGEMENT, SOCIAL_GOOD_ENGAGEMENT, SOCIAL_EXCELLENT_ENGAGEMENT
+    )
     
-    # Diversity bonus: reward varied activity (not just one type)
-    activity_types = sum([
-        1 if metrics.posts_created > 0 else 0,
-        1 if metrics.comments_made > 0 else 0,
-        1 if metrics.dms_initiated > 0 else 0,
-        1 if metrics.group_chats_joined > 0 else 0,
-        1 if metrics.mentions_given > 0 else 0,
-    ])
+    # Diversity bonus: count active activity types (more idiomatic)
+    activity_types = sum(1 for val in [
+        metrics.posts_created, metrics.comments_made, metrics.dms_initiated,
+        metrics.group_chats_joined, metrics.mentions_given
+    ] if val > 0)
     diversity_bonus = min(0.2, activity_types * 0.04)
     
     return min(1.0, volume_score + diversity_bonus)
@@ -1850,41 +1864,17 @@ def calculate_information_spread_score(metrics: BehaviorMetrics) -> float:
     """
     Calculate score based on how well content spread through the network.
     
-    This rewards agents whose posts/content generate engagement:
-    - Reactions (likes, shares)
-    - Information reaching multiple users
-    - Content that sparks discussion
-    
     Args:
         metrics: Behavior metrics containing influence data
     
     Returns:
         Information spread score in [0.0, 1.0]
     """
-    # Primary signal: direct spread metric
-    spread = metrics.information_spread
-    
-    # Secondary signal: positive reactions as proxy for engaging content
-    reactions = metrics.positive_reactions
-    
-    # Tertiary signal: follower gains indicate influential content
-    followers = metrics.followers_gained
-    
-    # Score information spread
-    if spread >= SOCIAL_EXCELLENT_SPREAD:
-        spread_score = 1.0
-    elif spread >= SOCIAL_GOOD_SPREAD:
-        spread_score = 0.6 + (spread - SOCIAL_GOOD_SPREAD) / (SOCIAL_EXCELLENT_SPREAD - SOCIAL_GOOD_SPREAD) * 0.4
-    elif spread > 0:
-        spread_score = 0.2 + (spread / SOCIAL_GOOD_SPREAD) * 0.4
-    else:
-        spread_score = 0.0
-    
-    # Bonus for reactions (capped at 0.2)
-    reaction_bonus = min(0.2, reactions * 0.02)
-    
-    # Bonus for follower gains (capped at 0.15)
-    follower_bonus = min(0.15, max(0, followers) * 0.03)
+    spread_score = _interpolate_score(
+        metrics.information_spread, 1, SOCIAL_GOOD_SPREAD, SOCIAL_EXCELLENT_SPREAD
+    )
+    reaction_bonus = min(0.2, metrics.positive_reactions * 0.02)
+    follower_bonus = min(0.15, max(0, metrics.followers_gained) * 0.03)
     
     return min(1.0, spread_score + reaction_bonus + follower_bonus)
 
@@ -1893,43 +1883,27 @@ def calculate_network_score(metrics: BehaviorMetrics) -> float:
     """
     Calculate score based on network building and connections.
     
-    Rewards agents for:
-    - Building a wide network of connections
-    - Participating in group activities
-    - Maintaining positive reputation
-    
     Args:
         metrics: Behavior metrics containing social connection data
     
     Returns:
         Network score in [0.0, 1.0]
     """
-    connections = metrics.unique_users_interacted
-    groups = metrics.group_chats_joined
-    reputation = metrics.reputation_delta
+    network_score = _interpolate_score(
+        metrics.unique_users_interacted, SOCIAL_MIN_NETWORK, SOCIAL_GOOD_NETWORK, SOCIAL_EXCELLENT_NETWORK
+    )
+    group_bonus = min(0.2, metrics.group_chats_joined * 0.04)
     
-    # Score network breadth
-    if connections >= SOCIAL_EXCELLENT_NETWORK:
-        network_score = 1.0
-    elif connections >= SOCIAL_GOOD_NETWORK:
-        network_score = 0.6 + (connections - SOCIAL_GOOD_NETWORK) / (SOCIAL_EXCELLENT_NETWORK - SOCIAL_GOOD_NETWORK) * 0.4
-    elif connections >= 3:
-        network_score = 0.2 + (connections - 3) / (SOCIAL_GOOD_NETWORK - 3) * 0.4
-    else:
-        network_score = connections * 0.07
-    
-    # Bonus for group participation (capped at 0.2)
-    group_bonus = min(0.2, groups * 0.04)
-    
-    # Reputation modifier (can be negative)
-    if reputation > 20:
+    # Reputation modifier (can be negative, clamped to [-0.15, 0.15])
+    rep = metrics.reputation_delta
+    if rep > 20:
         reputation_mod = 0.15
-    elif reputation > 0:
-        reputation_mod = reputation * 0.0075
-    elif reputation < -10:
+    elif rep > 0:
+        reputation_mod = rep * 0.0075
+    elif rep < -10:
         reputation_mod = -0.15
     else:
-        reputation_mod = reputation * 0.01
+        reputation_mod = rep * 0.01
     
     return max(0.0, min(1.0, network_score + group_bonus + reputation_mod))
 
@@ -1961,14 +1935,7 @@ def calculate_narrative_alignment_score(
     """
     Calculate how well agent's actions aligned with ground truth narrative.
     
-    This rewards agents who:
-    - React appropriately to revealed causal events
-    - Share accurate information about events
-    - Don't spread misinformation
-    - Time their actions to narrative developments
-    
-    For simpler evaluation (without timeline), uses prediction accuracy
-    as a proxy for narrative alignment.
+    For simpler evaluation (without timeline), uses prediction accuracy as proxy.
     
     Args:
         metrics: Behavior metrics containing prediction data
@@ -1978,40 +1945,32 @@ def calculate_narrative_alignment_score(
     Returns:
         Narrative alignment score in [0.0, 1.0]
     """
-    # If no detailed timeline, use prediction accuracy as proxy
+    # Simple mode: use prediction accuracy as proxy
     if not actions_timeline or not narrative_events:
-        # Use prediction accuracy as simple proxy
-        if metrics.predictions_made == 0:
-            return 0.5  # Neutral if no predictions
-        return metrics.prediction_accuracy
+        return 0.5 if metrics.predictions_made == 0 else metrics.prediction_accuracy
     
-    # Advanced scoring with timeline analysis
-    alignment_score = 0.0
-    total_events = len(narrative_events)
+    if not narrative_events:
+        return 0.5
     
-    if total_events == 0:
-        return 0.5  # Neutral if no events
-    
+    # Advanced mode: analyze timeline against events
     events_reacted_to = 0
     correct_reactions = 0
     
     for event in narrative_events:
         if not event.revealed:
-            continue  # Skip unrevealed events
+            continue
         
-        # Check if agent took action after this event
+        # Find actions within 5 ticks after event
         post_event_actions = [
             a for a in actions_timeline
-            if a.get("tick", 0) > event.tick
-            and a.get("tick", 0) <= event.tick + 5  # Within 5 ticks
+            if event.tick < a.get("tick", 0) <= event.tick + 5
         ]
-        
         if not post_event_actions:
             continue
         
         events_reacted_to += 1
         
-        # Check if action direction matches event direction
+        # Check if any action aligns with event direction
         for action in post_event_actions:
             action_type = action.get("action_type", "").lower()
             ticker = action.get("ticker", "")
@@ -2019,24 +1978,14 @@ def calculate_narrative_alignment_score(
             if ticker not in event.affected_tickers:
                 continue
             
-            # Determine if action aligns with narrative
             is_buy = "buy" in action_type or "long" in action_type
             is_sell = "sell" in action_type or "short" in action_type
             
-            if event.direction == "up" and is_buy:
-                correct_reactions += 1
-                break
-            elif event.direction == "down" and is_sell:
+            if (event.direction == "up" and is_buy) or (event.direction == "down" and is_sell):
                 correct_reactions += 1
                 break
     
-    # Calculate alignment ratio
-    if events_reacted_to > 0:
-        alignment_score = correct_reactions / events_reacted_to
-    else:
-        alignment_score = 0.5  # Neutral if no reactions
-    
-    return alignment_score
+    return correct_reactions / events_reacted_to if events_reacted_to > 0 else 0.5
 
 
 def calculate_social_reward(
@@ -2047,18 +1996,6 @@ def calculate_social_reward(
 ) -> SocialRewardResult:
     """
     Calculate comprehensive social reward for non-trading archetypes.
-    
-    This provides a PnL-independent reward signal based on:
-    1. Engagement: Volume and diversity of social activity
-    2. Information Spread: Content that reaches and engages others
-    3. Network: Building connections and maintaining reputation
-    4. Narrative Alignment: Actions that align with ground truth
-    
-    Different archetypes weight these components differently:
-    - Social Butterfly: Emphasizes network and engagement
-    - Information Trader: Emphasizes narrative alignment and spread
-    - Scammer/Liar: Emphasizes spread (for misinformation)
-    - Others: Balanced weights
     
     Args:
         metrics: Behavior metrics from trajectory
@@ -2075,56 +2012,11 @@ def calculate_social_reward(
     engagement = calculate_engagement_score(metrics)
     spread = calculate_information_spread_score(metrics)
     network = calculate_network_score(metrics)
-    narrative = calculate_narrative_alignment_score(
-        metrics, actions_timeline, narrative_events
-    )
+    narrative = calculate_narrative_alignment_score(metrics, actions_timeline, narrative_events)
     
-    # Archetype-specific weights
-    if archetype_norm == "social-butterfly":
-        weights = {
-            "engagement": 0.30,
-            "spread": 0.20,
-            "network": 0.40,
-            "narrative": 0.10,
-        }
-    elif archetype_norm == "information-trader":
-        weights = {
-            "engagement": 0.15,
-            "spread": 0.25,
-            "network": 0.20,
-            "narrative": 0.40,
-        }
-    elif archetype_norm in ("scammer", "liar"):
-        weights = {
-            "engagement": 0.20,
-            "spread": 0.40,
-            "network": 0.25,
-            "narrative": 0.15,
-        }
-    elif archetype_norm == "goody-twoshoes":
-        weights = {
-            "engagement": 0.25,
-            "spread": 0.20,
-            "network": 0.30,
-            "narrative": 0.25,
-        }
-    elif archetype_norm == "ass-kisser":
-        weights = {
-            "engagement": 0.35,
-            "spread": 0.15,
-            "network": 0.40,
-            "narrative": 0.10,
-        }
-    else:
-        # Default balanced weights
-        weights = {
-            "engagement": 0.25,
-            "spread": 0.25,
-            "network": 0.25,
-            "narrative": 0.25,
-        }
+    # Get archetype-specific weights (fall back to default)
+    weights = SOCIAL_REWARD_WEIGHTS.get(archetype_norm, SOCIAL_REWARD_WEIGHTS["default"])
     
-    # Compute weighted total
     total = (
         engagement * weights["engagement"]
         + spread * weights["spread"]
@@ -2141,6 +2033,15 @@ def calculate_social_reward(
     )
 
 
+# Composite weights for social-focused archetypes
+SOCIAL_COMPOSITE_WEIGHTS: Dict[str, Dict[str, float]] = {
+    "social-butterfly": {"social": 0.55, "format": 0.20, "reasoning": 0.15, "pnl": 0.10},
+    "ass-kisser": {"social": 0.50, "format": 0.25, "reasoning": 0.15, "pnl": 0.10},
+    "goody-twoshoes": {"social": 0.50, "format": 0.25, "reasoning": 0.15, "pnl": 0.10},
+    "default": {"social": 0.40, "format": 0.25, "reasoning": 0.20, "pnl": 0.15},
+}
+
+
 def social_only_composite_reward(
     inputs: TrajectoryRewardInputs,
     archetype: str,
@@ -2150,14 +2051,6 @@ def social_only_composite_reward(
 ) -> float:
     """
     Composite reward optimized for social archetypes (minimal PnL weight).
-    
-    This is designed for archetypes like Social Butterfly where trading
-    performance is largely irrelevant. The reward is primarily based on:
-    - Social engagement and network building
-    - Information spread and influence
-    - Format and reasoning quality
-    
-    PnL only matters for bankruptcy prevention (hard penalty).
     
     Args:
         inputs: Standard trajectory reward inputs
@@ -2169,61 +2062,32 @@ def social_only_composite_reward(
     Returns:
         Composite reward in [-1.0, 1.0]
     """
-    archetype_norm = normalize_archetype(archetype)
-    
-    # Hard bankruptcy penalty (even social butterflies shouldn't go broke)
     if inputs.end_balance <= 0:
-        return -0.5  # Less severe than trader bankruptcy
+        return -0.5  # Bankruptcy penalty (less severe than trader)
+    
+    archetype_norm = normalize_archetype(archetype)
     
     # Calculate social reward
     social_result = SocialRewardResult()
     if behavior_metrics is not None:
         social_result = calculate_social_reward(
-            metrics=behavior_metrics,
-            archetype=archetype_norm,
-            actions_timeline=actions_timeline,
-            narrative_events=narrative_events,
+            behavior_metrics, archetype_norm, actions_timeline, narrative_events
         )
     
-    # Format and reasoning scores
-    format_score = inputs.format_score
-    reasoning_score = inputs.reasoning_score
-    
-    # Minimal PnL component (just for slight profit incentive)
+    # Minimal PnL scoring (slight profit incentive, moderate loss penalty)
     pnl_score = 0.0
-    if inputs.final_pnl > 0:
-        pnl_score = min(0.5, inputs.final_pnl / inputs.starting_balance * 5)
-    elif inputs.final_pnl < -inputs.starting_balance * 0.5:
-        pnl_score = -0.3  # Moderate penalty for heavy losses
+    if inputs.starting_balance > 0:
+        if inputs.final_pnl > 0:
+            pnl_score = min(0.5, inputs.final_pnl / inputs.starting_balance * 5)
+        elif inputs.final_pnl < -inputs.starting_balance * 0.5:
+            pnl_score = -0.3
     
-    # Social archetype weights
-    if archetype_norm == "social-butterfly":
-        weights = {
-            "social": 0.55,
-            "format": 0.20,
-            "reasoning": 0.15,
-            "pnl": 0.10,
-        }
-    elif archetype_norm in ("ass-kisser", "goody-twoshoes"):
-        weights = {
-            "social": 0.50,
-            "format": 0.25,
-            "reasoning": 0.15,
-            "pnl": 0.10,
-        }
-    else:
-        # Default for other social-ish archetypes
-        weights = {
-            "social": 0.40,
-            "format": 0.25,
-            "reasoning": 0.20,
-            "pnl": 0.15,
-        }
+    weights = SOCIAL_COMPOSITE_WEIGHTS.get(archetype_norm, SOCIAL_COMPOSITE_WEIGHTS["default"])
     
     composite = (
         social_result.total_score * weights["social"]
-        + format_score * weights["format"]
-        + reasoning_score * weights["reasoning"]
+        + inputs.format_score * weights["format"]
+        + inputs.reasoning_score * weights["reasoning"]
         + pnl_score * weights["pnl"]
     )
     

--- a/packages/training/python/src/training/rewards.py
+++ b/packages/training/python/src/training/rewards.py
@@ -1752,3 +1752,479 @@ def enhanced_composite_reward(
     )
     
     return max(-1.0, min(1.0, composite))
+
+
+# =============================================================================
+# Social & Narrative Rewards (BAB-71)
+# =============================================================================
+# These functions provide PnL-independent reward signals for social archetypes
+# like "Social Butterfly" and "Information Trader".
+
+@dataclass
+class SocialRewardResult:
+    """
+    Breakdown of social reward components for logging and analysis.
+    
+    Attributes:
+        engagement_score: Score from social interactions (DMs, posts, comments)
+        information_spread_score: Score from content that gets reactions/shares
+        narrative_alignment_score: Score from actions aligned with ground truth
+        network_score: Score from building connections
+        total_score: Combined social reward
+    """
+    engagement_score: float = 0.0
+    information_spread_score: float = 0.0
+    narrative_alignment_score: float = 0.0
+    network_score: float = 0.0
+    total_score: float = 0.0
+    
+    def to_dict(self) -> Dict:
+        """Serialize for logging."""
+        return {
+            "engagement_score": self.engagement_score,
+            "information_spread_score": self.information_spread_score,
+            "narrative_alignment_score": self.narrative_alignment_score,
+            "network_score": self.network_score,
+            "total_score": self.total_score,
+        }
+
+
+# Thresholds for social reward scoring
+SOCIAL_EXCELLENT_SPREAD = 15  # Content spread to 15+ users
+SOCIAL_GOOD_SPREAD = 5        # Content spread to 5+ users
+SOCIAL_EXCELLENT_ENGAGEMENT = 20  # 20+ social actions
+SOCIAL_GOOD_ENGAGEMENT = 10       # 10+ social actions
+SOCIAL_EXCELLENT_NETWORK = 15     # 15+ unique connections
+SOCIAL_GOOD_NETWORK = 8           # 8+ unique connections
+
+
+def calculate_engagement_score(metrics: BehaviorMetrics) -> float:
+    """
+    Calculate engagement score based on social activity volume and quality.
+    
+    Rewards agents for:
+    - Posting content
+    - Commenting on others' content
+    - Initiating DM conversations
+    - Responding to group chats
+    
+    Args:
+        metrics: Behavior metrics containing social activity counts
+    
+    Returns:
+        Engagement score in [0.0, 1.0]
+    """
+    # Count total social actions
+    total_social = (
+        metrics.posts_created
+        + metrics.comments_made
+        + metrics.dms_initiated
+        + metrics.group_chats_joined
+        + metrics.mentions_given
+    )
+    
+    # Base score from action volume
+    if total_social >= SOCIAL_EXCELLENT_ENGAGEMENT:
+        volume_score = 1.0
+    elif total_social >= SOCIAL_GOOD_ENGAGEMENT:
+        volume_score = 0.7 + (total_social - SOCIAL_GOOD_ENGAGEMENT) / (SOCIAL_EXCELLENT_ENGAGEMENT - SOCIAL_GOOD_ENGAGEMENT) * 0.3
+    elif total_social >= 3:
+        volume_score = 0.3 + (total_social - 3) / (SOCIAL_GOOD_ENGAGEMENT - 3) * 0.4
+    else:
+        volume_score = total_social * 0.1
+    
+    # Diversity bonus: reward varied activity (not just one type)
+    activity_types = sum([
+        1 if metrics.posts_created > 0 else 0,
+        1 if metrics.comments_made > 0 else 0,
+        1 if metrics.dms_initiated > 0 else 0,
+        1 if metrics.group_chats_joined > 0 else 0,
+        1 if metrics.mentions_given > 0 else 0,
+    ])
+    diversity_bonus = min(0.2, activity_types * 0.04)
+    
+    return min(1.0, volume_score + diversity_bonus)
+
+
+def calculate_information_spread_score(metrics: BehaviorMetrics) -> float:
+    """
+    Calculate score based on how well content spread through the network.
+    
+    This rewards agents whose posts/content generate engagement:
+    - Reactions (likes, shares)
+    - Information reaching multiple users
+    - Content that sparks discussion
+    
+    Args:
+        metrics: Behavior metrics containing influence data
+    
+    Returns:
+        Information spread score in [0.0, 1.0]
+    """
+    # Primary signal: direct spread metric
+    spread = metrics.information_spread
+    
+    # Secondary signal: positive reactions as proxy for engaging content
+    reactions = metrics.positive_reactions
+    
+    # Tertiary signal: follower gains indicate influential content
+    followers = metrics.followers_gained
+    
+    # Score information spread
+    if spread >= SOCIAL_EXCELLENT_SPREAD:
+        spread_score = 1.0
+    elif spread >= SOCIAL_GOOD_SPREAD:
+        spread_score = 0.6 + (spread - SOCIAL_GOOD_SPREAD) / (SOCIAL_EXCELLENT_SPREAD - SOCIAL_GOOD_SPREAD) * 0.4
+    elif spread > 0:
+        spread_score = 0.2 + (spread / SOCIAL_GOOD_SPREAD) * 0.4
+    else:
+        spread_score = 0.0
+    
+    # Bonus for reactions (capped at 0.2)
+    reaction_bonus = min(0.2, reactions * 0.02)
+    
+    # Bonus for follower gains (capped at 0.15)
+    follower_bonus = min(0.15, max(0, followers) * 0.03)
+    
+    return min(1.0, spread_score + reaction_bonus + follower_bonus)
+
+
+def calculate_network_score(metrics: BehaviorMetrics) -> float:
+    """
+    Calculate score based on network building and connections.
+    
+    Rewards agents for:
+    - Building a wide network of connections
+    - Participating in group activities
+    - Maintaining positive reputation
+    
+    Args:
+        metrics: Behavior metrics containing social connection data
+    
+    Returns:
+        Network score in [0.0, 1.0]
+    """
+    connections = metrics.unique_users_interacted
+    groups = metrics.group_chats_joined
+    reputation = metrics.reputation_delta
+    
+    # Score network breadth
+    if connections >= SOCIAL_EXCELLENT_NETWORK:
+        network_score = 1.0
+    elif connections >= SOCIAL_GOOD_NETWORK:
+        network_score = 0.6 + (connections - SOCIAL_GOOD_NETWORK) / (SOCIAL_EXCELLENT_NETWORK - SOCIAL_GOOD_NETWORK) * 0.4
+    elif connections >= 3:
+        network_score = 0.2 + (connections - 3) / (SOCIAL_GOOD_NETWORK - 3) * 0.4
+    else:
+        network_score = connections * 0.07
+    
+    # Bonus for group participation (capped at 0.2)
+    group_bonus = min(0.2, groups * 0.04)
+    
+    # Reputation modifier (can be negative)
+    if reputation > 20:
+        reputation_mod = 0.15
+    elif reputation > 0:
+        reputation_mod = reputation * 0.0075
+    elif reputation < -10:
+        reputation_mod = -0.15
+    else:
+        reputation_mod = reputation * 0.01
+    
+    return max(0.0, min(1.0, network_score + group_bonus + reputation_mod))
+
+
+@dataclass
+class NarrativeEvent:
+    """
+    A ground truth event that agents should react to.
+    
+    Attributes:
+        tick: When the event occurred
+        event_type: Type of causal event
+        affected_tickers: Markets affected by this event
+        direction: Expected market direction ("up", "down", "volatile")
+        revealed: Whether the event was publicly revealed
+    """
+    tick: int = 0
+    event_type: str = ""
+    affected_tickers: List[str] = field(default_factory=list)
+    direction: str = ""
+    revealed: bool = False
+
+
+def calculate_narrative_alignment_score(
+    metrics: BehaviorMetrics,
+    actions_timeline: Optional[List[Dict]] = None,
+    narrative_events: Optional[List[NarrativeEvent]] = None,
+) -> float:
+    """
+    Calculate how well agent's actions aligned with ground truth narrative.
+    
+    This rewards agents who:
+    - React appropriately to revealed causal events
+    - Share accurate information about events
+    - Don't spread misinformation
+    - Time their actions to narrative developments
+    
+    For simpler evaluation (without timeline), uses prediction accuracy
+    as a proxy for narrative alignment.
+    
+    Args:
+        metrics: Behavior metrics containing prediction data
+        actions_timeline: Optional list of agent actions with timestamps
+        narrative_events: Optional list of ground truth events
+    
+    Returns:
+        Narrative alignment score in [0.0, 1.0]
+    """
+    # If no detailed timeline, use prediction accuracy as proxy
+    if not actions_timeline or not narrative_events:
+        # Use prediction accuracy as simple proxy
+        if metrics.predictions_made == 0:
+            return 0.5  # Neutral if no predictions
+        return metrics.prediction_accuracy
+    
+    # Advanced scoring with timeline analysis
+    alignment_score = 0.0
+    total_events = len(narrative_events)
+    
+    if total_events == 0:
+        return 0.5  # Neutral if no events
+    
+    events_reacted_to = 0
+    correct_reactions = 0
+    
+    for event in narrative_events:
+        if not event.revealed:
+            continue  # Skip unrevealed events
+        
+        # Check if agent took action after this event
+        post_event_actions = [
+            a for a in actions_timeline
+            if a.get("tick", 0) > event.tick
+            and a.get("tick", 0) <= event.tick + 5  # Within 5 ticks
+        ]
+        
+        if not post_event_actions:
+            continue
+        
+        events_reacted_to += 1
+        
+        # Check if action direction matches event direction
+        for action in post_event_actions:
+            action_type = action.get("action_type", "").lower()
+            ticker = action.get("ticker", "")
+            
+            if ticker not in event.affected_tickers:
+                continue
+            
+            # Determine if action aligns with narrative
+            is_buy = "buy" in action_type or "long" in action_type
+            is_sell = "sell" in action_type or "short" in action_type
+            
+            if event.direction == "up" and is_buy:
+                correct_reactions += 1
+                break
+            elif event.direction == "down" and is_sell:
+                correct_reactions += 1
+                break
+    
+    # Calculate alignment ratio
+    if events_reacted_to > 0:
+        alignment_score = correct_reactions / events_reacted_to
+    else:
+        alignment_score = 0.5  # Neutral if no reactions
+    
+    return alignment_score
+
+
+def calculate_social_reward(
+    metrics: BehaviorMetrics,
+    archetype: str,
+    actions_timeline: Optional[List[Dict]] = None,
+    narrative_events: Optional[List[NarrativeEvent]] = None,
+) -> SocialRewardResult:
+    """
+    Calculate comprehensive social reward for non-trading archetypes.
+    
+    This provides a PnL-independent reward signal based on:
+    1. Engagement: Volume and diversity of social activity
+    2. Information Spread: Content that reaches and engages others
+    3. Network: Building connections and maintaining reputation
+    4. Narrative Alignment: Actions that align with ground truth
+    
+    Different archetypes weight these components differently:
+    - Social Butterfly: Emphasizes network and engagement
+    - Information Trader: Emphasizes narrative alignment and spread
+    - Scammer/Liar: Emphasizes spread (for misinformation)
+    - Others: Balanced weights
+    
+    Args:
+        metrics: Behavior metrics from trajectory
+        archetype: Agent archetype for weight selection
+        actions_timeline: Optional action timeline for narrative analysis
+        narrative_events: Optional ground truth events
+    
+    Returns:
+        SocialRewardResult with component breakdown
+    """
+    archetype_norm = normalize_archetype(archetype)
+    
+    # Calculate component scores
+    engagement = calculate_engagement_score(metrics)
+    spread = calculate_information_spread_score(metrics)
+    network = calculate_network_score(metrics)
+    narrative = calculate_narrative_alignment_score(
+        metrics, actions_timeline, narrative_events
+    )
+    
+    # Archetype-specific weights
+    if archetype_norm == "social-butterfly":
+        weights = {
+            "engagement": 0.30,
+            "spread": 0.20,
+            "network": 0.40,
+            "narrative": 0.10,
+        }
+    elif archetype_norm == "information-trader":
+        weights = {
+            "engagement": 0.15,
+            "spread": 0.25,
+            "network": 0.20,
+            "narrative": 0.40,
+        }
+    elif archetype_norm in ("scammer", "liar"):
+        weights = {
+            "engagement": 0.20,
+            "spread": 0.40,
+            "network": 0.25,
+            "narrative": 0.15,
+        }
+    elif archetype_norm == "goody-twoshoes":
+        weights = {
+            "engagement": 0.25,
+            "spread": 0.20,
+            "network": 0.30,
+            "narrative": 0.25,
+        }
+    elif archetype_norm == "ass-kisser":
+        weights = {
+            "engagement": 0.35,
+            "spread": 0.15,
+            "network": 0.40,
+            "narrative": 0.10,
+        }
+    else:
+        # Default balanced weights
+        weights = {
+            "engagement": 0.25,
+            "spread": 0.25,
+            "network": 0.25,
+            "narrative": 0.25,
+        }
+    
+    # Compute weighted total
+    total = (
+        engagement * weights["engagement"]
+        + spread * weights["spread"]
+        + network * weights["network"]
+        + narrative * weights["narrative"]
+    )
+    
+    return SocialRewardResult(
+        engagement_score=engagement,
+        information_spread_score=spread,
+        narrative_alignment_score=narrative,
+        network_score=network,
+        total_score=total,
+    )
+
+
+def social_only_composite_reward(
+    inputs: TrajectoryRewardInputs,
+    archetype: str,
+    behavior_metrics: Optional[BehaviorMetrics] = None,
+    actions_timeline: Optional[List[Dict]] = None,
+    narrative_events: Optional[List[NarrativeEvent]] = None,
+) -> float:
+    """
+    Composite reward optimized for social archetypes (minimal PnL weight).
+    
+    This is designed for archetypes like Social Butterfly where trading
+    performance is largely irrelevant. The reward is primarily based on:
+    - Social engagement and network building
+    - Information spread and influence
+    - Format and reasoning quality
+    
+    PnL only matters for bankruptcy prevention (hard penalty).
+    
+    Args:
+        inputs: Standard trajectory reward inputs
+        archetype: Agent archetype
+        behavior_metrics: Behavior metrics for social scoring
+        actions_timeline: Optional action timeline
+        narrative_events: Optional ground truth events
+    
+    Returns:
+        Composite reward in [-1.0, 1.0]
+    """
+    archetype_norm = normalize_archetype(archetype)
+    
+    # Hard bankruptcy penalty (even social butterflies shouldn't go broke)
+    if inputs.end_balance <= 0:
+        return -0.5  # Less severe than trader bankruptcy
+    
+    # Calculate social reward
+    social_result = SocialRewardResult()
+    if behavior_metrics is not None:
+        social_result = calculate_social_reward(
+            metrics=behavior_metrics,
+            archetype=archetype_norm,
+            actions_timeline=actions_timeline,
+            narrative_events=narrative_events,
+        )
+    
+    # Format and reasoning scores
+    format_score = inputs.format_score
+    reasoning_score = inputs.reasoning_score
+    
+    # Minimal PnL component (just for slight profit incentive)
+    pnl_score = 0.0
+    if inputs.final_pnl > 0:
+        pnl_score = min(0.5, inputs.final_pnl / inputs.starting_balance * 5)
+    elif inputs.final_pnl < -inputs.starting_balance * 0.5:
+        pnl_score = -0.3  # Moderate penalty for heavy losses
+    
+    # Social archetype weights
+    if archetype_norm == "social-butterfly":
+        weights = {
+            "social": 0.55,
+            "format": 0.20,
+            "reasoning": 0.15,
+            "pnl": 0.10,
+        }
+    elif archetype_norm in ("ass-kisser", "goody-twoshoes"):
+        weights = {
+            "social": 0.50,
+            "format": 0.25,
+            "reasoning": 0.15,
+            "pnl": 0.10,
+        }
+    else:
+        # Default for other social-ish archetypes
+        weights = {
+            "social": 0.40,
+            "format": 0.25,
+            "reasoning": 0.20,
+            "pnl": 0.15,
+        }
+    
+    composite = (
+        social_result.total_score * weights["social"]
+        + format_score * weights["format"]
+        + reasoning_score * weights["reasoning"]
+        + pnl_score * weights["pnl"]
+    )
+    
+    return max(-1.0, min(1.0, composite))

--- a/packages/training/python/src/training/rewards.py
+++ b/packages/training/python/src/training/rewards.py
@@ -1799,7 +1799,16 @@ SOCIAL_EXCELLENT_NETWORK = 15     # 15+ unique connections
 SOCIAL_GOOD_NETWORK = 8           # 8+ unique connections
 SOCIAL_MIN_NETWORK = 3            # Minimum for base score
 
-# Archetype-specific weight profiles for social rewards
+# Archetype-specific weight profiles for social rewards.
+# NOTE: These are initial estimates based on archetype design goals. Weights should be
+# refined based on training results and behavioral analysis. All profiles sum to 1.0.
+#
+# Design rationale:
+# - Social Butterfly: Network (40%) - building connections is primary goal
+# - Information Trader: Narrative (40%) - acting on ground truth events is key
+# - Scammer/Liar: Spread (40%) - successful deception requires information spread
+# - Goody Two-Shoes: Balanced - helpful in all dimensions
+# - Ass-Kisser: Network (40%) + Engagement (35%) - reputation through interaction
 SOCIAL_REWARD_WEIGHTS: Dict[str, Dict[str, float]] = {
     "social-butterfly": {"engagement": 0.30, "spread": 0.20, "network": 0.40, "narrative": 0.10},
     "information-trader": {"engagement": 0.15, "spread": 0.25, "network": 0.20, "narrative": 0.40},
@@ -1815,9 +1824,21 @@ def _interpolate_score(value: int, min_val: int, good_val: int, excellent_val: i
     """
     Interpolate a score in [0, 1] based on value thresholds.
     
+    Args:
+        value: The metric value to score
+        min_val: Minimum threshold for base score (0.2)
+        good_val: Good threshold for mid score (0.6)
+        excellent_val: Excellent threshold for max score (1.0)
+    
     Returns:
-        1.0 if value >= excellent, interpolated otherwise
+        Score in [0.0, 1.0] - 1.0 if value >= excellent, interpolated otherwise
     """
+    # Defensive: handle equal thresholds to avoid division by zero
+    if excellent_val <= good_val:
+        return 1.0 if value >= good_val else 0.6
+    if good_val <= min_val:
+        return 0.6 if value >= min_val else 0.0
+    
     if value >= excellent_val:
         return 1.0
     elif value >= good_val:
@@ -1850,7 +1871,9 @@ def calculate_engagement_score(metrics: BehaviorMetrics) -> float:
         total_social, SOCIAL_MIN_ENGAGEMENT, SOCIAL_GOOD_ENGAGEMENT, SOCIAL_EXCELLENT_ENGAGEMENT
     )
     
-    # Diversity bonus: count active activity types (more idiomatic)
+    # Diversity bonus: reward engaging across multiple activity types
+    # Each active type adds 0.04 (4%), capped at 0.20 (20%) for 5 types
+    # Rationale: breadth of engagement indicates genuine social participation
     activity_types = sum(1 for val in [
         metrics.posts_created, metrics.comments_made, metrics.dms_initiated,
         metrics.group_chats_joined, metrics.mentions_given
@@ -1873,6 +1896,8 @@ def calculate_information_spread_score(metrics: BehaviorMetrics) -> float:
     spread_score = _interpolate_score(
         metrics.information_spread, 1, SOCIAL_GOOD_SPREAD, SOCIAL_EXCELLENT_SPREAD
     )
+    # Bonus coefficients: reactions are common (0.02 each, cap 0.20), followers are
+    # harder to gain (0.03 each, cap 0.15). Caps prevent any single metric from dominating.
     reaction_bonus = min(0.2, metrics.positive_reactions * 0.02)
     follower_bonus = min(0.15, max(0, metrics.followers_gained) * 0.03)
     
@@ -1892,18 +1917,22 @@ def calculate_network_score(metrics: BehaviorMetrics) -> float:
     network_score = _interpolate_score(
         metrics.unique_users_interacted, SOCIAL_MIN_NETWORK, SOCIAL_GOOD_NETWORK, SOCIAL_EXCELLENT_NETWORK
     )
+    # Group bonus: 0.04 per group, capped at 0.20 (5 groups = max bonus)
     group_bonus = min(0.2, metrics.group_chats_joined * 0.04)
     
-    # Reputation modifier (can be negative, clamped to [-0.15, 0.15])
+    # Reputation modifier: can boost or penalize score, clamped to [-0.15, 0.15]
+    # Coefficients: positive rep is harder to earn (0.0075), negative rep penalizes
+    # more harshly (0.01) to discourage bad behavior. Thresholds (20, -10) define
+    # where the modifier caps out.
     rep = metrics.reputation_delta
     if rep > 20:
-        reputation_mod = 0.15
+        reputation_mod = 0.15  # Max positive boost
     elif rep > 0:
-        reputation_mod = rep * 0.0075
+        reputation_mod = rep * 0.0075  # ~0.15 at rep=20
     elif rep < -10:
-        reputation_mod = -0.15
+        reputation_mod = -0.15  # Max negative penalty
     else:
-        reputation_mod = rep * 0.01
+        reputation_mod = rep * 0.01  # ~-0.10 at rep=-10
     
     return max(0.0, min(1.0, network_score + group_bonus + reputation_mod))
 
@@ -1945,14 +1974,11 @@ def calculate_narrative_alignment_score(
     Returns:
         Narrative alignment score in [0.0, 1.0]
     """
-    # Simple mode: use prediction accuracy as proxy
+    # Simple mode: use prediction accuracy as proxy when timeline data unavailable
     if not actions_timeline or not narrative_events:
         return 0.5 if metrics.predictions_made == 0 else metrics.prediction_accuracy
     
-    if not narrative_events:
-        return 0.5
-    
-    # Advanced mode: analyze timeline against events
+    # Advanced mode: analyze timeline against revealed events
     events_reacted_to = 0
     correct_reactions = 0
     

--- a/packages/training/python/tests/test_social_rewards.py
+++ b/packages/training/python/tests/test_social_rewards.py
@@ -95,6 +95,20 @@ class TestInterpolateScore:
         # When min_val is 0, values below should still work
         score = _interpolate_score(0, 1, 5, 10)
         assert score == 0.0
+    
+    def test_equal_good_and_excellent_thresholds(self):
+        """Should handle excellent_val == good_val without division by zero"""
+        score = _interpolate_score(10, 3, 10, 10)  # good == excellent
+        assert score == 1.0  # At or above good should return 1.0
+        score_below = _interpolate_score(5, 3, 10, 10)
+        assert score_below == 0.6  # Below good should return 0.6
+    
+    def test_equal_min_and_good_thresholds(self):
+        """Should handle good_val == min_val without division by zero"""
+        score = _interpolate_score(5, 5, 5, 10)  # min == good
+        assert score == 0.6  # At or above min should return 0.6
+        score_below = _interpolate_score(2, 5, 5, 10)
+        assert score_below == 0.0  # Below min with equal thresholds
 
 
 # =============================================================================

--- a/packages/training/python/tests/test_social_rewards.py
+++ b/packages/training/python/tests/test_social_rewards.py
@@ -1,0 +1,520 @@
+"""
+Unit tests for Social Reward Functions (BAB-71)
+
+Tests the social reward calculation functions that enable
+non-trading archetypes like "Social Butterfly" to achieve
+high scores without trading.
+"""
+
+import pytest
+from src.training.rewards import (
+    BehaviorMetrics,
+    SocialRewardResult,
+    NarrativeEvent,
+    calculate_engagement_score,
+    calculate_information_spread_score,
+    calculate_network_score,
+    calculate_narrative_alignment_score,
+    calculate_social_reward,
+    social_only_composite_reward,
+    TrajectoryRewardInputs,
+)
+
+
+class TestEngagementScore:
+    """Tests for calculate_engagement_score()"""
+
+    def test_high_engagement_score(self):
+        """Agent with lots of social activity should score high"""
+        metrics = BehaviorMetrics(
+            posts_created=10,
+            comments_made=8,
+            dms_initiated=5,
+            group_chats_joined=4,
+            mentions_given=3,
+        )
+        score = calculate_engagement_score(metrics)
+        assert score >= 0.8, f"High activity should score >= 0.8, got {score}"
+
+    def test_moderate_engagement_score(self):
+        """Agent with moderate activity should score moderately"""
+        metrics = BehaviorMetrics(
+            posts_created=2,
+            comments_made=2,
+            dms_initiated=1,
+            group_chats_joined=1,
+            mentions_given=0,
+        )
+        score = calculate_engagement_score(metrics)
+        assert 0.4 <= score <= 0.8, f"Moderate activity should score 0.4-0.8, got {score}"
+
+    def test_zero_engagement_score(self):
+        """Agent with no social activity should score low"""
+        metrics = BehaviorMetrics()
+        score = calculate_engagement_score(metrics)
+        assert score <= 0.2, f"No activity should score <= 0.2, got {score}"
+
+    def test_diversity_bonus(self):
+        """Diverse activity types should score higher than single type"""
+        # Single type: all posts
+        single_type = BehaviorMetrics(posts_created=10)
+        
+        # Diverse: spread across types
+        diverse = BehaviorMetrics(
+            posts_created=2,
+            comments_made=2,
+            dms_initiated=2,
+            group_chats_joined=2,
+            mentions_given=2,
+        )
+        
+        single_score = calculate_engagement_score(single_type)
+        diverse_score = calculate_engagement_score(diverse)
+        
+        assert diverse_score > single_score, \
+            f"Diverse activity ({diverse_score}) should beat single type ({single_score})"
+
+
+class TestInformationSpreadScore:
+    """Tests for calculate_information_spread_score()"""
+
+    def test_high_spread_score(self):
+        """Content that spreads widely should score high"""
+        metrics = BehaviorMetrics(
+            information_spread=20,
+            positive_reactions=10,
+            followers_gained=5,
+        )
+        score = calculate_information_spread_score(metrics)
+        assert score >= 0.9, f"High spread should score >= 0.9, got {score}"
+
+    def test_moderate_spread_score(self):
+        """Content that spreads moderately should score moderately"""
+        metrics = BehaviorMetrics(
+            information_spread=6,
+            positive_reactions=3,
+            followers_gained=1,
+        )
+        score = calculate_information_spread_score(metrics)
+        assert 0.5 <= score <= 0.9, f"Moderate spread should score 0.5-0.9, got {score}"
+
+    def test_zero_spread_score(self):
+        """Content that doesn't spread should score low"""
+        metrics = BehaviorMetrics(
+            information_spread=0,
+            positive_reactions=0,
+            followers_gained=0,
+        )
+        score = calculate_information_spread_score(metrics)
+        assert score <= 0.2, f"No spread should score <= 0.2, got {score}"
+
+    def test_reactions_boost_score(self):
+        """Reactions should boost score even without direct spread"""
+        no_reactions = BehaviorMetrics(information_spread=5)
+        with_reactions = BehaviorMetrics(
+            information_spread=5,
+            positive_reactions=10,
+        )
+        
+        assert calculate_information_spread_score(with_reactions) > \
+               calculate_information_spread_score(no_reactions)
+
+
+class TestNetworkScore:
+    """Tests for calculate_network_score()"""
+
+    def test_large_network_score(self):
+        """Agent with many connections should score high"""
+        metrics = BehaviorMetrics(
+            unique_users_interacted=20,
+            group_chats_joined=5,
+            reputation_delta=30,
+        )
+        score = calculate_network_score(metrics)
+        assert score >= 0.9, f"Large network should score >= 0.9, got {score}"
+
+    def test_moderate_network_score(self):
+        """Agent with moderate connections should score moderately"""
+        metrics = BehaviorMetrics(
+            unique_users_interacted=8,
+            group_chats_joined=2,
+            reputation_delta=5,
+        )
+        score = calculate_network_score(metrics)
+        assert 0.5 <= score <= 0.9, f"Moderate network should score 0.5-0.9, got {score}"
+
+    def test_isolated_score(self):
+        """Agent with few connections should score low"""
+        metrics = BehaviorMetrics(
+            unique_users_interacted=1,
+            group_chats_joined=0,
+            reputation_delta=0,
+        )
+        score = calculate_network_score(metrics)
+        assert score <= 0.3, f"Isolated agent should score <= 0.3, got {score}"
+
+    def test_negative_reputation_penalty(self):
+        """Negative reputation should penalize score"""
+        good_rep = BehaviorMetrics(
+            unique_users_interacted=10,
+            reputation_delta=20,
+        )
+        bad_rep = BehaviorMetrics(
+            unique_users_interacted=10,
+            reputation_delta=-20,
+        )
+        
+        assert calculate_network_score(good_rep) > calculate_network_score(bad_rep)
+
+
+class TestNarrativeAlignmentScore:
+    """Tests for calculate_narrative_alignment_score()"""
+
+    def test_prediction_accuracy_proxy(self):
+        """Without timeline, prediction accuracy should be used"""
+        metrics = BehaviorMetrics(
+            predictions_made=10,
+            correct_predictions=8,
+            prediction_accuracy=0.8,
+        )
+        score = calculate_narrative_alignment_score(metrics)
+        assert score == 0.8, f"Should use prediction_accuracy, got {score}"
+
+    def test_no_predictions_neutral(self):
+        """No predictions should return neutral score"""
+        metrics = BehaviorMetrics(predictions_made=0)
+        score = calculate_narrative_alignment_score(metrics)
+        assert score == 0.5, f"No predictions should return 0.5, got {score}"
+
+    def test_timeline_alignment(self):
+        """Agent that reacts correctly to events should score high"""
+        metrics = BehaviorMetrics()
+        
+        events = [
+            NarrativeEvent(
+                tick=10,
+                event_type="earnings",
+                affected_tickers=["AAPL"],
+                direction="up",
+                revealed=True,
+            ),
+        ]
+        
+        actions = [
+            {"tick": 12, "action_type": "buy", "ticker": "AAPL"},
+        ]
+        
+        score = calculate_narrative_alignment_score(metrics, actions, events)
+        assert score == 1.0, f"Correct reaction should score 1.0, got {score}"
+
+    def test_timeline_misalignment(self):
+        """Agent that reacts incorrectly to events should score low"""
+        metrics = BehaviorMetrics()
+        
+        events = [
+            NarrativeEvent(
+                tick=10,
+                event_type="scandal",
+                affected_tickers=["AAPL"],
+                direction="down",
+                revealed=True,
+            ),
+        ]
+        
+        actions = [
+            {"tick": 12, "action_type": "buy", "ticker": "AAPL"},  # Wrong: should sell
+        ]
+        
+        score = calculate_narrative_alignment_score(metrics, actions, events)
+        assert score == 0.0, f"Wrong reaction should score 0.0, got {score}"
+
+
+class TestCalculateSocialReward:
+    """Tests for calculate_social_reward()"""
+
+    def test_social_butterfly_weights(self):
+        """Social Butterfly should weight network highly"""
+        metrics = BehaviorMetrics(
+            unique_users_interacted=20,
+            group_chats_joined=5,
+            posts_created=10,
+            information_spread=5,
+            reputation_delta=20,
+        )
+        
+        result = calculate_social_reward(metrics, "social-butterfly")
+        
+        assert isinstance(result, SocialRewardResult)
+        assert result.network_score > 0.8
+        assert result.total_score > 0.6
+
+    def test_information_trader_weights(self):
+        """Information Trader should weight narrative alignment highly"""
+        metrics = BehaviorMetrics(
+            predictions_made=10,
+            correct_predictions=8,
+            prediction_accuracy=0.8,
+            unique_users_interacted=5,
+            group_chats_joined=3,
+        )
+        
+        result = calculate_social_reward(metrics, "information-trader")
+        
+        assert result.narrative_alignment_score == 0.8
+        # Info trader weights narrative at 40%
+        assert result.total_score > 0.4
+
+    def test_scammer_weights(self):
+        """Scammer should weight spread highly"""
+        metrics = BehaviorMetrics(
+            information_spread=15,
+            positive_reactions=10,
+            unique_users_interacted=10,
+        )
+        
+        result = calculate_social_reward(metrics, "scammer")
+        
+        assert result.information_spread_score > 0.8
+        # Scammer weights spread at 40%
+        assert result.total_score > 0.5
+
+    def test_default_archetype_balanced(self):
+        """Unknown archetype should use balanced weights"""
+        metrics = BehaviorMetrics(
+            unique_users_interacted=10,
+            posts_created=5,
+            information_spread=5,
+            predictions_made=5,
+            correct_predictions=3,
+            prediction_accuracy=0.6,
+        )
+        
+        result = calculate_social_reward(metrics, "unknown-archetype")
+        
+        # All components should contribute equally (25% each)
+        assert 0.3 <= result.total_score <= 0.7
+
+
+class TestSocialOnlyCompositeReward:
+    """Tests for social_only_composite_reward()"""
+
+    def test_social_butterfly_pnl_irrelevant(self):
+        """Social Butterfly should score high even with zero PnL"""
+        inputs = TrajectoryRewardInputs(
+            final_pnl=0,
+            starting_balance=10000,
+            end_balance=10000,
+            format_score=0.8,
+            reasoning_score=0.7,
+        )
+        
+        metrics = BehaviorMetrics(
+            unique_users_interacted=20,
+            group_chats_joined=5,
+            posts_created=10,
+            dms_initiated=8,
+            reputation_delta=30,
+        )
+        
+        reward = social_only_composite_reward(
+            inputs=inputs,
+            archetype="social-butterfly",
+            behavior_metrics=metrics,
+        )
+        
+        assert reward > 0.5, f"Social Butterfly with great social metrics should score > 0.5 even with $0 PnL, got {reward}"
+
+    def test_bankruptcy_still_penalized(self):
+        """Even social butterflies shouldn't go bankrupt"""
+        inputs = TrajectoryRewardInputs(
+            final_pnl=-10000,
+            starting_balance=10000,
+            end_balance=0,
+            format_score=0.8,
+            reasoning_score=0.7,
+        )
+        
+        metrics = BehaviorMetrics(
+            unique_users_interacted=20,
+            group_chats_joined=5,
+        )
+        
+        reward = social_only_composite_reward(
+            inputs=inputs,
+            archetype="social-butterfly",
+            behavior_metrics=metrics,
+        )
+        
+        assert reward == -0.5, f"Bankruptcy should return -0.5, got {reward}"
+
+    def test_social_butterfly_beats_poor_trader(self):
+        """Social Butterfly with great social should beat trader with poor trading"""
+        # Great social, no trading
+        social_inputs = TrajectoryRewardInputs(
+            final_pnl=0,
+            starting_balance=10000,
+            end_balance=10000,
+            format_score=0.8,
+            reasoning_score=0.7,
+        )
+        social_metrics = BehaviorMetrics(
+            unique_users_interacted=20,
+            group_chats_joined=5,
+            posts_created=15,
+            dms_initiated=10,
+            reputation_delta=40,
+        )
+        
+        # Bad trading, no social
+        trader_inputs = TrajectoryRewardInputs(
+            final_pnl=-500,
+            starting_balance=10000,
+            end_balance=9500,
+            format_score=0.6,
+            reasoning_score=0.5,
+        )
+        trader_metrics = BehaviorMetrics(
+            trades_executed=10,
+            profitable_trades=3,
+            win_rate=0.3,
+            total_pnl=-500,
+        )
+        
+        social_reward = social_only_composite_reward(
+            inputs=social_inputs,
+            archetype="social-butterfly",
+            behavior_metrics=social_metrics,
+        )
+        
+        # For fair comparison, evaluate trader using same social scoring
+        trader_reward = social_only_composite_reward(
+            inputs=trader_inputs,
+            archetype="social-butterfly",
+            behavior_metrics=trader_metrics,
+        )
+        
+        assert social_reward > trader_reward, \
+            f"Social butterfly ({social_reward}) should beat poor trader ({trader_reward})"
+
+
+class TestIntegrationNonTraderCanWin:
+    """
+    Integration test: Non-trader archetype can outscore passive trader
+    
+    This proves that the reward function allows social-focused agents
+    to achieve high scores without trading profitably.
+    """
+
+    def test_social_butterfly_outscores_passive_trader(self):
+        """
+        A Social Butterfly with high social engagement should outscore
+        a passive trader who just holds their balance.
+        """
+        # Passive trader: held balance, did nothing
+        passive_inputs = TrajectoryRewardInputs(
+            final_pnl=0,
+            starting_balance=10000,
+            end_balance=10000,
+            format_score=0.5,  # Average format
+            reasoning_score=0.5,  # Average reasoning
+        )
+        passive_metrics = BehaviorMetrics(
+            trades_executed=0,
+            unique_users_interacted=0,
+        )
+        
+        # Active Social Butterfly: lots of engagement, no trading
+        butterfly_inputs = TrajectoryRewardInputs(
+            final_pnl=0,
+            starting_balance=10000,
+            end_balance=10000,
+            format_score=0.8,
+            reasoning_score=0.7,
+        )
+        butterfly_metrics = BehaviorMetrics(
+            trades_executed=0,
+            unique_users_interacted=25,
+            group_chats_joined=6,
+            dms_initiated=15,
+            posts_created=20,
+            comments_made=30,
+            mentions_given=10,
+            followers_gained=15,
+            reputation_delta=50,
+            positive_reactions=25,
+            information_spread=12,
+        )
+        
+        passive_reward = social_only_composite_reward(
+            inputs=passive_inputs,
+            archetype="social-butterfly",
+            behavior_metrics=passive_metrics,
+        )
+        
+        butterfly_reward = social_only_composite_reward(
+            inputs=butterfly_inputs,
+            archetype="social-butterfly",
+            behavior_metrics=butterfly_metrics,
+        )
+        
+        assert butterfly_reward > passive_reward, \
+            f"Active butterfly ({butterfly_reward:.3f}) should outscore passive ({passive_reward:.3f})"
+        
+        # The difference should be significant
+        assert butterfly_reward - passive_reward > 0.2, \
+            f"Score difference ({butterfly_reward - passive_reward:.3f}) should be > 0.2"
+
+    def test_information_trader_with_predictions_outscores_random_trader(self):
+        """
+        Information Trader with good predictions but no trading
+        should outscore trader with random trades.
+        """
+        # Random trader: traded randomly, lost money
+        random_inputs = TrajectoryRewardInputs(
+            final_pnl=-200,
+            starting_balance=10000,
+            end_balance=9800,
+            format_score=0.5,
+            reasoning_score=0.4,
+        )
+        random_metrics = BehaviorMetrics(
+            trades_executed=10,
+            profitable_trades=4,
+            win_rate=0.4,
+            total_pnl=-200,
+        )
+        
+        # Information trader: gathered intel, made predictions
+        intel_inputs = TrajectoryRewardInputs(
+            final_pnl=0,
+            starting_balance=10000,
+            end_balance=10000,
+            format_score=0.9,
+            reasoning_score=0.85,
+        )
+        intel_metrics = BehaviorMetrics(
+            trades_executed=0,
+            predictions_made=15,
+            correct_predictions=12,
+            prediction_accuracy=0.8,
+            unique_users_interacted=10,
+            group_chats_joined=4,
+            dms_initiated=8,
+            info_requests_sent=10,
+        )
+        
+        random_reward = social_only_composite_reward(
+            inputs=random_inputs,
+            archetype="information-trader",
+            behavior_metrics=random_metrics,
+        )
+        
+        intel_reward = social_only_composite_reward(
+            inputs=intel_inputs,
+            archetype="information-trader",
+            behavior_metrics=intel_metrics,
+        )
+        
+        assert intel_reward > random_reward, \
+            f"Intel trader ({intel_reward:.3f}) should outscore random ({random_reward:.3f})"
+

--- a/packages/training/python/tests/test_social_rewards.py
+++ b/packages/training/python/tests/test_social_rewards.py
@@ -92,9 +92,13 @@ class TestInterpolateScore:
     
     def test_handles_zero_min(self):
         """Should handle min_val of 0 without division by zero"""
-        # When min_val is 0, values below should still work
-        score = _interpolate_score(0, 1, 5, 10)
-        assert score == 0.0
+        # When min_val is 0, value at min should return 0.2 (the base score at min threshold)
+        score_at_min = _interpolate_score(0, 0, 5, 10)
+        assert score_at_min == 0.2  # At min threshold
+        
+        # Value above min but below good should interpolate correctly
+        score_above_min = _interpolate_score(2, 0, 5, 10)
+        assert 0.2 < score_above_min < 0.6  # Between min and good scores
     
     def test_equal_good_and_excellent_thresholds(self):
         """Should handle excellent_val == good_val without division by zero"""
@@ -434,7 +438,8 @@ class TestNetworkScore:
         score = calculate_network_score(metrics)
         # -5 * 0.01 = -0.05 penalty
         base_score = calculate_network_score(BehaviorMetrics(unique_users_interacted=10))
-        assert score == base_score - 0.05
+        # Use approximate comparison to avoid floating-point precision issues
+        assert abs(score - (base_score - 0.05)) < 1e-9
 
 
 # =============================================================================

--- a/packages/training/python/tests/test_social_rewards.py
+++ b/packages/training/python/tests/test_social_rewards.py
@@ -4,6 +4,14 @@ Unit tests for Social Reward Functions (BAB-71)
 Tests the social reward calculation functions that enable
 non-trading archetypes like "Social Butterfly" to achieve
 high scores without trading.
+
+Coverage includes:
+- Happy path tests
+- Boundary conditions (exact thresholds)
+- Edge cases (zeros, negatives, large values)
+- Error handling (invalid inputs)
+- Weight validation (sums to 1.0)
+- All archetypes
 """
 
 import pytest
@@ -18,8 +26,80 @@ from src.training.rewards import (
     calculate_social_reward,
     social_only_composite_reward,
     TrajectoryRewardInputs,
+    # Import constants and helpers for boundary testing
+    SOCIAL_EXCELLENT_SPREAD,
+    SOCIAL_GOOD_SPREAD,
+    SOCIAL_EXCELLENT_ENGAGEMENT,
+    SOCIAL_GOOD_ENGAGEMENT,
+    SOCIAL_MIN_ENGAGEMENT,
+    SOCIAL_EXCELLENT_NETWORK,
+    SOCIAL_GOOD_NETWORK,
+    SOCIAL_MIN_NETWORK,
+    SOCIAL_REWARD_WEIGHTS,
+    SOCIAL_COMPOSITE_WEIGHTS,
+    _interpolate_score,
 )
 
+
+# =============================================================================
+# Helper Function Tests
+# =============================================================================
+
+class TestInterpolateScore:
+    """Tests for _interpolate_score() helper - the core scoring logic"""
+    
+    def test_at_excellent_threshold(self):
+        """Value at excellent threshold should score 1.0"""
+        score = _interpolate_score(20, 3, 10, 20)
+        assert score == 1.0
+    
+    def test_above_excellent_threshold(self):
+        """Value above excellent threshold should still score 1.0 (capped)"""
+        score = _interpolate_score(100, 3, 10, 20)
+        assert score == 1.0
+    
+    def test_at_good_threshold(self):
+        """Value at good threshold should score 0.6"""
+        score = _interpolate_score(10, 3, 10, 20)
+        assert score == 0.6
+    
+    def test_at_min_threshold(self):
+        """Value at min threshold should score 0.2"""
+        score = _interpolate_score(3, 3, 10, 20)
+        assert score == 0.2
+    
+    def test_zero_value(self):
+        """Zero value should score 0.0"""
+        score = _interpolate_score(0, 3, 10, 20)
+        assert score == 0.0
+    
+    def test_between_good_and_excellent(self):
+        """Value between good and excellent should interpolate linearly"""
+        # Midpoint between 10 and 20 is 15, should be midpoint between 0.6 and 1.0 = 0.8
+        score = _interpolate_score(15, 3, 10, 20)
+        assert 0.75 <= score <= 0.85
+    
+    def test_between_min_and_good(self):
+        """Value between min and good should interpolate linearly"""
+        # Midpoint between 3 and 10 is 6.5
+        score = _interpolate_score(6, 3, 10, 20)
+        assert 0.35 <= score <= 0.45
+    
+    def test_below_min(self):
+        """Value below min should scale proportionally"""
+        score = _interpolate_score(1, 3, 10, 20)
+        assert 0.0 < score < 0.2
+    
+    def test_handles_zero_min(self):
+        """Should handle min_val of 0 without division by zero"""
+        # When min_val is 0, values below should still work
+        score = _interpolate_score(0, 1, 5, 10)
+        assert score == 0.0
+
+
+# =============================================================================
+# Engagement Score Tests
+# =============================================================================
 
 class TestEngagementScore:
     """Tests for calculate_engagement_score()"""
@@ -74,6 +154,54 @@ class TestEngagementScore:
         assert diverse_score > single_score, \
             f"Diverse activity ({diverse_score}) should beat single type ({single_score})"
 
+    # Boundary condition tests
+    def test_exactly_at_excellent_threshold(self):
+        """Engagement exactly at SOCIAL_EXCELLENT_ENGAGEMENT"""
+        metrics = BehaviorMetrics(posts_created=SOCIAL_EXCELLENT_ENGAGEMENT)
+        score = calculate_engagement_score(metrics)
+        # Should hit 1.0 volume + diversity bonus (1 type = 0.04)
+        assert score >= 1.0, f"At excellent threshold should score >= 1.0, got {score}"
+    
+    def test_exactly_at_good_threshold(self):
+        """Engagement exactly at SOCIAL_GOOD_ENGAGEMENT"""
+        metrics = BehaviorMetrics(posts_created=SOCIAL_GOOD_ENGAGEMENT)
+        score = calculate_engagement_score(metrics)
+        # Volume score 0.6 + diversity bonus 0.04 = 0.64
+        assert 0.6 <= score <= 0.7, f"At good threshold should score ~0.64, got {score}"
+    
+    def test_exactly_at_min_threshold(self):
+        """Engagement exactly at SOCIAL_MIN_ENGAGEMENT"""
+        metrics = BehaviorMetrics(posts_created=SOCIAL_MIN_ENGAGEMENT)
+        score = calculate_engagement_score(metrics)
+        # Volume score 0.2 + diversity bonus 0.04 = 0.24
+        assert 0.2 <= score <= 0.3, f"At min threshold should score ~0.24, got {score}"
+    
+    def test_max_diversity_bonus(self):
+        """All 5 activity types should give max diversity bonus (0.20)"""
+        metrics = BehaviorMetrics(
+            posts_created=1,
+            comments_made=1,
+            dms_initiated=1,
+            group_chats_joined=1,
+            mentions_given=1,
+        )
+        score = calculate_engagement_score(metrics)
+        # Total = 5 actions, all types active
+        # Volume + 0.20 diversity = should be higher than 4 actions of same type
+        single_type = BehaviorMetrics(posts_created=5)
+        single_score = calculate_engagement_score(single_type)
+        assert score > single_score
+    
+    def test_very_large_engagement(self):
+        """Very large engagement values should still score 1.0 (capped)"""
+        metrics = BehaviorMetrics(posts_created=1000)
+        score = calculate_engagement_score(metrics)
+        assert score == 1.0, f"Very large engagement should cap at 1.0, got {score}"
+
+
+# =============================================================================
+# Information Spread Score Tests
+# =============================================================================
 
 class TestInformationSpreadScore:
     """Tests for calculate_information_spread_score()"""
@@ -119,6 +247,64 @@ class TestInformationSpreadScore:
         assert calculate_information_spread_score(with_reactions) > \
                calculate_information_spread_score(no_reactions)
 
+    # Boundary tests
+    def test_exactly_at_excellent_spread(self):
+        """Spread exactly at SOCIAL_EXCELLENT_SPREAD"""
+        metrics = BehaviorMetrics(information_spread=SOCIAL_EXCELLENT_SPREAD)
+        score = calculate_information_spread_score(metrics)
+        assert score == 1.0, f"At excellent spread should score 1.0, got {score}"
+    
+    def test_exactly_at_good_spread(self):
+        """Spread exactly at SOCIAL_GOOD_SPREAD"""
+        metrics = BehaviorMetrics(information_spread=SOCIAL_GOOD_SPREAD)
+        score = calculate_information_spread_score(metrics)
+        assert score == 0.6, f"At good spread should score 0.6, got {score}"
+    
+    def test_follower_bonus_caps_at_015(self):
+        """Follower bonus should cap at 0.15"""
+        # Very high followers to test cap
+        metrics = BehaviorMetrics(
+            information_spread=0,
+            followers_gained=100,
+        )
+        score = calculate_information_spread_score(metrics)
+        # With spread=0 and followers_gained=100, bonus = min(0.15, 100*0.03) = 0.15
+        assert score <= 0.35, f"Follower bonus should be capped, got {score}"
+    
+    def test_reaction_bonus_caps_at_020(self):
+        """Reaction bonus should cap at 0.20"""
+        metrics = BehaviorMetrics(
+            information_spread=0,
+            positive_reactions=100,
+        )
+        score = calculate_information_spread_score(metrics)
+        # With spread=0 and reactions=100, bonus = min(0.2, 100*0.02) = 0.2
+        assert score <= 0.2, f"Reaction bonus should be capped, got {score}"
+    
+    def test_negative_followers_handled(self):
+        """Negative follower gains should not break scoring"""
+        metrics = BehaviorMetrics(
+            information_spread=5,
+            followers_gained=-10,  # Lost followers
+        )
+        score = calculate_information_spread_score(metrics)
+        # Should handle gracefully, bonus = min(0.15, max(0, -10)*0.03) = 0
+        assert 0.0 <= score <= 1.0, f"Should handle negative followers, got {score}"
+    
+    def test_all_bonuses_stack(self):
+        """All bonuses should stack up to cap of 1.0"""
+        metrics = BehaviorMetrics(
+            information_spread=SOCIAL_EXCELLENT_SPREAD,  # 1.0
+            positive_reactions=20,  # +0.2 (capped)
+            followers_gained=10,    # +0.15 (capped)
+        )
+        score = calculate_information_spread_score(metrics)
+        assert score == 1.0, f"Bonuses should stack to 1.0 cap, got {score}"
+
+
+# =============================================================================
+# Network Score Tests
+# =============================================================================
 
 class TestNetworkScore:
     """Tests for calculate_network_score()"""
@@ -166,6 +352,80 @@ class TestNetworkScore:
         
         assert calculate_network_score(good_rep) > calculate_network_score(bad_rep)
 
+    # Boundary tests
+    def test_exactly_at_excellent_network(self):
+        """Connections exactly at SOCIAL_EXCELLENT_NETWORK"""
+        metrics = BehaviorMetrics(unique_users_interacted=SOCIAL_EXCELLENT_NETWORK)
+        score = calculate_network_score(metrics)
+        assert score == 1.0, f"At excellent network should score 1.0, got {score}"
+    
+    def test_exactly_at_good_network(self):
+        """Connections exactly at SOCIAL_GOOD_NETWORK"""
+        metrics = BehaviorMetrics(unique_users_interacted=SOCIAL_GOOD_NETWORK)
+        score = calculate_network_score(metrics)
+        assert score == 0.6, f"At good network should score 0.6, got {score}"
+    
+    def test_exactly_at_min_network(self):
+        """Connections exactly at SOCIAL_MIN_NETWORK"""
+        metrics = BehaviorMetrics(unique_users_interacted=SOCIAL_MIN_NETWORK)
+        score = calculate_network_score(metrics)
+        assert score == 0.2, f"At min network should score 0.2, got {score}"
+    
+    def test_reputation_cap_positive(self):
+        """Positive reputation bonus caps at 0.15"""
+        metrics = BehaviorMetrics(
+            unique_users_interacted=SOCIAL_EXCELLENT_NETWORK,
+            reputation_delta=100,  # Very high
+        )
+        score = calculate_network_score(metrics)
+        # 1.0 base + 0.15 cap = capped at 1.0
+        assert score == 1.0
+    
+    def test_reputation_cap_negative(self):
+        """Negative reputation penalty caps at -0.15"""
+        metrics = BehaviorMetrics(
+            unique_users_interacted=SOCIAL_EXCELLENT_NETWORK,
+            reputation_delta=-100,  # Very negative
+        )
+        score = calculate_network_score(metrics)
+        # 1.0 base - 0.15 penalty = 0.85
+        assert score == 0.85, f"Reputation penalty should cap, got {score}"
+    
+    def test_group_bonus_caps(self):
+        """Group participation bonus caps at 0.20"""
+        metrics = BehaviorMetrics(
+            unique_users_interacted=0,
+            group_chats_joined=50,  # Very high
+        )
+        score = calculate_network_score(metrics)
+        # 0 network + 0.20 group cap = 0.20
+        assert score == 0.2, f"Group bonus should cap at 0.20, got {score}"
+    
+    def test_score_floor_at_zero(self):
+        """Score should never go below 0.0"""
+        metrics = BehaviorMetrics(
+            unique_users_interacted=0,
+            group_chats_joined=0,
+            reputation_delta=-100,  # Very negative
+        )
+        score = calculate_network_score(metrics)
+        assert score == 0.0, f"Score should floor at 0.0, got {score}"
+    
+    def test_reputation_in_mild_negative_range(self):
+        """Mild negative reputation (> -10) uses proportional penalty"""
+        metrics = BehaviorMetrics(
+            unique_users_interacted=10,
+            reputation_delta=-5,  # Mild negative
+        )
+        score = calculate_network_score(metrics)
+        # -5 * 0.01 = -0.05 penalty
+        base_score = calculate_network_score(BehaviorMetrics(unique_users_interacted=10))
+        assert score == base_score - 0.05
+
+
+# =============================================================================
+# Narrative Alignment Score Tests
+# =============================================================================
 
 class TestNarrativeAlignmentScore:
     """Tests for calculate_narrative_alignment_score()"""
@@ -228,6 +488,202 @@ class TestNarrativeAlignmentScore:
         score = calculate_narrative_alignment_score(metrics, actions, events)
         assert score == 0.0, f"Wrong reaction should score 0.0, got {score}"
 
+    # Edge cases
+    def test_unrevealed_events_ignored(self):
+        """Unrevealed events should not affect scoring"""
+        metrics = BehaviorMetrics()
+        
+        events = [
+            NarrativeEvent(
+                tick=10,
+                event_type="insider",
+                affected_tickers=["AAPL"],
+                direction="up",
+                revealed=False,  # Not revealed
+            ),
+        ]
+        
+        actions = [
+            {"tick": 12, "action_type": "sell", "ticker": "AAPL"},  # "Wrong" but event not revealed
+        ]
+        
+        score = calculate_narrative_alignment_score(metrics, actions, events)
+        assert score == 0.5, f"Unrevealed events should return neutral, got {score}"
+    
+    def test_action_on_wrong_ticker(self):
+        """Action on different ticker should not count"""
+        metrics = BehaviorMetrics()
+        
+        events = [
+            NarrativeEvent(
+                tick=10,
+                event_type="earnings",
+                affected_tickers=["AAPL"],
+                direction="up",
+                revealed=True,
+            ),
+        ]
+        
+        actions = [
+            {"tick": 12, "action_type": "buy", "ticker": "GOOG"},  # Wrong ticker
+        ]
+        
+        score = calculate_narrative_alignment_score(metrics, actions, events)
+        # Action was taken but on wrong ticker, so no correct reaction
+        assert score == 0.0, f"Wrong ticker should score 0.0, got {score}"
+    
+    def test_action_too_late(self):
+        """Action more than 5 ticks after event should not count"""
+        metrics = BehaviorMetrics()
+        
+        events = [
+            NarrativeEvent(
+                tick=10,
+                event_type="earnings",
+                affected_tickers=["AAPL"],
+                direction="up",
+                revealed=True,
+            ),
+        ]
+        
+        actions = [
+            {"tick": 20, "action_type": "buy", "ticker": "AAPL"},  # Too late (10 ticks)
+        ]
+        
+        score = calculate_narrative_alignment_score(metrics, actions, events)
+        assert score == 0.5, f"Late action should not count, got {score}"
+    
+    def test_action_before_event(self):
+        """Action before event should not count as reaction"""
+        metrics = BehaviorMetrics()
+        
+        events = [
+            NarrativeEvent(
+                tick=10,
+                event_type="earnings",
+                affected_tickers=["AAPL"],
+                direction="up",
+                revealed=True,
+            ),
+        ]
+        
+        actions = [
+            {"tick": 8, "action_type": "buy", "ticker": "AAPL"},  # Before event
+        ]
+        
+        score = calculate_narrative_alignment_score(metrics, actions, events)
+        assert score == 0.5, f"Action before event should not count, got {score}"
+    
+    def test_multiple_events_partial_alignment(self):
+        """Score should reflect proportion of correct reactions"""
+        metrics = BehaviorMetrics()
+        
+        events = [
+            NarrativeEvent(tick=10, event_type="good", affected_tickers=["AAPL"], direction="up", revealed=True),
+            NarrativeEvent(tick=20, event_type="bad", affected_tickers=["GOOG"], direction="down", revealed=True),
+        ]
+        
+        actions = [
+            {"tick": 12, "action_type": "buy", "ticker": "AAPL"},   # Correct
+            {"tick": 22, "action_type": "buy", "ticker": "GOOG"},   # Wrong (should sell)
+        ]
+        
+        score = calculate_narrative_alignment_score(metrics, actions, events)
+        assert score == 0.5, f"Half right should score 0.5, got {score}"
+    
+    def test_long_action_type(self):
+        """'long' in action_type should count as buy"""
+        metrics = BehaviorMetrics()
+        
+        events = [
+            NarrativeEvent(tick=10, event_type="good", affected_tickers=["BTC"], direction="up", revealed=True),
+        ]
+        
+        actions = [
+            {"tick": 12, "action_type": "open_long", "ticker": "BTC"},
+        ]
+        
+        score = calculate_narrative_alignment_score(metrics, actions, events)
+        assert score == 1.0, f"'long' should count as buy, got {score}"
+    
+    def test_short_action_type(self):
+        """'short' in action_type should count as sell"""
+        metrics = BehaviorMetrics()
+        
+        events = [
+            NarrativeEvent(tick=10, event_type="bad", affected_tickers=["BTC"], direction="down", revealed=True),
+        ]
+        
+        actions = [
+            {"tick": 12, "action_type": "open_short", "ticker": "BTC"},
+        ]
+        
+        score = calculate_narrative_alignment_score(metrics, actions, events)
+        assert score == 1.0, f"'short' should count as sell, got {score}"
+    
+    def test_empty_events_list(self):
+        """Empty events list should return neutral"""
+        metrics = BehaviorMetrics()
+        score = calculate_narrative_alignment_score(metrics, [{"tick": 1}], [])
+        assert score == 0.5, f"Empty events should return 0.5, got {score}"
+    
+    def test_empty_actions_list(self):
+        """Empty actions list should return neutral (no reactions)"""
+        metrics = BehaviorMetrics()
+        events = [NarrativeEvent(tick=10, event_type="x", affected_tickers=["A"], direction="up", revealed=True)]
+        score = calculate_narrative_alignment_score(metrics, [], events)
+        assert score == 0.5, f"Empty actions should return 0.5, got {score}"
+    
+    def test_missing_tick_in_action(self):
+        """Action missing tick field should be handled"""
+        metrics = BehaviorMetrics()
+        events = [NarrativeEvent(tick=10, event_type="x", affected_tickers=["A"], direction="up", revealed=True)]
+        actions = [{"action_type": "buy", "ticker": "A"}]  # No tick
+        score = calculate_narrative_alignment_score(metrics, actions, events)
+        # get("tick", 0) defaults to 0, which is before event
+        assert score == 0.5
+
+
+# =============================================================================
+# Social Reward Weight Validation
+# =============================================================================
+
+class TestSocialRewardWeights:
+    """Verify weight configurations are valid"""
+    
+    def test_all_social_weights_sum_to_one(self):
+        """All archetype weight profiles should sum to 1.0"""
+        for archetype, weights in SOCIAL_REWARD_WEIGHTS.items():
+            total = sum(weights.values())
+            assert abs(total - 1.0) < 1e-9, f"Weights for {archetype} sum to {total}, expected 1.0"
+    
+    def test_all_composite_weights_sum_to_one(self):
+        """All composite weight profiles should sum to 1.0"""
+        for archetype, weights in SOCIAL_COMPOSITE_WEIGHTS.items():
+            total = sum(weights.values())
+            assert abs(total - 1.0) < 1e-9, f"Composite weights for {archetype} sum to {total}, expected 1.0"
+    
+    def test_all_weights_non_negative(self):
+        """All weights should be non-negative"""
+        for archetype, weights in SOCIAL_REWARD_WEIGHTS.items():
+            for key, value in weights.items():
+                assert value >= 0, f"Weight {key} for {archetype} is negative: {value}"
+    
+    def test_required_weight_keys_present(self):
+        """All weight dicts should have required keys"""
+        required_social = {"engagement", "spread", "network", "narrative"}
+        required_composite = {"social", "format", "reasoning", "pnl"}
+        
+        for archetype, weights in SOCIAL_REWARD_WEIGHTS.items():
+            assert set(weights.keys()) == required_social, f"Missing keys in {archetype}"
+        
+        for archetype, weights in SOCIAL_COMPOSITE_WEIGHTS.items():
+            assert set(weights.keys()) == required_composite, f"Missing keys in {archetype}"
+
+
+# =============================================================================
+# Calculate Social Reward Tests
+# =============================================================================
 
 class TestCalculateSocialReward:
     """Tests for calculate_social_reward()"""
@@ -294,6 +750,88 @@ class TestCalculateSocialReward:
         # All components should contribute equally (25% each)
         assert 0.3 <= result.total_score <= 0.7
 
+    # Additional archetype tests
+    def test_liar_weights(self):
+        """Liar should use same weights as scammer (spread-focused)"""
+        metrics = BehaviorMetrics(information_spread=15)
+        
+        scammer_result = calculate_social_reward(metrics, "scammer")
+        liar_result = calculate_social_reward(metrics, "liar")
+        
+        assert scammer_result.total_score == liar_result.total_score
+    
+    def test_goody_twoshoes_weights(self):
+        """Goody Two-Shoes should have balanced weights"""
+        metrics = BehaviorMetrics(
+            unique_users_interacted=10,
+            posts_created=5,
+            information_spread=5,
+            prediction_accuracy=0.6,
+            predictions_made=5,
+        )
+        
+        result = calculate_social_reward(metrics, "goody-twoshoes")
+        assert 0.3 <= result.total_score <= 0.7
+    
+    def test_ass_kisser_weights(self):
+        """Ass-Kisser should weight engagement and network highly"""
+        metrics = BehaviorMetrics(
+            unique_users_interacted=15,
+            posts_created=10,
+            comments_made=10,
+        )
+        
+        result = calculate_social_reward(metrics, "ass-kisser")
+        # 35% engagement + 40% network = 75% from these two
+        assert result.total_score > 0.5
+    
+    def test_archetype_normalization(self):
+        """Archetype names should be normalized (case, underscores)"""
+        metrics = BehaviorMetrics(unique_users_interacted=10)
+        
+        # Test various formats
+        r1 = calculate_social_reward(metrics, "social-butterfly")
+        r2 = calculate_social_reward(metrics, "Social-Butterfly")
+        r3 = calculate_social_reward(metrics, "SOCIAL_BUTTERFLY")
+        r4 = calculate_social_reward(metrics, "social_butterfly")
+        
+        assert r1.total_score == r2.total_score == r3.total_score == r4.total_score
+    
+    def test_result_to_dict(self):
+        """SocialRewardResult.to_dict() should return all components"""
+        metrics = BehaviorMetrics(
+            unique_users_interacted=10,
+            posts_created=5,
+            information_spread=5,
+        )
+        
+        result = calculate_social_reward(metrics, "social-butterfly")
+        result_dict = result.to_dict()
+        
+        assert "engagement_score" in result_dict
+        assert "information_spread_score" in result_dict
+        assert "narrative_alignment_score" in result_dict
+        assert "network_score" in result_dict
+        assert "total_score" in result_dict
+        
+        # Verify values match
+        assert result_dict["total_score"] == result.total_score
+    
+    def test_all_zero_metrics(self):
+        """All zero metrics should still return valid result"""
+        metrics = BehaviorMetrics()
+        result = calculate_social_reward(metrics, "social-butterfly")
+        
+        assert result.engagement_score >= 0.0
+        assert result.network_score >= 0.0
+        assert result.information_spread_score >= 0.0
+        assert result.narrative_alignment_score == 0.5  # Neutral with no predictions
+        assert 0.0 <= result.total_score <= 1.0
+
+
+# =============================================================================
+# Social Only Composite Reward Tests
+# =============================================================================
 
 class TestSocialOnlyCompositeReward:
     """Tests for social_only_composite_reward()"""
@@ -395,6 +933,159 @@ class TestSocialOnlyCompositeReward:
         
         assert social_reward > trader_reward, \
             f"Social butterfly ({social_reward}) should beat poor trader ({trader_reward})"
+
+    # Edge cases
+    def test_negative_end_balance(self):
+        """Negative end balance should trigger bankruptcy penalty"""
+        inputs = TrajectoryRewardInputs(
+            final_pnl=-15000,
+            starting_balance=10000,
+            end_balance=-5000,
+            format_score=1.0,
+            reasoning_score=1.0,
+        )
+        
+        reward = social_only_composite_reward(
+            inputs=inputs,
+            archetype="social-butterfly",
+            behavior_metrics=BehaviorMetrics(unique_users_interacted=100),
+        )
+        
+        assert reward == -0.5, f"Negative balance should return -0.5, got {reward}"
+    
+    def test_zero_starting_balance(self):
+        """Zero starting balance should not cause division by zero"""
+        inputs = TrajectoryRewardInputs(
+            final_pnl=0,
+            starting_balance=0,
+            end_balance=100,  # Not bankrupt
+            format_score=0.5,
+            reasoning_score=0.5,
+        )
+        
+        reward = social_only_composite_reward(
+            inputs=inputs,
+            archetype="social-butterfly",
+            behavior_metrics=BehaviorMetrics(),
+        )
+        
+        # Should not raise, should return valid score
+        assert -1.0 <= reward <= 1.0
+    
+    def test_no_behavior_metrics(self):
+        """Should handle None behavior_metrics gracefully"""
+        inputs = TrajectoryRewardInputs(
+            final_pnl=100,
+            starting_balance=10000,
+            end_balance=10100,
+            format_score=0.8,
+            reasoning_score=0.7,
+        )
+        
+        reward = social_only_composite_reward(
+            inputs=inputs,
+            archetype="social-butterfly",
+            behavior_metrics=None,
+        )
+        
+        # Should use empty SocialRewardResult
+        assert -1.0 <= reward <= 1.0
+    
+    def test_large_profit_pnl_bonus(self):
+        """Large profit should give PnL bonus (but social still dominates)"""
+        inputs_profit = TrajectoryRewardInputs(
+            final_pnl=1000,
+            starting_balance=10000,
+            end_balance=11000,
+            format_score=0.5,
+            reasoning_score=0.5,
+        )
+        
+        inputs_break_even = TrajectoryRewardInputs(
+            final_pnl=0,
+            starting_balance=10000,
+            end_balance=10000,
+            format_score=0.5,
+            reasoning_score=0.5,
+        )
+        
+        metrics = BehaviorMetrics(unique_users_interacted=10)
+        
+        profit_reward = social_only_composite_reward(inputs_profit, "social-butterfly", metrics)
+        even_reward = social_only_composite_reward(inputs_break_even, "social-butterfly", metrics)
+        
+        # Profit should give slight bonus
+        assert profit_reward > even_reward
+    
+    def test_heavy_loss_penalty(self):
+        """Heavy loss (>50% of starting) should give penalty"""
+        inputs = TrajectoryRewardInputs(
+            final_pnl=-6000,  # >50% loss
+            starting_balance=10000,
+            end_balance=4000,
+            format_score=0.8,
+            reasoning_score=0.8,
+        )
+        
+        metrics = BehaviorMetrics(unique_users_interacted=10)
+        
+        reward = social_only_composite_reward(inputs, "social-butterfly", metrics)
+        
+        # Should have -0.3 penalty on PnL component
+        break_even = social_only_composite_reward(
+            TrajectoryRewardInputs(final_pnl=0, starting_balance=10000, end_balance=10000, format_score=0.8, reasoning_score=0.8),
+            "social-butterfly", metrics
+        )
+        
+        assert reward < break_even
+    
+    def test_all_weights_archetypes(self):
+        """All archetypes with composite weights should work"""
+        inputs = TrajectoryRewardInputs(
+            final_pnl=0,
+            starting_balance=10000,
+            end_balance=10000,
+            format_score=0.5,
+            reasoning_score=0.5,
+        )
+        metrics = BehaviorMetrics(unique_users_interacted=10)
+        
+        for archetype in ["social-butterfly", "ass-kisser", "goody-twoshoes", "unknown"]:
+            reward = social_only_composite_reward(inputs, archetype, metrics)
+            assert -1.0 <= reward <= 1.0, f"Invalid reward for {archetype}: {reward}"
+    
+    def test_reward_clamped_to_bounds(self):
+        """Reward should always be in [-1.0, 1.0]"""
+        # Best case: everything perfect
+        best_inputs = TrajectoryRewardInputs(
+            final_pnl=5000,
+            starting_balance=10000,
+            end_balance=15000,
+            format_score=1.0,
+            reasoning_score=1.0,
+        )
+        best_metrics = BehaviorMetrics(
+            unique_users_interacted=50,
+            posts_created=50,
+            information_spread=50,
+            reputation_delta=100,
+        )
+        
+        best_reward = social_only_composite_reward(best_inputs, "social-butterfly", best_metrics)
+        assert best_reward <= 1.0, f"Best case should cap at 1.0, got {best_reward}"
+        
+        # Worst case (non-bankrupt): everything bad
+        worst_inputs = TrajectoryRewardInputs(
+            final_pnl=-4000,
+            starting_balance=10000,
+            end_balance=6000,  # Not bankrupt but bad
+            format_score=0.0,
+            reasoning_score=0.0,
+        )
+        worst_metrics = BehaviorMetrics()
+        
+        worst_reward = social_only_composite_reward(worst_inputs, "social-butterfly", worst_metrics)
+        assert worst_reward >= -1.0, f"Worst case should floor at -1.0, got {worst_reward}"
 
 
 class TestIntegrationNonTraderCanWin:


### PR DESCRIPTION
<!--
Babylon PR template

Goal: make PRs easy to review + easy to ship.
- Prefer small, focused PRs (one theme). Avoid catch‑all PRs.
- Keep app-layer thin and portable (validate → service → map errors).
- Put domain logic in packages (framework-agnostic), not in Next handlers/components.
- Before requesting review, run the relevant checks (see "Test plan").
-->

## Summary
<!-- 1–3 bullets: what changed + why (user impact / business goal). -->

- **Social Butterfly and other non-trading archetypes can now achieve high scores without trading profitably.** The reward function previously over-weighted PnL, making it impossible for social-focused agents to succeed.
- Added `calculate_social_reward()` with four components: engagement, information spread, network building, and narrative alignment—each with archetype-specific weights.
- Integration test proves a Social Butterfly with zero P&L but strong social metrics outscores a passive trader.

## Type
<!-- Helps triage + release notes. -->

- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [x] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
<!-- Link issues, Linear tickets, docs, prior PRs. -->

- Linear: BAB-71 (Social Narrative Rewards)
- Related: Enables training non-trader archetypes like Social Butterfly, Information Trader

## Scope (keep it focused)
<!-- If you had to touch multiple areas, explain why and what you intentionally left out. -->

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Non-goals / follow-ups:**
- [ ] Using `social_only_composite_reward()` as the default reward for social archetypes (requires training config changes)
- [ ] Extending narrative alignment to use full timeline data (currently uses prediction accuracy as proxy)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [x] Other: `packages/training` (Python reward functions, W&B logging, documentation)

## Changes
<!-- List the notable changes (what is new/removed/modified). Link key files if it helps. -->

**New in `rewards.py`:**
- `SocialRewardResult` dataclass - breakdown of social reward components
- `NarrativeEvent` dataclass - ground truth events for narrative alignment
- `calculate_engagement_score()` - posts, DMs, comments, group activity
- `calculate_information_spread_score()` - reactions, shares, follower gains
- `calculate_network_score()` - unique connections, groups, reputation
- `calculate_narrative_alignment_score()` - alignment with revealed events
- `calculate_social_reward()` - combines components with archetype-specific weights
- `social_only_composite_reward()` - PnL-independent composite for social archetypes
- `SOCIAL_REWARD_WEIGHTS` - per-archetype component weights (6 archetypes + default)
- `SOCIAL_COMPOSITE_WEIGHTS` - composite weights for social-focused archetypes
- `_interpolate_score()` helper - reduces redundant threshold logic

**Updated in `babylon_env.py`:**
- Calls `calculate_social_reward()` and stores component scores
- Logs 5 new W&B metrics: `train/social_{engagement,spread,network,narrative,total}_mean`

**New tests (`test_social_rewards.py`):**
- 80 tests covering all social reward functions
- Boundary conditions, edge cases, error handling
- Integration test proving non-trader can outscore passive trader

**Documentation updates:**
- `enhanced-rewards.md` - Social & Narrative Rewards section
- `archetype-system.md` - Social Archetypes section with weight tables
- `adding-archetypes.md` - Guide for adding social archetypes
- `reward-system.md` - Social Rewards section
- `rubrics.md` - Social Butterfly scoring notes
- `glossary.md` - Social Reward, Narrative Event definitions
- `wandb.md` - Social metrics documentation

## Review guide
<!-- Help reviewers go fast: where to start, ignore, tricky bits, key decisions. -->

**Start here**
- `packages/training/python/src/training/rewards.py` lines 1760-2095 (all new social reward code)
- `packages/training/python/tests/test_social_rewards.py` (comprehensive tests)

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- All new code is additive—existing reward functions unchanged
- `social_only_composite_reward()` is not yet wired as default for any archetype (opt-in only)
- Weight values (e.g., Social Butterfly 40% network) are initial estimates; may need tuning after training runs
- Narrative alignment currently uses `prediction_accuracy` as proxy when full timeline data unavailable

## Test plan
<!-- Tick what you ran. Add manual steps for anything user-facing. -->

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run test` (unit + integration) - `make tier1` in packages/training
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Ran `pytest tests/test_social_rewards.py -v` - 80 tests passed
2. Ran `make tier1` - 766 tests passed
3. Verified W&B metrics appear in `wandb_log()` output

## Ops / Migration / Deployment
<!-- Anything that impacts deploys, data, cron, config, or rollouts. -->

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy
<!-- Authn/authz, secrets handling, PII, prompt injection surfaces, etc. -->

- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend-only change to Python reward functions. No UI impact. New W&B metrics will appear in training dashboards automatically.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Social reward metrics system tracking engagement, information spread, network strength, and narrative alignment
  * Counterfactual alpha metric for causal evaluation
  * Narrative event framework for decision tracking

* **Documentation**
  * Expanded guides on social archetypes, weighting, metrics, rubrics, and W&B logging
  * New glossary entries for Social Reward and Narrative Event

* **Tests**
  * Comprehensive test suite covering social reward calculations, weighting validation, and integration scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR successfully implements a comprehensive social reward system that enables non-trading archetypes (Social Butterfly, Information Trader, etc.) to achieve high scores without profitable trading. Previously, PnL-focused rewards made it impossible for social-focused agents to succeed.

**Key Changes:**
- Adds `calculate_social_reward()` with four weighted components: engagement (social activity volume/diversity), information spread (content reach), network building (connections/reputation), and narrative alignment (prediction accuracy or timeline analysis)
- Each archetype has custom weights (e.g., Social Butterfly prioritizes network at 40%, Information Trader prioritizes narrative at 40%)
- New `social_only_composite_reward()` function minimizes PnL weight (10%) and maximizes social weight (40-55%) for social archetypes
- Integration test proves a Social Butterfly with zero P&L but strong social metrics outscores a passive trader
- Comprehensive test suite with 80 tests covering all functions, boundaries, edge cases, and weight validation
- Full documentation across 7 book chapters with tables, examples, and W&B metric definitions
- W&B logging tracks 5 new metrics: engagement, spread, network, narrative, and total social scores

**Code Quality:**
- Clean implementation using dataclasses (`SocialRewardResult`, `NarrativeEvent`)
- DRY helper function `_interpolate_score()` reduces threshold logic duplication
- All weights validated to sum to 1.0
- Proper boundary handling (clamping, zero-division protection)
- Additive changes only—existing reward functions untouched

**Minor Issue:**
- One inline import should be moved to top-level (style comment added)

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk—all changes are additive, well-tested, and properly documented.
- Score reflects excellent test coverage (80 tests with boundary/edge cases), comprehensive documentation, clean additive implementation with no changes to existing functionality, and successful integration test. Minor point deduction for one inline import style issue.
- No files require special attention—the minor style issue in `babylon_env.py` is non-critical.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/training/python/src/training/rewards.py | Adds comprehensive social reward system with 4 scoring components (engagement, spread, network, narrative) and archetype-specific weights. Clean implementation with proper dataclasses and helper functions. |
| packages/training/python/src/training/babylon_env.py | Integrates social rewards into training loop, adds W&B logging for 5 social metrics. Uses inline import instead of top-level import (minor style issue). |
| packages/training/python/tests/test_social_rewards.py | Excellent test coverage with 80 tests covering all functions, boundary conditions, edge cases, weight validation, and integration scenarios proving non-traders can outscore traders. |
| packages/training/book/src/scoring/enhanced-rewards.md | Clear documentation of social reward system with component descriptions, archetype weight tables, usage examples, and W&B metrics. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Env as BabylonEnv
    participant Rewards as rewards.py
    participant Metrics as BehaviorMetrics
    participant WandB as Weights & Biases
    
    Note over Env: Training loop processes trajectory
    
    Env->>Metrics: Extract behavior metrics from trajectory
    Metrics-->>Env: BehaviorMetrics (posts, DMs, connections, etc.)
    
    Env->>Rewards: calculate_social_reward(metrics, archetype)
    
    activate Rewards
    Rewards->>Rewards: calculate_engagement_score(metrics)
    Note right of Rewards: Posts + DMs + comments + groups<br/>Diversity bonus for activity types
    
    Rewards->>Rewards: calculate_information_spread_score(metrics)
    Note right of Rewards: Spread count + reactions + followers<br/>Content reach and influence
    
    Rewards->>Rewards: calculate_network_score(metrics)
    Note right of Rewards: Unique users + groups<br/>Reputation modifier
    
    Rewards->>Rewards: calculate_narrative_alignment_score(metrics)
    Note right of Rewards: Prediction accuracy (proxy)<br/>Or timeline analysis if available
    
    Rewards->>Rewards: Apply archetype-specific weights
    Note right of Rewards: e.g. Social Butterfly:<br/>network=40%, engagement=30%
    
    Rewards-->>Env: SocialRewardResult (components + total)
    deactivate Rewards
    
    Env->>Env: Store component scores in enhanced_reward_metrics
    Note over Env: Accumulate for W&B logging
    
    Env->>WandB: Log social metrics (every N steps)
    Note right of WandB: train/social_engagement_mean<br/>train/social_spread_mean<br/>train/social_network_mean<br/>train/social_narrative_mean<br/>train/social_total_mean

```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->