### PR TITLE
fix(agent-tick): add time budgets to prevent long lock holds

### DIFF
--- a/apps/web/src/app/api/cron/agent-tick/route.ts
+++ b/apps/web/src/app/api/cron/agent-tick/route.ts
@@ -457,6 +457,13 @@ export async function POST(_req: NextRequest) {
         // Always record trajectories for RL training data collection
         // For USER_CONTROLLED agents, pass user.id (userId for User table lookup)
         // Wrap with per-agent timeout to prevent single agent from blocking tick
+        //
+        // Note on timeout behavior: When timeout fires, the underlying executeAutonomousTick
+        // continues running in the background. This is intentional - we don't want to add
+        // AbortSignal complexity throughout the coordinator. The per-agent lock (acquireAgentLock)
+        // prevents duplicate execution: if this agent is still running when the next tick starts,
+        // it will be skipped via the lock check. The timeout just prevents blocking OTHER agents.
+        let timeoutId: ReturnType<typeof setTimeout> | undefined;
         const tickResult = await Promise.race([
           autonomousCoordinator.executeAutonomousTick(
             eligibleAgent.user.id,
@@ -464,18 +471,22 @@ export async function POST(_req: NextRequest) {
             true, // Always record trajectories
             false // isNpc = false for user agents
           ),
-          new Promise<never>((_, reject) =>
-            setTimeout(
-              () =>
-                reject(
-                  new Error(
-                    `Agent timeout after ${PER_AGENT_TIMEOUT_MS / 1000}s`
-                  )
-                ),
-              PER_AGENT_TIMEOUT_MS
-            )
-          ),
-        ]);
+          new Promise<never>((_, reject) => {
+            timeoutId = setTimeout(() => {
+              logger.warn(
+                `Agent ${eligibleAgent.name} timed out after ${PER_AGENT_TIMEOUT_MS / 1000}s - execution continues in background`,
+                { agentId: eligibleAgent.agentId },
+                'AgentTick'
+              );
+              reject(
+                new Error(`Agent timeout after ${PER_AGENT_TIMEOUT_MS / 1000}s`)
+              );
+            }, PER_AGENT_TIMEOUT_MS);
+          }),
+        ]).finally(() => {
+          // Clear timeout to prevent timer leak when main promise resolves first
+          if (timeoutId) clearTimeout(timeoutId);
+        });
 
         // Validation: Verify tick executed successfully
         if (!tickResult.success) {

--- a/apps/web/src/app/api/cron/agent-tick/route.ts
+++ b/apps/web/src/app/api/cron/agent-tick/route.ts
@@ -91,6 +91,20 @@ const TICK_TIME_BUDGET_MS = 180_000; // 3 minutes
 const PER_AGENT_TIMEOUT_MS = 90_000; // 90 seconds
 
 /**
+ * Custom error for agent timeouts. Using a typed error class instead of
+ * string matching for more robust timeout detection in catch blocks.
+ */
+class AgentTimeoutError extends Error {
+  constructor(
+    public readonly agentId: string,
+    timeoutMs: number
+  ) {
+    super(`Agent timeout after ${timeoutMs / 1000}s`);
+    this.name = 'AgentTimeoutError';
+  }
+}
+
+/**
  * Points cost per autonomous tick.
  * Set to 0 for free ticks, or a positive number to charge agents.
  * Used for both eligibility checks and deductions.
@@ -479,7 +493,10 @@ export async function POST(_req: NextRequest) {
                 'AgentTick'
               );
               reject(
-                new Error(`Agent timeout after ${PER_AGENT_TIMEOUT_MS / 1000}s`)
+                new AgentTimeoutError(
+                  eligibleAgent.agentId,
+                  PER_AGENT_TIMEOUT_MS
+                )
               );
             }, PER_AGENT_TIMEOUT_MS);
           }),
@@ -581,8 +598,7 @@ export async function POST(_req: NextRequest) {
           'AgentTick'
         );
       } catch (error) {
-        const isTimeout =
-          error instanceof Error && error.message.includes('Agent timeout');
+        const isTimeout = error instanceof AgentTimeoutError;
         errors++;
         logger.error(
           `Error processing agent ${eligibleAgent.name}`,

--- a/apps/web/src/app/api/cron/agent-tick/route.ts
+++ b/apps/web/src/app/api/cron/agent-tick/route.ts
@@ -75,9 +75,20 @@ import { NextResponse } from 'next/server';
 import { ensureEngineServices } from '@/lib/engine/ensure-engine-services';
 
 // Vercel function configuration
-// Note: vercel.json overrides this with 800 seconds (13.3 minutes)
-export const maxDuration = 800; // 13.3 minutes max for agent tick (matches vercel.json)
+export const maxDuration = 300; // 5 minutes max - reduced from 800s to prevent long lock holds
 export const dynamic = 'force-dynamic';
+
+/**
+ * Time budget for entire tick (ms). Stop processing new agents after this.
+ * Set to 180s to leave headroom before function timeout (300s).
+ */
+const TICK_TIME_BUDGET_MS = 180_000; // 3 minutes
+
+/**
+ * Per-agent processing timeout (ms). Abort agent if exceeds this.
+ * Prevents single slow agent from blocking entire tick.
+ */
+const PER_AGENT_TIMEOUT_MS = 90_000; // 90 seconds
 
 /**
  * Points cost per autonomous tick.
@@ -152,10 +163,10 @@ export async function POST(_req: NextRequest) {
   }
 
   // 1.5 Acquire global lock to prevent overlapping cron invocations
-  // Duration matches function timeout (800s) to prevent overlap when ticks take longer than cron interval
+  // Duration matches function timeout (300s) to prevent overlap when ticks take longer than cron interval
   const globalLockAcquired = await DistributedLockService.acquireLock({
     lockId: 'agent-tick-global',
-    durationMs: 800 * 1000, // 800 seconds (13.3 minutes) - matches function timeout
+    durationMs: 300 * 1000, // 300 seconds (5 minutes) - matches function timeout
     operation: 'agent-tick-global',
     processId,
   });
@@ -360,8 +371,22 @@ export async function POST(_req: NextRequest) {
     let totalActionsExecuted = 0;
     let errors = 0;
     let skippedDueToLock = 0;
+    let skippedDueToTimeBudget = 0;
 
     for (const eligibleAgent of eligibleAgents) {
+      // Check tick-level time budget before processing each agent
+      const tickElapsed = Date.now() - startTime;
+      if (tickElapsed >= TICK_TIME_BUDGET_MS) {
+        const remainingAgents = eligibleAgents.length - results.length;
+        logger.warn(
+          `Tick time budget exceeded (${Math.round(tickElapsed / 1000)}s) - skipping ${remainingAgents} remaining agents`,
+          { processId, processed: results.length, remaining: remainingAgents },
+          'AgentTick'
+        );
+        skippedDueToTimeBudget = remainingAgents;
+        break;
+      }
+
       const agentStartTime = Date.now();
 
       // Try to acquire lock for this agent - skip if already running
@@ -423,14 +448,34 @@ export async function POST(_req: NextRequest) {
         if (features.dms) enabledFeatures.push('DMs');
         if (features.groupChats) enabledFeatures.push('group chats');
 
+        logger.info(
+          `Processing agent ${eligibleAgent.name}`,
+          { agentId: eligibleAgent.agentId, features: enabledFeatures },
+          'AgentTick'
+        );
+
         // Always record trajectories for RL training data collection
         // For USER_CONTROLLED agents, pass user.id (userId for User table lookup)
-        const tickResult = await autonomousCoordinator.executeAutonomousTick(
-          eligibleAgent.user.id,
-          runtime,
-          true, // Always record trajectories
-          false // isNpc = false for user agents
-        );
+        // Wrap with per-agent timeout to prevent single agent from blocking tick
+        const tickResult = await Promise.race([
+          autonomousCoordinator.executeAutonomousTick(
+            eligibleAgent.user.id,
+            runtime,
+            true, // Always record trajectories
+            false // isNpc = false for user agents
+          ),
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () =>
+                reject(
+                  new Error(
+                    `Agent timeout after ${PER_AGENT_TIMEOUT_MS / 1000}s`
+                  )
+                ),
+              PER_AGENT_TIMEOUT_MS
+            )
+          ),
+        ]);
 
         // Validation: Verify tick executed successfully
         if (!tickResult.success) {
@@ -559,6 +604,7 @@ export async function POST(_req: NextRequest) {
         agentsEligible: eligibleAgents.length,
         agentsProcessed: results.length - skippedDueToLock,
         agentsSkippedLocked: skippedDueToLock,
+        agentsSkippedTimeBudget: skippedDueToTimeBudget,
         totalActions: totalActionsExecuted,
         errors,
         averageActionsPerAgent:
@@ -599,6 +645,7 @@ export async function POST(_req: NextRequest) {
       eligible: eligibleAgents.length,
       processed: results.length - skippedDueToLock,
       skippedLocked: skippedDueToLock,
+      skippedTimeBudget: skippedDueToTimeBudget,
       duration,
       totalActions: totalActionsExecuted,
       errors,

--- a/apps/web/src/app/api/cron/agent-tick/route.ts
+++ b/apps/web/src/app/api/cron/agent-tick/route.ts
@@ -581,6 +581,8 @@ export async function POST(_req: NextRequest) {
           'AgentTick'
         );
       } catch (error) {
+        const isTimeout =
+          error instanceof Error && error.message.includes('Agent timeout');
         errors++;
         logger.error(
           `Error processing agent ${eligibleAgent.name}`,
@@ -588,6 +590,7 @@ export async function POST(_req: NextRequest) {
             agentId: eligibleAgent.agentId,
             agentType: eligibleAgent.type,
             error: error instanceof Error ? error.message : String(error),
+            isTimeout,
           },
           'AgentTick'
         );
@@ -596,7 +599,7 @@ export async function POST(_req: NextRequest) {
           agentId: eligibleAgent.agentId,
           agentType: eligibleAgent.type,
           name: eligibleAgent.name,
-          status: 'error',
+          status: isTimeout ? 'timeout' : 'error',
           error: error instanceof Error ? error.message : String(error),
           duration: Date.now() - agentStartTime,
         });

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
       "maxDuration": 60
     },
     "src/app/api/cron/agent-tick/route.ts": {
-      "maxDuration": 800
+      "maxDuration": 300
     },
     "src/app/api/cron/game-tick/route.ts": {
       "maxDuration": 800


### PR DESCRIPTION
## Summary
- Reduce function timeout from 800s to 300s (5 min max)
- Reduce global lock duration from 800s to 300s  
- Add tick-level time budget (180s) - stops processing new agents after 3 min
- Add per-agent timeout (90s) - aborts single agent if exceeds 90s
- Add per-agent processing log for debugging slow agents

## Problem
Agent ticks were holding the global lock for 9-13 minutes, blocking subsequent cron triggers and causing "no recent agent ticks" despite cron firing every minute. Logs showed:
```
Lock agent-tick-global held by agent-tick-1769616542095-157ab312 - skipping {"ageMinutes":9,"expiresIn":261}
```

## Solution
1. **Tick-level time budget**: Stop processing new agents after 3 min to leave headroom
2. **Per-agent timeout**: Abort agent processing if > 90s (prevents single slow agent from blocking everything)
3. **Reduce lock duration**: 300s instead of 800s (tick should complete in < 5 min)

## Test plan
- [ ] Deploy to staging and monitor agent-tick logs
- [ ] Verify ticks complete in < 5 min
- [ ] Verify `skippedTimeBudget` appears in logs when tick runs long
- [ ] Verify subsequent cron triggers are not blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced overall tick timeout to a 5-minute cap and added per-agent execution limits so runs stay within a fixed time budget.

* **Improvements**
  * New metrics and run summaries report counts of agents skipped due to time budget.
  * Enhanced per-agent logging shows processing start, timeout events, and skipped-agent counts.

* **Bug Fixes**
  * Timeouts are now distinguished from generic errors; timed-out agents are marked and do not block the tick.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR implements time budgets to prevent agent-tick from holding the global lock for excessive periods (previously 9-13 minutes, now capped at 5 minutes).

**Key changes:**
- Reduced function timeout from 800s to 300s (5 min) in both code and `vercel.json`
- Added tick-level time budget (180s) - stops processing new agents after 3 minutes to leave headroom before function timeout
- Added per-agent timeout (90s) - aborts individual agent processing using `Promise.race` to prevent single slow agent from blocking the entire tick
- Reduced global lock duration from 800s to 300s to match new function timeout
- Added `skippedDueToTimeBudget` tracking and logging for observability

**Implementation notes:**
- The per-agent timeout uses `Promise.race`, which means `executeAutonomousTick()` continues running in background after timeout fires. However, the agent lock is properly released in the finally block, preventing double-execution.
- Time budget check occurs before each agent (line 378), not during execution, so an agent that starts at 179s could still run until 269s (179s + 90s timeout). The 120s buffer (300s function timeout - 180s budget) provides headroom for this.
- The cron runs every 3 minutes while locks are held for 5 minutes, which is intentional - overlapping cron invocations will be blocked by the global lock and return early.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with low risk - implements sensible timeouts to prevent long-running ticks
- The implementation correctly adds time budgets at both tick and per-agent levels, with proper lock management and error handling. The per-agent timeout using `Promise.race` is a standard pattern, though it means timed-out operations continue in the background (acceptable since locks prevent re-entry). The time budget values are reasonable (180s tick budget, 90s agent timeout, 300s function timeout) with sufficient buffer. One minor concern: an agent starting at 179s could run until 269s, but the 120s buffer accommodates this.
- No files require special attention - the changes are straightforward timeout configurations

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/api/cron/agent-tick/route.ts | Added time budgets (180s tick-level, 90s per-agent) and reduced function timeout from 800s to 300s to prevent long lock holds |
| vercel.json | Reduced `maxDuration` from 800s to 300s to align with code changes |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Cron as Vercel Cron
    participant Route as agent-tick/route.ts
    participant Lock as DistributedLockService
    participant Agent as Agent Loop
    participant Coordinator as AutonomousCoordinator
    participant Runtime as AgentRuntime

    Cron->>Route: POST /api/cron/agent-tick (every 3 min)
    Route->>Route: Verify CRON_SECRET
    Route->>Lock: acquireLock(agent-tick-global, 300s)
    alt Lock acquired
        Lock-->>Route: true
        Route->>Route: Check game state & fetch eligible agents
        
        loop For each eligible agent (max 180s)
            Route->>Route: Check tick time budget
            alt Time budget exceeded (>180s)
                Route->>Route: Break loop, skip remaining agents
            else Within budget
                Route->>Lock: acquireAgentLock(agentId)
                alt Agent locked
                    Lock-->>Route: false (skip, still running)
                else Agent available
                    Lock-->>Route: true
                    Route->>Route: Deduct points if TICK_POINTS_COST > 0
                    
                    par Per-agent timeout race (90s)
                        Route->>Coordinator: executeAutonomousTick(userId, runtime)
                        Coordinator->>Runtime: Execute actions (trade/post/comment/dm)
                        Runtime-->>Coordinator: tickResult
                        Coordinator-->>Route: tickResult
                    and Timeout monitor
                        Route->>Route: setTimeout(90s)
                        alt Timeout fires first
                            Route-->>Route: Reject with timeout error
                        end
                    end
                    
                    alt Success
                        Route->>Route: Log success, update config
                    else Error or timeout
                        Route->>Route: Log error, increment error count
                    end
                    
                    Route->>Lock: releaseAgentLock(agentId)
                end
            end
        end
        
        Route->>Route: Log metrics (processed, skipped, errors)
        Route->>Lock: releaseLock(agent-tick-global)
        Route-->>Cron: 200 OK (success, metrics)
    else Lock held by previous tick
        Lock-->>Route: false
        Route-->>Cron: 200 OK (skipped, reason: previous tick running)
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->