### PR TITLE
feat(api): add /api/auth/whoami endpoint for API key user lookup

### DIFF
--- a/apps/web/src/app/api/auth/whoami/route.ts
+++ b/apps/web/src/app/api/auth/whoami/route.ts
@@ -5,7 +5,7 @@
  * @access Requires API Key (X-Babylon-Api-Key header)
  *
  * @description
- * Returns the authenticated user's basic info based on their API key.
+ * Returns the authenticated user's ID based on their API key.
  * Used by external agents/clients to discover their user ID for A2A requests.
  *
  * @openapi
@@ -14,7 +14,7 @@
  *     tags:
  *       - Authentication
  *     summary: Get current user info from API key
- *     description: Returns user ID and basic info for the authenticated API key owner. Used to get the contextId for A2A requests.
+ *     description: Returns user ID for the authenticated API key owner. Used to get the contextId for A2A requests.
  *     security:
  *       - ApiKeyAuth: []
  *     responses:
@@ -31,9 +31,7 @@
  *                 username:
  *                   type: string
  *                   nullable: true
- *                 displayName:
- *                   type: string
- *                   nullable: true
+ *                   description: Username for debugging/logging purposes
  *       401:
  *         description: Invalid or missing API key
  *       404:
@@ -41,7 +39,7 @@
  *
  * @example
  * ```bash
- * curl -H "X-Babylon-Api-Key: bab_live_..." https://babylon.market/api/auth/whoami
+ * curl -H "X-Babylon-Api-Key: YOUR_API_KEY_HERE" https://babylon.market/api/auth/whoami
  * ```
  *
  * @example
@@ -65,10 +63,13 @@ export const dynamic = 'force-dynamic';
 export async function GET(request: NextRequest) {
   const apiKey = request.headers.get('x-babylon-api-key');
 
+  // Headers for auth responses - prevent caching of sensitive identity data
+  const noCacheHeaders = { 'Cache-Control': 'no-store' };
+
   if (!apiKey) {
     return NextResponse.json(
       { error: 'X-Babylon-Api-Key header is required' },
-      { status: 401 }
+      { status: 401, headers: noCacheHeaders }
     );
   }
 
@@ -78,34 +79,36 @@ export async function GET(request: NextRequest) {
   if (!result) {
     return NextResponse.json(
       { error: 'Invalid or expired API key' },
-      { status: 401 }
+      { status: 401, headers: noCacheHeaders }
     );
   }
 
-  // Fetch user details
+  // Fetch user details (minimal: only id and username for debugging)
   const [user] = await db
     .select({
       id: users.id,
       username: users.username,
-      displayName: users.displayName,
     })
     .from(users)
     .where(eq(users.id, result.userId))
     .limit(1);
 
   if (!user) {
-    logger.warn('API key valid but user not found', { userId: result.userId }, 'whoami');
+    logger.warn(
+      'API key valid but user not found',
+      { userId: result.userId },
+      'whoami'
+    );
     return NextResponse.json(
       { error: 'User not found' },
-      { status: 404 }
+      { status: 404, headers: noCacheHeaders }
     );
   }
 
-  logger.debug('Whoami request', { userId: user.id, username: user.username }, 'whoami');
+  logger.debug('Whoami request', { userId: user.id }, 'whoami');
 
-  return NextResponse.json({
-    userId: user.id,
-    username: user.username,
-    displayName: user.displayName,
-  });
+  return NextResponse.json(
+    { userId: user.id, username: user.username },
+    { headers: noCacheHeaders }
+  );
 }

--- a/apps/web/src/app/api/auth/whoami/route.ts
+++ b/apps/web/src/app/api/auth/whoami/route.ts
@@ -1,0 +1,111 @@
+/**
+ * API Key User Info Endpoint
+ *
+ * @route GET /api/auth/whoami
+ * @access Requires API Key (X-Babylon-Api-Key header)
+ *
+ * @description
+ * Returns the authenticated user's basic info based on their API key.
+ * Used by external agents/clients to discover their user ID for A2A requests.
+ *
+ * @openapi
+ * /api/auth/whoami:
+ *   get:
+ *     tags:
+ *       - Authentication
+ *     summary: Get current user info from API key
+ *     description: Returns user ID and basic info for the authenticated API key owner. Used to get the contextId for A2A requests.
+ *     security:
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: User info
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 userId:
+ *                   type: string
+ *                   description: The user's unique ID (use as contextId in A2A requests)
+ *                 username:
+ *                   type: string
+ *                   nullable: true
+ *                 displayName:
+ *                   type: string
+ *                   nullable: true
+ *       401:
+ *         description: Invalid or missing API key
+ *       404:
+ *         description: User not found
+ *
+ * @example
+ * ```bash
+ * curl -H "X-Babylon-Api-Key: bab_live_..." https://babylon.market/api/auth/whoami
+ * ```
+ *
+ * @example
+ * ```typescript
+ * const response = await fetch('/api/auth/whoami', {
+ *   headers: { 'X-Babylon-Api-Key': apiKey }
+ * });
+ * const { userId } = await response.json();
+ * // Use userId as contextId in A2A requests
+ * ```
+ */
+
+import { validateUserApiKey } from '@babylon/api';
+import { db, eq, users } from '@babylon/db';
+import { logger } from '@babylon/shared';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const apiKey = request.headers.get('x-babylon-api-key');
+
+  if (!apiKey) {
+    return NextResponse.json(
+      { error: 'X-Babylon-Api-Key header is required' },
+      { status: 401 }
+    );
+  }
+
+  // Validate API key and get user ID
+  const result = await validateUserApiKey(apiKey);
+
+  if (!result) {
+    return NextResponse.json(
+      { error: 'Invalid or expired API key' },
+      { status: 401 }
+    );
+  }
+
+  // Fetch user details
+  const [user] = await db
+    .select({
+      id: users.id,
+      username: users.username,
+      displayName: users.displayName,
+    })
+    .from(users)
+    .where(eq(users.id, result.userId))
+    .limit(1);
+
+  if (!user) {
+    logger.warn('API key valid but user not found', { userId: result.userId }, 'whoami');
+    return NextResponse.json(
+      { error: 'User not found' },
+      { status: 404 }
+    );
+  }
+
+  logger.debug('Whoami request', { userId: user.id, username: user.username }, 'whoami');
+
+  return NextResponse.json({
+    userId: user.id,
+    username: user.username,
+    displayName: user.displayName,
+  });
+}

--- a/packages/testing/unit/auth/whoami.test.ts
+++ b/packages/testing/unit/auth/whoami.test.ts
@@ -1,0 +1,286 @@
+/**
+ * /api/auth/whoami Endpoint Unit Tests
+ *
+ * Tests for the API key user info endpoint used by external clients
+ * to discover their contextId for A2A requests.
+ */
+
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+// Mock user data (minimal: only id and username)
+const mockUsers = new Map([
+  ['user-123', { id: 'user-123', username: 'testuser' }],
+  ['user-456', { id: 'user-456', username: 'anotheruser' }],
+]);
+
+// Mock validateUserApiKey
+const mockValidateUserApiKey = mock(async (apiKey: string) => {
+  if (apiKey === 'bab_live_valid123') {
+    return { userId: 'user-123' };
+  }
+  if (apiKey === 'bab_live_valid456') {
+    return { userId: 'user-456' };
+  }
+  if (apiKey === 'bab_live_deleted_user') {
+    return { userId: 'user-deleted' }; // User doesn't exist in DB
+  }
+  // Invalid/expired/revoked keys return null
+  return null;
+});
+
+// Mock db query
+const mockDbSelect = mock(() => ({
+  from: () => ({
+    where: () => ({
+      limit: (n: number) => {
+        // Return based on last query context
+        const userId = mockDbSelect.mock.calls.at(-1)?.[0]?.userId;
+        const user = mockUsers.get(userId);
+        return Promise.resolve(user ? [user] : []);
+      },
+    }),
+  }),
+}));
+
+// Track the userId being queried
+let lastQueriedUserId: string | null = null;
+
+// Mock @babylon/api
+mock.module('@babylon/api', () => ({
+  validateUserApiKey: mockValidateUserApiKey,
+}));
+
+// Mock @babylon/db
+mock.module('@babylon/db', () => ({
+  db: {
+    select: (fields: { id: unknown; username: unknown }) => ({
+      from: () => ({
+        where: (condition: unknown) => ({
+          limit: () => {
+            // Extract userId from the mock call context
+            const user = mockUsers.get(lastQueriedUserId || '');
+            return Promise.resolve(user ? [user] : []);
+          },
+        }),
+      }),
+    }),
+  },
+  eq: (field: unknown, value: string) => {
+    lastQueriedUserId = value;
+    return { field, value };
+  },
+  users: {
+    id: 'users.id',
+    username: 'users.username',
+  },
+}));
+
+// Mock @babylon/shared
+mock.module('@babylon/shared', () => ({
+  logger: {
+    debug: () => {},
+    warn: () => {},
+    error: () => {},
+    info: () => {},
+  },
+}));
+
+// Expected headers for all auth responses
+const noCacheHeaders = { 'Cache-Control': 'no-store' };
+
+// Mock NextResponse
+const mockJsonResponse = mock(
+  (
+    body: unknown,
+    init?: { status?: number; headers?: Record<string, string> }
+  ) => ({
+    body,
+    status: init?.status || 200,
+    headers: init?.headers,
+  })
+);
+
+mock.module('next/server', () => ({
+  NextResponse: {
+    json: mockJsonResponse,
+  },
+}));
+
+// Import the route handler after mocks are set up
+const { GET } = await import(
+  '../../../../apps/web/src/app/api/auth/whoami/route'
+);
+
+// Helper to create mock NextRequest
+const createMockRequest = (apiKey: string | null): Request => {
+  const headers = new Headers();
+  if (apiKey) {
+    headers.set('x-babylon-api-key', apiKey);
+  }
+  return {
+    headers: {
+      get: (name: string) => headers.get(name),
+    },
+  } as unknown as Request;
+};
+
+describe('/api/auth/whoami endpoint', () => {
+  beforeEach(() => {
+    mockValidateUserApiKey.mockClear();
+    mockJsonResponse.mockClear();
+    lastQueriedUserId = null;
+  });
+
+  describe('Valid API key scenarios', () => {
+    it('should return correct user info for valid API key', async () => {
+      const request = createMockRequest('bab_live_valid123');
+      await GET(request as never);
+
+      expect(mockValidateUserApiKey).toHaveBeenCalledWith('bab_live_valid123');
+      expect(mockJsonResponse).toHaveBeenCalledWith(
+        { userId: 'user-123', username: 'testuser' },
+        { headers: noCacheHeaders }
+      );
+    });
+
+    it('should return correct user info for different valid API key', async () => {
+      const request = createMockRequest('bab_live_valid456');
+      await GET(request as never);
+
+      expect(mockValidateUserApiKey).toHaveBeenCalledWith('bab_live_valid456');
+      expect(mockJsonResponse).toHaveBeenCalledWith(
+        { userId: 'user-456', username: 'anotheruser' },
+        { headers: noCacheHeaders }
+      );
+    });
+  });
+
+  describe('Invalid API key scenarios', () => {
+    it('should return 401 for invalid API key', async () => {
+      const request = createMockRequest('bab_live_invalid_key');
+      await GET(request as never);
+
+      expect(mockValidateUserApiKey).toHaveBeenCalledWith(
+        'bab_live_invalid_key'
+      );
+      expect(mockJsonResponse).toHaveBeenCalledWith(
+        { error: 'Invalid or expired API key' },
+        { status: 401, headers: noCacheHeaders }
+      );
+    });
+
+    it('should return 401 for expired API key', async () => {
+      const request = createMockRequest('bab_live_expired_key_xyz');
+      await GET(request as never);
+
+      expect(mockJsonResponse).toHaveBeenCalledWith(
+        { error: 'Invalid or expired API key' },
+        { status: 401, headers: noCacheHeaders }
+      );
+    });
+
+    it('should return 401 for revoked API key', async () => {
+      const request = createMockRequest('bab_live_revoked_key_abc');
+      await GET(request as never);
+
+      expect(mockJsonResponse).toHaveBeenCalledWith(
+        { error: 'Invalid or expired API key' },
+        { status: 401, headers: noCacheHeaders }
+      );
+    });
+  });
+
+  describe('Missing API key scenarios', () => {
+    it('should return 401 when API key header is missing', async () => {
+      const request = createMockRequest(null);
+      await GET(request as never);
+
+      // Should not even call validateUserApiKey
+      expect(mockValidateUserApiKey).not.toHaveBeenCalled();
+      expect(mockJsonResponse).toHaveBeenCalledWith(
+        { error: 'X-Babylon-Api-Key header is required' },
+        { status: 401, headers: noCacheHeaders }
+      );
+    });
+
+    it('should return 401 when API key header is empty string', async () => {
+      const request = createMockRequest('');
+      await GET(request as never);
+
+      // Empty string is falsy, should not call validateUserApiKey
+      expect(mockValidateUserApiKey).not.toHaveBeenCalled();
+      expect(mockJsonResponse).toHaveBeenCalledWith(
+        { error: 'X-Babylon-Api-Key header is required' },
+        { status: 401, headers: noCacheHeaders }
+      );
+    });
+  });
+
+  describe('User not found scenarios', () => {
+    it('should return 404 when API key is valid but user does not exist', async () => {
+      const request = createMockRequest('bab_live_deleted_user');
+      await GET(request as never);
+
+      // API key validation passes
+      expect(mockValidateUserApiKey).toHaveBeenCalledWith(
+        'bab_live_deleted_user'
+      );
+      // But user lookup fails
+      expect(mockJsonResponse).toHaveBeenCalledWith(
+        { error: 'User not found' },
+        { status: 404, headers: noCacheHeaders }
+      );
+    });
+  });
+
+  describe('Security considerations', () => {
+    it('should only expose userId and username (minimal data)', async () => {
+      const request = createMockRequest('bab_live_valid123');
+      await GET(request as never);
+
+      const responseBody = mockJsonResponse.mock.calls[0]?.[0];
+
+      // Should only contain these two fields (minimal for contextId use case)
+      expect(Object.keys(responseBody as object)).toEqual([
+        'userId',
+        'username',
+      ]);
+
+      // Should not contain PII or sensitive fields
+      expect(responseBody).not.toHaveProperty('displayName');
+      expect(responseBody).not.toHaveProperty('email');
+      expect(responseBody).not.toHaveProperty('walletAddress');
+      expect(responseBody).not.toHaveProperty('apiKeys');
+      expect(responseBody).not.toHaveProperty('password');
+      expect(responseBody).not.toHaveProperty('bio');
+    });
+
+    it('should validate API key before any database queries', async () => {
+      const request = createMockRequest('bab_live_invalid_key');
+      await GET(request as never);
+
+      // Should call validateUserApiKey first
+      expect(mockValidateUserApiKey).toHaveBeenCalledTimes(1);
+      // Should not query DB for invalid keys
+      expect(lastQueriedUserId).toBeNull();
+    });
+
+    it('should set Cache-Control: no-store header on all responses', async () => {
+      // Test success response
+      const successRequest = createMockRequest('bab_live_valid123');
+      await GET(successRequest as never);
+      expect(mockJsonResponse.mock.calls[0]?.[1]?.headers).toEqual(
+        noCacheHeaders
+      );
+
+      mockJsonResponse.mockClear();
+
+      // Test error response
+      const errorRequest = createMockRequest('invalid_key');
+      await GET(errorRequest as never);
+      expect(mockJsonResponse.mock.calls[0]?.[1]?.headers).toEqual(
+        noCacheHeaders
+      );
+    });
+  });
+});


### PR DESCRIPTION
Returns user ID and basic info for the authenticated API key owner. External clients can use this to discover their userId for setting contextId in A2A requests.

GET /api/auth/whoami
Headers: X-Babylon-Api-Key: bab_live_...
Returns: { userId, username, displayName }

## Summary

- **Security fix**: Prevent A2A impersonation attacks by enforcing `contextId` matches the authenticated user when using per-user API keys
- **Hardening**: Executor now prioritizes `context.contextId` over `params.userId` for actor identity in write operations (likePost, getBalance, getPositions, getUserWallet)
- **Audit logging**: Server API key and localhost bypass operations are now logged for security monitoring

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Discovered via testing: A2A posts using API key showed up under random UUID instead of authenticated user
- Prior work: A2A API key authentication implementation

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Non-goals / follow-ups:**
- MCP endpoint hardening (uses same auth but different execution path)
- Rate limiting for A2A endpoints
- Comprehensive audit log persistence (currently just logging)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [x] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- `apps/web/src/app/api/a2a/route.ts`: 
  - Added try-catch for malformed JSON (400 response)
  - For `user-key` auth: enforce `contextId` in both `body.params.message` and `body.params` to authenticated user ID
  - For `server-key`/`localhost`: audit-log operations with user context
  - Added `isPlainObject` type guard for safe mutation
  - Validate `authenticatedUserId` is non-empty string (401 if invalid)

- `packages/a2a/src/executors/babylon-executor.ts`:
  - `likePost`, `getBalance`, `getPositions`, `getUserWallet`: prefer `context.contextId` over `params.userId` for actor identity

- `packages/a2a/src/utils/api-key-auth.ts`:
  - `timingSafeEqual` now uses SHA-256 hashing to prevent length-based timing leaks

- `packages/api/src/utils/api-keys.ts`:
  - True LRU eviction (by `lastAccessedAt`, not `cachedAt`)
  - New cache entries trigger `scheduleLastUsedUpdate` for first-use DB recording

- `apps/web/src/app/api/users/api-keys/[keyId]/route.ts`:
  - Added `invalidateCachedKey()` on key revocation

- `packages/testing/e2e/cron-endpoints.e2e.test.ts`:
  - Converted from `bun:test` to `@playwright/test` (CI fix)

## Review guide

**Start here**
- `apps/web/src/app/api/a2a/route.ts` - Core security enforcement logic (lines 188-250)
- `packages/a2a/src/executors/babylon-executor.ts` - Actor identity resolution changes

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- The key insight: `contextId` is the ACTOR identity, `params.userId` is often the TARGET (e.g., blockUser targets `params.userId`, actor is `contextId`)
- We do NOT enforce `params.userId` because it would break target-user operations
- Server API keys intentionally allow arbitrary `contextId` for admin/internal operations

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [ ] `bun run build` (local Bun segfault in babylon-docs - unrelated to changes)
- [ ] `bun run test` (DATABASE_URL not set locally)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Used `test-a2a.ts` client script to create posts via A2A with user API key
2. Verified posts now correctly attributed to authenticated user (not random UUID)
3. Verified `contextId` in response matches authenticated user

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Note**: User API key requests that previously relied on client-provided `contextId` will now have it overridden. This is intentional security hardening - legitimate clients should not notice any difference.

## Security / privacy

- [ ] No security impact
- [x] Needs extra review (describe)

**Security improvements:**
- Prevents impersonation: User API keys can no longer act as arbitrary users
- Timing-safe comparison: SHA-256 hashing prevents length-based timing attacks
- Audit logging: Server/localhost operations with user context are logged
- Cache invalidation: Revoked keys are immediately removed from cache

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- A2A endpoint behavior change: `contextId` is now enforced for `user-key` auth
- Response shape unchanged
- Server API keys retain full impersonation capability (intentional for admin ops)

### Database
- No schema changes
- `userApiKeys.lastUsedAt` updates now correctly triggered on first use after cache miss

### Contracts / on-chain
- N/A

### Docs
- N/A

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend-only security fix for A2A API endpoint. No UI components affected.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added `/api/auth/whoami` endpoint that returns authenticated user info from API key. External A2A clients can use this to discover their `userId` for setting `contextId` in requests.

**Key changes:**
- New GET endpoint validates API key via `validateUserApiKey` (uses LRU cache with 5min TTL)
- Returns `userId`, `username`, and `displayName` for authenticated user
- Proper error handling for missing/invalid keys (401) and missing users (404)
- Includes comprehensive OpenAPI documentation and examples
- Follows established patterns from other auth endpoints (thin handler, proper logging)

**Implementation quality:**
- Security: Leverages existing secure validation with SHA-256 hashing and timing-safe comparison
- Error handling: Appropriate status codes and clear error messages
- Logging: Debug logging on success, warning on user-not-found edge case
- Performance: Benefits from cached key validation (99%+ hit rate per docs)
- Documentation: Excellent inline JSDoc with OpenAPI spec and usage examples

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- Score reflects simple, well-implemented endpoint that follows established patterns. The implementation reuses proven security mechanisms (`validateUserApiKey`), handles all edge cases appropriately, includes comprehensive documentation, and introduces no breaking changes. The endpoint is read-only and self-contained.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/api/auth/whoami/route.ts | New endpoint that returns user info from API key authentication, properly validates keys and handles edge cases |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as External Client
    participant API as /api/auth/whoami
    participant Validator as validateUserApiKey
    participant Cache as API Key Cache
    participant DB as Database (userApiKeys)
    participant UsersDB as Database (users)

    Client->>API: GET /api/auth/whoami<br/>Header: X-Babylon-Api-Key
    
    alt Missing API Key
        API->>Client: 401 Unauthorized<br/>(Missing header)
    end
    
    API->>Validator: validateUserApiKey(apiKey)
    Validator->>Validator: Hash API key with SHA-256
    
    alt Cache Hit
        Validator->>Cache: Check cache by hash
        Cache-->>Validator: Return cached user info
        Validator->>Validator: Validate TTL and expiry
        Validator->>Validator: Update lastAccessedAt (LRU)
        Validator->>DB: Schedule async lastUsedAt update (throttled)
    else Cache Miss
        Validator->>DB: Query userApiKeys<br/>(validate hash, not revoked, not expired)
        alt Invalid/Revoked/Expired Key
            DB-->>Validator: null
            Validator-->>API: null
            API->>Client: 401 Unauthorized<br/>(Invalid or expired API key)
        end
        DB-->>Validator: API key record
        Validator->>Cache: Store in cache with metadata
        Validator->>DB: Schedule async lastUsedAt update
    end
    
    Validator-->>API: { userId }
    
    API->>UsersDB: SELECT id, username, displayName<br/>WHERE id = userId
    
    alt User Not Found
        UsersDB-->>API: null
        API->>API: Log warning
        API->>Client: 404 Not Found<br/>(User not found)
    end
    
    UsersDB-->>API: User record
    API->>API: Log debug info
    API->>Client: 200 OK<br/>{ userId, username, displayName }
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint to return the current authenticated user's ID and username using an API key from the request header.

* **Bug Fixes / Security**
  * Returns 401 for missing/invalid keys and 404 if the referenced user is not found.
  * Responses include strict no-store cache controls and expose only minimal non-PII fields.

* **Tests**
  * Added comprehensive unit tests covering authentication scenarios, error cases, and response headers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->