### PR TITLE
fix(engine): avoid nested transaction deadlock in fee service

### DIFF
--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -642,7 +642,8 @@ async function executePredictionTrade(params: {
                 type as (typeof FEE_CONFIG.FEE_TYPES)[keyof typeof FEE_CONFIG.FEE_TYPES],
                 amount,
                 positionId,
-                relatedId
+                relatedId,
+                txDb // Pass the existing transaction to avoid nested transaction deadlocks
               ),
           },
     });
@@ -768,7 +769,8 @@ async function executePredictionSell(params: {
                 type as (typeof FEE_CONFIG.FEE_TYPES)[keyof typeof FEE_CONFIG.FEE_TYPES],
                 amount,
                 positionId,
-                relatedId
+                relatedId,
+                txDb // Pass the existing transaction to avoid nested transaction deadlocks
               ),
           },
     });

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/buy-prediction.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/buy-prediction.ts
@@ -188,7 +188,8 @@ export const buyPredictionAction: Action = {
                 type as (typeof FEE_CONFIG.FEE_TYPES)[keyof typeof FEE_CONFIG.FEE_TYPES],
                 amount,
                 positionId,
-                relatedId
+                relatedId,
+                txDb // Pass the existing transaction to avoid nested transaction deadlocks
               ),
           },
         });

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/sell-prediction.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/sell-prediction.ts
@@ -193,7 +193,8 @@ export const sellPredictionAction: Action = {
                 type as (typeof FEE_CONFIG.FEE_TYPES)[keyof typeof FEE_CONFIG.FEE_TYPES],
                 amount,
                 positionId,
-                relatedId
+                relatedId,
+                txDb // Pass the existing transaction to avoid nested transaction deadlocks
               ),
           },
         });

--- a/packages/engine/src/services/fee-service.ts
+++ b/packages/engine/src/services/fee-service.ts
@@ -28,6 +28,24 @@ import type { SQL } from 'drizzle-orm';
 import { FEE_CONFIG, type FeeType } from '../config/fees';
 
 /**
+ * Transaction context type - either an existing transaction or the db client
+ * Used to avoid nested transactions which can cause deadlocks
+ */
+export type TransactionContext = Transaction | DrizzleClient;
+
+/**
+ * Execute a function within a transaction context
+ * If an existing transaction is provided, uses it directly; otherwise creates a new one
+ * This prevents nested transaction deadlocks
+ */
+async function runInTransaction<T>(
+  existingTx: TransactionContext | undefined,
+  fn: (tx: TransactionContext) => Promise<T>
+): Promise<T> {
+  return existingTx ? fn(existingTx) : withTransaction(fn);
+}
+
+/**
  * Fee calculation result
  *
  * @description Contains calculated fee amounts and distribution breakdown.
@@ -141,7 +159,7 @@ export class FeeService {
    * @param {number} tradeAmount - Trade amount
    * @param {string} [tradeId] - Optional trade ID for reference
    * @param {string} [marketId] - Optional market ID for reference
-   * @param {Transaction | DrizzleClient} [existingTx] - Optional existing transaction/client to reuse (avoids nested transactions)
+   * @param {TransactionContext} [existingTx] - Optional existing transaction/client to reuse (avoids nested transactions)
    * @returns {Promise<FeeDistributionResult>} Fee distribution result
    *
    * @example
@@ -161,7 +179,7 @@ export class FeeService {
     tradeAmount: number,
     tradeId?: string,
     marketId?: string,
-    existingTx?: Transaction | DrizzleClient
+    existingTx?: TransactionContext
   ): Promise<FeeDistributionResult> {
     const feeCalc = FeeService.calculateFee(tradeAmount);
 
@@ -191,7 +209,7 @@ export class FeeService {
       : await FeeService.getUserReferrer(userId);
 
     // Core fee processing logic
-    const processFee = async (tx: Transaction | DrizzleClient) => {
+    const processFee = async (tx: TransactionContext) => {
       // Create trading fee record
       await tx.insert(tradingFees).values({
         id: await generateSnowflakeId(),
@@ -246,11 +264,8 @@ export class FeeService {
       };
     };
 
-    // If an existing transaction is provided, use it directly to avoid nested transactions
-    // (which can cause deadlocks when the inner tx waits on locks held by the outer tx)
-    const result = existingTx
-      ? await processFee(existingTx)
-      : await withTransaction(processFee);
+    // Use existing transaction if provided, otherwise create a new one
+    const result = await runInTransaction(existingTx, processFee);
 
     logger.info(
       'Trading fee processed',
@@ -285,7 +300,7 @@ export class FeeService {
    */
   private static async getUserReferrerInTx(
     userId: string,
-    tx: Transaction | DrizzleClient
+    tx: TransactionContext
   ): Promise<string | null> {
     const [user] = await tx
       .select({ referredBy: users.referredBy })
@@ -303,7 +318,7 @@ export class FeeService {
     referrerId: string,
     feeAmount: number,
     traderId: string,
-    tx: Transaction | DrizzleClient
+    tx: TransactionContext
   ): Promise<void> {
     // Credit referrer's virtual balance
     const [referrer] = await tx

--- a/packages/engine/src/services/fee-service.ts
+++ b/packages/engine/src/services/fee-service.ts
@@ -11,6 +11,7 @@ import {
   balanceTransactions,
   count,
   Decimal,
+  type DrizzleClient,
   db,
   desc,
   eq,
@@ -140,6 +141,7 @@ export class FeeService {
    * @param {number} tradeAmount - Trade amount
    * @param {string} [tradeId] - Optional trade ID for reference
    * @param {string} [marketId] - Optional market ID for reference
+   * @param {Transaction | DrizzleClient} [existingTx] - Optional existing transaction/client to reuse (avoids nested transactions)
    * @returns {Promise<FeeDistributionResult>} Fee distribution result
    *
    * @example
@@ -158,7 +160,8 @@ export class FeeService {
     tradeType: FeeType,
     tradeAmount: number,
     tradeId?: string,
-    marketId?: string
+    marketId?: string,
+    existingTx?: Transaction | DrizzleClient
   ): Promise<FeeDistributionResult> {
     const feeCalc = FeeService.calculateFee(tradeAmount);
 
@@ -182,11 +185,13 @@ export class FeeService {
       };
     }
 
-    // Get user's referrer
-    const referrerId = await FeeService.getUserReferrer(userId);
+    // Get user's referrer (use existing tx if provided to avoid deadlock)
+    const referrerId = existingTx
+      ? await FeeService.getUserReferrerInTx(userId, existingTx)
+      : await FeeService.getUserReferrer(userId);
 
-    // Execute in transaction
-    const result = await withTransaction(async (tx) => {
+    // Core fee processing logic
+    const processFee = async (tx: Transaction | DrizzleClient) => {
       // Create trading fee record
       await tx.insert(tradingFees).values({
         id: await generateSnowflakeId(),
@@ -239,7 +244,13 @@ export class FeeService {
           : feeCalc.feeAmount,
         referrerId,
       };
-    });
+    };
+
+    // If an existing transaction is provided, use it directly to avoid nested transactions
+    // (which can cause deadlocks when the inner tx waits on locks held by the outer tx)
+    const result = existingTx
+      ? await processFee(existingTx)
+      : await withTransaction(processFee);
 
     logger.info(
       'Trading fee processed',
@@ -270,13 +281,29 @@ export class FeeService {
   }
 
   /**
+   * Get user's referrer within an existing transaction
+   */
+  private static async getUserReferrerInTx(
+    userId: string,
+    tx: Transaction | DrizzleClient
+  ): Promise<string | null> {
+    const [user] = await tx
+      .select({ referredBy: users.referredBy })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1);
+
+    return user?.referredBy || null;
+  }
+
+  /**
    * Distribute referral fee to referrer (within transaction)
    */
   private static async distributeReferralFeeInTx(
     referrerId: string,
     feeAmount: number,
     traderId: string,
-    tx: Transaction
+    tx: Transaction | DrizzleClient
   ): Promise<void> {
     // Credit referrer's virtual balance
     const [referrer] = await tx


### PR DESCRIPTION
## Summary
- Pass existing transaction to `distributeTradingFee` to prevent deadlocks when the inner transaction waits on locks held by the outer transaction
- Add optional `existingTx` parameter to `distributeTradingFee` method
- Add `getUserReferrerInTx` for queries within existing transaction
- Update all callers (`DirectExecutors.ts`, `buy-prediction.ts`, `sell-prediction.ts`) to pass `txDb` parameter

## Test plan
- [ ] Verify prediction buy/sell operations complete without deadlock
- [ ] Verify fee distribution works correctly within transactions
- [ ] Check that referral fees are still properly credited

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fee processing during prediction buy/sell now executes within the surrounding transaction to avoid nested-transaction deadlocks and improve reliability.

* **Refactor**
  * Transaction-context handling for fee processing was unified and made optional so existing transactions can be reused, reducing failure scenarios and improving consistency across trading flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed nested transaction deadlock in fee service by adding transaction reuse capability. The issue occurred when `FeeService.processTradingFee` was called within an existing transaction context from prediction market trades - the inner `withTransaction` would wait for locks held by the outer transaction.

- Added optional `existingTx` parameter to `FeeService.processTradingFee` to accept an existing transaction context
- Created `getUserReferrerInTx` to query user referrals within an existing transaction (avoiding separate database connection)
- Updated `distributeReferralFeeInTx` signature to accept `Transaction | DrizzleClient`
- Updated all callers in `DirectExecutors.ts`, `buy-prediction.ts`, and `sell-prediction.ts` to pass the existing `txDb` context

The fix ensures that when fee processing is called from within a transaction (like during prediction trades), it reuses the existing transaction rather than creating a nested one, eliminating the deadlock condition.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no blocking issues
- The changes directly address a specific deadlock issue with a clean, well-documented solution. The fix follows a sound architectural pattern (transaction reuse), maintains backward compatibility through optional parameters, and updates all callers consistently. The implementation is straightforward with no complex logic changes.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/engine/src/services/fee-service.ts | Added `existingTx` parameter to `processTradingFee` and `getUserReferrerInTx` to enable transaction reuse, preventing nested transaction deadlocks |
| packages/agents/src/autonomous/DirectExecutors.ts | Updated prediction trade executors to pass `txDb` to `FeeService.processTradingFee`, avoiding nested transactions |
| packages/agents/src/plugins/plugin-agent-core/src/actions/buy-prediction.ts | Updated to pass `txDb` to `FeeService.processTradingFee` in the fee processor, reusing existing transaction |
| packages/agents/src/plugins/plugin-agent-core/src/actions/sell-prediction.ts | Updated to pass `txDb` to `FeeService.processTradingFee` in the fee processor, reusing existing transaction |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant DirectExecutors
    participant asUser
    participant PredictionMarketService
    participant FeeService
    participant Database

    Note over Client,Database: Before Fix: Nested Transaction Deadlock

    Client->>DirectExecutors: executePredictionTrade()
    DirectExecutors->>asUser: asUser(tradeOperation)
    asUser->>Database: BEGIN TRANSACTION (outer)
    asUser->>PredictionMarketService: buy()
    PredictionMarketService->>Database: Update market state (holds locks)
    PredictionMarketService->>FeeService: processTradingFee()
    FeeService->>Database: withTransaction (inner)
    Note over FeeService,Database: ❌ DEADLOCK: Inner tx waits for locks<br/>held by outer tx
    
    Note over Client,Database: After Fix: Transaction Reuse

    Client->>DirectExecutors: executePredictionTrade()
    DirectExecutors->>asUser: asUser(tradeOperation)
    asUser->>Database: BEGIN TRANSACTION
    Note over asUser: txDb context created
    asUser->>PredictionMarketService: buy(txDb)
    PredictionMarketService->>Database: Update market state
    PredictionMarketService->>FeeService: processTradingFee(txDb)
    Note over FeeService: existingTx provided
    FeeService->>FeeService: getUserReferrerInTx(txDb)
    FeeService->>Database: Query referrer (same tx)
    FeeService->>Database: Insert fee records (same tx)
    FeeService->>Database: Update user balances (same tx)
    Database-->>asUser: COMMIT
    Note over Client,Database: ✅ No nested transaction,<br/>no deadlock
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->