### PR TITLE
fix: restore NPC trading to game-tick (revert regression)

### DIFF
--- a/apps/web/src/app/api/cron/npc-tick/route.ts
+++ b/apps/web/src/app/api/cron/npc-tick/route.ts
@@ -38,8 +38,6 @@ import {
   getRecentlyMentionedActorIds,
   getTrendingPromptContext,
   isActiveHour,
-  MarketContextService,
-  MarketDecisionEngine,
   NPC_ENGAGEMENT_CONFIG,
   NPC_TICK_CONFIG,
   NPCInvestmentManager,
@@ -50,8 +48,6 @@ import {
   processNPCSocialEngagements,
   StaticDataRegistry,
   secureRandom,
-  TradeExecutionService,
-  updateMarketPricesFromTrades,
   worldFactsService,
 } from '@babylon/engine';
 import { logger } from '@babylon/shared';
@@ -530,74 +526,14 @@ export async function POST(_req: NextRequest) {
     }
 
     // =======================================================================
-    // NPC BATCH TRADING (MarketDecisionEngine)
-    // Generate and execute batch trading decisions for market liquidity
+    // NPC BATCH TRADING - NOW HANDLED BY game-tick
     // =======================================================================
-    let npcTradesExecuted = 0;
-    let marketsUpdated = 0;
-    const tradeDeadline = startTime + 240000; // 4 minute budget
+    // NPC trading (MarketDecisionEngine, batch decisions, trade execution) is now
+    // handled by game-tick for consistent 1-minute interval trading.
+    // See: packages/engine/src/game-tick.ts
+    // =======================================================================
 
-    if (Date.now() < tradeDeadline && !abortedDueToCircuitBreaker) {
-      try {
-        logger.info('Starting NPC batch trading', {}, 'NPCTick');
-
-        // Initialize trading infrastructure
-        const marketDecisionLLM = BabylonLLMClient.forGameTick();
-        const contextService = new MarketContextService();
-
-        // Configure decision engine
-        const modelName = process.env.MARKET_DECISION_MODEL || 'qwen/qwen3-32b';
-        const isKimiModel = modelName.toLowerCase().includes('kimi');
-        const defaultMaxOutput = isKimiModel ? 16000 : 32000;
-        const maxOutputTokens = Number.parseInt(
-          process.env.MARKET_DECISION_MAX_OUTPUT_TOKENS ||
-            defaultMaxOutput.toString(),
-          10
-        );
-
-        const decisionEngine = new MarketDecisionEngine(
-          marketDecisionLLM,
-          contextService,
-          { model: modelName, maxOutputTokens }
-        );
-        const executionService = new TradeExecutionService();
-
-        // Generate batch decisions
-        const marketDecisions = await decisionEngine.generateBatchDecisions();
-
-        if (marketDecisions.length === 0) {
-          logger.info('No NPC batch trades generated', {}, 'NPCTick');
-        } else {
-          const executionResult =
-            await executionService.executeDecisionBatch(marketDecisions);
-
-          npcTradesExecuted = executionResult.successfulTrades;
-
-          logger.info(
-            `NPC Batch Trading: ${executionResult.successfulTrades} trades executed`,
-            {
-              successful: executionResult.successfulTrades,
-              failed: executionResult.failedTrades,
-              holds: executionResult.holdDecisions,
-            },
-            'NPCTick'
-          );
-
-          // Update prices based on NPC trades
-          const timestamp = new Date();
-          marketsUpdated = await updateMarketPricesFromTrades(
-            timestamp,
-            executionResult
-          );
-        }
-      } catch (error) {
-        logger.error(
-          'NPC batch trading failed',
-          { error: error instanceof Error ? error.message : String(error) },
-          'NPCTick'
-        );
-      }
-    }
+    const tradeDeadline = startTime + 240000; // 4 minute budget (used by other sections)
 
     // -------------------------------------------------------------------------
     // NPC-TO-NPC FEED INTERACTIONS (discourse + comments/likes/shares)
@@ -786,43 +722,11 @@ export async function POST(_req: NextRequest) {
     }
 
     // =======================================================================
-    // NPC BASELINE INVESTMENTS
-    // Ensure each NPC pool has an initial baseline allocation across aligned companies
+    // NPC BASELINE INVESTMENTS - NOW HANDLED BY game-tick
     // =======================================================================
-    let baselineInvestmentsExecuted = 0;
-
-    if (Date.now() < tradeDeadline && !abortedDueToCircuitBreaker) {
-      try {
-        const baselineResult =
-          await NPCInvestmentManager.executeBaselineInvestments(new Date());
-
-        if (baselineResult) {
-          baselineInvestmentsExecuted = baselineResult.successfulTrades;
-
-          logger.info(
-            'NPC baseline investments executed',
-            {
-              successful: baselineResult.successfulTrades,
-              failed: baselineResult.failedTrades,
-            },
-            'NPCTick'
-          );
-
-          // Update prices based on baseline investments
-          const baselineMarketsUpdated = await updateMarketPricesFromTrades(
-            new Date(),
-            baselineResult
-          );
-          marketsUpdated += baselineMarketsUpdated;
-        }
-      } catch (error) {
-        logger.error(
-          'NPC baseline investments failed',
-          { error: error instanceof Error ? error.message : String(error) },
-          'NPCTick'
-        );
-      }
-    }
+    // Baseline investments are now handled by game-tick for consistent timing.
+    // See: packages/engine/src/game-tick.ts
+    // =======================================================================
 
     // =======================================================================
     // NPC PORTFOLIO REBALANCING
@@ -954,12 +858,9 @@ export async function POST(_req: NextRequest) {
         npcsProcessed: results.length - skippedDueToLock,
         npcsSkippedLocked: skippedDueToLock,
         totalActions: totalActionsExecuted,
-        npcTradesExecuted,
-        marketsUpdated,
         npcSocialActionsProcessed,
         npcFollowsCreated,
         npcUnfollows,
-        baselineInvestmentsExecuted,
         rebalanceActionsExecuted,
         discourseCreated,
         socialEngagement,
@@ -979,12 +880,9 @@ export async function POST(_req: NextRequest) {
       success: !abortedDueToCircuitBreaker,
       processed: results.length - skippedDueToLock,
       totalActions: totalActionsExecuted,
-      npcTradesExecuted,
-      marketsUpdated,
       npcSocialActionsProcessed,
       npcFollowsCreated,
       npcUnfollows,
-      baselineInvestmentsExecuted,
       rebalanceActionsExecuted,
       discourseCreated: discourseCreated,
       socialEngagement: socialEngagement
@@ -1013,12 +911,9 @@ export async function POST(_req: NextRequest) {
       skippedLocked: skippedDueToLock,
       duration,
       totalActions: totalActionsExecuted,
-      npcTradesExecuted,
-      marketsUpdated,
       npcSocialActionsProcessed,
       npcFollowsCreated,
       npcUnfollows,
-      baselineInvestmentsExecuted,
       rebalanceActionsExecuted,
       discourseCreated,
       socialEngagement,

--- a/packages/engine/src/game-tick.ts
+++ b/packages/engine/src/game-tick.ts
@@ -75,8 +75,8 @@ import {
   StaticDataRegistry,
   syncReputationIfAvailable,
   TokenStatsService,
-  timeframeArcProcessor,
   TradeExecutionService,
+  timeframeArcProcessor,
   WalletService,
   worldFactsGenerator,
 } from './services';

--- a/packages/engine/src/game-tick.ts
+++ b/packages/engine/src/game-tick.ts
@@ -48,6 +48,7 @@ import {
   REPUTATION_SYSTEM_BASE_SEPOLIA,
 } from '@babylon/shared';
 import { BabylonLLMClient } from './llm/openai-client';
+import { MarketDecisionEngine } from './MarketDecisionEngine';
 import { NPCInvestmentManager } from './npc/npc-investment-manager';
 import { QuestionManager } from './QuestionManager';
 import { RelationshipEvolutionEngine } from './RelationshipEvolutionEngine';
@@ -65,6 +66,7 @@ import {
   getOracleService,
   initFalClient,
   invalidateAfterPredictionTrade,
+  MarketContextService,
   NPCGroupDynamicsService,
   PriceUpdateService,
   processArcTick,
@@ -74,6 +76,7 @@ import {
   syncReputationIfAvailable,
   TokenStatsService,
   timeframeArcProcessor,
+  TradeExecutionService,
   WalletService,
   worldFactsGenerator,
 } from './services';
@@ -365,18 +368,93 @@ export async function executeGameTick(
     );
   }
 
-  // ==========================================================================
-  // NPC TRADING - HANDLED BY npc-tick (DEDUPLICATION)
-  // ==========================================================================
-  // NPC trading (MarketDecisionEngine, batch decisions, trade execution) is now
-  // exclusively handled by /api/cron/npc-tick to prevent race conditions
-  // and duplicate trades. npc-tick has per-agent locking for safe execution.
-  //
-  // - game-tick: World simulation (events, question creation, oracle commits)
-  // - npc-tick: NPC trading, NPC posts, social engagement
-  //
-  // See: apps/web/src/app/api/cron/npc-tick/route.ts::NPC BATCH TRADING section
-  // ==========================================================================
+  // =========================================================================
+  // CRITICAL PRIORITY: Generate and execute NPC trading decisions
+  // This ALWAYS runs - uses the full deadline, not the critical ops deadline
+  // Market decisions are essential for game economy and must always execute
+  // =========================================================================
+  logger.info(
+    'Starting critical market decision operations',
+    {
+      timeRemaining: deadline - Date.now(),
+    },
+    'GameTick'
+  );
+
+  const baselineResult =
+    await NPCInvestmentManager.executeBaselineInvestments(timestamp);
+
+  if (baselineResult) {
+    const baselineUpdates = await updateMarketPricesFromTrades(
+      timestamp,
+      baselineResult
+    );
+    result.marketsUpdated += baselineUpdates;
+  }
+
+  const contextService = new MarketContextService();
+
+  // Create LLM client for market decisions
+  // Priority: Groq > Claude > OpenAI
+  const marketDecisionLLM = BabylonLLMClient.forGameTick();
+  const marketLLMStats = marketDecisionLLM.getStats();
+  logger.info(
+    `Using ${marketLLMStats.provider} for market decisions`,
+    { model: marketLLMStats.model },
+    'GameTick'
+  );
+
+  // Configure decision engine with model and token limits from environment
+  // Use qwen/qwen3-32b on Groq for background trading operations
+  const modelName = process.env.MARKET_DECISION_MODEL || 'qwen/qwen3-32b';
+
+  // Model-aware output token limits:
+  // Input and output are SEPARATE limits on modern models
+  // - Kimi models: 260k INPUT + 16k OUTPUT (separate)
+  // - qwen3-32b: 130k INPUT + 32k OUTPUT (separate)
+  const isKimiModel = modelName.toLowerCase().includes('kimi');
+  const defaultMaxOutput = isKimiModel ? 16000 : 32000;
+  const maxOutputTokens = Number.parseInt(
+    process.env.MARKET_DECISION_MAX_OUTPUT_TOKENS ||
+      defaultMaxOutput.toString(),
+    10
+  );
+
+  const decisionEngine = new MarketDecisionEngine(
+    marketDecisionLLM,
+    contextService,
+    {
+      model: modelName,
+      maxOutputTokens,
+    }
+  );
+  const executionService = new TradeExecutionService();
+
+  const marketDecisions = await decisionEngine.generateBatchDecisions();
+
+  if (marketDecisions.length === 0) {
+    logger.info('No NPC market trades generated this tick', {}, 'GameTick');
+  } else {
+    const executionResult =
+      await executionService.executeDecisionBatch(marketDecisions);
+
+    logger.info(
+      `NPC Trading: ${executionResult.successfulTrades} trades executed`,
+      {
+        successful: executionResult.successfulTrades,
+        failed: executionResult.failedTrades,
+        holds: executionResult.holdDecisions,
+      },
+      'GameTick'
+    );
+
+    // Update prices based on NPC trades
+    const marketsUpdated = await updateMarketPricesFromTrades(
+      timestamp,
+      executionResult
+    );
+    result.marketsUpdated += marketsUpdated;
+  }
 
   // ==========================================================================
   // NPC SOCIAL ENGAGEMENT - HANDLED BY npc-tick (DEDUPLICATION)


### PR DESCRIPTION
## Summary

- Restores NPC trading (MarketDecisionEngine + baseline investments) to `game-tick` where it should run every 1 minute
- Removes duplicate trading code from `npc-tick` to prevent race conditions
- Reverts the accidental regression from commit `4f3b789da`

## Context

Shaw's commit `e4fc1abb5` (Jan 12) restored NPC trading to game-tick for consistent 1-minute interval trading. This was accidentally removed in commit `4f3b789da` (Jan 25, "cleanup unused imports and deprecated code").

**Timeline:**
| Date | Commit | Action |
|------|--------|--------|
| Jan 9 | c9cbd1d6c | Trading moved to npc-tick |
| Jan 12 | e4fc1abb5 | Shaw restored trading to game-tick |
| Jan 25 | 4f3b789da | Accidentally removed (regression) |
| This PR | - | Restores Shaw's implementation |

## Changes

### `packages/engine/src/game-tick.ts`
- Added imports: `MarketDecisionEngine`, `MarketContextService`, `TradeExecutionService`
- Restored trading block with:
  - Baseline investments via `NPCInvestmentManager.executeBaselineInvestments()`
  - Full MarketDecisionEngine batch trading with LLM configuration
  - Price updates via `updateMarketPricesFromTrades()`

### `apps/web/src/app/api/cron/npc-tick/route.ts`
- Removed NPC BATCH TRADING section (now handled by game-tick)
- Removed NPC BASELINE INVESTMENTS section (now handled by game-tick)
- Removed unused imports: `MarketContextService`, `MarketDecisionEngine`, `TradeExecutionService`, `updateMarketPricesFromTrades`

## Test plan

- [x] Engine package typechecks successfully
- [x] Both modified files lint cleanly
- [x] Engine package builds successfully
- [ ] Verify NPC trades appear in game-tick logs after deployment
- [ ] Verify npc-tick no longer logs trading activity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved NPC trading and baseline investment execution into the central game tick for consistent timing and behavior.
  * Removed in-route batch trading and inline baseline-investment execution, simplifying the NPC tick endpoint and its state reporting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR correctly restores NPC trading to `game-tick` where it runs every 1 minute, fixing the regression introduced in commit `4f3b789da`.

## What Changed

**Before this PR (regression state):**
- NPC trading was accidentally removed from `game-tick` (runs every 1 min)
- Trading logic remained in `npc-tick` (runs every 2 min)
- Inconsistent 2-minute trading intervals

**After this PR (restored state):**
- NPC trading restored to `game-tick` for consistent 1-minute intervals
- Duplicate trading code removed from `npc-tick`
- Clear comments document the separation of concerns

## Changes Verified

- `MarketDecisionEngine`, `MarketContextService`, and `TradeExecutionService` imports restored to `game-tick.ts`
- Full trading block restored: baseline investments → batch decisions → trade execution → price updates
- Duplicate trading sections properly removed from `npc-tick/route.ts`
- Response metrics cleaned up (removed `npcTradesExecuted`, `marketsUpdated`, `baselineInvestmentsExecuted`)
- Comments added to `npc-tick` pointing to `game-tick.ts` as authoritative location

## Architecture

The PR correctly restores the intended separation:
- **game-tick** (every 1 min): World simulation, NPC trading, market decisions
- **npc-tick** (every 2 min): NPC social engagement, follows, discourse

This matches Shaw's original implementation from commit `e4fc1abb5` (Jan 12) and prevents race conditions.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it's a clean revert of an accidental regression
- Perfect score because this is a well-documented regression fix with clear git history showing the accidental removal. The code being restored is identical to Shaw's working implementation from Jan 12, all imports are correct, and duplicate code has been properly removed from npc-tick to prevent race conditions.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/engine/src/game-tick.ts | restored NPC trading logic (baseline investments + MarketDecisionEngine) to run every 1 minute in game-tick |
| apps/web/src/app/api/cron/npc-tick/route.ts | removed duplicate NPC trading code, added comments pointing to game-tick as the authoritative location |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Cron as Vercel Cron
    participant GameTick as game-tick<br/>(every 1 min)
    participant NPCTick as npc-tick<br/>(every 2 min)
    participant MDE as MarketDecisionEngine
    participant TES as TradeExecutionService
    participant NPCInv as NPCInvestmentManager
    
    Note over Cron,NPCTick: BEFORE this PR (regression)
    Cron->>GameTick: Trigger (every minute)
    Note over GameTick: ❌ Trading removed by mistake
    GameTick-->>Cron: Complete (no trading)
    
    Cron->>NPCTick: Trigger (every 2 minutes)
    NPCTick->>NPCInv: executeBaselineInvestments()
    NPCTick->>MDE: generateBatchDecisions()
    NPCTick->>TES: executeDecisionBatch()
    Note over NPCTick: Trading ran every 2 min<br/>(inconsistent interval)
    NPCTick-->>Cron: Complete
    
    Note over Cron,NPCTick: AFTER this PR (restored)
    Cron->>GameTick: Trigger (every minute)
    GameTick->>NPCInv: executeBaselineInvestments()
    NPCInv-->>GameTick: baseline trades
    GameTick->>MDE: generateBatchDecisions()
    MDE-->>GameTick: market decisions
    GameTick->>TES: executeDecisionBatch()
    TES-->>GameTick: execution results
    GameTick->>GameTick: updateMarketPricesFromTrades()
    Note over GameTick: ✅ Trading runs every 1 min<br/>(consistent interval)
    GameTick-->>Cron: Complete
    
    Cron->>NPCTick: Trigger (every 2 minutes)
    Note over NPCTick: ✅ Trading code removed<br/>Comments point to game-tick
    NPCTick->>NPCTick: Social engagement only
    NPCTick-->>Cron: Complete
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->