### PR TITLE
fix(runtime): createRooms stub must return rooms to avoid error

### DIFF
--- a/packages/agents/src/runtime/AgentRuntimeManager.ts
+++ b/packages/agents/src/runtime/AgentRuntimeManager.ts
@@ -97,7 +97,7 @@ function createAdapterStubs(existingAdapter: unknown): unknown {
     getRoomsByWorld: async () => [],
     getRoomsForParticipant: async () => [],
     getRoomsForParticipants: async () => [],
-    createRooms: async () => [],
+    createRooms: async (rooms: unknown[]) => rooms, // Return rooms to avoid "Failed to create room" error
     deleteRoom: async () => {},
     deleteRoomsByWorldId: async () => {},
     updateRoom: async () => {},


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Room creation now properly returns the created rooms instead of returning empty data, resolving room creation failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Fixed `createRooms` adapter stub to return the input rooms array instead of an empty array, preventing "Failed to create room" errors from ElizaOS validation.

- Modified `createRooms` in `createAdapterStubs` function to accept and return the `rooms` parameter
- The change satisfies ElizaOS's internal validation that checks `if (!res.length)` after calling `createRooms`
- Since Babylon uses its own database system and doesn't rely on ElizaOS's persistence layer, the stub can safely return the input rooms without side effects

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is a minimal, targeted fix to an adapter stub that addresses a specific error condition. The stub returns the input rooms instead of an empty array, which satisfies ElizaOS's validation without introducing side effects since Babylon doesn't use ElizaOS's persistence layer.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agents/src/runtime/AgentRuntimeManager.ts | Fixed `createRooms` stub to return input rooms instead of empty array to satisfy ElizaOS validation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant ElizaOS
    participant AgentRuntime
    participant createAdapterStubs
    participant BabylonDB

    Note over ElizaOS,BabylonDB: Room Creation Flow

    ElizaOS->>AgentRuntime: createRooms(rooms[])
    AgentRuntime->>createAdapterStubs: adapter.createRooms(rooms[])
    
    alt Before Fix
        createAdapterStubs-->>AgentRuntime: [] (empty array)
        AgentRuntime->>ElizaOS: res = []
        ElizaOS->>ElizaOS: if (!res.length) throw Error
        ElizaOS--xAgentRuntime: Error: "Failed to create room"
    end
    
    alt After Fix
        createAdapterStubs-->>AgentRuntime: rooms[] (input rooms)
        AgentRuntime->>ElizaOS: res = rooms[]
        ElizaOS->>ElizaOS: if (!res.length) ✓ pass
        ElizaOS-->>AgentRuntime: Success
    end
    
    Note over createAdapterStubs,BabylonDB: Babylon uses its own DB,<br/>so stub returns input without<br/>actual persistence
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->