### PR TITLE
fix: prevent wide markdown content from squeezing chat list sidebar

### DIFF
--- a/apps/web/src/app/agents/team/page.tsx
+++ b/apps/web/src/app/agents/team/page.tsx
@@ -212,7 +212,7 @@ export default function TeamChatPage() {
         <Separator orientation="vertical" className="hidden lg:block" />
 
         {/* Chat Area */}
-        <div className="flex min-h-0 flex-1 flex-col bg-background">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background">
           <TeamChatView
             chatDetails={chatDetails}
             currentUserId={user?.id}

--- a/apps/web/src/app/chats/page.tsx
+++ b/apps/web/src/app/chats/page.tsx
@@ -196,7 +196,7 @@ export default function ChatsPage() {
           {/* Desktop (xl): always shown */}
           <div
             className={cn(
-              'h-full min-h-0 flex-1 bg-background',
+              'h-full min-h-0 min-w-0 flex-1 bg-background',
               selectedChatId ? 'block' : 'hidden xl:block'
             )}
           >

--- a/apps/web/src/components/agents/AgentChat.tsx
+++ b/apps/web/src/components/agents/AgentChat.tsx
@@ -499,7 +499,7 @@ export function AgentChat({
       {/* Messages - Scrollable */}
       <div
         ref={chatContainerRef}
-        className="relative min-h-0 flex-1 overflow-y-auto px-4 py-3"
+        className="relative min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden px-4 py-3"
       >
         <div className="flex flex-col space-y-4">
           <MessageList

--- a/apps/web/src/components/chat/Response.tsx
+++ b/apps/web/src/components/chat/Response.tsx
@@ -135,6 +135,11 @@ export const Response = memo(
             '[&_a:not([href^="babylon://"])]:break-words',
             // Blockquote
             '[&_blockquote]:my-2 [&_blockquote]:border-muted-foreground/30 [&_blockquote]:border-l-4 [&_blockquote]:pl-4 [&_blockquote]:italic',
+            // Tables - contained with horizontal scroll
+            '[&_table]:my-2 [&_table]:w-full [&_table]:border-collapse [&_table]:text-sm',
+            '[&_th]:border [&_th]:border-border [&_th]:bg-muted/50 [&_th]:px-3 [&_th]:py-2 [&_th]:text-left [&_th]:font-semibold',
+            '[&_td]:border [&_td]:border-border [&_td]:px-3 [&_td]:py-2',
+            '[&_.table-wrapper]:max-w-full [&_.table-wrapper]:overflow-x-auto',
             // Strong/Bold
             '[&_strong]:font-semibold',
             // Horizontal rule

--- a/apps/web/src/components/chats/ChatView.tsx
+++ b/apps/web/src/components/chats/ChatView.tsx
@@ -104,7 +104,7 @@ export function ChatView({
       {/* Messages - Scrollable */}
       <div
         ref={containerRef}
-        className="relative min-h-0 flex-1 overflow-y-auto px-4 py-3"
+        className="relative min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden px-4 py-3"
       >
         <div className="flex flex-col space-y-4">
           <MessageList

--- a/apps/web/src/components/chats/MessageBubble.tsx
+++ b/apps/web/src/components/chats/MessageBubble.tsx
@@ -65,7 +65,7 @@ export function MessageBubble({
       )}
       <div
         className={cn(
-          'flex w-full min-w-0 flex-col',
+          'flex min-w-0 max-w-[80%] flex-col',
           isCurrentUser ? 'items-end' : 'items-start'
         )}
       >

--- a/apps/web/src/components/chats/MessageBubble.tsx
+++ b/apps/web/src/components/chats/MessageBubble.tsx
@@ -65,7 +65,7 @@ export function MessageBubble({
       )}
       <div
         className={cn(
-          'flex max-w-[70%] flex-col',
+          'flex w-full min-w-0 flex-col',
           isCurrentUser ? 'items-end' : 'items-start'
         )}
       >
@@ -98,7 +98,7 @@ export function MessageBubble({
         </div>
         <div
           className={cn(
-            'message-bubble break-words rounded-2xl px-4 py-3 text-sm',
+            'message-bubble max-w-full overflow-x-auto break-words rounded-2xl px-4 py-3 text-sm',
             isCurrentUser
               ? 'rounded-tr-sm bg-primary/20'
               : 'rounded-tl-sm bg-sidebar-accent/50'

--- a/apps/web/src/components/chats/TeamChatView.tsx
+++ b/apps/web/src/components/chats/TeamChatView.tsx
@@ -203,7 +203,7 @@ export function TeamChatView({
 
       {/* Messages - Scrollable */}
       <div
-        className="relative min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-3"
+        className="relative min-h-0 min-w-0 flex-1 space-y-4 overflow-y-auto overflow-x-hidden px-4 py-3"
         onScroll={(e) => onScroll?.(e.currentTarget)}
       >
         <MessageList


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved flexbox constraints in chat and team panes to fix shrinking and layout issues.
  * Prevented unwanted horizontal scrolling in chat areas while preserving vertical scrolling.
  * Adjusted message bubble sizing to better handle long content (wrap and scroll behavior).
  * Enhanced table styling with borders, cell padding, reduced text size, and a horizontal-scroll wrapper.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Applied `min-w-0` and `overflow-x-hidden` CSS utilities across all chat view components to fix flexbox overflow issues where wide markdown content (tables, code blocks, long URLs) was causing the chat list sidebar to squeeze or compress. The fix follows the standard flexbox pattern used throughout the codebase where flex children need explicit minimum width constraints to prevent overflow. Additionally added table styling to the Response component for better markdown table rendering.

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with minimal risk - addresses a specific layout bug with a well-established CSS pattern
- Score reflects consistent application of the min-w-0 flexbox fix pattern across all affected components, with one minor uncertainty about table-wrapper styling that needs verification
- Check apps/web/src/components/chat/Response.tsx to verify that streamdown generates .table-wrapper elements for the overflow styles to work

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/components/chat/Response.tsx | Added table styling with wrapper styles that may not apply if streamdown doesn't generate .table-wrapper elements |
| apps/web/src/components/chats/ChatView.tsx | Added min-w-0 and overflow-x-hidden to prevent wide content from breaking flexbox layout |
| apps/web/src/components/agents/AgentChat.tsx | Added min-w-0 and overflow-x-hidden to prevent wide content from breaking flexbox layout |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Browser
    participant ChatPage as Chat Page Container
    participant ChatArea as Chat Area (min-w-0)
    participant Response as Response Component
    participant Markdown as Wide Markdown Content

    User->>Browser: Navigate to chat page
    Browser->>ChatPage: Render flexbox layout
    ChatPage->>ChatArea: Apply flex-1 min-w-0
    Note over ChatArea: min-w-0 prevents flex child<br/>from expanding beyond parent
    
    User->>Response: AI sends message with wide table
    Response->>Markdown: Render markdown with table
    Markdown->>ChatArea: Content width exceeds viewport
    ChatArea->>ChatArea: Apply overflow-x-hidden
    Note over ChatArea: Horizontal scroll contained<br/>within chat area only
    
    ChatArea-->>ChatPage: Width stays constrained
    ChatPage-->>Browser: Sidebar maintains size
    Browser-->>User: Layout preserved, no squeeze
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->