### PR TITLE
fix(privy): BAB-147 store smart wallet address in User.walletAddress

### DIFF
--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -162,7 +162,9 @@ type PrivyWalletLite = {
   id?: string | null;
   address?: string;
   chainType?: string;
+  chain_type?: string;
   walletClientType?: string | null;
+  wallet_client?: string | null;
   type?: string | null;
 };
 
@@ -193,16 +195,20 @@ function pickEmbeddedEvmWallet(
 ): PrivyWalletLite | null {
   const candidates: PrivyWalletLite[] = [];
   if (user.wallet) candidates.push(user.wallet);
-  if (Array.isArray(user.linkedAccounts)) {
-    for (const acc of user.linkedAccounts) {
-      if (acc?.type === 'wallet') candidates.push(acc);
-    }
+  for (const acc of user.linkedAccounts ?? []) {
+    if (acc?.type === 'wallet') candidates.push(acc);
+  }
+  for (const acc of user.linked_accounts ?? []) {
+    if (acc?.type === 'wallet') candidates.push(acc);
   }
   return (
     candidates.find(
       (w) =>
-        (w.walletClientType === 'privy' || Boolean(w.id)) &&
-        (!w.chainType || w.chainType === 'ethereum') &&
+        (w.walletClientType === 'privy' ||
+          w.wallet_client === 'privy' ||
+          Boolean(w.id)) &&
+        (!(w.chainType ?? w.chain_type) ||
+          (w.chainType ?? w.chain_type) === 'ethereum') &&
         typeof w.address === 'string'
     ) ?? null
   );
@@ -214,21 +220,8 @@ async function ensureSmartWalletAddress(privyId: string): Promise<{
 }> {
   const privyClient = getPrivyClient();
   const user = (await privyClient.getUser(privyId)) as PrivyUserWithSmartWallet;
-  let smartWalletAddress = pickSmartWalletAddress(user);
-  let embeddedWallet = pickEmbeddedEvmWallet(user);
-
-  if (!smartWalletAddress) {
-    // Note: createEthereumWallet must be true when creating a smart wallet
-    // If user already has an embedded wallet, Privy will skip creating a new one
-    const updated = (await privyClient.createWallets({
-      userId: privyId,
-      createEthereumSmartWallet: true,
-      createEthereumWallet: true,
-    })) as PrivyUserWithSmartWallet;
-
-    smartWalletAddress = pickSmartWalletAddress(updated);
-    embeddedWallet = embeddedWallet ?? pickEmbeddedEvmWallet(updated);
-  }
+  const smartWalletAddress = pickSmartWalletAddress(user);
+  const embeddedWallet = pickEmbeddedEvmWallet(user);
 
   return {
     smartWalletAddress,

--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -163,13 +163,30 @@ type PrivyWalletLite = {
   address?: string;
   chainType?: string;
   walletClientType?: string | null;
+  type?: string | null;
 };
 
 type PrivyUserWithSmartWallet = PrivyUser &
   PrivyUserWithEmails & {
     smartWallet?: { address?: string | null };
     wallet?: PrivyWalletLite;
+    linkedAccounts?: PrivyWalletLite[];
+    linked_accounts?: PrivyWalletLite[];
   };
+
+function pickSmartWalletAddress(user: PrivyUserWithSmartWallet): string | null {
+  const direct = user.smartWallet?.address?.toLowerCase() ?? null;
+  if (direct) return direct;
+
+  const accounts = [
+    ...(user.linkedAccounts ?? []),
+    ...(user.linked_accounts ?? []),
+  ];
+  const smartWallet = accounts.find(
+    (a) => a.type === 'smart_wallet' && typeof a.address === 'string'
+  );
+  return smartWallet?.address?.toLowerCase() ?? null;
+}
 
 function pickEmbeddedEvmWallet(
   user: PrivyUserWithSmartWallet
@@ -197,7 +214,7 @@ async function ensureSmartWalletAddress(privyId: string): Promise<{
 }> {
   const privyClient = getPrivyClient();
   const user = (await privyClient.getUser(privyId)) as PrivyUserWithSmartWallet;
-  let smartWalletAddress = user.smartWallet?.address?.toLowerCase() ?? null;
+  let smartWalletAddress = pickSmartWalletAddress(user);
   let embeddedWallet = pickEmbeddedEvmWallet(user);
 
   if (!smartWalletAddress) {
@@ -209,7 +226,7 @@ async function ensureSmartWalletAddress(privyId: string): Promise<{
       createEthereumWallet: true,
     })) as PrivyUserWithSmartWallet;
 
-    smartWalletAddress = updated.smartWallet?.address?.toLowerCase() ?? null;
+    smartWalletAddress = pickSmartWalletAddress(updated);
     embeddedWallet = embeddedWallet ?? pickEmbeddedEvmWallet(updated);
   }
 
@@ -291,7 +308,9 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     let smartWalletAddress: string | null = null;
 
     const privyClient = getPrivyClient();
-    const privyUser = await privyClient.getUser(privyId);
+    const privyUser = (await privyClient.getUser(
+      privyId
+    )) as PrivyUserWithSmartWallet;
 
     // Extract email from linked accounts
     if (privyUser.email?.address) {
@@ -313,7 +332,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     }
 
     // Prefer Privy smart wallet over linked/embedded wallet for DB storage
-    smartWalletAddress = privyUser.smartWallet?.address?.toLowerCase() ?? null;
+    smartWalletAddress = pickSmartWalletAddress(privyUser);
     if (smartWalletAddress) {
       authUser.walletAddress = smartWalletAddress;
     }
@@ -554,6 +573,36 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   // At this point dbUser should always be defined (either fetched or created)
   if (!dbUser) {
     throw new InternalServerError('Failed to create or find user record');
+  }
+
+  // Backfill: store smart wallet address in DB when we previously persisted the
+  // embedded wallet (legacy behavior).
+  const { smartWalletAddress: ensuredSmartWallet, embeddedWalletAddress } =
+    await ensureSmartWalletAddress(privyId);
+  if (ensuredSmartWallet) {
+    const normalizedDbWallet = dbUser.walletAddress?.toLowerCase() ?? null;
+    const normalizedEmbedded = embeddedWalletAddress?.toLowerCase() ?? null;
+    const normalizedSmart = ensuredSmartWallet.toLowerCase();
+
+    const shouldUpgradeFromEmbedded =
+      normalizedDbWallet !== null &&
+      normalizedEmbedded !== null &&
+      normalizedDbWallet === normalizedEmbedded &&
+      normalizedDbWallet !== normalizedSmart;
+
+    const shouldFillMissing = normalizedDbWallet === null;
+
+    if (shouldUpgradeFromEmbedded || shouldFillMissing) {
+      const [updatedUser] = await db
+        .update(users)
+        .set({ walletAddress: ensuredSmartWallet, updatedAt: new Date() })
+        .where(eq(users.id, dbUser.id))
+        .returning(userSelectFields);
+
+      if (updatedUser) {
+        dbUser = updatedUser;
+      }
+    }
   }
 
   // Auto-promote existing users to admin if they have a verified admin domain email

--- a/apps/web/src/app/api/users/signup/route.ts
+++ b/apps/web/src/app/api/users/signup/route.ts
@@ -144,13 +144,30 @@ type PrivyWalletLite = {
   address?: string;
   chainType?: string;
   walletClientType?: string | null;
+  type?: string | null;
 };
 
 type PrivyUserWithSmartWallet = PrivyUser &
   PrivyUserWithEmails & {
     smartWallet?: { address?: string | null };
     wallet?: PrivyWalletLite;
+    linkedAccounts?: PrivyWalletLite[];
+    linked_accounts?: PrivyWalletLite[];
   };
+
+function pickSmartWalletAddress(user: PrivyUserWithSmartWallet): string | null {
+  const direct = user.smartWallet?.address?.toLowerCase() ?? null;
+  if (direct) return direct;
+
+  const accounts = [
+    ...(user.linkedAccounts ?? []),
+    ...(user.linked_accounts ?? []),
+  ];
+  const smartWallet = accounts.find(
+    (a) => a.type === 'smart_wallet' && typeof a.address === 'string'
+  );
+  return smartWallet?.address?.toLowerCase() ?? null;
+}
 
 function pickEmbeddedEvmWallet(
   user: PrivyUserWithSmartWallet
@@ -180,7 +197,7 @@ async function ensureSmartWalletAddress(
   embeddedWalletAddress: string | null;
 }> {
   const user = (await privyClient.getUser(privyId)) as PrivyUserWithSmartWallet;
-  let smartWalletAddress = user.smartWallet?.address?.toLowerCase() ?? null;
+  let smartWalletAddress = pickSmartWalletAddress(user);
   let embeddedWallet = pickEmbeddedEvmWallet(user);
 
   if (!smartWalletAddress) {
@@ -192,7 +209,7 @@ async function ensureSmartWalletAddress(
       createEthereumWallet: true,
     })) as PrivyUserWithSmartWallet;
 
-    smartWalletAddress = updated.smartWallet?.address?.toLowerCase() ?? null;
+    smartWalletAddress = pickSmartWalletAddress(updated);
     embeddedWallet = embeddedWallet ?? pickEmbeddedEvmWallet(updated);
   }
 

--- a/apps/web/src/app/api/users/signup/route.ts
+++ b/apps/web/src/app/api/users/signup/route.ts
@@ -143,7 +143,9 @@ type PrivyWalletLite = {
   id?: string | null;
   address?: string;
   chainType?: string;
+  chain_type?: string;
   walletClientType?: string | null;
+  wallet_client?: string | null;
   type?: string | null;
 };
 
@@ -174,16 +176,20 @@ function pickEmbeddedEvmWallet(
 ): PrivyWalletLite | null {
   const candidates: PrivyWalletLite[] = [];
   if (user.wallet) candidates.push(user.wallet);
-  if (Array.isArray(user.linkedAccounts)) {
-    for (const acc of user.linkedAccounts) {
-      if (acc?.type === 'wallet') candidates.push(acc);
-    }
+  for (const acc of user.linkedAccounts ?? []) {
+    if (acc?.type === 'wallet') candidates.push(acc);
+  }
+  for (const acc of user.linked_accounts ?? []) {
+    if (acc?.type === 'wallet') candidates.push(acc);
   }
   return (
     candidates.find(
       (w) =>
-        (w.walletClientType === 'privy' || Boolean(w.id)) &&
-        (!w.chainType || w.chainType === 'ethereum') &&
+        (w.walletClientType === 'privy' ||
+          w.wallet_client === 'privy' ||
+          Boolean(w.id)) &&
+        (!(w.chainType ?? w.chain_type) ||
+          (w.chainType ?? w.chain_type) === 'ethereum') &&
         typeof w.address === 'string'
     ) ?? null
   );
@@ -197,21 +203,8 @@ async function ensureSmartWalletAddress(
   embeddedWalletAddress: string | null;
 }> {
   const user = (await privyClient.getUser(privyId)) as PrivyUserWithSmartWallet;
-  let smartWalletAddress = pickSmartWalletAddress(user);
-  let embeddedWallet = pickEmbeddedEvmWallet(user);
-
-  if (!smartWalletAddress) {
-    // Note: createEthereumWallet must be true when creating a smart wallet
-    // If user already has an embedded wallet, Privy will skip creating a new one
-    const updated = (await privyClient.createWallets({
-      userId: privyId,
-      createEthereumSmartWallet: true,
-      createEthereumWallet: true,
-    })) as PrivyUserWithSmartWallet;
-
-    smartWalletAddress = pickSmartWalletAddress(updated);
-    embeddedWallet = embeddedWallet ?? pickEmbeddedEvmWallet(updated);
-  }
+  const smartWalletAddress = pickSmartWalletAddress(user);
+  const embeddedWallet = pickEmbeddedEvmWallet(user);
 
   return {
     smartWalletAddress,


### PR DESCRIPTION
## Summary
- Persist Privy **smart wallet (AA)** address into `User.walletAddress` (instead of embedded EOA).
- Avoid concurrent server-side wallet provisioning that could create duplicate embedded wallets.
- Backfill existing users when DB still points at the embedded wallet.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Linear: https://linear.app/eliza-labs/issue/BAB-147/privy-userwalletaddress-stores-embedded-wallet-instead-of-smart-wallet

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- `apps/web/src/app/api/users/me/route.ts`: extract smart wallet address from `linkedAccounts` / `linked_accounts`; backfill DB from embedded → smart.
- `apps/web/src/app/api/users/signup/route.ts`: persist smart wallet address (prefer smart wallet over embedded).
- Remove server-side `createWallets` calls from normal onboarding requests.

## Review guide
**Start here**
- `apps/web/src/app/api/users/me/route.ts`
- `apps/web/src/app/api/users/signup/route.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- Backfill is intentionally conservative: only upgrades when DB wallet matches embedded wallet.

## Test plan
**Commands run**
- [ ] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Create a fresh user.
2. Confirm Privy shows 1 embedded wallet + 1 smart wallet (no extra embedded wallets created).
3. Confirm `User.walletAddress` is the smart wallet address.

## Ops / Migration / Deployment
- [ ] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: none
- Changed: none
- Removed: none

**DB / data migration**
- Backfill happens opportunistically on `GET /api/users/me` (no separate migration).

**Rollout / rollback plan**
- Rollout: deploy normally.
- Rollback: revert PR.

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)
### Option B: No visual changes
- Reason: Backend-only change (API route behavior + DB persistence).

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
