### PR TITLE
fix: Make comment avatars, names, and usernames clickable to profile pages

### DIFF
--- a/apps/web/src/app/comment/[id]/page.tsx
+++ b/apps/web/src/app/comment/[id]/page.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import type { CommentData } from '@babylon/shared';
-import { cn } from '@babylon/shared';
+import { cn, getProfileUrl } from '@babylon/shared';
 import { formatDistanceToNow } from 'date-fns';
 import { ArrowLeft, MessageCircle } from 'lucide-react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { use, useCallback, useEffect, useRef, useState } from 'react';
 import { CommentInput } from '@/components/interactions/CommentInput';
@@ -103,26 +104,38 @@ function OriginalPostCard({ post }: { post: PostData }) {
         onClick={() => router.push(`/post/${post.id}`)}
       >
         {/* Avatar */}
-        <div className="relative z-10 shrink-0">
+        <Link
+          href={getProfileUrl(post.authorId, post.authorUsername)}
+          className="relative z-10 shrink-0 transition-opacity hover:opacity-80"
+          onClick={(e) => e.stopPropagation()}
+        >
           <Avatar
             id={post.authorId}
             name={post.authorName}
             size="sm"
             imageUrl={post.authorProfileImageUrl || undefined}
           />
-        </div>
+        </Link>
 
         {/* Content */}
         <div className="min-w-0 flex-1">
           {/* Header */}
           <div className="mb-1 flex items-center gap-2">
-            <span className="truncate font-semibold text-sm">
+            <Link
+              href={getProfileUrl(post.authorId, post.authorUsername)}
+              className="truncate font-semibold text-sm hover:underline"
+              onClick={(e) => e.stopPropagation()}
+            >
               {post.authorName}
-            </span>
+            </Link>
             {showVerifiedBadge && <VerifiedBadge size="sm" className="-ml-1" />}
-            <span className="truncate text-muted-foreground text-xs">
+            <Link
+              href={getProfileUrl(post.authorId, post.authorUsername)}
+              className="truncate text-muted-foreground text-xs hover:underline"
+              onClick={(e) => e.stopPropagation()}
+            >
               @{post.authorUsername || post.authorName}
-            </span>
+            </Link>
             <span className="text-muted-foreground text-xs">·</span>
             <span className="text-muted-foreground text-xs">
               {formatDistanceToNow(new Date(post.createdAt), {
@@ -167,26 +180,38 @@ function ParentCommentCard({
         onClick={() => router.push(`/comment/${parent.id}`)}
       >
         {/* Avatar */}
-        <div className="relative z-10 shrink-0">
+        <Link
+          href={getProfileUrl(parent.authorId, parent.authorUsername)}
+          className="relative z-10 shrink-0 transition-opacity hover:opacity-80"
+          onClick={(e) => e.stopPropagation()}
+        >
           <Avatar
             id={parent.authorId}
             name={parent.authorName}
             size="sm"
             imageUrl={parent.authorProfileImageUrl || undefined}
           />
-        </div>
+        </Link>
 
         {/* Content */}
         <div className="min-w-0 flex-1">
           {/* Header */}
           <div className="mb-1 flex items-center gap-2">
-            <span className="truncate font-semibold text-sm">
+            <Link
+              href={getProfileUrl(parent.authorId, parent.authorUsername)}
+              className="truncate font-semibold text-sm hover:underline"
+              onClick={(e) => e.stopPropagation()}
+            >
               {parent.authorName}
-            </span>
+            </Link>
             {showVerifiedBadge && <VerifiedBadge size="sm" className="-ml-1" />}
-            <span className="truncate text-muted-foreground text-xs">
+            <Link
+              href={getProfileUrl(parent.authorId, parent.authorUsername)}
+              className="truncate text-muted-foreground text-xs hover:underline"
+              onClick={(e) => e.stopPropagation()}
+            >
               @{parent.authorUsername || parent.authorName}
-            </span>
+            </Link>
             <span className="text-muted-foreground text-xs">·</span>
             <span className="text-muted-foreground text-xs">
               {formatDistanceToNow(new Date(parent.createdAt), {
@@ -231,26 +256,38 @@ function ReplyCard({
   return (
     <div className="flex gap-3 border-border border-b py-4 last:border-b-0">
       {/* Avatar */}
-      <div className="shrink-0">
+      <Link
+        href={getProfileUrl(reply.authorId, reply.authorUsername)}
+        className="shrink-0 transition-opacity hover:opacity-80"
+        onClick={(e) => e.stopPropagation()}
+      >
         <Avatar
           id={reply.authorId}
           name={reply.authorName}
           size="sm"
           imageUrl={reply.authorProfileImageUrl || undefined}
         />
-      </div>
+      </Link>
 
       {/* Content */}
       <div className="min-w-0 flex-1">
         {/* Header */}
         <div className="mb-1 flex items-center gap-2">
-          <span className="truncate font-semibold text-sm">
+          <Link
+            href={getProfileUrl(reply.authorId, reply.authorUsername)}
+            className="truncate font-semibold text-sm hover:underline"
+            onClick={(e) => e.stopPropagation()}
+          >
             {reply.authorName}
-          </span>
+          </Link>
           {showVerifiedBadge && <VerifiedBadge size="sm" className="-ml-1" />}
-          <span className="truncate text-muted-foreground text-xs">
+          <Link
+            href={getProfileUrl(reply.authorId, reply.authorUsername)}
+            className="truncate text-muted-foreground text-xs hover:underline"
+            onClick={(e) => e.stopPropagation()}
+          >
             @{reply.authorUsername || reply.authorName}
-          </span>
+          </Link>
           <span className="text-muted-foreground text-xs">·</span>
           <span className="text-muted-foreground text-xs">
             {formatDistanceToNow(new Date(reply.createdAt), {
@@ -491,26 +528,37 @@ export default function CommentPage({ params }: CommentPageProps) {
             >
               <div className="flex gap-3">
                 {/* Avatar */}
-                <div className="shrink-0">
+                <Link
+                  href={getProfileUrl(comment.authorId, comment.authorUsername)}
+                  className="shrink-0 transition-opacity hover:opacity-80"
+                >
                   <Avatar
                     id={comment.authorId}
                     name={comment.authorName}
                     size="md"
                     imageUrl={comment.authorProfileImageUrl || undefined}
                   />
-                </div>
+                </Link>
 
                 {/* Content */}
                 <div className="min-w-0 flex-1">
                   {/* Author info */}
                   <div className="mb-2 flex items-center gap-2">
-                    <span className="font-semibold">{comment.authorName}</span>
+                    <Link
+                      href={getProfileUrl(comment.authorId, comment.authorUsername)}
+                      className="font-semibold hover:underline"
+                    >
+                      {comment.authorName}
+                    </Link>
                     {showVerifiedBadge && (
                       <VerifiedBadge size="sm" className="-ml-1" />
                     )}
-                    <span className="text-muted-foreground text-sm">
+                    <Link
+                      href={getProfileUrl(comment.authorId, comment.authorUsername)}
+                      className="text-muted-foreground text-sm hover:underline"
+                    >
                       @{comment.authorUsername || comment.authorName}
-                    </span>
+                    </Link>
                   </div>
 
                   {/* Comment content - larger for main comment */}

--- a/apps/web/src/app/comment/[id]/page.tsx
+++ b/apps/web/src/app/comment/[id]/page.tsx
@@ -545,7 +545,10 @@ export default function CommentPage({ params }: CommentPageProps) {
                   {/* Author info */}
                   <div className="mb-2 flex items-center gap-2">
                     <Link
-                      href={getProfileUrl(comment.authorId, comment.authorUsername)}
+                      href={getProfileUrl(
+                        comment.authorId,
+                        comment.authorUsername
+                      )}
                       className="font-semibold hover:underline"
                     >
                       {comment.authorName}
@@ -554,7 +557,10 @@ export default function CommentPage({ params }: CommentPageProps) {
                       <VerifiedBadge size="sm" className="-ml-1" />
                     )}
                     <Link
-                      href={getProfileUrl(comment.authorId, comment.authorUsername)}
+                      href={getProfileUrl(
+                        comment.authorId,
+                        comment.authorUsername
+                      )}
                       className="text-muted-foreground text-sm hover:underline"
                     >
                       @{comment.authorUsername || comment.authorName}

--- a/apps/web/src/components/interactions/CommentCard.tsx
+++ b/apps/web/src/components/interactions/CommentCard.tsx
@@ -4,6 +4,7 @@ import type { CommentCardProps, CommentData } from '@babylon/shared';
 import { cn, getProfileUrl } from '@babylon/shared';
 import { formatDistanceToNow } from 'date-fns';
 import { Edit2, MessageCircle, MoreVertical, Trash2 } from 'lucide-react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { Avatar } from '@/components/shared/Avatar';
@@ -116,7 +117,11 @@ export function CommentCard({
   return (
     <div className={cn('flex gap-3', className)}>
       {/* Avatar - Round */}
-      <div className="shrink-0">
+      <Link
+        href={getProfileUrl(comment.userId, comment.userUsername)}
+        className="shrink-0 transition-opacity hover:opacity-80"
+        onClick={(e) => e.stopPropagation()}
+      >
         <Avatar
           id={comment.userId}
           name={comment.userName}
@@ -124,20 +129,28 @@ export function CommentCard({
           src={comment.userAvatar || undefined}
           imageUrl={comment.userAvatar || undefined}
         />
-      </div>
+      </Link>
 
       {/* Content */}
       <div className="min-w-0 flex-1">
         {/* Header: Username/handle on left, timestamp and actions on right */}
         <div className="mb-2 flex items-center justify-between gap-2">
           <div className="flex min-w-0 flex-1 items-center gap-2">
-            <span className="truncate font-semibold text-sm">
+            <Link
+              href={getProfileUrl(comment.userId, comment.userUsername)}
+              className="truncate font-semibold text-sm hover:underline"
+              onClick={(e) => e.stopPropagation()}
+            >
               {comment.userName}
-            </span>
+            </Link>
             {showVerifiedBadge && <VerifiedBadge size="sm" className="-ml-1" />}
-            <span className="truncate text-muted-foreground text-xs">
+            <Link
+              href={getProfileUrl(comment.userId, comment.userUsername)}
+              className="truncate text-muted-foreground text-xs hover:underline"
+              onClick={(e) => e.stopPropagation()}
+            >
               @{comment.userUsername || comment.userName}
-            </span>
+            </Link>
           </div>
           <div className="flex shrink-0 items-center gap-2">
             {/* Timestamp - Right aligned */}


### PR DESCRIPTION
Previously, clicking on comment avatars, names, or usernames did not navigate to the user's profile page. This PR wraps these elements in Link components across CommentCard and the comment thread page to enable profile navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now click on author avatars and names to navigate to user profiles directly from comments and replies.
  * Added hover styling to profile links for improved discoverability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR wraps comment avatars, names, and usernames in `Link` components to enable profile navigation. The changes are applied consistently across `CommentCard` and the comment thread page (`apps/web/src/app/comment/[id]/page.tsx`), including in `OriginalPostCard`, `ParentCommentCard`, `ReplyCard`, and the main comment section.

- Added appropriate `e.stopPropagation()` handlers on Links within clickable parent containers to prevent navigation conflicts
- Correctly omitted `stopPropagation()` on the main comment section which has no clickable parent
- Applied consistent hover states (`hover:underline`, `hover:opacity-80`) matching the existing `PostCard` implementation
- Properly uses `getProfileUrl()` utility with userId and username parameters

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no issues found
- The implementation is consistent with existing patterns in PostCard, correctly handles event propagation, uses the proper utility functions, and includes appropriate hover states. No logical errors, syntax issues, or security concerns identified.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/comment/[id]/page.tsx | Wrapped avatars, names, and usernames in Link components across OriginalPostCard, ParentCommentCard, ReplyCard, and main comment sections with appropriate stopPropagation handlers |
| apps/web/src/components/interactions/CommentCard.tsx | Added Link components to avatar, name, and username elements with hover states and stopPropagation to prevent conflicts with thread navigation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CommentUI as Comment UI
    participant NextLink as Next.js Link
    participant Router as Next.js Router
    participant ProfilePage as Profile Page

    User->>CommentUI: Click avatar/name/username
    CommentUI->>NextLink: onClick event
    NextLink->>NextLink: e.stopPropagation()
    NextLink->>Router: Navigate to profile URL
    Router->>ProfilePage: Load profile page
    ProfilePage-->>User: Display user profile
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->