### PR TITLE
fix(points): catch errors in recompute to prevent batch abort

### DIFF
--- a/packages/engine/src/services/total-points-service.ts
+++ b/packages/engine/src/services/total-points-service.ts
@@ -72,15 +72,19 @@ function calculatePredictionPositionValue(position: {
   }
 
   const sideKey = position.side ? 'yes' : 'no';
-  const sellPreview = PredictionPricing.calculateSellWithFees(
-    yesShares,
-    noShares,
-    sideKey,
-    shares,
-    feeRate
-  );
-
-  return sellPreview.netProceeds ?? sellPreview.totalCost;
+  try {
+    const sellPreview = PredictionPricing.calculateSellWithFees(
+      yesShares,
+      noShares,
+      sideKey,
+      shares,
+      feeRate
+    );
+    return sellPreview.netProceeds ?? sellPreview.totalCost;
+  } catch {
+    // Fall back to cost basis when sell preview fails (e.g. negative proceeds)
+    return costBasis;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -255,8 +259,19 @@ export const TotalPointsService = {
 
       await Promise.all(
         batch.map(async (user) => {
-          await TotalPointsService.recomputeTotalPoints(user.id);
-          // Only clear flag if it wasn't re-dirtied after we started
+          try {
+            await TotalPointsService.recomputeTotalPoints(user.id);
+          } catch (error) {
+            logger.error(
+              'Failed to recompute totalPoints for user',
+              {
+                userId: user.id,
+                error: error instanceof Error ? error.message : String(error),
+              },
+              'TotalPointsService'
+            );
+          }
+          // Clear flag even on error to avoid infinite retry loops
           await db
             .update(users)
             .set({ totalPointsDirtyAt: null })


### PR DESCRIPTION
## Summary
- `calculateSellWithFees` throws when proceeds are negative (bad market share data). One user's bad position was aborting the entire recompute batch.
- Wrapped per-user recompute in try/catch so failures are logged but don't stop the batch.
- Wrapped `calculateSellWithFees` call to fall back to cost basis on error.

## Test plan
- [ ] Trigger `/api/cron/points-recompute` on staging — should complete without error
- [ ] Check logs for any per-user error entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for calculation edge cases with improved fallback behavior
  * Resolved issue preventing system lockups during data recomputation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Prevented batch abort by wrapping error-prone operations in try/catch blocks. When `calculateSellWithFees` throws on negative proceeds from bad market data, the code now falls back to cost basis. Per-user recompute failures are logged but don't stop the batch.

Key changes:
- Wrapped `calculateSellWithFees` call with fallback to cost basis on error
- Wrapped per-user recompute in try/catch to isolate failures
- Dirty flag cleared even on error to prevent infinite retry loops

The fix addresses the immediate issue but creates potential blind spots - silent fallbacks in position valuation and permanent abandonment of problematic users. Consider adding monitoring for recurring errors.

<h3>Confidence Score: 4/5</h3>

- Safe to merge with minor observability concerns
- The error handling approach solves the immediate problem (batch abort) effectively. Logic is sound and addresses the root cause. Score reduced from 5 because: (1) silent fallback in calculatePredictionPositionValue could hide issues, (2) clearing dirty flag on error means persistently broken users won't be retried, (3) inconsistency with portfolio-breakdown.ts which lacks similar protection
- Consider adding similar error handling to portfolio-breakdown.ts for consistency

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/engine/src/services/total-points-service.ts | Added error handling to prevent batch failures from bad position data, with try/catch around calculateSellWithFees and per-user recompute |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Cron as Cron Job
    participant TPS as TotalPointsService
    participant DB as Database
    participant PP as PredictionPricing
    participant Logger as Logger

    Cron->>TPS: recomputeDirtyUsers()
    loop For each batch of users
        TPS->>DB: Query dirty users (batch)
        DB-->>TPS: Return user batch
        
        par For each user in batch
            TPS->>TPS: try recomputeTotalPoints(userId)
            TPS->>DB: Fetch user & positions
            DB-->>TPS: Return data
            
            TPS->>TPS: calculatePredictionPositionValue()
            TPS->>PP: try calculateSellWithFees()
            
            alt Success
                PP-->>TPS: Return sell preview
                TPS->>TPS: Use netProceeds
            else Error (negative proceeds)
                PP--xTPS: Throw error
                TPS->>TPS: catch - Use cost basis fallback
            end
            
            TPS->>DB: Update totalPoints
            
            alt Recompute success
                DB-->>TPS: Success
            else Recompute error
                TPS->>Logger: Log error with userId
            end
            
            Note over TPS: Clear dirty flag even on error
            TPS->>DB: Set totalPointsDirtyAt = null
        end
    end
    
    TPS-->>Cron: Return processed count
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->