### PR TITLE
refactor: move MessageType and GameOnboardingStep types to shared package

### DIFF
--- a/apps/web/src/components/chats/MessageList.tsx
+++ b/apps/web/src/components/chats/MessageList.tsx
@@ -1,12 +1,11 @@
 'use client';
 
-import type { MessageType } from '@babylon/db';
 import { Loader2, MessageCircle } from 'lucide-react';
 import React, { useMemo } from 'react';
 import { Skeleton } from '@/components/shared/Skeleton';
 import { MessageBubble } from './MessageBubble';
 import { SystemMessage } from './SystemMessage';
-import type { ChatParticipant, Message } from './types';
+import type { ChatParticipant, Message, MessageType } from './types';
 import { MessageTypeEnum } from './types';
 
 /**

--- a/apps/web/src/components/chats/types.ts
+++ b/apps/web/src/components/chats/types.ts
@@ -31,8 +31,9 @@ export interface Chat {
   };
 }
 
+import type { MessageType } from '@babylon/shared';
 export { MessageTypeEnum } from '@babylon/shared';
-export type { MessageType } from '@babylon/shared';
+export type { MessageType };
 
 export interface Message {
   id: string;

--- a/apps/web/src/components/chats/types.ts
+++ b/apps/web/src/components/chats/types.ts
@@ -31,13 +31,8 @@ export interface Chat {
   };
 }
 
-import type { MessageType } from '@babylon/db';
-
-// Enum for runtime checks, type-guarded by MessageType from db
-export const MessageTypeEnum = {
-  USER: 'user' as MessageType,
-  SYSTEM: 'system' as MessageType,
-} as const;
+export { MessageTypeEnum } from '@babylon/shared';
+export type { MessageType } from '@babylon/shared';
 
 export interface Message {
   id: string;

--- a/apps/web/src/components/chats/types.ts
+++ b/apps/web/src/components/chats/types.ts
@@ -1,3 +1,8 @@
+import type { MessageType } from '@babylon/shared';
+
+export { MessageTypeEnum } from '@babylon/shared';
+export type { MessageType };
+
 export type ChatFilter = 'all' | 'dms' | 'groups';
 
 export interface Chat {
@@ -30,10 +35,6 @@ export interface Chat {
     chainName: string;
   };
 }
-
-import type { MessageType } from '@babylon/shared';
-export { MessageTypeEnum } from '@babylon/shared';
-export type { MessageType };
 
 export interface Message {
   id: string;

--- a/apps/web/src/components/onboarding/GameOnboardingProvider.tsx
+++ b/apps/web/src/components/onboarding/GameOnboardingProvider.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import type { GameOnboardingStep } from '@babylon/db';
 import { ONBOARDING_STEP_INFO } from '@babylon/shared';
+import type { GameOnboardingStep } from '@babylon/shared';
 import {
   createContext,
   useCallback,

--- a/apps/web/src/components/onboarding/GameOnboardingProvider.tsx
+++ b/apps/web/src/components/onboarding/GameOnboardingProvider.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { ONBOARDING_STEP_INFO } from '@babylon/shared';
 import type { GameOnboardingStep } from '@babylon/shared';
+import { ONBOARDING_STEP_INFO } from '@babylon/shared';
 import {
   createContext,
   useCallback,

--- a/apps/web/src/components/onboarding/GameOnboardingTooltip.tsx
+++ b/apps/web/src/components/onboarding/GameOnboardingTooltip.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { GameOnboardingStep } from '@babylon/db';
+import type { GameOnboardingStep } from '@babylon/shared';
 import { cn, ONBOARDING_STEP_ORDER } from '@babylon/shared';
 import { Check, ChevronRight, Sparkles, X } from 'lucide-react';
 import { STEP_INFO, useGameOnboarding } from './GameOnboardingProvider';

--- a/apps/web/src/hooks/useChatMessages.ts
+++ b/apps/web/src/hooks/useChatMessages.ts
@@ -1,8 +1,7 @@
-import type { MessageType } from '@babylon/db';
 import { logger } from '@babylon/shared';
 import { usePrivy } from '@privy-io/react-auth';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { MessageTypeEnum } from '@/components/chats/types';
+import { MessageTypeEnum, type MessageType } from '@/components/chats/types';
 import { CHAT_PAGE_SIZE } from '@/lib/constants';
 import { useSSEChannel } from './useSSE';
 

--- a/apps/web/src/hooks/useChatMessages.ts
+++ b/apps/web/src/hooks/useChatMessages.ts
@@ -1,7 +1,7 @@
 import { logger } from '@babylon/shared';
 import { usePrivy } from '@privy-io/react-auth';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { MessageTypeEnum, type MessageType } from '@/components/chats/types';
+import { type MessageType, MessageTypeEnum } from '@/components/chats/types';
 import { CHAT_PAGE_SIZE } from '@/lib/constants';
 import { useSSEChannel } from './useSSE';
 

--- a/packages/db/src/schema/messaging.ts
+++ b/packages/db/src/schema/messaging.ts
@@ -439,7 +439,8 @@ export type NewUserAgentTeamChat = typeof userAgentTeamChats.$inferInsert;
 export type GroupType = 'user' | 'npc' | 'agent';
 export type GroupMemberRole = 'owner' | 'admin' | 'member';
 export type GroupInviteStatus = 'pending' | 'accepted' | 'declined';
-export type MessageType = 'user' | 'system';
+// MessageType is exported from @babylon/shared - use that canonical definition
+export type { MessageType } from '@babylon/shared';
 // TierLevel is exported from @babylon/shared - use that canonical definition
 
 // Alpha group enhancement types (for grandfathering and invite decay)

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -25,6 +25,8 @@ export {
 } from './errors';
 // Group types (tiers, alpha levels)
 export * from './groups';
+// Message types (chat/system)
+export * from './messages';
 // Social interaction types
 export * from './interactions';
 // Agent monitoring types

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -25,10 +25,10 @@ export {
 } from './errors';
 // Group types (tiers, alpha levels)
 export * from './groups';
-// Message types (chat/system)
-export * from './messages';
 // Social interaction types
 export * from './interactions';
+// Message types (chat/system)
+export * from './messages';
 // Agent monitoring types
 export * from './monitoring';
 // Payment types

--- a/packages/shared/src/types/messages.ts
+++ b/packages/shared/src/types/messages.ts
@@ -1,0 +1,12 @@
+/**
+ * Message types for chat and notifications.
+ * Client-safe enum and union used across web and services.
+ */
+
+export const MessageTypeEnum = {
+  USER: 'user',
+  SYSTEM: 'system',
+} as const;
+
+export type MessageType =
+  (typeof MessageTypeEnum)[keyof typeof MessageTypeEnum];

--- a/packages/shared/src/types/messages.ts
+++ b/packages/shared/src/types/messages.ts
@@ -1,6 +1,10 @@
 /**
  * Message types for chat and notifications.
  * Client-safe enum and union used across web and services.
+ *
+ * Note: This type must stay in sync with the database enum defined in
+ * `packages/db/src/schema/messaging.ts` (`messageTypeEnum` pgEnum).
+ * If new message types are added to the database, update this definition accordingly.
  */
 
 export const MessageTypeEnum = {

--- a/packages/testing/unit/shared/message-types.test.ts
+++ b/packages/testing/unit/shared/message-types.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Message Types Sync Test
+ * 
+ * Validates that MessageTypeEnum values stay in sync with the database enum.
+ * This prevents type drift between the shared types and database schema.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { MessageTypeEnum } from '@babylon/shared';
+import { messageTypeEnum } from '@babylon/db/schema/messaging';
+
+describe('MessageTypeEnum Sync', () => {
+  it('should have MessageTypeEnum values match database enum values', () => {
+    // Extract enum values from the database pgEnum
+    // messageTypeEnum is a pgEnum with values: ['user', 'system']
+    const dbEnumValues = messageTypeEnum.enumValues;
+    
+    // Extract values from MessageTypeEnum object
+    const sharedEnumValues = Object.values(MessageTypeEnum);
+    
+    // Sort both arrays for comparison
+    const sortedDbValues = [...dbEnumValues].sort();
+    const sortedSharedValues = [...sharedEnumValues].sort();
+    
+    expect(sortedSharedValues).toEqual(sortedDbValues);
+  });
+  
+  it('should have all database enum values present in MessageTypeEnum', () => {
+    const dbEnumValues = messageTypeEnum.enumValues;
+    const sharedEnumValues = Object.values(MessageTypeEnum);
+    
+    for (const dbValue of dbEnumValues) {
+      expect(sharedEnumValues).toContain(dbValue);
+    }
+  });
+  
+  it('should have all MessageTypeEnum values present in database enum', () => {
+    const dbEnumValues = messageTypeEnum.enumValues;
+    const sharedEnumValues = Object.values(MessageTypeEnum);
+    
+    for (const sharedValue of sharedEnumValues) {
+      expect(dbEnumValues).toContain(sharedValue);
+    }
+  });
+});


### PR DESCRIPTION
Moves MessageType/MessageTypeEnum and updates GameOnboardingStep imports from @babylon/db to @babylon/shared for better type portability across web and services.

## Changes
- Created `packages/shared/src/types/messages.ts` with MessageTypeEnum and MessageType
- Updated imports in web components to use shared types
- Updated GameOnboardingStep imports in onboarding components to use @babylon/shared
- Updated shared types index to export message types
- Removed duplicate MessageType definition from db schema (now re-exports from shared)
- Added unit test to validate MessageTypeEnum stays in sync with database enum

## Files Changed
- `packages/shared/src/types/messages.ts` (new)
- `packages/shared/src/types/index.ts`
- `packages/db/src/schema/messaging.ts` (removed duplicate, added re-export)
- `apps/web/src/components/chats/MessageList.tsx`
- `apps/web/src/components/chats/types.ts`
- `apps/web/src/components/onboarding/GameOnboardingProvider.tsx`
- `apps/web/src/components/onboarding/GameOnboardingTooltip.tsx`
- `apps/web/src/hooks/useChatMessages.ts`
- `packages/testing/unit/shared/message-types.test.ts` (new - sync validation test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated message type definitions to a centralized shared module for improved consistency across the application.

* **Tests**
  * Added validation tests to ensure message type definitions remain synchronized across modules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->