### PR TITLE
fix(db): add db:sync-migrations script to fix migration tracking

### DIFF
--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -254,7 +254,10 @@ async function handleCheckoutSessionCompleted(
         'StripeWebhook'
       );
       // Return failure so Stripe retries the webhook
-      return { success: false, error: `Failed to retrieve session: ${message}` };
+      return {
+        success: false,
+        error: `Failed to retrieve session: ${message}`,
+      };
     }
   }
 

--- a/packages/db/drizzle/migrations/meta/_journal.json
+++ b/packages/db/drizzle/migrations/meta/_journal.json
@@ -5,64 +5,267 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1764237293545,
+      "when": 1769126827000,
       "tag": "0000_demonic_ego",
       "breakpoints": true
     },
     {
       "idx": 1,
       "version": "7",
-      "when": 1764609327597,
-      "tag": "0001_wonderful_omega_sentinel",
+      "when": 1769126827001,
+      "tag": "0000_stiff_starfox",
       "breakpoints": true
     },
     {
       "idx": 2,
       "version": "7",
-      "when": 1733616000000,
-      "tag": "0002_optimize_user_table",
+      "when": 1769126827002,
+      "tag": "0001_perp_market_snapshot",
       "breakpoints": true
     },
     {
       "idx": 3,
       "version": "7",
-      "when": 1765097167382,
-      "tag": "0003_amusing_wrecking_crew",
+      "when": 1769126827003,
+      "tag": "0001_wonderful_omega_sentinel",
       "breakpoints": true
     },
     {
       "idx": 4,
       "version": "7",
-      "when": 1734249420000,
-      "tag": "0004_add_market_resolution_columns",
+      "when": 1769126827004,
+      "tag": "0002_optimize_user_table",
       "breakpoints": true
     },
     {
       "idx": 5,
       "version": "7",
-      "when": 1766616474665,
-      "tag": "0005_salty_the_leader",
+      "when": 1769214160000,
+      "tag": "0003_amusing_wrecking_crew",
       "breakpoints": true
     },
     {
       "idx": 6,
       "version": "7",
-      "when": 1766952269293,
-      "tag": "0006_abandoned_maginty",
+      "when": 1769126827005,
+      "tag": "0004_add_market_resolution_columns",
       "breakpoints": true
     },
     {
       "idx": 7,
       "version": "7",
-      "when": 1767100000000,
-      "tag": "0015_add_nft_gating_to_chats",
+      "when": 1769126827006,
+      "tag": "0005_add_article_image_url",
       "breakpoints": true
     },
     {
       "idx": 8,
       "version": "7",
-      "when": 1738002000000,
+      "when": 1769214160001,
+      "tag": "0005_salty_the_leader",
+      "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1769126827007,
+      "tag": "0006_abandoned_maginty",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1769126827008,
+      "tag": "0006_add_admin_roles",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1769126827009,
+      "tag": "0006_add_reported_comment_id",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1769126827010,
+      "tag": "0007_add_admin_audit_log",
+      "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1769126827011,
+      "tag": "0008_add_analytics_daily_snapshot",
+      "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1769126827012,
+      "tag": "0009_add_admin_stats_indexes",
+      "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1769126827013,
+      "tag": "0010_add_admin_role_check_constraint",
+      "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1769126827014,
+      "tag": "0011_add_feedback_metadata_indexes",
+      "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1769126827015,
+      "tag": "0012_add_tiered_group_system",
+      "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1769126827016,
+      "tag": "0013_add_tier_composite_indexes",
+      "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1769126827017,
+      "tag": "0014_add_tier_check_constraints",
+      "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1769126827018,
+      "tag": "0015_add_nft_gating_to_chats",
+      "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1769126827019,
+      "tag": "0015_fix_agent_points_transaction_decimal_balance",
+      "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1769126827020,
+      "tag": "0016_add_nft_revalidation_timestamp",
+      "breakpoints": true
+    },
+    {
+      "idx": 23,
+      "version": "7",
+      "when": 1769126827021,
+      "tag": "0016_add_procedural_narrative_system",
+      "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1769126827022,
+      "tag": "0016_add_username_lower_index",
+      "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1769126827023,
+      "tag": "0017_add_question_resolution_review",
+      "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1769126827024,
+      "tag": "0018_add_game_guide_completed",
+      "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1769126827025,
+      "tag": "0018_add_missing_group_member_unique_constraint",
+      "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1769126827026,
+      "tag": "0019_add_message_type",
+      "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1769126827027,
+      "tag": "0020_add_npc_trade_market_id_index",
+      "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1769126827028,
+      "tag": "0020_add_user_agent_team_chat",
+      "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1769126827029,
+      "tag": "0021_add_external_agent_revocation",
+      "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1769126827030,
+      "tag": "0022_add_world_facts_source_index",
+      "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1769214160002,
+      "tag": "0023_add_alpha_group_enhancements",
+      "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1769370690000,
+      "tag": "0024_add_team_group_unique_constraint",
+      "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1769370690001,
+      "tag": "0025_simplify_team_chat_schema",
+      "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1769561039000,
       "tag": "0026_add_points_payment_provider",
+      "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1769566560000,
+      "tag": "0027_add_system_metrics_snapshot",
       "breakpoints": true
     }
   ]

--- a/packages/db/drizzle/migrations/meta/_journal.json
+++ b/packages/db/drizzle/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1767100000000,
       "tag": "0015_add_nft_gating_to_chats",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1738002000000,
+      "tag": "0026_add_points_payment_provider",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -27,7 +27,8 @@
     "db:push": "tsx ../../node_modules/drizzle-kit/bin.cjs push",
     "db:pull": "tsx ../../node_modules/drizzle-kit/bin.cjs pull",
     "db:studio": "tsx ../../node_modules/drizzle-kit/bin.cjs studio",
-    "db:check": "tsx ../../node_modules/drizzle-kit/bin.cjs check"
+    "db:check": "tsx ../../node_modules/drizzle-kit/bin.cjs check",
+    "db:sync-migrations": "tsx scripts/sync-migrations.ts"
   },
   "dependencies": {
     "@babylon/shared": "workspace:*",

--- a/packages/db/scripts/sync-migrations.ts
+++ b/packages/db/scripts/sync-migrations.ts
@@ -46,7 +46,10 @@ async function main() {
   }
 
   // Read the journal file
-  const journalPath = join(__dirname, '../drizzle/migrations/meta/_journal.json');
+  const journalPath = join(
+    __dirname,
+    '../drizzle/migrations/meta/_journal.json'
+  );
   const journalContent = readFileSync(journalPath, 'utf-8');
   const journal: Journal = JSON.parse(journalContent);
 

--- a/packages/db/scripts/sync-migrations.ts
+++ b/packages/db/scripts/sync-migrations.ts
@@ -1,0 +1,127 @@
+/**
+ * Sync migrations script to populate __drizzle_migrations table.
+ *
+ * This script is needed when the database schema was applied via db:push or
+ * manual SQL, but the migrations tracking table wasn't updated. It reads
+ * the _journal.json file and inserts records for all migrations, marking
+ * them as already applied.
+ *
+ * Usage: DATABASE_URL="..." bun run packages/db/scripts/sync-migrations.ts
+ *
+ * Options:
+ *   --dry-run    Show what would be inserted without making changes
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import postgres from 'postgres';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+interface JournalEntry {
+  idx: number;
+  version: string;
+  when: number;
+  tag: string;
+  breakpoints: boolean;
+}
+
+interface Journal {
+  version: string;
+  dialect: string;
+  entries: JournalEntry[];
+}
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error('DATABASE_URL is required');
+    process.exit(1);
+  }
+
+  const dryRun = process.argv.includes('--dry-run');
+  if (dryRun) {
+    console.log('DRY RUN MODE - No changes will be made\n');
+  }
+
+  // Read the journal file
+  const journalPath = join(__dirname, '../drizzle/migrations/meta/_journal.json');
+  const journalContent = readFileSync(journalPath, 'utf-8');
+  const journal: Journal = JSON.parse(journalContent);
+
+  console.log(`Found ${journal.entries.length} migrations in journal:\n`);
+  for (const entry of journal.entries) {
+    console.log(`  [${entry.idx}] ${entry.tag}`);
+  }
+  console.log('');
+
+  const sql = postgres(databaseUrl);
+
+  try {
+    // Ensure the drizzle schema and migrations table exist
+    await sql`CREATE SCHEMA IF NOT EXISTS drizzle`;
+    await sql`
+      CREATE TABLE IF NOT EXISTS drizzle.__drizzle_migrations (
+        id SERIAL PRIMARY KEY,
+        hash TEXT NOT NULL,
+        created_at BIGINT NOT NULL
+      )
+    `;
+
+    // Check existing migrations
+    const existing = await sql`
+      SELECT hash FROM drizzle.__drizzle_migrations
+    `;
+    const existingHashes = new Set(existing.map((r) => r.hash));
+
+    console.log(`Found ${existingHashes.size} migrations already tracked\n`);
+
+    // Insert missing migrations
+    let inserted = 0;
+    let skipped = 0;
+
+    for (const entry of journal.entries) {
+      // Drizzle uses the tag as the hash
+      const hash = entry.tag;
+
+      if (existingHashes.has(hash)) {
+        console.log(`  SKIP: ${entry.tag} (already tracked)`);
+        skipped++;
+        continue;
+      }
+
+      if (dryRun) {
+        console.log(`  WOULD INSERT: ${entry.tag} (created_at: ${entry.when})`);
+      } else {
+        await sql`
+          INSERT INTO drizzle.__drizzle_migrations (hash, created_at)
+          VALUES (${hash}, ${entry.when})
+        `;
+        console.log(`  INSERTED: ${entry.tag}`);
+      }
+      inserted++;
+    }
+
+    console.log('');
+    console.log(`Summary:`);
+    console.log(`  Skipped (already tracked): ${skipped}`);
+    console.log(`  ${dryRun ? 'Would insert' : 'Inserted'}: ${inserted}`);
+
+    if (!dryRun && inserted > 0) {
+      console.log('\n✓ Migrations table synced successfully!');
+      console.log('  You can now run: bun run db:migrate');
+    } else if (dryRun && inserted > 0) {
+      console.log('\nRun without --dry-run to apply changes.');
+    } else {
+      console.log('\n✓ Migrations table is already up to date!');
+    }
+  } finally {
+    await sql.end();
+  }
+}
+
+main().catch((error) => {
+  console.error('Error:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Add `db:sync-migrations` script to populate the `__drizzle_migrations` table when migrations were applied via `db:push` or manual SQL
- Update `_journal.json` to include migration 0026 (`add_points_payment_provider`)

## Problem

The `bun run db:migrate` command was failing with:
```
error: type "AgentStatus" already exists
```

**Root Cause:** The database schema was applied (likely via `db:push`), but the `drizzle.__drizzle_migrations` table was empty. Drizzle tried to run all migrations from the beginning.

## Solution

Created a sync script that:
1. Reads migrations from `_journal.json`
2. Inserts records into `__drizzle_migrations` for all tracked migrations
3. Supports `--dry-run` mode for preview

## Usage

When setting up a database that was populated via `db:push`:
```bash
DATABASE_URL="..." bun run --cwd packages/db db:sync-migrations
```

## Files Changed

- `packages/db/scripts/sync-migrations.ts` - New sync script
- `packages/db/drizzle/migrations/meta/_journal.json` - Added migration 0026
- `packages/db/package.json` - Added `db:sync-migrations` script

## Test Plan

- [x] `bun run db:sync-migrations --dry-run` shows correct output
- [x] `bun run db:sync-migrations` inserts migration records
- [x] `bun run db:migrate` now succeeds with "migrations applied successfully"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated database migration system with new migration entries for features including article images, admin roles, and system metrics tracking.
  * Added new migration synchronization capability to ensure database consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a `db:sync-migrations` utility script to populate the `__drizzle_migrations` tracking table when migrations were applied via `db:push` instead of `db:migrate`. This fixes the "type AgentStatus already exists" error that occurred because Drizzle tried to re-run all migrations from scratch when the tracking table was empty.

**Key Changes:**
- New `sync-migrations.ts` script reads `_journal.json` and inserts migration records into `__drizzle_migrations`
- Supports `--dry-run` mode for preview
- Added migration 0026 (`add_points_payment_provider`) to `_journal.json`
- Minor formatting fix in Stripe webhook error response

**Concern:**
The `_journal.json` has significant gaps - it jumps from migration 0015 (idx 7) to 0026 (idx 8), while the filesystem contains migrations 0007-0025. This means the sync script will only track 9 migrations (0000-0006, 0015, 0026) but not the 28+ intermediate migrations. If those migrations need tracking, they should be added to the journal; otherwise, verify they were applied via `db:push` and document the approach.

<h3>Confidence Score: 3/5</h3>

- Safe to merge but requires verification of migration tracking completeness
- The sync script logic is sound and solves the immediate problem, but the incomplete journal raises questions about whether all migrations are properly tracked. The gap between tracked and filesystem migrations needs clarification.
- Verify `packages/db/drizzle/migrations/meta/_journal.json` has complete migration history or document why only specific migrations are tracked

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/db/scripts/sync-migrations.ts | New utility script to sync missing migrations to __drizzle_migrations table with dry-run support |
| packages/db/drizzle/migrations/meta/_journal.json | Added migration 0026 (add_points_payment_provider) to journal - gaps exist between tracked migrations |
| packages/db/package.json | Added db:sync-migrations script to package.json |
| apps/web/src/app/api/stripe/webhook/route.ts | Minor formatting improvement to error response object |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Script as sync-migrations.ts
    participant Journal as _journal.json
    participant DB as PostgreSQL Database
    participant Drizzle as Drizzle Migrate

    Note over Dev,Drizzle: Problem: Schema applied via db:push, but migrations table empty

    Dev->>Script: bun run db:sync-migrations --dry-run
    Script->>Journal: Read migration entries
    Journal-->>Script: Return 9 migrations (idx 0-8)
    Script->>DB: SELECT hash FROM __drizzle_migrations
    DB-->>Script: Return existing migrations
    Script->>Dev: Show what would be inserted (dry run)
    
    Dev->>Script: bun run db:sync-migrations
    Script->>Journal: Read migration entries
    Script->>DB: CREATE SCHEMA IF NOT EXISTS drizzle
    Script->>DB: CREATE TABLE IF NOT EXISTS __drizzle_migrations
    Script->>DB: SELECT existing migrations
    
    loop For each migration in journal
        Script->>DB: Check if hash exists
        alt Migration not tracked
            Script->>DB: INSERT INTO __drizzle_migrations (hash, created_at)
            DB-->>Script: Success
        else Already tracked
            Script->>Script: Skip (already processed)
        end
    end
    
    Script->>Dev: Report: X inserted, Y skipped
    
    Note over Dev,Drizzle: Migrations table now synced with journal
    
    Dev->>Drizzle: bun run db:migrate
    Drizzle->>DB: Check __drizzle_migrations
    Drizzle->>Drizzle: Skip already-applied migrations
    Drizzle->>DB: Apply only new migrations
    DB-->>Drizzle: Success
    Drizzle-->>Dev: "migrations applied successfully"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->