### PR TITLE
feat(auth): add SIWE authentication for agent registration

### DIFF
--- a/apps/web/src/app/api/auth/siwe/authenticate/route.ts
+++ b/apps/web/src/app/api/auth/siwe/authenticate/route.ts
@@ -99,7 +99,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
   // Validate request body
   const parseResult = AuthSchema.safeParse(body);
   if (!parseResult.success) {
-    const firstError = parseResult.error.errors[0];
+    const firstError = parseResult.error.issues[0];
     return NextResponse.json(
       {
         error: 'validation_error',

--- a/apps/web/src/app/api/auth/siwe/authenticate/route.ts
+++ b/apps/web/src/app/api/auth/siwe/authenticate/route.ts
@@ -1,0 +1,270 @@
+/**
+ * SIWE Authentication Endpoint
+ *
+ * @route POST /api/auth/siwe/authenticate
+ * @access Public
+ *
+ * @description
+ * Authenticates an agent using SIWE (Sign-In With Ethereum).
+ * - If wallet exists: Issues a new API key (login)
+ * - If wallet doesn't exist: Creates new user with isAgent=true (register)
+ *
+ * @openapi
+ * /api/auth/siwe/authenticate:
+ *   post:
+ *     tags:
+ *       - Authentication
+ *     summary: Authenticate/Register agent via SIWE
+ *     description: |
+ *       Verify SIWE signature and either login (existing wallet) or register (new wallet).
+ *       For new registrations, username is required.
+ *       For existing users, a new API key is issued.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - message
+ *               - signature
+ *               - username
+ *             properties:
+ *               message:
+ *                 type: string
+ *                 description: EIP-4361 SIWE message
+ *               signature:
+ *                 type: string
+ *                 description: Signature from wallet
+ *               username:
+ *                 type: string
+ *                 description: Desired username (3-30 chars) - used for registration, ignored for login
+ *     responses:
+ *       200:
+ *         description: Authentication successful
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                 isNewUser:
+ *                   type: boolean
+ *                   description: True if this was a new registration
+ *                 userId:
+ *                   type: string
+ *                 username:
+ *                   type: string
+ *                 walletAddress:
+ *                   type: string
+ *                 apiKey:
+ *                   type: string
+ *                   description: API key (only shown once!)
+ *       400:
+ *         description: Invalid nonce, signature, domain, or username
+ *       409:
+ *         description: Username already taken
+ */
+
+import {
+  generateApiKey,
+  hashApiKey,
+  successResponse,
+  verifySiweMessage,
+  withErrorHandling,
+} from '@babylon/api';
+import {
+  db,
+  eq,
+  generateSnowflakeId,
+  sql,
+  userApiKeys,
+  users,
+  withTransaction,
+} from '@babylon/db';
+import { logger, UsernameSchema } from '@babylon/shared';
+import { type NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const AuthSchema = z.object({
+  message: z.string().min(1, 'Message is required'),
+  signature: z.string().min(1, 'Signature is required'),
+  username: UsernameSchema, // Always required - used for registration, ignored for login
+});
+
+export const POST = withErrorHandling(async (request: NextRequest) => {
+  const body = await request.json();
+
+  // Validate request body
+  const parseResult = AuthSchema.safeParse(body);
+  if (!parseResult.success) {
+    const firstError = parseResult.error.errors[0];
+    return NextResponse.json(
+      {
+        error: 'validation_error',
+        message: firstError?.message || 'Invalid request',
+      },
+      { status: 400 }
+    );
+  }
+
+  const { message, signature, username } = parseResult.data;
+
+  // Verify SIWE signature
+  const verifyResult = await verifySiweMessage(message, signature);
+  if (!verifyResult.success) {
+    return NextResponse.json(
+      {
+        error: verifyResult.error,
+        message: getErrorMessage(verifyResult.error),
+      },
+      { status: 400 }
+    );
+  }
+
+  const walletAddress = verifyResult.address.toLowerCase();
+
+  // Check if wallet already registered
+  const [existingUser] = await db
+    .select({
+      id: users.id,
+      username: users.username,
+      walletAddress: users.walletAddress,
+    })
+    .from(users)
+    .where(eq(users.walletAddress, walletAddress))
+    .limit(1);
+
+  if (existingUser) {
+    // LOGIN FLOW: Existing user - issue new API key
+    const apiKey = generateApiKey();
+    const keyHash = hashApiKey(apiKey);
+    const keyId = await generateSnowflakeId();
+
+    await db.insert(userApiKeys).values({
+      id: keyId,
+      userId: existingUser.id,
+      keyHash,
+      name: `SIWE Login ${new Date().toISOString().split('T')[0]}`,
+      createdAt: new Date(),
+    });
+
+    logger.info(
+      'SIWE agent login',
+      {
+        userId: existingUser.id,
+        username: existingUser.username,
+        walletAddress: existingUser.walletAddress,
+      },
+      'SIWE'
+    );
+
+    return successResponse({
+      success: true,
+      isNewUser: false,
+      userId: existingUser.id,
+      username: existingUser.username,
+      walletAddress: existingUser.walletAddress,
+      apiKey, // Only shown once!
+    });
+  }
+
+  // REGISTER FLOW: New user - check username availability (case-insensitive)
+  const [existingUsername] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(sql`lower(${users.username}) = lower(${username})`)
+    .limit(1);
+
+  if (existingUsername) {
+    return NextResponse.json(
+      {
+        error: 'username_taken',
+        message: `Username '${username}' is already taken`,
+      },
+      { status: 409 }
+    );
+  }
+
+  // Create user and API key in transaction
+  const result = await withTransaction(async (tx) => {
+    const userId = await generateSnowflakeId();
+
+    // Create user
+    const [user] = await tx
+      .insert(users)
+      .values({
+        id: userId,
+        username,
+        displayName: username,
+        walletAddress,
+        isAgent: true,
+        profileComplete: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .returning({
+        id: users.id,
+        username: users.username,
+        walletAddress: users.walletAddress,
+      });
+
+    if (!user) {
+      throw new Error('Failed to create user');
+    }
+
+    // Generate API key
+    const apiKey = generateApiKey();
+    const keyHash = hashApiKey(apiKey);
+    const keyId = await generateSnowflakeId();
+
+    await tx.insert(userApiKeys).values({
+      id: keyId,
+      userId,
+      keyHash,
+      name: 'SIWE Registration',
+      createdAt: new Date(),
+    });
+
+    return { user, apiKey };
+  });
+
+  logger.info(
+    'SIWE agent registration',
+    {
+      userId: result.user.id,
+      username: result.user.username,
+      walletAddress: result.user.walletAddress,
+    },
+    'SIWE'
+  );
+
+  return successResponse({
+    success: true,
+    isNewUser: true,
+    userId: result.user.id,
+    username: result.user.username,
+    walletAddress: result.user.walletAddress,
+    apiKey: result.apiKey, // Only shown once!
+  });
+});
+
+function getErrorMessage(
+  error:
+    | 'invalid_nonce'
+    | 'invalid_domain'
+    | 'invalid_signature'
+    | 'expired_message'
+): string {
+  switch (error) {
+    case 'invalid_nonce':
+      return 'Nonce is invalid, expired, or already used. Please request a new nonce.';
+    case 'invalid_domain':
+      return 'Domain in SIWE message does not match expected domain.';
+    case 'invalid_signature':
+      return 'Signature verification failed.';
+    case 'expired_message':
+      return 'SIWE message has expired.';
+  }
+}

--- a/apps/web/src/app/api/auth/siwe/nonce/route.ts
+++ b/apps/web/src/app/api/auth/siwe/nonce/route.ts
@@ -69,12 +69,13 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       { ip: clientIp.slice(0, 10) + '...' },
       'SIWE'
     );
+    const retryAfterSeconds = Math.max(1, rateLimitResult.retryAfter ?? 60);
     return NextResponse.json(
       { error: 'rate_limited', message: 'Too many requests. Try again later.' },
       {
         status: 429,
         headers: {
-          'Retry-After': String(Math.ceil(rateLimitResult.resetIn / 1000)),
+          'Retry-After': String(retryAfterSeconds),
         },
       }
     );

--- a/apps/web/src/app/api/auth/siwe/nonce/route.ts
+++ b/apps/web/src/app/api/auth/siwe/nonce/route.ts
@@ -1,0 +1,91 @@
+/**
+ * SIWE Nonce Endpoint
+ *
+ * @route GET /api/auth/siwe/nonce
+ * @access Public (rate limited)
+ *
+ * @description
+ * Generates a time-limited nonce for SIWE (Sign-In With Ethereum) authentication.
+ * The nonce is single-use and expires after 5 minutes.
+ *
+ * @openapi
+ * /api/auth/siwe/nonce:
+ *   get:
+ *     tags:
+ *       - Authentication
+ *     summary: Get SIWE nonce
+ *     description: Generate a nonce for SIWE message signing. Rate limited to 10/min per IP.
+ *     responses:
+ *       200:
+ *         description: Nonce generated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 nonce:
+ *                   type: string
+ *                   description: Random nonce to include in SIWE message
+ *                 issuedAt:
+ *                   type: string
+ *                   format: date-time
+ *                 expiresAt:
+ *                   type: string
+ *                   format: date-time
+ *                 domain:
+ *                   type: string
+ *                   description: Domain to use in SIWE message
+ *       429:
+ *         description: Rate limit exceeded
+ *
+ * @example
+ * ```bash
+ * curl https://babylon.market/api/auth/siwe/nonce
+ * ```
+ */
+
+import {
+  checkRateLimitAsync,
+  generateNonce,
+  getClientIp,
+  RATE_LIMIT_CONFIGS,
+  successResponse,
+  withErrorHandling,
+} from '@babylon/api';
+import { logger } from '@babylon/shared';
+import { type NextRequest, NextResponse } from 'next/server';
+
+export const GET = withErrorHandling(async (request: NextRequest) => {
+  // Rate limit by IP
+  const clientIp = getClientIp(request.headers) || 'unknown';
+  const rateLimitResult = await checkRateLimitAsync(
+    clientIp,
+    RATE_LIMIT_CONFIGS.SIWE_NONCE
+  );
+
+  if (!rateLimitResult.allowed) {
+    logger.warn(
+      'SIWE nonce rate limit exceeded',
+      { ip: clientIp.slice(0, 10) + '...' },
+      'SIWE'
+    );
+    return NextResponse.json(
+      { error: 'rate_limited', message: 'Too many requests. Try again later.' },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(Math.ceil(rateLimitResult.resetIn / 1000)),
+        },
+      }
+    );
+  }
+
+  const nonceResponse = await generateNonce();
+
+  return successResponse({
+    nonce: nonceResponse.nonce,
+    issuedAt: nonceResponse.issuedAt.toISOString(),
+    expiresAt: nonceResponse.expiresAt.toISOString(),
+    domain: nonceResponse.domain,
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "babylon",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "babylon",
@@ -310,6 +309,7 @@
         "graphql-request": "^7.2.0",
         "ioredis": "^5.6.1",
         "nanoid": "^5.1.6",
+        "siwe": "^3.0.0",
         "viem": "^2.41.2",
       },
       "devDependencies": {
@@ -1942,7 +1942,17 @@
 
     "@solidity-parser/parser": ["@solidity-parser/parser@0.20.2", "", {}, "sha512-rbu0bzwNvMcwAjH86hiEAcOeRI2EeK8zCkHDrFykh/Al8mvJeFmjy3UrE7GYQjNwOgbGUUtCn5/k8CB8zIu7QA=="],
 
+    "@spruceid/siwe-parser": ["@spruceid/siwe-parser@3.0.0", "", { "dependencies": { "@noble/hashes": "^1.1.2", "apg-js": "^4.4.0" } }, "sha512-Y92k63ilw/8jH9Ry4G2e7lQd0jZAvb0d/Q7ssSD0D9mp/Zt2aCXIc3g0ny9yhplpAx1QXHsMz/JJptHK/zDGdw=="],
+
     "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
+
+    "@stablelib/binary": ["@stablelib/binary@1.0.1", "", { "dependencies": { "@stablelib/int": "^1.0.1" } }, "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q=="],
+
+    "@stablelib/int": ["@stablelib/int@1.0.1", "", {}, "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w=="],
+
+    "@stablelib/random": ["@stablelib/random@1.0.2", "", { "dependencies": { "@stablelib/binary": "^1.0.1", "@stablelib/wipe": "^1.0.1" } }, "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w=="],
+
+    "@stablelib/wipe": ["@stablelib/wipe@1.0.1", "", {}, "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
 
@@ -2487,6 +2497,8 @@
     "any-signal": ["any-signal@3.0.1", "", {}, "sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "apg-js": ["apg-js@4.4.0", "", {}, "sha512-fefmXFknJmtgtNEXfPwZKYkMFX4Fyeyz+fNF6JWp87biGOPslJbCBVU158zvKRZfHBKnJDy8CMM40oLFGkXT8Q=="],
 
     "apg-lite": ["apg-lite@1.0.5", "", {}, "sha512-SlI+nLMQDzCZfS39ihzjGp3JNBQfJXyMi6cg9tkLOCPVErgFsUIAEdO9IezR7kbP5Xd0ozcPNQBkf9TO5cHgWw=="],
 
@@ -4552,6 +4564,8 @@
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
+    "siwe": ["siwe@3.0.0", "", { "dependencies": { "@spruceid/siwe-parser": "^3.0.0", "@stablelib/random": "^1.0.1" }, "peerDependencies": { "ethers": "^5.6.8 || ^6.0.8" } }, "sha512-P2/ry7dHYJA6JJ5+veS//Gn2XDwNb3JMvuD6xiXX8L/PJ1SNVD4a3a8xqEbmANx+7kNQcD8YAh1B9bNKKvRy/g=="],
+
     "slash": ["slash@5.1.0", "", {}, "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg=="],
 
     "slice-ansi": ["slice-ansi@4.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "astral-regex": "^2.0.0", "is-fullwidth-code-point": "^3.0.0" } }, "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ=="],
@@ -5637,6 +5651,8 @@
     "@solana/web3.js/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
     "@solana/web3.js/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+
+    "@spruceid/siwe-parser/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@swagger-api/apidom-parser-adapter-yaml-1-2/tree-sitter": ["tree-sitter@0.22.4", "", { "dependencies": { "node-addon-api": "^8.3.0", "node-gyp-build": "^4.8.4" } }, "sha512-usbHZP9/oxNsUY65MQUsduGRqDHQOou1cagUSwjhoSYAmSahjQDAVsh9s+SlZkn8X8+O1FULRGwHu7AFP3kjzg=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -14,16 +14,17 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.71.0",
-    "graphql": "^16.10.0",
-    "graphql-request": "^7.2.0",
     "@aws-sdk/client-s3": "^3.943.0",
     "@aws-sdk/lib-storage": "^3.943.0",
     "@babylon/contracts": "workspace:*",
     "@babylon/shared": "workspace:*",
     "@privy-io/server-auth": "^1.18.4",
     "@vercel/blob": "^2.0.0",
+    "graphql": "^16.10.0",
+    "graphql-request": "^7.2.0",
     "ioredis": "^5.6.1",
     "nanoid": "^5.1.6",
+    "siwe": "^3.0.0",
     "viem": "^2.41.2"
   },
   "peerDependencies": {

--- a/packages/api/src/auth/index.ts
+++ b/packages/api/src/auth/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Auth Module Exports
+ */
+
+export {
+  consumeNonce,
+  createSiweMessage,
+  generateNonce,
+  getAppUrl,
+  getExpectedDomain,
+  type NonceResponse,
+  type SiweVerifyFailure,
+  type SiweVerifyResult,
+  type SiweVerifySuccess,
+  verifySiweMessage,
+} from './siwe';

--- a/packages/api/src/auth/siwe.ts
+++ b/packages/api/src/auth/siwe.ts
@@ -1,0 +1,162 @@
+/**
+ * SIWE (Sign-In With Ethereum) Authentication
+ *
+ * @description Provides EIP-4361 SIWE authentication for agent registration.
+ * Handles nonce generation/validation and signature verification.
+ *
+ * @see https://eips.ethereum.org/EIPS/eip-4361
+ */
+
+import { logger } from '@babylon/shared';
+import { SiweMessage, generateNonce as siweGenerateNonce } from 'siwe';
+import { getAddress } from 'viem';
+import { getRedis } from '../redis/client';
+
+/** Nonce TTL in seconds (5 minutes) */
+const NONCE_TTL_SECONDS = 300;
+
+/** Redis key prefix for SIWE nonces */
+const NONCE_PREFIX = 'siwe:nonce:';
+
+/** In-memory nonce store fallback */
+const memoryNonceStore = new Map<string, number>();
+
+/**
+ * Get the expected domain for SIWE messages.
+ */
+export function getExpectedDomain(): string {
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+  return new URL(appUrl).hostname;
+}
+
+/**
+ * Get the full app URL for SIWE URI field.
+ */
+export function getAppUrl(): string {
+  return process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+}
+
+export interface NonceResponse {
+  nonce: string;
+  issuedAt: Date;
+  expiresAt: Date;
+  domain: string;
+}
+
+/**
+ * Generate a new SIWE nonce.
+ */
+export async function generateNonce(): Promise<NonceResponse> {
+  const nonce = siweGenerateNonce();
+  const issuedAt = new Date();
+  const expiresAt = new Date(Date.now() + NONCE_TTL_SECONDS * 1000);
+
+  const redis = getRedis();
+  if (redis) {
+    await redis.setex(`${NONCE_PREFIX}${nonce}`, NONCE_TTL_SECONDS, '1');
+  } else {
+    logger.warn('Redis unavailable - using in-memory nonce store', {}, 'SIWE');
+    memoryNonceStore.set(nonce, expiresAt.getTime());
+    setTimeout(() => memoryNonceStore.delete(nonce), NONCE_TTL_SECONDS * 1000);
+  }
+
+  return { nonce, issuedAt, expiresAt, domain: getExpectedDomain() };
+}
+
+/**
+ * Consume a SIWE nonce (single-use).
+ */
+export async function consumeNonce(nonce: string): Promise<boolean> {
+  const redis = getRedis();
+  if (redis) {
+    const deleted = await redis.del(`${NONCE_PREFIX}${nonce}`);
+    return deleted > 0;
+  }
+  const expiresAt = memoryNonceStore.get(nonce);
+  if (!expiresAt || Date.now() > expiresAt) return false;
+  memoryNonceStore.delete(nonce);
+  return true;
+}
+
+export interface SiweVerifySuccess {
+  success: true;
+  address: string;
+}
+
+export interface SiweVerifyFailure {
+  success: false;
+  error:
+    | 'invalid_nonce'
+    | 'invalid_domain'
+    | 'invalid_signature'
+    | 'expired_message';
+}
+
+export type SiweVerifyResult = SiweVerifySuccess | SiweVerifyFailure;
+
+/**
+ * Verify a SIWE message signature.
+ */
+export async function verifySiweMessage(
+  message: string,
+  signature: string
+): Promise<SiweVerifyResult> {
+  try {
+    const siweMessage = new SiweMessage(message);
+    const expectedDomain = getExpectedDomain();
+
+    if (siweMessage.domain !== expectedDomain) {
+      logger.warn(
+        'SIWE domain mismatch',
+        { expected: expectedDomain, received: siweMessage.domain },
+        'SIWE'
+      );
+      return { success: false, error: 'invalid_domain' };
+    }
+
+    const nonceValid = await consumeNonce(siweMessage.nonce);
+    if (!nonceValid) {
+      return { success: false, error: 'invalid_nonce' };
+    }
+
+    const result = await siweMessage.verify({ signature });
+
+    if (
+      siweMessage.expirationTime &&
+      new Date() > new Date(siweMessage.expirationTime)
+    ) {
+      return { success: false, error: 'expired_message' };
+    }
+
+    return { success: true, address: getAddress(result.data.address) };
+  } catch (err) {
+    logger.warn(
+      'SIWE verification failed',
+      { error: err instanceof Error ? err.message : String(err) },
+      'SIWE'
+    );
+    return { success: false, error: 'invalid_signature' };
+  }
+}
+
+/**
+ * Create a SIWE message for testing.
+ */
+export function createSiweMessage(params: {
+  address: string;
+  nonce: string;
+  statement?: string;
+  chainId?: number;
+}): string {
+  const siweMessage = new SiweMessage({
+    domain: getExpectedDomain(),
+    address: params.address,
+    statement: params.statement ?? 'Register as agent on Babylon',
+    uri: getAppUrl(),
+    version: '1',
+    chainId: params.chainId ?? 1,
+    nonce: params.nonce,
+    issuedAt: new Date().toISOString(),
+  });
+  return siweMessage.prepareMessage();
+}

--- a/packages/api/src/auth/siwe.ts
+++ b/packages/api/src/auth/siwe.ts
@@ -8,7 +8,11 @@
  */
 
 import { logger } from '@babylon/shared';
-import { SiweMessage, generateNonce as siweGenerateNonce } from 'siwe';
+import {
+  SiweErrorType,
+  SiweMessage,
+  generateNonce as siweGenerateNonce,
+} from 'siwe';
 import { getAddress } from 'viem';
 import { getRedis } from '../redis/client';
 
@@ -101,42 +105,71 @@ export async function verifySiweMessage(
   message: string,
   signature: string
 ): Promise<SiweVerifyResult> {
+  let siweMessage: SiweMessage;
   try {
-    const siweMessage = new SiweMessage(message);
-    const expectedDomain = getExpectedDomain();
-
-    if (siweMessage.domain !== expectedDomain) {
-      logger.warn(
-        'SIWE domain mismatch',
-        { expected: expectedDomain, received: siweMessage.domain },
-        'SIWE'
-      );
-      return { success: false, error: 'invalid_domain' };
-    }
-
-    const nonceValid = await consumeNonce(siweMessage.nonce);
-    if (!nonceValid) {
-      return { success: false, error: 'invalid_nonce' };
-    }
-
-    const result = await siweMessage.verify({ signature });
-
-    if (
-      siweMessage.expirationTime &&
-      new Date() > new Date(siweMessage.expirationTime)
-    ) {
-      return { success: false, error: 'expired_message' };
-    }
-
-    return { success: true, address: getAddress(result.data.address) };
+    siweMessage = new SiweMessage(message);
   } catch (err) {
     logger.warn(
-      'SIWE verification failed',
+      'SIWE message parse failed',
       { error: err instanceof Error ? err.message : String(err) },
       'SIWE'
     );
     return { success: false, error: 'invalid_signature' };
   }
+
+  const expectedDomain = getExpectedDomain();
+
+  if (siweMessage.domain !== expectedDomain) {
+    logger.warn(
+      'SIWE domain mismatch',
+      { expected: expectedDomain, received: siweMessage.domain },
+      'SIWE'
+    );
+    return { success: false, error: 'invalid_domain' };
+  }
+
+  const nonceValid = await consumeNonce(siweMessage.nonce);
+  if (!nonceValid) {
+    return { success: false, error: 'invalid_nonce' };
+  }
+
+  const verifyResponse = await siweMessage.verify(
+    {
+      signature,
+      domain: expectedDomain,
+      time: new Date().toISOString(),
+    },
+    { suppressExceptions: true }
+  );
+
+  if (!verifyResponse.success) {
+    const errorType =
+      verifyResponse.error &&
+      typeof verifyResponse.error === 'object' &&
+      'type' in verifyResponse.error
+        ? verifyResponse.error.type
+        : undefined;
+
+    if (errorType === SiweErrorType.EXPIRED_MESSAGE) {
+      return { success: false, error: 'expired_message' };
+    }
+
+    logger.warn(
+      'SIWE verification failed',
+      {
+        error:
+          verifyResponse.error instanceof Error
+            ? verifyResponse.error.message
+            : typeof verifyResponse.error === 'string'
+              ? verifyResponse.error
+              : (errorType ?? 'unknown'),
+      },
+      'SIWE'
+    );
+    return { success: false, error: 'invalid_signature' };
+  }
+
+  return { success: true, address: getAddress(verifyResponse.data.address) };
 }
 
 /**

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -44,6 +44,19 @@ export {
   verifyAgentCredentials,
   verifyAgentSession,
 } from './agent-auth';
+// SIWE Authentication
+export {
+  consumeNonce,
+  createSiweMessage,
+  generateNonce,
+  getAppUrl,
+  getExpectedDomain,
+  type NonceResponse,
+  type SiweVerifyFailure,
+  type SiweVerifyResult,
+  type SiweVerifySuccess,
+  verifySiweMessage,
+} from './auth';
 // Auth Middleware
 export {
   type AuthenticationError,

--- a/packages/api/src/rate-limiting/user-rate-limiter.ts
+++ b/packages/api/src/rate-limiting/user-rate-limiter.ts
@@ -84,6 +84,13 @@ export const RATE_LIMIT_CONFIGS = {
     actionType: 'update_profile',
   }, // 5 updates per minute
 
+  // SIWE Authentication
+  SIWE_NONCE: {
+    maxRequests: 10,
+    windowMs: 60000,
+    actionType: 'siwe_nonce',
+  }, // 10 nonce requests per minute per IP
+
   // Agent actions
   GENERATE_AGENT_PROFILE: {
     maxRequests: 5,

--- a/packages/testing/unit/auth/siwe.test.ts
+++ b/packages/testing/unit/auth/siwe.test.ts
@@ -45,34 +45,52 @@ describe('SIWE Authentication', () => {
   describe('getExpectedDomain', () => {
     test('returns localhost for development', () => {
       const originalEnv = process.env.NEXT_PUBLIC_APP_URL;
-      delete process.env.NEXT_PUBLIC_APP_URL;
+      try {
+        delete process.env.NEXT_PUBLIC_APP_URL;
 
-      const domain = getExpectedDomain();
-      expect(domain).toBe('localhost');
-
-      process.env.NEXT_PUBLIC_APP_URL = originalEnv;
+        const domain = getExpectedDomain();
+        expect(domain).toBe('localhost');
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env.NEXT_PUBLIC_APP_URL;
+        } else {
+          process.env.NEXT_PUBLIC_APP_URL = originalEnv;
+        }
+      }
     });
 
     test('extracts hostname from NEXT_PUBLIC_APP_URL', () => {
       const originalEnv = process.env.NEXT_PUBLIC_APP_URL;
-      process.env.NEXT_PUBLIC_APP_URL = 'https://babylon.market';
+      try {
+        process.env.NEXT_PUBLIC_APP_URL = 'https://babylon.market';
 
-      const domain = getExpectedDomain();
-      expect(domain).toBe('babylon.market');
-
-      process.env.NEXT_PUBLIC_APP_URL = originalEnv;
+        const domain = getExpectedDomain();
+        expect(domain).toBe('babylon.market');
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env.NEXT_PUBLIC_APP_URL;
+        } else {
+          process.env.NEXT_PUBLIC_APP_URL = originalEnv;
+        }
+      }
     });
   });
 
   describe('getAppUrl', () => {
     test('returns full URL', () => {
       const originalEnv = process.env.NEXT_PUBLIC_APP_URL;
-      process.env.NEXT_PUBLIC_APP_URL = 'https://babylon.market';
+      try {
+        process.env.NEXT_PUBLIC_APP_URL = 'https://babylon.market';
 
-      const url = getAppUrl();
-      expect(url).toBe('https://babylon.market');
-
-      process.env.NEXT_PUBLIC_APP_URL = originalEnv;
+        const url = getAppUrl();
+        expect(url).toBe('https://babylon.market');
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env.NEXT_PUBLIC_APP_URL;
+        } else {
+          process.env.NEXT_PUBLIC_APP_URL = originalEnv;
+        }
+      }
     });
   });
 
@@ -104,10 +122,11 @@ describe('SIWE Authentication', () => {
       await generateNonce();
 
       expect(mockRedis.setex).toHaveBeenCalledTimes(1);
-      const call = mockRedis.setex.mock.calls[0];
-      expect(call[0]).toMatch(/^siwe:nonce:/);
-      expect(call[1]).toBe(300); // 5 minutes TTL
-      expect(call[2]).toBe('1');
+      expect(mockRedis.setex).toHaveBeenCalledWith(
+        expect.stringMatching(/^siwe:nonce:/),
+        300,
+        '1'
+      );
     });
   });
 
@@ -115,15 +134,15 @@ describe('SIWE Authentication', () => {
     test('returns true when nonce exists in Redis', async () => {
       mockRedis.del.mockImplementation(() => Promise.resolve(1));
 
-      const result = await consumeNonce('test-nonce');
+      const result = await consumeNonce('testnonce');
       expect(result).toBe(true);
-      expect(mockRedis.del).toHaveBeenCalledWith('siwe:nonce:test-nonce');
+      expect(mockRedis.del).toHaveBeenCalledWith('siwe:nonce:testnonce');
     });
 
     test('returns false when nonce does not exist', async () => {
       mockRedis.del.mockImplementation(() => Promise.resolve(0));
 
-      const result = await consumeNonce('nonexistent-nonce');
+      const result = await consumeNonce('nonexistentnonce');
       expect(result).toBe(false);
     });
   });
@@ -193,6 +212,36 @@ describe('SIWE Authentication', () => {
       expect(result.success).toBe(false);
       if (!result.success) {
         expect(result.error).toBe('invalid_nonce');
+      }
+    });
+
+    test('returns expired_message when message is expired', async () => {
+      mockRedis.del.mockImplementation(() => Promise.resolve(1));
+
+      const { SiweMessage } = await import('siwe');
+      const { privateKeyToAccount } = await import('viem/accounts');
+
+      const account = privateKeyToAccount(`0x${'1'.repeat(64)}`);
+      const expiredMessage = new SiweMessage({
+        domain: getExpectedDomain(),
+        address: account.address,
+        statement: 'Test',
+        uri: getAppUrl(),
+        version: '1',
+        chainId: 1,
+        nonce: 'validnonce123',
+        issuedAt: new Date(Date.now() - 10_000).toISOString(),
+        expirationTime: new Date(Date.now() - 1_000).toISOString(),
+      });
+
+      const message = expiredMessage.prepareMessage();
+      const signature = await account.signMessage({ message });
+
+      const result = await verifySiweMessage(message, signature);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('expired_message');
       }
     });
   });

--- a/packages/testing/unit/auth/siwe.test.ts
+++ b/packages/testing/unit/auth/siwe.test.ts
@@ -1,0 +1,199 @@
+/**
+ * SIWE Authentication Tests
+ *
+ * Tests for nonce generation, consumption, and SIWE message verification.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// Mock Redis before importing siwe module
+const mockRedis = {
+  setex: mock(() => Promise.resolve('OK')),
+  del: mock(() => Promise.resolve(1)),
+};
+
+mock.module('../../../api/src/redis/client', () => ({
+  getRedis: () => mockRedis,
+}));
+
+// Mock logger
+mock.module('@babylon/shared', () => ({
+  logger: {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  },
+}));
+
+// Import after mocks
+const {
+  generateNonce,
+  consumeNonce,
+  verifySiweMessage,
+  createSiweMessage,
+  getExpectedDomain,
+  getAppUrl,
+} = await import('../../../api/src/auth/siwe');
+
+describe('SIWE Authentication', () => {
+  beforeEach(() => {
+    mockRedis.setex.mockClear();
+    mockRedis.del.mockClear();
+  });
+
+  describe('getExpectedDomain', () => {
+    test('returns localhost for development', () => {
+      const originalEnv = process.env.NEXT_PUBLIC_APP_URL;
+      delete process.env.NEXT_PUBLIC_APP_URL;
+
+      const domain = getExpectedDomain();
+      expect(domain).toBe('localhost');
+
+      process.env.NEXT_PUBLIC_APP_URL = originalEnv;
+    });
+
+    test('extracts hostname from NEXT_PUBLIC_APP_URL', () => {
+      const originalEnv = process.env.NEXT_PUBLIC_APP_URL;
+      process.env.NEXT_PUBLIC_APP_URL = 'https://babylon.market';
+
+      const domain = getExpectedDomain();
+      expect(domain).toBe('babylon.market');
+
+      process.env.NEXT_PUBLIC_APP_URL = originalEnv;
+    });
+  });
+
+  describe('getAppUrl', () => {
+    test('returns full URL', () => {
+      const originalEnv = process.env.NEXT_PUBLIC_APP_URL;
+      process.env.NEXT_PUBLIC_APP_URL = 'https://babylon.market';
+
+      const url = getAppUrl();
+      expect(url).toBe('https://babylon.market');
+
+      process.env.NEXT_PUBLIC_APP_URL = originalEnv;
+    });
+  });
+
+  describe('generateNonce', () => {
+    test('generates nonce with correct structure', async () => {
+      const result = await generateNonce();
+
+      expect(result).toHaveProperty('nonce');
+      expect(result).toHaveProperty('issuedAt');
+      expect(result).toHaveProperty('expiresAt');
+      expect(result).toHaveProperty('domain');
+
+      expect(typeof result.nonce).toBe('string');
+      expect(result.nonce.length).toBeGreaterThan(0);
+      expect(result.issuedAt).toBeInstanceOf(Date);
+      expect(result.expiresAt).toBeInstanceOf(Date);
+    });
+
+    test('expiration is 5 minutes after issuedAt', async () => {
+      const result = await generateNonce();
+
+      const diffMs = result.expiresAt.getTime() - result.issuedAt.getTime();
+      const diffMinutes = diffMs / 1000 / 60;
+
+      expect(diffMinutes).toBeCloseTo(5, 0);
+    });
+
+    test('stores nonce in Redis', async () => {
+      await generateNonce();
+
+      expect(mockRedis.setex).toHaveBeenCalledTimes(1);
+      const call = mockRedis.setex.mock.calls[0];
+      expect(call[0]).toMatch(/^siwe:nonce:/);
+      expect(call[1]).toBe(300); // 5 minutes TTL
+      expect(call[2]).toBe('1');
+    });
+  });
+
+  describe('consumeNonce', () => {
+    test('returns true when nonce exists in Redis', async () => {
+      mockRedis.del.mockImplementation(() => Promise.resolve(1));
+
+      const result = await consumeNonce('test-nonce');
+      expect(result).toBe(true);
+      expect(mockRedis.del).toHaveBeenCalledWith('siwe:nonce:test-nonce');
+    });
+
+    test('returns false when nonce does not exist', async () => {
+      mockRedis.del.mockImplementation(() => Promise.resolve(0));
+
+      const result = await consumeNonce('nonexistent-nonce');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('createSiweMessage', () => {
+    test('creates properly formatted SIWE message', () => {
+      // SIWE nonces must be alphanumeric (no hyphens)
+      const testNonce = 'testnonce123abc';
+      const message = createSiweMessage({
+        address: '0x1234567890123456789012345678901234567890',
+        nonce: testNonce,
+      });
+
+      expect(message).toContain('wants you to sign in');
+      expect(message).toContain('0x1234567890123456789012345678901234567890');
+      expect(message).toContain(testNonce);
+      expect(message).toContain('Register as agent on Babylon');
+    });
+
+    test('uses custom statement if provided', () => {
+      const message = createSiweMessage({
+        address: '0x1234567890123456789012345678901234567890',
+        nonce: 'testnonce456',
+        statement: 'Custom statement',
+      });
+
+      expect(message).toContain('Custom statement');
+    });
+  });
+
+  describe('verifySiweMessage', () => {
+    test('returns invalid_domain when domain mismatch', async () => {
+      // Create a message with wrong domain
+      const { SiweMessage } = await import('siwe');
+      const wrongDomainMessage = new SiweMessage({
+        domain: 'wrongdomain.com',
+        address: '0x1234567890123456789012345678901234567890',
+        statement: 'Test',
+        uri: 'https://wrongdomain.com',
+        version: '1',
+        chainId: 1,
+        nonce: 'validnonce123',
+        issuedAt: new Date().toISOString(),
+      });
+
+      const result = await verifySiweMessage(
+        wrongDomainMessage.prepareMessage(),
+        '0x' + '0'.repeat(130) // dummy signature
+      );
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('invalid_domain');
+      }
+    });
+
+    test('returns invalid_nonce when nonce not found', async () => {
+      mockRedis.del.mockImplementation(() => Promise.resolve(0));
+
+      const message = createSiweMessage({
+        address: '0x1234567890123456789012345678901234567890',
+        nonce: 'invalidnonce789',
+      });
+
+      const result = await verifySiweMessage(message, '0x' + '0'.repeat(130));
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toBe('invalid_nonce');
+      }
+    });
+  });
+});


### PR DESCRIPTION
Preface: not sure if we want this, we could go with an 8004 requirement too (I didn't because of the registration charge friction). Also using redis could be changed. But this makes it really easy for agent-devs to go from an existing wallet to being able to play the game.

Enable agents with only an EVM keypair to authenticate via Sign-In With Ethereum (EIP-4361). The endpoint handles both registration (new wallet) and login (existing wallet) in a single flow.

- Add siwe package dependency
- Add nonce endpoint with Redis storage (in-memory fallback)
- Add authenticate endpoint that issues API keys
- Add SIWE_NONCE rate limit config (10/min per IP)
- Add unit tests for nonce generation and verification

Endpoints:
- GET /api/auth/siwe/nonce - generate time-limited nonce
- POST /api/auth/siwe/authenticate - verify signature, return API key

## Summary
<!-- 1–3 bullets: what changed + why (user impact / business goal). -->

- Add SIWE (Sign-In With Ethereum) authentication for agent registration
- Enables agents with only an EVM keypair to self-register and authenticate without Privy or admin intervention
- Single endpoint handles both registration (new wallet) and login (existing wallet), issuing API keys

## Type
<!-- Helps triage + release notes. -->

- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
<!-- Link issues, Linear tickets, docs, prior PRs. -->

- EIP-4361 SIWE spec: https://eips.ethereum.org/EIPS/eip-4361
- Enables autonomous agent onboarding for A2A protocol

## Scope (keep it focused)
<!-- If you had to touch multiple areas, explain why and what you intentionally left out. -->

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

**Non-goals / follow-ups**
- API key management UI (revoke, list keys)
- Rate limiting on authenticate endpoint (currently only nonce is rate limited)

## Changes
<!-- List the notable changes (what is new/removed/modified). Link key files if it helps. -->

- Add `siwe` npm package to `@babylon/api`
- Add `packages/api/src/auth/siwe.ts` - nonce generation/consumption (Redis + in-memory fallback), SIWE message verification
- Add `GET /api/auth/siwe/nonce` - generates time-limited (5min) single-use nonce
- Add `POST /api/auth/siwe/authenticate` - verifies signature, handles login (existing wallet) or registration (new wallet)
- Add `SIWE_NONCE` rate limit config (10 requests/min per IP)
- Add unit tests for SIWE utilities

## Review guide
<!-- Help reviewers go fast: where to start, what to ignore, tricky bits, key decisions. -->

**Start here**
- `packages/api/src/auth/siwe.ts` - core SIWE logic
- `apps/web/src/app/api/auth/siwe/authenticate/route.ts` - main endpoint

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- Nonce storage uses Redis with in-memory fallback (logs warning when fallback used)
- Each login issues a NEW API key (old keys remain valid) - allows multiple deployments
- Username is always required in request but ignored on login (simplifies agent logic)
- Users created via SIWE have `isAgent: true`

## Test plan
<!-- Tick what you ran. Add manual steps for anything user-facing. -->

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [x] `bun run test` (unit tests for SIWE)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Request nonce: `curl https://babylon.market/api/auth/siwe/nonce`
2. Sign SIWE message with wallet
3. POST to `/api/auth/siwe/authenticate` with message, signature, username
4. Verify API key returned works for A2A requests

## Ops / Migration / Deployment
<!-- Anything that impacts deploys, data, cron, config, or rollouts. -->

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

Uses existing `NEXT_PUBLIC_APP_URL` for domain validation and existing Redis for nonce storage.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy
<!-- Authn/authz, secrets handling, PII, prompt injection surfaces, etc. -->

- [ ] No security impact
- [x] Needs extra review (describe)

**Security considerations:**
- Nonces are single-use and expire after 5 minutes (prevents replay attacks)
- Domain validation prevents phishing (message must match expected domain)
- Rate limiting on nonce endpoint prevents enumeration/DoS
- API keys are hashed before storage (plaintext only returned once)
- Supports ERC-1271 contract wallet signatures via `siwe` package

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
<!-- New/changed endpoints, SSE event payloads, shared types. -->

**New endpoints:**
- `GET /api/auth/siwe/nonce` - Returns `{ nonce, issuedAt, expiresAt, domain }`
- `POST /api/auth/siwe/authenticate` - Accepts `{ message, signature, username }`, returns `{ success, isNewUser, userId, username, walletAddress, apiKey }`

**New exports from `@babylon/api`:**
- `generateNonce`, `consumeNonce`, `verifySiweMessage`, `createSiweMessage`
- `getExpectedDomain`, `getAppUrl`
- Types: `NonceResponse`, `SiweVerifyResult`, `SiweVerifySuccess`, `SiweVerifyFailure`

### Database
<!-- Tables/columns/indexes, perf implications, how to verify. -->
- Uses existing `users` table (`walletAddress`, `isAgent` fields)
- Uses existing `userApiKeys` table
- No schema changes required

</details>

## Screenshots / recordings (UI)
<!--
⚠️ REQUIRED SECTION - Do not leave empty.
-->

### Option B: No visual changes

- Reason: Backend-only API endpoints, no UI components added

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ethereum wallet (SIWE) sign-in: login or register using a connected wallet and username.
  * One-time nonce endpoint to support wallet-based sign-ins.
  * Case-insensitive username uniqueness when creating new accounts.

* **Stability**
  * Rate limiting applied to nonce requests to reduce abuse.

* **Tests**
  * Unit tests covering nonce lifecycle and SIWE verification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


- Add SIWE (Sign-In With Ethereum) authentication enabling agents with EVM keypairs to self-register and authenticate without Privy or admin intervention
- Implement two new API endpoints: nonce generation and signature verification with unified login/registration flow
- Include comprehensive security measures with Redis-backed nonce storage, rate limiting, domain validation, and proper error handling

<h3>Important Files Changed</h3>


| Filename | Overview |
|----------|----------|
| `packages/api/src/auth/siwe.ts` | Core SIWE authentication logic with nonce management, signature verification, and domain validation |
| `apps/web/src/app/api/auth/siwe/authenticate/route.ts` | Main authentication endpoint handling both registration and login flows with transaction safety |

<h3>Confidence score: 4/5</h3>


- This PR is safe to merge with careful attention to security implementation details
- Score reflects solid architecture and comprehensive testing, but deducted one point due to security-critical authentication logic requiring extra scrutiny
- Pay close attention to `packages/api/src/auth/siwe.ts` and the authenticate endpoint for proper security validation

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent
    participant API as "/api/auth/siwe"
    participant SIWEService as "SIWE Service"
    participant Redis
    participant Database

    Agent->>API: "GET /nonce"
    API->>SIWEService: "generateNonce()"
    SIWEService->>Redis: "store nonce with 5min TTL"
    Redis-->>SIWEService: "confirm stored"
    SIWEService-->>API: "return nonce + domain + expiry"
    API-->>Agent: "nonce response"

    Agent->>Agent: "sign SIWE message with wallet"
    
    Agent->>API: "POST /authenticate {message, signature, username}"
    API->>SIWEService: "verifySiweMessage(message, signature)"
    SIWEService->>Redis: "consumeNonce()"
    Redis-->>SIWEService: "nonce valid & consumed"
    SIWEService->>SIWEService: "verify signature"
    SIWEService-->>API: "verification success + wallet address"

    API->>Database: "check if wallet exists"
    
    alt Existing User (Login)
        Database-->>API: "user found"
        API->>API: "generateApiKey()"
        API->>Database: "insert new API key"
        Database-->>API: "key created"
        API-->>Agent: "login success + API key"
    else New User (Registration)
        Database-->>API: "wallet not found"
        API->>Database: "check username availability"
        Database-->>API: "username available"
        API->>Database: "begin transaction"
        API->>Database: "create user with isAgent=true"
        API->>API: "generateApiKey()"
        API->>Database: "create API key"
        API->>Database: "commit transaction"
        Database-->>API: "registration complete"
        API-->>Agent: "registration success + API key"
    end
```

<!-- greptile_other_comments_section -->

<details><summary><h3>Context used (3)</h3></summary>

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=d07fd731-326a-4ea1-84d3-eec6a8044b74))
- Context from `dashboard` - .cursorrules ([source](https://app.greptile.com/review/custom-context?memory=d8da6060-b92a-430f-81d2-446cd9e51763))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=445626a4-e384-4d3b-99de-4ccf9a293a0d))
</details>


<!-- /greptile_comment -->