### PR TITLE
fix: auto-link existing accounts when logging in with Farcaster/Twitter

### DIFF
--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -261,6 +261,91 @@ const userSelectFields = {
   gameGuideCompletedAt: users.gameGuideCompletedAt,
 } as const;
 
+type UserSelectResult = {
+  id: string;
+  privyId: string | null;
+  username: string | null;
+  displayName: string | null;
+  bio: string | null;
+  profileImageUrl: string | null;
+  coverImageUrl: string | null;
+  walletAddress: string | null;
+  email: string | null;
+  profileComplete: boolean | null;
+  hasUsername: boolean | null;
+  hasBio: boolean | null;
+  hasProfileImage: boolean | null;
+  onChainRegistered: boolean | null;
+  nftTokenId: number | null;
+  referralCode: string | null;
+  referredBy: string | null;
+  reputationPoints: number | null;
+  virtualBalance: string | null;
+  pointsAwardedForProfile: boolean | null;
+  pointsAwardedForFarcasterFollow: boolean | null;
+  pointsAwardedForTwitterFollow: boolean | null;
+  pointsAwardedForDiscordJoin: boolean | null;
+  hasFarcaster: boolean | null;
+  hasTwitter: boolean | null;
+  hasDiscord: boolean | null;
+  farcasterUsername: string | null;
+  twitterUsername: string | null;
+  discordUsername: string | null;
+  showTwitterPublic: boolean | null;
+  showFarcasterPublic: boolean | null;
+  showWalletPublic: boolean | null;
+  isAdmin: boolean | null;
+  isActor: boolean | null;
+  createdAt: Date;
+  updatedAt: Date;
+  gameGuideCompletedAt: Date | null;
+};
+
+function buildUserResponse(
+  dbUser: UserSelectResult,
+  stats: Awaited<ReturnType<typeof cachedDb.getUserProfileStats>> | null
+) {
+  return {
+    id: dbUser.id,
+    privyId: dbUser.privyId,
+    username: dbUser.username,
+    displayName: dbUser.displayName,
+    bio: dbUser.bio,
+    profileImageUrl: dbUser.profileImageUrl,
+    coverImageUrl: dbUser.coverImageUrl,
+    walletAddress: dbUser.walletAddress,
+    profileComplete: dbUser.profileComplete,
+    hasUsername: dbUser.hasUsername,
+    hasBio: dbUser.hasBio,
+    hasProfileImage: dbUser.hasProfileImage,
+    onChainRegistered: dbUser.onChainRegistered,
+    nftTokenId: dbUser.nftTokenId,
+    referralCode: dbUser.referralCode,
+    referredBy: dbUser.referredBy,
+    reputationPoints: dbUser.reputationPoints,
+    virtualBalance: Number(dbUser.virtualBalance ?? 0),
+    pointsAwardedForProfile: dbUser.pointsAwardedForProfile,
+    pointsAwardedForFarcasterFollow: dbUser.pointsAwardedForFarcasterFollow,
+    pointsAwardedForTwitterFollow: dbUser.pointsAwardedForTwitterFollow,
+    pointsAwardedForDiscordJoin: dbUser.pointsAwardedForDiscordJoin,
+    hasFarcaster: dbUser.hasFarcaster,
+    hasTwitter: dbUser.hasTwitter,
+    hasDiscord: dbUser.hasDiscord,
+    farcasterUsername: dbUser.farcasterUsername,
+    twitterUsername: dbUser.twitterUsername,
+    discordUsername: dbUser.discordUsername,
+    showTwitterPublic: dbUser.showTwitterPublic,
+    showFarcasterPublic: dbUser.showFarcasterPublic,
+    showWalletPublic: dbUser.showWalletPublic,
+    isAdmin: dbUser.isAdmin,
+    isActor: dbUser.isActor,
+    createdAt: dbUser.createdAt.toISOString(),
+    updatedAt: dbUser.updatedAt.toISOString(),
+    gameGuideCompletedAt: dbUser.gameGuideCompletedAt?.toISOString() ?? null,
+    stats: stats || undefined,
+  };
+}
+
 export const GET = withErrorHandling(async (request: NextRequest) => {
   const authUser = await authenticate(request);
   const privyId = authUser.privyId ?? authUser.userId;
@@ -344,17 +429,41 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
         conditions.push(eq(users.twitterId, twitterId));
       }
 
-      const [existingUserWithSocial] = await db
+      const existingUsersWithSocial = await db
         .select(userSelectFields)
         .from(users)
         .where(or(...conditions))
-        .limit(1);
+        .limit(2);
 
-      if (existingUserWithSocial) {
+      // If multiple users found, it means Farcaster and Twitter belong to different accounts
+      // Skip auto-linking to prevent linking the wrong account
+      if (existingUsersWithSocial.length > 1) {
+        logger.error(
+          'Multiple users found with conflicting social accounts - skipping auto-link',
+          {
+            newPrivyId: privyId,
+            farcasterFid,
+            twitterId,
+            foundUserIds: existingUsersWithSocial.map((u) => u.id),
+          },
+          'GET /api/users/me'
+        );
+      } else if (existingUsersWithSocial.length === 1) {
+        const existingUserWithSocial = existingUsersWithSocial[0]!;
+        const matchedByFarcaster =
+          !!farcasterFid &&
+          existingUserWithSocial.farcasterFid === farcasterFid;
+        const matchedByTwitter =
+          !!twitterId && existingUserWithSocial.twitterId === twitterId;
+
         const linkedAccount =
-          farcasterFid && existingUserWithSocial.farcasterFid === farcasterFid
-            ? 'Farcaster'
-            : 'Twitter';
+          matchedByFarcaster && matchedByTwitter
+            ? 'Farcaster+Twitter'
+            : matchedByFarcaster
+              ? 'Farcaster'
+              : matchedByTwitter
+                ? 'Twitter'
+                : 'Unknown';
 
         logger.info(
           'Found existing user by social account - auto-linking new Privy session',
@@ -370,28 +479,48 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
           'GET /api/users/me'
         );
 
-        // Update the existing user's privyId to the new one
-        const [updatedUser] = await db
-          .update(users)
-          .set({
-            privyId,
-            updatedAt: new Date(),
-          })
-          .where(eq(users.id, existingUserWithSocial.id))
-          .returning(userSelectFields);
+        // Check if the new privyId is already linked to a different user
+        const [existingUserWithPrivyId] = await db
+          .select({ id: users.id })
+          .from(users)
+          .where(eq(users.privyId, privyId))
+          .limit(1);
 
-        if (updatedUser) {
-          dbUser = updatedUser;
-
-          logger.info(
-            'Successfully linked new Privy session to existing user',
+        if (existingUserWithPrivyId && existingUserWithPrivyId.id !== existingUserWithSocial.id) {
+          logger.warn(
+            'New privyId already linked to a different user - skipping auto-link to prevent account conflict',
             {
-              userId: updatedUser.id,
-              username: updatedUser.username,
               newPrivyId: privyId,
+              existingPrivyUserId: existingUserWithPrivyId.id,
+              socialMatchUserId: existingUserWithSocial.id,
             },
             'GET /api/users/me'
           );
+          // Skip auto-linking, let normal flow continue
+        } else {
+          // Update the existing user's privyId to the new one
+          const [updatedUser] = await db
+            .update(users)
+            .set({
+              privyId,
+              updatedAt: new Date(),
+            })
+            .where(eq(users.id, existingUserWithSocial.id))
+            .returning(userSelectFields);
+
+          if (updatedUser) {
+            dbUser = updatedUser;
+
+            logger.info(
+              'Successfully linked new Privy session to existing user',
+              {
+                userId: updatedUser.id,
+                username: updatedUser.username,
+                newPrivyId: privyId,
+              },
+              'GET /api/users/me'
+            );
+          }
         }
       }
     }
@@ -401,45 +530,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       // Get cached profile stats for the linked user
       const stats = await cachedDb.getUserProfileStats(dbUser.id);
 
-      const responseUser = {
-        id: dbUser.id,
-        privyId: dbUser.privyId,
-        username: dbUser.username,
-        displayName: dbUser.displayName,
-        bio: dbUser.bio,
-        profileImageUrl: dbUser.profileImageUrl,
-        coverImageUrl: dbUser.coverImageUrl,
-        walletAddress: dbUser.walletAddress,
-        profileComplete: dbUser.profileComplete,
-        hasUsername: dbUser.hasUsername,
-        hasBio: dbUser.hasBio,
-        hasProfileImage: dbUser.hasProfileImage,
-        onChainRegistered: dbUser.onChainRegistered,
-        nftTokenId: dbUser.nftTokenId,
-        referralCode: dbUser.referralCode,
-        referredBy: dbUser.referredBy,
-        reputationPoints: dbUser.reputationPoints,
-        virtualBalance: Number(dbUser.virtualBalance ?? 0),
-        pointsAwardedForProfile: dbUser.pointsAwardedForProfile,
-        pointsAwardedForFarcasterFollow: dbUser.pointsAwardedForFarcasterFollow,
-        pointsAwardedForTwitterFollow: dbUser.pointsAwardedForTwitterFollow,
-        pointsAwardedForDiscordJoin: dbUser.pointsAwardedForDiscordJoin,
-        hasFarcaster: dbUser.hasFarcaster,
-        hasTwitter: dbUser.hasTwitter,
-        hasDiscord: dbUser.hasDiscord,
-        farcasterUsername: dbUser.farcasterUsername,
-        twitterUsername: dbUser.twitterUsername,
-        discordUsername: dbUser.discordUsername,
-        showTwitterPublic: dbUser.showTwitterPublic,
-        showFarcasterPublic: dbUser.showFarcasterPublic,
-        showWalletPublic: dbUser.showWalletPublic,
-        isAdmin: dbUser.isAdmin,
-        isActor: dbUser.isActor,
-        createdAt: dbUser.createdAt.toISOString(),
-        updatedAt: dbUser.updatedAt.toISOString(),
-        gameGuideCompletedAt: dbUser.gameGuideCompletedAt?.toISOString() ?? null,
-        stats: stats || undefined,
-      };
+      const responseUser = buildUserResponse(dbUser, stats);
 
       const needsOnboarding = !dbUser.profileComplete;
       const needsOnchain = dbUser.profileComplete && !dbUser.onChainRegistered;
@@ -726,45 +817,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   // Get cached profile stats
   const stats = await cachedDb.getUserProfileStats(dbUser.id);
 
-  const responseUser = {
-    id: dbUser.id,
-    privyId: dbUser.privyId,
-    username: dbUser.username,
-    displayName: dbUser.displayName,
-    bio: dbUser.bio,
-    profileImageUrl: dbUser.profileImageUrl,
-    coverImageUrl: dbUser.coverImageUrl,
-    walletAddress: dbUser.walletAddress,
-    profileComplete: dbUser.profileComplete,
-    hasUsername: dbUser.hasUsername,
-    hasBio: dbUser.hasBio,
-    hasProfileImage: dbUser.hasProfileImage,
-    onChainRegistered: dbUser.onChainRegistered,
-    nftTokenId: dbUser.nftTokenId,
-    referralCode: dbUser.referralCode,
-    referredBy: dbUser.referredBy,
-    reputationPoints: dbUser.reputationPoints,
-    virtualBalance: Number(dbUser.virtualBalance ?? 0),
-    pointsAwardedForProfile: dbUser.pointsAwardedForProfile,
-    pointsAwardedForFarcasterFollow: dbUser.pointsAwardedForFarcasterFollow,
-    pointsAwardedForTwitterFollow: dbUser.pointsAwardedForTwitterFollow,
-    pointsAwardedForDiscordJoin: dbUser.pointsAwardedForDiscordJoin,
-    hasFarcaster: dbUser.hasFarcaster,
-    hasTwitter: dbUser.hasTwitter,
-    hasDiscord: dbUser.hasDiscord,
-    farcasterUsername: dbUser.farcasterUsername,
-    twitterUsername: dbUser.twitterUsername,
-    discordUsername: dbUser.discordUsername,
-    showTwitterPublic: dbUser.showTwitterPublic,
-    showFarcasterPublic: dbUser.showFarcasterPublic,
-    showWalletPublic: dbUser.showWalletPublic,
-    isAdmin: dbUser.isAdmin,
-    isActor: dbUser.isActor,
-    createdAt: dbUser.createdAt.toISOString(),
-    updatedAt: dbUser.updatedAt.toISOString(),
-    gameGuideCompletedAt: dbUser.gameGuideCompletedAt?.toISOString() ?? null,
-    stats: stats || undefined,
-  };
+  const responseUser = buildUserResponse(dbUser, stats);
 
   const needsOnboarding = !dbUser.profileComplete;
   const needsOnchain = dbUser.profileComplete && !dbUser.onChainRegistered;

--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -149,7 +149,7 @@ import {
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
-import { db, eq, sql, users } from '@babylon/db';
+import { db, eq, or, sql, users } from '@babylon/db';
 import {
   checkForAdminEmail,
   logger,
@@ -247,7 +247,9 @@ const userSelectFields = {
   hasTwitter: users.hasTwitter,
   hasDiscord: users.hasDiscord,
   farcasterUsername: users.farcasterUsername,
+  farcasterFid: users.farcasterFid,
   twitterUsername: users.twitterUsername,
+  twitterId: users.twitterId,
   discordUsername: users.discordUsername,
   showTwitterPublic: users.showTwitterPublic,
   showFarcasterPublic: users.showFarcasterPublic,
@@ -329,6 +331,139 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       },
       'GET /api/users/me'
     );
+
+    // Check if Farcaster or Twitter account is already linked to an existing user
+    // If found, auto-link the new Privy session to the existing account
+    // This allows users to login with their social account and access their existing Babylon account
+    if (farcasterFid || twitterId) {
+      const conditions = [];
+      if (farcasterFid) {
+        conditions.push(eq(users.farcasterFid, farcasterFid));
+      }
+      if (twitterId) {
+        conditions.push(eq(users.twitterId, twitterId));
+      }
+
+      const [existingUserWithSocial] = await db
+        .select(userSelectFields)
+        .from(users)
+        .where(or(...conditions))
+        .limit(1);
+
+      if (existingUserWithSocial) {
+        const linkedAccount =
+          farcasterFid && existingUserWithSocial.farcasterFid === farcasterFid
+            ? 'Farcaster'
+            : 'Twitter';
+
+        logger.info(
+          'Found existing user by social account - auto-linking new Privy session',
+          {
+            newPrivyId: privyId,
+            oldPrivyId: existingUserWithSocial.privyId,
+            existingUserId: existingUserWithSocial.id,
+            existingUsername: existingUserWithSocial.username,
+            linkedAccount,
+            farcasterFid,
+            twitterId,
+          },
+          'GET /api/users/me'
+        );
+
+        // Update the existing user's privyId to the new one
+        const [updatedUser] = await db
+          .update(users)
+          .set({
+            privyId,
+            updatedAt: new Date(),
+          })
+          .where(eq(users.id, existingUserWithSocial.id))
+          .returning(userSelectFields);
+
+        if (updatedUser) {
+          dbUser = updatedUser;
+
+          logger.info(
+            'Successfully linked new Privy session to existing user',
+            {
+              userId: updatedUser.id,
+              username: updatedUser.username,
+              newPrivyId: privyId,
+            },
+            'GET /api/users/me'
+          );
+        }
+      }
+    }
+
+    // If we found and linked to an existing user, skip the new user creation
+    if (dbUser) {
+      // Get cached profile stats for the linked user
+      const stats = await cachedDb.getUserProfileStats(dbUser.id);
+
+      const responseUser = {
+        id: dbUser.id,
+        privyId: dbUser.privyId,
+        username: dbUser.username,
+        displayName: dbUser.displayName,
+        bio: dbUser.bio,
+        profileImageUrl: dbUser.profileImageUrl,
+        coverImageUrl: dbUser.coverImageUrl,
+        walletAddress: dbUser.walletAddress,
+        profileComplete: dbUser.profileComplete,
+        hasUsername: dbUser.hasUsername,
+        hasBio: dbUser.hasBio,
+        hasProfileImage: dbUser.hasProfileImage,
+        onChainRegistered: dbUser.onChainRegistered,
+        nftTokenId: dbUser.nftTokenId,
+        referralCode: dbUser.referralCode,
+        referredBy: dbUser.referredBy,
+        reputationPoints: dbUser.reputationPoints,
+        virtualBalance: Number(dbUser.virtualBalance ?? 0),
+        pointsAwardedForProfile: dbUser.pointsAwardedForProfile,
+        pointsAwardedForFarcasterFollow: dbUser.pointsAwardedForFarcasterFollow,
+        pointsAwardedForTwitterFollow: dbUser.pointsAwardedForTwitterFollow,
+        pointsAwardedForDiscordJoin: dbUser.pointsAwardedForDiscordJoin,
+        hasFarcaster: dbUser.hasFarcaster,
+        hasTwitter: dbUser.hasTwitter,
+        hasDiscord: dbUser.hasDiscord,
+        farcasterUsername: dbUser.farcasterUsername,
+        twitterUsername: dbUser.twitterUsername,
+        discordUsername: dbUser.discordUsername,
+        showTwitterPublic: dbUser.showTwitterPublic,
+        showFarcasterPublic: dbUser.showFarcasterPublic,
+        showWalletPublic: dbUser.showWalletPublic,
+        isAdmin: dbUser.isAdmin,
+        isActor: dbUser.isActor,
+        createdAt: dbUser.createdAt.toISOString(),
+        updatedAt: dbUser.updatedAt.toISOString(),
+        gameGuideCompletedAt: dbUser.gameGuideCompletedAt?.toISOString() ?? null,
+        stats: stats || undefined,
+      };
+
+      const needsOnboarding = !dbUser.profileComplete;
+      const needsOnchain = dbUser.profileComplete && !dbUser.onChainRegistered;
+
+      logger.info(
+        'Returning linked existing user profile',
+        {
+          userId: dbUser.id,
+          username: dbUser.username,
+          profileComplete: dbUser.profileComplete,
+          onChainRegistered: dbUser.onChainRegistered,
+          needsOnboarding,
+          needsOnchain,
+        },
+        'GET /api/users/me'
+      );
+
+      return successResponse({
+        authenticated: true,
+        needsOnboarding,
+        needsOnchain,
+        user: responseUser,
+      });
+    }
 
     // Resolve referrer if referralCode provided
     let resolvedReferrerId: string | null = null;

--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -144,6 +144,7 @@
 import {
   authenticate,
   cachedDb,
+  ConflictError,
   getPrivyClient,
   InternalServerError,
   successResponse,
@@ -289,7 +290,9 @@ type UserSelectResult = {
   hasTwitter: boolean | null;
   hasDiscord: boolean | null;
   farcasterUsername: string | null;
+  farcasterFid: string | null;
   twitterUsername: string | null;
+  twitterId: string | null;
   discordUsername: string | null;
   showTwitterPublic: boolean | null;
   showFarcasterPublic: boolean | null;
@@ -448,6 +451,12 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
           },
           'GET /api/users/me'
         );
+        
+        // Return error to prevent insert failure due to unique constraint violation
+        throw new ConflictError(
+          'Your social accounts are linked to different existing users. Please contact support.',
+          'User.socialAccounts'
+        );
       } else if (existingUsersWithSocial.length === 1) {
         const existingUserWithSocial = existingUsersWithSocial[0]!;
         const matchedByFarcaster =
@@ -486,7 +495,10 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
           .where(eq(users.privyId, privyId))
           .limit(1);
 
-        if (existingUserWithPrivyId && existingUserWithPrivyId.id !== existingUserWithSocial.id) {
+        if (
+          existingUserWithPrivyId &&
+          existingUserWithPrivyId.id !== existingUserWithSocial.id
+        ) {
           logger.warn(
             'New privyId already linked to a different user - skipping auto-link to prevent account conflict',
             {
@@ -527,6 +539,48 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
 
     // If we found and linked to an existing user, skip the new user creation
     if (dbUser) {
+      // Handle referral attribution for auto-linked users with incomplete profiles
+      if (referralCode && !dbUser.profileComplete) {
+        const normalizedCode = referralCode.trim();
+
+        // Try to find referrer by username first
+        let [referrer] = await db
+          .select({ id: users.id, username: users.username })
+          .from(users)
+          .where(sql`lower(${users.username}) = lower(${normalizedCode})`)
+          .limit(1);
+
+        // If not found by username, try by referralCode
+        if (!referrer) {
+          [referrer] = await db
+            .select({ id: users.id, username: users.username })
+            .from(users)
+            .where(eq(users.referralCode, normalizedCode))
+            .limit(1);
+        }
+
+        if (referrer && referrer.id !== dbUser.id && dbUser.referredBy !== referrer.id) {
+          const [updatedUser] = await db
+            .update(users)
+            .set({ referredBy: referrer.id, updatedAt: new Date() })
+            .where(eq(users.id, dbUser.id))
+            .returning(userSelectFields);
+
+          if (updatedUser) {
+            dbUser = updatedUser;
+            logger.info(
+              'Updated auto-linked user with referrer',
+              {
+                userId: dbUser.id,
+                referrerId: referrer.id,
+                referrerUsername: referrer.username,
+              },
+              'GET /api/users/me'
+            );
+          }
+        }
+      }
+
       // Get cached profile stats for the linked user
       const stats = await cachedDb.getUserProfileStats(dbUser.id);
 

--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -272,33 +272,33 @@ type UserSelectResult = {
   coverImageUrl: string | null;
   walletAddress: string | null;
   email: string | null;
-  profileComplete: boolean | null;
-  hasUsername: boolean | null;
-  hasBio: boolean | null;
-  hasProfileImage: boolean | null;
-  onChainRegistered: boolean | null;
+  profileComplete: boolean;
+  hasUsername: boolean;
+  hasBio: boolean;
+  hasProfileImage: boolean;
+  onChainRegistered: boolean;
   nftTokenId: number | null;
   referralCode: string | null;
   referredBy: string | null;
-  reputationPoints: number | null;
-  virtualBalance: string | null;
-  pointsAwardedForProfile: boolean | null;
-  pointsAwardedForFarcasterFollow: boolean | null;
-  pointsAwardedForTwitterFollow: boolean | null;
-  pointsAwardedForDiscordJoin: boolean | null;
-  hasFarcaster: boolean | null;
-  hasTwitter: boolean | null;
-  hasDiscord: boolean | null;
+  reputationPoints: number;
+  virtualBalance: string;
+  pointsAwardedForProfile: boolean;
+  pointsAwardedForFarcasterFollow: boolean;
+  pointsAwardedForTwitterFollow: boolean;
+  pointsAwardedForDiscordJoin: boolean;
+  hasFarcaster: boolean;
+  hasTwitter: boolean;
+  hasDiscord: boolean;
   farcasterUsername: string | null;
   farcasterFid: string | null;
   twitterUsername: string | null;
   twitterId: string | null;
   discordUsername: string | null;
-  showTwitterPublic: boolean | null;
-  showFarcasterPublic: boolean | null;
-  showWalletPublic: boolean | null;
-  isAdmin: boolean | null;
-  isActor: boolean | null;
+  showTwitterPublic: boolean;
+  showFarcasterPublic: boolean;
+  showWalletPublic: boolean;
+  isAdmin: boolean;
+  isActor: boolean;
   createdAt: Date;
   updatedAt: Date;
   gameGuideCompletedAt: Date | null;
@@ -347,6 +347,80 @@ function buildUserResponse(
     gameGuideCompletedAt: dbUser.gameGuideCompletedAt?.toISOString() ?? null,
     stats: stats || undefined,
   };
+}
+
+async function updateReferrerForIncompleteUser(
+  dbUser: UserSelectResult,
+  referralCode: string
+): Promise<UserSelectResult> {
+  const normalizedCode = referralCode.trim();
+
+  // First, try to find referrer by username (legacy system, case-insensitive)
+  let [referrer] = await db
+    .select({ id: users.id, username: users.username })
+    .from(users)
+    .where(sql`lower(${users.username}) = lower(${normalizedCode})`)
+    .limit(1);
+
+  // If not found by username, try by referralCode
+  if (!referrer) {
+    [referrer] = await db
+      .select({ id: users.id, username: users.username })
+      .from(users)
+      .where(eq(users.referralCode, normalizedCode))
+      .limit(1);
+  }
+
+  if (referrer && referrer.id !== dbUser.id) {
+    const previousReferrer = dbUser.referredBy;
+
+    const [updatedUser] = await db
+      .update(users)
+      .set({ referredBy: referrer.id })
+      .where(eq(users.id, dbUser.id))
+      .returning(userSelectFields);
+
+    if (!updatedUser) {
+      throw new InternalServerError('Failed to update user record');
+    }
+
+    if (previousReferrer && previousReferrer !== referrer.id) {
+      logger.info(
+        'Updated user with NEW referrer (latest referral wins)',
+        {
+          userId: updatedUser.id,
+          previousReferrer,
+          newReferrer: referrer.id,
+          referrerUsername: referrer.username,
+          referralCode,
+        },
+        'GET /api/users/me'
+      );
+    } else if (!previousReferrer) {
+      logger.info(
+        'Updated existing user with referrer',
+        {
+          userId: updatedUser.id,
+          referrerId: referrer.id,
+          referrerUsername: referrer.username,
+          referralCode,
+        },
+        'GET /api/users/me'
+      );
+    }
+
+    return updatedUser;
+  }
+
+  if (referrer?.id === dbUser.id) {
+    logger.warn(
+      'Self-referral attempt blocked for existing user',
+      { userId: dbUser.id, referralCode },
+      'GET /api/users/me'
+    );
+  }
+
+  return dbUser;
 }
 
 export const GET = withErrorHandling(async (request: NextRequest) => {
@@ -441,7 +515,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       // If multiple users found, it means Farcaster and Twitter belong to different accounts
       // Skip auto-linking to prevent linking the wrong account
       if (existingUsersWithSocial.length > 1) {
-        logger.error(
+        logger.warn(
           'Multiple users found with conflicting social accounts - skipping auto-link',
           {
             newPrivyId: privyId,
@@ -451,7 +525,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
           },
           'GET /api/users/me'
         );
-        
+
         // Return error to prevent insert failure due to unique constraint violation
         throw new ConflictError(
           'Your social accounts are linked to different existing users. Please contact support.',
@@ -539,63 +613,41 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
 
     // If we found and linked to an existing user, skip the new user creation
     if (dbUser) {
-      // Handle referral attribution for auto-linked users with incomplete profiles
-      if (referralCode && !dbUser.profileComplete) {
-        const normalizedCode = referralCode.trim();
+      let linkedUser = dbUser;
 
-        // Try to find referrer by username first
-        let [referrer] = await db
-          .select({ id: users.id, username: users.username })
-          .from(users)
-          .where(sql`lower(${users.username}) = lower(${normalizedCode})`)
-          .limit(1);
-
-        // If not found by username, try by referralCode
-        if (!referrer) {
-          [referrer] = await db
-            .select({ id: users.id, username: users.username })
-            .from(users)
-            .where(eq(users.referralCode, normalizedCode))
-            .limit(1);
-        }
-
-        if (referrer && referrer.id !== dbUser.id && dbUser.referredBy !== referrer.id) {
-          const [updatedUser] = await db
-            .update(users)
-            .set({ referredBy: referrer.id, updatedAt: new Date() })
-            .where(eq(users.id, dbUser.id))
-            .returning(userSelectFields);
-
-          if (updatedUser) {
-            dbUser = updatedUser;
-            logger.info(
-              'Updated auto-linked user with referrer',
-              {
-                userId: dbUser.id,
-                referrerId: referrer.id,
-                referrerUsername: referrer.username,
-              },
-              'GET /api/users/me'
-            );
-          }
-        }
+      if (referralCode && !linkedUser.profileComplete) {
+        linkedUser = await updateReferrerForIncompleteUser(
+          linkedUser,
+          referralCode
+        );
+      } else if (referralCode && linkedUser.profileComplete) {
+        logger.warn(
+          'Referral change blocked - profile already complete',
+          {
+            userId: linkedUser.id,
+            referralCode,
+            existingReferrer: linkedUser.referredBy,
+          },
+          'GET /api/users/me'
+        );
       }
 
       // Get cached profile stats for the linked user
-      const stats = await cachedDb.getUserProfileStats(dbUser.id);
+      const stats = await cachedDb.getUserProfileStats(linkedUser.id);
 
-      const responseUser = buildUserResponse(dbUser, stats);
+      const responseUser = buildUserResponse(linkedUser, stats);
 
-      const needsOnboarding = !dbUser.profileComplete;
-      const needsOnchain = dbUser.profileComplete && !dbUser.onChainRegistered;
+      const needsOnboarding = !linkedUser.profileComplete;
+      const needsOnchain =
+        linkedUser.profileComplete && !linkedUser.onChainRegistered;
 
       logger.info(
         'Returning linked existing user profile',
         {
-          userId: dbUser.id,
-          username: dbUser.username,
-          profileComplete: dbUser.profileComplete,
-          onChainRegistered: dbUser.onChainRegistered,
+          userId: linkedUser.id,
+          username: linkedUser.username,
+          profileComplete: linkedUser.profileComplete,
+          onChainRegistered: linkedUser.onChainRegistered,
           needsOnboarding,
           needsOnchain,
         },
@@ -759,69 +811,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   } else if (referralCode && dbUser && !dbUser.profileComplete) {
     // User exists BUT profile not complete - update referredBy with latest referral code (latest wins!)
     // ⚠️ IMPORTANT: Only allow referral changes BEFORE profile completion to prevent gaming
-    const normalizedCode = referralCode.trim();
-
-    // First, try to find referrer by username (legacy system, case-insensitive)
-    let [referrer] = await db
-      .select({ id: users.id, username: users.username })
-      .from(users)
-      .where(sql`lower(${users.username}) = lower(${normalizedCode})`)
-      .limit(1);
-
-    // If not found by username, try by referralCode
-    if (!referrer) {
-      [referrer] = await db
-        .select({ id: users.id, username: users.username })
-        .from(users)
-        .where(eq(users.referralCode, normalizedCode))
-        .limit(1);
-    }
-
-    if (referrer && referrer.id !== dbUser.id) {
-      const previousReferrer = dbUser.referredBy;
-
-      const [updatedUser] = await db
-        .update(users)
-        .set({ referredBy: referrer.id })
-        .where(eq(users.id, dbUser.id))
-        .returning(userSelectFields);
-
-      if (!updatedUser) {
-        throw new InternalServerError('Failed to update user record');
-      }
-      dbUser = updatedUser;
-
-      if (previousReferrer && previousReferrer !== referrer.id) {
-        logger.info(
-          'Updated user with NEW referrer (latest referral wins)',
-          {
-            userId: dbUser.id,
-            previousReferrer,
-            newReferrer: referrer.id,
-            referrerUsername: referrer.username,
-            referralCode,
-          },
-          'GET /api/users/me'
-        );
-      } else if (!previousReferrer) {
-        logger.info(
-          'Updated existing user with referrer',
-          {
-            userId: dbUser.id,
-            referrerId: referrer.id,
-            referrerUsername: referrer.username,
-            referralCode,
-          },
-          'GET /api/users/me'
-        );
-      }
-    } else if (referrer?.id === dbUser.id) {
-      logger.warn(
-        'Self-referral attempt blocked for existing user',
-        { userId: dbUser.id, referralCode },
-        'GET /api/users/me'
-      );
-    }
+    dbUser = await updateReferrerForIncompleteUser(dbUser, referralCode);
   } else if (referralCode && dbUser && dbUser.profileComplete) {
     // User has completed profile - don't allow referral changes anymore
     logger.warn(


### PR DESCRIPTION
## Summary

- Fixes the issue where users would see the onboarding screen repeatedly even though they already had a completed profile
- When users login with a new Privy session but the same Farcaster or Twitter account, the system now automatically links them to their existing Babylon account instead of creating a duplicate

## Problem

When a user logged in with their Farcaster or Twitter account using a different Privy session than the one that originally created their account, the system would:
1. Not find them by `privyId` (since it's a new session)
2. Create a duplicate user record with `profileComplete = false`
3. Show the onboarding screen even though they're already registered

## Solution

Before creating a new user, check if the `farcasterFid` or `twitterId` already exists in the database. If found:
1. Update the existing user's `privyId` to the new session
2. Return the existing user profile
3. Skip creating a duplicate user

## Changes

- Add `farcasterFid` and `twitterId` to `userSelectFields`
- Add auto-link logic before new user creation in `/api/users/me`

## Test plan

- [ ] Login with Farcaster account that's already linked to an existing user
- [ ] Verify you're logged into your existing account (not shown onboarding)
- [ ] Login with Twitter account that's already linked to an existing user
- [ ] Verify the `privyId` is updated on the existing user record

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authentication now auto-links Farcaster and Twitter sign-ins to existing profiles and returns the linked profile, preserving user history.

* **Bug Fixes**
  * Improved conflict detection when multiple social matches exist — linking is skipped and logged to avoid incorrect merges.
  * Warns and skips linking if a social account is already connected elsewhere.

* **Behavioral**
  * Consistent profile output formatting (ISO timestamps, normalized balances, optional stats) and improved referrer resolution for incomplete accounts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added auto-linking logic to prevent duplicate accounts when users login with a different Privy session but the same Farcaster or Twitter account. When a new login occurs, the system now checks if the `farcasterFid` or `twitterId` already exists in the database before creating a new user. If found, it updates the existing user's `privyId` to the new session and returns the existing profile, preventing the onboarding screen from appearing for users who already have completed profiles.

**Key Changes:**
- Added `farcasterFid` and `twitterId` to `userSelectFields` for querying
- Implemented social account lookup before user creation using `or()` condition
- Updates existing user's `privyId` when social account match is found
- Returns early with linked user profile, skipping new user creation flow
- Added comprehensive logging for auto-linking events

**Issue Found:**
- Edge case where a user has both Farcaster and Twitter linked to different existing accounts will only process the first match from the query, potentially linking to the wrong account

<h3>Confidence Score: 4/5</h3>


- This PR is safe to merge with low risk, solving a real user issue
- The implementation correctly solves the duplicate account problem by checking for existing social accounts before creating new users. The logic is sound and includes proper logging. However, there's an edge case where a user with both Farcaster and Twitter linked to different existing accounts could be auto-linked to the wrong one. This scenario is unlikely in practice but should be considered.
- No files require special attention beyond the edge case noted in the comment

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/api/users/me/route.ts | Added auto-linking logic to connect existing accounts when users login with Farcaster/Twitter. The implementation correctly checks for existing social accounts before creating duplicates and updates the privyId. Minor edge case: if both Farcaster and Twitter match different users, only the first match is processed. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API as GET /api/users/me
    participant Privy
    participant DB as Database

    Client->>API: Login with new Privy session
    API->>API: Authenticate user
    API->>DB: Query user by privyId
    DB-->>API: User not found
    
    API->>Privy: Get user data (email, social accounts)
    Privy-->>API: Return Farcaster/Twitter info
    
    alt Social Account Check (NEW)
        API->>DB: Query users by farcasterFid OR twitterId
        alt Existing user found
            DB-->>API: Return existing user
            API->>DB: Update existing user's privyId
            DB-->>API: Return updated user
            API->>DB: Get profile stats
            DB-->>API: Return stats
            API-->>Client: Return linked existing user profile
        else No existing user
            API->>API: Continue to create new user
            API->>DB: Resolve referrer (if referralCode)
            API->>Privy: Ensure smart wallet
            API->>DB: Insert new user record
            DB-->>API: Return new user
            API->>DB: Get profile stats
            DB-->>API: Return stats
            API-->>Client: Return new user profile
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->