### PR TITLE
feat: add activity filters to Command Center

### DIFF
--- a/apps/web/src/app/agents/team/ActivityFilters.tsx
+++ b/apps/web/src/app/agents/team/ActivityFilters.tsx
@@ -13,6 +13,7 @@ import {
   X,
 } from 'lucide-react';
 import { memo, useMemo, useState } from 'react';
+import type { ActivityTypeFilter } from '@/components/agents/AgentActivityFeed';
 import { Avatar } from '@/components/shared/Avatar';
 import {
   DropdownMenu,
@@ -23,7 +24,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 
-export type ActivityType = 'all' | 'trade' | 'post' | 'comment';
+export type ActivityType = ActivityTypeFilter;
 
 export interface AgentOption {
   id: string;

--- a/apps/web/src/app/agents/team/ActivityFilters.tsx
+++ b/apps/web/src/app/agents/team/ActivityFilters.tsx
@@ -1,0 +1,331 @@
+'use client';
+
+import { cn } from '@babylon/shared';
+import {
+  ArrowRightLeft,
+  Bot,
+  Check,
+  ChevronDown,
+  Filter,
+  MessageCircle,
+  MessageSquare,
+  Sparkles,
+  X,
+} from 'lucide-react';
+import { memo, useMemo, useState } from 'react';
+import { Avatar } from '@/components/shared/Avatar';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+export type ActivityType = 'all' | 'trade' | 'post' | 'comment';
+
+export interface AgentOption {
+  id: string;
+  name: string;
+  username?: string;
+  profileImageUrl?: string | null;
+}
+
+interface ActivityFiltersProps {
+  /** Currently selected activity type */
+  activityType: ActivityType;
+  /** Callback when activity type changes */
+  onActivityTypeChange: (type: ActivityType) => void;
+  /** Currently selected agent ID (null = all agents) */
+  selectedAgentId: string | null;
+  /** Callback when agent selection changes */
+  onAgentChange: (agentId: string | null) => void;
+  /** List of agents to show in dropdown */
+  agents: AgentOption[];
+  /** Whether agents are still loading */
+  agentsLoading?: boolean;
+  /** Optional className */
+  className?: string;
+}
+
+const ACTIVITY_TYPES: {
+  value: ActivityType;
+  label: string;
+  icon: typeof ArrowRightLeft;
+  color: string;
+  bgColor: string;
+}[] = [
+  {
+    value: 'all',
+    label: 'All Activity',
+    icon: Sparkles,
+    color: 'text-blue-500',
+    bgColor: 'bg-blue-500/10',
+  },
+  {
+    value: 'trade',
+    label: 'Trades',
+    icon: ArrowRightLeft,
+    color: 'text-emerald-500',
+    bgColor: 'bg-emerald-500/10',
+  },
+  {
+    value: 'post',
+    label: 'Posts',
+    icon: MessageSquare,
+    color: 'text-violet-500',
+    bgColor: 'bg-violet-500/10',
+  },
+  {
+    value: 'comment',
+    label: 'Comments',
+    icon: MessageCircle,
+    color: 'text-amber-500',
+    bgColor: 'bg-amber-500/10',
+  },
+];
+
+/**
+ * Activity filter bar component.
+ *
+ * Provides pill-style buttons for activity type filtering and a dropdown
+ * for agent selection. Designed for the Command Center activity feed.
+ */
+export const ActivityFilters = memo(function ActivityFilters({
+  activityType,
+  onActivityTypeChange,
+  selectedAgentId,
+  onAgentChange,
+  agents,
+  agentsLoading = false,
+  className,
+}: ActivityFiltersProps) {
+  const [agentDropdownOpen, setAgentDropdownOpen] = useState(false);
+
+  // Find the selected agent for display
+  const selectedAgent = useMemo(
+    () => agents.find((a) => a.id === selectedAgentId),
+    [agents, selectedAgentId]
+  );
+
+  // Count of active filters (excluding defaults)
+  const activeFilterCount = useMemo(() => {
+    let count = 0;
+    if (activityType !== 'all') count++;
+    if (selectedAgentId) count++;
+    return count;
+  }, [activityType, selectedAgentId]);
+
+  const handleClearFilters = () => {
+    onActivityTypeChange('all');
+    onAgentChange(null);
+  };
+
+  return (
+    <div className={cn('space-y-4', className)}>
+      {/* Filter Bar Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-muted-foreground text-sm">
+          <Filter className="h-4 w-4" />
+          <span className="font-medium">Filters</span>
+          {activeFilterCount > 0 && (
+            <span className="flex h-5 min-w-5 items-center justify-center rounded-full bg-blue-500 px-1.5 font-medium text-white text-xs">
+              {activeFilterCount}
+            </span>
+          )}
+        </div>
+
+        {activeFilterCount > 0 && (
+          <button
+            onClick={handleClearFilters}
+            className="flex items-center gap-1.5 rounded-full px-3 py-1.5 text-muted-foreground text-xs transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <X className="h-3 w-3" />
+            Clear all
+          </button>
+        )}
+      </div>
+
+      {/* Filter Controls */}
+      <div className="flex flex-wrap items-center gap-3">
+        {/* Activity Type Pills */}
+        <div className="flex flex-wrap gap-2">
+          {ACTIVITY_TYPES.map((type) => {
+            const Icon = type.icon;
+            const isActive = activityType === type.value;
+
+            return (
+              <button
+                key={type.value}
+                onClick={() => onActivityTypeChange(type.value)}
+                className={cn(
+                  'group flex items-center gap-2 rounded-full px-4 py-2 font-medium text-sm transition-all duration-200',
+                  isActive
+                    ? cn(type.bgColor, type.color, 'ring-1 ring-current/20')
+                    : 'bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground'
+                )}
+              >
+                <Icon
+                  className={cn(
+                    'h-4 w-4 transition-transform duration-200 group-hover:scale-110',
+                    isActive ? type.color : 'text-current'
+                  )}
+                />
+                <span>{type.label}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Divider */}
+        <div className="hidden h-6 w-px bg-border sm:block" />
+
+        {/* Agent Dropdown */}
+        <DropdownMenu
+          open={agentDropdownOpen}
+          onOpenChange={setAgentDropdownOpen}
+        >
+          <DropdownMenuTrigger asChild>
+            <button
+              className={cn(
+                'flex items-center gap-2 rounded-full px-4 py-2 font-medium text-sm transition-all duration-200',
+                selectedAgentId
+                  ? 'bg-blue-500/10 text-blue-500 ring-1 ring-blue-500/20'
+                  : 'bg-muted/50 text-muted-foreground hover:bg-muted hover:text-foreground'
+              )}
+            >
+              {selectedAgent ? (
+                <>
+                  <Avatar
+                    id={selectedAgent.id}
+                    name={selectedAgent.name}
+                    src={selectedAgent.profileImageUrl ?? undefined}
+                    type="user"
+                    size="sm"
+                  />
+                  <span className="max-w-24 truncate">
+                    {selectedAgent.name}
+                  </span>
+                </>
+              ) : (
+                <>
+                  <Bot className="h-4 w-4" />
+                  <span>All Agents</span>
+                </>
+              )}
+              <ChevronDown
+                className={cn(
+                  'h-4 w-4 transition-transform duration-200',
+                  agentDropdownOpen && 'rotate-180'
+                )}
+              />
+            </button>
+          </DropdownMenuTrigger>
+
+          <DropdownMenuContent align="start" className="w-64">
+            <DropdownMenuLabel className="flex items-center gap-2 text-muted-foreground">
+              <Bot className="h-4 w-4" />
+              Filter by Agent
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+
+            {/* All Agents Option */}
+            <DropdownMenuItem
+              onClick={() => onAgentChange(null)}
+              className="flex items-center justify-between gap-2"
+            >
+              <div className="flex items-center gap-2">
+                <div className="flex h-8 w-8 items-center justify-center rounded-full bg-muted">
+                  <Sparkles className="h-4 w-4 text-muted-foreground" />
+                </div>
+                <span className="font-medium">All Agents</span>
+              </div>
+              {!selectedAgentId && <Check className="h-4 w-4 text-blue-500" />}
+            </DropdownMenuItem>
+
+            <DropdownMenuSeparator />
+
+            {/* Agent List */}
+            {agentsLoading ? (
+              <div className="space-y-2 p-2">
+                {[1, 2, 3].map((i) => (
+                  <div
+                    key={i}
+                    className="flex animate-pulse items-center gap-2"
+                  >
+                    <div className="h-8 w-8 rounded-full bg-muted" />
+                    <div className="h-4 w-24 rounded bg-muted" />
+                  </div>
+                ))}
+              </div>
+            ) : agents.length === 0 ? (
+              <div className="p-4 text-center text-muted-foreground text-sm">
+                No agents found
+              </div>
+            ) : (
+              <div className="max-h-64 overflow-y-auto">
+                {agents.map((agent) => (
+                  <DropdownMenuItem
+                    key={agent.id}
+                    onClick={() => onAgentChange(agent.id)}
+                    className="flex items-center justify-between gap-2"
+                  >
+                    <div className="flex min-w-0 items-center gap-2">
+                      <Avatar
+                        id={agent.id}
+                        name={agent.name}
+                        src={agent.profileImageUrl ?? undefined}
+                        type="user"
+                        size="sm"
+                      />
+                      <div className="min-w-0">
+                        <div className="truncate font-medium">{agent.name}</div>
+                        {agent.username && (
+                          <div className="truncate text-muted-foreground text-xs">
+                            @{agent.username}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                    {selectedAgentId === agent.id && (
+                      <Check className="h-4 w-4 shrink-0 text-blue-500" />
+                    )}
+                  </DropdownMenuItem>
+                ))}
+              </div>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      {/* Active Filters Summary (mobile-friendly) */}
+      {activeFilterCount > 0 && (
+        <div className="flex flex-wrap items-center gap-2 sm:hidden">
+          {activityType !== 'all' && (
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-muted px-3 py-1 text-xs">
+              {ACTIVITY_TYPES.find((t) => t.value === activityType)?.label}
+              <button
+                onClick={() => onActivityTypeChange('all')}
+                className="rounded-full p-0.5 hover:bg-foreground/10"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          )}
+          {selectedAgent && (
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-muted px-3 py-1 text-xs">
+              {selectedAgent.name}
+              <button
+                onClick={() => onAgentChange(null)}
+                className="rounded-full p-0.5 hover:bg-foreground/10"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+});

--- a/apps/web/src/app/agents/team/page.tsx
+++ b/apps/web/src/app/agents/team/page.tsx
@@ -30,6 +30,7 @@ import { Skeleton } from '@/components/shared/Skeleton';
 import { Button } from '@/components/ui/button';
 import { useAuth } from '@/hooks/useAuth';
 import { useTeamChat } from '@/hooks/useTeamChat';
+import { ActivityFilters, type ActivityType } from './ActivityFilters';
 import { ConversationList } from './ConversationList';
 import { MemberList } from './MemberList';
 
@@ -149,6 +150,13 @@ export default function TeamChatPage() {
 
   // Create agent view state
   const [showCreateAgent, setShowCreateAgent] = useState(false);
+
+  // Activity tab filter state
+  const [activityTypeFilter, setActivityTypeFilter] =
+    useState<ActivityType>('all');
+  const [activityAgentFilter, setActivityAgentFilter] = useState<string | null>(
+    null
+  );
 
   // Fetch agents for Agents tab
   const fetchAgents = useCallback(async () => {
@@ -882,20 +890,49 @@ export default function TeamChatPage() {
           {/* Activity Tab */}
           {activeTab === 'activity' && (
             <div className="flex-1 overflow-y-auto p-4">
-              <div className="mb-4">
+              <div className="mb-6">
                 <h2 className="flex items-center gap-2 font-bold text-xl">
                   <Activity className="h-5 w-5 text-blue-500" />
                   Recent Activity
                 </h2>
                 <p className="mt-1 text-muted-foreground text-sm">
-                  Recent trades, posts, and comments from all your agents
+                  {activityAgentFilter
+                    ? `Activity from ${teamChat?.agents.find((a) => a.id === activityAgentFilter)?.displayName || 'selected agent'}`
+                    : 'Recent trades, posts, and comments from all your agents'}
                 </p>
               </div>
+
+              {/* Activity Filters */}
+              <ActivityFilters
+                activityType={activityTypeFilter}
+                onActivityTypeChange={setActivityTypeFilter}
+                selectedAgentId={activityAgentFilter}
+                onAgentChange={setActivityAgentFilter}
+                agents={
+                  teamChat?.agents.map((agent) => ({
+                    id: agent.id,
+                    name: agent.displayName || agent.username || 'Agent',
+                    username: agent.username || undefined,
+                    profileImageUrl: agent.profileImageUrl,
+                  })) || []
+                }
+                agentsLoading={loading}
+                className="mb-6"
+              />
+
               <AgentActivityFeed
-                limit={20}
-                showAgent={true}
-                showConnectionStatus={false}
-                emptyMessage="No agent activity yet. Your agents' trades, posts, and comments will appear here."
+                agentId={activityAgentFilter || undefined}
+                type={activityTypeFilter}
+                limit={30}
+                showAgent={!activityAgentFilter}
+                showConnectionStatus={!!activityAgentFilter}
+                emptyMessage={
+                  activityAgentFilter
+                    ? 'No activity from this agent yet.'
+                    : activityTypeFilter !== 'all'
+                      ? `No ${activityTypeFilter} activity yet.`
+                      : "No agent activity yet. Your agents' trades, posts, and comments will appear here."
+                }
               />
             </div>
           )}

--- a/apps/web/src/app/agents/team/page.tsx
+++ b/apps/web/src/app/agents/team/page.tsx
@@ -925,7 +925,7 @@ export default function TeamChatPage() {
                 type={activityTypeFilter}
                 limit={30}
                 showAgent={!activityAgentFilter}
-                showConnectionStatus={!!activityAgentFilter}
+                showConnectionStatus
                 emptyMessage={
                   activityAgentFilter
                     ? 'No activity from this agent yet.'

--- a/apps/web/src/components/agents/AgentActivityFeed.tsx
+++ b/apps/web/src/components/agents/AgentActivityFeed.tsx
@@ -6,10 +6,12 @@ import { memo } from 'react';
 import { useAgentActivity } from '@/hooks/useAgentActivity';
 import { AgentActivityCard } from './AgentActivityCard';
 
+export type ActivityTypeFilter = 'all' | 'trade' | 'post' | 'comment';
+
 interface AgentActivityFeedProps {
   agentId?: string;
   limit?: number;
-  type?: 'all' | 'trade' | 'post' | 'comment';
+  type?: ActivityTypeFilter;
   showAgent?: boolean;
   showConnectionStatus?: boolean;
   emptyMessage?: string;

--- a/apps/web/src/hooks/useTeamChat.ts
+++ b/apps/web/src/hooks/useTeamChat.ts
@@ -1096,7 +1096,7 @@ export function useTeamChat(): UseTeamChatReturn {
 
   // Fetch conversations when team chat loads
   useEffect(() => {
-    if (teamChat && user) {
+    if (teamChat?.id && user) {
       refreshConversations();
     }
   }, [teamChat?.id, user, refreshConversations]);


### PR DESCRIPTION
## Summary

- Add filters to the Recent Activity tab in Command Center, allowing users to filter by activity type (trades, posts, comments) and by specific agent
- Improves discoverability and usability when users have multiple agents with high activity volume

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- User request for filtering activity feed by agent and activity type

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- **New**: `ActivityFilters.tsx` — filter bar component with pill-style activity type buttons and agent dropdown
- **Modified**: `page.tsx` — added filter state and wired up `ActivityFilters` to the Activity tab
- **Modified**: `AgentActivityFeed.tsx` — exported `ActivityTypeFilter` type for reuse

## Review guide

**Start here**
- `apps/web/src/app/agents/team/ActivityFilters.tsx` — new component, main logic
- `apps/web/src/app/agents/team/page.tsx` — integration in Activity tab (lines ~887-934)

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- Leverages existing `useAgentActivity` hook which already supports `agentId` and `type` filtering
- Uses existing Radix dropdown menu component for agent selection
- No API changes required

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Navigate to Command Center → Activity tab
2. Click activity type pills (All, Trades, Posts, Comments) and verify feed filters correctly
3. Open agent dropdown and select a specific agent, verify feed shows only that agent's activity
4. Verify "Clear all" button resets filters
5. Verify filter count badge updates correctly
6. Test on mobile viewport to verify responsive layout

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option A: Visual demo

<img width="973" height="719" alt="image" src="https://github.com/user-attachments/assets/211ade93-b683-4665-b742-b40d4de34514" />

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [ ] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a filter bar for the Activity tab to filter by type (All, Trades, Posts, Comments) with per-type visuals and active-count + Clear all.
  * Added an agent dropdown to filter activities by team member, with avatars, names, loading/empty states, and scrollable selection.
  * Activity tab now reflects selected filters in its header/subtext and empty-state messaging; mobile-friendly active-filter summary included.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds filtering capabilities to the Command Center Activity tab, allowing users to filter by activity type (All, Trades, Posts, Comments) and by specific agent.

Key changes:
- New `ActivityFilters` component with pill-style activity type buttons and agent dropdown selector
- Filter state management integrated into the Activity tab in `page.tsx`
- Active filter count badge and "Clear all" functionality
- Mobile-responsive filter summary view
- Dynamic empty messages based on active filters
- Leverages existing `useAgentActivity` hook which already supports filtering by `agentId` and `type`

The implementation follows established patterns in the codebase with proper use of `memo`, `useMemo`, existing UI components (DropdownMenu, Avatar), and responsive design. The filter UI is well-polished with visual feedback, hover states, and accessibility considerations.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk
- Well-implemented feature with clean integration, only minor type duplication issue that doesn't affect functionality
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/agents/team/ActivityFilters.tsx | New filter component with pill-style activity type buttons and agent dropdown, well-structured with responsive design and accessibility features |
| apps/web/src/app/agents/team/page.tsx | Integrated ActivityFilters component into Activity tab with state management and dynamic empty messages |
| apps/web/src/components/agents/AgentActivityFeed.tsx | Exported ActivityTypeFilter type for reuse, creating duplicate type definition |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ActivityTab as Activity Tab (page.tsx)
    participant Filters as ActivityFilters Component
    participant Feed as AgentActivityFeed
    participant Hook as useAgentActivity Hook
    participant API as /api/agents/activity

    User->>ActivityTab: Navigate to Activity tab
    ActivityTab->>Filters: Render with initial state (type='all', agentId=null)
    ActivityTab->>Feed: Render with filters (type='all', agentId=undefined)
    Feed->>Hook: useAgentActivity({type: 'all'})
    Hook->>API: GET /api/agents/activity?limit=30&type=all
    API-->>Hook: Return all agent activities
    Hook-->>Feed: Display activities from all agents
    
    User->>Filters: Click "Trades" pill
    Filters->>ActivityTab: onActivityTypeChange('trade')
    ActivityTab->>Feed: Update with type='trade'
    Feed->>Hook: useAgentActivity({type: 'trade'})
    Hook->>API: GET /api/agents/activity?limit=30&type=trade
    API-->>Hook: Return only trade activities
    Hook-->>Feed: Display filtered trade activities
    
    User->>Filters: Select agent from dropdown
    Filters->>ActivityTab: onAgentChange(agentId)
    ActivityTab->>Feed: Update with agentId and type='trade'
    Feed->>Hook: useAgentActivity({agentId, type: 'trade', enableSSE: true})
    Hook->>API: GET /api/agents/{agentId}/activity?limit=30&type=trade
    API-->>Hook: Return agent's trade activities
    Hook-->>Feed: Display agent-specific activities
    
    User->>Filters: Click "Clear all"
    Filters->>ActivityTab: Reset (type='all', agentId=null)
    ActivityTab->>Feed: Reset filters
    Feed->>Hook: useAgentActivity({type: 'all'})
    Hook->>API: GET /api/agents/activity?limit=30&type=all
    API-->>Hook: Return all activities
    Hook-->>Feed: Display all agent activities
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->