### PR TITLE
feat: gate NFT chat access (stacked on #826)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -495,6 +495,12 @@ NFT_CHAIN_ID=1
 # and most authenticated API routes return 403 unless the user has minted via the Top 100 flow.
 NFT_GATING_ENABLED=false
 
+# Enable NFT-gated chat access (default: false).
+# When enabled, a single configured chat is gated behind `NftSnapshot.hasMinted === true`.
+NFT_CHAT_GATING_ENABLED=false
+# Chat ID (Chat.id) for the gated chat (required when NFT_CHAT_GATING_ENABLED=true)
+NFT_CHAT_GATING_CHAT_ID=
+
 
 # ============================================================================
 # Currency Configuration

--- a/apps/web/src/app/api/chats/[id]/message/route.ts
+++ b/apps/web/src/app/api/chats/[id]/message/route.ts
@@ -103,6 +103,7 @@ import {
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
+import { requireNftChatAccess } from '@babylon/api/services/nft-chat-gating-service';
 import {
   and,
   asUser,
@@ -332,6 +333,8 @@ export const POST = withErrorHandling(
           );
         }
 
+        await requireNftChatAccess(user, chatId);
+
         // Verify NFT ownership for NFT-gated chats (cached)
         if (chat.nftGated && chat.requiredNftContractAddress) {
           const [userData] = await db
@@ -351,20 +354,22 @@ export const POST = withErrorHandling(
             // Remove user from chat since they no longer have NFT access
             // Wrap in transaction for consistency
             await db.transaction(async (tx) => {
-              await tx
-                .update(groupMembers)
-                .set({
-                  isActive: false,
-                  kickedAt: new Date(),
-                  kickReason: 'Lost NFT access',
-                })
-                .where(
-                  and(
-                    eq(groupMembers.groupId, chatId),
-                    eq(groupMembers.userId, user.userId),
-                    eq(groupMembers.isActive, true)
-                  )
-                );
+              if (chat.groupId) {
+                await tx
+                  .update(groupMembers)
+                  .set({
+                    isActive: false,
+                    kickedAt: new Date(),
+                    kickReason: 'Lost NFT access',
+                  })
+                  .where(
+                    and(
+                      eq(groupMembers.groupId, chat.groupId),
+                      eq(groupMembers.userId, user.userId),
+                      eq(groupMembers.isActive, true)
+                    )
+                  );
+              }
 
               await tx
                 .delete(chatParticipants)

--- a/apps/web/src/app/api/chats/[id]/participants/route.ts
+++ b/apps/web/src/app/api/chats/[id]/participants/route.ts
@@ -131,6 +131,7 @@ import {
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
+import { requireNftChatAccess } from '@babylon/api/services/nft-chat-gating-service';
 import { asSystem, asUser } from '@babylon/db';
 import { generateSnowflakeId, logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
@@ -150,6 +151,8 @@ export const POST = withErrorHandling(
     if (!chatId) {
       throw new BusinessLogicError('Chat ID is required', 'CHAT_ID_REQUIRED');
     }
+
+    await requireNftChatAccess(user, chatId);
 
     // Validate request body
     const body = await request.json();
@@ -394,6 +397,8 @@ export const GET = withErrorHandling(
     if (!chatId) {
       throw new BusinessLogicError('Chat ID is required', 'CHAT_ID_REQUIRED');
     }
+
+    await requireNftChatAccess(user, chatId);
 
     // Get chat participants
     const participants = await asUser(user, async (db) => {

--- a/apps/web/src/app/api/chats/[id]/route.ts
+++ b/apps/web/src/app/api/chats/[id]/route.ts
@@ -58,6 +58,7 @@ import {
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
+import { requireNftChatAccess } from '@babylon/api/services/nft-chat-gating-service';
 import {
   and,
   asSystem,
@@ -170,6 +171,8 @@ export const GET = withErrorHandling(
           'read'
         );
       }
+
+      await requireNftChatAccess(authUser, chatId);
     }
 
     // Get chat with messages

--- a/apps/web/src/app/api/chats/route.ts
+++ b/apps/web/src/app/api/chats/route.ts
@@ -198,6 +198,10 @@ import {
   logger,
 } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
+import {
+  canAccessNftChatGate,
+  getNftChatGatingConfig,
+} from '@babylon/api/services/nft-chat-gating-service';
 
 /**
  * GET /api/chats
@@ -306,6 +310,13 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   }
 
   const user = await authenticate(request);
+  const nftChatGatingConfig = getNftChatGatingConfig();
+  const gatedChatId = nftChatGatingConfig.chatId;
+  const canAccessNftGatedChat =
+    !nftChatGatingConfig.enabled ||
+    !gatedChatId ||
+    user.isAgent === true ||
+    (await canAccessNftChatGate(user.userId, gatedChatId));
 
   logger.info(
     'Fetching chats for user',
@@ -341,8 +352,23 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       )
       .orderBy(desc(groupMembers.lastMessageAt));
 
+    const gatedChatGroupId =
+      gatedChatId && canAccessNftGatedChat === false
+        ? (
+            await dbClient
+              .select({ groupId: chats.groupId })
+              .from(chats)
+              .where(eq(chats.id, gatedChatId))
+              .limit(1)
+          )[0]?.groupId
+        : undefined;
+    const filteredMemberships =
+      gatedChatGroupId && canAccessNftGatedChat === false
+        ? memberships.filter((m) => m.groupId !== gatedChatGroupId)
+        : memberships;
+
     // Get chat IDs via Chat.groupId relationship
-    const groupIds = memberships.map((m) => m.groupId);
+    const groupIds = filteredMemberships.map((m) => m.groupId);
     const groupChatsWithGroupId =
       groupIds.length > 0
         ? await dbClient
@@ -355,13 +381,19 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     const filteredGroupChats = teamChatId
       ? groupChatsWithGroupId.filter((c) => c.id !== teamChatId)
       : groupChatsWithGroupId;
-    const groupChatIds = filteredGroupChats.map((c) => c.id);
+    const filteredGroupChatsForAccess =
+      gatedChatId && canAccessNftGatedChat === false
+        ? filteredGroupChats.filter((c) => c.id !== gatedChatId)
+        : filteredGroupChats;
+    const groupChatIds = filteredGroupChatsForAccess.map((c) => c.id);
     // Map groupId -> chatId for lookup
     const groupIdToChatId = new Map(
-      filteredGroupChats.map((c) => [c.groupId, c.id])
+      filteredGroupChatsForAccess.map((c) => [c.groupId, c.id])
     );
     // Map chatId -> chat details
-    const chatDetailsMap = new Map(filteredGroupChats.map((c) => [c.id, c]));
+    const chatDetailsMap = new Map(
+      filteredGroupChatsForAccess.map((c) => [c.id, c])
+    );
 
     // Get last messages for group chats
     const groupChatMessages = await Promise.all(
@@ -436,7 +468,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     });
 
     // Format group chats - use groupId -> chatId mapping
-    const formattedGroupChats = memberships
+    const formattedGroupChats = filteredMemberships
       .map((membership) => {
         // Get the chatId from groupId
         const chatId = groupIdToChatId.get(membership.groupId);

--- a/apps/web/src/app/api/chats/route.ts
+++ b/apps/web/src/app/api/chats/route.ts
@@ -172,6 +172,10 @@ import {
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
+import {
+  canAccessNftChatGate,
+  getNftChatGatingConfig,
+} from '@babylon/api/services/nft-chat-gating-service';
 // Import from new Drizzle client
 import {
   agentMessages,
@@ -198,10 +202,6 @@ import {
   logger,
 } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
-import {
-  canAccessNftChatGate,
-  getNftChatGatingConfig,
-} from '@babylon/api/services/nft-chat-gating-service';
 
 /**
  * GET /api/chats

--- a/apps/web/src/app/api/chats/route.ts
+++ b/apps/web/src/app/api/chats/route.ts
@@ -316,7 +316,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     !nftChatGatingConfig.enabled ||
     !gatedChatId ||
     user.isAgent === true ||
-    (await canAccessNftChatGate(user.userId, gatedChatId));
+    (await canAccessNftChatGate(user.dbUserId ?? user.userId, gatedChatId));
 
   logger.info(
     'Fetching chats for user',

--- a/apps/web/src/app/api/nft/chat/ensure/route.ts
+++ b/apps/web/src/app/api/nft/chat/ensure/route.ts
@@ -16,4 +16,3 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
   const user = await authenticateWithDbUser(request);
   return successResponse(await ensureNftChatMembership(user.dbUserId));
 });
-

--- a/apps/web/src/app/api/nft/chat/ensure/route.ts
+++ b/apps/web/src/app/api/nft/chat/ensure/route.ts
@@ -1,0 +1,19 @@
+import {
+  authenticateWithDbUser,
+  successResponse,
+  withErrorHandling,
+} from '@babylon/api';
+import { ensureNftChatMembership } from '@babylon/api/services/nft-chat-gating-service';
+import type { NextRequest } from 'next/server';
+
+/**
+ * POST /api/nft/chat/ensure
+ *
+ * Ensures the authenticated user is a member of the configured NFT-gated chat.
+ * This is used after minting to grant access to the private chat experience.
+ */
+export const POST = withErrorHandling(async (request: NextRequest) => {
+  const user = await authenticateWithDbUser(request);
+  return successResponse(await ensureNftChatMembership(user.dbUserId));
+});
+

--- a/apps/web/src/app/nft/page.tsx
+++ b/apps/web/src/app/nft/page.tsx
@@ -137,6 +137,8 @@ export default function NftGalleryPage() {
       }
 
       router.push('/chats');
+    } catch {
+      toast.error('Failed to unlock chat access');
     } finally {
       setEnsuringChatAccess(false);
     }

--- a/apps/web/src/app/nft/page.tsx
+++ b/apps/web/src/app/nft/page.tsx
@@ -1,14 +1,14 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
 import { NftGrid, RevealModal } from '@/components/nft';
 import { PageContainer } from '@/components/shared/PageContainer';
 import { useAuth } from '@/hooks/useAuth';
 import { useNftMint } from '@/hooks/useNftMint';
 import type { NftGalleryResponse, NftSummary } from '@/types/nft';
 import { apiFetch } from '@/utils/api-fetch';
-import { useRouter } from 'next/navigation';
-import { toast } from 'sonner';
 
 type ViewTab = 'all' | 'mine';
 
@@ -129,9 +129,9 @@ export default function NftGalleryPage() {
       });
 
       if (!response.ok) {
-        const json = (await response.json().catch(() => null)) as
-          | { error?: string }
-          | null;
+        const json = (await response.json().catch(() => null)) as {
+          error?: string;
+        } | null;
         toast.error(json?.error ?? 'Failed to unlock chat access');
         return;
       }
@@ -175,7 +175,9 @@ export default function NftGalleryPage() {
                   disabled={ensuringChatAccess}
                   className="rounded-lg border border-[#0066FF]/30 bg-[#0066FF]/10 px-4 py-2 text-[#0066FF] text-sm transition-colors hover:bg-[#0066FF]/20 disabled:cursor-not-allowed disabled:opacity-60"
                 >
-                  {ensuringChatAccess ? 'Opening chat...' : 'Open FD Alpha Chat →'}
+                  {ensuringChatAccess
+                    ? 'Opening chat...'
+                    : 'Open FD Alpha Chat →'}
                 </button>
                 <a
                   href={`/nft/${eligibility.mintedNft.tokenId}`}

--- a/apps/web/src/app/nft/page.tsx
+++ b/apps/web/src/app/nft/page.tsx
@@ -6,11 +6,15 @@ import { PageContainer } from '@/components/shared/PageContainer';
 import { useAuth } from '@/hooks/useAuth';
 import { useNftMint } from '@/hooks/useNftMint';
 import type { NftGalleryResponse, NftSummary } from '@/types/nft';
+import { apiFetch } from '@/utils/api-fetch';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
 
 type ViewTab = 'all' | 'mine';
 
 export default function NftGalleryPage() {
   const { authenticated, user } = useAuth();
+  const router = useRouter();
   const {
     eligibility,
     isCheckingEligibility,
@@ -39,6 +43,7 @@ export default function NftGalleryPage() {
   // Modals
   const [showEligibilityModal, setShowEligibilityModal] = useState(false);
   const showRevealModal = flowState === 'revealing';
+  const [ensuringChatAccess, setEnsuringChatAccess] = useState(false);
 
   // Debounce search
   useEffect(() => {
@@ -113,6 +118,30 @@ export default function NftGalleryPage() {
     fetchNfts();
   };
 
+  const handleOpenGatedChat = async () => {
+    if (!authenticated) return;
+    if (!eligibility?.hasMinted) return;
+
+    setEnsuringChatAccess(true);
+    try {
+      const response = await apiFetch('/api/nft/chat/ensure', {
+        method: 'POST',
+      });
+
+      if (!response.ok) {
+        const json = (await response.json().catch(() => null)) as
+          | { error?: string }
+          | null;
+        toast.error(json?.error ?? 'Failed to unlock chat access');
+        return;
+      }
+
+      router.push('/chats');
+    } finally {
+      setEnsuringChatAccess(false);
+    }
+  };
+
   return (
     <PageContainer noPadding className="flex h-full flex-col">
       {/* Header */}
@@ -139,12 +168,22 @@ export default function NftGalleryPage() {
             )}
 
             {eligibility?.hasMinted && eligibility.mintedNft && (
-              <a
-                href={`/nft/${eligibility.mintedNft.tokenId}`}
-                className="rounded-lg border border-green-500/30 bg-green-500/10 px-4 py-2 text-green-600 text-sm transition-colors hover:bg-green-500/20"
-              >
-                View My NFT →
-              </a>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={handleOpenGatedChat}
+                  disabled={ensuringChatAccess}
+                  className="rounded-lg border border-[#0066FF]/30 bg-[#0066FF]/10 px-4 py-2 text-[#0066FF] text-sm transition-colors hover:bg-[#0066FF]/20 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {ensuringChatAccess ? 'Opening chat...' : 'Open FD Alpha Chat →'}
+                </button>
+                <a
+                  href={`/nft/${eligibility.mintedNft.tokenId}`}
+                  className="rounded-lg border border-green-500/30 bg-green-500/10 px-4 py-2 text-green-600 text-sm transition-colors hover:bg-green-500/20"
+                >
+                  View My NFT →
+                </a>
+              </div>
             )}
           </div>
 

--- a/packages/api/src/__tests__/nft-chat-gating-service.test.ts
+++ b/packages/api/src/__tests__/nft-chat-gating-service.test.ts
@@ -1,0 +1,736 @@
+/**
+ * Unit Tests: NFT Chat Gating Service
+ *
+ * Tests the NFT chat gating functionality including:
+ * - Configuration parsing from environment variables
+ * - Access control logic (isNftChatGatedChat, canAccessNftChatGate)
+ * - Authorization enforcement (requireNftChatAccess)
+ * - Membership management (ensureNftChatMembership, revokeNftChatMembershipIfNeeded)
+ *
+ * Run with: bun test packages/api/src/__tests__/nft-chat-gating-service.test.ts
+ */
+
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+// Mock tables
+const chatsTable = { id: 'id', isGroup: 'isGroup', groupId: 'groupId' };
+const groupMembersTable = {
+  id: 'id',
+  groupId: 'groupId',
+  userId: 'userId',
+  isActive: 'isActive',
+};
+const chatParticipantsTable = {
+  id: 'id',
+  chatId: 'chatId',
+  userId: 'userId',
+  isActive: 'isActive',
+};
+
+// Mock functions
+const mockIsUserAdmin = mock();
+const mockHasNftAccess = mock();
+const mockDbSelect = mock();
+const mockDbInsert = mock();
+const mockDbUpdate = mock();
+const mockDbTransaction = mock();
+const mockGenerateSnowflakeId = mock();
+const mockLogger = {
+  info: mock(),
+  warn: mock(),
+  error: mock(),
+};
+
+// Mock dependencies - use paths relative to the module being tested
+mock.module('../services/nft-access-service', () => ({
+  hasNftAccess: mockHasNftAccess,
+}));
+
+mock.module('../admin-middleware', () => ({
+  isUserAdmin: mockIsUserAdmin,
+}));
+
+mock.module('@babylon/db', () => ({
+  db: {
+    select: mockDbSelect,
+    insert: mockDbInsert,
+    update: mockDbUpdate,
+    transaction: mockDbTransaction,
+  },
+  eq: (field: unknown, value: unknown) => ({ type: 'eq', field, value }),
+  and: (...conditions: unknown[]) => ({ type: 'and', conditions }),
+  chats: chatsTable,
+  groupMembers: groupMembersTable,
+  chatParticipants: chatParticipantsTable,
+}));
+
+mock.module('drizzle-orm', () => ({
+  sql: (strings: TemplateStringsArray) => ({ type: 'sql', value: strings[0] }),
+}));
+
+mock.module('@babylon/shared', () => ({
+  generateSnowflakeId: mockGenerateSnowflakeId,
+  logger: mockLogger,
+  ValidationError: class ValidationError extends Error {
+    constructor(
+      message: string,
+      public fields: string[],
+      public errors: Array<{ field: string; message: string }>
+    ) {
+      super(message);
+      this.name = 'ValidationError';
+    }
+  },
+}));
+
+mock.module('../errors', () => ({
+  AuthorizationError: class AuthorizationError extends Error {
+    constructor(
+      message: string,
+      public resource: string,
+      public action: string,
+      public context?: Record<string, unknown>
+    ) {
+      super(message);
+      this.name = 'AuthorizationError';
+    }
+  },
+  NotFoundError: class NotFoundError extends Error {
+    constructor(
+      public resourceType: string,
+      public resourceId: string
+    ) {
+      super(`${resourceType} not found: ${resourceId}`);
+      this.name = 'NotFoundError';
+    }
+  },
+}));
+
+// Import after mocks are set up
+import {
+  canAccessNftChatGate,
+  ensureNftChatMembership,
+  getNftChatGatingConfig,
+  isNftChatGatedChat,
+  requireNftChatAccess,
+  revokeNftChatMembershipIfNeeded,
+} from '../services/nft-chat-gating-service';
+
+describe('NFT Chat Gating Service', () => {
+  beforeEach(() => {
+    // Reset all mocks
+    mockIsUserAdmin.mockReset();
+    mockHasNftAccess.mockReset();
+    mockDbSelect.mockReset();
+    mockDbInsert.mockReset();
+    mockDbUpdate.mockReset();
+    mockDbTransaction.mockReset();
+    mockGenerateSnowflakeId.mockReset();
+    mockLogger.info.mockReset();
+    mockLogger.warn.mockReset();
+    mockLogger.error.mockReset();
+
+    // Reset environment variables
+    delete process.env.NFT_CHAT_GATING_ENABLED;
+    delete process.env.NFT_CHAT_GATING_CHAT_ID;
+  });
+
+  describe('getNftChatGatingConfig', () => {
+    it('should return disabled config when env vars are not set', () => {
+      const config = getNftChatGatingConfig();
+      expect(config.enabled).toBe(false);
+      expect(config.chatId).toBeNull();
+    });
+
+    it('should return enabled config when NFT_CHAT_GATING_ENABLED=true', () => {
+      process.env.NFT_CHAT_GATING_ENABLED = 'true';
+      process.env.NFT_CHAT_GATING_CHAT_ID = 'chat-123';
+
+      const config = getNftChatGatingConfig();
+      expect(config.enabled).toBe(true);
+      expect(config.chatId).toBe('chat-123');
+    });
+
+    it('should parse various truthy values for enabled flag', () => {
+      const truthyValues = ['true', 'TRUE', '1', 'yes', 'YES', 'on', 'ON'];
+
+      for (const value of truthyValues) {
+        process.env.NFT_CHAT_GATING_ENABLED = value;
+        const config = getNftChatGatingConfig();
+        expect(config.enabled).toBe(true);
+      }
+    });
+
+    it('should return false for non-truthy enabled values', () => {
+      const falsyValues = ['false', '0', 'no', 'off', 'random', ''];
+
+      for (const value of falsyValues) {
+        process.env.NFT_CHAT_GATING_ENABLED = value;
+        const config = getNftChatGatingConfig();
+        expect(config.enabled).toBe(false);
+      }
+    });
+
+    it('should trim whitespace from chat ID', () => {
+      process.env.NFT_CHAT_GATING_ENABLED = 'true';
+      process.env.NFT_CHAT_GATING_CHAT_ID = '  chat-123  ';
+
+      const config = getNftChatGatingConfig();
+      expect(config.chatId).toBe('chat-123');
+    });
+
+    it('should return null chatId for empty or whitespace-only value', () => {
+      process.env.NFT_CHAT_GATING_ENABLED = 'true';
+      process.env.NFT_CHAT_GATING_CHAT_ID = '   ';
+
+      const config = getNftChatGatingConfig();
+      expect(config.chatId).toBeNull();
+    });
+  });
+
+  describe('isNftChatGatedChat', () => {
+    it('should return false when gating is disabled', () => {
+      process.env.NFT_CHAT_GATING_ENABLED = 'false';
+      process.env.NFT_CHAT_GATING_CHAT_ID = 'chat-123';
+
+      expect(isNftChatGatedChat('chat-123')).toBe(false);
+    });
+
+    it('should return false when chatId does not match gated chat', () => {
+      process.env.NFT_CHAT_GATING_ENABLED = 'true';
+      process.env.NFT_CHAT_GATING_CHAT_ID = 'chat-123';
+
+      expect(isNftChatGatedChat('chat-456')).toBe(false);
+    });
+
+    it('should return true when chatId matches gated chat and gating is enabled', () => {
+      process.env.NFT_CHAT_GATING_ENABLED = 'true';
+      process.env.NFT_CHAT_GATING_CHAT_ID = 'chat-123';
+
+      expect(isNftChatGatedChat('chat-123')).toBe(true);
+    });
+
+    it('should return false when gated chatId is not configured', () => {
+      process.env.NFT_CHAT_GATING_ENABLED = 'true';
+
+      expect(isNftChatGatedChat('chat-123')).toBe(false);
+    });
+  });
+
+  describe('canAccessNftChatGate', () => {
+    beforeEach(() => {
+      process.env.NFT_CHAT_GATING_ENABLED = 'true';
+      process.env.NFT_CHAT_GATING_CHAT_ID = 'gated-chat';
+    });
+
+    it('should return true for non-gated chats', async () => {
+      const result = await canAccessNftChatGate('user-123', 'regular-chat');
+      expect(result).toBe(true);
+      expect(mockIsUserAdmin).not.toHaveBeenCalled();
+      expect(mockHasNftAccess).not.toHaveBeenCalled();
+    });
+
+    it('should return true for admins on gated chat', async () => {
+      mockIsUserAdmin.mockResolvedValue(true);
+
+      const result = await canAccessNftChatGate('admin-user', 'gated-chat');
+      expect(result).toBe(true);
+      expect(mockIsUserAdmin).toHaveBeenCalledWith('admin-user');
+      expect(mockHasNftAccess).not.toHaveBeenCalled();
+    });
+
+    it('should check NFT access for non-admin on gated chat', async () => {
+      mockIsUserAdmin.mockResolvedValue(false);
+      mockHasNftAccess.mockResolvedValue(true);
+
+      const result = await canAccessNftChatGate('regular-user', 'gated-chat');
+      expect(result).toBe(true);
+      expect(mockIsUserAdmin).toHaveBeenCalledWith('regular-user');
+      expect(mockHasNftAccess).toHaveBeenCalledWith('regular-user');
+    });
+
+    it('should return false for non-admin without NFT access', async () => {
+      mockIsUserAdmin.mockResolvedValue(false);
+      mockHasNftAccess.mockResolvedValue(false);
+
+      const result = await canAccessNftChatGate('regular-user', 'gated-chat');
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('requireNftChatAccess', () => {
+    beforeEach(() => {
+      process.env.NFT_CHAT_GATING_ENABLED = 'true';
+      process.env.NFT_CHAT_GATING_CHAT_ID = 'gated-chat';
+    });
+
+    it('should not throw for non-gated chats', async () => {
+      const user = { userId: 'user-123' };
+      await expect(
+        requireNftChatAccess(user, 'regular-chat')
+      ).resolves.toBeUndefined();
+    });
+
+    it('should not throw for agents', async () => {
+      const user = { userId: 'agent-123', isAgent: true };
+      await expect(
+        requireNftChatAccess(user, 'gated-chat')
+      ).resolves.toBeUndefined();
+      expect(mockIsUserAdmin).not.toHaveBeenCalled();
+    });
+
+    it('should not throw when user has access', async () => {
+      mockIsUserAdmin.mockResolvedValue(false);
+      mockHasNftAccess.mockResolvedValue(true);
+
+      const user = { userId: 'user-123', dbUserId: 'db-user-123' };
+      await expect(
+        requireNftChatAccess(user, 'gated-chat')
+      ).resolves.toBeUndefined();
+    });
+
+    it('should throw AuthorizationError when user lacks access', async () => {
+      mockIsUserAdmin.mockResolvedValue(false);
+      mockHasNftAccess.mockResolvedValue(false);
+
+      const user = { userId: 'user-123' };
+      await expect(requireNftChatAccess(user, 'gated-chat')).rejects.toThrow(
+        'NFT chat access required'
+      );
+    });
+
+    it('should prefer dbUserId over userId for access check', async () => {
+      mockIsUserAdmin.mockResolvedValue(false);
+      mockHasNftAccess.mockResolvedValue(true);
+
+      const user = { userId: 'privy-id', dbUserId: 'db-user-123' };
+      await requireNftChatAccess(user, 'gated-chat');
+
+      // Should call with dbUserId, not userId
+      expect(mockHasNftAccess).toHaveBeenCalledWith('db-user-123');
+    });
+
+    it('should fallback to userId when dbUserId is not available', async () => {
+      mockIsUserAdmin.mockResolvedValue(false);
+      mockHasNftAccess.mockResolvedValue(true);
+
+      const user = { userId: 'user-123' };
+      await requireNftChatAccess(user, 'gated-chat');
+
+      expect(mockHasNftAccess).toHaveBeenCalledWith('user-123');
+    });
+  });
+
+  describe('ensureNftChatMembership', () => {
+    beforeEach(() => {
+      process.env.NFT_CHAT_GATING_ENABLED = 'true';
+      process.env.NFT_CHAT_GATING_CHAT_ID = 'gated-chat';
+    });
+
+    it('should throw ValidationError when gating is disabled', async () => {
+      process.env.NFT_CHAT_GATING_ENABLED = 'false';
+
+      await expect(ensureNftChatMembership('user-123')).rejects.toThrow(
+        'NFT chat gating is disabled'
+      );
+    });
+
+    it('should throw ValidationError when chatId is not configured', async () => {
+      delete process.env.NFT_CHAT_GATING_CHAT_ID;
+
+      await expect(ensureNftChatMembership('user-123')).rejects.toThrow(
+        'NFT chat gating chat id not configured'
+      );
+    });
+
+    it('should throw AuthorizationError when user lacks NFT access', async () => {
+      mockIsUserAdmin.mockResolvedValue(false);
+      mockHasNftAccess.mockResolvedValue(false);
+
+      await expect(ensureNftChatMembership('user-123')).rejects.toThrow(
+        'NFT chat access required'
+      );
+    });
+
+    it('should allow admin access without NFT', async () => {
+      mockIsUserAdmin.mockResolvedValue(true);
+      mockHasNftAccess.mockResolvedValue(false);
+
+      // Mock db.select for chat lookup
+      mockDbSelect.mockImplementation(() => ({
+        from: () => ({
+          where: () => ({
+            limit: () =>
+              Promise.resolve([
+                { id: 'gated-chat', isGroup: true, groupId: 'group-123' },
+              ]),
+          }),
+        }),
+      }));
+
+      // Mock transaction
+      mockDbTransaction.mockImplementation(async (callback: Function) => {
+        const tx = {
+          insert: () => ({
+            values: () => ({
+              onConflictDoUpdate: () => Promise.resolve(),
+            }),
+          }),
+        };
+        await callback(tx);
+      });
+
+      mockGenerateSnowflakeId.mockResolvedValue('new-id-123');
+
+      const result = await ensureNftChatMembership('admin-user');
+      expect(result).toEqual({ success: true, chatId: 'gated-chat' });
+    });
+
+    it('should throw NotFoundError when chat does not exist', async () => {
+      mockIsUserAdmin.mockResolvedValue(false);
+      mockHasNftAccess.mockResolvedValue(true);
+
+      // Mock db.select returning empty
+      mockDbSelect.mockImplementation(() => ({
+        from: () => ({
+          where: () => ({
+            limit: () => Promise.resolve([]),
+          }),
+        }),
+      }));
+
+      await expect(ensureNftChatMembership('user-123')).rejects.toThrow(
+        'Chat not found'
+      );
+    });
+
+    it('should throw ValidationError when chat is not a group chat', async () => {
+      mockIsUserAdmin.mockResolvedValue(false);
+      mockHasNftAccess.mockResolvedValue(true);
+
+      // Mock db.select returning non-group chat
+      mockDbSelect.mockImplementation(() => ({
+        from: () => ({
+          where: () => ({
+            limit: () =>
+              Promise.resolve([
+                { id: 'gated-chat', isGroup: false, groupId: null },
+              ]),
+          }),
+        }),
+      }));
+
+      await expect(ensureNftChatMembership('user-123')).rejects.toThrow(
+        'NFT gated chat is not a group chat'
+      );
+    });
+
+    it('should create membership records for eligible user', async () => {
+      mockIsUserAdmin.mockResolvedValue(false);
+      mockHasNftAccess.mockResolvedValue(true);
+
+      mockDbSelect.mockImplementation(() => ({
+        from: () => ({
+          where: () => ({
+            limit: () =>
+              Promise.resolve([
+                { id: 'gated-chat', isGroup: true, groupId: 'group-123' },
+              ]),
+          }),
+        }),
+      }));
+
+      let insertCalls = 0;
+      mockDbTransaction.mockImplementation(async (callback: Function) => {
+        const tx = {
+          insert: () => {
+            insertCalls++;
+            return {
+              values: () => ({
+                onConflictDoUpdate: () => Promise.resolve(),
+              }),
+            };
+          },
+        };
+        await callback(tx);
+      });
+
+      mockGenerateSnowflakeId.mockResolvedValue('new-id-123');
+
+      const result = await ensureNftChatMembership('user-123');
+
+      expect(result).toEqual({ success: true, chatId: 'gated-chat' });
+      // Should insert into both groupMembers and chatParticipants
+      expect(insertCalls).toBe(2);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Ensured NFT gated chat membership',
+        { userId: 'user-123', chatId: 'gated-chat' },
+        'NFTChatGatingService'
+      );
+    });
+  });
+
+  describe('revokeNftChatMembershipIfNeeded', () => {
+    beforeEach(() => {
+      process.env.NFT_CHAT_GATING_ENABLED = 'true';
+      process.env.NFT_CHAT_GATING_CHAT_ID = 'gated-chat';
+    });
+
+    it('should do nothing for non-gated chats', async () => {
+      await revokeNftChatMembershipIfNeeded(
+        'user-123',
+        'regular-chat',
+        'test reason'
+      );
+      expect(mockIsUserAdmin).not.toHaveBeenCalled();
+    });
+
+    it('should not revoke for admins', async () => {
+      mockIsUserAdmin.mockResolvedValue(true);
+
+      await revokeNftChatMembershipIfNeeded(
+        'admin-user',
+        'gated-chat',
+        'test reason'
+      );
+
+      expect(mockDbTransaction).not.toHaveBeenCalled();
+    });
+
+    it('should not revoke if user still has NFT access', async () => {
+      mockIsUserAdmin.mockResolvedValue(false);
+      mockHasNftAccess.mockResolvedValue(true);
+
+      await revokeNftChatMembershipIfNeeded(
+        'user-123',
+        'gated-chat',
+        'test reason'
+      );
+
+      expect(mockDbTransaction).not.toHaveBeenCalled();
+    });
+
+    it('should revoke membership when user loses NFT access', async () => {
+      mockIsUserAdmin.mockResolvedValue(false);
+      mockHasNftAccess.mockResolvedValue(false);
+
+      // Mock db.select for chat lookup
+      mockDbSelect.mockImplementation(() => ({
+        from: () => ({
+          where: () => ({
+            limit: () =>
+              Promise.resolve([{ groupId: 'group-123' }]),
+          }),
+        }),
+      }));
+
+      let updateCalls = 0;
+      mockDbTransaction.mockImplementation(async (callback: Function) => {
+        const tx = {
+          update: () => {
+            updateCalls++;
+            return {
+              set: () => ({
+                where: () => Promise.resolve(),
+              }),
+            };
+          },
+        };
+        await callback(tx);
+      });
+
+      await revokeNftChatMembershipIfNeeded(
+        'user-123',
+        'gated-chat',
+        'Lost NFT access'
+      );
+
+      // Should update both chatParticipants and groupMembers
+      expect(updateCalls).toBe(2);
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        'Revoked NFT gated chat membership',
+        {
+          userId: 'user-123',
+          chatId: 'gated-chat',
+          groupId: 'group-123',
+          reason: 'Lost NFT access',
+        },
+        'NFTChatGatingService'
+      );
+    });
+
+    it('should only update chatParticipants when chat has no groupId', async () => {
+      mockIsUserAdmin.mockResolvedValue(false);
+      mockHasNftAccess.mockResolvedValue(false);
+
+      // Mock db.select returning chat without groupId
+      mockDbSelect.mockImplementation(() => ({
+        from: () => ({
+          where: () => ({
+            limit: () => Promise.resolve([{ groupId: null }]),
+          }),
+        }),
+      }));
+
+      let updateCalls = 0;
+      mockDbTransaction.mockImplementation(async (callback: Function) => {
+        const tx = {
+          update: () => {
+            updateCalls++;
+            return {
+              set: () => ({
+                where: () => Promise.resolve(),
+              }),
+            };
+          },
+        };
+        await callback(tx);
+      });
+
+      await revokeNftChatMembershipIfNeeded(
+        'user-123',
+        'gated-chat',
+        'Lost NFT access'
+      );
+
+      // Should only update chatParticipants (not groupMembers)
+      expect(updateCalls).toBe(1);
+    });
+  });
+});
+
+describe('NFT Chat Gating - Integration Scenarios', () => {
+  beforeEach(() => {
+    mockIsUserAdmin.mockReset();
+    mockHasNftAccess.mockReset();
+    delete process.env.NFT_CHAT_GATING_ENABLED;
+    delete process.env.NFT_CHAT_GATING_CHAT_ID;
+  });
+
+  describe('Complete Access Flow', () => {
+    it('should handle the full access check flow for eligible user', async () => {
+      process.env.NFT_CHAT_GATING_ENABLED = 'true';
+      process.env.NFT_CHAT_GATING_CHAT_ID = 'fd-alpha-chat';
+
+      mockIsUserAdmin.mockResolvedValue(false);
+      mockHasNftAccess.mockResolvedValue(true);
+
+      // Step 1: Check if chat is gated
+      const isGated = isNftChatGatedChat('fd-alpha-chat');
+      expect(isGated).toBe(true);
+
+      // Step 2: Check access
+      const canAccess = await canAccessNftChatGate('user-123', 'fd-alpha-chat');
+      expect(canAccess).toBe(true);
+
+      // Step 3: Require access (should not throw)
+      await expect(
+        requireNftChatAccess(
+          { userId: 'user-123', dbUserId: 'user-123' },
+          'fd-alpha-chat'
+        )
+      ).resolves.toBeUndefined();
+    });
+
+    it('should handle the full access check flow for ineligible user', async () => {
+      process.env.NFT_CHAT_GATING_ENABLED = 'true';
+      process.env.NFT_CHAT_GATING_CHAT_ID = 'fd-alpha-chat';
+
+      mockIsUserAdmin.mockResolvedValue(false);
+      mockHasNftAccess.mockResolvedValue(false);
+
+      // Step 1: Check if chat is gated
+      const isGated = isNftChatGatedChat('fd-alpha-chat');
+      expect(isGated).toBe(true);
+
+      // Step 2: Check access
+      const canAccess = await canAccessNftChatGate('user-123', 'fd-alpha-chat');
+      expect(canAccess).toBe(false);
+
+      // Step 3: Require access (should throw)
+      await expect(
+        requireNftChatAccess({ userId: 'user-123' }, 'fd-alpha-chat')
+      ).rejects.toThrow('NFT chat access required');
+    });
+
+    it('should bypass gating for regular chats', async () => {
+      process.env.NFT_CHAT_GATING_ENABLED = 'true';
+      process.env.NFT_CHAT_GATING_CHAT_ID = 'fd-alpha-chat';
+
+      // Even without NFT access, regular chats should be accessible
+      mockIsUserAdmin.mockResolvedValue(false);
+      mockHasNftAccess.mockResolvedValue(false);
+
+      // Step 1: Check if chat is gated
+      const isGated = isNftChatGatedChat('regular-chat');
+      expect(isGated).toBe(false);
+
+      // Step 2: Check access (should return true without checking NFT)
+      const canAccess = await canAccessNftChatGate('user-123', 'regular-chat');
+      expect(canAccess).toBe(true);
+      expect(mockHasNftAccess).not.toHaveBeenCalled();
+
+      // Step 3: Require access (should not throw)
+      await expect(
+        requireNftChatAccess({ userId: 'user-123' }, 'regular-chat')
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('Feature Flag Scenarios', () => {
+    it('should disable all gating when feature flag is off', async () => {
+      process.env.NFT_CHAT_GATING_ENABLED = 'false';
+      process.env.NFT_CHAT_GATING_CHAT_ID = 'fd-alpha-chat';
+
+      // Even for the configured chat ID, gating should be disabled
+      expect(isNftChatGatedChat('fd-alpha-chat')).toBe(false);
+
+      const canAccess = await canAccessNftChatGate('user-123', 'fd-alpha-chat');
+      expect(canAccess).toBe(true);
+      expect(mockHasNftAccess).not.toHaveBeenCalled();
+    });
+
+    it('should handle missing chat ID gracefully', async () => {
+      process.env.NFT_CHAT_GATING_ENABLED = 'true';
+      // NFT_CHAT_GATING_CHAT_ID not set
+
+      expect(isNftChatGatedChat('any-chat')).toBe(false);
+
+      const canAccess = await canAccessNftChatGate('user-123', 'any-chat');
+      expect(canAccess).toBe(true);
+    });
+  });
+
+  describe('Admin Bypass Scenarios', () => {
+    it('should always allow admins to access gated chats', async () => {
+      process.env.NFT_CHAT_GATING_ENABLED = 'true';
+      process.env.NFT_CHAT_GATING_CHAT_ID = 'fd-alpha-chat';
+
+      mockIsUserAdmin.mockResolvedValue(true);
+      // NFT access check should not even be called for admins
+      mockHasNftAccess.mockResolvedValue(false);
+
+      const canAccess = await canAccessNftChatGate('admin-user', 'fd-alpha-chat');
+      expect(canAccess).toBe(true);
+      expect(mockHasNftAccess).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Agent Bypass Scenarios', () => {
+    it('should always allow agents to access gated chats', async () => {
+      process.env.NFT_CHAT_GATING_ENABLED = 'true';
+      process.env.NFT_CHAT_GATING_CHAT_ID = 'fd-alpha-chat';
+
+      // Agent should bypass all checks
+      const user = { userId: 'agent-123', isAgent: true };
+
+      await expect(
+        requireNftChatAccess(user, 'fd-alpha-chat')
+      ).resolves.toBeUndefined();
+
+      // Should not have checked admin status or NFT access
+      expect(mockIsUserAdmin).not.toHaveBeenCalled();
+      expect(mockHasNftAccess).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/api/src/services/index.ts
+++ b/packages/api/src/services/index.ts
@@ -24,6 +24,7 @@ export * from './generation-lock-service';
 // Moderation Services
 export * from './moderation';
 export * from './nft-access-service';
+export * from './nft-chat-gating-service';
 export * from './nft-group-service';
 export * from './nft-mint-service';
 export * from './nft-verification-service';

--- a/packages/api/src/services/nft-chat-gating-service.ts
+++ b/packages/api/src/services/nft-chat-gating-service.ts
@@ -59,25 +59,28 @@ export function isNftChatGatedChat(chatId: string): boolean {
 }
 
 export async function canAccessNftChatGate(
-  userId: string,
+  dbUserId: string,
   chatId: string
 ): Promise<boolean> {
   if (!isNftChatGatedChat(chatId)) return true;
 
-  const isAdmin = await isUserAdmin(userId);
+  const isAdmin = await isUserAdmin(dbUserId);
   if (isAdmin) return true;
 
-  return hasNftAccess(userId);
+  return hasNftAccess(dbUserId);
 }
 
 export async function requireNftChatAccess(
-  user: { userId: string; isAgent?: boolean },
+  user: { userId: string; dbUserId?: string; isAgent?: boolean },
   chatId: string
 ): Promise<void> {
   if (!isNftChatGatedChat(chatId)) return;
   if (user.isAgent) return;
 
-  const allowed = await canAccessNftChatGate(user.userId, chatId);
+  // Prefer dbUserId for NFT access check (hasNftAccess expects database user ID).
+  // Falls back to userId for backwards compatibility (userId === dbUserId when user exists in DB).
+  const effectiveUserId = user.dbUserId ?? user.userId;
+  const allowed = await canAccessNftChatGate(effectiveUserId, chatId);
   if (!allowed) {
     throw new AuthorizationError('NFT chat access required', 'chat', 'access', {
       chatId,
@@ -180,6 +183,11 @@ export async function ensureNftChatMembership(userId: string): Promise<{
   return { success: true, chatId };
 }
 
+/**
+ * Revoke NFT chat membership if the user no longer has NFT access.
+ * TODO: Wire this up to a scheduled job or on-chain event listener
+ * to automatically revoke access when NFT ownership changes.
+ */
 export async function revokeNftChatMembershipIfNeeded(
   userId: string,
   chatId: string,
@@ -229,4 +237,10 @@ export async function revokeNftChatMembershipIfNeeded(
         );
     }
   });
+
+  logger.info(
+    'Revoked NFT gated chat membership',
+    { userId, chatId, groupId, reason },
+    'NFTChatGatingService'
+  );
 }

--- a/packages/api/src/services/nft-chat-gating-service.ts
+++ b/packages/api/src/services/nft-chat-gating-service.ts
@@ -1,8 +1,15 @@
-import { and, chatParticipants, chats, db, eq, groupMembers } from '@babylon/db';
+import {
+  and,
+  chatParticipants,
+  chats,
+  db,
+  eq,
+  groupMembers,
+} from '@babylon/db';
 import { generateSnowflakeId, logger, ValidationError } from '@babylon/shared';
 import { sql } from 'drizzle-orm';
-import { AuthorizationError, NotFoundError } from '../errors';
 import { isUserAdmin } from '../admin-middleware';
+import { AuthorizationError, NotFoundError } from '../errors';
 import { hasNftAccess } from './nft-access-service';
 
 export interface NftChatGatingConfig {
@@ -223,4 +230,3 @@ export async function revokeNftChatMembershipIfNeeded(
     }
   });
 }
-

--- a/packages/api/src/services/nft-chat-gating-service.ts
+++ b/packages/api/src/services/nft-chat-gating-service.ts
@@ -1,0 +1,226 @@
+import { and, chatParticipants, chats, db, eq, groupMembers } from '@babylon/db';
+import { generateSnowflakeId, logger, ValidationError } from '@babylon/shared';
+import { sql } from 'drizzle-orm';
+import { AuthorizationError, NotFoundError } from '../errors';
+import { isUserAdmin } from '../admin-middleware';
+import { hasNftAccess } from './nft-access-service';
+
+export interface NftChatGatingConfig {
+  enabled: boolean;
+  chatId: string | null;
+}
+
+function parseBooleanFlag(value: string | undefined): boolean {
+  if (!value) return false;
+  return ['true', '1', 'yes', 'on'].includes(value.toLowerCase());
+}
+
+export function getNftChatGatingConfig(): NftChatGatingConfig {
+  const enabled = parseBooleanFlag(process.env.NFT_CHAT_GATING_ENABLED);
+  const chatId = process.env.NFT_CHAT_GATING_CHAT_ID?.trim() || null;
+  return { enabled, chatId };
+}
+
+function assertChatIdConfigured(config: NftChatGatingConfig): string {
+  if (!config.enabled) {
+    throw new ValidationError(
+      'NFT chat gating is disabled',
+      ['NFT_CHAT_GATING_ENABLED'],
+      [{ field: 'NFT_CHAT_GATING_ENABLED', message: 'Flag is disabled' }]
+    );
+  }
+
+  if (!config.chatId) {
+    throw new ValidationError(
+      'NFT chat gating chat id not configured',
+      ['NFT_CHAT_GATING_CHAT_ID'],
+      [
+        {
+          field: 'NFT_CHAT_GATING_CHAT_ID',
+          message: 'Must be set when NFT chat gating is enabled',
+        },
+      ]
+    );
+  }
+
+  return config.chatId;
+}
+
+export function isNftChatGatedChat(chatId: string): boolean {
+  const { enabled, chatId: gatedChatId } = getNftChatGatingConfig();
+  return enabled && gatedChatId !== null && chatId === gatedChatId;
+}
+
+export async function canAccessNftChatGate(
+  userId: string,
+  chatId: string
+): Promise<boolean> {
+  if (!isNftChatGatedChat(chatId)) return true;
+
+  const isAdmin = await isUserAdmin(userId);
+  if (isAdmin) return true;
+
+  return hasNftAccess(userId);
+}
+
+export async function requireNftChatAccess(
+  user: { userId: string; isAgent?: boolean },
+  chatId: string
+): Promise<void> {
+  if (!isNftChatGatedChat(chatId)) return;
+  if (user.isAgent) return;
+
+  const allowed = await canAccessNftChatGate(user.userId, chatId);
+  if (!allowed) {
+    throw new AuthorizationError('NFT chat access required', 'chat', 'access', {
+      chatId,
+    });
+  }
+}
+
+export async function ensureNftChatMembership(userId: string): Promise<{
+  success: true;
+  chatId: string;
+}> {
+  const config = getNftChatGatingConfig();
+  const chatId = assertChatIdConfigured(config);
+
+  const isAdmin = await isUserAdmin(userId);
+  const allowed = isAdmin ? true : await hasNftAccess(userId);
+
+  if (!allowed) {
+    throw new AuthorizationError('NFT chat access required', 'chat', 'join', {
+      chatId,
+    });
+  }
+
+  const [chat] = await db
+    .select({ id: chats.id, isGroup: chats.isGroup, groupId: chats.groupId })
+    .from(chats)
+    .where(eq(chats.id, chatId))
+    .limit(1);
+
+  if (!chat) {
+    throw new NotFoundError('Chat', chatId);
+  }
+  if (!chat.isGroup || !chat.groupId) {
+    throw new ValidationError(
+      'NFT gated chat is not a group chat',
+      ['chatId'],
+      [
+        {
+          field: 'chatId',
+          message: 'Chat must be a group chat with a linked groupId',
+        },
+      ]
+    );
+  }
+
+  const now = new Date();
+
+  await db.transaction(async (tx) => {
+    const memberId = await generateSnowflakeId();
+    await tx
+      .insert(groupMembers)
+      .values({
+        id: memberId,
+        groupId: chat.groupId!,
+        userId,
+        role: 'member',
+        addedBy: 'system',
+        joinedAt: now,
+        isActive: true,
+        messageCount: 0,
+        qualityScore: 1.0,
+      })
+      .onConflictDoUpdate({
+        target: [groupMembers.groupId, groupMembers.userId],
+        set: {
+          isActive: true,
+          role: 'member',
+          addedBy: 'system',
+          joinedAt: now,
+          kickedAt: sql`NULL`,
+          kickReason: sql`NULL`,
+        },
+      });
+
+    const participantId = await generateSnowflakeId();
+    await tx
+      .insert(chatParticipants)
+      .values({
+        id: participantId,
+        chatId,
+        userId,
+        joinedAt: now,
+        isActive: true,
+      })
+      .onConflictDoUpdate({
+        target: [chatParticipants.chatId, chatParticipants.userId],
+        set: {
+          isActive: true,
+          joinedAt: now,
+        },
+      });
+  });
+
+  logger.info(
+    'Ensured NFT gated chat membership',
+    { userId, chatId },
+    'NFTChatGatingService'
+  );
+
+  return { success: true, chatId };
+}
+
+export async function revokeNftChatMembershipIfNeeded(
+  userId: string,
+  chatId: string,
+  reason: string
+): Promise<void> {
+  if (!isNftChatGatedChat(chatId)) return;
+  const isAdmin = await isUserAdmin(userId);
+  if (isAdmin) return;
+
+  const allowed = await hasNftAccess(userId);
+  if (allowed) return;
+
+  const [chat] = await db
+    .select({ groupId: chats.groupId })
+    .from(chats)
+    .where(eq(chats.id, chatId))
+    .limit(1);
+
+  const groupId = chat?.groupId ?? null;
+
+  await db.transaction(async (tx) => {
+    await tx
+      .update(chatParticipants)
+      .set({ isActive: false })
+      .where(
+        and(
+          eq(chatParticipants.chatId, chatId),
+          eq(chatParticipants.userId, userId),
+          eq(chatParticipants.isActive, true)
+        )
+      );
+
+    if (groupId) {
+      await tx
+        .update(groupMembers)
+        .set({
+          isActive: false,
+          kickedAt: new Date(),
+          kickReason: reason,
+        })
+        .where(
+          and(
+            eq(groupMembers.groupId, groupId),
+            eq(groupMembers.userId, userId),
+            eq(groupMembers.isActive, true)
+          )
+        );
+    }
+  });
+}
+


### PR DESCRIPTION
**Stacked PR:** depends on #826. Please merge #826 first, then this PR can be retargeted to `staging` (or merged after).

## Summary

- Adds NFT-gated access to the "FD Alpha" group chat, using our current minted-based eligibility (snapshot) until on-chain indexing is introduced.
- Introduces a small API service to centralize chat gating + membership provisioning, and wires it into chat routes.
- Adds an entrypoint from `/nft` to unlock chat access (behind a flag + configured chat id).

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: `BAB-144`
- Stacked on: `fix/bab-144-nft-app-gating` (PR 2)

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- Adds `@babylon/api/services/nft-chat-gating-service` to:
  - Read chat gating config from env.
  - Enforce access checks (admins/agents bypass).
  - Ensure chat membership records exist for eligible users.
- Adds `POST /api/nft/chat/ensure` to provision membership for the configured gated chat.
- Wires gating into chat routes:
  - List chats filters out the gated chat for non-eligible users.
  - Chat read/write endpoints enforce access (deny when gated + not eligible).
- Adds a UI CTA on `/nft` to unlock/open the gated chat (when eligibility is minted).

## Review guide

**Start here**
- `packages/api/src/services/nft-chat-gating-service.ts`
- `apps/web/src/app/api/nft/chat/ensure/route.ts`
- `apps/web/src/app/api/chats/*` (gating enforcement)

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- Eligibility is intentionally minted-based for now (`hasMinted` in snapshot). On-chain ownership/indexer is planned as a follow-up.
- Feature is behind a flag + chat id config; default is disabled.

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Set `NFT_CHAT_GATING_ENABLED=true` and `NFT_CHAT_GATING_CHAT_ID=<FD_ALPHA_CHAT_ID>`.
2. As a minted/eligible user, go to `/nft`, click "Open FD Alpha Chat" → you should see the gated chat in `/chats` and be able to read/post.
3. As a non-minted user, direct calls to gated chat endpoints should return an authz error and the gated chat should not appear in `/chats`.

## Ops / Migration / Deployment

- [ ] No deploy impact
- [x] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [x] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `NFT_CHAT_GATING_ENABLED` (default: `false`)
- Added: `NFT_CHAT_GATING_CHAT_ID` (the gated chat `Chat.id`)

**DB / data migration**
- Migration(s): N/A
- Backfill/seed: N/A

**Rollout / rollback plan**
- Rollout: deploy then set `NFT_CHAT_GATING_ENABLED=true` (with a valid `NFT_CHAT_GATING_CHAT_ID`).
- Rollback: set `NFT_CHAT_GATING_ENABLED=false`.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy

- [ ] No security impact
- [x] Needs extra review (authz enforcement for chat endpoints)

## Screenshots / recordings (UI)

### Option A: Visual demo

*Recording:*
- https://discord.com/channels/1438561373012627456/1457968219410141225/1463704980836974708

*Demo script (for recording):*
1. Go to `/nft` as a minted user.
2. Click "Open FD Alpha Chat".
3. Verify the gated chat appears in `/chats` and messages can be sent.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (stacked on `fix/bab-144-nft-app-gating`)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NFT-gated chat access: a designated chat can be restricted to verified NFT holders; access enforced across chat listing, retrieval, participants, and messaging flows.
  * UI: "Open FD Alpha Chat" button on the NFT page with loading/feedback while joining.

* **API**
  * New endpoint to ensure membership in the gated chat and server-side membership grant/revoke flows.

* **Documentation**
  * New environment variables and usage comments to enable/configure NFT gating.

* **Tests**
  * Comprehensive unit tests covering gating logic, membership, and revocation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Implemented NFT-gated chat access by adding environment-based configuration (`NFT_CHAT_GATING_ENABLED`, `NFT_CHAT_GATING_CHAT_ID`), a new `nft-chat-gating-service` with access control functions, and UI for NFT holders to unlock the gated chat.

**Key Changes:**
- New `NftChatGatingService` provides centralized access control with admin bypass and membership management
- Chat list endpoint filters out gated chat for users without access
- All chat API endpoints (`GET /chats/[id]`, `POST /chats/[id]/message`, `GET/POST /chats/[id]/participants`) now check NFT chat access via `requireNftChatAccess()`
- New `POST /api/nft/chat/ensure` endpoint grants chat membership after minting
- NFT gallery page displays "Open FD Alpha Chat" button for users who have minted
- Fixed bug where `groupId` could be null during NFT verification removal

**Critical Issue:**
- Line 70 in `nft-chat-gating-service.ts` passes wrong user ID type to `hasNftAccess()` - uses Privy `userId` instead of database `dbUserId`

<h3>Confidence Score: 3/5</h3>


- Has a logical bug that will cause runtime failures when checking NFT chat access
- The type mismatch in `canAccessNftChatGate` will cause incorrect access decisions since it passes the wrong user ID to `hasNftAccess()`. This is a blocking issue that will prevent the feature from working correctly. The rest of the implementation is solid with proper filtering, access checks, and transaction handling.
- packages/api/src/services/nft-chat-gating-service.ts needs immediate fix for the userId/dbUserId mismatch

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/api/src/services/nft-chat-gating-service.ts | New service implementing NFT-gated chat access control with admin bypass, membership management, and config validation - has parameter type mismatch with `hasNftAccess` |
| apps/web/src/app/api/chats/route.ts | Added NFT chat gating logic to filter out gated chats from list when user lacks access - correctly filters at multiple levels |
| apps/web/src/app/api/chats/[id]/message/route.ts | Added NFT chat access check and fixed null groupId bug in NFT verification removal logic |
| apps/web/src/app/api/nft/chat/ensure/route.ts | New endpoint that grants NFT-gated chat access after minting - correctly uses `authenticateWithDbUser` to get DB user ID |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant NFTPage as NFT Gallery Page
    participant EnsureAPI as POST /api/nft/chat/ensure
    participant ChatService as NftChatGatingService
    participant NftAccessService as hasNftAccess()
    participant DB as Database
    participant ChatsPage as /chats

    User->>NFTPage: Clicks "Open FD Alpha Chat" button
    NFTPage->>EnsureAPI: POST request (authenticated)
    EnsureAPI->>ChatService: ensureNftChatMembership(dbUserId)
    ChatService->>ChatService: getNftChatGatingConfig()
    ChatService->>NftAccessService: hasNftAccess(dbUserId)
    NftAccessService->>DB: Query nftSnapshot.hasMinted
    DB-->>NftAccessService: hasMinted: true/false
    NftAccessService-->>ChatService: Access granted/denied
    
    alt User has NFT access
        ChatService->>DB: Begin transaction
        ChatService->>DB: INSERT/UPDATE groupMembers (upsert)
        ChatService->>DB: INSERT/UPDATE chatParticipants (upsert)
        DB-->>ChatService: Membership created
        ChatService-->>EnsureAPI: {success: true, chatId}
        EnsureAPI-->>NFTPage: 200 OK
        NFTPage->>ChatsPage: router.push('/chats')
    else User lacks NFT access
        ChatService-->>EnsureAPI: AuthorizationError
        EnsureAPI-->>NFTPage: 403 Forbidden
        NFTPage->>User: Show error toast
    end

    Note over User,ChatsPage: Chat List Access Flow
    
    User->>ChatsPage: Navigate to /chats
    ChatsPage->>ChatService: canAccessNftChatGate(userId, gatedChatId)
    ChatService->>NftAccessService: hasNftAccess(userId)
    NftAccessService->>DB: Query nftSnapshot.hasMinted
    DB-->>NftAccessService: hasMinted status
    NftAccessService-->>ChatService: Access result
    
    alt User can access gated chat
        ChatService-->>ChatsPage: true
        ChatsPage->>DB: Query all chats including gated
        DB-->>ChatsPage: Full chat list
    else User cannot access gated chat
        ChatService-->>ChatsPage: false
        ChatsPage->>DB: Query chats (filter out gated chat)
        DB-->>ChatsPage: Chat list without gated chat
    end
    
    ChatsPage->>User: Display chat list
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->