### PR TITLE
fix(chat): improve scroll-to-bottom reliability and restore infinite scroll

### DIFF
--- a/apps/web/src/components/agents/AgentChat.tsx
+++ b/apps/web/src/components/agents/AgentChat.tsx
@@ -319,6 +319,7 @@ export function AgentChat({
       observer.disconnect();
       if (idleTimeout) clearTimeout(idleTimeout);
     };
+    // biome-ignore lint/correctness/useExhaustiveDependencies: messages.length needed to re-run effect when DOM is ready after messages load
   }, [agent.id, loading, messages.length]);
 
   // Load older messages when scrolling up (near top)

--- a/apps/web/src/components/agents/AgentChat.tsx
+++ b/apps/web/src/components/agents/AgentChat.tsx
@@ -266,6 +266,7 @@ export function AgentChat({
     }
   }, [agent.id]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: messages.length needed to re-run effect when DOM is ready after messages load
   useEffect(() => {
     const container = chatContainerRef.current;
     const endMarker = messagesEndRef.current;
@@ -319,7 +320,6 @@ export function AgentChat({
       observer.disconnect();
       if (idleTimeout) clearTimeout(idleTimeout);
     };
-    // biome-ignore lint/correctness/useExhaustiveDependencies: messages.length needed to re-run effect when DOM is ready after messages load
   }, [agent.id, loading, messages.length]);
 
   // Load older messages when scrolling up (near top)

--- a/apps/web/src/components/agents/AgentChat.tsx
+++ b/apps/web/src/components/agents/AgentChat.tsx
@@ -275,6 +275,7 @@ export function AgentChat({
     if (pendingInitialScrollRef.current !== agent.id) return;
 
     let idleTimeout: ReturnType<typeof setTimeout> | null = null;
+    let observer: MutationObserver | null = null;
     const IDLE_MS = 500;
     const MAX_TIME = 2000;
     const startTime = Date.now();
@@ -284,12 +285,14 @@ export function AgentChat({
     };
 
     const finish = () => {
+      observer?.disconnect();
+      if (idleTimeout) clearTimeout(idleTimeout);
       pendingInitialScrollRef.current = null;
     };
 
     scrollToEnd();
 
-    const observer = new MutationObserver(() => {
+    observer = new MutationObserver(() => {
       if (pendingInitialScrollRef.current !== agent.id) return;
       if (Date.now() - startTime > MAX_TIME) {
         scrollToEnd();
@@ -304,11 +307,10 @@ export function AgentChat({
       }, IDLE_MS);
     });
 
+    // Only observe childList and subtree - attributes/characterData are unnecessary for scroll
     observer.observe(container, {
       childList: true,
       subtree: true,
-      attributes: true,
-      characterData: true,
     });
 
     idleTimeout = setTimeout(() => {
@@ -317,7 +319,7 @@ export function AgentChat({
     }, IDLE_MS);
 
     return () => {
-      observer.disconnect();
+      observer?.disconnect();
       if (idleTimeout) clearTimeout(idleTimeout);
     };
   }, [agent.id, loading, messages.length]);

--- a/apps/web/src/components/agents/AgentChat.tsx
+++ b/apps/web/src/components/agents/AgentChat.tsx
@@ -257,6 +257,70 @@ export function AgentChat({
     lastMessageIdRef.current = lastId;
   }, [messages, loading]);
 
+  // Scroll to bottom on initial load using MutationObserver
+  const pendingInitialScrollRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (agent.id) {
+      pendingInitialScrollRef.current = agent.id;
+    }
+  }, [agent.id]);
+
+  useEffect(() => {
+    const container = chatContainerRef.current;
+    const endMarker = messagesEndRef.current;
+
+    if (!container || !endMarker || loading) return;
+    if (pendingInitialScrollRef.current !== agent.id) return;
+
+    let idleTimeout: ReturnType<typeof setTimeout> | null = null;
+    const IDLE_MS = 500;
+    const MAX_TIME = 2000;
+    const startTime = Date.now();
+
+    const scrollToEnd = () => {
+      endMarker.scrollIntoView({ behavior: 'auto', block: 'end' });
+    };
+
+    const finish = () => {
+      pendingInitialScrollRef.current = null;
+    };
+
+    scrollToEnd();
+
+    const observer = new MutationObserver(() => {
+      if (pendingInitialScrollRef.current !== agent.id) return;
+      if (Date.now() - startTime > MAX_TIME) {
+        scrollToEnd();
+        finish();
+        return;
+      }
+      scrollToEnd();
+      if (idleTimeout) clearTimeout(idleTimeout);
+      idleTimeout = setTimeout(() => {
+        scrollToEnd();
+        finish();
+      }, IDLE_MS);
+    });
+
+    observer.observe(container, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      characterData: true,
+    });
+
+    idleTimeout = setTimeout(() => {
+      scrollToEnd();
+      finish();
+    }, IDLE_MS);
+
+    return () => {
+      observer.disconnect();
+      if (idleTimeout) clearTimeout(idleTimeout);
+    };
+  }, [agent.id, loading, messages.length]);
+
   // Load older messages when scrolling up (near top)
   useEffect(() => {
     const container = chatContainerRef.current;

--- a/apps/web/src/components/chats/hooks/useChatPage.ts
+++ b/apps/web/src/components/chats/hooks/useChatPage.ts
@@ -591,6 +591,7 @@ export function useChatPage() {
   }, [selectedChatId, chatDetails]);
 
   // Load older messages when scrolling up (near top)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: chatDetails needed to re-run effect when DOM is ready after chat loads
   useEffect(() => {
     const container = chatContainerRef.current;
     const sentinel = topSentinelRef.current;
@@ -626,7 +627,6 @@ export function useChatPage() {
 
     observer.observe(sentinel);
     return () => observer.disconnect();
-    // biome-ignore lint/correctness/useExhaustiveDependencies: chatDetails needed to re-run effect when DOM is ready after chat loads
   }, [selectedChatId, hasMore, isLoadingMore, loadMore, chatDetails]);
 
   // Maintain scroll position after loading older messages

--- a/apps/web/src/components/chats/hooks/useChatPage.ts
+++ b/apps/web/src/components/chats/hooks/useChatPage.ts
@@ -626,7 +626,7 @@ export function useChatPage() {
 
     observer.observe(sentinel);
     return () => observer.disconnect();
-    // chatDetails needed to re-run when DOM is ready after chat loads
+    // biome-ignore lint/correctness/useExhaustiveDependencies: chatDetails needed to re-run effect when DOM is ready after chat loads
   }, [selectedChatId, hasMore, isLoadingMore, loadMore, chatDetails]);
 
   // Maintain scroll position after loading older messages

--- a/apps/web/src/components/chats/hooks/useChatPage.ts
+++ b/apps/web/src/components/chats/hooks/useChatPage.ts
@@ -517,11 +517,14 @@ export function useChatPage() {
     }
   }, [chatDetails?.messages, isAtBottom, scrollToBottom, loadingChat]);
 
-  // Handle initial scroll - keep scrolling to bottom until stable
+  // Handle initial scroll - use MutationObserver to scroll on any DOM change
   useEffect(() => {
     const container = chatContainerRef.current;
+    const endMarker = messagesEndRef.current;
+
     if (
       !container ||
+      !endMarker ||
       !selectedChatId ||
       chatDetails?.chat?.id !== selectedChatId
     )
@@ -529,52 +532,61 @@ export function useChatPage() {
 
     if (pendingInitialScrollRef.current !== selectedChatId) return;
 
-    let rafId: number;
-    let lastScrollHeight = 0;
-    let stableCount = 0;
-    const MAX_STABLE = 5; // Need 5 consecutive stable frames
-    const MAX_TIME = 2000; // Give up after 2 seconds
+    let idleTimeout: ReturnType<typeof setTimeout> | null = null;
+    const IDLE_MS = 500; // Stop after 500ms of no DOM changes
+    const MAX_TIME = 2000; // Hard timeout after 2 seconds
     const startTime = Date.now();
 
-    const tick = () => {
+    const scrollToEnd = () => {
+      endMarker.scrollIntoView({ behavior: 'auto', block: 'end' });
+    };
+
+    const finish = () => {
+      pendingInitialScrollRef.current = null;
+      setIsAtBottom(true);
+    };
+
+    // Scroll immediately
+    scrollToEnd();
+
+    // Watch for DOM changes and scroll on each
+    const observer = new MutationObserver(() => {
       if (pendingInitialScrollRef.current !== selectedChatId) return;
+
+      // Check hard timeout
       if (Date.now() - startTime > MAX_TIME) {
-        // Timeout - clear flag and stop
-        pendingInitialScrollRef.current = null;
-        setIsAtBottom(true);
+        scrollToEnd();
+        finish();
         return;
       }
 
-      const currentHeight = container.scrollHeight;
-      const maxScroll = currentHeight - container.clientHeight;
+      // Scroll on mutation
+      scrollToEnd();
 
-      // Always scroll to bottom
-      if (maxScroll > 0) {
-        container.scrollTop = maxScroll;
-      }
+      // Reset idle timer - finish after no changes for IDLE_MS
+      if (idleTimeout) clearTimeout(idleTimeout);
+      idleTimeout = setTimeout(() => {
+        scrollToEnd();
+        finish();
+      }, IDLE_MS);
+    });
 
-      // Check if height is stable
-      if (currentHeight === lastScrollHeight) {
-        stableCount++;
-        if (stableCount >= MAX_STABLE) {
-          // Height stable for 5 frames - we're done
-          pendingInitialScrollRef.current = null;
-          setIsAtBottom(true);
-          return;
-        }
-      } else {
-        stableCount = 0;
-        lastScrollHeight = currentHeight;
-      }
+    observer.observe(container, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      characterData: true,
+    });
 
-      // Keep going
-      rafId = requestAnimationFrame(tick);
-    };
-
-    rafId = requestAnimationFrame(tick);
+    // Start idle timer (will finish if no mutations happen)
+    idleTimeout = setTimeout(() => {
+      scrollToEnd();
+      finish();
+    }, IDLE_MS);
 
     return () => {
-      cancelAnimationFrame(rafId);
+      observer.disconnect();
+      if (idleTimeout) clearTimeout(idleTimeout);
     };
   }, [selectedChatId, chatDetails]);
 
@@ -583,6 +595,15 @@ export function useChatPage() {
     const container = chatContainerRef.current;
     const sentinel = topSentinelRef.current;
 
+    console.log('[DEBUG infinite scroll] setup', {
+      hasContainer: !!container,
+      hasSentinel: !!sentinel,
+      selectedChatId,
+      hasMore,
+      isLoadingMore,
+      pendingScroll: pendingInitialScrollRef.current,
+    });
+
     if (!container || !sentinel || !selectedChatId) return;
 
     const observer = new IntersectionObserver(
@@ -590,12 +611,24 @@ export function useChatPage() {
         const entry = entries[0];
         if (!entry) return;
 
+        console.log('[DEBUG infinite scroll] intersection', {
+          isIntersecting: entry.isIntersecting,
+          scrollTop: container.scrollTop,
+          hasMore,
+          isLoadingMore,
+          pendingScroll: pendingInitialScrollRef.current,
+        });
+
         // Don't load more during initial scroll - wait until scrolled to bottom
-        if (pendingInitialScrollRef.current === selectedChatId) return;
+        if (pendingInitialScrollRef.current === selectedChatId) {
+          console.log('[DEBUG infinite scroll] blocked - pending initial scroll');
+          return;
+        }
 
         // Check if user is near the top (scrollTop close to 0)
         const nearTop = container.scrollTop <= 200;
         if (entry.isIntersecting && nearTop && hasMore && !isLoadingMore) {
+          console.log('[DEBUG infinite scroll] LOADING MORE');
           pendingScrollAdjustRef.current = {
             previousHeight: container.scrollHeight,
             previousTop: container.scrollTop,
@@ -608,7 +641,8 @@ export function useChatPage() {
 
     observer.observe(sentinel);
     return () => observer.disconnect();
-  }, [selectedChatId, hasMore, isLoadingMore, loadMore]);
+    // chatDetails needed to re-run when DOM is ready after chat loads
+  }, [selectedChatId, hasMore, isLoadingMore, loadMore, chatDetails]);
 
   // Maintain scroll position after loading older messages
   useEffect(() => {

--- a/apps/web/src/components/chats/hooks/useChatPage.ts
+++ b/apps/web/src/components/chats/hooks/useChatPage.ts
@@ -533,6 +533,7 @@ export function useChatPage() {
     if (pendingInitialScrollRef.current !== selectedChatId) return;
 
     let idleTimeout: ReturnType<typeof setTimeout> | null = null;
+    let observer: MutationObserver | null = null;
     const IDLE_MS = 500; // Stop after 500ms of no DOM changes
     const MAX_TIME = 2000; // Hard timeout after 2 seconds
     const startTime = Date.now();
@@ -542,6 +543,8 @@ export function useChatPage() {
     };
 
     const finish = () => {
+      observer?.disconnect();
+      if (idleTimeout) clearTimeout(idleTimeout);
       pendingInitialScrollRef.current = null;
       setIsAtBottom(true);
     };
@@ -550,7 +553,7 @@ export function useChatPage() {
     scrollToEnd();
 
     // Watch for DOM changes and scroll on each
-    const observer = new MutationObserver(() => {
+    observer = new MutationObserver(() => {
       if (pendingInitialScrollRef.current !== selectedChatId) return;
 
       // Check hard timeout
@@ -571,11 +574,10 @@ export function useChatPage() {
       }, IDLE_MS);
     });
 
+    // Only observe childList and subtree - attributes/characterData are unnecessary for scroll
     observer.observe(container, {
       childList: true,
       subtree: true,
-      attributes: true,
-      characterData: true,
     });
 
     // Start idle timer (will finish if no mutations happen)
@@ -585,7 +587,7 @@ export function useChatPage() {
     }, IDLE_MS);
 
     return () => {
-      observer.disconnect();
+      observer?.disconnect();
       if (idleTimeout) clearTimeout(idleTimeout);
     };
   }, [selectedChatId, chatDetails]);
@@ -604,17 +606,11 @@ export function useChatPage() {
         if (!entry) return;
 
         // Don't load more during initial scroll - wait until scrolled to bottom
-        if (pendingInitialScrollRef.current === selectedChatId) {
-          console.log(
-            '[DEBUG infinite scroll] blocked - pending initial scroll'
-          );
-          return;
-        }
+        if (pendingInitialScrollRef.current === selectedChatId) return;
 
         // Check if user is near the top (scrollTop close to 0)
         const nearTop = container.scrollTop <= 200;
         if (entry.isIntersecting && nearTop && hasMore && !isLoadingMore) {
-          console.log('[DEBUG infinite scroll] LOADING MORE');
           pendingScrollAdjustRef.current = {
             previousHeight: container.scrollHeight,
             previousTop: container.scrollTop,

--- a/apps/web/src/components/chats/hooks/useChatPage.ts
+++ b/apps/web/src/components/chats/hooks/useChatPage.ts
@@ -595,15 +595,6 @@ export function useChatPage() {
     const container = chatContainerRef.current;
     const sentinel = topSentinelRef.current;
 
-    console.log('[DEBUG infinite scroll] setup', {
-      hasContainer: !!container,
-      hasSentinel: !!sentinel,
-      selectedChatId,
-      hasMore,
-      isLoadingMore,
-      pendingScroll: pendingInitialScrollRef.current,
-    });
-
     if (!container || !sentinel || !selectedChatId) return;
 
     const observer = new IntersectionObserver(
@@ -611,17 +602,11 @@ export function useChatPage() {
         const entry = entries[0];
         if (!entry) return;
 
-        console.log('[DEBUG infinite scroll] intersection', {
-          isIntersecting: entry.isIntersecting,
-          scrollTop: container.scrollTop,
-          hasMore,
-          isLoadingMore,
-          pendingScroll: pendingInitialScrollRef.current,
-        });
-
         // Don't load more during initial scroll - wait until scrolled to bottom
         if (pendingInitialScrollRef.current === selectedChatId) {
-          console.log('[DEBUG infinite scroll] blocked - pending initial scroll');
+          console.log(
+            '[DEBUG infinite scroll] blocked - pending initial scroll'
+          );
           return;
         }
 


### PR DESCRIPTION
This PR fixes chat scrolling issues introduced after the flex-col-reverse revert. The scroll-to-bottom mechanism now uses a MutationObserver that continuously scrolls to the end marker element whenever DOM changes occur, finishing after 500ms of idle time or a 2-second hard timeout. This approach is more reliable than the previous RAF-based height checking since it reacts to actual DOM mutations (images loading, lazy content, etc.) rather than guessing when content is stable. Additionally, this PR adds the missing scroll-to-bottom logic to AgentChat (which was lost when flex-col-reverse was reverted) and restores the chatDetails dependency in the infinite scroll effect that was incorrectly removed by a linter fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable auto-scroll to newest messages on initial load and as new content renders, using a content-update-driven approach with debounce/timeout to finalize scrolling.
  * Improved handling when loading older messages near the top to avoid unwanted scroll jumps.
  * Cleanup and trigger improvements to ensure consistent scroll behavior across chats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Improved chat scroll behavior by replacing RAF-based height checking with MutationObserver pattern for initial scroll-to-bottom. The new implementation scrolls continuously on DOM mutations (images loading, lazy content) with a 500ms idle timeout or 2-second hard limit. Also restored the `chatDetails` dependency in the infinite scroll effect that was incorrectly removed by a linter fix.

**Key Changes:**
- Replaced `requestAnimationFrame` loop with `MutationObserver` in both `useChatPage.ts` and added to `AgentChat.tsx`
- Observes container for `childList`, `subtree`, `attributes`, and `characterData` mutations
- Scrolls immediately, then on each mutation, finishing after 500ms idle or 2s hard timeout
- Added missing scroll-to-bottom logic to `AgentChat` component
- Restored `chatDetails` dependency in infinite scroll effect with biome-ignore comment explaining necessity
- Added debug console logs (should be removed before production)

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minor cleanup recommended
- The implementation is solid with proper timeout handling and cleanup. The MutationObserver approach is more reliable than RAF for handling async DOM changes. The biome-ignore comment properly documents why chatDetails dependency is needed. Only concern is debug logging that should be removed before production.
- Minor cleanup needed in useChatPage.ts to remove debug console logs

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/components/agents/AgentChat.tsx | Added scroll-to-bottom logic using MutationObserver with timeout handling |
| apps/web/src/components/chats/hooks/useChatPage.ts | Replaced RAF-based scroll with MutationObserver approach, restored chatDetails dependency, added debug logging |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Component
    participant Effect
    participant Observer as MutationObserver
    participant DOM
    participant EndMarker
    
    User->>Component: Opens chat
    Component->>Effect: agent.id changes
    Effect->>Effect: Set pendingInitialScrollRef = agent.id
    
    Note over Effect: Wait for messages to load (loading = false)
    
    Component->>Effect: messages.length changes, loading = false
    Effect->>Effect: Check pendingInitialScrollRef === agent.id
    Effect->>EndMarker: scrollIntoView() - initial scroll
    Effect->>Observer: Create & observe container
    
    loop While observing (max 2000ms)
        DOM->>Observer: Mutation detected (images load, etc.)
        Observer->>Observer: Check hard timeout (MAX_TIME)
        alt Hard timeout exceeded
            Observer->>EndMarker: scrollIntoView() - final
            Observer->>Effect: Clear pendingInitialScrollRef
            Observer->>Observer: Disconnect
        else Within timeout
            Observer->>EndMarker: scrollIntoView() - continuous
            Observer->>Observer: Reset idle timer (500ms)
        end
    end
    
    alt 500ms of no mutations
        Observer->>EndMarker: scrollIntoView() - final
        Observer->>Effect: Clear pendingInitialScrollRef
        Observer->>Observer: Disconnect
    end
    
    Note over Effect,Observer: IntersectionObserver blocks load-more<br/>while pendingInitialScrollRef is set
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->