### PR TITLE
fix(agents): add sell_yes/sell_no guidance for prediction position exits

### DIFF
--- a/packages/agents/src/autonomous/templates/multi-step-decision.ts
+++ b/packages/agents/src/autonomous/templates/multi-step-decision.ts
@@ -874,7 +874,7 @@ function formatPositionManagementGuidance(
     // Significant loss
     else if (p.pnlPercent < LOSS_THRESHOLD_PERCENT) {
       alerts.push(
-        `🔴 LOSING: ${p.ticker} ${p.side} is down ${p.pnlPercent.toFixed(1)}%. Consider cutting losses or averaging down if still bullish.`
+        `🔴 LOSING: ${p.ticker} ${p.side} is down ${p.pnlPercent.toFixed(1)}%. To cut losses, use side="close_position" with this ticker.`
       );
     }
     // Good profit - consider taking
@@ -894,27 +894,28 @@ function formatPositionManagementGuidance(
   // Check prediction positions
   for (const p of positions.predictions) {
     const absChange = Math.abs(p.pnlPercent);
+    const sellAction = p.side.toLowerCase() === 'yes' ? 'sell_yes' : 'sell_no';
 
     if (
       absChange < STAGNANT_THRESHOLD_PERCENT &&
       p.timeHeldMs > STAGNANT_TIME_MS
     ) {
       alerts.push(
-        `⚠️ STAGNANT: "${p.question.substring(0, 30)}..." ${p.side} hasn't moved (${p.pnlPercent >= 0 ? '+' : ''}${p.pnlPercent.toFixed(1)}%) in ${p.timeHeld}.`
+        `⚠️ STAGNANT: "${p.question.substring(0, 30)}..." ${p.side} hasn't moved (${p.pnlPercent >= 0 ? '+' : ''}${p.pnlPercent.toFixed(1)}%) in ${p.timeHeld}. To exit: use side="${sellAction}" on marketId ${p.marketId}.`
       );
     } else if (p.pnlPercent < LOSS_THRESHOLD_PERCENT) {
       alerts.push(
-        `🔴 LOSING: "${p.question.substring(0, 30)}..." ${p.side} down ${p.pnlPercent.toFixed(1)}%.`
+        `🔴 LOSING: "${p.question.substring(0, 30)}..." ${p.side} down ${p.pnlPercent.toFixed(1)}%. To cut losses: use side="${sellAction}" on marketId ${p.marketId}.`
       );
     } else if (p.pnlPercent > PROFIT_THRESHOLD_PERCENT) {
       alerts.push(
-        `🟢 PROFIT: "${p.question.substring(0, 30)}..." ${p.side} up +${p.pnlPercent.toFixed(1)}%.`
+        `🟢 PROFIT: "${p.question.substring(0, 30)}..." ${p.side} up +${p.pnlPercent.toFixed(1)}%. To take profits: use side="${sellAction}" on marketId ${p.marketId}.`
       );
     }
     // Very long hold - check if thesis still valid
     else if (p.timeHeldMs > LONG_HOLD_TIME_MS) {
       alerts.push(
-        `⏰ AGED: "${p.question.substring(0, 30)}..." ${p.side} held for ${p.timeHeld} (${p.pnlPercent >= 0 ? '+' : ''}${p.pnlPercent.toFixed(1)}%). Review if thesis still valid.`
+        `⏰ AGED: "${p.question.substring(0, 30)}..." ${p.side} held for ${p.timeHeld} (${p.pnlPercent >= 0 ? '+' : ''}${p.pnlPercent.toFixed(1)}%). To exit if thesis invalid: use side="${sellAction}" on marketId ${p.marketId}.`
       );
     }
   }
@@ -1054,13 +1055,26 @@ function formatActionSchemas(enabledFeatures: string[]): string {
 }`);
     } else if (action.name === Actions.TRADE) {
       // Special handling for TRADE with multiple variants
-      schemas.push(`TRADE (prediction - buy):
+      schemas.push(`TRADE (prediction - open position):
 {
   "marketType": "prediction",
   "marketId": "exact_market_id_from_list",
   "side": "buy_yes | buy_no",
   "amount": 100,
   "reasoning": "Why this trade"
+}
+
+TRADE (prediction - close/sell position):
+⚠️ To EXIT a position, you must SELL the same side you bought!
+- To close a YES position → use "sell_yes"
+- To close a NO position → use "sell_no"
+- Buying the opposite side does NOT close your position!
+{
+  "marketType": "prediction",
+  "marketId": "marketId_from_your_positions",
+  "side": "sell_yes | sell_no",
+  "amount": 50,
+  "reasoning": "Closing position because..."
 }
 
 TRADE (perp):

--- a/packages/db/src/database-service.ts
+++ b/packages/db/src/database-service.ts
@@ -24,6 +24,7 @@ import {
   isNull,
   lt,
   lte,
+  sql,
 } from 'drizzle-orm';
 import { db } from './db';
 import { logger } from './logger';
@@ -710,13 +711,18 @@ class DatabaseService {
    * Get all organization states with current prices ordered by price.
    * This replaces the old getCompanies() method.
    *
-   * @returns Array of organization states ordered by price descending
+   * NOTE: Uses NULLS LAST to ensure organizations with prices appear first.
+   * Without this, PostgreSQL's default DESC ordering puts NULL values first,
+   * causing agents to see no perp markets (since media outlets have NULL prices
+   * and get filtered out by the type='company' check).
+   *
+   * @returns Array of organization states ordered by price descending (NULLs last)
    */
   async getOrganizationsByPrice(): Promise<OrganizationStateRow[]> {
     return db
       .select()
       .from(organizationState)
-      .orderBy(desc(organizationState.currentPrice));
+      .orderBy(sql`${organizationState.currentPrice} DESC NULLS LAST`);
   }
 
   // ========== STOCK PRICES ==========


### PR DESCRIPTION
## Summary
- Agents were incorrectly buying NO shares to "stop loss" on YES positions, instead of selling their YES shares
- This happened because the action schema only showed `buy_yes | buy_no` for predictions, not sell options
- Position management alerts didn't explain HOW to close positions

## Changes
- Add explicit "TRADE (prediction - close/sell position)" schema with `sell_yes | sell_no`
- Add clear warning that buying opposite side does NOT close position
- Update all position alerts (stagnant, losing, profit, aged) to include the correct sell action and marketId needed to exit

## Root Cause
From sayo_trader_agent logs, the agent tried to "stop the bleed" on a -81% YES position by buying NO:
```
"Stop the bleed. Position is -81.7% and no reversal catalyst in sight..."
```
But buying NO creates a separate position - it doesn't close the YES position.

## Test Plan
- [ ] Deploy to staging and verify agent prompts now include sell_yes/sell_no schema
- [ ] Monitor agent trades to confirm they use proper sell actions for exits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prediction position alerts now include explicit exit/close guidance with marketplace-specific closing actions and identifiers.
  * Action schema updated to document both opening and closing workflows for prediction positions.

* **Bug Fixes**
  * Ordering of organizations by price adjusted so items with missing prices appear after priced items, preventing empty market lists.

* **Documentation**
  * Added note clarifying NULLs-last ordering behavior in price-related docs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Fixes critical agent trading bug where agents incorrectly bought NO shares to exit YES positions instead of selling YES shares
- Updates position alerts to include specific sell actions (`sell_yes`/`sell_no`) and market IDs needed for proper exits
- Adds explicit TRADE schema documentation with warnings that buying opposite side creates separate positions

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| packages/agents/src/autonomous/templates/multi-step-decision.ts | Fixed prediction position management by adding sell action schemas and position-specific exit guidance to prevent agents from incorrectly trading opposite positions |

<h3>Confidence score: 5/5</h3>


- This PR is safe to merge with minimal risk due to its targeted nature fixing a specific, well-identified bug
- Score reflects clear problem identification, appropriate fix implementation, and no changes to core trading logic beyond guidance
- No files require special attention as the single modified file contains straightforward template improvements

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Agent
    participant DecisionTemplate
    participant ActionExecutor
    participant Market
    participant Database

    User->>Agent: "Trigger agent tick"
    Agent->>DecisionTemplate: "buildMultiStepDecisionPrompt(context)"
    DecisionTemplate->>DecisionTemplate: "formatPositionManagementGuidance(positions)"
    DecisionTemplate->>DecisionTemplate: "formatPredictionMarkets(markets)"
    DecisionTemplate->>DecisionTemplate: "formatAgentPositions(positions)"
    DecisionTemplate-->>Agent: "Return formatted prompt"
    
    Agent->>Agent: "Generate decision via LLM"
    Agent->>ActionExecutor: "executeAction(decision.action, parameters)"
    
    alt Trade Action
        ActionExecutor->>Market: "submitTrade(marketId, side, amount)"
        Market-->>ActionExecutor: "Trade result"
    else Post Action
        ActionExecutor->>Database: "createPost(content)"
        Database-->>ActionExecutor: "Post created"
    else Comment Action
        ActionExecutor->>Database: "createComment(postId, content)"
        Database-->>ActionExecutor: "Comment created"
    end
    
    ActionExecutor-->>Agent: "ActionTraceResult"
    Agent->>Agent: "Check if isFinish or maxIterations reached"
    Agent-->>User: "Tick completed"
```

<!-- greptile_other_comments_section -->

<details><summary><h3>Context used (3)</h3></summary>

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=d07fd731-326a-4ea1-84d3-eec6a8044b74))
- Context from `dashboard` - .cursorrules ([source](https://app.greptile.com/review/custom-context?memory=d8da6060-b92a-430f-81d2-446cd9e51763))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=445626a4-e384-4d3b-99de-4ccf9a293a0d))
</details>


<!-- /greptile_comment -->