### PR TITLE
feat: on-chain NFT gating via Envio indexer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -491,14 +491,20 @@ LINEAR_GAME_FEEDBACK_LABEL_ID=
 NFT_CONTRACT_ADDRESS=
 # Chain ID where the NFT contract is deployed (defaults to 1 = Ethereum mainnet)
 NFT_CHAIN_ID=1
+# Envio hosted GraphQL endpoint for on-chain NFT ownership checks (required for on-chain gating / secondary transfers).
+# Example: https://indexer.dev.hyperindex.xyz/<project>/v1/graphql
+NFT_INDEXER_GRAPHQL_URL=
 # Enable NFT-gated app access (default: false). When enabled, non-holders are redirected to /nft
 # and most authenticated API routes return 403 unless the user has minted via the Top 100 flow.
 NFT_GATING_ENABLED=false
 
-# Enable NFT-gated chat access (default: false).
-# When enabled, a single configured chat is gated behind `NftSnapshot.hasMinted === true`.
+# ============================================
+# NFT Chat Gating (single gated chat)
+# ============================================
+# Note: chat gating uses `NFT_GATING_ENABLED` as the primary flag.
+# `NFT_CHAT_GATING_ENABLED` is kept for backwards compatibility but should not be necessary.
 NFT_CHAT_GATING_ENABLED=false
-# Chat ID (Chat.id) for the gated chat (required when NFT_CHAT_GATING_ENABLED=true)
+# Chat ID (Chat.id) for the gated chat (required when NFT_GATING_ENABLED=true)
 NFT_CHAT_GATING_CHAT_ID=
 
 

--- a/apps/web/src/app/api/chats/route.ts
+++ b/apps/web/src/app/api/chats/route.ts
@@ -315,10 +315,18 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   // Best-effort reconciliation: grant/revoke gated chat membership based on the
   // latest access check (on-chain when available; falls back when degraded).
   if (user.dbUserId) {
-    await reconcileNftChatMembershipForUser({
-      dbUserId: user.dbUserId,
-      isAgent: user.isAgent,
-    });
+    try {
+      await reconcileNftChatMembershipForUser({
+        dbUserId: user.dbUserId,
+        isAgent: user.isAgent,
+      });
+    } catch (error) {
+      logger.warn(
+        'NFT chat reconciliation failed',
+        { error, userId: user.userId, dbUserId: user.dbUserId },
+        'GET /api/chats'
+      );
+    }
   }
   const nftChatGatingConfig = getNftChatGatingConfig();
   const gatedChatId = nftChatGatingConfig.chatId;

--- a/apps/web/src/app/api/chats/route.ts
+++ b/apps/web/src/app/api/chats/route.ts
@@ -175,6 +175,7 @@ import {
 import {
   canAccessNftChatGate,
   getNftChatGatingConfig,
+  reconcileNftChatMembershipForUser,
 } from '@babylon/api/services/nft-chat-gating-service';
 // Import from new Drizzle client
 import {
@@ -310,6 +311,15 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   }
 
   const user = await authenticate(request);
+
+  // Best-effort reconciliation: grant/revoke gated chat membership based on the
+  // latest access check (on-chain when available; falls back when degraded).
+  if (user.dbUserId) {
+    await reconcileNftChatMembershipForUser({
+      dbUserId: user.dbUserId,
+      isAgent: user.isAgent,
+    });
+  }
   const nftChatGatingConfig = getNftChatGatingConfig();
   const gatedChatId = nftChatGatingConfig.chatId;
   const canAccessNftGatedChat =

--- a/apps/web/src/app/api/nft/[tokenId]/route.ts
+++ b/apps/web/src/app/api/nft/[tokenId]/route.ts
@@ -16,6 +16,11 @@ import {
   withErrorHandling,
 } from '@babylon/api';
 import {
+  getNftTokenOwnersFromIndexer,
+  getOwnerUsersByWalletAddresses,
+  NftIndexerUnavailableError,
+} from '@babylon/api/services/nft-indexer-service';
+import {
   db,
   eq,
   nftClaims,
@@ -66,21 +71,73 @@ export const GET = withErrorHandling(
       throw new NotFoundError(`NFT with token ID ${tokenId} not found`);
     }
 
-    // Get current ownership
-    const [ownership] = await db
-      .select({
-        ownerAddress: nftOwnership.ownerAddress,
-        userId: nftOwnership.userId,
-        acquiredAt: nftOwnership.acquiredAt,
-        txHash: nftOwnership.txHash,
-        username: users.username,
-        displayName: users.displayName,
-        profileImageUrl: users.profileImageUrl,
-      })
-      .from(nftOwnership)
-      .leftJoin(users, eq(nftOwnership.userId, users.id))
-      .where(eq(nftOwnership.tokenId, tokenId))
-      .limit(1);
+    // Get current ownership (prefer indexer, fallback to DB ownership)
+    let ownership: {
+      ownerAddress: string;
+      user: {
+        id: string;
+        username: string | null;
+        displayName: string | null;
+        profileImageUrl: string | null;
+      } | null;
+      acquiredAt: string;
+      txHash: string | null;
+    } | null = null;
+
+    try {
+      const owners = await getNftTokenOwnersFromIndexer([tokenId]);
+      const owner = owners.get(tokenId) ?? null;
+      if (owner) {
+        const ownerUsers = await getOwnerUsersByWalletAddresses([
+          owner.ownerAddress,
+        ]);
+        const user = ownerUsers.get(owner.ownerAddress) ?? null;
+        ownership = {
+          ownerAddress: owner.ownerAddress,
+          user,
+          acquiredAt: owner.acquiredAt,
+          txHash: null,
+        };
+      }
+    } catch (error) {
+      if (
+        !(error instanceof NftIndexerUnavailableError) &&
+        !(error instanceof Error && error.name === 'ValidationError')
+      ) {
+        throw error;
+      }
+
+      const [dbOwnership] = await db
+        .select({
+          ownerAddress: nftOwnership.ownerAddress,
+          userId: nftOwnership.userId,
+          acquiredAt: nftOwnership.acquiredAt,
+          txHash: nftOwnership.txHash,
+          username: users.username,
+          displayName: users.displayName,
+          profileImageUrl: users.profileImageUrl,
+        })
+        .from(nftOwnership)
+        .leftJoin(users, eq(nftOwnership.userId, users.id))
+        .where(eq(nftOwnership.tokenId, tokenId))
+        .limit(1);
+
+      ownership = dbOwnership
+        ? {
+            ownerAddress: dbOwnership.ownerAddress,
+            user: dbOwnership.userId
+              ? {
+                  id: dbOwnership.userId,
+                  username: dbOwnership.username,
+                  displayName: dbOwnership.displayName,
+                  profileImageUrl: dbOwnership.profileImageUrl,
+                }
+              : null,
+            acquiredAt: dbOwnership.acquiredAt.toISOString(),
+            txHash: dbOwnership.txHash,
+          }
+        : null;
+    }
 
     // Get original claim info
     const [claim] = await db
@@ -120,15 +177,8 @@ export const GET = withErrorHandling(
       currentOwner: ownership
         ? {
             walletAddress: ownership.ownerAddress,
-            user: ownership.userId
-              ? {
-                  id: ownership.userId,
-                  username: ownership.username,
-                  displayName: ownership.displayName,
-                  profileImageUrl: ownership.profileImageUrl,
-                }
-              : null,
-            acquiredAt: ownership.acquiredAt.toISOString(),
+            user: ownership.user,
+            acquiredAt: ownership.acquiredAt,
             txHash: ownership.txHash,
           }
         : null,

--- a/apps/web/src/app/api/nft/access/route.ts
+++ b/apps/web/src/app/api/nft/access/route.ts
@@ -1,0 +1,15 @@
+import { authenticate, successResponse, withErrorHandling } from '@babylon/api';
+import { getNftAccessStatusForAuthUser } from '@babylon/api/services/nft-access-service';
+import type { NextRequest } from 'next/server';
+import type { NftAccessResponse } from '@/types/nft';
+
+export const GET = withErrorHandling(async (request: NextRequest) => {
+  const user = await authenticate(request);
+
+  const { allowed, degraded } = await getNftAccessStatusForAuthUser(user);
+
+  return successResponse({
+    success: true,
+    data: { hasAccess: allowed, degraded },
+  } satisfies NftAccessResponse);
+});

--- a/apps/web/src/app/api/nft/collection/route.ts
+++ b/apps/web/src/app/api/nft/collection/route.ts
@@ -1,8 +1,12 @@
 import { successResponse, withErrorHandling } from '@babylon/api';
 import {
+  getNftTokenOwnersFromIndexer,
+  getOwnerUsersByWalletAddresses,
+  NftIndexerUnavailableError,
+} from '@babylon/api/services/nft-indexer-service';
+import {
   and,
   asc,
-  count,
   db,
   desc,
   eq,
@@ -13,6 +17,7 @@ import {
   or,
   users,
 } from '@babylon/db';
+import type { SQL } from 'drizzle-orm';
 import type { NextRequest } from 'next/server';
 import type { NftGalleryResponse, NftSummary } from '@/types/nft';
 
@@ -37,7 +42,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   const offset = (page - 1) * limit;
 
   // Build WHERE conditions
-  const conditions: ReturnType<typeof eq>[] = [];
+  const conditions: SQL[] = [];
 
   if (searchQuery) {
     const tokenIdSearch = parseInt(searchQuery, 10);
@@ -53,24 +58,6 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     }
   }
 
-  // Get total count (with search conditions)
-  const [totalResult] = await db
-    .select({ count: count() })
-    .from(nftCollection)
-    .where(conditions.length > 0 ? and(...conditions) : undefined);
-
-  const totalNfts = totalResult?.count ?? 0;
-
-  // Get claimed count (with same search conditions)
-  const [claimedCountResult] = await db
-    .select({ count: count() })
-    .from(nftCollection)
-    .innerJoin(nftOwnership, eq(nftCollection.tokenId, nftOwnership.tokenId))
-    .where(conditions.length > 0 ? and(...conditions) : undefined);
-
-  const claimedCount = claimedCountResult?.count ?? 0;
-  const unclaimedCount = totalNfts - claimedCount;
-
   // Build ORDER BY clause
   let orderByClause;
   const orderFn = order === 'desc' ? desc : asc;
@@ -85,8 +72,101 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       break;
   }
 
-  // Build query based on claimed filter
-  // For unclaimed filter, add isNull condition; for claimed, use inner join
+  // Prefer indexer-based ownership (secondary transfers included). Fall back to DB
+  // ownership when the indexer is unavailable or not configured (local tests/dev).
+  try {
+    const allNfts = await db
+      .select({
+        tokenId: nftCollection.tokenId,
+        name: nftCollection.name,
+        thumbnailUrl: nftCollection.thumbnailUrl,
+        imageUrl: nftCollection.imageUrl,
+      })
+      .from(nftCollection)
+      .where(conditions.length > 0 ? and(...conditions) : undefined)
+      .orderBy(orderByClause);
+
+    const allTokenIds = allNfts.map((n) => n.tokenId);
+    const ownersByTokenId = await getNftTokenOwnersFromIndexer(allTokenIds);
+    const ownerAddresses = Array.from(ownersByTokenId.values()).map(
+      (o) => o.ownerAddress
+    );
+    const ownerUsersByAddress =
+      await getOwnerUsersByWalletAddresses(ownerAddresses);
+
+    const totalNfts = allNfts.length;
+    const claimedCount = ownersByTokenId.size;
+    const unclaimedCount = totalNfts - claimedCount;
+
+    const filtered =
+      claimedFilter === 'true'
+        ? allNfts.filter((n) => ownersByTokenId.has(n.tokenId))
+        : claimedFilter === 'false'
+          ? allNfts.filter((n) => !ownersByTokenId.has(n.tokenId))
+          : allNfts;
+
+    const paged = filtered.slice(offset, offset + limit);
+
+    const nfts: NftSummary[] = paged.map((nft) => {
+      const owner = ownersByTokenId.get(nft.tokenId);
+      const user = owner ? ownerUsersByAddress.get(owner.ownerAddress) : null;
+
+      return {
+        tokenId: nft.tokenId,
+        name: nft.name,
+        thumbnailUrl: nft.thumbnailUrl ?? nft.imageUrl,
+        imageUrl: nft.imageUrl,
+        owner: owner
+          ? {
+              walletAddress: owner.ownerAddress,
+              user: user
+                ? {
+                    id: user.id,
+                    username: user.username,
+                    displayName: user.displayName,
+                    profileImageUrl: user.profileImageUrl,
+                  }
+                : null,
+              acquiredAt: owner.acquiredAt,
+              txHash: null,
+            }
+          : null,
+      };
+    });
+
+    const filteredTotal =
+      claimedFilter === 'true'
+        ? claimedCount
+        : claimedFilter === 'false'
+          ? unclaimedCount
+          : totalNfts;
+
+    return successResponse({
+      success: true,
+      data: {
+        nfts,
+        pagination: {
+          page,
+          limit,
+          total: filteredTotal,
+          totalPages: Math.ceil(filteredTotal / limit),
+        },
+        stats: { totalNfts, claimedCount, unclaimedCount },
+        filters: { traits: [] },
+      },
+    } satisfies NftGalleryResponse);
+  } catch (error) {
+    if (
+      error instanceof NftIndexerUnavailableError ||
+      (error instanceof Error && error.name === 'ValidationError')
+    ) {
+      // Fall back to DB ownership for local/testing/degraded mode.
+    } else {
+      throw error;
+    }
+  }
+
+  // Degraded mode: DB-based ownership (mint-only).
   const baseSelect = {
     tokenId: nftCollection.tokenId,
     name: nftCollection.name,
@@ -102,9 +182,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   };
 
   let nftsResult;
-
   if (claimedFilter === 'true') {
-    // Only claimed NFTs - use inner join to filter
     nftsResult = await db
       .select(baseSelect)
       .from(nftCollection)
@@ -115,7 +193,6 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       .limit(limit)
       .offset(offset);
   } else if (claimedFilter === 'false') {
-    // Only unclaimed NFTs - add isNull condition
     nftsResult = await db
       .select(baseSelect)
       .from(nftCollection)
@@ -126,7 +203,6 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       .limit(limit)
       .offset(offset);
   } else {
-    // All NFTs
     nftsResult = await db
       .select(baseSelect)
       .from(nftCollection)
@@ -138,7 +214,6 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       .offset(offset);
   }
 
-  // Transform results to response format
   const nfts: NftSummary[] = nftsResult.map((nft) => ({
     tokenId: nft.tokenId,
     name: nft.name,
@@ -161,7 +236,22 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       : null,
   }));
 
-  // Calculate total for current filter
+  // Counts in degraded mode (DB-based ownership).
+  const totalNfts = (
+    await db
+      .select({ tokenId: nftCollection.tokenId })
+      .from(nftCollection)
+      .where(conditions.length > 0 ? and(...conditions) : undefined)
+  ).length;
+  const claimedCount = (
+    await db
+      .select({ tokenId: nftOwnership.tokenId })
+      .from(nftOwnership)
+      .innerJoin(nftCollection, eq(nftCollection.tokenId, nftOwnership.tokenId))
+      .where(conditions.length > 0 ? and(...conditions) : undefined)
+  ).length;
+  const unclaimedCount = totalNfts - claimedCount;
+
   const filteredTotal =
     claimedFilter === 'true'
       ? claimedCount

--- a/apps/web/src/app/api/nft/collection/route.ts
+++ b/apps/web/src/app/api/nft/collection/route.ts
@@ -17,6 +17,7 @@ import {
   or,
   users,
 } from '@babylon/db';
+import { logger } from '@babylon/shared';
 import type { SQL } from 'drizzle-orm';
 import type { NextRequest } from 'next/server';
 import type { NftGalleryResponse, NftSummary } from '@/types/nft';
@@ -161,6 +162,11 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       (error instanceof Error && error.name === 'ValidationError')
     ) {
       // Fall back to DB ownership for local/testing/degraded mode.
+      logger.warn(
+        'NFT indexer unavailable for collection, falling back to DB ownership',
+        { error: error instanceof Error ? error.message : error },
+        'GET /api/nft/collection'
+      );
     } else {
       throw error;
     }

--- a/apps/web/src/app/api/nft/holdings/route.ts
+++ b/apps/web/src/app/api/nft/holdings/route.ts
@@ -1,0 +1,101 @@
+import {
+  authenticateWithDbUser,
+  successResponse,
+  withErrorHandling,
+} from '@babylon/api';
+import {
+  getNftCollectionIdFromEnv,
+  getOwnedTokenIdsFromDbFallback,
+  getOwnedTokenIdsFromIndexer,
+  NftIndexerUnavailableError,
+} from '@babylon/api/services/nft-indexer-service';
+import { db, inArray, nftCollection } from '@babylon/db';
+import { logger } from '@babylon/shared';
+import type { NextRequest } from 'next/server';
+import type { NftHoldingsResponse } from '@/types/nft';
+
+export const GET = withErrorHandling(async (request: NextRequest) => {
+  const user = await authenticateWithDbUser(request);
+
+  const walletAddress = user.walletAddress?.trim() ?? '';
+  if (!walletAddress) {
+    return successResponse({
+      success: true,
+      data: {
+        walletAddress: null,
+        collectionId: null,
+        tokenIds: [],
+        nfts: [],
+        degraded: false,
+      },
+    } satisfies NftHoldingsResponse);
+  }
+
+  let tokenIds: number[] = [];
+  let degraded = false;
+
+  try {
+    tokenIds = await getOwnedTokenIdsFromIndexer(walletAddress, { limit: 200 });
+  } catch (error) {
+    if (
+      error instanceof NftIndexerUnavailableError ||
+      (error instanceof Error && error.name === 'ValidationError')
+    ) {
+      degraded = true;
+      logger.warn(
+        'NFT indexer unavailable for holdings, falling back to DB ownership',
+        { userId: user.dbUserId },
+        'GET /api/nft/holdings'
+      );
+      tokenIds = await getOwnedTokenIdsFromDbFallback(user.dbUserId);
+    } else {
+      throw error;
+    }
+  }
+
+  const uniqueTokenIds = Array.from(new Set(tokenIds)).sort((a, b) => a - b);
+  const rows =
+    uniqueTokenIds.length === 0
+      ? []
+      : await db
+          .select({
+            tokenId: nftCollection.tokenId,
+            name: nftCollection.name,
+            thumbnailUrl: nftCollection.thumbnailUrl,
+            imageUrl: nftCollection.imageUrl,
+          })
+          .from(nftCollection)
+          .where(inArray(nftCollection.tokenId, uniqueTokenIds));
+
+  const byId = new Map(rows.map((r) => [r.tokenId, r]));
+  const nfts = uniqueTokenIds
+    .map((tokenId) => {
+      const row = byId.get(tokenId);
+      if (!row) return null;
+      return {
+        tokenId: row.tokenId,
+        name: row.name,
+        thumbnailUrl: row.thumbnailUrl ?? row.imageUrl,
+      };
+    })
+    .filter((v): v is NonNullable<typeof v> => v !== null);
+
+  const collectionId = (() => {
+    try {
+      return getNftCollectionIdFromEnv();
+    } catch {
+      return null;
+    }
+  })();
+
+  return successResponse({
+    success: true,
+    data: {
+      walletAddress,
+      collectionId,
+      tokenIds: uniqueTokenIds,
+      nfts,
+      degraded,
+    },
+  } satisfies NftHoldingsResponse);
+});

--- a/apps/web/src/app/nft/page.tsx
+++ b/apps/web/src/app/nft/page.tsx
@@ -120,7 +120,7 @@ export default function NftGalleryPage() {
 
   const handleOpenGatedChat = async () => {
     if (!authenticated) return;
-    if (!eligibility?.hasMinted) return;
+    if (myNftCount === 0) return;
 
     setEnsuringChatAccess(true);
     try {
@@ -159,7 +159,7 @@ export default function NftGalleryPage() {
               </p>
             </div>
 
-            {authenticated && !eligibility?.hasMinted && (
+            {authenticated && myNftCount === 0 && !eligibility?.hasMinted && (
               <button
                 onClick={handleClaimClick}
                 disabled={isMinting || isCheckingEligibility}
@@ -169,7 +169,7 @@ export default function NftGalleryPage() {
               </button>
             )}
 
-            {eligibility?.hasMinted && eligibility.mintedNft && (
+            {authenticated && myNftCount > 0 && (
               <div className="flex items-center gap-2">
                 <button
                   type="button"
@@ -181,12 +181,14 @@ export default function NftGalleryPage() {
                     ? 'Opening chat...'
                     : 'Open FD Alpha Chat →'}
                 </button>
-                <a
-                  href={`/nft/${eligibility.mintedNft.tokenId}`}
-                  className="rounded-lg border border-green-500/30 bg-green-500/10 px-4 py-2 text-green-600 text-sm transition-colors hover:bg-green-500/20"
-                >
-                  View My NFT →
-                </a>
+                {eligibility?.mintedNft ? (
+                  <a
+                    href={`/nft/${eligibility.mintedNft.tokenId}`}
+                    className="rounded-lg border border-green-500/30 bg-green-500/10 px-4 py-2 text-green-600 text-sm transition-colors hover:bg-green-500/20"
+                  >
+                    View My NFT →
+                  </a>
+                ) : null}
               </div>
             )}
           </div>

--- a/apps/web/src/components/nft/NftAccessGate.tsx
+++ b/apps/web/src/components/nft/NftAccessGate.tsx
@@ -4,7 +4,7 @@ import { isNftGatingAllowlistedPath } from '@babylon/shared';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 import { useAuth } from '@/hooks/useAuth';
-import type { EligibilityApiResponse } from '@/types/nft';
+import type { NftAccessResponse } from '@/types/nft';
 import { apiFetch } from '@/utils/api-fetch';
 
 function buildNftRedirectUrl(searchParams: URLSearchParams): string {
@@ -14,9 +14,7 @@ function buildNftRedirectUrl(searchParams: URLSearchParams): string {
   return qs ? `/nft?${qs}` : '/nft';
 }
 
-function isEligibilityApiResponse(
-  value: unknown
-): value is EligibilityApiResponse {
+function isNftAccessResponse(value: unknown): value is NftAccessResponse {
   if (typeof value !== 'object' || value === null) return false;
   if (
     !('success' in value) ||
@@ -27,7 +25,7 @@ function isEligibilityApiResponse(
   if (!('data' in value)) return false;
   const data = (value as { data: unknown }).data;
   if (typeof data !== 'object' || data === null) return false;
-  return 'hasMinted' in data;
+  return 'hasAccess' in data;
 }
 export function NftAccessGate({ enabled }: { enabled: boolean }) {
   const pathname = usePathname();
@@ -59,7 +57,7 @@ export function NftAccessGate({ enabled }: { enabled: boolean }) {
 
     const run = async () => {
       try {
-        const response = await apiFetch('/api/nft/eligibility', {
+        const response = await apiFetch('/api/nft/access', {
           cache: 'no-store',
           signal: controller.signal,
         });
@@ -70,7 +68,7 @@ export function NftAccessGate({ enabled }: { enabled: boolean }) {
         }
 
         const json = (await response.json()) as unknown;
-        if (!isEligibilityApiResponse(json) || json.data.hasMinted !== true) {
+        if (!isNftAccessResponse(json) || json.data.hasAccess !== true) {
           router.replace(targetUrl);
         }
       } catch {

--- a/apps/web/src/types/nft.ts
+++ b/apps/web/src/types/nft.ts
@@ -140,6 +140,39 @@ export interface MintPrepareResponse {
   encodedData: string;
 }
 
+// ============================================================================
+// Ownership / Holdings Types
+// ============================================================================
+
+export interface NftHoldingsResponse {
+  success: true;
+  data: {
+    walletAddress: string | null;
+    collectionId: string | null;
+    tokenIds: number[];
+    nfts: Array<{
+      tokenId: number;
+      name: string;
+      thumbnailUrl: string;
+    }>;
+    /**
+     * True when the indexer was unavailable and we fell back to DB ownership.
+     */
+    degraded: boolean;
+  };
+}
+
+export interface NftAccessResponse {
+  success: true;
+  data: {
+    hasAccess: boolean;
+    /**
+     * True when the indexer was unavailable and we fell back to DB-based access.
+     */
+    degraded: boolean;
+  };
+}
+
 /**
  * Mint confirmation request
  */

--- a/packages/api/src/__tests__/auth-middleware.test.ts
+++ b/packages/api/src/__tests__/auth-middleware.test.ts
@@ -28,6 +28,11 @@ const nftSnapshotTable = {
   hasMinted: 'hasMinted',
 };
 
+const nftOwnershipTable = {
+  tokenId: 'tokenId',
+  userId: 'userId',
+};
+
 // Mock the local agent-auth module
 mock.module('../agent-auth', () => ({
   verifyAgentSession: mockVerifyAgentSession,
@@ -41,6 +46,7 @@ mock.module('@babylon/db', () => ({
   eq: (field: unknown, value: unknown) => ({ field, value }),
   users: usersTable,
   nftSnapshot: nftSnapshotTable,
+  nftOwnership: nftOwnershipTable,
 }));
 
 // Mock @privy-io/server-auth - PrivyClient is a class that gets instantiated
@@ -56,6 +62,7 @@ import { authenticate } from '../auth-middleware';
 let usersRows: Array<{ id: string; walletAddress: string; isAdmin?: boolean }> =
   [];
 let snapshotRows: Array<{ hasMinted: boolean }> = [];
+let ownershipRows: Array<{ tokenId: number }> = [];
 
 const createRequest = (token: string, pathname: string): NextRequest =>
   ({
@@ -79,6 +86,7 @@ describe('authenticate middleware', () => {
     process.env.NFT_GATING_ENABLED = 'false';
     usersRows = [];
     snapshotRows = [];
+    ownershipRows = [];
 
     // Default mock chain for db.select().from().where().limit()
     mockSelect.mockImplementation(() => ({
@@ -88,6 +96,8 @@ describe('authenticate middleware', () => {
             if (table === usersTable) return Promise.resolve(usersRows);
             if (table === nftSnapshotTable)
               return Promise.resolve(snapshotRows);
+            if (table === nftOwnershipTable)
+              return Promise.resolve(ownershipRows);
             return Promise.resolve([]);
           },
         }),

--- a/packages/api/src/__tests__/nft-chat-gating-service.test.ts
+++ b/packages/api/src/__tests__/nft-chat-gating-service.test.ts
@@ -131,6 +131,7 @@ describe('NFT Chat Gating Service', () => {
     mockLogger.error.mockReset();
 
     // Reset environment variables
+    delete process.env.NFT_GATING_ENABLED;
     delete process.env.NFT_CHAT_GATING_ENABLED;
     delete process.env.NFT_CHAT_GATING_CHAT_ID;
   });
@@ -518,8 +519,7 @@ describe('NFT Chat Gating Service', () => {
       mockDbSelect.mockImplementation(() => ({
         from: () => ({
           where: () => ({
-            limit: () =>
-              Promise.resolve([{ groupId: 'group-123' }]),
+            limit: () => Promise.resolve([{ groupId: 'group-123' }]),
           }),
         }),
       }));
@@ -710,7 +710,10 @@ describe('NFT Chat Gating - Integration Scenarios', () => {
       // NFT access check should not even be called for admins
       mockHasNftAccess.mockResolvedValue(false);
 
-      const canAccess = await canAccessNftChatGate('admin-user', 'fd-alpha-chat');
+      const canAccess = await canAccessNftChatGate(
+        'admin-user',
+        'fd-alpha-chat'
+      );
       expect(canAccess).toBe(true);
       expect(mockHasNftAccess).not.toHaveBeenCalled();
     });

--- a/packages/api/src/auth-middleware.ts
+++ b/packages/api/src/auth-middleware.ts
@@ -20,7 +20,7 @@ import {
   AuthorizationError,
   isAuthenticationError,
 } from './errors';
-import { hasNftAccess } from './services/nft-access-service';
+import { hasNftAccessForAuthUser } from './services/nft-access-service';
 
 // Re-export types from shared for backwards compatibility
 export type { AuthenticatedUser } from '@babylon/shared';
@@ -208,7 +208,7 @@ export async function authenticate(
           });
         }
 
-        const allowed = await hasNftAccess(authedUser.dbUserId);
+        const allowed = await hasNftAccessForAuthUser(authedUser);
         if (!allowed) {
           throw new AuthorizationError('NFT access required', 'nft', 'access', {
             pathname,

--- a/packages/api/src/services/index.ts
+++ b/packages/api/src/services/index.ts
@@ -26,6 +26,7 @@ export * from './moderation';
 export * from './nft-access-service';
 export * from './nft-chat-gating-service';
 export * from './nft-group-service';
+export * from './nft-indexer-service';
 export * from './nft-mint-service';
 export * from './nft-verification-service';
 export * from './notification-service';

--- a/packages/api/src/services/nft-access-service.ts
+++ b/packages/api/src/services/nft-access-service.ts
@@ -59,6 +59,9 @@ export async function hasNftAccessForAuthUser(user: {
       return await hasOnchainNftAccess(walletAddress);
     } catch (error) {
       if (!(error instanceof NftIndexerUnavailableError)) throw error;
+      // Short-circuit to DB fallback to avoid double indexer call via hasNftAccess
+      if (user.dbUserId) return hasDbNftAccessFallback(user.dbUserId);
+      return false;
     }
   }
 

--- a/packages/api/src/services/nft-access-service.ts
+++ b/packages/api/src/services/nft-access-service.ts
@@ -1,10 +1,17 @@
-import { db, eq, nftSnapshot } from '@babylon/db';
+import { db, eq, nftOwnership, nftSnapshot, users } from '@babylon/db';
+import {
+  hasOnchainNftAccess,
+  NftIndexerUnavailableError,
+} from './nft-indexer-service';
 
-/**
- * Returns true if the user has minted via our Top 100 claim flow.
- * (Secondary ownership / on-chain indexing is handled in a later PR.)
- */
-export async function hasNftAccess(dbUserId: string): Promise<boolean> {
+async function hasDbNftAccessFallback(dbUserId: string): Promise<boolean> {
+  const [owned] = await db
+    .select({ tokenId: nftOwnership.tokenId })
+    .from(nftOwnership)
+    .where(eq(nftOwnership.userId, dbUserId))
+    .limit(1);
+  if (owned) return true;
+
   const [row] = await db
     .select({ hasMinted: nftSnapshot.hasMinted })
     .from(nftSnapshot)
@@ -12,4 +19,68 @@ export async function hasNftAccess(dbUserId: string): Promise<boolean> {
     .limit(1);
 
   return row?.hasMinted === true;
+}
+
+/**
+ * Returns true if the user currently holds at least one NFT from the configured
+ * Top 100 collection.
+ *
+ * Primary source of truth: Envio indexer (secondary transfers supported).
+ * Fallback (best-effort): DB ownership/snapshot (keeps local/dev behavior and
+ * avoids hard failures if the indexer is temporarily unavailable).
+ */
+export async function hasNftAccess(dbUserId: string): Promise<boolean> {
+  const [dbUser] = await db
+    .select({ walletAddress: users.walletAddress })
+    .from(users)
+    .where(eq(users.id, dbUserId))
+    .limit(1);
+
+  const walletAddress = dbUser?.walletAddress ?? null;
+  if (walletAddress) {
+    try {
+      return await hasOnchainNftAccess(walletAddress);
+    } catch (error) {
+      if (!(error instanceof NftIndexerUnavailableError)) throw error;
+    }
+  }
+
+  // Degraded mode: keep existing behavior (minted or DB ownership).
+  return hasDbNftAccessFallback(dbUserId);
+}
+
+export async function hasNftAccessForAuthUser(user: {
+  dbUserId?: string | null;
+  walletAddress?: string | null;
+}): Promise<boolean> {
+  const walletAddress = user.walletAddress ?? null;
+  if (walletAddress) {
+    try {
+      return await hasOnchainNftAccess(walletAddress);
+    } catch (error) {
+      if (!(error instanceof NftIndexerUnavailableError)) throw error;
+    }
+  }
+
+  if (!user.dbUserId) return false;
+  return hasNftAccess(user.dbUserId);
+}
+
+export async function getNftAccessStatusForAuthUser(user: {
+  dbUserId?: string | null;
+  walletAddress?: string | null;
+}): Promise<{ allowed: boolean; degraded: boolean }> {
+  const walletAddress = user.walletAddress ?? null;
+  if (walletAddress) {
+    try {
+      const allowed = await hasOnchainNftAccess(walletAddress);
+      return { allowed, degraded: false };
+    } catch (error) {
+      if (!(error instanceof NftIndexerUnavailableError)) throw error;
+    }
+  }
+
+  if (!user.dbUserId) return { allowed: false, degraded: true };
+  const allowed = await hasDbNftAccessFallback(user.dbUserId);
+  return { allowed, degraded: true };
 }

--- a/packages/api/src/services/nft-chat-gating-service.ts
+++ b/packages/api/src/services/nft-chat-gating-service.ts
@@ -262,7 +262,10 @@ export async function reconcileNftChatMembershipForUser(user: {
   dbUserId: string;
   isAgent?: boolean;
 }): Promise<
-  | { status: 'skipped'; reason: 'disabled' | 'agent' | 'missing_chat_id' | 'error' }
+  | {
+      status: 'skipped';
+      reason: 'disabled' | 'agent' | 'missing_chat_id' | 'error';
+    }
   | { status: 'noop'; allowed: boolean }
   | { status: 'ensured'; chatId: string }
   | { status: 'revoked'; chatId: string }

--- a/packages/api/src/services/nft-chat-gating-service.ts
+++ b/packages/api/src/services/nft-chat-gating-service.ts
@@ -22,12 +22,19 @@ function parseBooleanFlag(value: string | undefined): boolean {
   return ['true', '1', 'yes', 'on'].includes(value.toLowerCase());
 }
 
+/**
+ * Returns the NFT chat gating configuration.
+ *
+ * Flag precedence:
+ * - If NFT_GATING_ENABLED is defined, it is authoritative (overrides legacy flag)
+ * - Otherwise, falls back to NFT_CHAT_GATING_ENABLED for backwards compatibility
+ */
 export function getNftChatGatingConfig(): NftChatGatingConfig {
-  // Prefer the global flag (NFT_GATING_ENABLED) to avoid proliferating flags.
-  // Keep the legacy chat-only flag for backwards compatibility.
+  const globalFlag = process.env.NFT_GATING_ENABLED;
   const enabled =
-    parseBooleanFlag(process.env.NFT_GATING_ENABLED) ||
-    parseBooleanFlag(process.env.NFT_CHAT_GATING_ENABLED);
+    globalFlag !== undefined
+      ? parseBooleanFlag(globalFlag)
+      : parseBooleanFlag(process.env.NFT_CHAT_GATING_ENABLED);
   const chatId = process.env.NFT_CHAT_GATING_CHAT_ID?.trim() || null;
   return { enabled, chatId };
 }
@@ -255,72 +262,82 @@ export async function reconcileNftChatMembershipForUser(user: {
   dbUserId: string;
   isAgent?: boolean;
 }): Promise<
-  | { status: 'skipped'; reason: 'disabled' | 'agent' | 'missing_chat_id' }
+  | { status: 'skipped'; reason: 'disabled' | 'agent' | 'missing_chat_id' | 'error' }
   | { status: 'noop'; allowed: boolean }
   | { status: 'ensured'; chatId: string }
   | { status: 'revoked'; chatId: string }
 > {
-  if (user.isAgent) return { status: 'skipped', reason: 'agent' };
+  try {
+    if (user.isAgent) return { status: 'skipped', reason: 'agent' };
 
-  const config = getNftChatGatingConfig();
-  if (!config.enabled) return { status: 'skipped', reason: 'disabled' };
-  if (!config.chatId) return { status: 'skipped', reason: 'missing_chat_id' };
+    const config = getNftChatGatingConfig();
+    if (!config.enabled) return { status: 'skipped', reason: 'disabled' };
+    if (!config.chatId) return { status: 'skipped', reason: 'missing_chat_id' };
 
-  const chatId = config.chatId;
+    const chatId = config.chatId;
 
-  const allowed = await canAccessNftChatGate(user.dbUserId, chatId);
+    const allowed = await canAccessNftChatGate(user.dbUserId, chatId);
 
-  // Check current membership state to avoid write-amplifying on every /api/chats call.
-  const [chatRow] = await db
-    .select({ groupId: chats.groupId })
-    .from(chats)
-    .where(eq(chats.id, chatId))
-    .limit(1);
+    // Check current membership state to avoid write-amplifying on every /api/chats call.
+    const [chatRow] = await db
+      .select({ groupId: chats.groupId })
+      .from(chats)
+      .where(eq(chats.id, chatId))
+      .limit(1);
 
-  const groupId = chatRow?.groupId ?? null;
-  const [activeParticipant] = await db
-    .select({ id: chatParticipants.id })
-    .from(chatParticipants)
-    .where(
-      and(
-        eq(chatParticipants.chatId, chatId),
-        eq(chatParticipants.userId, user.dbUserId),
-        eq(chatParticipants.isActive, true)
+    const groupId = chatRow?.groupId ?? null;
+    const [activeParticipant] = await db
+      .select({ id: chatParticipants.id })
+      .from(chatParticipants)
+      .where(
+        and(
+          eq(chatParticipants.chatId, chatId),
+          eq(chatParticipants.userId, user.dbUserId),
+          eq(chatParticipants.isActive, true)
+        )
       )
-    )
-    .limit(1);
+      .limit(1);
 
-  const [activeMember] =
-    groupId === null
-      ? [undefined]
-      : await db
-          .select({ id: groupMembers.id })
-          .from(groupMembers)
-          .where(
-            and(
-              eq(groupMembers.groupId, groupId),
-              eq(groupMembers.userId, user.dbUserId),
-              eq(groupMembers.isActive, true)
+    const [activeMember] =
+      groupId === null
+        ? [undefined]
+        : await db
+            .select({ id: groupMembers.id })
+            .from(groupMembers)
+            .where(
+              and(
+                eq(groupMembers.groupId, groupId),
+                eq(groupMembers.userId, user.dbUserId),
+                eq(groupMembers.isActive, true)
+              )
             )
-          )
-          .limit(1);
+            .limit(1);
 
-  const hasActiveMembership = Boolean(
-    activeParticipant && (groupId ? activeMember : true)
-  );
+    const hasActiveMembership = Boolean(
+      activeParticipant && (groupId ? activeMember : true)
+    );
 
-  if (allowed) {
-    if (hasActiveMembership) return { status: 'noop', allowed: true };
-    await ensureNftChatMembership(user.dbUserId);
-    return { status: 'ensured', chatId };
+    if (allowed) {
+      if (hasActiveMembership) return { status: 'noop', allowed: true };
+      await ensureNftChatMembership(user.dbUserId);
+      return { status: 'ensured', chatId };
+    }
+
+    if (!hasActiveMembership) return { status: 'noop', allowed: false };
+
+    await revokeNftChatMembershipIfNeeded(
+      user.dbUserId,
+      chatId,
+      'NFT access revoked (ownership check)'
+    );
+    return { status: 'revoked', chatId };
+  } catch (error) {
+    logger.warn(
+      'Failed to reconcile NFT chat membership',
+      { error, dbUserId: user.dbUserId },
+      'NFTChatGatingService'
+    );
+    // Return safe noop to avoid accidental revocation on error
+    return { status: 'skipped', reason: 'error' };
   }
-
-  if (!hasActiveMembership) return { status: 'noop', allowed: false };
-
-  await revokeNftChatMembershipIfNeeded(
-    user.dbUserId,
-    chatId,
-    'NFT access revoked (ownership check)'
-  );
-  return { status: 'revoked', chatId };
 }

--- a/packages/api/src/services/nft-chat-gating-service.ts
+++ b/packages/api/src/services/nft-chat-gating-service.ts
@@ -23,7 +23,11 @@ function parseBooleanFlag(value: string | undefined): boolean {
 }
 
 export function getNftChatGatingConfig(): NftChatGatingConfig {
-  const enabled = parseBooleanFlag(process.env.NFT_CHAT_GATING_ENABLED);
+  // Prefer the global flag (NFT_GATING_ENABLED) to avoid proliferating flags.
+  // Keep the legacy chat-only flag for backwards compatibility.
+  const enabled =
+    parseBooleanFlag(process.env.NFT_GATING_ENABLED) ||
+    parseBooleanFlag(process.env.NFT_CHAT_GATING_ENABLED);
   const chatId = process.env.NFT_CHAT_GATING_CHAT_ID?.trim() || null;
   return { enabled, chatId };
 }
@@ -185,8 +189,10 @@ export async function ensureNftChatMembership(userId: string): Promise<{
 
 /**
  * Revoke NFT chat membership if the user no longer has NFT access.
- * TODO: Wire this up to a scheduled job or on-chain event listener
- * to automatically revoke access when NFT ownership changes.
+ *
+ * Note: PR4 introduces a best-effort reconciliation path via `GET /api/chats`
+ * (grant/revoke on user activity). This remains useful as a targeted helper for
+ * other entry points.
  */
 export async function revokeNftChatMembershipIfNeeded(
   userId: string,
@@ -243,4 +249,78 @@ export async function revokeNftChatMembershipIfNeeded(
     { userId, chatId, groupId, reason },
     'NFTChatGatingService'
   );
+}
+
+export async function reconcileNftChatMembershipForUser(user: {
+  dbUserId: string;
+  isAgent?: boolean;
+}): Promise<
+  | { status: 'skipped'; reason: 'disabled' | 'agent' | 'missing_chat_id' }
+  | { status: 'noop'; allowed: boolean }
+  | { status: 'ensured'; chatId: string }
+  | { status: 'revoked'; chatId: string }
+> {
+  if (user.isAgent) return { status: 'skipped', reason: 'agent' };
+
+  const config = getNftChatGatingConfig();
+  if (!config.enabled) return { status: 'skipped', reason: 'disabled' };
+  if (!config.chatId) return { status: 'skipped', reason: 'missing_chat_id' };
+
+  const chatId = config.chatId;
+
+  const allowed = await canAccessNftChatGate(user.dbUserId, chatId);
+
+  // Check current membership state to avoid write-amplifying on every /api/chats call.
+  const [chatRow] = await db
+    .select({ groupId: chats.groupId })
+    .from(chats)
+    .where(eq(chats.id, chatId))
+    .limit(1);
+
+  const groupId = chatRow?.groupId ?? null;
+  const [activeParticipant] = await db
+    .select({ id: chatParticipants.id })
+    .from(chatParticipants)
+    .where(
+      and(
+        eq(chatParticipants.chatId, chatId),
+        eq(chatParticipants.userId, user.dbUserId),
+        eq(chatParticipants.isActive, true)
+      )
+    )
+    .limit(1);
+
+  const [activeMember] =
+    groupId === null
+      ? [undefined]
+      : await db
+          .select({ id: groupMembers.id })
+          .from(groupMembers)
+          .where(
+            and(
+              eq(groupMembers.groupId, groupId),
+              eq(groupMembers.userId, user.dbUserId),
+              eq(groupMembers.isActive, true)
+            )
+          )
+          .limit(1);
+
+  const hasActiveMembership = Boolean(
+    activeParticipant && (groupId ? activeMember : true)
+  );
+
+  if (allowed) {
+    if (hasActiveMembership) return { status: 'noop', allowed: true };
+    await ensureNftChatMembership(user.dbUserId);
+    return { status: 'ensured', chatId };
+  }
+
+  if (!hasActiveMembership) return { status: 'noop', allowed: false };
+
+  await revokeNftChatMembershipIfNeeded(
+    user.dbUserId,
+    chatId,
+    'NFT access revoked (ownership check)'
+  );
+  return { status: 'revoked', chatId };
 }

--- a/packages/api/src/services/nft-indexer-service.ts
+++ b/packages/api/src/services/nft-indexer-service.ts
@@ -1,0 +1,372 @@
+import { db, eq, inArray, nftOwnership, users } from '@babylon/db';
+import { ValidationError } from '@babylon/shared';
+
+type JsonPrimitive = string | number | boolean | null;
+type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
+type JsonObject = { [key: string]: JsonValue };
+
+export class NftIndexerUnavailableError extends Error {
+  constructor(
+    message: string,
+    public cause?: unknown
+  ) {
+    super(message);
+    this.name = 'NftIndexerUnavailableError';
+  }
+}
+
+function normalizeHexAddress(address: string): string {
+  const trimmed = address.trim();
+  if (!trimmed) return '';
+  if (!trimmed.startsWith('0x') && !trimmed.startsWith('0X')) return trimmed;
+  return `0x${trimmed.slice(2).toLowerCase()}`;
+}
+
+function getNftIndexerGraphqlUrl(): string | null {
+  const url = process.env.NFT_INDEXER_GRAPHQL_URL?.trim();
+  return url && url.length > 0 ? url : null;
+}
+
+export function getNftCollectionIdFromEnv(): string {
+  const chainIdRaw = process.env.NFT_CHAIN_ID?.trim();
+  const contractAddressRaw = process.env.NFT_CONTRACT_ADDRESS?.trim();
+
+  if (!chainIdRaw) {
+    throw new ValidationError(
+      'NFT_CHAIN_ID not configured',
+      ['NFT_CHAIN_ID'],
+      [{ field: 'NFT_CHAIN_ID', message: 'Must be set' }]
+    );
+  }
+
+  const chainId = Number.parseInt(chainIdRaw, 10);
+  if (!Number.isFinite(chainId) || chainId <= 0) {
+    throw new ValidationError(
+      'NFT_CHAIN_ID is invalid',
+      ['NFT_CHAIN_ID'],
+      [{ field: 'NFT_CHAIN_ID', message: 'Must be a positive integer' }]
+    );
+  }
+
+  if (!contractAddressRaw) {
+    throw new ValidationError(
+      'NFT_CONTRACT_ADDRESS not configured',
+      ['NFT_CONTRACT_ADDRESS'],
+      [{ field: 'NFT_CONTRACT_ADDRESS', message: 'Must be set' }]
+    );
+  }
+
+  const contractAddress = normalizeHexAddress(contractAddressRaw);
+  if (!/^0x[0-9a-f]{40}$/.test(contractAddress)) {
+    throw new ValidationError(
+      'NFT_CONTRACT_ADDRESS is invalid',
+      ['NFT_CONTRACT_ADDRESS'],
+      [{ field: 'NFT_CONTRACT_ADDRESS', message: 'Must be a valid address' }]
+    );
+  }
+
+  return `${chainId}_${contractAddress}`;
+}
+
+type CachedAccess = { allowed: boolean; expiresAtMs: number };
+const accessCache = new Map<string, CachedAccess>();
+
+const DEFAULT_POSITIVE_TTL_MS = 10_000;
+const DEFAULT_NEGATIVE_TTL_MS = 60_000;
+const DEFAULT_TIMEOUT_MS = 2_500;
+
+function getCacheTtls(): { positiveTtlMs: number; negativeTtlMs: number } {
+  // Keep this intentionally simple: TTLs are internal defaults for now.
+  return {
+    positiveTtlMs: DEFAULT_POSITIVE_TTL_MS,
+    negativeTtlMs: DEFAULT_NEGATIVE_TTL_MS,
+  };
+}
+
+async function fetchGraphql<TData extends JsonObject>(
+  url: string,
+  payload: { query: string; variables?: JsonObject }
+): Promise<TData> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+
+    const json = (await res.json()) as unknown;
+    if (!res.ok) {
+      throw new NftIndexerUnavailableError(
+        `Indexer returned HTTP ${res.status}`,
+        json
+      );
+    }
+
+    if (!json || typeof json !== 'object') {
+      throw new NftIndexerUnavailableError(
+        'Indexer returned non-JSON response'
+      );
+    }
+
+    const obj = json as { data?: TData; errors?: unknown };
+    if (obj.errors) {
+      throw new NftIndexerUnavailableError(
+        'Indexer GraphQL errors',
+        obj.errors
+      );
+    }
+    if (!obj.data) {
+      throw new NftIndexerUnavailableError('Indexer response missing data');
+    }
+
+    return obj.data;
+  } catch (error) {
+    if (error instanceof NftIndexerUnavailableError) throw error;
+    throw new NftIndexerUnavailableError('Failed to reach indexer', error);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+type HolderBalanceQueryData = {
+  NftHolder: Array<{ balance: string }>;
+};
+
+export async function getNftHolderBalanceFromIndexer(
+  walletAddress: string
+): Promise<bigint> {
+  const url = getNftIndexerGraphqlUrl();
+  if (!url) {
+    throw new NftIndexerUnavailableError(
+      'NFT_INDEXER_GRAPHQL_URL not configured'
+    );
+  }
+
+  let collectionId: string;
+  try {
+    collectionId = getNftCollectionIdFromEnv();
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      throw new NftIndexerUnavailableError(
+        'NFT collection config not valid',
+        error
+      );
+    }
+    throw error;
+  }
+  const address = normalizeHexAddress(walletAddress);
+
+  const data = await fetchGraphql<HolderBalanceQueryData>(url, {
+    query:
+      'query($cid:String!,$addr:String!){NftHolder(where:{collection_id:{_eq:$cid},address:{_eq:$addr}},limit:1){balance}}',
+    variables: { cid: collectionId, addr: address },
+  });
+
+  const row = data.NftHolder[0];
+  if (!row) return 0n;
+  const balance = BigInt(row.balance);
+  return balance;
+}
+
+export async function hasOnchainNftAccess(
+  walletAddress: string
+): Promise<boolean> {
+  let collectionId: string;
+  try {
+    collectionId = getNftCollectionIdFromEnv();
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      throw new NftIndexerUnavailableError(
+        'NFT collection config not valid',
+        error
+      );
+    }
+    throw error;
+  }
+  const address = normalizeHexAddress(walletAddress);
+  const cacheKey = `${collectionId}:${address}`;
+
+  const nowMs = Date.now();
+  const cached = accessCache.get(cacheKey);
+  if (cached && cached.expiresAtMs > nowMs) {
+    return cached.allowed;
+  }
+
+  const balance = await getNftHolderBalanceFromIndexer(address);
+  const allowed = balance > 0n;
+
+  const { positiveTtlMs, negativeTtlMs } = getCacheTtls();
+  const ttlMs = allowed ? positiveTtlMs : negativeTtlMs;
+  accessCache.set(cacheKey, { allowed, expiresAtMs: nowMs + ttlMs });
+
+  return allowed;
+}
+
+type TokenOwnerRow = {
+  tokenId: string;
+  updatedAt: string;
+  owner: { address: string } | null;
+};
+
+type TokensByIdsQueryData = {
+  NftToken: TokenOwnerRow[];
+};
+
+export async function getNftTokenOwnersFromIndexer(
+  tokenIds: number[]
+): Promise<Map<number, { ownerAddress: string; acquiredAt: string }>> {
+  const url = getNftIndexerGraphqlUrl();
+  if (!url) {
+    throw new NftIndexerUnavailableError(
+      'NFT_INDEXER_GRAPHQL_URL not configured'
+    );
+  }
+
+  let collectionId: string;
+  try {
+    collectionId = getNftCollectionIdFromEnv();
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      throw new NftIndexerUnavailableError(
+        'NFT collection config not valid',
+        error
+      );
+    }
+    throw error;
+  }
+  const tokenIdStrings = tokenIds.map((id) => String(id));
+
+  const data = await fetchGraphql<TokensByIdsQueryData>(url, {
+    query:
+      'query($cid:String!,$tokenIds:[numeric!]!){NftToken(where:{collection_id:{_eq:$cid},tokenId:{_in:$tokenIds}}){tokenId updatedAt owner{address}}}',
+    variables: { cid: collectionId, tokenIds: tokenIdStrings },
+  });
+
+  const map = new Map<number, { ownerAddress: string; acquiredAt: string }>();
+  for (const row of data.NftToken) {
+    if (!row.owner?.address) continue;
+    const tokenIdNumber = Number.parseInt(row.tokenId, 10);
+    if (!Number.isSafeInteger(tokenIdNumber)) continue;
+    map.set(tokenIdNumber, {
+      ownerAddress: normalizeHexAddress(row.owner.address),
+      acquiredAt: new Date(row.updatedAt).toISOString(),
+    });
+  }
+
+  return map;
+}
+
+type OwnedTokensQueryData = {
+  NftToken: Array<{ tokenId: string }>;
+};
+
+export async function getOwnedTokenIdsFromIndexer(
+  walletAddress: string,
+  opts?: { limit?: number }
+): Promise<number[]> {
+  const url = getNftIndexerGraphqlUrl();
+  if (!url) {
+    throw new NftIndexerUnavailableError(
+      'NFT_INDEXER_GRAPHQL_URL not configured'
+    );
+  }
+
+  let collectionId: string;
+  try {
+    collectionId = getNftCollectionIdFromEnv();
+  } catch (error) {
+    if (error instanceof ValidationError) {
+      throw new NftIndexerUnavailableError(
+        'NFT collection config not valid',
+        error
+      );
+    }
+    throw error;
+  }
+  const address = normalizeHexAddress(walletAddress);
+  const limit = Math.min(500, Math.max(1, opts?.limit ?? 200));
+
+  const data = await fetchGraphql<OwnedTokensQueryData>(url, {
+    query:
+      'query($cid:String!,$addr:String!,$limit:Int!){NftToken(where:{collection_id:{_eq:$cid},owner:{address:{_eq:$addr}}},order_by:[{tokenId:asc}],limit:$limit){tokenId}}',
+    variables: { cid: collectionId, addr: address, limit },
+  });
+
+  const tokenIds: number[] = [];
+  for (const row of data.NftToken) {
+    const tokenIdNumber = Number.parseInt(row.tokenId, 10);
+    if (Number.isSafeInteger(tokenIdNumber)) tokenIds.push(tokenIdNumber);
+  }
+  return tokenIds;
+}
+
+/**
+ * Best-effort "keep current access" fallback when the indexer is unavailable:
+ * treat DB ownership as truthy for minted users and local testing.
+ */
+export async function getOwnedTokenIdsFromDbFallback(
+  dbUserId: string
+): Promise<number[]> {
+  const rows = await db
+    .select({ tokenId: nftOwnership.tokenId })
+    .from(nftOwnership)
+    .where(eq(nftOwnership.userId, dbUserId));
+  return rows.map((r) => r.tokenId);
+}
+
+export async function getOwnerUsersByWalletAddresses(
+  ownerAddresses: string[]
+): Promise<
+  Map<
+    string,
+    {
+      id: string;
+      username: string | null;
+      displayName: string | null;
+      profileImageUrl: string | null;
+    }
+  >
+> {
+  if (ownerAddresses.length === 0) return new Map();
+
+  const normalized = Array.from(
+    new Set(ownerAddresses.map(normalizeHexAddress))
+  );
+  const rows = await db
+    .select({
+      id: users.id,
+      walletAddress: users.walletAddress,
+      username: users.username,
+      displayName: users.displayName,
+      profileImageUrl: users.profileImageUrl,
+    })
+    .from(users)
+    .where(inArray(users.walletAddress, normalized));
+
+  const map = new Map<
+    string,
+    {
+      id: string;
+      username: string | null;
+      displayName: string | null;
+      profileImageUrl: string | null;
+    }
+  >();
+  for (const row of rows) {
+    const addr = row.walletAddress
+      ? normalizeHexAddress(row.walletAddress)
+      : null;
+    if (!addr) continue;
+    map.set(addr, {
+      id: row.id,
+      username: row.username,
+      displayName: row.displayName,
+      profileImageUrl: row.profileImageUrl,
+    });
+  }
+  return map;
+}

--- a/packages/api/src/services/nft-indexer-service.ts
+++ b/packages/api/src/services/nft-indexer-service.ts
@@ -74,6 +74,27 @@ const accessCache = new Map<string, CachedAccess>();
 const DEFAULT_POSITIVE_TTL_MS = 10_000;
 const DEFAULT_NEGATIVE_TTL_MS = 60_000;
 const DEFAULT_TIMEOUT_MS = 2_500;
+const MAX_CACHE_ENTRIES = 10_000;
+
+/**
+ * Evicts expired entries and enforces size cap on the cache.
+ * Uses FIFO eviction when size exceeds MAX_CACHE_ENTRIES.
+ */
+function evictExpiredCacheEntries(nowMs: number): void {
+  // Evict expired entries
+  for (const [key, value] of accessCache) {
+    if (value.expiresAtMs <= nowMs) {
+      accessCache.delete(key);
+    }
+  }
+
+  // Enforce size cap with FIFO eviction
+  while (accessCache.size > MAX_CACHE_ENTRIES) {
+    const oldestKey = accessCache.keys().next().value;
+    if (oldestKey) accessCache.delete(oldestKey);
+    else break;
+  }
+}
 
 function getCacheTtls(): { positiveTtlMs: number; negativeTtlMs: number } {
   // Keep this intentionally simple: TTLs are internal defaults for now.
@@ -192,8 +213,12 @@ export async function hasOnchainNftAccess(
 
   const nowMs = Date.now();
   const cached = accessCache.get(cacheKey);
-  if (cached && cached.expiresAtMs > nowMs) {
-    return cached.allowed;
+  if (cached) {
+    if (cached.expiresAtMs > nowMs) {
+      return cached.allowed;
+    }
+    // Delete expired entry
+    accessCache.delete(cacheKey);
   }
 
   const balance = await getNftHolderBalanceFromIndexer(address);
@@ -202,6 +227,9 @@ export async function hasOnchainNftAccess(
   const { positiveTtlMs, negativeTtlMs } = getCacheTtls();
   const ttlMs = allowed ? positiveTtlMs : negativeTtlMs;
   accessCache.set(cacheKey, { allowed, expiresAtMs: nowMs + ttlMs });
+
+  // Periodic eviction to prevent unbounded growth
+  evictExpiredCacheEntries(nowMs);
 
   return allowed;
 }

--- a/packages/testing/unit/markets/portfolio-actions.test.ts
+++ b/packages/testing/unit/markets/portfolio-actions.test.ts
@@ -1,20 +1,18 @@
 import { describe, expect, it } from 'bun:test';
-import type { PortfolioPnLSnapshot } from '@babylon/engine/client';
+import type { PortfolioBreakdownSnapshot } from '@babylon/engine/client';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { PortfolioPnLCard } from '../../../../apps/web/src/components/markets/PortfolioPnLCard';
 
-const snapshot: PortfolioPnLSnapshot = {
-  lifetimePnL: 0,
-  netContributions: 0,
-  totalDeposited: 0,
-  totalWithdrawn: 0,
-  availableBalance: 0,
-  unrealizedPerpPnL: 0,
-  unrealizedPredictionPnL: 0,
-  totalUnrealizedPnL: 0,
+const snapshot: PortfolioBreakdownSnapshot = {
+  wallet: 0,
+  agents: 0,
+  positions: 0,
+  available: 0,
+  originalAmount: 0,
+  totalAssets: 0,
   totalPnL: 0,
-  accountEquity: 0,
+  agentCount: 0,
 };
 
 describe('PortfolioPnLCard rendering', () => {


### PR DESCRIPTION
## Summary

- Switches NFT gating (app + single gated chat) to **on-chain holder checks** via our **Envio hosted indexer** (secondary transfers included).
- Updates the NFT gallery ownership display to use the indexer (falls back to DB ownership in degraded/local mode).
- Adds best-effort chat membership reconciliation on `/api/chats` so users **gain/lose access after buy/sell** without WebSockets.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: `BAB-144`
- Indexer: Envio hosted GraphQL (configured via env)

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- Adds `packages/api/src/services/nft-indexer-service.ts` (GraphQL client + helpers):
  - Holder access check (balance > 0)
  - Token ownership lookups (tokenId -> owner)
  - Owned tokenIds lookup (address -> tokenIds)
  - Degraded fallback (DB ownership) when the indexer is unavailable/not configured
- App gating:
  - Server/API gating now uses on-chain access when available (`hasNftAccess*`), fallback to DB in degraded mode.
  - Client gate (`apps/web/src/components/nft/NftAccessGate.tsx`) now calls `GET /api/nft/access` instead of relying on minted snapshot.
- Chat gating:
  - Adds `reconcileNftChatMembershipForUser()` and wires it into `GET /api/chats` for best-effort grant/revoke on user activity.
  - Keeps `NFT_GATING_ENABLED` as the primary flag; `NFT_CHAT_GATING_ENABLED` remains supported for backwards compatibility.
- Gallery:
  - `/api/nft/collection` and `/api/nft/[tokenId]` prefer indexer-derived ownership (secondary supported), with DB fallback.
  - `/nft` page uses “My NFT” tab (ownership) to show chat CTA for *any holder*, not only “hasMinted”.
- New endpoints:
  - `GET /api/nft/access` → `{ hasAccess, degraded }`
  - `GET /api/nft/holdings` → `{ tokenIds, nfts, degraded }` (ownership via indexer; DB fallback)

## Review guide

**Start here**
- `packages/api/src/services/nft-indexer-service.ts`
- `packages/api/src/services/nft-access-service.ts`
- `apps/web/src/components/nft/NftAccessGate.tsx`
- `apps/web/src/app/api/nft/collection/route.ts`
- `apps/web/src/app/api/chats/route.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- No WebSockets/subscriptions: access updates are enforced on next relevant API call (especially `/api/nft/access` + `/api/chats`).
- Degraded behavior: if indexer is unavailable, we fall back to DB ownership so we don’t hard-break UX.
- Includes a small test-type fix in `packages/testing` to restore repo-wide `bun run typecheck`.

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun test packages/api/src/__tests__/auth-middleware.test.ts`
- [x] `bun test packages/api/src/__tests__/nft-chat-gating-service.test.ts`

**Manual verification**
1. Set env:
   - `NFT_GATING_ENABLED=true`
   - `NFT_INDEXER_GRAPHQL_URL=https://indexer.dev.hyperindex.xyz/11f26f0/v1/graphql`
   - `NFT_CHAIN_ID=11155111`
   - `NFT_CONTRACT_ADDRESS=<collection address>`
   - `NFT_CHAT_GATING_CHAT_ID=<FD alpha chat id>`
2. As a holder (including secondary):
   - `GET /api/nft/access` returns `hasAccess: true`
   - `/api/chats` ensures membership + gated chat appears; sending messages works
   - `/nft` “My NFT” tab shows owned NFTs
3. Transfer/sell NFT away:
   - After indexer catches up, `GET /api/nft/access` returns `hasAccess: false`
   - Visiting `/chats` revokes membership and hides the gated chat; direct access to chat endpoints is denied

## Ops / Migration / Deployment

- [ ] No deploy impact
- [x] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [x] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `NFT_INDEXER_GRAPHQL_URL`
- Note: `NFT_GATING_ENABLED` remains the primary flag for gating.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy

- [ ] No security impact
- [x] Needs extra review (authz enforcement depends on indexer availability + fallback)

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Behavior change is mostly access control + data source swap; UI remains the same components.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging`)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time NFT ownership checks via an indexer with automatic DB fallback and graceful degradation
  * New endpoints to check NFT access status and to retrieve a user’s NFT holdings (includes degraded flag)
  * Chat access gating now depends on current NFT ownership (not one-time mint); automatic chat membership reconciliation
  * Added configurable indexer endpoint via env variable

* **Tests**
  * Updated tests to cover NFT ownership and gating flows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR integrates Envio's GraphQL indexer as the primary source of truth for NFT ownership checks, enabling support for secondary transfers beyond just mint-based ownership tracking.

## Key Changes

- **New `nft-indexer-service`**: Implements GraphQL queries to Envio indexer for real-time on-chain ownership data with timeout handling, caching (10s for holders, 60s for non-holders), and graceful degradation to DB fallback
- **Updated NFT access logic**: Modified `nft-access-service` to prioritize on-chain indexer, falling back to DB ownership/snapshot when indexer unavailable
- **Enhanced chat gating**: Added automatic membership reconciliation in `GET /api/chats` - grants/revokes NFT-gated chat access based on current ownership on every chat list fetch
- **New API endpoints**: 
  - `GET /api/nft/holdings` - Returns user's owned tokens with `degraded` flag
  - `GET /api/nft/access` - Returns access status with `degraded` flag
- **Updated existing endpoints**: `/api/nft/collection` and `/api/nft/[tokenId]` now query indexer first with DB fallback

## Architecture

The implementation follows a resilient pattern: try indexer → catch `NftIndexerUnavailableError` → fall back to DB. The `degraded` flag in API responses indicates when fallback mode is active. The NFT_GATING_ENABLED flag now controls both global app access gating and chat-specific gating (with legacy NFT_CHAT_GATING_ENABLED still supported).

## Observations

- Comprehensive test coverage for chat gating service scenarios
- Good error handling with custom `NftIndexerUnavailableError`
- Address normalization ensures case-insensitive matching
- Timeout protection (2.5s) prevents slow indexer queries from blocking requests

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor style improvements recommended
- The implementation is well-structured with proper error handling, fallback mechanisms, and test coverage. The resilient design (indexer-first with DB fallback) ensures the system continues functioning even when the indexer is unavailable. Three minor style suggestions were identified but no logic errors or security issues were found. The code follows established patterns and maintains backwards compatibility.
- No files require special attention - the style suggestions in `nft-indexer-service.ts`, `nft-collection/route.ts`, and `nft-chat-gating-service.ts` are optional improvements

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/api/src/services/nft-indexer-service.ts | New service integrating Envio GraphQL indexer for on-chain NFT ownership queries with caching and DB fallback |
| packages/api/src/services/nft-access-service.ts | Updated to use on-chain indexer as primary source with DB fallback for degraded mode |
| packages/api/src/services/nft-chat-gating-service.ts | Enhanced with NFT_GATING_ENABLED flag support and reconciliation logic for automatic membership management |
| apps/web/src/app/api/nft/collection/route.ts | Updated gallery endpoint to use indexer for ownership with comprehensive DB fallback for pagination |
| apps/web/src/app/api/chats/route.ts | Added automatic NFT chat membership reconciliation on chat list fetch |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant API as API Route
    participant AuthMW as Auth Middleware
    participant ChatSvc as Chat Gating Service
    participant AccessSvc as NFT Access Service
    participant Indexer as Envio Indexer
    participant DB as Database
    
    User->>API: GET /api/chats
    API->>AuthMW: authenticate(request)
    AuthMW->>AccessSvc: hasNftAccessForAuthUser(user)
    AccessSvc->>Indexer: hasOnchainNftAccess(wallet)
    
    alt Indexer Available
        Indexer->>Indexer: Query NftHolder balance
        Indexer-->>AccessSvc: balance > 0
        AccessSvc-->>AuthMW: true (has access)
    else Indexer Unavailable
        Indexer-->>AccessSvc: NftIndexerUnavailableError
        AccessSvc->>DB: Check nftOwnership/nftSnapshot
        DB-->>AccessSvc: hasMinted or owns token
        AccessSvc-->>AuthMW: true (degraded mode)
    end
    
    AuthMW-->>API: AuthenticatedUser
    
    API->>ChatSvc: reconcileNftChatMembershipForUser(user)
    ChatSvc->>ChatSvc: Check if NFT_GATING_ENABLED
    ChatSvc->>AccessSvc: canAccessNftChatGate(userId, chatId)
    AccessSvc->>Indexer: hasOnchainNftAccess(wallet)
    Indexer-->>AccessSvc: access status
    AccessSvc-->>ChatSvc: allowed: boolean
    
    alt User Has Access & Not Member
        ChatSvc->>DB: Insert groupMembers + chatParticipants
        DB-->>ChatSvc: Membership created
        ChatSvc-->>API: status: 'ensured'
    else User Lost Access & Is Member
        ChatSvc->>DB: Update isActive=false, set kickedAt
        DB-->>ChatSvc: Membership revoked
        ChatSvc-->>API: status: 'revoked'
    else No Change Needed
        ChatSvc-->>API: status: 'noop'
    end
    
    API->>DB: Fetch user's chats
    DB-->>API: Chat list
    API-->>User: Chats with NFT gate reconciled
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->