### PR TITLE
fix: deduct points after success and show agent response immediately

### DIFF
--- a/apps/web/src/app/api/agents/[agentId]/chat/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/chat/route.ts
@@ -343,7 +343,8 @@ export const POST = withErrorHandling(
       ? GROQ_MODELS.PRO.displayName
       : GROQ_MODELS.FREE.displayName;
 
-    // Check balance BEFORE deducting (to return clear error in production)
+    // Check balance BEFORE processing (to return clear error upfront)
+    // Points will be deducted AFTER successful response generation
     let newBalance = Number(agentWithConfig.virtualBalance ?? 0);
     if (pointsCost > 0 && newBalance < pointsCost) {
       return NextResponse.json(
@@ -352,16 +353,6 @@ export const POST = withErrorHandling(
           error: `Insufficient balance. Have: ${newBalance.toFixed(2)}, Need: ${pointsCost.toFixed(2)}`,
         },
         { status: 402 }
-      );
-    }
-
-    // Deduct points for pro mode (from virtualBalance)
-    if (pointsCost > 0) {
-      newBalance = await agentService.deductPoints(
-        agentId,
-        pointsCost,
-        `Chat message (pro mode)`,
-        undefined
       );
     }
 
@@ -854,6 +845,27 @@ export const POST = withErrorHandling(
         },
       },
     });
+
+    // Deduct points ONLY after successful response generation and DB save
+    // This ensures users don't lose points on failed/cancelled requests
+    if (pointsCost > 0) {
+      try {
+        newBalance = await agentService.deductPoints(
+          agentId,
+          pointsCost,
+          `Chat message (${usePro ? 'pro' : 'free'} mode)`,
+          undefined
+        );
+      } catch (err) {
+        // Log but don't fail - response already saved, points can be reconciled
+        logger.error(
+          'Failed to deduct points after successful response',
+          { agentId, pointsCost, error: err },
+          'AgentChat'
+        );
+        // Keep original balance in response (will be slightly incorrect but safe)
+      }
+    }
 
     logger.info(
       `Chat completed for agent ${agentId}`,

--- a/apps/web/src/hooks/useTeamChat.ts
+++ b/apps/web/src/hooks/useTeamChat.ts
@@ -786,7 +786,7 @@ export function useTeamChat(): UseTeamChatReturn {
             // Show toast if points were deducted
             if (data.pointsCost && data.pointsCost > 0) {
               toast.success(
-                `Response from ${agent?.displayName} (-${data.pointsCost} point${data.pointsCost > 1 ? 's' : ''})`
+                `Response from ${agent?.displayName} (-${data.pointsCost} points)`
               );
             }
 

--- a/apps/web/src/hooks/useTeamChat.ts
+++ b/apps/web/src/hooks/useTeamChat.ts
@@ -758,17 +758,35 @@ export function useTeamChat(): UseTeamChatReturn {
           });
 
           if (agentResponse.ok) {
-            // Parse response to get points info
+            // Parse response to get points info and message content
             const data = (await agentResponse.json()) as {
               success?: boolean;
+              messageId?: string;
+              response?: string;
               pointsCost?: number;
               balanceAfter?: number;
             };
 
+            // Add agent response message IMMEDIATELY from JSON response
+            // This prevents the delay from waiting for SSE broadcast
+            // stableKey prevents duplicate if SSE also delivers the same message
+            // Note: Auto-scroll is handled by the realtimeMessages.length effect
+            if (data.response && data.messageId) {
+              addMessage({
+                id: data.messageId,
+                chatId: teamChat.chatId,
+                content: data.response,
+                senderId: agentId,
+                type: 'user',
+                createdAt: new Date().toISOString(),
+                stableKey: data.messageId,
+              });
+            }
+
             // Show toast if points were deducted
             if (data.pointsCost && data.pointsCost > 0) {
               toast.success(
-                `Message sent to ${agent?.displayName} (-${data.pointsCost} point${data.pointsCost > 1 ? 's' : ''})`
+                `Response from ${agent?.displayName} (-${data.pointsCost} point${data.pointsCost > 1 ? 's' : ''})`
               );
             }
 


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Chat responses now display instantly on your screen without waiting for server synchronization.
  * Point deductions now process after successful responses, ensuring reliable transactions.
  * Enhanced error handling prevents point deduction issues from interrupting your chat experience.
  * Updated point notification messaging for clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Improved agent chat UX by deferring point deduction until after successful response generation and displaying agent responses immediately to the user.

Key changes:
- **Point deduction timing**: Moved from before to after successful response generation and DB save, preventing users from losing points on failed/cancelled requests
- **Immediate response display**: Agent responses now show instantly from the JSON response instead of waiting for SSE broadcast
- **Toast message**: Changed from "Message sent" to "Response from {agent}" to better reflect the actual action

The deferred point deduction ensures better user experience when requests fail or are cancelled. The immediate response display reduces perceived latency by showing the agent's message without waiting for SSE.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor issue to address regarding balance reporting when point deduction fails
- The changes improve UX and error handling, but there's a logic issue where `balanceAfter` could be incorrect if point deduction fails after the response is saved. The error is caught and logged but the stale balance is still returned to the client.
- Pay attention to route.ts:866 where the catch block doesn't update the balance value returned to the client

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/api/agents/[agentId]/chat/route.ts | Moved point deduction to after successful response generation and DB save; added error handling for deduction failures |
| apps/web/src/hooks/useTeamChat.ts | Added immediate agent response display from JSON response and updated toast message format |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Frontend as useTeamChat Hook
    participant API as /api/agents/[agentId]/chat
    participant DB as Database
    participant AgentService
    participant SSE as SSE Broadcast

    User->>Frontend: Send message to agent
    Frontend->>Frontend: Create optimistic message
    Frontend->>API: POST /api/agents/[agentId]/chat
    
    API->>API: Check balance (don't deduct yet)
    alt Insufficient balance
        API-->>Frontend: 402 Insufficient balance error
        Frontend->>User: Show error toast
    else Sufficient balance
        API->>API: Generate agent response
        API->>DB: Save user message + agent response
        
        Note over API,AgentService: NEW: Deduct points AFTER success
        API->>AgentService: deductPoints()
        
        alt Deduction succeeds
            AgentService->>DB: Update virtualBalance
            AgentService-->>API: Return new balance
        else Deduction fails
            AgentService-->>API: Error (logged, not thrown)
            Note over API: Balance returned may be stale
        end
        
        API-->>Frontend: JSON response (messageId, response, balanceAfter)
        
        Note over Frontend: NEW: Show response immediately
        Frontend->>Frontend: Add agent message to UI (stableKey prevents duplicate)
        Frontend->>User: Show toast "Response from Agent (-X points)"
        Frontend->>Frontend: Update agent balance in state
        
        API->>SSE: Broadcast agent response
        SSE-->>Frontend: SSE message (deduplicated by stableKey)
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->