### PR TITLE
fix: prevent @babylon/db from being bundled in client code

### DIFF
--- a/apps/web/src/app/markets/_lib/formatters.ts
+++ b/apps/web/src/app/markets/_lib/formatters.ts
@@ -2,7 +2,7 @@
  * Utility functions for formatting values in the Markets page.
  */
 
-import { PredictionPricing } from '@babylon/core/markets/prediction';
+import { PredictionPricing } from '@babylon/core/markets/prediction/client';
 import { BABYLON_POINTS_SYMBOL } from '@babylon/shared';
 
 /**

--- a/apps/web/src/app/markets/perps/[ticker]/page.tsx
+++ b/apps/web/src/app/markets/perps/[ticker]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FEE_CONFIG } from '@babylon/engine/config/fees';
+import { FEE_CONFIG } from '@babylon/engine/client';
 import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
 import {
   AlertTriangle,

--- a/apps/web/src/components/markets/PerpTradingModal.tsx
+++ b/apps/web/src/components/markets/PerpTradingModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FEE_CONFIG } from '@babylon/engine/config/fees';
+import { FEE_CONFIG } from '@babylon/engine/client';
 import { BABYLON_POINTS_SYMBOL, cn, logger } from '@babylon/shared';
 import {
   AlertTriangle,

--- a/packages/core/markets/prediction/adapters/drizzle/PredictionDbAdapter.ts
+++ b/packages/core/markets/prediction/adapters/drizzle/PredictionDbAdapter.ts
@@ -291,6 +291,7 @@ export class PredictionDbAdapter implements PredictionDbPort {
         set: {
           shares: row.shares,
           avgPrice: row.avgPrice,
+          amount: row.amount,
           pnl: row.pnl,
           outcome: row.outcome,
           resolvedAt: row.resolvedAt,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,6 +21,16 @@
       "import": "./markets/prediction/index.ts",
       "require": "./markets/prediction/index.ts"
     },
+    "./markets/prediction/client": {
+      "types": "./markets/prediction/client.ts",
+      "import": "./markets/prediction/client.ts",
+      "require": "./markets/prediction/client.ts"
+    },
+    "./markets/prediction/pricing": {
+      "types": "./markets/prediction/pricing.ts",
+      "import": "./markets/prediction/pricing.ts",
+      "require": "./markets/prediction/pricing.ts"
+    },
     "./markets/shared": {
       "types": "./markets/shared/index.ts",
       "import": "./markets/shared/index.ts",

--- a/packages/engine/src/client.ts
+++ b/packages/engine/src/client.ts
@@ -15,7 +15,7 @@ export {
   PredictionPricing,
   type ShareCalculation,
   type ShareCalculationWithFees,
-} from '@babylon/core/markets/prediction';
+} from '@babylon/core/markets/prediction/pricing';
 // Fee Configuration (pure constants, no dependencies)
 export {
   FEE_CONFIG,

--- a/packages/engine/src/prediction-concentrated-liquidity.ts
+++ b/packages/engine/src/prediction-concentrated-liquidity.ts
@@ -42,7 +42,7 @@
  * ```
  */
 
-import { PredictionPricing } from '@babylon/core/markets/prediction';
+import { PredictionPricing } from '@babylon/core/markets/prediction/pricing';
 import { logger } from '@babylon/shared';
 
 /**

--- a/packages/testing/unit/shared/message-types.test.ts
+++ b/packages/testing/unit/shared/message-types.test.ts
@@ -1,43 +1,43 @@
 /**
  * Message Types Sync Test
- * 
+ *
  * Validates that MessageTypeEnum values stay in sync with the database enum.
  * This prevents type drift between the shared types and database schema.
  */
 
 import { describe, expect, it } from 'bun:test';
-import { MessageTypeEnum } from '@babylon/shared';
 import { messageTypeEnum } from '@babylon/db/schema/messaging';
+import { MessageTypeEnum } from '@babylon/shared';
 
 describe('MessageTypeEnum Sync', () => {
   it('should have MessageTypeEnum values match database enum values', () => {
     // Extract enum values from the database pgEnum
     // messageTypeEnum is a pgEnum with values: ['user', 'system']
     const dbEnumValues = messageTypeEnum.enumValues;
-    
+
     // Extract values from MessageTypeEnum object
     const sharedEnumValues = Object.values(MessageTypeEnum);
-    
+
     // Sort both arrays for comparison
     const sortedDbValues = [...dbEnumValues].sort();
     const sortedSharedValues = [...sharedEnumValues].sort();
-    
+
     expect(sortedSharedValues).toEqual(sortedDbValues);
   });
-  
+
   it('should have all database enum values present in MessageTypeEnum', () => {
     const dbEnumValues = messageTypeEnum.enumValues;
     const sharedEnumValues = Object.values(MessageTypeEnum);
-    
+
     for (const dbValue of dbEnumValues) {
       expect(sharedEnumValues).toContain(dbValue);
     }
   });
-  
+
   it('should have all MessageTypeEnum values present in database enum', () => {
     const dbEnumValues = messageTypeEnum.enumValues;
     const sharedEnumValues = Object.values(MessageTypeEnum);
-    
+
     for (const sharedValue of sharedEnumValues) {
       expect(dbEnumValues).toContain(sharedValue);
     }


### PR DESCRIPTION
## Problem

Client-side routes were failing with `Cannot find module '@babylon/db'` errors because server-only database dependencies were being included in client bundles.

**Affected routes:**
- `/markets`
- `/markets/perps/[ticker]`
- `/profile`

## Root Cause

1. **Commit 392b128ba** changed `formatters.ts` to import from `@babylon/core/markets/prediction` (server barrel) instead of `@babylon/core/markets/prediction/client` (client-safe)
2. The server barrel export includes `PredictionDbAdapter` which depends on `@babylon/db`
3. `FEE_CONFIG` imports were using `@babylon/engine/config/fees` which could transitively pull in server dependencies

## Solution

- ✅ Fix `formatters.ts` to import from `@babylon/core/markets/prediction/client`
- ✅ Fix perps page and `PerpTradingModal` to import `FEE_CONFIG` from `@babylon/engine/client`
- ✅ Update `engine/client.ts` to import from `/pricing` subpath instead of barrel export
- ✅ Update `prediction-concentrated-liquidity` to use `/pricing` subpath
- ✅ Add package.json exports for `/client` and `/pricing` subpaths in `@babylon/core`

## Testing

- ✅ Typecheck passes
- ✅ Lint passes
- ✅ Build passes (Foundry errors are expected when not installed)

## Related Commits

- Fixes regression introduced in commit `392b128ba`
- Related to previous fix attempt in commit `0cac575c6`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized internal module structure for improved code maintainability
  * Updated package exports for better API organization and accessibility
  * Enhanced database operations with additional data tracking capabilities

* **Tests**
  * Formatted test files for improved readability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes client-side bundling errors by ensuring server-only dependencies (`@babylon/db`) are never included in client bundles. The fix reverts problematic imports introduced in commit `392b128ba` and establishes proper client-safe import paths.

**Key Changes:**
- Fixed `formatters.ts` to import from `@babylon/core/markets/prediction/client` instead of the server barrel export
- Updated perps page and `PerpTradingModal` to import `FEE_CONFIG` from `@babylon/engine/client` instead of direct config paths
- Added package.json exports for `/client` and `/pricing` subpaths in `@babylon/core`
- Updated `engine/client.ts` to import from `/pricing` subpath to avoid transitive server dependencies
- Added missing `amount` field in `PredictionDbAdapter.upsertPosition` for data consistency
- Minor import reordering in test file for consistency

The solution correctly separates client-safe code (pure math functions, constants) from server-only code (database adapters) using explicit subpath exports.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- All changes are focused, well-documented, and directly address the stated problem. The fix properly separates client and server code using explicit package exports. The PredictionDbAdapter change adds a missing field that should have been included. No breaking changes or risky patterns introduced.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/markets/_lib/formatters.ts | Reverted import to use client-safe `/client` path instead of server barrel export |
| apps/web/src/app/markets/perps/[ticker]/page.tsx | Changed FEE_CONFIG import to use `@babylon/engine/client` instead of direct config path |
| apps/web/src/components/markets/PerpTradingModal.tsx | Changed FEE_CONFIG import to use `@babylon/engine/client` instead of direct config path |
| packages/core/package.json | Added package exports for `/client` and `/pricing` subpaths to support client-safe imports |
| packages/engine/src/client.ts | Updated import to use `/pricing` subpath instead of barrel export to avoid server dependencies |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Client Component<br/>(formatters.ts, page.tsx, PerpTradingModal)
    participant EngineClient as @babylon/engine/client
    participant CoreClient as @babylon/core/.../client
    participant Pricing as @babylon/core/.../pricing
    participant FeeConfig as config/fees.ts
    
    Note over Client,FeeConfig: Before Fix (Broken)
    Client->>CoreClient: import from @babylon/core/markets/prediction
    CoreClient-->>Client: ❌ Bundles PredictionDbAdapter + @babylon/db
    Note over Client: Client fails with "Cannot find module @babylon/db"
    
    Note over Client,FeeConfig: After Fix (Working)
    Client->>CoreClient: import from @babylon/core/markets/prediction/client
    CoreClient->>Pricing: re-exports from ./pricing
    Pricing-->>CoreClient: PredictionPricing (pure math)
    CoreClient-->>Client: ✅ Client-safe exports only
    
    Client->>EngineClient: import FEE_CONFIG from @babylon/engine/client
    EngineClient->>FeeConfig: import from ./config/fees
    FeeConfig-->>EngineClient: FEE_CONFIG (constants)
    EngineClient-->>Client: ✅ Client-safe constants
    
    Note over Client: Client builds successfully
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->