### PR TITLE
fix: don't charge points for LLM failures and show error toasts

### DIFF
--- a/apps/web/src/app/agents/team/page.tsx
+++ b/apps/web/src/app/agents/team/page.tsx
@@ -218,12 +218,9 @@ export default function TeamChatPage() {
   // Handle sidebar "View Profile" - switch to Agents tab and show detail
   const handleViewProfile = useCallback(
     (agentId: string) => {
-      setActiveTab('agents');
-      setShowCreateAgent(false);
-      setSelectedAgentDefaultTab('activity');
-      fetchAgentDetail(agentId);
+      router.push(`/profile/${agentId}`);
     },
-    [fetchAgentDetail]
+    [router]
   );
 
   // Handle sidebar "Settings" - switch to Agents tab and show detail with Settings tab

--- a/apps/web/src/app/api/agents/[agentId]/chat/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/chat/route.ts
@@ -423,6 +423,8 @@ export const POST = withErrorHandling(
       }
     > = [];
     let finalResponse: string | null = null;
+    // Track if response is due to LLM failure (don't charge points)
+    let isLLMFailure = false;
 
     for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
       // Check if client cancelled the request
@@ -527,6 +529,7 @@ export const POST = withErrorHandling(
       if (!parsedStep) {
         finalResponse =
           "I'm having trouble processing your request. Could you try rephrasing?";
+        isLLMFailure = true; // Don't charge points for LLM parse failures
         break;
       }
 
@@ -861,32 +864,38 @@ export const POST = withErrorHandling(
       .set({ lastChatAt: new Date(), updatedAt: new Date() })
       .where(eq(userAgentConfigs.userId, agentId));
 
+    // Calculate actual points cost - skip charging for LLM failures
+    const actualPointsCost = isLLMFailure ? 0 : pointsCost;
+
     await db.agentLog.create({
       data: {
         id: uuidv4(),
         agentUserId: agentId,
         type: 'chat',
-        level: 'info',
-        message: 'Chat interaction completed',
+        level: isLLMFailure ? 'warn' : 'info',
+        message: isLLMFailure
+          ? 'Chat interaction completed with LLM failure'
+          : 'Chat interaction completed',
         prompt: message,
         completion: responseText,
         metadata: {
           usePro,
-          pointsCost,
+          pointsCost: actualPointsCost,
           modelUsed,
           multiStep: true,
           actionsExecuted: traceActionResults.length,
+          isLLMFailure,
         },
       },
     });
 
     // Deduct points ONLY after successful response generation and DB save
     // This ensures users don't lose points on failed/cancelled requests
-    if (pointsCost > 0) {
+    if (actualPointsCost > 0) {
       try {
         newBalance = await agentService.deductPoints(
           agentId,
-          pointsCost,
+          actualPointsCost,
           `Chat message (${usePro ? 'pro' : 'free'} mode)`,
           undefined
         );
@@ -894,7 +903,7 @@ export const POST = withErrorHandling(
         // Log but don't fail - response already saved, points can be reconciled
         logger.error(
           'Failed to deduct points after successful response',
-          { agentId, pointsCost, error: err },
+          { agentId, pointsCost: actualPointsCost, error: err },
           'AgentChat'
         );
         // Keep original balance in response (will be slightly incorrect but safe)
@@ -911,9 +920,10 @@ export const POST = withErrorHandling(
       success: true,
       messageId: responseMessageId,
       response: responseText,
-      pointsCost,
+      pointsCost: actualPointsCost,
       modelUsed,
       balanceAfter: newBalance,
+      isLLMFailure, // Let frontend know if this was a fallback response
       multiStep: {
         actionsExecuted: traceActionResults.length,
         actions: traceActionResults.map((a) => ({

--- a/apps/web/src/app/api/agents/[agentId]/chat/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/chat/route.ts
@@ -782,6 +782,10 @@ export const POST = withErrorHandling(
     // Ensure finalResponse is never null
     const responseText = finalResponse ?? "I'm here to help!";
 
+    // Calculate actual points cost early - skip charging for LLM failures
+    // This needs to happen before DB writes so stored pointsCost is accurate
+    const actualPointsCost = isLLMFailure ? 0 : pointsCost;
+
     const userMessageTime = new Date();
     const assistantMessageTime = new Date(userMessageTime.getTime() + 1);
     let responseMessageId: string;
@@ -843,7 +847,7 @@ export const POST = withErrorHandling(
             role: 'assistant',
             content: responseText,
             modelUsed,
-            pointsCost,
+            pointsCost: actualPointsCost, // Use actual cost (0 for LLM failures)
             createdAt: assistantMessageTime,
             metadata: {
               multiStep: true,
@@ -852,6 +856,7 @@ export const POST = withErrorHandling(
                 type: a.actionType,
                 success: a.success,
               })),
+              isLLMFailure, // Track if this was a fallback response
             },
           },
         ],
@@ -863,9 +868,6 @@ export const POST = withErrorHandling(
       .update(userAgentConfigs)
       .set({ lastChatAt: new Date(), updatedAt: new Date() })
       .where(eq(userAgentConfigs.userId, agentId));
-
-    // Calculate actual points cost - skip charging for LLM failures
-    const actualPointsCost = isLLMFailure ? 0 : pointsCost;
 
     await db.agentLog.create({
       data: {

--- a/apps/web/src/hooks/useTeamChat.ts
+++ b/apps/web/src/hooks/useTeamChat.ts
@@ -765,6 +765,7 @@ export function useTeamChat(): UseTeamChatReturn {
               response?: string;
               pointsCost?: number;
               balanceAfter?: number;
+              isLLMFailure?: boolean;
             };
 
             // Add agent response message IMMEDIATELY from JSON response
@@ -783,8 +784,14 @@ export function useTeamChat(): UseTeamChatReturn {
               });
             }
 
-            // Show toast if points were deducted
-            if (data.pointsCost && data.pointsCost > 0) {
+            // Show toast based on response type
+            if (data.isLLMFailure) {
+              // LLM failed to parse - no points charged, show warning
+              toast.warning(
+                `${agent?.displayName} had trouble understanding. No points charged.`
+              );
+            } else if (data.pointsCost && data.pointsCost > 0) {
+              // Successful response with points deducted
               toast.success(
                 `Response from ${agent?.displayName} (-${data.pointsCost} points)`
               );
@@ -820,18 +827,22 @@ export function useTeamChat(): UseTeamChatReturn {
                   `${agent?.displayName}: Insufficient points. Deposit to continue.`
                 );
               } else {
-                console.error(`Agent ${agentId} error:`, errorMessage);
+                // Show toast for other errors instead of just logging
+                toast.error(`${agent?.displayName}: ${errorMessage}`);
               }
             } catch {
-              console.error(`Agent ${agentId} failed to respond`);
+              toast.error(`${agent?.displayName} failed to respond`);
             }
           }
         } catch (err) {
-          // Don't log abort errors - they're expected when user stops
+          // Don't show toast for abort errors - they're expected when user stops
           if (err instanceof Error && err.name === 'AbortError') {
-            console.log(`Agent ${agentId} request was cancelled`);
+            // User cancelled, no need to notify
           } else {
-            console.error(`Error calling agent ${agentId}:`, err);
+            // Network or other unexpected errors - show toast
+            toast.error(
+              `${agent?.displayName}: Connection error. Please try again.`
+            );
           }
         } finally {
           // Clean up AbortController


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detect LLM failures and include an isLLMFailure flag in responses so frontend can show fallback behavior.
  * Warn users when an agent fails to parse input and no points were charged.

* **Improvements**
  * Direct profile navigation now routes to the agent profile page.
  * Replace silent errors with visible toast notifications for backend and connection issues.

* **Bug Fixes**
  * Prevents point deduction when an LLM failure occurs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR improves error handling for LLM failures in agent chat by preventing point deductions when the LLM fails to parse responses and providing better user feedback through toast notifications.

**Key Changes:**
- Backend now tracks LLM parse failures with `isLLMFailure` flag and sets points cost to 0 when failures occur
- Frontend displays warning toasts for LLM failures and error toasts for other failure types instead of silently logging to console
- View Profile button now navigates to dedicated profile page instead of switching tabs internally

**Impact:**
- Users won't lose points when the LLM fails to generate valid responses
- Better visibility into errors through toast notifications
- Improved navigation UX for viewing agent profiles

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are well-structured defensive improvements that protect users from being charged for system failures. The logic correctly distinguishes between LLM failures and successful responses, properly propagates the failure state to the frontend, and maintains backward compatibility.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/api/agents/[agentId]/chat/route.ts | Added `isLLMFailure` tracking to prevent charging points when LLM parsing fails, with proper logging and metadata |
| apps/web/src/hooks/useTeamChat.ts | Enhanced error handling with toast notifications for LLM failures and network errors, replacing console.log calls |
| apps/web/src/app/agents/team/page.tsx | Simplified `handleViewProfile` to navigate to profile page using router instead of internal tab switching |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Frontend as useTeamChat Hook
    participant API as /api/agents/[agentId]/chat
    participant LLM as Language Model
    participant DB as Database

    User->>Frontend: Send message to agent
    Frontend->>API: POST /api/agents/[agentId]/chat
    
    API->>API: Check balance (upfront)
    
    loop Multi-step execution (max 6 iterations)
        API->>LLM: Generate decision with prompt
        LLM-->>API: Return response
        
        API->>API: Parse response (parseKeyValueXml)
        
        alt Parse Success
            API->>API: Execute action if needed
        else Parse Failed (after 3 retries)
            API->>API: Set isLLMFailure = true
            API->>API: Set finalResponse = error message
            API->>API: Break loop
        end
    end
    
    API->>DB: Save agent response message
    API->>DB: Log interaction (level: warn if isLLMFailure)
    
    alt isLLMFailure = true
        API->>API: Set actualPointsCost = 0
        API->>DB: Deduct 0 points
    else isLLMFailure = false
        API->>API: Set actualPointsCost = pointsCost
        API->>DB: Deduct actualPointsCost
    end
    
    API-->>Frontend: Return {response, isLLMFailure, pointsCost: actualPointsCost}
    
    alt isLLMFailure = true
        Frontend->>User: Show warning toast (no points charged)
    else Success with points
        Frontend->>User: Show success toast (-X points)
    end
    
    Frontend->>Frontend: Update agent balance locally
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->