### PR TITLE
fix: select agent instead of @mentioning when redirecting to Command Center

### DIFF
--- a/apps/web/src/app/agents/create/page.tsx
+++ b/apps/web/src/app/agents/create/page.tsx
@@ -38,9 +38,8 @@ export default function CreateAgentPage() {
         onBack={() => router.push('/agents')}
         backLabel="Back"
         onSuccess={(agent) => {
-          // Redirect to team chat with @mention for the new agent
-          const mention = agent.username ? `${agent.username} ` : '';
-          router.push(`/agents/team?mention=${encodeURIComponent(mention)}`);
+          // Redirect to team chat and select the new agent
+          router.push(`/agents/team?selectAgent=${encodeURIComponent(agent.id)}`);
         }}
       />
     </PageContainer>

--- a/apps/web/src/app/agents/team/page.tsx
+++ b/apps/web/src/app/agents/team/page.tsx
@@ -104,7 +104,6 @@ export default function TeamChatPage() {
     hasMore,
     messageInput,
     handleInputChange,
-    setMessageInput,
     typingUsers,
     thinkingAgents,
     sendError,
@@ -260,16 +259,16 @@ export default function TeamChatPage() {
     }
   }, [activeTab]);
 
-  // Handle @mention from query parameter (when redirected from agent profile)
+  // Handle selectAgent from query parameter (when redirected from agent profile)
   useEffect(() => {
-    const mention = searchParams.get('mention');
-    if (mention && !loading && teamChat) {
-      // Pre-populate input with @mention and a trailing space
-      setMessageInput(`@${mention} `);
+    const agentIdToSelect = searchParams.get('selectAgent');
+    if (agentIdToSelect && !loading && teamChat) {
+      // Select the agent in the sidebar
+      selectAgent(agentIdToSelect);
       // Clean up URL by removing the query parameter
       router.replace('/agents/team', { scroll: false });
     }
-  }, [searchParams, loading, teamChat, setMessageInput, router]);
+  }, [searchParams, loading, teamChat, selectAgent, router]);
 
   // Scroll to bottom when switching to chat tab or on initial load
   // Uses MutationObserver to keep scrolling as images/content load

--- a/apps/web/src/app/chats/page.tsx
+++ b/apps/web/src/app/chats/page.tsx
@@ -110,23 +110,22 @@ export default function ChatsPage() {
 
   // Detect if the current chat is with the user's own agent
   // If so, redirect to team chat (Command Center) instead of this DM
-  const ownAgentUsername = useMemo(() => {
+  const ownAgentId = useMemo(() => {
     if (!chatDetails?.chat.otherUser || chatDetails.chat.isGroup) return null;
     const other = chatDetails.chat.otherUser;
     // Check if the other user is an agent managed by the current user
     if (other.isAgent && other.managedBy === user?.id) {
-      return other.username || other.id;
+      return other.id;
     }
     return null;
   }, [chatDetails, user?.id]);
 
-  // Redirect owned agent DMs to team chat
+  // Redirect owned agent DMs to team chat and select the agent
   useEffect(() => {
-    if (ownAgentUsername) {
-      const mention = `${ownAgentUsername} `;
-      router.replace(`/agents/team?mention=${encodeURIComponent(mention)}`);
+    if (ownAgentId) {
+      router.replace(`/agents/team?selectAgent=${encodeURIComponent(ownAgentId)}`);
     }
-  }, [ownAgentUsername, router]);
+  }, [ownAgentId, router]);
 
   // Auth required state
   if (ready && !authenticated) {
@@ -209,7 +208,7 @@ export default function ChatsPage() {
               selectedChatId ? 'block' : 'hidden xl:block'
             )}
           >
-            {ownAgentUsername ? (
+            {ownAgentId ? (
               // Redirecting to team chat...
               <div className="flex h-full items-center justify-center">
                 <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />

--- a/apps/web/src/app/profile/[id]/page.tsx
+++ b/apps/web/src/app/profile/[id]/page.tsx
@@ -163,10 +163,9 @@ export default function ActorProfilePage() {
 
     setIsCreatingDM(true);
 
-    // Check if this is the user's own agent - redirect to team chat with @mention
+    // Check if this is the user's own agent - redirect to team chat and select the agent
     if (actorInfo.isAgent && actorInfo.managedBy === user.id) {
-      const mentionHandle = actorInfo.username || actorInfo.id;
-      router.push(`/agents/team?mention=${encodeURIComponent(mentionHandle)}`);
+      router.push(`/agents/team?selectAgent=${encodeURIComponent(actorInfo.id)}`);
       setIsCreatingDM(false);
       return;
     }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated agent selection behavior across create and chat workflows to use sidebar-based selection instead of mention-based input prefilling.

* **Bug Fixes**
  * Corrected agent navigation flow for owned agent direct messages and team chat initiation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Changed the Command Center redirect mechanism from pre-populating the message input with an `@mention` to directly selecting the agent in the sidebar using the `selectAgent` function.

**Key Changes:**
- Updated all redirects to Command Center to pass `selectAgent={agent.id}` query parameter instead of `mention={username}`
- Modified `apps/web/src/app/agents/team/page.tsx` to call `selectAgent(agentId)` instead of `setMessageInput()` when processing the query parameter
- Removed unused `setMessageInput` from destructured `useTeamChat` hook
- Updated variable names from `ownAgentUsername`/`mentionHandle` to `ownAgentId` for clarity
- All four affected files (`create/page.tsx`, `team/page.tsx`, `chats/page.tsx`, `profile/[id]/page.tsx`) are now consistent

**Impact:**
This provides a cleaner UX by selecting the agent in the sidebar rather than pre-filling the input field. Users can now start fresh with the selected agent rather than having to clear the pre-filled mention.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues found
- The changes are straightforward and consistent across all files, properly use the existing `selectAgent` function from `useTeamChat` hook, correctly clean up query parameters after use, and improve UX by selecting agents in the sidebar instead of pre-filling the message input
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/agents/create/page.tsx | Updated redirect after agent creation to use `selectAgent` parameter instead of `mention` |
| apps/web/src/app/agents/team/page.tsx | Changed query parameter handling from `mention` to `selectAgent`, calls `selectAgent()` function and removed unused `setMessageInput` |
| apps/web/src/app/chats/page.tsx | Updated owned agent redirect to use agent ID with `selectAgent` parameter instead of username with `mention` |
| apps/web/src/app/profile/[id]/page.tsx | Changed owned agent redirect to use agent ID with `selectAgent` parameter instead of username with `mention` |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant CreateAgentPage
    participant ProfilePage
    participant ChatsPage
    participant Router
    participant TeamChatPage
    participant useTeamChat

    alt After Creating New Agent
        User->>CreateAgentPage: Creates new agent
        CreateAgentPage->>CreateAgentPage: onSuccess callback triggered
        CreateAgentPage->>Router: Push to /agents/team?selectAgent={agent.id}
        Router->>TeamChatPage: Navigate with query param
        TeamChatPage->>TeamChatPage: useEffect detects selectAgent param
        TeamChatPage->>useTeamChat: selectAgent(agentId)
        useTeamChat->>useTeamChat: setSelectedAgentIds(new Set([agentId]))
        TeamChatPage->>Router: Clean up URL (remove query param)
        TeamChatPage->>User: Shows Command Center with agent selected
    end

    alt From Owned Agent Profile
        User->>ProfilePage: Views own agent profile
        User->>ProfilePage: Clicks message button
        ProfilePage->>ProfilePage: Check if agent.managedBy === user.id
        ProfilePage->>Router: Push to /agents/team?selectAgent={agentInfo.id}
        Router->>TeamChatPage: Navigate with query param
        TeamChatPage->>TeamChatPage: useEffect detects selectAgent param
        TeamChatPage->>useTeamChat: selectAgent(agentId)
        useTeamChat->>useTeamChat: setSelectedAgentIds(new Set([agentId]))
        TeamChatPage->>Router: Clean up URL (remove query param)
        TeamChatPage->>User: Shows Command Center with agent selected
    end

    alt From Owned Agent DM
        User->>ChatsPage: Opens DM with owned agent
        ChatsPage->>ChatsPage: Detect ownAgentId (agent.managedBy === user.id)
        ChatsPage->>Router: Replace with /agents/team?selectAgent={ownAgentId}
        Router->>TeamChatPage: Navigate with query param
        TeamChatPage->>TeamChatPage: useEffect detects selectAgent param
        TeamChatPage->>useTeamChat: selectAgent(agentId)
        useTeamChat->>useTeamChat: setSelectedAgentIds(new Set([agentId]))
        TeamChatPage->>Router: Clean up URL (remove query param)
        TeamChatPage->>User: Shows Command Center with agent selected
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->