### PR TITLE
fix(agents): enable trading by default and auto-create agent configs

### DIFF
--- a/apps/web/src/app/api/cron/agent-tick/route.ts
+++ b/apps/web/src/app/api/cron/agent-tick/route.ts
@@ -573,10 +573,8 @@ export async function POST(_req: NextRequest) {
 
     // Validation: Warn if no actions were executed
     if (totalActionsExecuted === 0 && results.length > 0) {
-      // Count agents with autonomous features enabled
-      const agentsWithFeatures = eligibleAgents.filter((a) =>
-        hasAnyAutonomousFeature(a.config)
-      ).length;
+      // All eligible agents have at least one autonomous feature (pre-filtered during eligibility check)
+      const agentsWithFeatures = eligibleAgents.length;
 
       logger.warn(
         'Agent tick completed but no actions were executed',

--- a/apps/web/src/app/api/cron/agent-tick/route.ts
+++ b/apps/web/src/app/api/cron/agent-tick/route.ts
@@ -57,6 +57,8 @@ import {
   agentRuntimeManager,
   agentService,
   autonomousCoordinator,
+  getAutonomousFeatures,
+  hasAnyAutonomousFeature,
   releaseAgentLock,
 } from '@babylon/agents';
 import {
@@ -304,19 +306,7 @@ export async function POST(_req: NextRequest) {
         TICK_POINTS_COST <= 0 ||
         Number(user.virtualBalance ?? 0) >= TICK_POINTS_COST;
 
-      const hasAutonomousTrading = config?.autonomousTrading ?? true;
-      const hasAutonomousPosting = config?.autonomousPosting ?? false;
-      const hasAutonomousCommenting = config?.autonomousCommenting ?? false;
-      const hasAutonomousDMs = config?.autonomousDMs ?? false;
-      const hasAutonomousGroupChats = config?.autonomousGroupChats ?? false;
-      const hasAutonomousFeatures =
-        hasAutonomousTrading ||
-        hasAutonomousPosting ||
-        hasAutonomousCommenting ||
-        hasAutonomousDMs ||
-        hasAutonomousGroupChats;
-
-      if (user.isAgent && hasEnoughBalance && hasAutonomousFeatures) {
+      if (user.isAgent && hasEnoughBalance && hasAnyAutonomousFeature(config)) {
         eligibleAgents.push({
           agentId: agent.agentId,
           type: agent.type,
@@ -425,22 +415,13 @@ export async function POST(_req: NextRequest) {
         );
 
         // Determine enabled features from agent config
+        const features = getAutonomousFeatures(eligibleAgent.config);
         const enabledFeatures: string[] = [];
-        const hasAutonomousTrading =
-          eligibleAgent.config?.autonomousTrading ?? true;
-        const hasAutonomousPosting =
-          eligibleAgent.config?.autonomousPosting ?? false;
-        const hasAutonomousCommenting =
-          eligibleAgent.config?.autonomousCommenting ?? false;
-        const hasAutonomousDMs = eligibleAgent.config?.autonomousDMs ?? false;
-        const hasAutonomousGroupChats =
-          eligibleAgent.config?.autonomousGroupChats ?? false;
-
-        if (hasAutonomousTrading) enabledFeatures.push('trading');
-        if (hasAutonomousPosting) enabledFeatures.push('posting');
-        if (hasAutonomousCommenting) enabledFeatures.push('commenting');
-        if (hasAutonomousDMs) enabledFeatures.push('DMs');
-        if (hasAutonomousGroupChats) enabledFeatures.push('group chats');
+        if (features.trading) enabledFeatures.push('trading');
+        if (features.posting) enabledFeatures.push('posting');
+        if (features.commenting) enabledFeatures.push('commenting');
+        if (features.dms) enabledFeatures.push('DMs');
+        if (features.groupChats) enabledFeatures.push('group chats');
 
         // Always record trajectories for RL training data collection
         // For USER_CONTROLLED agents, pass user.id (userId for User table lookup)
@@ -593,20 +574,9 @@ export async function POST(_req: NextRequest) {
     // Validation: Warn if no actions were executed
     if (totalActionsExecuted === 0 && results.length > 0) {
       // Count agents with autonomous features enabled
-      const agentsWithFeatures = eligibleAgents.filter((a) => {
-        const hasAutonomousTrading = a.config?.autonomousTrading ?? true;
-        const hasAutonomousPosting = a.config?.autonomousPosting ?? false;
-        const hasAutonomousCommenting = a.config?.autonomousCommenting ?? false;
-        const hasAutonomousDMs = a.config?.autonomousDMs ?? false;
-        const hasAutonomousGroupChats = a.config?.autonomousGroupChats ?? false;
-        return (
-          hasAutonomousTrading ||
-          hasAutonomousPosting ||
-          hasAutonomousCommenting ||
-          hasAutonomousDMs ||
-          hasAutonomousGroupChats
-        );
-      }).length;
+      const agentsWithFeatures = eligibleAgents.filter((a) =>
+        hasAnyAutonomousFeature(a.config)
+      ).length;
 
       logger.warn(
         'Agent tick completed but no actions were executed',

--- a/apps/web/src/app/api/cron/agent-tick/route.ts
+++ b/apps/web/src/app/api/cron/agent-tick/route.ts
@@ -304,14 +304,22 @@ export async function POST(_req: NextRequest) {
         TICK_POINTS_COST <= 0 ||
         Number(user.virtualBalance ?? 0) >= TICK_POINTS_COST;
 
+      const hasAutonomousTrading = config?.autonomousTrading ?? true;
+      const hasAutonomousPosting = config?.autonomousPosting ?? false;
+      const hasAutonomousCommenting = config?.autonomousCommenting ?? false;
+      const hasAutonomousDMs = config?.autonomousDMs ?? false;
+      const hasAutonomousGroupChats = config?.autonomousGroupChats ?? false;
+      const hasAutonomousFeatures =
+        hasAutonomousTrading ||
+        hasAutonomousPosting ||
+        hasAutonomousCommenting ||
+        hasAutonomousDMs ||
+        hasAutonomousGroupChats;
+
       if (
         user.isAgent &&
         hasEnoughBalance &&
-        (config?.autonomousTrading ||
-          config?.autonomousPosting ||
-          config?.autonomousCommenting ||
-          config?.autonomousDMs ||
-          config?.autonomousGroupChats)
+        hasAutonomousFeatures
       ) {
         eligibleAgents.push({
           agentId: agent.agentId,
@@ -422,17 +430,21 @@ export async function POST(_req: NextRequest) {
 
         // Determine enabled features from agent config
         const enabledFeatures: string[] = [];
-        if (eligibleAgent.config) {
-          if (eligibleAgent.config.autonomousTrading)
-            enabledFeatures.push('trading');
-          if (eligibleAgent.config.autonomousPosting)
-            enabledFeatures.push('posting');
-          if (eligibleAgent.config.autonomousCommenting)
-            enabledFeatures.push('commenting');
-          if (eligibleAgent.config.autonomousDMs) enabledFeatures.push('DMs');
-          if (eligibleAgent.config.autonomousGroupChats)
-            enabledFeatures.push('group chats');
-        }
+        const hasAutonomousTrading =
+          eligibleAgent.config?.autonomousTrading ?? true;
+        const hasAutonomousPosting =
+          eligibleAgent.config?.autonomousPosting ?? false;
+        const hasAutonomousCommenting =
+          eligibleAgent.config?.autonomousCommenting ?? false;
+        const hasAutonomousDMs = eligibleAgent.config?.autonomousDMs ?? false;
+        const hasAutonomousGroupChats =
+          eligibleAgent.config?.autonomousGroupChats ?? false;
+
+        if (hasAutonomousTrading) enabledFeatures.push('trading');
+        if (hasAutonomousPosting) enabledFeatures.push('posting');
+        if (hasAutonomousCommenting) enabledFeatures.push('commenting');
+        if (hasAutonomousDMs) enabledFeatures.push('DMs');
+        if (hasAutonomousGroupChats) enabledFeatures.push('group chats');
 
         // Always record trajectories for RL training data collection
         // For USER_CONTROLLED agents, pass user.id (userId for User table lookup)
@@ -586,12 +598,19 @@ export async function POST(_req: NextRequest) {
     if (totalActionsExecuted === 0 && results.length > 0) {
       // Count agents with autonomous features enabled
       const agentsWithFeatures = eligibleAgents.filter((a) => {
+        const hasAutonomousTrading = a.config?.autonomousTrading ?? true;
+        const hasAutonomousPosting = a.config?.autonomousPosting ?? false;
+        const hasAutonomousCommenting =
+          a.config?.autonomousCommenting ?? false;
+        const hasAutonomousDMs = a.config?.autonomousDMs ?? false;
+        const hasAutonomousGroupChats =
+          a.config?.autonomousGroupChats ?? false;
         return (
-          a.config?.autonomousTrading ||
-          a.config?.autonomousPosting ||
-          a.config?.autonomousCommenting ||
-          a.config?.autonomousDMs ||
-          a.config?.autonomousGroupChats
+          hasAutonomousTrading ||
+          hasAutonomousPosting ||
+          hasAutonomousCommenting ||
+          hasAutonomousDMs ||
+          hasAutonomousGroupChats
         );
       }).length;
 

--- a/apps/web/src/app/api/cron/agent-tick/route.ts
+++ b/apps/web/src/app/api/cron/agent-tick/route.ts
@@ -316,11 +316,7 @@ export async function POST(_req: NextRequest) {
         hasAutonomousDMs ||
         hasAutonomousGroupChats;
 
-      if (
-        user.isAgent &&
-        hasEnoughBalance &&
-        hasAutonomousFeatures
-      ) {
+      if (user.isAgent && hasEnoughBalance && hasAutonomousFeatures) {
         eligibleAgents.push({
           agentId: agent.agentId,
           type: agent.type,
@@ -600,11 +596,9 @@ export async function POST(_req: NextRequest) {
       const agentsWithFeatures = eligibleAgents.filter((a) => {
         const hasAutonomousTrading = a.config?.autonomousTrading ?? true;
         const hasAutonomousPosting = a.config?.autonomousPosting ?? false;
-        const hasAutonomousCommenting =
-          a.config?.autonomousCommenting ?? false;
+        const hasAutonomousCommenting = a.config?.autonomousCommenting ?? false;
         const hasAutonomousDMs = a.config?.autonomousDMs ?? false;
-        const hasAutonomousGroupChats =
-          a.config?.autonomousGroupChats ?? false;
+        const hasAutonomousGroupChats = a.config?.autonomousGroupChats ?? false;
         return (
           hasAutonomousTrading ||
           hasAutonomousPosting ||

--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -14,7 +14,7 @@ import type { IAgentRuntime } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
 import { getNpcGameContext } from '../plugins/babylon/providers/npc-game-context';
 import { agentService } from '../services/AgentService';
-import { getAgentConfig } from '../shared/agent-config';
+import { getAgentConfig, getAutonomousFeatures } from '../shared/agent-config';
 import { logger } from '../shared/logger';
 import {
   executeDirectComment,
@@ -134,19 +134,14 @@ export class MultiStepExecutor {
         Features.GROUP_CHATS
       );
     } else {
-      const hasAutonomousTrading = config?.autonomousTrading ?? true;
-      const hasAutonomousPosting = config?.autonomousPosting ?? false;
-      const hasAutonomousCommenting = config?.autonomousCommenting ?? false;
-      const hasAutonomousDMs = config?.autonomousDMs ?? false;
-      const hasAutonomousGroupChats = config?.autonomousGroupChats ?? false;
-
-      if (hasAutonomousTrading) enabledFeatures.push(Features.TRADING);
-      if (hasAutonomousPosting) enabledFeatures.push(Features.POSTING);
-      if (hasAutonomousCommenting) enabledFeatures.push(Features.COMMENTING);
+      const features = getAutonomousFeatures(config);
+      if (features.trading) enabledFeatures.push(Features.TRADING);
+      if (features.posting) enabledFeatures.push(Features.POSTING);
+      if (features.commenting) enabledFeatures.push(Features.COMMENTING);
       // User-controlled agents can also engage if they can comment
-      if (hasAutonomousCommenting) enabledFeatures.push(Features.ENGAGING);
-      if (hasAutonomousDMs) enabledFeatures.push(Features.DMS);
-      if (hasAutonomousGroupChats) enabledFeatures.push(Features.GROUP_CHATS);
+      if (features.commenting) enabledFeatures.push(Features.ENGAGING);
+      if (features.dms) enabledFeatures.push(Features.DMS);
+      if (features.groupChats) enabledFeatures.push(Features.GROUP_CHATS);
     }
 
     // Get NPC game context ONCE before loop (arc awareness, world events)

--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -122,6 +122,7 @@ export class MultiStepExecutor {
       config?.systemPrompt ?? 'You are an autonomous trading agent on Babylon.';
 
     // Determine enabled features - NPCs have all features enabled by default
+    // For USER_CONTROLLED agents: trading defaults to true, others default to false
     const enabledFeatures: string[] = [];
     if (isNpc) {
       enabledFeatures.push(
@@ -133,15 +134,19 @@ export class MultiStepExecutor {
         Features.GROUP_CHATS
       );
     } else {
-      if (config?.autonomousTrading) enabledFeatures.push(Features.TRADING);
-      if (config?.autonomousPosting) enabledFeatures.push(Features.POSTING);
-      if (config?.autonomousCommenting)
-        enabledFeatures.push(Features.COMMENTING);
+      const hasAutonomousTrading = config?.autonomousTrading ?? true;
+      const hasAutonomousPosting = config?.autonomousPosting ?? false;
+      const hasAutonomousCommenting = config?.autonomousCommenting ?? false;
+      const hasAutonomousDMs = config?.autonomousDMs ?? false;
+      const hasAutonomousGroupChats = config?.autonomousGroupChats ?? false;
+
+      if (hasAutonomousTrading) enabledFeatures.push(Features.TRADING);
+      if (hasAutonomousPosting) enabledFeatures.push(Features.POSTING);
+      if (hasAutonomousCommenting) enabledFeatures.push(Features.COMMENTING);
       // User-controlled agents can also engage if they can comment
-      if (config?.autonomousCommenting) enabledFeatures.push(Features.ENGAGING);
-      if (config?.autonomousDMs) enabledFeatures.push(Features.DMS);
-      if (config?.autonomousGroupChats)
-        enabledFeatures.push(Features.GROUP_CHATS);
+      if (hasAutonomousCommenting) enabledFeatures.push(Features.ENGAGING);
+      if (hasAutonomousDMs) enabledFeatures.push(Features.DMS);
+      if (hasAutonomousGroupChats) enabledFeatures.push(Features.GROUP_CHATS);
     }
 
     // Get NPC game context ONCE before loop (arc awareness, world events)

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -55,6 +55,17 @@ export * from './services';
 export * from './templates-loader';
 // Training utilities (RL model fetching, config)
 export * from './training';
+// Shared utilities
+export {
+  getAgentConfig,
+  getAutonomousFeatures,
+  hasAnyAutonomousFeature,
+  isAutonomousCommentingEnabled,
+  isAutonomousDMsEnabled,
+  isAutonomousGroupChatsEnabled,
+  isAutonomousPostingEnabled,
+  isAutonomousTradingEnabled,
+} from './shared/agent-config';
 // Core types
 export * from './types';
 export * from './types/agent-template';

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -51,10 +51,6 @@ export * from './plugins/plugin-trajectory-logger/src';
 export * from './runtime/AgentRuntimeManager';
 // Services
 export * from './services';
-// Templates loader
-export * from './templates-loader';
-// Training utilities (RL model fetching, config)
-export * from './training';
 // Shared utilities
 export {
   getAgentConfig,
@@ -66,6 +62,10 @@ export {
   isAutonomousPostingEnabled,
   isAutonomousTradingEnabled,
 } from './shared/agent-config';
+// Templates loader
+export * from './templates-loader';
+// Training utilities (RL model fetching, config)
+export * from './training';
 // Core types
 export * from './types';
 export * from './types/agent-template';

--- a/packages/agents/src/shared/agent-config.ts
+++ b/packages/agents/src/shared/agent-config.ts
@@ -216,11 +216,12 @@ export function getPlanningHorizon(config: UserAgentConfig | null): string {
 
 /**
  * Helper to check if autonomous trading is enabled
+ * Defaults to true - agents trade by default unless explicitly disabled
  */
 export function isAutonomousTradingEnabled(
   config: UserAgentConfig | null
 ): boolean {
-  return config?.autonomousTrading ?? false;
+  return config?.autonomousTrading ?? true;
 }
 
 /**

--- a/packages/agents/src/shared/agent-config.ts
+++ b/packages/agents/src/shared/agent-config.ts
@@ -261,6 +261,28 @@ export function isAutonomousGroupChatsEnabled(
 }
 
 /**
+ * Get all autonomous feature flags with proper defaults
+ * Trading defaults to true, all others default to false
+ */
+export function getAutonomousFeatures(config: UserAgentConfig | null) {
+  return {
+    trading: isAutonomousTradingEnabled(config),
+    posting: isAutonomousPostingEnabled(config),
+    commenting: isAutonomousCommentingEnabled(config),
+    dms: isAutonomousDMsEnabled(config),
+    groupChats: isAutonomousGroupChatsEnabled(config),
+  };
+}
+
+/**
+ * Check if any autonomous feature is enabled
+ */
+export function hasAnyAutonomousFeature(config: UserAgentConfig | null): boolean {
+  const features = getAutonomousFeatures(config);
+  return features.trading || features.posting || features.commenting || features.dms || features.groupChats;
+}
+
+/**
  * Helper to get model tier from config
  */
 export function getModelTier(config: UserAgentConfig | null): string {

--- a/packages/agents/src/shared/agent-config.ts
+++ b/packages/agents/src/shared/agent-config.ts
@@ -13,6 +13,7 @@ import {
   userAgentConfigs,
   users,
 } from '@babylon/db';
+import { generateSnowflakeId } from './snowflake';
 
 /** User with agent configuration attached */
 export type UserWithAgentConfig = User & {
@@ -22,7 +23,7 @@ export type UserWithAgentConfig = User & {
 /**
  * Get agent config for a user
  */
-export async function getAgentConfig(
+async function fetchAgentConfig(
   userId: string
 ): Promise<UserAgentConfig | null> {
   const result = await db
@@ -31,6 +32,38 @@ export async function getAgentConfig(
     .where(eq(userAgentConfigs.userId, userId))
     .limit(1);
   return result[0] ?? null;
+}
+
+export async function getAgentConfig(
+  userId: string
+): Promise<UserAgentConfig | null> {
+  const existing = await fetchAgentConfig(userId);
+  if (existing) return existing;
+
+  const [user] = await db
+    .select({ id: users.id, isAgent: users.isAgent })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  if (!user?.isAgent) return null;
+
+  const now = new Date();
+  const [created] = await db
+    .insert(userAgentConfigs)
+    .values({
+      id: await generateSnowflakeId(),
+      userId,
+      autonomousTrading: true,
+      status: 'idle',
+      updatedAt: now,
+    })
+    .onConflictDoNothing()
+    .returning();
+
+  if (created) return created;
+
+  return await fetchAgentConfig(userId);
 }
 
 /**

--- a/packages/agents/src/shared/agent-config.ts
+++ b/packages/agents/src/shared/agent-config.ts
@@ -54,11 +54,13 @@ export async function getAgentConfig(
     .values({
       id: await generateSnowflakeId(),
       userId,
+      // Explicit true ensures agents trade by default regardless of DB migration state
       autonomousTrading: true,
       status: 'idle',
+      createdAt: now,
       updatedAt: now,
     })
-    .onConflictDoNothing()
+    .onConflictDoNothing({ target: userAgentConfigs.userId })
     .returning();
 
   if (created) return created;
@@ -121,15 +123,17 @@ export async function upsertAgentConfig(
     return result[0]!;
   }
 
-  // Generate a new ID
-  const id = `uac_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+  // Generate a new ID using snowflake for consistency
+  const id = await generateSnowflakeId();
+  const now = new Date();
   const result = await db
     .insert(userAgentConfigs)
     .values({
       id,
       userId,
       ...config,
-      updatedAt: new Date(),
+      createdAt: now,
+      updatedAt: now,
     })
     .returning();
 
@@ -277,9 +281,17 @@ export function getAutonomousFeatures(config: UserAgentConfig | null) {
 /**
  * Check if any autonomous feature is enabled
  */
-export function hasAnyAutonomousFeature(config: UserAgentConfig | null): boolean {
+export function hasAnyAutonomousFeature(
+  config: UserAgentConfig | null
+): boolean {
   const features = getAutonomousFeatures(config);
-  return features.trading || features.posting || features.commenting || features.dms || features.groupChats;
+  return (
+    features.trading ||
+    features.posting ||
+    features.commenting ||
+    features.dms ||
+    features.groupChats
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes [BAB-140](https://linear.app/eliza-labs/issue/BAB-140/agent-trading-bot-stagnation-agents-not-trading-despite-being-active) - Agent Trading Bot Stagnation

**Root Cause:** Agents without explicit config or with `autonomousTrading: null` were not getting trading enabled in their feature set, despite passing eligibility checks. The `MultiStepExecutor` checked `config?.autonomousTrading` without a default value.

## Changes

### Core Fix
- **MultiStepExecutor.ts**: Apply `?? true` default for `autonomousTrading` when building enabled features
- **agent-tick/route.ts**: Use consistent `?? true` default in eligibility checks

### Auto-Creation
- **agent-config.ts**: Auto-create `UserAgentConfig` with `autonomousTrading: true` for agents that don't have one

### DRY Refactoring
- Add `getAutonomousFeatures()` and `hasAnyAutonomousFeature()` helpers
- Export helpers from `@babylon/agents` package
- Single source of truth for defaults (trading=`true`, others=`false`)

### Code Quality (from review feedback)
- Use `generateSnowflakeId()` consistently for ID generation
- Add explicit `createdAt` field to config inserts
- Specify conflict target in `onConflictDoNothing()`
- Remove redundant `agentsWithFeatures` filter

## Test Plan

- [x] Verify agents created in last 3 days now have TRADING in enabled features
- [ ] Monitor next agent tick to confirm trades are being executed
- [ ] Check trajectories show `tradesExecuted > 0` for active agents

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated autonomous feature handling so agent feature flags are derived consistently across the system.
  * Standardized defaults (trading enabled; posting, commenting, DMs, group chats disabled).

* **New Features**
  * Automatic creation/initialization of agent configuration for new agents.
  * Added public utilities to query an agent’s enabled autonomous features and detect if any are active.
  * Agent configs now use consistent Snowflake-style IDs and populate created/updated timestamps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->