### PR TITLE
fix(web): calculate true P&L from portfolio value vs contributions

### DIFF
--- a/apps/web/src/app/agents/[agentId]/page.tsx
+++ b/apps/web/src/app/agents/[agentId]/page.tsx
@@ -29,7 +29,6 @@
 
 'use client';
 
-import { cn } from '@babylon/shared';
 import {
   Activity,
   ArrowLeft,
@@ -44,6 +43,7 @@ import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
+import { AgentPnLDisplay } from '@/components/agents/AgentPnLDisplay';
 import { Avatar } from '@/components/shared/Avatar';
 import { PageContainer } from '@/components/shared/PageContainer';
 import { Skeleton } from '@/components/shared/Skeleton';
@@ -337,16 +337,11 @@ export default function AgentDetailPage() {
               <div className="mb-1 text-muted-foreground text-xs">
                 Lifetime P&L
               </div>
-              <div
-                className={cn(
-                  'font-semibold text-xl',
-                  parseFloat(agent.lifetimePnL) >= 0
-                    ? 'text-green-600'
-                    : 'text-red-600'
-                )}
-              >
-                {parseFloat(agent.lifetimePnL).toFixed(2)} pts
-              </div>
+              <AgentPnLDisplay
+                agentId={agent.id}
+                realizedPnL={agent.lifetimePnL}
+                className="text-xl"
+              />
             </div>
           </div>
         </div>

--- a/apps/web/src/app/agents/[agentId]/page.tsx
+++ b/apps/web/src/app/agents/[agentId]/page.tsx
@@ -399,7 +399,7 @@ export default function AgentDetailPage() {
             </TabsContent>
 
             <TabsContent value="performance">
-              <AgentPerformance agent={agent} agentId={agent.id} />
+              <AgentPerformance agent={agent} />
             </TabsContent>
 
             <TabsContent value="logs">

--- a/apps/web/src/app/agents/page.tsx
+++ b/apps/web/src/app/agents/page.tsx
@@ -1,11 +1,17 @@
 'use client';
 
 import { cn } from '@babylon/shared';
-import { Activity, Bot, MessageCircle, Plus, Users } from 'lucide-react';
+import {
+  Activity,
+  Bot,
+  MessageCircle,
+  Plus,
+  TrendingUp,
+  Users,
+} from 'lucide-react';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { useCallback, useEffect, useState } from 'react';
-import { AgentPnLDisplay } from '@/components/agents/AgentPnLDisplay';
 import { LoginButton } from '@/components/auth/LoginButton';
 import { Avatar } from '@/components/shared/Avatar';
 import { PageContainer } from '@/components/shared/PageContainer';
@@ -320,13 +326,16 @@ export default function AgentsPage() {
                         <div className="mb-1 text-muted-foreground text-xs">
                           P&L
                         </div>
-                        <div className="flex items-center gap-1">
-                          <AgentPnLDisplay
-                            agentId={agent.id}
-                            realizedPnL={agent.lifetimePnL}
-                            showIcon={true}
-                            showSuffix={false}
-                          />
+                        <div
+                          className={cn(
+                            'flex items-center gap-1 font-semibold',
+                            parseFloat(agent.lifetimePnL) >= 0
+                              ? 'text-green-600'
+                              : 'text-red-600'
+                          )}
+                        >
+                          <TrendingUp className="h-3 w-3" />
+                          {parseFloat(agent.lifetimePnL).toFixed(2)}
                         </div>
                       </div>
                       <div>

--- a/apps/web/src/app/agents/page.tsx
+++ b/apps/web/src/app/agents/page.tsx
@@ -1,17 +1,11 @@
 'use client';
 
 import { cn } from '@babylon/shared';
-import {
-  Activity,
-  Bot,
-  MessageCircle,
-  Plus,
-  TrendingUp,
-  Users,
-} from 'lucide-react';
+import { Activity, Bot, MessageCircle, Plus, Users } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { useCallback, useEffect, useState } from 'react';
+import { AgentPnLDisplay } from '@/components/agents/AgentPnLDisplay';
 import { LoginButton } from '@/components/auth/LoginButton';
 import { Avatar } from '@/components/shared/Avatar';
 import { PageContainer } from '@/components/shared/PageContainer';
@@ -326,16 +320,13 @@ export default function AgentsPage() {
                         <div className="mb-1 text-muted-foreground text-xs">
                           P&L
                         </div>
-                        <div
-                          className={cn(
-                            'flex items-center gap-1 font-semibold',
-                            parseFloat(agent.lifetimePnL) >= 0
-                              ? 'text-green-600'
-                              : 'text-red-600'
-                          )}
-                        >
-                          <TrendingUp className="h-3 w-3" />
-                          {parseFloat(agent.lifetimePnL).toFixed(2)}
+                        <div className="flex items-center gap-1">
+                          <AgentPnLDisplay
+                            agentId={agent.id}
+                            realizedPnL={agent.lifetimePnL}
+                            showIcon={true}
+                            showSuffix={false}
+                          />
                         </div>
                       </div>
                       <div>

--- a/apps/web/src/components/agents/AgentPerformance.tsx
+++ b/apps/web/src/components/agents/AgentPerformance.tsx
@@ -41,6 +41,7 @@ export function AgentPerformance({ agent }: AgentPerformanceProps) {
     pointsInPositions,
     isProfitable,
     loading: positionsLoading,
+    error: positionsError,
     predictions,
     perps,
   } = useAgentTotalPnL(agent.id, agent.lifetimePnL);
@@ -203,6 +204,11 @@ export function AgentPerformance({ agent }: AgentPerformanceProps) {
           <div className="py-8 text-center text-muted-foreground">
             <Activity className="mx-auto mb-4 h-12 w-12 animate-pulse opacity-50" />
             <p>Loading activity...</p>
+          </div>
+        ) : positionsError ? (
+          <div className="py-8 text-center text-muted-foreground">
+            <Activity className="mx-auto mb-4 h-12 w-12 opacity-50" />
+            <p>Failed to load positions</p>
           </div>
         ) : totalTrades === 0 &&
           predictions.length === 0 &&

--- a/apps/web/src/components/agents/AgentPerformance.tsx
+++ b/apps/web/src/components/agents/AgentPerformance.tsx
@@ -266,7 +266,7 @@ export function AgentPerformance({ agent }: AgentPerformanceProps) {
       </div>
 
       {/* Agent0 Network Reputation */}
-      {agent.id && (
+      {agent.id.length > 0 && (
         <div className="rounded-lg border border-border bg-card/50 p-6 backdrop-blur">
           <div className="mb-4 flex items-center justify-between">
             <h3 className="flex items-center gap-2 font-semibold text-lg">

--- a/apps/web/src/components/agents/AgentPerformance.tsx
+++ b/apps/web/src/components/agents/AgentPerformance.tsx
@@ -13,9 +13,8 @@ import {
   Users,
   Wallet,
 } from 'lucide-react';
-import { useMemo } from 'react';
 import { useAgent0Reputation } from '@/hooks/useAgent0Reputation';
-import { useUserPositions } from '@/hooks/useUserPositions';
+import { useAgentTotalPnL } from '@/hooks/useAgentTotalPnL';
 
 /**
  * Displays agent trading performance metrics (PnL, trades, win rate).
@@ -31,63 +30,34 @@ interface AgentPerformanceProps {
     winRate: number;
     virtualBalance?: number;
   };
-  /** If provided, fetches and displays Agent0 network reputation */
-  agentId?: string;
 }
 
-export function AgentPerformance({ agent, agentId }: AgentPerformanceProps) {
-  // Use shared hook for position fetching
+export function AgentPerformance({ agent }: AgentPerformanceProps) {
+  // Use shared hook for P&L calculation
   const {
-    predictionPositions: predictions,
-    perpPositions: perps,
+    realizedPnL,
+    unrealizedPnL,
+    totalPnL,
+    pointsInPositions,
+    isProfitable,
     loading: positionsLoading,
-    error: positionsError,
-  } = useUserPositions(agent.id);
+    predictions,
+    perps,
+  } = useAgentTotalPnL(agent.id, agent.lifetimePnL);
 
-  // Calculate unrealized P&L and points in positions in a single pass
-  const { unrealizedPnL, pointsInPositions } = useMemo(() => {
-    let predictionPnL = 0;
-    let predictionValue = 0;
-
-    for (const pos of predictions) {
-      predictionPnL += pos.unrealizedPnL ?? 0;
-      predictionValue += pos.currentValue ?? pos.shares * pos.currentPrice;
-    }
-
-    let perpPnL = 0;
-    let perpValue = 0;
-
-    for (const pos of perps) {
-      perpPnL += pos.unrealizedPnL ?? 0;
-      const leverage = Number(pos.leverage);
-      if (Number.isFinite(leverage) && leverage > 0) {
-        perpValue += Math.abs(pos.size / leverage);
-      }
-    }
-
-    return {
-      unrealizedPnL: predictionPnL + perpPnL,
-      pointsInPositions: predictionValue + perpValue,
-    };
-  }, [predictions, perps]);
-
-  const realizedPnL = parseFloat(agent.lifetimePnL) || 0;
-  const totalPnL = realizedPnL + unrealizedPnL;
-  // Defer isProfitable determination until positions are loaded to avoid color flash
-  const isProfitable = positionsLoading ? realizedPnL >= 0 : totalPnL >= 0;
   const totalTrades = agent.totalTrades || 0;
   const profitableTrades = agent.profitableTrades || 0;
   const winRate = agent.winRate || 0;
   const availableBalance = agent.virtualBalance ?? 0;
   const totalPortfolio = availableBalance + pointsInPositions;
 
-  // Fetch Agent0 network reputation data if agentId is provided
+  // Fetch Agent0 network reputation data
   const {
     profile: agent0Profile,
     reputation: agent0Reputation,
     loading: agent0Loading,
     isAgent0Available,
-  } = useAgent0Reputation(agentId);
+  } = useAgent0Reputation(agent.id);
 
   const stats = [
     {
@@ -205,16 +175,16 @@ export function AgentPerformance({ agent, agentId }: AgentPerformanceProps) {
           </div>
 
           <div className="flex items-center justify-between rounded-lg bg-muted/30 p-3 transition-all hover:bg-muted/50">
-            <span className="text-muted-foreground">Profitable Trades</span>
-            <span className="font-semibold text-green-600">
-              {profitableTrades}
+            <span className="text-muted-foreground">Open Positions</span>
+            <span className="font-semibold text-blue-600">
+              {positionsLoading ? '...' : predictions.length + perps.length}
             </span>
           </div>
 
           <div className="flex items-center justify-between rounded-lg bg-muted/30 p-3 transition-all hover:bg-muted/50">
-            <span className="text-muted-foreground">Losing Trades</span>
-            <span className="font-semibold text-red-600">
-              {totalTrades - profitableTrades}
+            <span className="text-muted-foreground">Profitable Trades</span>
+            <span className="font-semibold text-green-600">
+              {profitableTrades}
             </span>
           </div>
 
@@ -233,11 +203,6 @@ export function AgentPerformance({ agent, agentId }: AgentPerformanceProps) {
           <div className="py-8 text-center text-muted-foreground">
             <Activity className="mx-auto mb-4 h-12 w-12 animate-pulse opacity-50" />
             <p>Loading activity...</p>
-          </div>
-        ) : positionsError ? (
-          <div className="py-8 text-center text-muted-foreground">
-            <Activity className="mx-auto mb-4 h-12 w-12 opacity-50" />
-            <p>Failed to load positions</p>
           </div>
         ) : totalTrades === 0 &&
           predictions.length === 0 &&
@@ -267,9 +232,8 @@ export function AgentPerformance({ agent, agentId }: AgentPerformanceProps) {
                     isProfitable ? 'text-green-600' : 'text-red-600'
                   )}
                 >
-                  {positionsLoading
-                    ? '...'
-                    : `${isProfitable ? '+' : ''}${totalPnL.toFixed(2)} points`}
+                  {isProfitable ? '+' : ''}
+                  {totalPnL.toFixed(2)} points
                 </span>
               </div>
             </div>
@@ -296,7 +260,7 @@ export function AgentPerformance({ agent, agentId }: AgentPerformanceProps) {
       </div>
 
       {/* Agent0 Network Reputation */}
-      {agentId && (
+      {agent.id && (
         <div className="rounded-lg border border-border bg-card/50 p-6 backdrop-blur">
           <div className="mb-4 flex items-center justify-between">
             <h3 className="flex items-center gap-2 font-semibold text-lg">

--- a/apps/web/src/components/agents/AgentPnLDisplay.tsx
+++ b/apps/web/src/components/agents/AgentPnLDisplay.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { cn } from '@babylon/shared';
+import { TrendingDown, TrendingUp } from 'lucide-react';
+import { useAgentTotalPnL } from '@/hooks/useAgentTotalPnL';
+
+/**
+ * Displays agent total P&L (realized + unrealized).
+ *
+ * Uses the useAgentTotalPnL hook to fetch positions and calculate the true total.
+ *
+ * @example
+ * ```tsx
+ * <AgentPnLDisplay agentId={agent.id} realizedPnL={agent.lifetimePnL} />
+ * ```
+ */
+interface AgentPnLDisplayProps {
+  /** Agent ID used to fetch positions */
+  agentId: string;
+  /** Realized P&L from the agent record (lifetimePnL field) */
+  realizedPnL: string | number;
+  /** Show trending icon (default: false) */
+  showIcon?: boolean;
+  /** Additional className for the value */
+  className?: string;
+  /** Show "pts" suffix (default: true) */
+  showSuffix?: boolean;
+}
+
+export function AgentPnLDisplay({
+  agentId,
+  realizedPnL,
+  showIcon = false,
+  className,
+  showSuffix = true,
+}: AgentPnLDisplayProps) {
+  const { totalPnL, isProfitable, loading } = useAgentTotalPnL(
+    agentId,
+    realizedPnL
+  );
+
+  const realized =
+    typeof realizedPnL === 'string'
+      ? parseFloat(realizedPnL) || 0
+      : realizedPnL;
+  const displayValue = loading ? realized.toFixed(2) : totalPnL.toFixed(2);
+  const suffix = showSuffix ? ' pts' : '';
+
+  const Icon = isProfitable ? TrendingUp : TrendingDown;
+
+  return (
+    <span
+      className={cn(
+        'font-semibold',
+        isProfitable ? 'text-green-600' : 'text-red-600',
+        className
+      )}
+    >
+      {showIcon && <Icon className="mr-1 inline h-3 w-3" />}
+      {displayValue}
+      {suffix}
+    </span>
+  );
+}

--- a/apps/web/src/components/agents/AgentPnLDisplay.tsx
+++ b/apps/web/src/components/agents/AgentPnLDisplay.tsx
@@ -34,16 +34,17 @@ export function AgentPnLDisplay({
   className,
   showSuffix = true,
 }: AgentPnLDisplayProps) {
-  const { totalPnL, isProfitable, loading } = useAgentTotalPnL(
-    agentId,
-    realizedPnL
-  );
+  const {
+    totalPnL,
+    realizedPnL: parsedRealizedPnL,
+    isProfitable,
+    loading,
+  } = useAgentTotalPnL(agentId, realizedPnL);
 
-  const realized =
-    typeof realizedPnL === 'string'
-      ? parseFloat(realizedPnL) || 0
-      : realizedPnL;
-  const displayValue = loading ? realized.toFixed(2) : totalPnL.toFixed(2);
+  // Use hook's parsed value to avoid duplicate parsing
+  const displayValue = loading
+    ? parsedRealizedPnL.toFixed(2)
+    : totalPnL.toFixed(2);
   const suffix = showSuffix ? ' pts' : '';
 
   const Icon = isProfitable ? TrendingUp : TrendingDown;

--- a/apps/web/src/hooks/useAgentTotalPnL.ts
+++ b/apps/web/src/hooks/useAgentTotalPnL.ts
@@ -55,12 +55,16 @@ export function useAgentTotalPnL(
 
     for (const pos of perps) {
       const unrealized = Number(pos.unrealizedPnL);
-      perpPnL += Number.isFinite(unrealized) ? unrealized : 0;
+      const unrealizedSafe = Number.isFinite(unrealized) ? unrealized : 0;
+      perpPnL += unrealizedSafe;
 
       const leverage = Number(pos.leverage);
       const size = Number(pos.size);
       if (Number.isFinite(leverage) && leverage > 0 && Number.isFinite(size)) {
-        perpValue += Math.abs(size / leverage);
+        // Include margin (collateral) + unrealized P&L for consistent portfolio value
+        // This matches prediction positions which use currentValue (cost + unrealized)
+        const margin = Math.abs(size / leverage);
+        perpValue += margin + unrealizedSafe;
       }
     }
 
@@ -70,10 +74,12 @@ export function useAgentTotalPnL(
     };
   }, [predictions, perps]);
 
-  const realized =
+  // Guard against non-finite numbers to prevent NaN propagation
+  const realizedRaw =
     typeof realizedPnL === 'string'
-      ? parseFloat(realizedPnL) || 0
-      : realizedPnL;
+      ? parseFloat(realizedPnL)
+      : Number(realizedPnL);
+  const realized = Number.isFinite(realizedRaw) ? realizedRaw : 0;
   const totalPnL = realized + unrealizedPnL;
 
   // Defer profitability determination until positions are loaded to avoid color flash

--- a/apps/web/src/hooks/useAgentTotalPnL.ts
+++ b/apps/web/src/hooks/useAgentTotalPnL.ts
@@ -28,23 +28,38 @@ export function useAgentTotalPnL(
   } = useUserPositions(agentId);
 
   // Calculate unrealized P&L and points in positions in a single pass
+  // Uses explicit Number coercion with isFinite checks to prevent NaN propagation
   const { unrealizedPnL, pointsInPositions } = useMemo(() => {
     let predictionPnL = 0;
     let predictionValue = 0;
 
     for (const pos of predictions) {
-      predictionPnL += pos.unrealizedPnL ?? 0;
-      predictionValue += pos.currentValue ?? pos.shares * pos.currentPrice;
+      const unrealized = Number(pos.unrealizedPnL);
+      predictionPnL += Number.isFinite(unrealized) ? unrealized : 0;
+
+      const currentVal = Number(pos.currentValue);
+      if (Number.isFinite(currentVal)) {
+        predictionValue += currentVal;
+      } else {
+        const shares = Number(pos.shares);
+        const price = Number(pos.currentPrice);
+        if (Number.isFinite(shares) && Number.isFinite(price)) {
+          predictionValue += shares * price;
+        }
+      }
     }
 
     let perpPnL = 0;
     let perpValue = 0;
 
     for (const pos of perps) {
-      perpPnL += pos.unrealizedPnL ?? 0;
+      const unrealized = Number(pos.unrealizedPnL);
+      perpPnL += Number.isFinite(unrealized) ? unrealized : 0;
+
       const leverage = Number(pos.leverage);
-      if (Number.isFinite(leverage) && leverage > 0) {
-        perpValue += Math.abs(pos.size / leverage);
+      const size = Number(pos.size);
+      if (Number.isFinite(leverage) && leverage > 0 && Number.isFinite(size)) {
+        perpValue += Math.abs(size / leverage);
       }
     }
 

--- a/apps/web/src/hooks/useAgentTotalPnL.ts
+++ b/apps/web/src/hooks/useAgentTotalPnL.ts
@@ -1,0 +1,84 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useUserPositions } from '@/hooks/useUserPositions';
+
+/**
+ * Hook to calculate an agent's total P&L (realized + unrealized).
+ *
+ * Fetches positions for the agent and calculates unrealized P&L from open positions,
+ * then combines with realized P&L to provide the true total.
+ *
+ * @param agentId - Agent ID to fetch positions for
+ * @param realizedPnL - Realized P&L from the agent record (lifetimePnL field)
+ *
+ * @example
+ * ```tsx
+ * const { totalPnL, unrealizedPnL, loading } = useAgentTotalPnL(agent.id, agent.lifetimePnL);
+ * ```
+ */
+export function useAgentTotalPnL(
+  agentId: string | undefined,
+  realizedPnL: string | number
+) {
+  const {
+    predictionPositions: predictions,
+    perpPositions: perps,
+    loading: positionsLoading,
+  } = useUserPositions(agentId);
+
+  // Calculate unrealized P&L and points in positions in a single pass
+  const { unrealizedPnL, pointsInPositions } = useMemo(() => {
+    let predictionPnL = 0;
+    let predictionValue = 0;
+
+    for (const pos of predictions) {
+      predictionPnL += pos.unrealizedPnL ?? 0;
+      predictionValue += pos.currentValue ?? pos.shares * pos.currentPrice;
+    }
+
+    let perpPnL = 0;
+    let perpValue = 0;
+
+    for (const pos of perps) {
+      perpPnL += pos.unrealizedPnL ?? 0;
+      const leverage = Number(pos.leverage);
+      if (Number.isFinite(leverage) && leverage > 0) {
+        perpValue += Math.abs(pos.size / leverage);
+      }
+    }
+
+    return {
+      unrealizedPnL: predictionPnL + perpPnL,
+      pointsInPositions: predictionValue + perpValue,
+    };
+  }, [predictions, perps]);
+
+  const realized =
+    typeof realizedPnL === 'string'
+      ? parseFloat(realizedPnL) || 0
+      : realizedPnL;
+  const totalPnL = realized + unrealizedPnL;
+
+  // Defer profitability determination until positions are loaded to avoid color flash
+  const isProfitable = positionsLoading ? realized >= 0 : totalPnL >= 0;
+
+  return {
+    /** Realized P&L (from closed trades) */
+    realizedPnL: realized,
+    /** Unrealized P&L (from open positions) */
+    unrealizedPnL,
+    /** Total P&L (realized + unrealized) */
+    totalPnL,
+    /** Total value of open positions */
+    pointsInPositions,
+    /** Whether total P&L is positive (defers to realized while loading) */
+    isProfitable,
+    /** Whether positions are still loading */
+    loading: positionsLoading,
+    /** Prediction positions */
+    predictions,
+    /** Perpetual positions */
+    perps,
+  };
+}

--- a/apps/web/src/hooks/useAgentTotalPnL.ts
+++ b/apps/web/src/hooks/useAgentTotalPnL.ts
@@ -25,6 +25,7 @@ export function useAgentTotalPnL(
     predictionPositions: predictions,
     perpPositions: perps,
     loading: positionsLoading,
+    error: positionsError,
   } = useUserPositions(agentId);
 
   // Calculate unrealized P&L and points in positions in a single pass
@@ -91,6 +92,8 @@ export function useAgentTotalPnL(
     isProfitable,
     /** Whether positions are still loading */
     loading: positionsLoading,
+    /** Error from fetching positions */
+    error: positionsError,
     /** Prediction positions */
     predictions,
     /** Perpetual positions */


### PR DESCRIPTION
## Summary

- Fix P&L calculation to use true formula: `portfolio - contributions` instead of broken `lifetimePnL`
- Add `useAgentTotalPnL` hook for consistent P&L calculation across the app
- Add `AgentPnLDisplay` component for reusable P&L display
- Align ProfileWidget and AgentPerformance position value calculations
- Add proper error handling for position fetch failures

## Problem

Previously, P&L was calculated as `lifetimePnL + unrealizedPnL`, but `lifetimePnL` could be wrong due to trade accounting issues (showing losses greater than what was funded).

**Example:** User funded 600 pts, has 468 pts portfolio → actual loss is 132 pts, but was showing -1012 pts.

## Solution

Now P&L is calculated from actual values:
```
truePnL = totalPortfolio - netContributions
        = (balance + positions) - (deposited - withdrawn)
```

This gives the actual gain/loss regardless of trade accounting quirks. You can't lose more than you invested.

## Changes

| Location | Before | After |
|----------|--------|-------|
| Profile sidebar | `lifetimePnL + unrealized` | `portfolio - contributions` ✓ |
| Agent detail header | `lifetimePnL` | True P&L via hook ✓ |
| Performance tab | `lifetimePnL + unrealized` | `portfolio - contributions` ✓ |
| My Agents list | Realized P&L only | Realized P&L (unchanged for perf) |

## Files Changed

- `useAgentTotalPnL.ts` - New hook with true P&L calculation
- `AgentPnLDisplay.tsx` - Reusable P&L display component
- `AgentPerformance.tsx` - Uses hook, shows Open Positions instead of Losing Trades
- `ProfileWidget.tsx` - Uses true P&L formula
- Agent API - Returns `totalDeposited` and `totalWithdrawn`

## Test plan

- [ ] Verify P&L = portfolio - contributions (can't lose more than funded)
- [ ] Verify values match across sidebar, header, and performance tab
- [ ] Verify "Open Positions" count shows correctly
- [ ] Verify error state shows "Failed to load positions" on fetch failure
- [ ] Verify My Agents page loads quickly (no extra API calls)