### PR TITLE
fix: calculate true P&L as portfolio minus net contributions

### DIFF
--- a/apps/web/src/app/agents/[agentId]/page.tsx
+++ b/apps/web/src/app/agents/[agentId]/page.tsx
@@ -118,6 +118,8 @@ interface Agent {
   personality?: string;
   tradingStrategy?: string;
   virtualBalance?: number;
+  totalDeposited?: number;
+  totalWithdrawn?: number;
   isActive: boolean;
   autonomousEnabled: boolean;
   modelTier: 'free' | 'pro';

--- a/apps/web/src/app/api/agents/[agentId]/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/route.ts
@@ -258,8 +258,8 @@ export async function GET(
           return tradingStrategyMatch ? tradingStrategyMatch[1]!.trim() : '';
         })(),
       virtualBalance: Number(agent!.virtualBalance ?? 0),
-      totalDeposited: Number(agent!.totalDeposited ?? 0),
-      totalWithdrawn: Number(agent!.totalWithdrawn ?? 0),
+      totalDeposited: agent!.totalDeposited == null ? null : Number(agent!.totalDeposited),
+      totalWithdrawn: agent!.totalWithdrawn == null ? null : Number(agent!.totalWithdrawn),
       isActive: config?.status === 'active',
       autonomousEnabled: tradingEnabled,
       autonomousTrading: tradingEnabled,

--- a/apps/web/src/app/api/agents/[agentId]/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/route.ts
@@ -258,6 +258,8 @@ export async function GET(
           return tradingStrategyMatch ? tradingStrategyMatch[1]!.trim() : '';
         })(),
       virtualBalance: Number(agent!.virtualBalance ?? 0),
+      totalDeposited: Number(agent!.totalDeposited ?? 0),
+      totalWithdrawn: Number(agent!.totalWithdrawn ?? 0),
       isActive: config?.status === 'active',
       autonomousEnabled: tradingEnabled,
       autonomousTrading: tradingEnabled,

--- a/apps/web/src/components/agents/AgentPerformance.tsx
+++ b/apps/web/src/components/agents/AgentPerformance.tsx
@@ -29,28 +29,37 @@ interface AgentPerformanceProps {
     profitableTrades: number;
     winRate: number;
     virtualBalance?: number;
+    totalDeposited?: number;
+    totalWithdrawn?: number;
   };
 }
 
 export function AgentPerformance({ agent }: AgentPerformanceProps) {
   // Use shared hook for P&L calculation
+  // Pass deposit data to calculate true P&L (portfolio - contributions)
   const {
     realizedPnL,
     unrealizedPnL,
     totalPnL,
     pointsInPositions,
+    totalPortfolio,
     isProfitable,
     loading: positionsLoading,
     error: positionsError,
     predictions,
     perps,
-  } = useAgentTotalPnL(agent.id, agent.lifetimePnL);
+  } = useAgentTotalPnL({
+    agentId: agent.id,
+    availableBalance: agent.virtualBalance ?? 0,
+    totalDeposited: agent.totalDeposited,
+    totalWithdrawn: agent.totalWithdrawn,
+    realizedPnL: agent.lifetimePnL,
+  });
 
   const totalTrades = agent.totalTrades || 0;
   const profitableTrades = agent.profitableTrades || 0;
   const winRate = agent.winRate || 0;
   const availableBalance = agent.virtualBalance ?? 0;
-  const totalPortfolio = availableBalance + pointsInPositions;
 
   // Fetch Agent0 network reputation data
   const {

--- a/apps/web/src/components/profile/ProfileWidget.tsx
+++ b/apps/web/src/components/profile/ProfileWidget.tsx
@@ -164,13 +164,14 @@ export function ProfileWidget({ userId }: ProfileWidgetProps) {
   // Calculate points in positions from actual position data
   // Sum of currentValue from predictions + (margin + unrealized) from perpetuals
   // For perps, include unrealized P&L for consistency with prediction currentValue
-  const pointsInPositions = useMemo(() => {
+  const positionsValue = useMemo(() => {
     const predictionValue = predictions.reduce(
       (sum, pos) => sum + (pos.currentValue ?? pos.shares * pos.currentPrice),
       0
     );
     // Use margin + unrealized P&L for perps to match prediction positions
-    // (prediction currentValue = cost + unrealized, so perp should be margin + unrealized)
+    // (prediction currentValue is the position's current worth including unrealized gains,
+    // so perp value should similarly be margin + unrealized)
     const perpValue = perps.reduce((sum, pos) => {
       const leverage = Number(pos.leverage);
       const effectiveLeverage =
@@ -185,25 +186,45 @@ export function ProfileWidget({ userId }: ProfileWidgetProps) {
 
   // Total portfolio = available balance + points in positions
   const totalPortfolio = useMemo(
-    () => (balance?.balance || 0) + pointsInPositions,
-    [balance?.balance, pointsInPositions]
+    () => (balance?.balance || 0) + positionsValue,
+    [balance?.balance, positionsValue]
+  );
+
+  // Check if we have reliable deposit data for true P&L calculation
+  const hasDepositData = useMemo(
+    () =>
+      balance != null &&
+      typeof balance.totalDeposited === 'number' &&
+      typeof balance.totalWithdrawn === 'number',
+    [balance]
   );
 
   // Net contributions = what user actually put in
   const netContributions = useMemo(
-    () => (balance?.totalDeposited || 0) - (balance?.totalWithdrawn || 0),
-    [balance?.totalDeposited, balance?.totalWithdrawn]
+    () =>
+      hasDepositData
+        ? (balance!.totalDeposited ?? 0) - (balance!.totalWithdrawn ?? 0)
+        : undefined,
+    [hasDepositData, balance]
   );
 
   // True P&L = Current Portfolio Value - Net Contributions
-  // This gives the actual gain/loss regardless of trade accounting quirks
+  // Only calculated when we have reliable deposit/withdrawal tracking.
+  // Note: This assumes all portfolio funds came from tracked deposits;
+  // may not account for airdrops, rewards, or admin adjustments.
   const totalPnL = useMemo(
-    () => totalPortfolio - netContributions,
+    () =>
+      typeof netContributions === 'number'
+        ? totalPortfolio - netContributions
+        : 0,
     [totalPortfolio, netContributions]
   );
 
   const pnlPercent = useMemo(
-    () => (netContributions > 0 ? (totalPnL / netContributions) * 100 : 0),
+    () =>
+      typeof netContributions === 'number' && netContributions > 0
+        ? (totalPnL / netContributions) * 100
+        : 0,
     [totalPnL, netContributions]
   );
 
@@ -362,7 +383,7 @@ export function ProfileWidget({ userId }: ProfileWidgetProps) {
           <div className="flex items-center justify-between">
             <span className="text-muted-foreground text-sm">In Positions</span>
             <span className="font-semibold text-foreground text-sm">
-              {formatPoints(pointsInPositions)} pts
+              {formatPoints(positionsValue)} pts
             </span>
           </div>
           <div className="flex items-center justify-between">

--- a/apps/web/src/components/profile/ProfileWidget.tsx
+++ b/apps/web/src/components/profile/ProfileWidget.tsx
@@ -189,26 +189,17 @@ export function ProfileWidget({ userId }: ProfileWidgetProps) {
     [balance?.balance, pointsInPositions]
   );
 
-  // Calculate total unrealized P&L from positions
-  const unrealizedPnL = useMemo(() => {
-    const predictionPnL = predictions.reduce(
-      (sum, pos) => sum + (pos.unrealizedPnL ?? 0),
-      0
-    );
-    const perpPnL = perps.reduce((sum, pos) => sum + pos.unrealizedPnL, 0);
-    return predictionPnL + perpPnL;
-  }, [predictions, perps]);
-
-  // Total P&L = lifetime realized P&L + unrealized P&L
-  const totalPnL = useMemo(
-    () => (balance?.lifetimePnL || 0) + unrealizedPnL,
-    [balance?.lifetimePnL, unrealizedPnL]
-  );
-
-  // P&L percentage based on net contributions (totalDeposited - totalWithdrawn)
+  // Net contributions = what user actually put in
   const netContributions = useMemo(
     () => (balance?.totalDeposited || 0) - (balance?.totalWithdrawn || 0),
     [balance?.totalDeposited, balance?.totalWithdrawn]
+  );
+
+  // True P&L = Current Portfolio Value - Net Contributions
+  // This gives the actual gain/loss regardless of trade accounting quirks
+  const totalPnL = useMemo(
+    () => totalPortfolio - netContributions,
+    [totalPortfolio, netContributions]
   );
 
   const pnlPercent = useMemo(

--- a/apps/web/src/components/profile/ProfileWidget.tsx
+++ b/apps/web/src/components/profile/ProfileWidget.tsx
@@ -162,19 +162,23 @@ export function ProfileWidget({ userId }: ProfileWidgetProps) {
   >(null);
 
   // Calculate points in positions from actual position data
-  // Sum of currentValue from predictions + margin from perpetuals
-  // For perps, we use size/leverage to get actual capital tied up (margin), not notional value
+  // Sum of currentValue from predictions + (margin + unrealized) from perpetuals
+  // For perps, include unrealized P&L for consistency with prediction currentValue
   const pointsInPositions = useMemo(() => {
     const predictionValue = predictions.reduce(
       (sum, pos) => sum + (pos.currentValue ?? pos.shares * pos.currentPrice),
       0
     );
-    // Use margin (size/leverage) for perps to represent actual capital at risk
+    // Use margin + unrealized P&L for perps to match prediction positions
+    // (prediction currentValue = cost + unrealized, so perp should be margin + unrealized)
     const perpValue = perps.reduce((sum, pos) => {
       const leverage = Number(pos.leverage);
       const effectiveLeverage =
         Number.isFinite(leverage) && leverage > 0 ? leverage : 1;
-      return sum + Math.abs(pos.size / effectiveLeverage);
+      const margin = Math.abs(pos.size / effectiveLeverage);
+      const unrealized = Number(pos.unrealizedPnL);
+      const unrealizedSafe = Number.isFinite(unrealized) ? unrealized : 0;
+      return sum + margin + unrealizedSafe;
     }, 0);
     return predictionValue + perpValue;
   }, [predictions, perps]);

--- a/apps/web/src/hooks/useAgentTotalPnL.ts
+++ b/apps/web/src/hooks/useAgentTotalPnL.ts
@@ -19,12 +19,13 @@ interface UseAgentTotalPnLOptions {
 /**
  * Hook to calculate an agent's true P&L.
  *
- * If totalDeposited is provided, calculates true P&L as:
+ * If totalDeposited is provided and finite, calculates true P&L as:
  *   truePnL = totalPortfolio - netContributions
  *           = (availableBalance + pointsInPositions) - (totalDeposited - totalWithdrawn)
  *
  * This gives the actual gain/loss regardless of trade accounting quirks.
- * Falls back to realized + unrealized if deposit data isn't available.
+ * Falls back to realized + unrealized if totalDeposited is undefined or non-finite.
+ * totalWithdrawn defaults to 0 if undefined or non-finite.
  *
  * @example
  * ```tsx
@@ -120,9 +121,16 @@ export function useAgentTotalPnL(
   // Calculate total portfolio value
   const totalPortfolio = availableBalance + pointsInPositions;
 
+  // Sanitize deposit/withdrawal values to prevent NaN propagation
+  const depositedRaw = Number(totalDeposited);
+  const withdrawnRaw = Number(totalWithdrawn);
+  const depositedSafe = Number.isFinite(depositedRaw) ? depositedRaw : undefined;
+  const withdrawnSafe = Number.isFinite(withdrawnRaw) ? withdrawnRaw : 0;
+
   // Calculate net contributions (what was actually put in)
+  // Only computed when totalDeposited is a valid finite number
   const netContributions =
-    totalDeposited !== undefined ? totalDeposited - totalWithdrawn : undefined;
+    depositedSafe !== undefined ? depositedSafe - withdrawnSafe : undefined;
 
   // True P&L = Current Portfolio - Net Contributions
   // This gives the actual gain/loss regardless of trade accounting quirks.

--- a/apps/web/src/hooks/useAgentTotalPnL.ts
+++ b/apps/web/src/hooks/useAgentTotalPnL.ts
@@ -3,24 +3,60 @@
 import { useMemo } from 'react';
 import { useUserPositions } from '@/hooks/useUserPositions';
 
+interface UseAgentTotalPnLOptions {
+  /** Agent ID to fetch positions for */
+  agentId: string | undefined;
+  /** Available balance (virtualBalance) */
+  availableBalance?: number;
+  /** Total amount deposited to the agent */
+  totalDeposited?: number;
+  /** Total amount withdrawn from the agent */
+  totalWithdrawn?: number;
+  /** Fallback: Realized P&L from the agent record (lifetimePnL field) - used if deposits not available */
+  realizedPnL?: string | number;
+}
+
 /**
- * Hook to calculate an agent's total P&L (realized + unrealized).
+ * Hook to calculate an agent's true P&L.
  *
- * Fetches positions for the agent and calculates unrealized P&L from open positions,
- * then combines with realized P&L to provide the true total.
+ * If totalDeposited is provided, calculates true P&L as:
+ *   truePnL = totalPortfolio - netContributions
+ *           = (availableBalance + pointsInPositions) - (totalDeposited - totalWithdrawn)
  *
- * @param agentId - Agent ID to fetch positions for
- * @param realizedPnL - Realized P&L from the agent record (lifetimePnL field)
+ * This gives the actual gain/loss regardless of trade accounting quirks.
+ * Falls back to realized + unrealized if deposit data isn't available.
  *
  * @example
  * ```tsx
- * const { totalPnL, unrealizedPnL, loading } = useAgentTotalPnL(agent.id, agent.lifetimePnL);
+ * const { totalPnL, loading } = useAgentTotalPnL({
+ *   agentId: agent.id,
+ *   availableBalance: agent.virtualBalance,
+ *   totalDeposited: agent.totalDeposited,
+ *   totalWithdrawn: agent.totalWithdrawn,
+ *   realizedPnL: agent.lifetimePnL,
+ * });
  * ```
  */
 export function useAgentTotalPnL(
-  agentId: string | undefined,
-  realizedPnL: string | number
+  optionsOrAgentId: UseAgentTotalPnLOptions | string | undefined,
+  legacyRealizedPnL?: string | number
 ) {
+  // Support both new object API and legacy (agentId, realizedPnL) signature
+  const options: UseAgentTotalPnLOptions =
+    typeof optionsOrAgentId === 'object' && optionsOrAgentId !== null
+      ? optionsOrAgentId
+      : {
+          agentId: optionsOrAgentId,
+          realizedPnL: legacyRealizedPnL,
+        };
+
+  const {
+    agentId,
+    availableBalance = 0,
+    totalDeposited,
+    totalWithdrawn = 0,
+    realizedPnL,
+  } = options;
   const {
     predictionPositions: predictions,
     perpPositions: perps,
@@ -77,23 +113,41 @@ export function useAgentTotalPnL(
   // Guard against non-finite numbers to prevent NaN propagation
   const realizedRaw =
     typeof realizedPnL === 'string'
-      ? parseFloat(realizedPnL)
-      : Number(realizedPnL);
+      ? parseFloat(realizedPnL ?? '0')
+      : Number(realizedPnL ?? 0);
   const realized = Number.isFinite(realizedRaw) ? realizedRaw : 0;
-  const totalPnL = realized + unrealizedPnL;
+
+  // Calculate total portfolio value
+  const totalPortfolio = availableBalance + pointsInPositions;
+
+  // Calculate net contributions (what was actually put in)
+  const netContributions =
+    totalDeposited !== undefined ? totalDeposited - totalWithdrawn : undefined;
+
+  // True P&L = Current Portfolio - Net Contributions
+  // This gives the actual gain/loss regardless of trade accounting quirks.
+  // Falls back to realized + unrealized if deposit data isn't available.
+  const totalPnL =
+    netContributions !== undefined
+      ? totalPortfolio - netContributions
+      : realized + unrealizedPnL;
 
   // Defer profitability determination until positions are loaded to avoid color flash
   const isProfitable = positionsLoading ? realized >= 0 : totalPnL >= 0;
 
   return {
-    /** Realized P&L (from closed trades) */
+    /** Realized P&L (from closed trades) - may be inaccurate, prefer totalPnL */
     realizedPnL: realized,
     /** Unrealized P&L (from open positions) */
     unrealizedPnL,
-    /** Total P&L (realized + unrealized) */
+    /** True total P&L (portfolio - contributions, or realized + unrealized as fallback) */
     totalPnL,
     /** Total value of open positions */
     pointsInPositions,
+    /** Total portfolio value (available + in positions) */
+    totalPortfolio,
+    /** Net contributions (deposited - withdrawn), undefined if not available */
+    netContributions,
     /** Whether total P&L is positive (defers to realized while loading) */
     isProfitable,
     /** Whether positions are still loading */


### PR DESCRIPTION
## Summary

Fixes P&L display to show the true gain/loss by calculating:

**True P&L = Portfolio Value - Net Contributions**

This replaces the previous `realized + unrealized` formula which could be inaccurate due to trade accounting quirks.

## Changes

- **`useAgentTotalPnL` hook**: New object-based API that calculates true P&L when deposit data is available, with fallback to the legacy formula
- **Agent API**: Added `totalDeposited` and `totalWithdrawn` fields to agent responses
- **`ProfileWidget`**: Perp position values now include unrealized P&L (margin + unrealized) for consistency with prediction positions
- **`AgentPerformance`**: Uses the updated hook with deposit/withdrawal data

## Files changed

- `apps/web/src/hooks/useAgentTotalPnL.ts` - Core P&L calculation logic
- `apps/web/src/components/profile/ProfileWidget.tsx` - User P&L display
- `apps/web/src/components/agents/AgentPerformance.tsx` - Agent P&L display  
- `apps/web/src/app/agents/[agentId]/page.tsx` - Agent interface types
- `apps/web/src/app/api/agents/[agentId]/route.ts` - API response fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent profiles now surface total deposits and total withdrawals for clearer account history.
* **Improvements**
  * Portfolio and P&L calculations updated to use net contributions and a true total-portfolio view, improving accuracy of profit/loss and percentage displays.
  * "In Positions" valuation refined to better reflect current position values and unrealized P&L.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


This PR improves P&L calculation accuracy by using a portfolio-based approach rather than relying on trade accounting. The key change calculates true P&L as `totalPortfolio - netContributions` where:
- `totalPortfolio` = available balance + value of open positions (including unrealized P&L)
- `netContributions` = total deposited - total withdrawn

**Key improvements:**
- Adds `totalDeposited` and `totalWithdrawn` fields to agent API responses and TypeScript interfaces
- Updates `useAgentTotalPnL` hook to calculate true P&L when deposit data is available, falling back to `realized + unrealized` for backward compatibility
- Aligns perpetual position valuation with prediction positions by including unrealized P&L in both (previously perps only used margin)
- Updates `ProfileWidget` and `AgentPerformance` components to use the new calculation method

**Minor observation:**
- `AgentPnLDisplay` component still uses the legacy API signature and won't benefit from the improved calculation unless updated (though it continues to work via backward compatibility)

<h3>Confidence Score: 4/5</h3>


- Safe to merge with minor consideration for AgentPnLDisplay component
- The P&L calculation logic is sound and well-tested across multiple components. Backward compatibility is maintained through the hook's dual API signature. The only minor issue is that AgentPnLDisplay wasn't updated to use the new calculation method, though it continues to work correctly via legacy API support.
- Consider updating `apps/web/src/components/agents/AgentPnLDisplay.tsx` to use the new API for consistency

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/hooks/useAgentTotalPnL.ts | Adds true P&L calculation using portfolio minus contributions approach, with backward-compatible API support |
| apps/web/src/components/profile/ProfileWidget.tsx | Updates P&L calculation to use true portfolio value approach and includes unrealized P&L in perp positions |
| apps/web/src/components/agents/AgentPerformance.tsx | Migrates to new useAgentTotalPnL API with deposit data for accurate P&L calculation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as AgentPerformance/ProfileWidget
    participant Hook as useAgentTotalPnL
    participant API as /api/agents/[agentId]
    participant DB as Database (User table)
    participant Positions as useUserPositions

    UI->>API: GET /api/agents/[agentId]
    API->>DB: Query agent (user with isActor=true)
    DB-->>API: Return user data (virtualBalance, totalDeposited, totalWithdrawn, lifetimePnL)
    API-->>UI: Agent data with deposit/withdrawal fields

    UI->>Hook: useAgentTotalPnL({ agentId, availableBalance, totalDeposited, totalWithdrawn })
    Hook->>Positions: useUserPositions(agentId)
    Positions-->>Hook: Return predictions + perps positions
    
    Note over Hook: Calculate pointsInPositions:<br/>predictions.currentValue + perps(margin + unrealized)
    Note over Hook: Calculate totalPortfolio:<br/>availableBalance + pointsInPositions
    Note over Hook: Calculate netContributions:<br/>totalDeposited - totalWithdrawn
    Note over Hook: Calculate true P&L:<br/>totalPortfolio - netContributions
    
    Hook-->>UI: Return { totalPnL, totalPortfolio, realizedPnL, unrealizedPnL, ... }
    UI->>UI: Display P&L metrics
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->