### PR TITLE
fix: mint NFTs on Sepolia via Privy smart wallets

### DIFF
--- a/apps/web/src/hooks/useNftMint.ts
+++ b/apps/web/src/hooks/useNftMint.ts
@@ -1,7 +1,7 @@
+import { useSmartWallets } from '@privy-io/react-auth/smart-wallets';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
-import { useSmartWallet } from '@/hooks/useSmartWallet';
 import type {
   EligibilityResponse,
   MintConfirmResponse,
@@ -30,8 +30,7 @@ interface UseNftMintResult {
 
 export function useNftMint(): UseNftMintResult {
   const { authenticated, getAccessToken } = useAuth();
-  const { smartWalletReady, smartWalletAddress, sendSmartWalletTransaction } =
-    useSmartWallet();
+  const { getClientForChain } = useSmartWallets();
 
   const [eligibility, setEligibility] = useState<EligibilityResponse | null>(
     null
@@ -143,11 +142,6 @@ export function useNftMint(): UseNftMintResult {
       return;
     }
 
-    if (!smartWalletReady || !smartWalletAddress) {
-      toast.error('Smart wallet not ready');
-      return;
-    }
-
     setFlowState('preparing');
     setError(null);
 
@@ -208,7 +202,24 @@ export function useNftMint(): UseNftMintResult {
 
     let txHash: string;
     try {
-      txHash = await sendSmartWalletTransaction({
+      const chainClient = await getClientForChain({
+        id: prepareData.chainId,
+      });
+
+      const chainClientAddress = chainClient?.account?.address;
+      if (!chainClientAddress) {
+        handleError('Smart wallet not ready');
+        return;
+      }
+
+      if (prepareData.to.toLowerCase() !== chainClientAddress.toLowerCase()) {
+        handleError(
+          'Smart wallet mismatch. Please refresh and try again (or re-login).'
+        );
+        return;
+      }
+
+      txHash = await chainClient.sendTransaction({
         to: prepareData.contractAddress as `0x${string}`,
         data: prepareData.encodedData as `0x${string}`,
         value: 0n,
@@ -238,7 +249,7 @@ export function useNftMint(): UseNftMintResult {
         },
         body: JSON.stringify({
           txHash,
-          walletAddress: smartWalletAddress,
+          walletAddress: prepareData.to,
         }),
       });
 
@@ -278,14 +289,7 @@ export function useNftMint(): UseNftMintResult {
     );
 
     toast.success('NFT minted successfully!');
-  }, [
-    authenticated,
-    eligibility,
-    smartWalletReady,
-    smartWalletAddress,
-    getAccessToken,
-    sendSmartWalletTransaction,
-  ]);
+  }, [authenticated, eligibility, getAccessToken, getClientForChain]);
 
   const resetFlow = useCallback(() => {
     setFlowState(

--- a/packages/api/src/services/nft-mint-service.ts
+++ b/packages/api/src/services/nft-mint-service.ts
@@ -40,6 +40,7 @@ import {
   keccak256,
 } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
+import { getPrivyClient } from '../auth-middleware';
 
 // ============================================================================
 // Types
@@ -148,6 +149,18 @@ const TRANSFER_EVENT_SIGNATURE =
 // Helper Functions
 // ============================================================================
 
+type PrivyWalletAccountLite = {
+  type?: string | null;
+  address?: string | null;
+};
+
+type PrivyUserWalletsLite = {
+  smartWallet?: { address?: string | null } | null;
+  wallet?: PrivyWalletAccountLite | null;
+  linkedAccounts?: PrivyWalletAccountLite[] | null;
+  linked_accounts?: PrivyWalletAccountLite[] | null;
+};
+
 function getChainConfig(chainId: number) {
   const config = CHAIN_CONFIG[chainId];
   if (!config) {
@@ -219,6 +232,103 @@ function validateConfig(): {
   }
 
   return { contractAddress, chainId, signerPrivateKey };
+}
+
+function isPrivyConfigured(): boolean {
+  return Boolean(
+    process.env.NEXT_PUBLIC_PRIVY_APP_ID && process.env.PRIVY_APP_SECRET
+  );
+}
+
+async function getDbUserForMint(dbUserId: string): Promise<{
+  privyId: string;
+  walletAddress: string | null;
+}> {
+  const [user] = await db
+    .select({ privyId: users.privyId, walletAddress: users.walletAddress })
+    .from(users)
+    .where(eq(users.id, dbUserId))
+    .limit(1);
+
+  if (!user?.privyId) {
+    throw new ValidationError(
+      'User profile not found',
+      ['userId'],
+      [{ field: 'userId', message: 'User not found in database' }]
+    );
+  }
+
+  return { privyId: user.privyId, walletAddress: user.walletAddress };
+}
+
+function pickPrivySmartWalletAddress(privyUser: PrivyUserWalletsLite): string {
+  const direct = privyUser.smartWallet?.address?.toLowerCase() ?? null;
+  if (direct) return direct;
+
+  const accounts = [
+    ...(privyUser.linkedAccounts ?? []),
+    ...(privyUser.linked_accounts ?? []),
+  ];
+  const smartWallet = accounts.find((a) => a.type === 'smart_wallet');
+  const fromLinked = smartWallet?.address?.toLowerCase() ?? null;
+  if (fromLinked) return fromLinked;
+
+  throw new ValidationError(
+    'Smart wallet not ready',
+    ['walletAddress'],
+    [
+      {
+        field: 'walletAddress',
+        message:
+          'Smart wallet address not available. Please re-login and try again.',
+      },
+    ]
+  );
+}
+
+async function resolveUserSmartWalletAddress(userId: string): Promise<Address> {
+  const { privyId, walletAddress } = await getDbUserForMint(userId);
+
+  if (isPrivyConfigured()) {
+    const privyClient = getPrivyClient();
+    try {
+      const privyUser = (await privyClient.getUser(
+        privyId
+      )) as PrivyUserWalletsLite;
+      const address = pickPrivySmartWalletAddress(privyUser);
+      if (!isAddress(address)) {
+        throw new ValidationError(
+          'Invalid smart wallet address',
+          ['walletAddress'],
+          [{ field: 'walletAddress', message: 'Invalid Ethereum address' }]
+        );
+      }
+      return address.toLowerCase() as Address;
+    } catch (error) {
+      if (
+        process.env.NODE_ENV !== 'test' &&
+        process.env.NODE_ENV !== 'development'
+      ) {
+        throw error;
+      }
+    }
+  }
+
+  if (walletAddress && isAddress(walletAddress)) {
+    return walletAddress.toLowerCase() as Address;
+  }
+
+  throw new ValidationError(
+    'Smart wallet not ready',
+    ['walletAddress'],
+    [
+      {
+        field: 'walletAddress',
+        message:
+          'Smart wallet address not available. Please re-login and try again.',
+      },
+    ]
+  );
 }
 
 /**
@@ -370,25 +480,8 @@ export async function prepareMint(userId: string): Promise<PrepareResult> {
     );
   }
 
-  // Get user's wallet address
-  const [user] = await db
-    .select({
-      id: users.id,
-      walletAddress: users.walletAddress,
-    })
-    .from(users)
-    .where(eq(users.id, userId))
-    .limit(1);
-
-  if (!user?.walletAddress || !isAddress(user.walletAddress)) {
-    throw new ValidationError(
-      'Wallet not connected',
-      ['walletAddress'],
-      [{ field: 'walletAddress', message: 'No valid wallet address' }]
-    );
-  }
-
-  const walletAddress = user.walletAddress.toLowerCase() as Address;
+  // Resolve user's smart wallet address from Privy (multi-chain safe).
+  const walletAddress = await resolveUserSmartWalletAddress(userId);
 
   // Generate nonce and deadline (1 hour from now)
   const nonce = generateNonce();
@@ -469,29 +562,18 @@ export async function confirmMint(
   const normalizedWallet = walletAddress.toLowerCase() as Address;
   const normalizedContract = contractAddress.toLowerCase() as Address;
 
-  // Verify wallet matches user
-  const [user] = await db
-    .select({
-      id: users.id,
-      walletAddress: users.walletAddress,
-    })
-    .from(users)
-    .where(eq(users.id, userId))
-    .limit(1);
-
-  if (!user?.walletAddress) {
-    throw new ValidationError(
-      'No wallet connected',
-      ['walletAddress'],
-      [{ field: 'walletAddress', message: 'User has no wallet' }]
-    );
-  }
-
-  if (user.walletAddress.toLowerCase() !== normalizedWallet) {
+  // Verify wallet belongs to the authenticated user via Privy (do not rely on DB).
+  const expectedSmartWallet = await resolveUserSmartWalletAddress(userId);
+  if (expectedSmartWallet.toLowerCase() !== normalizedWallet.toLowerCase()) {
     throw new ValidationError(
       'Wallet mismatch',
       ['walletAddress'],
-      [{ field: 'walletAddress', message: 'Wallet does not match user' }]
+      [
+        {
+          field: 'walletAddress',
+          message: 'Wallet does not match authenticated user smart wallet',
+        },
+      ]
     );
   }
 

--- a/packages/shared/src/auth/privy-config.ts
+++ b/packages/shared/src/auth/privy-config.ts
@@ -1,6 +1,6 @@
 import type { PrivyClientConfig } from '@privy-io/react-auth';
 
-import { CHAIN } from '../constants/chains';
+import { baseSepolia, CHAIN, sepolia } from '../constants/chains';
 
 type SolanaConnectors = ReturnType<
   typeof import('@privy-io/react-auth/solana')['toSolanaWalletConnectors']
@@ -82,7 +82,16 @@ export const privyConfig: { appId: string; config: BabylonPrivyConfig } = {
     loginMethodsAndOrder,
     embeddedWallets,
     defaultChain: CHAIN,
-    supportedChains: [CHAIN],
+    // Multi-chain: keep app default chain, but allow chain-specific actions
+    // (ex: NFT minting on Ethereum Sepolia while app defaults to Base Sepolia).
+    supportedChains: (() => {
+      const chains = [CHAIN, baseSepolia, sepolia];
+      const uniqueById = new Map<number, (typeof chains)[number]>();
+      for (const chain of chains) {
+        uniqueById.set(chain.id, chain);
+      }
+      return Array.from(uniqueById.values());
+    })(),
     externalWallets,
   },
 };


### PR DESCRIPTION
## Summary
- Make the ProtoMonkeys NFT claim flow work end-to-end on Ethereum Sepolia while keeping the app default chain on Base Sepolia.
- Enable multi-chain Privy smart wallet usage so we can execute chain-specific transactions (e.g. Sepolia mint) from the same user smart wallet.
- Verify minting against the user’s Privy smart wallet address (resolved on-the-fly) instead of relying on a DB-stored wallet address.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Linear: BAB-144
- Branch: `fix/bab-144-nft-claim-smartwallet-sepolia`

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [x] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- `packages/shared/src/auth/privy-config.ts`: add `sepolia` + `baseSepolia` to `supportedChains` (keeps `defaultChain` unchanged).
- `apps/web/src/hooks/useNftMint.ts`: use `useSmartWallets().getClientForChain({ id: chainId })` so the mint tx is sent on the chain returned by `prepareMint` (Ethereum Sepolia).
- `packages/api/src/services/nft-mint-service.ts`: resolve the authenticated user’s smart wallet address via Privy and validate mint confirmations against it.

## Review guide

**Start here**
- `packages/api/src/services/nft-mint-service.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- This supports a multi-chain setup where the app defaults to Base Sepolia, but the NFT contract lives on Ethereum Sepolia.
- Requires Sepolia (eip155:11155111) to be enabled in the Privy dashboard smart wallet supported networks for the app env.

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Ensure the ProtoMonkeys collection is deployed on Ethereum Sepolia and the env points to it (`NFT_CHAIN_ID=11155111`, `NFT_CONTRACT_ADDRESS=…`).
2. Login and open `/nft`.
3. With a user present in the Top 100 snapshot, click “Claim”, confirm the smart wallet tx on Sepolia, then confirm it server-side.
4. Verify the UI switches to the minted state and DB is updated accordingly.

## Ops / Migration / Deployment
- [ ] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: none
- Changed: none
- Removed: none

**DB / data migration**
- None

**Rollout / rollback plan**
- Rollout: merge to `staging` and deploy; ensure Privy smart wallet supported networks include Sepolia.
- Rollback: revert this PR (claim flow will fall back to single-chain behavior).

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option A: Visual demo

- Recording: https://discord.com/channels/1438561373012627456/1457968219410141225/1463635549100179611

*Demo script (for recording):*
1. Login.
2. Navigate to `/nft`.
3. Confirm “eligible” state (Top 100 snapshot user).
4. Click “Claim” and approve the smart wallet transaction on Ethereum Sepolia.
5. Confirm minted success state + minted NFT displayed.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

