### PR TITLE
fix: update position amount field in upsertPosition

### DIFF
--- a/packages/core/markets/prediction/adapters/drizzle/PredictionDbAdapter.ts
+++ b/packages/core/markets/prediction/adapters/drizzle/PredictionDbAdapter.ts
@@ -291,6 +291,7 @@ export class PredictionDbAdapter implements PredictionDbPort {
         set: {
           shares: row.shares,
           avgPrice: row.avgPrice,
+          amount: row.amount,
           pnl: row.pnl,
           outcome: row.outcome,
           resolvedAt: row.resolvedAt,


### PR DESCRIPTION
## Summary
- Fixed bug where `amount` field was not being updated when adding to existing positions in `PredictionDbAdapter.upsertPosition()`
- The `amount` field was only set during initial position creation, not on subsequent updates via `onConflictDoUpdate`
- This caused incorrect portfolio calculations as `amount` stayed at the initial trade value instead of accumulating

## Root Cause
When a user/agent added to an existing position (e.g., buying more YES shares in the same market), the `onConflictDoUpdate` clause was missing `amount: row.amount`, so only `shares` and `avgPrice` were updated.

## Impact
- 2,511 out of 2,848 positions had incorrect `amount` values in the database
- Portfolio "In Positions" and unrealized P&L calculations were affected

## Database Fix (Already Applied)
```sql
UPDATE "Position" 
SET amount = ROUND((shares::numeric * "avgPrice"::numeric), 2)
WHERE ABS(amount::numeric - (shares::numeric * "avgPrice"::numeric)) > 0.01;
-- Updated 2,511 rows
```

## Test plan
- [x] Typecheck passes
- [x] Lint passes  
- [x] Build passes
- [x] Verified database fix corrected all positions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data synchronization for position amounts in prediction markets. Positions now display accurate amount information that remains consistent with system computations, improving the reliability of position tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed critical bug in `PredictionDbAdapter.upsertPosition()` where the `amount` field was not updated when adding to existing positions. The `amount` field represents the total capital invested in a position (shares × avgPrice) and is used for portfolio calculations, P&L tracking, and risk assessment.

**What changed:**
- Added `amount: row.amount` to the `onConflictDoUpdate` clause in `upsertPosition()` at line 294

**Why this matters:**
- When users added to existing positions, only `shares` and `avgPrice` were updated, leaving `amount` at its initial value
- This caused incorrect portfolio "In Positions" values and unrealized P&L calculations across the platform
- The bug affected 2,511 out of 2,848 positions (88%) in production

**Impact areas:**
- Portfolio breakdown calculations in `packages/engine/src/services/portfolio-breakdown.ts`
- Trade feedback and risk calculations in `packages/engine/src/reputation/trade-feedback-calculator.ts`
- Agent P&L tracking in `packages/training/src/benchmark/SimulationEngine.ts`

The fix is straightforward and correct - `row.amount` is already calculated as `String(position.avgPrice * position.shares)` at line 283, ensuring the accumulated amount stays synchronized with shares and avgPrice.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk - it's a targeted one-line fix for a critical data consistency bug
- The fix is a simple, well-understood addition of a missing field to an existing update clause. The `amount` calculation is already correct (line 283), and the field just needs to be included in the conflict resolution. The database fix has already been applied and verified to correct 2,511 positions, confirming both the bug and the solution. The change has no side effects and restores correct behavior.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/core/markets/prediction/adapters/drizzle/PredictionDbAdapter.ts | Added `amount` field to conflict update clause to fix position accumulation bug |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant PredictionMarketService
    participant PredictionDbAdapter
    participant Database

    User->>PredictionMarketService: buy(userId, marketId, side, amount)
    PredictionMarketService->>PredictionDbAdapter: getPosition(userId, marketId, side)
    PredictionDbAdapter->>Database: SELECT from Position
    Database-->>PredictionDbAdapter: existingPos (shares: 100, avgPrice: 0.50, amount: 50)
    PredictionDbAdapter-->>PredictionMarketService: existingPos
    
    Note over PredictionMarketService: Calculate new shares and avgPrice<br/>newShares = 100 + 50 = 150<br/>newAvgPrice = (100*0.50 + 50*0.60) / 150 = 0.533<br/>newAmount = 150 * 0.533 = 80
    
    PredictionMarketService->>PredictionDbAdapter: upsertPosition({...existingPos, shares: 150, avgPrice: 0.533})
    
    Note over PredictionDbAdapter: Before fix: amount not in onConflictDoUpdate<br/>After fix: amount: row.amount (calculated as shares * avgPrice)
    
    PredictionDbAdapter->>Database: INSERT ... ON CONFLICT DO UPDATE<br/>SET shares=150, avgPrice=0.533, amount=80
    Database-->>PredictionDbAdapter: Updated position
    PredictionDbAdapter-->>PredictionMarketService: position
    PredictionMarketService-->>User: trade result
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->