### PR TITLE
feat(web): perps trading terminal UI + chart stability

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -107,6 +107,7 @@
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
     "react-hook-form": "^7.67.0",
+    "react-resizable-panels": "2.1.7",
     "recharts": "^3.5.1",
     "sonner": "^2.0.7",
     "streamdown": "^1.4.0",

--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -254,7 +254,10 @@ async function handleCheckoutSessionCompleted(
         'StripeWebhook'
       );
       // Return failure so Stripe retries the webhook
-      return { success: false, error: `Failed to retrieve session: ${message}` };
+      return {
+        success: false,
+        error: `Failed to retrieve session: ${message}`,
+      };
     }
   }
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -121,6 +121,10 @@
   --shadow-2xl: 0px 2px 0px 0px hsl(226 89% 58% / 0.00);
 }
 
+.writing-vertical-lr {
+  writing-mode: vertical-lr;
+}
+
 /* @tailwind-css v4 theme block */
 /* stylelint-disable-next-line at-rule-no-unknown */
 @theme inline {

--- a/apps/web/src/app/markets/_components/perps-terminal/PerpsMarketDetailPanel.tsx
+++ b/apps/web/src/app/markets/_components/perps-terminal/PerpsMarketDetailPanel.tsx
@@ -134,21 +134,29 @@ export function PerpsMarketDetailPanel({
 
           <button
             type="button"
-            className="inline-flex items-center gap-1 rounded px-2 py-1 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground"
-            aria-label="Compare (coming soon)"
+            className="inline-flex cursor-not-allowed items-center gap-1 rounded px-2 py-1 text-muted-foreground/60"
+            aria-label="Compare (soon)"
+            disabled
           >
             <Plus size={14} />
             <span className="font-medium">Compare</span>
+            <span className="ml-1 rounded bg-muted/20 px-1 py-0.5 text-[10px] text-muted-foreground">
+              soon
+            </span>
           </button>
         </div>
 
         <button
           type="button"
-          className="inline-flex items-center gap-1 rounded px-2 py-1 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground"
-          aria-label="Indicators (coming soon)"
+          className="inline-flex cursor-not-allowed items-center gap-1 rounded px-2 py-1 text-muted-foreground/60"
+          aria-label="Indicators (soon)"
+          disabled
         >
           <BarChart2 size={14} />
           <span className="hidden font-medium sm:inline">Indicators</span>
+          <span className="ml-1 hidden rounded bg-muted/20 px-1 py-0.5 text-[10px] text-muted-foreground sm:inline">
+            soon
+          </span>
         </button>
       </div>
 

--- a/apps/web/src/app/markets/_components/perps-terminal/PerpsMarketDetailPanel.tsx
+++ b/apps/web/src/app/markets/_components/perps-terminal/PerpsMarketDetailPanel.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import { cn } from '@babylon/shared';
+import { BarChart2, Plus } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { PerpPriceChart } from '@/components/markets/PerpPriceChart';
+import { Skeleton } from '@/components/shared/Skeleton';
+import { useMarketPrices } from '@/hooks/useMarketPrices';
+import { usePerpHistory } from '@/hooks/usePerpHistory';
+import type { MarketTimeRange, PerpMarket } from '@/types/markets';
+import { formatPrice, formatVolume } from '../../_lib/formatters';
+
+interface PerpsMarketDetailPanelProps {
+  market: PerpMarket | null;
+}
+
+const TERMINAL_TIMEFRAMES: MarketTimeRange[] = ['1H', '4H', '1D', '1W'];
+
+export function PerpsMarketDetailPanel({
+  market,
+}: PerpsMarketDetailPanelProps) {
+  const [timeRange, setTimeRange] = useState<MarketTimeRange>('1D');
+
+  const trackedTicker = market?.ticker ?? null;
+  const livePrices = useMarketPrices(trackedTicker ? [trackedTicker] : []);
+  const livePrice = trackedTicker ? livePrices.get(trackedTicker) : undefined;
+  const displayPrice = livePrice?.price ?? market?.currentPrice ?? 0;
+
+  const { history, loading } = usePerpHistory(trackedTicker, {
+    limit: 1000,
+    range: timeRange,
+    seed: market ? { currentPrice: market.currentPrice } : undefined,
+  });
+
+  const changePct = market?.changePercent24h ?? 0;
+  const isPositive = changePct >= 0;
+
+  const stats = useMemo(() => {
+    if (!market) return null;
+    return [
+      { label: '24h Vol', value: formatVolume(market.volume24h) },
+      { label: 'Open Interest', value: formatVolume(market.openInterest) },
+      {
+        label: 'Funding',
+        value: `${(market.fundingRate.rate * 100).toFixed(4)}%`,
+      },
+    ];
+  }, [market]);
+
+  if (!market) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="w-full max-w-md space-y-3 rounded-lg border border-white/5 bg-background/20 p-6 text-center backdrop-blur-sm">
+          <div className="font-semibold text-muted-foreground">
+            Select a market
+          </div>
+          <div className="text-muted-foreground/70 text-sm">
+            Pick a perp from the left panel to view the chart and trade.
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      {/* Header */}
+      <div className="flex shrink-0 items-center justify-between border-white/5 border-b bg-background/30 px-4 py-3 backdrop-blur-md">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h1 className="font-bold text-lg tracking-tight">
+              {market.ticker}
+            </h1>
+            <span className="rounded-full border border-white/10 bg-white/5 px-2 py-0.5 text-[10px] text-muted-foreground uppercase tracking-wider">
+              PERP
+            </span>
+            <span className="hidden truncate text-muted-foreground text-xs sm:inline">
+              {market.name}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-6">
+          <div className="text-right">
+            <div className="font-mono text-foreground text-xl tabular-nums">
+              {formatPrice(displayPrice)}
+            </div>
+            <div
+              className={cn(
+                'font-bold text-xs tabular-nums',
+                isPositive ? 'text-green-500' : 'text-red-500'
+              )}
+            >
+              {isPositive ? '+' : ''}
+              {changePct.toFixed(2)}%
+            </div>
+          </div>
+
+          <div className="hidden items-center gap-6 text-xs md:flex">
+            {stats?.map((s) => (
+              <div key={s.label} className="flex flex-col">
+                <span className="text-[10px] text-muted-foreground uppercase tracking-wider">
+                  {s.label}
+                </span>
+                <span className="font-mono text-foreground">{s.value}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Chart toolbar */}
+      <div className="flex shrink-0 items-center justify-between border-white/5 border-b bg-background/20 px-3 py-2 text-xs backdrop-blur-sm">
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-1 rounded bg-muted/20 p-0.5">
+            {TERMINAL_TIMEFRAMES.map((t) => (
+              <button
+                key={t}
+                type="button"
+                onClick={() => setTimeRange(t)}
+                className={cn(
+                  'rounded px-2 py-1 font-semibold transition-colors',
+                  timeRange === t
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
+              >
+                {t}
+              </button>
+            ))}
+          </div>
+
+          <div className="h-4 w-px bg-white/10" />
+
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 rounded px-2 py-1 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground"
+            aria-label="Compare (coming soon)"
+          >
+            <Plus size={14} />
+            <span className="font-medium">Compare</span>
+          </button>
+        </div>
+
+        <button
+          type="button"
+          className="inline-flex items-center gap-1 rounded px-2 py-1 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground"
+          aria-label="Indicators (coming soon)"
+        >
+          <BarChart2 size={14} />
+          <span className="hidden font-medium sm:inline">Indicators</span>
+        </button>
+      </div>
+
+      {/* Chart */}
+      <div className="min-h-0 flex-1 p-2">
+        <div className="h-full min-h-0 overflow-hidden rounded-md border border-white/5 bg-background/20 backdrop-blur-sm">
+          {loading && history.length === 0 ? (
+            <div className="p-4">
+              <Skeleton className="h-6 w-36" />
+              <Skeleton className="mt-3 h-64 w-full" />
+            </div>
+          ) : (
+            <div className="h-full min-h-0 p-2">
+              <PerpPriceChart
+                data={history}
+                currentPrice={displayPrice}
+                ticker={market.ticker}
+                timeRange={timeRange}
+                onTimeRangeChange={setTimeRange}
+                showHeader={false}
+                className="h-full"
+              />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/markets/_components/perps-terminal/PerpsMarketListPanel.tsx
+++ b/apps/web/src/app/markets/_components/perps-terminal/PerpsMarketListPanel.tsx
@@ -1,0 +1,250 @@
+'use client';
+
+import { cn } from '@babylon/shared';
+import { ArrowDown, ArrowUp, Filter, Search, Star } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import type { PerpMarket } from '@/types/markets';
+import { useWatchlistStore } from '../../_hooks/useWatchlistStore';
+import { formatPrice, formatVolume } from '../../_lib/formatters';
+
+type SortKey =
+  | 'ticker'
+  | 'currentPrice'
+  | 'changePercent24h'
+  | 'volume24h'
+  | 'openInterest';
+
+interface PerpsMarketListPanelProps {
+  markets: PerpMarket[];
+  activeTicker: string | null;
+  onSelectTicker: (ticker: string) => void;
+  onCollapse: () => void;
+}
+
+export function PerpsMarketListPanel({
+  markets,
+  activeTicker,
+  onSelectTicker,
+  onCollapse,
+}: PerpsMarketListPanelProps) {
+  const { toggleFavorite, isFavorite } = useWatchlistStore();
+  const [query, setQuery] = useState('');
+  const [showFavoritesOnly, setShowFavoritesOnly] = useState(false);
+  const [sortKey, setSortKey] = useState<SortKey>('volume24h');
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('desc');
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const favorites = showFavoritesOnly
+      ? markets.filter((m) => isFavorite(m.ticker))
+      : markets;
+
+    const searched =
+      q.length === 0
+        ? favorites
+        : favorites.filter(
+            (m) =>
+              m.ticker.toLowerCase().includes(q) ||
+              m.name.toLowerCase().includes(q)
+          );
+
+    const sorted = [...searched].sort((a, b) => {
+      const valA = a[sortKey] ?? 0;
+      const valB = b[sortKey] ?? 0;
+      if (valA < valB) return sortDirection === 'desc' ? 1 : -1;
+      if (valA > valB) return sortDirection === 'desc' ? -1 : 1;
+      return a.ticker.localeCompare(b.ticker);
+    });
+
+    return sorted;
+  }, [markets, query, showFavoritesOnly, sortKey, sortDirection, isFavorite]);
+
+  const toggleSort = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDirection((d) => (d === 'desc' ? 'asc' : 'desc'));
+      return;
+    }
+    setSortKey(key);
+    setSortDirection('desc');
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex items-center justify-between border-white/5 border-b px-3 py-2">
+        <div className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+          Markets
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => setShowFavoritesOnly((v) => !v)}
+            className={cn(
+              'rounded p-1.5 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground',
+              showFavoritesOnly && 'bg-muted/20 text-primary'
+            )}
+            aria-label="Toggle favorites filter"
+          >
+            <Filter size={14} />
+          </button>
+          <button
+            type="button"
+            onClick={onCollapse}
+            className="rounded p-1.5 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground"
+            aria-label="Collapse markets panel"
+          >
+            ◀
+          </button>
+        </div>
+      </div>
+
+      <div className="p-3">
+        <div className="relative">
+          <Search className="-translate-y-1/2 absolute top-1/2 left-2 h-3.5 w-3.5 text-muted-foreground" />
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search…"
+            className="w-full rounded border border-white/10 bg-background/40 py-2 pr-3 pl-7 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30"
+          />
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        <table className="w-full text-left text-xs">
+          <thead className="sticky top-0 z-10 bg-background/70 text-muted-foreground backdrop-blur-md">
+            <tr className="border-white/5 border-b">
+              <th className="w-10 px-3 py-2" />
+              <th
+                className="cursor-pointer px-2 py-2 hover:text-foreground"
+                onClick={() => toggleSort('ticker')}
+              >
+                <Header
+                  label="Market"
+                  active={sortKey === 'ticker'}
+                  direction={sortDirection}
+                />
+              </th>
+              <th
+                className="cursor-pointer px-2 py-2 text-right hover:text-foreground"
+                onClick={() => toggleSort('currentPrice')}
+              >
+                <Header
+                  label="Price"
+                  active={sortKey === 'currentPrice'}
+                  direction={sortDirection}
+                />
+              </th>
+              <th
+                className="cursor-pointer px-3 py-2 text-right hover:text-foreground"
+                onClick={() => toggleSort('changePercent24h')}
+              >
+                <Header
+                  label="24h"
+                  active={sortKey === 'changePercent24h'}
+                  direction={sortDirection}
+                />
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {filtered.map((m) => {
+              const isActive =
+                activeTicker?.toLowerCase() === m.ticker.toLowerCase();
+              const changePositive = (m.changePercent24h ?? 0) >= 0;
+              return (
+                <tr
+                  key={m.ticker}
+                  className={cn(
+                    'cursor-pointer border-white/5 border-b transition-colors hover:bg-muted/20',
+                    isActive && 'bg-muted/30'
+                  )}
+                  onClick={() => onSelectTicker(m.ticker)}
+                >
+                  <td className="px-3 py-2">
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        toggleFavorite(m.ticker);
+                      }}
+                      className={cn(
+                        'text-muted-foreground/60 transition-colors hover:text-yellow-400',
+                        isFavorite(m.ticker) && 'text-yellow-400'
+                      )}
+                      aria-label={`Toggle favorite for ${m.ticker}`}
+                    >
+                      <Star
+                        size={14}
+                        fill={isFavorite(m.ticker) ? 'currentColor' : 'none'}
+                      />
+                    </button>
+                  </td>
+                  <td className="px-2 py-2">
+                    <div className="flex min-w-0 flex-col">
+                      <div className="font-bold text-foreground">
+                        {m.ticker}
+                      </div>
+                      <div className="truncate text-[10px] text-muted-foreground">
+                        {m.name}
+                      </div>
+                    </div>
+                  </td>
+                  <td className="px-2 py-2 text-right">
+                    <div className="font-mono text-foreground/90 tabular-nums">
+                      {formatPrice(m.currentPrice)}
+                    </div>
+                    <div className="font-mono text-[9px] text-muted-foreground tabular-nums">
+                      Vol {formatVolume(m.volume24h)}
+                    </div>
+                  </td>
+                  <td className="px-3 py-2 text-right">
+                    <div
+                      className={cn(
+                        'inline-flex items-center justify-end rounded-full px-2 py-0.5 font-bold text-[10px] tabular-nums',
+                        changePositive
+                          ? 'bg-green-500/10 text-green-500'
+                          : 'bg-red-500/10 text-red-500'
+                      )}
+                    >
+                      {changePositive ? '+' : ''}
+                      {(m.changePercent24h ?? 0).toFixed(2)}%
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+            {filtered.length === 0 && (
+              <tr>
+                <td
+                  colSpan={4}
+                  className="p-6 text-center text-muted-foreground"
+                >
+                  No markets found
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function Header({
+  label,
+  active,
+  direction,
+}: {
+  label: string;
+  active: boolean;
+  direction: 'asc' | 'desc';
+}) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      {label}
+      {active &&
+        (direction === 'asc' ? <ArrowUp size={12} /> : <ArrowDown size={12} />)}
+    </span>
+  );
+}

--- a/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
+++ b/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
@@ -63,6 +63,9 @@ export function PerpsOrderEntryPanel({ market }: PerpsOrderEntryPanelProps) {
     const openPositions = activePositions.filter((p) => !p.closedAt);
     if (openPositions.length === 0) return null;
 
+    const first = openPositions[0];
+    if (!first) return null;
+
     return openPositions.reduce<(typeof openPositions)[number]>((best, pos) => {
       const bestTs = Number.isFinite(Date.parse(best.openedAt))
         ? Date.parse(best.openedAt)
@@ -80,7 +83,7 @@ export function PerpsOrderEntryPanel({ market }: PerpsOrderEntryPanelProps) {
       }
 
       return best;
-    }, openPositions[0]);
+    }, first);
   }, [activePositions]);
 
   const sizeNum = Number.parseFloat(size) || 0;

--- a/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
+++ b/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
@@ -59,10 +59,29 @@ export function PerpsOrderEntryPanel({ market }: PerpsOrderEntryPanelProps) {
     );
   }, [perpPositions, market]);
 
-  const existingPosition = useMemo(
-    () => activePositions.find((p) => !p.closedAt) ?? null,
-    [activePositions]
-  );
+  const existingPosition = useMemo(() => {
+    const openPositions = activePositions.filter((p) => !p.closedAt);
+    if (openPositions.length === 0) return null;
+
+    return openPositions.reduce<(typeof openPositions)[number]>((best, pos) => {
+      const bestTs = Number.isFinite(Date.parse(best.openedAt))
+        ? Date.parse(best.openedAt)
+        : 0;
+      const posTs = Number.isFinite(Date.parse(pos.openedAt))
+        ? Date.parse(pos.openedAt)
+        : 0;
+
+      if (posTs !== bestTs) {
+        return posTs > bestTs ? pos : best;
+      }
+
+      if (pos.size !== best.size) {
+        return pos.size > best.size ? pos : best;
+      }
+
+      return best;
+    }, openPositions[0]);
+  }, [activePositions]);
 
   const sizeNum = Number.parseFloat(size) || 0;
   const effectiveMaxLeverage = market?.maxLeverage ?? 100;
@@ -118,6 +137,21 @@ export function PerpsOrderEntryPanel({ market }: PerpsOrderEntryPanelProps) {
       newSize: flipSize,
     };
   }, [existingPosition, market, side, sizeNum]);
+
+  const submitLabel = useMemo(() => {
+    if (submitting) return 'Processing…';
+    if (!authenticated) return 'Log In to Trade';
+    if (rebalanceInfo) {
+      const labels = {
+        add: 'ADD TO POSITION',
+        reduce: 'REDUCE POSITION',
+        close: 'CLOSE POSITION',
+        flip: 'FLIP POSITION',
+      } as const;
+      return labels[rebalanceInfo.type];
+    }
+    return `PLACE ${side.toUpperCase()} ORDER`;
+  }, [authenticated, rebalanceInfo, side, submitting]);
 
   const handleSubmit = () => {
     if (!market) return;
@@ -272,7 +306,7 @@ export function PerpsOrderEntryPanel({ market }: PerpsOrderEntryPanelProps) {
       </div>
 
       {/* Order form */}
-      <div className="min-h-0 flex-1 overflow-auto p-4">
+      <div className="min-h-0 flex-1 overflow-auto p-4 pb-[calc(72px+env(safe-area-inset-bottom)+24px)]">
         <div className="flex items-center justify-between">
           <div className="font-semibold text-sm">Place Order</div>
           <div className="rounded bg-muted/20 px-2 py-1 text-[10px] text-muted-foreground uppercase tracking-wider">
@@ -397,6 +431,22 @@ export function PerpsOrderEntryPanel({ market }: PerpsOrderEntryPanelProps) {
           )}
         </div>
 
+        {rebalanceInfo && (
+          <div className="mt-4 rounded border border-white/10 bg-muted/10 p-3 text-xs">
+            <div className="flex items-center justify-between">
+              <span className="font-semibold text-muted-foreground">
+                {rebalanceInfo.label}
+              </span>
+              <span className="font-mono text-foreground tabular-nums">
+                {formatPrice(rebalanceInfo.newSize)}
+              </span>
+            </div>
+            <div className="mt-1 text-[10px] text-muted-foreground">
+              {rebalanceInfo.description}
+            </div>
+          </div>
+        )}
+
         <button
           type="button"
           onClick={handleSubmit}
@@ -410,11 +460,7 @@ export function PerpsOrderEntryPanel({ market }: PerpsOrderEntryPanelProps) {
               'cursor-not-allowed opacity-50'
           )}
         >
-          {submitting
-            ? 'Processing…'
-            : !authenticated
-              ? 'Log In to Trade'
-              : `PLACE ${side.toUpperCase()} ORDER`}
+          {submitLabel}
         </button>
       </div>
 

--- a/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
+++ b/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
@@ -317,7 +317,11 @@ export function PerpsOrderEntryPanel({ market }: PerpsOrderEntryPanelProps) {
             />
             Market
           </label>
-          <label className="flex cursor-pointer items-center gap-2 text-muted-foreground hover:text-foreground">
+          <label
+            className="flex cursor-not-allowed items-center gap-2 text-muted-foreground/60"
+            aria-disabled="true"
+            title="Coming soon"
+          >
             <input
               type="radio"
               checked={orderType === 'limit'}

--- a/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
+++ b/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
@@ -1,0 +1,466 @@
+'use client';
+
+import { FEE_CONFIG } from '@babylon/engine/config/fees';
+import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
+import { Wallet } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import {
+  type OpenPerpDetails,
+  TradeConfirmationDialog,
+} from '@/components/markets/TradeConfirmationDialog';
+import { Skeleton } from '@/components/shared/Skeleton';
+import { useAuth } from '@/hooks/useAuth';
+import { usePerpTrade } from '@/hooks/usePerpTrade';
+import { invalidatePerpMarketsCache } from '@/stores/perpMarketsStore';
+import {
+  invalidateUserPositions,
+  usePerpPositions,
+} from '@/stores/userPositionsStore';
+import {
+  invalidateWalletBalance,
+  useWalletBalance,
+} from '@/stores/walletBalanceStore';
+import type { PerpMarket } from '@/types/markets';
+import { formatPrice } from '../../_lib/formatters';
+
+interface PerpsOrderEntryPanelProps {
+  market: PerpMarket | null;
+}
+
+export function PerpsOrderEntryPanel({ market }: PerpsOrderEntryPanelProps) {
+  const { user, authenticated, login, getAccessToken } = useAuth();
+  const userId = authenticated ? (user?.id ?? null) : null;
+
+  const {
+    balance,
+    loading: balanceLoading,
+    refresh: refreshWalletBalance,
+  } = useWalletBalance(userId);
+  const {
+    positions: perpPositions,
+    loading: positionsLoading,
+    refresh: refreshUserPositions,
+  } = usePerpPositions(userId);
+
+  const { openPosition } = usePerpTrade({ getAccessToken });
+
+  const [side, setSide] = useState<'long' | 'short'>('long');
+  const [orderType, setOrderType] = useState<'market' | 'limit'>('market');
+  const [size, setSize] = useState('100');
+  const [leverage, setLeverage] = useState(10);
+  const [submitting, setSubmitting] = useState(false);
+  const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
+
+  const activePositions = useMemo(() => {
+    if (!market) return [];
+    return perpPositions.filter(
+      (p) => p.ticker.toLowerCase() === market.ticker.toLowerCase()
+    );
+  }, [perpPositions, market]);
+
+  const existingPosition = useMemo(
+    () => activePositions.find((p) => !p.closedAt) ?? null,
+    [activePositions]
+  );
+
+  const sizeNum = Number.parseFloat(size) || 0;
+  const effectiveMaxLeverage = market?.maxLeverage ?? 100;
+  const clampedLeverage = Math.min(Math.max(leverage, 1), effectiveMaxLeverage);
+
+  const baseMargin = sizeNum > 0 ? sizeNum / clampedLeverage : 0;
+  const estimatedFee = sizeNum > 0 ? sizeNum * FEE_CONFIG.TRADING_FEE_RATE : 0;
+  const totalRequired = sizeNum > 0 ? baseMargin + estimatedFee : 0;
+  const hasSufficientBalance = !authenticated || balance >= totalRequired;
+  const showBalanceWarning =
+    authenticated && sizeNum > 0 && !hasSufficientBalance;
+
+  const rebalanceInfo = useMemo(() => {
+    if (!market) return null;
+    if (!existingPosition) return null;
+    if (sizeNum <= 0) return null;
+
+    const isSameSide = existingPosition.side === side;
+    const newTotalSize = existingPosition.size + sizeNum;
+
+    if (isSameSide) {
+      return {
+        type: 'add' as const,
+        label: 'Add to Position',
+        description: `Adding ${formatPrice(sizeNum)} to your ${existingPosition.side.toUpperCase()} position`,
+        newSize: newTotalSize,
+      };
+    }
+
+    if (sizeNum < existingPosition.size) {
+      return {
+        type: 'reduce' as const,
+        label: 'Reduce Position',
+        description: `Reducing your ${existingPosition.side.toUpperCase()} by ${formatPrice(sizeNum)}`,
+        newSize: existingPosition.size - sizeNum,
+      };
+    }
+
+    if (Math.abs(sizeNum - existingPosition.size) < 0.01) {
+      return {
+        type: 'close' as const,
+        label: 'Close Position',
+        description: `Closing your ${existingPosition.side.toUpperCase()} position`,
+        newSize: 0,
+      };
+    }
+
+    const flipSize = sizeNum - existingPosition.size;
+    return {
+      type: 'flip' as const,
+      label: 'Flip Position',
+      description: `Closing ${existingPosition.side.toUpperCase()} and opening ${side.toUpperCase()} ${formatPrice(flipSize)}`,
+      newSize: flipSize,
+    };
+  }, [existingPosition, market, side, sizeNum]);
+
+  const handleSubmit = () => {
+    if (!market) return;
+    if (!authenticated) {
+      login();
+      return;
+    }
+
+    if (!user) return;
+
+    if (sizeNum < market.minOrderSize) {
+      toast.error(
+        `Minimum order size is ${BABYLON_POINTS_SYMBOL}${market.minOrderSize}`
+      );
+      return;
+    }
+
+    if (authenticated && showBalanceWarning) {
+      toast.error('Insufficient balance for margin + fees');
+      return;
+    }
+
+    setConfirmDialogOpen(true);
+  };
+
+  const handleConfirmOpen = useCallback(async () => {
+    if (!market) return;
+    if (sizeNum <= 0) return;
+
+    setSubmitting(true);
+    setConfirmDialogOpen(false);
+
+    await openPosition({
+      ticker: market.ticker,
+      side,
+      size: sizeNum,
+      leverage: clampedLeverage,
+    })
+      .then(async () => {
+        if (rebalanceInfo) {
+          const messages = {
+            add: {
+              title: 'Position increased!',
+              description: `Added ${formatPrice(sizeNum)} to your ${side.toUpperCase()} position`,
+            },
+            reduce: {
+              title: 'Position reduced!',
+              description: `Reduced your position by ${formatPrice(sizeNum)}`,
+            },
+            close: {
+              title: 'Position closed!',
+              description: `Closed your ${existingPosition?.side?.toUpperCase()} position`,
+            },
+            flip: {
+              title: 'Position flipped!',
+              description: `Flipped to ${clampedLeverage}x ${side.toUpperCase()} on ${market.ticker}`,
+            },
+          } as const;
+          const msg = messages[rebalanceInfo.type];
+          toast.success(msg.title, { description: msg.description });
+        } else {
+          toast.success('Position opened!', {
+            description: `Opened ${clampedLeverage}x ${side.toUpperCase()} on ${market.ticker}`,
+          });
+        }
+
+        invalidatePerpMarketsCache();
+        invalidateUserPositions();
+        invalidateWalletBalance();
+
+        await Promise.all([refreshUserPositions(), refreshWalletBalance()]);
+      })
+      .catch((error: Error) => {
+        toast.error(error.message);
+      })
+      .finally(() => {
+        setSubmitting(false);
+      });
+  }, [
+    market,
+    sizeNum,
+    openPosition,
+    side,
+    clampedLeverage,
+    rebalanceInfo,
+    existingPosition?.side,
+    refreshUserPositions,
+    refreshWalletBalance,
+  ]);
+
+  const liquidationPrice = useMemo(() => {
+    if (!market) return 0;
+    const price = market.currentPrice;
+    return side === 'long'
+      ? price * (1 - 0.9 / clampedLeverage)
+      : price * (1 + 0.9 / clampedLeverage);
+  }, [market, side, clampedLeverage]);
+
+  const liquidationDistance = useMemo(() => {
+    if (!market) return 0;
+    const price = market.currentPrice;
+    if (price <= 0) return 0;
+    return side === 'long'
+      ? ((price - liquidationPrice) / price) * 100
+      : ((liquidationPrice - price) / price) * 100;
+  }, [market, side, liquidationPrice]);
+
+  if (!market) {
+    return (
+      <div className="flex h-full flex-col p-4">
+        <div className="flex flex-1 flex-col items-center justify-center rounded-lg border border-white/5 bg-background/20 p-6 text-center">
+          <div className="font-semibold text-muted-foreground">Trade</div>
+          <div className="mt-1 text-muted-foreground/70 text-sm">
+            Select a market to place an order.
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-background/10">
+      {/* Account summary */}
+      <div className="border-white/5 border-b bg-muted/10 p-4">
+        <div className="flex items-start justify-between">
+          <div className="space-y-1">
+            <div className="text-[10px] text-muted-foreground uppercase tracking-wider">
+              Available Balance
+            </div>
+            <div className="flex items-center gap-2 font-mono text-foreground text-lg tabular-nums">
+              <Wallet size={14} className="text-muted-foreground" />
+              {balanceLoading ? (
+                <Skeleton className="h-5 w-20" />
+              ) : (
+                formatPrice(balance)
+              )}
+            </div>
+          </div>
+          {existingPosition && (
+            <div className="text-right">
+              <div className="text-[10px] text-muted-foreground uppercase tracking-wider">
+                Open Position
+              </div>
+              <div className="font-mono text-foreground text-xs">
+                {existingPosition.leverage}x{' '}
+                {existingPosition.side.toUpperCase()} •{' '}
+                {formatPrice(existingPosition.size)}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Order form */}
+      <div className="min-h-0 flex-1 overflow-auto p-4">
+        <div className="flex items-center justify-between">
+          <div className="font-semibold text-sm">Place Order</div>
+          <div className="rounded bg-muted/20 px-2 py-1 text-[10px] text-muted-foreground uppercase tracking-wider">
+            Standard
+          </div>
+        </div>
+
+        <div className="mt-3 flex rounded-md bg-muted/20 p-1">
+          <button
+            type="button"
+            onClick={() => setSide('long')}
+            className={cn(
+              'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
+              side === 'long'
+                ? 'bg-green-600 text-white'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            LONG
+          </button>
+          <button
+            type="button"
+            onClick={() => setSide('short')}
+            className={cn(
+              'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
+              side === 'short'
+                ? 'bg-red-600 text-white'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            SHORT
+          </button>
+        </div>
+
+        <div className="mt-4 flex gap-4 text-xs">
+          <label className="flex cursor-pointer items-center gap-2 text-muted-foreground hover:text-foreground">
+            <input
+              type="radio"
+              checked={orderType === 'market'}
+              onChange={() => setOrderType('market')}
+              className="accent-primary"
+            />
+            Market
+          </label>
+          <label className="flex cursor-pointer items-center gap-2 text-muted-foreground hover:text-foreground">
+            <input
+              type="radio"
+              checked={orderType === 'limit'}
+              onChange={() => setOrderType('limit')}
+              className="accent-primary"
+              disabled
+            />
+            Limit
+            <span className="ml-1 rounded bg-muted/20 px-1 py-0.5 text-[10px] text-muted-foreground">
+              soon
+            </span>
+          </label>
+        </div>
+
+        <div className="mt-4 space-y-4">
+          <div>
+            <div className="mb-1 flex items-center justify-between">
+              <label className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+                Size (USD)
+              </label>
+              <span className="text-[10px] text-muted-foreground">
+                Min {BABYLON_POINTS_SYMBOL}
+                {market.minOrderSize} • Max {market.maxLeverage}x
+              </span>
+            </div>
+            <input
+              type="number"
+              value={size}
+              onChange={(e) => setSize(e.target.value)}
+              min={market.minOrderSize}
+              step="10"
+              className="w-full rounded border border-white/10 bg-background/30 px-3 py-2 font-mono text-sm tabular-nums focus:border-primary/40 focus:outline-none focus:ring-2 focus:ring-primary/20"
+              placeholder="0.00"
+            />
+          </div>
+
+          <div>
+            <div className="mb-1 flex items-center justify-between">
+              <label className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+                Leverage
+              </label>
+              <span className="font-mono text-foreground text-xs">
+                {clampedLeverage}x
+              </span>
+            </div>
+            <input
+              type="range"
+              min="1"
+              max={market.maxLeverage}
+              value={clampedLeverage}
+              onChange={(e) => setLeverage(Number.parseInt(e.target.value))}
+              className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-muted accent-primary"
+            />
+          </div>
+
+          <div className="rounded border border-white/10 bg-muted/10 p-3 text-xs">
+            <Row label="Margin" value={formatPrice(baseMargin)} />
+            <Row label="Fees" value={formatPrice(estimatedFee)} />
+            <div className="my-2 border-white/10 border-t" />
+            <Row label="Total" value={formatPrice(totalRequired)} strong />
+          </div>
+
+          {showBalanceWarning && (
+            <div className="rounded border border-red-500/20 bg-red-500/10 p-2 text-[10px] text-red-400">
+              Insufficient balance ({formatPrice(balance)})
+            </div>
+          )}
+
+          {positionsLoading && authenticated && (
+            <div className="text-[10px] text-muted-foreground">
+              Syncing positions…
+            </div>
+          )}
+        </div>
+
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={submitting || (authenticated && showBalanceWarning)}
+          className={cn(
+            'mt-5 w-full rounded py-3 font-bold text-sm text-white shadow transition-all',
+            side === 'long'
+              ? 'bg-green-600 hover:brightness-110'
+              : 'bg-red-600 hover:brightness-110',
+            (submitting || (authenticated && showBalanceWarning)) &&
+              'cursor-not-allowed opacity-50'
+          )}
+        >
+          {submitting
+            ? 'Processing…'
+            : !authenticated
+              ? 'Log In to Trade'
+              : `PLACE ${side.toUpperCase()} ORDER`}
+        </button>
+      </div>
+
+      {/* Confirmation dialog */}
+      <TradeConfirmationDialog
+        open={confirmDialogOpen}
+        onOpenChange={setConfirmDialogOpen}
+        onConfirm={handleConfirmOpen}
+        isSubmitting={submitting}
+        tradeDetails={
+          market
+            ? ({
+                type: 'open-perp',
+                ticker: market.ticker,
+                side,
+                size: sizeNum,
+                leverage: clampedLeverage,
+                entryPrice: market.currentPrice,
+                margin: baseMargin,
+                estimatedFee,
+                liquidationPrice,
+                liquidationDistance,
+              } satisfies OpenPerpDetails)
+            : null
+        }
+      />
+    </div>
+  );
+}
+
+function Row({
+  label,
+  value,
+  strong,
+}: {
+  label: string;
+  value: string;
+  strong?: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between">
+      <span className="text-muted-foreground">{label}</span>
+      <span
+        className={cn(
+          'font-mono tabular-nums',
+          strong ? 'font-bold text-foreground' : 'text-foreground/90'
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/app/markets/_components/perps-terminal/PerpsTerminalBottomPanel.tsx
+++ b/apps/web/src/app/markets/_components/perps-terminal/PerpsTerminalBottomPanel.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { cn } from '@babylon/shared';
+import { Minus } from 'lucide-react';
+import { useMemo, useRef } from 'react';
+import { AssetTradesFeed } from '@/components/markets/AssetTradesFeed';
+import { PerpPositionsList } from '@/components/markets/PerpPositionsList';
+import { useAuth } from '@/hooks/useAuth';
+import { invalidatePerpMarketsCache } from '@/stores/perpMarketsStore';
+import {
+  invalidateUserPositions,
+  usePerpPositions,
+} from '@/stores/userPositionsStore';
+import { invalidateWalletBalance } from '@/stores/walletBalanceStore';
+
+interface PerpsTerminalBottomPanelProps {
+  ticker: string | null;
+  activeTab: 'positions' | 'trades';
+  onTabChange: (tab: 'positions' | 'trades') => void;
+  onCollapse: () => void;
+}
+
+export function PerpsTerminalBottomPanel({
+  ticker,
+  activeTab,
+  onTabChange,
+  onCollapse,
+}: PerpsTerminalBottomPanelProps) {
+  const { user, authenticated } = useAuth();
+  const userId = authenticated ? (user?.id ?? null) : null;
+
+  const { positions: perpPositions, refresh: refreshUserPositions } =
+    usePerpPositions(userId);
+
+  const filteredPositions = useMemo(() => {
+    if (!ticker) return [];
+    return perpPositions.filter(
+      (p) => p.ticker.toLowerCase() === ticker.toLowerCase() && !p.closedAt
+    );
+  }, [perpPositions, ticker]);
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const handlePositionClosed = async () => {
+    invalidatePerpMarketsCache();
+    invalidateUserPositions();
+    invalidateWalletBalance();
+    await refreshUserPositions();
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex items-center justify-between border-white/5 border-b bg-background/30 px-2">
+        <div className="scrollbar-hide flex min-w-0 flex-1 overflow-x-auto">
+          <TabButton
+            active={activeTab === 'positions'}
+            onClick={() => onTabChange('positions')}
+          >
+            Positions
+            {ticker && (
+              <span className="ml-2 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-muted/20 px-1.5 text-[10px] tabular-nums">
+                {filteredPositions.length}
+              </span>
+            )}
+          </TabButton>
+          <TabButton
+            active={activeTab === 'trades'}
+            onClick={() => onTabChange('trades')}
+          >
+            Trades
+          </TabButton>
+        </div>
+
+        <button
+          type="button"
+          onClick={onCollapse}
+          className="ml-2 rounded p-2 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground"
+          aria-label="Collapse bottom panel"
+        >
+          <Minus size={14} />
+        </button>
+      </div>
+
+      <div ref={containerRef} className="min-h-0 flex-1 overflow-hidden">
+        {!ticker ? (
+          <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
+            Select a market to see positions and trades.
+          </div>
+        ) : !authenticated ? (
+          <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
+            Log in to view your positions.
+          </div>
+        ) : activeTab === 'positions' ? (
+          <div className="h-full overflow-auto">
+            {filteredPositions.length > 0 ? (
+              <PerpPositionsList
+                positions={filteredPositions}
+                onPositionClosed={handlePositionClosed}
+              />
+            ) : (
+              <div className="flex h-full items-center justify-center text-muted-foreground text-xs">
+                No open positions
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="h-full">
+            <AssetTradesFeed
+              marketType="perp"
+              assetId={ticker}
+              containerRef={containerRef}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        '-mb-px border-b-2 px-4 py-2 font-semibold text-xs transition-colors',
+        active
+          ? 'border-primary text-primary'
+          : 'border-transparent text-muted-foreground hover:text-foreground'
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/apps/web/src/app/markets/_components/perps-terminal/PerpsTerminalBottomPanel.tsx
+++ b/apps/web/src/app/markets/_components/perps-terminal/PerpsTerminalBottomPanel.tsx
@@ -2,7 +2,7 @@
 
 import { cn } from '@babylon/shared';
 import { Minus } from 'lucide-react';
-import { useMemo, useRef } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { AssetTradesFeed } from '@/components/markets/AssetTradesFeed';
 import { PerpPositionsList } from '@/components/markets/PerpPositionsList';
 import { useAuth } from '@/hooks/useAuth';
@@ -13,21 +13,35 @@ import {
 } from '@/stores/userPositionsStore';
 import { invalidateWalletBalance } from '@/stores/walletBalanceStore';
 
+export type PerpsTerminalBottomTab =
+  | 'agent'
+  | 'socials'
+  | 'pnl'
+  | 'positions'
+  | 'orders'
+  | 'trades';
+
 interface PerpsTerminalBottomPanelProps {
   ticker: string | null;
-  activeTab: 'positions' | 'trades';
-  onTabChange: (tab: 'positions' | 'trades') => void;
-  onCollapse: () => void;
+  activeTab?: PerpsTerminalBottomTab;
+  onTabChange?: (tab: PerpsTerminalBottomTab) => void;
+  onCollapse?: () => void;
+  hideHeader?: boolean;
 }
 
 export function PerpsTerminalBottomPanel({
   ticker,
-  activeTab,
+  activeTab: propActiveTab,
   onTabChange,
   onCollapse,
+  hideHeader = false,
 }: PerpsTerminalBottomPanelProps) {
   const { user, authenticated } = useAuth();
   const userId = authenticated ? (user?.id ?? null) : null;
+
+  const [internalActiveTab, setInternalActiveTab] =
+    useState<PerpsTerminalBottomTab>('positions');
+  const activeTab = propActiveTab ?? internalActiveTab;
 
   const { positions: perpPositions, refresh: refreshUserPositions } =
     usePerpPositions(userId);
@@ -48,38 +62,79 @@ export function PerpsTerminalBottomPanel({
     await refreshUserPositions();
   };
 
+  const setActiveTab = (tab: PerpsTerminalBottomTab) => {
+    onTabChange?.(tab);
+    if (propActiveTab == null) setInternalActiveTab(tab);
+  };
+
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="flex items-center justify-between border-white/5 border-b bg-background/30 px-2">
-        <div className="scrollbar-hide flex min-w-0 flex-1 overflow-x-auto">
-          <TabButton
-            active={activeTab === 'positions'}
-            onClick={() => onTabChange('positions')}
-          >
-            Positions
-            {ticker && (
-              <span className="ml-2 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-muted/20 px-1.5 text-[10px] tabular-nums">
-                {filteredPositions.length}
-              </span>
-            )}
-          </TabButton>
-          <TabButton
-            active={activeTab === 'trades'}
-            onClick={() => onTabChange('trades')}
-          >
-            Trades
-          </TabButton>
-        </div>
+      {!hideHeader && (
+        <div className="flex items-center justify-between border-white/5 border-b bg-background/30 px-2">
+          <div className="scrollbar-hide flex min-w-0 flex-1 overflow-x-auto">
+            <TabButton
+              active={activeTab === 'positions'}
+              onClick={() => setActiveTab('positions')}
+            >
+              Positions
+              {ticker && (
+                <span className="ml-2 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-muted/20 px-1.5 text-[10px] tabular-nums">
+                  {filteredPositions.length}
+                </span>
+              )}
+            </TabButton>
+            <TabButton
+              active={activeTab === 'orders'}
+              onClick={() => setActiveTab('orders')}
+              disabled
+              soon
+            >
+              Orders
+            </TabButton>
+            <TabButton
+              active={activeTab === 'pnl'}
+              onClick={() => setActiveTab('pnl')}
+              disabled
+              soon
+            >
+              PnL Analysis
+            </TabButton>
+            <TabButton
+              active={activeTab === 'agent'}
+              onClick={() => setActiveTab('agent')}
+              disabled
+              soon
+            >
+              Agent
+            </TabButton>
+            <TabButton
+              active={activeTab === 'socials'}
+              onClick={() => setActiveTab('socials')}
+              disabled
+              soon
+            >
+              Social
+            </TabButton>
+            <TabButton
+              active={activeTab === 'trades'}
+              onClick={() => setActiveTab('trades')}
+            >
+              Trades
+            </TabButton>
+          </div>
 
-        <button
-          type="button"
-          onClick={onCollapse}
-          className="ml-2 rounded p-2 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground"
-          aria-label="Collapse bottom panel"
-        >
-          <Minus size={14} />
-        </button>
-      </div>
+          {onCollapse && (
+            <button
+              type="button"
+              onClick={onCollapse}
+              className="ml-2 rounded p-2 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground"
+              aria-label="Collapse bottom panel"
+            >
+              <Minus size={14} />
+            </button>
+          )}
+        </div>
+      )}
 
       <div ref={containerRef} className="min-h-0 flex-1 overflow-hidden">
         {!ticker ? (
@@ -103,13 +158,22 @@ export function PerpsTerminalBottomPanel({
               </div>
             )}
           </div>
-        ) : (
+        ) : activeTab === 'trades' ? (
           <div className="h-full">
             <AssetTradesFeed
               marketType="perp"
               assetId={ticker}
               containerRef={containerRef}
             />
+          </div>
+        ) : (
+          <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
+            <div className="flex flex-col items-center gap-2">
+              <span className="font-semibold">Coming soon</span>
+              <span className="rounded-full bg-muted/20 px-3 py-1 text-[10px] text-muted-foreground uppercase tracking-wider">
+                Soon
+              </span>
+            </div>
           </div>
         )}
       </div>
@@ -121,23 +185,34 @@ function TabButton({
   active,
   onClick,
   children,
+  disabled,
+  soon,
 }: {
   active: boolean;
   onClick: () => void;
   children: React.ReactNode;
+  disabled?: boolean;
+  soon?: boolean;
 }) {
   return (
     <button
       type="button"
       onClick={onClick}
+      disabled={disabled}
       className={cn(
-        '-mb-px border-b-2 px-4 py-2 font-semibold text-xs transition-colors',
+        '-mb-px inline-flex items-center gap-2 border-b-2 px-4 py-2 font-semibold text-xs transition-colors',
         active
           ? 'border-primary text-primary'
-          : 'border-transparent text-muted-foreground hover:text-foreground'
+          : 'border-transparent text-muted-foreground hover:text-foreground',
+        disabled && 'cursor-not-allowed opacity-60 hover:text-muted-foreground'
       )}
     >
       {children}
+      {soon && (
+        <span className="rounded-full bg-muted/20 px-2 py-0.5 text-[10px] text-muted-foreground uppercase tracking-wider">
+          Soon
+        </span>
+      )}
     </button>
   );
 }

--- a/apps/web/src/app/markets/_components/perps-terminal/PerpsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/perps-terminal/PerpsTradingTerminal.tsx
@@ -1,8 +1,12 @@
 'use client';
 
 import { cn } from '@babylon/shared';
+import { BarChart2, Bell, Home, Trophy, X } from 'lucide-react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
+import { Avatar } from '@/components/shared/Avatar';
 import { MarketsToggle } from '@/components/shared/MarketsToggle';
 import { Skeleton } from '@/components/shared/Skeleton';
 import { useAuth } from '@/hooks/useAuth';
@@ -19,7 +23,10 @@ import type { MarketTab, PerpMarket } from '@/types/markets';
 import { PerpsMarketDetailPanel } from './PerpsMarketDetailPanel';
 import { PerpsMarketListPanel } from './PerpsMarketListPanel';
 import { PerpsOrderEntryPanel } from './PerpsOrderEntryPanel';
-import { PerpsTerminalBottomPanel } from './PerpsTerminalBottomPanel';
+import {
+  PerpsTerminalBottomPanel,
+  type PerpsTerminalBottomTab,
+} from './PerpsTerminalBottomPanel';
 
 interface PerpsTradingTerminalProps {
   activeTab: MarketTab;
@@ -52,9 +59,13 @@ export function PerpsTradingTerminal({
   const [leftCollapsed, setLeftCollapsed] = useState(false);
   const [rightCollapsed, setRightCollapsed] = useState(false);
   const [bottomCollapsed, setBottomCollapsed] = useState(false);
-  const [bottomTab, setBottomTab] = useState<'positions' | 'trades'>(
-    'positions'
-  );
+  const [bottomTab, setBottomTab] =
+    useState<PerpsTerminalBottomTab>('positions');
+
+  const [isMobileMarketListOpen, setIsMobileMarketListOpen] = useState(false);
+  const [isMobileOrderSheetOpen, setIsMobileOrderSheetOpen] = useState(false);
+  const [activeMobileTab, setActiveMobileTab] =
+    useState<PerpsTerminalBottomTab>('positions');
 
   const fallbackMarket = useMemo(() => pickDefaultMarket(markets), [markets]);
 
@@ -73,12 +84,220 @@ export function PerpsTradingTerminal({
     );
   }, [markets, activeTicker]);
 
+  const pathname = usePathname();
+
   return (
     <div className="relative flex h-full w-full flex-col overflow-hidden bg-background text-foreground">
-      {/* Terminal header (keeps app navigation coherent while matching terminal density) */}
-      <div className="flex h-10 shrink-0 items-center justify-between border-white/5 border-b bg-background/40 px-3 backdrop-blur-md">
-        <div className="flex min-w-0 flex-1 items-center">
-          <div className="min-w-0 flex-1">
+      {/* -------------------- DESKTOP LAYOUT (Hidden on Mobile) -------------------- */}
+      <div className="hidden min-h-0 flex-1 flex-col md:flex">
+        {/* Terminal header (keeps app navigation coherent while matching terminal density) */}
+        <div className="flex h-10 shrink-0 items-center justify-between border-white/5 border-b bg-background/40 px-3 backdrop-blur-md">
+          <div className="flex min-w-0 flex-1 items-center">
+            <div className="min-w-0 flex-1">
+              <MarketsToggle
+                activeTab={activeTab}
+                onTabChange={onTabChange}
+                balance={balance}
+                authenticated={authenticated}
+                loading={balanceLoading}
+              />
+            </div>
+          </div>
+
+          <div className="ml-3 hidden items-center gap-2 text-muted-foreground text-xs lg:flex">
+            <button
+              type="button"
+              onClick={() => setLeftCollapsed((v) => !v)}
+              className="rounded border border-white/10 bg-background/30 px-2 py-1 transition-colors hover:bg-muted/20 hover:text-foreground"
+            >
+              {leftCollapsed ? 'Show markets' : 'Hide markets'}
+            </button>
+            <button
+              type="button"
+              onClick={() => setRightCollapsed((v) => !v)}
+              className="rounded border border-white/10 bg-background/30 px-2 py-1 transition-colors hover:bg-muted/20 hover:text-foreground"
+            >
+              {rightCollapsed ? 'Show trade' : 'Hide trade'}
+            </button>
+            <button
+              type="button"
+              onClick={() => setBottomCollapsed((v) => !v)}
+              className="rounded border border-white/10 bg-background/30 px-2 py-1 transition-colors hover:bg-muted/20 hover:text-foreground"
+            >
+              {bottomCollapsed ? 'Show bottom' : 'Hide bottom'}
+            </button>
+          </div>
+        </div>
+
+        {/* Terminal body */}
+        <div className="flex min-h-0 flex-1 flex-row overflow-hidden">
+          {/* Left collapsed strip */}
+          {leftCollapsed && (
+            <button
+              type="button"
+              onClick={() => setLeftCollapsed(false)}
+              className="w-9 shrink-0 border-white/5 border-r bg-background/30 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground"
+              aria-label="Open markets panel"
+            >
+              <div className="flex h-full flex-col items-center justify-center gap-3">
+                <div className="h-6 w-6 rounded bg-muted/30" />
+                <span className="writing-vertical-lr rotate-180 font-semibold text-[10px] tracking-wider">
+                  MARKETS
+                </span>
+              </div>
+            </button>
+          )}
+
+          <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+            <PanelGroup direction="vertical" className="flex min-h-0 flex-1">
+              <Panel
+                defaultSize={bottomCollapsed ? 100 : 70}
+                minSize={35}
+                className="min-h-0"
+              >
+                <PanelGroup direction="horizontal" className="min-h-0">
+                  {/* Left: Markets list */}
+                  {!leftCollapsed && (
+                    <>
+                      <Panel
+                        defaultSize={22}
+                        minSize={15}
+                        maxSize={32}
+                        className="min-h-0 border-white/5 border-r"
+                      >
+                        <div className="flex h-full min-h-0 flex-col bg-background/20">
+                          {loading ? (
+                            <div className="p-3">
+                              <Skeleton className="h-8 w-full" />
+                              <div className="mt-3 space-y-2">
+                                <Skeleton className="h-10 w-full" />
+                                <Skeleton className="h-10 w-full" />
+                                <Skeleton className="h-10 w-full" />
+                              </div>
+                            </div>
+                          ) : error ? (
+                            <div className="p-4 text-muted-foreground text-sm">
+                              Failed to load markets.
+                            </div>
+                          ) : (
+                            <PerpsMarketListPanel
+                              markets={markets}
+                              activeTicker={activeTicker}
+                              onSelectTicker={setActiveTicker}
+                              onCollapse={() => setLeftCollapsed(true)}
+                            />
+                          )}
+                        </div>
+                      </Panel>
+                      <PanelResizeHandle className="w-1 bg-white/5 hover:bg-primary/40" />
+                    </>
+                  )}
+
+                  {/* Center: Market detail + chart */}
+                  <Panel
+                    defaultSize={leftCollapsed ? 72 : 56}
+                    minSize={40}
+                    className="min-h-0"
+                  >
+                    <div className="h-full min-h-0 bg-background/10">
+                      <PerpsMarketDetailPanel market={activeMarket} />
+                    </div>
+                  </Panel>
+
+                  {/* Right: Order entry */}
+                  {!rightCollapsed && (
+                    <>
+                      <PanelResizeHandle className="w-1 bg-white/5 hover:bg-primary/40" />
+                      <Panel
+                        defaultSize={22}
+                        minSize={18}
+                        maxSize={32}
+                        className="min-h-0 border-white/5 border-l bg-background/20"
+                      >
+                        <PerpsOrderEntryPanel market={activeMarket} />
+                      </Panel>
+                    </>
+                  )}
+
+                  {/* Right collapsed strip */}
+                  {rightCollapsed && (
+                    <button
+                      type="button"
+                      onClick={() => setRightCollapsed(false)}
+                      className="w-9 shrink-0 border-white/5 border-l bg-background/30 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground"
+                      aria-label="Open trade panel"
+                    >
+                      <div className="flex h-full flex-col items-center justify-center gap-3">
+                        <div className="h-6 w-6 rounded bg-muted/30" />
+                        <span className="writing-vertical-lr rotate-180 font-semibold text-[10px] tracking-wider">
+                          TRADE
+                        </span>
+                      </div>
+                    </button>
+                  )}
+                </PanelGroup>
+              </Panel>
+
+              {!bottomCollapsed && (
+                <>
+                  <PanelResizeHandle className="h-1 bg-white/5 hover:bg-primary/40" />
+                  <Panel
+                    defaultSize={30}
+                    minSize={12}
+                    className="min-h-0 border-white/5 border-t bg-background/20"
+                  >
+                    <PerpsTerminalBottomPanel
+                      ticker={activeMarket?.ticker ?? null}
+                      activeTab={bottomTab}
+                      onTabChange={setBottomTab}
+                      onCollapse={() => setBottomCollapsed(true)}
+                    />
+                  </Panel>
+                </>
+              )}
+            </PanelGroup>
+
+            {bottomCollapsed && (
+              <button
+                type="button"
+                onClick={() => setBottomCollapsed(false)}
+                className={cn(
+                  'flex h-7 shrink-0 items-center justify-between border-white/5 border-t bg-background/40 px-4 text-muted-foreground',
+                  'transition-colors hover:bg-muted/20 hover:text-foreground'
+                )}
+              >
+                <span className="font-semibold text-[10px] tracking-widest">
+                  POSITIONS & TRADES
+                </span>
+                <span className="text-[10px]">▲</span>
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* -------------------- MOBILE LAYOUT (Visible on Mobile) -------------------- */}
+      <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden md:hidden">
+        <div className="shrink-0 border-white/5 border-b bg-background">
+          <div className="flex h-14 items-center justify-between px-4">
+            <div className="flex items-center gap-2">
+              <div className="flex h-7 w-7 items-center justify-center rounded-full bg-foreground text-background">
+                <span className="font-bold text-xs">B</span>
+              </div>
+              <span className="font-bold text-lg tracking-tight">babylon</span>
+            </div>
+            <button
+              type="button"
+              onClick={() => setIsMobileMarketListOpen(true)}
+              className="flex items-center gap-2 rounded-full bg-muted px-3 py-1.5"
+            >
+              <span className="font-bold text-sm">
+                {activeMarket?.ticker ?? 'Select'}
+              </span>
+              <span className="text-muted-foreground text-xs">▼</span>
+            </button>
+          </div>
+          <div className="px-3">
             <MarketsToggle
               activeTab={activeTab}
               onTabChange={onTabChange}
@@ -89,176 +308,229 @@ export function PerpsTradingTerminal({
           </div>
         </div>
 
-        <div className="ml-3 hidden items-center gap-2 text-muted-foreground text-xs md:flex">
-          <button
-            type="button"
-            onClick={() => setLeftCollapsed((v) => !v)}
-            className="rounded border border-white/10 bg-background/30 px-2 py-1 transition-colors hover:bg-muted/20 hover:text-foreground"
-          >
-            {leftCollapsed ? 'Show markets' : 'Hide markets'}
-          </button>
-          <button
-            type="button"
-            onClick={() => setRightCollapsed((v) => !v)}
-            className="rounded border border-white/10 bg-background/30 px-2 py-1 transition-colors hover:bg-muted/20 hover:text-foreground"
-          >
-            {rightCollapsed ? 'Show trade' : 'Hide trade'}
-          </button>
-          <button
-            type="button"
-            onClick={() => setBottomCollapsed((v) => !v)}
-            className="rounded border border-white/10 bg-background/30 px-2 py-1 transition-colors hover:bg-muted/20 hover:text-foreground"
-          >
-            {bottomCollapsed ? 'Show bottom' : 'Hide bottom'}
-          </button>
-        </div>
-      </div>
-
-      {/* Terminal body */}
-      <div className="flex min-h-0 flex-1 flex-row overflow-hidden">
-        {/* Left collapsed strip */}
-        {leftCollapsed && (
-          <button
-            type="button"
-            onClick={() => setLeftCollapsed(false)}
-            className="w-9 shrink-0 border-white/5 border-r bg-background/30 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground"
-            aria-label="Open markets panel"
-          >
-            <div className="flex h-full flex-col items-center justify-center gap-3">
-              <div className="h-6 w-6 rounded bg-muted/30" />
-              <span className="writing-vertical-lr rotate-180 font-semibold text-[10px] tracking-wider">
-                MARKETS
-              </span>
+        <div className="relative min-h-0 flex-1 overflow-hidden">
+          <div className="hide-scrollbar flex h-full flex-col overflow-y-auto overflow-x-hidden">
+            <div className="h-[45vh] w-full shrink-0 border-white/5 border-b">
+              <PerpsMarketDetailPanel market={activeMarket} />
             </div>
-          </button>
-        )}
 
-        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-          <PanelGroup direction="vertical" className="flex min-h-0 flex-1">
-            <Panel
-              defaultSize={bottomCollapsed ? 100 : 70}
-              minSize={35}
-              className="min-h-0"
-            >
-              <PanelGroup direction="horizontal" className="min-h-0">
-                {/* Left: Markets list */}
-                {!leftCollapsed && (
-                  <>
-                    <Panel
-                      defaultSize={22}
-                      minSize={15}
-                      maxSize={32}
-                      className="min-h-0 border-white/5 border-r"
-                    >
-                      <div className="flex h-full min-h-0 flex-col bg-background/20">
-                        {loading ? (
-                          <div className="p-3">
-                            <Skeleton className="h-8 w-full" />
-                            <div className="mt-3 space-y-2">
-                              <Skeleton className="h-10 w-full" />
-                              <Skeleton className="h-10 w-full" />
-                              <Skeleton className="h-10 w-full" />
-                            </div>
-                          </div>
-                        ) : error ? (
-                          <div className="p-4 text-muted-foreground text-sm">
-                            Failed to load markets.
-                          </div>
-                        ) : (
-                          <PerpsMarketListPanel
-                            markets={markets}
-                            activeTicker={activeTicker}
-                            onSelectTicker={setActiveTicker}
-                            onCollapse={() => setLeftCollapsed(true)}
-                          />
-                        )}
-                      </div>
-                    </Panel>
-                    <PanelResizeHandle className="w-1 bg-white/5 hover:bg-primary/40" />
-                  </>
-                )}
-
-                {/* Center: Market detail + chart */}
-                <Panel
-                  defaultSize={leftCollapsed ? 72 : 56}
-                  minSize={40}
-                  className="min-h-0"
-                >
-                  <div className="h-full min-h-0 bg-background/10">
-                    <PerpsMarketDetailPanel market={activeMarket} />
-                  </div>
-                </Panel>
-
-                {/* Right: Order entry */}
-                {!rightCollapsed && (
-                  <>
-                    <PanelResizeHandle className="w-1 bg-white/5 hover:bg-primary/40" />
-                    <Panel
-                      defaultSize={22}
-                      minSize={18}
-                      maxSize={32}
-                      className="min-h-0 border-white/5 border-l bg-background/20"
-                    >
-                      <PerpsOrderEntryPanel market={activeMarket} />
-                    </Panel>
-                  </>
-                )}
-
-                {/* Right collapsed strip */}
-                {rightCollapsed && (
+            <div className="sticky top-0 z-30 flex h-12 shrink-0 items-center border-white/5 border-b bg-background px-2 shadow-sm">
+              {(
+                [
+                  { id: 'positions', label: 'Positions', enabled: true },
+                  { id: 'orders', label: 'Orders', enabled: false },
+                  { id: 'pnl', label: 'PnL Analysis', enabled: false },
+                  { id: 'agent', label: 'Agent', enabled: false },
+                  { id: 'socials', label: 'Social', enabled: false },
+                  { id: 'trades', label: 'Trades', enabled: true },
+                ] as const
+              ).map(({ id, label, enabled }) => {
+                const isActive = activeMobileTab === id;
+                return (
                   <button
+                    key={id}
                     type="button"
-                    onClick={() => setRightCollapsed(false)}
-                    className="w-9 shrink-0 border-white/5 border-l bg-background/30 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground"
-                    aria-label="Open trade panel"
+                    disabled={!enabled}
+                    className={cn(
+                      'relative flex h-full min-w-[88px] flex-1 items-center justify-center py-3 font-bold text-sm capitalize transition-colors',
+                      isActive ? 'text-foreground' : 'text-muted-foreground',
+                      !enabled && 'cursor-not-allowed opacity-60'
+                    )}
+                    onClick={() => {
+                      if (!enabled) return;
+                      setActiveMobileTab(id);
+                    }}
                   >
-                    <div className="flex h-full flex-col items-center justify-center gap-3">
-                      <div className="h-6 w-6 rounded bg-muted/30" />
-                      <span className="writing-vertical-lr rotate-180 font-semibold text-[10px] tracking-wider">
-                        TRADE
+                    {label}
+                    {isActive && (
+                      <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
+                    )}
+                    {!enabled && (
+                      <span className="ml-2 rounded-full bg-muted/20 px-2 py-0.5 text-[10px] text-muted-foreground uppercase tracking-wider">
+                        Soon
                       </span>
-                    </div>
+                    )}
                   </button>
-                )}
-              </PanelGroup>
-            </Panel>
+                );
+              })}
+            </div>
 
-            {!bottomCollapsed && (
-              <>
-                <PanelResizeHandle className="h-1 bg-white/5 hover:bg-primary/40" />
-                <Panel
-                  defaultSize={30}
-                  minSize={12}
-                  className="min-h-0 border-white/5 border-t bg-background/20"
-                >
-                  <PerpsTerminalBottomPanel
-                    ticker={activeMarket?.ticker ?? null}
-                    activeTab={bottomTab}
-                    onTabChange={setBottomTab}
-                    onCollapse={() => setBottomCollapsed(true)}
-                  />
-                </Panel>
-              </>
-            )}
-          </PanelGroup>
+            <div className="min-h-[320px] flex-1">
+              <PerpsTerminalBottomPanel
+                ticker={activeMarket?.ticker ?? null}
+                activeTab={activeMobileTab}
+                onTabChange={setActiveMobileTab}
+                hideHeader
+              />
+            </div>
 
-          {bottomCollapsed && (
+            <div className="h-28 shrink-0" />
+          </div>
+
+          <div className="pointer-events-none absolute bottom-[calc(72px+env(safe-area-inset-bottom)+12px)] left-0 z-30 flex w-full justify-center px-4">
             <button
               type="button"
-              onClick={() => setBottomCollapsed(false)}
-              className={cn(
-                'flex h-7 shrink-0 items-center justify-between border-white/5 border-t bg-background/40 px-4 text-muted-foreground',
-                'transition-colors hover:bg-muted/20 hover:text-foreground'
-              )}
+              onClick={() => setIsMobileOrderSheetOpen(true)}
+              className="pointer-events-auto w-full max-w-sm rounded-full bg-foreground py-3.5 font-bold text-background shadow-lg transition-transform active:scale-95"
+              disabled={!activeMarket}
             >
-              <span className="font-semibold text-[10px] tracking-widest">
-                POSITIONS & TRADES
-              </span>
-              <span className="text-[10px]">▲</span>
+              Trade {activeMarket?.ticker ?? ''}
             </button>
+          </div>
+
+          <MobileBottomNav
+            authenticated={authenticated}
+            userId={user?.id ?? undefined}
+            username={user?.username ?? user?.email ?? undefined}
+            activePathname={pathname}
+          />
+
+          {isMobileMarketListOpen && (
+            <div className="fade-in slide-in-from-bottom-2 absolute inset-0 z-50 flex animate-in flex-col bg-background duration-200">
+              <div className="flex items-center justify-between border-white/5 border-b p-4">
+                <h2 className="font-bold text-lg">Markets</h2>
+                <button
+                  type="button"
+                  onClick={() => setIsMobileMarketListOpen(false)}
+                  className="rounded-full p-2 transition-colors hover:bg-muted/20"
+                  aria-label="Close markets list"
+                >
+                  <X size={20} />
+                </button>
+              </div>
+              <div className="min-h-0 flex-1 overflow-hidden">
+                {loading ? (
+                  <div className="p-3">
+                    <Skeleton className="h-8 w-full" />
+                    <div className="mt-3 space-y-2">
+                      <Skeleton className="h-10 w-full" />
+                      <Skeleton className="h-10 w-full" />
+                      <Skeleton className="h-10 w-full" />
+                    </div>
+                  </div>
+                ) : error ? (
+                  <div className="p-4 text-muted-foreground text-sm">
+                    Failed to load markets.
+                  </div>
+                ) : (
+                  <PerpsMarketListPanel
+                    markets={markets}
+                    activeTicker={activeTicker}
+                    onSelectTicker={(ticker) => {
+                      setActiveTicker(ticker);
+                      setIsMobileMarketListOpen(false);
+                    }}
+                    onCollapse={() => setIsMobileMarketListOpen(false)}
+                  />
+                )}
+              </div>
+            </div>
+          )}
+
+          {isMobileOrderSheetOpen && (
+            <div className="fixed inset-0 z-50 flex flex-col justify-end">
+              <button
+                type="button"
+                aria-label="Close trade sheet"
+                className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+                onClick={() => setIsMobileOrderSheetOpen(false)}
+              />
+              <div className="slide-in-from-bottom-2 relative z-10 flex max-h-[85vh] w-full animate-in flex-col rounded-t-2xl border-white/5 border-t bg-background/95 shadow-2xl duration-200">
+                <div className="flex items-center justify-between border-white/5 border-b p-4">
+                  <h2 className="font-bold text-lg">
+                    Trade {activeMarket?.ticker ?? ''}
+                  </h2>
+                  <button
+                    type="button"
+                    onClick={() => setIsMobileOrderSheetOpen(false)}
+                    className="rounded-full p-2 transition-colors hover:bg-muted/20"
+                    aria-label="Close trade sheet"
+                  >
+                    <X size={20} />
+                  </button>
+                </div>
+                <div className="min-h-0 flex-1 overflow-y-auto">
+                  <PerpsOrderEntryPanel market={activeMarket} />
+                </div>
+              </div>
+            </div>
           )}
         </div>
       </div>
+    </div>
+  );
+}
+
+function MobileBottomNav({
+  authenticated,
+  userId,
+  username,
+  activePathname,
+}: {
+  authenticated: boolean;
+  userId?: string;
+  username?: string;
+  activePathname: string;
+}) {
+  const items = [
+    {
+      href: '/profile',
+      key: 'profile',
+      label: 'Profile',
+      icon: (
+        <div className="h-6 w-6">
+          <Avatar
+            id={authenticated ? userId : undefined}
+            name={username}
+            type="user"
+            size="sm"
+            className="h-6 w-6"
+          />
+        </div>
+      ),
+    },
+    { href: '/', key: 'home', label: 'Home', icon: <Home size={22} /> },
+    {
+      href: '/notifications',
+      key: 'notifications',
+      label: 'Notifications',
+      icon: <Bell size={22} />,
+    },
+    {
+      href: '/leaderboard',
+      key: 'leaderboard',
+      label: 'Leaderboard',
+      icon: <Trophy size={22} />,
+    },
+    {
+      href: '/markets',
+      key: 'markets',
+      label: 'Markets',
+      icon: <BarChart2 size={22} strokeWidth={2.5} />,
+    },
+  ] as const;
+
+  return (
+    <div className="relative z-40 flex h-[72px] select-none items-center justify-between rounded-t-[20px] border-white/5 border-t bg-background px-2 pb-safe font-medium text-[10px] text-muted-foreground shadow-[0_-5px_15px_rgba(0,0,0,0.12)]">
+      {items.map((item) => {
+        const isActive =
+          item.href === '/markets'
+            ? activePathname.startsWith('/markets')
+            : activePathname === item.href;
+        return (
+          <Link
+            key={item.key}
+            href={item.href}
+            className={cn(
+              'flex flex-1 flex-col items-center justify-center gap-1 py-1 transition-colors',
+              isActive ? 'font-bold text-foreground' : 'hover:text-foreground'
+            )}
+          >
+            {item.icon}
+            <span className="scale-90">{item.label}</span>
+          </Link>
+        );
+      })}
     </div>
   );
 }

--- a/apps/web/src/app/markets/_components/perps-terminal/PerpsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/perps-terminal/PerpsTradingTerminal.tsx
@@ -1,0 +1,264 @@
+'use client';
+
+import { cn } from '@babylon/shared';
+import { useEffect, useMemo, useState } from 'react';
+import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
+import { MarketsToggle } from '@/components/shared/MarketsToggle';
+import { Skeleton } from '@/components/shared/Skeleton';
+import { useAuth } from '@/hooks/useAuth';
+import {
+  usePerpMarkets,
+  usePerpMarketsRealtime,
+} from '@/stores/perpMarketsStore';
+import { useUserPositionsPolling } from '@/stores/userPositionsStore';
+import {
+  useWalletBalance,
+  useWalletBalancePolling,
+} from '@/stores/walletBalanceStore';
+import type { MarketTab, PerpMarket } from '@/types/markets';
+import { PerpsMarketDetailPanel } from './PerpsMarketDetailPanel';
+import { PerpsMarketListPanel } from './PerpsMarketListPanel';
+import { PerpsOrderEntryPanel } from './PerpsOrderEntryPanel';
+import { PerpsTerminalBottomPanel } from './PerpsTerminalBottomPanel';
+
+interface PerpsTradingTerminalProps {
+  activeTab: MarketTab;
+  onTabChange: (tab: MarketTab) => void;
+}
+
+function pickDefaultMarket(markets: PerpMarket[]): PerpMarket | null {
+  if (markets.length === 0) return null;
+  const sorted = [...markets].sort(
+    (a, b) => (b.volume24h ?? 0) - (a.volume24h ?? 0)
+  );
+  return sorted[0] ?? null;
+}
+
+export function PerpsTradingTerminal({
+  activeTab,
+  onTabChange,
+}: PerpsTradingTerminalProps) {
+  const { user, authenticated } = useAuth();
+  const { markets, loading, error } = usePerpMarkets();
+  usePerpMarketsRealtime();
+
+  const userId = authenticated ? (user?.id ?? null) : null;
+  useUserPositionsPolling(userId);
+  useWalletBalancePolling(userId);
+
+  const { balance, loading: balanceLoading } = useWalletBalance(userId);
+
+  const [activeTicker, setActiveTicker] = useState<string | null>(null);
+  const [leftCollapsed, setLeftCollapsed] = useState(false);
+  const [rightCollapsed, setRightCollapsed] = useState(false);
+  const [bottomCollapsed, setBottomCollapsed] = useState(false);
+  const [bottomTab, setBottomTab] = useState<'positions' | 'trades'>(
+    'positions'
+  );
+
+  const fallbackMarket = useMemo(() => pickDefaultMarket(markets), [markets]);
+
+  useEffect(() => {
+    if (activeTicker) return;
+    if (!fallbackMarket) return;
+    setActiveTicker(fallbackMarket.ticker);
+  }, [activeTicker, fallbackMarket]);
+
+  const activeMarket = useMemo(() => {
+    if (!activeTicker) return null;
+    return (
+      markets.find(
+        (m) => m.ticker.toLowerCase() === activeTicker.toLowerCase()
+      ) ?? null
+    );
+  }, [markets, activeTicker]);
+
+  return (
+    <div className="relative flex h-full w-full flex-col overflow-hidden bg-background text-foreground">
+      {/* Terminal header (keeps app navigation coherent while matching terminal density) */}
+      <div className="flex h-10 shrink-0 items-center justify-between border-white/5 border-b bg-background/40 px-3 backdrop-blur-md">
+        <div className="flex min-w-0 flex-1 items-center">
+          <div className="min-w-0 flex-1">
+            <MarketsToggle
+              activeTab={activeTab}
+              onTabChange={onTabChange}
+              balance={balance}
+              authenticated={authenticated}
+              loading={balanceLoading}
+            />
+          </div>
+        </div>
+
+        <div className="ml-3 hidden items-center gap-2 text-muted-foreground text-xs md:flex">
+          <button
+            type="button"
+            onClick={() => setLeftCollapsed((v) => !v)}
+            className="rounded border border-white/10 bg-background/30 px-2 py-1 transition-colors hover:bg-muted/20 hover:text-foreground"
+          >
+            {leftCollapsed ? 'Show markets' : 'Hide markets'}
+          </button>
+          <button
+            type="button"
+            onClick={() => setRightCollapsed((v) => !v)}
+            className="rounded border border-white/10 bg-background/30 px-2 py-1 transition-colors hover:bg-muted/20 hover:text-foreground"
+          >
+            {rightCollapsed ? 'Show trade' : 'Hide trade'}
+          </button>
+          <button
+            type="button"
+            onClick={() => setBottomCollapsed((v) => !v)}
+            className="rounded border border-white/10 bg-background/30 px-2 py-1 transition-colors hover:bg-muted/20 hover:text-foreground"
+          >
+            {bottomCollapsed ? 'Show bottom' : 'Hide bottom'}
+          </button>
+        </div>
+      </div>
+
+      {/* Terminal body */}
+      <div className="flex min-h-0 flex-1 flex-row overflow-hidden">
+        {/* Left collapsed strip */}
+        {leftCollapsed && (
+          <button
+            type="button"
+            onClick={() => setLeftCollapsed(false)}
+            className="w-9 shrink-0 border-white/5 border-r bg-background/30 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground"
+            aria-label="Open markets panel"
+          >
+            <div className="flex h-full flex-col items-center justify-center gap-3">
+              <div className="h-6 w-6 rounded bg-muted/30" />
+              <span className="writing-vertical-lr rotate-180 font-semibold text-[10px] tracking-wider">
+                MARKETS
+              </span>
+            </div>
+          </button>
+        )}
+
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+          <PanelGroup direction="vertical" className="flex min-h-0 flex-1">
+            <Panel
+              defaultSize={bottomCollapsed ? 100 : 70}
+              minSize={35}
+              className="min-h-0"
+            >
+              <PanelGroup direction="horizontal" className="min-h-0">
+                {/* Left: Markets list */}
+                {!leftCollapsed && (
+                  <>
+                    <Panel
+                      defaultSize={22}
+                      minSize={15}
+                      maxSize={32}
+                      className="min-h-0 border-white/5 border-r"
+                    >
+                      <div className="flex h-full min-h-0 flex-col bg-background/20">
+                        {loading ? (
+                          <div className="p-3">
+                            <Skeleton className="h-8 w-full" />
+                            <div className="mt-3 space-y-2">
+                              <Skeleton className="h-10 w-full" />
+                              <Skeleton className="h-10 w-full" />
+                              <Skeleton className="h-10 w-full" />
+                            </div>
+                          </div>
+                        ) : error ? (
+                          <div className="p-4 text-muted-foreground text-sm">
+                            Failed to load markets.
+                          </div>
+                        ) : (
+                          <PerpsMarketListPanel
+                            markets={markets}
+                            activeTicker={activeTicker}
+                            onSelectTicker={setActiveTicker}
+                            onCollapse={() => setLeftCollapsed(true)}
+                          />
+                        )}
+                      </div>
+                    </Panel>
+                    <PanelResizeHandle className="w-1 bg-white/5 hover:bg-primary/40" />
+                  </>
+                )}
+
+                {/* Center: Market detail + chart */}
+                <Panel
+                  defaultSize={leftCollapsed ? 72 : 56}
+                  minSize={40}
+                  className="min-h-0"
+                >
+                  <div className="h-full min-h-0 bg-background/10">
+                    <PerpsMarketDetailPanel market={activeMarket} />
+                  </div>
+                </Panel>
+
+                {/* Right: Order entry */}
+                {!rightCollapsed && (
+                  <>
+                    <PanelResizeHandle className="w-1 bg-white/5 hover:bg-primary/40" />
+                    <Panel
+                      defaultSize={22}
+                      minSize={18}
+                      maxSize={32}
+                      className="min-h-0 border-white/5 border-l bg-background/20"
+                    >
+                      <PerpsOrderEntryPanel market={activeMarket} />
+                    </Panel>
+                  </>
+                )}
+
+                {/* Right collapsed strip */}
+                {rightCollapsed && (
+                  <button
+                    type="button"
+                    onClick={() => setRightCollapsed(false)}
+                    className="w-9 shrink-0 border-white/5 border-l bg-background/30 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground"
+                    aria-label="Open trade panel"
+                  >
+                    <div className="flex h-full flex-col items-center justify-center gap-3">
+                      <div className="h-6 w-6 rounded bg-muted/30" />
+                      <span className="writing-vertical-lr rotate-180 font-semibold text-[10px] tracking-wider">
+                        TRADE
+                      </span>
+                    </div>
+                  </button>
+                )}
+              </PanelGroup>
+            </Panel>
+
+            {!bottomCollapsed && (
+              <>
+                <PanelResizeHandle className="h-1 bg-white/5 hover:bg-primary/40" />
+                <Panel
+                  defaultSize={30}
+                  minSize={12}
+                  className="min-h-0 border-white/5 border-t bg-background/20"
+                >
+                  <PerpsTerminalBottomPanel
+                    ticker={activeMarket?.ticker ?? null}
+                    activeTab={bottomTab}
+                    onTabChange={setBottomTab}
+                    onCollapse={() => setBottomCollapsed(true)}
+                  />
+                </Panel>
+              </>
+            )}
+          </PanelGroup>
+
+          {bottomCollapsed && (
+            <button
+              type="button"
+              onClick={() => setBottomCollapsed(false)}
+              className={cn(
+                'flex h-7 shrink-0 items-center justify-between border-white/5 border-t bg-background/40 px-4 text-muted-foreground',
+                'transition-colors hover:bg-muted/20 hover:text-foreground'
+              )}
+            >
+              <span className="font-semibold text-[10px] tracking-widest">
+                POSITIONS & TRADES
+              </span>
+              <span className="text-[10px]">▲</span>
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/markets/_hooks/index.ts
+++ b/apps/web/src/app/markets/_hooks/index.ts
@@ -5,3 +5,4 @@ export type {
   TrendingPerpMarket,
 } from './useMarketsPageData';
 export { useMarketsPageData } from './useMarketsPageData';
+export { useWatchlistStore } from './useWatchlistStore';

--- a/apps/web/src/app/markets/_hooks/useWatchlistStore.ts
+++ b/apps/web/src/app/markets/_hooks/useWatchlistStore.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface WatchlistState {
+  favorites: string[];
+  toggleFavorite: (ticker: string) => void;
+  isFavorite: (ticker: string) => boolean;
+  clear: () => void;
+}
+
+function normalizeTicker(ticker: string): string {
+  return ticker.trim().toUpperCase();
+}
+
+export const useWatchlistStore = create<WatchlistState>()(
+  persist(
+    (set, get) => ({
+      favorites: [],
+      toggleFavorite: (ticker: string) => {
+        const normalized = normalizeTicker(ticker);
+        if (!normalized) return;
+
+        const existing = new Set(get().favorites.map(normalizeTicker));
+        if (existing.has(normalized)) {
+          existing.delete(normalized);
+        } else {
+          existing.add(normalized);
+        }
+        set({ favorites: Array.from(existing) });
+      },
+      isFavorite: (ticker: string) => {
+        const normalized = normalizeTicker(ticker);
+        if (!normalized) return false;
+        return get().favorites.map(normalizeTicker).includes(normalized);
+      },
+      clear: () => set({ favorites: [] }),
+    }),
+    {
+      name: 'markets.watchlist.v1',
+      version: 1,
+      partialize: (state) => ({ favorites: state.favorites }),
+    }
+  )
+);

--- a/apps/web/src/app/markets/page.tsx
+++ b/apps/web/src/app/markets/page.tsx
@@ -12,7 +12,6 @@ import {
   DashboardTabContent,
   LoginPrompt,
   MarketsSearchInput,
-  PerpsTabContent,
   PredictionsTabContent,
 } from './_components';
 import { useMarketsPageData } from './_hooks';
@@ -186,13 +185,6 @@ export default function MarketsPage() {
     [router]
   );
 
-  const handlePerpsTabMarketNavigation = useCallback(
-    (market: PerpMarket) => {
-      router.push(`/markets/perps/${market.ticker}?from=perps`);
-    },
-    [router]
-  );
-
   const handlePredictionClick = useCallback(
     (prediction: PredictionMarket) => {
       router.push(`/markets/predictions/${prediction.id}?from=dashboard`);
@@ -221,10 +213,6 @@ export default function MarketsPage() {
     () => setShowBuyPointsModal(false),
     []
   );
-  const handleShowPerpsPnLShare = useCallback(
-    () => setShowCategoryPnLShareModal('perps'),
-    []
-  );
   const handleShowPredictionsPnLShare = useCallback(
     () => setShowCategoryPnLShareModal('predictions'),
     []
@@ -234,68 +222,6 @@ export default function MarketsPage() {
     []
   );
 
-  // Quick Trade Handler
-  const handleTradeAction = useCallback(
-    (market: PerpMarket | PredictionMarketWithPosition, side: string) => {
-      // 1. Select the market
-      if ('ticker' in market) {
-        setSelectedMarket({
-          type: 'perp',
-          market,
-          side: side as 'long' | 'short',
-        });
-      } else {
-        setSelectedMarket({
-          type: 'prediction',
-          market,
-          side: side as 'yes' | 'no',
-        });
-      }
-      // 2. Ensure we are in Order Entry mode (if we had hidden it, though layout is persistent on Desktop)
-      // On mobile, this should navigate to detail page with side param ideally.
-      // For this task, we assume Desktop usage mainly or simple navigation.
-    },
-    []
-  );
-
-  const handlePerpsQuickTradeMobile = useCallback(
-    (market: PerpMarket, side: 'long' | 'short') => {
-      router.push(
-        `/markets/perps/${market.ticker}?from=perps&side=${encodeURIComponent(side)}`
-      );
-    },
-    [router]
-  );
-
-  // Keyboard Shortcuts
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      // Toggle Favorites Filter (Future)
-
-      // Search Focus (/)
-      if (
-        e.key === '/' &&
-        !['INPUT', 'TEXTAREA'].includes((e.target as HTMLElement).tagName)
-      ) {
-        e.preventDefault();
-        const searchInput = document.querySelector('input[type="text"]');
-        if (searchInput instanceof HTMLInputElement) {
-          searchInput.focus();
-        }
-      }
-
-      // Clear Selection / Blur (Esc)
-      if (e.key === 'Escape') {
-        if (document.activeElement instanceof HTMLElement) {
-          document.activeElement.blur();
-        }
-        setSelectedMarket(null);
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, []);
   if (data.loading) {
     return (
       <PageContainer noPadding className="flex flex-col">
@@ -340,32 +266,7 @@ export default function MarketsPage() {
           />
         );
       case 'perps':
-        return (
-          <PerpsTabContent
-            authenticated={data.authenticated}
-            perpPnLData={data.perpPnLData}
-            portfolioLoading={data.portfolioLoading}
-            portfolioError={data.portfolioError}
-            portfolioUpdatedAt={data.portfolioUpdatedAt}
-            onShowCategoryPnLShare={handleShowPerpsPnLShare}
-            onRefreshPortfolio={data.refreshPortfolio}
-            perpPositions={data.perpPositions}
-            onPositionClosed={data.handlePositionsRefresh}
-            filteredMarkets={data.filteredPerpMarkets}
-            onMarketClick={
-              isMobile ? handlePerpsTabMarketNavigation : handleMarketSelect
-            }
-            selectedMarketTicker={
-              selectedMarket?.type === 'perp'
-                ? selectedMarket.market.ticker
-                : null
-            }
-            onMarketSelect={handleMarketSelect}
-            onTradeAction={
-              isMobile ? handlePerpsQuickTradeMobile : handleTradeAction
-            }
-          />
-        );
+        return null;
       case 'predictions':
         return (
           <PredictionsTabContent
@@ -389,6 +290,8 @@ export default function MarketsPage() {
             compact={isMobile}
           />
         );
+      default:
+        return null;
     }
   };
 
@@ -406,77 +309,44 @@ export default function MarketsPage() {
         </div>
       ) : (
         <>
-          {/* Desktop Layout (Terminal) */}
-          <div className="hidden flex-1 overflow-hidden bg-background/20 xl:flex">
-            <>
-              {/* Left Panel: Navigation & Table */}
-              <div className="flex min-w-0 flex-1 flex-col overflow-hidden border-white/5 border-r">
-                {/* Header */}
-                <div className="sticky top-0 z-10 flex-shrink-0 bg-background/80 backdrop-blur-md">
-                  <div className="flex items-center justify-between border-white/5 border-b px-4 py-3">
-                    <MarketsToggle
+          <div className="hidden flex-1 overflow-hidden xl:flex">
+            <div className="flex min-w-0 flex-1 flex-col overflow-hidden border-[rgba(120,120,120,0.5)] lg:border-r lg:border-l">
+              <div className="sticky top-0 z-10 flex-shrink-0 bg-background shadow-sm">
+                <div className="px-3 sm:px-4 lg:px-6">
+                  <MarketsToggle
+                    activeTab={activeTab}
+                    onTabChange={handleTabChange}
+                    balance={data.portfolioPnL?.available}
+                    authenticated={data.authenticated}
+                    loading={data.portfolioLoading}
+                  />
+                </div>
+                {activeTab !== 'dashboard' && (
+                  <div className="px-3 pb-3 sm:px-4 lg:px-6">
+                    <MarketsSearchInput
+                      value={data.searchQuery}
+                      onChange={data.setSearchQuery}
                       activeTab={activeTab}
-                      onTabChange={handleTabChange}
-                      balance={data.portfolioPnL?.available}
-                      authenticated={data.authenticated}
-                      loading={data.portfolioLoading}
                     />
-                    {activeTab !== 'dashboard' && (
-                      <div className="w-[300px]">
-                        <MarketsSearchInput
-                          value={data.searchQuery}
-                          onChange={data.setSearchQuery}
-                          activeTab={activeTab}
-                        />
-                      </div>
-                    )}
                   </div>
-                </div>
-
-                {/* Content (Table) */}
-                <div
-                  className={`flex-1 overflow-y-auto p-4 transition-opacity duration-150 ${
-                    isPending ? 'opacity-80' : 'opacity-100'
-                  }`}
-                >
-                  {renderTabContent(false)}
-
-                  {!data.authenticated && activeTab !== 'dashboard' && (
-                    <div className="flex justify-center p-8">
-                      <LoginPrompt onLogin={data.login} />
-                    </div>
-                  )}
-                </div>
+                )}
               </div>
 
-              {/* Right Panel: Order Entry & Aux (Positions later) */}
-              {activeTab !== 'dashboard' && selectedMarket && (
-                <div className="flex w-[380px] flex-col border-white/5 border-l bg-background/30 backdrop-blur-sm">
-                  <OrderEntryPanel
-                    selectedMarket={selectedMarket}
-                    onTradeClick={handleOrderEntryTrade}
-                    onClose={() => setSelectedMarket(null)}
-                    className="flex-1"
-                  />
-                  {/* Positions Panel (Bottom Right) */}
-                  <div className="min-h-[250px] flex-1 overflow-hidden border-white/5 border-t bg-background/30">
-                    <PositionsPanel
-                      activeTab={activeTab}
-                      perpPositions={data.perpPositions}
-                      predictionPositions={data.predictionPositions}
-                      onPositionClosed={data.handlePositionsRefresh}
-                      onPositionSold={data.handlePositionsRefresh}
-                      className="h-full"
-                    />
-                  </div>
-                </div>
+              <div
+                className={`flex-1 overflow-y-auto transition-opacity duration-150 ${
+                  isPending ? 'opacity-80' : 'opacity-100'
+                }`}
+              >
+                {renderTabContent(false)}
+              </div>
+
+              {!data.authenticated && activeTab !== 'dashboard' && (
+                <LoginPrompt onLogin={data.login} />
               )}
-            </>
+            </div>
           </div>
 
-          {/* Mobile/Tablet Layout (Stack) */}
           <div className="flex flex-1 flex-col overflow-hidden xl:hidden">
-            {/* Original Mobile Header */}
             <div className="sticky top-0 z-10 flex-shrink-0 bg-background shadow-sm">
               <div className="px-3 sm:px-4">
                 <MarketsToggle
@@ -498,7 +368,6 @@ export default function MarketsPage() {
               )}
             </div>
 
-            {/* Content */}
             <div
               className={`flex-1 overflow-y-auto transition-opacity duration-150 ${
                 isPending ? 'opacity-80' : 'opacity-100'

--- a/apps/web/src/app/markets/page.tsx
+++ b/apps/web/src/app/markets/page.tsx
@@ -397,119 +397,122 @@ export default function MarketsPage() {
       noPadding
       className="flex h-[calc(100vh-theme(spacing.16))] flex-col"
     >
-      {/* Desktop Layout (Terminal) */}
-      <div className="hidden flex-1 overflow-hidden bg-background/20 xl:flex">
-        {activeTab === 'perps' ? (
+      {activeTab === 'perps' ? (
+        <div className="flex flex-1 overflow-hidden bg-background/20">
           <PerpsTradingTerminal
             activeTab={activeTab}
             onTabChange={handleTabChange}
           />
-        ) : (
-          <>
-            {/* Left Panel: Navigation & Table */}
-            <div className="flex min-w-0 flex-1 flex-col overflow-hidden border-white/5 border-r">
-              {/* Header */}
-              <div className="sticky top-0 z-10 flex-shrink-0 bg-background/80 backdrop-blur-md">
-                <div className="flex items-center justify-between border-white/5 border-b px-4 py-3">
-                  <MarketsToggle
-                    activeTab={activeTab}
-                    onTabChange={handleTabChange}
-                    balance={data.portfolioPnL?.available}
-                    authenticated={data.authenticated}
-                    loading={data.portfolioLoading}
-                  />
-                  {activeTab !== 'dashboard' && (
-                    <div className="w-[300px]">
-                      <MarketsSearchInput
-                        value={data.searchQuery}
-                        onChange={data.setSearchQuery}
-                        activeTab={activeTab}
-                      />
+        </div>
+      ) : (
+        <>
+          {/* Desktop Layout (Terminal) */}
+          <div className="hidden flex-1 overflow-hidden bg-background/20 xl:flex">
+            <>
+              {/* Left Panel: Navigation & Table */}
+              <div className="flex min-w-0 flex-1 flex-col overflow-hidden border-white/5 border-r">
+                {/* Header */}
+                <div className="sticky top-0 z-10 flex-shrink-0 bg-background/80 backdrop-blur-md">
+                  <div className="flex items-center justify-between border-white/5 border-b px-4 py-3">
+                    <MarketsToggle
+                      activeTab={activeTab}
+                      onTabChange={handleTabChange}
+                      balance={data.portfolioPnL?.available}
+                      authenticated={data.authenticated}
+                      loading={data.portfolioLoading}
+                    />
+                    {activeTab !== 'dashboard' && (
+                      <div className="w-[300px]">
+                        <MarketsSearchInput
+                          value={data.searchQuery}
+                          onChange={data.setSearchQuery}
+                          activeTab={activeTab}
+                        />
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                {/* Content (Table) */}
+                <div
+                  className={`flex-1 overflow-y-auto p-4 transition-opacity duration-150 ${
+                    isPending ? 'opacity-80' : 'opacity-100'
+                  }`}
+                >
+                  {renderTabContent(false)}
+
+                  {!data.authenticated && activeTab !== 'dashboard' && (
+                    <div className="flex justify-center p-8">
+                      <LoginPrompt onLogin={data.login} />
                     </div>
                   )}
                 </div>
               </div>
 
-              {/* Content (Table) */}
-              <div
-                className={`flex-1 overflow-y-auto p-4 transition-opacity duration-150 ${
-                  isPending ? 'opacity-80' : 'opacity-100'
-                }`}
-              >
-                {renderTabContent(false)}
-
-                {!data.authenticated && activeTab !== 'dashboard' && (
-                  <div className="flex justify-center p-8">
-                    <LoginPrompt onLogin={data.login} />
+              {/* Right Panel: Order Entry & Aux (Positions later) */}
+              {activeTab !== 'dashboard' && selectedMarket && (
+                <div className="flex w-[380px] flex-col border-white/5 border-l bg-background/30 backdrop-blur-sm">
+                  <OrderEntryPanel
+                    selectedMarket={selectedMarket}
+                    onTradeClick={handleOrderEntryTrade}
+                    onClose={() => setSelectedMarket(null)}
+                    className="flex-1"
+                  />
+                  {/* Positions Panel (Bottom Right) */}
+                  <div className="min-h-[250px] flex-1 overflow-hidden border-white/5 border-t bg-background/30">
+                    <PositionsPanel
+                      activeTab={activeTab}
+                      perpPositions={data.perpPositions}
+                      predictionPositions={data.predictionPositions}
+                      onPositionClosed={data.handlePositionsRefresh}
+                      onPositionSold={data.handlePositionsRefresh}
+                      className="h-full"
+                    />
                   </div>
-                )}
-              </div>
-            </div>
+                </div>
+              )}
+            </>
+          </div>
 
-            {/* Right Panel: Order Entry & Aux (Positions later) */}
-            {activeTab !== 'dashboard' && selectedMarket && (
-              <div className="flex w-[380px] flex-col border-white/5 border-l bg-background/30 backdrop-blur-sm">
-                <OrderEntryPanel
-                  selectedMarket={selectedMarket}
-                  onTradeClick={handleOrderEntryTrade}
-                  onClose={() => setSelectedMarket(null)}
-                  className="flex-1"
+          {/* Mobile/Tablet Layout (Stack) */}
+          <div className="flex flex-1 flex-col overflow-hidden xl:hidden">
+            {/* Original Mobile Header */}
+            <div className="sticky top-0 z-10 flex-shrink-0 bg-background shadow-sm">
+              <div className="px-3 sm:px-4">
+                <MarketsToggle
+                  activeTab={activeTab}
+                  onTabChange={handleTabChange}
+                  balance={data.portfolioPnL?.available}
+                  authenticated={data.authenticated}
+                  loading={data.portfolioLoading}
                 />
-                {/* Positions Panel (Bottom Right) */}
-                <div className="min-h-[250px] flex-1 overflow-hidden border-white/5 border-t bg-background/30">
-                  <PositionsPanel
+              </div>
+              {activeTab !== 'dashboard' && (
+                <div className="px-3 pb-3 sm:px-4">
+                  <MarketsSearchInput
+                    value={data.searchQuery}
+                    onChange={data.setSearchQuery}
                     activeTab={activeTab}
-                    perpPositions={data.perpPositions}
-                    predictionPositions={data.predictionPositions}
-                    onPositionClosed={data.handlePositionsRefresh}
-                    onPositionSold={data.handlePositionsRefresh}
-                    className="h-full"
                   />
                 </div>
-              </div>
-            )}
-          </>
-        )}
-      </div>
-
-      {/* Mobile/Tablet Layout */}
-      <div className="flex flex-1 flex-col overflow-hidden xl:hidden">
-        {/* Header */}
-        <div className="sticky top-0 z-10 flex-shrink-0 bg-background shadow-sm">
-          <div className="px-3 sm:px-4">
-            <MarketsToggle
-              activeTab={activeTab}
-              onTabChange={handleTabChange}
-              balance={data.portfolioPnL?.available}
-              authenticated={data.authenticated}
-              loading={data.portfolioLoading}
-            />
-          </div>
-          {activeTab !== 'dashboard' && (
-            <div className="px-3 pb-3 sm:px-4">
-              <MarketsSearchInput
-                value={data.searchQuery}
-                onChange={data.setSearchQuery}
-                activeTab={activeTab}
-              />
+              )}
             </div>
-          )}
-        </div>
 
-        {/* Content */}
-        <div
-          className={`flex-1 overflow-y-auto transition-opacity duration-150 ${
-            isPending ? 'opacity-80' : 'opacity-100'
-          }`}
-        >
-          {renderTabContent(true)}
-        </div>
+            {/* Content */}
+            <div
+              className={`flex-1 overflow-y-auto transition-opacity duration-150 ${
+                isPending ? 'opacity-80' : 'opacity-100'
+              }`}
+            >
+              {renderTabContent(true)}
+            </div>
 
-        {/* Login prompt for non-dashboard tabs */}
-        {!data.authenticated && activeTab !== 'dashboard' && (
-          <LoginPrompt onLogin={data.login} />
-        )}
-      </div>
+            {!data.authenticated && activeTab !== 'dashboard' && (
+              <LoginPrompt onLogin={data.login} />
+            )}
+          </div>
+        </>
+      )}
 
       {/* Lazy loaded modals */}
       {showPnLShareModal && (

--- a/apps/web/src/app/markets/page.tsx
+++ b/apps/web/src/app/markets/page.tsx
@@ -42,6 +42,14 @@ const BuyPointsModal = dynamic(
   { ssr: false }
 );
 
+const PerpsTradingTerminal = dynamic(
+  () =>
+    import('./_components/perps-terminal/PerpsTradingTerminal').then((m) => ({
+      default: m.PerpsTradingTerminal,
+    })),
+  { ssr: false }
+);
+
 /**
  * Valid tab values from URL params.
  */
@@ -297,46 +305,83 @@ export default function MarketsPage() {
   };
 
   return (
-    <PageContainer noPadding className="flex flex-col">
-      {/* Desktop Layout */}
-      <div className="hidden flex-1 overflow-hidden xl:flex">
-        <div className="flex min-w-0 flex-1 flex-col overflow-hidden border-[rgba(120,120,120,0.5)] lg:border-r lg:border-l">
-          {/* Header */}
-          <div className="sticky top-0 z-10 flex-shrink-0 bg-background shadow-sm">
-            <div className="px-3 sm:px-4 lg:px-6">
-              <MarketsToggle
-                activeTab={activeTab}
-                onTabChange={handleTabChange}
-                balance={data.portfolioPnL?.available}
-                authenticated={data.authenticated}
-                loading={data.portfolioLoading}
-              />
+    <PageContainer
+      noPadding
+      className="flex h-[calc(100vh-theme(spacing.16))] flex-col"
+    >
+      {/* Desktop Layout (Terminal) */}
+      <div className="hidden flex-1 overflow-hidden bg-background/20 xl:flex">
+        {activeTab === 'perps' ? (
+          <PerpsTradingTerminal
+            activeTab={activeTab}
+            onTabChange={handleTabChange}
+          />
+        ) : (
+          <>
+            {/* Left Panel: Navigation & Table */}
+            <div className="flex min-w-0 flex-1 flex-col overflow-hidden border-white/5 border-r">
+              {/* Header */}
+              <div className="sticky top-0 z-10 flex-shrink-0 bg-background/80 backdrop-blur-md">
+                <div className="flex items-center justify-between border-white/5 border-b px-4 py-3">
+                  <MarketsToggle
+                    activeTab={activeTab}
+                    onTabChange={handleTabChange}
+                    balance={data.portfolioPnL?.available}
+                    authenticated={data.authenticated}
+                    loading={data.portfolioLoading}
+                  />
+                  {activeTab !== 'dashboard' && (
+                    <div className="w-[300px]">
+                      <MarketsSearchInput
+                        value={data.searchQuery}
+                        onChange={data.setSearchQuery}
+                        activeTab={activeTab}
+                      />
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* Content (Table) */}
+              <div
+                className={`flex-1 overflow-y-auto p-4 transition-opacity duration-150 ${
+                  isPending ? 'opacity-80' : 'opacity-100'
+                }`}
+              >
+                {renderTabContent(false)}
+
+                {!data.authenticated && activeTab !== 'dashboard' && (
+                  <div className="flex justify-center p-8">
+                    <LoginPrompt onLogin={data.login} />
+                  </div>
+                )}
+              </div>
             </div>
-            {activeTab !== 'dashboard' && (
-              <div className="px-3 pb-3 sm:px-4 lg:px-6">
-                <MarketsSearchInput
-                  value={data.searchQuery}
-                  onChange={data.setSearchQuery}
-                  activeTab={activeTab}
+
+            {/* Right Panel: Order Entry & Aux (Positions later) */}
+            {activeTab !== 'dashboard' && selectedMarket && (
+              <div className="flex w-[380px] flex-col border-white/5 border-l bg-background/30 backdrop-blur-sm">
+                <OrderEntryPanel
+                  selectedMarket={selectedMarket}
+                  onTradeClick={handleOrderEntryTrade}
+                  onClose={() => setSelectedMarket(null)}
+                  className="flex-1"
                 />
+                {/* Positions Panel (Bottom Right) */}
+                <div className="min-h-[250px] flex-1 overflow-hidden border-white/5 border-t bg-background/30">
+                  <PositionsPanel
+                    activeTab={activeTab}
+                    perpPositions={data.perpPositions}
+                    predictionPositions={data.predictionPositions}
+                    onPositionClosed={data.handlePositionsRefresh}
+                    onPositionSold={data.handlePositionsRefresh}
+                    className="h-full"
+                  />
+                </div>
               </div>
             )}
-          </div>
-
-          {/* Content */}
-          <div
-            className={`flex-1 overflow-y-auto transition-opacity duration-150 ${
-              isPending ? 'opacity-80' : 'opacity-100'
-            }`}
-          >
-            {renderTabContent(false)}
-          </div>
-
-          {/* Login prompt for non-dashboard tabs */}
-          {!data.authenticated && activeTab !== 'dashboard' && (
-            <LoginPrompt onLogin={data.login} />
-          )}
-        </div>
+          </>
+        )}
       </div>
 
       {/* Mobile/Tablet Layout */}

--- a/apps/web/src/app/markets/page.tsx
+++ b/apps/web/src/app/markets/page.tsx
@@ -59,7 +59,7 @@ const VALID_TABS: MarketTab[] = ['dashboard', 'perps', 'predictions'];
  * Parse tab from URL search params.
  */
 function parseTabFromParams(params: URLSearchParams): MarketTab {
-  const tab = params.get('tab');
+  const tab = params.get('tab') ?? params.get('tabs');
   if (tab && VALID_TABS.includes(tab as MarketTab)) {
     return tab as MarketTab;
   }

--- a/apps/web/src/app/markets/page.tsx
+++ b/apps/web/src/app/markets/page.tsx
@@ -186,9 +186,23 @@ export default function MarketsPage() {
     [router]
   );
 
+  const handlePerpsTabMarketNavigation = useCallback(
+    (market: PerpMarket) => {
+      router.push(`/markets/perps/${market.ticker}?from=perps`);
+    },
+    [router]
+  );
+
   const handlePredictionClick = useCallback(
     (prediction: PredictionMarket) => {
       router.push(`/markets/predictions/${prediction.id}?from=dashboard`);
+    },
+    [router]
+  );
+
+  const handlePredictionNavigation = useCallback(
+    (prediction: PredictionMarket) => {
+      router.push(`/markets/predictions/${prediction.id}?from=predictions`);
     },
     [router]
   );
@@ -220,7 +234,68 @@ export default function MarketsPage() {
     []
   );
 
-  // Loading state
+  // Quick Trade Handler
+  const handleTradeAction = useCallback(
+    (market: PerpMarket | PredictionMarketWithPosition, side: string) => {
+      // 1. Select the market
+      if ('ticker' in market) {
+        setSelectedMarket({
+          type: 'perp',
+          market,
+          side: side as 'long' | 'short',
+        });
+      } else {
+        setSelectedMarket({
+          type: 'prediction',
+          market,
+          side: side as 'yes' | 'no',
+        });
+      }
+      // 2. Ensure we are in Order Entry mode (if we had hidden it, though layout is persistent on Desktop)
+      // On mobile, this should navigate to detail page with side param ideally.
+      // For this task, we assume Desktop usage mainly or simple navigation.
+    },
+    []
+  );
+
+  const handlePerpsQuickTradeMobile = useCallback(
+    (market: PerpMarket, side: 'long' | 'short') => {
+      router.push(
+        `/markets/perps/${market.ticker}?from=perps&side=${encodeURIComponent(side)}`
+      );
+    },
+    [router]
+  );
+
+  // Keyboard Shortcuts
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Toggle Favorites Filter (Future)
+
+      // Search Focus (/)
+      if (
+        e.key === '/' &&
+        !['INPUT', 'TEXTAREA'].includes((e.target as HTMLElement).tagName)
+      ) {
+        e.preventDefault();
+        const searchInput = document.querySelector('input[type="text"]');
+        if (searchInput instanceof HTMLInputElement) {
+          searchInput.focus();
+        }
+      }
+
+      // Clear Selection / Blur (Esc)
+      if (e.key === 'Escape') {
+        if (document.activeElement instanceof HTMLElement) {
+          document.activeElement.blur();
+        }
+        setSelectedMarket(null);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
   if (data.loading) {
     return (
       <PageContainer noPadding className="flex flex-col">
@@ -277,7 +352,18 @@ export default function MarketsPage() {
             perpPositions={data.perpPositions}
             onPositionClosed={data.handlePositionsRefresh}
             filteredMarkets={data.filteredPerpMarkets}
-            onMarketClick={handleMarketClick}
+            onMarketClick={
+              isMobile ? handlePerpsTabMarketNavigation : handleMarketSelect
+            }
+            selectedMarketTicker={
+              selectedMarket?.type === 'perp'
+                ? selectedMarket.market.ticker
+                : null
+            }
+            onMarketSelect={handleMarketSelect}
+            onTradeAction={
+              isMobile ? handlePerpsQuickTradeMobile : handleTradeAction
+            }
           />
         );
       case 'predictions':
@@ -296,7 +382,9 @@ export default function MarketsPage() {
             onSortChange={data.setPredictionSort}
             activePredictions={data.activePredictions}
             resolvedPredictions={data.resolvedPredictions}
-            onPredictionClick={handlePredictionClick}
+            onPredictionClick={
+              isMobile ? handlePredictionNavigation : handlePredictionClick
+            }
             predictionsError={data.predictionsError}
             compact={isMobile}
           />

--- a/apps/web/src/app/markets/perps/[ticker]/page.tsx
+++ b/apps/web/src/app/markets/perps/[ticker]/page.tsx
@@ -56,12 +56,16 @@ export default function PerpDetailPage() {
   const ticker = params.ticker as string;
   const { trackMarketView } = useMarketTracking();
   const from = searchParams.get('from');
+  const sideParam = searchParams.get('side');
 
   // Use shared perp markets store
   const { market, loading, refetch, initialLoadComplete } =
     usePerpMarket(ticker);
 
-  const [side, setSide] = useState<'long' | 'short'>('long');
+  const [side, setSide] = useState<'long' | 'short'>(() => {
+    if (sideParam === 'short') return 'short';
+    return 'long';
+  });
   const [size, setSize] = useState('100');
   const [leverage, setLeverage] = useState(10);
   const [submitting, setSubmitting] = useState(false);
@@ -128,6 +132,17 @@ export default function PerpDetailPage() {
       trackMarketView(ticker, 'perp');
     }
   }, [ticker, market, trackMarketView]);
+
+  // Sync side from URL (used by mobile quick-trade buttons)
+  useEffect(() => {
+    if (sideParam === 'short') {
+      setSide('short');
+      return;
+    }
+    if (sideParam === 'long') {
+      setSide('long');
+    }
+  }, [sideParam]);
 
   // Redirect if market not found after initial load is complete
   useEffect(() => {

--- a/apps/web/src/components/charts/LightweightChartBase.tsx
+++ b/apps/web/src/components/charts/LightweightChartBase.tsx
@@ -171,6 +171,7 @@ export function useLightweightChart(
     let mounted = true;
     let rafId: number | null = null;
     let resizeObserver: ResizeObserver | null = null;
+    let initTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
     const createChartInstance = () => {
       const container = chartContainerRef.current;
@@ -225,6 +226,43 @@ export function useLightweightChart(
     // Use RAF to ensure DOM is ready after hydration
     scheduleCreate();
 
+    // If we still haven't created a chart shortly after mount, surface a concrete error.
+    // This prevents "Initializing chart..." from hanging forever when the container never
+    // gets real dimensions (a common layout bug).
+    initTimeoutId = setTimeout(() => {
+      if (!mounted) return;
+      if (chartInstanceRef.current) return;
+
+      const container = chartContainerRef.current;
+      if (!container) {
+        setError('Chart container ref was not attached.');
+        // eslint-disable-next-line no-console
+        console.error('[useLightweightChart] container ref missing');
+        return;
+      }
+
+      const { width, height } = container.getBoundingClientRect();
+      if (width === 0 || height === 0) {
+        const message = `Chart container has zero size (${Math.floor(width)}x${Math.floor(height)}).`;
+        setError(message);
+        // eslint-disable-next-line no-console
+        console.error('[useLightweightChart]', message, container);
+        return;
+      }
+
+      // We have dimensions but still no chart; try once more and then error.
+      scheduleCreate();
+      setTimeout(() => {
+        if (!mounted) return;
+        if (chartInstanceRef.current) return;
+        const retryRect = container.getBoundingClientRect();
+        const message = `Chart failed to initialize (container ${Math.floor(retryRect.width)}x${Math.floor(retryRect.height)}).`;
+        setError(message);
+        // eslint-disable-next-line no-console
+        console.error('[useLightweightChart]', message, container);
+      }, 250);
+    }, 1500);
+
     // If the chart initially mounts into a zero-sized container (common with tabs/panels),
     // listen for size changes and retry initialization when dimensions become available.
     if (typeof ResizeObserver !== 'undefined') {
@@ -270,6 +308,10 @@ export function useLightweightChart(
       mounted = false;
       if (rafId !== null) {
         cancelAnimationFrame(rafId);
+      }
+      if (initTimeoutId) {
+        clearTimeout(initTimeoutId);
+        initTimeoutId = null;
       }
       if (resizeObserver) {
         resizeObserver.disconnect();

--- a/apps/web/src/components/charts/LightweightChartBase.tsx
+++ b/apps/web/src/components/charts/LightweightChartBase.tsx
@@ -166,10 +166,9 @@ export function useLightweightChart(
     // Skip during SSR
     if (typeof window === 'undefined') return;
 
-    let rafId: number | null = null;
     let mounted = true;
-    let retryCount = 0;
-    const MAX_RETRIES = 60; // ~1 second at 60fps
+    let rafId: number | null = null;
+    let resizeObserver: ResizeObserver | null = null;
 
     const createChartInstance = () => {
       const container = chartContainerRef.current;
@@ -181,17 +180,6 @@ export function useLightweightChart(
       // Check if container has dimensions
       const { width, height } = container.getBoundingClientRect();
       if (width === 0 || height === 0) {
-        retryCount++;
-        if (retryCount >= MAX_RETRIES) {
-          logger.warn(
-            'Chart container never acquired dimensions after max retries',
-            { retryCount },
-            'useLightweightChart'
-          );
-          return;
-        }
-        // Container not ready yet, retry on next frame
-        rafId = requestAnimationFrame(createChartInstance);
         return;
       }
 
@@ -215,14 +203,40 @@ export function useLightweightChart(
       }
     };
 
+    const scheduleCreate = () => {
+      if (rafId !== null) cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(createChartInstance);
+    };
+
     // Use RAF to ensure DOM is ready after hydration
-    rafId = requestAnimationFrame(createChartInstance);
+    scheduleCreate();
+
+    // If the chart initially mounts into a zero-sized container (common with tabs/panels),
+    // listen for size changes and retry initialization when dimensions become available.
+    if (typeof ResizeObserver !== 'undefined') {
+      resizeObserver = new ResizeObserver(() => {
+        scheduleCreate();
+      });
+      if (chartContainerRef.current) {
+        resizeObserver.observe(chartContainerRef.current);
+      }
+    }
+
+    const handleVisibility = () => {
+      scheduleCreate();
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
 
     return () => {
       mounted = false;
       if (rafId !== null) {
         cancelAnimationFrame(rafId);
       }
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+        resizeObserver = null;
+      }
+      document.removeEventListener('visibilitychange', handleVisibility);
       if (chartInstanceRef.current) {
         chartInstanceRef.current.remove();
         chartInstanceRef.current = null;

--- a/apps/web/src/components/charts/LightweightChartBase.tsx
+++ b/apps/web/src/components/charts/LightweightChartBase.tsx
@@ -138,6 +138,7 @@ export const LINE_STYLES = {
 interface UseLightweightChartResult {
   chartContainerRef: React.RefObject<HTMLDivElement | null>;
   chart: IChartApi | null;
+  error: string | null;
 }
 
 /**
@@ -158,6 +159,7 @@ export function useLightweightChart(
 ): UseLightweightChartResult {
   const chartContainerRef = useRef<HTMLDivElement | null>(null);
   const [chart, setChart] = useState<IChartApi | null>(null);
+  const [error, setError] = useState<string | null>(null);
   const chartInstanceRef = useRef<IChartApi | null>(null);
   // Capture initial options to avoid re-creating chart on every render
   const initialOptionsRef = useRef(options);
@@ -184,6 +186,7 @@ export function useLightweightChart(
       }
 
       try {
+        setError(null);
         // NOTE: Do not rely on `autoSize` here.
         // Our repo pins lightweight-charts ~5.0.x in some environments, and `autoSize`
         // support can be inconsistent. We instead pass explicit dimensions and handle
@@ -200,6 +203,12 @@ export function useLightweightChart(
           setChart(chartInstance);
         }
       } catch (error) {
+        const message =
+          error instanceof Error ? error.message : 'Failed to create chart';
+        setError(message);
+        // Ensure we always surface this in devtools; logger output can be filtered.
+        // eslint-disable-next-line no-console
+        console.error('[useLightweightChart] createChart failed:', error);
         logger.error(
           'Failed to create chart',
           { error },
@@ -237,6 +246,9 @@ export function useLightweightChart(
             height: Math.floor(height),
           });
         } catch (error) {
+          const message =
+            error instanceof Error ? error.message : 'Failed to resize chart';
+          setError(message);
           logger.warn(
             'Failed to resize chart',
             { error },
@@ -272,7 +284,7 @@ export function useLightweightChart(
     };
   }, []);
 
-  return { chartContainerRef, chart };
+  return { chartContainerRef, chart, error };
 }
 
 /**

--- a/apps/web/src/components/charts/LightweightChartBase.tsx
+++ b/apps/web/src/components/charts/LightweightChartBase.tsx
@@ -184,10 +184,15 @@ export function useLightweightChart(
       }
 
       try {
+        // NOTE: Do not rely on `autoSize` here.
+        // Our repo pins lightweight-charts ~5.0.x in some environments, and `autoSize`
+        // support can be inconsistent. We instead pass explicit dimensions and handle
+        // resizing via ResizeObserver below.
         const chartInstance = createChart(container, {
           ...DARK_CHART_THEME,
           ...initialOptionsRef.current,
-          autoSize: true,
+          width: Math.floor(width),
+          height: Math.floor(height),
         });
 
         chartInstanceRef.current = chartInstance;
@@ -215,7 +220,29 @@ export function useLightweightChart(
     // listen for size changes and retry initialization when dimensions become available.
     if (typeof ResizeObserver !== 'undefined') {
       resizeObserver = new ResizeObserver(() => {
-        scheduleCreate();
+        const container = chartContainerRef.current;
+        if (!container) return;
+
+        const instance = chartInstanceRef.current;
+        if (!instance) {
+          scheduleCreate();
+          return;
+        }
+
+        const { width, height } = container.getBoundingClientRect();
+        if (width === 0 || height === 0) return;
+        try {
+          instance.applyOptions({
+            width: Math.floor(width),
+            height: Math.floor(height),
+          });
+        } catch (error) {
+          logger.warn(
+            'Failed to resize chart',
+            { error },
+            'useLightweightChart'
+          );
+        }
       });
       if (chartContainerRef.current) {
         resizeObserver.observe(chartContainerRef.current);

--- a/apps/web/src/components/markets/PerpPriceChart.tsx
+++ b/apps/web/src/components/markets/PerpPriceChart.tsx
@@ -86,7 +86,11 @@ export function PerpPriceChart({
   > | null>(null);
   const seriesInitialized = useRef(false);
 
-  const { chartContainerRef, chart } = useLightweightChart({
+  const {
+    chartContainerRef,
+    chart,
+    error: chartBaseError,
+  } = useLightweightChart({
     crosshair: {
       mode: CrosshairMode.Normal,
     },
@@ -295,6 +299,17 @@ export function PerpPriceChart({
         <div className="text-center">
           <div className="text-sm">Chart unavailable</div>
           <div className="mt-1 text-xs">{chartInitError}</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (chartBaseError) {
+    return (
+      <div className="flex h-[400px] items-center justify-center text-muted-foreground">
+        <div className="text-center">
+          <div className="text-sm">Chart unavailable</div>
+          <div className="mt-1 text-xs">{chartBaseError}</div>
         </div>
       </div>
     );

--- a/apps/web/src/components/markets/PerpPriceChart.tsx
+++ b/apps/web/src/components/markets/PerpPriceChart.tsx
@@ -73,7 +73,7 @@ interface PerpPriceChartProps {
 export function PerpPriceChart({
   data,
   currentPrice,
-  ticker,
+  ticker: _ticker,
   timeRange,
   onTimeRangeChange,
   showHeader = true,

--- a/apps/web/src/components/markets/PerpPriceChart.tsx
+++ b/apps/web/src/components/markets/PerpPriceChart.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { cn } from '@babylon/shared';
 import type { ISeriesApi, Time } from 'lightweight-charts';
 import { AreaSeries, CrosshairMode } from 'lightweight-charts';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -45,6 +46,10 @@ interface PerpPriceChartProps {
   onTimeRangeChange: (range: MarketTimeRange) => void;
   /** Whether to show brush selector (unused, for future) */
   showBrush?: boolean;
+  /** Whether to show the header (price + range controls). Defaults to true. */
+  showHeader?: boolean;
+  /** Optional className for the container */
+  className?: string;
 }
 
 /**
@@ -71,6 +76,8 @@ export function PerpPriceChart({
   ticker,
   timeRange,
   onTimeRangeChange,
+  showHeader = true,
+  className,
 }: PerpPriceChartProps) {
   const [chartInitError, setChartInitError] = useState<string | null>(null);
   const priceSeries = useRef<ISeriesApi<'Area'> | null>(null);
@@ -294,42 +301,54 @@ export function PerpPriceChart({
   }
 
   return (
-    <div className="w-full space-y-3" key={ticker}>
+    <div
+      className={cn(
+        'flex h-full w-full flex-col',
+        showHeader ? 'space-y-3' : '',
+        className
+      )}
+    >
       {/* Header with price info and time range selector */}
-      <div className="flex flex-wrap items-center justify-between gap-3 px-1">
-        <div className="flex items-center gap-3">
-          <div>
-            <div className="font-bold text-2xl">
-              {formatChartPrice(currentPrice, true)}
-            </div>
-            <div
-              className={`font-medium text-sm ${isPositive ? 'text-green-600' : 'text-red-600'}`}
-            >
-              {isPositive ? '↑' : '↓'}{' '}
-              {formatChartPrice(Math.abs(priceChange), true)} (
-              {priceChangePercent >= 0 ? '+' : ''}
-              {priceChangePercent.toFixed(2)}%)
+      {showHeader && (
+        <div className="flex flex-shrink-0 flex-wrap items-center justify-between gap-3 px-1">
+          <div className="flex items-center gap-3">
+            <div>
+              <div className="font-bold text-2xl">
+                {formatChartPrice(currentPrice, true)}
+              </div>
+              <div
+                className={cn(
+                  'font-medium text-sm',
+                  isPositive ? 'text-green-600' : 'text-red-600'
+                )}
+              >
+                {isPositive ? '↑' : '↓'}{' '}
+                {formatChartPrice(Math.abs(priceChange), true)} (
+                {priceChangePercent >= 0 ? '+' : ''}
+                {priceChangePercent.toFixed(2)}%)
+              </div>
             </div>
           </div>
-        </div>
 
-        {/* Time range selector */}
-        <div className="flex items-center gap-1 rounded-md bg-muted/30 p-1">
-          {MARKET_TIME_RANGES.map((range) => (
-            <button
-              key={range}
-              onClick={() => onTimeRangeChange(range)}
-              className={`cursor-pointer rounded px-2 py-1 text-xs transition-colors ${
-                timeRange === range
-                  ? 'bg-primary text-primary-foreground'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              {range}
-            </button>
-          ))}
+          {/* Time range selector */}
+          <div className="flex items-center gap-1 rounded-md bg-muted/30 p-1">
+            {MARKET_TIME_RANGES.map((range) => (
+              <button
+                key={range}
+                onClick={() => onTimeRangeChange(range)}
+                className={cn(
+                  'cursor-pointer rounded px-2 py-1 text-xs transition-colors',
+                  timeRange === range
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
+              >
+                {range}
+              </button>
+            ))}
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Chart container */}
       <div className="relative">

--- a/bun.lock
+++ b/bun.lock
@@ -198,6 +198,7 @@
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
         "react-hook-form": "^7.67.0",
+        "react-resizable-panels": "2.1.7",
         "recharts": "^3.5.1",
         "sonner": "^2.0.7",
         "streamdown": "^1.4.0",
@@ -4327,6 +4328,8 @@
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
+
+    "react-resizable-panels": ["react-resizable-panels@2.1.7", "", { "peerDependencies": { "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-JtT6gI+nURzhMYQYsx8DKkx6bSoOGFp7A3CwMrOb8y5jFHFyqwo9m68UhmXRw57fRVJksFn1TSlm3ywEQ9vMgA=="],
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 


### PR DESCRIPTION
## Summary
- Implement trading-terminal-like Perps Markets UI for `/markets?tab=perps`, including a dedicated mobile experience (market picker modal, sticky tabs, trade bottom sheet, bottom nav).
- Fix and harden perps price chart initialization so it doesn't get stuck on “Initializing…” and doesn't disappear on ticker changes.
- Add lightweight local watchlist persistence for perps tickers (favorites filter).

## Type
- [x] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Design reference: `Babylontradingterminal` (Figma Make export)
- Affected routes:
  - `/markets?tab=perps` (new terminal experience)
  - `/markets/perps/[ticker]` (mobile navigation + preselect side)

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- New perps terminal UI components under `apps/web/src/app/markets/_components/perps-terminal/*`.
- `/markets?tab=perps` now renders the perps terminal across breakpoints (mobile + desktop).
- Mobile improvements:
  - Market list modal (ticker picker)
  - Floating trade CTA opening a bottom sheet
  - Sticky bottom content tabs (Positions/Trades + disabled Soon tabs)
  - Bottom navigation links to real routes
- Chart fixes:
  - Stabilize lightweight-charts initialization + surface init errors.
  - Avoid infinite “Initializing…” by timing out into a visible error.
  - Prevent chart container remount on ticker change.
- UX adjustments:
  - Trade button labels reflect netting intent (add/reduce/close/flip) when a position exists.
  - Favorites (watchlist) persisted locally.

## Review guide

**Start here**
- `apps/web/src/app/markets/_components/perps-terminal/PerpsTradingTerminal.tsx`
- `apps/web/src/components/charts/LightweightChartBase.tsx`
- `apps/web/src/components/markets/PerpPriceChart.tsx`
- `apps/web/src/app/markets/page.tsx`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- Several tabs/actions are intentionally disabled with a “Soon” badge (Agent/Social/PnL/Orders; Compare/Indicators; Limit).
- This PR keeps market/trade logic on the existing APIs/stores; no new backend contract introduced.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Open `/markets?tab=perps` on desktop, switch tickers, verify chart updates without getting stuck.
2. Open `/markets?tab=perps` on mobile, pick a ticker from the modal, open the trade sheet, verify CTA and submit button are reachable above the bottom nav.
3. Open `/markets/perps/[ticker]` and verify `?side=long|short` preselects the trade side.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: —
- Changed: —
- Removed: —

**DB / data migration**
- Migration(s): —
- Backfill/seed: —

**Rollout / rollback plan**
- Rollout: merge to `staging`.
- Rollback: revert this PR.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option A: Visual demo

| Feature | Before | After |
|---------|--------|-------|
| Perps markets terminal (`/markets?tab=perps`) | Legacy markets list | Trading terminal UI (desktop + mobile) |
| Perps chart | “Initializing…” could hang | Stable init + errors surfaced |

*Demo script (for recording):*
1. Desktop: `/markets?tab=perps` → switch tickers/timeframes → verify chart + order entry + bottom panel.
2. Mobile: `/markets?tab=perps` → open ticker picker → select ticker → open “Trade” sheet → verify submit button is reachable.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Perpetual markets trading terminal with interactive panels: market list, detail view with charts, order entry, and positions/trades management
  * Market watchlist with favorites functionality
  * Mobile-optimized responsive interface for trading
  * Enhanced chart customization with optional headers and error messaging
  * URL-driven side selection for quick trading actions

* **Bug Fixes**
  * Improved chart error handling with user-facing error messages

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR delivers a comprehensive trading terminal UI for perpetual futures markets at `/markets?tab=perps`, with significant chart stability improvements.

**Key Changes:**
- **Trading Terminal UI**: Full-featured terminal with resizable panels (markets list, chart, order entry, positions/trades) for desktop and mobile-optimized sheet-based UI
- **Chart Stability Fixes**: Resolved "Initializing..." hang by adding RAF-based initialization, 1.5s timeout with error surfacing, and ResizeObserver for zero-sized containers
- **Mobile Experience**: Market picker modal, floating trade CTA, bottom sheet, and tab navigation with proper z-index layering
- **Position Netting**: Trade button dynamically shows add/reduce/close/flip based on existing position
- **Watchlist**: Local storage-based favorites with normalized ticker handling

**Technical Highlights:**
- Dynamic import of `PerpsTradingTerminal` to reduce initial bundle
- Proper lifecycle management preventing chart re-initialization on ticker changes
- Compatible with both lightweight-charts v4 and v5 APIs
- Side preselection via URL params (`?side=long|short`) for mobile quick-trade flows

The implementation is well-structured with proper separation of concerns and robust error handling.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor observations - no blocking issues found
- Well-implemented feature with robust chart fixes and proper error handling. Chart initialization logic is thoroughly tested with multiple fallback mechanisms. Minor observations about mobile z-index stacking and potential memory considerations with ResizeObserver cleanup, but overall implementation is solid.
- Pay attention to `LightweightChartBase.tsx` for chart initialization logic and `PerpsTradingTerminal.tsx` for mobile layout complexity

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/components/charts/LightweightChartBase.tsx | Robust chart initialization with timeout handling and error surfacing to prevent infinite loading states |
| apps/web/src/components/markets/PerpPriceChart.tsx | Improved error handling and chart lifecycle management with proper series initialization tracking |
| apps/web/src/app/markets/_components/perps-terminal/PerpsTradingTerminal.tsx | Comprehensive terminal UI with proper state management for desktop and mobile layouts |
| apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx | Trade panel with position netting logic and proper validation before execution |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant MarketsPage
    participant PerpsTradingTerminal
    participant PerpsMarketListPanel
    participant PerpsMarketDetailPanel
    participant PerpPriceChart
    participant LightweightChartBase
    participant PerpsOrderEntryPanel
    participant API

    User->>MarketsPage: Navigate to /markets?tab=perps
    MarketsPage->>PerpsTradingTerminal: Render terminal
    PerpsTradingTerminal->>PerpsMarketListPanel: Load markets list
    PerpsTradingTerminal->>PerpsMarketDetailPanel: Pass null market initially
    
    User->>PerpsMarketListPanel: Select ticker (e.g., BTC)
    PerpsMarketListPanel->>PerpsTradingTerminal: onSelectTicker(ticker)
    PerpsTradingTerminal->>PerpsMarketDetailPanel: Pass selected market
    PerpsMarketDetailPanel->>PerpPriceChart: Render with market data
    PerpPriceChart->>LightweightChartBase: useLightweightChart()
    
    Note over LightweightChartBase: RAF + ResizeObserver + timeout<br/>prevents infinite "Initializing..."
    
    LightweightChartBase-->>PerpPriceChart: Return chart instance
    PerpPriceChart->>PerpPriceChart: Initialize series & set data
    PerpPriceChart-->>PerpsMarketDetailPanel: Chart rendered
    
    PerpsTradingTerminal->>PerpsOrderEntryPanel: Pass selected market
    User->>PerpsOrderEntryPanel: Configure trade (side, size, leverage)
    PerpsOrderEntryPanel->>PerpsOrderEntryPanel: Calculate position netting
    User->>PerpsOrderEntryPanel: Click submit
    PerpsOrderEntryPanel->>API: POST /api/perps/open
    API-->>PerpsOrderEntryPanel: Position created
    PerpsOrderEntryPanel->>PerpsOrderEntryPanel: Invalidate caches & refresh
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->