### PR TITLE
fix: rename Command Center to Agents and Markets to Terminal

### DIFF
--- a/apps/web/src/app/agents/page.tsx
+++ b/apps/web/src/app/agents/page.tsx
@@ -148,7 +148,7 @@ export default function AgentsPage() {
           </Link>
         </div>
 
-        {/* Command Center Card - shown when user has agents */}
+        {/* Agents Chat Card - shown when user has agents */}
         {agents.length > 0 && (
           <div className="mb-4">
             <Link href="/agents/team" className="block">
@@ -160,7 +160,7 @@ export default function AgentsPage() {
                     </div>
                     <div>
                       <h3 className="font-semibold text-foreground text-lg">
-                        Command Center
+                        Agents Chat
                       </h3>
                       <p className="text-muted-foreground text-sm">
                         Coordinate all {agents.length} agent

--- a/apps/web/src/app/agents/team/ActivityFilters.tsx
+++ b/apps/web/src/app/agents/team/ActivityFilters.tsx
@@ -91,7 +91,7 @@ const ACTIVITY_TYPES: {
  * Activity filter bar component.
  *
  * Provides pill-style buttons for activity type filtering and a dropdown
- * for agent selection. Designed for the Command Center activity feed.
+ * for agent selection. Designed for the Agents activity feed.
  */
 export const ActivityFilters = memo(function ActivityFilters({
   activityType,

--- a/apps/web/src/app/agents/team/ConversationList.tsx
+++ b/apps/web/src/app/agents/team/ConversationList.tsx
@@ -25,7 +25,7 @@ interface ConversationListProps {
 }
 
 /**
- * Conversation list component for Command Center sidebar
+ * Conversation list component for Agents sidebar
  *
  * Shows all conversations in the team chat.
  * Allows creating new conversations (fresh chat).

--- a/apps/web/src/app/agents/team/MemberList.tsx
+++ b/apps/web/src/app/agents/team/MemberList.tsx
@@ -56,7 +56,7 @@ interface MemberListProps {
 }
 
 /**
- * Member list component for Command Center sidebar/drawer
+ * Member list component for Agents sidebar/drawer
  *
  * Shows all agents in the team chat.
  * Supports agent selection for parallel task execution.

--- a/apps/web/src/app/agents/team/page.tsx
+++ b/apps/web/src/app/agents/team/page.tsx
@@ -60,7 +60,7 @@ const AgentActivityFeed = dynamic(
   }
 );
 
-/** Tab type for Command Center */
+/** Tab type for Agents */
 type TabType = 'chat' | 'agents' | 'activity';
 
 /** Agent data for agents tab */
@@ -84,7 +84,7 @@ interface AgentData {
 }
 
 /**
- * Agent Team Chat Page (Command Center)
+ * Agent Team Chat Page (Agents)
  *
  * A unified group chat containing all the user's agents.
  * Users can @mention specific agents to direct tasks.
@@ -141,7 +141,7 @@ export default function TeamChatPage() {
     'all'
   );
 
-  // Selected agent detail state (for viewing agent within Command Center)
+  // Selected agent detail state (for viewing agent within Agents page)
   const [selectedAgentDetail, setSelectedAgentDetail] =
     useState<AgentDetailData | null>(null);
   const [selectedAgentLoading, setSelectedAgentLoading] = useState(false);
@@ -360,7 +360,7 @@ export default function TeamChatPage() {
           <div className="max-w-md text-center">
             <Users className="mx-auto mb-4 h-16 w-16 text-muted-foreground" />
             <h2 className="mb-2 font-bold text-foreground text-xl">
-              Log in to access Command Center
+              Log in to access Agents
             </h2>
             <p className="mb-6 text-muted-foreground">
               Sign in to coordinate your agents
@@ -409,7 +409,7 @@ export default function TeamChatPage() {
           <div className="max-w-md text-center">
             <Users className="mx-auto mb-4 h-16 w-16 text-red-500" />
             <h2 className="mb-2 font-bold text-foreground text-xl">
-              Failed to load Command Center
+              Failed to load Agents
             </h2>
             <p className="mb-6 text-muted-foreground">{error}</p>
           </div>
@@ -440,7 +440,7 @@ export default function TeamChatPage() {
             {/* Header */}
             <div className="flex items-center justify-between p-4">
               <h3 id="drawer-title" className="font-semibold text-foreground">
-                Command Center
+                Agents
               </h3>
               <button
                 onClick={() => setShowMemberDrawer(false)}

--- a/apps/web/src/app/api/agents/[agentId]/chat/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/chat/route.ts
@@ -75,7 +75,7 @@ Your owner created you and may fund your wallet, but you manage your own assets 
 
 {{#if isTeamChatMode}}
 # Team Chat Context
-You are in the **Command Center** team chat owned by **{{teamChatOwnerName}}**{{#if teamChatOwnerUsername}} (@{{teamChatOwnerUsername}}){{/if}}.
+You are in the **Agents** team chat owned by **{{teamChatOwnerName}}**{{#if teamChatOwnerUsername}} (@{{teamChatOwnerUsername}}){{/if}}.
 Other agents may also be working on this task. Focus on YOUR contribution - do your best work independently.
 You can use the CHECK_TEAM_CHAT action if you want to see what other agents have said.
 
@@ -234,7 +234,7 @@ Your owner created you and may fund your wallet, but you manage your own assets 
 
 {{#if isTeamChatMode}}
 # Team Chat Context
-You are **{{agentName}}** (@{{agentUsername}}) in the **Command Center** team chat owned by **{{teamChatOwnerName}}**{{#if teamChatOwnerUsername}} (@{{teamChatOwnerUsername}}){{/if}}.
+You are **{{agentName}}** (@{{agentUsername}}) in the **Agents** team chat owned by **{{teamChatOwnerName}}**{{#if teamChatOwnerUsername}} (@{{teamChatOwnerUsername}}){{/if}}.
 Other agents may also be responding. Focus on YOUR findings and contribution.
 
 ## Team Members

--- a/apps/web/src/app/api/agents/team-chat/conversations/route.ts
+++ b/apps/web/src/app/api/agents/team-chat/conversations/route.ts
@@ -1,7 +1,7 @@
 /**
  * Team Chat Conversations API
  *
- * Manages conversation sessions within the team chat (Command Center).
+ * Manages conversation sessions within the team chat (Agents).
  * Supports "New Chat" feature like ChatGPT.
  *
  * @route GET /api/agents/team-chat/conversations - List all conversations

--- a/apps/web/src/app/api/agents/team-chat/message/route.ts
+++ b/apps/web/src/app/api/agents/team-chat/message/route.ts
@@ -5,7 +5,7 @@
  * @access Authenticated
  *
  * @description
- * Sends a message to the user's Command Center team chat.
+ * Sends a message to the user's Agents team chat.
  * Agent responses are triggered separately by the frontend calling /api/agents/[agentId]/chat
  * for each selected agent (parallel execution model).
  *
@@ -16,7 +16,7 @@
  *       - Agents
  *     summary: Send team chat message
  *     description: |
- *       Sends a message to Command Center.
+ *       Sends a message to Agents.
  *       Agent responses are triggered separately via /api/agents/[agentId]/chat.
  *     security:
  *       - PrivyAuth: []
@@ -115,7 +115,7 @@ export async function POST(req: NextRequest) {
       {
         success: false,
         error: 'No team chat exists',
-        message: 'Create your first agent to initialize your Command Center.',
+        message: 'Create your first agent to initialize your Agents chat.',
       },
       { status: 404 }
     );

--- a/apps/web/src/app/api/agents/team-chat/route.ts
+++ b/apps/web/src/app/api/agents/team-chat/route.ts
@@ -1,12 +1,12 @@
 /**
- * Agent Team Chat (Command Center) API
+ * Agent Team Chat (Agents) API
  *
  * @route GET /api/agents/team-chat - Get user's team chat info
  * @route POST /api/agents/team-chat - Ensure team chat exists (creates if needed)
  * @access Authenticated
  *
  * @description
- * Manages the unified "Command Center" group chat for a user's agents.
+ * Manages the unified "Agents" group chat for a user's agents.
  * Each user has exactly ONE team chat containing ALL their agents.
  *
  * The team chat is automatically created when the first agent is created,
@@ -18,7 +18,7 @@
  *     tags:
  *       - Agents
  *     summary: Get team chat info
- *     description: Returns the user's Command Center team chat with member list.
+ *     description: Returns the user's Agents team chat with member list.
  *     security:
  *       - PrivyAuth: []
  *     responses:
@@ -92,7 +92,7 @@ export async function GET(req: NextRequest) {
       {
         success: false,
         error: 'No team chat exists',
-        message: 'Create your first agent to initialize your Command Center.',
+        message: 'Create your first agent to initialize your Agents chat.',
       },
       { status: 404 }
     );
@@ -151,8 +151,8 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
   const user = await authenticateUser(req);
 
-  // Always create Command Center - even with 0 agents
-  // This allows users to see the Command Center UI before creating their first agent
+  // Always create Agents chat - even with 0 agents
+  // This allows users to see the Agents UI before creating their first agent
   const teamChat = await teamChatService.ensureTeamChat(user.id);
 
   // Sync any existing agents that aren't in the team chat yet
@@ -218,7 +218,7 @@ export async function POST(req: NextRequest) {
  * ⚠️ DESTRUCTIVE OPERATION - DEVELOPMENT ONLY:
  * Disabled in production. Use only for development/testing.
  *
- * This permanently deletes all Command Center data including:
+ * This permanently deletes all Agents data including:
  * - All messages and conversation history
  * - Group membership records
  * - Chat participant records
@@ -229,7 +229,7 @@ export async function POST(req: NextRequest) {
  * - Development/testing reset
  *
  * The team chat will be recreated automatically when the user
- * visits Command Center again or when an agent is created.
+ * visits Agents again or when an agent is created.
  */
 export async function DELETE(req: NextRequest) {
   // Gate destructive endpoint to development only
@@ -293,7 +293,6 @@ export async function DELETE(req: NextRequest) {
 
   return NextResponse.json({
     success: true,
-    message:
-      'Team chat deleted. Visit Command Center again to create a fresh one.',
+    message: 'Team chat deleted. Visit Agents again to create a fresh one.',
   });
 }

--- a/apps/web/src/app/api/agents/team-chat/typing/route.ts
+++ b/apps/web/src/app/api/agents/team-chat/typing/route.ts
@@ -5,7 +5,7 @@
  * @access Authenticated
  *
  * @description
- * Broadcasts typing indicator status to the user's Command Center team chat.
+ * Broadcasts typing indicator status to the user's Agents team chat.
  * This allows other participants (and agents) to see when someone is typing.
  */
 

--- a/apps/web/src/app/api/chats/route.ts
+++ b/apps/web/src/app/api/chats/route.ts
@@ -349,9 +349,9 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
 
   // Get user's chats with proper RLS context
   const { groupChats, directChats } = await asUser(user, async (dbClient) => {
-    // Get ALL user's Command Center groups to exclude from regular chat list
+    // Get ALL user's Agents groups to exclude from regular chat list
     // (handles edge case of duplicate team groups from race conditions)
-    // Command Center is managed separately at /agents/team
+    // Agents is managed separately at /agents/team
     const teamGroups = await dbClient
       .select({ id: groups.id })
       .from(groups)
@@ -395,7 +395,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
             .where(inArray(chats.groupId, groupIds))
         : [];
 
-    // Filter out Command Center chats (all chats linked to any team group)
+    // Filter out Agents chats (all chats linked to any team group)
     const filteredGroupChats =
       teamGroupIds.size > 0
         ? groupChatsWithGroupId.filter(

--- a/apps/web/src/app/chats/page.tsx
+++ b/apps/web/src/app/chats/page.tsx
@@ -109,7 +109,7 @@ export default function ChatsPage() {
   } = useChatPage();
 
   // Detect if the current chat is with the user's own agent
-  // If so, redirect to team chat (Command Center) instead of this DM
+  // If so, redirect to team chat (Agents) instead of this DM
   const ownAgentId = useMemo(() => {
     if (!chatDetails?.chat.otherUser || chatDetails.chat.isGroup) return null;
     const other = chatDetails.chat.otherUser;

--- a/apps/web/src/app/profile/[id]/page.tsx
+++ b/apps/web/src/app/profile/[id]/page.tsx
@@ -845,7 +845,7 @@ export default function ActorProfilePage() {
                             title={
                               actorInfo.isAgent &&
                               actorInfo.managedBy === user.id
-                                ? 'Message in Command Center'
+                                ? 'Message in Agents'
                                 : 'Send message'
                             }
                           >

--- a/apps/web/src/components/admin/GroupsTab.tsx
+++ b/apps/web/src/components/admin/GroupsTab.tsx
@@ -144,7 +144,7 @@ export function GroupsTab() {
       case 'agent':
         return 'Agent Group';
       case 'team':
-        return 'Command Center';
+        return 'Agents';
       default:
         return 'Unknown';
     }

--- a/apps/web/src/components/agents/AgentCreate.tsx
+++ b/apps/web/src/components/agents/AgentCreate.tsx
@@ -2,7 +2,7 @@
  * Agent Create Component
  *
  * @description Reusable multi-step form for creating a new agent.
- * Used in both the standalone create page and the Command Center.
+ * Used in both the standalone create page and the Agents page.
  */
 
 'use client';

--- a/apps/web/src/components/agents/AgentDetail.tsx
+++ b/apps/web/src/components/agents/AgentDetail.tsx
@@ -2,7 +2,7 @@
  * Agent Detail Component
  *
  * @description Reusable component for displaying agent details.
- * Used in both the standalone agent page and the Command Center.
+ * Used in both the standalone agent page and the Agents page.
  */
 
 'use client';

--- a/apps/web/src/components/chats/TeamChatView.tsx
+++ b/apps/web/src/components/chats/TeamChatView.tsx
@@ -127,7 +127,7 @@ interface TeamChatViewProps {
 }
 
 /**
- * Chat view component for Team Chat (Command Center)
+ * Chat view component for Team Chat (Agents)
  *
  * Similar to ChatView but with typing/thinking indicators and custom header
  */
@@ -161,9 +161,7 @@ export function TeamChatView({
       <div className="flex h-full flex-1 items-center justify-center">
         <div className="max-w-md p-8 text-center text-muted-foreground">
           <MessageCircle className="mx-auto mb-4 h-16 w-16 opacity-50" />
-          <h3 className="mb-2 font-bold text-foreground text-xl">
-            Command Center
-          </h3>
+          <h3 className="mb-2 font-bold text-foreground text-xl">Agents</h3>
           <p className="text-sm">Loading your team chat...</p>
         </div>
       </div>
@@ -176,9 +174,7 @@ export function TeamChatView({
       <div className="shrink-0">
         <div className="flex items-center justify-between px-4 py-3">
           <div>
-            <h2 className="font-semibold text-foreground text-lg">
-              Command Center
-            </h2>
+            <h2 className="font-semibold text-foreground text-lg">Agents</h2>
             <p className="text-muted-foreground text-sm">
               {chatDetails.participants.length} member
               {chatDetails.participants.length !== 1 ? 's' : ''}

--- a/apps/web/src/components/groups/MemberTypeBadge.tsx
+++ b/apps/web/src/components/groups/MemberTypeBadge.tsx
@@ -54,7 +54,7 @@ export function GroupTypeBadge({ type }: { type: GroupType }) {
     case 'team':
       return (
         <span className="rounded bg-primary/10 px-2 py-1 text-primary text-xs">
-          Command Center
+          Agents
         </span>
       );
     default:

--- a/apps/web/src/components/shared/BottomNav.tsx
+++ b/apps/web/src/components/shared/BottomNav.tsx
@@ -12,7 +12,7 @@ import { getAuthToken } from '@/lib/auth';
 /**
  * Bottom navigation content component for mobile devices.
  *
- * Provides mobile navigation with Feed, Markets, Chats, Agents, and Notifications tabs.
+ * Provides mobile navigation with Feed, Terminal, Chats, Agents, and Notifications tabs.
  * Shows unread message and notification badges. Automatically hides when WAITLIST_MODE
  * is enabled on home page.
  *
@@ -79,7 +79,7 @@ function BottomNavContent() {
       active: pathname === '/feed' || pathname === '/',
     },
     {
-      name: 'Markets',
+      name: 'Terminal',
       href: '/markets',
       icon: TrendingUp,
       color: '#0066FF',
@@ -155,7 +155,7 @@ function BottomNavContent() {
 /**
  * Bottom navigation component for mobile devices.
  *
- * Provides mobile navigation with Feed, Markets, Chats, Agents, and Notifications tabs.
+ * Provides mobile navigation with Feed, Terminal, Chats, Agents, and Notifications tabs.
  * Shows unread message and notification badges. Automatically hides when WAITLIST_MODE
  * is enabled on home page.
  *

--- a/apps/web/src/components/shared/MobileHeader.tsx
+++ b/apps/web/src/components/shared/MobileHeader.tsx
@@ -212,7 +212,7 @@ function MobileHeaderContent() {
       active: pathname === '/feed' || pathname === '/',
     },
     {
-      name: 'Markets',
+      name: 'Terminal',
       href: '/markets',
       icon: TrendingUp,
       active: pathname === '/markets',

--- a/apps/web/src/components/shared/Sidebar.tsx
+++ b/apps/web/src/components/shared/Sidebar.tsx
@@ -146,7 +146,7 @@ function SidebarContent() {
       active: pathname === '/leaderboard',
     },
     {
-      name: 'Markets',
+      name: 'Terminal',
       href: '/markets',
       icon: TrendingUp,
       color: '#0066FF',
@@ -160,7 +160,7 @@ function SidebarContent() {
       active: pathname === '/chats',
     },
     {
-      name: 'Command Center',
+      name: 'Agents',
       href: '/agents/team',
       icon: Users,
       color: '#0066FF',

--- a/apps/web/src/hooks/useTeamChat.ts
+++ b/apps/web/src/hooks/useTeamChat.ts
@@ -1,7 +1,7 @@
 /**
  * useTeamChat Hook
  *
- * Manages the user's Command Center team chat - a unified group chat
+ * Manages the user's Agents team chat - a unified group chat
  * containing all their agents.
  */
 
@@ -515,16 +515,14 @@ export function useTeamChat(): UseTeamChatReturn {
 
       if (!response.ok) {
         const data = await response.json();
-        setError(data.message || data.error || 'Failed to load Command Center');
+        setError(data.message || data.error || 'Failed to load Agents');
         return;
       }
 
       const data = await response.json();
       setTeamChat(data.teamChat);
     } catch (err) {
-      setError(
-        err instanceof Error ? err.message : 'Failed to load Command Center'
-      );
+      setError(err instanceof Error ? err.message : 'Failed to load Agents');
     } finally {
       setLoading(false);
     }
@@ -610,7 +608,7 @@ export function useTeamChat(): UseTeamChatReturn {
     ? {
         chat: {
           id: teamChat.chatId,
-          name: 'Command Center',
+          name: 'Agents',
           isGroup: true,
           createdAt: teamChat.createdAt,
           updatedAt: teamChat.updatedAt,

--- a/packages/agents/src/autonomous/AutonomousDMService.ts
+++ b/packages/agents/src/autonomous/AutonomousDMService.ts
@@ -45,7 +45,7 @@ export class AutonomousDMService {
     const config = await getAgentConfig(agentUserId);
 
     // For user-controlled agents, get the owner ID to filter out owner DMs
-    // (Owner should use Command Center/team chat instead of DMs)
+    // (Owner should use Agents/team chat instead of DMs)
     let ownerUserId: string | null = null;
     if (!isNpcUser(agentUserId)) {
       const [agentRecord] = await db
@@ -71,7 +71,7 @@ export class AutonomousDMService {
       const chat = chatParticipant.chat;
       if (!chat || chat.isGroup) continue; // Skip group chats
 
-      // Skip DMs with the owner - owner should use Command Center instead
+      // Skip DMs with the owner - owner should use Agents chat instead
       // Directly check if owner is a participant (more reliable than checking arbitrary other participant)
       if (ownerUserId && chat.id) {
         const ownerParticipation = await db
@@ -87,7 +87,7 @@ export class AutonomousDMService {
 
         if (ownerParticipation.length > 0) {
           logger.debug(
-            `Skipping DM with owner ${ownerUserId} - use Command Center instead`,
+            `Skipping DM with owner ${ownerUserId} - use Agents chat instead`,
             undefined,
             'AutonomousDM'
           );

--- a/packages/agents/src/autonomous/AutonomousGroupChatService.ts
+++ b/packages/agents/src/autonomous/AutonomousGroupChatService.ts
@@ -49,7 +49,7 @@ export class AutonomousGroupChatService {
 
     let messagesCreated = 0;
 
-    // Filter out team chats (Command Center) - agents shouldn't auto-respond there
+    // Filter out team chats (Agents) - agents shouldn't auto-respond there
     // Team chats use group.type = 'team'
     const groupIds = groupChatsRaw
       .map((c) => c.chat?.groupId)
@@ -71,7 +71,7 @@ export class AutonomousGroupChatService {
       const chat = chatParticipant.chat;
       if (!chat || !chat.isGroup) continue; // Skip DMs
 
-      // Skip team chats (Command Center) - user explicitly triggers agent responses there
+      // Skip team chats (Agents) - user explicitly triggers agent responses there
       if (chat.groupId && teamGroupIds.has(chat.groupId)) {
         continue;
       }

--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -1328,7 +1328,7 @@ export async function executeDirectMessage(
   // If chatId not provided, resolve it from recipientId
   if (!chatId && recipientId) {
     // Check if agent is trying to DM their owner - not allowed
-    // Agents should communicate with owners through Command Center (team chat)
+    // Agents should communicate with owners through Agents (team chat)
     const [agent] = await db
       .select({ managedBy: users.managedBy })
       .from(users)
@@ -1338,7 +1338,7 @@ export async function executeDirectMessage(
     if (agent?.managedBy === recipientId) {
       return {
         success: false,
-        error: 'Agent-owner DMs are not allowed - use Command Center instead',
+        error: 'Agent-owner DMs are not allowed - use Agents chat instead',
       };
     }
 

--- a/packages/agents/src/autonomous/utils/context-gatherers.ts
+++ b/packages/agents/src/autonomous/utils/context-gatherers.ts
@@ -245,13 +245,13 @@ export async function getAgentPositions(agentUserId: string): Promise<{
 
 /**
  * Get agent's group chats for potential sharing
- * Excludes team chats (Command Center) - agents shouldn't auto-respond there
+ * Excludes team chats (Agents) - agents shouldn't auto-respond there
  */
 export async function getAgentGroupChats(
   agentUserId: string
 ): Promise<{ id: string; name: string; memberCount: number }[]> {
   try {
-    // Filter out team chats (Command Center)
+    // Filter out team chats (Agents)
     const teamGroups = await db
       .select({ id: groups.id })
       .from(groups)

--- a/packages/agents/src/autonomous/utils/interaction-gatherers.ts
+++ b/packages/agents/src/autonomous/utils/interaction-gatherers.ts
@@ -203,7 +203,7 @@ export async function gatherPendingChatMessages(
   const validChats = agentChats.filter((c) => c.chat !== null);
   if (validChats.length === 0) return interactions;
 
-  // Filter out team chats (Command Center) - agents shouldn't auto-respond there
+  // Filter out team chats (Agents) - agents shouldn't auto-respond there
   // Team chats use group.type = 'team'
   const teamGroups = await db
     .select({ id: groups.id })

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/check-team-chat.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/check-team-chat.ts
@@ -18,7 +18,7 @@ import { logger } from '../../../../shared/logger';
 export const checkTeamChatAction: Action = {
   name: 'CHECK_TEAM_CHAT',
   description:
-    'View recent messages from the team Command Center chat. Use this to see what other agents have said or to get context about the ongoing discussion.',
+    'View recent messages from the team Agents chat. Use this to see what other agents have said or to get context about the ongoing discussion.',
   parameters: {
     limit: {
       type: 'number',

--- a/packages/agents/src/plugins/plugin-agent-core/src/providers/team-members.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/providers/team-members.ts
@@ -2,7 +2,7 @@
  * Team Members Provider
  *
  * Provides information about team chat members for agent context.
- * Allows agents to know who else is in the Command Center and
+ * Allows agents to know who else is in the Agents chat and
  * properly @mention other agents.
  *
  * Requires `teamChatId` to be set in state.values.
@@ -33,7 +33,7 @@ interface TeamMember {
  */
 export const teamMembersProvider: Provider = {
   name: 'TEAM_MEMBERS',
-  description: 'List of team members in the Command Center chat',
+  description: 'List of team members in the Agents chat',
 
   get: async (
     runtime: IAgentRuntime,

--- a/packages/agents/src/services/AgentService.ts
+++ b/packages/agents/src/services/AgentService.ts
@@ -336,19 +336,19 @@ export class AgentServiceV2 {
       void this.setupAgentIdentity(agentUserId);
     }
 
-    // Add agent to Command Center (team chat)
+    // Add agent to Agents (team chat)
     // This creates the team chat if it doesn't exist (first agent)
     try {
       await teamChatService.addAgentToTeamChat(managerUserId, agentUserId);
       logger.info(
-        `Agent ${agentUserId} added to Command Center`,
+        `Agent ${agentUserId} added to Agents`,
         undefined,
         'AgentService'
       );
     } catch (error) {
       // Log but don't fail agent creation - team chat can be synced later
       logger.error(
-        `Failed to add agent ${agentUserId} to Command Center: ${error}`,
+        `Failed to add agent ${agentUserId} to Agents: ${error}`,
         { managerUserId, agentUserId },
         'AgentService'
       );
@@ -522,10 +522,10 @@ export class AgentServiceV2 {
     );
     if (!agentWithConfig) throw new Error('Agent not found');
 
-    // Remove agent from Command Center BEFORE deleting (so we can still get agent info)
+    // Remove agent from Agents BEFORE deleting (so we can still get agent info)
     await teamChatService.removeAgentFromTeamChat(managerUserId, agentUserId);
     logger.info(
-      `Agent ${agentUserId} removed from Command Center`,
+      `Agent ${agentUserId} removed from Agents`,
       undefined,
       'AgentService'
     );

--- a/packages/agents/src/services/TeamChatService.ts
+++ b/packages/agents/src/services/TeamChatService.ts
@@ -1,7 +1,7 @@
 /**
- * Team Chat Service - Agent Command Center
+ * Team Chat Service - Agents
  *
- * Manages the unified "Command Center" group chat for each user's agents.
+ * Manages the unified "Agents" group chat for each user's agents.
  * Each user has exactly ONE team chat containing ALL their agents.
  *
  * Lifecycle:
@@ -33,8 +33,8 @@ import {
 } from '@babylon/db';
 import { logger } from '../shared/logger';
 
-/** Constants for Command Center */
-const TEAM_CHAT_NAME = 'Command Center';
+/** Constants for Agents */
+const TEAM_CHAT_NAME = 'Agents';
 const TEAM_CHAT_DESCRIPTION = 'Coordinate all your agents in one place';
 
 /**
@@ -64,7 +64,7 @@ export interface TeamChatWithMembers extends TeamChatInfo {
 }
 
 /**
- * Service for managing user agent team chats (Command Center)
+ * Service for managing user agent team chats (Agents)
  */
 export class TeamChatService {
   /**
@@ -112,7 +112,7 @@ export class TeamChatService {
           generateSnowflakeId(),
         ]);
 
-        // 1. Create the Group (type='team' for Command Center)
+        // 1. Create the Group (type='team' for Agents)
         // activeChatId will be set after creating the first Chat
         await tx.insert(groups).values({
           id: groupId,

--- a/packages/db/src/schema/messaging.ts
+++ b/packages/db/src/schema/messaging.ts
@@ -16,7 +16,7 @@ import {
 // - 'user': User-created groups
 // - 'npc': NPC-managed groups (tiered alpha groups)
 // - 'agent': Agent-created groups
-// - 'team': User's Command Center (team chat with their agents)
+// - 'team': User's Agents (team chat with their agents)
 export const groupTypeEnum = pgEnum('group_type', [
   'user',
   'npc',
@@ -209,7 +209,7 @@ export const groups = pgTable(
     index('Group_tier_idx').on(table.tier),
     index('Group_ownerId_tier_idx').on(table.ownerId, table.tier),
     index('Group_parentGroupId_idx').on(table.parentGroupId),
-    // Ensure only ONE team group (Command Center) per owner
+    // Ensure only ONE team group (Agents) per owner
     // This prevents race conditions from creating duplicate team chats
     uniqueIndex('Group_team_ownerId_unique')
       .on(table.ownerId)

--- a/packages/engine/src/services/dm-service.ts
+++ b/packages/engine/src/services/dm-service.ts
@@ -23,7 +23,7 @@ import { generateSnowflakeId, logger } from '@babylon/shared';
  * Get or create a DM chat between two users.
  *
  * NOTE: This function should NOT be used for agent-owner communication.
- * Agents should communicate with their owners through the Command Center (team chat).
+ * Agents should communicate with their owners through the Agents (team chat).
  *
  * @param userA - First user ID
  * @param userB - Second user ID
@@ -35,7 +35,7 @@ export async function getOrCreateDMChat(
   userB: string
 ): Promise<string> {
   // Check if either user is an agent trying to DM their owner
-  // Agents should use Command Center instead
+  // Agents should use Agents chat instead
   const [userAInfo, userBInfo] = await Promise.all([
     db
       .select({ isAgent: users.isAgent, managedBy: users.managedBy })
@@ -55,12 +55,12 @@ export async function getOrCreateDMChat(
   // Block agent-owner DMs (both directions)
   if (userAData?.isAgent && userAData?.managedBy === userB) {
     throw new Error(
-      'Agent-owner DMs are not allowed - use Command Center instead'
+      'Agent-owner DMs are not allowed - use Agents chat instead'
     );
   }
   if (userBData?.isAgent && userBData?.managedBy === userA) {
     throw new Error(
-      'Agent-owner DMs are not allowed - use Command Center instead'
+      'Agent-owner DMs are not allowed - use Agents chat instead'
     );
   }
 

--- a/packages/testing/integration/team-chat.integration.test.ts
+++ b/packages/testing/integration/team-chat.integration.test.ts
@@ -1,5 +1,5 @@
 /**
- * Team Chat (Command Center) Integration Tests
+ * Team Chat (Agents) Integration Tests
  *
  * Tests the unified team chat functionality with real database operations:
  * - TeamChatService lifecycle (create, add, remove)
@@ -7,7 +7,7 @@
  * - Concurrent operations
  * - API endpoint validation
  *
- * These tests verify the Command Center works correctly for agent coordination.
+ * These tests verify the Agents chat works correctly for agent coordination.
  */
 
 import { afterAll, describe, expect, test } from 'bun:test';
@@ -156,7 +156,7 @@ describe('TeamChatService', () => {
         .from(groups)
         .where(eq(groups.id, teamChat.groupId));
       expect(group).toBeDefined();
-      expect(group!.name).toBe('Command Center');
+      expect(group!.name).toBe('Agents');
       expect(group!.type).toBe('team');
       expect(group!.ownerId).toBe(user.id);
 

--- a/packages/testing/synpress/11-agent-team-chat.synpress.spec.ts
+++ b/packages/testing/synpress/11-agent-team-chat.synpress.spec.ts
@@ -1,8 +1,8 @@
 /**
- * Agent Team Chat (Command Center) E2E Tests with Synpress
+ * Agent Team Chat (Agents) E2E Tests with Synpress
  *
  * Tests the unified team chat functionality for agent coordination:
- * - Loading the Command Center page
+ * - Loading the Agents page
  * - Viewing agent member list
  * - Sending messages with @mentions
  * - Mobile responsive design
@@ -21,7 +21,7 @@ import { ROUTES } from './helpers/test-data';
 // Increase test timeout for network operations
 test.setTimeout(90000);
 
-test.describe('Agent Team Chat (Command Center)', () => {
+test.describe('Agent Team Chat (Agents)', () => {
   test.beforeEach(async ({ page }) => {
     // Desktop viewport
     await page.setViewportSize({ width: 1920, height: 1080 });
@@ -50,24 +50,24 @@ test.describe('Agent Team Chat (Command Center)', () => {
     await cooldownBetweenTests(page);
   });
 
-  test('should load Command Center page', async ({ page }) => {
+  test('should load Agents page', async ({ page }) => {
     expect(page.url()).toContain('/agents/team');
 
     const pageContent = await page.locator('body').textContent();
 
-    // Check for Command Center content
-    const hasCommandCenterContent =
-      pageContent?.toLowerCase().includes('command center') ||
+    // Check for Agents content
+    const hasAgentsContent =
+      pageContent?.toLowerCase().includes('agents') ||
       pageContent?.toLowerCase().includes('team') ||
       pageContent?.toLowerCase().includes('agent');
 
-    expect(hasCommandCenterContent).toBe(true);
+    expect(hasAgentsContent).toBe(true);
 
     await page.screenshot({
-      path: 'test-results/screenshots/11-command-center-page.png',
+      path: 'test-results/screenshots/11-agents-page.png',
       fullPage: true,
     });
-    console.log('✅ Command Center page loaded');
+    console.log('✅ Agents page loaded');
   });
 
   test('should display "no agents" state when user has no agents', async ({
@@ -82,10 +82,10 @@ test.describe('Agent Team Chat (Command Center)', () => {
     const hasContent =
       pageContent?.toLowerCase().includes('create') ||
       pageContent?.toLowerCase().includes('agent') ||
-      pageContent?.toLowerCase().includes('command center');
+      pageContent?.toLowerCase().includes('agents');
 
     expect(hasContent).toBe(true);
-    console.log('✅ Command Center displays appropriate state');
+    console.log('✅ Agents displays appropriate state');
   });
 
   test('should show connection status indicator', async ({ page }) => {
@@ -154,7 +154,7 @@ test.describe('Agent Team Chat (Command Center)', () => {
   });
 });
 
-test.describe('Command Center @Mention Functionality', () => {
+test.describe('Agents @Mention Functionality', () => {
   test.beforeEach(async ({ page }) => {
     await page.setViewportSize({ width: 1920, height: 1080 });
     await navigateTo(page, ROUTES.HOME);
@@ -258,7 +258,7 @@ test.describe('Command Center @Mention Functionality', () => {
   });
 });
 
-test.describe('Command Center Mobile Responsiveness', () => {
+test.describe('Agents Mobile Responsiveness', () => {
   test.beforeEach(async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 667 });
     await navigateTo(page, ROUTES.HOME);
@@ -270,7 +270,7 @@ test.describe('Command Center Mobile Responsiveness', () => {
     await cooldownBetweenTests(page);
   });
 
-  test('should load Command Center on mobile', async ({ page }) => {
+  test('should load Agents on mobile', async ({ page }) => {
     await navigateTo(page, ROUTES.AGENTS_TEAM_CHAT);
     await waitForPageLoad(page);
     await page.waitForTimeout(2000);
@@ -281,11 +281,11 @@ test.describe('Command Center Mobile Responsiveness', () => {
     expect(pageContent).toBeTruthy();
 
     await page.screenshot({
-      path: 'test-results/screenshots/11-command-center-mobile.png',
+      path: 'test-results/screenshots/11-agents-mobile.png',
       fullPage: true,
     });
 
-    console.log('✅ Command Center loads on mobile');
+    console.log('✅ Agents loads on mobile');
   });
 
   test('should show mobile member drawer button', async ({ page }) => {
@@ -371,7 +371,7 @@ test.describe('Command Center Mobile Responsiveness', () => {
   });
 });
 
-test.describe('Command Center Navigation', () => {
+test.describe('Agents Navigation', () => {
   test.beforeEach(async ({ page }) => {
     await page.setViewportSize({ width: 1920, height: 1080 });
     await navigateTo(page, ROUTES.HOME);
@@ -383,59 +383,57 @@ test.describe('Command Center Navigation', () => {
     await cooldownBetweenTests(page);
   });
 
-  test('should navigate to Command Center from sidebar', async ({ page }) => {
-    // Look for Command Center link in sidebar
-    const commandCenterLink = page
+  test('should navigate to Agents from sidebar', async ({ page }) => {
+    // Look for Agents link in sidebar
+    const agentsLink = page
       .locator('a[href="/agents/team"]')
-      .or(page.getByRole('link', { name: /Command Center/i }))
+      .or(page.getByRole('link', { name: /Agents/i }))
       .first();
 
-    const linkVisible = await commandCenterLink
+    const linkVisible = await agentsLink
       .isVisible({ timeout: 5000 })
       .catch(() => false);
 
     if (linkVisible) {
-      await commandCenterLink.click();
+      await agentsLink.click();
       await page.waitForTimeout(2000);
 
       expect(page.url()).toContain('/agents/team');
-      console.log('✅ Navigation to Command Center from sidebar works');
+      console.log('✅ Navigation to Agents from sidebar works');
     } else {
       // User may not have agents
-      console.log('ℹ️ Command Center link not visible (requires agents)');
+      console.log('ℹ️ Agents link not visible (requires agents)');
     }
   });
 
-  test('should navigate to Command Center from agents page', async ({
-    page,
-  }) => {
+  test('should navigate to Agents from agents page', async ({ page }) => {
     await navigateTo(page, ROUTES.AGENTS);
     await waitForPageLoad(page);
     await page.waitForTimeout(1500);
 
-    // Look for Command Center card/link on agents page
-    const commandCenterCard = page
+    // Look for Agents Chat card/link on agents page
+    const agentsCard = page
       .locator('a[href="/agents/team"]')
       .or(
         page
-          .getByText(/Command Center/i)
+          .getByText(/Agents Chat/i)
           .locator('..')
           .locator('a')
       )
       .first();
 
-    const cardVisible = await commandCenterCard
+    const cardVisible = await agentsCard
       .isVisible({ timeout: 5000 })
       .catch(() => false);
 
     if (cardVisible) {
-      await commandCenterCard.click();
+      await agentsCard.click();
       await page.waitForTimeout(2000);
 
       expect(page.url()).toContain('/agents/team');
-      console.log('✅ Navigation to Command Center from agents page works');
+      console.log('✅ Navigation to Agents from agents page works');
     } else {
-      console.log('ℹ️ Command Center card not visible (requires agents)');
+      console.log('ℹ️ Agents card not visible (requires agents)');
     }
   });
 


### PR DESCRIPTION
## Summary

- Rename "Command Center" to "Agents" throughout the codebase
- Rename "Markets" to "Terminal" in navigation UI

## Changes

### Navigation (3 files)
- Sidebar, MobileHeader, BottomNav: Markets → Terminal, Command Center → Agents

### Team Chat UI (10 files)
- TeamChatView, team/page.tsx, agents/page.tsx, admin GroupsTab
- MemberTypeBadge, ActivityFilters, ConversationList, MemberList
- AgentCreate, AgentDetail component doc comments

### Hooks & Pages (3 files)
- useTeamChat error messages and chat name
- chats/page.tsx redirect comment
- profile page message button tooltip

### Service Layer (2 files)
- TeamChatService: TEAM_CHAT_NAME constant changed to "Agents"
- AgentService: log messages updated

### API Routes (6 files)
- team-chat routes: error messages, doc comments, OpenAPI descriptions
- agent chat route: system prompts for team chat context
- chats route: comments about filtering team chats

### Autonomous Agent System (7 files)
- DirectExecutors, AutonomousDMService, AutonomousGroupChatService
- context-gatherers, interaction-gatherers
- check-team-chat action, team-members provider

### Database & Engine (2 files)
- messaging.ts schema comments (enum values unchanged)
- dm-service error messages

### Tests (2 files)
- team-chat.integration.test.ts: expected group name
- synpress E2E tests: descriptions, assertions, screenshot filenames

## Test plan
- [ ] Verify navigation shows "Terminal" instead of "Markets"
- [ ] Verify sidebar shows "Agents" instead of "Command Center"
- [ ] Verify team chat UI displays "Agents" headers
- [ ] Verify error messages reference "Agents" correctly
- [ ] Run integration tests to confirm assertions pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Rebranded "Command Center" to "Agents" across the user interface, including cards, chat features, and navigation.
  * Renamed "Markets" navigation item to "Terminal."
  * Updated related UI labels and tooltips.

* **Tests**
  * Updated test suites to reflect terminology changes.

* **Documentation**
  * Updated inline comments and documentation strings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR comprehensively renames "Command Center" to "Agents" and "Markets" to "Terminal" throughout the codebase. The changes are purely cosmetic - updating user-facing labels, documentation comments, error messages, and test assertions - without modifying any underlying logic, data structures, or API contracts.

## Key Changes

- **Navigation UI**: Updated `Sidebar`, `BottomNav`, and `MobileHeader` to display "Terminal" instead of "Markets" and "Agents" instead of "Command Center"
- **Service Layer**: Changed `TEAM_CHAT_NAME` constant from "Command Center" to "Agents" in `TeamChatService.ts`
- **API Routes**: Updated OpenAPI documentation, error messages, and comments across all team-chat endpoints
- **UI Components**: Updated headers, titles, and loading states in `TeamChatView`, team chat page, and related components
- **System Prompts**: Updated agent context descriptions to reference "Agents" team chat
- **Error Messages**: Consistent messaging throughout hooks, services, and DM protection logic
- **Tests**: Updated integration test assertions to expect group name "Agents"
- **E2E Tests**: Updated synpress test descriptions and assertions

## Strengths

- Very thorough and consistent renaming across 35 files spanning UI, API, services, and tests
- No breaking changes to database schema, API endpoints, or data structures
- Maintains backward compatibility (enum values unchanged)
- Test expectations properly updated to match new naming

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- This is a straightforward, cosmetic renaming PR with no logic changes, breaking changes, or risky modifications. All changes are find-and-replace style updates to strings, comments, and documentation. Tests have been updated to match the new naming conventions.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agents/src/services/TeamChatService.ts | Updated TEAM_CHAT_NAME constant to 'Agents' and all related documentation |
| apps/web/src/app/api/agents/team-chat/route.ts | Updated API documentation, error messages, and comments to reference Agents |
| apps/web/src/hooks/useTeamChat.ts | Updated hook documentation, error messages, and chat name property |
| apps/web/src/components/chats/TeamChatView.tsx | Updated UI headers from 'Command Center' to 'Agents' throughout component |
| apps/web/src/app/agents/team/page.tsx | Updated documentation, UI text, and error messages to reference Agents |
| packages/testing/integration/team-chat.integration.test.ts | Updated test expectations to assert group name is 'Agents' instead of 'Command Center' |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant UI as UI Components
    participant API as API Routes
    participant Service as Service Layer
    participant DB as Database
    
    Note over User,DB: Navigation Renaming: Markets → Terminal
    User->>UI: Views Navigation
    UI->>UI: Displays "Terminal" (was "Markets")
    Note over UI: Sidebar, BottomNav, MobileHeader
    
    Note over User,DB: Team Chat Renaming: Command Center → Agents
    User->>UI: Opens /agents/team
    UI->>API: GET /api/agents/team-chat
    API->>Service: teamChatService.getTeamChat()
    Service->>DB: Query groups table
    DB-->>Service: Return group (name: "Agents")
    Service-->>API: TeamChat with "Agents" name
    API-->>UI: TeamChat data
    UI->>UI: Display "Agents" header/title
    UI-->>User: Shows "Agents" throughout UI
    
    Note over User,DB: Error Messages & Documentation
    User->>API: Request without team chat
    API-->>User: "Create your first agent to initialize your Agents chat"
    
    Note over User,DB: Agent System Prompts
    User->>API: POST /api/agents/[agentId]/chat
    API->>API: Generate system prompt
    Note over API: References "Agents" team chat<br/>in context (not "Command Center")
    API->>Service: Process agent chat
    
    Note over User,DB: DM Service Protection
    User->>Service: Attempt agent-owner DM
    Service->>Service: Check if agent-owner communication
    Service-->>User: Error: "Use Agents chat instead"
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->