### PR TITLE
fix(feed): show comment input bar on all posts

### DIFF
--- a/apps/web/src/components/posts/CommentPreview.test.tsx
+++ b/apps/web/src/components/posts/CommentPreview.test.tsx
@@ -1,6 +1,5 @@
-'use client';
-
 import { describe, expect, it } from 'bun:test';
+import { formatTimeAgo } from './CommentPreview';
 
 /**
  * Tests for CommentPreview component logic.
@@ -8,32 +7,6 @@ import { describe, expect, it } from 'bun:test';
  * Note: These tests verify the conditional rendering logic and utility functions.
  * Full component rendering tests would require @testing-library/react.
  */
-
-/**
- * Replicated formatTimeAgo logic from CommentPreview for unit testing.
- */
-function formatTimeAgo(timestamp: string): string {
-  try {
-    const date = new Date(timestamp);
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffMinutes = Math.floor(diffMs / 60000);
-    const diffHours = Math.floor(diffMs / 3600000);
-    const diffDays = Math.floor(diffMs / 86400000);
-    const diffWeeks = Math.floor(diffDays / 7);
-
-    if (diffMinutes < 1) return 'just now';
-    if (diffMinutes < 60) return `${diffMinutes}m ago`;
-    if (diffHours < 24) return `${diffHours}h ago`;
-    if (diffDays < 7) return `${diffDays}d ago`;
-    if (diffWeeks < 4) return `${diffWeeks}w ago`;
-
-    // For older dates, fall back to a general format
-    return 'over a month ago';
-  } catch {
-    return '';
-  }
-}
 
 describe('CommentPreview - formatTimeAgo', () => {
   it('should return "just now" for timestamps less than 1 minute ago', () => {
@@ -73,15 +46,43 @@ describe('CommentPreview - formatTimeAgo', () => {
       Date.now() - 14 * 24 * 60 * 60 * 1000
     ).toISOString();
     expect(formatTimeAgo(twoWeeksAgo)).toBe('2w ago');
+
+    // 3 weeks (21 days) - still under 4 weeks boundary
+    const threeWeeksAgo = new Date(
+      Date.now() - 21 * 24 * 60 * 60 * 1000
+    ).toISOString();
+    expect(formatTimeAgo(threeWeeksAgo)).toBe('3w ago');
   });
 
-  it('should handle edge case timestamps gracefully', () => {
-    // Invalid dates result in NaN calculations, which produces unexpected output
-    // The actual component uses try/catch which handles this
-    // For truly invalid input that throws, empty string is returned
-    const result = formatTimeAgo('');
-    // Empty string creates Invalid Date, NaN diff, returns fallback
-    expect(typeof result).toBe('string');
+  it('should handle 4-week boundary and older timestamps', () => {
+    // Exactly 4 weeks (28 days) - at the boundary, should use formatDistanceToNow
+    const fourWeeksAgo = new Date(
+      Date.now() - 28 * 24 * 60 * 60 * 1000
+    ).toISOString();
+    const fourWeeksResult = formatTimeAgo(fourWeeksAgo);
+    // formatDistanceToNow returns strings like "about 1 month ago"
+    expect(fourWeeksResult).toContain('ago');
+    expect(fourWeeksResult).not.toBe('4w ago'); // Should NOT be weeks format
+
+    // 60 days - well past the 4-week boundary
+    const sixtyDaysAgo = new Date(
+      Date.now() - 60 * 24 * 60 * 60 * 1000
+    ).toISOString();
+    const sixtyDaysResult = formatTimeAgo(sixtyDaysAgo);
+    expect(sixtyDaysResult).toContain('ago');
+    expect(sixtyDaysResult).not.toMatch(/^\d+w ago$/); // Should NOT be weeks format
+  });
+
+  it('should return empty string for invalid timestamps', () => {
+    // Empty string creates Invalid Date with NaN time
+    // The try/catch in formatTimeAgo handles this gracefully
+    expect(formatTimeAgo('')).toBe('');
+
+    // Completely invalid date string
+    expect(formatTimeAgo('not-a-date')).toBe('');
+
+    // Invalid format that can't be parsed
+    expect(formatTimeAgo('invalid')).toBe('');
   });
 });
 
@@ -93,6 +94,13 @@ describe('CommentPreview - Conditional Rendering Logic', () => {
    * Note: The actual component requires comments as CommentPreviewData[],
    * and PostCard always passes `post.commentPreviews ?? []`, so comments
    * is always a valid array. This test reflects that type-safe behavior.
+   */
+
+  /**
+   * Intentionally minimal subset of CommentPreviewData from @babylon/shared.
+   * The render-decision logic only checks comments.length, not individual
+   * comment properties, so we use a minimal shape for test clarity.
+   * See: packages/shared/src/game-types.ts for the full CommentPreviewData type.
    */
   interface CommentPreviewData {
     id: string;
@@ -114,14 +122,14 @@ describe('CommentPreview - Conditional Rendering Logic', () => {
     const hasComments = comments.length > 0;
 
     return {
-      // Comment list only shown if there are comments
-      showCommentList: hasComments,
-      // View all link only shown if there are more comments than previewed
-      showViewAllLink: hasComments && totalCommentCount > comments.length,
+      // Comment list only shown if there are comments - explicit boolean
+      showCommentList: !!hasComments,
+      // View all link only shown if there are more comments than previewed - explicit boolean
+      showViewAllLink: !!hasComments && totalCommentCount > comments.length,
       // Input bar is ALWAYS shown (this is the new behavior)
       showInputBar: true,
-      // Input bar has margin-top only when there are comments above it
-      inputBarMarginTop: hasComments,
+      // Input bar has margin-top only when there are comments above it - explicit boolean
+      inputBarMarginTop: !!hasComments,
     };
   }
 

--- a/apps/web/src/components/posts/CommentPreview.test.tsx
+++ b/apps/web/src/components/posts/CommentPreview.test.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import { describe, expect, it } from 'bun:test';
+
+/**
+ * Tests for CommentPreview component logic.
+ *
+ * Note: These tests verify the conditional rendering logic and utility functions.
+ * Full component rendering tests would require @testing-library/react.
+ */
+
+/**
+ * Replicated formatTimeAgo logic from CommentPreview for unit testing.
+ */
+function formatTimeAgo(timestamp: string): string {
+  try {
+    const date = new Date(timestamp);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMinutes = Math.floor(diffMs / 60000);
+    const diffHours = Math.floor(diffMs / 3600000);
+    const diffDays = Math.floor(diffMs / 86400000);
+    const diffWeeks = Math.floor(diffDays / 7);
+
+    if (diffMinutes < 1) return 'just now';
+    if (diffMinutes < 60) return `${diffMinutes}m ago`;
+    if (diffHours < 24) return `${diffHours}h ago`;
+    if (diffDays < 7) return `${diffDays}d ago`;
+    if (diffWeeks < 4) return `${diffWeeks}w ago`;
+
+    // For older dates, fall back to a general format
+    return 'over a month ago';
+  } catch {
+    return '';
+  }
+}
+
+describe('CommentPreview - formatTimeAgo', () => {
+  it('should return "just now" for timestamps less than 1 minute ago', () => {
+    const now = new Date().toISOString();
+    expect(formatTimeAgo(now)).toBe('just now');
+  });
+
+  it('should return minutes ago for timestamps under 1 hour', () => {
+    const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    expect(formatTimeAgo(fiveMinutesAgo)).toBe('5m ago');
+
+    const thirtyMinutesAgo = new Date(
+      Date.now() - 30 * 60 * 1000
+    ).toISOString();
+    expect(formatTimeAgo(thirtyMinutesAgo)).toBe('30m ago');
+  });
+
+  it('should return hours ago for timestamps under 24 hours', () => {
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    expect(formatTimeAgo(twoHoursAgo)).toBe('2h ago');
+
+    const twelveHoursAgo = new Date(
+      Date.now() - 12 * 60 * 60 * 1000
+    ).toISOString();
+    expect(formatTimeAgo(twelveHoursAgo)).toBe('12h ago');
+  });
+
+  it('should return days ago for timestamps under 7 days', () => {
+    const threeDaysAgo = new Date(
+      Date.now() - 3 * 24 * 60 * 60 * 1000
+    ).toISOString();
+    expect(formatTimeAgo(threeDaysAgo)).toBe('3d ago');
+  });
+
+  it('should return weeks ago for timestamps under 4 weeks', () => {
+    const twoWeeksAgo = new Date(
+      Date.now() - 14 * 24 * 60 * 60 * 1000
+    ).toISOString();
+    expect(formatTimeAgo(twoWeeksAgo)).toBe('2w ago');
+  });
+
+  it('should handle edge case timestamps gracefully', () => {
+    // Invalid dates result in NaN calculations, which produces unexpected output
+    // The actual component uses try/catch which handles this
+    // For truly invalid input that throws, empty string is returned
+    const result = formatTimeAgo('');
+    // Empty string creates Invalid Date, NaN diff, returns fallback
+    expect(typeof result).toBe('string');
+  });
+});
+
+describe('CommentPreview - Conditional Rendering Logic', () => {
+  /**
+   * Simulates the conditional logic used in CommentPreview component.
+   * Returns what sections should be rendered based on input.
+   */
+  interface CommentPreviewData {
+    id: string;
+    content: string;
+  }
+
+  interface RenderDecision {
+    showCommentList: boolean;
+    showViewAllLink: boolean;
+    showInputBar: boolean;
+    inputBarMarginTop: boolean;
+  }
+
+  function getCommentPreviewRenderDecision(
+    comments: CommentPreviewData[] | undefined | null,
+    totalCommentCount: number
+  ): RenderDecision {
+    const hasComments = comments && comments.length > 0;
+
+    return {
+      // Comment list only shown if there are comments
+      showCommentList: hasComments ?? false,
+      // View all link only shown if there are more comments than previewed
+      showViewAllLink: hasComments ? totalCommentCount > comments.length : false,
+      // Input bar is ALWAYS shown (this is the new behavior)
+      showInputBar: true,
+      // Input bar has margin-top only when there are comments above it
+      inputBarMarginTop: hasComments ?? false,
+    };
+  }
+
+  describe('with no comments', () => {
+    it('should show input bar but not comment list', () => {
+      const result = getCommentPreviewRenderDecision([], 0);
+
+      expect(result.showCommentList).toBe(false);
+      expect(result.showViewAllLink).toBe(false);
+      expect(result.showInputBar).toBe(true);
+      expect(result.inputBarMarginTop).toBe(false);
+    });
+
+    it('should show input bar when comments is undefined', () => {
+      const result = getCommentPreviewRenderDecision(undefined, 0);
+
+      expect(result.showCommentList).toBe(false);
+      expect(result.showInputBar).toBe(true);
+    });
+
+    it('should show input bar when comments is null', () => {
+      const result = getCommentPreviewRenderDecision(null, 0);
+
+      expect(result.showCommentList).toBe(false);
+      expect(result.showInputBar).toBe(true);
+    });
+  });
+
+  describe('with comments', () => {
+    const mockComments: CommentPreviewData[] = [
+      { id: '1', content: 'First comment' },
+      { id: '2', content: 'Second comment' },
+    ];
+
+    it('should show comment list and input bar', () => {
+      const result = getCommentPreviewRenderDecision(mockComments, 2);
+
+      expect(result.showCommentList).toBe(true);
+      expect(result.showInputBar).toBe(true);
+      expect(result.inputBarMarginTop).toBe(true);
+    });
+
+    it('should show "view all" link when total exceeds previewed count', () => {
+      const result = getCommentPreviewRenderDecision(mockComments, 10);
+
+      expect(result.showViewAllLink).toBe(true);
+    });
+
+    it('should not show "view all" link when all comments are previewed', () => {
+      const result = getCommentPreviewRenderDecision(mockComments, 2);
+
+      expect(result.showViewAllLink).toBe(false);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle single comment correctly', () => {
+      const singleComment = [{ id: '1', content: 'Only comment' }];
+      const result = getCommentPreviewRenderDecision(singleComment, 1);
+
+      expect(result.showCommentList).toBe(true);
+      expect(result.showViewAllLink).toBe(false);
+      expect(result.showInputBar).toBe(true);
+    });
+
+    it('should handle high engagement post (50+ comments)', () => {
+      const twoComments = [
+        { id: '1', content: 'Comment 1' },
+        { id: '2', content: 'Comment 2' },
+      ];
+      const result = getCommentPreviewRenderDecision(twoComments, 150);
+
+      expect(result.showCommentList).toBe(true);
+      expect(result.showViewAllLink).toBe(true);
+      expect(result.showInputBar).toBe(true);
+    });
+  });
+});

--- a/apps/web/src/components/posts/CommentPreview.test.tsx
+++ b/apps/web/src/components/posts/CommentPreview.test.tsx
@@ -89,6 +89,10 @@ describe('CommentPreview - Conditional Rendering Logic', () => {
   /**
    * Simulates the conditional logic used in CommentPreview component.
    * Returns what sections should be rendered based on input.
+   *
+   * Note: The actual component requires comments as CommentPreviewData[],
+   * and PostCard always passes `post.commentPreviews ?? []`, so comments
+   * is always a valid array. This test reflects that type-safe behavior.
    */
   interface CommentPreviewData {
     id: string;
@@ -103,24 +107,25 @@ describe('CommentPreview - Conditional Rendering Logic', () => {
   }
 
   function getCommentPreviewRenderDecision(
-    comments: CommentPreviewData[] | undefined | null,
+    comments: CommentPreviewData[],
     totalCommentCount: number
   ): RenderDecision {
-    const hasComments = comments && comments.length > 0;
+    // Type-safe: comments is always an array (required prop)
+    const hasComments = comments.length > 0;
 
     return {
       // Comment list only shown if there are comments
-      showCommentList: hasComments ?? false,
+      showCommentList: hasComments,
       // View all link only shown if there are more comments than previewed
-      showViewAllLink: hasComments ? totalCommentCount > comments.length : false,
+      showViewAllLink: hasComments && totalCommentCount > comments.length,
       // Input bar is ALWAYS shown (this is the new behavior)
       showInputBar: true,
       // Input bar has margin-top only when there are comments above it
-      inputBarMarginTop: hasComments ?? false,
+      inputBarMarginTop: hasComments,
     };
   }
 
-  describe('with no comments', () => {
+  describe('with no comments (empty array)', () => {
     it('should show input bar but not comment list', () => {
       const result = getCommentPreviewRenderDecision([], 0);
 
@@ -130,15 +135,10 @@ describe('CommentPreview - Conditional Rendering Logic', () => {
       expect(result.inputBarMarginTop).toBe(false);
     });
 
-    it('should show input bar when comments is undefined', () => {
-      const result = getCommentPreviewRenderDecision(undefined, 0);
-
-      expect(result.showCommentList).toBe(false);
-      expect(result.showInputBar).toBe(true);
-    });
-
-    it('should show input bar when comments is null', () => {
-      const result = getCommentPreviewRenderDecision(null, 0);
+    it('should handle empty array correctly (PostCard always passes [])', () => {
+      // PostCard always passes `post.commentPreviews ?? []`
+      // so this is the expected input for posts without comments
+      const result = getCommentPreviewRenderDecision([], 0);
 
       expect(result.showCommentList).toBe(false);
       expect(result.showInputBar).toBe(true);

--- a/apps/web/src/components/posts/CommentPreview.tsx
+++ b/apps/web/src/components/posts/CommentPreview.tsx
@@ -167,8 +167,9 @@ const CommentPreviewItem = memo(function CommentPreviewItem({
 
 /**
  * Format timestamp to relative time with suffix (e.g., "5m ago", "2h ago", "just now")
+ * Exported for unit testing.
  */
-function formatTimeAgo(timestamp: string): string {
+export function formatTimeAgo(timestamp: string): string {
   try {
     const date = new Date(timestamp);
     const now = new Date();

--- a/apps/web/src/components/posts/CommentPreview.tsx
+++ b/apps/web/src/components/posts/CommentPreview.tsx
@@ -50,7 +50,8 @@ export const CommentPreview = memo(function CommentPreview({
   onViewAllClick,
   className,
 }: CommentPreviewProps) {
-  const hasComments = comments && comments.length > 0;
+  // Type-safe check: comments is always an array (required prop)
+  const hasComments = comments.length > 0;
 
   return (
     <div

--- a/apps/web/src/components/posts/CommentPreview.tsx
+++ b/apps/web/src/components/posts/CommentPreview.tsx
@@ -50,24 +50,24 @@ export const CommentPreview = memo(function CommentPreview({
   onViewAllClick,
   className,
 }: CommentPreviewProps) {
-  if (!comments || comments.length === 0) {
-    return null;
-  }
+  const hasComments = comments && comments.length > 0;
 
   return (
     <div
-      className={cn('mt-3 border-muted border-b pb-3', className)}
+      className={cn('mt-3 border-muted border-t pt-3', className)}
       onClick={(e) => e.stopPropagation()}
     >
-      {/* Comment list */}
-      <div className="space-y-3">
-        {comments.map((comment) => (
-          <CommentPreviewItem key={comment.id} comment={comment} />
-        ))}
-      </div>
+      {/* Comment list - only show if there are comments */}
+      {hasComments && (
+        <div className="space-y-3">
+          {comments.map((comment) => (
+            <CommentPreviewItem key={comment.id} comment={comment} />
+          ))}
+        </div>
+      )}
 
-      {/* View all comments link */}
-      {totalCommentCount > comments.length && (
+      {/* View all comments link - only show if there are more comments than previewed */}
+      {hasComments && totalCommentCount > comments.length && (
         <button
           type="button"
           onClick={(e) => {
@@ -80,7 +80,7 @@ export const CommentPreview = memo(function CommentPreview({
         </button>
       )}
 
-      {/* Comment input bar - opens full comment section on click */}
+      {/* Comment input bar - always shown on all posts */}
       <button
         type="button"
         onClick={(e) => {
@@ -88,7 +88,8 @@ export const CommentPreview = memo(function CommentPreview({
           onViewAllClick?.();
         }}
         className={cn(
-          'mt-3 w-full rounded-full border border-border/20 bg-muted',
+          hasComments ? 'mt-3' : '',
+          'w-full rounded-full border border-border/20 bg-muted',
           'px-4 py-2 text-left text-muted-foreground text-sm',
           'hover:bg-muted/80',
           'cursor-text transition-colors'

--- a/apps/web/src/components/posts/PostCard.tsx
+++ b/apps/web/src/components/posts/PostCard.tsx
@@ -542,17 +542,14 @@ export const PostCard = memo(function PostCard({
         </div>
       )}
 
-      {/* Row 4: Comment Previews - Shows top 1-2 comments inline based on engagement */}
-      {showCommentPreviews &&
-        !isDetail &&
-        post.commentPreviews &&
-        post.commentPreviews.length > 0 && (
-          <CommentPreview
-            comments={post.commentPreviews}
-            totalCommentCount={post.commentCount ?? 0}
-            onViewAllClick={onCommentClick}
-          />
-        )}
+      {/* Row 4: Comment Section - Shows previews (if any) + "Leave a comment" input on all posts */}
+      {showCommentPreviews && !isDetail && (
+        <CommentPreview
+          comments={post.commentPreviews ?? []}
+          totalCommentCount={post.commentCount ?? 0}
+          onViewAllClick={onCommentClick}
+        />
+      )}
     </article>
   );
 });


### PR DESCRIPTION
## Summary

- Show "Leave a comment..." input bar on ALL posts in the feed, not just posts with existing comments
- Adds visual separator (border-top) to all posts for consistent spacing

## Problem

Previously, the comment input bar only appeared on posts that already had comments. This missed an opportunity to encourage engagement on posts without comments.

## Changes

- `CommentPreview.tsx` - No longer returns `null` when comments array is empty
- `PostCard.tsx` - Always renders `CommentPreview` section (removed conditional check for `comments.length > 0`)
- Changed from `border-b` to `border-t` for proper visual separation above the comment section

## Test plan

- [x] `bun typecheck` passes
- [ ] Load feed and verify "Leave a comment..." appears on all posts
- [ ] Verify posts with comments still show comment previews above the input
- [ ] Verify clicking input opens full comment section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Comment section now uses a top border and top spacing for clearer visual hierarchy.
  * "View all comments" appears only when comments exist and counts warrant it.
  * Comment preview area is consistently shown across posts; the comment list remains hidden when empty.
  * Comment input stays visible and gains top margin only when comments are present.

* **Tests**
  * Added unit tests covering comment preview rendering decisions and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Enabled comment input bar on all posts to encourage engagement, not just posts with existing comments. Changed visual separator from `border-b` to `border-t` for consistent spacing above the comment section.

<h3>Confidence Score: 5/5</h3>

- Safe to merge - simple UI change with no logical or functional risks
- Changes are minimal, well-structured, and achieve the stated goal without introducing bugs or breaking existing functionality
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/components/posts/CommentPreview.tsx | Removed early return for empty comments; added conditional rendering for comment list and "View all" link; changed border from bottom to top with appropriate spacing adjustments |
| apps/web/src/components/posts/PostCard.tsx | Removed conditional check for commentPreviews length; now always renders CommentPreview section with empty array fallback |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant PostCard
    participant CommentPreview
    
    User->>PostCard: View post in feed
    PostCard->>PostCard: Check showCommentPreviews && !isDetail
    alt showCommentPreviews is true
        PostCard->>CommentPreview: Render with comments={commentPreviews ?? []}
        CommentPreview->>CommentPreview: Check hasComments = comments.length > 0
        alt hasComments is true
            CommentPreview->>User: Show comment list
            CommentPreview->>User: Show "View all X comments" link
        end
        CommentPreview->>User: Show "Leave a comment..." input bar
    end
    User->>CommentPreview: Click "Leave a comment..." or "View all"
    CommentPreview->>PostCard: Trigger onViewAllClick()
    PostCard->>User: Open full comment section
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->