### PR TITLE
fix: improve agent exit trade awareness and add feature entropy

### DIFF
--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -123,7 +123,7 @@ export class MultiStepExecutor {
 
     // Determine enabled features - NPCs have all features enabled by default
     // For USER_CONTROLLED agents: trading defaults to true, others default to false
-    const enabledFeatures: string[] = [];
+    let enabledFeatures: string[] = [];
     if (isNpc) {
       enabledFeatures.push(
         Features.TRADING,
@@ -142,6 +142,38 @@ export class MultiStepExecutor {
       if (features.commenting) enabledFeatures.push(Features.ENGAGING);
       if (features.dms) enabledFeatures.push(Features.DMS);
       if (features.groupChats) enabledFeatures.push(Features.GROUP_CHATS);
+    }
+
+    // Add entropy by randomly disabling some non-essential features (15% chance each)
+    // TRADING is never disabled (agents need to exit positions)
+    // At least one social feature is kept enabled
+    const ENTROPY_DISABLE_CHANCE = 0.15;
+    const socialFeatures: string[] = [
+      Features.POSTING,
+      Features.COMMENTING,
+      Features.ENGAGING,
+      Features.DMS,
+      Features.GROUP_CHATS,
+    ];
+    const featuresToMaybeDisable = enabledFeatures.filter(
+      (f) => socialFeatures.includes(f) && Math.random() < ENTROPY_DISABLE_CHANCE
+    );
+    // Ensure at least one social feature remains if agent had any
+    const enabledSocialFeatures = enabledFeatures.filter((f) =>
+      socialFeatures.includes(f)
+    );
+    if (
+      featuresToMaybeDisable.length > 0 &&
+      featuresToMaybeDisable.length < enabledSocialFeatures.length
+    ) {
+      enabledFeatures = enabledFeatures.filter(
+        (f) => !featuresToMaybeDisable.includes(f)
+      );
+      logger.debug(
+        `[Entropy] Temporarily disabled features for tick: ${featuresToMaybeDisable.join(', ')}`,
+        { agentUserId },
+        'MultiStepExecutor'
+      );
     }
 
     const balanceGuidance =

--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -156,24 +156,31 @@ export class MultiStepExecutor {
       Features.GROUP_CHATS,
     ];
     const featuresToMaybeDisable = enabledFeatures.filter(
-      (f) => socialFeatures.includes(f) && Math.random() < ENTROPY_DISABLE_CHANCE
+      (f) =>
+        socialFeatures.includes(f) && Math.random() < ENTROPY_DISABLE_CHANCE
     );
     // Ensure at least one social feature remains if agent had any
     const enabledSocialFeatures = enabledFeatures.filter((f) =>
       socialFeatures.includes(f)
     );
-    if (
-      featuresToMaybeDisable.length > 0 &&
-      featuresToMaybeDisable.length < enabledSocialFeatures.length
-    ) {
-      enabledFeatures = enabledFeatures.filter(
-        (f) => !featuresToMaybeDisable.includes(f)
-      );
-      logger.debug(
-        `[Entropy] Temporarily disabled features for tick: ${featuresToMaybeDisable.join(', ')}`,
-        { agentUserId },
-        'MultiStepExecutor'
-      );
+    if (featuresToMaybeDisable.length > 0 && enabledSocialFeatures.length > 0) {
+      // If all social features were selected for disabling, keep one random one
+      if (featuresToMaybeDisable.length >= enabledSocialFeatures.length) {
+        const keepIndex = Math.floor(
+          Math.random() * featuresToMaybeDisable.length
+        );
+        featuresToMaybeDisable.splice(keepIndex, 1);
+      }
+      if (featuresToMaybeDisable.length > 0) {
+        enabledFeatures = enabledFeatures.filter(
+          (f) => !featuresToMaybeDisable.includes(f)
+        );
+        logger.debug(
+          `[Entropy] Temporarily disabled features for tick: ${featuresToMaybeDisable.join(', ')}`,
+          { agentUserId },
+          'MultiStepExecutor'
+        );
+      }
     }
 
     const balanceGuidance =

--- a/packages/agents/src/autonomous/templates/multi-step-decision.ts
+++ b/packages/agents/src/autonomous/templates/multi-step-decision.ts
@@ -704,7 +704,7 @@ ${creatorSection}${npcContextSection}${tradePostEncouragement}# Current Executio
 **Actions Completed This Tick**: ${traceActionResults.length}
 
 # Your Current State
-- Balance: $${context.balance.toFixed(2)}
+- Balance: $${context.balance.toFixed(2)}${context.balance < 10 && context.openPositions > 0 ? ' ⚠️ LOW BALANCE but you have open positions - you CAN still SELL/CLOSE positions to free up funds!' : ''}
 - Lifetime P&L: ${context.pnl >= 0 ? '+' : ''}$${context.pnl.toFixed(2)}
 - Open Positions: ${context.openPositions}
 - Pending Comments: ${context.pendingCommentReplies.length}
@@ -926,6 +926,7 @@ function formatPositionManagementGuidance(
 
   return `
 # Position Management Alerts
+💡 REMINDER: Selling/closing positions does NOT require balance - you receive funds FROM the sale!
 ${alerts.join('\n')}
 `;
 }


### PR DESCRIPTION
## Summary

Follow-up to #861 - despite allowing exit trades at zero balance in the executor, agents were still not attempting to sell positions because the LLM was dismissing trading entirely when seeing $0 balance.

**Changes:**
- Add prominent warning in decision prompt when balance < $10 with open positions: "⚠️ LOW BALANCE but you have open positions - you CAN still SELL/CLOSE positions to free up funds!"
- Add reminder in Position Management Alerts: "💡 REMINDER: Selling/closing positions does NOT require balance - you receive funds FROM the sale!"
- Add 15% random chance to disable social features per tick for behavior diversity (TRADING never disabled, at least one social feature always remains)

## Test plan

- [ ] Verify agent with zero balance and open positions sees the new warnings
- [ ] Verify feature entropy logs appear in debug output
- [ ] Verify agents still function normally with random feature disabling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Low-balance warnings now display when balance falls below 10 with open positions.
  * Pending Chats count is now visible in the agent state section.
  * Added informational message clarifying that position closing doesn't require available balance.
  * Non-essential social features may be occasionally disabled (small chance) to vary agent interactions; trading remains available and at least one social feature stays enabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixes agent behavior when balance reaches $0 with open positions by adding explicit LLM prompts that clarify exit trades don't require balance. Also introduces 15% random feature entropy for behavioral diversity.

**Key changes:**
- Added conditional warning when `balance < $10 && openPositions > 0` to explicitly tell agents they can still sell/close positions
- Added reminder in Position Management Alerts that selling doesn't require balance
- Implemented feature entropy: 15% random chance per tick to disable individual social features (trading never disabled, at least one social feature always remains)
- Entropy logic correctly preserves trading capability and ensures agents aren't completely disabled

The PR successfully addresses the issue where agents with $0 balance were ignoring their ability to exit positions. The entropy implementation properly constrains randomization to avoid breaking core functionality.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no risk - targeted prompt improvements and well-constrained behavioral entropy
- Changes are limited to LLM prompt enhancements and controlled randomization logic. The entropy implementation includes proper safeguards (trading never disabled, at least one social feature preserved). The low balance warnings address a specific bug without touching execution logic. No breaking changes or security concerns.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agents/src/autonomous/MultiStepExecutor.ts | Added feature entropy logic (15% random disable chance for social features) to introduce behavioral diversity while preserving trading capability |
| packages/agents/src/autonomous/templates/multi-step-decision.ts | Added low balance warnings and position sale reminders to help agents understand they can exit positions even at $0 balance |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Executor as MultiStepExecutor
    participant Config as Agent Config
    participant Entropy as Feature Entropy Logic
    participant Prompt as Decision Prompt
    participant LLM as Agent LLM

    Executor->>Config: Get enabled features
    Config-->>Executor: Return feature list
    
    Executor->>Entropy: Apply 15% random disable
    Note over Entropy: Filter social features only<br/>Keep TRADING enabled<br/>Preserve ≥1 social feature
    Entropy-->>Executor: Modified feature list
    
    Executor->>Prompt: Build decision context
    Note over Prompt: Check balance < $10<br/>AND openPositions > 0
    alt Low Balance + Open Positions
        Prompt->>Prompt: Add warning to balance line<br/>"⚠️ LOW BALANCE but you have<br/>open positions - you CAN still<br/>SELL/CLOSE positions!"
        Prompt->>Prompt: Add reminder to alerts<br/>"💡 Selling positions does NOT<br/>require balance"
    end
    
    Prompt-->>Executor: Complete prompt with warnings
    Executor->>LLM: Send decision prompt
    LLM-->>Executor: Agent decision
    Note over LLM: Now aware of exit trade<br/>capability at $0 balance
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->