### PR TITLE
fix(agents): BAB-104 agent creation UX improvements

### DIFF
--- a/apps/web/src/app/agents/create/components/AgentConfigForm.tsx
+++ b/apps/web/src/app/agents/create/components/AgentConfigForm.tsx
@@ -55,12 +55,12 @@ const FieldWithAI = memo(function FieldWithAI({
           {isGenerating ? (
             <>
               <Loader2 className="h-3 w-3 animate-spin" />
-              Generating...
+              Enhancing...
             </>
           ) : (
             <>
               <Sparkles className="h-3 w-3" />
-              Regenerate
+              Enhance
             </>
           )}
         </button>
@@ -90,13 +90,13 @@ export const AgentConfigForm = memo(function AgentConfigForm({
   onRegenerate,
 }: AgentConfigFormProps) {
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <FieldWithAI
         id="system"
         label="System Prompt"
         value={agentData.system}
         placeholder="You are a trading agent focused on..."
-        rows={6}
+        rows={4}
         isGenerating={generatingField === 'system'}
         onRegenerate={() => onRegenerate('system')}
         onChange={(v) => onFieldChange('system', v)}
@@ -108,7 +108,7 @@ export const AgentConfigForm = memo(function AgentConfigForm({
         label="Personality"
         value={agentData.personality}
         placeholder="Analytical and methodical..."
-        rows={4}
+        rows={3}
         isGenerating={generatingField === 'personality'}
         onRegenerate={() => onRegenerate('personality')}
         onChange={(v) => onFieldChange('personality', v)}
@@ -120,7 +120,7 @@ export const AgentConfigForm = memo(function AgentConfigForm({
         label="Trading Strategy"
         value={agentData.tradingStrategy}
         placeholder="Focus on momentum indicators..."
-        rows={5}
+        rows={3}
         isGenerating={generatingField === 'tradingStrategy'}
         onRegenerate={() => onRegenerate('tradingStrategy')}
         onChange={(v) => onFieldChange('tradingStrategy', v)}

--- a/apps/web/src/app/agents/create/hooks/useAgentForm.ts
+++ b/apps/web/src/app/agents/create/hooks/useAgentForm.ts
@@ -261,7 +261,7 @@ export function useAgentForm(): UseAgentFormResult {
         );
       }
 
-      toast.success(`Regenerated ${field}!`);
+      toast.success(`Enhanced ${field}!`);
       setGeneratingField(null);
     },
     [agentData, profileData, getAccessToken, updateAgentField]

--- a/apps/web/src/app/api/agents/[agentId]/onboarding/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/onboarding/route.ts
@@ -13,7 +13,7 @@
 
 import { agentRuntimeManager, agentService } from '@babylon/agents';
 import { authenticateUser, withErrorHandling } from '@babylon/api';
-import { db, messages as messagesTable } from '@babylon/db';
+import { chats, db, eq, messages as messagesTable } from '@babylon/db';
 import { GROQ_MODELS, generateSnowflakeId, logger } from '@babylon/shared';
 import {
   composePromptFromState,
@@ -211,24 +211,39 @@ export const POST = withErrorHandling(
     const dmChatId = `dm-${sortedIds.join('-')}`;
 
     try {
-      const dmMessageId = await generateSnowflakeId();
-      await db
-        .insert(messagesTable)
-        .values({
-          id: dmMessageId,
-          chatId: dmChatId,
-          senderId: agentId,
-          content: welcomeMessage,
-          type: 'system',
-          createdAt: messageTime,
-        })
-        .onConflictDoNothing(); // Ignore if DM chat doesn't exist yet
+      // Verify the DM chat exists before inserting to prevent orphaned records
+      const existingChat = await db
+        .select({ id: chats.id })
+        .from(chats)
+        .where(eq(chats.id, dmChatId))
+        .limit(1);
 
-      logger.info(
-        `Onboarding message also posted to DM chat`,
-        { dmChatId, dmMessageId },
-        'AgentOnboarding'
-      );
+      if (existingChat.length === 0) {
+        logger.debug(
+          `Skipping DM message - chat does not exist yet`,
+          { dmChatId },
+          'AgentOnboarding'
+        );
+      } else {
+        const dmMessageId = await generateSnowflakeId();
+        await db
+          .insert(messagesTable)
+          .values({
+            id: dmMessageId,
+            chatId: dmChatId,
+            senderId: agentId,
+            content: welcomeMessage,
+            type: 'system',
+            createdAt: messageTime,
+          })
+          .onConflictDoNothing(); // Ignore insert conflicts (e.g., duplicate DM message ID)
+
+        logger.info(
+          `Onboarding message also posted to DM chat`,
+          { dmChatId, dmMessageId },
+          'AgentOnboarding'
+        );
+      }
     } catch (error) {
       // Don't fail the whole request if DM message fails
       logger.warn(

--- a/apps/web/src/app/api/agents/[agentId]/onboarding/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/onboarding/route.ts
@@ -6,13 +6,15 @@
  *
  * @description
  * Generates an initial onboarding message from the agent to introduce
- * itself and its capabilities to the user.
+ * itself and its capabilities to the user. Posts message to both:
+ * 1. agentMessages table (for agent chat history)
+ * 2. DM messages table (for regular chat UI)
  */
 
 import { agentRuntimeManager, agentService } from '@babylon/agents';
 import { authenticateUser, withErrorHandling } from '@babylon/api';
-import { db } from '@babylon/db';
-import { GROQ_MODELS, logger } from '@babylon/shared';
+import { db, messages as messagesTable } from '@babylon/db';
+import { generateSnowflakeId, GROQ_MODELS, logger } from '@babylon/shared';
 import {
   composePromptFromState,
   type Memory,
@@ -202,6 +204,39 @@ export const POST = withErrorHandling(
         createdAt: messageTime,
       },
     });
+
+    // Also post to the DM chat so it shows in the regular chat UI
+    // DM chat ID format: dm-{sortedId1}-{sortedId2}
+    const sortedIds = [user.id, agentId].sort();
+    const dmChatId = `dm-${sortedIds.join('-')}`;
+
+    try {
+      const dmMessageId = await generateSnowflakeId();
+      await db
+        .insert(messagesTable)
+        .values({
+          id: dmMessageId,
+          chatId: dmChatId,
+          senderId: agentId,
+          content: welcomeMessage,
+          type: 'user',
+          createdAt: messageTime,
+        })
+        .onConflictDoNothing(); // Ignore if DM chat doesn't exist yet
+
+      logger.info(
+        `Onboarding message also posted to DM chat`,
+        { dmChatId, dmMessageId },
+        'AgentOnboarding'
+      );
+    } catch (error) {
+      // Don't fail the whole request if DM message fails
+      logger.warn(
+        `Failed to post onboarding message to DM chat`,
+        { dmChatId, error: error instanceof Error ? error.message : 'Unknown' },
+        'AgentOnboarding'
+      );
+    }
 
     logger.info(
       `Onboarding message generated for agent ${agentId}`,

--- a/apps/web/src/app/api/agents/[agentId]/onboarding/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/onboarding/route.ts
@@ -14,7 +14,7 @@
 import { agentRuntimeManager, agentService } from '@babylon/agents';
 import { authenticateUser, withErrorHandling } from '@babylon/api';
 import { db, messages as messagesTable } from '@babylon/db';
-import { generateSnowflakeId, GROQ_MODELS, logger } from '@babylon/shared';
+import { GROQ_MODELS, generateSnowflakeId, logger } from '@babylon/shared';
 import {
   composePromptFromState,
   type Memory,
@@ -219,7 +219,7 @@ export const POST = withErrorHandling(
           chatId: dmChatId,
           senderId: agentId,
           content: welcomeMessage,
-          type: 'user',
+          type: 'system',
           createdAt: messageTime,
         })
         .onConflictDoNothing(); // Ignore if DM chat doesn't exist yet

--- a/apps/web/src/components/agents/AgentChat.tsx
+++ b/apps/web/src/components/agents/AgentChat.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { logger } from '@babylon/shared';
+import { Wallet } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { ChatViewHeader } from '@/components/chats/ChatViewHeader';
@@ -401,6 +402,19 @@ export function AgentChat({
           onManageGroup={() => {}}
           onLeaveChat={() => {}}
         />
+
+        {/* Agent Balance Banner */}
+        {agent.virtualBalance !== undefined && (
+          <div className="flex items-center justify-between border-border border-b bg-muted/30 px-4 py-2">
+            <div className="flex items-center gap-2 text-muted-foreground text-sm">
+              <Wallet className="h-4 w-4" />
+              <span>Agent Balance</span>
+            </div>
+            <span className="font-medium font-mono text-sm">
+              ${agent.virtualBalance.toLocaleString()}
+            </span>
+          </div>
+        )}
 
         {/* Header Separator */}
         <div className="px-4">

--- a/apps/web/src/components/agents/AgentChat.tsx
+++ b/apps/web/src/components/agents/AgentChat.tsx
@@ -405,13 +405,16 @@ export function AgentChat({
 
         {/* Agent Balance Banner */}
         {agent.virtualBalance !== undefined && (
-          <div className="flex items-center justify-between border-border border-b bg-muted/30 px-4 py-2">
+          <div
+            className="flex items-center justify-between border-border border-b bg-muted/30 px-4 py-2"
+            aria-label={`Agent balance: $${agent.virtualBalance.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
+          >
             <div className="flex items-center gap-2 text-muted-foreground text-sm">
-              <Wallet className="h-4 w-4" />
+              <Wallet className="h-4 w-4" aria-hidden="true" />
               <span>Agent Balance</span>
             </div>
             <span className="font-medium font-mono text-sm">
-              ${agent.virtualBalance.toLocaleString()}
+              ${agent.virtualBalance.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
             </span>
           </div>
         )}


### PR DESCRIPTION
## Summary
- Reduce form spacing for less scrolling
- Rename "Regenerate" → "Enhance" button
- Post welcome message to DM chat on onboarding
- Add agent balance banner in chat header

## Linear
Closes BAB-104

## Test plan
- [ ] Create new agent, verify reduced scrolling in form
- [ ] Click "Enhance" button, verify it enhances existing content
- [ ] Complete agent onboarding, verify welcome message in DM
- [ ] Open agent chat, verify balance banner visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent balance displayed in chat header when available
  * Onboarding messages also posted to direct messages (non-blocking on failure)

* **UI Updates**
  * Regeneration button label changed to "Enhance" and in-progress text to "Enhancing..."
  * Reduced form spacing and smaller textarea heights for a tighter layout
  * Success toast updated to "Enhanced {field}!"

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR implements UX improvements for the agent creation flow, focusing on reducing scrolling and improving the onboarding experience.

**Key Changes:**
- Reduced form spacing and textarea heights to minimize scrolling during agent creation
- Renamed "Regenerate" button to "Enhance" for clearer semantics about improving existing content
- Added welcome message posting to DM chat during onboarding (in addition to agent messages table) so users see it in the regular chat UI
- Added agent balance banner in chat header to display `virtualBalance` with `Wallet` icon

**Implementation Notes:**
- The onboarding message is posted with `.onConflictDoNothing()` as a safety measure, though the DM chat is created before the onboarding API call in the normal flow
- The balance banner conditionally renders only when `agent.virtualBalance` is defined
- Error handling is graceful - DM message insertion failures are logged but don't fail the request

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The changes are straightforward UX improvements with no logical errors or security concerns. The form spacing adjustments are simple CSS changes, the button renaming is consistent across all usages, the onboarding message dual-posting has proper error handling, and the balance banner is a simple conditional render. The code follows existing patterns in the codebase.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/agents/create/components/AgentConfigForm.tsx | Reduced form spacing (space-y-6 → space-y-4) and textarea rows for less scrolling, renamed "Regenerate" → "Enhance" button |
| apps/web/src/app/agents/create/hooks/useAgentForm.ts | Updated toast message from "Regenerated" to "Enhanced" to match button text change |
| apps/web/src/app/api/agents/[agentId]/onboarding/route.ts | Added logic to post onboarding message to DM chat (in addition to agentMessages table) so it appears in regular chat UI |
| apps/web/src/components/agents/AgentChat.tsx | Added agent balance banner with Wallet icon below chat header to display virtualBalance |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant AgentCreatePage
    participant API
    participant DMChatAPI
    participant OnboardingAPI
    participant DB
    participant AgentChat

    User->>AgentCreatePage: Fill form and submit
    AgentCreatePage->>API: POST /api/agents (create agent)
    API->>DB: Insert agent record
    API-->>AgentCreatePage: Return agentId
    
    AgentCreatePage->>DMChatAPI: POST /api/chats/dm (create DM chat)
    DMChatAPI->>DB: Create chat with ID: dm-{sorted ids}
    DMChatAPI->>DB: Add both participants
    DMChatAPI-->>AgentCreatePage: Return chatId
    
    AgentCreatePage->>OnboardingAPI: POST /api/agents/{agentId}/onboarding
    OnboardingAPI->>DB: Insert into agentMessages table
    OnboardingAPI->>DB: Insert into messages table (DM chat)
    OnboardingAPI-->>AgentCreatePage: Success
    
    AgentCreatePage->>User: Redirect to /chats?chat={chatId}
    User->>AgentChat: View agent chat
    AgentChat->>AgentChat: Render balance banner
    AgentChat->>DB: Fetch messages from DM chat
    AgentChat-->>User: Display welcome message + balance
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->