### PR TITLE
refactor(agents): centralize autonomous trading check with isAutonomousTradingEnabled

### DIFF
--- a/apps/web/src/app/api/agents/[agentId]/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/route.ts
@@ -197,6 +197,8 @@ export async function GET(
     getAgentConfig(agentId),
   ]);
 
+  const tradingEnabled = isAutonomousTradingEnabled(config);
+
   return NextResponse.json({
     success: true,
     agent: {
@@ -257,8 +259,8 @@ export async function GET(
         })(),
       virtualBalance: Number(agent!.virtualBalance ?? 0),
       isActive: config?.status === 'active',
-      autonomousEnabled: isAutonomousTradingEnabled(config),
-      autonomousTrading: isAutonomousTradingEnabled(config),
+      autonomousEnabled: tradingEnabled,
+      autonomousTrading: tradingEnabled,
       autonomousPosting: config?.autonomousPosting ?? false,
       autonomousCommenting: config?.autonomousCommenting ?? false,
       autonomousDMs: config?.autonomousDMs ?? false,

--- a/apps/web/src/app/api/agents/[agentId]/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/route.ts
@@ -174,7 +174,11 @@
  * @see {@link /src/app/agents/[agentId]/page.tsx} Agent detail page
  */
 
-import { agentService, getAgentConfig } from '@babylon/agents';
+import {
+  agentService,
+  getAgentConfig,
+  isAutonomousTradingEnabled,
+} from '@babylon/agents';
 import { authenticateUser } from '@babylon/api';
 import { logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
@@ -253,8 +257,8 @@ export async function GET(
         })(),
       virtualBalance: Number(agent!.virtualBalance ?? 0),
       isActive: config?.status === 'active',
-      autonomousEnabled: config?.autonomousTrading ?? false,
-      autonomousTrading: config?.autonomousTrading ?? false,
+      autonomousEnabled: isAutonomousTradingEnabled(config),
+      autonomousTrading: isAutonomousTradingEnabled(config),
       autonomousPosting: config?.autonomousPosting ?? false,
       autonomousCommenting: config?.autonomousCommenting ?? false,
       autonomousDMs: config?.autonomousDMs ?? false,
@@ -347,7 +351,7 @@ export async function PUT(
       description: agent.bio,
       profileImageUrl: agent.profileImageUrl,
       virtualBalance: Number(agent.virtualBalance ?? 0),
-      autonomousTrading: updatedConfig?.autonomousTrading ?? false,
+      autonomousTrading: isAutonomousTradingEnabled(updatedConfig),
       autonomousPosting: updatedConfig?.autonomousPosting ?? false,
       modelTier: updatedConfig?.modelTier ?? 'lite',
       updatedAt: agent.updatedAt.toISOString(),

--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -267,6 +267,7 @@ export async function GET(req: NextRequest) {
         agentService.getPerformance(agent.id),
         getAgentConfig(agent.id),
       ]);
+      const tradingEnabled = isAutonomousTradingEnabled(config);
       return {
         id: agent.id,
         username: agent.username,
@@ -274,8 +275,8 @@ export async function GET(req: NextRequest) {
         description: agent.bio,
         profileImageUrl: agent.profileImageUrl,
         virtualBalance: Number(agent.virtualBalance ?? 0),
-        autonomousEnabled: isAutonomousTradingEnabled(config),
-        autonomousTrading: isAutonomousTradingEnabled(config),
+        autonomousEnabled: tradingEnabled,
+        autonomousTrading: tradingEnabled,
         autonomousPosting: config?.autonomousPosting ?? false,
         autonomousCommenting: config?.autonomousCommenting ?? false,
         autonomousDMs: config?.autonomousDMs ?? false,

--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -155,7 +155,11 @@
  * @see {@link /src/app/agents/page.tsx} Agents management UI
  */
 
-import { agentService, getAgentConfig } from '@babylon/agents';
+import {
+  agentService,
+  getAgentConfig,
+  isAutonomousTradingEnabled,
+} from '@babylon/agents';
 import { authenticateUser } from '@babylon/api';
 import { logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
@@ -230,7 +234,7 @@ export async function POST(req: NextRequest) {
       description: agentUser.bio,
       profileImageUrl: agentUser.profileImageUrl,
       virtualBalance: Number(agentUser.virtualBalance ?? 0),
-      autonomousTrading: config?.autonomousTrading ?? false,
+      autonomousTrading: isAutonomousTradingEnabled(config),
       autonomousPosting: config?.autonomousPosting ?? false,
       autonomousCommenting: config?.autonomousCommenting ?? false,
       autonomousDMs: config?.autonomousDMs ?? false,
@@ -270,8 +274,8 @@ export async function GET(req: NextRequest) {
         description: agent.bio,
         profileImageUrl: agent.profileImageUrl,
         virtualBalance: Number(agent.virtualBalance ?? 0),
-        autonomousEnabled: config?.autonomousTrading ?? false,
-        autonomousTrading: config?.autonomousTrading ?? false,
+        autonomousEnabled: isAutonomousTradingEnabled(config),
+        autonomousTrading: isAutonomousTradingEnabled(config),
         autonomousPosting: config?.autonomousPosting ?? false,
         autonomousCommenting: config?.autonomousCommenting ?? false,
         autonomousDMs: config?.autonomousDMs ?? false,

--- a/packages/agents/src/autonomous/AutonomousA2AService.ts
+++ b/packages/agents/src/autonomous/AutonomousA2AService.ts
@@ -11,7 +11,10 @@ import { db, eq, users } from '@babylon/db';
 import type { IAgentRuntime } from '@elizaos/core';
 import type { BabylonRuntime } from '../plugins/babylon/types';
 import { agentPnLService } from '../services/AgentPnLService';
-import { getAgentConfig } from '../shared/agent-config';
+import {
+  getAgentConfig,
+  isAutonomousTradingEnabled,
+} from '../shared/agent-config';
 import { logger } from '../shared/logger';
 
 /**
@@ -105,7 +108,7 @@ export class AutonomousA2AService {
     const agent = agentResult[0];
     const config = await getAgentConfig(agentUserId);
 
-    if (!agent || !agent.isAgent || !config?.autonomousTrading) {
+    if (!agent || !agent.isAgent || !isAutonomousTradingEnabled(config)) {
       return {
         success: false,
         marketId: undefined,
@@ -585,7 +588,7 @@ Your JSON response:`;
     const agent = agentResult[0];
     const tradingConfig = await getAgentConfig(agentUserId);
 
-    if (!agent || !agent.isAgent || !tradingConfig?.autonomousTrading) {
+    if (!agent || !agent.isAgent || !isAutonomousTradingEnabled(tradingConfig)) {
       return { success: false, actionsTaken: 0 };
     }
 

--- a/packages/agents/src/autonomous/AutonomousA2AService.ts
+++ b/packages/agents/src/autonomous/AutonomousA2AService.ts
@@ -588,7 +588,11 @@ Your JSON response:`;
     const agent = agentResult[0];
     const tradingConfig = await getAgentConfig(agentUserId);
 
-    if (!agent || !agent.isAgent || !isAutonomousTradingEnabled(tradingConfig)) {
+    if (
+      !agent ||
+      !agent.isAgent ||
+      !isAutonomousTradingEnabled(tradingConfig)
+    ) {
       return { success: false, actionsTaken: 0 };
     }
 

--- a/packages/agents/src/identity/AgentIdentityService.ts
+++ b/packages/agents/src/identity/AgentIdentityService.ts
@@ -20,7 +20,10 @@ import {
 } from '@babylon/db';
 import { getAgent0Client } from '../agent0/Agent0Client';
 import { syncAfterAgent0Registration } from '../agent0/reputation/agent0-reputation-sync';
-import { getAgentConfig } from '../shared/agent-config';
+import {
+  getAgentConfig,
+  isAutonomousTradingEnabled,
+} from '../shared/agent-config';
 import { logger } from '../shared/logger';
 import { generateSnowflakeId } from '../shared/snowflake';
 import { agentWalletService } from './AgentWalletService';
@@ -121,7 +124,7 @@ export class AgentIdentityService {
       userType: 'agent',
       x402Support: true,
       moderationEscrowSupport: true,
-      autonomousTrading: config?.autonomousTrading ?? false,
+      autonomousTrading: isAutonomousTradingEnabled(config),
       autonomousPosting: config?.autonomousPosting ?? false,
       skills: [],
       domains: [],

--- a/packages/agents/src/identity/AgentWalletService.ts
+++ b/packages/agents/src/identity/AgentWalletService.ts
@@ -13,7 +13,10 @@ import { PrivyClient } from '@privy-io/server-auth';
 import { ethers } from 'ethers';
 import { v4 as uuidv4 } from 'uuid';
 import { getAgent0Client } from '../agent0/Agent0Client';
-import { getAgentConfig } from '../shared/agent-config';
+import {
+  getAgentConfig,
+  isAutonomousTradingEnabled,
+} from '../shared/agent-config';
 import { logger } from '../shared/logger';
 
 /**
@@ -270,7 +273,7 @@ export class AgentWalletService {
       userType: 'agent',
       x402Support: true,
       moderationEscrowSupport: true,
-      autonomousTrading: config?.autonomousTrading ?? false,
+      autonomousTrading: isAutonomousTradingEnabled(config),
       autonomousPosting: config?.autonomousPosting ?? false,
       skills: [],
       domains: [],

--- a/packages/agents/src/plugins/babylon/providers/goals.ts
+++ b/packages/agents/src/plugins/babylon/providers/goals.ts
@@ -12,7 +12,10 @@ import type {
   ProviderResult,
   State,
 } from '@elizaos/core';
-import { getAgentConfig } from '../../../shared/agent-config';
+import {
+  getAgentConfig,
+  isAutonomousTradingEnabled,
+} from '../../../shared/agent-config';
 
 /**
  * Provider: Agent Goals & Directives
@@ -77,7 +80,7 @@ ${config?.tradingStrategy || 'No trading strategy set - be conservative'}
 • If you run out of points, you cannot take actions
 
 🔒 PERMISSIONS & CAPABILITIES:
-${config?.autonomousTrading ? '✅ Trading: You CAN execute trades autonomously' : '❌ Trading: You CANNOT trade - viewing only'}
+${isAutonomousTradingEnabled(config) ? '✅ Trading: You CAN execute trades autonomously' : '❌ Trading: You CANNOT trade - viewing only'}
 ${config?.autonomousPosting ? '✅ Posting: You CAN create posts autonomously' : '❌ Posting: You CANNOT post - commenting only'}
 ${config?.autonomousCommenting ? '✅ Commenting: You CAN comment on posts' : '❌ Commenting: You CANNOT comment'}
 ${config?.autonomousDMs ? '✅ Direct Messages: You CAN send DMs' : '❌ Direct Messages: You CANNOT send DMs'}
@@ -106,7 +109,7 @@ ${config?.autonomousGroupChats ? '✅ Group Chats: You CAN participate in group 
         tradingStrategy: config?.tradingStrategy,
         balance: Number(user.virtualBalance ?? 0),
         permissions: {
-          trading: config?.autonomousTrading ?? false,
+          trading: isAutonomousTradingEnabled(config),
           posting: config?.autonomousPosting ?? false,
           commenting: config?.autonomousCommenting ?? false,
           dms: config?.autonomousDMs ?? false,

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/check-autonomy.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/check-autonomy.ts
@@ -12,7 +12,10 @@ import type {
   Memory,
   State,
 } from '@elizaos/core';
-import { getAgentConfig } from '../../../../shared/agent-config';
+import {
+  getAgentConfig,
+  isAutonomousTradingEnabled,
+} from '../../../../shared/agent-config';
 import { logger } from '../../../../shared/logger';
 import type { AutonomyStatus } from '../types';
 
@@ -97,9 +100,10 @@ export const checkAutonomyAction: Action = {
       // Get agent config directly from userAgentConfigs table
       const config = await getAgentConfig(agentId);
 
-      // Extract autonomy status from config (defaults to false if no config)
+      // Extract autonomy status from config
+      // Note: autonomousTrading defaults to true per database schema
       const status: AutonomyStatus = {
-        autonomousTrading: config?.autonomousTrading ?? false,
+        autonomousTrading: isAutonomousTradingEnabled(config),
         autonomousPosting: config?.autonomousPosting ?? false,
         autonomousCommenting: config?.autonomousCommenting ?? false,
         autonomousDMs: config?.autonomousDMs ?? false,

--- a/packages/agents/src/services/AgentService.ts
+++ b/packages/agents/src/services/AgentService.ts
@@ -66,6 +66,20 @@ export async function getAgentConfig(
 }
 
 /**
+ * Helper to check if autonomous trading is enabled
+ * Defaults to true to match database schema (autonomousTrading defaults to true)
+ */
+export function isAutonomousTradingEnabled(
+  config: UserAgentConfig | null
+): boolean {
+  // Note: Database schema defaults autonomousTrading to true for new agents
+  // When config is null (no config exists), we default to false (agent not set up)
+  // When config exists but autonomousTrading is null/undefined (legacy), default to true
+  if (!config) return false;
+  return config.autonomousTrading ?? true;
+}
+
+/**
  * Get user with their agent config
  */
 export async function getUserWithConfig(

--- a/packages/agents/src/services/AgentService.ts
+++ b/packages/agents/src/services/AgentService.ts
@@ -66,20 +66,6 @@ export async function getAgentConfig(
 }
 
 /**
- * Helper to check if autonomous trading is enabled
- * Defaults to true to match database schema (autonomousTrading defaults to true)
- */
-export function isAutonomousTradingEnabled(
-  config: UserAgentConfig | null
-): boolean {
-  // Note: Database schema defaults autonomousTrading to true for new agents
-  // When config is null (no config exists), we default to false (agent not set up)
-  // When config exists but autonomousTrading is null/undefined (legacy), default to true
-  if (!config) return false;
-  return config.autonomousTrading ?? true;
-}
-
-/**
  * Get user with their agent config
  */
 export async function getUserWithConfig(

--- a/packages/agents/src/shared/agent-config.ts
+++ b/packages/agents/src/shared/agent-config.ts
@@ -220,12 +220,16 @@ export function getPlanningHorizon(config: UserAgentConfig | null): string {
 
 /**
  * Helper to check if autonomous trading is enabled
- * Defaults to true - agents trade by default unless explicitly disabled
+ * Defaults to true to match database schema (autonomousTrading defaults to true)
  */
 export function isAutonomousTradingEnabled(
   config: UserAgentConfig | null
 ): boolean {
-  return config?.autonomousTrading ?? true;
+  // Note: Database schema defaults autonomousTrading to true for new agents
+  // When config is null (no config exists), we default to false (agent not set up)
+  // When config exists but autonomousTrading is null/undefined (legacy), default to true
+  if (!config) return false;
+  return config.autonomousTrading ?? true;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Consolidates all autonomous trading status checks to use the shared `isAutonomousTradingEnabled` helper function
- Ensures consistent behavior across all services:
  - Returns `false` when config is null (agent not configured)
  - Returns `true` when config exists but `autonomousTrading` is undefined (legacy agents)
- Matches database schema default (`autonomousTrading` defaults to `true`)

## Changes

- Updated 9 files to use centralized `isAutonomousTradingEnabled()` helper
- Fixed inconsistent fallback behavior where some checks defaulted to `false` and others to `true`

## Test plan

- [ ] Verify new agents default to autonomous trading enabled
- [ ] Verify legacy agents without explicit `autonomousTrading` field default to enabled
- [ ] Verify agents with `autonomousTrading: false` are correctly disabled
- [ ] Verify agents without any config return trading disabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified autonomous trading capability evaluation across agent services for consistent behavior.
  * Standardized configuration handling for autonomous trading feature detection across identity, wallet, and trading execution services.
  * Improved reliability of autonomous trading enablement checks throughout the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR successfully centralizes autonomous trading status checks across the codebase by introducing and using the `isAutonomousTradingEnabled()` helper function. The refactoring ensures consistent behavior:

- **Returns `false`** when config is null (agent not configured)
- **Returns `true`** when config exists but `autonomousTrading` is undefined (legacy agents default to enabled per database schema)
- **Returns the explicit value** when `autonomousTrading` is set

**Major changes:**
- Updated 8 files to use centralized `isAutonomousTradingEnabled()` helper from `@babylon/agents`
- Fixed inconsistent fallback behavior where some checks defaulted to `false` and others to `true`
- Aligned with database schema default (`autonomousTrading` defaults to `true`)
- Ensured legacy agents without explicit `autonomousTrading` field default to enabled
- Applied consistent logic across API routes, autonomous services, identity services, and plugins

**Impact:**
- Eliminates code duplication and reduces risk of inconsistent behavior
- Single source of truth for autonomous trading checks
- Matches expected behavior per database schema and user feedback
- No functional changes for properly configured agents

The refactoring is clean, well-documented, and follows the DRY principle. All changes are purely refactoring with no new features or breaking changes.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- Score reflects a pure refactoring with consistent application of a centralized helper function across all relevant files, proper alignment with database schema defaults, no introduction of new logic or breaking changes, and adherence to DRY principles
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agents/src/shared/agent-config.ts | Added `isAutonomousTradingEnabled` helper that returns false when config is null, true when autonomousTrading is undefined (legacy agents) |
| apps/web/src/app/api/agents/[agentId]/route.ts | Replaced direct `config?.autonomousTrading ?? false` checks with centralized `isAutonomousTradingEnabled(config)` helper in GET and PUT endpoints |
| apps/web/src/app/api/agents/route.ts | Replaced direct `config?.autonomousTrading ?? false` checks with centralized `isAutonomousTradingEnabled(config)` helper in POST and GET endpoints |
| packages/agents/src/autonomous/AutonomousA2AService.ts | Replaced `config?.autonomousTrading` checks with `isAutonomousTradingEnabled(config)` in trade creation and management functions |
| packages/agents/src/identity/AgentIdentityService.ts | Updated agent0 registration to use `isAutonomousTradingEnabled(config)` instead of `config?.autonomousTrading ?? false` |
| packages/agents/src/identity/AgentWalletService.ts | Updated wallet registration to use `isAutonomousTradingEnabled(config)` instead of `config?.autonomousTrading ?? false` |
| packages/agents/src/plugins/babylon/providers/goals.ts | Updated goals provider to use `isAutonomousTradingEnabled(config)` in prompt generation and permissions object |
| packages/agents/src/plugins/plugin-agent-core/src/actions/check-autonomy.ts | Updated autonomy status check to use `isAutonomousTradingEnabled(config)` with updated comment explaining default behavior |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as API Client
    participant API as API Route
    participant Helper as isAutonomousTradingEnabled()
    participant DB as Database
    participant Service as Agent Services
    
    Note over Client,Service: Centralized Autonomous Trading Check Flow
    
    Client->>API: GET /api/agents/[agentId]
    API->>DB: getAgentConfig(agentId)
    DB-->>API: UserAgentConfig | null
    API->>Helper: isAutonomousTradingEnabled(config)
    
    alt config is null
        Helper-->>API: false (agent not configured)
    else config exists, autonomousTrading undefined
        Helper-->>API: true (legacy agent, default enabled)
    else config exists, autonomousTrading set
        Helper-->>API: config.autonomousTrading value
    end
    
    API-->>Client: { autonomousTrading: boolean }
    
    Note over Service,Helper: Same Logic in All Services
    
    Service->>DB: getAgentConfig(agentId)
    DB-->>Service: UserAgentConfig | null
    Service->>Helper: isAutonomousTradingEnabled(config)
    Helper-->>Service: boolean (consistent default)
    
    alt trading enabled
        Service->>Service: Execute trading actions
    else trading disabled
        Service->>Service: Skip trading (view only)
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->