### PR TITLE
fix(agents): show total P&L with unrealized gains on agent profile

### DIFF
--- a/apps/web/src/app/agents/[agentId]/page.tsx
+++ b/apps/web/src/app/agents/[agentId]/page.tsx
@@ -404,7 +404,7 @@ export default function AgentDetailPage() {
             </TabsContent>
 
             <TabsContent value="performance">
-              <AgentPerformance agent={agent} />
+              <AgentPerformance agent={agent} agentId={agent.id} />
             </TabsContent>
 
             <TabsContent value="logs">

--- a/apps/web/src/components/agents/AgentPerformance.tsx
+++ b/apps/web/src/components/agents/AgentPerformance.tsx
@@ -11,30 +11,71 @@ import {
   TrendingDown,
   TrendingUp,
   Users,
+  Wallet,
 } from 'lucide-react';
+import { useMemo } from 'react';
 import { useAgent0Reputation } from '@/hooks/useAgent0Reputation';
+import { useUserPositions } from '@/hooks/useUserPositions';
 
 /**
  * Displays agent trading performance metrics (PnL, trades, win rate).
+ * Fetches positions to calculate unrealized PnL for total portfolio value.
  * Optionally shows Agent0 network reputation when agentId is provided.
  */
 interface AgentPerformanceProps {
   agent: {
+    id: string;
     lifetimePnL: string;
     totalTrades: number;
     profitableTrades: number;
     winRate: number;
+    virtualBalance?: number;
   };
   /** If provided, fetches and displays Agent0 network reputation */
   agentId?: string;
 }
 
 export function AgentPerformance({ agent, agentId }: AgentPerformanceProps) {
-  const pnl = parseFloat(agent.lifetimePnL);
-  const isProfitable = pnl >= 0;
+  // Use shared hook for position fetching
+  const {
+    predictionPositions: predictions,
+    perpPositions: perps,
+    loading: positionsLoading,
+  } = useUserPositions(agent.id);
+
+  // Calculate unrealized P&L from open positions
+  const unrealizedPnL = useMemo(() => {
+    const predictionPnL = predictions.reduce(
+      (sum, pos) => sum + (pos.unrealizedPnL ?? 0),
+      0
+    );
+    const perpPnL = perps.reduce((sum, pos) => sum + pos.unrealizedPnL, 0);
+    return predictionPnL + perpPnL;
+  }, [predictions, perps]);
+
+  // Calculate points in positions
+  const pointsInPositions = useMemo(() => {
+    const predictionValue = predictions.reduce(
+      (sum, pos) => sum + (pos.currentValue ?? pos.shares * pos.currentPrice),
+      0
+    );
+    const perpValue = perps.reduce((sum, pos) => {
+      const leverage = Number(pos.leverage);
+      const effectiveLeverage =
+        Number.isFinite(leverage) && leverage > 0 ? leverage : 1;
+      return sum + Math.abs(pos.size / effectiveLeverage);
+    }, 0);
+    return predictionValue + perpValue;
+  }, [predictions, perps]);
+
+  const realizedPnL = parseFloat(agent.lifetimePnL);
+  const totalPnL = realizedPnL + unrealizedPnL;
+  const isProfitable = totalPnL >= 0;
   const totalTrades = agent.totalTrades || 0;
   const profitableTrades = agent.profitableTrades || 0;
   const winRate = agent.winRate || 0;
+  const availableBalance = agent.virtualBalance ?? 0;
+  const totalPortfolio = availableBalance + pointsInPositions;
 
   // Fetch Agent0 network reputation data if agentId is provided
   const {
@@ -47,7 +88,7 @@ export function AgentPerformance({ agent, agentId }: AgentPerformanceProps) {
   const stats = [
     {
       label: 'Lifetime P&L',
-      value: pnl.toFixed(2),
+      value: positionsLoading ? '...' : totalPnL.toFixed(2),
       icon: isProfitable ? TrendingUp : TrendingDown,
       color: isProfitable ? 'text-green-600' : 'text-red-600',
     },
@@ -91,6 +132,64 @@ export function AgentPerformance({ agent, agentId }: AgentPerformanceProps) {
         ))}
       </div>
 
+      {/* Portfolio Overview */}
+      <div className="rounded-lg border border-border bg-card/50 p-6 backdrop-blur">
+        <h3 className="mb-4 flex items-center gap-2 font-semibold text-lg">
+          <Wallet className="h-5 w-5 text-[#0066FF]" />
+          Portfolio Overview
+        </h3>
+
+        <div className="space-y-4">
+          <div className="flex items-center justify-between rounded-lg bg-muted/30 p-3 transition-all hover:bg-muted/50">
+            <span className="text-muted-foreground">Available Balance</span>
+            <span className="font-semibold">
+              {availableBalance.toFixed(2)} pts
+            </span>
+          </div>
+
+          <div className="flex items-center justify-between rounded-lg bg-muted/30 p-3 transition-all hover:bg-muted/50">
+            <span className="text-muted-foreground">In Positions</span>
+            <span className="font-semibold">
+              {positionsLoading ? '...' : pointsInPositions.toFixed(2)} pts
+            </span>
+          </div>
+
+          <div className="flex items-center justify-between rounded-lg bg-muted/30 p-3 transition-all hover:bg-muted/50">
+            <span className="text-muted-foreground">Total Portfolio</span>
+            <span className="font-semibold">
+              {positionsLoading ? '...' : totalPortfolio.toFixed(2)} pts
+            </span>
+          </div>
+
+          <div className="flex items-center justify-between rounded-lg border-t border-border bg-muted/30 p-3 pt-4 transition-all hover:bg-muted/50">
+            <span className="text-muted-foreground">Unrealized P&L</span>
+            <span
+              className={cn(
+                'font-semibold',
+                unrealizedPnL >= 0 ? 'text-green-600' : 'text-red-600'
+              )}
+            >
+              {positionsLoading
+                ? '...'
+                : `${unrealizedPnL >= 0 ? '+' : ''}${unrealizedPnL.toFixed(2)} pts`}
+            </span>
+          </div>
+
+          <div className="flex items-center justify-between rounded-lg bg-muted/30 p-3 transition-all hover:bg-muted/50">
+            <span className="text-muted-foreground">Realized P&L</span>
+            <span
+              className={cn(
+                'font-semibold',
+                realizedPnL >= 0 ? 'text-green-600' : 'text-red-600'
+              )}
+            >
+              {realizedPnL >= 0 ? '+' : ''}
+              {realizedPnL.toFixed(2)} pts
+            </span>
+          </div>
+        </div>
+      </div>
+
       {/* Detailed Stats */}
       <div className="rounded-lg border border-border bg-card/50 p-6 backdrop-blur">
         <h3 className="mb-4 font-semibold text-lg">Detailed Statistics</h3>
@@ -126,7 +225,7 @@ export function AgentPerformance({ agent, agentId }: AgentPerformanceProps) {
       <div className="rounded-lg border border-border bg-card/50 p-6 backdrop-blur">
         <h3 className="mb-4 font-semibold text-lg">Activity Summary</h3>
 
-        {totalTrades === 0 ? (
+        {totalTrades === 0 && predictions.length === 0 && perps.length === 0 ? (
           <div className="py-8 text-center text-muted-foreground">
             <Activity className="mx-auto mb-4 h-12 w-12 opacity-50" />
             <p>No trading activity yet</p>
@@ -138,7 +237,7 @@ export function AgentPerformance({ agent, agentId }: AgentPerformanceProps) {
           <div className="space-y-3">
             <div className="rounded-lg bg-muted/30 p-4 transition-all hover:bg-muted/50">
               <div className="mb-2 text-muted-foreground text-sm">
-                Performance
+                Total Performance (Realized + Unrealized)
               </div>
               <div className="flex items-center gap-2">
                 {isProfitable ? (
@@ -152,11 +251,30 @@ export function AgentPerformance({ agent, agentId }: AgentPerformanceProps) {
                     isProfitable ? 'text-green-600' : 'text-red-600'
                   )}
                 >
-                  {isProfitable ? '+' : ''}
-                  {pnl.toFixed(2)} points
+                  {positionsLoading
+                    ? '...'
+                    : `${isProfitable ? '+' : ''}${totalPnL.toFixed(2)} points`}
                 </span>
               </div>
             </div>
+
+            {predictions.length > 0 && (
+              <div className="rounded-lg bg-muted/30 p-4 transition-all hover:bg-muted/50">
+                <div className="mb-2 text-muted-foreground text-sm">
+                  Open Prediction Positions
+                </div>
+                <div className="font-semibold">{predictions.length}</div>
+              </div>
+            )}
+
+            {perps.length > 0 && (
+              <div className="rounded-lg bg-muted/30 p-4 transition-all hover:bg-muted/50">
+                <div className="mb-2 text-muted-foreground text-sm">
+                  Open Stock Positions
+                </div>
+                <div className="font-semibold">{perps.length}</div>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/apps/web/src/components/agents/AgentPerformance.tsx
+++ b/apps/web/src/components/agents/AgentPerformance.tsx
@@ -41,36 +41,40 @@ export function AgentPerformance({ agent, agentId }: AgentPerformanceProps) {
     predictionPositions: predictions,
     perpPositions: perps,
     loading: positionsLoading,
+    error: positionsError,
   } = useUserPositions(agent.id);
 
-  // Calculate unrealized P&L from open positions
-  const unrealizedPnL = useMemo(() => {
-    const predictionPnL = predictions.reduce(
-      (sum, pos) => sum + (pos.unrealizedPnL ?? 0),
-      0
-    );
-    const perpPnL = perps.reduce((sum, pos) => sum + pos.unrealizedPnL, 0);
-    return predictionPnL + perpPnL;
-  }, [predictions, perps]);
+  // Calculate unrealized P&L and points in positions in a single pass
+  const { unrealizedPnL, pointsInPositions } = useMemo(() => {
+    let predictionPnL = 0;
+    let predictionValue = 0;
 
-  // Calculate points in positions
-  const pointsInPositions = useMemo(() => {
-    const predictionValue = predictions.reduce(
-      (sum, pos) => sum + (pos.currentValue ?? pos.shares * pos.currentPrice),
-      0
-    );
-    const perpValue = perps.reduce((sum, pos) => {
+    for (const pos of predictions) {
+      predictionPnL += pos.unrealizedPnL ?? 0;
+      predictionValue += pos.currentValue ?? pos.shares * pos.currentPrice;
+    }
+
+    let perpPnL = 0;
+    let perpValue = 0;
+
+    for (const pos of perps) {
+      perpPnL += pos.unrealizedPnL ?? 0;
       const leverage = Number(pos.leverage);
-      const effectiveLeverage =
-        Number.isFinite(leverage) && leverage > 0 ? leverage : 1;
-      return sum + Math.abs(pos.size / effectiveLeverage);
-    }, 0);
-    return predictionValue + perpValue;
+      if (Number.isFinite(leverage) && leverage > 0) {
+        perpValue += Math.abs(pos.size / leverage);
+      }
+    }
+
+    return {
+      unrealizedPnL: predictionPnL + perpPnL,
+      pointsInPositions: predictionValue + perpValue,
+    };
   }, [predictions, perps]);
 
-  const realizedPnL = parseFloat(agent.lifetimePnL);
+  const realizedPnL = parseFloat(agent.lifetimePnL) || 0;
   const totalPnL = realizedPnL + unrealizedPnL;
-  const isProfitable = totalPnL >= 0;
+  // Defer isProfitable determination until positions are loaded to avoid color flash
+  const isProfitable = positionsLoading ? realizedPnL >= 0 : totalPnL >= 0;
   const totalTrades = agent.totalTrades || 0;
   const profitableTrades = agent.profitableTrades || 0;
   const winRate = agent.winRate || 0;
@@ -161,7 +165,7 @@ export function AgentPerformance({ agent, agentId }: AgentPerformanceProps) {
             </span>
           </div>
 
-          <div className="flex items-center justify-between rounded-lg border-t border-border bg-muted/30 p-3 pt-4 transition-all hover:bg-muted/50">
+          <div className="flex items-center justify-between rounded-lg border-border border-t bg-muted/30 p-3 pt-4 transition-all hover:bg-muted/50">
             <span className="text-muted-foreground">Unrealized P&L</span>
             <span
               className={cn(
@@ -225,7 +229,19 @@ export function AgentPerformance({ agent, agentId }: AgentPerformanceProps) {
       <div className="rounded-lg border border-border bg-card/50 p-6 backdrop-blur">
         <h3 className="mb-4 font-semibold text-lg">Activity Summary</h3>
 
-        {totalTrades === 0 && predictions.length === 0 && perps.length === 0 ? (
+        {positionsLoading ? (
+          <div className="py-8 text-center text-muted-foreground">
+            <Activity className="mx-auto mb-4 h-12 w-12 animate-pulse opacity-50" />
+            <p>Loading activity...</p>
+          </div>
+        ) : positionsError ? (
+          <div className="py-8 text-center text-muted-foreground">
+            <Activity className="mx-auto mb-4 h-12 w-12 opacity-50" />
+            <p>Failed to load positions</p>
+          </div>
+        ) : totalTrades === 0 &&
+          predictions.length === 0 &&
+          perps.length === 0 ? (
           <div className="py-8 text-center text-muted-foreground">
             <Activity className="mx-auto mb-4 h-12 w-12 opacity-50" />
             <p>No trading activity yet</p>

--- a/packages/agents/src/services/AgentService.ts
+++ b/packages/agents/src/services/AgentService.ts
@@ -16,7 +16,6 @@
 import {
   agentLogs,
   agentMessages,
-  agentPerformanceMetrics,
   agentPointsTransactions,
   agentTrades,
   and,
@@ -941,46 +940,17 @@ export class AgentServiceV2 {
     const agent = agentResult[0];
     if (!agent || !agent.isAgent) throw new Error('Agent not found');
 
-    // Get pre-calculated performance metrics from agentPerformanceMetrics table
-    const metricsResult = await db
-      .select()
-      .from(agentPerformanceMetrics)
-      .where(eq(agentPerformanceMetrics.userId, agentUserId))
-      .limit(1);
-
-    const metrics = metricsResult[0];
-
-    // If metrics exist, use them; otherwise fall back to calculating from trades
-    if (metrics) {
-      // Get trades for avgTradeSize calculation
-      const trades = await db
-        .select()
-        .from(agentTrades)
-        .where(eq(agentTrades.agentUserId, agentUserId));
-
-      const tradesWithPnl = trades.filter((t) => t.pnl !== null);
-      const avgTradeSize =
-        tradesWithPnl.length > 0
-          ? tradesWithPnl.reduce((sum, t) => sum + t.amount, 0) /
-            tradesWithPnl.length
-          : 0;
-
-      return {
-        lifetimePnL: Number(agent.lifetimePnL),
-        totalTrades: metrics.totalTrades,
-        profitableTrades: metrics.profitableTrades,
-        winRate: metrics.winRate,
-        avgTradeSize,
-      };
-    }
-
-    // Fallback: calculate from agentTrades if no metrics record exists
+    // Always calculate trade stats from agentTrades (source of truth)
+    // agentPerformanceMetrics is for reputation scoring, not trade stats
     const trades = await db
       .select()
       .from(agentTrades)
       .where(eq(agentTrades.agentUserId, agentUserId));
 
     const closedTrades = trades.filter((t) => t.pnl !== null);
+    const profitableTrades = closedTrades.filter(
+      (t) => t.pnl && t.pnl > 0
+    ).length;
     const avgTradeSize =
       trades.length > 0
         ? trades.reduce((sum, t) => sum + t.amount, 0) / trades.length
@@ -989,12 +959,9 @@ export class AgentServiceV2 {
     return {
       lifetimePnL: Number(agent.lifetimePnL),
       totalTrades: trades.length,
-      profitableTrades: closedTrades.filter((t) => t.pnl && t.pnl > 0).length,
+      profitableTrades,
       winRate:
-        closedTrades.length > 0
-          ? closedTrades.filter((t) => t.pnl && t.pnl > 0).length /
-            closedTrades.length
-          : 0,
+        closedTrades.length > 0 ? profitableTrades / closedTrades.length : 0,
       avgTradeSize,
     };
   }


### PR DESCRIPTION
## Summary

- Agent performance stats now correctly display total P&L (realized + unrealized) matching the ProfileWidget
- Fixed `getPerformance()` to calculate stats from `agentTrades` table instead of `agentPerformanceMetrics` which wasn't being updated
- AgentPerformance component now uses shared `useUserPositions` hook (DRY)
- Added Portfolio Overview section showing: Available Balance, In Positions, Total Portfolio, Unrealized P&L, Realized P&L

## Problem

The agent profile page was showing 0 for Lifetime P&L and incorrect trade stats because:
1. `AgentService.getPerformance()` used `agentPerformanceMetrics` table which wasn't updated when trades happen
2. Only realized P&L was displayed, not unrealized gains from open positions

## Test plan

- [ ] View agent profile for an agent with open positions
- [ ] Verify Lifetime P&L shows total (realized + unrealized)
- [ ] Verify Portfolio Overview shows correct balance breakdown
- [ ] Verify trade stats (Total Trades, Profitable Trades, Win Rate) match actual trades

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Portfolio Overview showing available balance, in-position value, total portfolio, and PnL breakdown
  - Shows counts of open prediction and stock positions in the performance view
  - Performance now reflects combined realized + unrealized PnL and uses trade history for metrics

* **Bug Fixes / UX**
  - Improved loading/error states and conditional visuals in the activity/performance sections

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed agent profile performance display to show total P&L (realized + unrealized) matching the ProfileWidget behavior, and simplified trade statistics calculation to use `agentTrades` table as source of truth.

## Key Changes
- `AgentPerformance` component now uses `useUserPositions` hook to fetch open positions and calculate unrealized P&L
- Added Portfolio Overview section displaying available balance, points in positions, total portfolio value, and P&L breakdown
- `AgentService.getPerformance()` now always calculates stats from `agentTrades` table instead of relying on `agentPerformanceMetrics` which wasn't being kept in sync
- Lifetime P&L stat now shows total performance (realized + unrealized) instead of just realized P&L

## Implementation
The PR correctly implements the unrealized P&L calculation by:
1. Fetching prediction and perpetual positions using the shared `useUserPositions` hook
2. Summing unrealized P&L from both position types
3. Adding realized P&L (from `agent.lifetimePnL`) to unrealized P&L for total performance
4. Using the same calculation pattern as `ProfileWidget.tsx` for consistency

<h3>Confidence Score: 4/5</h3>


- Safe to merge with minor considerations about loading states
- The PR makes logical improvements by fixing data source issues and adding unrealized P&L calculations. The code follows existing patterns from ProfileWidget and uses the shared useUserPositions hook properly. Minor score reduction due to potential UX consideration around loading state handling.
- No files require special attention - all changes are well-structured

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/agents/[agentId]/page.tsx | Added agentId prop to AgentPerformance component - minimal change, safe |
| apps/web/src/components/agents/AgentPerformance.tsx | Added Portfolio Overview section and unrealized P&L calculations using useUserPositions hook - logic appears correct |
| packages/agents/src/services/AgentService.ts | Simplified getPerformance() to always use agentTrades table instead of agentPerformanceMetrics - correct approach |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant AgentPage as Agent Page
    participant AgentPerf as AgentPerformance Component
    participant API as /api/markets/positions
    participant AgentSvc as AgentService.getPerformance()
    participant DB as Database

    User->>AgentPage: View Agent Profile
    AgentPage->>API: GET /api/agents/:agentId
    API->>AgentSvc: getPerformance(agentUserId)
    AgentSvc->>DB: SELECT from agentTrades
    DB-->>AgentSvc: trades data
    AgentSvc->>AgentSvc: Calculate stats from trades
    AgentSvc-->>API: { lifetimePnL, totalTrades, profitableTrades, winRate }
    API-->>AgentPage: agent data with performance
    AgentPage->>AgentPerf: Pass agent + agentId props
    AgentPerf->>API: GET /api/markets/positions/:userId
    API->>DB: SELECT prediction + perp positions
    DB-->>API: positions with unrealizedPnL
    API-->>AgentPerf: { predictionPositions, perpPositions }
    AgentPerf->>AgentPerf: Calculate unrealizedPnL from positions
    AgentPerf->>AgentPerf: totalPnL = realizedPnL + unrealizedPnL
    AgentPerf->>AgentPerf: Calculate pointsInPositions
    AgentPerf-->>User: Display Portfolio Overview + Total P&L
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->