### PR TITLE
feat: add CHECK_OWNER_PNL action to view owner's trading performance

### DIFF
--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/check-owner-pnl.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/check-owner-pnl.ts
@@ -1,0 +1,228 @@
+/**
+ * CHECK_OWNER_PNL Action
+ *
+ * Returns the owner's balance, P&L, open positions, and recent trades.
+ * This shows the owner's trading performance, not the agent's.
+ */
+
+import {
+  and,
+  db,
+  eq,
+  isNull,
+  markets,
+  perpPositions,
+  positions,
+  users,
+} from '@babylon/db';
+import { WalletService } from '@babylon/engine';
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from '@elizaos/core';
+import { logger } from '../../../../shared/logger';
+
+export const checkOwnerPnlAction: Action = {
+  name: 'CHECK_OWNER_PNL',
+  description:
+    "Check your OWNER's balance, P&L, and open positions. This shows your owner's trading performance, not yours. Useful for understanding their strategy or coordinating trades.",
+
+  parameters: {},
+
+  examples: [
+    [
+      {
+        name: 'user',
+        content: { text: "What's my P&L?" },
+      },
+      {
+        name: 'assistant',
+        content: { text: 'Let me check your trading performance...' },
+      },
+    ],
+    [
+      {
+        name: 'user',
+        content: { text: 'Show me my positions' },
+      },
+      {
+        name: 'assistant',
+        content: { text: "I'll pull up your current positions..." },
+      },
+    ],
+    [
+      {
+        name: 'user',
+        content: { text: 'How am I doing on trades?' },
+      },
+      {
+        name: 'assistant',
+        content: { text: 'Let me check your trading stats...' },
+      },
+    ],
+    [
+      {
+        name: 'user',
+        content: { text: "What's your owner's balance?" },
+      },
+      {
+        name: 'assistant',
+        content: { text: "I'll check my owner's balance..." },
+      },
+    ],
+  ],
+
+  validate: async (
+    _runtime: IAgentRuntime,
+    _message: Memory,
+    _state?: State
+  ): Promise<boolean> => {
+    // Always valid - handler checks for ownerId and returns helpful error if missing
+    // Note: ownerId is added to state AFTER composeState/validate runs
+    return true;
+  },
+
+  handler: async (
+    _runtime: IAgentRuntime,
+    _message: Memory,
+    state?: State,
+    _options?: Record<string, unknown>,
+    _callback?: HandlerCallback
+  ): Promise<ActionResult> => {
+    const ownerId = state?.values?.ownerId as string | undefined;
+
+    if (!ownerId) {
+      return {
+        success: false,
+        text: 'Owner ID not available in this context.',
+        error: 'No owner ID provided',
+      };
+    }
+
+    try {
+      // Get owner info
+      const [owner] = await db
+        .select({
+          displayName: users.displayName,
+          username: users.username,
+          lifetimePnL: users.lifetimePnL,
+        })
+        .from(users)
+        .where(eq(users.id, ownerId))
+        .limit(1);
+
+      if (!owner) {
+        return {
+          success: false,
+          text: 'Owner not found.',
+          error: 'Owner not found',
+        };
+      }
+
+      const ownerName = owner.displayName || owner.username || 'Owner';
+
+      // Get wallet balance
+      let balance = 0;
+      let lifetimePnL = 0;
+      try {
+        const walletBalance = await WalletService.getBalance(ownerId);
+        balance = walletBalance.balance;
+        lifetimePnL = walletBalance.lifetimePnL;
+      } catch {
+        lifetimePnL = Number(owner?.lifetimePnL ?? 0);
+      }
+
+      // Get active prediction positions with market details
+      const predictionPositions = await db
+        .select({
+          id: positions.id,
+          marketId: positions.marketId,
+          side: positions.side,
+          shares: positions.shares,
+          avgPrice: positions.avgPrice,
+          amount: positions.amount,
+          question: markets.question,
+          yesShares: markets.yesShares,
+          noShares: markets.noShares,
+        })
+        .from(positions)
+        .leftJoin(markets, eq(positions.marketId, markets.id))
+        .where(
+          and(eq(positions.userId, ownerId), eq(positions.status, 'active'))
+        );
+
+      // Get active perp positions
+      const perpPositionsList = await db
+        .select()
+        .from(perpPositions)
+        .where(
+          and(eq(perpPositions.userId, ownerId), isNull(perpPositions.closedAt))
+        );
+
+      const totalPositions =
+        predictionPositions.length + perpPositionsList.length;
+
+      logger.info(
+        `[CHECK_OWNER_PNL] Retrieved P&L for owner ${ownerName}`,
+        { positions: totalPositions, ownerId },
+        'CheckOwnerPnL'
+      );
+
+      return {
+        success: true,
+        text: `Retrieved ${ownerName}'s P&L: $${balance.toFixed(2)} balance, ${totalPositions} open positions.`,
+        data: {
+          ownerName,
+          ownerId,
+          balance,
+          lifetimePnL,
+          predictionPositions: predictionPositions.map((p) => ({
+            id: p.id,
+            marketId: p.marketId,
+            side: p.side ? 'YES' : 'NO',
+            shares: Number(p.shares),
+            avgPrice: Number(p.avgPrice),
+          })),
+          perpPositions: perpPositionsList.map((p) => ({
+            id: p.id,
+            ticker: p.ticker,
+            side: p.side,
+            size: Number(p.size),
+            entryPrice: Number(p.entryPrice),
+            leverage: p.leverage,
+          })),
+        },
+        values: {
+          ownerName,
+          balance,
+          lifetimePnL,
+          predictionPositions: predictionPositions.map((p) => ({
+            id: p.id,
+            question: p.question?.substring(0, 80) || 'Unknown',
+            side: p.side ? 'YES' : 'NO',
+            shares: Number(p.shares),
+          })),
+          perpPositions: perpPositionsList.map((p) => ({
+            id: p.id,
+            ticker: p.ticker,
+            side: p.side,
+            size: Number(p.size),
+          })),
+        },
+      };
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : 'Unknown error';
+      logger.error('[CHECK_OWNER_PNL] Error:', errorMsg);
+
+      return {
+        success: false,
+        text: `Failed to retrieve owner's P&L: ${errorMsg}`,
+        error: errorMsg,
+      };
+    }
+  },
+};

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/index.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/index.ts
@@ -7,6 +7,7 @@ export { checkAutonomyAction } from './check-autonomy';
 export { checkBalanceAction } from './check-balance';
 export { checkCommentDetailAction } from './check-comment-detail';
 export { checkFeedPostsAction } from './check-feed-posts';
+export { checkOwnerPnlAction } from './check-owner-pnl';
 export { checkPerpsAction } from './check-perps';
 export { checkPnlAction } from './check-pnl';
 export { checkPostDetailAction } from './check-post-detail';

--- a/packages/agents/src/plugins/plugin-agent-core/src/index.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/index.ts
@@ -6,6 +6,7 @@
  * - CHECK_AUTONOMY action for viewing current autonomous feature status
  * - CHECK_BALANCE action for checking wallet balance
  * - CHECK_PNL action for balance, P&L, positions (with IDs), and recent trades
+ * - CHECK_OWNER_PNL action for checking owner's balance, P&L, and positions
  * - CHECK_FEED_POSTS action for viewing latest posts from global feed
  * - CHECK_RECENT_POSTS action for viewing recent posts (self or by userId)
  * - CHECK_RECENT_COMMENTS action for viewing recent comments (self or by userId)
@@ -32,6 +33,7 @@ import { checkAutonomyAction } from './actions/check-autonomy';
 import { checkBalanceAction } from './actions/check-balance';
 import { checkCommentDetailAction } from './actions/check-comment-detail';
 import { checkFeedPostsAction } from './actions/check-feed-posts';
+import { checkOwnerPnlAction } from './actions/check-owner-pnl';
 import { checkPerpsAction } from './actions/check-perps';
 import { checkPnlAction } from './actions/check-pnl';
 import { checkPostDetailAction } from './actions/check-post-detail';
@@ -69,6 +71,7 @@ export const agentCorePlugin: Plugin = {
     // Info/check actions
     checkBalanceAction,
     checkPnlAction,
+    checkOwnerPnlAction,
     checkFeedPostsAction,
     checkRecentPostsAction,
     checkRecentCommentsAction,


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to retrieve and view owner trading performance metrics, including account balance, lifetime profit/loss, and open market positions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added `CHECK_OWNER_PNL` action to allow agents to view their owner's trading performance, mirroring the existing `CHECK_PNL` action (which shows the agent's own data).

**Key changes:**
- Created new action that retrieves owner's balance, lifetime P&L, active prediction positions, and perpetual positions
- Properly handles missing `ownerId` in state with helpful error messages
- Implements graceful fallback when `WalletService.getBalance()` fails
- Follows existing patterns from `check-pnl.ts` for consistency

**Issue found:**
- The first three examples show user asking "my P&L" / "my positions", which would actually trigger `CHECK_PNL` (agent's data) not `CHECK_OWNER_PNL` (owner's data). These examples need to explicitly reference "owner" to correctly demonstrate when this action should be invoked.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge after fixing the action examples
- The implementation correctly follows existing patterns from `CHECK_PNL`, includes proper error handling, and has clear separation of concerns. The main issue is incorrect examples that would cause the LLM to trigger the wrong action, but this is easily fixed and doesn't affect runtime behavior.
- Pay attention to `check-owner-pnl.ts` - fix the examples to reference "owner" explicitly

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agents/src/plugins/plugin-agent-core/src/actions/check-owner-pnl.ts | added new action to check owner's trading P&L and positions, but examples would trigger wrong action |
| packages/agents/src/plugins/plugin-agent-core/src/actions/index.ts | exported new `checkOwnerPnlAction` in alphabetical order |
| packages/agents/src/plugins/plugin-agent-core/src/index.ts | registered new action in plugin and updated documentation |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Agent
    participant Handler as CHECK_OWNER_PNL Handler
    participant State
    participant DB as Database
    participant WalletService
    
    User->>Agent: "What's your owner's balance?"
    Agent->>Handler: Execute action
    Handler->>State: Get ownerId from state.values
    
    alt ownerId not found
        Handler-->>Agent: Error: Owner ID not available
        Agent-->>User: Owner ID not available in this context
    else ownerId found
        Handler->>DB: Query owner info (displayName, username, lifetimePnL)
        DB-->>Handler: Owner record
        
        alt owner not found
            Handler-->>Agent: Error: Owner not found
            Agent-->>User: Owner not found
        else owner found
            Handler->>WalletService: getBalance(ownerId)
            
            alt WalletService success
                WalletService-->>Handler: balance, lifetimePnL
            else WalletService fails
                WalletService-->>Handler: error (use DB lifetimePnL)
            end
            
            Handler->>DB: Query active prediction positions + markets (leftJoin)
            DB-->>Handler: predictionPositions[]
            
            Handler->>DB: Query active perp positions (closedAt IS NULL)
            DB-->>Handler: perpPositions[]
            
            Handler->>Handler: Calculate totalPositions
            Handler->>Handler: Format response data and values
            Handler-->>Agent: Success with owner P&L data
            Agent-->>User: "Retrieved {ownerName}'s P&L: ${balance} balance, {totalPositions} open positions"
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->