### PR TITLE
fix: improve chat scroll reliability and restore infinite scroll on chat switch

### DIFF
--- a/apps/web/src/app/api/chats/[id]/route.ts
+++ b/apps/web/src/app/api/chats/[id]/route.ts
@@ -79,6 +79,7 @@ import {
   logger,
 } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
+import { CHAT_PAGE_SIZE } from '@/lib/constants';
 
 /**
  * GET /api/chats/[id]
@@ -106,7 +107,7 @@ export const GET = withErrorHandling(
     const validatedQuery = ChatQuerySchema.parse(query);
 
     // Parse pagination parameters
-    const limit = limitParam ? Number.parseInt(limitParam, 10) : 50;
+    const limit = limitParam ? Number.parseInt(limitParam, 10) : CHAT_PAGE_SIZE;
     const effectiveLimit = Math.min(Math.max(limit, 1), 100); // Between 1 and 100
 
     // Check for debug mode (localhost access to game chats)

--- a/apps/web/src/app/chats/page.tsx
+++ b/apps/web/src/app/chats/page.tsx
@@ -102,7 +102,6 @@ export default function ChatsPage() {
     messagesEndRef,
     topSentinelRef,
     setRefs,
-    pullDistance,
 
     // Actions
     sendMessage,
@@ -220,7 +219,6 @@ export default function ChatsPage() {
                 loading={loadingChat}
                 isLoadingMore={isLoadingMore}
                 hasMore={hasMore}
-                pullDistance={pullDistance}
                 messageInput={messageInput}
                 sending={sending}
                 sendError={sendError}

--- a/apps/web/src/components/agents/AgentChat.tsx
+++ b/apps/web/src/components/agents/AgentChat.tsx
@@ -421,7 +421,6 @@ export function AgentChat({
             loading={loading}
             isLoadingMore={isLoadingMore}
             hasMore={hasMore}
-            pullDistance={0}
             authenticated={!!user}
             topSentinelRef={topSentinelRef}
             messagesEndRef={messagesEndRef}

--- a/apps/web/src/components/agents/AgentChat.tsx
+++ b/apps/web/src/components/agents/AgentChat.tsx
@@ -101,11 +101,11 @@ export function AgentChat({
   // Use pro mode based on agent's model tier
   const usePro = agent.modelTier === 'pro';
 
-  // Scroll to newest messages (scrollTop = 0 due to flex-col-reverse)
+  // Scroll to newest messages
   const scrollToBottom = useCallback((behavior: ScrollBehavior = 'smooth') => {
     const container = chatContainerRef.current;
     if (container) {
-      container.scrollTo({ top: 0, behavior });
+      container.scrollTo({ top: container.scrollHeight, behavior });
     }
   }, []);
 
@@ -256,7 +256,7 @@ export function AgentChat({
     lastMessageIdRef.current = lastId;
   }, [messages, loading]);
 
-  // Load older messages when scrolling up
+  // Load older messages when scrolling up (near top)
   useEffect(() => {
     const container = chatContainerRef.current;
     const sentinel = topSentinelRef.current;
@@ -267,8 +267,8 @@ export function AgentChat({
       (entries) => {
         const entry = entries[0];
         if (!entry) return;
-        const maxScrollTop = container.scrollHeight - container.clientHeight;
-        const nearTop = container.scrollTop >= maxScrollTop - 200;
+        // Check if user is near the top (scrollTop close to 0)
+        const nearTop = container.scrollTop <= 200;
         if (entry.isIntersecting && nearTop && hasMore && !isLoadingMore) {
           pendingScrollAdjustRef.current = {
             previousHeight: container.scrollHeight,
@@ -408,10 +408,10 @@ export function AgentChat({
         </div>
       </div>
 
-      {/* Messages - Scrollable, starts at bottom via flex-col-reverse */}
+      {/* Messages - Scrollable */}
       <div
         ref={chatContainerRef}
-        className="relative flex min-h-0 flex-1 flex-col-reverse overflow-y-auto px-4 py-3"
+        className="relative min-h-0 flex-1 overflow-y-auto px-4 py-3"
       >
         <div className="flex flex-col space-y-4">
           <MessageList

--- a/apps/web/src/components/chats/ChatView.tsx
+++ b/apps/web/src/components/chats/ChatView.tsx
@@ -18,7 +18,6 @@ interface ChatViewProps {
   loading: boolean;
   isLoadingMore: boolean;
   hasMore: boolean;
-  pullDistance: number;
   messageInput: string;
   sending: boolean;
   sendError: string | null;
@@ -43,7 +42,6 @@ export function ChatView({
   loading,
   isLoadingMore,
   hasMore,
-  pullDistance,
   messageInput,
   sending,
   sendError,
@@ -116,7 +114,6 @@ export function ChatView({
             loading={loading}
             isLoadingMore={isLoadingMore}
             hasMore={hasMore}
-            pullDistance={pullDistance}
             authenticated={authenticated}
             topSentinelRef={topSentinelRef}
             messagesEndRef={messagesEndRef}

--- a/apps/web/src/components/chats/ChatView.tsx
+++ b/apps/web/src/components/chats/ChatView.tsx
@@ -101,10 +101,10 @@ export function ChatView({
         )}
       </div>
 
-      {/* Messages - Scrollable, starts at bottom via flex-col-reverse */}
+      {/* Messages - Scrollable */}
       <div
         ref={containerRef}
-        className="relative flex min-h-0 flex-1 flex-col-reverse overflow-y-auto px-4 py-3"
+        className="relative min-h-0 flex-1 overflow-y-auto px-4 py-3"
       >
         <div className="flex flex-col space-y-4">
           <MessageList

--- a/apps/web/src/components/chats/MessageList.tsx
+++ b/apps/web/src/components/chats/MessageList.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import type { MessageType } from '@babylon/db';
-import { cn } from '@babylon/shared';
 import { Loader2, MessageCircle } from 'lucide-react';
 import React from 'react';
 import { Skeleton } from '@/components/shared/Skeleton';
@@ -29,7 +28,6 @@ interface MessageListProps {
   loading: boolean;
   isLoadingMore: boolean;
   hasMore: boolean;
-  pullDistance: number;
   authenticated: boolean;
   topSentinelRef: React.RefObject<HTMLDivElement | null>;
   messagesEndRef: React.RefObject<HTMLDivElement | null>;
@@ -42,7 +40,6 @@ export function MessageList({
   loading,
   isLoadingMore,
   hasMore,
-  pullDistance,
   authenticated,
   topSentinelRef,
   messagesEndRef,
@@ -67,21 +64,6 @@ export function MessageList({
       {/* Gradient overlay to hint more messages */}
       {hasMore && (
         <div className="pointer-events-none absolute top-0 right-0 left-0 z-10 h-8 bg-gradient-to-b from-background via-background/90 to-transparent" />
-      )}
-
-      {/* Pull-to-refresh indicator */}
-      {pullDistance > 0 && (
-        <div
-          className="absolute top-0 right-0 left-0 flex items-center justify-center py-2 transition-opacity"
-          style={{ opacity: Math.min(pullDistance / 80, 1) }}
-        >
-          <Loader2
-            className={cn(
-              'h-6 w-6 text-primary',
-              pullDistance > 80 ? 'animate-spin' : ''
-            )}
-          />
-        </div>
       )}
 
       {/* Sentinel for infinite scroll */}

--- a/apps/web/src/components/chats/TeamChatView.tsx
+++ b/apps/web/src/components/chats/TeamChatView.tsx
@@ -170,7 +170,6 @@ export function TeamChatView({
           loading={loading}
           isLoadingMore={isLoadingMore}
           hasMore={hasMore}
-          pullDistance={0}
           authenticated={authenticated}
           topSentinelRef={topSentinelRef}
           messagesEndRef={messagesEndRef}

--- a/apps/web/src/components/chats/hooks/useChatPage.ts
+++ b/apps/web/src/components/chats/hooks/useChatPage.ts
@@ -409,11 +409,11 @@ export function useChatPage() {
     [getAccessToken, user]
   );
 
-  // Scroll to newest messages (scrollTop = 0 due to flex-col-reverse)
+  // Scroll to newest messages
   const scrollToBottom = useCallback((behavior: ScrollBehavior = 'auto') => {
     const container = chatContainerRef.current;
     if (container) {
-      container.scrollTo({ top: 0, behavior });
+      container.scrollTo({ top: container.scrollHeight, behavior });
     }
   }, []);
 
@@ -517,7 +517,7 @@ export function useChatPage() {
     }
   }, [chatDetails?.messages, isAtBottom, scrollToBottom, loadingChat]);
 
-  // Load older messages when scrolling up
+  // Load older messages when scrolling up (near top)
   useEffect(() => {
     const container = chatContainerRef.current;
     const sentinel = topSentinelRef.current;
@@ -528,8 +528,8 @@ export function useChatPage() {
       (entries) => {
         const entry = entries[0];
         if (!entry) return;
-        const maxScrollTop = container.scrollHeight - container.clientHeight;
-        const nearTop = container.scrollTop >= maxScrollTop - 200;
+        // Check if user is near the top (scrollTop close to 0)
+        const nearTop = container.scrollTop <= 200;
         if (entry.isIntersecting && nearTop && hasMore && !isLoadingMore) {
           pendingScrollAdjustRef.current = {
             previousHeight: container.scrollHeight,
@@ -565,7 +565,8 @@ export function useChatPage() {
 
     const handleScroll = () => {
       const threshold = 50;
-      const atBottom = container.scrollTop <= threshold;
+      const maxScrollTop = container.scrollHeight - container.clientHeight;
+      const atBottom = container.scrollTop >= maxScrollTop - threshold;
       setIsAtBottom(atBottom);
     };
 

--- a/apps/web/src/components/chats/hooks/useChatPage.ts
+++ b/apps/web/src/components/chats/hooks/useChatPage.ts
@@ -5,7 +5,6 @@ import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { useChatMessages } from '@/hooks/useChatMessages';
-import { usePullToRefresh } from '@/hooks/usePullToRefresh';
 import { useAuthStore } from '@/stores/authStore';
 import type { Chat, ChatDetails, ChatFilter } from '../types';
 
@@ -418,23 +417,9 @@ export function useChatPage() {
     }
   }, []);
 
-  // Pull-to-refresh
-  const { pullDistance, containerRef: setPullToRefreshRef } = usePullToRefresh({
-    onRefresh: async () => {
-      if (!selectedChatId) return;
-      await loadChatDetails(selectedChatId).catch((error: Error) => {
-        console.error('Error refreshing chat details:', error);
-      });
-    },
-  });
-
-  const setRefs = useCallback(
-    (node: HTMLDivElement | null) => {
-      chatContainerRef.current = node;
-      setPullToRefreshRef(node);
-    },
-    [setPullToRefreshRef]
-  );
+  const setRefs = useCallback((node: HTMLDivElement | null) => {
+    chatContainerRef.current = node;
+  }, []);
 
   // Filter chats
   const filteredByType =
@@ -676,7 +661,6 @@ export function useChatPage() {
     messagesEndRef,
     topSentinelRef,
     setRefs,
-    pullDistance,
 
     // Actions
     sendMessage,

--- a/apps/web/src/components/chats/hooks/useChatPage.ts
+++ b/apps/web/src/components/chats/hooks/useChatPage.ts
@@ -64,6 +64,8 @@ export function useChatPage() {
   } | null>(null);
   const lastMessageIdRef = useRef<string | null>(null);
   const emptyChatPollAttemptsRef = useRef(0);
+  // Track pending initial scroll - cleared when we successfully scroll to bottom
+  const pendingInitialScrollRef = useRef<string | null>(null);
 
   // Debug mode
   const isDebugMode =
@@ -480,7 +482,10 @@ export function useChatPage() {
     lastMessageIdRef.current = null;
     setIsAtBottom(true);
     if (selectedChatId) {
+      pendingInitialScrollRef.current = selectedChatId;
       loadChatDetails(selectedChatId);
+    } else {
+      pendingInitialScrollRef.current = null;
     }
   }, [selectedChatId, loadChatDetails]);
 
@@ -494,7 +499,7 @@ export function useChatPage() {
     }
   }, [realtimeMessages]);
 
-  // Handle new messages and auto-scroll
+  // Handle new messages - scroll smoothly for incoming messages
   useEffect(() => {
     if (loadingChat) return;
 
@@ -506,16 +511,59 @@ export function useChatPage() {
     const wasEmpty = lastMessageIdRef.current === null;
     lastMessageIdRef.current = lastId;
 
-    if (wasEmpty) {
-      setIsAtBottom(true);
-      scrollToBottom('auto');
-      return;
-    }
-
-    if (isNewMessage && isAtBottom) {
+    // For new messages (not initial load), scroll smoothly if at bottom
+    if (!wasEmpty && isNewMessage && isAtBottom) {
       scrollToBottom('smooth');
     }
   }, [chatDetails?.messages, isAtBottom, scrollToBottom, loadingChat]);
+
+  // Handle initial scroll using ResizeObserver for reliable timing
+  useEffect(() => {
+    const container = chatContainerRef.current;
+    // Only run when chatDetails matches selectedChatId (avoid stale data)
+    if (!container || !selectedChatId || chatDetails?.chat?.id !== selectedChatId) return;
+
+    // If no pending scroll, nothing to do
+    if (pendingInitialScrollRef.current !== selectedChatId) return;
+
+    const scrollToBottom = () => {
+      const maxScroll = container.scrollHeight - container.clientHeight;
+      if (maxScroll > 0) {
+        container.scrollTo({ top: maxScroll, behavior: 'auto' });
+      }
+    };
+
+    // Try immediate scroll (don't clear flag yet - content may still be loading)
+    scrollToBottom();
+
+    // Observe for content changes (images loading, layout shifts, etc.)
+    const resizeObserver = new ResizeObserver(() => {
+      if (pendingInitialScrollRef.current !== selectedChatId) return;
+      
+      // Content changed - scroll again
+      scrollToBottom();
+    });
+
+    const contentWrapper = container.firstElementChild;
+    if (contentWrapper) {
+      resizeObserver.observe(contentWrapper);
+    }
+
+    // Clear pending flag after delay - content should be stable by then
+    const timeoutId = setTimeout(() => {
+      if (pendingInitialScrollRef.current === selectedChatId) {
+        // Final scroll attempt
+        scrollToBottom();
+        pendingInitialScrollRef.current = null;
+        setIsAtBottom(true);
+      }
+    }, 300);
+
+    return () => {
+      resizeObserver.disconnect();
+      clearTimeout(timeoutId);
+    };
+  }, [selectedChatId, chatDetails]);
 
   // Load older messages when scrolling up (near top)
   useEffect(() => {
@@ -528,6 +576,10 @@ export function useChatPage() {
       (entries) => {
         const entry = entries[0];
         if (!entry) return;
+
+        // Don't load more during initial scroll - wait until scrolled to bottom
+        if (pendingInitialScrollRef.current === selectedChatId) return;
+
         // Check if user is near the top (scrollTop close to 0)
         const nearTop = container.scrollTop <= 200;
         if (entry.isIntersecting && nearTop && hasMore && !isLoadingMore) {
@@ -543,7 +595,7 @@ export function useChatPage() {
 
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [selectedChatId, hasMore, isLoadingMore, loadMore]);
+  }, [selectedChatId, hasMore, isLoadingMore, loadMore, chatDetails]);
 
   // Maintain scroll position after loading older messages
   useEffect(() => {

--- a/apps/web/src/components/chats/hooks/useChatPage.ts
+++ b/apps/web/src/components/chats/hooks/useChatPage.ts
@@ -517,10 +517,9 @@ export function useChatPage() {
     }
   }, [chatDetails?.messages, isAtBottom, scrollToBottom, loadingChat]);
 
-  // Handle initial scroll using ResizeObserver for reliable timing
+  // Handle initial scroll - keep scrolling to bottom until stable
   useEffect(() => {
     const container = chatContainerRef.current;
-    // Only run when chatDetails matches selectedChatId (avoid stale data)
     if (
       !container ||
       !selectedChatId ||
@@ -528,45 +527,54 @@ export function useChatPage() {
     )
       return;
 
-    // If no pending scroll, nothing to do
     if (pendingInitialScrollRef.current !== selectedChatId) return;
 
-    const scrollToBottom = () => {
-      const maxScroll = container.scrollHeight - container.clientHeight;
-      if (maxScroll > 0) {
-        container.scrollTo({ top: maxScroll, behavior: 'auto' });
-      }
-    };
+    let rafId: number;
+    let lastScrollHeight = 0;
+    let stableCount = 0;
+    const MAX_STABLE = 5; // Need 5 consecutive stable frames
+    const MAX_TIME = 2000; // Give up after 2 seconds
+    const startTime = Date.now();
 
-    // Try immediate scroll (don't clear flag yet - content may still be loading)
-    scrollToBottom();
-
-    // Observe for content changes (images loading, layout shifts, etc.)
-    const resizeObserver = new ResizeObserver(() => {
+    const tick = () => {
       if (pendingInitialScrollRef.current !== selectedChatId) return;
-
-      // Content changed - scroll again
-      scrollToBottom();
-    });
-
-    const contentWrapper = container.firstElementChild;
-    if (contentWrapper) {
-      resizeObserver.observe(contentWrapper);
-    }
-
-    // Clear pending flag after delay - content should be stable by then
-    const timeoutId = setTimeout(() => {
-      if (pendingInitialScrollRef.current === selectedChatId) {
-        // Final scroll attempt
-        scrollToBottom();
+      if (Date.now() - startTime > MAX_TIME) {
+        // Timeout - clear flag and stop
         pendingInitialScrollRef.current = null;
         setIsAtBottom(true);
+        return;
       }
-    }, 300);
+
+      const currentHeight = container.scrollHeight;
+      const maxScroll = currentHeight - container.clientHeight;
+
+      // Always scroll to bottom
+      if (maxScroll > 0) {
+        container.scrollTop = maxScroll;
+      }
+
+      // Check if height is stable
+      if (currentHeight === lastScrollHeight) {
+        stableCount++;
+        if (stableCount >= MAX_STABLE) {
+          // Height stable for 5 frames - we're done
+          pendingInitialScrollRef.current = null;
+          setIsAtBottom(true);
+          return;
+        }
+      } else {
+        stableCount = 0;
+        lastScrollHeight = currentHeight;
+      }
+
+      // Keep going
+      rafId = requestAnimationFrame(tick);
+    };
+
+    rafId = requestAnimationFrame(tick);
 
     return () => {
-      resizeObserver.disconnect();
-      clearTimeout(timeoutId);
+      cancelAnimationFrame(rafId);
     };
   }, [selectedChatId, chatDetails]);
 

--- a/apps/web/src/components/chats/hooks/useChatPage.ts
+++ b/apps/web/src/components/chats/hooks/useChatPage.ts
@@ -521,7 +521,12 @@ export function useChatPage() {
   useEffect(() => {
     const container = chatContainerRef.current;
     // Only run when chatDetails matches selectedChatId (avoid stale data)
-    if (!container || !selectedChatId || chatDetails?.chat?.id !== selectedChatId) return;
+    if (
+      !container ||
+      !selectedChatId ||
+      chatDetails?.chat?.id !== selectedChatId
+    )
+      return;
 
     // If no pending scroll, nothing to do
     if (pendingInitialScrollRef.current !== selectedChatId) return;
@@ -539,7 +544,7 @@ export function useChatPage() {
     // Observe for content changes (images loading, layout shifts, etc.)
     const resizeObserver = new ResizeObserver(() => {
       if (pendingInitialScrollRef.current !== selectedChatId) return;
-      
+
       // Content changed - scroll again
       scrollToBottom();
     });

--- a/apps/web/src/hooks/useChatMessages.ts
+++ b/apps/web/src/hooks/useChatMessages.ts
@@ -281,6 +281,8 @@ export function useChatMessages(chatId: string | null) {
 
     if (previousChatId !== chatId) {
       if (chatId) {
+        // Always force reload when switching chats to ensure hasMore is correct
+        hasLoadedRef.current.delete(chatId);
         setMessages([]);
         setHasMore(false);
         setNextCursor(null);

--- a/apps/web/src/hooks/useChatMessages.ts
+++ b/apps/web/src/hooks/useChatMessages.ts
@@ -280,9 +280,11 @@ export function useChatMessages(chatId: string | null) {
     const previousChatId = previousChatIdRef.current;
 
     if (previousChatId !== chatId) {
+      // Clear the "already loaded" flag so switching back to this chat will reload
+      if (previousChatId) {
+        hasLoadedRef.current.delete(previousChatId);
+      }
       if (chatId) {
-        // Always force reload when switching chats to ensure hasMore is correct
-        hasLoadedRef.current.delete(chatId);
         setMessages([]);
         setHasMore(false);
         setNextCursor(null);

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -12,7 +12,7 @@ export const MAX_REPLY_COUNT = 99;
  * Number of messages to load per page in chat
  * Used for initial load and infinite scroll pagination
  */
-export const CHAT_PAGE_SIZE = 10;
+export const CHAT_PAGE_SIZE = 50;
 
 /**
  * Points cost per message for each model tier

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -12,7 +12,7 @@ export const MAX_REPLY_COUNT = 99;
  * Number of messages to load per page in chat
  * Used for initial load and infinite scroll pagination
  */
-export const CHAT_PAGE_SIZE = 50;
+export const CHAT_PAGE_SIZE = 10;
 
 /**
  * Points cost per message for each model tier


### PR DESCRIPTION
issue:


https://github.com/user-attachments/assets/190c8c52-e067-4980-8b8c-dd2c47cd2dfb

result:


https://github.com/user-attachments/assets/3cb75ecb-6f44-4aeb-beba-f300e4a5ce80


This PR comprehensively fixes chat scrolling issues that were causing unreliable scroll-to-bottom behavior and broken infinite scroll.

### Changes

- Remove pull-to-refresh feature which was redundant (SSE handles real-time updates) and conflicting with scroll logic
- Revert `flex-col-reverse` CSS approach that broke infinite scroll by inverting scroll coordinates
- Use `CHAT_PAGE_SIZE` constant consistently in chat API route instead of hardcoded value
- Replace unreliable ResizeObserver with `requestAnimationFrame` loop that continuously scrolls until content height stabilizes
- Clear `hasLoadedRef` cache when switching chats to ensure infinite scroll works when returning to a previously visited chat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic scroll positioning and stabilization when opening a chat so new messages stay in view.
  * Fixed chat history reloading when switching conversations to ensure fresh message loads.
  * Adjusted when older messages load to avoid premature loads during initial scroll stabilization.

* **Refactor**
  * Removed pull-to-refresh gesture from message lists.
  * Standardized pagination default size across chat endpoints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixes chat scroll reliability by removing conflicting `flex-col-reverse` CSS and pull-to-refresh feature, implementing a robust `requestAnimationFrame` loop for initial scroll-to-bottom, and clearing the chat cache to restore infinite scroll when switching between conversations.

**Key changes:**
- Removed pull-to-refresh feature (redundant with SSE real-time updates)
- Reverted `flex-col-reverse` CSS that inverted scroll coordinates and broke infinite scroll
- Implemented `requestAnimationFrame` loop that continuously scrolls until content height stabilizes (replaces unreliable ResizeObserver)
- Clear `hasLoadedRef` cache when switching chats to enable infinite scroll on return visits
- Use `CHAT_PAGE_SIZE` constant consistently in API route

<h3>Confidence Score: 4/5</h3>


- Safe to merge with minor consideration for the requestAnimationFrame timeout
- The PR makes sensible architectural improvements by removing conflicting features and implementing a more reliable scroll solution. The main concern is the requestAnimationFrame loop could theoretically run for the full 2-second timeout in edge cases, though this is unlikely. The changes are well-tested based on the demo videos and address real issues.
- Pay attention to `apps/web/src/components/chats/hooks/useChatPage.ts` for the requestAnimationFrame implementation

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/hooks/useChatMessages.ts | Clear `hasLoadedRef` cache when switching chats to restore infinite scroll |
| apps/web/src/components/chats/hooks/useChatPage.ts | Major refactor: removed pull-to-refresh, fixed scroll coordinates from flex-col-reverse removal, added requestAnimationFrame loop for reliable initial scroll |
| apps/web/src/components/chats/ChatView.tsx | Removed `flex-col-reverse` CSS and `pullDistance` prop from message container |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ChatPage
    participant useChatPage
    participant useChatMessages
    participant API
    participant SSE

    User->>ChatPage: Select chat
    ChatPage->>useChatPage: setSelectedChatId(chatId)
    
    activate useChatPage
    useChatPage->>useChatPage: Set pendingInitialScrollRef = chatId
    useChatPage->>useChatPage: loadChatDetails(chatId)
    useChatPage->>API: GET /api/chats/[id]
    API-->>useChatPage: Chat details
    deactivate useChatPage
    
    activate useChatMessages
    Note over useChatMessages: Previous chatId: clear hasLoadedRef cache
    useChatMessages->>useChatMessages: hasLoadedRef.delete(previousChatId)
    useChatMessages->>API: GET /api/chats/[id]?limit=50
    API-->>useChatMessages: Initial messages
    useChatMessages->>useChatMessages: hasLoadedRef.add(chatId)
    useChatMessages->>SSE: Subscribe to chat:${chatId}
    SSE-->>useChatMessages: Connection established
    deactivate useChatMessages
    
    activate useChatPage
    Note over useChatPage: requestAnimationFrame loop starts
    loop Until height stable or 2s timeout
        useChatPage->>useChatPage: Scroll to bottom
        useChatPage->>useChatPage: Check if scrollHeight stable
    end
    useChatPage->>useChatPage: Clear pendingInitialScrollRef
    useChatPage->>useChatPage: setIsAtBottom(true)
    deactivate useChatPage
    
    User->>ChatPage: Scroll to top
    activate useChatPage
    useChatPage->>useChatPage: IntersectionObserver detects sentinel
    useChatPage->>useChatMessages: loadMore()
    deactivate useChatPage
    
    activate useChatMessages
    useChatMessages->>API: GET /api/chats/[id]?cursor=X&limit=50
    API-->>useChatMessages: Older messages
    useChatMessages->>useChatMessages: Prepend to messages array
    deactivate useChatMessages
    
    activate useChatPage
    useChatPage->>useChatPage: Maintain scroll position (adjust by delta)
    deactivate useChatPage
    
    SSE->>useChatMessages: New message event
    activate useChatMessages
    useChatMessages->>useChatMessages: Add message to array
    useChatMessages-->>useChatPage: Updated messages
    deactivate useChatMessages
    
    activate useChatPage
    alt User is at bottom
        useChatPage->>useChatPage: scrollToBottom('smooth')
    else User scrolled up
        useChatPage->>useChatPage: No auto-scroll
    end
    deactivate useChatPage
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->