### PR TITLE
feat(web): sync Privy theme with app light/dark mode

### DIFF
--- a/apps/web/src/components/providers/Providers.tsx
+++ b/apps/web/src/components/providers/Providers.tsx
@@ -4,6 +4,7 @@ import { logger, privyConfig } from '@babylon/shared';
 import { type PrivyClientConfig, PrivyProvider } from '@privy-io/react-auth';
 import { SmartWalletsProvider } from '@privy-io/react-auth/smart-wallets';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useTheme } from 'next-themes';
 import { Fragment, Suspense, useEffect, useRef, useState } from 'react';
 import { PostHogErrorBoundary } from '@/components/analytics/PostHogErrorBoundary';
 import { PostHogIdentifier } from '@/components/analytics/PostHogIdentifier';
@@ -166,6 +167,28 @@ function PrivyProviderWrapper({
 }
 
 /**
+ * Syncs the app's resolved theme (from next-themes) to Privy's appearance config.
+ * Must be rendered inside ThemeProvider so useTheme() has access to the context.
+ */
+function ThemedPrivyProvider({ children }: { children: React.ReactNode }) {
+  const { resolvedTheme } = useTheme();
+
+  const config = {
+    ...privyConfig.config,
+    appearance: {
+      ...privyConfig.config.appearance,
+      theme: resolvedTheme === 'light' ? 'light' : 'dark',
+    },
+  } as PrivyClientConfig;
+
+  return (
+    <PrivyProviderWrapper appId={privyConfig.appId} config={config}>
+      <SmartWalletsProvider>{children}</SmartWalletsProvider>
+    </PrivyProviderWrapper>
+  );
+}
+
+/**
  * Root providers component wrapping the application with all necessary providers.
  *
  * Provides all application-level context providers including:
@@ -268,12 +291,8 @@ export function Providers({ children }: { children: React.ReactNode }) {
               <FontSizeProvider>
                 <QueryClientProvider client={queryClient}>
                   <GamePlaybackManager />
-                  <PrivyProviderWrapper
-                    appId={privyConfig.appId}
-                    config={privyConfig.config as PrivyClientConfig}
-                  >
-                    <SmartWalletsProvider>
-                      <FarcasterMiniAppProvider>
+                  <ThemedPrivyProvider>
+                    <FarcasterMiniAppProvider>
                         {/* PostHog user identification */}
                         <PostHogIdentifier />
                         {/* Capture referral code from URL if present */}
@@ -294,8 +313,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
                           </GameGuideProvider>
                         </OnboardingProvider>
                       </FarcasterMiniAppProvider>
-                    </SmartWalletsProvider>
-                  </PrivyProviderWrapper>
+                  </ThemedPrivyProvider>
                 </QueryClientProvider>
               </FontSizeProvider>
             </ThemeProvider>


### PR DESCRIPTION
## Summary
- Privy auth UI was always stuck in dark mode regardless of the app's theme setting
- Added `ThemedPrivyProvider` that reads the resolved theme from `next-themes` and passes it to Privy's appearance config
- Privy dialogs now correctly match the app's light/dark mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced theme synchronization to ensure Privy's interface dynamically matches your app's current theme preference (light or dark mode).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR syncs Privy's authentication UI theme with the app's light/dark mode by introducing `ThemedPrivyProvider` that reads `resolvedTheme` from `next-themes` and passes it to Privy's appearance config.

**Key changes:**
- Added `ThemedPrivyProvider` component that uses `useTheme()` hook to get the current theme
- Replaced direct `PrivyProviderWrapper` usage with `ThemedPrivyProvider` in the main provider tree
- Privy dialogs now correctly match the app's light/dark mode instead of staying in dark mode

**Issue found:**
- Potential hydration mismatch: `useTheme().resolvedTheme` is determined client-side, which can cause the server-rendered output to differ from the initial client render, leading to React hydration errors

<h3>Confidence Score: 3/5</h3>

- This PR has a potential hydration issue that could cause React warnings or errors
- The implementation is straightforward and achieves the goal of syncing Privy theme with app theme, but the use of `useTheme()` without hydration protection could cause SSR/CSR mismatches
- Pay attention to `apps/web/src/components/providers/Providers.tsx` for the hydration issue in `ThemedPrivyProvider`

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/components/providers/Providers.tsx | Added `ThemedPrivyProvider` to sync Privy UI theme with app's light/dark mode — potential hydration issue with `useTheme()` hook |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App
    participant Providers
    participant ThemeProvider
    participant ThemedPrivyProvider
    participant useTheme
    participant PrivyProvider
    
    App->>Providers: Render
    Providers->>ThemeProvider: Mount with default theme
    ThemeProvider->>ThemeProvider: Initialize next-themes
    Providers->>ThemedPrivyProvider: Render children
    ThemedPrivyProvider->>useTheme: Call useTheme()
    useTheme-->>ThemedPrivyProvider: Return {resolvedTheme}
    Note over ThemedPrivyProvider: resolvedTheme determined<br/>client-side (light/dark/system)
    ThemedPrivyProvider->>ThemedPrivyProvider: Build config with theme
    ThemedPrivyProvider->>PrivyProvider: Pass config with appearance.theme
    PrivyProvider-->>App: Render with matching theme
```

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->