### PR TITLE
fix: unblock exit trades at zero balance

### DIFF
--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -471,6 +471,11 @@ export async function executeDirectTrade(
   const npcActor = StaticDataRegistry.getActor(agentUserId);
   const isNpc = !!npcActor;
 
+  const isExitTrade =
+    (marketType === 'prediction' &&
+      (side === 'sell_yes' || side === 'sell_no')) ||
+    (marketType === 'perp' && side === 'close_position');
+
   // Get current balance
   let balance = 0;
   if (isNpc) {
@@ -485,39 +490,46 @@ export async function executeDirectTrade(
     balance = walletBalance.balance;
   }
 
-  const looksLikeShareCount =
-    Number.isInteger(amount) &&
-    amount >= 1 &&
-    amount <= SHARE_LIKE_MAX_INTEGER &&
-    balance > 0 &&
-    amount / balance < SHARE_LIKE_RATIO_THRESHOLD;
-  if (looksLikeShareCount) {
-    logger.warn(
-      `[DirectExecutor] Trade amount $${amount.toFixed(
-        2
-      )} looks like a share count relative to $${balance.toFixed(
-        2
-      )} balance. Expected Babylon Points.`,
-      { agentUserId, marketType, side, balance },
-      'DirectExecutors'
-    );
-  }
+  if (!isExitTrade) {
+    const looksLikeShareCount =
+      Number.isInteger(amount) &&
+      amount >= 1 &&
+      amount <= SHARE_LIKE_MAX_INTEGER &&
+      balance > 0 &&
+      amount / balance < SHARE_LIKE_RATIO_THRESHOLD;
+    if (looksLikeShareCount) {
+      logger.warn(
+        `[DirectExecutor] Trade amount $${amount.toFixed(
+          2
+        )} looks like a share count relative to $${balance.toFixed(
+          2
+        )} balance. Expected Babylon Points.`,
+        { agentUserId, marketType, side, balance },
+        'DirectExecutors'
+      );
+    }
 
-  // Cannot trade more than balance
-  if (amount > balance) {
-    logger.warn(
-      `[DirectExecutor] Trade capped to balance: $${amount} -> $${balance}`,
-      { agentUserId, isNpc },
-      'DirectExecutors'
-    );
-    amount = balance;
-  }
+    // Cannot trade more than balance
+    if (amount > balance) {
+      logger.warn(
+        `[DirectExecutor] Trade capped to balance: $${amount} -> $${balance}`,
+        { agentUserId, isNpc },
+        'DirectExecutors'
+      );
+      amount = balance;
+    }
 
-  // Reject if insufficient funds
-  if (amount < 1) {
+    // Reject if insufficient funds
+    if (amount < 1) {
+      return {
+        success: false,
+        error: `Insufficient balance: $${balance.toFixed(2)}`,
+      };
+    }
+  } else if (amount < 0) {
     return {
       success: false,
-      error: `Insufficient balance: $${balance.toFixed(2)}`,
+      error: 'Amount must be 0 or greater for exit trades',
     };
   }
 

--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -457,13 +457,21 @@ export interface DirectRepostResult {
 
 /**
  * Execute a trade directly without LLM decision-making.
- * Validates balance - cannot trade more than you have.
+ * Validates balance for entry trades; exit trades (sell_yes/sell_no/close_position)
+ * can close positions even when balance is $0.
  */
 export async function executeDirectTrade(
   params: DirectTradeParams
 ): Promise<DirectTradeResult> {
   const { agentUserId, marketType, marketId, side, reasoning } = params;
   let { amount } = params;
+
+  if (!Number.isFinite(amount)) {
+    return {
+      success: false,
+      error: 'Invalid trade amount. Must be a finite number.',
+    };
+  }
 
   // Check if this is an NPC (system-defined actor from static data files).
   // User-created agents are NOT in StaticDataRegistry, so they won't match.

--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -118,8 +118,11 @@ export class MultiStepExecutor {
 
     // Get agent config (may be null for NPCs)
     const config = await getAgentConfig(agentUserId);
-    const systemPrompt =
+    const baseSystemPrompt =
       config?.systemPrompt ?? 'You are an autonomous trading agent on Babylon.';
+    const balanceGuidance =
+      'Trading guidance: If your balance is low or $0 but you have open positions, you can still sell/close positions to free balance. Do not assume trading is impossible; check your open positions and consider trimming or closing to unlock funds before switching to social-only actions.';
+    const systemPrompt = `${baseSystemPrompt}\n\n${balanceGuidance}`;
 
     // Determine enabled features - NPCs have all features enabled by default
     // For USER_CONTROLLED agents: trading defaults to true, others default to false

--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -120,9 +120,6 @@ export class MultiStepExecutor {
     const config = await getAgentConfig(agentUserId);
     const baseSystemPrompt =
       config?.systemPrompt ?? 'You are an autonomous trading agent on Babylon.';
-    const balanceGuidance =
-      'Trading guidance: If your balance is low or $0 but you have open positions, you can still sell/close positions to free balance. Do not assume trading is impossible; check your open positions and consider trimming or closing to unlock funds before switching to social-only actions.';
-    const systemPrompt = `${baseSystemPrompt}\n\n${balanceGuidance}`;
 
     // Determine enabled features - NPCs have all features enabled by default
     // For USER_CONTROLLED agents: trading defaults to true, others default to false
@@ -146,6 +143,12 @@ export class MultiStepExecutor {
       if (features.dms) enabledFeatures.push(Features.DMS);
       if (features.groupChats) enabledFeatures.push(Features.GROUP_CHATS);
     }
+
+    const balanceGuidance =
+      'Trading guidance: If your balance is low or $0 but you have open positions, you can still sell/close positions to free balance. Do not assume trading is impossible; check your open positions and consider trimming or closing to unlock funds before switching to social-only actions.';
+    const systemPrompt = enabledFeatures.includes(Features.TRADING)
+      ? `${baseSystemPrompt}\n\n${balanceGuidance}`
+      : baseSystemPrompt;
 
     // Get NPC game context ONCE before loop (arc awareness, world events)
     // Graceful degradation: if context fetch fails, continue without it

--- a/packages/agents/src/autonomous/__tests__/prediction-price-history.test.ts
+++ b/packages/agents/src/autonomous/__tests__/prediction-price-history.test.ts
@@ -28,7 +28,7 @@ const questions = {
 };
 const users = { table: 'User', id: 'id', displayName: 'displayName' };
 
-const marketRow = {
+const baseMarketRow = {
   id: 'm1',
   question: 'Will something happen?',
   description: null,
@@ -44,10 +44,50 @@ const marketRow = {
   updatedAt: new Date(),
 };
 
+const marketRow = { ...baseMarketRow };
+
 const userRow = { displayName: 'Test Agent' };
+
+type PositionRow = {
+  id: string;
+  userId: string;
+  marketId: string;
+  side: boolean;
+  shares: number;
+  avgPrice: number;
+  status: string;
+  outcome: null;
+  pnl: number;
+  resolvedAt: null;
+  createdAt: Date;
+  updatedAt: Date;
+  amount: number;
+  questionId: null;
+};
+
+const basePositionRow: PositionRow = {
+  id: 'pos1',
+  userId: 'agent1',
+  marketId: marketRow.id,
+  side: true,
+  shares: 10,
+  avgPrice: 0.5,
+  status: 'active',
+  outcome: null,
+  pnl: 0,
+  resolvedAt: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  amount: 5,
+  questionId: null,
+};
+
+let positionRow: PositionRow | null = null;
 
 const insertedPredictionHistory: Array<Record<string, unknown>> = [];
 const broadcastedMarketsEvents: Array<Record<string, unknown>> = [];
+
+const walletGetBalance = mock(async () => ({ balance: 10000 }));
 
 const mockTxDb = {
   select: mock(() => ({
@@ -55,10 +95,14 @@ const mockTxDb = {
       where: mock(() => ({
         limit: mock(async () => {
           if (table === markets) return [marketRow];
+          if (table === positions) return positionRow ? [positionRow] : [];
           return [];
         }),
         orderBy: mock(() => ({
-          limit: mock(async () => []),
+          limit: mock(async () => {
+            if (table === positions) return positionRow ? [positionRow] : [];
+            return [];
+          }),
         })),
       })),
     })),
@@ -161,7 +205,7 @@ mock.module('@babylon/engine', () => ({
     getAllOrganizations: () => [],
   },
   WalletService: {
-    getBalance: mock(async () => ({ balance: 10000 })),
+    getBalance: walletGetBalance,
     debit: mock(async () => undefined),
     credit: mock(async () => undefined),
     recordPnL: mock(async () => undefined),
@@ -211,15 +255,19 @@ mock.module('@babylon/db', () => ({
   desc: (a: unknown) => a,
 }));
 
+// Import after mocks are set up
+import { executeDirectTrade } from '../DirectExecutors';
+
 describe('DirectExecutors prediction history pipeline', () => {
   beforeEach(() => {
     insertedPredictionHistory.length = 0;
     broadcastedMarketsEvents.length = 0;
+    Object.assign(marketRow, baseMarketRow);
+    positionRow = null;
+    walletGetBalance.mockImplementation(async () => ({ balance: 10000 }));
   });
 
   test('records PredictionPriceHistory + broadcasts for agent prediction buys', async () => {
-    const { executeDirectTrade } = await import('../DirectExecutors');
-
     const result = await executeDirectTrade({
       agentUserId: 'agent1',
       marketType: 'prediction',
@@ -239,5 +287,67 @@ describe('DirectExecutors prediction history pipeline', () => {
     expect(
       broadcastedMarketsEvents.some((e) => e.type === 'prediction_trade')
     ).toBe(true);
+  });
+
+  test('allows sell_yes exits with zero balance', async () => {
+    positionRow = { ...basePositionRow, side: true };
+    walletGetBalance.mockImplementationOnce(async () => ({ balance: 0 }));
+
+    const result = await executeDirectTrade({
+      agentUserId: 'agent1',
+      marketType: 'prediction',
+      marketId: marketRow.id,
+      side: 'sell_yes',
+      amount: 0,
+      reasoning: 'exit',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test('allows sell_no exits with zero balance', async () => {
+    positionRow = { ...basePositionRow, side: false };
+    walletGetBalance.mockImplementationOnce(async () => ({ balance: 0 }));
+
+    const result = await executeDirectTrade({
+      agentUserId: 'agent1',
+      marketType: 'prediction',
+      marketId: marketRow.id,
+      side: 'sell_no',
+      amount: 0,
+      reasoning: 'exit',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  test('blocks entry trades with zero balance', async () => {
+    walletGetBalance.mockImplementationOnce(async () => ({ balance: 0 }));
+
+    const result = await executeDirectTrade({
+      agentUserId: 'agent1',
+      marketType: 'prediction',
+      marketId: marketRow.id,
+      side: 'buy_yes',
+      amount: 10,
+      reasoning: 'entry',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Insufficient balance');
+  });
+
+  test('rejects non-finite trade amounts', async () => {
+    const result = await executeDirectTrade({
+      agentUserId: 'agent1',
+      marketType: 'prediction',
+      marketId: marketRow.id,
+      side: 'buy_yes',
+      amount: Number.NaN,
+      reasoning: 'invalid',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Invalid trade amount');
   });
 });


### PR DESCRIPTION
## Summary
- allow exit trades to bypass balance gating in direct executor
- add system prompt guidance to close positions when balance is zero

## Test plan
- `turbo typecheck`
- `turbo lint` (warned about `useTeamChat` dependencies)
- `turbo build` (contracts build logged missing deps but completed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined validation and error handling for exit trades, including clearer errors for insufficient funds and invalid amounts.
  * Adjusted balance checks so warnings and caps apply only where appropriate.

* **Refactor**
  * Improved system prompt guidance to include optional balance/trading guidance when trading is enabled.

* **Tests**
  * Added and reorganized tests covering exit/entry edge cases, balance scenarios, and invalid amounts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Allows agents to exit trading positions (sell prediction shares or close perp positions) even when their balance is zero. Previously, all trades were gated by balance checks, preventing agents from closing positions to free up capital when their balance reached zero.

**Changes:**
- `DirectExecutors.ts`: Exit trades (`sell_yes`, `sell_no`, `close_position`) now bypass balance validation while entry trades still require sufficient balance
- `MultiStepExecutor.ts`: System prompt now includes guidance for agents to close positions when balance is low/zero

The implementation correctly identifies exit trades and only validates that `amount >= 0` for exits (allowing `amount=0` to close full position as documented in `executePredictionSell`). Entry trades continue to enforce `amount <= balance` and `amount >= 1`.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor consideration around zero-amount validation
- Logic correctly distinguishes exit from entry trades and bypasses balance checks appropriately. The system prompt guidance helps agents understand this capability. Score is 4 rather than 5 due to the `amount < 0` check for exit trades which may be overly permissive - consider if `amount === 0` should be the only way to close full positions.
- No files require special attention - changes are straightforward and well-scoped

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agents/src/autonomous/DirectExecutors.ts | Added balance bypass for exit trades (sell/close positions) to allow closing positions at zero balance |
| packages/agents/src/autonomous/MultiStepExecutor.ts | Added system prompt guidance advising agents to close positions when balance is low or zero |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent
    participant MultiStepExecutor
    participant DirectExecutor
    participant BalanceCheck
    participant Market

    Agent->>MultiStepExecutor: execute() with low/zero balance
    MultiStepExecutor->>MultiStepExecutor: Add balance guidance to system prompt
    Note over MultiStepExecutor: "If balance is $0 but you have positions,<br/>you can still sell/close to free balance"
    MultiStepExecutor->>DirectExecutor: executeDirectTrade(side=sell/close)
    DirectExecutor->>BalanceCheck: Check if isExitTrade
    alt Exit Trade (sell_yes, sell_no, close_position)
        BalanceCheck-->>DirectExecutor: Skip balance gating
        DirectExecutor->>Market: Execute sell/close operation
        Market-->>DirectExecutor: Return proceeds
        DirectExecutor-->>Agent: Success (balance restored)
    else Entry Trade (buy_yes, buy_no, open_long, open_short)
        BalanceCheck->>BalanceCheck: Enforce balance >= amount
        alt Insufficient balance
            BalanceCheck-->>DirectExecutor: Reject trade
            DirectExecutor-->>Agent: Error: Insufficient balance
        else Sufficient balance
            DirectExecutor->>Market: Execute entry trade
            Market-->>DirectExecutor: Trade executed
            DirectExecutor-->>Agent: Success
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->