### PR TITLE
feat: remove Agents tab from sidebar navigation

### DIFF
--- a/apps/web/src/components/shared/Sidebar.tsx
+++ b/apps/web/src/components/shared/Sidebar.tsx
@@ -3,7 +3,6 @@
 import { cn, getReferralUrl } from '@babylon/shared';
 import {
   Bell,
-  Bot,
   Check,
   Copy,
   Gift,
@@ -159,15 +158,6 @@ function SidebarContent() {
       icon: MessageCircle,
       color: '#0066FF',
       active: pathname === '/chats',
-    },
-    {
-      name: 'Agents',
-      href: '/agents',
-      icon: Bot,
-      color: '#0066FF',
-      active:
-        pathname === '/agents' ||
-        (pathname.startsWith('/agents/') && pathname !== '/agents/team'),
     },
     {
       name: 'Command Center',


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Navigation Updates**
  * Removed the Agents option from the sidebar navigation menu.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Removed the "Agents" navigation tab from the desktop sidebar, leaving only "Command Center" (`/agents/team`) as the agents-related navigation option.

**Key Changes:**
- Removed `Bot` icon import (unused after removing Agents tab)
- Removed Agents navigation item that linked to `/agents` with path-based active state detection
- Command Center tab remains at `/agents/team` for team agent coordination

**Cross-Platform Inconsistency:**
The mobile `BottomNav` component still includes an "Agents" tab pointing to `/agents` (see `BottomNav.tsx:96-101`), while the desktop sidebar no longer has it. This creates a fragmented user experience where mobile users can navigate to `/agents` but desktop users cannot, even though the `/agents` page (`apps/web/src/app/agents/page.tsx`) still exists and is fully functional. Additionally, `AgentDetail.tsx:372` has a fallback link to `/agents` that desktop users won't be able to use from the sidebar.

**Recommendations:**
- Verify this is intentional navigation divergence between mobile and desktop
- Check that `BottomNav` should also remove the Agents tab for consistency
- Consider whether `/agents` route should remain accessible or redirect to `/agents/team`

<h3>Confidence Score: 3/5</h3>

- This PR is functionally safe but creates UX inconsistency between desktop and mobile navigation
- The code change itself is clean and won't cause runtime errors, but it introduces a navigation inconsistency issue. Desktop users lose access to `/agents` while mobile users retain it via BottomNav. The `/agents` page remains functional, and there are references to it in other components (AgentDetail fallback link). This suggests the change may be incomplete or the divergence is unintentional.
- Check `BottomNav.tsx` to ensure mobile navigation aligns with this desktop sidebar change

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/components/shared/Sidebar.tsx | Removed Agents tab from sidebar navigation, but creates inconsistency with mobile BottomNav which still includes it |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Sidebar
    participant Router
    participant BottomNav
    participant AgentsPage
    
    User->>Sidebar: Navigate (Desktop)
    Note over Sidebar: Agents tab removed
    Sidebar->>Router: Navigate to /agents/team (Command Center)
    
    User->>BottomNav: Navigate (Mobile)
    Note over BottomNav: Agents tab still exists
    BottomNav->>Router: Navigate to /agents
    Router->>AgentsPage: Load agents list page
    
    Note over Sidebar,AgentsPage: Inconsistency: Desktop lacks /agents<br/>while mobile retains it
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->