### PR TITLE
fix(engine): prevent perp price explosion from unbounded event multipliers

### DIFF
--- a/packages/core/markets/perps/PerpMarketService.ts
+++ b/packages/core/markets/perps/PerpMarketService.ts
@@ -121,6 +121,13 @@ export class PerpMarketService {
 
     const entryPrice = market.currentPrice;
 
+    // Reject non-finite or extreme prices to prevent NaN/Infinity PnL
+    if (!Number.isFinite(entryPrice) || entryPrice <= 0) {
+      throw new Error(
+        `Invalid market price for ${ticker}: ${entryPrice}. Cannot open position.`
+      );
+    }
+
     // Slippage protection: if mark price differs significantly from spot, reject
     if (maxSlippage !== undefined && maxSlippage > 0 && market.markPrice) {
       const priceDeviation =
@@ -251,6 +258,13 @@ export class PerpMarketService {
     }
 
     const exitPrice = input.exitPriceOverride ?? market.currentPrice;
+
+    // Reject non-finite or extreme prices to prevent NaN/Infinity PnL
+    if (!Number.isFinite(exitPrice) || exitPrice <= 0) {
+      throw new Error(
+        `Invalid exit price for ${position.ticker}: ${exitPrice}. Cannot close position.`
+      );
+    }
 
     // Slippage protection: reject if execution price deviates too far from mark price
     // This protects against executing at a price that differs significantly from fair value
@@ -1105,8 +1119,13 @@ function calculateUnrealizedPnL(
   side: PerpSide,
   size: number
 ): { pnl: number; pnlPercent: number } {
-  // Guard against division by zero
-  if (entryPrice <= 0 || size <= 0) {
+  // Guard against division by zero and non-finite values
+  if (
+    entryPrice <= 0 ||
+    size <= 0 ||
+    !Number.isFinite(entryPrice) ||
+    !Number.isFinite(currentPrice)
+  ) {
     return { pnl: 0, pnlPercent: 0 };
   }
   const pnl =

--- a/packages/db/src/database-service.ts
+++ b/packages/db/src/database-service.ts
@@ -662,6 +662,7 @@ class DatabaseService {
       .values({
         id,
         currentPrice,
+        basePrice: currentPrice ?? 100,
         updatedAt: new Date(),
       })
       .returning();

--- a/packages/engine/src/services/event-market-pipeline.ts
+++ b/packages/engine/src/services/event-market-pipeline.ts
@@ -61,8 +61,8 @@ async function backoffDelay(attempt: number): Promise<void> {
 /**
  * Price bounds to prevent invalid prices
  */
-const MIN_PRICE_MULTIPLIER = 0.5; // Minimum 50% of base price per event
-const MAX_PRICE_MULTIPLIER = 1.5; // Maximum 150% of base price per event
+const MIN_EVENT_MULTIPLIER = 0.5; // Minimum 50% of base price per event
+const MAX_EVENT_MULTIPLIER = 1.5; // Maximum 150% of base price per event
 
 /**
  * Resolve a ticker to an organization ID.
@@ -153,8 +153,8 @@ export async function applyEventToMarkets(
       const rawEffect =
         impact.direction === 'up' ? 1 + magnitude : 1 - magnitude;
       const effect = Math.max(
-        MIN_PRICE_MULTIPLIER,
-        Math.min(MAX_PRICE_MULTIPLIER, rawEffect)
+        MIN_EVENT_MULTIPLIER,
+        Math.min(MAX_EVENT_MULTIPLIER, rawEffect)
       );
 
       const now = new Date();
@@ -229,8 +229,8 @@ export async function applyEventToMarkets(
 
         // Clamp combined multiplier to avoid extreme compounding from multiple impacts.
         const combinedMultiplier = Math.max(
-          MIN_PRICE_MULTIPLIER,
-          Math.min(MAX_PRICE_MULTIPLIER, entry.multiplier)
+          MIN_EVENT_MULTIPLIER,
+          Math.min(MAX_EVENT_MULTIPLIER, entry.multiplier)
         );
 
         const state = stateByOrgId.get(orgId);
@@ -241,12 +241,14 @@ export async function applyEventToMarkets(
         // Apply multiplier to currentPrice but clamp to basePrice bounds
         // to prevent exponential compounding across repeated events
         const rawPrice = currentPrice * combinedMultiplier;
-        const minPrice = Number.isFinite(basePrice) && basePrice > 0
-          ? basePrice * PERP_MARKET_CONFIG.PRICE_FLOOR_RATIO
-          : currentPrice * 0.25;
-        const maxPrice = Number.isFinite(basePrice) && basePrice > 0
-          ? basePrice * PERP_MARKET_CONFIG.PRICE_CEILING_RATIO
-          : currentPrice * 4.0;
+        const minPrice =
+          Number.isFinite(basePrice) && basePrice > 0
+            ? basePrice * PERP_MARKET_CONFIG.PRICE_FLOOR_RATIO
+            : currentPrice * 0.25;
+        const maxPrice =
+          Number.isFinite(basePrice) && basePrice > 0
+            ? basePrice * PERP_MARKET_CONFIG.PRICE_CEILING_RATIO
+            : currentPrice * 4.0;
         const newPrice = Math.max(minPrice, Math.min(maxPrice, rawPrice));
         if (!Number.isFinite(newPrice) || newPrice <= 0) return null;
 
@@ -381,8 +383,8 @@ export async function addPriceModifier(
       .map((m) => ({
         ...m,
         effect: Math.max(
-          MIN_PRICE_MULTIPLIER,
-          Math.min(MAX_PRICE_MULTIPLIER, m.effect)
+          MIN_EVENT_MULTIPLIER,
+          Math.min(MAX_EVENT_MULTIPLIER, m.effect)
         ),
       }));
 
@@ -445,8 +447,8 @@ export function calculateCurrentPrice(
   const now = new Date();
 
   // Pre-compute bounds for clamping during the loop
-  const minPrice = basePrice * MIN_PRICE_MULTIPLIER;
-  const maxPrice = basePrice * MAX_PRICE_MULTIPLIER;
+  const minPrice = basePrice * MIN_EVENT_MULTIPLIER;
+  const maxPrice = basePrice * MAX_EVENT_MULTIPLIER;
 
   // Apply all active modifiers with decay, clamping after each to avoid overflow
   for (const mod of modifiers) {
@@ -460,8 +462,8 @@ export function calculateCurrentPrice(
 
     // Bound effect to prevent extreme values
     const boundedEffect = Math.max(
-      MIN_PRICE_MULTIPLIER,
-      Math.min(MAX_PRICE_MULTIPLIER, mod.effect)
+      MIN_EVENT_MULTIPLIER,
+      Math.min(MAX_EVENT_MULTIPLIER, mod.effect)
     );
 
     const hoursSince = (now.getTime() - appliedAt.getTime()) / (1000 * 60 * 60);
@@ -470,8 +472,8 @@ export function calculateCurrentPrice(
 
     // Clamp decayed effect to prevent extreme per-modifier impact
     decayedEffect = Math.max(
-      MIN_PRICE_MULTIPLIER,
-      Math.min(MAX_PRICE_MULTIPLIER, decayedEffect)
+      MIN_EVENT_MULTIPLIER,
+      Math.min(MAX_EVENT_MULTIPLIER, decayedEffect)
     );
 
     price *= decayedEffect;
@@ -528,8 +530,8 @@ export async function updateStockPrice(
       .map((m) => ({
         ...m,
         effect: Math.max(
-          MIN_PRICE_MULTIPLIER,
-          Math.min(MAX_PRICE_MULTIPLIER, m.effect)
+          MIN_EVENT_MULTIPLIER,
+          Math.min(MAX_EVENT_MULTIPLIER, m.effect)
         ),
       }));
 

--- a/packages/engine/src/services/event-market-pipeline.ts
+++ b/packages/engine/src/services/event-market-pipeline.ts
@@ -21,7 +21,7 @@ import {
   type StructuredEventData,
   sql,
 } from '@babylon/db';
-import { logger } from '@babylon/shared';
+import { logger, PERP_MARKET_CONFIG } from '@babylon/shared';
 import { secureRandom } from '../utils/entropy';
 import { formatError } from '../utils/error-utils';
 import { parseModifiersSafe, validatePriceModifier } from './jsonb-validators';
@@ -61,8 +61,8 @@ async function backoffDelay(attempt: number): Promise<void> {
 /**
  * Price bounds to prevent invalid prices
  */
-const MIN_PRICE_MULTIPLIER = 0.01; // Minimum 1% of base price
-const MAX_PRICE_MULTIPLIER = 100; // Maximum 100x of base price
+const MIN_PRICE_MULTIPLIER = 0.5; // Minimum 50% of base price per event
+const MAX_PRICE_MULTIPLIER = 1.5; // Maximum 150% of base price per event
 
 /**
  * Resolve a ticker to an organization ID.
@@ -234,10 +234,20 @@ export async function applyEventToMarkets(
         );
 
         const state = stateByOrgId.get(orgId);
+        const basePrice = Number(state?.basePrice);
         const currentPrice = Number(state?.currentPrice ?? state?.basePrice);
         if (!Number.isFinite(currentPrice) || currentPrice <= 0) return null;
 
-        const newPrice = currentPrice * combinedMultiplier;
+        // Apply multiplier to currentPrice but clamp to basePrice bounds
+        // to prevent exponential compounding across repeated events
+        const rawPrice = currentPrice * combinedMultiplier;
+        const minPrice = Number.isFinite(basePrice) && basePrice > 0
+          ? basePrice * PERP_MARKET_CONFIG.PRICE_FLOOR_RATIO
+          : currentPrice * 0.25;
+        const maxPrice = Number.isFinite(basePrice) && basePrice > 0
+          ? basePrice * PERP_MARKET_CONFIG.PRICE_CEILING_RATIO
+          : currentPrice * 4.0;
+        const newPrice = Math.max(minPrice, Math.min(maxPrice, rawPrice));
         if (!Number.isFinite(newPrice) || newPrice <= 0) return null;
 
         const canonicalTicker =
@@ -282,12 +292,13 @@ export async function applyEventToMarkets(
         // Apply cascade effects to related organizations
         // Each primary org that had a price change may affect suppliers, competitors, partners
         for (const update of applied) {
-          if (Math.abs(update.changePercent) > 0.01) {
-            // Only cascade for >1% moves
+          if (Math.abs(update.changePercent) > 1) {
+            // Only cascade for >1% moves (changePercent is in % units, e.g. 5.0 = 5%)
             try {
+              // Convert percent to fraction for applyCascadeEffects (expects e.g. -0.10 for -10%)
               const cascadeResult = await applyCascadeEffects(
                 update.organizationId,
-                update.changePercent,
+                update.changePercent / 100,
                 `${event.type} event (arcId: ${event.arcId})`
               );
               if (cascadeResult.affectedCount > 0) {

--- a/packages/engine/src/services/market-correlation-service.ts
+++ b/packages/engine/src/services/market-correlation-service.ts
@@ -100,10 +100,19 @@ export async function applyCascadeEffects(
     const rawPrice = currentPrice * (1 + cascadeEffect);
 
     // Clamp to basePrice bounds to prevent cascade-driven price explosion
-    const minPrice = Number.isFinite(basePrice) && basePrice > 0
+    const hasValidBasePrice =
+      Number.isFinite(basePrice) && basePrice > 0;
+    if (!hasValidBasePrice) {
+      logger.warn(
+        'Missing basePrice for cascade target, using currentPrice fallback',
+        { orgId: affected.orgId, currentPrice },
+        'MarketCorrelationService'
+      );
+    }
+    const minPrice = hasValidBasePrice
       ? basePrice * PERP_MARKET_CONFIG.PRICE_FLOOR_RATIO
       : currentPrice * 0.25;
-    const maxPrice = Number.isFinite(basePrice) && basePrice > 0
+    const maxPrice = hasValidBasePrice
       ? basePrice * PERP_MARKET_CONFIG.PRICE_CEILING_RATIO
       : currentPrice * 4.0;
     const newPrice = Math.max(minPrice, Math.min(maxPrice, rawPrice));

--- a/packages/engine/src/services/market-correlation-service.ts
+++ b/packages/engine/src/services/market-correlation-service.ts
@@ -14,7 +14,7 @@
  */
 
 import { db, inArray, organizationState } from '@babylon/db';
-import { type JsonValue, logger } from '@babylon/shared';
+import { type JsonValue, logger, PERP_MARKET_CONFIG } from '@babylon/shared';
 import {
   correlations,
   getAffectedOrgs,
@@ -89,6 +89,7 @@ export async function applyCascadeEffects(
     const state = stateByOrgId.get(affected.orgId);
     if (!state) continue;
 
+    const basePrice = Number(state.basePrice);
     const currentPrice = Number(state.currentPrice ?? state.basePrice);
     if (!Number.isFinite(currentPrice) || currentPrice <= 0) continue;
 
@@ -96,7 +97,16 @@ export async function applyCascadeEffects(
     // Positive multiplier = same direction (suppliers hurt when customer hurts)
     // Negative multiplier = inverse direction (competitors benefit from rival's pain)
     const cascadeEffect = priceChangePercent * affected.multiplier;
-    const newPrice = currentPrice * (1 + cascadeEffect);
+    const rawPrice = currentPrice * (1 + cascadeEffect);
+
+    // Clamp to basePrice bounds to prevent cascade-driven price explosion
+    const minPrice = Number.isFinite(basePrice) && basePrice > 0
+      ? basePrice * PERP_MARKET_CONFIG.PRICE_FLOOR_RATIO
+      : currentPrice * 0.25;
+    const maxPrice = Number.isFinite(basePrice) && basePrice > 0
+      ? basePrice * PERP_MARKET_CONFIG.PRICE_CEILING_RATIO
+      : currentPrice * 4.0;
+    const newPrice = Math.max(minPrice, Math.min(maxPrice, rawPrice));
 
     if (!Number.isFinite(newPrice) || newPrice <= 0) continue;
 

--- a/packages/engine/src/services/price-update-service.ts
+++ b/packages/engine/src/services/price-update-service.ts
@@ -124,12 +124,22 @@ export class PriceUpdateService {
 
       // Central price clamp: enforce basePrice bounds on all updates
       let clampedNewPrice = update.newPrice;
+      if (!hasValidBasePrice) {
+        logger.warn(
+          'Missing basePrice for price update, skipping bounds enforcement',
+          { orgId, resolvedBasePrice },
+          'PriceUpdateService'
+        );
+      }
       if (hasValidBasePrice) {
         const minPrice =
           resolvedBasePrice * PERP_MARKET_CONFIG.PRICE_FLOOR_RATIO;
         const maxPrice =
           resolvedBasePrice * PERP_MARKET_CONFIG.PRICE_CEILING_RATIO;
-        clampedNewPrice = Math.max(minPrice, Math.min(maxPrice, clampedNewPrice));
+        clampedNewPrice = Math.max(
+          minPrice,
+          Math.min(maxPrice, clampedNewPrice)
+        );
       }
 
       const oldPriceCandidate =

--- a/packages/engine/src/services/price-update-service.ts
+++ b/packages/engine/src/services/price-update-service.ts
@@ -7,7 +7,7 @@ import {
   organizations,
 } from '@babylon/db';
 import type { JsonValue } from '@babylon/shared';
-import { logger } from '@babylon/shared';
+import { logger, PERP_MARKET_CONFIG } from '@babylon/shared';
 import { FEE_CONFIG } from '../config/fees';
 import { broadcastToChannel } from './realtime-broadcaster';
 import { WalletService } from './wallet-service';
@@ -117,48 +117,65 @@ export class PriceUpdateService {
         .where(eq(organizations.id, orgId))
         .limit(1);
 
+      // Resolve basePrice for bounds enforcement
+      const resolvedBasePrice = Number(state?.basePrice ?? 100);
+      const hasValidBasePrice =
+        Number.isFinite(resolvedBasePrice) && resolvedBasePrice > 0;
+
+      // Central price clamp: enforce basePrice bounds on all updates
+      let clampedNewPrice = update.newPrice;
+      if (hasValidBasePrice) {
+        const minPrice =
+          resolvedBasePrice * PERP_MARKET_CONFIG.PRICE_FLOOR_RATIO;
+        const maxPrice =
+          resolvedBasePrice * PERP_MARKET_CONFIG.PRICE_CEILING_RATIO;
+        clampedNewPrice = Math.max(minPrice, Math.min(maxPrice, clampedNewPrice));
+      }
+
       const oldPriceCandidate =
         organization?.currentPrice ??
         state?.currentPrice ??
         state?.basePrice ??
-        update.newPrice;
-      const oldPrice = Number(oldPriceCandidate ?? update.newPrice);
-      const change = update.newPrice - oldPrice;
+        clampedNewPrice;
+      const oldPrice = Number(oldPriceCandidate ?? clampedNewPrice);
+      const change = clampedNewPrice - oldPrice;
       const changePercent = oldPrice === 0 ? 0 : (change / oldPrice) * 100;
 
       if (organization) {
         await db
           .update(organizations)
-          .set({ currentPrice: update.newPrice, updatedAt: now })
+          .set({ currentPrice: clampedNewPrice, updatedAt: now })
           .where(eq(organizations.id, organization.id));
       }
 
       // Keep runtime price state in sync (used across engine + widgets)
+      // Ensure basePrice is always set to prevent null fallback drift
       await db
         .insert(organizationState)
         .values({
           id: orgId,
-          currentPrice: update.newPrice,
+          currentPrice: clampedNewPrice,
+          basePrice: resolvedBasePrice,
           updatedAt: now,
         })
         .onConflictDoUpdate({
           target: organizationState.id,
-          set: { currentPrice: update.newPrice, updatedAt: now },
+          set: { currentPrice: clampedNewPrice, updatedAt: now },
         });
 
       await getDbInstance().recordPriceUpdate(
         orgId,
-        update.newPrice,
+        clampedNewPrice,
         change,
         changePercent
       );
 
-      priceMap.set(orgId, update.newPrice);
+      priceMap.set(orgId, clampedNewPrice);
 
       appliedUpdates.push({
         organizationId: orgId,
         oldPrice,
-        newPrice: update.newPrice,
+        newPrice: clampedNewPrice,
         change,
         changePercent,
         source: update.source,

--- a/packages/engine/src/services/price-update-service.ts
+++ b/packages/engine/src/services/price-update-service.ts
@@ -112,13 +112,15 @@ export class PriceUpdateService {
         .select({
           id: organizations.id,
           currentPrice: organizations.currentPrice,
+          initialPrice: organizations.initialPrice,
         })
         .from(organizations)
         .where(eq(organizations.id, orgId))
         .limit(1);
 
       // Resolve basePrice for bounds enforcement
-      const resolvedBasePrice = Number(state?.basePrice ?? 100);
+      // Priority: organizationState.basePrice > organization.initialPrice
+      const resolvedBasePrice = Number(state?.basePrice ?? organization?.initialPrice ?? 0);
       const hasValidBasePrice =
         Number.isFinite(resolvedBasePrice) && resolvedBasePrice > 0;
 

--- a/packages/engine/src/services/wallet-service.ts
+++ b/packages/engine/src/services/wallet-service.ts
@@ -148,6 +148,17 @@ export class WalletService {
     const currentBalance = Number(user.virtualBalance ?? 0);
     const newBalance = currentBalance + delta;
 
+    // Reject non-finite values to prevent balance corruption
+    if (
+      !Number.isFinite(delta) ||
+      !Number.isFinite(currentBalance) ||
+      !Number.isFinite(newBalance)
+    ) {
+      throw new Error(
+        `Invalid wallet mutation for ${userId}: delta=${delta}, balance=${currentBalance}, result=${newBalance}`
+      );
+    }
+
     // Prevent negative balance on debits
     if (delta < 0 && newBalance < 0) {
       throw new InsufficientFundsError(Math.abs(delta), currentBalance, 'USD');
@@ -369,8 +380,21 @@ export class WalletService {
         );
       }
 
+      // Reject non-finite PnL to prevent lifetime stats corruption
+      if (!Number.isFinite(pnl)) {
+        throw new Error(
+          `Invalid PnL for ${userId}: pnl=${pnl}, tradeType=${tradeType}`
+        );
+      }
+
       const previousLifetimePnL = Number(user.lifetimePnL);
       const newLifetimePnL = previousLifetimePnL + pnl;
+
+      if (!Number.isFinite(newLifetimePnL)) {
+        throw new Error(
+          `Invalid lifetimePnL for ${userId}: prev=${previousLifetimePnL}, delta=${pnl}`
+        );
+      }
 
       // Update lifetimePnL first within the transaction
       await tx


### PR DESCRIPTION
## Summary

- **Event pipeline** was multiplying `currentPrice` by up to 100x per event with no `basePrice` ceiling → exponential compounding → prices reached `1e+308`
- **Cascade effects** had a percent-vs-fraction unit mismatch making cascades **100x too large**
- **Wallet/PnL** accepted `NaN`/`Infinity` values, corrupting balances (321T for one agent)

## Changes (5 files, 102 insertions)

### P0 — Event pipeline (`event-market-pipeline.ts`)
- Tighten multiplier range: `[0.01, 100]` → `[0.5, 1.5]`
- Clamp event prices to `basePrice * [0.25, 4.0]` bounds
- Fix cascade unit: `changePercent / 100` before passing as fraction
- Fix cascade threshold: `> 0.01` → `> 1` (was triggering at 0.01%)

### P0 — Cascade effects (`market-correlation-service.ts`)
- Clamp cascade results to `basePrice * [0.25, 4.0]` bounds

### P1 — Central enforcement (`price-update-service.ts`)
- All price updates now clamped to `basePrice` bounds
- `basePrice` always set on `OrganizationState` upsert (prevents null drift)

### P1 — Perp guards (`PerpMarketService.ts`)
- Reject non-finite/extreme prices on open and close
- `calculateUnrealizedPnL` returns 0 for non-finite inputs

### P2 — Wallet validation (`wallet-service.ts`)
- Reject `NaN`/`Infinity` on credit/debit/recordPnL

## Data migration (staging, already applied)
- Reset 35 corrupted `OrganizationState` prices to `basePrice` bounds
- Reset 13 `PerpMarketSnapshot` entries
- Reset 174 open `PerpPosition` entries with extreme prices
- Reset 3 agent wallets with balances > 1B → 1000

## Test plan
- [ ] Verify event pipeline prices stay within `[basePrice * 0.25, basePrice * 4.0]`
- [ ] Verify cascades apply fractional changes (not 100x)
- [ ] Verify agents can still open/close perp positions at normal prices
- [ ] Verify wallet rejects NaN/Infinity mutations
- [ ] Monitor staging logs for price update clamping

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added validations to prevent non-finite/zero prices and PnL, avoiding NaN/Infinity and early-error scenarios.
  * Enforced price clamping and bounds using configured base-price ratios to prevent extreme or out-of-range market moves.
  * Strengthened wallet checks to ensure finite balance and PnL updates.

* **Chores**
  * Persisted a new basePrice field in organization state to support clamping and price stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR addresses a critical price explosion bug in the perpetual markets system where unbounded event multipliers caused prices to reach `1e+308`, corrupting agent wallets with balances exceeding 321 trillion.

**Root causes fixed:**

- Event multipliers were unbounded [0.01, 100] allowing 100x moves per event with exponential compounding
- Cascade effects had a percent-vs-fraction unit mismatch (multiplying by 100x instead of dividing by 100)
- Wallet operations accepted `NaN`/`Infinity` values without validation

**Key changes:**

1. **Tightened event multipliers** from [0.01, 100] to [0.5, 1.5] per event
2. **Added `basePrice` bounds enforcement** across all price update paths: clamp to [basePrice × 0.25, basePrice × 4.0]
3. **Fixed cascade unit conversion**: changed from `changePercent` (already in %) to `changePercent / 100` (fractional)
4. **Fixed cascade threshold**: changed from `> 0.01` (0.01%) to `> 1` (1%)
5. **Added NaN/Infinity guards** in perp operations and wallet mutations
6. **Ensured `basePrice` is always set** on organizationState upsert to prevent null drift

**Data migration applied** (staging): Reset 35 corrupted OrganizationState prices, 13 PerpMarketSnapshot entries, 174 open PerpPosition entries, and 3 agent wallets with balances > 1B.

The fix implements defense-in-depth with validation at multiple layers (event pipeline, cascades, central price service, perp operations, wallet). The approach is sound and addresses all identified vectors.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor considerations - thoroughly addresses the price explosion bug with defense-in-depth validation
- The fix comprehensively addresses all identified price explosion vectors with proper bounds enforcement and validation. Score of 4 (not 5) due to potential edge case with basePrice overwriting (though onConflictDoUpdate only updates currentPrice, not basePrice, so this is likely fine) and the aggressive tightening of multipliers from [0.01, 100] to [0.5, 1.5] which may reduce narrative event impact significantly.
- All files are well-structured. Minor attention to `packages/engine/src/services/price-update-service.ts` regarding basePrice handling in existing rows.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/engine/src/services/event-market-pipeline.ts | Tightened event multipliers from [0.01, 100] to [0.5, 1.5] and added basePrice clamping to prevent exponential price explosion |
| packages/engine/src/services/market-correlation-service.ts | Added basePrice bounds to cascade effects and fixed percent-to-fraction conversion (dividing by 100) |
| packages/engine/src/services/price-update-service.ts | Centralized price clamping to basePrice bounds and ensures basePrice is always set on upsert (potential issue with overwriting custom values) |
| packages/core/markets/perps/PerpMarketService.ts | Added non-finite price validation on open/close operations and guarded PnL calculation against NaN/Infinity |
| packages/engine/src/services/wallet-service.ts | Added non-finite value validation on balance mutations and PnL recording to prevent corruption |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Event as Event Pipeline
    participant Cascade as Cascade Service
    participant PriceUpdate as Price Update Service
    participant Perp as Perp Market Service
    participant Wallet as Wallet Service
    participant DB as Database

    Note over Event: Narrative event occurs
    Event->>Event: Calculate event effect<br/>[0.5, 1.5] multiplier
    Event->>DB: Fetch organizationState<br/>(currentPrice, basePrice)
    DB-->>Event: Current state
    Event->>Event: Apply multiplier<br/>Clamp to [basePrice×0.25, basePrice×4.0]
    Event->>PriceUpdate: Submit price updates
    
    PriceUpdate->>DB: Fetch state & resolve basePrice
    DB-->>PriceUpdate: State with basePrice
    PriceUpdate->>PriceUpdate: Clamp to [basePrice×0.25, basePrice×4.0]
    PriceUpdate->>DB: Update currentPrice<br/>Set basePrice on INSERT only
    PriceUpdate->>Perp: Apply price updates (via map)
    
    Note over PriceUpdate,Cascade: If price change > 1%
    PriceUpdate->>Cascade: Trigger cascade (changePercent/100)
    Cascade->>DB: Fetch related org states
    DB-->>Cascade: Related states
    Cascade->>Cascade: Calculate cascade effect<br/>Clamp to [basePrice×0.25, basePrice×4.0]
    Cascade->>PriceUpdate: Submit cascade updates
    
    Perp->>Perp: Validate price is finite & > 0
    alt Price is NaN/Infinity
        Perp-->>Event: Error: Invalid price
    else Price is valid
        Perp->>Perp: Update position PnL
        Perp->>Perp: Check liquidation
        alt Should liquidate
            Perp->>Wallet: recordPnL (with NaN guard)
            Wallet->>Wallet: Validate finite values
            alt Non-finite value
                Wallet-->>Perp: Error: Invalid PnL
            else Valid
                Wallet->>DB: Update lifetimePnL
            end
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->