### PR TITLE
feat(profile): fix replies tab and add thread-style ProfileReplyCard component

### DIFF
--- a/apps/web/src/app/api/users/[userId]/posts/route.ts
+++ b/apps/web/src/app/api/users/[userId]/posts/route.ts
@@ -169,6 +169,13 @@ export const GET = withErrorHandling(
 
       const commentIds = userComments.map((c) => c.id);
       const postIds = [...new Set(userComments.map((c) => c.postId))];
+      const parentCommentIds = [
+        ...new Set(
+          userComments
+            .map((c) => c.parentCommentId)
+            .filter((id): id is string => id !== null)
+        ),
+      ];
 
       // Fetch posts for these comments
       const postsData = await db
@@ -182,6 +189,30 @@ export const GET = withErrorHandling(
         .where(inArray(posts.id, postIds));
 
       const postsMap = new Map(postsData.map((p) => [p.id, p]));
+
+      // Fetch parent comments (for replies to comments)
+      let parentCommentsMap = new Map<
+        string,
+        {
+          id: string;
+          content: string;
+          authorId: string;
+          createdAt: Date;
+        }
+      >();
+      if (parentCommentIds.length > 0) {
+        const parentCommentsData = await db
+          .select({
+            id: comments.id,
+            content: comments.content,
+            authorId: comments.authorId,
+            createdAt: comments.createdAt,
+          })
+          .from(comments)
+          .where(inArray(comments.id, parentCommentIds));
+
+        parentCommentsMap = new Map(parentCommentsData.map((c) => [c.id, c]));
+      }
 
       // Fetch like counts for comments
       const likeCountsResult = await db
@@ -236,9 +267,19 @@ export const GET = withErrorHandling(
         );
       }
 
-      // Fetch author info for posts
-      const postAuthorIds = [...new Set(postsData.map((p) => p.authorId))];
-      const postAuthorsUsers = await db
+      // Fetch author info for posts and parent comments
+      const parentCommentAuthorIds = [
+        ...new Set(
+          Array.from(parentCommentsMap.values()).map((c) => c.authorId)
+        ),
+      ];
+      const allAuthorIds = [
+        ...new Set([
+          ...postsData.map((p) => p.authorId),
+          ...parentCommentAuthorIds,
+        ]),
+      ];
+      const authorsUsers = await db
         .select({
           id: users.id,
           displayName: users.displayName,
@@ -246,11 +287,11 @@ export const GET = withErrorHandling(
           profileImageUrl: users.profileImageUrl,
         })
         .from(users)
-        .where(inArray(users.id, postAuthorIds));
+        .where(inArray(users.id, allAuthorIds));
 
-      const userAuthorsMap = new Map(postAuthorsUsers.map((u) => [u.id, u]));
+      const userAuthorsMap = new Map(authorsUsers.map((u) => [u.id, u]));
       const actorAuthorsMap = new Map(
-        postAuthorIds
+        allAuthorIds
           .map((id) => StaticDataRegistry.getActor(id))
           .filter((a): a is NonNullable<typeof a> => a !== null)
           .map((a) => [
@@ -262,37 +303,77 @@ export const GET = withErrorHandling(
       // Format comments as replies
       const replies = userComments.map((comment) => {
         const post = postsMap.get(comment.postId);
-        const authorUser = post ? userAuthorsMap.get(post.authorId) : null;
-        const authorActor = post ? actorAuthorsMap.get(post.authorId) : null;
+        const postAuthorUser = post ? userAuthorsMap.get(post.authorId) : null;
+        const postAuthorActor = post
+          ? actorAuthorsMap.get(post.authorId)
+          : null;
+
+        // Get parent comment if this is a reply to a comment
+        const parentComment = comment.parentCommentId
+          ? parentCommentsMap.get(comment.parentCommentId)
+          : null;
+        const parentCommentAuthorUser = parentComment
+          ? userAuthorsMap.get(parentComment.authorId)
+          : null;
+        const parentCommentAuthorActor = parentComment
+          ? actorAuthorsMap.get(parentComment.authorId)
+          : null;
 
         return {
           id: comment.id,
           content: comment.content,
           postId: comment.postId,
+          parentCommentId: comment.parentCommentId,
           createdAt: comment.createdAt.toISOString(),
           updatedAt: comment.updatedAt.toISOString(),
           likeCount: likeCountsMap.get(comment.id) ?? 0,
           replyCount: replyCountsMap.get(comment.id) ?? 0,
           isLiked: userLikesSet.has(comment.id),
+          // Parent comment (if replying to a comment)
+          parentComment: parentComment
+            ? {
+                id: parentComment.id,
+                content: parentComment.content,
+                authorId: parentComment.authorId,
+                createdAt: parentComment.createdAt.toISOString(),
+                author: parentCommentAuthorUser
+                  ? {
+                      id: parentCommentAuthorUser.id,
+                      displayName: parentCommentAuthorUser.displayName,
+                      username: parentCommentAuthorUser.username,
+                      profileImageUrl: parentCommentAuthorUser.profileImageUrl,
+                    }
+                  : parentCommentAuthorActor
+                    ? {
+                        id: parentCommentAuthorActor.id,
+                        displayName: parentCommentAuthorActor.name,
+                        username: null,
+                        profileImageUrl:
+                          parentCommentAuthorActor.profileImageUrl,
+                      }
+                    : null,
+              }
+            : null,
+          // Original post (always included for context)
           post: post
             ? {
                 id: post.id,
                 content: post.content,
                 authorId: post.authorId,
                 timestamp: post.timestamp.toISOString(),
-                author: authorUser
+                author: postAuthorUser
                   ? {
-                      id: authorUser.id,
-                      displayName: authorUser.displayName,
-                      username: authorUser.username,
-                      profileImageUrl: authorUser.profileImageUrl,
+                      id: postAuthorUser.id,
+                      displayName: postAuthorUser.displayName,
+                      username: postAuthorUser.username,
+                      profileImageUrl: postAuthorUser.profileImageUrl,
                     }
-                  : authorActor
+                  : postAuthorActor
                     ? {
-                        id: authorActor.id,
-                        displayName: authorActor.name,
+                        id: postAuthorActor.id,
+                        displayName: postAuthorActor.name,
                         username: null,
-                        profileImageUrl: authorActor.profileImageUrl,
+                        profileImageUrl: postAuthorActor.profileImageUrl,
                       }
                     : null,
               }

--- a/apps/web/src/app/profile/[id]/loading.tsx
+++ b/apps/web/src/app/profile/[id]/loading.tsx
@@ -2,8 +2,8 @@
  * Profile Loading Component
  *
  * @description Loading skeleton for the user profile page, displaying skeleton
- * loaders for the profile header and feed sections. Supports both desktop and
- * mobile layouts.
+ * loaders for the profile header and feed sections. Responsive layout with
+ * optional sidebar on large screens.
  *
  * @returns {JSX.Element} Profile loading skeleton
  */
@@ -16,10 +16,9 @@ import {
 export default function ProfileLoading() {
   return (
     <PageContainer noPadding className="flex min-h-screen flex-col">
-      {/* Desktop */}
-      <div className="hidden flex-1 lg:flex">
+      <div className="flex flex-1">
         {/* Main Content */}
-        <div className="flex min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.5)] border-r border-l">
+        <div className="flex min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.5)] lg:border-r lg:border-l">
           <div className="flex-1 overflow-y-auto">
             <div className="mx-auto w-full max-w-[700px]">
               {/* Profile Header */}
@@ -33,21 +32,8 @@ export default function ProfileLoading() {
           </div>
         </div>
 
-        {/* Right: Widget placeholder */}
-        <div className="w-80 shrink-0 border-border/5 border-l bg-background xl:w-96" />
-      </div>
-
-      {/* Mobile/Tablet */}
-      <div className="flex flex-1 overflow-y-auto lg:hidden">
-        <div className="w-full">
-          {/* Profile Header */}
-          <ProfileHeaderSkeleton />
-
-          {/* Posts */}
-          <div className="mt-4 border-border/5 border-t">
-            <FeedSkeleton count={4} />
-          </div>
-        </div>
+        {/* Right: Widget placeholder - only on large screens */}
+        <div className="hidden w-80 shrink-0 border-border/5 border-l bg-background lg:block xl:w-96" />
       </div>
     </PageContainer>
   );

--- a/apps/web/src/app/profile/[id]/page.tsx
+++ b/apps/web/src/app/profile/[id]/page.tsx
@@ -521,27 +521,38 @@ export default function ActorProfilePage() {
     if (tab !== 'replies') return;
     if (!actorInfo?.id) return;
 
+    const controller = new AbortController();
+
     const loadReplies = async () => {
       setLoadingReplies(true);
-      const token = await getAccessToken();
-      const headers: HeadersInit = { 'Content-Type': 'application/json' };
-      if (token) {
-        headers['Authorization'] = `Bearer ${token}`;
-      }
+      try {
+        const token = await getAccessToken();
+        const headers: HeadersInit = { 'Content-Type': 'application/json' };
+        if (token) {
+          headers['Authorization'] = `Bearer ${token}`;
+        }
 
-      const response = await fetch(
-        `/api/users/${encodeURIComponent(actorInfo.id)}/posts?type=replies`,
-        { headers }
-      );
-      if (response.ok) {
-        const data = await response.json();
-        const items = data?.data?.items ?? data?.items ?? [];
-        setReplies(items);
+        const response = await fetch(
+          `/api/users/${encodeURIComponent(actorInfo.id)}/posts?type=replies`,
+          { headers, signal: controller.signal }
+        );
+        if (response.ok) {
+          const data = await response.json();
+          const items = data?.data?.items ?? data?.items ?? [];
+          setReplies(items);
+        }
+      } catch (error) {
+        if (error instanceof Error && error.name !== 'AbortError') {
+          console.error('Failed to fetch replies:', error);
+        }
+      } finally {
+        setLoadingReplies(false);
       }
-      setLoadingReplies(false);
     };
 
     loadReplies();
+
+    return () => controller.abort();
   }, [tab, actorInfo?.id, getAccessToken]);
 
   // Get posts for this actor from all games

--- a/apps/web/src/app/profile/[id]/page.tsx
+++ b/apps/web/src/app/profile/[id]/page.tsx
@@ -7,7 +7,6 @@ import {
   extractUsername,
   type FeedPost,
   getBannerImageUrl,
-  getProfileUrl,
   isUsername,
   type Organization,
   POST_TYPES,
@@ -29,6 +28,10 @@ import { SendPointsModal } from '@/components/points/SendPointsModal';
 import { PostCard } from '@/components/posts/PostCard';
 import { FollowListModal } from '@/components/profile/FollowListModal';
 import { OnChainBadge } from '@/components/profile/OnChainBadge';
+import {
+  type ProfileReply,
+  ProfileReplyCard,
+} from '@/components/profile/ProfileReplyCard';
 import { ProfileWidget } from '@/components/profile/ProfileWidget';
 import { Avatar } from '@/components/shared/Avatar';
 import { PageContainer } from '@/components/shared/PageContainer';
@@ -36,7 +39,6 @@ import {
   FeedSkeleton,
   ProfileHeaderSkeleton,
 } from '@/components/shared/Skeleton';
-import { TaggedText } from '@/components/shared/TaggedText';
 import { VerifiedBadge } from '@/components/shared/VerifiedBadge';
 import { TradesFeed } from '@/components/trades/TradesFeed';
 import { useAuth } from '@/hooks/useAuth';
@@ -152,23 +154,7 @@ export default function ActorProfilePage() {
     }>
   >([]);
   const [loadingPosts, setLoadingPosts] = useState(false);
-  const [replies, setReplies] = useState<
-    Array<{
-      id: string;
-      content: string;
-      createdAt: string;
-      likeCount: number;
-      replyCount: number;
-      postId: string;
-      post: {
-        author?: {
-          displayName?: string | null;
-          username?: string | null;
-        } | null;
-        content: string;
-      };
-    }>
-  >([]);
+  const [replies, setReplies] = useState<ProfileReply[]>([]);
   const [loadingReplies, setLoadingReplies] = useState(false);
 
   // Handle creating DM with user
@@ -1027,61 +1013,28 @@ export default function ActorProfilePage() {
                     </p>
                   </div>
                 ) : (
-                  <div className="divide-y divide-border">
+                  <div>
                     {replies
-                      .filter((reply) =>
-                        !searchQuery.trim() ||
-                        reply.content?.toLowerCase().includes(searchQuery.toLowerCase())
+                      .filter(
+                        (reply) =>
+                          !searchQuery.trim() ||
+                          reply.content
+                            ?.toLowerCase()
+                            .includes(searchQuery.toLowerCase())
                       )
                       .map((reply) => (
-                        <div key={reply.id} className="px-4 py-4">
-                          <div className="mb-2 whitespace-pre-wrap break-words text-foreground">
-                            <TaggedText
-                              text={reply.content}
-                              onTagClick={(tag) => {
-                                if (tag.startsWith('@')) {
-                                  const username = tag.slice(1);
-                                  router.push(getProfileUrl('', username));
-                                } else if (tag.startsWith('$')) {
-                                  const symbol = tag.slice(1);
-                                  router.push(`/markets?search=${encodeURIComponent(symbol)}`);
-                                }
-                              }}
-                            />
-                          </div>
-                          <div className="mb-2 text-muted-foreground text-sm">
-                            Replying to{' '}
-                            <a
-                              href={`/post/${reply.postId}`}
-                              className="text-primary hover:underline"
-                            >
-                              {reply.post?.author?.displayName ||
-                                reply.post?.author?.username ||
-                                'a post'}
-                            </a>
-                          </div>
-                          {reply.post?.content && (
-                            <div className="mb-2 truncate text-muted-foreground text-xs">
-                              <TaggedText
-                                text={reply.post.content.substring(0, 100) + '...'}
-                                onTagClick={(tag) => {
-                                  if (tag.startsWith('@')) {
-                                    const username = tag.slice(1);
-                                    router.push(getProfileUrl('', username));
-                                  } else if (tag.startsWith('$')) {
-                                    const symbol = tag.slice(1);
-                                    router.push(`/markets?search=${encodeURIComponent(symbol)}`);
-                                  }
-                                }}
-                              />
-                            </div>
-                          )}
-                          <div className="flex items-center gap-4 text-muted-foreground text-sm">
-                            <span>{new Date(reply.createdAt).toLocaleDateString()}</span>
-                            <span>❤️ {reply.likeCount || 0}</span>
-                            <span>💬 {reply.replyCount || 0}</span>
-                          </div>
-                        </div>
+                        <ProfileReplyCard
+                          key={reply.id}
+                          reply={reply}
+                          authorId={actorInfo?.id || ''}
+                          authorName={
+                            actorInfo?.name || actorInfo?.username || ''
+                          }
+                          authorUsername={actorInfo?.username || null}
+                          authorProfileImageUrl={
+                            actorInfo?.profileImageUrl || null
+                          }
+                        />
                       ))}
                   </div>
                 )

--- a/apps/web/src/app/profile/[id]/page.tsx
+++ b/apps/web/src/app/profile/[id]/page.tsx
@@ -7,6 +7,7 @@ import {
   extractUsername,
   type FeedPost,
   getBannerImageUrl,
+  getProfileUrl,
   isUsername,
   type Organization,
   POST_TYPES,
@@ -35,6 +36,7 @@ import {
   FeedSkeleton,
   ProfileHeaderSkeleton,
 } from '@/components/shared/Skeleton';
+import { TaggedText } from '@/components/shared/TaggedText';
 import { VerifiedBadge } from '@/components/shared/VerifiedBadge';
 import { TradesFeed } from '@/components/trades/TradesFeed';
 import { useAuth } from '@/hooks/useAuth';
@@ -150,6 +152,24 @@ export default function ActorProfilePage() {
     }>
   >([]);
   const [loadingPosts, setLoadingPosts] = useState(false);
+  const [replies, setReplies] = useState<
+    Array<{
+      id: string;
+      content: string;
+      createdAt: string;
+      likeCount: number;
+      replyCount: number;
+      postId: string;
+      post: {
+        author?: {
+          displayName?: string | null;
+          username?: string | null;
+        } | null;
+        content: string;
+      };
+    }>
+  >([]);
+  const [loadingReplies, setLoadingReplies] = useState(false);
 
   // Handle creating DM with user
   const handleMessageClick = async () => {
@@ -510,6 +530,34 @@ export default function ActorProfilePage() {
     }
   }, [actorId, actorInfo?.id]);
 
+  // Load replies when tab changes to 'replies'
+  useEffect(() => {
+    if (tab !== 'replies') return;
+    if (!actorInfo?.id) return;
+
+    const loadReplies = async () => {
+      setLoadingReplies(true);
+      const token = await getAccessToken();
+      const headers: HeadersInit = { 'Content-Type': 'application/json' };
+      if (token) {
+        headers['Authorization'] = `Bearer ${token}`;
+      }
+
+      const response = await fetch(
+        `/api/users/${encodeURIComponent(actorInfo.id)}/posts?type=replies`,
+        { headers }
+      );
+      if (response.ok) {
+        const data = await response.json();
+        const items = data?.data?.items ?? data?.items ?? [];
+        setReplies(items);
+      }
+      setLoadingReplies(false);
+    };
+
+    loadReplies();
+  }, [tab, actorInfo?.id, getAccessToken]);
+
   // Get posts for this actor from all games
   const gameStorePosts = useMemo(() => {
     const posts: Array<{
@@ -678,8 +726,8 @@ export default function ActorProfilePage() {
 
   return (
     <PageContainer noPadding className="flex flex-col">
-      {/* Desktop: Content + Widget layout */}
-      <div className="hidden flex-1 overflow-hidden xl:flex">
+      {/* Main layout - responsive with optional sidebar on xl screens */}
+      <div className="flex flex-1 overflow-hidden">
         {/* Main content */}
         <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
           {/* Header */}
@@ -964,6 +1012,79 @@ export default function ActorProfilePage() {
             <div className="px-4">
               {tab === 'trades' ? (
                 <TradesFeed userId={actorInfo?.id} />
+              ) : tab === 'replies' ? (
+                // Replies tab - show actual comment replies
+                loadingReplies ? (
+                  <div className="w-full">
+                    <FeedSkeleton count={5} />
+                  </div>
+                ) : replies.length === 0 ? (
+                  <div className="py-12 text-center">
+                    <p className="text-muted-foreground">
+                      {searchQuery
+                        ? 'No replies found matching your search'
+                        : 'No replies yet'}
+                    </p>
+                  </div>
+                ) : (
+                  <div className="divide-y divide-border">
+                    {replies
+                      .filter((reply) =>
+                        !searchQuery.trim() ||
+                        reply.content?.toLowerCase().includes(searchQuery.toLowerCase())
+                      )
+                      .map((reply) => (
+                        <div key={reply.id} className="px-4 py-4">
+                          <div className="mb-2 whitespace-pre-wrap break-words text-foreground">
+                            <TaggedText
+                              text={reply.content}
+                              onTagClick={(tag) => {
+                                if (tag.startsWith('@')) {
+                                  const username = tag.slice(1);
+                                  router.push(getProfileUrl('', username));
+                                } else if (tag.startsWith('$')) {
+                                  const symbol = tag.slice(1);
+                                  router.push(`/markets?search=${encodeURIComponent(symbol)}`);
+                                }
+                              }}
+                            />
+                          </div>
+                          <div className="mb-2 text-muted-foreground text-sm">
+                            Replying to{' '}
+                            <a
+                              href={`/post/${reply.postId}`}
+                              className="text-primary hover:underline"
+                            >
+                              {reply.post?.author?.displayName ||
+                                reply.post?.author?.username ||
+                                'a post'}
+                            </a>
+                          </div>
+                          {reply.post?.content && (
+                            <div className="mb-2 truncate text-muted-foreground text-xs">
+                              <TaggedText
+                                text={reply.post.content.substring(0, 100) + '...'}
+                                onTagClick={(tag) => {
+                                  if (tag.startsWith('@')) {
+                                    const username = tag.slice(1);
+                                    router.push(getProfileUrl('', username));
+                                  } else if (tag.startsWith('$')) {
+                                    const symbol = tag.slice(1);
+                                    router.push(`/markets?search=${encodeURIComponent(symbol)}`);
+                                  }
+                                }}
+                              />
+                            </div>
+                          )}
+                          <div className="flex items-center gap-4 text-muted-foreground text-sm">
+                            <span>{new Date(reply.createdAt).toLocaleDateString()}</span>
+                            <span>❤️ {reply.likeCount || 0}</span>
+                            <span>💬 {reply.replyCount || 0}</span>
+                          </div>
+                        </div>
+                      ))}
+                  </div>
+                )
               ) : loadingPosts ? (
                 <div className="w-full">
                   <FeedSkeleton count={5} />
@@ -1032,308 +1153,6 @@ export default function ActorProfilePage() {
             <ProfileWidget userId={actorInfo.id} />
           </div>
         )}
-      </div>
-
-      {/* Mobile/Tablet: Full width content */}
-      <div className="flex flex-1 flex-col overflow-hidden xl:hidden">
-        {/* Header */}
-        <div className="sticky top-0 z-10 bg-background/95 backdrop-blur-sm">
-          <div className="flex items-center gap-4 px-4 py-3">
-            <Link
-              href="/feed"
-              className="rounded-full p-2 transition-colors hover:bg-muted/50"
-            >
-              <ArrowLeft className="h-5 w-5" />
-            </Link>
-            <div className="flex-1">
-              <h1 className="font-bold text-xl">{actorInfo.name}</h1>
-              <p className="text-muted-foreground text-sm">
-                {actorInfo.stats?.posts || actorPosts.length} posts
-              </p>
-            </div>
-          </div>
-        </div>
-
-        {/* Content area */}
-        <div className="flex-1 overflow-y-auto">
-          {/* Profile Header */}
-          <div className="border-border border-b">
-            {/* Cover Image */}
-            <div className="relative h-[200px] bg-muted">
-              {(() => {
-                // Get banner URL using the utility function (supports CDN)
-                const bannerUrl =
-                  actorInfo.isUser &&
-                  actorInfo.type === 'user' &&
-                  'coverImageUrl' in actorInfo
-                    ? (actorInfo.coverImageUrl as string)
-                    : getBannerImageUrl(
-                        null,
-                        actorInfo.id,
-                        actorInfo.type === 'organization'
-                          ? 'organization'
-                          : 'actor'
-                      );
-
-                return bannerUrl ? (
-                  <img
-                    src={bannerUrl}
-                    alt={`${actorInfo.name} banner`}
-                    className="h-full w-full object-cover"
-                    onError={(e) => {
-                      // Fallback to gradient if image not found
-                      e.currentTarget.style.display = 'none';
-                      e.currentTarget.nextElementSibling?.classList.remove(
-                        'hidden'
-                      );
-                    }}
-                  />
-                ) : null;
-              })()}
-              <div
-                className={cn(
-                  'pointer-events-none absolute inset-0 h-full w-full bg-gradient-to-br from-primary/20 to-primary/5',
-                  actorInfo.type === 'actor' ||
-                    actorInfo.type === 'organization'
-                    ? 'hidden'
-                    : ''
-                )}
-              />
-            </div>
-
-            {/* Profile Info Container */}
-            <div className="px-4 pb-4">
-              {/* Top Row: Avatar + Action Buttons */}
-              <div className="mb-4 flex items-start justify-between">
-                {/* Profile Picture - Overlapping cover */}
-                <div className="-mt-16 sm:-mt-20 relative">
-                  <div className="h-32 w-32 overflow-hidden rounded-full border-4 border-background bg-background sm:h-36 sm:w-36">
-                    <Avatar
-                      id={actorInfo.id}
-                      name={
-                        (actorInfo.name ?? actorInfo.username ?? '') as string
-                      }
-                      type={
-                        actorInfo.type === 'organization'
-                          ? 'business'
-                          : actorInfo.isUser || actorInfo.type === 'user'
-                            ? 'user'
-                            : (actorInfo.type as 'actor' | undefined)
-                      }
-                      src={actorInfo.profileImageUrl || undefined}
-                      size="lg"
-                      className="h-full w-full"
-                    />
-                  </div>
-                </div>
-
-                {/* Action Buttons */}
-                <div className="flex items-center gap-2 pt-3">
-                  {authenticated && user && user.id !== actorInfo.id && (
-                    <>
-                      {/* Message button - only for regular users, not actors/NPCs/agents */}
-                      {actorInfo.isUser && actorInfo.type === 'user' && (
-                        <button
-                          onClick={handleMessageClick}
-                          disabled={isCreatingDM}
-                          className="rounded-full border border-border p-2 transition-colors hover:bg-muted/50 disabled:cursor-not-allowed disabled:opacity-50"
-                          title="Send message"
-                        >
-                          <MessageCircle className="h-5 w-5" />
-                        </button>
-                      )}
-                      {/* Send points button - available for ALL users including agents and actors */}
-                      <button
-                        onClick={() => setSendPointsModalOpen(true)}
-                        className="rounded-full border border-border p-2 transition-colors hover:bg-muted/50"
-                        title="Send points"
-                      >
-                        <Coins className="h-5 w-5" />
-                      </button>
-                      <FollowButton
-                        userId={actorInfo.id}
-                        size="md"
-                        variant="button"
-                        onFollowerCountChange={(delta) => {
-                          // Optimistically update the follower count based on current displayed value
-                          setOptimisticFollowerCount((prev) => {
-                            const currentCount =
-                              prev !== null
-                                ? prev
-                                : actorInfo.stats?.followers || 0;
-                            return Math.max(0, currentCount + delta); // Never go negative
-                          });
-                        }}
-                      />
-                    </>
-                  )}
-                  {isOwnProfile && (
-                    <Link
-                      href="/settings"
-                      className="rounded-full border border-border px-4 py-2 font-bold transition-colors hover:bg-muted/50"
-                    >
-                      Edit profile
-                    </Link>
-                  )}
-                </div>
-              </div>
-
-              {/* Name and Handle */}
-              <div className="mb-3">
-                <div className="mb-0.5 flex items-center gap-1">
-                  <h2 className="font-bold text-xl">
-                    {actorInfo.name ?? actorInfo.username ?? ''}
-                  </h2>
-                  {actorInfo.type === 'actor' && !actorInfo.isUser && (
-                    <VerifiedBadge size="md" />
-                  )}
-                </div>
-                {actorInfo.username && (
-                  <p className="text-[15px] text-muted-foreground">
-                    @{actorInfo.username}
-                  </p>
-                )}
-              </div>
-
-              {/* Description/Bio */}
-              {(actorInfo.profileDescription || actorInfo.description) && (
-                <p className="mb-3 whitespace-pre-wrap text-[15px] text-foreground">
-                  {actorInfo.profileDescription || actorInfo.description}
-                </p>
-              )}
-
-              {/* Stats */}
-              <div className="flex gap-4 text-[15px]">
-                <button
-                  onClick={() =>
-                    setFollowListModal({ isOpen: true, type: 'following' })
-                  }
-                  className="hover:underline"
-                >
-                  <span className="font-bold text-foreground">
-                    {actorInfo.stats?.following || 0}
-                  </span>
-                  <span className="ml-1 text-muted-foreground">Following</span>
-                </button>
-                <button
-                  onClick={() =>
-                    setFollowListModal({ isOpen: true, type: 'followers' })
-                  }
-                  className="hover:underline"
-                >
-                  <span className="font-bold text-foreground">
-                    {optimisticFollowerCount !== null
-                      ? optimisticFollowerCount
-                      : actorInfo.stats?.followers || 0}
-                  </span>
-                  <span className="ml-1 text-muted-foreground">Followers</span>
-                </button>
-              </div>
-            </div>
-          </div>
-
-          {/* Tabs: Posts vs Replies */}
-          <div className="sticky top-0 z-10 border-border border-b bg-background/95 backdrop-blur-sm">
-            <div className="flex flex-col px-4 sm:flex-row sm:items-center sm:justify-between">
-              {/* Tab Buttons */}
-              <div className="flex flex-1 items-center">
-                <button
-                  onClick={() => setTab('posts')}
-                  className={cn(
-                    'relative h-14 px-4 font-semibold transition-all duration-300 hover:bg-muted/30',
-                    tab === 'posts'
-                      ? 'text-foreground opacity-100'
-                      : 'text-foreground opacity-50'
-                  )}
-                >
-                  Posts
-                </button>
-                <button
-                  onClick={() => setTab('replies')}
-                  className={cn(
-                    'relative h-14 px-4 font-semibold transition-all duration-300 hover:bg-muted/30',
-                    tab === 'replies'
-                      ? 'text-foreground opacity-100'
-                      : 'text-foreground opacity-50'
-                  )}
-                >
-                  Replies
-                </button>
-              </div>
-
-              {/* Search Bar - Top Right (hidden on small screens) */}
-              <div className="relative w-full py-2 sm:w-64 sm:py-0">
-                <Search className="-translate-y-1/2 absolute top-1/2 left-3 h-4 w-4 text-muted-foreground" />
-                <input
-                  type="text"
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  placeholder={`Search ${tab}...`}
-                  className="w-full rounded-full border-0 bg-muted py-2 pr-4 pl-10 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-                />
-              </div>
-            </div>
-          </div>
-
-          {/* Posts */}
-          <div className="px-4">
-            {loadingPosts ? (
-              <div className="w-full">
-                <FeedSkeleton count={4} />
-              </div>
-            ) : filteredPosts.length === 0 ? (
-              <div className="py-12 text-center">
-                <p className="text-muted-foreground">
-                  {searchQuery
-                    ? 'No posts found matching your search'
-                    : 'No posts yet'}
-                </p>
-              </div>
-            ) : (
-              <div className="space-y-0">
-                {filteredPosts.map((item, i) => {
-                  const postData = {
-                    id: item.post.id,
-                    type: item.post.type,
-                    content: item.post.content,
-                    fullContent: item.post.fullContent || null,
-                    articleTitle: item.post.articleTitle || null,
-                    byline: item.post.byline || null,
-                    biasScore: item.post.biasScore ?? null,
-                    category: item.post.category || null,
-                    authorId: item.post.author,
-                    authorName: item.post.authorName,
-                    authorUsername: item.post.authorUsername || null,
-                    authorProfileImageUrl:
-                      item.post.authorProfileImageUrl || null,
-                    timestamp: item.post.timestamp,
-                    likeCount: item.post.likeCount,
-                    commentCount: item.post.commentCount,
-                    shareCount: item.post.shareCount,
-                    isLiked: item.post.isLiked,
-                    isShared: item.post.isShared,
-                    // Repost metadata
-                    isRepost: item.post.isRepost || false,
-                    isQuote: item.post.isQuote || false,
-                    quoteComment: item.post.quoteComment || null,
-                    originalPostId: item.post.originalPostId || null,
-                    originalPost: item.post.originalPost || null,
-                  };
-
-                  return postData.type && postData.type === 'article' ? (
-                    <ArticleCard key={`${item.post.id}-${i}`} post={postData} />
-                  ) : (
-                    <PostCard
-                      key={`${item.post.id}-${i}`}
-                      post={postData}
-                      showInteractions={true}
-                    />
-                  );
-                })}
-              </div>
-            )}
-          </div>
-        </div>
       </div>
 
       {/* Send Points Modal - Available for all users, agents, and actors */}

--- a/apps/web/src/app/profile/loading.tsx
+++ b/apps/web/src/app/profile/loading.tsx
@@ -7,10 +7,9 @@ import {
 export default function ProfileLoading() {
   return (
     <PageContainer noPadding className="flex min-h-screen flex-col">
-      {/* Desktop */}
-      <div className="hidden flex-1 lg:flex">
+      <div className="flex flex-1">
         {/* Main Content */}
-        <div className="flex min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.5)] border-r border-l">
+        <div className="flex min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.5)] lg:border-r lg:border-l">
           <div className="flex-1 overflow-y-auto">
             <div className="mx-auto w-full max-w-[700px]">
               {/* Profile Header */}
@@ -24,21 +23,8 @@ export default function ProfileLoading() {
           </div>
         </div>
 
-        {/* Right: Widget placeholder */}
-        <div className="w-80 shrink-0 border-border/5 border-l bg-background xl:w-96" />
-      </div>
-
-      {/* Mobile/Tablet */}
-      <div className="flex flex-1 overflow-y-auto lg:hidden">
-        <div className="w-full">
-          {/* Profile Header */}
-          <ProfileHeaderSkeleton />
-
-          {/* Posts */}
-          <div className="mt-4 border-border/5 border-t">
-            <FeedSkeleton count={4} />
-          </div>
-        </div>
+        {/* Right: Widget placeholder - only on large screens */}
+        <div className="hidden w-80 shrink-0 border-border/5 border-l bg-background lg:block xl:w-96" />
       </div>
     </PageContainer>
   );

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -1004,8 +1004,8 @@ export default function ProfilePage() {
 
   return (
     <PageContainer noPadding className="flex flex-col">
-      {/* Desktop: Content + Widget layout */}
-      <div className="hidden flex-1 overflow-hidden xl:flex">
+      {/* Main layout - responsive with optional sidebar on xl screens */}
+      <div className="flex flex-1 overflow-hidden">
         {/* Main content */}
         <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
           {/* Header */}
@@ -1039,36 +1039,6 @@ export default function ProfilePage() {
         {/* Widget Sidebar */}
         <div className="hidden w-96 flex-shrink-0 flex-col overflow-y-auto bg-sidebar p-4 xl:flex">
           <ProfileWidget userId={user.id} />
-        </div>
-      </div>
-
-      {/* Mobile/Tablet: Full width content */}
-      <div className="flex flex-1 flex-col overflow-hidden xl:hidden">
-        {/* Header */}
-        <div className="sticky top-0 z-10 bg-background/95 backdrop-blur-sm">
-          <div className="flex items-center gap-4 px-4 py-3">
-            <Link
-              href="/feed"
-              className="rounded-full p-2 transition-colors hover:bg-muted/50"
-            >
-              <ArrowLeft className="h-5 w-5" />
-            </Link>
-            <div className="flex-1">
-              <h1 className="font-bold text-xl">
-                {formData.displayName || formData.username || 'Profile'}
-              </h1>
-              <p className="text-muted-foreground text-sm">
-                {posts.length} posts
-              </p>
-            </div>
-          </div>
-        </div>
-
-        {/* Content area */}
-        <div className="flex-1 overflow-y-auto">
-          {renderProfileHeader()}
-          {renderTabs()}
-          <div className="px-4">{renderContent()}</div>
         </div>
       </div>
 

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { cn, getProfileUrl } from '@babylon/shared';
+import { cn } from '@babylon/shared';
 import {
   AlertCircle,
   ArrowLeft,
@@ -22,6 +22,10 @@ import { PostCard } from '@/components/posts/PostCard';
 import { FollowListModal } from '@/components/profile/FollowListModal';
 import { LinkSocialAccountsModal } from '@/components/profile/LinkSocialAccountsModal';
 import { OnChainBadge } from '@/components/profile/OnChainBadge';
+import {
+  type ProfileReply,
+  ProfileReplyCard,
+} from '@/components/profile/ProfileReplyCard';
 import { ProfileWidget } from '@/components/profile/ProfileWidget';
 import { TradingProfile } from '@/components/profile/TradingProfile';
 import { Avatar } from '@/components/shared/Avatar';
@@ -30,7 +34,6 @@ import {
   FeedSkeleton,
   ProfileHeaderSkeleton,
 } from '@/components/shared/Skeleton';
-import { TaggedText } from '@/components/shared/TaggedText';
 import { useAuth } from '@/hooks/useAuth';
 import { useAuthStore } from '@/stores/authStore';
 
@@ -135,23 +138,7 @@ export default function ProfilePage() {
       } | null;
     }>
   >([]);
-  const [replies, setReplies] = useState<
-    Array<{
-      id: string;
-      content: string;
-      createdAt: string;
-      likeCount: number;
-      replyCount: number;
-      postId: string;
-      post: {
-        author?: {
-          displayName?: string | null;
-          username?: string | null;
-        } | null;
-        content: string;
-      };
-    }>
-  >([]);
+  const [replies, setReplies] = useState<ProfileReply[]>([]);
   const [loadingPosts, setLoadingPosts] = useState(false);
 
   // Social visibility toggles
@@ -909,62 +896,16 @@ export default function ProfilePage() {
     }
 
     return (
-      <div className="divide-y divide-border">
+      <div>
         {filteredReplies.map((reply) => (
-          <div key={reply.id} className="px-4 py-4">
-            <div className="mb-2 whitespace-pre-wrap break-words text-foreground">
-              <TaggedText
-                text={reply.content}
-                onTagClick={(tag) => {
-                  if (tag.startsWith('@')) {
-                    // Handle @mentions - route to profile
-                    const username = tag.slice(1);
-                    router.push(getProfileUrl('', username));
-                  } else if (tag.startsWith('$')) {
-                    // Handle $cashtags - route to markets
-                    const symbol = tag.slice(1);
-                    router.push(
-                      `/markets?search=${encodeURIComponent(symbol)}`
-                    );
-                  }
-                }}
-              />
-            </div>
-            <div className="mb-2 text-muted-foreground text-sm">
-              Replying to{' '}
-              <a
-                href={`/post/${reply.postId}`}
-                className="text-primary hover:underline"
-              >
-                {reply.post.author?.displayName ||
-                  reply.post.author?.username ||
-                  'a post'}
-              </a>
-            </div>
-            <div className="mb-2 truncate text-muted-foreground text-xs">
-              <TaggedText
-                text={reply.post.content.substring(0, 100) + '...'}
-                onTagClick={(tag) => {
-                  if (tag.startsWith('@')) {
-                    // Handle @mentions - route to profile
-                    const username = tag.slice(1);
-                    router.push(getProfileUrl('', username));
-                  } else if (tag.startsWith('$')) {
-                    // Handle $cashtags - route to markets
-                    const symbol = tag.slice(1);
-                    router.push(
-                      `/markets?search=${encodeURIComponent(symbol)}`
-                    );
-                  }
-                }}
-              />
-            </div>
-            <div className="flex items-center gap-4 text-muted-foreground text-sm">
-              <span>{new Date(reply.createdAt).toLocaleDateString()}</span>
-              <span>❤️ {reply.likeCount || 0}</span>
-              <span>💬 {reply.replyCount || 0}</span>
-            </div>
-          </div>
+          <ProfileReplyCard
+            key={reply.id}
+            reply={reply}
+            authorId={user?.id || ''}
+            authorName={formData.displayName || formData.username || ''}
+            authorUsername={formData.username || null}
+            authorProfileImageUrl={formData.profileImageUrl || null}
+          />
         ))}
       </div>
     );

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -205,31 +205,42 @@ export default function ProfilePage() {
   useEffect(() => {
     if (!user?.id) return;
 
+    const controller = new AbortController();
+
     const loadContent = async () => {
       setLoadingPosts(true);
-      const token = await getAccessToken();
-      const headers: HeadersInit = { 'Content-Type': 'application/json' };
-      if (token) {
-        headers['Authorization'] = `Bearer ${token}`;
-      }
-
-      const response = await fetch(
-        `/api/users/${encodeURIComponent(user.id)}/posts?type=${tab}`,
-        { headers }
-      );
-      if (response.ok) {
-        const data = await response.json();
-        const items = data?.data?.items ?? data?.items ?? [];
-        if (tab === 'posts') {
-          setPosts(items);
-        } else {
-          setReplies(items);
+      try {
+        const token = await getAccessToken();
+        const headers: HeadersInit = { 'Content-Type': 'application/json' };
+        if (token) {
+          headers['Authorization'] = `Bearer ${token}`;
         }
+
+        const response = await fetch(
+          `/api/users/${encodeURIComponent(user.id)}/posts?type=${tab}`,
+          { headers, signal: controller.signal }
+        );
+        if (response.ok) {
+          const data = await response.json();
+          const items = data?.data?.items ?? data?.items ?? [];
+          if (tab === 'posts') {
+            setPosts(items);
+          } else {
+            setReplies(items);
+          }
+        }
+      } catch (error) {
+        if (error instanceof Error && error.name !== 'AbortError') {
+          console.error('Failed to fetch content:', error);
+        }
+      } finally {
+        setLoadingPosts(false);
       }
-      setLoadingPosts(false);
     };
 
     loadContent();
+
+    return () => controller.abort();
   }, [user?.id, tab, getAccessToken]);
 
   // Listen for profile updates (when user follows/unfollows someone)

--- a/apps/web/src/components/profile/ProfileReplyCard.tsx
+++ b/apps/web/src/components/profile/ProfileReplyCard.tsx
@@ -1,0 +1,307 @@
+'use client';
+
+import { cn, getProfileUrl } from '@babylon/shared';
+import { formatDistanceToNow } from 'date-fns';
+import { MessageCircle } from 'lucide-react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { CommentInput } from '@/components/interactions/CommentInput';
+import { LikeButton } from '@/components/interactions/LikeButton';
+import { Avatar } from '@/components/shared/Avatar';
+import { TaggedText } from '@/components/shared/TaggedText';
+import {
+  isNpcIdentifier,
+  VerifiedBadge,
+} from '@/components/shared/VerifiedBadge';
+
+/**
+ * Author info structure
+ */
+interface AuthorInfo {
+  id?: string;
+  displayName?: string | null;
+  username?: string | null;
+  profileImageUrl?: string | null;
+}
+
+/**
+ * Reply data structure from the API
+ */
+export interface ProfileReply {
+  id: string;
+  content: string;
+  postId: string;
+  parentCommentId?: string | null;
+  createdAt: string;
+  updatedAt: string;
+  likeCount: number;
+  replyCount: number;
+  isLiked: boolean;
+  // Parent comment (if replying to a comment)
+  parentComment?: {
+    id: string;
+    content: string;
+    authorId: string;
+    createdAt: string;
+    author?: AuthorInfo | null;
+  } | null;
+  // Original post
+  post: {
+    id: string;
+    content: string;
+    authorId: string;
+    timestamp: string;
+    author?: AuthorInfo | null;
+  };
+}
+
+interface ProfileReplyCardProps {
+  reply: ProfileReply;
+  /** The profile owner's author ID */
+  authorId: string;
+  /** The profile owner's display name */
+  authorName: string;
+  /** The profile owner's username */
+  authorUsername: string | null;
+  /** The profile owner's profile image URL */
+  authorProfileImageUrl: string | null;
+  /** Callback when a reply is submitted */
+  onReplySubmit?: () => void;
+}
+
+/**
+ * ProfileReplyCard - Shows a user's reply in their profile with thread-style layout
+ *
+ * Layout:
+ * - Original post/comment (what they replied to) at top with vertical connector line
+ * - User's reply below, connected by the line
+ * - Action buttons (reply, like) at the bottom
+ */
+export function ProfileReplyCard({
+  reply,
+  authorId,
+  authorName,
+  authorUsername,
+  authorProfileImageUrl,
+  onReplySubmit,
+}: ProfileReplyCardProps) {
+  const router = useRouter();
+  const [isReplying, setIsReplying] = useState(false);
+  const [replyCount, setReplyCount] = useState(reply.replyCount);
+
+  // Determine if we're replying to a comment or directly to a post
+  const isReplyToComment = !!reply.parentComment;
+
+  // Get the parent content info (either parent comment or post)
+  const parentAuthorId = isReplyToComment
+    ? reply.parentComment?.author?.id || reply.parentComment?.authorId || ''
+    : reply.post?.author?.id || reply.post?.authorId || '';
+  const parentAuthorName = isReplyToComment
+    ? reply.parentComment?.author?.displayName ||
+      reply.parentComment?.author?.username ||
+      'User'
+    : reply.post?.author?.displayName || reply.post?.author?.username || 'User';
+  const parentAuthorUsername = isReplyToComment
+    ? reply.parentComment?.author?.username || null
+    : reply.post?.author?.username || null;
+  const parentAuthorProfileImageUrl = isReplyToComment
+    ? reply.parentComment?.author?.profileImageUrl || null
+    : reply.post?.author?.profileImageUrl || null;
+  const parentContent = isReplyToComment
+    ? reply.parentComment?.content || ''
+    : reply.post?.content || '';
+  const parentTimestamp = isReplyToComment
+    ? reply.parentComment?.createdAt || ''
+    : reply.post?.timestamp || '';
+  const parentAuthorIsNPC = isNpcIdentifier(parentAuthorId);
+
+  // Reply author (profile owner) info
+  const replyAuthorIsNPC = isNpcIdentifier(authorId);
+
+  // Navigation targets
+  const parentNavigateUrl = isReplyToComment
+    ? `/comment/${reply.parentComment?.id}`
+    : `/post/${reply.post.id}`;
+
+  const handleTagClick = (tag: string) => {
+    if (tag.startsWith('@')) {
+      const username = tag.slice(1);
+      router.push(getProfileUrl('', username));
+    } else if (tag.startsWith('$')) {
+      const symbol = tag.slice(1);
+      router.push(`/markets?search=${encodeURIComponent(symbol)}`);
+    }
+  };
+
+  const handleReplySubmit = async () => {
+    setIsReplying(false);
+    setReplyCount((prev) => prev + 1);
+    onReplySubmit?.();
+  };
+
+  return (
+    <div className="border-border border-b">
+      {/* Parent Content - what they replied to (post or comment) */}
+      <div className="relative">
+        {/* Connector line - from parent avatar down to reply */}
+        <div className="absolute top-10 bottom-0 left-[1.625rem] w-0.5 bg-border sm:left-[1.875rem]" />
+
+        <div
+          className="flex cursor-pointer gap-3 px-4 py-3 transition-colors hover:bg-muted/50 sm:px-6"
+          onClick={() => router.push(parentNavigateUrl)}
+        >
+          {/* Parent Author Avatar */}
+          <Link
+            href={getProfileUrl(parentAuthorId, parentAuthorUsername)}
+            className="relative z-10 shrink-0 transition-opacity hover:opacity-80"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Avatar
+              id={parentAuthorId}
+              name={parentAuthorName}
+              size="sm"
+              imageUrl={parentAuthorProfileImageUrl || undefined}
+            />
+          </Link>
+
+          {/* Parent Content */}
+          <div className="min-w-0 flex-1">
+            {/* Header */}
+            <div className="mb-1 flex items-center gap-2">
+              <Link
+                href={getProfileUrl(parentAuthorId, parentAuthorUsername)}
+                className="truncate font-semibold text-sm hover:underline"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {parentAuthorName}
+              </Link>
+              {parentAuthorIsNPC && (
+                <VerifiedBadge size="sm" className="-ml-1" />
+              )}
+              <Link
+                href={getProfileUrl(parentAuthorId, parentAuthorUsername)}
+                className="truncate text-muted-foreground text-xs hover:underline"
+                onClick={(e) => e.stopPropagation()}
+              >
+                @{parentAuthorUsername || parentAuthorName}
+              </Link>
+              <span className="text-muted-foreground text-xs">·</span>
+              <span className="text-muted-foreground text-xs">
+                {parentTimestamp &&
+                  formatDistanceToNow(new Date(parentTimestamp), {
+                    addSuffix: true,
+                  })}
+              </span>
+            </div>
+
+            {/* Parent Content - truncated */}
+            <p className="line-clamp-3 text-foreground text-sm">
+              <TaggedText text={parentContent} onTagClick={handleTagClick} />
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* User's Reply */}
+      <div
+        className="flex cursor-pointer gap-3 px-4 pb-3 transition-colors hover:bg-muted/50 sm:px-6"
+        onClick={() => router.push(`/comment/${reply.id}`)}
+      >
+        {/* Reply Author Avatar */}
+        <Link
+          href={getProfileUrl(authorId, authorUsername)}
+          className="shrink-0 transition-opacity hover:opacity-80"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Avatar
+            id={authorId}
+            name={authorName}
+            size="sm"
+            imageUrl={authorProfileImageUrl || undefined}
+          />
+        </Link>
+
+        {/* Reply Content */}
+        <div className="min-w-0 flex-1">
+          {/* Header */}
+          <div className="mb-1 flex items-center gap-2">
+            <Link
+              href={getProfileUrl(authorId, authorUsername)}
+              className="truncate font-semibold text-sm hover:underline"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {authorName}
+            </Link>
+            {replyAuthorIsNPC && <VerifiedBadge size="sm" className="-ml-1" />}
+            <Link
+              href={getProfileUrl(authorId, authorUsername)}
+              className="truncate text-muted-foreground text-xs hover:underline"
+              onClick={(e) => e.stopPropagation()}
+            >
+              @{authorUsername || authorName}
+            </Link>
+            <span className="text-muted-foreground text-xs">·</span>
+            <span className="text-muted-foreground text-xs">
+              {formatDistanceToNow(new Date(reply.createdAt), {
+                addSuffix: true,
+              })}
+            </span>
+          </div>
+
+          {/* Reply Content */}
+          <p className="mb-2 whitespace-pre-wrap break-words text-foreground text-sm">
+            <TaggedText text={reply.content} onTagClick={handleTagClick} />
+          </p>
+
+          {/* Action Buttons - reply and like only */}
+          <div className="flex items-center gap-1">
+            {/* Reply/Comment button - toggles inline reply */}
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                setIsReplying(!isReplying);
+              }}
+              className={cn(
+                'flex items-center gap-1.5 rounded-full px-2 py-1 text-xs transition-colors',
+                'text-muted-foreground hover:bg-[#0066FF]/10 hover:text-[#0066FF]',
+                isReplying && 'bg-[#0066FF]/10 text-[#0066FF]'
+              )}
+            >
+              <MessageCircle size={14} />
+              {replyCount > 0 && <span>{replyCount}</span>}
+            </button>
+
+            {/* Like button */}
+            <div onClick={(e) => e.stopPropagation()}>
+              <LikeButton
+                targetId={reply.id}
+                targetType="comment"
+                initialLiked={reply.isLiked}
+                initialCount={reply.likeCount}
+                size="sm"
+                showCount
+              />
+            </div>
+          </div>
+
+          {/* Inline reply input */}
+          {isReplying && (
+            <div className="mt-3" onClick={(e) => e.stopPropagation()}>
+              <CommentInput
+                postId={reply.postId}
+                parentCommentId={reply.id}
+                placeholder={`Reply to ${authorName}...`}
+                replyingToName={authorName}
+                autoFocus
+                onSubmit={handleReplySubmit}
+                onCancel={() => setIsReplying(false)}
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
The profile/[id] page replies tab was not displaying any replies - it was completely empty even when the user had replied to posts. This PR fixes the issue by adding proper data fetching for replies and introduces a new `ProfileReplyCard` component with thread-style layout matching the comment page (vertical connector line, parent content above, reply below). The API was updated to include `parentCommentId` and `parentComment` data so replies correctly show what they're responding to. Also merged duplicate mobile/desktop layouts into a single responsive component.

### Screenshot

before:

<img width="652" height="496" alt="Screenshot 2026-01-20 at 1 01 14 AM" src="https://github.com/user-attachments/assets/05387b1a-1cdb-4aef-b83c-012b25b61723" />

after

<img width="1191" height="854" alt="Screenshot 2026-01-20 at 1 00 21 AM" src="https://github.com/user-attachments/assets/c26d1d59-9878-41bb-9907-197971babb81" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replies tab: threaded replies with visible parent content (post or comment) and inline reply actions.
  * Rich repost/quote support: original-post details, author lineage (user/actor/org), and preserved interaction counts.
  * New ProfileReplyCard component to render replies with parent context and actions.

* **UI/UX Improvements**
  * Responsive profile layout: consolidated single-flow content, conditional right sidebar, revised loading skeletons and error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed empty replies tab on profile pages by adding proper data fetching for user comments. Introduced `ProfileReplyCard` component with thread-style layout (vertical connector line, parent content above, reply below) matching the comment page design. Updated API to include `parentCommentId` and `parentComment` data so replies correctly show context. Also merged duplicate mobile/desktop layouts into single responsive components across profile pages and loading states.

**Key Changes:**
- API now fetches parent comments and their authors for thread context
- New `ProfileReplyCard` shows what user replied to (post or comment) with visual thread connector
- Both `/profile` and `/profile/[id]` pages now display replies correctly
- Eliminated code duplication by merging separate mobile/desktop layouts
- Responsive design maintains functionality across all screen sizes

<h3>Confidence Score: 5/5</h3>


- Safe to merge - well-structured feature addition with proper data fetching and responsive design
- Clean implementation with proper separation of concerns, comprehensive API data fetching, and well-designed component. Code follows existing patterns, handles edge cases (replies to posts vs comments), and improves maintainability by removing duplicate layouts
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/api/users/[userId]/posts/route.ts | Added parent comment fetching and author details for replies API, enabling thread-style display |
| apps/web/src/components/profile/ProfileReplyCard.tsx | New component with thread-style layout showing parent content and reply with vertical connector |
| apps/web/src/app/profile/page.tsx | Replaced inline reply rendering with ProfileReplyCard component, removed duplicate mobile layout |
| apps/web/src/app/profile/[id]/page.tsx | Added replies data fetching and rendering using ProfileReplyCard, removed duplicate mobile layout |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ProfilePage as Profile Page
    participant API as /api/users/[userId]/posts
    participant DB as Database
    
    User->>ProfilePage: Navigate to profile & click "Replies" tab
    ProfilePage->>API: GET /api/users/[userId]/posts?type=replies
    
    API->>DB: Fetch user's comments
    DB-->>API: Return comments
    
    API->>DB: Fetch parent comments (for replies to comments)
    DB-->>API: Return parent comments
    
    API->>DB: Fetch original posts
    DB-->>API: Return posts
    
    API->>DB: Fetch authors (posts + parent comments)
    DB-->>API: Return user/actor info
    
    API->>DB: Fetch like/reply counts
    DB-->>API: Return interaction counts
    
    API-->>ProfilePage: Return replies with parentComment & post data
    
    ProfilePage->>ProfilePage: Render ProfileReplyCard for each reply
    ProfilePage-->>User: Display thread-style replies (parent + reply + connector)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->