### PR TITLE
fix(points): show totalPoints consistently across all UI

### DIFF
--- a/apps/web/src/components/auth/UserMenu.tsx
+++ b/apps/web/src/components/auth/UserMenu.tsx
@@ -126,20 +126,27 @@ export function UserMenu() {
         }
       }
 
-      // Update reputation points from profile
+      // Update points from profile
       if (profileResponse.ok) {
         const profileData = await profileResponse.json();
         if (isMounted && !fetchController.signal.aborted && profileData.user) {
+          const newTotalPoints = profileData.user.totalPoints;
           const newReputationPoints = profileData.user.reputationPoints;
-          // Only update if reputation points changed
+          const updates: Partial<typeof user> = {};
+          if (
+            newTotalPoints !== undefined &&
+            newTotalPoints !== user.totalPoints
+          ) {
+            updates.totalPoints = newTotalPoints;
+          }
           if (
             newReputationPoints !== undefined &&
             newReputationPoints !== user.reputationPoints
           ) {
-            setUser({
-              ...user,
-              reputationPoints: newReputationPoints,
-            });
+            updates.reputationPoints = newReputationPoints;
+          }
+          if (Object.keys(updates).length > 0) {
+            setUser({ ...user, ...updates });
           }
         }
       }
@@ -238,8 +245,8 @@ export function UserMenu() {
     </div>
   );
 
-  // Use reputation points from authStore (synced when rewards are claimed)
-  const reputationPoints = user?.reputationPoints ?? 0;
+  // Use total points from authStore (synced from profile API)
+  const totalPointsValue = user?.totalPoints ?? 0;
   const tradingBalanceValue = tradingBalance ?? 0;
 
   return (
@@ -248,10 +255,10 @@ export function UserMenu() {
       <div className="border-sidebar-accent border-b px-5 py-4">
         <div className="flex items-center justify-between">
           <span className="font-semibold text-muted-foreground text-sm">
-            Reputation
+            Total Points
           </span>
           <span className="font-bold text-foreground text-xl">
-            {reputationPoints.toLocaleString()}
+            {totalPointsValue.toLocaleString()}
           </span>
         </div>
         <div className="mt-2 flex items-center justify-between">

--- a/apps/web/src/components/profile/TradingProfile.tsx
+++ b/apps/web/src/components/profile/TradingProfile.tsx
@@ -54,7 +54,7 @@ interface UserStats {
   rank: number;
   totalPlayers: number;
   balance: number;
-  reputationPoints: number;
+  totalPoints: number;
   lifetimePnL: number;
 }
 
@@ -275,7 +275,7 @@ export function TradingProfile({
       rank,
       totalPlayers,
       balance: toNumber(userProfile.virtualBalance),
-      reputationPoints: toNumber(userProfile.reputationPoints),
+      totalPoints: toNumber(userProfile.totalPoints),
       lifetimePnL: toNumber(userProfile.lifetimePnL),
     });
 
@@ -416,11 +416,11 @@ export function TradingProfile({
           <div className="mb-2 flex items-center gap-2">
             <Trophy className="h-4 w-4 text-yellow-500" />
             <span className="font-medium text-muted-foreground text-xs">
-              Points
+              Total Points
             </span>
           </div>
           <p className="font-bold text-2xl">
-            {(stats?.reputationPoints || 0).toLocaleString()}
+            {(stats?.totalPoints || 0).toLocaleString()}
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
- **TradingProfile**: Was showing `reputationPoints` labeled "Points" — now shows `totalPoints` labeled "Total Points"
- **UserMenu**: Was showing `reputationPoints` as "Reputation" — now shows `totalPoints` as "Total Points" and syncs it from profile API

Findings validated by parallel Codex reviewers (Code Reviewer, Architect, Scope Analyst).

## Test plan
- [ ] Open TradingProfile — verify "Total Points" card shows portfolio value (wallet + positions), not reputation
- [ ] Open UserMenu dropdown — verify "Total Points" shows unified number
- [ ] Compare numbers against Leaderboard "Total Points" tab — should match

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Updated user points display terminology from "Reputation Points" to "Total Points" in profile and menu sections for clearer representation of overall achievement metrics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR standardizes the points display across the UI by replacing `reputationPoints` with `totalPoints` in both UserMenu and TradingProfile components. 

**Key Changes:**
- **UserMenu**: Changed label from "Reputation" to "Total Points" and now syncs `totalPoints` from the profile API alongside `reputationPoints`
- **TradingProfile**: Updated stats interface field from `reputationPoints` to `totalPoints` and changed display label to "Total Points"

**Context:**
According to the database schema (migration `0030_add_total_points_and_snapshots.sql`), `totalPoints` represents the unified portfolio value calculated as wallet + positions (excluding agents), which aligns with what's shown in the Leaderboard's "Total Points" tab. This differs from `reputationPoints` which tracks earned reputation separately.

The changes ensure users see a consistent "Total Points" value across UserMenu, TradingProfile, and Leaderboard, reflecting their actual portfolio value rather than just reputation points.

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no issues - clean refactoring that improves UI consistency
- The changes are straightforward and correctly implement the stated goal. Both files properly reference `totalPoints` from the profile API response, update labels consistently to "Total Points", and maintain backward compatibility by still syncing `reputationPoints` in UserMenu. The implementation aligns with the database schema where `totalPoints` = wallet + positions, matching the leaderboard display.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/components/auth/UserMenu.tsx | Updated to display `totalPoints` instead of `reputationPoints`, syncing from profile API for consistency with leaderboard |
| apps/web/src/components/profile/TradingProfile.tsx | Changed stats interface and UI to use `totalPoints` with "Total Points" label, aligning with unified points system |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant UserMenu as UserMenu Component
    participant TradingProfile as TradingProfile Component
    participant ProfileAPI as /api/users/[userId]/profile
    participant DB as Database
    participant Leaderboard as Leaderboard Page

    Note over UserMenu,DB: UserMenu Flow
    User->>UserMenu: Opens menu dropdown
    UserMenu->>ProfileAPI: GET /api/users/{userId}/profile
    ProfileAPI->>DB: Query user.totalPoints
    DB-->>ProfileAPI: Return totalPoints (wallet + positions)
    ProfileAPI-->>UserMenu: { user: { totalPoints, reputationPoints } }
    UserMenu->>UserMenu: Updates authStore with totalPoints
    UserMenu->>User: Displays "Total Points" with value

    Note over TradingProfile,DB: TradingProfile Flow
    User->>TradingProfile: Views profile page
    TradingProfile->>ProfileAPI: GET /api/users/{userId}/profile
    ProfileAPI->>DB: Query user.totalPoints
    DB-->>ProfileAPI: Return totalPoints
    ProfileAPI-->>TradingProfile: { user: { totalPoints } }
    TradingProfile->>TradingProfile: Sets stats.totalPoints
    TradingProfile->>User: Displays "Total Points" card

    Note over Leaderboard: Leaderboard Reference
    Leaderboard->>DB: Query totalPoints for ranking
    DB-->>Leaderboard: Return totalPoints values
    Leaderboard->>User: Shows "Total Points" tab

    Note over User: All UI now consistently shows totalPoints<br/>(wallet + positions value)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->