### PR TITLE
feat(web): UI consistency overhaul — auth gating, layout polish, and sidebar stability

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,24 @@
+# TODO
+
+## Comment Reposting
+
+The comment interaction bar currently shows a disabled repost icon as a placeholder. Backend support for comment reposting/sharing is needed.
+
+### Required changes
+
+- **Database**: Add `commentId` column to the `shares` table (make `postId` nullable or create a separate table)
+- **API**: Create `POST /api/comments/[id]/share` endpoint
+- **Types**: Add `shareCount` and `isShared` fields to `CommentInteraction` in `packages/shared/src/types/interactions.ts`
+- **Store**: Update `toggleShare` in `interactionStore` to support comment IDs
+- **UI**: Enable the `Repeat2` repost button in `CommentCard` (`apps/web/src/components/interactions/CommentCard.tsx`)
+- **UI**: Enable the repost button in `ReplyCard` and main comment on `comment/[id]/page.tsx`
+
+## Comment Delete on Thread Page
+
+The comment thread page (`apps/web/src/app/comment/[id]/page.tsx`) does not show a delete option for the user's own comments. The `CommentCard` component has edit/delete in its header menu, but the `ReplyCard` and main comment section on the thread page only show a `ModerationMenu` for other users' comments — own comments have no actions.
+
+### Required changes
+
+- **ReplyCard**: Add edit/delete menu (matching `CommentCard`'s `MoreHorizontal` dropdown) when the reply belongs to the current user
+- **Main comment**: Add edit/delete menu in the header row for own comments
+- **API**: Verify `DELETE /api/comments/[id]` and `PATCH /api/comments/[id]` endpoints exist and work from the thread page context

--- a/apps/web/src/app/agents/[agentId]/page.tsx
+++ b/apps/web/src/app/agents/[agentId]/page.tsx
@@ -18,7 +18,6 @@ import {
   AgentDetail,
   type AgentDetailData,
   AgentDetailNotFound,
-  AgentDetailSkeleton,
 } from '@/components/agents/AgentDetail';
 import { PageContainer } from '@/components/shared/PageContainer';
 import { useAuth } from '@/hooks/useAuth';
@@ -32,7 +31,7 @@ import { useAuth } from '@/hooks/useAuth';
 export default function AgentDetailPage() {
   const params = useParams();
   const router = useRouter();
-  const { authenticated, ready, getAccessToken } = useAuth();
+  const { authenticated, ready, getAccessToken, login } = useAuth();
   const agentId = params.agentId as string;
 
   const [agent, setAgent] = useState<AgentDetailData | null>(null);
@@ -77,12 +76,16 @@ export default function AgentDetailPage() {
     }
   }, [ready, authenticated, agentId, fetchAgent]);
 
+  // Auth required — redirect to feed and show login
+  useEffect(() => {
+    if (!ready || authenticated) return;
+    router.push('/feed');
+    const timer = setTimeout(() => login(), 500);
+    return () => clearTimeout(timer);
+  }, [ready, authenticated, router, login]);
+
   if (!ready || !authenticated || loading) {
-    return (
-      <PageContainer>
-        <AgentDetailSkeleton />
-      </PageContainer>
-    );
+    return null;
   }
 
   if (!agent) {

--- a/apps/web/src/app/agents/create/page.tsx
+++ b/apps/web/src/app/agents/create/page.tsx
@@ -1,35 +1,25 @@
 'use client';
 
-import { Bot } from 'lucide-react';
 import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
 import { AgentCreate } from '@/components/agents/AgentCreate';
-import { LoginButton } from '@/components/auth/LoginButton';
 import { PageContainer } from '@/components/shared/PageContainer';
 import { useAuth } from '@/hooks/useAuth';
 
 export default function CreateAgentPage() {
   const router = useRouter();
-  const { ready, authenticated } = useAuth();
+  const { ready, authenticated, login } = useAuth();
 
-  // Show sign-in prompt for unauthenticated users
+  // Auth required — redirect to feed and show login
+  useEffect(() => {
+    if (!ready || authenticated) return;
+    router.push('/feed');
+    const timer = setTimeout(() => login(), 500);
+    return () => clearTimeout(timer);
+  }, [ready, authenticated, router, login]);
+
   if (!ready || !authenticated) {
-    return (
-      <PageContainer noPadding className="flex flex-col">
-        <div className="flex flex-1 items-center justify-center p-8">
-          <div className="max-w-md text-center">
-            <Bot className="mx-auto mb-4 h-16 w-16 text-muted-foreground" />
-            <h2 className="mb-2 font-bold text-foreground text-xl">
-              Create an Agent
-            </h2>
-            <p className="mb-6 text-muted-foreground">
-              Sign in to create and manage AI agents that can chat and trade
-              autonomously
-            </p>
-            <LoginButton />
-          </div>
-        </div>
-      </PageContainer>
-    );
+    return null;
   }
 
   return (

--- a/apps/web/src/app/agents/page.tsx
+++ b/apps/web/src/app/agents/page.tsx
@@ -11,8 +11,8 @@ import {
 } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
-import { LoginButton } from '@/components/auth/LoginButton';
 import { Avatar } from '@/components/shared/Avatar';
 import { PageContainer } from '@/components/shared/PageContainer';
 import { Skeleton } from '@/components/shared/Skeleton';
@@ -65,7 +65,8 @@ interface Agent {
 }
 
 export default function AgentsPage() {
-  const { authenticated, ready, getAccessToken } = useAuth();
+  const router = useRouter();
+  const { authenticated, ready, getAccessToken, login } = useAuth();
   const [agents, setAgents] = useState<Agent[]>([]);
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState<'all' | 'active' | 'idle'>('all');
@@ -111,22 +112,16 @@ export default function AgentsPage() {
     }
   }, [ready, authenticated, fetchAgents]);
 
+  // Auth required — redirect to feed and show login
+  useEffect(() => {
+    if (!ready || authenticated) return;
+    router.push('/feed');
+    const timer = setTimeout(() => login(), 500);
+    return () => clearTimeout(timer);
+  }, [ready, authenticated, router, login]);
+
   if (ready && !authenticated) {
-    return (
-      <PageContainer noPadding className="flex flex-col">
-        <div className="flex flex-1 items-center justify-center p-8">
-          <div className="max-w-md text-center">
-            <Bot className="mx-auto mb-4 h-16 w-16 text-muted-foreground" />
-            <h2 className="mb-2 font-bold text-foreground text-xl">log in</h2>
-            <p className="mb-6 text-muted-foreground">
-              Sign in to create and manage AI agents that can chat and trade
-              autonomously
-            </p>
-            <LoginButton />
-          </div>
-        </div>
-      </PageContainer>
-    );
+    return null;
   }
 
   return (

--- a/apps/web/src/app/agents/team/ConversationList.tsx
+++ b/apps/web/src/app/agents/team/ConversationList.tsx
@@ -1,7 +1,14 @@
 'use client';
 
 import { cn } from '@babylon/shared';
-import { Check, Loader2, MessageSquarePlus, Pencil, X } from 'lucide-react';
+import {
+  Check,
+  Loader2,
+  MessageCircle,
+  MessageSquarePlus,
+  Pencil,
+  X,
+} from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 
@@ -120,9 +127,15 @@ export function ConversationList({
             <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
           </div>
         ) : conversations.length === 0 ? (
-          <p className="py-4 text-center text-muted-foreground text-xs">
-            No conversations yet
-          </p>
+          <div className="flex flex-col items-center justify-center py-12 text-center">
+            <MessageCircle className="mb-4 h-12 w-12 text-muted-foreground opacity-50" />
+            <p className="font-medium text-muted-foreground text-sm">
+              No conversations yet
+            </p>
+            <p className="text-muted-foreground/70 text-xs">
+              Start a new chat with your team
+            </p>
+          </div>
         ) : (
           conversations.map((conversation) => (
             <div

--- a/apps/web/src/app/agents/team/page.tsx
+++ b/apps/web/src/app/agents/team/page.tsx
@@ -21,7 +21,6 @@ import {
   AgentDetailSkeleton,
   type AgentDetailTab,
 } from '@/components/agents/AgentDetail';
-import { LoginButton } from '@/components/auth/LoginButton';
 import { TeamChatView } from '@/components/chats';
 import { Avatar } from '@/components/shared/Avatar';
 import { PageContainer } from '@/components/shared/PageContainer';
@@ -92,7 +91,7 @@ interface AgentData {
 export default function TeamChatPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { ready, authenticated, user, getAccessToken } = useAuth();
+  const { ready, authenticated, user, getAccessToken, login } = useAuth();
 
   const {
     teamChat,
@@ -352,24 +351,16 @@ export default function TeamChatPage() {
     };
   }, [activeTab, teamChat?.chatId, loading, messagesEndRef, scrollToBottom]);
 
-  // Auth required state
+  // Auth required — redirect to feed and show login
+  useEffect(() => {
+    if (!ready || authenticated) return;
+    router.push('/feed');
+    const timer = setTimeout(() => login(), 500);
+    return () => clearTimeout(timer);
+  }, [ready, authenticated, router, login]);
+
   if (ready && !authenticated) {
-    return (
-      <PageContainer noPadding className="flex flex-col">
-        <div className="flex flex-1 items-center justify-center p-8">
-          <div className="max-w-md text-center">
-            <Users className="mx-auto mb-4 h-16 w-16 text-muted-foreground" />
-            <h2 className="mb-2 font-bold text-foreground text-xl">
-              Log in to access Agents
-            </h2>
-            <p className="mb-6 text-muted-foreground">
-              Sign in to coordinate your agents
-            </p>
-            <LoginButton />
-          </div>
-        </div>
-      </PageContainer>
-    );
+    return null;
   }
 
   // Loading state

--- a/apps/web/src/app/article/[id]/page.tsx
+++ b/apps/web/src/app/article/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArrowLeft, MessageCircle } from 'lucide-react';
+import { ArrowLeft, Newspaper } from 'lucide-react';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { use, useEffect, useState } from 'react';
@@ -76,32 +76,56 @@ export default function ArticlePage({ params }: ArticlePageProps) {
 
   if (isLoading) {
     return (
-      <div className="flex min-h-screen items-center justify-center">
-        <div className="w-full max-w-feed space-y-4 px-4 py-3">
-          <Skeleton className="h-8 w-3/4" />
-          <Skeleton className="h-64 w-full" />
-          <Skeleton className="h-32 w-full" />
+      <PageContainer noPadding className="flex w-full flex-col">
+        <div className="relative flex min-h-screen flex-1">
+          <div className="flex min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:border-r lg:border-l">
+            <div className="sticky top-0 z-10 shrink-0 bg-background shadow-sm">
+              <div className="px-6 py-4">
+                <div className="flex items-center gap-4">
+                  <div className="h-9 w-9 rounded-full bg-muted" />
+                  <Skeleton className="h-6 w-20" />
+                </div>
+              </div>
+            </div>
+            <div className="flex-1 bg-background">
+              <div className="w-full lg:mx-auto lg:max-w-[700px]">
+                <div className="space-y-4 px-4 py-6">
+                  <Skeleton className="h-8 w-3/4" />
+                  <Skeleton className="h-64 w-full" />
+                  <Skeleton className="h-32 w-full" />
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="hidden w-96 flex-none xl:flex" />
         </div>
-      </div>
+      </PageContainer>
     );
   }
 
   if (error || !article) {
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center px-4 py-3">
-        <div className="text-center">
-          <h1 className="mb-2 font-bold text-2xl">Article Not Found</h1>
-          <p className="mb-4 text-muted-foreground">
-            {error || 'The article you are looking for does not exist.'}
-          </p>
-          <button
-            onClick={() => router.push('/feed')}
-            className="rounded-md bg-primary px-4 py-2 text-primary-foreground transition-colors hover:bg-primary/90"
-          >
-            Back to Feed
-          </button>
+      <PageContainer noPadding className="flex w-full flex-col">
+        <div className="relative flex min-h-screen flex-1">
+          <div className="flex min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:border-r lg:border-l">
+            <div className="flex flex-1 flex-col items-center justify-center bg-background">
+              <div className="text-center">
+                <h1 className="mb-2 font-bold text-2xl">Article Not Found</h1>
+                <p className="mb-4 text-muted-foreground">
+                  {error || 'The article you are looking for does not exist.'}
+                </p>
+                <button
+                  onClick={() => router.push('/feed')}
+                  className="rounded-md bg-primary px-4 py-2 text-primary-foreground transition-colors hover:bg-primary/90"
+                >
+                  Back to Feed
+                </button>
+              </div>
+            </div>
+          </div>
+          <div className="hidden w-96 flex-none xl:flex" />
         </div>
-      </div>
+      </PageContainer>
     );
   }
 
@@ -111,163 +135,165 @@ export default function ArticlePage({ params }: ArticlePageProps) {
   const articleBody = article.fullContent || article.content;
 
   return (
-    <PageContainer noPadding>
-      {/* Desktop: Multi-column layout with sidebar */}
-      <div className="hidden flex-1 overflow-hidden lg:flex">
-        {/* Left: Article content area */}
-        <div className="flex min-w-0 flex-1 flex-col">
+    <PageContainer noPadding className="flex w-full flex-col">
+      <div className="relative flex min-h-screen flex-1">
+        {/* Desktop: Article content area */}
+        <div className="hidden min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:flex lg:border-r lg:border-l">
           {/* Desktop: Top bar with back button */}
-          <div className="sticky top-0 z-10 shrink-0 border-border border-b bg-background shadow-sm">
+          <div className="sticky top-0 z-10 shrink-0 bg-background shadow-sm">
             <div className="px-6 py-4">
               <div className="flex items-center gap-4">
                 <button
                   onClick={() => router.back()}
-                  className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 >
                   <ArrowLeft size={20} />
                 </button>
                 <div className="flex items-center gap-2">
-                  <MessageCircle className="h-5 w-5 text-[#0066FF]" />
+                  <Newspaper className="h-5 w-5 text-[#0066FF]" />
                   <h1 className="font-semibold text-lg">Article</h1>
                 </div>
               </div>
             </div>
           </div>
 
-          {/* Article content with sidebar */}
-          <div className="flex flex-1 overflow-y-auto">
-            {/* Main article column */}
-            <div className="min-w-0 flex-1">
-              <div className="mx-auto w-full max-w-3xl">
-                <article className="px-6 py-6">
-                  {/* Article cover image */}
-                  {article.imageUrl && (
-                    <div className="relative mb-6 aspect-video w-full overflow-hidden rounded-lg">
-                      <Image
-                        src={article.imageUrl}
-                        alt={article.articleTitle || 'Article cover'}
-                        fill
-                        className="object-cover"
-                        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 800px"
-                        priority
-                      />
-                    </div>
-                  )}
-
-                  {/* Article title */}
-                  <h1 className="mb-4 font-bold text-3xl text-foreground leading-tight sm:text-4xl">
-                    {article.articleTitle}
-                  </h1>
-
-                  {/* Article metadata */}
-                  <div className="mb-6 flex flex-wrap items-center gap-3 text-muted-foreground text-sm">
-                    <span className="font-semibold text-[#0066FF]">
-                      {article.authorName}
-                    </span>
-                    {article.byline && (
-                      <>
-                        <span>·</span>
-                        <span>{article.byline}</span>
-                      </>
-                    )}
-                    <span>·</span>
-                    <time>
-                      {publishedDate.toLocaleDateString('en-US', {
-                        month: 'long',
-                        day: 'numeric',
-                        year: 'numeric',
-                      })}
-                    </time>
+          {/* Article content */}
+          <div className="flex-1 bg-background">
+            <div className="w-full lg:mx-auto lg:max-w-[700px]">
+              <article className="px-6 py-6">
+                {/* Article cover image */}
+                {article.imageUrl && (
+                  <div className="relative mb-6 aspect-video w-full overflow-hidden rounded-lg">
+                    <Image
+                      src={article.imageUrl}
+                      alt={article.articleTitle || 'Article cover'}
+                      fill
+                      className="object-cover"
+                      sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 800px"
+                      priority
+                    />
                   </div>
+                )}
 
-                  {/* Full article content with markdown rendering */}
-                  <Response className="mb-6 max-w-none text-foreground/90 [&_a]:text-[#0066FF] [&_a]:underline hover:[&_a]:text-[#0066FF]/80 [&_blockquote]:my-6 [&_blockquote]:border-[#0066FF] [&_blockquote]:border-l-4 [&_blockquote]:pl-4 [&_blockquote]:text-muted-foreground [&_blockquote]:italic [&_code]:rounded [&_code]:bg-muted [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-sm [&_em]:italic [&_h1]:mt-8 [&_h1]:mb-4 [&_h1]:font-bold [&_h1]:text-2xl [&_h2]:mt-6 [&_h2]:mb-3 [&_h2]:font-semibold [&_h2]:text-xl [&_h3]:mt-4 [&_h3]:mb-2 [&_h3]:font-medium [&_h3]:text-lg [&_hr]:my-8 [&_hr]:border-border [&_li]:my-2 [&_li]:text-base [&_li]:leading-relaxed [&_ol]:my-4 [&_ol]:list-decimal [&_ol]:pl-6 [&_p]:mb-6 [&_p]:text-base [&_p]:leading-relaxed sm:[&_p]:text-lg [&_pre]:my-4 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-muted [&_pre]:p-4 [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_strong]:font-bold [&_ul]:my-4 [&_ul]:list-disc [&_ul]:pl-6">
-                    {articleBody}
-                  </Response>
-                </article>
-              </div>
-            </div>
+                {/* Article title */}
+                <h1 className="mb-4 font-bold text-3xl text-foreground leading-tight sm:text-4xl">
+                  {article.articleTitle}
+                </h1>
 
-            {/* Right sidebar - More Articles */}
-            <aside className="hidden w-80 shrink-0 border-border border-l xl:block">
-              <div className="sticky top-0 p-6">
-                <MoreArticlesWidget currentArticleId={articleId} limit={5} />
-              </div>
-            </aside>
-          </div>
-        </div>
-      </div>
-
-      {/* Mobile/Tablet: Single column layout */}
-      <div className="flex flex-1 flex-col overflow-hidden lg:hidden">
-        {/* Mobile header */}
-        <div className="sticky top-0 z-10 shrink-0 border-border border-b bg-background">
-          <div className="flex items-center gap-4 px-4 py-3">
-            <button
-              onClick={() => router.back()}
-              className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-            >
-              <ArrowLeft size={20} />
-            </button>
-            <div className="flex items-center gap-2">
-              <MessageCircle className="h-5 w-5 text-[#0066FF]" />
-              <h1 className="font-semibold text-lg">Article</h1>
-            </div>
-          </div>
-        </div>
-
-        {/* Mobile content */}
-        <div className="flex-1 overflow-y-auto">
-          <article className="px-4 py-4 sm:px-6 sm:py-5">
-            {/* Article cover image */}
-            {article.imageUrl && (
-              <div className="relative mb-4 aspect-video w-full overflow-hidden rounded-lg">
-                <Image
-                  src={article.imageUrl}
-                  alt={article.articleTitle || 'Article cover'}
-                  fill
-                  className="object-cover"
-                  sizes="100vw"
-                  priority
-                />
-              </div>
-            )}
-
-            {/* Article title */}
-            <h1 className="mb-4 font-bold text-2xl text-foreground leading-tight sm:text-3xl">
-              {article.articleTitle}
-            </h1>
-
-            {/* Article metadata */}
-            <div className="mb-4 flex flex-wrap items-center gap-2 text-muted-foreground text-sm">
-              <span className="font-semibold text-[#0066FF]">
-                {article.authorName}
-              </span>
-              {article.byline && (
-                <>
+                {/* Article metadata */}
+                <div className="mb-6 flex flex-wrap items-center gap-3 text-muted-foreground text-sm">
+                  <span className="font-semibold text-[#0066FF]">
+                    {article.authorName}
+                  </span>
+                  {article.byline && (
+                    <>
+                      <span>·</span>
+                      <span>{article.byline}</span>
+                    </>
+                  )}
                   <span>·</span>
-                  <span>{article.byline}</span>
-                </>
+                  <time>
+                    {publishedDate.toLocaleDateString('en-US', {
+                      month: 'long',
+                      day: 'numeric',
+                      year: 'numeric',
+                    })}
+                  </time>
+                </div>
+
+                {/* Full article content with markdown rendering */}
+                <Response className="mb-6 max-w-none text-foreground/90 [&_a]:text-[#0066FF] [&_a]:underline hover:[&_a]:text-[#0066FF]/80 [&_blockquote]:my-6 [&_blockquote]:border-[#0066FF] [&_blockquote]:border-l-4 [&_blockquote]:pl-4 [&_blockquote]:text-muted-foreground [&_blockquote]:italic [&_code]:rounded [&_code]:bg-muted [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-sm [&_em]:italic [&_h1]:mt-8 [&_h1]:mb-4 [&_h1]:font-bold [&_h1]:text-2xl [&_h2]:mt-6 [&_h2]:mb-3 [&_h2]:font-semibold [&_h2]:text-xl [&_h3]:mt-4 [&_h3]:mb-2 [&_h3]:font-medium [&_h3]:text-lg [&_hr]:my-8 [&_hr]:border-border [&_li]:my-2 [&_li]:text-base [&_li]:leading-relaxed [&_ol]:my-4 [&_ol]:list-decimal [&_ol]:pl-6 [&_p]:mb-6 [&_p]:text-base [&_p]:leading-relaxed sm:[&_p]:text-lg [&_pre]:my-4 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-muted [&_pre]:p-4 [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_strong]:font-bold [&_ul]:my-4 [&_ul]:list-disc [&_ul]:pl-6">
+                  {articleBody}
+                </Response>
+              </article>
+
+              {/* Spacer for login bar */}
+              <div className="pb-24" />
+            </div>
+          </div>
+        </div>
+
+        {/* Right sidebar - More Articles (desktop only) */}
+        <div className="hidden w-96 flex-none flex-col xl:flex">
+          <div className="flex w-96 flex-col px-4 py-6">
+            <MoreArticlesWidget currentArticleId={articleId} limit={5} />
+          </div>
+        </div>
+
+        {/* Mobile/Tablet: Single column layout */}
+        <div className="flex flex-1 flex-col overflow-hidden lg:hidden">
+          {/* Mobile header */}
+          <div className="sticky top-0 z-10 shrink-0 border-border border-b bg-background">
+            <div className="flex items-center gap-4 px-4 py-3">
+              <button
+                onClick={() => router.back()}
+                className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <ArrowLeft size={20} />
+              </button>
+              <div className="flex items-center gap-2">
+                <Newspaper className="h-5 w-5 text-[#0066FF]" />
+                <h1 className="font-semibold text-lg">Article</h1>
+              </div>
+            </div>
+          </div>
+
+          {/* Mobile content */}
+          <div className="flex-1 overflow-y-auto">
+            <article className="px-4 py-4 sm:px-6 sm:py-5">
+              {/* Article cover image */}
+              {article.imageUrl && (
+                <div className="relative mb-4 aspect-video w-full overflow-hidden rounded-lg">
+                  <Image
+                    src={article.imageUrl}
+                    alt={article.articleTitle || 'Article cover'}
+                    fill
+                    className="object-cover"
+                    sizes="100vw"
+                    priority
+                  />
+                </div>
               )}
-              <span>·</span>
-              <time>
-                {publishedDate.toLocaleDateString('en-US', {
-                  month: 'short',
-                  day: 'numeric',
-                })}
-              </time>
-            </div>
 
-            {/* Full article content with markdown rendering */}
-            <Response className="mb-4 max-w-none text-foreground/90 [&_a]:text-[#0066FF] [&_a]:underline hover:[&_a]:text-[#0066FF]/80 [&_blockquote]:my-4 [&_blockquote]:border-[#0066FF] [&_blockquote]:border-l-4 [&_blockquote]:pl-4 [&_blockquote]:text-muted-foreground [&_blockquote]:italic [&_code]:rounded [&_code]:bg-muted [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-sm [&_em]:italic [&_h1]:mt-6 [&_h1]:mb-3 [&_h1]:font-bold [&_h1]:text-xl [&_h2]:mt-5 [&_h2]:mb-2 [&_h2]:font-semibold [&_h2]:text-lg [&_h3]:mt-4 [&_h3]:mb-2 [&_h3]:font-medium [&_h3]:text-base [&_hr]:my-6 [&_hr]:border-border [&_li]:my-1.5 [&_li]:text-base [&_li]:leading-relaxed [&_ol]:my-3 [&_ol]:list-decimal [&_ol]:pl-5 [&_p]:mb-5 [&_p]:text-base [&_p]:leading-relaxed [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-muted [&_pre]:p-3 [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_strong]:font-bold [&_ul]:my-3 [&_ul]:list-disc [&_ul]:pl-5">
-              {articleBody}
-            </Response>
+              {/* Article title */}
+              <h1 className="mb-4 font-bold text-2xl text-foreground leading-tight sm:text-3xl">
+                {article.articleTitle}
+              </h1>
 
-            {/* More Articles - Mobile */}
-            <div className="mt-8 border-border border-t pt-6">
-              <MoreArticlesWidget currentArticleId={articleId} limit={4} />
-            </div>
-          </article>
+              {/* Article metadata */}
+              <div className="mb-4 flex flex-wrap items-center gap-2 text-muted-foreground text-sm">
+                <span className="font-semibold text-[#0066FF]">
+                  {article.authorName}
+                </span>
+                {article.byline && (
+                  <>
+                    <span>·</span>
+                    <span>{article.byline}</span>
+                  </>
+                )}
+                <span>·</span>
+                <time>
+                  {publishedDate.toLocaleDateString('en-US', {
+                    month: 'short',
+                    day: 'numeric',
+                  })}
+                </time>
+              </div>
+
+              {/* Full article content with markdown rendering */}
+              <Response className="mb-4 max-w-none text-foreground/90 [&_a]:text-[#0066FF] [&_a]:underline hover:[&_a]:text-[#0066FF]/80 [&_blockquote]:my-4 [&_blockquote]:border-[#0066FF] [&_blockquote]:border-l-4 [&_blockquote]:pl-4 [&_blockquote]:text-muted-foreground [&_blockquote]:italic [&_code]:rounded [&_code]:bg-muted [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-sm [&_em]:italic [&_h1]:mt-6 [&_h1]:mb-3 [&_h1]:font-bold [&_h1]:text-xl [&_h2]:mt-5 [&_h2]:mb-2 [&_h2]:font-semibold [&_h2]:text-lg [&_h3]:mt-4 [&_h3]:mb-2 [&_h3]:font-medium [&_h3]:text-base [&_hr]:my-6 [&_hr]:border-border [&_li]:my-1.5 [&_li]:text-base [&_li]:leading-relaxed [&_ol]:my-3 [&_ol]:list-decimal [&_ol]:pl-5 [&_p]:mb-5 [&_p]:text-base [&_p]:leading-relaxed [&_pre]:my-3 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-muted [&_pre]:p-3 [&_pre_code]:bg-transparent [&_pre_code]:p-0 [&_strong]:font-bold [&_ul]:my-3 [&_ul]:list-disc [&_ul]:pl-5">
+                {articleBody}
+              </Response>
+
+              {/* More Articles - Mobile */}
+              <div className="mt-8 border-border border-t pt-6">
+                <MoreArticlesWidget currentArticleId={articleId} limit={4} />
+              </div>
+
+              {/* Spacer for login bar */}
+              <div className="pb-24" />
+            </article>
+          </div>
         </div>
       </div>
     </PageContainer>

--- a/apps/web/src/app/chats/page.tsx
+++ b/apps/web/src/app/chats/page.tsx
@@ -1,10 +1,9 @@
 'use client';
 
 import { cn } from '@babylon/shared';
-import { Loader2, MessageCircle } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useEffect, useMemo } from 'react';
-import { LoginButton } from '@/components/auth/LoginButton';
 import {
   ChatHeader,
   ChatList,
@@ -14,7 +13,6 @@ import {
 } from '@/components/chats';
 import { CreateGroupModal } from '@/components/groups/CreateGroupModal';
 import { GroupManagementModal } from '@/components/groups/GroupManagementModal';
-import { PageContainer } from '@/components/shared/PageContainer';
 import { Separator } from '@/components/shared/Separator';
 import {
   AlertDialog,
@@ -28,12 +26,14 @@ import {
 } from '@/components/ui/alert-dialog';
 import { buttonVariants } from '@/components/ui/button';
 import { useA2A } from '@/hooks/useA2A';
+import { useAuth } from '@/hooks/useAuth';
 import { useChatParam } from '@/hooks/useChatParam';
 import { useOwnedAgents } from '@/hooks/useOwnedAgents';
 import { useSSE } from '@/hooks/useSSE';
 
 export default function ChatsPage() {
   const router = useRouter();
+  const { login } = useAuth();
   useA2A();
   useChatParam();
 
@@ -129,22 +129,16 @@ export default function ChatsPage() {
     }
   }, [ownAgentId, router]);
 
-  // Auth required state
+  // Auth required — redirect to feed and show login
+  useEffect(() => {
+    if (!ready || authenticated) return;
+    router.push('/feed');
+    const timer = setTimeout(() => login(), 500);
+    return () => clearTimeout(timer);
+  }, [ready, authenticated, router, login]);
+
   if (ready && !authenticated) {
-    return (
-      <PageContainer noPadding className="flex flex-col">
-        <div className="flex flex-1 items-center justify-center p-8">
-          <div className="max-w-md text-center">
-            <MessageCircle className="mx-auto mb-4 h-16 w-16 text-muted-foreground" />
-            <h2 className="mb-2 font-bold text-foreground text-xl">log in</h2>
-            <p className="mb-6 text-muted-foreground">
-              Sign in to view and send messages
-            </p>
-            <LoginButton />
-          </div>
-        </div>
-      </PageContainer>
-    );
+    return null;
   }
 
   // Show back button only on mobile/tablet (not on xl+ where both columns visible)

--- a/apps/web/src/app/comment/[id]/page.tsx
+++ b/apps/web/src/app/comment/[id]/page.tsx
@@ -114,7 +114,7 @@ function OriginalPostCard({ post }: { post: PostData }) {
   return (
     <div className="relative">
       {/* Connector line - from avatar center down */}
-      <div className="absolute top-16 -bottom-3 left-[2.25rem] w-0.5 bg-border sm:left-[2.75rem]" />
+      <div className="-bottom-3 absolute top-16 left-[2.25rem] w-0.5 bg-border sm:left-[2.75rem]" />
 
       <div
         className="flex cursor-pointer gap-3 px-4 py-3 transition-colors hover:bg-muted/50 sm:px-6"
@@ -210,7 +210,7 @@ function ParentCommentCard({
     <div className="relative">
       {/* Connector line - from avatar center down */}
       {showConnector && (
-        <div className="absolute top-16 -bottom-3 left-[2.25rem] w-0.5 bg-border sm:left-[2.75rem]" />
+        <div className="-bottom-3 absolute top-16 left-[2.25rem] w-0.5 bg-border sm:left-[2.75rem]" />
       )}
 
       <div

--- a/apps/web/src/app/comment/[id]/page.tsx
+++ b/apps/web/src/app/comment/[id]/page.tsx
@@ -2,14 +2,15 @@
 
 import type { CommentData } from '@babylon/shared';
 import { cn, getProfileUrl } from '@babylon/shared';
-import { formatDistanceToNow } from 'date-fns';
-import { ArrowLeft, MessageCircle } from 'lucide-react';
+import { ArrowLeft, MessageCircle, Repeat2 } from 'lucide-react';
+import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { use, useCallback, useEffect, useRef, useState } from 'react';
 import { CommentInput } from '@/components/interactions/CommentInput';
 import { LikeButton } from '@/components/interactions/LikeButton';
 import { ModerationMenu } from '@/components/moderation/ModerationMenu';
+import { formatTimeAgo } from '@/components/posts/CommentPreview';
 import { Avatar } from '@/components/shared/Avatar';
 import { EmptyState } from '@/components/shared/EmptyState';
 import { PageContainer } from '@/components/shared/PageContainer';
@@ -21,6 +22,17 @@ import {
 } from '@/components/shared/VerifiedBadge';
 import { useAuth } from '@/hooks/useAuth';
 import { MAX_REPLY_COUNT } from '@/lib/constants';
+
+const WidgetSidebar = dynamic(
+  () =>
+    import('@/components/shared/WidgetSidebar').then((m) => ({
+      default: m.WidgetSidebar,
+    })),
+  {
+    ssr: false,
+    loading: () => <div className="hidden w-96 flex-none xl:block" />,
+  }
+);
 
 interface CommentPageProps {
   params: Promise<{ id: string }>;
@@ -102,7 +114,7 @@ function OriginalPostCard({ post }: { post: PostData }) {
   return (
     <div className="relative">
       {/* Connector line - from avatar center down */}
-      <div className="absolute top-10 bottom-0 left-[1.625rem] w-0.5 bg-border sm:left-[1.875rem]" />
+      <div className="absolute top-16 -bottom-3 left-[2.25rem] w-0.5 bg-border sm:left-[2.75rem]" />
 
       <div
         className="flex cursor-pointer gap-3 px-4 py-3 transition-colors hover:bg-muted/50 sm:px-6"
@@ -117,7 +129,7 @@ function OriginalPostCard({ post }: { post: PostData }) {
           <Avatar
             id={post.authorId}
             name={post.authorName}
-            size="sm"
+            size="md"
             imageUrl={post.authorProfileImageUrl || undefined}
           />
         </Link>
@@ -144,28 +156,27 @@ function OriginalPostCard({ post }: { post: PostData }) {
               >
                 @{post.authorUsername || post.authorName}
               </Link>
-              <span className="text-muted-foreground text-xs">·</span>
-              <span className="text-muted-foreground text-xs">
-                {formatDistanceToNow(new Date(post.createdAt), {
-                  addSuffix: true,
-                })}
-              </span>
             </div>
-            {/* Moderation menu for other users' posts */}
-            {user && !isOwnPost && (
-              <div onClick={(e) => e.stopPropagation()}>
-                <ModerationMenu
-                  targetUserId={post.authorId}
-                  targetUsername={post.authorUsername || undefined}
-                  targetDisplayName={post.authorName}
-                  targetProfileImageUrl={
-                    post.authorProfileImageUrl || undefined
-                  }
-                  postId={post.id}
-                  isNPC={authorIsNPC}
-                />
-              </div>
-            )}
+            <div className="flex shrink-0 items-center gap-2">
+              <span className="text-muted-foreground text-xs">
+                {formatTimeAgo(post.createdAt)}
+              </span>
+              {/* Moderation menu for other users' posts */}
+              {user && !isOwnPost && (
+                <div onClick={(e) => e.stopPropagation()}>
+                  <ModerationMenu
+                    targetUserId={post.authorId}
+                    targetUsername={post.authorUsername || undefined}
+                    targetDisplayName={post.authorName}
+                    targetProfileImageUrl={
+                      post.authorProfileImageUrl || undefined
+                    }
+                    postId={post.id}
+                    isNPC={authorIsNPC}
+                  />
+                </div>
+              )}
+            </div>
           </div>
 
           {/* Content - truncated */}
@@ -199,7 +210,7 @@ function ParentCommentCard({
     <div className="relative">
       {/* Connector line - from avatar center down */}
       {showConnector && (
-        <div className="absolute top-10 bottom-0 left-[1.625rem] w-0.5 bg-border sm:left-[1.875rem]" />
+        <div className="absolute top-16 -bottom-3 left-[2.25rem] w-0.5 bg-border sm:left-[2.75rem]" />
       )}
 
       <div
@@ -215,7 +226,7 @@ function ParentCommentCard({
           <Avatar
             id={parent.authorId}
             name={parent.authorName}
-            size="sm"
+            size="md"
             imageUrl={parent.authorProfileImageUrl || undefined}
           />
         </Link>
@@ -242,27 +253,26 @@ function ParentCommentCard({
               >
                 @{parent.authorUsername || parent.authorName}
               </Link>
-              <span className="text-muted-foreground text-xs">·</span>
-              <span className="text-muted-foreground text-xs">
-                {formatDistanceToNow(new Date(parent.createdAt), {
-                  addSuffix: true,
-                })}
-              </span>
             </div>
-            {/* Moderation menu for other users' comments */}
-            {user && !isOwnComment && (
-              <div onClick={(e) => e.stopPropagation()}>
-                <ModerationMenu
-                  targetUserId={parent.authorId}
-                  targetUsername={parent.authorUsername || undefined}
-                  targetDisplayName={parent.authorName}
-                  targetProfileImageUrl={
-                    parent.authorProfileImageUrl || undefined
-                  }
-                  isNPC={authorIsNPC}
-                />
-              </div>
-            )}
+            <div className="flex shrink-0 items-center gap-2">
+              <span className="text-muted-foreground text-xs">
+                {formatTimeAgo(parent.createdAt)}
+              </span>
+              {/* Moderation menu for other users' comments */}
+              {user && !isOwnComment && (
+                <div onClick={(e) => e.stopPropagation()}>
+                  <ModerationMenu
+                    targetUserId={parent.authorId}
+                    targetUsername={parent.authorUsername || undefined}
+                    targetDisplayName={parent.authorName}
+                    targetProfileImageUrl={
+                      parent.authorProfileImageUrl || undefined
+                    }
+                    isNPC={authorIsNPC}
+                  />
+                </div>
+              )}
+            </div>
           </div>
 
           {/* Content - truncated for parent chain */}
@@ -302,134 +312,160 @@ function ReplyCard({
   };
 
   return (
-    <div className="flex gap-3 border-border border-b py-4 last:border-b-0">
-      {/* Avatar */}
-      <Link
-        href={getProfileUrl(reply.authorId, reply.authorUsername)}
-        className="shrink-0 transition-opacity hover:opacity-80"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <Avatar
-          id={reply.authorId}
-          name={reply.authorName}
-          size="sm"
-          imageUrl={reply.authorProfileImageUrl || undefined}
-        />
-      </Link>
+    <div
+      className="cursor-pointer border-border border-b px-4 py-4 transition-all duration-200 hover:bg-muted/30 sm:px-6"
+      onClick={handleNavigateToReply}
+    >
+      <div className="flex gap-3">
+        {/* Avatar */}
+        <Link
+          href={getProfileUrl(reply.authorId, reply.authorUsername)}
+          className="shrink-0 transition-opacity hover:opacity-80"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Avatar
+            id={reply.authorId}
+            name={reply.authorName}
+            size="md"
+            imageUrl={reply.authorProfileImageUrl || undefined}
+          />
+        </Link>
 
-      {/* Content */}
-      <div className="min-w-0 flex-1">
-        {/* Header */}
-        <div className="mb-1 flex items-center justify-between gap-2">
-          <div className="flex min-w-0 flex-1 items-center gap-2">
-            <Link
-              href={getProfileUrl(reply.authorId, reply.authorUsername)}
-              className="truncate font-semibold text-sm hover:underline"
-              onClick={(e) => e.stopPropagation()}
-            >
-              {reply.authorName}
-            </Link>
-            {showVerifiedBadge && <VerifiedBadge size="sm" className="-ml-1" />}
-            <Link
-              href={getProfileUrl(reply.authorId, reply.authorUsername)}
-              className="truncate text-muted-foreground text-xs hover:underline"
-              onClick={(e) => e.stopPropagation()}
-            >
-              @{reply.authorUsername || reply.authorName}
-            </Link>
-            <span className="text-muted-foreground text-xs">·</span>
-            <span className="text-muted-foreground text-xs">
-              {formatDistanceToNow(new Date(reply.createdAt), {
-                addSuffix: true,
-              })}
-            </span>
+        {/* Content */}
+        <div className="min-w-0 flex-1">
+          {/* Header */}
+          <div className="mb-1 flex items-center justify-between gap-2">
+            <div className="flex min-w-0 flex-1 items-center gap-2">
+              <Link
+                href={getProfileUrl(reply.authorId, reply.authorUsername)}
+                className="truncate font-semibold text-sm hover:underline"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {reply.authorName}
+              </Link>
+              {showVerifiedBadge && (
+                <VerifiedBadge size="sm" className="-ml-1" />
+              )}
+              <Link
+                href={getProfileUrl(reply.authorId, reply.authorUsername)}
+                className="truncate text-muted-foreground text-xs hover:underline"
+                onClick={(e) => e.stopPropagation()}
+              >
+                @{reply.authorUsername || reply.authorName}
+              </Link>
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              <span className="text-muted-foreground text-xs">
+                {formatTimeAgo(reply.createdAt)}
+              </span>
+              {/* Moderation menu for other users' comments */}
+              {user && !isOwnComment && (
+                <div onClick={(e) => e.stopPropagation()}>
+                  <ModerationMenu
+                    targetUserId={reply.authorId}
+                    targetUsername={reply.authorUsername || undefined}
+                    targetDisplayName={reply.authorName}
+                    targetProfileImageUrl={
+                      reply.authorProfileImageUrl || undefined
+                    }
+                    isNPC={authorIsNPC}
+                  />
+                </div>
+              )}
+            </div>
           </div>
-          {/* Moderation menu for other users' comments */}
-          {user && !isOwnComment && (
-            <div onClick={(e) => e.stopPropagation()}>
-              <ModerationMenu
-                targetUserId={reply.authorId}
-                targetUsername={reply.authorUsername || undefined}
-                targetDisplayName={reply.authorName}
-                targetProfileImageUrl={reply.authorProfileImageUrl || undefined}
-                isNPC={authorIsNPC}
+
+          {/* Reply content */}
+          <div className="mb-2">
+            <p className="whitespace-pre-wrap break-words text-foreground text-sm">
+              <TaggedText
+                text={reply.content}
+                onTagClick={(tag) => {
+                  if (tag.startsWith('@')) {
+                    const username = tag.slice(1);
+                    router.push(`/profile/${username}`);
+                  } else if (tag.startsWith('$')) {
+                    const symbol = tag.slice(1);
+                    router.push(
+                      `/markets?search=${encodeURIComponent(symbol)}`
+                    );
+                  }
+                }}
+              />
+            </p>
+          </div>
+
+          {/* Footer actions - matches feed InteractionBar style */}
+          <div
+            className="mt-2 flex w-full items-center justify-between gap-6 text-muted-foreground"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {/* Reply button */}
+            <button
+              type="button"
+              onClick={() => setIsReplying(!isReplying)}
+              className={cn(
+                'flex items-center gap-1',
+                'bg-transparent transition-all duration-200 hover:opacity-70',
+                'cursor-pointer text-muted-foreground text-xs',
+                isReplying && 'text-[#0066FF]'
+              )}
+            >
+              <MessageCircle size={18} />
+              {hasReplies && (
+                <span className="font-medium tabular-nums">
+                  {reply.replyCount >= MAX_REPLY_COUNT
+                    ? `${MAX_REPLY_COUNT}+`
+                    : reply.replyCount}
+                </span>
+              )}
+            </button>
+
+            {/* Repost button (placeholder) */}
+            <div>
+              <button
+                type="button"
+                disabled
+                className="flex cursor-default items-center gap-1 text-muted-foreground/40 text-xs"
+              >
+                <Repeat2 size={18} />
+              </button>
+            </div>
+
+            {/* Like button */}
+            <div>
+              <LikeButton
+                targetId={reply.id}
+                targetType="comment"
+                initialLiked={reply.isLiked}
+                initialCount={reply.likeCount}
+                size="sm"
+                showCount
+              />
+            </div>
+
+            {/* Empty spacer to match 4-column layout */}
+            <div />
+          </div>
+
+          {/* Inline reply input */}
+          {isReplying && (
+            <div className="mt-3" onClick={(e) => e.stopPropagation()}>
+              <CommentInput
+                postId={postId}
+                parentCommentId={reply.id}
+                placeholder={`Reply to ${reply.authorName}...`}
+                replyingToName={reply.authorName}
+                autoFocus
+                onSubmit={async () => {
+                  setIsReplying(false);
+                  onReplySubmit();
+                }}
+                onCancel={() => setIsReplying(false)}
               />
             </div>
           )}
         </div>
-
-        {/* Reply content - clickable to navigate to thread */}
-        <button
-          type="button"
-          onClick={handleNavigateToReply}
-          className="mb-2 w-full cursor-pointer text-left transition-colors hover:text-muted-foreground"
-        >
-          <p className="whitespace-pre-wrap break-words text-foreground text-sm">
-            <TaggedText
-              text={reply.content}
-              onTagClick={(tag) => {
-                if (tag.startsWith('@')) {
-                  const username = tag.slice(1);
-                  router.push(`/profile/${username}`);
-                } else if (tag.startsWith('$')) {
-                  const symbol = tag.slice(1);
-                  router.push(`/markets?search=${encodeURIComponent(symbol)}`);
-                }
-              }}
-            />
-          </p>
-        </button>
-
-        {/* Footer actions */}
-        <div className="flex items-center gap-1">
-          {/* Message icon - reply to this comment */}
-          <button
-            type="button"
-            onClick={() => setIsReplying(!isReplying)}
-            className={cn(
-              'flex items-center gap-1.5 rounded-full px-2 py-1 text-xs transition-colors',
-              'text-muted-foreground hover:bg-[#0066FF]/10 hover:text-[#0066FF]',
-              isReplying && 'bg-[#0066FF]/10 text-[#0066FF]'
-            )}
-          >
-            <MessageCircle size={14} />
-            <span>
-              {hasReplies
-                ? reply.replyCount >= MAX_REPLY_COUNT
-                  ? `${MAX_REPLY_COUNT}+`
-                  : reply.replyCount
-                : ''}
-            </span>
-          </button>
-
-          {/* Like button */}
-          <LikeButton
-            targetId={reply.id}
-            targetType="comment"
-            initialLiked={reply.isLiked}
-            initialCount={reply.likeCount}
-            size="sm"
-            showCount
-          />
-        </div>
-
-        {/* Inline reply input */}
-        {isReplying && (
-          <div className="mt-3">
-            <CommentInput
-              postId={postId}
-              parentCommentId={reply.id}
-              placeholder={`Reply to ${reply.authorName}...`}
-              replyingToName={reply.authorName}
-              autoFocus
-              onSubmit={async () => {
-                setIsReplying(false);
-                onReplySubmit();
-              }}
-              onCancel={() => setIsReplying(false)}
-            />
-          </div>
-        )}
       </div>
     </div>
   );
@@ -504,12 +540,42 @@ export default function CommentPage({ params }: CommentPageProps) {
 
   if (isLoading) {
     return (
-      <PageContainer>
-        <div className="flex min-h-screen items-center justify-center">
-          <div className="w-full max-w-feed space-y-4 px-4 py-3">
-            <Skeleton className="h-8 w-3/4" />
-            <Skeleton className="h-32 w-full" />
-            <Skeleton className="h-20 w-full" />
+      <PageContainer noPadding className="flex w-full flex-col">
+        <div className="relative flex min-h-screen flex-1">
+          {/* Desktop loading */}
+          <div className="hidden min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:flex lg:border-r lg:border-l">
+            <div className="sticky top-0 z-10 shrink-0 bg-background shadow-sm">
+              <div className="px-6 py-4">
+                <div className="flex items-center gap-4">
+                  <div className="h-9 w-9 rounded-full bg-muted" />
+                  <Skeleton className="h-6 w-20" />
+                </div>
+              </div>
+            </div>
+            <div className="flex-1 bg-background">
+              <div className="w-full lg:mx-auto lg:max-w-[700px]">
+                <div className="space-y-4 px-4 py-6">
+                  <Skeleton className="h-8 w-3/4" />
+                  <Skeleton className="h-32 w-full" />
+                  <Skeleton className="h-20 w-full" />
+                </div>
+              </div>
+            </div>
+          </div>
+          <WidgetSidebar showLatestNews={false} showMarkets={false} />
+          {/* Mobile loading */}
+          <div className="flex flex-1 flex-col lg:hidden">
+            <div className="sticky top-0 z-10 shrink-0 border-border border-b bg-background">
+              <div className="flex items-center gap-4 px-4 py-3">
+                <div className="h-9 w-9 rounded-full bg-muted" />
+                <Skeleton className="h-6 w-20" />
+              </div>
+            </div>
+            <div className="space-y-4 px-4 py-6">
+              <Skeleton className="h-8 w-3/4" />
+              <Skeleton className="h-32 w-full" />
+              <Skeleton className="h-20 w-full" />
+            </div>
           </div>
         </div>
       </PageContainer>
@@ -518,55 +584,265 @@ export default function CommentPage({ params }: CommentPageProps) {
 
   if (error || !comment) {
     return (
-      <PageContainer>
-        <div className="flex min-h-screen flex-col items-center justify-center px-4 py-3">
-          <div className="text-center">
-            <h1 className="mb-2 font-bold text-2xl">Comment Not Found</h1>
-            <p className="mb-4 text-muted-foreground">
-              {error || 'The comment you are looking for does not exist.'}
-            </p>
-            <button
-              onClick={() => router.push('/feed')}
-              className="rounded-md bg-primary px-4 py-2 text-primary-foreground transition-colors hover:bg-primary/90"
-            >
-              Go to Feed
-            </button>
+      <PageContainer noPadding className="flex w-full flex-col">
+        <div className="relative flex min-h-screen flex-1">
+          {/* Desktop error */}
+          <div className="hidden min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:flex lg:border-r lg:border-l">
+            <div className="flex flex-1 flex-col items-center justify-center bg-background">
+              <div className="text-center">
+                <h1 className="mb-2 font-bold text-2xl">Comment Not Found</h1>
+                <p className="mb-4 text-muted-foreground">
+                  {error || 'The comment you are looking for does not exist.'}
+                </p>
+                <button
+                  onClick={() => router.push('/feed')}
+                  className="rounded-md bg-primary px-4 py-2 text-primary-foreground transition-colors hover:bg-primary/90"
+                >
+                  Go to Feed
+                </button>
+              </div>
+            </div>
+          </div>
+          <WidgetSidebar showLatestNews={false} showMarkets={false} />
+          {/* Mobile error */}
+          <div className="flex flex-1 flex-col items-center justify-center lg:hidden">
+            <div className="px-4 text-center">
+              <h1 className="mb-2 font-bold text-2xl">Comment Not Found</h1>
+              <p className="mb-4 text-muted-foreground">
+                {error || 'The comment you are looking for does not exist.'}
+              </p>
+              <button
+                onClick={() => router.push('/feed')}
+                className="rounded-md bg-primary px-4 py-2 text-primary-foreground transition-colors hover:bg-primary/90"
+              >
+                Go to Feed
+              </button>
+            </div>
           </div>
         </div>
       </PageContainer>
     );
   }
 
-  return (
-    <PageContainer noPadding className="!overflow-visible flex w-full flex-col">
-      <div className="relative flex flex-1">
-        {/* Content area with same borders as feed */}
-        <div className="flex min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.5)] lg:border-r lg:border-l">
-          {/* Header */}
-          <div className="sticky top-0 z-10 shrink-0 bg-background shadow-sm">
-            <div className="px-3 sm:px-4 lg:px-6">
-              <div className="flex items-center gap-4 py-3">
-                <button
-                  onClick={() => {
-                    // Navigate to parent: immediate parent comment > post > feed
-                    if (parentChain.length > 0) {
+  const backButtonHandler = () => {
+    // Navigate to parent: immediate parent comment > post > feed
+    if (parentChain.length > 0) {
+      router.push(`/comment/${parentChain[parentChain.length - 1]?.id}`);
+    } else if (post) {
+      router.push(`/post/${post.id}`);
+    } else {
+      router.push('/feed');
+    }
+  };
+
+  const threadContent = (
+    <>
+      {/* Original post */}
+      {post && <OriginalPostCard post={post} />}
+
+      {/* Parent chain - show all parent comments leading up to this one */}
+      {parentChain.length > 0 && (
+        <div>
+          {parentChain.map((parent, index) => (
+            <ParentCommentCard
+              key={parent.id}
+              parent={parent}
+              showConnector={index < parentChain.length}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Main comment */}
+      <div
+        ref={mainCommentRef}
+        className="border-border border-b px-4 py-4 sm:px-6"
+      >
+        <div className="flex gap-3">
+          {/* Avatar */}
+          <Link
+            href={getProfileUrl(comment.authorId, comment.authorUsername)}
+            className="shrink-0 transition-opacity hover:opacity-80"
+          >
+            <Avatar
+              id={comment.authorId}
+              name={comment.authorName}
+              size="md"
+              imageUrl={comment.authorProfileImageUrl || undefined}
+            />
+          </Link>
+
+          {/* Content */}
+          <div className="min-w-0 flex-1">
+            {/* Author info */}
+            <div className="mb-2 flex items-center justify-between gap-2">
+              <div className="flex min-w-0 flex-1 items-center gap-2">
+                <Link
+                  href={getProfileUrl(comment.authorId, comment.authorUsername)}
+                  className="font-semibold hover:underline"
+                >
+                  {comment.authorName}
+                </Link>
+                {showVerifiedBadge && (
+                  <VerifiedBadge size="sm" className="-ml-1" />
+                )}
+                <Link
+                  href={getProfileUrl(comment.authorId, comment.authorUsername)}
+                  className="text-muted-foreground text-sm hover:underline"
+                >
+                  @{comment.authorUsername || comment.authorName}
+                </Link>
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                <span className="text-muted-foreground text-xs">
+                  {formatTimeAgo(comment.createdAt)}
+                </span>
+                {/* Moderation menu for other users' comments */}
+                {user && !isOwnComment && (
+                  <ModerationMenu
+                    targetUserId={comment.authorId}
+                    targetUsername={comment.authorUsername || undefined}
+                    targetDisplayName={comment.authorName}
+                    targetProfileImageUrl={
+                      comment.authorProfileImageUrl || undefined
+                    }
+                    isNPC={mainCommentAuthorIsNPC}
+                  />
+                )}
+              </div>
+            </div>
+
+            {/* Comment content - larger for main comment */}
+            <div className="mb-3">
+              <p className="whitespace-pre-wrap break-words text-base text-foreground leading-relaxed">
+                <TaggedText
+                  text={comment.content}
+                  onTagClick={(tag) => {
+                    if (tag.startsWith('@')) {
+                      const username = tag.slice(1);
+                      router.push(`/profile/${username}`);
+                    } else if (tag.startsWith('$')) {
+                      const symbol = tag.slice(1);
                       router.push(
-                        `/comment/${parentChain[parentChain.length - 1]?.id}`
+                        `/markets?search=${encodeURIComponent(symbol)}`
                       );
-                    } else if (post) {
-                      router.push(`/post/${post.id}`);
-                    } else {
-                      router.push('/feed');
                     }
                   }}
-                  aria-label={
-                    parentChain.length > 0
-                      ? 'Go back to parent comment'
-                      : post
-                        ? 'Go back to post'
-                        : 'Go back to feed'
-                  }
-                  className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                />
+              </p>
+            </div>
+
+            {/* Actions - matches CommentCard/ReplyCard 4-column layout */}
+            <div
+              className="mt-2 flex w-full items-center justify-between gap-6 text-muted-foreground"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {/* Reply button */}
+              <button
+                type="button"
+                onClick={() => setIsReplying(!isReplying)}
+                className={cn(
+                  'flex items-center gap-1',
+                  'bg-transparent transition-all duration-200 hover:opacity-70',
+                  'cursor-pointer text-muted-foreground text-xs',
+                  isReplying && 'text-[#0066FF]'
+                )}
+              >
+                <MessageCircle size={18} />
+                {comment.replyCount > 0 && (
+                  <span className="font-medium tabular-nums">
+                    {comment.replyCount >= MAX_REPLY_COUNT
+                      ? `${MAX_REPLY_COUNT}+`
+                      : comment.replyCount}
+                  </span>
+                )}
+              </button>
+
+              {/* Repost button (placeholder) */}
+              <div>
+                <button
+                  type="button"
+                  disabled
+                  className="flex cursor-default items-center gap-1 text-muted-foreground/40 text-xs"
+                >
+                  <Repeat2 size={18} />
+                </button>
+              </div>
+
+              {/* Like button */}
+              <div>
+                <LikeButton
+                  targetId={comment.id}
+                  targetType="comment"
+                  initialLiked={comment.isLiked}
+                  initialCount={comment.likeCount}
+                  size="sm"
+                  showCount
+                />
+              </div>
+
+              {/* Empty spacer to match 4-column layout */}
+              <div />
+            </div>
+
+            {/* Reply input */}
+            {isReplying && post && (
+              <div className="mt-4">
+                <CommentInput
+                  postId={post.id}
+                  parentCommentId={comment.id}
+                  placeholder={`Reply to ${comment.authorName}...`}
+                  replyingToName={comment.authorName}
+                  autoFocus
+                  onSubmit={handleReplySubmit}
+                  onCancel={() => setIsReplying(false)}
+                />
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Replies section */}
+      <div>
+        {replies.length === 0 ? (
+          <EmptyState
+            icon={MessageCircle}
+            title="No replies yet"
+            description="Be the first to reply!"
+            className="py-12"
+          />
+        ) : (
+          <div>
+            {replies.map((reply) => (
+              <ReplyCard
+                key={reply.id}
+                reply={reply}
+                postId={post?.id || ''}
+                onReplySubmit={loadComment}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Spacer for login bar */}
+      <div className="pb-24" />
+    </>
+  );
+
+  return (
+    <PageContainer noPadding className="flex w-full flex-col">
+      <div className="relative flex min-h-screen flex-1">
+        {/* Desktop: Thread content area */}
+        <div className="hidden min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:flex lg:border-r lg:border-l">
+          {/* Desktop: Top bar with back button */}
+          <div className="sticky top-0 z-10 shrink-0 bg-background shadow-sm">
+            <div className="px-6 py-4">
+              <div className="flex items-center gap-4">
+                <button
+                  onClick={backButtonHandler}
+                  className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 >
                   <ArrowLeft size={20} />
                 </button>
@@ -578,197 +854,37 @@ export default function CommentPage({ params }: CommentPageProps) {
             </div>
           </div>
 
-          {/* Content */}
-          <div className="flex-1 overflow-y-auto bg-background">
+          {/* Thread content */}
+          <div className="flex-1 bg-background">
             <div className="w-full lg:mx-auto lg:max-w-[700px]">
-              {/* Original post */}
-              {post && <OriginalPostCard post={post} />}
+              {threadContent}
+            </div>
+          </div>
+        </div>
 
-              {/* Parent chain - show all parent comments leading up to this one */}
-              {parentChain.length > 0 && (
-                <div>
-                  {parentChain.map((parent, index) => (
-                    <ParentCommentCard
-                      key={parent.id}
-                      parent={parent}
-                      showConnector={index < parentChain.length - 1}
-                    />
-                  ))}
-                </div>
-              )}
+        {/* Widget sidebar - desktop only */}
+        <WidgetSidebar showLatestNews={false} showMarkets={false} />
 
-              {/* Main comment */}
-              <div
-                ref={mainCommentRef}
-                className="border-border border-b px-4 py-4 sm:px-6"
+        {/* Mobile/Tablet: Single column layout */}
+        <div className="flex flex-1 flex-col overflow-hidden lg:hidden">
+          {/* Mobile header */}
+          <div className="sticky top-0 z-10 shrink-0 border-border border-b bg-background">
+            <div className="flex items-center gap-4 px-4 py-3">
+              <button
+                onClick={backButtonHandler}
+                className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
               >
-                <div className="flex gap-3">
-                  {/* Avatar */}
-                  <Link
-                    href={getProfileUrl(
-                      comment.authorId,
-                      comment.authorUsername
-                    )}
-                    className="shrink-0 transition-opacity hover:opacity-80"
-                  >
-                    <Avatar
-                      id={comment.authorId}
-                      name={comment.authorName}
-                      size="md"
-                      imageUrl={comment.authorProfileImageUrl || undefined}
-                    />
-                  </Link>
-
-                  {/* Content */}
-                  <div className="min-w-0 flex-1">
-                    {/* Author info */}
-                    <div className="mb-2 flex items-center justify-between gap-2">
-                      <div className="flex min-w-0 flex-1 items-center gap-2">
-                        <Link
-                          href={getProfileUrl(
-                            comment.authorId,
-                            comment.authorUsername
-                          )}
-                          className="font-semibold hover:underline"
-                        >
-                          {comment.authorName}
-                        </Link>
-                        {showVerifiedBadge && (
-                          <VerifiedBadge size="sm" className="-ml-1" />
-                        )}
-                        <Link
-                          href={getProfileUrl(
-                            comment.authorId,
-                            comment.authorUsername
-                          )}
-                          className="text-muted-foreground text-sm hover:underline"
-                        >
-                          @{comment.authorUsername || comment.authorName}
-                        </Link>
-                      </div>
-                      {/* Moderation menu for other users' comments */}
-                      {user && !isOwnComment && (
-                        <ModerationMenu
-                          targetUserId={comment.authorId}
-                          targetUsername={comment.authorUsername || undefined}
-                          targetDisplayName={comment.authorName}
-                          targetProfileImageUrl={
-                            comment.authorProfileImageUrl || undefined
-                          }
-                          isNPC={mainCommentAuthorIsNPC}
-                        />
-                      )}
-                    </div>
-
-                    {/* Comment content - larger for main comment */}
-                    <div className="mb-3">
-                      <p className="whitespace-pre-wrap break-words text-base text-foreground leading-relaxed">
-                        <TaggedText
-                          text={comment.content}
-                          onTagClick={(tag) => {
-                            if (tag.startsWith('@')) {
-                              const username = tag.slice(1);
-                              router.push(`/profile/${username}`);
-                            } else if (tag.startsWith('$')) {
-                              const symbol = tag.slice(1);
-                              router.push(
-                                `/markets?search=${encodeURIComponent(symbol)}`
-                              );
-                            }
-                          }}
-                        />
-                      </p>
-                    </div>
-
-                    {/* Timestamp */}
-                    <div className="mb-3 text-muted-foreground text-sm">
-                      {new Date(comment.createdAt).toLocaleString('en-US', {
-                        month: 'short',
-                        day: 'numeric',
-                        year: 'numeric',
-                        hour: 'numeric',
-                        minute: '2-digit',
-                      })}
-                    </div>
-
-                    {/* Actions - like post page */}
-                    <div className="flex items-center gap-1 border-border border-t pt-3">
-                      {/* Message icon - reply to main comment */}
-                      <button
-                        type="button"
-                        onClick={() => setIsReplying(!isReplying)}
-                        className={cn(
-                          'flex items-center gap-1.5 rounded-full px-2 py-1 text-sm transition-colors',
-                          'text-muted-foreground hover:bg-[#0066FF]/10 hover:text-[#0066FF]',
-                          isReplying && 'bg-[#0066FF]/10 text-[#0066FF]'
-                        )}
-                      >
-                        <MessageCircle size={16} />
-                        <span>
-                          {comment.replyCount > 0
-                            ? comment.replyCount >= MAX_REPLY_COUNT
-                              ? `${MAX_REPLY_COUNT}+`
-                              : comment.replyCount
-                            : ''}
-                        </span>
-                      </button>
-
-                      <LikeButton
-                        targetId={comment.id}
-                        targetType="comment"
-                        initialLiked={comment.isLiked}
-                        initialCount={comment.likeCount}
-                        size="sm"
-                        showCount
-                      />
-                    </div>
-
-                    {/* Reply input */}
-                    {isReplying && post && (
-                      <div className="mt-4">
-                        <CommentInput
-                          postId={post.id}
-                          parentCommentId={comment.id}
-                          placeholder={`Reply to ${comment.authorName}...`}
-                          replyingToName={comment.authorName}
-                          autoFocus
-                          onSubmit={handleReplySubmit}
-                          onCancel={() => setIsReplying(false)}
-                        />
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-
-              {/* Replies section */}
-              <div className="px-4 sm:px-6">
-                {replies.length === 0 ? (
-                  <EmptyState
-                    icon={MessageCircle}
-                    title="No replies yet"
-                    description="Be the first to reply!"
-                    className="py-12"
-                  />
-                ) : post ? (
-                  <div>
-                    {replies.map((reply) => (
-                      <ReplyCard
-                        key={reply.id}
-                        reply={reply}
-                        postId={post.id}
-                        onReplySubmit={loadComment}
-                      />
-                    ))}
-                  </div>
-                ) : (
-                  <div className="py-8 text-center text-muted-foreground">
-                    Unable to load replies - post not found
-                  </div>
-                )}
+                <ArrowLeft size={20} />
+              </button>
+              <div className="flex items-center gap-2">
+                <MessageCircle className="h-5 w-5 text-[#0066FF]" />
+                <h1 className="font-semibold text-lg">Thread</h1>
               </div>
             </div>
           </div>
+
+          {/* Mobile content */}
+          <div className="flex-1 overflow-y-auto">{threadContent}</div>
         </div>
       </div>
     </PageContainer>

--- a/apps/web/src/app/feed/FeedClient.tsx
+++ b/apps/web/src/app/feed/FeedClient.tsx
@@ -24,7 +24,10 @@ const WidgetSidebar = dynamic(
     import('@/components/shared/WidgetSidebar').then((m) => ({
       default: m.WidgetSidebar,
     })),
-  { ssr: false }
+  {
+    ssr: false,
+    loading: () => <div className="hidden w-96 flex-none xl:block" />,
+  }
 );
 
 const TradesFeed = dynamic(
@@ -288,17 +291,13 @@ export function FeedClient() {
   };
 
   return (
-    <PageContainer noPadding className="!overflow-visible flex w-full flex-col">
+    <PageContainer noPadding className="flex w-full flex-col">
       <div ref={scrollContainerRef} className="relative flex flex-1">
         {/* Feed area */}
-        <div className="flex min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.5)] lg:border-r lg:border-l">
+        <div className="flex min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:border-r lg:border-l">
           {/* Header with tabs */}
           <div className="sticky top-0 z-10 flex-shrink-0 bg-background shadow-sm">
-            <div className="px-3 sm:px-4 lg:px-6">
-              <div className="flex items-center justify-between lg:mb-3">
-                <FeedToggle activeTab={tab} onTabChange={setTab} />
-              </div>
-            </div>
+            <FeedToggle activeTab={tab} onTabChange={setTab} />
           </div>
 
           {/* Feed content */}

--- a/apps/web/src/app/feed/components/EmptyFeed.tsx
+++ b/apps/web/src/app/feed/components/EmptyFeed.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import { Clock, FileText, Flame, Users } from 'lucide-react';
+import { EmptyState } from '@/components/shared/EmptyState';
+
 type EmptyFeedVariant = 'latest' | 'hot' | 'following' | 'default';
 
 interface EmptyFeedProps {
@@ -19,69 +22,43 @@ interface EmptyFeedProps {
 export function EmptyFeed({ variant, isLoading = false }: EmptyFeedProps) {
   if (variant === 'latest') {
     return (
-      <div className="w-full p-4 text-center sm:p-8">
-        <div className="py-8 text-muted-foreground sm:py-12">
-          <h2 className="mb-2 font-bold text-foreground text-lg sm:text-2xl">
-            No Posts Yet
-          </h2>
-          <p className="mb-4 text-sm sm:text-base">
-            Engine is generating posts...
-          </p>
-          <div className="space-y-2 text-muted-foreground text-xs sm:text-sm">
-            <p>Check terminal for tick logs.</p>
-            <p>Posts appear within 60 seconds.</p>
-          </div>
-        </div>
-      </div>
+      <EmptyState
+        icon={FileText}
+        title="No Posts Yet"
+        description="Engine is generating posts. Check terminal for tick logs. Posts appear within 60 seconds."
+      />
     );
   }
 
   if (variant === 'hot') {
     return (
-      <div className="w-full p-4 text-center sm:p-8">
-        <div className="py-8 text-muted-foreground sm:py-12">
-          <h2 className="mb-2 font-bold text-foreground text-lg sm:text-2xl">
-            🔥 No Hot Posts Yet
-          </h2>
-          <p className="mb-4 text-sm sm:text-base">
-            Posts with the most engagement in the last 24 hours appear here.
-          </p>
-          <p className="text-muted-foreground text-xs sm:text-sm">
-            Like, comment, and share posts to heat things up!
-          </p>
-        </div>
-      </div>
+      <EmptyState
+        icon={Flame}
+        title="No Hot Posts Yet"
+        description="Posts with the most engagement in the last 24 hours appear here. Like, comment, and share posts to heat things up!"
+      />
     );
   }
 
   if (variant === 'following') {
     return (
-      <div className="w-full p-4 text-center sm:p-8">
-        <div className="py-8 text-muted-foreground sm:py-12">
-          <h2 className="mb-2 font-semibold text-foreground text-lg sm:text-xl">
-            👥 Not Following Anyone Yet
-          </h2>
-          <p className="mb-4 text-sm sm:text-base">
-            {isLoading
-              ? 'Loading following...'
-              : 'Follow profiles to see their posts here. Visit a profile and click the Follow button.'}
-          </p>
-        </div>
-      </div>
+      <EmptyState
+        icon={Users}
+        title="Not Following Anyone Yet"
+        description={
+          isLoading
+            ? 'Loading following...'
+            : 'Follow profiles to see their posts here. Visit a profile and click the Follow button.'
+        }
+      />
     );
   }
 
   return (
-    <div className="w-full p-4 text-center sm:p-8">
-      <div className="py-8 text-muted-foreground sm:py-12">
-        <h2 className="mb-2 font-semibold text-foreground text-lg sm:text-xl">
-          ⏱️ No Posts Yet
-        </h2>
-        <p className="mb-4 text-sm sm:text-base">
-          Game tick runs every 60 seconds. Content will appear here as it&apos;s
-          generated.
-        </p>
-      </div>
-    </div>
+    <EmptyState
+      icon={Clock}
+      title="No Posts Yet"
+      description="Game tick runs every 60 seconds. Content will appear here as it's generated."
+    />
   );
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -187,12 +187,14 @@ body {
   font-feature-settings: "rlig" 1, "calt" 1;
   /* Prevent native pull-to-refresh and overscroll effects */
   overscroll-behavior-y: contain;
-  overflow-y: auto;
 }
 
 /* Prevent pull-to-refresh on the entire app */
 html {
   overscroll-behavior-y: contain;
+  /* Always show scrollbar and reserve space to prevent layout shift */
+  overflow-y: scroll;
+  scrollbar-gutter: stable;
 }
 
 /* All buttons and links should have pointer cursor */

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -26,11 +26,11 @@
   --chart-3: #f7b928;
   --chart-4: #17bf63;
   --chart-5: #e0245e;
-  --sidebar: #fafafa;
+  --sidebar: #ffffff;
   --sidebar-foreground: #0f1419;
   --sidebar-primary: #0066FF;
   --sidebar-primary-foreground: #ffffff;
-  --sidebar-accent: #e3ecf6;
+  --sidebar-accent: #eeeeee;
   --sidebar-accent-foreground: #0066FF;
   --sidebar-border: #e1e8ed;
   --sidebar-ring: #0066FF;
@@ -87,11 +87,11 @@
   --chart-3: #f7b928;
   --chart-4: #17bf63;
   --chart-5: #e0245e;
-  --sidebar: #0a0a0a;
+  --sidebar: #000000;
   --sidebar-foreground: #d9d9d9;
   --sidebar-primary: #0066FF;
   --sidebar-primary-foreground: #ffffff;
-  --sidebar-accent: #1a1a1a;
+  --sidebar-accent: #2a2a2a;
   --sidebar-accent-foreground: #0066FF;
   --sidebar-border: #2f3336;
   --sidebar-ring: #0066FF;

--- a/apps/web/src/app/leaderboard/page.tsx
+++ b/apps/web/src/app/leaderboard/page.tsx
@@ -1,13 +1,7 @@
 'use client';
 
 import { formatCurrency } from '@babylon/shared';
-import {
-  ChevronLeft,
-  ChevronRight,
-  TrendingUp,
-  Trophy,
-  Users,
-} from 'lucide-react';
+import { ChevronLeft, ChevronRight, Trophy } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
@@ -29,7 +23,10 @@ const LeaderboardWidgetSidebar = dynamic(
     import('@/components/leaderboard/LeaderboardWidgetSidebar').then((m) => ({
       default: m.LeaderboardWidgetSidebar,
     })),
-  { ssr: false }
+  {
+    ssr: false,
+    loading: () => <div className="hidden w-96 flex-none xl:block" />,
+  }
 );
 
 interface LeaderboardUser {
@@ -240,15 +237,6 @@ export default function LeaderboardPage() {
 
     return (
       <div className="flex-1 overflow-y-auto">
-        <div className="mb-4 flex items-center gap-3 px-4 pt-4">
-          <Users className="h-5 w-5 text-[#0066FF]" />
-          <h2 className="font-semibold text-foreground text-lg">
-            {leaderboardData.leaderboard.length}{' '}
-            {leaderboardData.leaderboard.length === 1 ? 'Player' : 'Players'}
-          </h2>
-          <TrendingUp className="h-4 w-4 text-muted-foreground" />
-        </div>
-
         <div className="space-y-0">
           {leaderboardData.leaderboard.map((player) => {
             const isCurrentUser =
@@ -317,7 +305,7 @@ export default function LeaderboardPage() {
                       />
                     </div>
                     <div className="min-w-0 flex-1">
-                      <div className="mb-1 flex items-center gap-3">
+                      <div className="flex items-center gap-1.5">
                         <h3 className="truncate font-semibold text-foreground">
                           {player.displayName || player.username || 'Anonymous'}
                         </h3>
@@ -351,13 +339,6 @@ export default function LeaderboardPage() {
                           <div className="text-muted-foreground text-xs">
                             {activePointsLabel}
                           </div>
-                        </div>
-                        <div className="shrink-0">
-                          <RankBadge
-                            rank={player.rank}
-                            size="md"
-                            showLabel={false}
-                          />
                         </div>
                         {authenticated && !isCurrentUser && (
                           <div
@@ -463,7 +444,7 @@ export default function LeaderboardPage() {
                       />
                     </div>
                     <div className="min-w-0 flex-1">
-                      <div className="mb-1 flex items-center gap-3">
+                      <div className="flex items-center gap-1.5">
                         <h3 className="truncate font-semibold text-foreground text-sm sm:text-base">
                           {player.displayName || player.username || 'Anonymous'}
                         </h3>
@@ -588,18 +569,16 @@ export default function LeaderboardPage() {
       {/* Desktop: Content + Widgets layout */}
       <div className="hidden flex-1 overflow-hidden xl:flex">
         {/* Main content */}
-        <div className="flex min-w-0 flex-1 flex-col overflow-hidden border-[rgba(120,120,120,0.5)] lg:border-r lg:border-l">
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden border-[rgba(120,120,120,0.15)] lg:border-r lg:border-l">
           {/* Header with tabs */}
           <div className="sticky top-0 z-10 flex-shrink-0 bg-background shadow-sm">
-            <div className="px-3 sm:px-4 lg:px-6">
-              <LeaderboardToggle
-                activeTab={selectedTab}
-                onTabChange={handleTabChange}
-              />
-              <p className="py-3 text-muted-foreground text-sm">
-                {tabDescriptions[selectedTab]}
-              </p>
-            </div>
+            <LeaderboardToggle
+              activeTab={selectedTab}
+              onTabChange={handleTabChange}
+            />
+            <p className="px-3 py-3 text-muted-foreground text-sm sm:px-4 lg:px-6">
+              {tabDescriptions[selectedTab]}
+            </p>
           </div>
 
           {/* Content */}
@@ -617,15 +596,13 @@ export default function LeaderboardPage() {
       <div className="flex flex-1 flex-col overflow-hidden xl:hidden">
         {/* Header with tabs */}
         <div className="sticky top-0 z-10 flex-shrink-0 bg-background shadow-sm">
-          <div className="px-3 sm:px-4">
-            <LeaderboardToggle
-              activeTab={selectedTab}
-              onTabChange={handleTabChange}
-            />
-            <p className="py-2 text-muted-foreground text-xs sm:text-sm">
-              {tabDescriptions[selectedTab]}
-            </p>
-          </div>
+          <LeaderboardToggle
+            activeTab={selectedTab}
+            onTabChange={handleTabChange}
+          />
+          <p className="px-3 py-2 text-muted-foreground text-xs sm:px-4 sm:text-sm">
+            {tabDescriptions[selectedTab]}
+          </p>
         </div>
 
         {/* Content */}

--- a/apps/web/src/app/markets/_components/tabs/PredictionsTabContent.tsx
+++ b/apps/web/src/app/markets/_components/tabs/PredictionsTabContent.tsx
@@ -1,9 +1,11 @@
 'use client';
 
 import type { UserPredictionPosition } from '@babylon/shared';
+import { TrendingUp } from 'lucide-react';
 import { memo, useState } from 'react';
 import { CategoryPnLCard } from '@/components/markets/CategoryPnLCard';
 import { PredictionPositionsList } from '@/components/markets/PredictionPositionsList';
+import { EmptyState } from '@/components/shared/EmptyState';
 import type {
   PredictionMarketWithPosition,
   PredictionSort,
@@ -160,9 +162,11 @@ export const PredictionsTabContent = memo(function PredictionsTabContent({
             )
           )
         ) : (
-          <p className="py-8 text-center text-muted-foreground text-sm">
-            No markets found
-          </p>
+          <EmptyState
+            icon={TrendingUp}
+            title="No markets found"
+            description="Try adjusting your filters or check back later for new markets"
+          />
         )}
       </div>
     </div>

--- a/apps/web/src/app/notifications/page.tsx
+++ b/apps/web/src/app/notifications/page.tsx
@@ -43,12 +43,19 @@ interface GroupInvite {
 }
 
 export default function NotificationsPage() {
-  const { authenticated, user, getAccessToken } = useAuth();
+  const { authenticated, user, getAccessToken, login } = useAuth();
   const router = useRouter();
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [groupInvites, setGroupInvites] = useState<GroupInvite[]>([]);
   const [loading, setLoading] = useState(true);
   const [unreadCount, setUnreadCount] = useState(0);
+
+  useEffect(() => {
+    if (authenticated) return;
+    router.push('/feed');
+    const timer = setTimeout(() => login(), 500);
+    return () => clearTimeout(timer);
+  }, [authenticated, router, login]);
 
   const fetchNotifications = useCallback(
     async (showLoading = true, silent = false) => {
@@ -341,36 +348,12 @@ export default function NotificationsPage() {
   };
 
   if (!authenticated) {
-    return (
-      <PageContainer
-        noPadding
-        className="!overflow-visible flex w-full flex-col"
-      >
-        <div className="flex min-w-0 flex-1 flex-col overflow-hidden border-[rgba(120,120,120,0.5)] lg:border-r lg:border-l">
-          <div className="sticky top-0 z-10 border-border border-b bg-background">
-            <div className="px-4 py-3 lg:px-6">
-              <h1 className="font-bold text-xl">Notifications</h1>
-            </div>
-          </div>
-          <div className="flex flex-1 flex-col items-center justify-center gap-4">
-            <p className="text-muted-foreground">
-              Please sign in to view notifications
-            </p>
-            <Link
-              href="/feed"
-              className="rounded-lg bg-primary px-6 py-3 font-semibold text-primary-foreground transition-all hover:bg-primary/90"
-            >
-              Go to Feed
-            </Link>
-          </div>
-        </div>
-      </PageContainer>
-    );
+    return null;
   }
 
   return (
     <PageContainer noPadding className="!overflow-visible flex w-full flex-col">
-      <div className="flex min-w-0 flex-1 flex-col overflow-hidden border-[rgba(120,120,120,0.5)] lg:border-r lg:border-l">
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden border-[rgba(120,120,120,0.15)] lg:border-r lg:border-l">
         {/* Header */}
         <div className="sticky top-0 z-10 border-border border-b bg-background/95 backdrop-blur-sm">
           <div className="px-4 py-3 lg:px-6">
@@ -398,7 +381,7 @@ export default function NotificationsPage() {
             </div>
           ) : notifications.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-12">
-              <Bell className="mb-4 h-16 w-16 text-muted-foreground opacity-50" />
+              <Bell className="mb-4 h-12 w-12 text-muted-foreground opacity-50" />
               <h2 className="mb-2 font-semibold text-xl">
                 No notifications yet
               </h2>

--- a/apps/web/src/app/post/[id]/loading.tsx
+++ b/apps/web/src/app/post/[id]/loading.tsx
@@ -7,7 +7,7 @@ export default function PostDetailLoading() {
       {/* Desktop */}
       <div className="hidden flex-1 lg:flex">
         {/* Main Content */}
-        <div className="flex min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.5)] border-r border-l">
+        <div className="flex min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] border-r border-l">
           <div className="flex-1 overflow-y-auto">
             <div className="mx-auto w-full max-w-[700px]">
               {/* Post Detail */}

--- a/apps/web/src/app/post/[id]/page.tsx
+++ b/apps/web/src/app/post/[id]/page.tsx
@@ -187,7 +187,10 @@ export default function PostPage({ params }: PostPageProps) {
 
   if (isLoading) {
     return (
-      <PageContainer noPadding className="!overflow-visible flex w-full flex-col">
+      <PageContainer
+        noPadding
+        className="!overflow-visible flex w-full flex-col"
+      >
         <div className="relative flex min-h-screen flex-1">
           {/* Desktop loading */}
           <div className="hidden min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:flex lg:border-r lg:border-l">
@@ -217,7 +220,10 @@ export default function PostPage({ params }: PostPageProps) {
 
   if (error || !post) {
     return (
-      <PageContainer noPadding className="!overflow-visible flex w-full flex-col">
+      <PageContainer
+        noPadding
+        className="!overflow-visible flex w-full flex-col"
+      >
         <div className="relative flex min-h-screen flex-1">
           {/* Desktop error */}
           <div className="hidden min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:flex lg:border-r lg:border-l">
@@ -239,7 +245,7 @@ export default function PostPage({ params }: PostPageProps) {
           <WidgetSidebar showLatestNews={false} showMarkets={false} />
           {/* Mobile error */}
           <div className="flex flex-1 flex-col items-center justify-center lg:hidden">
-            <div className="text-center px-4">
+            <div className="px-4 text-center">
               <h1 className="mb-2 font-bold text-2xl">Post Not Found</h1>
               <p className="mb-4 text-muted-foreground">
                 {error || 'The post you are looking for does not exist.'}
@@ -376,110 +382,110 @@ export default function PostPage({ params }: PostPageProps) {
 
         {/* Mobile/Tablet: Single column layout */}
         <div className="flex flex-1 flex-col overflow-hidden lg:hidden">
-        {/* Mobile header */}
-        <div className="sticky top-0 z-10 shrink-0 border-border border-b bg-background">
-          <div className="flex items-center gap-4 px-4 py-3">
-            <button
-              onClick={() => router.push('/feed')}
-              className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-            >
-              <ArrowLeft size={20} />
-            </button>
-            <div className="flex items-center gap-2">
-              <MessageCircle className="h-5 w-5 text-[#0066FF]" />
-              <h1 className="font-semibold text-lg">Post</h1>
+          {/* Mobile header */}
+          <div className="sticky top-0 z-10 shrink-0 border-border border-b bg-background">
+            <div className="flex items-center gap-4 px-4 py-3">
+              <button
+                onClick={() => router.push('/feed')}
+                className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <ArrowLeft size={20} />
+              </button>
+              <div className="flex items-center gap-2">
+                <MessageCircle className="h-5 w-5 text-[#0066FF]" />
+                <h1 className="font-semibold text-lg">Post</h1>
+              </div>
             </div>
           </div>
-        </div>
 
-        {/* Mobile content */}
-        <div className="flex-1 overflow-y-auto">
-          {/* Post */}
-          <div className="border-border border-b">
-            {post.type === 'article' &&
-            post.fullContent &&
-            post.fullContent.length > 100 ? (
-              // Article detail view - Only show if has substantial full content (> 100 chars)
-              <article className="px-4 py-4 sm:px-6 sm:py-5">
-                {/* Category badge */}
-                {post.category && (
-                  <div className="mb-4">
-                    <span className="rounded bg-[#0066FF]/20 px-3 py-1 font-semibold text-[#0066FF] text-sm uppercase">
-                      {post.category}
-                    </span>
-                  </div>
-                )}
-
-                {/* Article title */}
-                <h1 className="mb-4 font-bold text-2xl text-foreground leading-tight sm:text-3xl">
-                  {post.articleTitle || 'Untitled Article'}
-                </h1>
-
-                {/* Article metadata */}
-                <div className="mb-4 flex flex-wrap items-center gap-2 text-muted-foreground text-sm">
-                  <span className="font-semibold text-[#0066FF]">
-                    {post.authorName}
-                  </span>
-                  {post.byline && (
-                    <>
-                      <span>·</span>
-                      <span>{post.byline}</span>
-                    </>
+          {/* Mobile content */}
+          <div className="flex-1 overflow-y-auto">
+            {/* Post */}
+            <div className="border-border border-b">
+              {post.type === 'article' &&
+              post.fullContent &&
+              post.fullContent.length > 100 ? (
+                // Article detail view - Only show if has substantial full content (> 100 chars)
+                <article className="px-4 py-4 sm:px-6 sm:py-5">
+                  {/* Category badge */}
+                  {post.category && (
+                    <div className="mb-4">
+                      <span className="rounded bg-[#0066FF]/20 px-3 py-1 font-semibold text-[#0066FF] text-sm uppercase">
+                        {post.category}
+                      </span>
+                    </div>
                   )}
-                  <span>·</span>
-                  <time>
-                    {new Date(post.timestamp).toLocaleDateString('en-US', {
-                      month: 'short',
-                      day: 'numeric',
-                    })}
-                  </time>
-                </div>
 
-                {/* Full article content */}
-                <div className="prose prose-invert mb-4 max-w-none">
-                  {post.fullContent.split('\n\n').map((paragraph, i) => (
-                    <p
-                      key={i}
-                      className="mb-4 text-base text-foreground leading-relaxed"
-                    >
-                      {paragraph}
-                    </p>
-                  ))}
-                </div>
+                  {/* Article title */}
+                  <h1 className="mb-4 font-bold text-2xl text-foreground leading-tight sm:text-3xl">
+                    {post.articleTitle || 'Untitled Article'}
+                  </h1>
 
-                {/* Interaction bar */}
-                <div className="mt-4 border-border border-t pt-4">
-                  <InteractionBar
-                    postId={post.id}
-                    initialInteractions={{
-                      postId: post.id,
-                      likeCount: post.likeCount,
-                      commentCount: post.commentCount,
-                      shareCount: post.shareCount,
-                      isLiked: post.isLiked,
-                      isShared: post.isShared,
-                    }}
-                    postData={post}
-                    onCommentClick={handleCommentClick}
-                  />
-                </div>
-              </article>
-            ) : (
-              // Regular post
-              <PostCard
-                post={post}
-                showInteractions={true}
-                isDetail
-                onCommentClick={handleCommentClick}
-              />
-            )}
+                  {/* Article metadata */}
+                  <div className="mb-4 flex flex-wrap items-center gap-2 text-muted-foreground text-sm">
+                    <span className="font-semibold text-[#0066FF]">
+                      {post.authorName}
+                    </span>
+                    {post.byline && (
+                      <>
+                        <span>·</span>
+                        <span>{post.byline}</span>
+                      </>
+                    )}
+                    <span>·</span>
+                    <time>
+                      {new Date(post.timestamp).toLocaleDateString('en-US', {
+                        month: 'short',
+                        day: 'numeric',
+                      })}
+                    </time>
+                  </div>
+
+                  {/* Full article content */}
+                  <div className="prose prose-invert mb-4 max-w-none">
+                    {post.fullContent.split('\n\n').map((paragraph, i) => (
+                      <p
+                        key={i}
+                        className="mb-4 text-base text-foreground leading-relaxed"
+                      >
+                        {paragraph}
+                      </p>
+                    ))}
+                  </div>
+
+                  {/* Interaction bar */}
+                  <div className="mt-4 border-border border-t pt-4">
+                    <InteractionBar
+                      postId={post.id}
+                      initialInteractions={{
+                        postId: post.id,
+                        likeCount: post.likeCount,
+                        commentCount: post.commentCount,
+                        shareCount: post.shareCount,
+                        isLiked: post.isLiked,
+                        isShared: post.isShared,
+                      }}
+                      postData={post}
+                      onCommentClick={handleCommentClick}
+                    />
+                  </div>
+                </article>
+              ) : (
+                // Regular post
+                <PostCard
+                  post={post}
+                  showInteractions={true}
+                  isDetail
+                  onCommentClick={handleCommentClick}
+                />
+              )}
+            </div>
+
+            {/* Comments Section - Always visible below the post */}
+            <FeedCommentSection postId={postId} postData={post} />
           </div>
-
-          {/* Comments Section - Always visible below the post */}
-          <FeedCommentSection postId={postId} postData={post} />
         </div>
       </div>
-    </div>
 
       {/* Comment Modal */}
       {isCommentModalOpen && (

--- a/apps/web/src/app/post/[id]/page.tsx
+++ b/apps/web/src/app/post/[id]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ArrowLeft, MessageCircle } from 'lucide-react';
+import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { use, useEffect, useState } from 'react';
 import { FeedCommentSection } from '@/components/feed/FeedCommentSection';
@@ -9,6 +10,17 @@ import { PostCard } from '@/components/posts/PostCard';
 import { PageContainer } from '@/components/shared/PageContainer';
 import { Skeleton } from '@/components/shared/Skeleton';
 import { useInteractionStore } from '@/stores/interactionStore';
+
+const WidgetSidebar = dynamic(
+  () =>
+    import('@/components/shared/WidgetSidebar').then((m) => ({
+      default: m.WidgetSidebar,
+    })),
+  {
+    ssr: false,
+    loading: () => <div className="hidden w-96 flex-none xl:block" />,
+  }
+);
 
 interface PostPageProps {
   params: Promise<{ id: string }>;
@@ -175,48 +187,88 @@ export default function PostPage({ params }: PostPageProps) {
 
   if (isLoading) {
     return (
-      <div className="flex min-h-screen items-center justify-center">
-        <div className="w-full max-w-feed space-y-4 px-4 py-3">
-          <Skeleton className="h-8 w-3/4" />
-          <Skeleton className="h-64 w-full" />
-          <Skeleton className="h-32 w-full" />
+      <PageContainer noPadding className="!overflow-visible flex w-full flex-col">
+        <div className="relative flex min-h-screen flex-1">
+          {/* Desktop loading */}
+          <div className="hidden min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:flex lg:border-r lg:border-l">
+            <div className="flex-1 bg-background">
+              <div className="w-full lg:mx-auto lg:max-w-[700px]">
+                <div className="space-y-4 px-4 py-6">
+                  <Skeleton className="h-8 w-3/4" />
+                  <Skeleton className="h-64 w-full" />
+                  <Skeleton className="h-32 w-full" />
+                </div>
+              </div>
+            </div>
+          </div>
+          <WidgetSidebar showLatestNews={false} showMarkets={false} />
+          {/* Mobile loading */}
+          <div className="flex flex-1 flex-col lg:hidden">
+            <div className="space-y-4 px-4 py-6">
+              <Skeleton className="h-8 w-3/4" />
+              <Skeleton className="h-64 w-full" />
+              <Skeleton className="h-32 w-full" />
+            </div>
+          </div>
         </div>
-      </div>
+      </PageContainer>
     );
   }
 
   if (error || !post) {
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center px-4 py-3">
-        <div className="text-center">
-          <h1 className="mb-2 font-bold text-2xl">Post Not Found</h1>
-          <p className="mb-4 text-muted-foreground">
-            {error || 'The post you are looking for does not exist.'}
-          </p>
-          <button
-            onClick={() => router.push('/feed')}
-            className="rounded-md bg-primary px-4 py-2 text-primary-foreground transition-colors hover:bg-primary/90"
-          >
-            Back to Feed
-          </button>
+      <PageContainer noPadding className="!overflow-visible flex w-full flex-col">
+        <div className="relative flex min-h-screen flex-1">
+          {/* Desktop error */}
+          <div className="hidden min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:flex lg:border-r lg:border-l">
+            <div className="flex flex-1 flex-col items-center justify-center bg-background">
+              <div className="text-center">
+                <h1 className="mb-2 font-bold text-2xl">Post Not Found</h1>
+                <p className="mb-4 text-muted-foreground">
+                  {error || 'The post you are looking for does not exist.'}
+                </p>
+                <button
+                  onClick={() => router.push('/feed')}
+                  className="rounded-md bg-primary px-4 py-2 text-primary-foreground transition-colors hover:bg-primary/90"
+                >
+                  Back to Feed
+                </button>
+              </div>
+            </div>
+          </div>
+          <WidgetSidebar showLatestNews={false} showMarkets={false} />
+          {/* Mobile error */}
+          <div className="flex flex-1 flex-col items-center justify-center lg:hidden">
+            <div className="text-center px-4">
+              <h1 className="mb-2 font-bold text-2xl">Post Not Found</h1>
+              <p className="mb-4 text-muted-foreground">
+                {error || 'The post you are looking for does not exist.'}
+              </p>
+              <button
+                onClick={() => router.push('/feed')}
+                className="rounded-md bg-primary px-4 py-2 text-primary-foreground transition-colors hover:bg-primary/90"
+              >
+                Back to Feed
+              </button>
+            </div>
+          </div>
         </div>
-      </div>
+      </PageContainer>
     );
   }
 
   return (
     <PageContainer noPadding className="!overflow-visible flex w-full flex-col">
-      {/* Desktop: Multi-column layout matching feed */}
-      <div className="relative hidden flex-1 lg:flex">
-        {/* Content area with same borders as feed */}
-        <div className="flex min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.5)] lg:border-r lg:border-l">
+      <div className="relative flex min-h-screen flex-1">
+        {/* Desktop: Post content area */}
+        <div className="hidden min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:flex lg:border-r lg:border-l">
           {/* Desktop: Top bar with back button */}
           <div className="sticky top-0 z-10 shrink-0 bg-background shadow-sm">
-            <div className="px-3 sm:px-4 lg:px-6">
-              <div className="flex items-center gap-4 py-3">
+            <div className="px-6 py-4">
+              <div className="flex items-center gap-4">
                 <button
                   onClick={() => router.push('/feed')}
-                  className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 >
                   <ArrowLeft size={20} />
                 </button>
@@ -229,7 +281,7 @@ export default function PostPage({ params }: PostPageProps) {
           </div>
 
           {/* Post content */}
-          <div className="flex-1 overflow-y-auto bg-background">
+          <div className="flex-1 bg-background">
             <div className="w-full lg:mx-auto lg:max-w-[700px]">
               {/* Post */}
               <div className="border-border border-b">
@@ -314,22 +366,22 @@ export default function PostPage({ params }: PostPageProps) {
               </div>
 
               {/* Comments Section - Always visible below the post */}
-              <div className="border-border border-b">
-                <FeedCommentSection postId={postId} postData={post} />
-              </div>
+              <FeedCommentSection postId={postId} postData={post} />
             </div>
           </div>
         </div>
-      </div>
 
-      {/* Mobile/Tablet: Single column layout */}
-      <div className="flex flex-1 flex-col overflow-hidden lg:hidden">
+        {/* Widget sidebar - desktop only */}
+        <WidgetSidebar showLatestNews={false} showMarkets={false} />
+
+        {/* Mobile/Tablet: Single column layout */}
+        <div className="flex flex-1 flex-col overflow-hidden lg:hidden">
         {/* Mobile header */}
         <div className="sticky top-0 z-10 shrink-0 border-border border-b bg-background">
           <div className="flex items-center gap-4 px-4 py-3">
             <button
               onClick={() => router.push('/feed')}
-              className="rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             >
               <ArrowLeft size={20} />
             </button>
@@ -424,11 +476,10 @@ export default function PostPage({ params }: PostPageProps) {
           </div>
 
           {/* Comments Section - Always visible below the post */}
-          <div className="border-border border-b">
-            <FeedCommentSection postId={postId} postData={post} />
-          </div>
+          <FeedCommentSection postId={postId} postData={post} />
         </div>
       </div>
+    </div>
 
       {/* Comment Modal */}
       {isCommentModalOpen && (

--- a/apps/web/src/app/profile/[id]/loading.tsx
+++ b/apps/web/src/app/profile/[id]/loading.tsx
@@ -15,25 +15,23 @@ import {
 
 export default function ProfileLoading() {
   return (
-    <PageContainer noPadding className="flex min-h-screen flex-col">
-      <div className="flex flex-1">
+    <PageContainer noPadding className="min-h-screen">
+      <div className="flex flex-1 overflow-hidden">
         {/* Main Content */}
-        <div className="flex min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.5)] lg:border-r lg:border-l">
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
           <div className="flex-1 overflow-y-auto">
-            <div className="mx-auto w-full max-w-[700px]">
-              {/* Profile Header */}
-              <ProfileHeaderSkeleton />
+            {/* Profile Header */}
+            <ProfileHeaderSkeleton />
 
-              {/* Posts */}
-              <div className="mt-4 border-border/5 border-t">
-                <FeedSkeleton count={5} />
-              </div>
+            {/* Posts */}
+            <div className="mt-4 border-border/5 border-t">
+              <FeedSkeleton count={5} />
             </div>
           </div>
         </div>
 
-        {/* Right: Widget placeholder - only on large screens */}
-        <div className="hidden w-80 shrink-0 border-border/5 border-l bg-background lg:block xl:w-96" />
+        {/* Right: Widget placeholder - only on xl screens to match actual page */}
+        <div className="hidden w-96 flex-shrink-0 flex-col bg-sidebar p-4 xl:flex" />
       </div>
     </PageContainer>
   );

--- a/apps/web/src/app/profile/[id]/page.tsx
+++ b/apps/web/src/app/profile/[id]/page.tsx
@@ -11,7 +11,7 @@ import {
   type Organization,
   POST_TYPES,
 } from '@babylon/shared';
-import { ArrowLeft, Coins, MessageCircle, Search } from 'lucide-react';
+import { ArrowLeft, Coins, FileText, MessageCircle, Search } from 'lucide-react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import {
@@ -34,6 +34,7 @@ import {
 } from '@/components/profile/ProfileReplyCard';
 import { ProfileWidget } from '@/components/profile/ProfileWidget';
 import { Avatar } from '@/components/shared/Avatar';
+import { EmptyState } from '@/components/shared/EmptyState';
 import { PageContainer } from '@/components/shared/PageContainer';
 import {
   FeedSkeleton,
@@ -695,11 +696,19 @@ export default function ActorProfilePage() {
 
     return (
       <PageContainer noPadding className="min-h-screen">
-        <div className="mx-auto w-full max-w-[700px]">
-          <ProfileHeaderSkeleton />
-          <div className="mt-4 border-border/5 border-t">
-            <FeedSkeleton count={5} />
+        <div className="flex flex-1 overflow-hidden">
+          {/* Main Content */}
+          <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+            <div className="flex-1 overflow-y-auto">
+              <ProfileHeaderSkeleton />
+              <div className="mt-4 border-border/5 border-t">
+                <FeedSkeleton count={5} />
+              </div>
+            </div>
           </div>
+
+          {/* Right: Widget placeholder */}
+          <div className="hidden w-96 flex-shrink-0 flex-col bg-sidebar p-4 xl:flex" />
         </div>
       </PageContainer>
     );
@@ -1035,13 +1044,15 @@ export default function ActorProfilePage() {
                     <FeedSkeleton count={5} />
                   </div>
                 ) : replies.length === 0 ? (
-                  <div className="py-12 text-center">
-                    <p className="text-muted-foreground">
-                      {searchQuery
-                        ? 'No replies found matching your search'
-                        : 'No replies yet'}
-                    </p>
-                  </div>
+                  <EmptyState
+                    icon={MessageCircle}
+                    title={searchQuery ? 'No replies found' : 'No replies yet'}
+                    description={
+                      searchQuery
+                        ? 'Try adjusting your search terms'
+                        : "Replies to other posts will appear here"
+                    }
+                  />
                 ) : (
                   <div>
                     {replies
@@ -1073,13 +1084,15 @@ export default function ActorProfilePage() {
                   <FeedSkeleton count={5} />
                 </div>
               ) : filteredPosts.length === 0 ? (
-                <div className="py-12 text-center">
-                  <p className="text-muted-foreground">
-                    {searchQuery
-                      ? 'No posts found matching your search'
-                      : 'No posts yet'}
-                  </p>
-                </div>
+                <EmptyState
+                  icon={FileText}
+                  title={searchQuery ? 'No posts found' : 'No posts yet'}
+                  description={
+                    searchQuery
+                      ? 'Try adjusting your search terms'
+                      : "Posts will appear here once published"
+                  }
+                />
               ) : (
                 <div className="space-y-0">
                   {filteredPosts.map((item, i) => {

--- a/apps/web/src/app/profile/[id]/page.tsx
+++ b/apps/web/src/app/profile/[id]/page.tsx
@@ -11,7 +11,13 @@ import {
   type Organization,
   POST_TYPES,
 } from '@babylon/shared';
-import { ArrowLeft, Coins, FileText, MessageCircle, Search } from 'lucide-react';
+import {
+  ArrowLeft,
+  Coins,
+  FileText,
+  MessageCircle,
+  Search,
+} from 'lucide-react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import {
@@ -1050,7 +1056,7 @@ export default function ActorProfilePage() {
                     description={
                       searchQuery
                         ? 'Try adjusting your search terms'
-                        : "Replies to other posts will appear here"
+                        : 'Replies to other posts will appear here'
                     }
                   />
                 ) : (
@@ -1090,7 +1096,7 @@ export default function ActorProfilePage() {
                   description={
                     searchQuery
                       ? 'Try adjusting your search terms'
-                      : "Posts will appear here once published"
+                      : 'Posts will appear here once published'
                   }
                 />
               ) : (

--- a/apps/web/src/app/profile/loading.tsx
+++ b/apps/web/src/app/profile/loading.tsx
@@ -6,25 +6,23 @@ import {
 
 export default function ProfileLoading() {
   return (
-    <PageContainer noPadding className="flex min-h-screen flex-col">
-      <div className="flex flex-1">
+    <PageContainer noPadding className="min-h-screen">
+      <div className="flex flex-1 overflow-hidden">
         {/* Main Content */}
-        <div className="flex min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.5)] lg:border-r lg:border-l">
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
           <div className="flex-1 overflow-y-auto">
-            <div className="mx-auto w-full max-w-[700px]">
-              {/* Profile Header */}
-              <ProfileHeaderSkeleton />
+            {/* Profile Header */}
+            <ProfileHeaderSkeleton />
 
-              {/* Posts */}
-              <div className="mt-4 border-border/5 border-t">
-                <FeedSkeleton count={5} />
-              </div>
+            {/* Posts */}
+            <div className="mt-4 border-border/5 border-t">
+              <FeedSkeleton count={5} />
             </div>
           </div>
         </div>
 
-        {/* Right: Widget placeholder - only on large screens */}
-        <div className="hidden w-80 shrink-0 border-border/5 border-l bg-background lg:block xl:w-96" />
+        {/* Right: Widget placeholder - only on xl screens to match actual page */}
+        <div className="hidden w-96 flex-shrink-0 flex-col bg-sidebar p-4 xl:flex" />
       </div>
     </PageContainer>
   );

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -17,7 +17,6 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { ArticleCard } from '@/components/articles/ArticleCard';
-import { LoginButton } from '@/components/auth/LoginButton';
 import { PostCard } from '@/components/posts/PostCard';
 import { FollowListModal } from '@/components/profile/FollowListModal';
 import { LinkSocialAccountsModal } from '@/components/profile/LinkSocialAccountsModal';
@@ -61,7 +60,7 @@ interface EditModalState {
 }
 
 export default function ProfilePage() {
-  const { ready, authenticated, getAccessToken } = useAuth();
+  const { ready, authenticated, getAccessToken, login } = useAuth();
   const { user, setUser } = useAuthStore();
   const router = useRouter();
 
@@ -285,6 +284,14 @@ export default function ProfilePage() {
       reply.content?.toLowerCase().includes(query)
     );
   }, [replies, searchQuery]);
+
+  // Auth required — redirect to feed and show login
+  useEffect(() => {
+    if (!ready || (authenticated && user)) return;
+    router.push('/feed');
+    const timer = setTimeout(() => login(), 500);
+    return () => clearTimeout(timer);
+  }, [ready, authenticated, user, router, login]);
 
   const openEditModal = () => {
     setEditModal({
@@ -942,22 +949,8 @@ export default function ProfilePage() {
     );
   }
 
-  // Not authenticated
   if (!authenticated || !user) {
-    return (
-      <PageContainer noPadding className="flex flex-col">
-        <div className="flex flex-1 items-center justify-center p-8">
-          <div className="max-w-md text-center">
-            <User className="mx-auto mb-4 h-16 w-16 text-muted-foreground" />
-            <h2 className="mb-2 font-bold text-foreground text-xl">log in</h2>
-            <p className="mb-6 text-muted-foreground">
-              Sign in to view and edit your profile
-            </p>
-            <LoginButton />
-          </div>
-        </div>
-      </PageContainer>
-    );
+    return null;
   }
 
   return (

--- a/apps/web/src/app/rewards/page.tsx
+++ b/apps/web/src/app/rewards/page.tsx
@@ -20,10 +20,9 @@ import {
   Users,
   Wallet,
 } from 'lucide-react';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
-import { LoginButton } from '@/components/auth/LoginButton';
 import { LinkSocialAccountsModal } from '@/components/profile/LinkSocialAccountsModal';
 import { RewardsSkeleton } from '@/components/rewards/RewardsSkeleton';
 import { Avatar } from '@/components/shared/Avatar';
@@ -79,8 +78,17 @@ interface ReferralData {
 }
 
 export default function RewardsPage() {
+  const router = useRouter();
   const { ready, authenticated, getAccessToken, login, refresh } = useAuth();
   const { user } = useAuthStore();
+
+  // Auth required — redirect to feed and show login
+  useEffect(() => {
+    if (!ready || authenticated) return;
+    router.push('/feed');
+    const timer = setTimeout(() => login(), 500);
+    return () => clearTimeout(timer);
+  }, [ready, authenticated, router, login]);
   const searchParams = useSearchParams();
   const [referralData, setReferralData] = useState<ReferralData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -277,19 +285,7 @@ export default function RewardsPage() {
 
   return (
     <PageContainer noPadding className="flex flex-col">
-      {/* Auth Required Banner */}
-      {ready && !authenticated && (
-        <div className="flex flex-1 items-center justify-center p-8">
-          <div className="max-w-md text-center">
-            <Award className="mx-auto mb-4 h-16 w-16 text-muted-foreground" />
-            <h2 className="mb-2 font-bold text-foreground text-xl">log in</h2>
-            <p className="mb-6 text-muted-foreground">
-              Sign in to earn rewards and track your progress
-            </p>
-            <LoginButton />
-          </div>
-        </div>
-      )}
+      {/* Auth required — handled by redirect effect above */}
 
       {/* Loading State */}
       {authenticated && loading && <RewardsSkeleton />}
@@ -856,7 +852,7 @@ export default function RewardsPage() {
 
               {referralData.referredUsers.length === 0 ? (
                 <div className="rounded-lg border border-border bg-muted/30 py-12 text-center">
-                  <Users className="mx-auto mb-4 h-16 w-16 text-muted-foreground" />
+                  <Users className="mx-auto mb-4 h-12 w-12 text-muted-foreground opacity-50" />
                   <h3 className="mb-2 font-semibold text-foreground text-lg">
                     No referrals yet
                   </h3>

--- a/apps/web/src/app/trending/[tag]/loading.tsx
+++ b/apps/web/src/app/trending/[tag]/loading.tsx
@@ -3,44 +3,51 @@ import { FeedSkeleton, Skeleton } from '@/components/shared/Skeleton';
 
 export default function TrendingTagLoading() {
   return (
-    <PageContainer noPadding className="flex min-h-screen flex-col">
-      {/* Desktop */}
-      <div className="hidden flex-1 lg:flex">
-        {/* Main Content */}
-        <div className="flex min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.5)] border-r border-l">
+    <PageContainer noPadding className="flex w-full flex-col">
+      <div className="relative flex min-h-screen flex-1">
+        {/* Desktop */}
+        <div className="hidden min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:flex lg:border-r lg:border-l">
           {/* Header */}
-          <div className="sticky top-0 z-10 border-border/5 border-b bg-background p-4 shadow-sm sm:p-6">
-            <div className="space-y-2">
-              <Skeleton className="h-8 w-48 max-w-full" />
-              <Skeleton className="h-4 w-32 max-w-full" />
+          <div className="sticky top-0 z-10 shrink-0 bg-background shadow-sm">
+            <div className="px-6 py-4">
+              <div className="flex items-center gap-4">
+                <div className="h-9 w-9 rounded-full bg-muted" />
+                <div className="space-y-1">
+                  <Skeleton className="h-6 w-40" />
+                  <Skeleton className="h-4 w-24" />
+                </div>
+              </div>
             </div>
           </div>
 
           {/* Posts */}
-          <div className="flex-1 overflow-y-auto">
-            <div className="mx-auto w-full max-w-[700px]">
+          <div className="flex-1 bg-background">
+            <div className="w-full lg:mx-auto lg:max-w-[700px]">
               <FeedSkeleton count={8} />
             </div>
           </div>
         </div>
 
         {/* Right: Widget placeholder */}
-        <div className="w-80 shrink-0 border-border/5 border-l bg-background xl:w-96" />
-      </div>
+        <div className="hidden w-80 shrink-0 xl:block xl:w-96" />
 
-      {/* Mobile/Tablet */}
-      <div className="flex flex-1 flex-col overflow-hidden lg:hidden">
-        {/* Header */}
-        <div className="sticky top-0 z-10 border-border/5 border-b bg-background p-4 shadow-sm">
-          <div className="space-y-2">
-            <Skeleton className="h-7 w-40 max-w-full" />
-            <Skeleton className="h-3 w-24 max-w-full" />
+        {/* Mobile/Tablet */}
+        <div className="flex flex-1 flex-col overflow-hidden lg:hidden">
+          {/* Header */}
+          <div className="sticky top-0 z-10 shrink-0 border-border border-b bg-background">
+            <div className="flex items-center gap-4 px-4 py-3">
+              <div className="h-9 w-9 rounded-full bg-muted" />
+              <div className="space-y-1">
+                <Skeleton className="h-6 w-36" />
+                <Skeleton className="h-3 w-20" />
+              </div>
+            </div>
           </div>
-        </div>
 
-        {/* Posts */}
-        <div className="flex-1 overflow-y-auto">
-          <FeedSkeleton count={6} />
+          {/* Posts */}
+          <div className="flex-1 overflow-y-auto">
+            <FeedSkeleton count={6} />
+          </div>
         </div>
       </div>
     </PageContainer>

--- a/apps/web/src/app/trending/[tag]/page.tsx
+++ b/apps/web/src/app/trending/[tag]/page.tsx
@@ -1,11 +1,24 @@
 'use client';
 
 import { logger } from '@babylon/shared';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, TrendingUp } from 'lucide-react';
+import dynamic from 'next/dynamic';
 import { useParams, useRouter } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 import { PostCard } from '@/components/posts/PostCard';
 import { PageContainer } from '@/components/shared/PageContainer';
+import { Skeleton } from '@/components/shared/Skeleton';
+
+const WidgetSidebar = dynamic(
+  () =>
+    import('@/components/shared/WidgetSidebar').then((m) => ({
+      default: m.WidgetSidebar,
+    })),
+  {
+    ssr: false,
+    loading: () => <div className="hidden w-96 flex-none xl:block" />,
+  }
+);
 
 interface PostData {
   id: string;
@@ -109,181 +122,132 @@ export default function TrendingTagPage() {
     }
   };
 
-  return (
-    <PageContainer
-      noPadding
-      className="flex min-h-screen w-full flex-col overflow-visible"
-    >
-      {/* Mobile/Tablet: Header */}
-      <div className="sticky top-0 z-10 shrink-0 border-border border-b bg-background px-4 py-3 lg:hidden">
-        <div className="flex items-center gap-4">
-          <button
-            onClick={() => router.back()}
-            className="rounded-full p-2 transition-colors hover:bg-muted"
-            aria-label="Go back"
-          >
-            <ArrowLeft className="h-5 w-5" />
-          </button>
-          <div className="flex-1">
-            {tagInfo ? (
-              <>
-                <h1 className="font-bold text-2xl">{tagInfo.displayName}</h1>
-                {tagInfo.category && (
-                  <p className="text-muted-foreground text-sm">
-                    {tagInfo.category} · Trending
-                  </p>
-                )}
-              </>
-            ) : (
-              <h1 className="font-bold text-2xl">{decodeURIComponent(tag)}</h1>
-            )}
+  const headerTitle = tagInfo?.displayName || decodeURIComponent(tag);
+  const headerCategory = tagInfo?.category || null;
+
+  const feedContent = (
+    <>
+      {loading ? (
+        <div className="space-y-4 px-4 py-6">
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+        </div>
+      ) : posts.length === 0 ? (
+        <div className="flex items-center justify-center py-12">
+          <div className="text-center">
+            <h2 className="mb-2 font-semibold text-xl">No posts found</h2>
+            <p className="text-muted-foreground">
+              No posts have been tagged with &quot;
+              {tagInfo?.displayName || tag}&quot; yet.
+            </p>
           </div>
         </div>
-      </div>
+      ) : (
+        <div>
+          {posts.map((post) => (
+            <PostCard key={post.id} post={post} showCommentInputBar={false} />
+          ))}
 
-      {/* Desktop: Multi-column layout with sidebar */}
-      <div className="hidden min-h-0 flex-1 lg:flex">
-        {/* Left: Feed area */}
-        <div className="flex min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.5)] border-r border-l">
-          {/* Desktop Header */}
+          {hasMore && (
+            <div className="py-4 text-center">
+              {loadingMore ? (
+                <div className="text-muted-foreground text-sm">
+                  Loading more posts...
+                </div>
+              ) : (
+                <button
+                  onClick={handleLoadMore}
+                  className="rounded-lg bg-primary px-6 py-2 text-primary-foreground transition-opacity hover:opacity-90"
+                >
+                  Load More
+                </button>
+              )}
+            </div>
+          )}
+
+          {!hasMore && posts.length > 0 && (
+            <div className="py-4 text-center text-muted-foreground text-xs">
+              You&apos;re all caught up.
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Spacer for login bar */}
+      <div className="pb-24" />
+    </>
+  );
+
+  return (
+    <PageContainer noPadding className="flex w-full flex-col">
+      <div className="relative flex min-h-screen flex-1">
+        {/* Desktop: Content area */}
+        <div className="hidden min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:flex lg:border-r lg:border-l">
+          {/* Desktop header */}
           <div className="sticky top-0 z-10 shrink-0 bg-background shadow-sm">
             <div className="px-6 py-4">
               <div className="flex items-center gap-4">
                 <button
                   onClick={() => router.back()}
-                  className="rounded-full p-2 transition-colors hover:bg-muted"
+                  className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                   aria-label="Go back"
                 >
-                  <ArrowLeft className="h-5 w-5" />
+                  <ArrowLeft size={20} />
                 </button>
-                <div className="flex-1">
-                  {tagInfo ? (
-                    <>
-                      <h1 className="font-bold text-2xl">
-                        {tagInfo.displayName}
-                      </h1>
-                      {tagInfo.category && (
-                        <p className="text-muted-foreground text-sm">
-                          {tagInfo.category} · Trending
-                        </p>
-                      )}
-                    </>
-                  ) : (
-                    <h1 className="font-bold text-2xl">
-                      {decodeURIComponent(tag)}
-                    </h1>
-                  )}
+                <div className="flex items-center gap-2">
+                  <TrendingUp className="h-5 w-5 text-[#0066FF]" />
+                  <h1 className="font-bold text-xl">{headerTitle}</h1>
                 </div>
+                {headerCategory && (
+                  <p className="ml-auto text-muted-foreground text-sm">
+                    {headerCategory} · Trending
+                  </p>
+                )}
               </div>
             </div>
           </div>
 
-          {/* Feed content - Scrollable */}
-          <div className="flex-1 overflow-y-auto overflow-x-hidden bg-background">
-            {loading ? (
-              <div className="flex items-center justify-center py-12">
-                <div className="text-muted-foreground">Loading posts...</div>
-              </div>
-            ) : posts.length === 0 ? (
-              <div className="flex items-center justify-center py-12">
-                <div className="text-center">
-                  <h2 className="mb-2 font-semibold text-xl">No posts found</h2>
-                  <p className="text-muted-foreground">
-                    No posts have been tagged with &quot;
-                    {tagInfo?.displayName || tag}&quot; yet.
-                  </p>
-                </div>
-              </div>
-            ) : (
-              <div className="mx-auto max-w-feed space-y-0 px-6 py-4">
-                {posts.map((post) => (
-                  <PostCard
-                    key={post.id}
-                    post={post}
-                    showCommentInputBar={false}
-                    onCommentClick={() => router.push(`/post/${post.id}`)}
-                  />
-                ))}
-
-                {hasMore && (
-                  <div className="py-4 text-center">
-                    {loadingMore ? (
-                      <div className="text-muted-foreground text-sm">
-                        Loading more posts...
-                      </div>
-                    ) : (
-                      <button
-                        onClick={handleLoadMore}
-                        className="rounded-lg bg-primary px-6 py-2 text-primary-foreground transition-opacity hover:opacity-90"
-                      >
-                        Load More
-                      </button>
-                    )}
-                  </div>
-                )}
-
-                {!hasMore && posts.length > 0 && (
-                  <div className="py-4 text-center text-muted-foreground text-xs">
-                    You&apos;re all caught up.
-                  </div>
-                )}
-              </div>
-            )}
+          {/* Feed content */}
+          <div className="flex-1 bg-background">
+            <div className="w-full lg:mx-auto lg:max-w-[700px]">
+              {feedContent}
+            </div>
           </div>
         </div>
-      </div>
 
-      {/* Mobile/Tablet: Content */}
-      <div className="flex w-full flex-1 overflow-y-auto overflow-x-hidden bg-background lg:hidden">
-        {loading ? (
-          <div className="flex w-full items-center justify-center py-12">
-            <div className="text-muted-foreground">Loading posts...</div>
-          </div>
-        ) : posts.length === 0 ? (
-          <div className="flex w-full items-center justify-center py-12">
-            <div className="px-4 text-center">
-              <h2 className="mb-2 font-semibold text-xl">No posts found</h2>
-              <p className="text-muted-foreground">
-                No posts have been tagged with &quot;
-                {tagInfo?.displayName || tag}&quot; yet.
-              </p>
+        {/* Widget sidebar - desktop only */}
+        <WidgetSidebar />
+
+        {/* Mobile/Tablet: Single column layout */}
+        <div className="flex flex-1 flex-col overflow-hidden lg:hidden">
+          {/* Mobile header */}
+          <div className="sticky top-0 z-10 shrink-0 border-border border-b bg-background">
+            <div className="flex items-center gap-4 px-4 py-3">
+              <button
+                onClick={() => router.back()}
+                className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                aria-label="Go back"
+              >
+                <ArrowLeft size={20} />
+              </button>
+              <div className="flex items-center gap-2">
+                <TrendingUp className="h-5 w-5 text-[#0066FF]" />
+                <h1 className="font-bold text-xl">{headerTitle}</h1>
+              </div>
+              {headerCategory && (
+                <p className="ml-auto text-muted-foreground text-sm">
+                  {headerCategory} · Trending
+                </p>
+              )}
             </div>
           </div>
-        ) : (
-          <div className="w-full px-4 py-4">
-            {posts.map((post) => (
-              <PostCard
-                key={post.id}
-                post={post}
-                showCommentInputBar={false}
-                onCommentClick={() => router.push(`/post/${post.id}`)}
-              />
-            ))}
 
-            {hasMore && (
-              <div className="py-4 text-center">
-                {loadingMore ? (
-                  <div className="text-muted-foreground text-sm">
-                    Loading more posts...
-                  </div>
-                ) : (
-                  <button
-                    onClick={handleLoadMore}
-                    className="rounded-lg bg-primary px-6 py-2 text-primary-foreground transition-opacity hover:opacity-90"
-                  >
-                    Load More
-                  </button>
-                )}
-              </div>
-            )}
-
-            {!hasMore && posts.length > 0 && (
-              <div className="py-4 text-center text-muted-foreground text-xs">
-                You&apos;re all caught up.
-              </div>
-            )}
+          {/* Mobile content */}
+          <div className="flex-1 overflow-y-auto">
+            {feedContent}
           </div>
-        )}
+        </div>
       </div>
     </PageContainer>
   );

--- a/apps/web/src/app/trending/[tag]/page.tsx
+++ b/apps/web/src/app/trending/[tag]/page.tsx
@@ -244,9 +244,7 @@ export default function TrendingTagPage() {
           </div>
 
           {/* Mobile content */}
-          <div className="flex-1 overflow-y-auto">
-            {feedContent}
-          </div>
+          <div className="flex-1 overflow-y-auto">{feedContent}</div>
         </div>
       </div>
     </PageContainer>

--- a/apps/web/src/app/trending/group/page.tsx
+++ b/apps/web/src/app/trending/group/page.tsx
@@ -1,11 +1,24 @@
 'use client';
 
 import { logger } from '@babylon/shared';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, TrendingUp } from 'lucide-react';
+import dynamic from 'next/dynamic';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 import { PostCard } from '@/components/posts/PostCard';
 import { PageContainer } from '@/components/shared/PageContainer';
+import { Skeleton } from '@/components/shared/Skeleton';
+
+const WidgetSidebar = dynamic(
+  () =>
+    import('@/components/shared/WidgetSidebar').then((m) => ({
+      default: m.WidgetSidebar,
+    })),
+  {
+    ssr: false,
+    loading: () => <div className="hidden w-96 flex-none xl:block" />,
+  }
+);
 
 interface PostData {
   id: string;
@@ -76,71 +89,118 @@ export default function GroupedTrendingPage() {
     fetchPosts();
   }, [fetchPosts]);
 
-  const handleBack = () => {
-    router.back();
-  };
+  const headerTitle = tags.length > 0
+    ? tags.map((t) => t.displayName).join(' · ')
+    : 'Grouped Trending';
+
+  const headerCategory = tags.length > 0 && tags[0]?.category
+    ? tags[0].category
+    : null;
+
+  const feedContent = (
+    <>
+      {loading ? (
+        <div className="space-y-4 px-4 py-6">
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+        </div>
+      ) : posts.length === 0 ? (
+        <div className="flex items-center justify-center py-12">
+          <div className="text-center">
+            <h2 className="mb-2 font-semibold text-xl">No posts found</h2>
+            <p className="text-muted-foreground">
+              No posts found for these trending topics yet.
+            </p>
+          </div>
+        </div>
+      ) : (
+        <div>
+          {posts.map((post) => (
+            <PostCard key={post.id} post={post} showCommentInputBar={false} />
+          ))}
+
+          {posts.length > 0 && (
+            <div className="py-4 text-center text-muted-foreground text-xs">
+              You&apos;re all caught up.
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Spacer for login bar */}
+      <div className="pb-24" />
+    </>
+  );
 
   return (
-    <PageContainer>
-      <div className="flex h-full flex-col">
-        {/* Header */}
-        <div className="sticky top-0 z-10 border-border border-b bg-background px-4 py-3">
-          <div className="flex items-center gap-4">
-            <button
-              onClick={handleBack}
-              className="rounded-full p-2 transition-colors hover:bg-muted"
-              aria-label="Go back"
-            >
-              <ArrowLeft className="h-5 w-5" />
-            </button>
-            <div className="flex-1">
-              <h1 className="font-bold text-xl">
-                {tags.length > 0
-                  ? tags.map((t) => t.displayName).join(' • ')
-                  : 'Grouped Trending'}
-              </h1>
-              {tags.length > 0 && tags[0]?.category && (
-                <p className="text-muted-foreground text-sm">
-                  {tags[0].category}
-                </p>
-              )}
+    <PageContainer noPadding className="flex w-full flex-col">
+      <div className="relative flex min-h-screen flex-1">
+        {/* Desktop: Content area */}
+        <div className="hidden min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:flex lg:border-r lg:border-l">
+          {/* Desktop header */}
+          <div className="sticky top-0 z-10 shrink-0 bg-background shadow-sm">
+            <div className="px-6 py-4">
+              <div className="flex items-center gap-4">
+                <button
+                  onClick={() => router.back()}
+                  className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  aria-label="Go back"
+                >
+                  <ArrowLeft size={20} />
+                </button>
+                <div className="flex items-center gap-2">
+                  <TrendingUp className="h-5 w-5 text-[#0066FF]" />
+                  <h1 className="font-bold text-xl">{headerTitle}</h1>
+                </div>
+                {headerCategory && (
+                  <p className="ml-auto text-muted-foreground text-sm">
+                    {headerCategory}
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* Feed content */}
+          <div className="flex-1 bg-background">
+            <div className="w-full lg:mx-auto lg:max-w-[700px]">
+              {feedContent}
             </div>
           </div>
         </div>
 
-        {/* Feed content - Scrollable */}
-        <div className="flex-1 overflow-y-auto overflow-x-hidden bg-background">
-          {loading ? (
-            <div className="flex items-center justify-center py-12">
-              <div className="text-muted-foreground">Loading posts...</div>
-            </div>
-          ) : posts.length === 0 ? (
-            <div className="flex items-center justify-center py-12">
-              <div className="text-center">
-                <h2 className="mb-2 font-semibold text-xl">No posts found</h2>
-                <p className="text-muted-foreground">
-                  No posts found for these trending topics yet.
-                </p>
-              </div>
-            </div>
-          ) : (
-            <div className="mx-auto max-w-feed space-y-0 px-6 py-4">
-              {posts.map((post) => (
-                <PostCard
-                  key={post.id}
-                  post={post}
-                  showCommentInputBar={false}
-                  onCommentClick={() => router.push(`/post/${post.id}`)}
-                />
-              ))}
+        {/* Widget sidebar - desktop only */}
+        <WidgetSidebar />
 
-              {posts.length > 0 && (
-                <div className="py-4 text-center text-muted-foreground text-xs">
-                  You&apos;re all caught up.
-                </div>
+        {/* Mobile/Tablet: Single column layout */}
+        <div className="flex flex-1 flex-col overflow-hidden lg:hidden">
+          {/* Mobile header */}
+          <div className="sticky top-0 z-10 shrink-0 border-border border-b bg-background">
+            <div className="flex items-center gap-4 px-4 py-3">
+              <button
+                onClick={() => router.back()}
+                className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                aria-label="Go back"
+              >
+                <ArrowLeft size={20} />
+              </button>
+              <div className="flex items-center gap-2">
+                <TrendingUp className="h-5 w-5 text-[#0066FF]" />
+                <h1 className="font-bold text-xl">{headerTitle}</h1>
+              </div>
+              {headerCategory && (
+                <p className="ml-auto text-muted-foreground text-sm">
+                  {headerCategory}
+                </p>
               )}
             </div>
-          )}
+          </div>
+
+          {/* Mobile content */}
+          <div className="flex-1 overflow-y-auto">
+            {feedContent}
+          </div>
         </div>
       </div>
     </PageContainer>

--- a/apps/web/src/app/trending/group/page.tsx
+++ b/apps/web/src/app/trending/group/page.tsx
@@ -89,13 +89,13 @@ export default function GroupedTrendingPage() {
     fetchPosts();
   }, [fetchPosts]);
 
-  const headerTitle = tags.length > 0
-    ? tags.map((t) => t.displayName).join(' · ')
-    : 'Grouped Trending';
+  const headerTitle =
+    tags.length > 0
+      ? tags.map((t) => t.displayName).join(' · ')
+      : 'Grouped Trending';
 
-  const headerCategory = tags.length > 0 && tags[0]?.category
-    ? tags[0].category
-    : null;
+  const headerCategory =
+    tags.length > 0 && tags[0]?.category ? tags[0].category : null;
 
   const feedContent = (
     <>
@@ -198,9 +198,7 @@ export default function GroupedTrendingPage() {
           </div>
 
           {/* Mobile content */}
-          <div className="flex-1 overflow-y-auto">
-            {feedContent}
-          </div>
+          <div className="flex-1 overflow-y-auto">{feedContent}</div>
         </div>
       </div>
     </PageContainer>

--- a/apps/web/src/components/agents/AgentActivityFeed.tsx
+++ b/apps/web/src/components/agents/AgentActivityFeed.tsx
@@ -165,11 +165,9 @@ function ActivitySkeleton() {
 function EmptyState({ message }: { message: string }) {
   return (
     <div className="flex flex-col items-center justify-center py-12 text-center">
-      <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted">
-        <Activity className="h-6 w-6 text-muted-foreground" />
-      </div>
-      <p className="text-muted-foreground text-sm">{message}</p>
-      <p className="mt-1 text-muted-foreground/70 text-xs">
+      <Activity className="mb-4 h-12 w-12 text-muted-foreground opacity-50" />
+      <p className="font-semibold text-lg">{message}</p>
+      <p className="mt-1 max-w-sm text-muted-foreground text-sm">
         Activity will appear here when your agent takes actions
       </p>
     </div>

--- a/apps/web/src/components/articles/ArticleCard.tsx
+++ b/apps/web/src/components/articles/ArticleCard.tsx
@@ -8,9 +8,6 @@ import { memo } from 'react';
 import { z } from 'zod';
 import { Avatar } from '@/components/shared/Avatar';
 
-/**
- * Article card post schema for validation.
- */
 const _ArticleCardPostSchema = z.object({
   id: z.string(),
   type: z.string().optional(),
@@ -28,33 +25,6 @@ const _ArticleCardPostSchema = z.object({
   timestamp: z.string(),
 });
 
-/**
- * Article card component for displaying article posts.
- *
- * Displays a formatted card for article posts with title, byline, content
- * preview, author information, and timestamp. Includes bias score display
- * and click handling for navigation.
- *
- * Features:
- * - Article title and byline
- * - Content preview
- * - Author display
- * - Timestamp formatting
- * - Bias score indicator
- * - Click handling
- * - Memoized for performance
- *
- * @param props - ArticleCard component props
- * @returns Article card element
- *
- * @example
- * ```tsx
- * <ArticleCard
- *   post={articleData}
- *   onClick={() => router.push(`/articles/${post.id}`)}
- * />
- * ```
- */
 export type ArticleCardProps = {
   post: z.infer<typeof _ArticleCardPostSchema>;
   className?: string;
@@ -81,7 +51,6 @@ export const ArticleCard = memo(function ArticleCard({
   } else if (diffHours < 24) {
     timeAgo = `${diffHours}h ago`;
   } else {
-    // Show date for articles older than 24 hours
     timeAgo = publishedDate.toLocaleDateString('en-US', {
       month: 'short',
       day: 'numeric',
@@ -96,7 +65,6 @@ export const ArticleCard = memo(function ArticleCard({
     if (onClick) {
       onClick();
     } else {
-      // Navigate directly to article page (ArticleCard is only used for article-type posts)
       router.push(`/article/${post.id}`);
     }
   };
@@ -104,17 +72,17 @@ export const ArticleCard = memo(function ArticleCard({
   return (
     <article
       className={cn(
-        'px-4 py-3',
+        'px-4 py-4',
         'cursor-pointer transition-all duration-200 hover:bg-muted/30',
         'w-full overflow-hidden',
-        'border-border/5 border-b',
+        'border-border border-b',
         className
       )}
       onClick={handleClick}
     >
-      {/* Header: Avatar + Author + Timestamp */}
-      <div className="mb-3 flex w-full items-start gap-3">
-        {/* Avatar */}
+      {/* Two-column layout: Avatar | Content */}
+      <div className="flex gap-3">
+        {/* Left column: Avatar */}
         <Link
           href={`/profile/${post.authorId}`}
           className="shrink-0 transition-opacity hover:opacity-80"
@@ -129,73 +97,77 @@ export const ArticleCard = memo(function ArticleCard({
           />
         </Link>
 
-        {/* Author name and timestamp */}
-        <div className="flex min-w-0 flex-1 items-start justify-between gap-3">
-          <div className="flex min-w-0 flex-col">
-            <Link
-              href={`/profile/${post.authorId}`}
-              className="truncate font-semibold text-foreground text-lg hover:underline sm:text-xl"
-              onClick={(e) => e.stopPropagation()}
+        {/* Right column: All content */}
+        <div className="min-w-0 flex-1">
+          {/* Author row: Name · @handle · Category | timeAgo right-aligned */}
+          <div className="mb-2 flex items-center justify-between gap-1.5 text-[15px] leading-tight">
+            <div className="flex min-w-0 items-center gap-1.5">
+              <Link
+                href={`/profile/${post.authorId}`}
+                className="truncate font-semibold text-foreground hover:underline"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {post.authorName}
+              </Link>
+              {post.authorUsername && (
+                <Link
+                  href={`/profile/${post.authorId}`}
+                  className="truncate text-muted-foreground hover:underline"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  @{post.authorUsername}
+                </Link>
+              )}
+              {post.category && (
+                <>
+                  <span className="text-muted-foreground">·</span>
+                  <span className="shrink-0 font-semibold text-[#0066FF] text-xs uppercase tracking-wide">
+                    {post.category}
+                  </span>
+                </>
+              )}
+            </div>
+            <time
+              className="shrink-0 text-[15px] text-muted-foreground"
+              title={publishedDate.toLocaleString()}
             >
-              {post.authorName}
-            </Link>
-          </div>
-          <time
-            className="ml-2 shrink-0 text-base text-muted-foreground"
-            title={publishedDate.toLocaleString()}
-          >
-            {timeAgo}
-          </time>
-        </div>
-      </div>
-
-      {/* Mobile: Article Image (shown full width on small screens) */}
-      {post.imageUrl && (
-        <div className="relative mb-3 aspect-video w-full overflow-hidden rounded-lg sm:hidden">
-          <Image
-            src={post.imageUrl}
-            alt={post.articleTitle || 'Article image'}
-            fill
-            className="object-cover"
-            sizes="100vw"
-          />
-        </div>
-      )}
-
-      {/* Article Content: Image + Text (desktop) */}
-      <div className="mb-3 flex gap-4">
-        {/* Article Image thumbnail (desktop only) */}
-        {post.imageUrl && (
-          <div className="relative hidden aspect-video w-32 shrink-0 overflow-hidden rounded-lg sm:block md:w-40">
-            <Image
-              src={post.imageUrl}
-              alt={post.articleTitle || 'Article image'}
-              fill
-              className="object-cover"
-              sizes="(max-width: 768px) 128px, 160px"
-            />
-          </div>
-        )}
-
-        {/* Title and Summary */}
-        <div className="flex min-w-0 flex-1 flex-col">
-          {/* Article Title with Read More Button */}
-          <div className="mb-2 flex items-start justify-between gap-4">
-            <h2 className="flex-1 font-bold text-foreground text-lg leading-tight sm:text-xl">
-              {post.articleTitle || 'Untitled Article'}
-            </h2>
-            <button
-              type="button"
-              className="inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-lg bg-[#0066FF] px-3 py-2 font-semibold text-primary-foreground text-sm transition-colors hover:bg-[#2952d9]"
-              onClick={handleClick}
-            >
-              Read Full Article →
-            </button>
+              {timeAgo}
+            </time>
           </div>
 
-          {/* Article Summary */}
-          <div className="line-clamp-3 whitespace-pre-wrap break-words text-foreground leading-relaxed">
+          {/* Cover image */}
+          {post.imageUrl && (
+            <div className="relative mb-3 aspect-video w-full overflow-hidden rounded-lg">
+              <Image
+                src={post.imageUrl}
+                alt={post.articleTitle || 'Article image'}
+                fill
+                className="object-cover"
+                sizes="(max-width: 768px) 100vw, 600px"
+              />
+            </div>
+          )}
+
+          {/* Article Title */}
+          <h2 className="mb-1.5 line-clamp-2 font-bold text-foreground text-lg leading-tight">
+            {post.articleTitle || 'Untitled Article'}
+          </h2>
+
+          {/* Summary */}
+          <p className="mb-3 line-clamp-2 text-muted-foreground text-sm leading-relaxed">
             {post.content}
+          </p>
+
+          {/* Footer */}
+          <div className="flex flex-col gap-1">
+            {post.byline && (
+              <span className="truncate text-muted-foreground text-xs">
+                {post.byline}
+              </span>
+            )}
+            <span className="text-[#0066FF] text-sm">
+              Read Full Article →
+            </span>
           </div>
         </div>
       </div>

--- a/apps/web/src/components/articles/ArticleCard.tsx
+++ b/apps/web/src/components/articles/ArticleCard.tsx
@@ -165,9 +165,7 @@ export const ArticleCard = memo(function ArticleCard({
                 {post.byline}
               </span>
             )}
-            <span className="text-[#0066FF] text-sm">
-              Read Full Article →
-            </span>
+            <span className="text-[#0066FF] text-sm">Read Full Article →</span>
           </div>
         </div>
       </div>

--- a/apps/web/src/components/articles/MoreArticlesWidget.tsx
+++ b/apps/web/src/components/articles/MoreArticlesWidget.tsx
@@ -103,9 +103,7 @@ export function MoreArticlesWidget({
 
   return (
     <div className={className}>
-      <h2 className="mb-3 font-bold text-foreground text-lg">
-        More Articles
-      </h2>
+      <h2 className="mb-3 font-bold text-foreground text-lg">More Articles</h2>
 
       <div className="space-y-2">
         {articles.map((article) => (

--- a/apps/web/src/components/articles/MoreArticlesWidget.tsx
+++ b/apps/web/src/components/articles/MoreArticlesWidget.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { Newspaper } from 'lucide-react';
-import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { Skeleton } from '@/components/shared/Skeleton';
@@ -87,20 +85,13 @@ export function MoreArticlesWidget({
   if (isLoading) {
     return (
       <div className={className}>
-        <div className="mb-4 flex items-center gap-2">
-          <Newspaper className="h-5 w-5 text-[#0066FF]" />
-          <h3 className="font-semibold text-foreground">More Articles</h3>
-        </div>
-        <div className="space-y-4">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <div key={i} className="flex gap-3">
-              <Skeleton className="h-16 w-20 shrink-0 rounded-md" />
-              <div className="flex-1 space-y-2">
-                <Skeleton className="h-4 w-full" />
-                <Skeleton className="h-3 w-2/3" />
-              </div>
-            </div>
-          ))}
+        <h2 className="mb-3 font-bold text-foreground text-lg">
+          More Articles
+        </h2>
+        <div className="space-y-3">
+          <Skeleton className="h-12 w-full" />
+          <Skeleton className="h-12 w-full" />
+          <Skeleton className="h-12 w-full" />
         </div>
       </div>
     );
@@ -112,48 +103,23 @@ export function MoreArticlesWidget({
 
   return (
     <div className={className}>
-      <div className="mb-4 flex items-center gap-2">
-        <Newspaper className="h-5 w-5 text-[#0066FF]" />
-        <h3 className="font-semibold text-foreground">More Articles</h3>
-      </div>
+      <h2 className="mb-3 font-bold text-foreground text-lg">
+        More Articles
+      </h2>
 
-      <div className="space-y-4">
+      <div className="space-y-2">
         {articles.map((article) => (
           <Link
             key={article.id}
             href={`/article/${article.id}`}
-            className="group flex gap-3 rounded-lg p-2 transition-colors hover:bg-muted/50"
+            className="-mx-2 block rounded-lg px-2 py-1.5 transition-colors duration-200 hover:bg-muted/50"
           >
-            {/* Thumbnail */}
-            {article.imageUrl ? (
-              <div className="relative h-16 w-20 shrink-0 overflow-hidden rounded-md">
-                <Image
-                  src={article.imageUrl}
-                  alt={article.articleTitle || 'Article thumbnail'}
-                  fill
-                  className="object-cover transition-transform group-hover:scale-105"
-                  sizes="80px"
-                />
-              </div>
-            ) : (
-              <div className="flex h-16 w-20 shrink-0 items-center justify-center rounded-md bg-muted">
-                <Newspaper className="h-6 w-6 text-muted-foreground" />
-              </div>
-            )}
-
-            {/* Article info */}
-            <div className="flex min-w-0 flex-1 flex-col justify-center">
-              <h4 className="line-clamp-2 font-medium text-foreground text-sm leading-tight transition-colors group-hover:text-[#0066FF]">
-                {article.articleTitle || 'Untitled Article'}
-              </h4>
-              <div className="mt-1 flex items-center gap-2 text-muted-foreground text-xs">
-                <span className="truncate">{article.authorName}</span>
-                <span>·</span>
-                <span className="shrink-0">
-                  {formatTimeAgo(article.timestamp)}
-                </span>
-              </div>
-            </div>
+            <p className="font-semibold text-foreground text-sm leading-snug">
+              {article.articleTitle || 'Untitled Article'}
+            </p>
+            <p className="mt-0.5 text-muted-foreground text-xs">
+              {article.authorName} · {formatTimeAgo(article.timestamp)}
+            </p>
           </Link>
         ))}
       </div>

--- a/apps/web/src/components/chats/ChatList.tsx
+++ b/apps/web/src/components/chats/ChatList.tsx
@@ -31,7 +31,7 @@ export function ChatList({
   if (chats.length === 0) {
     return (
       <div className="px-4 py-12 text-center text-muted-foreground">
-        <MessageCircle className="mx-auto mb-3 h-12 w-12 opacity-50" />
+        <MessageCircle className="mx-auto mb-4 h-12 w-12 opacity-50" />
         <p className="text-sm">
           {searchQuery
             ? 'No conversations found'

--- a/apps/web/src/components/chats/MessageList.tsx
+++ b/apps/web/src/components/chats/MessageList.tsx
@@ -120,7 +120,7 @@ export function MessageList({
       {messages.length === 0 && (
         <div className="flex h-full items-center justify-center">
           <div className="max-w-md p-8 text-center text-muted-foreground">
-            <MessageCircle className="mx-auto mb-3 h-12 w-12 opacity-50" />
+            <MessageCircle className="mx-auto mb-4 h-12 w-12 opacity-50" />
             <p className="mb-2 text-foreground">No messages yet</p>
             {authenticated && (
               <p className="text-muted-foreground text-xs">

--- a/apps/web/src/components/explore/EntitySearchAutocomplete.tsx
+++ b/apps/web/src/components/explore/EntitySearchAutocomplete.tsx
@@ -248,7 +248,7 @@ export function EntitySearchAutocomplete({
         onKeyDown={handleKeyDown}
         className={cn(
           'w-full',
-          'border border-border bg-muted/50',
+          'border border-border bg-transparent',
           'focus:border-border focus:outline-none',
           'transition-all duration-200',
           'text-foreground',

--- a/apps/web/src/components/feed/FeedCommentSection.tsx
+++ b/apps/web/src/components/feed/FeedCommentSection.tsx
@@ -579,9 +579,9 @@ export function FeedCommentSection({
           )}
 
           {/* Comments list */}
-          <div className="flex-1 overflow-y-auto px-4 py-3">
+          <div className="flex-1 overflow-y-auto">
             {isLoading ? (
-              <div className="flex items-center justify-center py-8">
+              <div className="flex items-center justify-center px-4 py-8">
                 <div className="w-full space-y-3">
                   <Skeleton className="h-20 w-full" />
                   <Skeleton className="h-20 w-full" />
@@ -594,7 +594,7 @@ export function FeedCommentSection({
                 description="Be the first to comment!"
               />
             ) : (
-              <div className="space-y-4">
+              <div>
                 {sortedComments.map((comment) => (
                   <CommentCard
                     key={comment.id}

--- a/apps/web/src/components/feed/LatestNewsPanel.tsx
+++ b/apps/web/src/components/feed/LatestNewsPanel.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { type ArticleItem, logger } from '@babylon/shared';
-import { AlertCircle, Newspaper, TrendingUp } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Skeleton } from '@/components/shared/Skeleton';
@@ -284,17 +283,6 @@ export function LatestNewsPanel() {
     void fetchArticles(true);
   });
 
-  const getSentimentIcon = (sentiment?: string) => {
-    switch (sentiment) {
-      case 'positive':
-        return <TrendingUp className="h-4 w-4 text-green-500" />;
-      case 'negative':
-        return <AlertCircle className="h-4 w-4 text-red-500" />;
-      default:
-        return <Newspaper className="h-4 w-4 text-[#0066FF]" />;
-    }
-  };
-
   const getTimeAgo = (timestamp: string) => {
     const now = Date.now();
     const diff = now - new Date(timestamp).getTime();
@@ -320,45 +308,38 @@ export function LatestNewsPanel() {
   };
 
   return (
-    <>
-      <div className="flex flex-1 flex-col rounded-2xl bg-sidebar p-4">
-        <h2 className="mb-3 text-left font-bold text-foreground text-lg">
-          Latest News
-        </h2>
+    <div className="flex flex-1 flex-col">
+      <h2 className="mb-3 font-bold text-foreground text-lg">
+        Latest News
+      </h2>
         {loading ? (
-          <div className="flex-1 space-y-3 pl-3">
+          <div className="flex-1 space-y-3">
             <Skeleton className="h-16 w-full" />
             <Skeleton className="h-16 w-full" />
             <Skeleton className="h-16 w-full" />
           </div>
         ) : articles.length === 0 ? (
-          <div className="flex-1 pl-3 text-muted-foreground text-sm">
+          <div className="flex-1 text-muted-foreground text-sm">
             No articles available yet.
           </div>
         ) : (
-          <div className="flex-1 space-y-2 pl-3">
+          <div className="flex-1 space-y-2">
             {articles.map((article) => (
               <div
                 key={article.id}
                 onClick={() => handleArticleClick(article.id)}
-                className="-ml-1.5 flex cursor-pointer items-start gap-3 rounded-lg p-1.5 transition-colors duration-200 hover:bg-muted/50"
+                className="-mx-2 cursor-pointer rounded-lg px-2 py-1.5 transition-colors duration-200 hover:bg-muted/50"
               >
-                <div className="mt-0.5 shrink-0">
-                  {getSentimentIcon(article.sentiment)}
-                </div>
-                <div className="min-w-0 flex-1">
-                  <p className="font-semibold text-foreground text-sm leading-snug">
-                    {article.title}
-                  </p>
-                  <p className="mt-0.5 text-muted-foreground text-xs">
-                    {article.authorOrgName} · {getTimeAgo(article.publishedAt)}
-                  </p>
-                </div>
+                <p className="font-semibold text-foreground text-sm leading-snug">
+                  {article.title}
+                </p>
+                <p className="mt-0.5 text-muted-foreground text-xs">
+                  {article.authorOrgName} · {getTimeAgo(article.publishedAt)}
+                </p>
               </div>
             ))}
           </div>
         )}
-      </div>
-    </>
+    </div>
   );
 }

--- a/apps/web/src/components/feed/LatestNewsPanel.tsx
+++ b/apps/web/src/components/feed/LatestNewsPanel.tsx
@@ -309,37 +309,35 @@ export function LatestNewsPanel() {
 
   return (
     <div className="flex flex-1 flex-col">
-      <h2 className="mb-3 font-bold text-foreground text-lg">
-        Latest News
-      </h2>
-        {loading ? (
-          <div className="flex-1 space-y-3">
-            <Skeleton className="h-16 w-full" />
-            <Skeleton className="h-16 w-full" />
-            <Skeleton className="h-16 w-full" />
-          </div>
-        ) : articles.length === 0 ? (
-          <div className="flex-1 text-muted-foreground text-sm">
-            No articles available yet.
-          </div>
-        ) : (
-          <div className="flex-1 space-y-2">
-            {articles.map((article) => (
-              <div
-                key={article.id}
-                onClick={() => handleArticleClick(article.id)}
-                className="-mx-2 cursor-pointer rounded-lg px-2 py-1.5 transition-colors duration-200 hover:bg-muted/50"
-              >
-                <p className="font-semibold text-foreground text-sm leading-snug">
-                  {article.title}
-                </p>
-                <p className="mt-0.5 text-muted-foreground text-xs">
-                  {article.authorOrgName} · {getTimeAgo(article.publishedAt)}
-                </p>
-              </div>
-            ))}
-          </div>
-        )}
+      <h2 className="mb-3 font-bold text-foreground text-lg">Latest News</h2>
+      {loading ? (
+        <div className="flex-1 space-y-3">
+          <Skeleton className="h-16 w-full" />
+          <Skeleton className="h-16 w-full" />
+          <Skeleton className="h-16 w-full" />
+        </div>
+      ) : articles.length === 0 ? (
+        <div className="flex-1 text-muted-foreground text-sm">
+          No articles available yet.
+        </div>
+      ) : (
+        <div className="flex-1 space-y-2">
+          {articles.map((article) => (
+            <div
+              key={article.id}
+              onClick={() => handleArticleClick(article.id)}
+              className="-mx-2 cursor-pointer rounded-lg px-2 py-1.5 transition-colors duration-200 hover:bg-muted/50"
+            >
+              <p className="font-semibold text-foreground text-sm leading-snug">
+                {article.title}
+              </p>
+              <p className="mt-0.5 text-muted-foreground text-xs">
+                {article.authorOrgName} · {getTimeAgo(article.publishedAt)}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/feed/MarketsPanel.tsx
+++ b/apps/web/src/components/feed/MarketsPanel.tsx
@@ -133,25 +133,25 @@ export function MarketsPanel() {
   }, [perpMarkets]);
 
   return (
-    <div className="flex flex-1 flex-col rounded-2xl bg-sidebar px-4 py-3">
-      <h2 className="mb-3 text-left font-bold text-foreground text-lg">
+    <div className="flex flex-1 flex-col">
+      <h2 className="mb-3 font-bold text-foreground text-lg">
         Markets
       </h2>
       {loading ? (
-        <div className="flex-1 space-y-3 pl-3">
+        <div className="flex-1 space-y-3">
           <Skeleton className="h-16 w-full" />
           <Skeleton className="h-16 w-full" />
           <Skeleton className="h-16 w-full" />
         </div>
       ) : markets.length === 0 && perpMarkets.length === 0 ? (
-        <div className="flex-1 pl-3 text-muted-foreground text-sm">
+        <div className="flex-1 text-muted-foreground text-sm">
           No active markets at the moment.
         </div>
       ) : (
         <>
           {/* Top Movers Section - show when we have price changes */}
           {topMovers.length > 0 && (
-            <div className="mb-4 pl-3">
+            <div className="mb-4">
               <div className="mb-2 flex items-center gap-1.5">
                 <TrendingUp className="h-4 w-4 text-[#0066FF]" />
                 <h3 className="font-semibold text-foreground text-sm">
@@ -163,7 +163,7 @@ export function MarketsPanel() {
                   <div
                     key={`mover-${market.id}`}
                     onClick={() => handleMarketClick(market.id)}
-                    className="-ml-1.5 flex cursor-pointer items-start gap-3 rounded-lg px-2 py-2 transition-colors duration-200 hover:bg-muted/50"
+                    className="-mx-2 cursor-pointer rounded-lg px-2 py-2 transition-colors duration-200 hover:bg-muted/50"
                   >
                     <div className="min-w-0 flex-1">
                       <p className="line-clamp-1 font-medium text-foreground text-sm leading-snug">
@@ -194,13 +194,13 @@ export function MarketsPanel() {
                   </div>
                 ))}
               </div>
-              <div className="mt-3 border-border border-t pt-3" />
+              <div className="-mx-2 mt-3 border-border border-t pt-3" />
             </div>
           )}
 
           {/* Trending Tokens Section - show perp futures gainers and losers */}
           {perpMarkets.length > 0 && (
-            <div className="mb-4 pl-3">
+            <div className="mb-4">
               <div className="grid grid-cols-2 gap-3">
                 {/* Top Gainers Column */}
                 <div>
@@ -222,7 +222,7 @@ export function MarketsPanel() {
                         </p>
                         <div className="mt-0.5 flex items-center justify-between gap-1">
                           <span className="truncate text-muted-foreground text-xs">
-                            ${token.currentPrice.toFixed(2)}
+                            ${token.currentPrice.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                           </span>
                           <span
                             className={cn(
@@ -261,7 +261,7 @@ export function MarketsPanel() {
                         </p>
                         <div className="mt-0.5 flex items-center justify-between gap-1">
                           <span className="truncate text-muted-foreground text-xs">
-                            ${token.currentPrice.toFixed(2)}
+                            ${token.currentPrice.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                           </span>
                           <span
                             className={cn(
@@ -284,13 +284,13 @@ export function MarketsPanel() {
 
           {/* Prediction Markets List - only show when there are prediction markets */}
           {markets.length > 0 && (
-            <div className="flex-1 pl-3">
+            <div className="flex-1">
               <div className="space-y-2.5">
                 {markets.slice(0, 5).map((market) => (
                   <div
                     key={market.id}
                     onClick={() => handleMarketClick(market.id)}
-                    className="-ml-1.5 flex cursor-pointer items-start gap-3 rounded-lg px-2 py-2 transition-colors duration-200 hover:bg-muted/50"
+                    className="-mx-2 cursor-pointer rounded-lg px-2 py-2 transition-colors duration-200 hover:bg-muted/50"
                   >
                     <div className="min-w-0 flex-1">
                       {/* Market question */}
@@ -298,32 +298,20 @@ export function MarketsPanel() {
                         {market.question}
                       </p>
                       {/* Market stats */}
-                      <div className="mt-1 flex items-center gap-3">
-                        <span className="text-green-500 text-xs">
-                          Yes {(market.yesPrice * 100).toFixed(0)}%
-                        </span>
-                        <span className="text-red-500 text-xs">
-                          No {(market.noPrice * 100).toFixed(0)}%
-                        </span>
+                      <div className="mt-1 flex items-center justify-between">
+                        <div className="flex items-center gap-3">
+                          <span className="text-green-500 text-xs">
+                            Yes {(market.yesPrice * 100).toFixed(0)}%
+                          </span>
+                          <span className="text-red-500 text-xs">
+                            No {(market.noPrice * 100).toFixed(0)}%
+                          </span>
+                        </div>
                         {market.volume > 0 && (
                           <span className="text-muted-foreground text-xs">
-                            ${market.volume.toFixed(0)}
+                            Vol ${Math.round(market.volume).toLocaleString()}
                           </span>
                         )}
-                        {market.changePercent24h !== undefined &&
-                          market.changePercent24h !== 0 && (
-                            <span
-                              className={cn(
-                                'font-medium text-xs',
-                                market.changePercent24h >= 0
-                                  ? 'text-green-600'
-                                  : 'text-red-600'
-                              )}
-                            >
-                              {market.changePercent24h >= 0 ? '+' : ''}
-                              {market.changePercent24h.toFixed(1)}%
-                            </span>
-                          )}
                       </div>
                     </div>
                   </div>

--- a/apps/web/src/components/feed/MarketsPanel.tsx
+++ b/apps/web/src/components/feed/MarketsPanel.tsx
@@ -134,9 +134,7 @@ export function MarketsPanel() {
 
   return (
     <div className="flex flex-1 flex-col">
-      <h2 className="mb-3 font-bold text-foreground text-lg">
-        Markets
-      </h2>
+      <h2 className="mb-3 font-bold text-foreground text-lg">Markets</h2>
       {loading ? (
         <div className="flex-1 space-y-3">
           <Skeleton className="h-16 w-full" />
@@ -222,7 +220,11 @@ export function MarketsPanel() {
                         </p>
                         <div className="mt-0.5 flex items-center justify-between gap-1">
                           <span className="truncate text-muted-foreground text-xs">
-                            ${token.currentPrice.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                            $
+                            {token.currentPrice.toLocaleString('en-US', {
+                              minimumFractionDigits: 2,
+                              maximumFractionDigits: 2,
+                            })}
                           </span>
                           <span
                             className={cn(
@@ -261,7 +263,11 @@ export function MarketsPanel() {
                         </p>
                         <div className="mt-0.5 flex items-center justify-between gap-1">
                           <span className="truncate text-muted-foreground text-xs">
-                            ${token.currentPrice.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                            $
+                            {token.currentPrice.toLocaleString('en-US', {
+                              minimumFractionDigits: 2,
+                              maximumFractionDigits: 2,
+                            })}
                           </span>
                           <span
                             className={cn(

--- a/apps/web/src/components/feed/TrendingPanel.tsx
+++ b/apps/web/src/components/feed/TrendingPanel.tsx
@@ -101,9 +101,7 @@ export function TrendingPanel() {
 
   return (
     <div className="flex flex-1 flex-col">
-      <h2 className="mb-3 font-bold text-foreground text-lg">
-        Trending
-      </h2>
+      <h2 className="mb-3 font-bold text-foreground text-lg">Trending</h2>
       {loading ? (
         <div className="flex-1 space-y-3">
           <Skeleton className="h-14 w-full" />
@@ -126,7 +124,9 @@ export function TrendingPanel() {
                 {/* Category and tag name(s) */}
                 <p className="font-semibold text-foreground text-sm leading-snug">
                   {item.category && (
-                    <span className="text-muted-foreground">{item.category} · </span>
+                    <span className="text-muted-foreground">
+                      {item.category} ·{' '}
+                    </span>
                   )}
                   {item.tags.join(' · ')}
                 </p>

--- a/apps/web/src/components/feed/TrendingPanel.tsx
+++ b/apps/web/src/components/feed/TrendingPanel.tsx
@@ -100,48 +100,36 @@ export function TrendingPanel() {
   };
 
   return (
-    <div className="flex flex-1 flex-col rounded-2xl bg-sidebar p-4">
-      <h2 className="mb-3 text-left font-bold text-foreground text-lg">
+    <div className="flex flex-1 flex-col">
+      <h2 className="mb-3 font-bold text-foreground text-lg">
         Trending
       </h2>
       {loading ? (
-        <div className="flex-1 space-y-3 pl-3">
+        <div className="flex-1 space-y-3">
           <Skeleton className="h-14 w-full" />
           <Skeleton className="h-14 w-full" />
           <Skeleton className="h-14 w-full" />
         </div>
       ) : trending.length === 0 ? (
-        <div className="flex-1 pl-3 text-muted-foreground text-sm">
+        <div className="flex-1 text-muted-foreground text-sm">
           No trending topics at the moment.
         </div>
       ) : (
-        <div className="flex-1 space-y-2 pl-3">
+        <div className="flex-1 space-y-2">
           {trending.map((item) => (
             <div
               key={item.id}
               onClick={() => handleTrendingClick(item)}
-              className="-ml-1.5 flex cursor-pointer items-start gap-3 rounded-lg p-1.5 transition-colors duration-200 hover:bg-muted/50"
+              className="-mx-2 cursor-pointer rounded-lg px-2 py-1.5 transition-colors duration-200 hover:bg-muted/50"
             >
               <div className="min-w-0 flex-1">
-                {/* Category and status */}
-                <p className="text-muted-foreground text-xs">
-                  {item.category || 'Trending'} · Trending
+                {/* Category and tag name(s) */}
+                <p className="font-semibold text-foreground text-sm leading-snug">
+                  {item.category && (
+                    <span className="text-muted-foreground">{item.category} · </span>
+                  )}
+                  {item.tags.join(' · ')}
                 </p>
-                {/* Tag name(s) - show all tags if grouped */}
-                <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
-                  {item.tags.map((tag, idx) => (
-                    <span key={idx}>
-                      <span className="font-semibold text-foreground text-sm leading-snug">
-                        {tag}
-                      </span>
-                      {idx < item.tags.length - 1 && (
-                        <span className="mx-1 text-muted-foreground text-xs">
-                          •
-                        </span>
-                      )}
-                    </span>
-                  ))}
-                </div>
                 {/* Summary */}
                 {item.summary && (
                   <p className="mt-0.5 line-clamp-1 text-muted-foreground text-xs">

--- a/apps/web/src/components/interactions/CommentCard.tsx
+++ b/apps/web/src/components/interactions/CommentCard.tsx
@@ -2,13 +2,19 @@
 
 import type { CommentCardProps, CommentData } from '@babylon/shared';
 import { cn, getProfileUrl } from '@babylon/shared';
-import { formatDistanceToNow } from 'date-fns';
-import { Edit2, MessageCircle, MoreHorizontal, Trash2 } from 'lucide-react';
+import {
+  Edit2,
+  MessageCircle,
+  MoreHorizontal,
+  Repeat2,
+  Trash2,
+} from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { createPortal } from 'react-dom';
 import { ModerationMenu } from '@/components/moderation/ModerationMenu';
+import { formatTimeAgo } from '@/components/posts/CommentPreview';
 import { Avatar } from '@/components/shared/Avatar';
 import { TaggedText } from '@/components/shared/TaggedText';
 import {
@@ -76,7 +82,7 @@ export function CommentCard({
   className,
 }: CommentCardProps) {
   const router = useRouter();
-  const { user } = useAuth();
+  const { user, authenticated, login } = useAuth();
   const [showActions, setShowActions] = useState(false);
   const [isReplying, setIsReplying] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
@@ -102,6 +108,10 @@ export function CommentCard({
   const authorIsNPC = isNpcIdentifier(comment.userId);
 
   const handleReply = () => {
+    if (!authenticated) {
+      login();
+      return;
+    }
     setIsReplying(true);
     if (onReply) {
       onReply(comment.id);
@@ -138,245 +148,272 @@ export function CommentCard({
   };
 
   return (
-    <div className={cn('flex gap-3', className)}>
-      {/* Avatar - Round */}
-      <Link
-        href={getProfileUrl(comment.userId, comment.userUsername)}
-        className="shrink-0 transition-opacity hover:opacity-80"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <Avatar
-          id={comment.userId}
-          name={comment.userName}
-          size="sm"
-          src={comment.userAvatar || undefined}
-          imageUrl={comment.userAvatar || undefined}
-        />
-      </Link>
+    <div
+      className={cn(
+        'border-border border-b px-4 py-4',
+        'cursor-pointer transition-all duration-200 hover:bg-muted/30',
+        className
+      )}
+      onClick={handleNavigateToThread}
+    >
+      <div className="flex gap-3">
+        {/* Avatar - Round */}
+        <Link
+          href={getProfileUrl(comment.userId, comment.userUsername)}
+          className="shrink-0 transition-opacity hover:opacity-80"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Avatar
+            id={comment.userId}
+            name={comment.userName}
+            size="sm"
+            src={comment.userAvatar || undefined}
+            imageUrl={comment.userAvatar || undefined}
+          />
+        </Link>
 
-      {/* Content */}
-      <div className="min-w-0 flex-1">
-        {/* Header: Username/handle on left, timestamp and actions on right */}
-        <div className="mb-2 flex items-center justify-between gap-2">
-          <div className="flex min-w-0 flex-1 items-center gap-2">
-            <Link
-              href={getProfileUrl(comment.userId, comment.userUsername)}
-              className="truncate font-semibold text-sm hover:underline"
-              onClick={(e) => e.stopPropagation()}
-            >
-              {comment.userName}
-            </Link>
-            {showVerifiedBadge && <VerifiedBadge size="sm" className="-ml-1" />}
-            <Link
-              href={getProfileUrl(comment.userId, comment.userUsername)}
-              className="truncate text-muted-foreground text-xs hover:underline"
-              onClick={(e) => e.stopPropagation()}
-            >
-              @{comment.userUsername || comment.userName}
-            </Link>
-          </div>
-          <div className="flex shrink-0 items-center gap-2">
-            {/* Timestamp - Right aligned */}
-            <span className="text-muted-foreground text-xs">
-              {formatDistanceToNow(new Date(comment.createdAt), {
-                addSuffix: true,
-              })}
-            </span>
-
-            {/* Actions menu - different for own vs others' comments */}
-            {isOwnComment ? (
-              // Own comment: Show Edit/Delete
-              <div className="relative">
-                <button
-                  ref={actionButtonRef}
-                  type="button"
-                  onClick={() => {
-                    if (!showActions) {
-                      updatePosition();
-                    }
-                    setShowActions(!showActions);
-                  }}
-                  className="rounded-lg p-2 transition-colors hover:bg-muted"
-                  aria-label="More options"
-                >
-                  <MoreHorizontal className="h-5 w-5 text-muted-foreground" />
-                </button>
-
-                {/* Only render portal on client side (mounted check for SSR compatibility) */}
-                {showActions &&
-                  mounted &&
-                  createPortal(
-                    <>
-                      {/* Backdrop */}
-                      <div
-                        className="fixed inset-0 z-40"
-                        onClick={() => setShowActions(false)}
-                      />
-
-                      {/* Dropdown */}
-                      <div
-                        className="fade-in slide-in-from-top-2 fixed z-50 min-w-[120px] animate-in rounded-md border border-border bg-popover py-1 shadow-lg duration-150"
-                        style={{
-                          top: menuPosition.openUpward
-                            ? 'auto'
-                            : menuPosition.top,
-                          bottom: menuPosition.openUpward
-                            ? menuPosition.windowHeight - menuPosition.top
-                            : 'auto',
-                          left: menuPosition.left,
-                        }}
-                      >
-                        <button
-                          type="button"
-                          onClick={handleEdit}
-                          className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors hover:bg-muted"
-                        >
-                          <Edit2 size={14} />
-                          Edit
-                        </button>
-                        <button
-                          type="button"
-                          onClick={handleDelete}
-                          className="flex w-full items-center gap-2 px-3 py-2 text-left text-destructive text-sm transition-colors hover:bg-muted"
-                        >
-                          <Trash2 size={14} />
-                          Delete
-                        </button>
-                      </div>
-                    </>,
-                    document.body
-                  )}
-              </div>
-            ) : user ? (
-              // Other user's comment: Show ModerationMenu (Follow/Mute/Block/Report)
-              <ModerationMenu
-                targetUserId={comment.userId}
-                targetUsername={comment.userUsername || undefined}
-                targetDisplayName={comment.userName}
-                targetProfileImageUrl={comment.userAvatar || undefined}
-                isNPC={authorIsNPC}
-              />
-            ) : null}
-          </div>
-        </div>
-
-        {/* Replying to indicator */}
-        {comment.parentCommentId && comment.parentCommentAuthorName && (
-          <div className="mb-1 flex items-center gap-1 text-muted-foreground text-xs">
-            <span>Replying to</span>
-            <span className="font-medium text-primary">
-              @{comment.parentCommentAuthorName}
-            </span>
-          </div>
-        )}
-
-        {/* Comment body - Clickable to navigate to thread */}
-        {isEditing ? (
-          <div className="mb-2">
-            <textarea
-              value={editContent}
-              onChange={(e) => setEditContent(e.target.value)}
-              className="min-h-[60px] w-full resize-none rounded-md border border-border bg-muted p-2 text-sm focus:border-border focus:outline-none"
-              autoFocus
-            />
-            <div className="mt-2 flex gap-2">
-              <button
-                type="button"
-                onClick={handleSaveEdit}
-                disabled={!editContent.trim()}
-                className="rounded-md bg-primary px-3 py-1 text-primary-foreground text-sm transition-colors hover:bg-primary/90 disabled:opacity-50"
+        {/* Content */}
+        <div className="min-w-0 flex-1">
+          {/* Header: Username/handle on left, timestamp and actions on right */}
+          <div className="mb-2 flex items-center justify-between gap-2">
+            <div className="flex min-w-0 flex-1 items-center gap-2">
+              <Link
+                href={getProfileUrl(comment.userId, comment.userUsername)}
+                className="truncate font-semibold text-sm hover:underline"
+                onClick={(e) => e.stopPropagation()}
               >
-                Save
-              </button>
-              <button
-                type="button"
-                onClick={handleCancelEdit}
-                className="px-3 py-1 text-muted-foreground text-sm transition-colors hover:text-foreground"
+                {comment.userName}
+              </Link>
+              {showVerifiedBadge && (
+                <VerifiedBadge size="sm" className="-ml-1" />
+              )}
+              <Link
+                href={getProfileUrl(comment.userId, comment.userUsername)}
+                className="truncate text-muted-foreground text-xs hover:underline"
+                onClick={(e) => e.stopPropagation()}
               >
-                Cancel
-              </button>
+                @{comment.userUsername || comment.userName}
+              </Link>
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              {/* Timestamp - Right aligned */}
+              <span className="text-muted-foreground text-xs">
+                {formatTimeAgo(new Date(comment.createdAt).toISOString())}
+              </span>
+
+              {/* Actions menu - different for own vs others' comments */}
+              {isOwnComment ? (
+                // Own comment: Show Edit/Delete
+                <div className="relative" onClick={(e) => e.stopPropagation()}>
+                  <button
+                    ref={actionButtonRef}
+                    type="button"
+                    onClick={() => {
+                      if (!showActions) {
+                        updatePosition();
+                      }
+                      setShowActions(!showActions);
+                    }}
+                    className="rounded-lg p-2 transition-colors hover:bg-muted"
+                    aria-label="More options"
+                  >
+                    <MoreHorizontal className="h-5 w-5 text-muted-foreground" />
+                  </button>
+
+                  {/* Only render portal on client side (mounted check for SSR compatibility) */}
+                  {showActions &&
+                    mounted &&
+                    createPortal(
+                      <>
+                        {/* Backdrop */}
+                        <div
+                          className="fixed inset-0 z-40"
+                          onClick={() => setShowActions(false)}
+                        />
+
+                        {/* Dropdown */}
+                        <div
+                          className="fade-in slide-in-from-top-2 fixed z-50 min-w-[120px] animate-in rounded-md border border-border bg-popover py-1 shadow-lg duration-150"
+                          style={{
+                            top: menuPosition.openUpward
+                              ? 'auto'
+                              : menuPosition.top,
+                            bottom: menuPosition.openUpward
+                              ? menuPosition.windowHeight - menuPosition.top
+                              : 'auto',
+                            left: menuPosition.left,
+                          }}
+                        >
+                          <button
+                            type="button"
+                            onClick={handleEdit}
+                            className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors hover:bg-muted"
+                          >
+                            <Edit2 size={14} />
+                            Edit
+                          </button>
+                          <button
+                            type="button"
+                            onClick={handleDelete}
+                            className="flex w-full items-center gap-2 px-3 py-2 text-left text-destructive text-sm transition-colors hover:bg-muted"
+                          >
+                            <Trash2 size={14} />
+                            Delete
+                          </button>
+                        </div>
+                      </>,
+                      document.body
+                    )}
+                </div>
+              ) : user ? (
+                // Other user's comment: Show ModerationMenu (Follow/Mute/Block/Report)
+                <div onClick={(e) => e.stopPropagation()}>
+                  <ModerationMenu
+                    targetUserId={comment.userId}
+                    targetUsername={comment.userUsername || undefined}
+                    targetDisplayName={comment.userName}
+                    targetProfileImageUrl={comment.userAvatar || undefined}
+                    isNPC={authorIsNPC}
+                  />
+                </div>
+              ) : null}
             </div>
           </div>
-        ) : (
-          <button
-            type="button"
-            onClick={handleNavigateToThread}
-            className="mb-2 w-full cursor-pointer text-left transition-colors hover:text-muted-foreground"
+
+          {/* Replying to indicator */}
+          {comment.parentCommentId && comment.parentCommentAuthorName && (
+            <div className="mb-1 flex items-center gap-1 text-muted-foreground text-xs">
+              <span>Replying to</span>
+              <span className="font-medium text-primary">
+                @{comment.parentCommentAuthorName}
+              </span>
+            </div>
+          )}
+
+          {/* Comment body */}
+          {isEditing ? (
+            <div className="mb-2" onClick={(e) => e.stopPropagation()}>
+              <textarea
+                value={editContent}
+                onChange={(e) => setEditContent(e.target.value)}
+                className="min-h-[60px] w-full resize-none rounded-md border border-border bg-muted p-2 text-sm focus:border-border focus:outline-none"
+                autoFocus
+              />
+              <div className="mt-2 flex gap-2">
+                <button
+                  type="button"
+                  onClick={handleSaveEdit}
+                  disabled={!editContent.trim()}
+                  className="rounded-md bg-primary px-3 py-1 text-primary-foreground text-sm transition-colors hover:bg-primary/90 disabled:opacity-50"
+                >
+                  Save
+                </button>
+                <button
+                  type="button"
+                  onClick={handleCancelEdit}
+                  className="px-3 py-1 text-muted-foreground text-sm transition-colors hover:text-foreground"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="mb-2">
+              <p className="whitespace-pre-wrap break-words text-foreground text-sm">
+                <TaggedText
+                  text={comment.content}
+                  onTagClick={(tag) => {
+                    if (tag.startsWith('@')) {
+                      // Handle @mentions - route to profile
+                      const username = tag.slice(1);
+                      router.push(getProfileUrl('', username));
+                    } else if (tag.startsWith('$')) {
+                      // Handle $cashtags - route to markets
+                      const symbol = tag.slice(1);
+                      router.push(
+                        `/markets?search=${encodeURIComponent(symbol)}`
+                      );
+                    }
+                  }}
+                />
+              </p>
+            </div>
+          )}
+
+          {/* Footer actions - matches feed post InteractionBar style */}
+          <div
+            className="mt-2 flex w-full items-center justify-between gap-6 text-muted-foreground"
+            onClick={(e) => e.stopPropagation()}
           >
-            <p className="whitespace-pre-wrap break-words text-foreground text-sm">
-              <TaggedText
-                text={comment.content}
-                onTagClick={(tag) => {
-                  if (tag.startsWith('@')) {
-                    // Handle @mentions - route to profile
-                    const username = tag.slice(1);
-                    router.push(getProfileUrl('', username));
-                  } else if (tag.startsWith('$')) {
-                    // Handle $cashtags - route to markets
-                    const symbol = tag.slice(1);
-                    router.push(
-                      `/markets?search=${encodeURIComponent(symbol)}`
-                    );
+            {/* Reply button */}
+            <button
+              type="button"
+              onClick={handleReply}
+              className={cn(
+                'flex items-center gap-1',
+                'bg-transparent transition-all duration-200 hover:opacity-70',
+                'cursor-pointer text-muted-foreground text-xs',
+                isReplying && 'text-[#0066FF]'
+              )}
+            >
+              <MessageCircle size={18} />
+              {hasReplies && (
+                <span className="font-medium tabular-nums">
+                  {replyCount >= MAX_REPLY_COUNT
+                    ? `${MAX_REPLY_COUNT}+`
+                    : replyCount}
+                </span>
+              )}
+            </button>
+
+            {/* Repost button (placeholder - not yet implemented) */}
+            <div>
+              <button
+                type="button"
+                disabled
+                className="flex cursor-default items-center gap-1 text-muted-foreground/40 text-xs"
+              >
+                <Repeat2 size={18} />
+              </button>
+            </div>
+
+            {/* Like button */}
+            <div>
+              <LikeButton
+                targetId={comment.id}
+                targetType="comment"
+                initialLiked={comment.isLiked}
+                initialCount={comment.likeCount}
+                size="sm"
+                showCount
+              />
+            </div>
+
+            {/* Empty spacer to match post InteractionBar's 4-column layout */}
+            <div />
+          </div>
+
+          {/* Reply input */}
+          {isReplying && (
+            <div className="mt-3" onClick={(e) => e.stopPropagation()}>
+              <CommentInput
+                postId={postId}
+                parentCommentId={comment.id}
+                placeholder={`Reply to ${comment.userName}...`}
+                replyingToName={comment.userName}
+                autoFocus
+                onSubmit={async (replyComment: CommentData) => {
+                  setIsReplying(false);
+                  // Call onReplySubmit callback if provided to handle optimistic update
+                  if (onReplySubmit && replyComment) {
+                    onReplySubmit(replyComment);
                   }
                 }}
+                onCancel={() => setIsReplying(false)}
               />
-            </p>
-          </button>
-        )}
-
-        {/* Footer actions - Twitter-like layout */}
-        <div className="flex items-center gap-1">
-          {/* Message icon - always for reply to this comment */}
-          <button
-            type="button"
-            onClick={handleReply}
-            className={cn(
-              'flex items-center gap-1.5 rounded-full px-2 py-1 text-xs transition-colors',
-              'text-muted-foreground hover:bg-[#0066FF]/10 hover:text-[#0066FF]',
-              isReplying && 'bg-[#0066FF]/10 text-[#0066FF]'
-            )}
-          >
-            <MessageCircle size={14} />
-            <span>
-              {hasReplies
-                ? replyCount >= MAX_REPLY_COUNT
-                  ? `${MAX_REPLY_COUNT}+`
-                  : replyCount
-                : ''}
-            </span>
-          </button>
-
-          {/* Like button */}
-          <LikeButton
-            targetId={comment.id}
-            targetType="comment"
-            initialLiked={comment.isLiked}
-            initialCount={comment.likeCount}
-            size="sm"
-            showCount
-          />
+            </div>
+          )}
         </div>
-
-        {/* Reply input */}
-        {isReplying && (
-          <div className="mt-3">
-            <CommentInput
-              postId={postId}
-              parentCommentId={comment.id}
-              placeholder={`Reply to ${comment.userName}...`}
-              replyingToName={comment.userName}
-              autoFocus
-              onSubmit={async (replyComment: CommentData) => {
-                setIsReplying(false);
-                // Call onReplySubmit callback if provided to handle optimistic update
-                if (onReplySubmit && replyComment) {
-                  onReplySubmit(replyComment);
-                }
-              }}
-              onCancel={() => setIsReplying(false)}
-            />
-          </div>
-        )}
       </div>
     </div>
   );

--- a/apps/web/src/components/interactions/CommentInput.tsx
+++ b/apps/web/src/components/interactions/CommentInput.tsx
@@ -4,6 +4,7 @@ import type { CommentInputProps } from '@babylon/shared';
 import { cn } from '@babylon/shared';
 import { Send, X } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
+import { useAuth } from '@/hooks/useAuth';
 import { useInteractionStore } from '@/stores/interactionStore';
 
 /**
@@ -50,6 +51,7 @@ export function CommentInput({
   );
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
+  const { authenticated, login } = useAuth();
   const { addComment } = useInteractionStore();
 
   useEffect(() => {
@@ -68,6 +70,11 @@ export function CommentInput({
   }, []);
 
   const handleSubmit = async () => {
+    if (!authenticated) {
+      login();
+      return;
+    }
+
     const trimmedContent = content.trim();
 
     if (!trimmedContent || isSubmitting) {

--- a/apps/web/src/components/interactions/DeleteButton.tsx
+++ b/apps/web/src/components/interactions/DeleteButton.tsx
@@ -33,7 +33,7 @@ interface DeleteButtonProps {
 }
 
 const sizeClasses = {
-  sm: 'h-8 px-2 text-xs gap-1',
+  sm: 'text-xs gap-1',
   md: 'h-10 px-3 text-sm gap-1.5',
   lg: 'h-12 px-4 text-base gap-2',
 };

--- a/apps/web/src/components/interactions/InteractionBar.tsx
+++ b/apps/web/src/components/interactions/InteractionBar.tsx
@@ -6,7 +6,6 @@ import { MessageCircle } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { FeedCommentSection } from '@/components/feed/FeedCommentSection';
 import { useAuth } from '@/hooks/useAuth';
-import { useLoginModal } from '@/hooks/useLoginModal';
 import { useInteractionStore } from '@/stores/interactionStore';
 import { DeleteButton } from './DeleteButton';
 import { LikeButton } from './LikeButton';
@@ -50,8 +49,7 @@ export function InteractionBar({
 }: InteractionBarProps) {
   const [showComments, setShowComments] = useState(false);
   const { postInteractions } = useInteractionStore();
-  const { authenticated } = useAuth();
-  const { showLoginModal } = useLoginModal();
+  const { authenticated, login } = useAuth();
 
   // Determine if this is a simple repost (no quote commentary)
   // Simple repost: has originalPostId but no quote commentary
@@ -123,10 +121,7 @@ export function InteractionBar({
 
   const handleCommentClick = () => {
     if (!authenticated) {
-      showLoginModal({
-        title: 'Login to Comment',
-        message: 'Log in to reply to posts and engage with NPCs.',
-      });
+      login();
       return;
     }
     // If custom onCommentClick is provided, use that instead of opening our own modal
@@ -142,7 +137,7 @@ export function InteractionBar({
       <div
         className={cn(
           className,
-          'mt-3 flex w-full items-center justify-between gap-6 text-muted-foreground'
+          'mt-2 flex w-full items-center justify-between gap-6 text-muted-foreground'
         )}
       >
         {/* Comment button */}
@@ -153,7 +148,7 @@ export function InteractionBar({
             handleCommentClick();
           }}
           className={cn(
-            'flex h-8 items-center gap-1 px-2',
+            'flex items-center gap-1',
             'bg-transparent transition-all duration-200 hover:opacity-70',
             'cursor-pointer text-muted-foreground text-xs'
           )}

--- a/apps/web/src/components/interactions/LikeButton.tsx
+++ b/apps/web/src/components/interactions/LikeButton.tsx
@@ -6,7 +6,6 @@ import { Frown, Heart, Laugh } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { Skeleton } from '@/components/shared/Skeleton';
 import { useAuth } from '@/hooks/useAuth';
-import { useLoginModal } from '@/hooks/useLoginModal';
 import { useSocialTracking } from '@/hooks/usePostHog';
 import { useInteractionStore } from '@/stores/interactionStore';
 
@@ -93,7 +92,7 @@ type ReactionType = keyof typeof REACTION_TYPES;
  * ```
  */
 const sizeClasses = {
-  sm: 'h-8 px-2 text-xs gap-1',
+  sm: 'text-xs gap-1',
   md: 'h-10 px-3 text-sm gap-1.5',
   lg: 'h-12 px-4 text-base gap-2',
 };
@@ -120,6 +119,7 @@ export function LikeButton({
   showCount = true,
   className,
 }: LikeButtonProps & { initialReactionType?: ReactionType }) {
+  const { authenticated, login } = useAuth();
   // Ensure size is properly typed for index access
   const sizeKey: 'sm' | 'md' | 'lg' = size;
   const [currentReaction, setCurrentReaction] =
@@ -130,8 +130,6 @@ export function LikeButton({
   const longPressTimer = useRef<NodeJS.Timeout | null>(null);
   const longPressStartTime = useRef<number>(0);
 
-  const { authenticated } = useAuth();
-  const { showLoginModal } = useLoginModal();
   const {
     toggleLike,
     toggleCommentLike,
@@ -161,15 +159,10 @@ export function LikeButton({
   }, []);
 
   const handleClick = async () => {
-    // Check authentication before allowing like
     if (!authenticated) {
-      showLoginModal({
-        title: 'Login to Like',
-        message: `Log in to like ${targetType === 'post' ? 'posts' : 'comments'} and engage with the community.`,
-      });
+      login();
       return;
     }
-
     // Trigger animation
     setIsAnimating(true);
     setTimeout(() => setIsAnimating(false), 300);
@@ -187,17 +180,11 @@ export function LikeButton({
   };
 
   const handleReactionSelect = async (reactionType: ReactionType) => {
-    setShowReactionPicker(false);
-
-    // Check authentication before allowing reaction
     if (!authenticated) {
-      showLoginModal({
-        title: 'Login to React',
-        message: `Log in to react to ${targetType === 'post' ? 'posts' : 'comments'} and engage with the community.`,
-      });
+      login();
       return;
     }
-
+    setShowReactionPicker(false);
     setCurrentReaction(reactionType);
 
     // Trigger animation

--- a/apps/web/src/components/interactions/RepostButton.tsx
+++ b/apps/web/src/components/interactions/RepostButton.tsx
@@ -7,7 +7,6 @@ import { useState } from 'react';
 import { Avatar } from '@/components/shared/Avatar';
 import { Skeleton } from '@/components/shared/Skeleton';
 import { useAuth } from '@/hooks/useAuth';
-import { useLoginModal } from '@/hooks/useLoginModal';
 import { useFeedStore } from '@/stores/feedStore';
 import { useInteractionStore } from '@/stores/interactionStore';
 
@@ -39,7 +38,7 @@ import { useInteractionStore } from '@/stores/interactionStore';
  * ```
  */
 const sizeClasses = {
-  sm: 'h-8 px-2 text-xs gap-1',
+  sm: 'text-xs gap-1',
   md: 'h-10 px-3 text-sm gap-1.5',
   lg: 'h-12 px-4 text-base gap-2',
 };
@@ -81,15 +80,11 @@ export function RepostButton({
   const count = storeData?.shareCount ?? shareCount;
   const isLoading = loadingStates.get(`share-${postId}`) ?? false;
 
-  const { authenticated } = useAuth();
-  const { showLoginModal } = useLoginModal();
+  const { authenticated, login } = useAuth();
 
   const handleClick = () => {
     if (!authenticated) {
-      showLoginModal({
-        title: 'Login to Share',
-        message: 'Log in to share posts with your followers.',
-      });
+      login();
       return;
     }
     if (isShared) {

--- a/apps/web/src/components/posts/CommentPreview.tsx
+++ b/apps/web/src/components/posts/CommentPreview.tsx
@@ -4,6 +4,7 @@ import type { CommentPreviewData } from '@babylon/shared';
 import { cn, getProfileUrl } from '@babylon/shared';
 import { formatDistanceToNow } from 'date-fns';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { memo } from 'react';
 import { CommentInteractionBar } from '@/components/interactions';
 import { Avatar } from '@/components/shared/Avatar';
@@ -84,14 +85,14 @@ export const CommentPreview = memo(function CommentPreview({
             e.stopPropagation();
             onViewAllClick?.();
           }}
-          className="mt-3 text-primary text-sm transition-colors hover:text-primary/80"
+          className="text-primary text-sm transition-colors hover:underline"
         >
           View all {totalCommentCount} comments
         </button>
       )}
 
       {/* Line separator - shown under comments/view all when there are comments */}
-      {hasComments && <div className="mt-3 border-muted border-b" />}
+      {hasComments && <div className="mt-3 border-border border-b" />}
 
       {/* Comment input bar - shown when showInputBar is true */}
       {showInputBar && (
@@ -116,7 +117,7 @@ export const CommentPreview = memo(function CommentPreview({
 });
 
 /**
- * Individual comment preview item - full layout matching reference design
+ * Individual comment preview item - two-column layout matching post style
  */
 const CommentPreviewItem = memo(function CommentPreviewItem({
   comment,
@@ -125,41 +126,50 @@ const CommentPreviewItem = memo(function CommentPreviewItem({
   comment: CommentPreviewData;
   onClick?: () => void;
 }) {
+  const router = useRouter();
   const isNPC = isNpcIdentifier(comment.userId);
   const timeAgo = formatTimeAgo(comment.createdAt);
 
   return (
-    <div className="flex w-full items-start gap-3 text-left">
-      {/* Avatar */}
-      <Link
-        href={getProfileUrl(comment.userId, comment.userUsername)}
-        className="shrink-0 transition-opacity hover:opacity-80"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <Avatar
-          id={comment.userId}
-          name={comment.userName}
-          type="actor"
-          size="sm"
-          src={comment.userAvatar || undefined}
-        />
-      </Link>
+    <div
+      className="cursor-pointer flex gap-3"
+      onClick={(e) => {
+        e.stopPropagation();
+        router.push(`/comment/${comment.id}`);
+      }}
+    >
+      {/* Left column: Avatar */}
+      <div className="flex flex-col items-center">
+        <Link
+          href={getProfileUrl(comment.userId, comment.userUsername)}
+          className="shrink-0 transition-opacity hover:opacity-80"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Avatar
+            id={comment.userId}
+            name={comment.userName}
+            type="actor"
+            size="md"
+            src={comment.userAvatar || undefined}
+          />
+        </Link>
+      </div>
 
-      {/* Content area */}
+      {/* Right column: Content */}
       <div className="min-w-0 flex-1">
-        {/* Header: Name + Handle + Timestamp */}
-        <div className="flex items-center justify-between gap-2">
+        {/* Header: Name + Username + Time */}
+        <div className="flex items-start justify-between gap-2">
           <div className="flex min-w-0 items-center gap-1">
             <Link
               href={getProfileUrl(comment.userId, comment.userUsername)}
-              className="flex items-center gap-1 font-semibold text-foreground text-sm hover:underline"
+              className="truncate font-semibold text-foreground text-[15px] hover:underline"
               onClick={(e) => e.stopPropagation()}
             >
-              <span className="truncate">{comment.userName}</span>
-              {isNPC && <VerifiedBadge size="sm" />}
+              {comment.userName}
             </Link>
+            {isNPC && <VerifiedBadge size="sm" />}
             {comment.userUsername && (
-              <span className="truncate text-muted-foreground text-sm">
+              <span className="truncate text-[15px] text-muted-foreground">
                 @{comment.userUsername}
               </span>
             )}

--- a/apps/web/src/components/posts/CommentPreview.tsx
+++ b/apps/web/src/components/posts/CommentPreview.tsx
@@ -132,7 +132,7 @@ const CommentPreviewItem = memo(function CommentPreviewItem({
 
   return (
     <div
-      className="cursor-pointer flex gap-3"
+      className="flex cursor-pointer gap-3"
       onClick={(e) => {
         e.stopPropagation();
         router.push(`/comment/${comment.id}`);
@@ -162,7 +162,7 @@ const CommentPreviewItem = memo(function CommentPreviewItem({
           <div className="flex min-w-0 items-center gap-1">
             <Link
               href={getProfileUrl(comment.userId, comment.userUsername)}
-              className="truncate font-semibold text-foreground text-[15px] hover:underline"
+              className="truncate font-semibold text-[15px] text-foreground hover:underline"
               onClick={(e) => e.stopPropagation()}
             >
               {comment.userName}

--- a/apps/web/src/components/posts/PostCard.tsx
+++ b/apps/web/src/components/posts/PostCard.tsx
@@ -5,13 +5,7 @@ import { cn, getProfileUrl } from '@babylon/shared';
 import { Repeat2 } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import {
-  type KeyboardEvent,
-  type MouseEvent,
-  memo,
-  useEffect,
-  useState,
-} from 'react';
+import { type KeyboardEvent, type MouseEvent, memo } from 'react';
 import { InteractionBar } from '@/components/interactions';
 import { ModerationMenu } from '@/components/moderation/ModerationMenu';
 import {
@@ -113,19 +107,7 @@ export const PostCard = memo(function PostCard({
 }: PostCardProps) {
   const router = useRouter();
   const { fontSize } = useFontSize();
-  const [isDesktop, setIsDesktop] = useState(false);
-  const [isMobile, setIsMobile] = useState(false);
   const { user } = useAuth();
-
-  useEffect(() => {
-    const checkScreenSize = () => {
-      setIsDesktop(window.innerWidth >= 1024);
-      setIsMobile(window.innerWidth < 640);
-    };
-    checkScreenSize();
-    window.addEventListener('resize', checkScreenSize);
-    return () => window.removeEventListener('resize', checkScreenSize);
-  }, []);
 
   const postDate = new Date(post.timestamp);
   const now = new Date();
@@ -240,7 +222,7 @@ export const PostCard = memo(function PostCard({
         className={cn(
           'px-4 py-3',
           'w-full overflow-hidden',
-          'border-muted border-b',
+          'border-border border-b',
           className
         )}
       >
@@ -254,11 +236,11 @@ export const PostCard = memo(function PostCard({
   return (
     <article
       className={cn(
-        'px-4 py-3',
+        'px-4 py-4',
         !isDetail &&
           'cursor-pointer transition-all duration-200 hover:bg-muted/30',
         'w-full overflow-hidden',
-        'border-muted border-b',
+        !isDetail && 'border-border border-b',
         className
       )}
       style={{
@@ -268,7 +250,7 @@ export const PostCard = memo(function PostCard({
     >
       {/* Repost Indicator - Only show for simple reposts (not quote posts) */}
       {isSimpleRepost && (
-        <div className="mb-3 flex items-center gap-3 text-muted-foreground text-sm">
+        <div className="mb-2 flex items-center gap-3 pl-12 text-muted-foreground text-sm">
           <Repeat2 size={14} className="text-green-600" />
           <span>
             Reposted by{' '}
@@ -287,85 +269,85 @@ export const PostCard = memo(function PostCard({
         </div>
       )}
 
-      {/* Row 1: Avatar + Name/Handle/Timestamp Header */}
-      {!isSimpleRepost && (
-        <div className="mb-3 flex w-full items-start gap-3">
-          {/* Avatar - Clickable, Round - Shows original author for simple reposts, reposter for quote posts */}
-          <Link
-            href={getProfileUrl(displayAuthorId, displayAuthorUsername)}
-            className="shrink-0 transition-opacity hover:opacity-80"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <Avatar
-              id={displayAuthorId}
-              name={displayAuthorName}
-              type={post.type === 'article' ? 'business' : 'actor'}
-              size="md"
-              src={displayAuthorProfileImageUrl || undefined}
-              scaleFactor={
-                isDetail
-                  ? fontSize
-                  : fontSize * (isDesktop ? 1.4 : isMobile ? 0.8 : 1)
-              }
-            />
-          </Link>
+      {/* Two-column layout: Avatar | Content */}
+      <div className="flex gap-3">
+        {/* Left column: Avatar + Connecting Line */}
+        {!isSimpleRepost && (
+          <div className="flex flex-col items-center">
+            <Link
+              href={getProfileUrl(displayAuthorId, displayAuthorUsername)}
+              className="shrink-0 transition-opacity hover:opacity-80"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Avatar
+                id={displayAuthorId}
+                name={displayAuthorName}
+                type={post.type === 'article' ? 'business' : 'actor'}
+                size="md"
+                src={displayAuthorProfileImageUrl || undefined}
+                scaleFactor={fontSize}
+              />
+            </Link>
+            {/* Connecting line to comments */}
+            {showCommentPreviews && !isDetail && (post.commentPreviews?.length ?? 0) > 0 && (
+              <div className="mt-2 w-0.5 flex-1 bg-border" />
+            )}
+          </div>
+        )}
 
-          {/* Header: Name/Handle block on left, Timestamp and Menu on right */}
-          <div className="flex min-w-0 flex-1 items-start justify-between gap-3">
-            {/* Name and Handle stacked vertically - Shows original author for simple reposts, reposter for quote posts */}
-            <div className="flex min-w-0 flex-col">
-              {/* Name row with verified badge */}
-              <div className="flex min-w-0 items-center gap-1.5">
+        {/* Right column: All content */}
+        <div className="min-w-0 flex-1">
+          {/* Header: Name/Handle on left, Timestamp and Menu on right */}
+          {!isSimpleRepost && (
+            <div className="mb-2 flex items-center justify-between gap-3">
+              {/* Name and Handle inline */}
+              <div className="flex min-w-0 flex-1 items-center gap-1.5">
                 <Link
                   href={getProfileUrl(displayAuthorId, displayAuthorUsername)}
-                  className="truncate font-semibold text-foreground text-lg hover:underline sm:text-xl"
+                  className="truncate font-semibold text-foreground text-[15px] hover:underline"
                   onClick={(e) => e.stopPropagation()}
                 >
                   {displayAuthorName}
                 </Link>
                 {showVerifiedBadge && (
-                  <VerifiedBadge size="md" className="sm:h-6 sm:w-6" />
+                  <VerifiedBadge size="sm" />
+                )}
+                <Link
+                  href={getProfileUrl(displayAuthorId, displayAuthorUsername)}
+                  className="truncate text-[15px] text-muted-foreground hover:underline"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  @{displayAuthorUsername || displayAuthorId}
+                </Link>
+              </div>
+              {/* Timestamp and Menu - Right aligned */}
+              <div className="flex shrink-0 items-center gap-2">
+                <time
+                  className="text-[15px] text-muted-foreground"
+                  title={postDate.toLocaleString()}
+                >
+                  {timeAgo}
+                </time>
+                {user && user.id !== displayAuthorId && (
+                  <div onClick={(e) => e.stopPropagation()}>
+                    <ModerationMenu
+                      targetUserId={displayAuthorId}
+                      targetUsername={displayAuthorUsername || undefined}
+                      targetDisplayName={displayAuthorName}
+                      targetProfileImageUrl={
+                        displayAuthorProfileImageUrl || undefined
+                      }
+                      postId={post.id}
+                      isNPC={authorIsNPC}
+                    />
+                  </div>
                 )}
               </div>
-              {/* Handle row */}
-              <Link
-                href={getProfileUrl(displayAuthorId, displayAuthorUsername)}
-                className="truncate text-base text-muted-foreground hover:underline"
-                onClick={(e) => e.stopPropagation()}
-              >
-                @{displayAuthorUsername || displayAuthorId}
-              </Link>
             </div>
-            {/* Timestamp and Moderation Menu - Right aligned */}
-            <div className="flex shrink-0 items-center gap-2">
-              <time
-                className="text-base text-muted-foreground"
-                title={postDate.toLocaleString()}
-              >
-                {timeAgo}
-              </time>
-              {/* Show moderation menu only if not your own post */}
-              {user && user.id !== displayAuthorId && (
-                <div onClick={(e) => e.stopPropagation()}>
-                  <ModerationMenu
-                    targetUserId={displayAuthorId}
-                    targetUsername={displayAuthorUsername || undefined}
-                    targetDisplayName={displayAuthorName}
-                    targetProfileImageUrl={
-                      displayAuthorProfileImageUrl || undefined
-                    }
-                    postId={post.id}
-                    isNPC={authorIsNPC}
-                  />
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-      )}
+          )}
 
-      {/* Row 2: Post Content - Full width */}
-      {post.type === 'article' ? (
+          {/* Post Content */}
+          {post.type === 'article' ? (
         // Article card - Show title, summary, and "Read more" button
         <div className="mb-3 w-full">
           {/* Article title with Read More Button */}
@@ -389,7 +371,7 @@ export const PostCard = memo(function PostCard({
           </div>
 
           {/* Article summary */}
-          <div className="mb-3 whitespace-pre-wrap break-words text-foreground leading-relaxed">
+          <div className="mb-3 whitespace-pre-wrap break-words text-[15px] text-foreground leading-normal">
             {post.content}
           </div>
         </div>
@@ -398,7 +380,7 @@ export const PostCard = memo(function PostCard({
         <div className="mb-4 w-full">
           {/* Quote comment (if present) */}
           {post.quoteComment && (
-            <div className="post-content mb-4 whitespace-pre-wrap break-words text-foreground leading-relaxed">
+            <div className="post-content mb-3 whitespace-pre-wrap break-words text-[15px] text-foreground leading-normal">
               <TaggedText
                 text={post.quoteComment}
                 onTagClick={(tag) => {
@@ -421,11 +403,10 @@ export const PostCard = memo(function PostCard({
           {/* Embedded original post */}
           <div
             className={cn(
-              'rounded-xl border border-white/10 p-4',
-              'bg-white/5',
+              'rounded-xl border border-border p-4',
               'overflow-hidden transition-colors',
               quotedPostId
-                ? 'cursor-pointer hover:bg-white/[0.07]'
+                ? 'cursor-pointer hover:bg-muted/50'
                 : 'cursor-default'
             )}
             role={quotedPostId ? 'link' : undefined}
@@ -437,7 +418,7 @@ export const PostCard = memo(function PostCard({
             {post.originalPost ? (
               <>
                 {/* Original post author */}
-                <div className="mb-3 flex items-start gap-3">
+                <div className="mb-2 flex items-center gap-2">
                   <Link
                     href={getProfileUrl(
                       post.originalPost.authorId,
@@ -451,42 +432,39 @@ export const PostCard = memo(function PostCard({
                       name={post.originalPost.authorName}
                       type="actor"
                       size="sm"
+                      className="!h-5 !w-5"
                       src={post.originalPost.authorProfileImageUrl || undefined}
                     />
                   </Link>
-                  <div className="min-w-0 flex-1">
-                    <div className="flex items-center gap-2">
-                      <Link
-                        href={getProfileUrl(
-                          post.originalPost.authorId,
-                          post.originalPost.authorUsername
-                        )}
-                        className="truncate font-semibold text-foreground hover:underline"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        {post.originalPost.authorName}
-                      </Link>
-                      {isNpcIdentifier(post.originalPost.authorId) && (
-                        <VerifiedBadge size="sm" />
-                      )}
-                    </div>
+                  <div className="flex min-w-0 flex-1 items-center gap-1">
                     <Link
                       href={getProfileUrl(
                         post.originalPost.authorId,
                         post.originalPost.authorUsername
                       )}
-                      className="text-foreground/50 text-sm hover:underline"
+                      className="truncate font-semibold text-sm text-foreground hover:underline"
                       onClick={(e) => e.stopPropagation()}
                     >
-                      @
-                      {post.originalPost.authorUsername ||
-                        post.originalPost.authorId}
+                      {post.originalPost.authorName}
+                    </Link>
+                    {isNpcIdentifier(post.originalPost.authorId) && (
+                      <VerifiedBadge size="sm" />
+                    )}
+                    <Link
+                      href={getProfileUrl(
+                        post.originalPost.authorId,
+                        post.originalPost.authorUsername
+                      )}
+                      className="truncate text-foreground/50 text-sm hover:underline"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      @{post.originalPost.authorUsername || post.originalPost.authorId}
                     </Link>
                   </div>
                 </div>
 
                 {/* Original post content */}
-                <div className="whitespace-pre-wrap break-words text-foreground/90 leading-relaxed">
+                <div className="whitespace-pre-wrap break-words text-[15px] text-foreground/90 leading-normal">
                   <TaggedText
                     text={post.originalPost.content}
                     onTagClick={(tag) => {
@@ -514,7 +492,7 @@ export const PostCard = memo(function PostCard({
         </div>
       ) : (
         // Regular post - Show content as normal
-        <div className="post-content mb-4 w-full whitespace-pre-wrap break-words text-foreground leading-relaxed">
+        <div className="post-content mb-3 w-full whitespace-pre-wrap break-words text-[15px] text-foreground leading-normal">
           <TaggedText
             text={post.content || ''}
             onTagClick={(tag) => {
@@ -532,24 +510,27 @@ export const PostCard = memo(function PostCard({
         </div>
       )}
 
-      {/* Row 3: Interaction Bar - Full width */}
-      {showInteractions && (
-        <div onClick={(e) => e.stopPropagation()} className="w-full">
-          <InteractionBar
-            postId={post.id}
-            initialInteractions={initialInteractions}
-            onCommentClick={onCommentClick}
-            postData={post}
-          />
-        </div>
-      )}
+          {/* Interaction Bar */}
+          {showInteractions && (
+            <div onClick={(e) => e.stopPropagation()}>
+              <InteractionBar
+                postId={post.id}
+                initialInteractions={initialInteractions}
+                onCommentClick={onCommentClick}
+                postData={post}
+              />
+            </div>
+          )}
 
-      {/* Row 4: Comment Section - Shows previews (if any) + optional "Leave a comment" input */}
+        </div>
+      </div>
+
+      {/* Comment Section - Outside two-column layout so avatars align */}
       {showCommentPreviews && !isDetail && (
         <CommentPreview
           comments={post.commentPreviews ?? []}
           totalCommentCount={post.commentCount ?? 0}
-          onViewAllClick={onCommentClick}
+          onViewAllClick={onCommentClick ?? handleCardClick}
           showInputBar={showCommentInputBar}
         />
       )}

--- a/apps/web/src/components/posts/PostCard.tsx
+++ b/apps/web/src/components/posts/PostCard.tsx
@@ -289,9 +289,11 @@ export const PostCard = memo(function PostCard({
               />
             </Link>
             {/* Connecting line to comments */}
-            {showCommentPreviews && !isDetail && (post.commentPreviews?.length ?? 0) > 0 && (
-              <div className="mt-2 w-0.5 flex-1 bg-border" />
-            )}
+            {showCommentPreviews &&
+              !isDetail &&
+              (post.commentPreviews?.length ?? 0) > 0 && (
+                <div className="mt-2 w-0.5 flex-1 bg-border" />
+              )}
           </div>
         )}
 
@@ -304,14 +306,12 @@ export const PostCard = memo(function PostCard({
               <div className="flex min-w-0 flex-1 items-center gap-1.5">
                 <Link
                   href={getProfileUrl(displayAuthorId, displayAuthorUsername)}
-                  className="truncate font-semibold text-foreground text-[15px] hover:underline"
+                  className="truncate font-semibold text-[15px] text-foreground hover:underline"
                   onClick={(e) => e.stopPropagation()}
                 >
                   {displayAuthorName}
                 </Link>
-                {showVerifiedBadge && (
-                  <VerifiedBadge size="sm" />
-                )}
+                {showVerifiedBadge && <VerifiedBadge size="sm" />}
                 <Link
                   href={getProfileUrl(displayAuthorId, displayAuthorUsername)}
                   className="truncate text-[15px] text-muted-foreground hover:underline"
@@ -348,41 +348,157 @@ export const PostCard = memo(function PostCard({
 
           {/* Post Content */}
           {post.type === 'article' ? (
-        // Article card - Show title, summary, and "Read more" button
-        <div className="mb-3 w-full">
-          {/* Article title with Read More Button */}
-          <div className="mb-3 flex items-start justify-between gap-4">
-            <h2 className="flex-1 font-bold text-foreground text-lg leading-tight sm:text-xl">
-              {post.articleTitle || 'Untitled Article'}
-            </h2>
-            {!isDetail && (
-              <button
-                className="inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-lg bg-[#0066FF] px-3 py-2 font-semibold text-primary-foreground text-sm transition-colors hover:bg-[#2952d9]"
-                onClick={handleCardClick}
+            // Article card - Show title, summary, and "Read more" button
+            <div className="mb-3 w-full">
+              {/* Article title with Read More Button */}
+              <div className="mb-3 flex items-start justify-between gap-4">
+                <h2 className="flex-1 font-bold text-foreground text-lg leading-tight sm:text-xl">
+                  {post.articleTitle || 'Untitled Article'}
+                </h2>
+                {!isDetail && (
+                  <button
+                    className="inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-lg bg-[#0066FF] px-3 py-2 font-semibold text-primary-foreground text-sm transition-colors hover:bg-[#2952d9]"
+                    onClick={handleCardClick}
+                  >
+                    Read Full Article →
+                  </button>
+                )}
+              </div>
+
+              {/* Article metadata */}
+              <div className="mb-4 flex flex-wrap items-center gap-3 text-muted-foreground text-sm">
+                {post.byline && <span>{post.byline}</span>}
+              </div>
+
+              {/* Article summary */}
+              <div className="mb-3 whitespace-pre-wrap break-words text-[15px] text-foreground leading-normal">
+                {post.content}
+              </div>
+            </div>
+          ) : post.isRepost ? (
+            // Repost (with or without quote comment) - show embedded card
+            <div className="mb-4 w-full">
+              {/* Quote comment (if present) */}
+              {post.quoteComment && (
+                <div className="post-content mb-3 whitespace-pre-wrap break-words text-[15px] text-foreground leading-normal">
+                  <TaggedText
+                    text={post.quoteComment}
+                    onTagClick={(tag) => {
+                      if (tag.startsWith('@')) {
+                        // Handle @mentions - route to profile
+                        const username = tag.slice(1);
+                        router.push(getProfileUrl('', username));
+                      } else if (tag.startsWith('$')) {
+                        // Handle $cashtags - route to markets
+                        const symbol = tag.slice(1);
+                        router.push(
+                          `/markets?search=${encodeURIComponent(symbol)}`
+                        );
+                      }
+                    }}
+                  />
+                </div>
+              )}
+
+              {/* Embedded original post */}
+              <div
+                className={cn(
+                  'rounded-xl border border-border p-4',
+                  'overflow-hidden transition-colors',
+                  quotedPostId
+                    ? 'cursor-pointer hover:bg-muted/50'
+                    : 'cursor-default'
+                )}
+                role={quotedPostId ? 'link' : undefined}
+                tabIndex={quotedPostId ? 0 : undefined}
+                aria-label={quotedPostId ? 'View quoted post' : undefined}
+                onClick={handleQuotedPostClick}
+                onKeyDown={handleQuotedPostKeyDown}
               >
-                Read Full Article →
-              </button>
-            )}
-          </div>
+                {post.originalPost ? (
+                  <>
+                    {/* Original post author */}
+                    <div className="mb-2 flex items-center gap-2">
+                      <Link
+                        href={getProfileUrl(
+                          post.originalPost.authorId,
+                          post.originalPost.authorUsername
+                        )}
+                        className="shrink-0 transition-opacity hover:opacity-80"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <Avatar
+                          id={post.originalPost.authorId}
+                          name={post.originalPost.authorName}
+                          type="actor"
+                          size="sm"
+                          className="!h-5 !w-5"
+                          src={
+                            post.originalPost.authorProfileImageUrl || undefined
+                          }
+                        />
+                      </Link>
+                      <div className="flex min-w-0 flex-1 items-center gap-1">
+                        <Link
+                          href={getProfileUrl(
+                            post.originalPost.authorId,
+                            post.originalPost.authorUsername
+                          )}
+                          className="truncate font-semibold text-foreground text-sm hover:underline"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          {post.originalPost.authorName}
+                        </Link>
+                        {isNpcIdentifier(post.originalPost.authorId) && (
+                          <VerifiedBadge size="sm" />
+                        )}
+                        <Link
+                          href={getProfileUrl(
+                            post.originalPost.authorId,
+                            post.originalPost.authorUsername
+                          )}
+                          className="truncate text-foreground/50 text-sm hover:underline"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          @
+                          {post.originalPost.authorUsername ||
+                            post.originalPost.authorId}
+                        </Link>
+                      </div>
+                    </div>
 
-          {/* Article metadata */}
-          <div className="mb-4 flex flex-wrap items-center gap-3 text-muted-foreground text-sm">
-            {post.byline && <span>{post.byline}</span>}
-          </div>
-
-          {/* Article summary */}
-          <div className="mb-3 whitespace-pre-wrap break-words text-[15px] text-foreground leading-normal">
-            {post.content}
-          </div>
-        </div>
-      ) : post.isRepost ? (
-        // Repost (with or without quote comment) - show embedded card
-        <div className="mb-4 w-full">
-          {/* Quote comment (if present) */}
-          {post.quoteComment && (
-            <div className="post-content mb-3 whitespace-pre-wrap break-words text-[15px] text-foreground leading-normal">
+                    {/* Original post content */}
+                    <div className="whitespace-pre-wrap break-words text-[15px] text-foreground/90 leading-normal">
+                      <TaggedText
+                        text={post.originalPost.content}
+                        onTagClick={(tag) => {
+                          if (tag.startsWith('@')) {
+                            // Handle @mentions - route to profile
+                            const username = tag.slice(1);
+                            router.push(getProfileUrl('', username));
+                          } else if (tag.startsWith('$')) {
+                            // Handle $cashtags - route to markets
+                            const symbol = tag.slice(1);
+                            router.push(
+                              `/markets?search=${encodeURIComponent(symbol)}`
+                            );
+                          }
+                        }}
+                      />
+                    </div>
+                  </>
+                ) : (
+                  <div className="py-4 text-center text-foreground/50 italic">
+                    This post has been deleted
+                  </div>
+                )}
+              </div>
+            </div>
+          ) : (
+            // Regular post - Show content as normal
+            <div className="post-content mb-3 w-full whitespace-pre-wrap break-words text-[15px] text-foreground leading-normal">
               <TaggedText
-                text={post.quoteComment}
+                text={post.content || ''}
                 onTagClick={(tag) => {
                   if (tag.startsWith('@')) {
                     // Handle @mentions - route to profile
@@ -400,116 +516,6 @@ export const PostCard = memo(function PostCard({
             </div>
           )}
 
-          {/* Embedded original post */}
-          <div
-            className={cn(
-              'rounded-xl border border-border p-4',
-              'overflow-hidden transition-colors',
-              quotedPostId
-                ? 'cursor-pointer hover:bg-muted/50'
-                : 'cursor-default'
-            )}
-            role={quotedPostId ? 'link' : undefined}
-            tabIndex={quotedPostId ? 0 : undefined}
-            aria-label={quotedPostId ? 'View quoted post' : undefined}
-            onClick={handleQuotedPostClick}
-            onKeyDown={handleQuotedPostKeyDown}
-          >
-            {post.originalPost ? (
-              <>
-                {/* Original post author */}
-                <div className="mb-2 flex items-center gap-2">
-                  <Link
-                    href={getProfileUrl(
-                      post.originalPost.authorId,
-                      post.originalPost.authorUsername
-                    )}
-                    className="shrink-0 transition-opacity hover:opacity-80"
-                    onClick={(e) => e.stopPropagation()}
-                  >
-                    <Avatar
-                      id={post.originalPost.authorId}
-                      name={post.originalPost.authorName}
-                      type="actor"
-                      size="sm"
-                      className="!h-5 !w-5"
-                      src={post.originalPost.authorProfileImageUrl || undefined}
-                    />
-                  </Link>
-                  <div className="flex min-w-0 flex-1 items-center gap-1">
-                    <Link
-                      href={getProfileUrl(
-                        post.originalPost.authorId,
-                        post.originalPost.authorUsername
-                      )}
-                      className="truncate font-semibold text-sm text-foreground hover:underline"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      {post.originalPost.authorName}
-                    </Link>
-                    {isNpcIdentifier(post.originalPost.authorId) && (
-                      <VerifiedBadge size="sm" />
-                    )}
-                    <Link
-                      href={getProfileUrl(
-                        post.originalPost.authorId,
-                        post.originalPost.authorUsername
-                      )}
-                      className="truncate text-foreground/50 text-sm hover:underline"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      @{post.originalPost.authorUsername || post.originalPost.authorId}
-                    </Link>
-                  </div>
-                </div>
-
-                {/* Original post content */}
-                <div className="whitespace-pre-wrap break-words text-[15px] text-foreground/90 leading-normal">
-                  <TaggedText
-                    text={post.originalPost.content}
-                    onTagClick={(tag) => {
-                      if (tag.startsWith('@')) {
-                        // Handle @mentions - route to profile
-                        const username = tag.slice(1);
-                        router.push(getProfileUrl('', username));
-                      } else if (tag.startsWith('$')) {
-                        // Handle $cashtags - route to markets
-                        const symbol = tag.slice(1);
-                        router.push(
-                          `/markets?search=${encodeURIComponent(symbol)}`
-                        );
-                      }
-                    }}
-                  />
-                </div>
-              </>
-            ) : (
-              <div className="py-4 text-center text-foreground/50 italic">
-                This post has been deleted
-              </div>
-            )}
-          </div>
-        </div>
-      ) : (
-        // Regular post - Show content as normal
-        <div className="post-content mb-3 w-full whitespace-pre-wrap break-words text-[15px] text-foreground leading-normal">
-          <TaggedText
-            text={post.content || ''}
-            onTagClick={(tag) => {
-              if (tag.startsWith('@')) {
-                // Handle @mentions - route to profile
-                const username = tag.slice(1);
-                router.push(getProfileUrl('', username));
-              } else if (tag.startsWith('$')) {
-                // Handle $cashtags - route to markets
-                const symbol = tag.slice(1);
-                router.push(`/markets?search=${encodeURIComponent(symbol)}`);
-              }
-            }}
-          />
-        </div>
-      )}
-
           {/* Interaction Bar */}
           {showInteractions && (
             <div onClick={(e) => e.stopPropagation()}>
@@ -521,7 +527,6 @@ export const PostCard = memo(function PostCard({
               />
             </div>
           )}
-
         </div>
       </div>
 

--- a/apps/web/src/components/shared/EmptyState.tsx
+++ b/apps/web/src/components/shared/EmptyState.tsx
@@ -58,9 +58,7 @@ export function EmptyState({
       )}
     >
       {Icon && (
-        <div className="mb-4 rounded-full bg-muted/50 p-4">
-          <Icon size={48} className="text-muted-foreground/70" />
-        </div>
+        <Icon className="mb-4 h-12 w-12 text-muted-foreground opacity-50" />
       )}
       <h3 className="mb-2 font-semibold text-lg">{title}</h3>
       <p className="mb-6 max-w-sm text-muted-foreground text-sm">

--- a/apps/web/src/components/shared/PageContainer.tsx
+++ b/apps/web/src/components/shared/PageContainer.tsx
@@ -31,7 +31,7 @@ export const PageContainer = forwardRef<HTMLDivElement, PageContainerProps>(
         ref={ref}
         className={cn(
           // Sharp corners, simple boxy layout
-          'overflow-hidden bg-background',
+          'overflow-x-hidden bg-background',
           'h-full min-h-full w-full',
           // Desktop: Simple container - use full height
           'md:h-full',

--- a/apps/web/src/components/shared/Sidebar.tsx
+++ b/apps/web/src/components/shared/Sidebar.tsx
@@ -6,7 +6,6 @@ import {
   Check,
   Copy,
   Gift,
-  Home,
   LogOut,
   MessageCircle,
   Shield,
@@ -15,6 +14,7 @@ import {
   User,
   Users,
 } from 'lucide-react';
+import { HouseIcon } from '@/components/shared/icons/HouseIcon';
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
@@ -127,7 +127,7 @@ function SidebarContent() {
     {
       name: 'Home',
       href: '/feed',
-      icon: Home,
+      icon: HouseIcon,
       color: '#0066FF',
       active: pathname === '/feed' || pathname === '/',
     },
@@ -170,7 +170,7 @@ function SidebarContent() {
       name: 'Rewards',
       href: '/rewards',
       icon: Gift,
-      color: '#a855f7',
+      color: '#0066FF',
       active: pathname === '/rewards',
     },
     {
@@ -209,7 +209,7 @@ function SidebarContent() {
         <div className="flex items-center justify-center p-6 lg:justify-start">
           <Link
             href="/feed"
-            className="transition-transform duration-300 hover:scale-105"
+            className=""
           >
             {/* Icon-only logo for md (tablet) */}
             <Image
@@ -247,45 +247,18 @@ function SidebarContent() {
                   'group pointer-events-auto relative z-10 flex items-center px-4 py-3',
                   'transition-colors duration-200',
                   'md:justify-center lg:justify-start',
-                  !item.active && 'bg-transparent hover:bg-sidebar-accent'
+                  'bg-transparent hover:bg-sidebar-accent'
                 )}
                 title={item.name}
-                style={{
-                  backgroundColor: item.active ? item.color : undefined,
-                }}
-                onMouseEnter={(e) => {
-                  if (!item.active) {
-                    e.currentTarget.style.backgroundColor = item.color;
-                  }
-                }}
-                onMouseLeave={(e) => {
-                  if (!item.active) {
-                    e.currentTarget.style.backgroundColor = '';
-                  }
-                }}
               >
                 {/* Icon with notification indicator */}
                 <div className="relative lg:mr-3">
                   <Icon
                     className={cn(
                       'h-6 w-6 flex-shrink-0',
-                      'transition-all duration-300',
-                      'group-hover:scale-110',
-                      !item.active && 'text-sidebar-foreground'
+                      item.active ? 'text-sidebar-primary' : 'text-sidebar-foreground'
                     )}
-                    style={{
-                      color: item.active ? '#e4e4e4' : undefined,
-                    }}
-                    onMouseEnter={(e) => {
-                      if (!item.active) {
-                        e.currentTarget.style.color = '#e4e4e4';
-                      }
-                    }}
-                    onMouseLeave={(e) => {
-                      if (!item.active) {
-                        e.currentTarget.style.color = '';
-                      }
-                    }}
+                    fill={item.active ? 'currentColor' : 'none'}
                   />
                   {hasNotificationBadge && (
                     <span className="-top-1 -right-1 absolute h-2 w-2 rounded-full bg-blue-500 ring-2 ring-sidebar" />
@@ -297,21 +270,10 @@ function SidebarContent() {
                   className={cn(
                     'hidden lg:block',
                     'text-lg transition-colors duration-300',
-                    item.active ? 'font-semibold' : 'text-sidebar-foreground'
+                    item.active
+                      ? 'font-semibold text-black dark:text-white'
+                      : 'text-sidebar-foreground group-hover:text-black dark:group-hover:text-white'
                   )}
-                  style={{
-                    color: item.active ? '#e4e4e4' : undefined,
-                  }}
-                  onMouseEnter={(e) => {
-                    if (!item.active) {
-                      e.currentTarget.style.color = '#e4e4e4';
-                    }
-                  }}
-                  onMouseLeave={(e) => {
-                    if (!item.active) {
-                      e.currentTarget.style.color = '';
-                    }
-                  }}
                 >
                   {item.name}
                 </span>

--- a/apps/web/src/components/shared/Sidebar.tsx
+++ b/apps/web/src/components/shared/Sidebar.tsx
@@ -14,7 +14,6 @@ import {
   User,
   Users,
 } from 'lucide-react';
-import { HouseIcon } from '@/components/shared/icons/HouseIcon';
 import Image from 'next/image';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
@@ -22,6 +21,7 @@ import { useEffect, useRef, useState } from 'react';
 import { LoginButton } from '@/components/auth/LoginButton';
 import { UserMenu } from '@/components/auth/UserMenu';
 import { Avatar } from '@/components/shared/Avatar';
+import { HouseIcon } from '@/components/shared/icons/HouseIcon';
 import { Separator } from '@/components/shared/Separator';
 import { useAuth } from '@/hooks/useAuth';
 import { useUnreadMessages } from '@/hooks/useUnreadMessages';
@@ -42,7 +42,7 @@ function SidebarContent() {
   const [unreadNotifications, setUnreadNotifications] = useState(0);
   const mdMenuRef = useRef<HTMLDivElement>(null);
   const pathname = usePathname();
-  const { ready, authenticated, user, logout } = useAuth();
+  const { ready, authenticated, user, logout, login } = useAuth();
   const { totalUnread: unreadMessages } = useUnreadMessages();
 
   // Hide sidebar when WAITLIST_MODE is enabled on home page
@@ -137,6 +137,7 @@ function SidebarContent() {
       icon: Bell,
       color: '#0066FF',
       active: pathname === '/notifications',
+      requiresAuth: true,
     },
     {
       name: 'Leaderboard',
@@ -158,6 +159,7 @@ function SidebarContent() {
       icon: MessageCircle,
       color: '#0066FF',
       active: pathname === '/chats',
+      requiresAuth: true,
     },
     {
       name: 'Agents',
@@ -165,6 +167,7 @@ function SidebarContent() {
       icon: Users,
       color: '#0066FF',
       active: pathname === '/agents/team',
+      requiresAuth: true,
     },
     {
       name: 'Rewards',
@@ -172,6 +175,7 @@ function SidebarContent() {
       icon: Gift,
       color: '#0066FF',
       active: pathname === '/rewards',
+      requiresAuth: true,
     },
     {
       name: 'Profile',
@@ -179,6 +183,7 @@ function SidebarContent() {
       icon: User,
       color: '#0066FF',
       active: pathname === '/profile',
+      requiresAuth: true,
     },
     // Admin link (only shown for admins)
     ...(isAdmin
@@ -207,10 +212,7 @@ function SidebarContent() {
       >
         {/* Header - Logo */}
         <div className="flex items-center justify-center p-6 lg:justify-start">
-          <Link
-            href="/feed"
-            className=""
-          >
+          <Link href="/feed" className="">
             {/* Icon-only logo for md (tablet) */}
             <Image
               src="/assets/logos/logo.svg"
@@ -238,25 +240,17 @@ function SidebarContent() {
             const hasNotificationBadge =
               (item.name === 'Notifications' && unreadNotifications > 0) ||
               (item.name === 'Chats' && unreadMessages > 0);
-            return (
-              <Link
-                key={item.name}
-                href={item.href}
-                prefetch={true}
-                className={cn(
-                  'group pointer-events-auto relative z-10 flex items-center px-4 py-3',
-                  'transition-colors duration-200',
-                  'md:justify-center lg:justify-start',
-                  'bg-transparent hover:bg-sidebar-accent'
-                )}
-                title={item.name}
-              >
+
+            const navContent = (
+              <>
                 {/* Icon with notification indicator */}
                 <div className="relative lg:mr-3">
                   <Icon
                     className={cn(
                       'h-6 w-6 flex-shrink-0',
-                      item.active ? 'text-sidebar-primary' : 'text-sidebar-foreground'
+                      item.active
+                        ? 'text-sidebar-primary'
+                        : 'text-sidebar-foreground'
                     )}
                     fill={item.active ? 'currentColor' : 'none'}
                   />
@@ -277,6 +271,39 @@ function SidebarContent() {
                 >
                   {item.name}
                 </span>
+              </>
+            );
+
+            const sharedClassName = cn(
+              'group pointer-events-auto relative z-10 flex items-center px-4 py-3',
+              'transition-colors duration-200',
+              'md:justify-center lg:justify-start',
+              'bg-transparent hover:bg-sidebar-accent'
+            );
+
+            if (item.requiresAuth && !authenticated) {
+              return (
+                <button
+                  key={item.name}
+                  type="button"
+                  onClick={login}
+                  className={cn(sharedClassName, 'w-full')}
+                  title={item.name}
+                >
+                  {navContent}
+                </button>
+              );
+            }
+
+            return (
+              <Link
+                key={item.name}
+                href={item.href}
+                prefetch={true}
+                className={sharedClassName}
+                title={item.name}
+              >
+                {navContent}
               </Link>
             );
           })}

--- a/apps/web/src/components/shared/WidgetSidebar.tsx
+++ b/apps/web/src/components/shared/WidgetSidebar.tsx
@@ -6,6 +6,12 @@ import { LatestNewsPanel } from '@/components/feed/LatestNewsPanel';
 import { MarketsPanel } from '@/components/feed/MarketsPanel';
 import { TrendingPanel } from '@/components/feed/TrendingPanel';
 
+interface WidgetSidebarProps {
+  showLatestNews?: boolean;
+  showTrending?: boolean;
+  showMarkets?: boolean;
+}
+
 /**
  * Widget sidebar component for desktop layouts.
  *
@@ -16,14 +22,18 @@ import { TrendingPanel } from '@/components/feed/TrendingPanel';
  *
  * Features:
  * - Entity search autocomplete
- * - Latest news panel
- * - Trending panel
- * - Markets panel
+ * - Latest news panel (optional)
+ * - Trending panel (optional)
+ * - Markets panel (optional)
  * - Smart sticky scrolling on XL+ screens
  *
  * @returns Widget sidebar element (hidden on screens < XL)
  */
-export function WidgetSidebar() {
+export function WidgetSidebar({
+  showLatestNews = true,
+  showTrending = true,
+  showMarkets = true,
+}: WidgetSidebarProps = {}) {
   const [searchQuery, setSearchQuery] = useState('');
   const containerRef = useRef<HTMLDivElement>(null);
   const innerRef = useRef<HTMLDivElement>(null);
@@ -129,7 +139,7 @@ export function WidgetSidebar() {
 
   return (
     <div ref={containerRef} className="hidden w-96 flex-none flex-col xl:flex">
-      <div ref={innerRef} className="flex w-96 flex-col gap-6 px-4 py-6">
+      <div ref={innerRef} className="flex w-96 flex-col gap-8 px-4 py-6">
         <div className="flex-shrink-0">
           <EntitySearchAutocomplete
             value={searchQuery}
@@ -139,17 +149,23 @@ export function WidgetSidebar() {
           />
         </div>
 
-        <div className="flex-shrink-0">
-          <LatestNewsPanel />
-        </div>
+        {showLatestNews && (
+          <div className="flex-shrink-0">
+            <LatestNewsPanel />
+          </div>
+        )}
 
-        <div className="flex-shrink-0">
-          <TrendingPanel />
-        </div>
+        {showTrending && (
+          <div className="flex-shrink-0">
+            <TrendingPanel />
+          </div>
+        )}
 
-        <div className="flex-shrink-0">
-          <MarketsPanel />
-        </div>
+        {showMarkets && (
+          <div className="flex-shrink-0">
+            <MarketsPanel />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/components/shared/icons/HouseIcon.tsx
+++ b/apps/web/src/components/shared/icons/HouseIcon.tsx
@@ -1,0 +1,49 @@
+import type { SVGProps } from 'react';
+
+/**
+ * Custom House icon with door cutout.
+ * Uses fill when active (fill="currentColor"), stroke when inactive (fill="none").
+ */
+export function HouseIcon({
+  className,
+  fill = 'none',
+  ...props
+}: SVGProps<SVGSVGElement>) {
+  const isFilled = fill !== 'none';
+
+  if (isFilled) {
+    return (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        stroke="currentColor"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className={className}
+        aria-hidden="true"
+        {...props}
+      >
+        <path d="M21.591 7.146L12.52 1.157c-.316-.21-.724-.21-1.04 0l-9.071 5.99c-.26.173-.409.456-.409.757v13.183c0 .502.418.913.929.913H9.14c.51 0 .929-.41.929-.913v-7.075h3.909v7.075c0 .502.417.913.928.913h6.165c.511 0 .929-.41.929-.913V7.904c0-.301-.158-.584-.408-.758z" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M21.591 7.146L12.52 1.157c-.316-.21-.724-.21-1.04 0l-9.071 5.99c-.26.173-.409.456-.409.757v13.183c0 .502.418.913.929.913H9.14c.51 0 .929-.41.929-.913v-7.075h3.909v7.075c0 .502.417.913.928.913h6.165c.511 0 .929-.41.929-.913V7.904c0-.301-.158-.584-.408-.758z" />
+    </svg>
+  );
+}

--- a/apps/web/src/components/trades/TradeCard.tsx
+++ b/apps/web/src/components/trades/TradeCard.tsx
@@ -210,7 +210,7 @@ export function TradeCard({ trade }: TradeCardProps) {
   };
 
   return (
-    <div className="border-border border-b bg-card p-4 transition-colors hover:bg-muted/30">
+    <div className="border-border border-b p-4 transition-colors hover:bg-muted/30">
       <div className="flex items-start gap-3">
         {/* Avatar */}
         <div
@@ -227,19 +227,21 @@ export function TradeCard({ trade }: TradeCardProps) {
         {/* Trade Content */}
         <div className="min-w-0 flex-1">
           {/* User Info */}
-          <div className="mb-1 flex items-center gap-2">
-            <span
-              className="cursor-pointer truncate font-medium hover:underline"
-              onClick={handleProfileClick}
-            >
-              {displayName}
-            </span>
-            {trade.user.isActor && (
-              <span className="rounded bg-purple-500/20 px-2 py-0.5 text-purple-500 text-xs">
-                NPC
+          <div className="mb-1 flex items-center justify-between gap-2">
+            <div className="flex min-w-0 items-center gap-2">
+              <span
+                className="cursor-pointer truncate font-medium hover:underline"
+                onClick={handleProfileClick}
+              >
+                {displayName}
               </span>
-            )}
-            <span className="text-muted-foreground text-xs">
+              {trade.user.isActor && (
+                <span className="rounded bg-purple-500/20 px-2 py-0.5 text-purple-500 text-xs">
+                  NPC
+                </span>
+              )}
+            </div>
+            <span className="shrink-0 text-muted-foreground text-xs">
               {formatTime(trade.timestamp)}
             </span>
           </div>

--- a/apps/web/src/components/trades/TradesFeed.tsx
+++ b/apps/web/src/components/trades/TradesFeed.tsx
@@ -239,8 +239,8 @@ export function TradesFeed({ userId, containerRef }: TradesFeedProps) {
 
   if (trades.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-16 text-center">
-        <Activity className="mb-4 h-16 w-16 text-muted-foreground opacity-50" />
+      <div className="flex flex-col items-center justify-center py-12 text-center">
+        <Activity className="mb-4 h-12 w-12 text-muted-foreground opacity-50" />
         <h3 className="mb-2 font-semibold text-foreground text-lg">
           No trades yet
         </h3>

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -1,8 +1,12 @@
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import dotenv from 'dotenv';
 import { defineConfig } from 'drizzle-kit';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Load root .env file
+dotenv.config({ path: path.resolve(__dirname, '../../.env') });
 
 // Determine if we're in local development mode
 const isLocalDev =


### PR DESCRIPTION
## Summary

Redesign and unify the web app's UI patterns across feed, comments, articles, leaderboard, and auth-gated pages. Standardizes how unauthenticated users interact with protected features, makes card layouts consistent (two-column avatar|content), and fixes sidebar layout shift on hydration.

---

### Auth Gating

**Protected page redirects** — unauthenticated users on these pages are now redirected to `/feed` with Privy login modal:
- `agents/[agentId]/page.tsx` — removed `AgentDetailSkeleton`, returns `null` while redirecting
- `agents/create/page.tsx` — removed `<Bot>` icon + sign-in prompt UI
- `agents/page.tsx` — removed `<LoginButton>` placeholder
- `agents/team/page.tsx` — removed `<Users>` icon + sign-in prompt
- `chats/page.tsx` — removed `<MessageCircle>` icon + sign-in prompt
- `notifications/page.tsx` — removed full sign-in section and "Go to Feed" link
- `rewards/page.tsx` — added auth redirect pattern
- `profile/page.tsx` — added auth redirect pattern

All use the same pattern:
```tsx
useEffect(() => {
  if (!ready || authenticated) return;
  router.push('/feed');
  const timer = setTimeout(() => login(), 500);
  return () => clearTimeout(timer);
}, [ready, authenticated, router, login]);
if (ready && !authenticated) return null;
```

**Sidebar nav gating** (`Sidebar.tsx`):
- Added `requiresAuth: true` to Notifications, Chats, Agents, Rewards, Profile nav items
- Unauthenticated clicks render `<button onClick={login}>` instead of `<Link>`
- Extracted shared `navContent` and `sharedClassName` to avoid duplication between `<Link>` and `<button>` variants

**Interactive action gating**:
- `LikeButton.tsx` — calls `login()` if not authenticated (was using `showLoginModal`)
- `RepostButton.tsx` — calls `login()` if not authenticated
- `InteractionBar.tsx` — comment button calls `login()` if not authenticated
- `CommentInput.tsx` — added `onCommentPosted` callback prop
- `CommentCard.tsx` — reply button calls `login()` if not authenticated; added repost button (`Repeat2` icon)

---

### Sidebar & Navigation (`components/shared/Sidebar.tsx`)

- Replaced Lucide `Home` icon with custom `HouseIcon` (new file: `icons/HouseIcon.tsx`) — renders filled when active, stroked when inactive
- Removed all inline `onMouseEnter`/`onMouseLeave` JS hover handlers on icons and text — replaced with Tailwind `hover:bg-sidebar-accent` and `group-hover:text-black dark:group-hover:text-white`
- Active state: `style={{ color: '#e4e4e4' }}` → `text-sidebar-primary` + `fill="currentColor"`
- Rewards color: `#a855f7` → `#0066FF` (consistent with other items)
- Logo: removed `transition-transform duration-300 hover:scale-105` animation

---

### Global CSS (`globals.css`)

| Variable | Before | After |
|----------|--------|-------|
| `--sidebar` (light) | `#fafafa` | `#ffffff` |
| `--sidebar-accent` (light) | `#e3ecf6` | `#eeeeee` |
| `--sidebar` (dark) | `#0a0a0a` | `#000000` |
| `--sidebar-accent` (dark) | `#1a1a1a` | `#2a2a2a` |
| `body` | `overflow-y: auto` | _(removed)_ |
| `html` | — | `overflow-y: scroll; scrollbar-gutter: stable` |

The `scrollbar-gutter: stable` prevents layout shift when scrollbar appears/disappears.

---

### PostCard Layout (`components/posts/PostCard.tsx`)

Restructured from stacked rows to **two-column layout** (avatar column | content column):

- **Before**: Row 1 (avatar + header) → Row 2 (content) → Row 3 (interactions) → Row 4 (comment previews)
- **After**: `<div className="flex gap-3">` wrapping avatar column and content column; interactions inside content column; comment previews outside both columns for avatar alignment

Specific changes:
- Removed `isDesktop`/`isMobile` state + `window.resize` listener — all responsive via Tailwind
- Avatar `scaleFactor`: `fontSize * (isDesktop ? 1.4 : isMobile ? 0.8 : 1)` → just `fontSize`
- Header: author name + `@handle` + timestamp now inline in one row (was name/handle stacked, timestamp right-aligned separately)
- Font sizes: `text-lg sm:text-xl` → `text-[15px]` for author name; `leading-relaxed` → `leading-normal` for content
- New prop: `showCommentInputBar` (default `true`) — feed list passes `false`
- **Connecting line**: when comment previews exist, vertical line extends below avatar
- Border: `border-border/5` → `border-border` (visible separator)
- Padding: `py-3` → `py-4`
- Repost indicator: added `pl-12` to align with content column
- Quoted post embed: `border-white/10 bg-white/5` → `border-border` (works in light mode)

---

### CommentCard Layout (`components/interactions/CommentCard.tsx`)

Same two-column restructure as PostCard:
- Avatar column with vertical connecting lines (`w-0.5 bg-border`) between parent/child comments
- Content column with inline name/handle/timestamp header
- Removed `bg-muted/20 rounded-xl` card styling → flat with border separators
- Added repost button (`Repeat2` icon) to comment action row
- Reply now auth-gated (calls `login()`)
- Replaced `formatDistanceToNow(date-fns)` with shared `formatTimeAgo`
- Nested reply layout also uses two-column with connecting lines

---

### CommentPreview (`components/posts/CommentPreview.tsx`)

- Added `showInputBar` prop (default `true`) — controls whether "Leave a comment..." bar appears
- No longer returns `null` for empty comments array — shows input bar when `showInputBar=true` even with no comments
- Each comment item: avatar `sm` → `md`, two-column layout matching PostCard
- Added interaction bar (like, reply) below each preview comment
- Entire comment row clickable → navigates to `/comment/{id}`
- Added separator line between comments section and input bar
- `formatTimeAgo` now exported for reuse

---

### ArticleCard (`components/articles/ArticleCard.tsx`)

Restructured to match PostCard's two-column avatar|content layout:
- **Before**: avatar row → mobile image → desktop thumbnail + text side-by-side → "Read Full Article →" button
- **After**: avatar left column, content right column with inline name/handle/category/timestamp row → full-width cover image → title → summary → "Read Full Article →" text link at bottom
- Removed separate mobile/desktop image rendering — single `aspect-video w-full`
- Removed large JSDoc comment block
- Border: `border-border/5` → `border-border`

---

### MoreArticlesWidget (`components/articles/MoreArticlesWidget.tsx`)

- Removed thumbnail images and `Newspaper` icon
- Simplified to text-only list (title + author · time) matching `LatestNewsPanel` style
- Loading skeleton simplified to 3 flat bars

---

### Feed Sidebar Panels

| File | Changes |
|------|---------|
| `LatestNewsPanel.tsx` | Removed `rounded-2xl bg-sidebar p-4` container (now flat). Removed `getSentimentIcon()` function (no more sentiment icons). Removed `pl-3` left indent. Item hover: `-mx-2 px-2 py-1.5`. |
| `TrendingPanel.tsx` | Same container cleanup. Category + tags merged into single line. |
| `MarketsPanel.tsx` | Same container cleanup. Price formatting: `toFixed(2)` → `toLocaleString('en-US', {min/maxFractionDigits: 2})`. Volume formatting improved. Removed 24h change percentage from prediction items. |
| `FeedCommentSection.tsx` | Removed `px-4 py-3` padding from comment list container. Removed `space-y-4` gap between comments. |

---

### WidgetSidebar (`components/shared/WidgetSidebar.tsx`)

- Added `WidgetSidebarProps` interface: `showLatestNews?`, `showTrending?`, `showMarkets?` (all default `true`)
- Panels conditionally rendered based on props
- Gap between panels: `gap-6` → `gap-8`

---

### Sidebar Layout Shift Fix

Added loading placeholder `<div className="hidden w-96 flex-none xl:block" />` to dynamically imported `WidgetSidebar` in 6 pages to prevent content from expanding then snapping on hydration:
- `FeedClient.tsx`
- `post/[id]/page.tsx`
- `comment/[id]/page.tsx`
- `trending/[tag]/page.tsx`
- `trending/group/page.tsx`
- `leaderboard/page.tsx`

---

### Detail Pages Layout

All detail pages now use three-column layout (sidebar | content | widget-sidebar):

| Page | Changes |
|------|---------|
| `post/[id]/page.tsx` | Added `WidgetSidebar` with `showLatestNews={false} showMarkets={false}`. Loading/error states now use full layout. |
| `comment/[id]/page.tsx` | Added `WidgetSidebar`. Original post avatar size updated. Connector line repositioned. Added `ModerationMenu`. Replaced `formatDistanceToNow` with `formatTimeAgo`. Added `Repeat2` repost. Auth-gated reply. |
| `article/[id]/page.tsx` | Added three-column layout. Loading skeleton matches layout. `MessageCircle` → `Newspaper` icon. |
| `trending/[tag]/page.tsx` | Added `WidgetSidebar` + `TrendingUp` icon. Restructured to shared `feedContent` variable. |
| `trending/group/page.tsx` | Same restructure with sidebar. |

---

### Feed Page

| File | Changes |
|------|---------|
| `FeedClient.tsx` | Removed `!overflow-visible` from PageContainer. Border opacity updated. Removed wrapper div around `FeedToggle`. |
| `EmptyFeed.tsx` | All 4 variants replaced with `<EmptyState>` component. Emoji icons → Lucide icons (`FileText`, `Flame`, `Users`, `Clock`). |

---

### Leaderboard Page

- Removed "N Players" header with `Users`/`TrendingUp` icons
- Removed `RankBadge` medal from right side of top 10 entries (desktop)
- Name/badge gap: `gap-3` → `gap-1.5`
- Border opacity updated
- `LeaderboardToggle` moved outside wrapper div

---

### Other Changes

- `PageContainer.tsx` — `overflow-hidden` → `overflow-x-hidden`
- `EmptyState.tsx` — Icon simplified: removed rounded bg wrapper
- `TradeCard.tsx` — Removed `bg-card`. Timestamp repositioned.
- `TradesFeed.tsx` — Icon and padding size adjustments
- Profile pages — auth redirect pattern, skeleton simplification
- Agents team chat — enhanced empty state

### New Files

| File | Description |
|------|-------------|
| `components/shared/icons/HouseIcon.tsx` | Custom SVG house icon — filled when active, stroked when inactive |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added comment sharing/reposting capability with dedicated UI controls
  * Enhanced thread page with edit and delete actions for own comments
  * Improved widget sidebar with toggleable content panels

* **Improvements**
  * Streamlined authentication flow with automatic redirects for unauthenticated users
  * Enhanced empty state messaging across feeds and panels with better icons and descriptions
  * Redesigned multi-column layouts for improved content organization
  * Refined post and comment interactions with updated visual indicators
  * Improved responsive design across desktop and mobile views

* **UI/Style Updates**
  * Updated spacing and typography for better visual hierarchy
  * Adjusted border colors and opacity for improved contrast
  * Refined icon usage and sizing throughout the interface

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR implements a comprehensive UI consistency overhaul that standardizes auth gating patterns, unifies card layouts to a two-column avatar|content structure, and improves sidebar styling with better hover states and layout shift prevention.

## Key Changes

- **Auth Gating**: Standardized authentication flow across 8+ protected pages (`/agents`, `/chats`, `/notifications`, `/rewards`, `/profile`) with redirect-to-feed + Privy modal pattern; replaced custom login UI with consistent `useEffect` hook pattern; auth-gated all interactive buttons (like, comment, repost) to call `login()` directly instead of `showLoginModal`

- **UI Consistency**: Restructured `PostCard`, `CommentCard`, and `ArticleCard` to unified two-column layout (avatar column | content column); removed responsive JavaScript logic in favor of Tailwind; standardized borders from `border-border/5` to `border-border` for better visibility; added connecting lines between threaded comments

- **Sidebar Improvements**: Replaced Lucide Home icon with custom `HouseIcon` (filled when active); removed all JavaScript hover handlers, replaced with pure CSS (`hover:bg-sidebar-accent`, `group-hover`); added `requiresAuth` flag to nav items that triggers `login()` instead of navigation; updated color scheme for better contrast

- **Layout Shift Fix**: Added `scrollbar-gutter: stable` to `html` element to reserve scrollbar space; added loading placeholders for dynamically imported `WidgetSidebar` on 6 pages to prevent content expansion during hydration

- **Configuration**: Added `dotenv.config()` to `drizzle.config.ts` to load root `.env` file; created `TODO.md` documenting incomplete comment reposting and delete features

## Issues Found

Two pages have React Hook dependency array issues where `ready` is checked but not included in dependencies (`agents/page.tsx:116`, `notifications/page.tsx:52`). All other auth redirect implementations have correct dependency arrays.

<h3>Confidence Score: 4.5/5</h3>

- Safe to merge after fixing two React Hook dependency array issues
- The PR implements well-structured UI consistency improvements with a clear, unified pattern for auth gating. The two dependency array issues are minor and easy to fix. All other changes follow best practices, improve code maintainability by removing JavaScript in favor of CSS, and enhance UX with better layout stability.
- apps/web/src/app/agents/page.tsx and apps/web/src/app/notifications/page.tsx need dependency array fixes

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/agents/page.tsx | added auth redirect pattern with minor dependency array issue |
| apps/web/src/app/notifications/page.tsx | replaced sign-in UI with auth redirect, has dependency array issue |
| apps/web/src/components/shared/Sidebar.tsx | added auth gating to nav items, replaced hover JS with Tailwind, new HouseIcon |
| apps/web/src/app/globals.css | updated sidebar colors, added scrollbar-gutter stable to prevent layout shift |
| apps/web/src/components/interactions/LikeButton.tsx | replaced showLoginModal with direct login() call for auth gating |
| apps/web/src/components/posts/PostCard.tsx | restructured to two-column layout, removed responsive JS logic, unified styling |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Browser
    participant Sidebar
    participant ProtectedPage
    participant AuthHook
    participant PrivyAuth
    participant LikeButton
    participant CommentButton
    participant RepostButton

    Note over User,RepostButton: Auth Gating Flow

    User->>Browser: Navigate to protected page
    Browser->>ProtectedPage: Load page
    ProtectedPage->>AuthHook: Check auth status
    
    alt Not Authenticated
        AuthHook-->>ProtectedPage: ready equals true, authenticated equals false
        ProtectedPage->>Browser: Redirect to feed page
        ProtectedPage->>PrivyAuth: Trigger auth modal (delayed 500ms)
        ProtectedPage-->>Browser: return null (hide page)
        Browser->>User: Show feed page with auth modal
    else Authenticated
        AuthHook-->>ProtectedPage: ready equals true, authenticated equals true
        ProtectedPage->>Browser: Render page content
        Browser->>User: Show protected page
    end

    Note over User,RepostButton: Sidebar Navigation Gating

    User->>Sidebar: Click protected nav item (not authenticated)
    Sidebar->>AuthHook: Check authenticated
    
    alt Not Authenticated
        Sidebar->>PrivyAuth: Trigger auth modal
        PrivyAuth->>User: Show auth modal
    else Authenticated
        Sidebar->>Browser: Navigate to protected route
    end

    Note over User,RepostButton: Interactive Action Gating

    User->>LikeButton: Click like button
    LikeButton->>AuthHook: Check authenticated
    
    alt Not Authenticated
        LikeButton->>PrivyAuth: Trigger auth modal
        PrivyAuth->>User: Show auth modal
    else Authenticated
        LikeButton->>Browser: Toggle like (optimistic update)
        LikeButton->>Browser: API call to update like status
    end

    User->>CommentButton: Click comment button
    CommentButton->>AuthHook: Check authenticated
    
    alt Not Authenticated
        CommentButton->>PrivyAuth: Trigger auth modal
        PrivyAuth->>User: Show auth modal
    else Authenticated
        CommentButton->>Browser: Open comment input
    end

    User->>RepostButton: Click repost button
    RepostButton->>AuthHook: Check authenticated
    
    alt Not Authenticated
        RepostButton->>PrivyAuth: Trigger auth modal
        PrivyAuth->>User: Show auth modal
    else Authenticated
        RepostButton->>Browser: Open repost dialog
    end
```

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->