### PR TITLE
fix: A2A Security upgrade: prevent impersonation

### DIFF
--- a/apps/web/src/app/api/a2a/route.ts
+++ b/apps/web/src/app/api/a2a/route.ts
@@ -186,89 +186,35 @@ export async function POST(request: NextRequest) {
   });
 
   // SECURITY: User-scoped execution for user API keys
-  // When authenticated via per-user API key, enforce that ALL operations
-  // use the authenticated user's identity. This prevents impersonation attacks.
+  // When authenticated via per-user API key, enforce that the ACTOR identity
+  // (contextId) is the authenticated user. This prevents impersonation attacks.
+  //
+  // NOTE: We do NOT enforce params.userId because many operations use it as
+  // the TARGET (e.g., blockUser targets params.userId, actor is contextId).
+  // The executor uses contextId as the actor for all write operations.
   if (authResult?.userId && authResult.authMethod === 'user-key') {
     const authenticatedUserId = authResult.userId;
 
-    // Override contextId in the message params
+    // Validate and override contextId in message params
     if (body.params?.message) {
+      if (body.params.message.contextId && body.params.message.contextId !== authenticatedUserId) {
+        logger.warn('Overriding mismatched message contextId', {
+          providedContextId: body.params.message.contextId,
+          authenticatedUserId,
+        });
+      }
       body.params.message.contextId = authenticatedUserId;
     }
 
-    // Set at params level for tasks/get and other methods
+    // Validate and override contextId at params level
     if (body.params) {
+      if (body.params.contextId && body.params.contextId !== authenticatedUserId) {
+        logger.warn('Overriding mismatched params contextId', {
+          providedContextId: body.params.contextId,
+          authenticatedUserId,
+        });
+      }
       body.params.contextId = authenticatedUserId;
-
-      // SECURITY: Block top-level userId override attempts
-      if (body.params.userId && body.params.userId !== authenticatedUserId) {
-        logger.warn('Blocked top-level userId override attempt', {
-          providedUserId: body.params.userId,
-          authenticatedUserId,
-        });
-        return NextResponse.json(
-          {
-            jsonrpc: '2.0',
-            error: {
-              code: -32001,
-              message: 'Forbidden: Cannot perform operations as another user',
-            },
-            id: body.id ?? null,
-          },
-          { status: 403 }
-        );
-      }
-      // Force top-level userId to authenticated user
-      body.params.userId = authenticatedUserId;
-    }
-
-    // SECURITY: Block userId override attempts in operation params
-    // Some operations accept params.userId - force it to authenticated user
-    // to prevent impersonation via "I want to act as user X" attacks
-    if (body.params?.message?.parts) {
-      // Validate parts is an array before iterating
-      if (!Array.isArray(body.params.message.parts)) {
-        logger.warn('Invalid message parts format', {
-          partsType: typeof body.params.message.parts,
-          authenticatedUserId,
-        });
-        return NextResponse.json(
-          {
-            jsonrpc: '2.0',
-            error: {
-              code: -32001,
-              message: 'Forbidden: Cannot perform operations as another user',
-            },
-            id: body.id ?? null,
-          },
-          { status: 403 }
-        );
-      }
-
-      for (const part of body.params.message.parts) {
-        if (part?.kind === 'data' && part.data?.params) {
-          // If userId is provided in operation params, it MUST match authenticated user
-          if (part.data.params.userId && part.data.params.userId !== authenticatedUserId) {
-            logger.warn('Blocked userId override attempt in message part', {
-              providedUserId: part.data.params.userId,
-              authenticatedUserId,
-            });
-            return NextResponse.json(
-              {
-                jsonrpc: '2.0',
-                error: {
-                  code: -32001,
-                  message: 'Forbidden: Cannot perform operations as another user',
-                },
-                id: body.id ?? null,
-              },
-              { status: 403 }
-            );
-          }
-          // Force userId to authenticated user
-          part.data.params.userId = authenticatedUserId;
-        }
-      }
     }
   }
 

--- a/apps/web/src/app/api/a2a/route.ts
+++ b/apps/web/src/app/api/a2a/route.ts
@@ -195,8 +195,13 @@ export async function POST(request: NextRequest) {
   if (authResult?.userId && authResult.authMethod === 'user-key') {
     const authenticatedUserId = authResult.userId;
 
+    // Ensure params exists so we can always set contextId
+    if (!body.params) {
+      body.params = {};
+    }
+
     // Validate and override contextId in message params
-    if (body.params?.message) {
+    if (body.params.message) {
       if (body.params.message.contextId && body.params.message.contextId !== authenticatedUserId) {
         logger.warn('Overriding mismatched message contextId', {
           providedContextId: body.params.message.contextId,
@@ -206,24 +211,22 @@ export async function POST(request: NextRequest) {
       body.params.message.contextId = authenticatedUserId;
     }
 
-    // Validate and override contextId at params level
-    if (body.params) {
-      if (body.params.contextId && body.params.contextId !== authenticatedUserId) {
-        logger.warn('Overriding mismatched params contextId', {
-          providedContextId: body.params.contextId,
-          authenticatedUserId,
-        });
-      }
-      body.params.contextId = authenticatedUserId;
+    // Validate and override contextId at params level (for tasks/get and other methods)
+    if (body.params.contextId && body.params.contextId !== authenticatedUserId) {
+      logger.warn('Overriding mismatched params contextId', {
+        providedContextId: body.params.contextId,
+        authenticatedUserId,
+      });
     }
+    body.params.contextId = authenticatedUserId;
   }
 
   // SECURITY: Server API key and localhost bypass
   // These auth methods allow arbitrary contextId, which enables acting as any user.
   // This is intentional for admin/internal operations but should be monitored.
   if (authResult?.authMethod === 'server-key' || authResult?.authMethod === 'localhost') {
-    const providedContextId = body.params?.message?.contextId || body.params?.contextId;
-    if (providedContextId) {
+    const providedContextId = body.params?.message?.contextId ?? body.params?.contextId;
+    if (providedContextId !== undefined && providedContextId !== null) {
       // Log server-key operations with user context for audit trail
       logger.info('Server/localhost A2A operation with user context', {
         authMethod: authResult.authMethod,

--- a/apps/web/src/app/api/a2a/route.ts
+++ b/apps/web/src/app/api/a2a/route.ts
@@ -192,8 +192,27 @@ export async function POST(request: NextRequest) {
   // NOTE: We do NOT enforce params.userId because many operations use it as
   // the TARGET (e.g., blockUser targets params.userId, actor is contextId).
   // The executor uses contextId as the actor for all write operations.
-  if (authResult?.userId && authResult.authMethod === 'user-key') {
+  if (authResult?.authMethod === 'user-key') {
     const authenticatedUserId = authResult.userId;
+
+    // Validate userId is present and non-empty
+    if (!authenticatedUserId || typeof authenticatedUserId !== 'string') {
+      logger.error('User API key authenticated but userId is missing', {
+        authMethod: authResult.authMethod,
+        hasUserId: !!authenticatedUserId,
+      });
+      return NextResponse.json(
+        {
+          jsonrpc: '2.0',
+          error: {
+            code: -32001,
+            message: 'Authentication error: Invalid user identity',
+          },
+          id: body.id ?? null,
+        },
+        { status: 401 }
+      );
+    }
 
     // Type guard: ensure params is a plain object
     const isPlainObject = (val: unknown): val is Record<string, unknown> =>

--- a/apps/web/src/app/api/a2a/route.ts
+++ b/apps/web/src/app/api/a2a/route.ts
@@ -195,13 +195,17 @@ export async function POST(request: NextRequest) {
   if (authResult?.userId && authResult.authMethod === 'user-key') {
     const authenticatedUserId = authResult.userId;
 
-    // Ensure params exists so we can always set contextId
-    if (!body.params) {
+    // Type guard: ensure params is a plain object
+    const isPlainObject = (val: unknown): val is Record<string, unknown> =>
+      typeof val === 'object' && val !== null && !Array.isArray(val);
+
+    // Ensure params exists and is a plain object
+    if (!isPlainObject(body.params)) {
       body.params = {};
     }
 
     // Validate and override contextId in message params
-    if (body.params.message) {
+    if (isPlainObject(body.params.message)) {
       if (body.params.message.contextId && body.params.message.contextId !== authenticatedUserId) {
         logger.warn('Overriding mismatched message contextId', {
           providedContextId: body.params.message.contextId,

--- a/apps/web/src/app/api/a2a/route.ts
+++ b/apps/web/src/app/api/a2a/route.ts
@@ -185,11 +185,68 @@ export async function POST(request: NextRequest) {
     userId: authResult?.userId,
   });
 
-  // User-scoped execution: When authenticated via user API key, authResult.userId
-  // contains the user ID. To enable user-specific operations:
-  // 1. Update BabylonAgentExecutor.execute() to accept optional userId parameter
-  // 2. Propagate userId to downstream service calls (trading, social, etc.)
-  // 3. Add feature flag ENABLE_USER_SCOPED_A2A_EXECUTION for gradual rollout
+  // SECURITY: User-scoped execution for user API keys
+  // When authenticated via per-user API key, enforce that ALL operations
+  // use the authenticated user's identity. This prevents impersonation attacks.
+  if (authResult?.userId && authResult.authMethod === 'user-key') {
+    const authenticatedUserId = authResult.userId;
+
+    // Override contextId in the message params
+    if (body.params?.message) {
+      body.params.message.contextId = authenticatedUserId;
+    }
+
+    // Set at params level for tasks/get and other methods
+    if (body.params) {
+      body.params.contextId = authenticatedUserId;
+    }
+
+    // SECURITY: Block userId override attempts in operation params
+    // Some operations accept params.userId - force it to authenticated user
+    // to prevent impersonation via "I want to act as user X" attacks
+    if (body.params?.message?.parts) {
+      for (const part of body.params.message.parts) {
+        if (part?.kind === 'data' && part.data?.params) {
+          // If userId is provided in operation params, it MUST match authenticated user
+          if (part.data.params.userId && part.data.params.userId !== authenticatedUserId) {
+            logger.warn('Blocked userId override attempt', {
+              providedUserId: part.data.params.userId,
+              authenticatedUserId,
+            });
+            return NextResponse.json(
+              {
+                jsonrpc: '2.0',
+                error: {
+                  code: -32001,
+                  message: 'Forbidden: Cannot perform operations as another user',
+                },
+                id: body.id ?? null,
+              },
+              { status: 403 }
+            );
+          }
+          // Force userId to authenticated user
+          part.data.params.userId = authenticatedUserId;
+        }
+      }
+    }
+  }
+
+  // SECURITY: Server API key and localhost bypass
+  // These auth methods allow arbitrary contextId, which enables acting as any user.
+  // This is intentional for admin/internal operations but should be monitored.
+  if (authResult?.authMethod === 'server-key' || authResult?.authMethod === 'localhost') {
+    const providedContextId = body.params?.message?.contextId || body.params?.contextId;
+    if (providedContextId) {
+      // Log server-key operations with user context for audit trail
+      logger.info('Server/localhost A2A operation with user context', {
+        authMethod: authResult.authMethod,
+        contextId: providedContextId,
+        method: body.method,
+        operation: body.params?.message?.parts?.[0]?.data?.operation,
+      });
+    }
+  }
 
   // Use the JSON-RPC transport handler
   const response = await jsonRpcHandler.handle(body);

--- a/apps/web/src/app/api/a2a/route.ts
+++ b/apps/web/src/app/api/a2a/route.ts
@@ -199,17 +199,57 @@ export async function POST(request: NextRequest) {
     // Set at params level for tasks/get and other methods
     if (body.params) {
       body.params.contextId = authenticatedUserId;
+
+      // SECURITY: Block top-level userId override attempts
+      if (body.params.userId && body.params.userId !== authenticatedUserId) {
+        logger.warn('Blocked top-level userId override attempt', {
+          providedUserId: body.params.userId,
+          authenticatedUserId,
+        });
+        return NextResponse.json(
+          {
+            jsonrpc: '2.0',
+            error: {
+              code: -32001,
+              message: 'Forbidden: Cannot perform operations as another user',
+            },
+            id: body.id ?? null,
+          },
+          { status: 403 }
+        );
+      }
+      // Force top-level userId to authenticated user
+      body.params.userId = authenticatedUserId;
     }
 
     // SECURITY: Block userId override attempts in operation params
     // Some operations accept params.userId - force it to authenticated user
     // to prevent impersonation via "I want to act as user X" attacks
     if (body.params?.message?.parts) {
+      // Validate parts is an array before iterating
+      if (!Array.isArray(body.params.message.parts)) {
+        logger.warn('Invalid message parts format', {
+          partsType: typeof body.params.message.parts,
+          authenticatedUserId,
+        });
+        return NextResponse.json(
+          {
+            jsonrpc: '2.0',
+            error: {
+              code: -32001,
+              message: 'Forbidden: Cannot perform operations as another user',
+            },
+            id: body.id ?? null,
+          },
+          { status: 403 }
+        );
+      }
+
       for (const part of body.params.message.parts) {
         if (part?.kind === 'data' && part.data?.params) {
           // If userId is provided in operation params, it MUST match authenticated user
           if (part.data.params.userId && part.data.params.userId !== authenticatedUserId) {
-            logger.warn('Blocked userId override attempt', {
+            logger.warn('Blocked userId override attempt in message part', {
               providedUserId: part.data.params.userId,
               authenticatedUserId,
             });

--- a/apps/web/src/app/api/users/api-keys/[keyId]/route.ts
+++ b/apps/web/src/app/api/users/api-keys/[keyId]/route.ts
@@ -60,7 +60,7 @@ export const DELETE = withErrorHandling(
 
     // Immediately invalidate cached key to prevent continued use
     const revokedKey = deleted[0];
-    if (revokedKey.keyHash) {
+    if (revokedKey?.keyHash) {
       invalidateCachedKey(revokedKey.keyHash);
     }
 

--- a/packages/a2a/src/executors/babylon-executor.ts
+++ b/packages/a2a/src/executors/babylon-executor.ts
@@ -543,11 +543,12 @@ export class BabylonAgentExecutor implements AgentExecutor {
       throw new Error('Post not found');
     }
 
-    // Use userId from params first (actual agent user ID), fall back to context
-    const userId =
-      typeof params.userId === 'string' && params.userId
-        ? params.userId
-        : context.contextId || context.taskId;
+    // Prefer request context identity when present (prevents params-based impersonation),
+    // then fall back to explicit params, then taskId.
+    const userIdFromContext = context.contextId;
+    const userIdFromParams =
+      typeof params.userId === 'string' ? params.userId.trim() : '';
+    const userId = userIdFromContext || userIdFromParams || context.taskId;
 
     // Check if already liked
     const existingLike = await db.reaction.findFirst({
@@ -924,11 +925,12 @@ export class BabylonAgentExecutor implements AgentExecutor {
     params: Record<string, JsonValue>,
     context: RequestContext
   ): Promise<ExecutorOperationResult> {
-    // Try to get userId from params, then from x-agent-id header (via contextId), then taskId
-    const userId =
-      typeof params.userId === 'string' && params.userId
-        ? params.userId
-        : context.contextId || context.taskId;
+    // Prefer contextId when present (prevents params-based impersonation),
+    // then fall back to explicit params, then taskId.
+    const userIdFromContext = context.contextId;
+    const userIdFromParams =
+      typeof params.userId === 'string' ? params.userId.trim() : '';
+    const userId = userIdFromContext || userIdFromParams || context.taskId;
 
     const user = await db.user.findUnique({
       where: { id: userId },
@@ -960,10 +962,10 @@ export class BabylonAgentExecutor implements AgentExecutor {
     params: Record<string, JsonValue>,
     context: RequestContext
   ): Promise<ExecutorOperationResult> {
-    const userId =
-      typeof params.userId === 'string' && params.userId
-        ? params.userId
-        : context.contextId || context.taskId;
+    const userIdFromContext = context.contextId;
+    const userIdFromParams =
+      typeof params.userId === 'string' ? params.userId.trim() : '';
+    const userId = userIdFromContext || userIdFromParams || context.taskId;
 
     // Check if user exists first (for graceful handling)
     const userExists = await db.user.findUnique({
@@ -1092,10 +1094,10 @@ export class BabylonAgentExecutor implements AgentExecutor {
     params: Record<string, JsonValue>,
     context: RequestContext
   ): Promise<ExecutorOperationResult> {
-    const userId =
-      typeof params.userId === 'string' && params.userId
-        ? params.userId
-        : context.contextId || context.taskId;
+    const userIdFromContext = context.contextId;
+    const userIdFromParams =
+      typeof params.userId === 'string' ? params.userId.trim() : '';
+    const userId = userIdFromContext || userIdFromParams || context.taskId;
 
     const [balance, positions] = await Promise.all([
       this.getBalance({ userId }, context),

--- a/packages/a2a/src/executors/babylon-executor.ts
+++ b/packages/a2a/src/executors/babylon-executor.ts
@@ -1092,14 +1092,11 @@ export class BabylonAgentExecutor implements AgentExecutor {
     params: Record<string, JsonValue>,
     context: RequestContext
   ): Promise<ExecutorOperationResult> {
-    const userId =
-      typeof params.userId === 'string' && params.userId
-        ? params.userId
-        : context.contextId || context.taskId;
-
+    // Pass params through - getBalance and getPositions handle userId resolution
+    // from params.userId or context.contextId internally
     const [balance, positions] = await Promise.all([
-      this.getBalance({ userId }, context),
-      this.getPositions({ userId }, context),
+      this.getBalance(params, context),
+      this.getPositions(params, context),
     ]);
 
     return {

--- a/packages/testing/e2e/cron-endpoints.e2e.test.ts
+++ b/packages/testing/e2e/cron-endpoints.e2e.test.ts
@@ -9,10 +9,10 @@
  * - CRON_SECRET environment variable set
  * - Database running with game state initialized
  *
- * Run with: bun test packages/testing/e2e/cron-endpoints.e2e.test.ts
+ * Run with: npx playwright test cron-endpoints.e2e.test.ts
  */
 
-import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { expect, test } from '@playwright/test';
 import { asSystem } from '@babylon/db';
 import { generateSnowflakeId } from '@babylon/shared';
 
@@ -30,8 +30,8 @@ let serverAvailable = false;
 let gameId: string | null = null;
 let initialGameRunning: boolean | undefined;
 
-describe('Cron Endpoints E2E', () => {
-  beforeAll(async () => {
+test.describe('Cron Endpoints E2E', () => {
+  test.beforeAll(async () => {
     // Check if server is running
     try {
       const response = await fetch(`${BASE_URL}/api/health`, {
@@ -80,7 +80,7 @@ describe('Cron Endpoints E2E', () => {
     }
   });
 
-  afterAll(async () => {
+  test.afterAll(async () => {
     // Restore game state if we changed it
     if (initialGameRunning !== undefined) {
       await asSystem(async (db) => {
@@ -92,12 +92,10 @@ describe('Cron Endpoints E2E', () => {
     }
   });
 
-  describe('Health Check Endpoint', () => {
+  test.describe('Health Check Endpoint', () => {
     test('GET /api/cron/health-check returns healthy status', async () => {
-      if (!serverAvailable) {
-        console.log('⏭️  Skipping - server not available');
-        return;
-      }
+      test.setTimeout(HEALTH_TIMEOUT + 5000);
+      test.skip(!serverAvailable, 'Server not available');
 
       const response = await fetch(`${BASE_URL}/api/cron/health-check`, {
         method: 'GET',
@@ -118,10 +116,8 @@ describe('Cron Endpoints E2E', () => {
     });
 
     test('returns 401 without valid auth', async () => {
-      if (!serverAvailable) {
-        console.log('⏭️  Skipping - server not available');
-        return;
-      }
+      test.setTimeout(HEALTH_TIMEOUT + 5000);
+      test.skip(!serverAvailable, 'Server not available');
 
       const response = await fetch(`${BASE_URL}/api/cron/health-check`, {
         method: 'GET',
@@ -137,108 +133,131 @@ describe('Cron Endpoints E2E', () => {
     });
   });
 
-  describe('Game Tick Endpoint', () => {
-    test(
-      'POST /api/cron/game-tick executes successfully',
-      async () => {
-        if (!serverAvailable) {
-          console.log('⏭️  Skipping - server not available');
-          return;
-        }
+  test.describe('Game Tick Endpoint', () => {
+    test('POST /api/cron/game-tick executes successfully', async () => {
+      test.setTimeout(CRON_TIMEOUT + 10000);
+      test.skip(!serverAvailable, 'Server not available');
 
-        const response = await fetch(`${BASE_URL}/api/cron/game-tick`, {
+      const response = await fetch(`${BASE_URL}/api/cron/game-tick`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${CRON_SECRET}`,
+          'Content-Type': 'application/json',
+        },
+        signal: AbortSignal.timeout(CRON_TIMEOUT),
+      });
+
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.success).toBe(true);
+
+      // Should either execute or be skipped with reason
+      if (data.skipped) {
+        expect(data.reason).toBeDefined();
+        console.log(`Game tick skipped: ${data.reason}`);
+      } else {
+        expect(data.duration).toBeGreaterThanOrEqual(0);
+        console.log(`Game tick completed in ${data.duration}ms`);
+
+        // Verify result structure if execution occurred
+        if (data.result) {
+          expect(typeof data.result.postsCreated).toBe('number');
+          expect(typeof data.result.marketsUpdated).toBe('number');
+        }
+      }
+    });
+
+    test('handles concurrent requests with lock', async () => {
+      test.setTimeout(CRON_TIMEOUT * 2 + 10000);
+      test.skip(!serverAvailable, 'Server not available');
+
+      // Fire two requests simultaneously
+      const [response1, response2] = await Promise.all([
+        fetch(`${BASE_URL}/api/cron/game-tick`, {
           method: 'POST',
           headers: {
             Authorization: `Bearer ${CRON_SECRET}`,
             'Content-Type': 'application/json',
           },
           signal: AbortSignal.timeout(CRON_TIMEOUT),
-        });
+        }),
+        fetch(`${BASE_URL}/api/cron/game-tick`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${CRON_SECRET}`,
+            'Content-Type': 'application/json',
+          },
+          signal: AbortSignal.timeout(CRON_TIMEOUT),
+        }),
+      ]);
 
-        expect(response.status).toBe(200);
+      expect(response1.status).toBe(200);
+      expect(response2.status).toBe(200);
 
-        const data = await response.json();
-        expect(data.success).toBe(true);
+      const [data1, data2] = await Promise.all([
+        response1.json(),
+        response2.json(),
+      ]);
 
-        // Should either execute or be skipped with reason
-        if (data.skipped) {
-          expect(data.reason).toBeDefined();
-          console.log(`Game tick skipped: ${data.reason}`);
-        } else {
-          expect(data.duration).toBeGreaterThanOrEqual(0);
-          console.log(`Game tick completed in ${data.duration}ms`);
+      // At least one should succeed, the other may be skipped due to lock
+      const bothSucceeded = data1.success && data2.success;
+      expect(bothSucceeded).toBe(true);
 
-          // Verify result structure if execution occurred
-          if (data.result) {
-            expect(typeof data.result.postsCreated).toBe('number');
-            expect(typeof data.result.marketsUpdated).toBe('number');
-          }
-        }
-      },
-      CRON_TIMEOUT + 10000
-    );
-
-    test(
-      'handles concurrent requests with lock',
-      async () => {
-        if (!serverAvailable) {
-          console.log('⏭️  Skipping - server not available');
-          return;
-        }
-
-        // Fire two requests simultaneously
-        const [response1, response2] = await Promise.all([
-          fetch(`${BASE_URL}/api/cron/game-tick`, {
-            method: 'POST',
-            headers: {
-              Authorization: `Bearer ${CRON_SECRET}`,
-              'Content-Type': 'application/json',
-            },
-            signal: AbortSignal.timeout(CRON_TIMEOUT),
-          }),
-          fetch(`${BASE_URL}/api/cron/game-tick`, {
-            method: 'POST',
-            headers: {
-              Authorization: `Bearer ${CRON_SECRET}`,
-              'Content-Type': 'application/json',
-            },
-            signal: AbortSignal.timeout(CRON_TIMEOUT),
-          }),
-        ]);
-
-        expect(response1.status).toBe(200);
-        expect(response2.status).toBe(200);
-
-        const [data1, data2] = await Promise.all([
-          response1.json(),
-          response2.json(),
-        ]);
-
-        // At least one should succeed, the other may be skipped due to lock
-        const bothSucceeded = data1.success && data2.success;
-        expect(bothSucceeded).toBe(true);
-
-        // Check if one was locked out
-        const oneSkipped = data1.skipped || data2.skipped;
-        if (oneSkipped) {
-          const skippedData = data1.skipped ? data1 : data2;
-          expect(skippedData.reason).toContain('lock');
-          console.log('Concurrent request properly handled with lock');
-        }
-      },
-      CRON_TIMEOUT * 2 + 10000
-    );
+      // Check if one was locked out
+      const oneSkipped = data1.skipped || data2.skipped;
+      if (oneSkipped) {
+        const skippedData = data1.skipped ? data1 : data2;
+        expect(skippedData.reason).toContain('lock');
+        console.log('Concurrent request properly handled with lock');
+      }
+    });
   });
 
-  describe('Agent Tick Endpoint', () => {
-    test(
-      'POST /api/cron/agent-tick executes successfully',
-      async () => {
-        if (!serverAvailable) {
-          console.log('⏭️  Skipping - server not available');
-          return;
-        }
+  test.describe('Agent Tick Endpoint', () => {
+    test('POST /api/cron/agent-tick executes successfully', async () => {
+      test.setTimeout(CRON_TIMEOUT + 10000);
+      test.skip(!serverAvailable, 'Server not available');
 
+      const response = await fetch(`${BASE_URL}/api/cron/agent-tick`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${CRON_SECRET}`,
+          'Content-Type': 'application/json',
+        },
+        signal: AbortSignal.timeout(CRON_TIMEOUT),
+      });
+
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.success).toBe(true);
+
+      if (data.skipped) {
+        expect(data.reason).toBeDefined();
+        console.log(`Agent tick skipped: ${data.reason}`);
+      } else {
+        expect(typeof data.processed).toBe('number');
+        expect(typeof data.duration).toBe('number');
+        console.log(
+          `Agent tick processed ${data.processed} agents in ${data.duration}ms`
+        );
+      }
+    });
+
+    test('respects GAME_START environment variable', async () => {
+      test.setTimeout(CRON_TIMEOUT + 10000);
+      test.skip(!serverAvailable, 'Server not available');
+
+      // First pause the game
+      await asSystem(async (db) => {
+        await db.game.updateMany({
+          where: { isContinuous: true },
+          data: { isRunning: false },
+        });
+      }, 'cron-e2e-pause-game');
+
+      try {
         const response = await fetch(`${BASE_URL}/api/cron/agent-tick`, {
           method: 'POST',
           headers: {
@@ -248,75 +267,26 @@ describe('Cron Endpoints E2E', () => {
           signal: AbortSignal.timeout(CRON_TIMEOUT),
         });
 
-        expect(response.status).toBe(200);
-
         const data = await response.json();
         expect(data.success).toBe(true);
-
-        if (data.skipped) {
-          expect(data.reason).toBeDefined();
-          console.log(`Agent tick skipped: ${data.reason}`);
-        } else {
-          expect(typeof data.processed).toBe('number');
-          expect(typeof data.duration).toBe('number');
-          console.log(
-            `Agent tick processed ${data.processed} agents in ${data.duration}ms`
-          );
-        }
-      },
-      CRON_TIMEOUT + 10000
-    );
-
-    test(
-      'respects GAME_START environment variable',
-      async () => {
-        if (!serverAvailable) {
-          console.log('⏭️  Skipping - server not available');
-          return;
-        }
-
-        // First pause the game
+        expect(data.skipped).toBe(true);
+        expect(data.reason).toBe('Game is paused');
+      } finally {
+        // Restore game running state
         await asSystem(async (db) => {
           await db.game.updateMany({
             where: { isContinuous: true },
-            data: { isRunning: false },
+            data: { isRunning: true },
           });
-        }, 'cron-e2e-pause-game');
-
-        try {
-          const response = await fetch(`${BASE_URL}/api/cron/agent-tick`, {
-            method: 'POST',
-            headers: {
-              Authorization: `Bearer ${CRON_SECRET}`,
-              'Content-Type': 'application/json',
-            },
-            signal: AbortSignal.timeout(CRON_TIMEOUT),
-          });
-
-          const data = await response.json();
-          expect(data.success).toBe(true);
-          expect(data.skipped).toBe(true);
-          expect(data.reason).toBe('Game is paused');
-        } finally {
-          // Restore game running state
-          await asSystem(async (db) => {
-            await db.game.updateMany({
-              where: { isContinuous: true },
-              data: { isRunning: true },
-            });
-          }, 'cron-e2e-restore-game-running');
-        }
-      },
-      CRON_TIMEOUT + 10000
-    );
+        }, 'cron-e2e-restore-game-running');
+      }
+    });
   });
 
-  describe('Realtime Drain Endpoint', () => {
+  test.describe('Realtime Drain Endpoint', () => {
     test('GET /api/cron/realtime-drain executes successfully', async () => {
-      if (!serverAvailable) {
-        console.log('⏭️  Skipping - server not available');
-        return;
-      }
+      test.setTimeout(HEALTH_TIMEOUT + 5000);
+      test.skip(!serverAvailable, 'Server not available');
 
       const response = await fetch(`${BASE_URL}/api/cron/realtime-drain`, {
         method: 'GET',
@@ -334,74 +304,62 @@ describe('Cron Endpoints E2E', () => {
     });
   });
 
-  describe('World Facts Endpoint', () => {
-    test(
-      'POST /api/cron/world-facts executes successfully',
-      async () => {
-        if (!serverAvailable) {
-          console.log('⏭️  Skipping - server not available');
-          return;
-        }
+  test.describe('World Facts Endpoint', () => {
+    test('POST /api/cron/world-facts executes successfully', async () => {
+      test.setTimeout(CRON_TIMEOUT + 10000);
+      test.skip(!serverAvailable, 'Server not available');
 
-        const response = await fetch(`${BASE_URL}/api/cron/world-facts`, {
-          method: 'POST',
-          headers: {
-            Authorization: `Bearer ${CRON_SECRET}`,
-            'Content-Type': 'application/json',
-          },
-          signal: AbortSignal.timeout(CRON_TIMEOUT),
-        });
+      const response = await fetch(`${BASE_URL}/api/cron/world-facts`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${CRON_SECRET}`,
+          'Content-Type': 'application/json',
+        },
+        signal: AbortSignal.timeout(CRON_TIMEOUT),
+      });
 
-        expect(response.status).toBe(200);
+      expect(response.status).toBe(200);
 
-        const data = await response.json();
-        expect(data.success).toBe(true);
-        expect(data.duration).toBeGreaterThanOrEqual(0);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.duration).toBeGreaterThanOrEqual(0);
 
-        if (data.stats) {
-          expect(typeof data.stats.feedsFetched).toBe('number');
-          expect(typeof data.stats.newHeadlines).toBe('number');
-          console.log(
-            `World facts: ${data.stats.feedsFetched} feeds, ${data.stats.newHeadlines} new headlines`
-          );
-        }
-      },
-      CRON_TIMEOUT + 10000
-    );
+      if (data.stats) {
+        expect(typeof data.stats.feedsFetched).toBe('number');
+        expect(typeof data.stats.newHeadlines).toBe('number');
+        console.log(
+          `World facts: ${data.stats.feedsFetched} feeds, ${data.stats.newHeadlines} new headlines`
+        );
+      }
+    });
   });
 
-  describe('Training Status Endpoint', () => {
-    test(
-      'GET /api/cron/training returns readiness status',
-      async () => {
-        if (!serverAvailable) {
-          console.log('⏭️  Skipping - server not available');
-          return;
-        }
+  test.describe('Training Status Endpoint', () => {
+    test('GET /api/cron/training returns readiness status', async () => {
+      test.setTimeout(CRON_TIMEOUT + 10000);
+      test.skip(!serverAvailable, 'Server not available');
 
-        const response = await fetch(`${BASE_URL}/api/cron/training`, {
-          method: 'GET',
-          headers: {
-            Authorization: `Bearer ${CRON_SECRET}`,
-          },
-          signal: AbortSignal.timeout(CRON_TIMEOUT),
-        });
+      const response = await fetch(`${BASE_URL}/api/cron/training`, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${CRON_SECRET}`,
+        },
+        signal: AbortSignal.timeout(CRON_TIMEOUT),
+      });
 
-        expect(response.status).toBe(200);
+      expect(response.status).toBe(200);
 
-        const data = await response.json();
-        expect(data.success).toBe(true);
-        expect(data.readiness).toBeDefined();
-        expect(typeof data.readiness.ready).toBe('boolean');
+      const data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.readiness).toBeDefined();
+      expect(typeof data.readiness.ready).toBe('boolean');
 
-        console.log(
-          `Training readiness: ${data.readiness.ready ? 'Ready' : 'Not ready'}`
-        );
-        if (!data.readiness.ready && data.readiness.reason) {
-          console.log(`Reason: ${data.readiness.reason}`);
-        }
-      },
-      CRON_TIMEOUT + 10000
-    );
+      console.log(
+        `Training readiness: ${data.readiness.ready ? 'Ready' : 'Not ready'}`
+      );
+      if (!data.readiness.ready && data.readiness.reason) {
+        console.log(`Reason: ${data.readiness.reason}`);
+      }
+    });
   });
 });

--- a/packages/testing/unit/babylon-integration-wallet.test.ts
+++ b/packages/testing/unit/babylon-integration-wallet.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, mock, test } from 'bun:test';
 // Tests use mocked db module
 const describeTests = describe;
 
+const a2aClientConstructorMock = mock((..._args: unknown[]) => undefined);
+
 const findUniqueMock = mock(async () => ({
   id: 'agent-1',
   isAgent: true,
@@ -17,10 +19,10 @@ const createWalletMock = mock(async () => ({
   privyWalletId: 'privy-wallet',
 }));
 
-const sdkFromCardMock = mock(async () => new MockA2AClient());
-
 class MockA2AClient {
-  static fromCardUrl = sdkFromCardMock;
+  constructor(...args: unknown[]) {
+    a2aClientConstructorMock(...args);
+  }
 }
 
 // Mock fetch to return a valid agent card
@@ -64,28 +66,17 @@ mock.module('@babylon/db', () => ({
       findUnique: findUniqueMock,
     },
   },
-  // All table exports that may be imported by dependencies
-  users: {},
-  actors: {},
-  agentLogs: {},
-  agentMessages: {},
-  agentRegistries: {},
-  llmCallLogs: {},
-  trajectories: {},
-  worldFacts: {},
-  referrals: {},
-  pointsTransactions: {},
-  // Operators
-  eq: () => ({}),
-  and: () => ({}),
-  or: () => ({}),
-  desc: () => ({}),
-  asc: () => ({}),
+}));
+
+mock.module('@babylon/engine', () => ({
+  StaticDataRegistry: {
+    getActor: () => null,
+  },
 }));
 
 // Mock the internal AgentWalletService module (not the whole @babylon/agents package)
 // This allows initializeAgentA2AClient to work while mocking agentWalletService
-mock.module('@babylon/agents/identity/AgentWalletService', () => ({
+mock.module('../../agents/src/identity/AgentWalletService', () => ({
   agentWalletService: {
     createAgentEmbeddedWallet: createWalletMock,
   },
@@ -96,13 +87,15 @@ mock.module('@a2a-js/sdk/client', () => ({
 }));
 
 // Dynamic import AFTER mocks are set up
-const { initializeAgentA2AClient } = await import('@babylon/agents');
+const { initializeAgentA2AClient } = await import(
+  '../../agents/src/plugins/babylon/integration-a2a-sdk'
+);
 
 describeTests('initializeAgentA2AClient wallet provisioning', () => {
   beforeEach(() => {
     findUniqueMock.mockClear();
     createWalletMock.mockClear();
-    sdkFromCardMock.mockClear();
+    a2aClientConstructorMock.mockClear();
     // Reset mock call counts (mockFetch is already properly typed)
     // Mock global fetch to return agent card
     globalThis.fetch = mockFetch;
@@ -122,7 +115,7 @@ describeTests('initializeAgentA2AClient wallet provisioning', () => {
     await initializeAgentA2AClient('agent-1');
 
     expect(createWalletMock).toHaveBeenCalledTimes(1);
-    expect(sdkFromCardMock).toHaveBeenCalledTimes(1);
+    expect(a2aClientConstructorMock).toHaveBeenCalledTimes(1);
   });
 
   test('does not call wallet service when wallet already exists', async () => {
@@ -139,6 +132,6 @@ describeTests('initializeAgentA2AClient wallet provisioning', () => {
     // Wallet service should not be called if wallet already exists
     expect(createWalletMock).not.toHaveBeenCalled();
     // SDK should still be initialized
-    expect(sdkFromCardMock).toHaveBeenCalledTimes(1);
+    expect(a2aClientConstructorMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/training/python/tests/integration/conftest.py
+++ b/packages/training/python/tests/integration/conftest.py
@@ -33,6 +33,8 @@ def is_database_available() -> bool:
     if not database_url:
         return False
     
+    conn = None
+    cur = None
     try:
         import psycopg2
         conn = psycopg2.connect(database_url)
@@ -45,8 +47,6 @@ def is_database_available() -> bool:
             )
         """)
         table_exists = cur.fetchone()[0]
-        cur.close()
-        conn.close()
         
         if not table_exists:
             print("\n" + "=" * 80)
@@ -69,6 +69,12 @@ def is_database_available() -> bool:
         print("Integration tests will be SKIPPED.")
         print("=" * 80 + "\n")
         return False
+    finally:
+        # Always close cursor and connection to prevent resource leaks
+        if cur is not None:
+            cur.close()
+        if conn is not None:
+            conn.close()
 
 
 def skip_if_no_database():


### PR DESCRIPTION
## Summary
- Security fix: Prevent user impersonation by forcing authenticated user's identity for all operations when using user API keys

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
<!-- Link issues, Linear tickets, docs, prior PRs. -->

- #800 

## Scope (keep it focused)
<!-- If you had to touch multiple areas, explain why and what you intentionally left out. -->

- [X] This PR is focused on a single change/theme (not a catch‑all)
- [X] Drive‑by refactors are excluded or split into a separate PR
- [X] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [X] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
<!-- List the notable changes (what is new/removed/modified). Link key files if it helps. -->

- apps/web/src/app/api/a2a/route.ts: Security enforcement - forces authenticated userId as contextId, blocks params.userId override attempts with 403
- apps/web/src/app/api/users/api-keys/[keyId]/route.ts: typescript warning


## Review guide
<!-- Help reviewers go fast: where to start, what to ignore, tricky bits, key decisions. -->

**Start here**
- apps/web/src/app/api/a2a/route.ts - Security enforcement logic (lines 188-249)


**Risk**
- [ ] Low
- [X] Medium
- [ ] High

**Notes for reviewers**
Security model: User API keys can ONLY act as the key owner. Server API key can impersonate (admin use) but is now audit-logged.

## Test plan
<!-- Tick what you ran. Add manual steps for anything user-facing. -->

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Create post via A2A with user API key → post attributed to API key owner
2. Attempt to override contextId or params.userId → returns 403 Forbidden
3. Server API key still works for admin operations (with audit log)


## Ops / Migration / Deployment
<!-- Anything that impacts deploys, data, cron, config, or rollouts. -->

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy
<!-- Authn/authz, secrets handling, PII, prompt injection surfaces, etc. -->

- [ ] No security impact
- [x] Needs extra review (describe)

Security changes:
- User API keys now enforce identity - cannot impersonate other users
- params.userId override attempts are blocked with 403

<details>
<summary>Area-specific notes (expand if relevant)</summary>

New error response: 403 with "Forbidden: Cannot perform operations as another user" when userId override is attempted

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend-only authentication changes, no UI impact. A2A is an API endpoint used by external agents.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Enforced per-user context for user-key requests and added audit logging for server/localhost operations; mismatched context IDs are now overridden and logged.

* **Bug Fixes**
  * Fixed null-reference guard when invalidating cached API keys.

* **Improvements**
  * Standardized user identity resolution to prefer explicit context IDs, reducing impersonation risk.

* **Tests**
  * Ensured DB connections/cursors are always closed; migrated tests to a newer framework and clarified client construction for invocation tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Security fix preventing user impersonation attacks through A2A API keys by enforcing authenticated user identity for all operations.

**Key Changes:**
- User API keys now force `contextId` to authenticated user ID, preventing impersonation
- Added validation to block `params.userId` override attempts with 403 Forbidden response
- Server/localhost auth methods log operations with user context for audit trail
- Added optional chaining in API key revocation to prevent potential null reference
- Fixed Python test DB connection leak with proper finally block cleanup

**Security Model:**
- User API keys: Restricted to key owner's identity only (no impersonation)
- Server API keys: Allow impersonation for admin operations (audit logged)
- Localhost: Development bypass with operation logging

**Potential Gap:**
The `userId` validation only checks within `body.params.message.parts[].data.params.userId` but doesn't validate other potential locations like `body.params.userId` (which is set but not checked) or other nested params. Consider validating all `userId` references or documenting which paths are safe.

<h3>Confidence Score: 3/5</h3>


- This PR addresses a critical security vulnerability but has incomplete validation coverage that could allow bypass
- The security fix correctly prevents the most obvious impersonation attack vector (userId in message parts), but only validates one specific nested path in the request structure. The code sets `body.params.userId` and `body.params.contextId` without validating if they already exist or could be read from other locations. Without comprehensive tests or documentation showing all possible userId injection points are covered, there's risk of bypass via alternate request structures that downstream code might honor.
- Pay close attention to `apps/web/src/app/api/a2a/route.ts` - the security enforcement logic needs validation that all userId paths are covered

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/api/a2a/route.ts | Added security enforcement to prevent user impersonation via user API keys by forcing contextId and blocking userId overrides. Server/localhost auth now logs operations for audit trail. The security logic is well-structured with clear comments. |
| apps/web/src/app/api/users/api-keys/[keyId]/route.ts | Added optional chaining for safe access to revokedKey.keyHash when invalidating cache. Simple defensive programming fix. |
| packages/training/python/tests/integration/conftest.py | Fixed resource leak by moving cursor/connection close operations to finally block, ensuring cleanup even on exceptions. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Route
    participant Auth
    participant Cache
    participant DB
    participant Executor

    Client->>Route: POST request
    Route->>Auth: check auth
    
    alt Localhost
        Auth-->>Route: allow
    else System
        Auth-->>Route: allow
    else User
        Auth->>Cache: check cache
        alt Found
            Cache-->>Auth: user data
        else Not Found
            Auth->>DB: query DB
            DB-->>Auth: user record
            Auth->>Cache: store
        end
        Auth-->>Route: allow with user
    end
    
    alt User Auth
        Route->>Route: enforce context
        Route->>Route: check params
        alt Invalid
            Route-->>Client: 403 Forbidden
        else Valid
            Route->>Route: apply rules
        end
    else System Auth
        Route->>Route: log action
    end
    
    Route->>Executor: process
    Executor-->>Route: result
    Route-->>Client: respond
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->