### PR TITLE
fix(agents): defer PnL recording to avoid nested transaction deadlocks

### DIFF
--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -216,15 +216,27 @@ function createPerpWalletAdapter(isNpc: boolean) {
   };
 }
 
+/** PnL record to be processed after transaction completes */
+interface DeferredPnLRecord {
+  userId: string;
+  pnl: number;
+  reason: string;
+  relatedId?: string;
+}
+
 /**
  * Creates a wallet adapter for prediction market trading operations.
  *
  * - NPCs use actorState.tradingBalance (within the provided transaction context).
  * - Regular users use WalletService.
+ *
+ * IMPORTANT: recordPnL is deferred to avoid nested transaction deadlocks.
+ * The caller must process deferredPnL after the transaction completes.
  */
 function createPredictionWalletAdapter(
   isNpc: boolean,
-  txDb?: Parameters<Parameters<typeof asUser>[1]>[0]
+  txDb?: Parameters<Parameters<typeof asUser>[1]>[0],
+  deferredPnL?: DeferredPnLRecord[]
 ) {
   if (isNpc) {
     if (!txDb) {
@@ -350,7 +362,14 @@ function createPredictionWalletAdapter(
       reason: string;
       relatedId?: string;
     }) => {
-      await WalletService.recordPnL(uid, pnl, reason, relatedId);
+      // Defer PnL recording to avoid nested transaction deadlocks
+      // The PnL will be recorded after the transaction completes
+      if (deferredPnL) {
+        deferredPnL.push({ userId: uid, pnl, reason, relatedId });
+      } else {
+        // Fallback for callers that don't use deferredPnL (shouldn't happen in new code)
+        await WalletService.recordPnL(uid, pnl, reason, relatedId);
+      }
     },
     getBalance: (uid: string) => WalletService.getBalance(uid),
   };
@@ -733,13 +752,16 @@ async function executePredictionSell(params: {
   const isSellYes = side === 'sell_yes';
   const sideLabel = isSellYes ? 'yes' : 'no';
 
+  // Collect PnL records to process after transaction completes (avoids nested transaction deadlocks)
+  const deferredPnL: DeferredPnLRecord[] = [];
+
   const sellOperation = async (
     txDb: Parameters<Parameters<typeof asUser>[1]>[0]
   ) => {
     const adapter = new PredictionDbAdapter(txDb);
     const service = new PredictionMarketService({
       db: adapter,
-      wallet: createPredictionWalletAdapter(isNpc, txDb),
+      wallet: createPredictionWalletAdapter(isNpc, txDb, deferredPnL),
       broadcast: {
         emit: (channel, payload) =>
           broadcastToChannel(channel, payload as Record<string, JsonValue>),
@@ -822,6 +844,17 @@ async function executePredictionSell(params: {
   const { sellResult, sharesToSell } = isNpc
     ? await asSystem(sellOperation, 'npc_prediction_sell')
     : await asUser({ userId: agentUserId }, sellOperation);
+
+  // Process deferred PnL records AFTER transaction completes (avoids nested transaction deadlocks)
+  for (const pnlRecord of deferredPnL) {
+    if (pnlRecord.pnl === 0) continue;
+    await WalletService.recordPnL(
+      pnlRecord.userId,
+      pnlRecord.pnl,
+      pnlRecord.reason,
+      pnlRecord.relatedId
+    );
+  }
 
   // Record in AgentTrade
   await agentPnLService.recordTrade({


### PR DESCRIPTION
## Problem
The agent tick was hanging for **87+ seconds** during trade execution (sell_yes). The staging logs showed:

```
Action sell_yes took 87.87s
```

## Root Cause
`WalletService.recordPnL()` creates its own transaction via `withTransaction()`. When called from within the `asUser()` transaction context (via the wallet adapter's `recordPnL` method), this caused a **nested transaction deadlock**.

## Solution
Follow the same pattern used in `game-tick.ts` which explicitly documents:
> "Record PnL post-transaction to avoid nested transactions inside the DB tx."

Changes:
1. Add `DeferredPnLRecord` interface to collect PnL records during transaction
2. Modify `createPredictionWalletAdapter` to accept optional `deferredPnL` array
3. In `executePredictionSell`, pass `deferredPnL` to wallet adapter
4. Process deferred PnL records **AFTER** transaction completes

## Testing
- TypeScript compilation passes
- Follows existing pattern from `game-tick.ts`

## Expected Result
Trade execution should complete in <5 seconds instead of 87+ seconds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Profit/loss recording in prediction trading operations now deferred until after transaction completion, improving transaction reliability and preventing potential conflicts during execution.
  * Enhanced prediction sell and trade flows to accumulate and process all profit/loss records following transaction completion, ensuring accurate and consistent recording of trading outcomes.
  * Improved transaction handling with better sequencing of profit/loss entries to maintain data integrity throughout trading operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR resolves an 87+ second hang during agent trade execution by implementing a deferred PnL recording pattern. The fix follows the established pattern from `game-tick.ts` to avoid nested transaction deadlocks.

**Key Changes:**
- Added `DeferredPnLRecord` interface to collect PnL records during transactions
- Modified `createPredictionWalletAdapter` to accept optional `deferredPnL` array parameter
- Updated `executePredictionSell` to collect PnL records during transaction and process them afterwards
- Includes fallback path for callers that don't use deferred PnL

**Technical Details:**
The root cause was that `WalletService.recordPnL()` creates its own transaction via `withTransaction()`. When called from within an existing transaction context (via `asUser()` or `asSystem()`), this created a nested transaction deadlock. The solution defers PnL recording until after the transaction completes, matching the pattern used in `packages/engine/src/game-tick.ts:1494-1503`.

**What Changed:**
- `executePredictionBuy` (line 654): No changes - buy operations don't call `recordPnL`
- `executePredictionSell` (line 764): Now uses deferred PnL pattern - sell operations call `recordPnL` which was causing the deadlock

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge - it implements a well-established pattern to fix a critical performance issue
- The implementation correctly follows the existing deferred PnL pattern from game-tick.ts, includes proper documentation, maintains backward compatibility with a fallback path, and solves a critical 87s performance issue with minimal code changes
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/agents/src/autonomous/DirectExecutors.ts | Added deferred PnL recording pattern to prevent nested transaction deadlocks during sell operations |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Executor as executePredictionSell
    participant TxCtx as Transaction Context (asUser/asSystem)
    participant Wallet as createPredictionWalletAdapter
    participant Service as PredictionMarketService
    participant WalletSvc as WalletService
    participant DB as Database

    Note over Executor: Initialize deferredPnL array
    Executor->>Executor: deferredPnL = []
    
    Executor->>TxCtx: Begin transaction
    activate TxCtx
    
    TxCtx->>Wallet: createPredictionWalletAdapter(isNpc, txDb, deferredPnL)
    activate Wallet
    
    TxCtx->>Service: new PredictionMarketService({ wallet })
    activate Service
    
    Service->>Service: sell({ userId, marketId, shares })
    Service->>DB: Update market state (within tx)
    DB-->>Service: Success
    
    Service->>DB: Update position (within tx)
    DB-->>Service: Success
    
    Note over Service,Wallet: recordPnL called during sell
    Service->>Wallet: recordPnL({ userId, pnl, reason })
    Note over Wallet: DEFERRED: Push to array instead of calling WalletService
    Wallet->>Wallet: deferredPnL.push({ userId, pnl, reason })
    Wallet-->>Service: Return (no DB call)
    
    Service-->>TxCtx: Return sell result
    deactivate Service
    deactivate Wallet
    
    TxCtx->>DB: Commit transaction
    DB-->>TxCtx: Success
    TxCtx-->>Executor: Transaction complete
    deactivate TxCtx
    
    Note over Executor: Process deferred PnL AFTER transaction
    loop For each pnlRecord in deferredPnL
        Executor->>WalletSvc: recordPnL(userId, pnl, reason, relatedId)
        Note over WalletSvc: Creates its own transaction via withTransaction()
        WalletSvc->>DB: Insert PnL record (new tx)
        DB-->>WalletSvc: Success
        WalletSvc-->>Executor: Success
    end
    
    Note over Executor: No nested transaction deadlock!
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->