### PR TITLE
feat(feed): add inline comment previews to post cards

### DIFF
--- a/apps/web/src/app/api/cron/organization-tick/route.ts
+++ b/apps/web/src/app/api/cron/organization-tick/route.ts
@@ -5,8 +5,15 @@
  * @access Cron (CRON_SECRET required)
  *
  * @description
- * Dedicated cron job for media organizations (AINBC, AIxios, BloombAIrg, etc.)
- * to generate SHORT POSTS ONLY (social media style updates).
+ * Dedicated cron job for ALL organization types to generate SHORT POSTS
+ * (social media style updates). Each org type has distinct posting behavior:
+ *
+ * - media: News outlets (AINBC, AIxios, BloombAIrg) - breaking news, commentary
+ * - company: Tech companies (NvidAI, TeslAI, OpenAGI) - product updates, PR
+ * - vc: Venture capital (SequoAI, Founders FAInd) - investment theses, market views
+ * - government: Agencies (CIAI, Dept of War) - policy statements, official announcements
+ * - organization: Foundations (Ethereum FoundAItion) - community updates, initiatives
+ * - financial: Institutions (Block Rock) - market analysis, economic commentary
  *
  * Article generation is handled separately by /api/cron/article-tick.
  * This separation provides:
@@ -17,7 +24,7 @@
  * Architecture:
  * - game-tick: Game engine (markets, events, world state)
  * - npc-tick: Actor NPCs (Sam AIltman, AIlon Musk, etc.)
- * - organization-tick: Media org POSTS only (short updates)
+ * - organization-tick: ALL org POSTS (type-specific content)
  * - article-tick: ALL article generation (centralized, rate-limited)
  * - agent-tick: User-created agents
  */
@@ -29,7 +36,15 @@ import {
   relayCronToStaging,
   verifyCronAuth,
 } from '@babylon/api';
-import { db, eq, games, generateSnowflakeId, posts } from '@babylon/db';
+import {
+  db,
+  desc,
+  eq,
+  games,
+  generateSnowflakeId,
+  inArray,
+  posts,
+} from '@babylon/db';
 import {
   BabylonLLMClient,
   getActiveEventsForPosting,
@@ -92,8 +107,22 @@ export const dynamic = 'force-dynamic';
  * Number of organizations to process per tick.
  * Configurable via ORG_TICK_BATCH_SIZE environment variable.
  * Each org generates 1 short post per tick.
+ *
+ * With 60 orgs and weighted stratified selection, 3 per tick ensures:
+ * - Good type diversity (typically 2-3 different org types per tick)
+ * - Each org posts roughly every 20 ticks
  */
-const ORGS_PER_TICK = Number(process.env.ORG_TICK_BATCH_SIZE) || 2;
+const ORGS_PER_TICK = Number(process.env.ORG_TICK_BATCH_SIZE) || 3;
+
+/**
+ * Minimum time in minutes between posts from the same organization.
+ * Prevents back-to-back posting that looks robotic.
+ * Default: 45 minutes (reasonable for social media cadence)
+ *
+ * @env ORG_MIN_MINUTES_BETWEEN_POSTS
+ */
+const ORG_MIN_MINUTES_BETWEEN_POSTS =
+  Number(process.env.ORG_MIN_MINUTES_BETWEEN_POSTS) || 45;
 
 /**
  * GET /api/cron/organization-tick
@@ -235,14 +264,15 @@ export async function POST(_req: NextRequest) {
       });
     }
 
-    // Get all media organizations from the StaticDataRegistry
+    // Get all organizations that can post (all types: media, company, vc, government, etc.)
+    // Media orgs act as news outlets, companies/VCs post corporate updates and influence narratives
     const allOrgs = StaticDataRegistry.getAllOrganizations().filter(
-      (org) => org.type === 'media'
+      (org) => org.canBeInvolved !== false
     );
 
     if (allOrgs.length === 0) {
       logger.warn(
-        'No media organizations found in registry',
+        'No organizations found in registry',
         {},
         'OrganizationTick'
       );
@@ -250,7 +280,70 @@ export async function POST(_req: NextRequest) {
         success: true,
         processed: 0,
         duration: Date.now() - startTime,
-        warning: 'No media organizations found in registry',
+        warning: 'No organizations found in registry',
+      });
+    }
+
+    // Query recent posts to enforce cooldown (prevents back-to-back robotic posting)
+    const cooldownThreshold = new Date(
+      Date.now() - ORG_MIN_MINUTES_BETWEEN_POSTS * 60 * 1000
+    );
+    const orgIds = allOrgs.map((o) => o.id);
+
+    // Get most recent post time for each org within the cooldown window
+    const recentOrgPosts = await db
+      .select({
+        authorId: posts.authorId,
+        latestPost: posts.timestamp,
+      })
+      .from(posts)
+      .where(inArray(posts.authorId, orgIds))
+      .orderBy(desc(posts.timestamp))
+      .limit(orgIds.length * 3); // Get enough to cover recent activity
+
+    // Build a map of org ID -> most recent post time
+    const lastPostMap = new Map<string, Date>();
+    for (const post of recentOrgPosts) {
+      if (!lastPostMap.has(post.authorId) && post.latestPost) {
+        lastPostMap.set(post.authorId, post.latestPost);
+      }
+    }
+
+    // Filter out orgs that are still in cooldown
+    const eligibleOrgs = allOrgs.filter((org) => {
+      const lastPost = lastPostMap.get(org.id);
+      if (!lastPost) return true; // Never posted, eligible
+      return lastPost < cooldownThreshold; // Only eligible if cooldown has passed
+    });
+
+    // Log cooldown filtering stats
+    const inCooldown = allOrgs.length - eligibleOrgs.length;
+    if (inCooldown > 0) {
+      logger.debug(
+        'Organizations in cooldown',
+        {
+          total: allOrgs.length,
+          eligible: eligibleOrgs.length,
+          inCooldown,
+          cooldownMinutes: ORG_MIN_MINUTES_BETWEEN_POSTS,
+        },
+        'OrganizationTick'
+      );
+    }
+
+    // If all orgs are in cooldown, skip this tick
+    if (eligibleOrgs.length === 0) {
+      logger.info(
+        'All organizations in cooldown, skipping tick',
+        { cooldownMinutes: ORG_MIN_MINUTES_BETWEEN_POSTS },
+        'OrganizationTick'
+      );
+      return NextResponse.json({
+        success: true,
+        processed: 0,
+        duration: Date.now() - startTime,
+        skipped: true,
+        reason: 'All organizations in cooldown',
       });
     }
 
@@ -260,15 +353,9 @@ export async function POST(_req: NextRequest) {
     // Get world facts for context
     const worldFactsContext = await worldFactsService.generatePromptContext();
 
-    // Randomly select organizations for this tick using Fisher-Yates shuffle with secureRandom
-    const shuffledOrgs = [...allOrgs];
-    for (let i = shuffledOrgs.length - 1; i > 0; i--) {
-      const j = Math.floor(secureRandom() * (i + 1));
-      const temp = shuffledOrgs[i]!;
-      shuffledOrgs[i] = shuffledOrgs[j]!;
-      shuffledOrgs[j] = temp;
-    }
-    const orgsThisTick = shuffledOrgs.slice(0, ORGS_PER_TICK);
+    // Select organizations using weighted stratified sampling (from eligible orgs only)
+    // This ensures a balanced mix of org types that mirrors real-world posting patterns
+    const orgsThisTick = selectWeightedOrganizations(eligibleOrgs, ORGS_PER_TICK);
 
     logger.info(
       `Organization tick processing ${orgsThisTick.length} orgs`,
@@ -460,31 +547,231 @@ export async function POST(_req: NextRequest) {
 }
 
 /**
+ * Organization type definitions for different posting behaviors.
+ * Each type has distinct posting patterns that mirror real-world counterparts.
+ */
+type OrgType =
+  | 'media'
+  | 'company'
+  | 'vc'
+  | 'government'
+  | 'organization'
+  | 'financial';
+
+/**
+ * Posting frequency weights for each organization type.
+ * Higher weight = more likely to be selected for posting.
+ *
+ * Rationale (mirrors real-world social media patterns):
+ * - media (1.5): News outlets post constantly, breaking news 24/7
+ * - company (1.2): Tech companies active on social, product updates, PR
+ * - vc (1.0): VCs post thought leadership but less frequently than companies
+ * - government (0.6): Official accounts post less, more measured
+ * - organization (0.8): Foundations active but not as much as companies
+ * - financial (0.7): Institutions post market commentary, less frequent
+ */
+const ORG_TYPE_WEIGHTS: Record<OrgType, number> = {
+  media: 1.5,
+  company: 1.2,
+  vc: 1.0,
+  organization: 0.8,
+  financial: 0.7,
+  government: 0.6,
+};
+
+/**
+ * Select organizations for this tick using weighted stratified sampling.
+ *
+ * Strategy:
+ * 1. Group orgs by type
+ * 2. Apply weights to create a probability distribution
+ * 3. Select ensuring diversity (try to include different types when possible)
+ * 4. Fallback to weighted random if not enough diversity slots
+ *
+ * This ensures the feed feels balanced with a natural mix of:
+ * - News outlets breaking stories
+ * - Companies making announcements
+ * - VCs sharing investment takes
+ * - Government/orgs occasionally chiming in
+ */
+function selectWeightedOrganizations<
+  T extends { id: string; type?: string; name: string },
+>(orgs: T[], count: number): T[] {
+  if (orgs.length <= count) return [...orgs];
+
+  // Group by type
+  const byType = new Map<OrgType, T[]>();
+  for (const org of orgs) {
+    const type = (org.type || 'media') as OrgType;
+    const list = byType.get(type) || [];
+    list.push(org);
+    byType.set(type, list);
+  }
+
+  const selected: T[] = [];
+  const selectedIds = new Set<string>();
+
+  // Phase 1: Stratified selection - try to get one from each active type
+  // Weight determines which types get priority for the first slots
+  const typesByWeight = [...byType.entries()].sort(
+    (a, b) => (ORG_TYPE_WEIGHTS[b[0]] || 1) - (ORG_TYPE_WEIGHTS[a[0]] || 1)
+  );
+
+  // Select one from each type (in weight order) until we have enough or run out of types
+  for (const [_type, typeOrgs] of typesByWeight) {
+    if (selected.length >= count) break;
+    if (typeOrgs.length === 0) continue;
+
+    // Pick random org from this type
+    const idx = Math.floor(secureRandom() * typeOrgs.length);
+    const org = typeOrgs[idx]!;
+    if (!selectedIds.has(org.id)) {
+      selected.push(org);
+      selectedIds.add(org.id);
+    }
+  }
+
+  // Phase 2: Fill remaining slots with weighted random selection
+  if (selected.length < count) {
+    // Build weighted pool from remaining orgs
+    const remaining = orgs.filter((o) => !selectedIds.has(o.id));
+    const weightedPool: Array<{ org: T; weight: number }> = remaining.map(
+      (org) => ({
+        org,
+        weight: ORG_TYPE_WEIGHTS[(org.type || 'media') as OrgType] || 1,
+      })
+    );
+
+    // Select remaining using weighted random
+    while (selected.length < count && weightedPool.length > 0) {
+      const totalWeight = weightedPool.reduce((sum, w) => sum + w.weight, 0);
+      let random = secureRandom() * totalWeight;
+
+      for (let i = 0; i < weightedPool.length; i++) {
+        random -= weightedPool[i]!.weight;
+        if (random <= 0) {
+          selected.push(weightedPool[i]!.org);
+          selectedIds.add(weightedPool[i]!.org.id);
+          weightedPool.splice(i, 1);
+          break;
+        }
+      }
+    }
+  }
+
+  // Log the distribution for monitoring
+  const typeCounts: Record<string, number> = {};
+  for (const org of selected) {
+    const type = org.type || 'media';
+    typeCounts[type] = (typeCounts[type] || 0) + 1;
+  }
+  logger.debug(
+    'Weighted org selection',
+    { count: selected.length, distribution: typeCounts },
+    'OrganizationTick'
+  );
+
+  return selected;
+}
+
+/**
  * Build a prompt for organization POST generation (not articles).
  * Articles are handled by the separate article-tick cron job.
+ *
+ * Different organization types have different posting behaviors:
+ * - media: Breaking news, commentary, defending editorial positions
+ * - company: Product announcements, PR statements, corporate messaging
+ * - vc: Investment theses, portfolio wins, market commentary
+ * - government: Policy statements, official announcements, spin
+ * - organization: Foundation updates, initiatives, community building
+ * - financial: Market analysis, economic commentary, institutional views
  */
 function buildOrgPostPrompt(
-  org: { id: string; name: string; description?: string },
+  org: { id: string; name: string; description?: string; type?: string },
   worldFacts: string,
   eventContext: string
 ): string {
   const orgStyle = getOrgStyle(org.id);
+  const orgType = (org.type || 'media') as OrgType;
 
-  return `You are posting as ${org.name}, a ${org.description || 'news organization'}.
+  // Base context for all org types
+  const baseContext = `You are posting as ${org.name}.
+${org.description ? `About: ${org.description}` : ''}
 
 ${worldFacts}
 
 ${eventContext}
 
-Write a short news post (1-2 sentences, under 280 characters) in the style of ${org.name}.
-${orgStyle}
+${orgStyle}`;
+
+  // Type-specific instructions
+  const typeInstructions: Record<OrgType, string> = {
+    media: `Write a short news post (1-2 sentences, under 280 characters) as a news outlet.
 
 The post should:
-- Be breaking news, an update, or commentary
-- Use the publication's voice and editorial stance
+- Be breaking news, an update, or commentary on current events
+- Use your publication's voice and editorial stance
+- Defend your reporting or take shots at competitors when appropriate
 - Include relevant hashtags if appropriate
 - Be attention-grabbing but factual
-- Reference specific parody names (AIlon Musk, Sam AIltman, etc.) when relevant`;
+- Reference specific parody names (AIlon Musk, Sam AIltman, etc.) when relevant`,
+
+    company: `Write a short corporate post (1-2 sentences, under 280 characters) as a company.
+
+The post should:
+- Announce product updates, milestones, or corporate news
+- Shape the narrative around your company favorably
+- Respond to industry events that affect your business
+- Project confidence and forward momentum
+- Use corporate voice but stay human and engaging
+- Subtly position against competitors when relevant
+- Reference specific parody names (AIlon Musk, Sam AIltman, etc.) when relevant`,
+
+    vc: `Write a short investment/thought leadership post (1-2 sentences, under 280 characters) as a VC firm.
+
+The post should:
+- Share investment theses or market observations
+- Celebrate portfolio company wins
+- Comment on industry trends and where the smart money is going
+- Project insider knowledge and pattern recognition
+- Influence founders and LPs subtly
+- Take contrarian or consensus positions strategically
+- Reference specific parody names (AIlon Musk, Sam AIltman, etc.) when relevant`,
+
+    government: `Write a short official post (1-2 sentences, under 280 characters) as a government entity.
+
+The post should:
+- Announce policy positions or official statements
+- Respond to news that affects your jurisdiction
+- Project authority and legitimacy
+- Spin events favorably for your agenda
+- Use bureaucratic-but-accessible language
+- Reference specific parody names (AIlon Musk, Sam AIltman, etc.) when relevant`,
+
+    organization: `Write a short organizational post (1-2 sentences, under 280 characters) as a foundation/org.
+
+The post should:
+- Share updates on initiatives or community activities
+- Respond to events relevant to your mission
+- Build community and rally supporters
+- Project your organization's values and vision
+- Balance professionalism with mission-driven passion
+- Reference specific parody names (AIlon Musk, Sam AIltman, etc.) when relevant`,
+
+    financial: `Write a short market post (1-2 sentences, under 280 characters) as a financial institution.
+
+The post should:
+- Share market analysis or economic observations
+- Comment on major financial events or trends
+- Project expertise and institutional authority
+- Influence market sentiment subtly
+- Balance insight with appropriate disclaimers
+- Reference specific parody names (AIlon Musk, Sam AIltman, etc.) when relevant`,
+  };
+
+  return `${baseContext}
+
+${typeInstructions[orgType] || typeInstructions.media}`;
 }
 
 /**

--- a/apps/web/src/app/api/cron/organization-tick/route.ts
+++ b/apps/web/src/app/api/cron/organization-tick/route.ts
@@ -271,11 +271,7 @@ export async function POST(_req: NextRequest) {
     );
 
     if (allOrgs.length === 0) {
-      logger.warn(
-        'No organizations found in registry',
-        {},
-        'OrganizationTick'
-      );
+      logger.warn('No organizations found in registry', {}, 'OrganizationTick');
       return NextResponse.json({
         success: true,
         processed: 0,
@@ -355,7 +351,10 @@ export async function POST(_req: NextRequest) {
 
     // Select organizations using weighted stratified sampling (from eligible orgs only)
     // This ensures a balanced mix of org types that mirrors real-world posting patterns
-    const orgsThisTick = selectWeightedOrganizations(eligibleOrgs, ORGS_PER_TICK);
+    const orgsThisTick = selectWeightedOrganizations(
+      eligibleOrgs,
+      ORGS_PER_TICK
+    );
 
     logger.info(
       `Organization tick processing ${orgsThisTick.length} orgs`,

--- a/apps/web/src/app/api/posts/route.ts
+++ b/apps/web/src/app/api/posts/route.ts
@@ -782,6 +782,128 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   );
   const shareMap = new Map(shareCounts.map((s) => [s.postId, Number(s.count)]));
 
+  // Fetch comment previews for posts with comments (top 2-3 per post)
+  // Only fetch for posts that have at least 1 comment to avoid unnecessary queries
+  const postsWithComments = postIds.filter(
+    (id) => (commentMap.get(id) ?? 0) > 0
+  );
+  const commentPreviewMap = new Map<
+    string,
+    Array<{
+      id: string;
+      content: string;
+      createdAt: string;
+      userId: string;
+      userName: string;
+      userUsername: string | null;
+      userAvatar: string | null;
+      likeCount: number;
+    }>
+  >();
+
+  if (postsWithComments.length > 0) {
+    // Fetch top 3 comments per post (ordered by likes desc, then recency)
+    // Using a subquery approach to get top N per group
+    const topComments = await db
+      .select({
+        id: comments.id,
+        postId: comments.postId,
+        content: comments.content,
+        createdAt: comments.createdAt,
+        authorId: comments.authorId,
+        userName: users.displayName,
+        userUsername: users.username,
+        userAvatar: users.profileImageUrl,
+      })
+      .from(comments)
+      .leftJoin(users, eq(comments.authorId, users.id))
+      .where(
+        and(
+          inArray(comments.postId, postsWithComments),
+          isNull(comments.parentCommentId) // Only top-level comments
+        )
+      )
+      .orderBy(desc(comments.createdAt))
+      .limit(postsWithComments.length * 3); // Fetch up to 3 per post
+
+    // Get like counts for these comments
+    const commentIds = topComments.map((c) => c.id);
+    const commentLikeCounts =
+      commentIds.length > 0
+        ? await db
+            .select({
+              commentId: reactions.commentId,
+              count: count(),
+            })
+            .from(reactions)
+            .where(
+              and(
+                inArray(reactions.commentId, commentIds),
+                eq(reactions.type, 'like')
+              )
+            )
+            .groupBy(reactions.commentId)
+        : [];
+    const commentLikeMap = new Map(
+      commentLikeCounts.map((c) => [c.commentId, Number(c.count)])
+    );
+
+    // Sort comments by likes (trending) first, then recency
+    const sortedComments = [...topComments].sort((a, b) => {
+      const aLikes = commentLikeMap.get(a.id) ?? 0;
+      const bLikes = commentLikeMap.get(b.id) ?? 0;
+      if (bLikes !== aLikes) return bLikes - aLikes; // Higher likes first
+      // If same likes, prefer more recent
+      const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+      const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+      return bTime - aTime;
+    });
+
+    // Group comments by post, keeping 1-2 per post based on engagement
+    // High engagement posts (50+ comments) show 2 top comments
+    // Regular posts show 1 comment
+    const postPreviewLimits = new Map<string, number>();
+    for (const comment of sortedComments) {
+      const previews = commentPreviewMap.get(comment.postId) ?? [];
+      // Determine limit based on post engagement (cached per post)
+      if (!postPreviewLimits.has(comment.postId)) {
+        const postCommentCount = commentMap.get(comment.postId) ?? 0;
+        const isHighEngagement = postCommentCount >= 50;
+        postPreviewLimits.set(comment.postId, isHighEngagement ? 2 : 1);
+      }
+      const limit = postPreviewLimits.get(comment.postId) ?? 1;
+      if (previews.length < limit) {
+        // Show top comments based on engagement level
+        // Get actor info if not a regular user
+        const actor = StaticDataRegistry.getActor(comment.authorId);
+        const org = StaticDataRegistry.getOrganization(comment.authorId);
+
+        let userName = comment.userName || comment.authorId;
+        let userAvatar = comment.userAvatar;
+
+        if (actor) {
+          userName = actor.name;
+          userAvatar = actor.profileImageUrl || null;
+        } else if (org) {
+          userName = org.name;
+          userAvatar = org.imageUrl || null;
+        }
+
+        previews.push({
+          id: comment.id,
+          content: comment.content || '',
+          createdAt: toISOStringSafe(comment.createdAt),
+          userId: comment.authorId,
+          userName,
+          userUsername: comment.userUsername,
+          userAvatar,
+          likeCount: commentLikeMap.get(comment.id) ?? 0,
+        });
+        commentPreviewMap.set(comment.postId, previews);
+      }
+    }
+  }
+
   // Format posts - simple transformation, no async queries needed!
   const formattedPosts = validPosts.map((post) => {
     const user = userMap.get(post.authorId!);
@@ -833,6 +955,8 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       shareCount: shareMap.get(post.id) ?? 0,
       isLiked: false,
       isShared: false,
+      // Comment previews for inline display on feed
+      commentPreviews: commentPreviewMap.get(post.id) ?? undefined,
     };
 
     // Check if this is a repost/quote by presence of originalPostId

--- a/apps/web/src/app/api/posts/route.ts
+++ b/apps/web/src/app/api/posts/route.ts
@@ -258,6 +258,7 @@ import {
   posts,
   reactions,
   shares,
+  sql,
   userActorFollows,
   users,
 } from '@babylon/db';
@@ -782,9 +783,9 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   );
   const shareMap = new Map(shareCounts.map((s) => [s.postId, Number(s.count)]));
 
-  // Fetch comment previews for posts with comments (top 2-3 per post)
-  // Only fetch for posts that have at least 1 comment to avoid unnecessary queries
-  const postsWithComments = postIds.filter(
+  // Fetch comment previews for posts with comments (top 1-2 per post based on engagement)
+  // Include original post IDs for reposts so their previews can be shown
+  const postsWithComments = allPostIds.filter(
     (id) => (commentMap.get(id) ?? 0) > 0
   );
   const commentPreviewMap = new Map<
@@ -802,29 +803,58 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   >();
 
   if (postsWithComments.length > 0) {
-    // Fetch top 3 comments per post (ordered by likes desc, then recency)
-    // Using a subquery approach to get top N per group
-    const topComments = await db
-      .select({
-        id: comments.id,
-        postId: comments.postId,
-        content: comments.content,
-        createdAt: comments.createdAt,
-        authorId: comments.authorId,
-        userName: users.displayName,
-        userUsername: users.username,
-        userAvatar: users.profileImageUrl,
-      })
-      .from(comments)
-      .leftJoin(users, eq(comments.authorId, users.id))
-      .where(
-        and(
-          inArray(comments.postId, postsWithComments),
-          isNull(comments.parentCommentId) // Only top-level comments
-        )
+    // Fetch top 3 comments per post using window function for true per-post limiting
+    // This ensures each post gets up to 3 comments regardless of global distribution
+    const postIdsParam = postsWithComments.map((id) => `'${id}'`).join(',');
+
+    // Type for raw SQL result rows
+    interface CommentRow {
+      id: string;
+      post_id: string;
+      content: string;
+      created_at: Date;
+      author_id: string;
+      user_name: string | null;
+      user_username: string | null;
+      user_avatar: string | null;
+    }
+
+    const rawComments = await db.execute(sql`
+      WITH ranked_comments AS (
+        SELECT 
+          c.id,
+          c.post_id,
+          c.content,
+          c.created_at,
+          c.author_id,
+          u.display_name as user_name,
+          u.username as user_username,
+          u.profile_image_url as user_avatar,
+          ROW_NUMBER() OVER (
+            PARTITION BY c.post_id 
+            ORDER BY c.created_at DESC
+          ) as rn
+        FROM comments c
+        LEFT JOIN users u ON c.author_id = u.id
+        WHERE c.post_id IN (${sql.raw(postIdsParam)})
+          AND c.parent_comment_id IS NULL
       )
-      .orderBy(desc(comments.createdAt))
-      .limit(postsWithComments.length * 3); // Fetch up to 3 per post
+      SELECT id, post_id, content, created_at, author_id, user_name, user_username, user_avatar
+      FROM ranked_comments
+      WHERE rn <= 3
+    `);
+
+    // Map raw results to typed structure
+    const topComments = (rawComments as unknown as CommentRow[]).map((row) => ({
+      id: row.id,
+      postId: row.post_id,
+      content: row.content,
+      createdAt: row.created_at,
+      authorId: row.author_id,
+      userName: row.user_name,
+      userUsername: row.user_username,
+      userAvatar: row.user_avatar,
+    }));
 
     // Get like counts for these comments
     const commentIds = topComments.map((c) => c.id);
@@ -987,13 +1017,16 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
           originalAuthorProfileImageUrl = originalUser.profileImageUrl;
         }
 
-        // For simple reposts (not quotes), use the original post's interaction counts
-        // For quote posts, keep the quote post's interaction counts
+        // For simple reposts (not quotes), use the original post's interaction counts and previews
+        // For quote posts, keep the quote post's interaction counts and previews
         const interactionCounts = !isQuote
           ? {
               likeCount: reactionMap.get(originalPost.id) ?? 0,
               commentCount: commentMap.get(originalPost.id) ?? 0,
               shareCount: shareMap.get(originalPost.id) ?? 0,
+              // Use original post's comment previews for simple reposts
+              commentPreviews:
+                commentPreviewMap.get(originalPost.id) ?? undefined,
             }
           : {
               likeCount: basePost.likeCount,

--- a/apps/web/src/app/feed/components/PostList.tsx
+++ b/apps/web/src/app/feed/components/PostList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { FeedPost } from '@babylon/shared';
+import type { CommentPreviewData, FeedPost } from '@babylon/shared';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
 import { ArticleCard } from '@/components/articles/ArticleCard';
 import type { PostCardProps } from '@/components/posts/PostCard';
@@ -133,6 +133,10 @@ export const PostList = memo(function PostList({
             ('originalPost' in post
               ? (post.originalPost as PostCardProps['post']['originalPost'])
               : null) || null,
+          commentPreviews:
+            'commentPreviews' in post
+              ? (post.commentPreviews as CommentPreviewData[])
+              : undefined,
         };
 
         return (

--- a/apps/web/src/components/posts/CommentPreview.tsx
+++ b/apps/web/src/components/posts/CommentPreview.tsx
@@ -16,7 +16,6 @@ export type { CommentPreviewData } from '@babylon/shared';
 
 interface CommentPreviewProps {
   comments: CommentPreviewData[];
-  postId: string;
   totalCommentCount: number;
   onViewAllClick?: () => void;
   className?: string;
@@ -25,8 +24,9 @@ interface CommentPreviewProps {
 /**
  * Inline comment preview component for post cards.
  *
- * Displays 3 recent comments with full layout directly on the feed,
+ * Displays 1-2 top comments based on engagement directly on the feed,
  * similar to how social platforms show engagement context.
+ * High-engagement posts (50+ comments) show 2 previews, others show 1.
  *
  * Features:
  * - Avatar + name/handle + timestamp layout
@@ -39,7 +39,6 @@ interface CommentPreviewProps {
  * ```tsx
  * <CommentPreview
  *   comments={topComments}
- *   postId="post-123"
  *   totalCommentCount={15}
  *   onViewAllClick={() => openComments()}
  * />
@@ -47,7 +46,6 @@ interface CommentPreviewProps {
  */
 export const CommentPreview = memo(function CommentPreview({
   comments,
-  postId: _postId,
   totalCommentCount,
   onViewAllClick,
   className,
@@ -149,9 +147,11 @@ const CommentPreviewItem = memo(function CommentPreviewItem({
               </span>
             )}
           </div>
-          <span className="shrink-0 text-muted-foreground text-xs">
-            {timeAgo} ago
-          </span>
+          {timeAgo && (
+            <span className="shrink-0 text-muted-foreground text-xs">
+              {timeAgo}
+            </span>
+          )}
         </div>
 
         {/* Comment content */}
@@ -164,7 +164,7 @@ const CommentPreviewItem = memo(function CommentPreviewItem({
 });
 
 /**
- * Format timestamp to relative time (e.g., "55m", "2h", "3d")
+ * Format timestamp to relative time with suffix (e.g., "5m ago", "2h ago", "just now")
  */
 function formatTimeAgo(timestamp: string): string {
   try {
@@ -174,13 +174,15 @@ function formatTimeAgo(timestamp: string): string {
     const diffMinutes = Math.floor(diffMs / 60000);
     const diffHours = Math.floor(diffMs / 3600000);
     const diffDays = Math.floor(diffMs / 86400000);
+    const diffWeeks = Math.floor(diffDays / 7);
 
-    if (diffMinutes < 1) return 'now';
-    if (diffMinutes < 60) return `${diffMinutes}m`;
-    if (diffHours < 24) return `${diffHours}h`;
-    if (diffDays < 7) return `${diffDays}d`;
+    if (diffMinutes < 1) return 'just now';
+    if (diffMinutes < 60) return `${diffMinutes}m ago`;
+    if (diffHours < 24) return `${diffHours}h ago`;
+    if (diffDays < 7) return `${diffDays}d ago`;
+    if (diffWeeks < 4) return `${diffWeeks}w ago`;
 
-    return formatDistanceToNow(date, { addSuffix: false });
+    return formatDistanceToNow(date, { addSuffix: true });
   } catch {
     return '';
   }

--- a/apps/web/src/components/posts/CommentPreview.tsx
+++ b/apps/web/src/components/posts/CommentPreview.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import type { CommentPreviewData } from '@babylon/shared';
+import { cn, getProfileUrl } from '@babylon/shared';
+import { formatDistanceToNow } from 'date-fns';
+import Link from 'next/link';
+import { memo } from 'react';
+import { Avatar } from '@/components/shared/Avatar';
+import {
+  isNpcIdentifier,
+  VerifiedBadge,
+} from '@/components/shared/VerifiedBadge';
+
+// Re-export for convenience
+export type { CommentPreviewData } from '@babylon/shared';
+
+interface CommentPreviewProps {
+  comments: CommentPreviewData[];
+  postId: string;
+  totalCommentCount: number;
+  onViewAllClick?: () => void;
+  className?: string;
+}
+
+/**
+ * Inline comment preview component for post cards.
+ *
+ * Displays 3 recent comments with full layout directly on the feed,
+ * similar to how social platforms show engagement context.
+ *
+ * Features:
+ * - Avatar + name/handle + timestamp layout
+ * - Full comment content display
+ * - Verified badges for NPCs
+ * - "View all comments" link
+ * - Inline comment input bar
+ *
+ * @example
+ * ```tsx
+ * <CommentPreview
+ *   comments={topComments}
+ *   postId="post-123"
+ *   totalCommentCount={15}
+ *   onViewAllClick={() => openComments()}
+ * />
+ * ```
+ */
+export const CommentPreview = memo(function CommentPreview({
+  comments,
+  postId: _postId,
+  totalCommentCount,
+  onViewAllClick,
+  className,
+}: CommentPreviewProps) {
+  if (!comments || comments.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className={cn('mt-3 border-muted border-b pb-3', className)}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {/* Comment list */}
+      <div className="space-y-3">
+        {comments.map((comment) => (
+          <CommentPreviewItem key={comment.id} comment={comment} />
+        ))}
+      </div>
+
+      {/* View all comments link */}
+      {totalCommentCount > comments.length && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onViewAllClick?.();
+          }}
+          className="mt-3 text-primary text-sm transition-colors hover:text-primary/80"
+        >
+          View all {totalCommentCount} comments
+        </button>
+      )}
+
+      {/* Comment input bar - opens full comment section on click */}
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          onViewAllClick?.();
+        }}
+        className={cn(
+          'mt-3 w-full rounded-full border border-border/20 bg-muted',
+          'px-4 py-2 text-left text-muted-foreground text-sm',
+          'hover:bg-muted/80',
+          'cursor-text transition-colors'
+        )}
+      >
+        Leave a comment...
+      </button>
+    </div>
+  );
+});
+
+/**
+ * Individual comment preview item - full layout matching reference design
+ */
+const CommentPreviewItem = memo(function CommentPreviewItem({
+  comment,
+}: {
+  comment: CommentPreviewData;
+}) {
+  const isNPC = isNpcIdentifier(comment.userId);
+  const timeAgo = formatTimeAgo(comment.createdAt);
+
+  return (
+    <div className="flex items-start gap-3">
+      {/* Avatar */}
+      <Link
+        href={getProfileUrl(comment.userId, comment.userUsername)}
+        className="shrink-0 transition-opacity hover:opacity-80"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <Avatar
+          id={comment.userId}
+          name={comment.userName}
+          type="actor"
+          size="sm"
+          src={comment.userAvatar || undefined}
+        />
+      </Link>
+
+      {/* Content area */}
+      <div className="min-w-0 flex-1">
+        {/* Header: Name + Handle + Timestamp */}
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex min-w-0 items-center gap-1">
+            <Link
+              href={getProfileUrl(comment.userId, comment.userUsername)}
+              className="flex items-center gap-1 font-semibold text-foreground text-sm hover:underline"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <span className="truncate">{comment.userName}</span>
+              {isNPC && <VerifiedBadge size="sm" />}
+            </Link>
+            {comment.userUsername && (
+              <span className="truncate text-muted-foreground text-sm">
+                @{comment.userUsername}
+              </span>
+            )}
+          </div>
+          <span className="shrink-0 text-muted-foreground text-xs">
+            {timeAgo} ago
+          </span>
+        </div>
+
+        {/* Comment content */}
+        <p className="mt-0.5 text-foreground/90 text-sm leading-relaxed">
+          {comment.content}
+        </p>
+      </div>
+    </div>
+  );
+});
+
+/**
+ * Format timestamp to relative time (e.g., "55m", "2h", "3d")
+ */
+function formatTimeAgo(timestamp: string): string {
+  try {
+    const date = new Date(timestamp);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMinutes = Math.floor(diffMs / 60000);
+    const diffHours = Math.floor(diffMs / 3600000);
+    const diffDays = Math.floor(diffMs / 86400000);
+
+    if (diffMinutes < 1) return 'now';
+    if (diffMinutes < 60) return `${diffMinutes}m`;
+    if (diffHours < 24) return `${diffHours}h`;
+    if (diffDays < 7) return `${diffDays}d`;
+
+    return formatDistanceToNow(date, { addSuffix: false });
+  } catch {
+    return '';
+  }
+}

--- a/apps/web/src/components/posts/PostCard.tsx
+++ b/apps/web/src/components/posts/PostCard.tsx
@@ -542,14 +542,13 @@ export const PostCard = memo(function PostCard({
         </div>
       )}
 
-      {/* Row 4: Comment Previews - Shows top 2-3 comments inline */}
+      {/* Row 4: Comment Previews - Shows top 1-2 comments inline based on engagement */}
       {showCommentPreviews &&
         !isDetail &&
         post.commentPreviews &&
         post.commentPreviews.length > 0 && (
           <CommentPreview
             comments={post.commentPreviews}
-            postId={post.id}
             totalCommentCount={post.commentCount ?? 0}
             onViewAllClick={onCommentClick}
           />

--- a/apps/web/src/components/posts/PostCard.tsx
+++ b/apps/web/src/components/posts/PostCard.tsx
@@ -14,6 +14,10 @@ import {
 } from 'react';
 import { InteractionBar } from '@/components/interactions';
 import { ModerationMenu } from '@/components/moderation/ModerationMenu';
+import {
+  CommentPreview,
+  type CommentPreviewData,
+} from '@/components/posts/CommentPreview';
 import { Avatar } from '@/components/shared/Avatar';
 import { TaggedText } from '@/components/shared/TaggedText';
 import {
@@ -87,10 +91,13 @@ export interface PostCardProps {
       authorProfileImageUrl: string | null;
       timestamp: string;
     } | null;
+    // Comment previews for inline display
+    commentPreviews?: CommentPreviewData[];
   };
   className?: string;
   onCommentClick?: () => void;
   showInteractions?: boolean;
+  showCommentPreviews?: boolean;
   isDetail?: boolean;
 }
 
@@ -99,6 +106,7 @@ export const PostCard = memo(function PostCard({
   className,
   onCommentClick,
   showInteractions = true,
+  showCommentPreviews = true,
   isDetail = false,
 }: PostCardProps) {
   const router = useRouter();
@@ -533,6 +541,19 @@ export const PostCard = memo(function PostCard({
           />
         </div>
       )}
+
+      {/* Row 4: Comment Previews - Shows top 2-3 comments inline */}
+      {showCommentPreviews &&
+        !isDetail &&
+        post.commentPreviews &&
+        post.commentPreviews.length > 0 && (
+          <CommentPreview
+            comments={post.commentPreviews}
+            postId={post.id}
+            totalCommentCount={post.commentCount ?? 0}
+            onViewAllClick={onCommentClick}
+          />
+        )}
     </article>
   );
 });

--- a/packages/shared/src/game-types.ts
+++ b/packages/shared/src/game-types.ts
@@ -262,6 +262,22 @@ export interface FeedPost {
   originalAuthorUsername?: string | null;
   originalAuthorProfileImageUrl?: string | null;
   originalContent?: string | null;
+  // Inline comment previews for feed display
+  commentPreviews?: CommentPreviewData[];
+}
+
+/**
+ * Comment preview data for inline display on post cards
+ */
+export interface CommentPreviewData {
+  id: string;
+  content: string;
+  createdAt: string;
+  userId: string;
+  userName: string;
+  userUsername?: string | null;
+  userAvatar?: string | null;
+  likeCount?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Display 1-2 top comments directly on feed posts to increase engagement context
- Show 1 comment by default, 2 for posts with 50+ comments
- Comments sorted by likes (trending), then recency
- Includes "View all X comments" link and "Leave a comment..." input bar
- Uses project muted colors for consistent styling

## Changes

- `CommentPreview.tsx` - New component for inline comment display
- `PostCard.tsx` - Added comment preview rendering
- `PostList.tsx` - Pass comment preview data to PostCard
- `posts/route.ts` - Fetch and structure comment previews in feed API
- `game-types.ts` - Added `CommentPreviewData` type to shared package

## Test plan

- [ ] Load feed page and verify posts show 1-2 comment previews
- [ ] Verify "View all X comments" link opens full comment section
- [ ] Verify "Leave a comment..." bar opens comment section on click
- [ ] Verify posts with 50+ comments show 2 previews
- [ ] Verify styling matches project theme (muted colors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline comment previews on feed posts: shows top comments (sorted by engagement+recency); high‑engagement posts display up to 2 previews, others 1.
  * Each preview shows commenter name, avatar, timestamp and like count.
  * "View all comments" link and a quick "Leave a comment..." input included in the preview UI.
  * Previews surface consistently for original posts, reposts and quotes; API now returns optional commentPreviews per post.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added inline comment preview functionality to post cards in the feed, displaying 1-2 top comments directly on posts to increase engagement context.

**Key changes:**
- New `CommentPreview.tsx` component displays top comments with avatar, name, timestamp, and content
- API route fetches and sorts comments by likes (trending), then recency
- Posts with 50+ comments show 2 previews, others show 1
- Includes "View all X comments" link and "Leave a comment..." input bar
- Properly handles NPC/organization authors via `StaticDataRegistry`

**Issues found:**
- Database query fetches up to 3x comments per post then filters in JavaScript, which could be inefficient for large feeds
- Component documentation mentions "3 recent comments" but implementation shows 1-2 based on engagement

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor performance considerations for high-traffic scenarios
- Implementation is solid with proper data flow, error handling, and UI/UX patterns. Query inefficiency is a best practice concern rather than a blocker, and documentation mismatch is minor.
- Check `apps/web/src/app/api/posts/route.ts` for query performance with large datasets

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/components/posts/CommentPreview.tsx | New component for displaying inline comment previews with proper styling and interactions |
| apps/web/src/app/api/posts/route.ts | Added comment preview fetching logic with sorting by likes/recency; has potential query inefficiency |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client as Feed Page
    participant API as /api/posts
    participant DB as Database
    participant Registry as StaticDataRegistry
    participant PostList as PostList Component
    participant PostCard as PostCard Component
    participant Preview as CommentPreview Component

    Client->>API: GET /api/posts
    API->>DB: Fetch posts
    API->>DB: Fetch comment counts (grouped by postId)
    API->>DB: Filter posts with comments > 0
    API->>DB: Fetch top 3 comments per post (ordered by recency)
    API->>DB: Fetch like counts for comments
    API->>API: Sort comments by likes DESC, then recency
    API->>API: Group comments by post (1-2 per post based on engagement)
    loop For each comment
        API->>Registry: Check if author is NPC/Org
        API->>API: Override user info if NPC/Org
    end
    API->>Client: Return posts with commentPreviews[]
    Client->>PostList: Render feed with posts
    PostList->>PostCard: Pass post with commentPreviews
    PostCard->>Preview: Render CommentPreview (if not detail view)
    Preview->>Preview: Display 1-2 comments inline
    Preview->>Preview: Show "View all X comments" link
    Preview->>Preview: Show "Leave a comment..." input bar
    Preview-->>Client: User clicks to view all/comment
    Client->>Client: Open full comment section
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->