### PR TITLE
fix(runtime): DRY ElizaOS adapter stubs and add missing methods

### DIFF
--- a/packages/agents/src/runtime/AgentRuntimeManager.ts
+++ b/packages/agents/src/runtime/AgentRuntimeManager.ts
@@ -63,6 +63,127 @@ const globalRuntimes = new Map<string, AgentRuntime>();
 /** Global trajectory logger instances per agent */
 const trajectoryLoggers = new Map<string, TrajectoryLoggerService>();
 
+/**
+ * Creates a stub adapter that catches ALL method calls.
+ * Uses a Proxy to provide sensible defaults for any method ElizaOS might call,
+ * preventing "is not a function" errors without manual whack-a-mole.
+ */
+function createStubAdapter(existingAdapter: unknown): unknown {
+  // Explicit stubs for known methods (with proper return types)
+  const explicitStubs: Record<string, unknown> = {
+    // Lifecycle
+    init: async () => {},
+    close: async () => {},
+    isReady: async () => true,
+    // Agent methods
+    getAgent: async () => null,
+    getAgents: async () => [],
+    createAgent: async () => true,
+    updateAgent: async () => true,
+    deleteAgent: async () => true,
+    // Entity methods
+    getEntitiesByIds: async () => [],
+    getEntityById: async () => null,
+    createEntity: async () => true,
+    updateEntity: async () => {},
+    // Room/Participant methods
+    getParticipantsForRoom: async () => [],
+    addParticipantsRoom: async () => true,
+    addParticipant: async () => true,
+    removeParticipant: async () => true,
+    getRoom: async () => null,
+    getRoomsByIds: async () => [],
+    createRoom: async () => crypto.randomUUID(),
+    createRooms: async () => [],
+    deleteRoom: async () => {},
+    updateRoom: async () => {},
+    // World methods
+    createWorld: async () => crypto.randomUUID(),
+    getWorld: async () => null,
+    getAllWorlds: async () => [],
+    updateWorld: async () => {},
+    removeWorld: async () => {},
+    ensureWorldExists: async () => {},
+    // Memory methods
+    createMemory: async (memory: { id?: string } | null) =>
+      (memory?.id || crypto.randomUUID()) as UUID,
+    getMemories: async () => [],
+    getMemoryById: async () => null,
+    getMemoriesByIds: async () => [],
+    getMemoriesByRoomIds: async () => [],
+    searchMemories: async () => [],
+    deleteMemory: async () => {},
+    deleteAllMemories: async () => {},
+    countMemories: async () => 0,
+    // Logging
+    log: async () => {},
+    getLogs: async () => [],
+    deleteLog: async () => {},
+    // Cache
+    getCache: async () => undefined,
+    setCache: async () => true,
+    deleteCache: async () => true,
+    // Relationships
+    createRelationship: async () => true,
+    getRelationship: async () => null,
+    getRelationships: async () => [],
+    updateRelationship: async () => {},
+    // Tasks
+    createTask: async () => crypto.randomUUID(),
+    getTask: async () => null,
+    getTasks: async () => [],
+    updateTask: async () => {},
+    deleteTask: async () => {},
+    // Components
+    getComponent: async () => null,
+    getComponents: async () => [],
+    createComponent: async () => true,
+    updateComponent: async () => {},
+    deleteComponent: async () => {},
+    // Embeddings
+    getCachedEmbeddings: async () => [],
+    ensureEmbeddingDimension: async () => {},
+    // Misc
+    getConnection: async () => null,
+    runMigrations: async () => {},
+    runPluginMigrations: async () => {},
+  };
+
+  // Create a Proxy that:
+  // 1. Returns explicit stubs if defined
+  // 2. Falls back to existing adapter method if available
+  // 3. Returns a no-op async function for any unknown method
+  return new Proxy(existingAdapter || {}, {
+    get(target, prop) {
+      const propName = String(prop);
+
+      // Check explicit stubs first
+      if (propName in explicitStubs) {
+        return explicitStubs[propName];
+      }
+
+      // Check existing adapter
+      const existing = (target as Record<string, unknown>)[propName];
+      if (existing !== undefined) {
+        return existing;
+      }
+
+      // For any unknown method, return a no-op async function
+      // This prevents "is not a function" errors for any method ElizaOS might add
+      if (propName !== 'then' && propName !== 'toJSON' && !propName.startsWith('_')) {
+        logger.debug(
+          `Adapter stub: unknown method "${propName}" called, returning no-op`,
+          undefined,
+          'AgentRuntimeManager'
+        );
+        return async () => null;
+      }
+
+      return undefined;
+    },
+  });
+}
+
 export class AgentRuntimeManager {
   private static instance: AgentRuntimeManager;
 
@@ -261,47 +382,9 @@ export class AgentRuntimeManager {
 
     runtime.currentModel = 'groq';
 
-    // Override adapter methods to prevent undefined errors
-    // Babylon doesn't use ElizaOS's memory system, so we stub these out
-    runtime.adapter = {
-      ...runtime.adapter,
-      // Required by composeState and runtime.initialize
-      init: async () => {},
-      close: async () => {},
-      // Agent methods - Babylon manages agents separately
-      getAgents: async () => [],
-      createAgent: async (_agent: unknown) => true,
-      updateAgent: async (_agentId: unknown, _agent: unknown) => true,
-      deleteAgent: async (_agentId: unknown) => true,
-      // Entity methods
-      getEntitiesByIds: async (_ids: unknown) => [],
-      getParticipantsForRoom: async (_roomId: unknown) => [],
-      addParticipantsRoom: async (_entityIds: unknown, _roomId: unknown) => true,
-      // Memory methods - Babylon uses its own DB
-      getAgent: async (_agentId: unknown) => null, // Required by composeState
-      isReady: async () => true,
-      log: async (_params: {
-        body: { [key: string]: JsonValue };
-        entityId: string;
-        roomId: string;
-        type: string;
-      }): Promise<void> => {
-        // No-op - Babylon uses its own logging
-      },
-      createMemory: async (
-        memory: unknown,
-        _tableName?: string
-      ): Promise<UUID> => {
-        // No-op - Babylon uses its own DB for message storage
-        // Return the memory ID or generate one
-        const memoryObj = memory as { id?: string } | null;
-        return (memoryObj?.id || crypto.randomUUID()) as UUID;
-      },
-      getMemories: async (_params: unknown): Promise<unknown[]> => {
-        // Return empty array - Babylon uses its own DB
-        return [];
-      },
-    } as typeof runtime.adapter;
+    // Create stub adapter that catches ALL method calls
+    // Uses Proxy to provide sensible defaults for any method ElizaOS might call
+    runtime.adapter = createStubAdapter(runtime.adapter) as typeof runtime.adapter;
 
     // Configure logger
     if (!runtime.logger || !runtime.logger.log) {

--- a/packages/agents/src/runtime/AgentRuntimeManager.ts
+++ b/packages/agents/src/runtime/AgentRuntimeManager.ts
@@ -64,13 +64,12 @@ const globalRuntimes = new Map<string, AgentRuntime>();
 const trajectoryLoggers = new Map<string, TrajectoryLoggerService>();
 
 /**
- * Creates a stub adapter that catches ALL method calls.
- * Uses a Proxy to provide sensible defaults for any method ElizaOS might call,
- * preventing "is not a function" errors without manual whack-a-mole.
+ * Creates adapter stub methods for ElizaOS runtime.
+ * Babylon doesn't use ElizaOS's memory/DB system, so we stub these out.
  */
-function createStubAdapter(existingAdapter: unknown): unknown {
-  // Explicit stubs for known methods (with proper return types)
-  const explicitStubs: Record<string, unknown> = {
+function createAdapterStubs(existingAdapter: unknown): unknown {
+  return {
+    ...(existingAdapter as object),
     // Lifecycle
     init: async () => {},
     close: async () => {},
@@ -83,27 +82,31 @@ function createStubAdapter(existingAdapter: unknown): unknown {
     deleteAgent: async () => true,
     // Entity methods
     getEntitiesByIds: async () => [],
-    getEntityById: async () => null,
-    createEntity: async () => true,
+    createEntities: async () => true,
     updateEntity: async () => {},
+    getEntitiesForRoom: async () => [],
     // Room/Participant methods
     getParticipantsForRoom: async () => [],
+    getParticipantsForEntity: async () => [],
     addParticipantsRoom: async () => true,
-    addParticipant: async () => true,
     removeParticipant: async () => true,
-    getRoom: async () => null,
+    isRoomParticipant: async () => false,
+    getParticipantUserState: async () => null,
+    setParticipantUserState: async () => {},
     getRoomsByIds: async () => [],
-    createRoom: async () => crypto.randomUUID(),
+    getRoomsByWorld: async () => [],
+    getRoomsForParticipant: async () => [],
+    getRoomsForParticipants: async () => [],
     createRooms: async () => [],
     deleteRoom: async () => {},
+    deleteRoomsByWorldId: async () => {},
     updateRoom: async () => {},
     // World methods
-    createWorld: async () => crypto.randomUUID(),
+    createWorld: async () => crypto.randomUUID() as UUID,
     getWorld: async () => null,
     getAllWorlds: async () => [],
     updateWorld: async () => {},
     removeWorld: async () => {},
-    ensureWorldExists: async () => {},
     // Memory methods
     createMemory: async (memory: { id?: string } | null) =>
       (memory?.id || crypto.randomUUID()) as UUID,
@@ -111,8 +114,11 @@ function createStubAdapter(existingAdapter: unknown): unknown {
     getMemoryById: async () => null,
     getMemoriesByIds: async () => [],
     getMemoriesByRoomIds: async () => [],
+    getMemoriesByWorldId: async () => [],
     searchMemories: async () => [],
+    updateMemory: async () => true,
     deleteMemory: async () => {},
+    deleteManyMemories: async () => {},
     deleteAllMemories: async () => {},
     countMemories: async () => 0,
     // Logging
@@ -123,15 +129,19 @@ function createStubAdapter(existingAdapter: unknown): unknown {
     getCache: async () => undefined,
     setCache: async () => true,
     deleteCache: async () => true,
+    // Embeddings
+    getCachedEmbeddings: async () => [],
+    ensureEmbeddingDimension: async () => {},
     // Relationships
     createRelationship: async () => true,
     getRelationship: async () => null,
     getRelationships: async () => [],
     updateRelationship: async () => {},
     // Tasks
-    createTask: async () => crypto.randomUUID(),
+    createTask: async () => crypto.randomUUID() as UUID,
     getTask: async () => null,
     getTasks: async () => [],
+    getTasksByName: async () => [],
     updateTask: async () => {},
     deleteTask: async () => {},
     // Components
@@ -140,48 +150,12 @@ function createStubAdapter(existingAdapter: unknown): unknown {
     createComponent: async () => true,
     updateComponent: async () => {},
     deleteComponent: async () => {},
-    // Embeddings
-    getCachedEmbeddings: async () => [],
-    ensureEmbeddingDimension: async () => {},
     // Misc
     getConnection: async () => null,
     runMigrations: async () => {},
     runPluginMigrations: async () => {},
+    db: null,
   };
-
-  // Create a Proxy that:
-  // 1. Returns explicit stubs if defined
-  // 2. Falls back to existing adapter method if available
-  // 3. Returns a no-op async function for any unknown method
-  return new Proxy(existingAdapter || {}, {
-    get(target, prop) {
-      const propName = String(prop);
-
-      // Check explicit stubs first
-      if (propName in explicitStubs) {
-        return explicitStubs[propName];
-      }
-
-      // Check existing adapter
-      const existing = (target as Record<string, unknown>)[propName];
-      if (existing !== undefined) {
-        return existing;
-      }
-
-      // For any unknown method, return a no-op async function
-      // This prevents "is not a function" errors for any method ElizaOS might add
-      if (propName !== 'then' && propName !== 'toJSON' && !propName.startsWith('_')) {
-        logger.debug(
-          `Adapter stub: unknown method "${propName}" called, returning no-op`,
-          undefined,
-          'AgentRuntimeManager'
-        );
-        return async () => null;
-      }
-
-      return undefined;
-    },
-  });
 }
 
 export class AgentRuntimeManager {
@@ -382,9 +356,8 @@ export class AgentRuntimeManager {
 
     runtime.currentModel = 'groq';
 
-    // Create stub adapter that catches ALL method calls
-    // Uses Proxy to provide sensible defaults for any method ElizaOS might call
-    runtime.adapter = createStubAdapter(runtime.adapter) as typeof runtime.adapter;
+    // Stub adapter methods - Babylon uses its own DB, not ElizaOS's
+    runtime.adapter = createAdapterStubs(runtime.adapter) as typeof runtime.adapter;
 
     // Configure logger
     if (!runtime.logger || !runtime.logger.log) {

--- a/packages/agents/src/runtime/AgentRuntimeManager.ts
+++ b/packages/agents/src/runtime/AgentRuntimeManager.ts
@@ -357,7 +357,9 @@ export class AgentRuntimeManager {
     runtime.currentModel = 'groq';
 
     // Stub adapter methods - Babylon uses its own DB, not ElizaOS's
-    runtime.adapter = createAdapterStubs(runtime.adapter) as typeof runtime.adapter;
+    runtime.adapter = createAdapterStubs(
+      runtime.adapter
+    ) as typeof runtime.adapter;
 
     // Configure logger
     if (!runtime.logger || !runtime.logger.log) {
@@ -651,47 +653,10 @@ export class AgentRuntimeManager {
     }
     runtime.currentModel = 'groq';
 
-    // Override adapter methods to prevent undefined errors
-    // Babylon doesn't use ElizaOS's memory system, so we stub these out
-    runtime.adapter = {
-      ...runtime.adapter,
-      // Required by composeState and runtime.initialize
-      init: async () => {},
-      close: async () => {},
-      // Agent methods - Babylon manages agents separately
-      getAgents: async () => [],
-      createAgent: async (_agent: unknown) => true,
-      updateAgent: async (_agentId: unknown, _agent: unknown) => true,
-      deleteAgent: async (_agentId: unknown) => true,
-      // Entity methods
-      getEntitiesByIds: async (_ids: unknown) => [],
-      getParticipantsForRoom: async (_roomId: unknown) => [],
-      addParticipantsRoom: async (_entityIds: unknown, _roomId: unknown) => true,
-      // Memory methods - Babylon uses its own DB
-      getAgent: async (_agentId: unknown) => null, // Required by composeState
-      isReady: async () => true, // Required by composeState
-      log: async (_params: {
-        body: { [key: string]: JsonValue };
-        entityId: string;
-        roomId: string;
-        type: string;
-      }): Promise<void> => {
-        // No-op - Babylon uses its own logging
-      },
-      createMemory: async (
-        memory: unknown,
-        _tableName?: string
-      ): Promise<UUID> => {
-        // No-op - Babylon uses its own DB for message storage
-        // Return the memory ID or generate one
-        const memoryObj = memory as { id?: string } | null;
-        return (memoryObj?.id || crypto.randomUUID()) as UUID;
-      },
-      getMemories: async (_params: unknown): Promise<unknown[]> => {
-        // Return empty array - Babylon uses its own DB
-        return [];
-      },
-    } as typeof runtime.adapter;
+    // Stub adapter methods - Babylon uses its own DB, not ElizaOS's
+    runtime.adapter = createAdapterStubs(
+      runtime.adapter
+    ) as typeof runtime.adapter;
 
     // Configure logger
     this.configureLogger(runtime, character.name);


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal adapter initialization logic to reduce code duplication and improve maintainability. Runtime functionality remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Extracted duplicate ElizaOS adapter stubbing code into a reusable `createAdapterStubs()` helper function. The function provides no-op implementations for ~50 adapter methods since Babylon uses its own database and memory system rather than ElizaOS's built-in systems.

**Key changes:**
- Created `createAdapterStubs()` helper (lines 70-159) with comprehensive method stubs
- Replaced two duplicate adapter stub implementations with calls to the helper (lines 360-362 and 656-659)
- Eliminated ~80 lines of duplicate code
- Added missing adapter methods that weren't in the previous duplicate implementations

This refactoring improves maintainability by centralizing the adapter stubbing logic in one place, making future updates easier to manage.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk - it's a pure refactoring that eliminates code duplication without changing behavior
- The refactoring extracts duplicate code into a single helper function without changing any logic or behavior. The new `createAdapterStubs()` function provides the same stub implementations that were previously duplicated in two places. This is a straightforward DRY (Don't Repeat Yourself) improvement with no functional changes.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agents/src/runtime/AgentRuntimeManager.ts | Refactored duplicated adapter stub code into reusable `createAdapterStubs` helper function, eliminating ~80 lines of duplication |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant ARM as AgentRuntimeManager
    participant RT as AgentRuntime
    participant CAS as createAdapterStubs()
    participant Adapter as runtime.adapter

    Note over ARM,Adapter: Legacy getRuntime() path (line 356-362)
    ARM->>RT: new AgentRuntime(config)
    ARM->>CAS: createAdapterStubs(runtime.adapter)
    CAS->>CAS: Spread existingAdapter properties
    CAS->>CAS: Override with ~50 stub methods
    CAS-->>ARM: Return stubbed adapter
    ARM->>RT: runtime.adapter = stubs
    
    Note over ARM,Adapter: createRuntimeWithPlugins() path (line 656-659)
    ARM->>RT: new AgentRuntime(config)
    ARM->>CAS: createAdapterStubs(runtime.adapter)
    CAS->>CAS: Spread existingAdapter properties
    CAS->>CAS: Override with ~50 stub methods
    CAS-->>ARM: Return stubbed adapter
    ARM->>RT: runtime.adapter = stubs
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->