### PR TITLE
feat: NFT-gated app access

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -491,6 +491,9 @@ LINEAR_GAME_FEEDBACK_LABEL_ID=
 NFT_CONTRACT_ADDRESS=
 # Chain ID where the NFT contract is deployed (defaults to 1 = Ethereum mainnet)
 NFT_CHAIN_ID=1
+# Enable NFT-gated app access (default: false). When enabled, non-holders are redirected to /nft
+# and most authenticated API routes return 403 unless the user has minted via the Top 100 flow.
+NFT_GATING_ENABLED=false
 
 
 # ============================================================================

--- a/apps/web/src/app/HomePageClient.tsx
+++ b/apps/web/src/app/HomePageClient.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Suspense, useEffect } from 'react';
+import { ComingSoon } from '@/components/shared/ComingSoon';
+import { Skeleton } from '@/components/shared/Skeleton';
+import { useAuth } from '@/hooks/useAuth';
+import { useLoginModal } from '@/hooks/useLoginModal';
+
+const waitlistModeEnabled = process.env.NEXT_PUBLIC_WAITLIST_MODE === 'true';
+
+function HomePageContent() {
+  const router = useRouter();
+  const { ready, authenticated } = useAuth();
+  const { showLoginModal } = useLoginModal();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    // Skip redirect logic if waitlist mode is enabled
+    if (waitlistModeEnabled) {
+      return;
+    }
+
+    // Wait for Privy to be ready before deciding to show login modal
+    // This prevents the modal from flashing on every page load
+    if (!ready) {
+      return;
+    }
+
+    // Show login modal if not authenticated
+    if (!authenticated) {
+      showLoginModal({
+        title: 'Welcome to Babylon',
+        message:
+          'Log in to start trading prediction markets, replying to NPCs, and earning rewards in this satirical game.',
+      });
+    }
+
+    // Redirect to feed, preserving referral code if present
+    const ref = searchParams.get('ref');
+    const feedUrl = ref ? `/feed?ref=${ref}` : '/feed';
+    router.push(feedUrl);
+  }, [ready, authenticated, router, showLoginModal, searchParams]);
+
+  // Show coming soon page if WAITLIST_MODE is enabled
+  if (waitlistModeEnabled) {
+    return <ComingSoon />;
+  }
+
+  // Show loading while redirecting to feed
+  return (
+    <div className="flex h-full items-center justify-center">
+      <div className="space-y-3">
+        <Skeleton className="h-12 w-48" />
+        <Skeleton className="h-4 w-64" />
+      </div>
+    </div>
+  );
+}
+
+export function HomePageClient() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex h-full items-center justify-center">
+          <div className="space-y-3">
+            <Skeleton className="h-12 w-48" />
+            <Skeleton className="h-4 w-64" />
+          </div>
+        </div>
+      }
+    >
+      <HomePageContent />
+    </Suspense>
+  );
+}

--- a/apps/web/src/app/HomePageClient.tsx
+++ b/apps/web/src/app/HomePageClient.tsx
@@ -38,7 +38,7 @@ function HomePageContent() {
 
     // Redirect to feed, preserving referral code if present
     const ref = searchParams.get('ref');
-    const feedUrl = ref ? `/feed?ref=${ref}` : '/feed';
+    const feedUrl = ref ? `/feed?ref=${encodeURIComponent(ref)}` : '/feed';
     router.push(feedUrl);
   }, [ready, authenticated, router, showLoginModal, searchParams]);
 

--- a/apps/web/src/app/api/nft/eligibility/route.ts
+++ b/apps/web/src/app/api/nft/eligibility/route.ts
@@ -1,7 +1,7 @@
 import { authenticate, successResponse, withErrorHandling } from '@babylon/api';
 import { db, eq, nftCollection, nftSnapshot } from '@babylon/db';
 import type { NextRequest } from 'next/server';
-import type { EligibilityResponse } from '@/types/nft';
+import type { EligibilityApiResponse, EligibilityResponse } from '@/types/nft';
 
 export const GET = withErrorHandling(async (request: NextRequest) => {
   const authUser = await authenticate(request);
@@ -25,12 +25,17 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     .limit(1);
 
   if (!snapshotEntry) {
-    return successResponse({
+    const payload = {
       eligible: false,
       status: 'not_eligible',
       hasMinted: false,
       reason: 'not_in_top_100',
-    } satisfies EligibilityResponse);
+    } satisfies EligibilityResponse;
+
+    return successResponse({
+      success: true,
+      data: payload,
+    } satisfies EligibilityApiResponse);
   }
 
   if (snapshotEntry.hasMinted && snapshotEntry.mintedTokenId !== null) {
@@ -44,7 +49,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       .where(eq(nftCollection.tokenId, snapshotEntry.mintedTokenId))
       .limit(1);
 
-    return successResponse({
+    const payload = {
       eligible: true,
       status: 'already_minted',
       snapshotRank: snapshotEntry.rank,
@@ -59,15 +64,25 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
             txHash: snapshotEntry.mintTxHash ?? '',
           }
         : undefined,
-    } satisfies EligibilityResponse);
+    } satisfies EligibilityResponse;
+
+    return successResponse({
+      success: true,
+      data: payload,
+    } satisfies EligibilityApiResponse);
   }
 
-  return successResponse({
+  const payload = {
     eligible: true,
     status: 'eligible',
     snapshotRank: snapshotEntry.rank,
     snapshotPoints: snapshotEntry.points,
     snapshotTakenAt: snapshotEntry.snapshotTakenAt.toISOString(),
     hasMinted: false,
-  } satisfies EligibilityResponse);
+  } satisfies EligibilityResponse;
+
+  return successResponse({
+    success: true,
+    data: payload,
+  } satisfies EligibilityApiResponse);
 });

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -10,6 +10,7 @@ import { Suspense } from 'react';
 import { Toaster } from 'sonner';
 import { FeedAuthBanner } from '@/components/auth/FeedAuthBanner';
 import { GlobalLoginModal } from '@/components/auth/GlobalLoginModal';
+import { isNftGatingEnabled } from '@babylon/shared';
 import { FeedbackButton } from '@/components/feedback/FeedbackButton';
 import { NftAccessGate, NftPromoBanner } from '@/components/nft';
 import { Providers } from '@/components/providers/Providers';
@@ -96,10 +97,7 @@ export default function RootLayout({
     (process.env.WAITLIST_MODE ?? process.env.NEXT_PUBLIC_WAITLIST_MODE) ===
     'true';
 
-  const nftGatingFlag = process.env.NFT_GATING_ENABLED ?? '';
-  const nftGatingEnabled = ['true', '1', 'yes', 'on'].includes(
-    nftGatingFlag.toLowerCase()
-  );
+  const nftGatingEnabled = isNftGatingEnabled();
 
   return (
     <html lang="en" suppressHydrationWarning className="overscroll-none">

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -11,7 +11,7 @@ import { Toaster } from 'sonner';
 import { FeedAuthBanner } from '@/components/auth/FeedAuthBanner';
 import { GlobalLoginModal } from '@/components/auth/GlobalLoginModal';
 import { FeedbackButton } from '@/components/feedback/FeedbackButton';
-import { NftPromoBanner } from '@/components/nft';
+import { NftAccessGate, NftPromoBanner } from '@/components/nft';
 import { Providers } from '@/components/providers/Providers';
 import { BottomNav } from '@/components/shared/BottomNav';
 import { MobileHeader } from '@/components/shared/MobileHeader';
@@ -96,6 +96,11 @@ export default function RootLayout({
     (process.env.WAITLIST_MODE ?? process.env.NEXT_PUBLIC_WAITLIST_MODE) ===
     'true';
 
+  const nftGatingFlag = process.env.NFT_GATING_ENABLED ?? '';
+  const nftGatingEnabled = ['true', '1', 'yes', 'on'].includes(
+    nftGatingFlag.toLowerCase()
+  );
+
   return (
     <html lang="en" suppressHydrationWarning className="overscroll-none">
       <body
@@ -109,6 +114,10 @@ export default function RootLayout({
           </Suspense>
 
           <WaitlistWrapper waitlistMode={waitlistMode}>
+            <Suspense fallback={null}>
+              <NftAccessGate enabled={nftGatingEnabled} />
+            </Suspense>
+
             {/* NFT Collection Promo Banner - at the very top */}
             <Suspense fallback={null}>
               <NftPromoBanner />

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next';
 import './globals.css';
 
+import { isNftGatingEnabled } from '@babylon/shared';
 // Vercel Analytics
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
@@ -10,7 +11,6 @@ import { Suspense } from 'react';
 import { Toaster } from 'sonner';
 import { FeedAuthBanner } from '@/components/auth/FeedAuthBanner';
 import { GlobalLoginModal } from '@/components/auth/GlobalLoginModal';
-import { isNftGatingEnabled } from '@babylon/shared';
 import { FeedbackButton } from '@/components/feedback/FeedbackButton';
 import { NftAccessGate, NftPromoBanner } from '@/components/nft';
 import { Providers } from '@/components/providers/Providers';

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,76 +1,27 @@
-'use client';
+import { redirect } from 'next/navigation';
+import { HomePageClient } from './HomePageClient';
 
-import { useRouter, useSearchParams } from 'next/navigation';
-import { Suspense, useEffect } from 'react';
-import { ComingSoon } from '@/components/shared/ComingSoon';
-import { Skeleton } from '@/components/shared/Skeleton';
-import { useAuth } from '@/hooks/useAuth';
-import { useLoginModal } from '@/hooks/useLoginModal';
+type HomePageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+};
 
-const waitlistModeEnabled = process.env.NEXT_PUBLIC_WAITLIST_MODE === 'true';
+export default async function HomePage({ searchParams }: HomePageProps) {
+  const nftGatingFlag = process.env.NFT_GATING_ENABLED ?? '';
+  const nftGatingEnabled = ['true', '1', 'yes', 'on'].includes(
+    nftGatingFlag.toLowerCase()
+  );
 
-function HomePageContent() {
-  const router = useRouter();
-  const { ready, authenticated } = useAuth();
-  const { showLoginModal } = useLoginModal();
-  const searchParams = useSearchParams();
+  if (nftGatingEnabled) {
+    const resolvedSearchParams = searchParams ? await searchParams : undefined;
+    const ref = resolvedSearchParams?.ref;
+    const referralCode = Array.isArray(ref) ? ref[0] : ref;
+    const params = new URLSearchParams();
+    if (referralCode) params.set('ref', referralCode);
+    params.set('gated', '1');
 
-  useEffect(() => {
-    // Skip redirect logic if waitlist mode is enabled
-    if (waitlistModeEnabled) {
-      return;
-    }
-
-    // Wait for Privy to be ready before deciding to show login modal
-    // This prevents the modal from flashing on every page load
-    if (!ready) {
-      return;
-    }
-
-    // Show login modal if not authenticated
-    if (!authenticated) {
-      showLoginModal({
-        title: 'Welcome to Babylon',
-        message:
-          'Log in to start trading prediction markets, replying to NPCs, and earning rewards in this satirical game.',
-      });
-    }
-
-    // Redirect to feed, preserving referral code if present
-    const ref = searchParams.get('ref');
-    const feedUrl = ref ? `/feed?ref=${ref}` : '/feed';
-    router.push(feedUrl);
-  }, [ready, authenticated, router, showLoginModal, searchParams]);
-
-  // Show coming soon page if WAITLIST_MODE is enabled
-  if (waitlistModeEnabled) {
-    return <ComingSoon />;
+    const qs = params.toString();
+    redirect(qs ? `/nft?${qs}` : '/nft');
   }
 
-  // Show loading while redirecting to feed
-  return (
-    <div className="flex h-full items-center justify-center">
-      <div className="space-y-3">
-        <Skeleton className="h-12 w-48" />
-        <Skeleton className="h-4 w-64" />
-      </div>
-    </div>
-  );
-}
-
-export default function HomePage() {
-  return (
-    <Suspense
-      fallback={
-        <div className="flex h-full items-center justify-center">
-          <div className="space-y-3">
-            <Skeleton className="h-12 w-48" />
-            <Skeleton className="h-4 w-64" />
-          </div>
-        </div>
-      }
-    >
-      <HomePageContent />
-    </Suspense>
-  );
+  return <HomePageClient />;
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,3 +1,4 @@
+import { isNftGatingEnabled } from '@babylon/shared';
 import { redirect } from 'next/navigation';
 import { HomePageClient } from './HomePageClient';
 
@@ -6,10 +7,7 @@ type HomePageProps = {
 };
 
 export default async function HomePage({ searchParams }: HomePageProps) {
-  const nftGatingFlag = process.env.NFT_GATING_ENABLED ?? '';
-  const nftGatingEnabled = ['true', '1', 'yes', 'on'].includes(
-    nftGatingFlag.toLowerCase()
-  );
+  const nftGatingEnabled = isNftGatingEnabled();
 
   if (nftGatingEnabled) {
     const resolvedSearchParams = searchParams ? await searchParams : undefined;

--- a/apps/web/src/components/nft/NftAccessGate.tsx
+++ b/apps/web/src/components/nft/NftAccessGate.tsx
@@ -58,18 +58,25 @@ export function NftAccessGate({ enabled }: { enabled: boolean }) {
     inFlightRef.current = controller;
 
     const run = async () => {
-      const response = await apiFetch('/api/nft/eligibility', {
-        cache: 'no-store',
-        signal: controller.signal,
-      });
+      try {
+        const response = await apiFetch('/api/nft/eligibility', {
+          cache: 'no-store',
+          signal: controller.signal,
+        });
 
-      if (!response.ok || controller.signal.aborted) {
-        router.replace(targetUrl);
-        return;
-      }
+        if (!response.ok || controller.signal.aborted) {
+          router.replace(targetUrl);
+          return;
+        }
 
-      const json = (await response.json()) as unknown;
-      if (!isEligibilityApiResponse(json) || json.data.hasMinted !== true) {
+        const json = (await response.json()) as unknown;
+        if (!isEligibilityApiResponse(json) || json.data.hasMinted !== true) {
+          router.replace(targetUrl);
+        }
+      } catch {
+        // Ignore abort errors from cleanup
+        if (controller.signal.aborted) return;
+        // On any other error, redirect to gate
         router.replace(targetUrl);
       }
     };

--- a/apps/web/src/components/nft/NftAccessGate.tsx
+++ b/apps/web/src/components/nft/NftAccessGate.tsx
@@ -21,8 +21,7 @@ export function NftAccessGate({ enabled }: { enabled: boolean }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const router = useRouter();
-  const { ready, authenticated, loadingProfile, user, getAccessToken } =
-    useAuth();
+  const { ready, authenticated, loadingProfile, user } = useAuth();
 
   const inFlightRef = useRef<AbortController | null>(null);
 
@@ -47,14 +46,9 @@ export function NftAccessGate({ enabled }: { enabled: boolean }) {
     inFlightRef.current = controller;
 
     const run = async () => {
-      const token = await getAccessToken();
-      if (!token || controller.signal.aborted) {
-        router.replace(targetUrl);
-        return;
-      }
-
       const response = await fetch('/api/nft/eligibility', {
-        headers: { Authorization: `Bearer ${token}` },
+        credentials: 'include',
+        cache: 'no-store',
         signal: controller.signal,
       });
 
@@ -88,7 +82,6 @@ export function NftAccessGate({ enabled }: { enabled: boolean }) {
     authenticated,
     loadingProfile,
     user?.isAdmin,
-    getAccessToken,
   ]);
 
   return null;

--- a/apps/web/src/components/nft/NftAccessGate.tsx
+++ b/apps/web/src/components/nft/NftAccessGate.tsx
@@ -5,6 +5,7 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import type { EligibilityResponse } from '@/types/nft';
+import { apiFetch } from '@/utils/api-fetch';
 
 type ApiResponse<T> =
   | { success: true; data: T }
@@ -46,8 +47,7 @@ export function NftAccessGate({ enabled }: { enabled: boolean }) {
     inFlightRef.current = controller;
 
     const run = async () => {
-      const response = await fetch('/api/nft/eligibility', {
-        credentials: 'include',
+      const response = await apiFetch('/api/nft/eligibility', {
         cache: 'no-store',
         signal: controller.signal,
       });

--- a/apps/web/src/components/nft/NftAccessGate.tsx
+++ b/apps/web/src/components/nft/NftAccessGate.tsx
@@ -4,12 +4,8 @@ import { isNftGatingAllowlistedPath } from '@babylon/shared';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 import { useAuth } from '@/hooks/useAuth';
-import type { EligibilityResponse } from '@/types/nft';
+import type { EligibilityApiResponse } from '@/types/nft';
 import { apiFetch } from '@/utils/api-fetch';
-
-type ApiResponse<T> =
-  | { success: true; data: T }
-  | { success: false; error?: unknown };
 
 function buildNftRedirectUrl(searchParams: URLSearchParams): string {
   const nextParams = new URLSearchParams(searchParams);
@@ -18,6 +14,21 @@ function buildNftRedirectUrl(searchParams: URLSearchParams): string {
   return qs ? `/nft?${qs}` : '/nft';
 }
 
+function isEligibilityApiResponse(
+  value: unknown
+): value is EligibilityApiResponse {
+  if (typeof value !== 'object' || value === null) return false;
+  if (
+    !('success' in value) ||
+    (value as { success: unknown }).success !== true
+  ) {
+    return false;
+  }
+  if (!('data' in value)) return false;
+  const data = (value as { data: unknown }).data;
+  if (typeof data !== 'object' || data === null) return false;
+  return 'hasMinted' in data;
+}
 export function NftAccessGate({ enabled }: { enabled: boolean }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -57,13 +68,8 @@ export function NftAccessGate({ enabled }: { enabled: boolean }) {
         return;
       }
 
-      const json = (await response.json()) as ApiResponse<EligibilityResponse>;
-      if (!('success' in json) || json.success !== true) {
-        router.replace(targetUrl);
-        return;
-      }
-
-      if (json.data.hasMinted !== true) {
+      const json = (await response.json()) as unknown;
+      if (!isEligibilityApiResponse(json) || json.data.hasMinted !== true) {
         router.replace(targetUrl);
       }
     };

--- a/apps/web/src/components/nft/NftAccessGate.tsx
+++ b/apps/web/src/components/nft/NftAccessGate.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { isNftGatingAllowlistedPath } from '@babylon/shared';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+import { useAuth } from '@/hooks/useAuth';
+import type { EligibilityResponse } from '@/types/nft';
+
+type ApiResponse<T> =
+  | { success: true; data: T }
+  | { success: false; error?: unknown };
+
+function buildNftRedirectUrl(searchParams: URLSearchParams): string {
+  const nextParams = new URLSearchParams(searchParams);
+  nextParams.set('gated', '1');
+  const qs = nextParams.toString();
+  return qs ? `/nft?${qs}` : '/nft';
+}
+
+export function NftAccessGate({ enabled }: { enabled: boolean }) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const { ready, authenticated, loadingProfile, user, getAccessToken } =
+    useAuth();
+
+  const inFlightRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (!pathname) return;
+    if (isNftGatingAllowlistedPath(pathname)) return;
+    if (!ready) return;
+
+    const targetUrl = buildNftRedirectUrl(searchParams);
+
+    if (!authenticated) {
+      router.replace(targetUrl);
+      return;
+    }
+
+    if (loadingProfile) return;
+    if (user?.isAdmin) return;
+
+    inFlightRef.current?.abort();
+    const controller = new AbortController();
+    inFlightRef.current = controller;
+
+    const run = async () => {
+      const token = await getAccessToken();
+      if (!token || controller.signal.aborted) {
+        router.replace(targetUrl);
+        return;
+      }
+
+      const response = await fetch('/api/nft/eligibility', {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: controller.signal,
+      });
+
+      if (!response.ok || controller.signal.aborted) {
+        router.replace(targetUrl);
+        return;
+      }
+
+      const json = (await response.json()) as ApiResponse<EligibilityResponse>;
+      if (!('success' in json) || json.success !== true) {
+        router.replace(targetUrl);
+        return;
+      }
+
+      if (json.data.hasMinted !== true) {
+        router.replace(targetUrl);
+      }
+    };
+
+    void run();
+
+    return () => {
+      controller.abort();
+    };
+  }, [
+    enabled,
+    pathname,
+    searchParams,
+    router,
+    ready,
+    authenticated,
+    loadingProfile,
+    user?.isAdmin,
+    getAccessToken,
+  ]);
+
+  return null;
+}

--- a/apps/web/src/components/nft/index.ts
+++ b/apps/web/src/components/nft/index.ts
@@ -1,4 +1,5 @@
 export { MintBanner } from './MintBanner';
+export { NftAccessGate } from './NftAccessGate';
 export { NftCard } from './NftCard';
 export { NftGrid } from './NftGrid';
 export { NftPromoBanner } from './NftPromoBanner';

--- a/apps/web/src/hooks/useNftMint.ts
+++ b/apps/web/src/hooks/useNftMint.ts
@@ -3,6 +3,7 @@ import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
 import { useSmartWallet } from '@/hooks/useSmartWallet';
 import type {
+  EligibilityApiResponse,
   EligibilityResponse,
   MintConfirmResponse,
   MintFlowState,
@@ -89,7 +90,8 @@ export function useNftMint(): UseNftMintResult {
           return;
         }
 
-        const data: EligibilityResponse = await response.json();
+        const json: EligibilityApiResponse = await response.json();
+        const data: EligibilityResponse = json.data;
 
         // Check if aborted before updating state
         if (signal?.aborted) return;

--- a/apps/web/src/types/nft.ts
+++ b/apps/web/src/types/nft.ts
@@ -117,6 +117,17 @@ export interface EligibilityResponse {
 }
 
 /**
+ * Eligibility API response wrapper
+ *
+ * Note: we use a wrapped format here to keep API responses consistent with other
+ * NFT endpoints that return `{ success, data }`.
+ */
+export interface EligibilityApiResponse {
+  success: true;
+  data: EligibilityResponse;
+}
+
+/**
  * Mint preparation response (contract call data with signature)
  */
 export interface MintPrepareResponse {

--- a/packages/api/src/__tests__/auth-middleware.test.ts
+++ b/packages/api/src/__tests__/auth-middleware.test.ts
@@ -3,6 +3,7 @@ import type { NextRequest } from 'next/server';
 
 // Type for mock request
 interface MockNextRequest {
+  url: string;
   headers: {
     get: (name: string) => string | null;
   };
@@ -15,6 +16,18 @@ const mockVerifyAgentSession = mock();
 const mockVerifyAuthToken = mock();
 const mockSelect = mock();
 
+const usersTable = {
+  id: 'id',
+  privyId: 'privyId',
+  walletAddress: 'walletAddress',
+  isAdmin: 'isAdmin',
+};
+
+const nftSnapshotTable = {
+  userId: 'userId',
+  hasMinted: 'hasMinted',
+};
+
 // Mock the local agent-auth module
 mock.module('../agent-auth', () => ({
   verifyAgentSession: mockVerifyAgentSession,
@@ -26,11 +39,8 @@ mock.module('@babylon/db', () => ({
     select: mockSelect,
   },
   eq: (field: unknown, value: unknown) => ({ field, value }),
-  users: {
-    id: 'id',
-    privyId: 'privyId',
-    walletAddress: 'walletAddress',
-  },
+  users: usersTable,
+  nftSnapshot: nftSnapshotTable,
 }));
 
 // Mock @privy-io/server-auth - PrivyClient is a class that gets instantiated
@@ -43,8 +53,13 @@ mock.module('@privy-io/server-auth', () => ({
 // Import after mocks are set up
 import { authenticate } from '../auth-middleware';
 
-const createRequest = (token: string): NextRequest =>
+let usersRows: Array<{ id: string; walletAddress: string; isAdmin?: boolean }> =
+  [];
+let snapshotRows: Array<{ hasMinted: boolean }> = [];
+
+const createRequest = (token: string, pathname: string): NextRequest =>
   ({
+    url: `https://example.com${pathname}`,
     headers: {
       get: (name: string) =>
         name.toLowerCase() === 'authorization' ? `Bearer ${token}` : null,
@@ -61,21 +76,29 @@ describe('authenticate middleware', () => {
     mockSelect.mockReset();
     process.env.NEXT_PUBLIC_PRIVY_APP_ID = 'test-app';
     process.env.PRIVY_APP_SECRET = 'test-secret';
+    process.env.NFT_GATING_ENABLED = 'false';
+    usersRows = [];
+    snapshotRows = [];
 
     // Default mock chain for db.select().from().where().limit()
-    mockSelect.mockReturnValue({
-      from: () => ({
+    mockSelect.mockImplementation(() => ({
+      from: (table: unknown) => ({
         where: () => ({
-          limit: () => Promise.resolve([]),
+          limit: () => {
+            if (table === usersTable) return Promise.resolve(usersRows);
+            if (table === nftSnapshotTable)
+              return Promise.resolve(snapshotRows);
+            return Promise.resolve([]);
+          },
         }),
       }),
-    });
+    }));
   });
 
   it('returns agent user when session token is valid', async () => {
     mockVerifyAgentSession.mockReturnValueOnce({ agentId: 'agent-123' });
 
-    const request = createRequest('agent-session-token');
+    const request = createRequest('agent-session-token', '/api/posts');
     const result = await authenticate(request);
 
     expect(result).toEqual({
@@ -90,16 +113,9 @@ describe('authenticate middleware', () => {
     mockVerifyAgentSession.mockReturnValueOnce(null);
     mockVerifyAuthToken.mockResolvedValueOnce({ userId: 'privy-user' });
 
-    // Mock empty db result
-    mockSelect.mockReturnValue({
-      from: () => ({
-        where: () => ({
-          limit: () => Promise.resolve([]),
-        }),
-      }),
-    });
+    usersRows = [];
 
-    const request = createRequest('privy-token');
+    const request = createRequest('privy-token', '/api/users/me');
     const result = await authenticate(request);
 
     expect(result).toMatchObject({
@@ -115,21 +131,9 @@ describe('authenticate middleware', () => {
     mockVerifyAuthToken.mockResolvedValueOnce({ userId: 'privy-user' });
 
     // Mock db user found
-    mockSelect.mockReturnValue({
-      from: () => ({
-        where: () => ({
-          limit: () =>
-            Promise.resolve([
-              {
-                id: 'db-user-id',
-                walletAddress: '0xabc',
-              },
-            ]),
-        }),
-      }),
-    });
+    usersRows = [{ id: 'db-user-id', walletAddress: '0xabc', isAdmin: false }];
 
-    const request = createRequest('privy-token');
+    const request = createRequest('privy-token', '/api/users/me');
     const result = await authenticate(request);
 
     expect(result).toMatchObject({
@@ -137,6 +141,7 @@ describe('authenticate middleware', () => {
       dbUserId: 'db-user-id',
       privyId: 'privy-user',
       walletAddress: '0xabc',
+      isAdmin: false,
     });
   });
 
@@ -146,7 +151,7 @@ describe('authenticate middleware', () => {
       new Error('token expired: exp mismatch')
     );
 
-    const request = createRequest('expired-token');
+    const request = createRequest('expired-token', '/api/users/me');
 
     try {
       await authenticate(request);
@@ -158,5 +163,59 @@ describe('authenticate middleware', () => {
       );
       expect((error as { code: string }).code).toBe('AUTH_FAILED');
     }
+  });
+
+  it('enforces NFT gating when enabled for non-allowlisted API paths', async () => {
+    process.env.NFT_GATING_ENABLED = 'true';
+
+    mockVerifyAgentSession.mockReturnValueOnce(null);
+    mockVerifyAuthToken.mockResolvedValueOnce({ userId: 'privy-user' });
+    usersRows = [{ id: 'db-user-id', walletAddress: '0xabc', isAdmin: false }];
+    snapshotRows = [{ hasMinted: false }];
+
+    const request = createRequest('privy-token', '/api/posts');
+
+    try {
+      await authenticate(request);
+      expect.unreachable('Should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe('NFT access required');
+      expect((error as { code: string }).code).toBe('FORBIDDEN');
+    }
+  });
+
+  it('does not enforce NFT gating for allowlisted paths', async () => {
+    process.env.NFT_GATING_ENABLED = 'true';
+
+    mockVerifyAgentSession.mockReturnValueOnce(null);
+    mockVerifyAuthToken.mockResolvedValueOnce({ userId: 'privy-user' });
+    usersRows = [{ id: 'db-user-id', walletAddress: '0xabc', isAdmin: false }];
+    snapshotRows = [{ hasMinted: false }];
+
+    const request = createRequest('privy-token', '/api/users/me');
+    const result = await authenticate(request);
+
+    expect(result).toMatchObject({
+      userId: 'db-user-id',
+      dbUserId: 'db-user-id',
+    });
+  });
+
+  it('bypasses NFT gating for admins', async () => {
+    process.env.NFT_GATING_ENABLED = 'true';
+
+    mockVerifyAgentSession.mockReturnValueOnce(null);
+    mockVerifyAuthToken.mockResolvedValueOnce({ userId: 'privy-user' });
+    usersRows = [{ id: 'db-user-id', walletAddress: '0xabc', isAdmin: true }];
+    snapshotRows = [{ hasMinted: false }];
+
+    const request = createRequest('privy-token', '/api/posts');
+    const result = await authenticate(request);
+
+    expect(result).toMatchObject({
+      userId: 'db-user-id',
+      isAdmin: true,
+    });
   });
 });

--- a/packages/api/src/__tests__/auth-middleware.test.ts
+++ b/packages/api/src/__tests__/auth-middleware.test.ts
@@ -218,4 +218,22 @@ describe('authenticate middleware', () => {
       isAdmin: true,
     });
   });
+
+  it('allows access for minted users when NFT gating is enabled', async () => {
+    process.env.NFT_GATING_ENABLED = 'true';
+
+    mockVerifyAgentSession.mockReturnValueOnce(null);
+    mockVerifyAuthToken.mockResolvedValueOnce({ userId: 'privy-user' });
+    usersRows = [{ id: 'db-user-id', walletAddress: '0xabc', isAdmin: false }];
+    snapshotRows = [{ hasMinted: true }];
+
+    const request = createRequest('privy-token', '/api/posts');
+    const result = await authenticate(request);
+
+    expect(result).toMatchObject({
+      userId: 'db-user-id',
+      dbUserId: 'db-user-id',
+      isAdmin: false,
+    });
+  });
 });

--- a/packages/api/src/auth-middleware.ts
+++ b/packages/api/src/auth-middleware.ts
@@ -320,7 +320,11 @@ export async function optionalAuth(
       const claims = await privy.verifyAuthToken(tokenToVerify);
 
       const dbUserResult = await db
-        .select({ id: users.id, walletAddress: users.walletAddress })
+        .select({
+          id: users.id,
+          walletAddress: users.walletAddress,
+          isAdmin: users.isAdmin,
+        })
         .from(users)
         .where(eq(users.privyId, claims.userId))
         .limit(1);
@@ -332,6 +336,7 @@ export async function optionalAuth(
         privyId: claims.userId,
         walletAddress: dbUser?.walletAddress ?? undefined,
         email: undefined,
+        isAdmin: dbUser?.isAdmin ?? false,
         isAgent: false,
       };
     } catch {

--- a/packages/api/src/auth-middleware.ts
+++ b/packages/api/src/auth-middleware.ts
@@ -7,12 +7,20 @@
  */
 
 import { db, eq, users } from '@babylon/db';
-import type { AuthenticatedUser } from '@babylon/shared';
+import {
+  type AuthenticatedUser,
+  isNftGatingAllowlistedPath,
+} from '@babylon/shared';
 import { PrivyClient } from '@privy-io/server-auth';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { verifyAgentSession } from './agent-auth';
-import { AuthenticationError, isAuthenticationError } from './errors';
+import {
+  AuthenticationError,
+  AuthorizationError,
+  isAuthenticationError,
+} from './errors';
+import { hasNftAccess } from './services/nft-access-service';
 
 // Re-export types from shared for backwards compatibility
 export type { AuthenticatedUser } from '@babylon/shared';
@@ -60,6 +68,13 @@ export function getPrivyClient(): PrivyClient {
 export async function authenticate(
   request: NextRequest
 ): Promise<AuthenticatedUser> {
+  const pathname = new URL(request.url).pathname;
+
+  const nftGatingFlag = process.env.NFT_GATING_ENABLED ?? '';
+  const nftGatingEnabled = ['true', '1', 'yes', 'on'].includes(
+    nftGatingFlag.toLowerCase()
+  );
+
   const authHeader = request.headers.get('authorization');
   let token: string | undefined;
 
@@ -161,21 +176,68 @@ export async function authenticate(
       const claims = await privy.verifyAuthToken(tokenToVerify);
 
       const dbUserResult = await db
-        .select({ id: users.id, walletAddress: users.walletAddress })
+        .select({
+          id: users.id,
+          walletAddress: users.walletAddress,
+          isAdmin: users.isAdmin,
+        })
         .from(users)
         .where(eq(users.privyId, claims.userId))
         .limit(1);
       const dbUser = dbUserResult[0];
 
-      return {
+      const authedUser: AuthenticatedUser = {
         userId: dbUser?.id ?? claims.userId,
         dbUserId: dbUser?.id,
         privyId: claims.userId,
         walletAddress: dbUser?.walletAddress ?? undefined,
         email: undefined,
+        isAdmin: dbUser?.isAdmin ?? false,
         isAgent: false,
       };
+
+      if (
+        nftGatingEnabled &&
+        !authedUser.isAgent &&
+        !authedUser.isAdmin &&
+        !isNftGatingAllowlistedPath(pathname)
+      ) {
+        if (!authedUser.dbUserId) {
+          throw new AuthorizationError('NFT access required', 'nft', 'access', {
+            pathname,
+          });
+        }
+
+        const allowed = await hasNftAccess(authedUser.dbUserId);
+        if (!allowed) {
+          throw new AuthorizationError('NFT access required', 'nft', 'access', {
+            pathname,
+          });
+        }
+      }
+
+      return authedUser;
     } catch (error) {
+      if (error instanceof AuthorizationError) {
+        throw error;
+      }
+
+      const errorMessage =
+        error instanceof Error ? error.message.toLowerCase() : '';
+      const isExpiredTokenError =
+        errorMessage.includes('token expired') ||
+        errorMessage.includes('exp mismatch');
+
+      if (isExpiredTokenError) {
+        // If this isn't the last token to try, continue to the next one
+        if (tokensToTry.indexOf(tokenToVerify) < tokensToTry.length - 1) {
+          continue;
+        }
+        throw new AuthenticationError(
+          'Authentication token has expired. Please refresh your session.'
+        );
+      }
+
       lastError = error as Error;
       // If this isn't the last token to try, continue to the next one
       if (tokensToTry.indexOf(tokenToVerify) < tokensToTry.length - 1) {

--- a/packages/api/src/services/index.ts
+++ b/packages/api/src/services/index.ts
@@ -23,6 +23,7 @@ export * from './feedback-service';
 export * from './generation-lock-service';
 // Moderation Services
 export * from './moderation';
+export * from './nft-access-service';
 export * from './nft-group-service';
 export * from './nft-mint-service';
 export * from './nft-verification-service';

--- a/packages/api/src/services/nft-access-service.ts
+++ b/packages/api/src/services/nft-access-service.ts
@@ -1,0 +1,15 @@
+import { db, eq, nftSnapshot } from '@babylon/db';
+
+/**
+ * Returns true if the user has minted via our Top 100 claim flow.
+ * (Secondary ownership / on-chain indexing is handled in a later PR.)
+ */
+export async function hasNftAccess(dbUserId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ hasMinted: nftSnapshot.hasMinted })
+    .from(nftSnapshot)
+    .where(eq(nftSnapshot.userId, dbUserId))
+    .limit(1);
+
+  return row?.hasMinted === true;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -118,6 +118,12 @@ export * from './share';
 export * from './config';
 
 // =============================================================================
+// NFT utilities (client-safe)
+// =============================================================================
+
+export * from './nft';
+
+// =============================================================================
 // NOT EXPORTED (Server-only modules - import from @babylon/api):
 // =============================================================================
 // - Token counting: import { countTokens, countTokensSync } from '@babylon/api'

--- a/packages/shared/src/nft/gating.ts
+++ b/packages/shared/src/nft/gating.ts
@@ -1,0 +1,35 @@
+const EXACT_ALLOWLIST = new Set<string>([
+  // Pages
+  '/nft',
+  '/share',
+  '/api-docs',
+  '/mcp',
+  '/.well-known',
+
+  // API routes (exact)
+  '/api/users/me',
+  '/api/users/signup',
+  '/api/upload',
+]);
+
+const PREFIX_ALLOWLIST = [
+  // Pages
+  '/nft/',
+  '/share/',
+  '/api-docs/',
+  '/.well-known/',
+
+  // API routes
+  '/api/nft/',
+  '/api/og/',
+  '/api/auth/',
+  '/api/users/onboarding/',
+  '/api/onboarding/',
+  '/api/upload/',
+  '/api/waitlist/',
+] as const;
+
+export function isNftGatingAllowlistedPath(pathname: string): boolean {
+  if (EXACT_ALLOWLIST.has(pathname)) return true;
+  return PREFIX_ALLOWLIST.some((prefix) => pathname.startsWith(prefix));
+}

--- a/packages/shared/src/nft/gating.ts
+++ b/packages/shared/src/nft/gating.ts
@@ -33,3 +33,12 @@ export function isNftGatingAllowlistedPath(pathname: string): boolean {
   if (EXACT_ALLOWLIST.has(pathname)) return true;
   return PREFIX_ALLOWLIST.some((prefix) => pathname.startsWith(prefix));
 }
+
+/**
+ * Check if NFT gating is enabled via environment variable.
+ * Accepts: 'true', '1', 'yes', 'on' (case-insensitive)
+ */
+export function isNftGatingEnabled(): boolean {
+  const flag = process.env.NFT_GATING_ENABLED ?? '';
+  return ['true', '1', 'yes', 'on'].includes(flag.toLowerCase());
+}

--- a/packages/shared/src/nft/index.ts
+++ b/packages/shared/src/nft/index.ts
@@ -1,0 +1,5 @@
+/**
+ * NFT utilities (client-safe)
+ */
+
+export * from './gating';

--- a/packages/shared/src/types/auth.ts
+++ b/packages/shared/src/types/auth.ts
@@ -16,5 +16,6 @@ export interface AuthenticatedUser {
   privyId?: string;
   walletAddress?: string;
   email?: string;
+  isAdmin?: boolean;
   isAgent?: boolean;
 }


### PR DESCRIPTION
## Summary
- Add NFT-gated app access (hard redirect to `/nft`) for users who have **not** minted via the Top 100 claim flow.
- Enforce gating at the API boundary (403) while keeping account creation + onboarding + claim-related endpoints functional.
- Preserve `?ref=` on redirects to `/nft` so referrals keep working under gating.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Linear: BAB-144
- Claim/multi-chain PR: https://github.com/BabylonSocial/babylon/pull/825

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] API infra (`packages/api`)
- [x] Shared types/utils (`packages/shared`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Tests (`packages/testing`)

## Changes
- Add env flag `NFT_GATING_ENABLED` (default `false`).
- Central allowlist matcher for gating (`isNftGatingAllowlistedPath`).
- API-side enforcement in `authenticate()`:
  - bypass: agents + admins
  - allowlisted paths: `/nft`, `/api/nft/*`, `/api/auth/*`, `/api/users/me`, onboarding, uploads, OG, share, etc.
  - otherwise: require `NftSnapshot.hasMinted === true` or return 403.
- UI-side enforcement:
  - global client gate component redirects non-holders to `/nft`.
  - home page server redirect to `/nft` when gating is enabled.

## Review guide

**Start here**
- `packages/api/src/auth-middleware.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- This PR gates based on **mint via our flow only** (`NftSnapshot.hasMinted`). On-chain secondary ownership will be handled later.
- Keep `NFT_GATING_ENABLED=false` by default; enable it in staging when ready.

## Test plan

**Commands run**
- [x] `bun test packages/api/src/__tests__/auth-middleware.test.ts`
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`

**Manual verification**
1. Set `NFT_GATING_ENABLED=true`.
2. Non-holder: navigating to `/feed` (or other pages) redirects to `/nft` (keeps `?ref=`).
3. Non-holder: `/nft` remains usable (login + eligibility + claim flow + onboarding endpoints).
4. Holder: can access the full app normally.
5. API: non-allowlisted authenticated endpoints return 403 for non-holders.

## Ops / Migration / Deployment
- [ ] No deploy impact
- [x] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `NFT_GATING_ENABLED` (default `false`)

**Rollout / rollback plan**
- Rollout: deploy, then set `NFT_GATING_ENABLED=true` in staging.
- Rollback: set `NFT_GATING_ENABLED=false` (no code rollback required).

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy
- [ ] No security impact
- [x] Needs extra review (authz change)

## Screenshots / recordings (UI)

### Option A: Visual demo
- Screen recording: https://discord.com/channels/1438561373012627456/1457968219410141225/1463704980836974708

*Demo script (for recording):*
1. Enable `NFT_GATING_ENABLED=true`.
2. Open `/feed` as non-holder → redirected to `/nft?gated=1` (preserves `?ref=`).
3. Mint via `/nft` flow → access granted (no more redirect) + API calls return 200 instead of 403.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NFT gating: when enabled, non-holders are redirected to the NFT verification page; admins and minted users bypass the gate. Home page now short-circuits to the gate when active and preserves ref query params.
  * Client-side gating UI: loading skeletons, login modal/redirect behavior, and a Coming Soon view in waitlist mode.

* **Chores**
  * Added NFT_GATING_ENABLED env var.
  * Standardized NFT eligibility API responses (wrapped success/data shape).

* **Tests**
  * Added tests covering NFT gating, allowlisted paths, admin bypass, and minted vs non-minted cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Adds NFT-gated app access controlled by `NFT_GATING_ENABLED` env flag (default: false). When enabled, non-holders are hard-redirected to `/nft` while preserving referral parameters.

**Key changes:**
- Central gating enforcement in `authenticate()` middleware that checks `NftSnapshot.hasMinted` after Privy verification
- Agents and admins bypass gating entirely
- Comprehensive path allowlist covers auth, onboarding, NFT claim flow, uploads, OG, share, and waitlist endpoints
- Client-side `NftAccessGate` component provides additional redirect protection with eligibility API checks
- Homepage server-side redirect ensures immediate gating without client-side flicker
- Tests cover enforcement, allowlist bypass, and admin bypass scenarios

**Implementation notes:**
- Gating is based solely on mint via the Top 100 claim flow (`NftSnapshot.hasMinted`); secondary on-chain ownership verification is deferred to a future PR
- The check for `!authedUser.dbUserId` at line 205 throws 403 for authenticated Privy users without DB records, which could affect new user onboarding if `/api/users/signup` isn't sufficient for the full flow (already noted in previous thread)

<h3>Confidence Score: 4/5</h3>


- Safe to merge with careful deployment
- Well-tested gating implementation with comprehensive test coverage and clear rollback path (toggle env flag). Minor concern about onboarding flow edge case when gating is enabled for new users without dbUserId, though this is already under review in previous thread. Default-off flag provides safety.
- Pay close attention to `packages/api/src/auth-middleware.ts` - verify the onboarding flow works correctly with gating enabled for new users

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/api/src/auth-middleware.ts | Added NFT gating enforcement in authenticate() with admin/agent bypass and path allowlist checking. Gating logic runs after Privy verification and checks hasMinted status. Improved error handling for expired tokens. |
| packages/shared/src/nft/gating.ts | Central allowlist matcher for NFT gating with exact and prefix matching. Covers auth, onboarding, nft, og, upload, waitlist, and share endpoints. |
| packages/api/src/services/nft-access-service.ts | Simple service to check if user has minted via Top 100 claim flow by querying NftSnapshot.hasMinted. Secondary ownership checks deferred to later PR. |
| apps/web/src/components/nft/NftAccessGate.tsx | Client-side gate component that redirects non-holders to /nft while preserving query params. Checks eligibility API and handles auth state transitions with abort controller cleanup. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Browser
    participant NftAccessGate
    participant HomePage
    participant API
    participant AuthMiddleware
    participant NftAccessService
    participant Database

    Note over User,Database: NFT Gating Flow (NFT_GATING_ENABLED=true)

    User->>Browser: Navigate to /feed
    Browser->>HomePage: Request page
    HomePage->>HomePage: Check NFT_GATING_ENABLED
    alt Gating enabled on homepage
        HomePage->>Browser: Server redirect to /nft?gated=1
        Browser->>User: Show /nft page
    end

    User->>Browser: Navigate to /feed (client-side)
    Browser->>NftAccessGate: useEffect triggered
    NftAccessGate->>NftAccessGate: Check if path allowlisted
    alt Path not allowlisted
        NftAccessGate->>NftAccessGate: Check if authenticated
        alt Not authenticated
            NftAccessGate->>Browser: Redirect to /nft?gated=1
        else Authenticated
            NftAccessGate->>API: GET /api/nft/eligibility
            API->>AuthMiddleware: authenticate(request)
            AuthMiddleware->>AuthMiddleware: Parse pathname & check NFT_GATING_ENABLED
            AuthMiddleware->>AuthMiddleware: Verify Privy token
            AuthMiddleware->>Database: Query user by privyId
            Database->>AuthMiddleware: Return user (with isAdmin)
            AuthMiddleware->>AuthMiddleware: Check if agent/admin
            alt Agent or admin
                AuthMiddleware->>API: Return authedUser (bypass gating)
            else Regular user
                AuthMiddleware->>AuthMiddleware: Check if path allowlisted
                alt Path allowlisted
                    AuthMiddleware->>API: Return authedUser
                else Path not allowlisted
                    AuthMiddleware->>AuthMiddleware: Check if dbUserId exists
                    alt No dbUserId
                        AuthMiddleware->>API: Throw AuthorizationError(403)
                    else Has dbUserId
                        AuthMiddleware->>NftAccessService: hasNftAccess(dbUserId)
                        NftAccessService->>Database: Query NftSnapshot.hasMinted
                        Database->>NftAccessService: Return hasMinted
                        alt hasMinted === true
                            NftAccessService->>AuthMiddleware: Return true
                            AuthMiddleware->>API: Return authedUser
                        else hasMinted === false
                            NftAccessService->>AuthMiddleware: Return false
                            AuthMiddleware->>API: Throw AuthorizationError(403)
                        end
                    end
                end
            end
            API->>Database: Query NftSnapshot for eligibility
            Database->>API: Return snapshot data
            API->>NftAccessGate: Return eligibility response
            alt hasMinted === false
                NftAccessGate->>Browser: Redirect to /nft?gated=1
            else hasMinted === true
                NftAccessGate->>Browser: Allow access
                Browser->>User: Show /feed
            end
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->