### PR TITLE
fix: resolve MCP tool handler URL construction and SubgraphClient errors

### DIFF
--- a/packages/agents/src/agent0/AgentDiscovery.ts
+++ b/packages/agents/src/agent0/AgentDiscovery.ts
@@ -262,8 +262,18 @@ export class AgentDiscoveryService implements IAgentDiscoveryService {
     agent0Data: SubgraphAgent,
     reputationBridge?: IReputationBridge | null
   ): Promise<AgentProfile> {
-    const parsed = JSON.parse(agent0Data.capabilities!);
-    const capabilities = parseCapabilities(parsed);
+    // Parse capabilities defensively - provide defaults if missing
+    const defaultCapabilities = {
+      strategies: [],
+      markets: [],
+      actions: [],
+      version: '1.0.0',
+      skills: [],
+      domains: [],
+    };
+    const capabilities = agent0Data.capabilities
+      ? parseCapabilities(JSON.parse(agent0Data.capabilities))
+      : defaultCapabilities;
 
     let reputation;
     if (reputationBridge) {
@@ -280,11 +290,12 @@ export class AgentDiscoveryService implements IAgentDiscoveryService {
         isBanned: aggregated.isBanned,
       };
     } else {
+      // Use optional chaining for reputation - may be undefined
       reputation = {
-        totalBets: agent0Data.reputation!.totalBets,
-        winningBets: agent0Data.reputation!.winningBets,
-        accuracyScore: agent0Data.reputation!.accuracyScore / 100,
-        trustScore: agent0Data.reputation!.trustScore / 100,
+        totalBets: agent0Data.reputation?.totalBets ?? 0,
+        winningBets: agent0Data.reputation?.winningBets ?? 0,
+        accuracyScore: (agent0Data.reputation?.accuracyScore ?? 0) / 100,
+        trustScore: (agent0Data.reputation?.trustScore ?? 0) / 100,
         totalVolume: '0',
         profitLoss: 0,
         isBanned: false,
@@ -296,7 +307,7 @@ export class AgentDiscoveryService implements IAgentDiscoveryService {
       tokenId: agent0Data.tokenId,
       address: agent0Data.walletAddress,
       name: agent0Data.name,
-      endpoint: agent0Data.a2aEndpoint!,
+      endpoint: agent0Data.a2aEndpoint ?? '',
       capabilities,
       reputation,
       isActive: true,
@@ -371,6 +382,9 @@ export class AgentDiscoveryService implements IAgentDiscoveryService {
 
       // Fallback to subgraph client
       const agent0Data = await this.subgraphClient.getAgent(tokenId);
+      if (!agent0Data) {
+        return null;
+      }
       return this.transformAgent0Profile(agent0Data, this.reputationBridge);
     }
 

--- a/packages/agents/src/agent0/SubgraphClient.ts
+++ b/packages/agents/src/agent0/SubgraphClient.ts
@@ -50,20 +50,15 @@ export interface SubgraphAgent {
 
 export class SubgraphClient {
   private client: GraphQLClient | null;
-  private isLocalnet: boolean;
 
   constructor() {
     const subgraphUrl = process.env.AGENT0_SUBGRAPH_URL;
-    const network = process.env.AGENT0_NETWORK || 'sepolia';
-    this.isLocalnet = network === 'localnet';
 
     if (!subgraphUrl) {
-      // For localnet, subgraph might not be available - allow graceful degradation
-      if (this.isLocalnet) {
-        this.client = null;
-        return;
-      }
-      throw new Error('AGENT0_SUBGRAPH_URL environment variable is required');
+      // Allow graceful degradation when subgraph URL is not configured
+      // This enables the API to function without Agent0 integration
+      this.client = null;
+      return;
     }
 
     this.client = new GraphQLClient(subgraphUrl, {
@@ -123,11 +118,10 @@ export class SubgraphClient {
   /**
    * Get agent by token ID
    */
-  async getAgent(tokenId: number): Promise<SubgraphAgent> {
+  async getAgent(tokenId: number): Promise<SubgraphAgent | null> {
     if (!this.client) {
-      throw new Error(
-        'Subgraph client not available (localnet mode or AGENT0_SUBGRAPH_URL not set)'
-      );
+      // Graceful degradation when subgraph is not configured
+      return null;
     }
 
     const query = `
@@ -152,7 +146,13 @@ export class SubgraphClient {
       agentId: tokenId.toString(),
     })) as { agents: RawSubgraphAgent[] };
 
-    return this.transformAgent(data.agents[0]!);
+    // Return null if agent not found in subgraph
+    const agent = data.agents[0];
+    if (!agent) {
+      return null;
+    }
+
+    return this.transformAgent(agent);
   }
 
   /**
@@ -258,6 +258,6 @@ export class SubgraphClient {
       return [];
     }
     const agent = await this.getAgent(tokenId);
-    return agent.feedbacks!;
+    return agent?.feedbacks ?? [];
   }
 }

--- a/packages/agents/src/agent0/SubgraphClient.ts
+++ b/packages/agents/src/agent0/SubgraphClient.ts
@@ -207,7 +207,8 @@ export class SubgraphClient {
 
     if (filters.strategies && filters.strategies.length > 0) {
       results = results.filter((agent) => {
-        const caps = JSON.parse(agent.capabilities!);
+        if (!agent.capabilities) return false;
+        const caps = JSON.parse(agent.capabilities);
         const parsed = parseCapabilities(caps);
         const agentStrategies = parsed.strategies ?? [];
         return filters.strategies!.some((s) => agentStrategies.includes(s));
@@ -216,7 +217,8 @@ export class SubgraphClient {
 
     if (filters.markets && filters.markets.length > 0) {
       results = results.filter((agent) => {
-        const caps = JSON.parse(agent.capabilities!);
+        if (!agent.capabilities) return false;
+        const caps = JSON.parse(agent.capabilities);
         const parsed = parseCapabilities(caps);
         const agentMarkets = parsed.markets ?? [];
         return filters.markets!.some((m) => agentMarkets.includes(m));

--- a/packages/api/src/__tests__/nft-chat-gating-service.test.ts
+++ b/packages/api/src/__tests__/nft-chat-gating-service.test.ts
@@ -518,8 +518,7 @@ describe('NFT Chat Gating Service', () => {
       mockDbSelect.mockImplementation(() => ({
         from: () => ({
           where: () => ({
-            limit: () =>
-              Promise.resolve([{ groupId: 'group-123' }]),
+            limit: () => Promise.resolve([{ groupId: 'group-123' }]),
           }),
         }),
       }));
@@ -710,7 +709,10 @@ describe('NFT Chat Gating - Integration Scenarios', () => {
       // NFT access check should not even be called for admins
       mockHasNftAccess.mockResolvedValue(false);
 
-      const canAccess = await canAccessNftChatGate('admin-user', 'fd-alpha-chat');
+      const canAccess = await canAccessNftChatGate(
+        'admin-user',
+        'fd-alpha-chat'
+      );
       expect(canAccess).toBe(true);
       expect(mockHasNftAccess).not.toHaveBeenCalled();
     });

--- a/packages/mcp/src/handlers/tool-handlers.ts
+++ b/packages/mcp/src/handlers/tool-handlers.ts
@@ -29,6 +29,26 @@ import {
   getAPIBaseUrl,
   logger,
 } from '@babylon/shared';
+
+/**
+ * Safe fetch helper that validates response status and returns typed JSON.
+ * Throws a descriptive error if the response is not OK.
+ */
+async function safeFetch<T>(
+  url: string | URL,
+  options?: RequestInit
+): Promise<T> {
+  const response = await fetch(url.toString(), options);
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => 'Unknown error');
+    throw new Error(
+      `API request failed: ${response.status} ${response.statusText} - ${errorText.slice(0, 200)}`
+    );
+  }
+
+  return (await response.json()) as T;
+}
 import type {
   AcceptGroupInviteArgs,
   AcceptGroupInviteResult,
@@ -316,8 +336,8 @@ export async function executePlaceBet(
 
   // Call the existing market API logic
   const apiBaseUrl = getAPIBaseUrl();
-  const response = await fetch(
-    `${apiBaseUrl}/api/markets/${args.marketId}/bet`,
+  const result = await safeFetch<PlaceBetResult>(
+    `${apiBaseUrl}/markets/${args.marketId}/bet`,
     {
       method: 'POST',
       headers: {
@@ -330,8 +350,6 @@ export async function executePlaceBet(
       }),
     }
   );
-
-  const result = (await response.json()) as PlaceBetResult;
   return result;
 }
 
@@ -421,8 +439,8 @@ export async function executeClosePosition(
 
   // Call the existing close position API logic
   const apiBaseUrl = getAPIBaseUrl();
-  const response = await fetch(
-    `${apiBaseUrl}/api/positions/${args.positionId}/close`,
+  const result = await safeFetch<ClosePositionResult>(
+    `${apiBaseUrl}/positions/${args.positionId}/close`,
     {
       method: 'POST',
       headers: {
@@ -433,8 +451,6 @@ export async function executeClosePosition(
       }),
     }
   );
-
-  const result = (await response.json()) as ClosePositionResult;
   return result;
 }
 
@@ -520,8 +536,8 @@ export async function executeBuyShares(
   args: BuySharesArgs
 ): Promise<BuySharesResult> {
   const apiBaseUrl = getAPIBaseUrl();
-  const response = await fetch(
-    `${apiBaseUrl}/api/markets/predictions/${args.marketId}/buy`,
+  return safeFetch<BuySharesResult>(
+    `${apiBaseUrl}/markets/predictions/${args.marketId}/buy`,
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -532,7 +548,6 @@ export async function executeBuyShares(
       }),
     }
   );
-  return (await response.json()) as BuySharesResult;
 }
 
 /**
@@ -549,8 +564,8 @@ export async function executeSellShares(
   if (!position || position.userId !== agent.userId) {
     throw new Error('Position not found or access denied');
   }
-  const response = await fetch(
-    `${apiBaseUrl}/api/markets/predictions/${position.marketId}/sell`,
+  return safeFetch<SellSharesResult>(
+    `${apiBaseUrl}/markets/predictions/${position.marketId}/sell`,
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -560,7 +575,6 @@ export async function executeSellShares(
       }),
     }
   );
-  return (await response.json()) as SellSharesResult;
 }
 
 /**
@@ -571,7 +585,7 @@ export async function executeOpenPosition(
   args: OpenPositionArgs
 ): Promise<OpenPositionResult> {
   const apiBaseUrl = getAPIBaseUrl();
-  const response = await fetch(`${apiBaseUrl}/api/markets/perps/open`, {
+  return safeFetch<OpenPositionResult>(`${apiBaseUrl}/markets/perps/open`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -582,7 +596,6 @@ export async function executeOpenPosition(
       leverage: args.leverage,
     }),
   });
-  return (await response.json()) as OpenPositionResult;
 }
 
 /**
@@ -639,11 +652,10 @@ export async function executeGetTrades(
   args: GetTradesArgs
 ): Promise<GetTradesResult> {
   const apiBaseUrl = getAPIBaseUrl();
-  const url = new URL(`${apiBaseUrl}/api/trades`);
+  const url = new URL(`${apiBaseUrl}/trades`);
   if (args.marketId) url.searchParams.set('marketId', args.marketId);
   if (args.limit) url.searchParams.set('limit', args.limit.toString());
-  const response = await fetch(url.toString());
-  const data = (await response.json()) as {
+  const data = await safeFetch<{
     trades: Array<{
       id: string;
       marketId: string;
@@ -653,7 +665,7 @@ export async function executeGetTrades(
       price: string;
       timestamp: Date | string;
     }>;
-  };
+  }>(url);
   return {
     trades: data.trades.map((trade) => ({
       id: trade.id,
@@ -679,11 +691,10 @@ export async function executeGetTradeHistory(
 ): Promise<GetTradeHistoryResult> {
   const apiBaseUrl = getAPIBaseUrl();
   const url = new URL(
-    `${apiBaseUrl}/api/markets/predictions/${args.userId}/trades`
+    `${apiBaseUrl}/markets/predictions/${args.userId}/trades`
   );
   if (args.limit) url.searchParams.set('limit', args.limit.toString());
-  const response = await fetch(url.toString());
-  const data = (await response.json()) as {
+  const data = await safeFetch<{
     trades: Array<{
       id: string;
       marketId: string;
@@ -692,7 +703,7 @@ export async function executeGetTradeHistory(
       price: string;
       timestamp: Date | string;
     }>;
-  };
+  }>(url);
   return {
     trades: data.trades.map((trade) => ({
       id: trade.id,
@@ -1784,24 +1795,13 @@ export async function executeGetLeaderboard(
   args: GetLeaderboardArgs
 ): Promise<GetLeaderboardResult> {
   const apiBaseUrl = getAPIBaseUrl();
-  const url = new URL(`${apiBaseUrl}/api/leaderboard`);
+  const url = new URL(`${apiBaseUrl}/leaderboard`);
   if (args.page) url.searchParams.set('page', args.page.toString());
   if (args.pageSize) url.searchParams.set('pageSize', args.pageSize.toString());
   if (args.pointsType) url.searchParams.set('pointsType', args.pointsType);
   if (args.minPoints)
     url.searchParams.set('minPoints', args.minPoints.toString());
-  const response = await fetch(url.toString());
-  const data = (await response.json()) as {
-    leaderboard: Array<{
-      rank: number;
-      userId: string;
-      username: string | null;
-      displayName: string | null;
-      points: number;
-    }>;
-    pagination: { page: number; pageSize: number; total: number };
-  };
-  return data;
+  return safeFetch<GetLeaderboardResult>(url);
 }
 
 /**
@@ -1924,9 +1924,7 @@ export async function executeGetReputation(
 ): Promise<GetReputationResult> {
   const userId = args.userId || agent.userId;
   const apiBaseUrl = getAPIBaseUrl();
-  const response = await fetch(`${apiBaseUrl}/api/reputation/${userId}`);
-  const data = (await response.json()) as GetReputationResult;
-  return data;
+  return safeFetch<GetReputationResult>(`${apiBaseUrl}/reputation/${userId}`);
 }
 
 /**
@@ -1937,11 +1935,9 @@ export async function executeGetReputationBreakdown(
   args: GetReputationBreakdownArgs
 ): Promise<GetReputationBreakdownResult> {
   const apiBaseUrl = getAPIBaseUrl();
-  const response = await fetch(
-    `${apiBaseUrl}/api/reputation/breakdown/${args.userId}`
+  return safeFetch<GetReputationBreakdownResult>(
+    `${apiBaseUrl}/reputation/breakdown/${args.userId}`
   );
-  const data = (await response.json()) as GetReputationBreakdownResult;
-  return data;
 }
 
 // ============================================================================
@@ -2012,7 +2008,7 @@ export async function executePaymentRequest(
 ): Promise<PaymentRequestResult> {
   // agent used for userId in request body
   const apiBaseUrl = getAPIBaseUrl();
-  const response = await fetch(`${apiBaseUrl}/api/payments/request`, {
+  return safeFetch<PaymentRequestResult>(`${apiBaseUrl}/payments/request`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -2023,7 +2019,6 @@ export async function executePaymentRequest(
       metadata: args.metadata,
     }),
   });
-  return (await response.json()) as PaymentRequestResult;
 }
 
 /**
@@ -2034,7 +2029,7 @@ export async function executePaymentReceipt(
   args: PaymentReceiptArgs
 ): Promise<PaymentReceiptResult> {
   const apiBaseUrl = getAPIBaseUrl();
-  const response = await fetch(`${apiBaseUrl}/api/payments/receipt`, {
+  return safeFetch<PaymentReceiptResult>(`${apiBaseUrl}/payments/receipt`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -2042,7 +2037,6 @@ export async function executePaymentReceipt(
       txHash: args.txHash,
     }),
   });
-  return (await response.json()) as PaymentReceiptResult;
 }
 
 // ============================================================================
@@ -2418,7 +2412,7 @@ export async function executeAppealBan(
   args: AppealBanArgs
 ): Promise<AppealBanResult> {
   const apiBaseUrl = getAPIBaseUrl();
-  const response = await fetch(`${apiBaseUrl}/api/moderation/appeal`, {
+  return safeFetch<AppealBanResult>(`${apiBaseUrl}/moderation/appeal`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -2426,7 +2420,6 @@ export async function executeAppealBan(
       reason: args.reason,
     }),
   });
-  return (await response.json()) as AppealBanResult;
 }
 
 /**
@@ -2550,20 +2543,19 @@ export async function executeGetFavoritePosts(
   args: GetFavoritePostsArgs
 ): Promise<GetFavoritePostsResult> {
   const apiBaseUrl = getAPIBaseUrl();
-  const url = new URL(`${apiBaseUrl}/api/posts/feed/favorites`);
+  const url = new URL(`${apiBaseUrl}/posts/feed/favorites`);
   if (args.limit) url.searchParams.set('limit', args.limit.toString());
   if (args.offset) url.searchParams.set('offset', args.offset.toString());
-  const response = await fetch(url.toString(), {
-    headers: { 'X-User-Id': agent.userId },
-  });
-  const data = (await response.json()) as {
+  const data = await safeFetch<{
     posts: Array<{
       id: string;
       content: string;
       authorId: string;
       timestamp: Date | string;
     }>;
-  };
+  }>(url, {
+    headers: { 'X-User-Id': agent.userId },
+  });
   return {
     posts: data.posts.map((post) => ({
       id: post.id,
@@ -2589,7 +2581,7 @@ export async function executeTransferPoints(
   args: TransferPointsArgs
 ): Promise<TransferPointsResult> {
   const apiBaseUrl = getAPIBaseUrl();
-  const response = await fetch(`${apiBaseUrl}/api/points/transfer`, {
+  return safeFetch<TransferPointsResult>(`${apiBaseUrl}/points/transfer`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -2599,8 +2591,6 @@ export async function executeTransferPoints(
       message: args.message,
     }),
   });
-  const result = (await response.json()) as TransferPointsResult;
-  return result;
 }
 
 // ============================================================================

--- a/packages/mcp/src/handlers/tool-handlers.ts
+++ b/packages/mcp/src/handlers/tool-handlers.ts
@@ -49,6 +49,7 @@ async function safeFetch<T>(
 
   return (await response.json()) as T;
 }
+
 import type {
   AcceptGroupInviteArgs,
   AcceptGroupInviteResult,

--- a/packages/mcp/src/handlers/tool-handlers.ts
+++ b/packages/mcp/src/handlers/tool-handlers.ts
@@ -48,15 +48,21 @@ async function safeFetch<T>(
     );
   }
 
-  // Handle 204 No Content or empty body responses
-  if (
-    response.status === 204 ||
-    response.headers.get('content-length') === '0'
-  ) {
+  // Handle 204 No Content early
+  if (response.status === 204) {
     return null;
   }
 
-  return (await response.json()) as T;
+  // Read body as text to handle empty responses reliably
+  // (content-length header may not always be present, e.g. chunked transfer)
+  const text = await response.text();
+  const trimmed = text.trim();
+
+  if (!trimmed) {
+    return null;
+  }
+
+  return JSON.parse(trimmed) as T;
 }
 
 /**

--- a/packages/mcp/src/handlers/tool-handlers.ts
+++ b/packages/mcp/src/handlers/tool-handlers.ts
@@ -33,12 +33,12 @@ import {
 /**
  * Safe fetch helper that validates response status and returns typed JSON.
  * Throws a descriptive error if the response is not OK.
- * Handles 204 No Content responses by returning null.
+ * Returns null for 204 No Content or empty body responses.
  */
 async function safeFetch<T>(
   url: string | URL,
   options?: RequestInit
-): Promise<T> {
+): Promise<T | null> {
   const response = await fetch(url.toString(), options);
 
   if (!response.ok) {
@@ -53,10 +53,25 @@ async function safeFetch<T>(
     response.status === 204 ||
     response.headers.get('content-length') === '0'
   ) {
-    return null as T;
+    return null;
   }
 
   return (await response.json()) as T;
+}
+
+/**
+ * Safe fetch helper that throws if the response is null/empty.
+ * Use this for endpoints that must return JSON data.
+ */
+async function safeFetchRequired<T>(
+  url: string | URL,
+  options?: RequestInit
+): Promise<T> {
+  const result = await safeFetch<T>(url, options);
+  if (result === null) {
+    throw new Error('API returned empty response when data was expected');
+  }
+  return result;
 }
 
 import type {
@@ -346,7 +361,7 @@ export async function executePlaceBet(
 
   // Call the existing market API logic
   const apiBaseUrl = getAPIBaseUrl();
-  const result = await safeFetch<PlaceBetResult>(
+  return safeFetchRequired<PlaceBetResult>(
     `${apiBaseUrl}/markets/${args.marketId}/bet`,
     {
       method: 'POST',
@@ -360,7 +375,6 @@ export async function executePlaceBet(
       }),
     }
   );
-  return result;
 }
 
 /**
@@ -449,7 +463,7 @@ export async function executeClosePosition(
 
   // Call the existing close position API logic
   const apiBaseUrl = getAPIBaseUrl();
-  const result = await safeFetch<ClosePositionResult>(
+  const result = await safeFetchRequired<ClosePositionResult>(
     `${apiBaseUrl}/positions/${args.positionId}/close`,
     {
       method: 'POST',
@@ -546,7 +560,7 @@ export async function executeBuyShares(
   args: BuySharesArgs
 ): Promise<BuySharesResult> {
   const apiBaseUrl = getAPIBaseUrl();
-  return safeFetch<BuySharesResult>(
+  return safeFetchRequired<BuySharesResult>(
     `${apiBaseUrl}/markets/predictions/${args.marketId}/buy`,
     {
       method: 'POST',
@@ -574,7 +588,7 @@ export async function executeSellShares(
   if (!position || position.userId !== agent.userId) {
     throw new Error('Position not found or access denied');
   }
-  return safeFetch<SellSharesResult>(
+  return safeFetchRequired<SellSharesResult>(
     `${apiBaseUrl}/markets/predictions/${position.marketId}/sell`,
     {
       method: 'POST',
@@ -595,17 +609,20 @@ export async function executeOpenPosition(
   args: OpenPositionArgs
 ): Promise<OpenPositionResult> {
   const apiBaseUrl = getAPIBaseUrl();
-  return safeFetch<OpenPositionResult>(`${apiBaseUrl}/markets/perps/open`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      userId: agent.userId,
-      ticker: args.ticker,
-      side: args.side,
-      amount: args.amount,
-      leverage: args.leverage,
-    }),
-  });
+  return safeFetchRequired<OpenPositionResult>(
+    `${apiBaseUrl}/markets/perps/open`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        userId: agent.userId,
+        ticker: args.ticker,
+        side: args.side,
+        amount: args.amount,
+        leverage: args.leverage,
+      }),
+    }
+  );
 }
 
 /**
@@ -676,6 +693,12 @@ export async function executeGetTrades(
       timestamp: Date | string;
     }>;
   }>(url);
+
+  // Handle null/empty response
+  if (!data) {
+    return { trades: [] };
+  }
+
   return {
     trades: data.trades.map((trade) => ({
       id: trade.id,
@@ -714,6 +737,12 @@ export async function executeGetTradeHistory(
       timestamp: Date | string;
     }>;
   }>(url);
+
+  // Handle null/empty response
+  if (!data) {
+    return { trades: [] };
+  }
+
   return {
     trades: data.trades.map((trade) => ({
       id: trade.id,
@@ -1811,7 +1840,7 @@ export async function executeGetLeaderboard(
   if (args.pointsType) url.searchParams.set('pointsType', args.pointsType);
   if (args.minPoints)
     url.searchParams.set('minPoints', args.minPoints.toString());
-  return safeFetch<GetLeaderboardResult>(url);
+  return safeFetchRequired<GetLeaderboardResult>(url);
 }
 
 /**
@@ -1934,7 +1963,9 @@ export async function executeGetReputation(
 ): Promise<GetReputationResult> {
   const userId = args.userId || agent.userId;
   const apiBaseUrl = getAPIBaseUrl();
-  return safeFetch<GetReputationResult>(`${apiBaseUrl}/reputation/${userId}`);
+  return safeFetchRequired<GetReputationResult>(
+    `${apiBaseUrl}/reputation/${userId}`
+  );
 }
 
 /**
@@ -1945,7 +1976,7 @@ export async function executeGetReputationBreakdown(
   args: GetReputationBreakdownArgs
 ): Promise<GetReputationBreakdownResult> {
   const apiBaseUrl = getAPIBaseUrl();
-  return safeFetch<GetReputationBreakdownResult>(
+  return safeFetchRequired<GetReputationBreakdownResult>(
     `${apiBaseUrl}/reputation/breakdown/${args.userId}`
   );
 }
@@ -2018,17 +2049,20 @@ export async function executePaymentRequest(
 ): Promise<PaymentRequestResult> {
   // agent used for userId in request body
   const apiBaseUrl = getAPIBaseUrl();
-  return safeFetch<PaymentRequestResult>(`${apiBaseUrl}/payments/request`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      from: args.from || agent.userId,
-      to: args.to,
-      amount: args.amount,
-      service: args.service,
-      metadata: args.metadata,
-    }),
-  });
+  return safeFetchRequired<PaymentRequestResult>(
+    `${apiBaseUrl}/payments/request`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        from: args.from || agent.userId,
+        to: args.to,
+        amount: args.amount,
+        service: args.service,
+        metadata: args.metadata,
+      }),
+    }
+  );
 }
 
 /**
@@ -2039,14 +2073,17 @@ export async function executePaymentReceipt(
   args: PaymentReceiptArgs
 ): Promise<PaymentReceiptResult> {
   const apiBaseUrl = getAPIBaseUrl();
-  return safeFetch<PaymentReceiptResult>(`${apiBaseUrl}/payments/receipt`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      requestId: args.requestId,
-      txHash: args.txHash,
-    }),
-  });
+  return safeFetchRequired<PaymentReceiptResult>(
+    `${apiBaseUrl}/payments/receipt`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        requestId: args.requestId,
+        txHash: args.txHash,
+      }),
+    }
+  );
 }
 
 // ============================================================================
@@ -2422,7 +2459,7 @@ export async function executeAppealBan(
   args: AppealBanArgs
 ): Promise<AppealBanResult> {
   const apiBaseUrl = getAPIBaseUrl();
-  return safeFetch<AppealBanResult>(`${apiBaseUrl}/moderation/appeal`, {
+  return safeFetchRequired<AppealBanResult>(`${apiBaseUrl}/moderation/appeal`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -2566,6 +2603,12 @@ export async function executeGetFavoritePosts(
   }>(url, {
     headers: { 'X-User-Id': agent.userId },
   });
+
+  // Handle null/empty response
+  if (!data) {
+    return { posts: [] };
+  }
+
   return {
     posts: data.posts.map((post) => ({
       id: post.id,
@@ -2591,16 +2634,19 @@ export async function executeTransferPoints(
   args: TransferPointsArgs
 ): Promise<TransferPointsResult> {
   const apiBaseUrl = getAPIBaseUrl();
-  return safeFetch<TransferPointsResult>(`${apiBaseUrl}/points/transfer`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      fromUserId: agent.userId,
-      recipientId: args.recipientId,
-      amount: args.amount,
-      message: args.message,
-    }),
-  });
+  return safeFetchRequired<TransferPointsResult>(
+    `${apiBaseUrl}/points/transfer`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        fromUserId: agent.userId,
+        recipientId: args.recipientId,
+        amount: args.amount,
+        message: args.message,
+      }),
+    }
+  );
 }
 
 // ============================================================================

--- a/packages/mcp/src/handlers/tool-handlers.ts
+++ b/packages/mcp/src/handlers/tool-handlers.ts
@@ -33,6 +33,7 @@ import {
 /**
  * Safe fetch helper that validates response status and returns typed JSON.
  * Throws a descriptive error if the response is not OK.
+ * Handles 204 No Content responses by returning null.
  */
 async function safeFetch<T>(
   url: string | URL,
@@ -45,6 +46,14 @@ async function safeFetch<T>(
     throw new Error(
       `API request failed: ${response.status} ${response.statusText} - ${errorText.slice(0, 200)}`
     );
+  }
+
+  // Handle 204 No Content or empty body responses
+  if (
+    response.status === 204 ||
+    response.headers.get('content-length') === '0'
+  ) {
+    return null as T;
   }
 
   return (await response.json()) as T;

--- a/packages/testing/unit/markets/portfolio-actions.test.ts
+++ b/packages/testing/unit/markets/portfolio-actions.test.ts
@@ -1,20 +1,18 @@
 import { describe, expect, it } from 'bun:test';
-import type { PortfolioPnLSnapshot } from '@babylon/engine/client';
+import type { PortfolioBreakdownSnapshot } from '@babylon/engine/client';
 import { createElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { PortfolioPnLCard } from '../../../../apps/web/src/components/markets/PortfolioPnLCard';
 
-const snapshot: PortfolioPnLSnapshot = {
-  lifetimePnL: 0,
-  netContributions: 0,
-  totalDeposited: 0,
-  totalWithdrawn: 0,
-  availableBalance: 0,
-  unrealizedPerpPnL: 0,
-  unrealizedPredictionPnL: 0,
-  totalUnrealizedPnL: 0,
+const snapshot: PortfolioBreakdownSnapshot = {
+  wallet: 0,
+  agents: 0,
+  positions: 0,
+  available: 0,
+  originalAmount: 0,
+  totalAssets: 0,
   totalPnL: 0,
-  accountEquity: 0,
+  agentCount: 0,
 };
 
 describe('PortfolioPnLCard rendering', () => {


### PR DESCRIPTION
## Summary

- Fix double `/api` path in 15 MCP tool handlers (`get_leaderboard`, trades, reputation, payments, moderation, favorites, points endpoints). The `getAPIBaseUrl()` already includes `/api` suffix, causing 404s when handlers appended `/api/` again, which returned HTML error pages instead of JSON.

- Make `SubgraphClient` gracefully degrade when `AGENT0_SUBGRAPH_URL` is not configured, instead of throwing an error. This prevents 500 errors on `/api/registry/all` endpoint in staging.

- Update `getAgent()` to return `null` instead of throwing when subgraph unavailable, with proper null handling in `AgentDiscovery`.

- Fix pre-existing test type error: `PortfolioPnLCard` test was using `PortfolioPnLSnapshot` type instead of the correct `PortfolioBreakdownSnapshot`.

## Fixes Staging Errors

1. **SyntaxError: Unexpected token '<'** - HTML being returned instead of JSON when MCP tools called internal APIs with malformed URLs (`/api/api/leaderboard`)

2. **Error: AGENT0_SUBGRAPH_URL environment variable is required** - Registry endpoint failing because SubgraphClient was throwing instead of gracefully degrading

## Test Plan

- [x] TypeScript compilation passes
- [x] Linting passes
- [ ] Verify MCP `get_leaderboard` tool returns JSON on staging after deploy
- [ ] Verify `/api/registry/all` returns data (or empty arrays) instead of 500 error

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes two critical staging errors: MCP tool handlers returning HTML instead of JSON due to double `/api` path, and registry endpoint failing due to missing subgraph configuration.

- **MCP URL Construction**: Correctly removes 15 instances of redundant `/api/` prefix since `getAPIBaseUrl()` already returns URLs ending in `/api` (verified in `public-config.json`)
- **Subgraph Graceful Degradation**: Allows `SubgraphClient` to function when `AGENT0_SUBGRAPH_URL` is not configured, preventing 500 errors on `/api/registry/all`
- **Test Type Fix**: Corrects pre-existing type error in `PortfolioPnLCard` test

**Critical Bug Found**: `SubgraphClient.getAgent()` at line 149 will crash when querying for an agent that doesn't exist in the subgraph - it uses non-null assertion on `data.agents[0]!` which will be `undefined` for empty arrays, causing `transformAgent()` to fail when accessing properties on `undefined`.

<h3>Confidence Score: 2/5</h3>

- This PR fixes critical staging errors but introduces a new bug that will cause runtime crashes
- The URL fixes are correct and will resolve the 404 errors, and the test fix is valid. However, the SubgraphClient changes introduce a critical logic error where `getAgent()` will crash when an agent doesn't exist in the subgraph database, which could happen in normal operation
- Pay close attention to `packages/agents/src/agent0/SubgraphClient.ts` line 149 - the unsafe array access must be fixed before merging

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/mcp/src/handlers/tool-handlers.ts | Fixes double `/api` path in 15 MCP tool handlers by removing redundant `/api/` prefix since `getAPIBaseUrl()` already includes it |
| packages/agents/src/agent0/SubgraphClient.ts | Makes SubgraphClient gracefully degrade when env var not set, but has critical bug: `getAgent()` will crash when agent doesn't exist in subgraph due to unsafe array access |
| packages/agents/src/agent0/AgentDiscovery.ts | Adds null check for subgraph response to prevent crashes when subgraph unavailable or returns null |
| packages/testing/unit/markets/portfolio-actions.test.ts | Fixes type error by using correct `PortfolioBreakdownSnapshot` instead of `PortfolioPnLSnapshot` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant MCP as MCP Tool Handler
    participant API as API Endpoint
    participant Config as getAPIBaseUrl()
    participant Agent as AgentDiscovery
    participant Subgraph as SubgraphClient
    participant DB as Subgraph DB
    
    Note over MCP,Config: URL Construction Fix
    MCP->>Config: getAPIBaseUrl()
    Config-->>MCP: "https://staging.babylon.market/api"
    Note over MCP: Before: ${apiBaseUrl}/api/leaderboard<br/>After: ${apiBaseUrl}/leaderboard
    MCP->>API: GET /api/leaderboard
    API-->>MCP: JSON response (not HTML)
    
    Note over Agent,DB: Subgraph Graceful Degradation
    Agent->>Subgraph: getAgent(tokenId)
    alt AGENT0_SUBGRAPH_URL not configured
        Subgraph-->>Agent: null (graceful degradation)
        Agent-->>Agent: return null
    else AGENT0_SUBGRAPH_URL configured
        Subgraph->>DB: GraphQL query
        alt Agent exists
            DB-->>Subgraph: agent data
            Subgraph->>Subgraph: transformAgent(data.agents[0])
            Subgraph-->>Agent: SubgraphAgent
        else Agent not found
            DB-->>Subgraph: empty array
            Note over Subgraph: BUG: data.agents[0]! is undefined<br/>crashes in transformAgent()
            Subgraph--xAgent: Runtime Error
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness and null-safety when agent data, reputation, endpoints, or capabilities are missing; functions now fail gracefully (returning null or empty results) instead of crashing.

* **Chores**
  * Added centralized safe HTTP handling and normalized request paths; services now degrade gracefully when external endpoints are unavailable and list endpoints may return empty arrays.
  * Removed environment-specific branching to simplify behavior.

* **Tests**
  * Updated unit test snapshots and minor test formatting to match revised data shapes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->