### PR TITLE
Markets terminal: UI/UX polish + mobile layout fixes

### DIFF
--- a/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
+++ b/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
@@ -27,11 +27,13 @@ import { formatPrice } from '../../_lib/formatters';
 interface PerpsOrderEntryPanelProps {
   market: PerpMarket | null;
   initialSide?: 'long' | 'short';
+  onRequestBuyPoints?: () => void;
 }
 
 export function PerpsOrderEntryPanel({
   market,
   initialSide,
+  onRequestBuyPoints,
 }: PerpsOrderEntryPanelProps) {
   const { user, authenticated, login, getAccessToken } = useAuth();
   const userId = authenticated ? (user?.id ?? null) : null;
@@ -299,6 +301,15 @@ export function PerpsOrderEntryPanel({
                 <Skeleton className="h-5 w-20" />
               ) : (
                 formatPrice(balance)
+              )}
+              {onRequestBuyPoints && (
+                <button
+                  type="button"
+                  onClick={onRequestBuyPoints}
+                  className="ml-2 rounded bg-muted/20 px-2 py-1 font-sans text-[10px] text-muted-foreground uppercase tracking-wider transition-colors hover:bg-muted/30 hover:text-foreground"
+                >
+                  Buy
+                </button>
               )}
             </div>
           </div>

--- a/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
+++ b/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
@@ -329,7 +329,7 @@ export function PerpsOrderEntryPanel({
       </div>
 
       {/* Order form */}
-      <div className="min-h-0 flex-1 overflow-auto p-4 pb-[calc(72px+env(safe-area-inset-bottom)+24px)]">
+      <div className="min-h-0 flex-1 overflow-auto p-4 pb-[calc(env(safe-area-inset-bottom)+24px)]">
         <div className="flex items-center justify-between">
           <div className="font-semibold text-sm">Place Order</div>
           <div className="rounded bg-muted/20 px-2 py-1 text-[10px] text-muted-foreground uppercase tracking-wider">

--- a/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
+++ b/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
@@ -22,7 +22,7 @@ import {
   useWalletBalance,
 } from '@/stores/walletBalanceStore';
 import type { PerpMarket } from '@/types/markets';
-import { formatPrice } from '../../_lib/formatters';
+import { formatBalance, formatPrice } from '../../_lib/formatters';
 
 interface PerpsOrderEntryPanelProps {
   market: PerpMarket | null;
@@ -300,7 +300,7 @@ export function PerpsOrderEntryPanel({
               {balanceLoading ? (
                 <Skeleton className="h-5 w-20" />
               ) : (
-                formatPrice(balance)
+                formatBalance(balance)
               )}
               {onRequestBuyPoints && (
                 <button

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -1796,7 +1796,7 @@ export function MarketsTradingTerminal({
       </button>
 
       {/* Mobile */}
-      <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden md:hidden">
+      <div className="relative flex h-full flex-col overflow-hidden overscroll-none md:hidden">
         <div className="shrink-0 border-white/5 border-b bg-background">
           <div className="flex h-14 items-center justify-between px-4">
             <div className="font-bold text-lg tracking-tight">Markets</div>
@@ -1839,7 +1839,7 @@ export function MarketsTradingTerminal({
           </div>
         </div>
 
-        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden pb-[calc(72px+env(safe-area-inset-bottom))]">
           <div className="min-h-0 flex-1 overflow-hidden">
             <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
               <div className="flex h-[42vh] w-full shrink-0 flex-col border-white/5 border-b">
@@ -2041,7 +2041,7 @@ export function MarketsTradingTerminal({
                       Log in to view positions.
                     </div>
                   ) : selected?.kind === 'prediction' ? (
-                    <div className="h-full overflow-auto">
+                    <div className="h-full overflow-auto overscroll-contain">
                       <PredictionPositionsList
                         positions={selectedPredictionPositions}
                         onPositionSold={async () => {
@@ -2057,7 +2057,7 @@ export function MarketsTradingTerminal({
                       />
                     </div>
                   ) : (
-                    <div className="h-full overflow-auto">
+                    <div className="h-full overflow-auto overscroll-contain">
                       <PerpPositionsList
                         positions={selectedPerpPositions}
                         onPositionClosed={async () => {
@@ -2076,7 +2076,7 @@ export function MarketsTradingTerminal({
                 ) : selected?.kind === 'prediction' ? (
                   <div
                     ref={mobileTradesContainerRef}
-                    className="h-full overflow-auto"
+                    className="h-full overflow-auto overscroll-contain"
                   >
                     <AssetTradesFeed
                       marketType="prediction"
@@ -2087,7 +2087,7 @@ export function MarketsTradingTerminal({
                 ) : selectedPerp ? (
                   <div
                     ref={mobileTradesContainerRef}
-                    className="h-full overflow-auto"
+                    className="h-full overflow-auto overscroll-contain"
                   >
                     <AssetTradesFeed
                       marketType="perp"
@@ -2104,7 +2104,7 @@ export function MarketsTradingTerminal({
             </div>
           </div>
 
-          <div className="relative z-40 flex h-[72px] select-none items-center justify-between rounded-t-[20px] border-white/5 border-t bg-background px-2 pb-safe font-medium text-[10px] text-muted-foreground shadow-[0_-5px_15px_rgba(0,0,0,0.12)]">
+          <div className="fixed bottom-0 left-0 z-40 flex h-[72px] w-full select-none items-center justify-between rounded-t-[20px] border-white/5 border-t bg-background px-2 pb-safe font-medium text-[10px] text-muted-foreground shadow-[0_-5px_15px_rgba(0,0,0,0.12)]">
             {/* Minimal bottom nav */}
             <button
               type="button"

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -82,6 +82,7 @@ import type {
 } from '@/types/markets';
 import { MARKET_TIME_RANGES } from '@/types/markets';
 import { PerpsOrderEntryPanel } from '../perps-terminal/PerpsOrderEntryPanel';
+import { formatBalance } from '../../_lib/formatters';
 
 type MarketsFilter = 'all' | 'favorites' | 'perp' | 'prediction';
 type MarketsSort = 'volume' | 'change' | 'openInterest' | 'name';
@@ -1272,7 +1273,7 @@ export function MarketsTradingTerminal({
                   {balanceLoading ? (
                     <Skeleton className="h-5 w-20" />
                   ) : (
-                    `${BABYLON_POINTS_SYMBOL}${Math.floor(balance).toLocaleString()}`
+                    formatBalance(balance)
                   )}
                   {onRequestBuyPoints && (
                     <button

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -180,6 +180,13 @@ function formatYesPct(raw: number): string {
   return `${rounded.toFixed(clamped >= 10 ? 0 : 1)}%`;
 }
 
+function formatDate(dateStr: string | undefined | null): string {
+  if (!dateStr) return '';
+  const date = new Date(dateStr);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toLocaleString();
+}
+
 function computeYesPctFromShares(
   market: PredictionMarketTerminalState
 ): number {
@@ -188,6 +195,161 @@ function computeYesPctFromShares(
   const total = yes + no;
   if (total <= 0) return 50;
   return (yes / total) * 100;
+}
+
+/** Reusable time range selector for market charts */
+function TimeRangeSelector({
+  timeRange,
+  onTimeRangeChange,
+}: {
+  timeRange: MarketTimeRange;
+  onTimeRangeChange: (range: MarketTimeRange) => void;
+}) {
+  return (
+    <div className="flex items-center gap-1 rounded-md bg-muted/20 p-1 font-semibold text-xs">
+      {MARKET_TIME_RANGES.map((range) => (
+        <button
+          key={range}
+          type="button"
+          onClick={() => onTimeRangeChange(range)}
+          className={cn(
+            'rounded px-2 py-1 transition-colors',
+            timeRange === range
+              ? 'bg-foreground text-background'
+              : 'text-muted-foreground hover:text-foreground'
+          )}
+        >
+          {range}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/** Reusable prediction market header for mobile/desktop views */
+function PredictionMarketHeader({
+  predictionState,
+  yesPct,
+  timeRange,
+  onTimeRangeChange,
+  onDetailsClick,
+  variant = 'default',
+}: {
+  predictionState: PredictionMarketTerminalState | null;
+  yesPct: number;
+  timeRange: MarketTimeRange;
+  onTimeRangeChange: (range: MarketTimeRange) => void;
+  onDetailsClick: () => void;
+  variant?: 'default' | 'compact';
+}) {
+  const isCompact = variant === 'compact';
+  const titleClass = isCompact
+    ? 'whitespace-normal break-words font-bold text-sm leading-snug'
+    : 'whitespace-normal break-words font-bold text-foreground text-lg leading-snug';
+
+  return (
+    <div
+      className={cn(
+        'shrink-0 border-white/5 border-b bg-background/40 px-4 py-3 backdrop-blur-md',
+        isCompact ? 'space-y-2' : ''
+      )}
+    >
+      <div
+        className={cn(
+          'flex gap-3',
+          isCompact
+            ? 'items-start justify-between'
+            : 'flex-col lg:flex-row lg:items-start lg:justify-between'
+        )}
+      >
+        <div className="min-w-0">
+          <div className={titleClass}>
+            {predictionState?.text ?? 'Prediction market'}
+          </div>
+          <div className="mt-1 whitespace-normal break-words text-muted-foreground text-xs">
+            {predictionState?.resolutionDescription?.trim()
+              ? predictionState.resolutionDescription
+              : `Scenario ${predictionState?.scenario ?? ''}`}
+          </div>
+        </div>
+        {isCompact ? (
+          <button
+            type="button"
+            onClick={onDetailsClick}
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded border border-white/10 bg-background/30 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+            aria-label="View market details"
+            title="Details"
+          >
+            <Info size={14} />
+          </button>
+        ) : null}
+      </div>
+
+      <div
+        className={cn(
+          'flex items-center gap-2',
+          isCompact ? 'flex-wrap justify-between' : 'flex-col gap-2 lg:items-end'
+        )}
+      >
+        <div className="flex items-center gap-2">
+          <div className="rounded-full bg-blue-500/10 px-2 py-1 font-bold text-[10px] text-blue-400 tabular-nums">
+            YES {formatYesPct(yesPct)}
+          </div>
+          <div className="rounded-full bg-violet-500/10 px-2 py-1 font-bold text-[10px] text-violet-400 tabular-nums">
+            NO {formatYesPct(100 - yesPct)}
+          </div>
+          {!isCompact && (
+            <button
+              type="button"
+              onClick={onDetailsClick}
+              className="inline-flex h-8 w-8 items-center justify-center rounded border border-white/10 bg-background/30 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+              aria-label="View market details"
+              title="Details"
+            >
+              <Info size={14} />
+            </button>
+          )}
+        </div>
+        <TimeRangeSelector
+          timeRange={timeRange}
+          onTimeRangeChange={onTimeRangeChange}
+        />
+      </div>
+    </div>
+  );
+}
+
+/** Reusable perp market header for mobile/desktop views */
+function PerpMarketHeader({
+  selectedPerp,
+  timeRange,
+  onTimeRangeChange,
+  variant = 'default',
+}: {
+  selectedPerp: PerpMarket;
+  timeRange: MarketTimeRange;
+  onTimeRangeChange: (range: MarketTimeRange) => void;
+  variant?: 'default' | 'compact';
+}) {
+  const isCompact = variant === 'compact';
+  const titleClass = isCompact
+    ? 'font-bold text-foreground text-sm'
+    : 'font-bold text-foreground text-lg';
+
+  return (
+    <div className="flex shrink-0 items-start justify-between gap-3 border-white/5 border-b bg-background/40 px-4 py-3 backdrop-blur-md">
+      <div className="min-w-0">
+        <div className={titleClass}>${selectedPerp.ticker}</div>
+        <div className="truncate text-muted-foreground text-xs">
+          {selectedPerp.name}
+        </div>
+      </div>
+      <TimeRangeSelector
+        timeRange={timeRange}
+        onTimeRangeChange={onTimeRangeChange}
+      />
+    </div>
+  );
 }
 
 export function MarketsTradingTerminal({
@@ -781,15 +943,11 @@ export function MarketsTradingTerminal({
           ? `/api/markets/predictions/${encodeURIComponent(predictionState.id.toString())}/buy`
           : `/api/markets/predictions/${encodeURIComponent(predictionState.id.toString())}/sell`;
 
+      // Note: sellPosition is validated earlier in this function for sell mode
       const body =
         predictionTradeMode === 'buy'
           ? { side: predictionSide, amount: predictionAmountNum }
-          : (() => {
-              if (!sellPosition) {
-                throw new Error('No sellable position for this side.');
-              }
-              return { shares: clampedSellShares, positionId: sellPosition.id };
-            })();
+          : { shares: clampedSellShares, positionId: sellPosition!.id };
 
       const response = await fetch(url, {
         method: 'POST',
@@ -1158,12 +1316,8 @@ export function MarketsTradingTerminal({
                   {predictionState?.resolutionDescription?.trim()
                     ? predictionState.resolutionDescription
                     : `Scenario ${predictionState?.scenario ?? ''}${
-                        (predictionState?.endDate ??
-                        predictionState?.resolutionDate)
-                          ? ` • Ends ${new Date(
-                              (predictionState.endDate ??
-                                predictionState.resolutionDate) as string
-                            ).toLocaleString()}`
+                        formatDate(predictionState?.endDate ?? predictionState?.resolutionDate)
+                          ? ` • Ends ${formatDate(predictionState?.endDate ?? predictionState?.resolutionDate)}`
                           : ''
                       }`}
                 </div>
@@ -1822,59 +1976,14 @@ export function MarketsTradingTerminal({
               <div className="relative flex w-full shrink-0 basis-[34%] flex-col border-white/5 border-b">
                 {selected?.kind === 'prediction' ? (
                   <>
-                    <div className="shrink-0 space-y-2 border-white/5 border-b bg-background/40 px-4 py-3 backdrop-blur-md">
-                      <div className="flex items-start justify-between gap-3">
-                        <div className="min-w-0">
-                          <div className="whitespace-normal break-words font-bold text-sm leading-snug">
-                            {predictionState?.text ?? 'Prediction market'}
-                          </div>
-                          <div className="mt-1 whitespace-normal break-words text-muted-foreground text-xs">
-                            {predictionState?.resolutionDescription?.trim()
-                              ? predictionState.resolutionDescription
-                              : `Scenario ${predictionState?.scenario ?? ''}`}
-                          </div>
-                        </div>
-                        <button
-                          type="button"
-                          onClick={() => setPredictionDetailsOpen(true)}
-                          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded border border-white/10 bg-background/30 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
-                          aria-label="View market details"
-                          title="Details"
-                        >
-                          <Info size={14} />
-                        </button>
-                      </div>
-
-                      <div className="flex flex-wrap items-center justify-between gap-2">
-                        <div className="flex items-center gap-2">
-                          <div className="rounded-full bg-blue-500/10 px-2 py-1 font-bold text-[10px] text-blue-400 tabular-nums">
-                            YES {formatYesPct(predictionYesPct)}
-                          </div>
-                          <div className="rounded-full bg-violet-500/10 px-2 py-1 font-bold text-[10px] text-violet-400 tabular-nums">
-                            NO {formatYesPct(100 - predictionYesPct)}
-                          </div>
-                        </div>
-
-                        <div className="flex items-center gap-1 rounded-md bg-muted/20 p-1 font-semibold text-xs">
-                          {MARKET_TIME_RANGES.map((range) => (
-                            <button
-                              key={range}
-                              type="button"
-                              onClick={() => setPredictionTimeRange(range)}
-                              className={cn(
-                                'rounded px-2 py-1 transition-colors',
-                                predictionTimeRange === range
-                                  ? 'bg-foreground text-background'
-                                  : 'text-muted-foreground hover:text-foreground'
-                              )}
-                            >
-                              {range}
-                            </button>
-                          ))}
-                        </div>
-                      </div>
-                    </div>
-
+                    <PredictionMarketHeader
+                      predictionState={predictionState}
+                      yesPct={predictionYesPct}
+                      timeRange={predictionTimeRange}
+                      onTimeRangeChange={setPredictionTimeRange}
+                      onDetailsClick={() => setPredictionDetailsOpen(true)}
+                      variant="compact"
+                    />
                     <div className="min-h-0 flex-1 p-2">
                       <PredictionProbabilityChart
                         data={predictionHistory}
@@ -1887,33 +1996,12 @@ export function MarketsTradingTerminal({
                   </>
                 ) : selectedPerp ? (
                   <>
-                    <div className="flex shrink-0 items-start justify-between gap-3 border-white/5 border-b bg-background/40 px-4 py-3 backdrop-blur-md">
-                      <div className="min-w-0">
-                        <div className="font-bold text-foreground text-sm">
-                          ${selectedPerp.ticker}
-                        </div>
-                        <div className="truncate text-muted-foreground text-xs">
-                          {selectedPerp.name}
-                        </div>
-                      </div>
-                      <div className="flex items-center gap-1 rounded-md bg-muted/20 p-1 font-semibold text-xs">
-                        {MARKET_TIME_RANGES.map((range) => (
-                          <button
-                            key={range}
-                            type="button"
-                            onClick={() => setPerpTimeRange(range)}
-                            className={cn(
-                              'rounded px-2 py-1 transition-colors',
-                              perpTimeRange === range
-                                ? 'bg-foreground text-background'
-                                : 'text-muted-foreground hover:text-foreground'
-                            )}
-                          >
-                            {range}
-                          </button>
-                        ))}
-                      </div>
-                    </div>
+                    <PerpMarketHeader
+                      selectedPerp={selectedPerp}
+                      timeRange={perpTimeRange}
+                      onTimeRangeChange={setPerpTimeRange}
+                      variant="compact"
+                    />
                     <div className="min-h-0 flex-1 p-2">
                       <PerpPriceChart
                         data={perpHistory.map((p) => ({
@@ -2201,59 +2289,14 @@ export function MarketsTradingTerminal({
               <div className="flex h-full flex-col pt-safe pb-safe">
                 {selected?.kind === 'prediction' ? (
                   <>
-                    <div className="shrink-0 space-y-2 border-white/5 border-b bg-background/40 px-4 py-3 backdrop-blur-md">
-                      <div className="flex items-start justify-between gap-3">
-                        <div className="min-w-0">
-                          <div className="whitespace-normal break-words font-bold text-sm leading-snug">
-                            {predictionState?.text ?? 'Prediction market'}
-                          </div>
-                          <div className="mt-1 whitespace-normal break-words text-muted-foreground text-xs">
-                            {predictionState?.resolutionDescription?.trim()
-                              ? predictionState.resolutionDescription
-                              : `Scenario ${predictionState?.scenario ?? ''}`}
-                          </div>
-                        </div>
-                        <button
-                          type="button"
-                          onClick={() => setPredictionDetailsOpen(true)}
-                          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded border border-white/10 bg-background/30 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
-                          aria-label="View market details"
-                          title="Details"
-                        >
-                          <Info size={14} />
-                        </button>
-                      </div>
-
-                      <div className="flex flex-wrap items-center justify-between gap-2">
-                        <div className="flex items-center gap-2">
-                          <div className="rounded-full bg-blue-500/10 px-2 py-1 font-bold text-[10px] text-blue-400 tabular-nums">
-                            YES {formatYesPct(predictionYesPct)}
-                          </div>
-                          <div className="rounded-full bg-violet-500/10 px-2 py-1 font-bold text-[10px] text-violet-400 tabular-nums">
-                            NO {formatYesPct(100 - predictionYesPct)}
-                          </div>
-                        </div>
-
-                        <div className="flex items-center gap-1 rounded-md bg-muted/20 p-1 font-semibold text-xs">
-                          {MARKET_TIME_RANGES.map((range) => (
-                            <button
-                              key={range}
-                              type="button"
-                              onClick={() => setPredictionTimeRange(range)}
-                              className={cn(
-                                'rounded px-2 py-1 transition-colors',
-                                predictionTimeRange === range
-                                  ? 'bg-foreground text-background'
-                                  : 'text-muted-foreground hover:text-foreground'
-                              )}
-                            >
-                              {range}
-                            </button>
-                          ))}
-                        </div>
-                      </div>
-                    </div>
-
+                    <PredictionMarketHeader
+                      predictionState={predictionState}
+                      yesPct={predictionYesPct}
+                      timeRange={predictionTimeRange}
+                      onTimeRangeChange={setPredictionTimeRange}
+                      onDetailsClick={() => setPredictionDetailsOpen(true)}
+                      variant="compact"
+                    />
                     <div className="min-h-0 flex-1 p-2">
                       <PredictionProbabilityChart
                         data={predictionHistory}
@@ -2266,33 +2309,12 @@ export function MarketsTradingTerminal({
                   </>
                 ) : selectedPerp ? (
                   <>
-                    <div className="flex shrink-0 items-start justify-between gap-3 border-white/5 border-b bg-background/40 px-4 py-3 backdrop-blur-md">
-                      <div className="min-w-0">
-                        <div className="font-bold text-foreground text-sm">
-                          ${selectedPerp.ticker}
-                        </div>
-                        <div className="truncate text-muted-foreground text-xs">
-                          {selectedPerp.name}
-                        </div>
-                      </div>
-                      <div className="flex items-center gap-1 rounded-md bg-muted/20 p-1 font-semibold text-xs">
-                        {MARKET_TIME_RANGES.map((range) => (
-                          <button
-                            key={range}
-                            type="button"
-                            onClick={() => setPerpTimeRange(range)}
-                            className={cn(
-                              'rounded px-2 py-1 transition-colors',
-                              perpTimeRange === range
-                                ? 'bg-foreground text-background'
-                                : 'text-muted-foreground hover:text-foreground'
-                            )}
-                          >
-                            {range}
-                          </button>
-                        ))}
-                      </div>
-                    </div>
+                    <PerpMarketHeader
+                      selectedPerp={selectedPerp}
+                      timeRange={perpTimeRange}
+                      onTimeRangeChange={setPerpTimeRange}
+                      variant="compact"
+                    />
                     <div className="min-h-0 flex-1 p-2">
                       <PerpPriceChart
                         data={perpHistory.map((p) => ({
@@ -2350,15 +2372,11 @@ export function MarketsTradingTerminal({
                   {predictionState?.scenario ?? '—'}
                 </span>
               </div>
-              {(predictionState?.endDate ??
-                predictionState?.resolutionDate) && (
+              {formatDate(predictionState?.endDate ?? predictionState?.resolutionDate) && (
                 <div className="mt-2 flex items-center justify-between">
                   <span className="text-muted-foreground">Ends</span>
                   <span className="font-mono text-foreground tabular-nums">
-                    {new Date(
-                      (predictionState?.endDate ??
-                        predictionState?.resolutionDate) as string
-                    ).toLocaleString()}
+                    {formatDate(predictionState?.endDate ?? predictionState?.resolutionDate)}
                   </span>
                 </div>
               )}

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -774,33 +774,34 @@ export function MarketsTradingTerminal({
 
   const listPanel = (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="shrink-0 space-y-3 border-white/5 border-b p-3">
+      <div
+        ref={marketsMenuRef}
+        className="shrink-0 space-y-3 border-white/5 border-b p-3"
+      >
         <div className="flex items-center justify-between">
           <div className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
             Markets
           </div>
           <div className="flex items-center gap-1">
-            <div ref={marketsMenuRef}>
-              <button
-                type="button"
-                onClick={() => setShowMarketsMenu((v) => !v)}
-                aria-expanded={showMarketsMenu}
-                aria-controls="markets-filter-sort"
-                className={cn(
-                  'rounded p-1.5 transition-colors hover:bg-muted/20',
-                  showMarketsMenu ||
-                    filter !== 'all' ||
-                    sortBy !== 'volume' ||
-                    sortDesc !== true
-                    ? 'bg-muted/20 text-primary'
-                    : 'text-muted-foreground'
-                )}
-                aria-label="Filter and sort markets"
-                title="Filter & Sort"
-              >
-                <Filter size={14} />
-              </button>
-            </div>
+            <button
+              type="button"
+              onClick={() => setShowMarketsMenu((v) => !v)}
+              aria-expanded={showMarketsMenu}
+              aria-controls="markets-filter-sort"
+              className={cn(
+                'rounded p-1.5 transition-colors hover:bg-muted/20',
+                showMarketsMenu ||
+                  filter !== 'all' ||
+                  sortBy !== 'volume' ||
+                  sortDesc !== true
+                  ? 'bg-muted/20 text-primary'
+                  : 'text-muted-foreground'
+              )}
+              aria-label="Filter and sort markets"
+              title="Filter & Sort"
+            >
+              <Filter size={14} />
+            </button>
 
             <button
               type="button"

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -15,6 +15,7 @@ import {
   Minimize2,
   Search,
   Star,
+  Wallet,
   X,
 } from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
@@ -851,17 +852,7 @@ export function MarketsTradingTerminal({
       </div>
 
       <div className="ml-3 flex items-center gap-2 text-xs">
-        {authenticated ? (
-          <button
-            type="button"
-            onClick={onRequestBuyPoints}
-            className="rounded border border-white/10 bg-background/30 px-2 py-1 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground"
-          >
-            {balanceLoading
-              ? '…'
-              : `${BABYLON_POINTS_SYMBOL}${Math.floor(balance).toLocaleString()}`}
-          </button>
-        ) : (
+        {!authenticated && (
           <button
             type="button"
             onClick={login}
@@ -1276,11 +1267,21 @@ export function MarketsTradingTerminal({
                 <div className="text-[10px] text-muted-foreground uppercase tracking-wider">
                   Available Balance
                 </div>
-                <div className="font-mono text-foreground text-lg tabular-nums">
+                <div className="flex items-center gap-2 font-mono text-foreground text-lg tabular-nums">
+                  <Wallet size={14} className="text-muted-foreground" />
                   {balanceLoading ? (
                     <Skeleton className="h-5 w-20" />
                   ) : (
                     `${BABYLON_POINTS_SYMBOL}${Math.floor(balance).toLocaleString()}`
+                  )}
+                  {onRequestBuyPoints && (
+                    <button
+                      type="button"
+                      onClick={onRequestBuyPoints}
+                      className="ml-2 rounded bg-muted/20 px-2 py-1 font-sans text-[10px] text-muted-foreground uppercase tracking-wider transition-colors hover:bg-muted/30 hover:text-foreground"
+                    >
+                      Buy
+                    </button>
                   )}
                 </div>
               </div>
@@ -1532,6 +1533,7 @@ export function MarketsTradingTerminal({
           <PerpsOrderEntryPanel
             market={selectedPerp}
             initialSide={perpSideFromUrl ?? undefined}
+            onRequestBuyPoints={onRequestBuyPoints}
           />
         </div>
       ) : (

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -1325,38 +1325,11 @@ export function MarketsTradingTerminal({
             <div className="mt-3 flex rounded-md bg-muted/20 p-1">
               <button
                 type="button"
-                onClick={() => setPredictionTradeMode('buy')}
-                className={cn(
-                  'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
-                  predictionTradeMode === 'buy'
-                    ? 'bg-foreground text-background'
-                    : 'text-muted-foreground hover:text-foreground'
-                )}
-              >
-                BUY
-              </button>
-              <button
-                type="button"
-                onClick={() => setPredictionTradeMode('sell')}
-                className={cn(
-                  'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
-                  predictionTradeMode === 'sell'
-                    ? 'bg-foreground text-background'
-                    : 'text-muted-foreground hover:text-foreground'
-                )}
-              >
-                SELL
-              </button>
-            </div>
-
-            <div className="mt-3 flex rounded-md bg-muted/20 p-1">
-              <button
-                type="button"
                 onClick={() => setPredictionSide('yes')}
                 className={cn(
                   'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
                   predictionSide === 'yes'
-                    ? 'bg-green-600 text-white'
+                    ? 'bg-blue-600 text-white'
                     : 'text-muted-foreground hover:text-foreground'
                 )}
               >
@@ -1368,11 +1341,38 @@ export function MarketsTradingTerminal({
                 className={cn(
                   'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
                   predictionSide === 'no'
-                    ? 'bg-red-600 text-white'
+                    ? 'bg-pink-600 text-white'
                     : 'text-muted-foreground hover:text-foreground'
                 )}
               >
                 NO
+              </button>
+            </div>
+
+            <div className="mt-3 flex rounded-md bg-muted/20 p-1">
+              <button
+                type="button"
+                onClick={() => setPredictionTradeMode('buy')}
+                className={cn(
+                  'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
+                  predictionTradeMode === 'buy'
+                    ? 'bg-green-600 text-white'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
+              >
+                BUY
+              </button>
+              <button
+                type="button"
+                onClick={() => setPredictionTradeMode('sell')}
+                className={cn(
+                  'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
+                  predictionTradeMode === 'sell'
+                    ? 'bg-red-600 text-white'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
+              >
+                SELL
               </button>
             </div>
 
@@ -1513,7 +1513,7 @@ export function MarketsTradingTerminal({
               }
               className={cn(
                 'mt-5 w-full rounded py-3 font-bold text-sm text-white shadow transition-all',
-                predictionSide === 'yes'
+                predictionTradeMode === 'buy'
                   ? 'bg-green-600 hover:brightness-110'
                   : 'bg-red-600 hover:brightness-110',
                 (predictionSubmitting ||

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -4,11 +4,13 @@ import {
   calculateExpectedPayout,
   PredictionPricing,
 } from '@babylon/core/markets/prediction/client';
+import { FEE_CONFIG } from '@babylon/engine/config/fees';
 import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
 import {
   ArrowUpDown,
   Check,
   Filter,
+  Info,
   Maximize2,
   Minimize2,
   Search,
@@ -26,9 +28,20 @@ import { PredictionPositionsList } from '@/components/markets/PredictionPosition
 import { PredictionProbabilityChart } from '@/components/markets/PredictionProbabilityChart';
 import {
   type BuyPredictionDetails,
+  type SellPredictionDetails,
   TradeConfirmationDialog,
 } from '@/components/markets/TradeConfirmationDialog';
 import { Skeleton } from '@/components/shared/Skeleton';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { useAuth } from '@/hooks/useAuth';
 import { usePerpHistory } from '@/hooks/usePerpHistory';
 import { usePredictionHistory } from '@/hooks/usePredictionHistory';
@@ -243,8 +256,13 @@ export function MarketsTradingTerminal({
     () => parsePredictionSide(searchParams) ?? 'yes'
   );
   const [predictionAmount, setPredictionAmount] = useState('10');
+  const [predictionTradeMode, setPredictionTradeMode] = useState<
+    'buy' | 'sell'
+  >('buy');
+  const [predictionSellShares, setPredictionSellShares] = useState('');
   const [predictionSubmitting, setPredictionSubmitting] = useState(false);
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
+  const [predictionDetailsOpen, setPredictionDetailsOpen] = useState(false);
 
   const [perpTimeRange, setPerpTimeRange] = useState<MarketTimeRange>('1D');
   const [predictionTimeRange, setPredictionTimeRange] =
@@ -607,118 +625,6 @@ export function MarketsTradingTerminal({
     [router, searchParams, sortBy, sortDesc]
   );
 
-  const predictionAmountNum = Number.parseFloat(predictionAmount) || 0;
-
-  const predictionCalculation = useMemo(() => {
-    if (!predictionEffectiveShares) return null;
-    if (predictionAmountNum <= 0) return null;
-    return PredictionPricing.calculateBuy(
-      predictionEffectiveShares.yesShares,
-      predictionEffectiveShares.noShares,
-      predictionSide,
-      predictionAmountNum
-    );
-  }, [predictionEffectiveShares, predictionSide, predictionAmountNum]);
-
-  const expectedPayout = useMemo(() => {
-    if (!predictionCalculation) return 0;
-    return calculateExpectedPayout(
-      predictionCalculation.sharesBought,
-      predictionCalculation.avgPrice
-    );
-  }, [predictionCalculation]);
-  const expectedProfit = expectedPayout - predictionAmountNum;
-
-  const handlePredictionSubmit = () => {
-    if (!authenticated) {
-      login();
-      return;
-    }
-    if (!predictionState) return;
-    if (predictionState.status !== 'active' || predictionState.resolved) {
-      toast.error('This market is not active.');
-      return;
-    }
-    if (predictionAmountNum < 1) {
-      toast.error(`Minimum bet is ${BABYLON_POINTS_SYMBOL}1`);
-      return;
-    }
-    setConfirmDialogOpen(true);
-  };
-
-  const handleConfirmPredictionBuy = async () => {
-    if (!predictionState) return;
-    if (!predictionCalculation) return;
-
-    setPredictionSubmitting(true);
-    setConfirmDialogOpen(false);
-
-    try {
-      const token = await getAccessToken();
-      if (!token) {
-        toast.error('Authentication required. Please log in.');
-        return;
-      }
-
-      const response = await fetch(
-        `/api/markets/predictions/${encodeURIComponent(predictionState.id.toString())}/buy`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({
-            side: predictionSide,
-            amount: predictionAmountNum,
-          }),
-        }
-      );
-
-      let data: unknown = null;
-      try {
-        data = await response.json();
-      } catch {
-        data = null;
-      }
-
-      if (!response.ok) {
-        const maybeError = data as {
-          error?: unknown;
-          message?: unknown;
-        } | null;
-        const errorMessage =
-          typeof maybeError?.error === 'object'
-            ? ((maybeError.error as { message?: unknown })
-                ?.message as string) || 'Failed to buy shares'
-            : (maybeError?.error as string) ||
-              (maybeError?.message as string) ||
-              'Failed to buy shares';
-        toast.error(errorMessage);
-        return;
-      }
-
-      toast.success(`Bought ${predictionSide.toUpperCase()} shares!`, {
-        description: `${predictionCalculation.sharesBought.toFixed(2)} shares at ${predictionCalculation.avgPrice.toFixed(3)} each`,
-      });
-
-      invalidateUserPositions();
-      invalidateWalletBalance();
-      await Promise.all([
-        refreshPredictionPositions(),
-        refreshPerpPositions(),
-        refreshWalletBalance(),
-        refreshPredictionHistory(),
-      ]);
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : 'Failed to buy shares';
-      toast.error(message);
-    } finally {
-      setPredictionSubmitting(false);
-    }
-  };
-
   const selectedPredictionId =
     selected?.kind === 'prediction' ? selected.id : null;
   const selectedPredictionPositions = useMemo(() => {
@@ -736,6 +642,203 @@ export function MarketsTradingTerminal({
         !p.closedAt
     );
   }, [perpPositions, selectedPerp]);
+
+  const predictionAmountNum = Number.parseFloat(predictionAmount) || 0;
+  const predictionSellSharesNum = Number.parseFloat(predictionSellShares) || 0;
+
+  const predictionBuyCalculation = useMemo(() => {
+    if (!predictionEffectiveShares) return null;
+    if (predictionAmountNum <= 0) return null;
+    return PredictionPricing.calculateBuyWithFees(
+      predictionEffectiveShares.yesShares,
+      predictionEffectiveShares.noShares,
+      predictionSide,
+      predictionAmountNum,
+      FEE_CONFIG.TRADING_FEE_RATE
+    );
+  }, [predictionEffectiveShares, predictionSide, predictionAmountNum]);
+
+  const sellPosition = useMemo(() => {
+    const wantedSide = predictionSide.toUpperCase() as 'YES' | 'NO';
+    const candidates = selectedPredictionPositions.filter(
+      (p) => p.side === wantedSide && p.shares >= 0.01
+    );
+    if (candidates.length === 0) return null;
+    const first = candidates[0];
+    if (!first) return null;
+    return candidates
+      .slice(1)
+      .reduce((best, pos) => (pos.shares > best.shares ? pos : best), first);
+  }, [predictionSide, selectedPredictionPositions]);
+
+  const maxSellShares = sellPosition?.shares ?? 0;
+  const clampedSellShares =
+    predictionSellSharesNum > 0
+      ? Math.min(predictionSellSharesNum, maxSellShares)
+      : 0;
+
+  const predictionSellCalculation = useMemo(() => {
+    if (!predictionEffectiveShares) return null;
+    if (!sellPosition) return null;
+    if (clampedSellShares <= 0) return null;
+    return PredictionPricing.calculateSellWithFees(
+      predictionEffectiveShares.yesShares,
+      predictionEffectiveShares.noShares,
+      predictionSide,
+      clampedSellShares,
+      FEE_CONFIG.TRADING_FEE_RATE
+    );
+  }, [
+    predictionEffectiveShares,
+    predictionSide,
+    sellPosition,
+    clampedSellShares,
+  ]);
+
+  const expectedPayout = useMemo(() => {
+    if (!predictionBuyCalculation) return 0;
+    return calculateExpectedPayout(
+      predictionBuyCalculation.sharesBought,
+      predictionBuyCalculation.avgPrice
+    );
+  }, [predictionBuyCalculation]);
+  const expectedProfit = expectedPayout - predictionAmountNum;
+
+  const handlePredictionSubmit = () => {
+    if (!authenticated) {
+      login();
+      return;
+    }
+    if (!predictionState) return;
+    if (predictionState.status !== 'active' || predictionState.resolved) {
+      toast.error('This market is not active.');
+      return;
+    }
+    if (predictionTradeMode === 'buy') {
+      if (predictionAmountNum < 1) {
+        toast.error(`Minimum bet is ${BABYLON_POINTS_SYMBOL}1`);
+        return;
+      }
+    } else {
+      if (!sellPosition) {
+        toast.error('No sellable position for this side.');
+        return;
+      }
+      if (clampedSellShares < 0.01) {
+        toast.error('Minimum sell is 0.01 shares');
+        return;
+      }
+    }
+    setConfirmDialogOpen(true);
+  };
+
+  const handleConfirmPredictionTrade = async () => {
+    if (!predictionState) return;
+    if (predictionTradeMode === 'buy' && !predictionBuyCalculation) {
+      toast.error('Invalid buy amount.');
+      return;
+    }
+    if (predictionTradeMode === 'sell') {
+      if (!sellPosition) {
+        toast.error('No sellable position for this side.');
+        return;
+      }
+      if (clampedSellShares < 0.01) {
+        toast.error('Minimum sell is 0.01 shares');
+        return;
+      }
+    }
+
+    setPredictionSubmitting(true);
+    setConfirmDialogOpen(false);
+
+    try {
+      const token = await getAccessToken();
+      if (!token) {
+        toast.error('Authentication required. Please log in.');
+        return;
+      }
+
+      const url =
+        predictionTradeMode === 'buy'
+          ? `/api/markets/predictions/${encodeURIComponent(predictionState.id.toString())}/buy`
+          : `/api/markets/predictions/${encodeURIComponent(predictionState.id.toString())}/sell`;
+
+      const body =
+        predictionTradeMode === 'buy'
+          ? { side: predictionSide, amount: predictionAmountNum }
+          : (() => {
+              if (!sellPosition) {
+                throw new Error('No sellable position for this side.');
+              }
+              return { shares: clampedSellShares, positionId: sellPosition.id };
+            })();
+
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(body),
+      });
+
+      let data: unknown = null;
+      try {
+        data = await response.json();
+      } catch {
+        data = null;
+      }
+
+      if (!response.ok) {
+        const maybeError = data as {
+          error?: unknown;
+          message?: unknown;
+        } | null;
+        const errorMessage =
+          typeof maybeError?.error === 'object'
+            ? ((maybeError.error as { message?: unknown })
+                ?.message as string) ||
+              (predictionTradeMode === 'sell'
+                ? 'Failed to sell shares'
+                : 'Failed to buy shares')
+            : (maybeError?.error as string) ||
+              (maybeError?.message as string) ||
+              (predictionTradeMode === 'sell'
+                ? 'Failed to sell shares'
+                : 'Failed to buy shares');
+        toast.error(errorMessage);
+        return;
+      }
+
+      if (predictionTradeMode === 'buy') {
+        toast.success(`Bought ${predictionSide.toUpperCase()} shares!`, {
+          description: predictionBuyCalculation
+            ? `${predictionBuyCalculation.sharesBought.toFixed(2)} shares at ${predictionBuyCalculation.avgPrice.toFixed(3)} each`
+            : undefined,
+        });
+      } else {
+        toast.success(`Sold ${predictionSide.toUpperCase()} shares!`, {
+          description: `${clampedSellShares.toFixed(2)} shares sold`,
+        });
+      }
+
+      invalidateUserPositions();
+      invalidateWalletBalance();
+      await Promise.all([
+        refreshPredictionPositions(),
+        refreshPerpPositions(),
+        refreshWalletBalance(),
+        refreshPredictionHistory(),
+      ]);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Failed to trade';
+      toast.error(message);
+    } finally {
+      setPredictionSubmitting(false);
+    }
+  };
 
   const desktopTradesContainerRef = useRef<HTMLDivElement | null>(null);
   const mobileTradesContainerRef = useRef<HTMLDivElement | null>(null);
@@ -1038,49 +1141,80 @@ export function MarketsTradingTerminal({
     <div className="flex h-full min-h-0 flex-col bg-background/10">
       {selected?.kind === 'prediction' ? (
         <>
-          <div className="flex shrink-0 items-center justify-between border-white/5 border-b px-4 py-3">
-            <div className="min-w-0">
-              <div className="truncate font-bold text-foreground text-lg">
-                {predictionState?.text ?? 'Prediction market'}
+          <div className="shrink-0 border-white/5 border-b px-4 py-3">
+            <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+              <div className="min-w-0">
+                <div className="whitespace-normal break-words font-bold text-foreground text-lg leading-snug">
+                  {predictionState?.text ?? 'Prediction market'}
+                </div>
+                <div className="mt-1 whitespace-normal break-words text-muted-foreground text-xs">
+                  {predictionState?.resolutionDescription?.trim()
+                    ? predictionState.resolutionDescription
+                    : `Scenario ${predictionState?.scenario ?? ''}${
+                        (predictionState?.endDate ??
+                        predictionState?.resolutionDate)
+                          ? ` • Ends ${new Date(
+                              (predictionState.endDate ??
+                                predictionState.resolutionDate) as string
+                            ).toLocaleString()}`
+                          : ''
+                      }`}
+                </div>
               </div>
-              <div className="text-muted-foreground text-xs">
-                YES {formatYesPct(predictionYesPct)} · NO{' '}
-                {formatYesPct(100 - predictionYesPct)}
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <div className="flex items-center gap-1 rounded-md bg-muted/20 p-1 font-semibold text-xs">
-                {MARKET_TIME_RANGES.map((range) => (
+
+              <div className="flex flex-col gap-2 lg:items-end">
+                <div className="flex items-center gap-2">
+                  <div className="rounded-full bg-green-600/10 px-2 py-1 font-bold text-[10px] text-green-500 tabular-nums">
+                    YES {formatYesPct(predictionYesPct)}
+                  </div>
+                  <div className="rounded-full bg-red-600/10 px-2 py-1 font-bold text-[10px] text-red-500 tabular-nums">
+                    NO {formatYesPct(100 - predictionYesPct)}
+                  </div>
                   <button
-                    key={range}
                     type="button"
-                    onClick={() => setPredictionTimeRange(range)}
-                    className={cn(
-                      'rounded px-2 py-1 transition-colors',
-                      predictionTimeRange === range
-                        ? 'bg-foreground text-background'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
+                    onClick={() => setPredictionDetailsOpen(true)}
+                    className="inline-flex h-8 w-8 items-center justify-center rounded border border-white/10 bg-background/30 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+                    aria-label="View market details"
+                    title="Details"
                   >
-                    {range}
+                    <Info size={14} />
                   </button>
-                ))}
+                </div>
+
+                <div className="flex items-center gap-1 rounded-md bg-muted/20 p-1 font-semibold text-xs">
+                  {MARKET_TIME_RANGES.map((range) => (
+                    <button
+                      key={range}
+                      type="button"
+                      onClick={() => setPredictionTimeRange(range)}
+                      className={cn(
+                        'rounded px-2 py-1 transition-colors',
+                        predictionTimeRange === range
+                          ? 'bg-foreground text-background'
+                          : 'text-muted-foreground hover:text-foreground'
+                      )}
+                    >
+                      {range}
+                    </button>
+                  ))}
+                </div>
               </div>
             </div>
           </div>
 
-          <div className="min-h-0 flex-1">
+          <div className="min-h-0 flex-1 p-4">
             <PredictionProbabilityChart
               data={predictionHistory}
               marketId={selectedPredictionId ?? 'unknown'}
               timeRange={predictionTimeRange}
               onTimeRangeChange={setPredictionTimeRange}
+              showHeader={false}
             />
           </div>
         </>
       ) : selectedPerp ? (
         <>
-          <div className="flex shrink-0 items-center justify-between border-white/5 border-b px-4 py-3">
+          <div className="flex shrink-0 items-start justify-between gap-3 border-white/5 border-b px-4 py-3">
             <div className="min-w-0">
               <div className="font-bold text-foreground text-lg">
                 ${selectedPerp.ticker}
@@ -1088,6 +1222,23 @@ export function MarketsTradingTerminal({
               <div className="truncate text-muted-foreground text-xs">
                 {selectedPerp.name}
               </div>
+            </div>
+            <div className="flex items-center gap-1 rounded-md bg-muted/20 p-1 font-semibold text-xs">
+              {MARKET_TIME_RANGES.map((range) => (
+                <button
+                  key={range}
+                  type="button"
+                  onClick={() => setPerpTimeRange(range)}
+                  className={cn(
+                    'rounded px-2 py-1 transition-colors',
+                    perpTimeRange === range
+                      ? 'bg-foreground text-background'
+                      : 'text-muted-foreground hover:text-foreground'
+                  )}
+                >
+                  {range}
+                </button>
+              ))}
             </div>
           </div>
           <div className="min-h-0 flex-1 p-4">
@@ -1127,107 +1278,263 @@ export function MarketsTradingTerminal({
       </div>
 
       {selected?.kind === 'prediction' ? (
-        <div className="min-h-0 flex-1 overflow-auto p-4 pb-[calc(72px+env(safe-area-inset-bottom)+24px)]">
-          <div className="flex items-center justify-between">
-            <div className="font-semibold text-sm">Buy Shares</div>
-            <div className="rounded bg-muted/20 px-2 py-1 text-[10px] text-muted-foreground uppercase tracking-wider">
-              Standard
-            </div>
-          </div>
-
-          <div className="mt-3 flex rounded-md bg-muted/20 p-1">
-            <button
-              type="button"
-              onClick={() => setPredictionSide('yes')}
-              className={cn(
-                'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
-                predictionSide === 'yes'
-                  ? 'bg-green-600 text-white'
-                  : 'text-muted-foreground hover:text-foreground'
+        <div className="flex h-full min-h-0 flex-col bg-background/10">
+          <div className="border-white/5 border-b bg-muted/10 p-4">
+            <div className="flex items-start justify-between gap-3">
+              <div className="space-y-1">
+                <div className="text-[10px] text-muted-foreground uppercase tracking-wider">
+                  Available Balance
+                </div>
+                <div className="font-mono text-foreground text-lg tabular-nums">
+                  {balanceLoading ? (
+                    <Skeleton className="h-5 w-20" />
+                  ) : (
+                    `${BABYLON_POINTS_SYMBOL}${Math.floor(balance).toLocaleString()}`
+                  )}
+                </div>
+              </div>
+              {selectedPredictionPositions.length > 0 && (
+                <div className="text-right">
+                  <div className="text-[10px] text-muted-foreground uppercase tracking-wider">
+                    Open Position
+                  </div>
+                  <div className="text-xs">
+                    {(['YES', 'NO'] as const)
+                      .map((side) => {
+                        const total = selectedPredictionPositions
+                          .filter((p) => p.side === side)
+                          .reduce((sum, p) => sum + p.shares, 0);
+                        return total > 0 ? `${side} ${total.toFixed(2)}` : null;
+                      })
+                      .filter(Boolean)
+                      .join(' • ')}
+                  </div>
+                </div>
               )}
-            >
-              YES
-            </button>
-            <button
-              type="button"
-              onClick={() => setPredictionSide('no')}
-              className={cn(
-                'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
-                predictionSide === 'no'
-                  ? 'bg-red-600 text-white'
-                  : 'text-muted-foreground hover:text-foreground'
-              )}
-            >
-              NO
-            </button>
+            </div>
           </div>
 
-          <div className="mt-4">
-            <div className="mb-1 flex items-center justify-between">
-              <label className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
-                Amount
-              </label>
-              <span className="text-[10px] text-muted-foreground">
-                Min {BABYLON_POINTS_SYMBOL}1
-              </span>
-            </div>
-            <input
-              type="number"
-              value={predictionAmount}
-              onChange={(e) => setPredictionAmount(e.target.value)}
-              min={1}
-              step="1"
-              className="w-full rounded border border-white/10 bg-background/30 px-3 py-2 font-mono text-sm tabular-nums focus:border-primary/40 focus:outline-none focus:ring-2 focus:ring-primary/20"
-              placeholder="10"
-            />
-          </div>
-
-          {predictionCalculation && (
-            <div className="mt-4 rounded border border-white/10 bg-muted/10 p-3 text-xs">
-              <div className="flex items-center justify-between">
-                <span className="text-muted-foreground">Shares</span>
-                <span className="font-mono text-foreground tabular-nums">
-                  {predictionCalculation.sharesBought.toFixed(2)}
-                </span>
-              </div>
-              <div className="mt-2 flex items-center justify-between">
-                <span className="text-muted-foreground">Avg price</span>
-                <span className="font-mono text-foreground tabular-nums">
-                  {(predictionCalculation.avgPrice * 100).toFixed(1)}%
-                </span>
-              </div>
-              <div className="mt-2 flex items-center justify-between">
-                <span className="text-muted-foreground">Expected payout</span>
-                <span className="font-mono text-foreground tabular-nums">
-                  {BABYLON_POINTS_SYMBOL}
-                  {expectedPayout.toFixed(2)}
-                </span>
+          <div className="min-h-0 flex-1 overflow-auto p-4 pb-[calc(72px+env(safe-area-inset-bottom)+24px)]">
+            <div className="flex items-center justify-between">
+              <div className="font-semibold text-sm">Place Order</div>
+              <div className="rounded bg-muted/20 px-2 py-1 text-[10px] text-muted-foreground uppercase tracking-wider">
+                Standard
               </div>
             </div>
-          )}
 
-          <button
-            type="button"
-            onClick={handlePredictionSubmit}
-            disabled={
-              predictionSubmitting || (authenticated && predictionAmountNum < 1)
-            }
-            className={cn(
-              'mt-5 w-full rounded py-3 font-bold text-sm text-white shadow transition-all',
-              predictionSide === 'yes'
-                ? 'bg-green-600 hover:brightness-110'
-                : 'bg-red-600 hover:brightness-110',
-              (predictionSubmitting ||
-                (authenticated && predictionAmountNum < 1)) &&
-                'cursor-not-allowed opacity-50'
+            <div className="mt-3 flex rounded-md bg-muted/20 p-1">
+              <button
+                type="button"
+                onClick={() => setPredictionTradeMode('buy')}
+                className={cn(
+                  'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
+                  predictionTradeMode === 'buy'
+                    ? 'bg-foreground text-background'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
+              >
+                BUY
+              </button>
+              <button
+                type="button"
+                onClick={() => setPredictionTradeMode('sell')}
+                className={cn(
+                  'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
+                  predictionTradeMode === 'sell'
+                    ? 'bg-foreground text-background'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
+              >
+                SELL
+              </button>
+            </div>
+
+            <div className="mt-3 flex rounded-md bg-muted/20 p-1">
+              <button
+                type="button"
+                onClick={() => setPredictionSide('yes')}
+                className={cn(
+                  'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
+                  predictionSide === 'yes'
+                    ? 'bg-green-600 text-white'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
+              >
+                YES
+              </button>
+              <button
+                type="button"
+                onClick={() => setPredictionSide('no')}
+                className={cn(
+                  'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
+                  predictionSide === 'no'
+                    ? 'bg-red-600 text-white'
+                    : 'text-muted-foreground hover:text-foreground'
+                )}
+              >
+                NO
+              </button>
+            </div>
+
+            {predictionTradeMode === 'buy' ? (
+              <div className="mt-4">
+                <div className="mb-1 flex items-center justify-between">
+                  <label className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+                    Amount
+                  </label>
+                  <span className="text-[10px] text-muted-foreground">
+                    Min {BABYLON_POINTS_SYMBOL}1
+                  </span>
+                </div>
+                <input
+                  type="number"
+                  value={predictionAmount}
+                  onChange={(e) => setPredictionAmount(e.target.value)}
+                  min={1}
+                  step="1"
+                  className="w-full rounded border border-white/10 bg-background/30 px-3 py-2 font-mono text-sm tabular-nums focus:border-primary/40 focus:outline-none focus:ring-2 focus:ring-primary/20"
+                  placeholder="10"
+                />
+              </div>
+            ) : (
+              <div className="mt-4">
+                <div className="mb-1 flex items-center justify-between">
+                  <label className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+                    Shares
+                  </label>
+                  <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
+                    <span>Min 0.01</span>
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setPredictionSellShares(
+                          maxSellShares > 0 ? maxSellShares.toFixed(2) : ''
+                        )
+                      }
+                      className="rounded bg-muted/20 px-2 py-0.5 hover:bg-muted/30"
+                      disabled={maxSellShares <= 0}
+                    >
+                      Max
+                    </button>
+                  </div>
+                </div>
+                <input
+                  type="number"
+                  value={predictionSellShares}
+                  onChange={(e) => setPredictionSellShares(e.target.value)}
+                  min={0.01}
+                  step="0.01"
+                  className="w-full rounded border border-white/10 bg-background/30 px-3 py-2 font-mono text-sm tabular-nums focus:border-primary/40 focus:outline-none focus:ring-2 focus:ring-primary/20"
+                  placeholder={
+                    maxSellShares > 0 ? maxSellShares.toFixed(2) : '0.00'
+                  }
+                  disabled={maxSellShares <= 0}
+                />
+                {maxSellShares <= 0 && (
+                  <div className="mt-2 text-[10px] text-muted-foreground">
+                    No sellable position for this side.
+                  </div>
+                )}
+              </div>
             )}
-          >
-            {predictionSubmitting
-              ? 'Processing…'
-              : !authenticated
-                ? 'Log In to Trade'
-                : `BUY ${predictionSide.toUpperCase()} · ${BABYLON_POINTS_SYMBOL}${predictionAmountNum.toFixed(0)}`}
-          </button>
+
+            {predictionTradeMode === 'buy' && predictionBuyCalculation && (
+              <div className="mt-4 rounded border border-white/10 bg-muted/10 p-3 text-xs">
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Shares</span>
+                  <span className="font-mono text-foreground tabular-nums">
+                    {predictionBuyCalculation.sharesBought.toFixed(2)}
+                  </span>
+                </div>
+                <div className="mt-2 flex items-center justify-between">
+                  <span className="text-muted-foreground">Avg price</span>
+                  <span className="font-mono text-foreground tabular-nums">
+                    {(predictionBuyCalculation.avgPrice * 100).toFixed(1)}%
+                  </span>
+                </div>
+                <div className="mt-2 flex items-center justify-between">
+                  <span className="text-muted-foreground">Fee</span>
+                  <span className="font-mono text-muted-foreground tabular-nums">
+                    {BABYLON_POINTS_SYMBOL}
+                    {predictionBuyCalculation.fee?.toFixed(2) ?? '0.00'}
+                  </span>
+                </div>
+                <div className="mt-2 flex items-center justify-between">
+                  <span className="text-muted-foreground">Expected payout</span>
+                  <span className="font-mono text-foreground tabular-nums">
+                    {BABYLON_POINTS_SYMBOL}
+                    {expectedPayout.toFixed(2)}
+                  </span>
+                </div>
+              </div>
+            )}
+
+            {predictionTradeMode === 'sell' && predictionSellCalculation && (
+              <div className="mt-4 rounded border border-white/10 bg-muted/10 p-3 text-xs">
+                <div className="flex items-center justify-between">
+                  <span className="text-muted-foreground">Gross proceeds</span>
+                  <span className="font-mono text-foreground tabular-nums">
+                    {BABYLON_POINTS_SYMBOL}
+                    {predictionSellCalculation.totalCost.toFixed(2)}
+                  </span>
+                </div>
+                <div className="mt-2 flex items-center justify-between">
+                  <span className="text-muted-foreground">Fee</span>
+                  <span className="font-mono text-muted-foreground tabular-nums">
+                    {BABYLON_POINTS_SYMBOL}
+                    {predictionSellCalculation.fee?.toFixed(2) ?? '0.00'}
+                  </span>
+                </div>
+                <div className="mt-2 flex items-center justify-between font-semibold">
+                  <span className="text-muted-foreground">Net proceeds</span>
+                  <span className="font-mono text-foreground tabular-nums">
+                    {BABYLON_POINTS_SYMBOL}
+                    {(
+                      predictionSellCalculation.netProceeds ??
+                      predictionSellCalculation.netAmount ??
+                      predictionSellCalculation.totalCost
+                    ).toFixed(2)}
+                  </span>
+                </div>
+              </div>
+            )}
+
+            <button
+              type="button"
+              onClick={handlePredictionSubmit}
+              disabled={
+                predictionSubmitting ||
+                (predictionTradeMode === 'buy' &&
+                  authenticated &&
+                  predictionAmountNum < 1) ||
+                (predictionTradeMode === 'sell' &&
+                  authenticated &&
+                  (maxSellShares <= 0 || clampedSellShares < 0.01))
+              }
+              className={cn(
+                'mt-5 w-full rounded py-3 font-bold text-sm text-white shadow transition-all',
+                predictionSide === 'yes'
+                  ? 'bg-green-600 hover:brightness-110'
+                  : 'bg-red-600 hover:brightness-110',
+                (predictionSubmitting ||
+                  (predictionTradeMode === 'buy' &&
+                    authenticated &&
+                    predictionAmountNum < 1) ||
+                  (predictionTradeMode === 'sell' &&
+                    authenticated &&
+                    (maxSellShares <= 0 || clampedSellShares < 0.01))) &&
+                  'cursor-not-allowed opacity-50'
+              )}
+            >
+              {predictionSubmitting
+                ? 'Processing…'
+                : !authenticated
+                  ? 'Log In to Trade'
+                  : predictionTradeMode === 'buy'
+                    ? `BUY ${predictionSide.toUpperCase()} · ${BABYLON_POINTS_SYMBOL}${predictionAmountNum.toFixed(0)}`
+                    : `SELL ${predictionSide.toUpperCase()} · ${clampedSellShares.toFixed(2)} shares`}
+            </button>
+          </div>
         </div>
       ) : selectedPerp ? (
         <div className="min-h-0 flex-1 overflow-auto">
@@ -1512,27 +1819,116 @@ export function MarketsTradingTerminal({
 
         <div className="min-h-0 flex-1 overflow-hidden">
           <div className="hide-scrollbar flex h-full flex-col overflow-y-auto overflow-x-hidden">
-            <div className="h-[45vh] w-full shrink-0 border-white/5 border-b">
+            <div className="flex h-[45vh] w-full shrink-0 flex-col border-white/5 border-b">
               {selected?.kind === 'prediction' ? (
-                <PredictionProbabilityChart
-                  data={predictionHistory}
-                  marketId={selectedPredictionId ?? 'unknown'}
-                  timeRange={predictionTimeRange}
-                  onTimeRangeChange={setPredictionTimeRange}
-                />
+                <>
+                  <div className="shrink-0 space-y-2 border-white/5 border-b bg-background/40 px-4 py-3 backdrop-blur-md">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="whitespace-normal break-words font-bold text-sm leading-snug">
+                          {predictionState?.text ?? 'Prediction market'}
+                        </div>
+                        <div className="mt-1 whitespace-normal break-words text-muted-foreground text-xs">
+                          {predictionState?.resolutionDescription?.trim()
+                            ? predictionState.resolutionDescription
+                            : `Scenario ${predictionState?.scenario ?? ''}`}
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => setPredictionDetailsOpen(true)}
+                        className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded border border-white/10 bg-background/30 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+                        aria-label="View market details"
+                        title="Details"
+                      >
+                        <Info size={14} />
+                      </button>
+                    </div>
+
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div className="flex items-center gap-2">
+                        <div className="rounded-full bg-green-600/10 px-2 py-1 font-bold text-[10px] text-green-500 tabular-nums">
+                          YES {formatYesPct(predictionYesPct)}
+                        </div>
+                        <div className="rounded-full bg-red-600/10 px-2 py-1 font-bold text-[10px] text-red-500 tabular-nums">
+                          NO {formatYesPct(100 - predictionYesPct)}
+                        </div>
+                      </div>
+
+                      <div className="flex items-center gap-1 rounded-md bg-muted/20 p-1 font-semibold text-xs">
+                        {MARKET_TIME_RANGES.map((range) => (
+                          <button
+                            key={range}
+                            type="button"
+                            onClick={() => setPredictionTimeRange(range)}
+                            className={cn(
+                              'rounded px-2 py-1 transition-colors',
+                              predictionTimeRange === range
+                                ? 'bg-foreground text-background'
+                                : 'text-muted-foreground hover:text-foreground'
+                            )}
+                          >
+                            {range}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="min-h-0 flex-1 p-3">
+                    <PredictionProbabilityChart
+                      data={predictionHistory}
+                      marketId={selectedPredictionId ?? 'unknown'}
+                      timeRange={predictionTimeRange}
+                      onTimeRangeChange={setPredictionTimeRange}
+                      showHeader={false}
+                    />
+                  </div>
+                </>
               ) : selectedPerp ? (
-                <PerpPriceChart
-                  data={perpHistory.map((p) => ({
-                    time: p.time,
-                    price: p.price,
-                  }))}
-                  currentPrice={selectedPerp.currentPrice}
-                  ticker={selectedPerp.ticker}
-                  timeRange={perpTimeRange}
-                  onTimeRangeChange={setPerpTimeRange}
-                  showHeader={false}
-                  className="h-full"
-                />
+                <>
+                  <div className="flex shrink-0 items-start justify-between gap-3 border-white/5 border-b bg-background/40 px-4 py-3 backdrop-blur-md">
+                    <div className="min-w-0">
+                      <div className="font-bold text-foreground text-sm">
+                        ${selectedPerp.ticker}
+                      </div>
+                      <div className="truncate text-muted-foreground text-xs">
+                        {selectedPerp.name}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-1 rounded-md bg-muted/20 p-1 font-semibold text-xs">
+                      {MARKET_TIME_RANGES.map((range) => (
+                        <button
+                          key={range}
+                          type="button"
+                          onClick={() => setPerpTimeRange(range)}
+                          className={cn(
+                            'rounded px-2 py-1 transition-colors',
+                            perpTimeRange === range
+                              ? 'bg-foreground text-background'
+                              : 'text-muted-foreground hover:text-foreground'
+                          )}
+                        >
+                          {range}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="min-h-0 flex-1 p-3">
+                    <PerpPriceChart
+                      data={perpHistory.map((p) => ({
+                        time: p.time,
+                        price: p.price,
+                      }))}
+                      currentPrice={selectedPerp.currentPrice}
+                      ticker={selectedPerp.ticker}
+                      timeRange={perpTimeRange}
+                      onTimeRangeChange={setPerpTimeRange}
+                      showHeader={false}
+                      className="h-full"
+                    />
+                  </div>
+                </>
               ) : (
                 <div className="flex h-full items-center justify-center text-muted-foreground">
                   Select a market
@@ -1744,29 +2140,135 @@ export function MarketsTradingTerminal({
         </div>
       </div>
 
+      <AlertDialog
+        open={predictionDetailsOpen}
+        onOpenChange={setPredictionDetailsOpen}
+      >
+        <AlertDialogContent className="max-w-xl">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Market details</AlertDialogTitle>
+            <AlertDialogDescription>
+              {predictionState?.text ?? 'Prediction market'}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          <div className="mt-4 space-y-3 text-sm">
+            {predictionState?.resolutionDescription?.trim() && (
+              <div className="rounded border border-white/10 bg-muted/10 p-3">
+                <div className="mb-1 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+                  Conditions
+                </div>
+                <div className="whitespace-pre-wrap break-words text-foreground">
+                  {predictionState.resolutionDescription}
+                </div>
+              </div>
+            )}
+
+            <div className="rounded border border-white/10 bg-muted/10 p-3 text-xs">
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Scenario</span>
+                <span className="font-mono text-foreground tabular-nums">
+                  {predictionState?.scenario ?? '—'}
+                </span>
+              </div>
+              {(predictionState?.endDate ??
+                predictionState?.resolutionDate) && (
+                <div className="mt-2 flex items-center justify-between">
+                  <span className="text-muted-foreground">Ends</span>
+                  <span className="font-mono text-foreground tabular-nums">
+                    {new Date(
+                      (predictionState?.endDate ??
+                        predictionState?.resolutionDate) as string
+                    ).toLocaleString()}
+                  </span>
+                </div>
+              )}
+            </div>
+
+            {predictionState?.resolutionProofUrl && (
+              <a
+                className="text-primary text-sm hover:underline"
+                href={predictionState.resolutionProofUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
+                View proof / source
+              </a>
+            )}
+          </div>
+
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={() => setPredictionDetailsOpen(false)}>
+              Close
+            </AlertDialogCancel>
+            <AlertDialogAction onClick={() => setPredictionDetailsOpen(false)}>
+              OK
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
       <TradeConfirmationDialog
         open={confirmDialogOpen}
         onOpenChange={setConfirmDialogOpen}
-        onConfirm={handleConfirmPredictionBuy}
+        onConfirm={handleConfirmPredictionTrade}
         isSubmitting={predictionSubmitting}
         tradeDetails={
-          predictionState && predictionCalculation
+          predictionState &&
+          predictionTradeMode === 'buy' &&
+          predictionBuyCalculation
             ? ({
                 type: 'buy-prediction',
                 question: predictionState.text,
                 side: predictionSide.toUpperCase() as 'YES' | 'NO',
                 amount: predictionAmountNum,
-                sharesBought: predictionCalculation.sharesBought,
-                avgPrice: predictionCalculation.avgPrice,
+                sharesBought: predictionBuyCalculation.sharesBought,
+                avgPrice: predictionBuyCalculation.avgPrice,
                 newPrice:
                   predictionSide === 'yes'
-                    ? predictionCalculation.newYesPrice
-                    : predictionCalculation.newNoPrice,
-                priceImpact: predictionCalculation.priceImpact,
+                    ? predictionBuyCalculation.newYesPrice
+                    : predictionBuyCalculation.newNoPrice,
+                priceImpact: predictionBuyCalculation.priceImpact,
                 expectedPayout,
                 expectedProfit,
               } satisfies BuyPredictionDetails)
-            : null
+            : predictionState &&
+                predictionTradeMode === 'sell' &&
+                predictionSellCalculation &&
+                sellPosition
+              ? (() => {
+                  const expectedValue =
+                    predictionSellCalculation.netProceeds ??
+                    predictionSellCalculation.netAmount ??
+                    predictionSellCalculation.totalCost;
+                  const costBasis =
+                    typeof sellPosition.costBasis === 'number' &&
+                    sellPosition.shares > 0
+                      ? sellPosition.costBasis *
+                        (clampedSellShares / sellPosition.shares)
+                      : clampedSellShares * sellPosition.avgPrice;
+                  const unrealizedPnL = expectedValue - costBasis;
+                  const unrealizedPnLPercent =
+                    costBasis !== 0 ? (unrealizedPnL / costBasis) * 100 : 0;
+                  const currentPrice =
+                    sellPosition.currentPrice ??
+                    (clampedSellShares > 0
+                      ? expectedValue / clampedSellShares
+                      : 0);
+
+                  return {
+                    type: 'sell-prediction',
+                    question: predictionState.text,
+                    side: predictionSide.toUpperCase() as 'YES' | 'NO',
+                    shares: clampedSellShares,
+                    avgPrice: sellPosition.avgPrice,
+                    currentPrice,
+                    expectedValue,
+                    unrealizedPnL,
+                    unrealizedPnLPercent,
+                  } satisfies SellPredictionDetails;
+                })()
+              : null
         }
       />
     </div>

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -1801,7 +1801,7 @@ export function MarketsTradingTerminal({
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
           <div className="min-h-0 flex-1 overflow-hidden">
             <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-              <div className="relative flex h-[40%] w-full shrink-0 flex-col border-white/5 border-b">
+              <div className="relative flex w-full shrink-0 basis-[34%] flex-col border-white/5 border-b">
                 {selected?.kind === 'prediction' ? (
                   <>
                     <div className="shrink-0 space-y-2 border-white/5 border-b bg-background/40 px-4 py-3 backdrop-blur-md">
@@ -1935,13 +1935,13 @@ export function MarketsTradingTerminal({
                 )}
               </div>
 
-              <div className="sticky top-0 z-30 flex h-12 shrink-0 items-center border-white/5 border-b bg-background px-2 shadow-sm">
+              <div className="sticky top-0 z-30 flex h-11 shrink-0 items-center border-white/5 border-b bg-background px-2 shadow-sm">
                 <div className="flex min-w-0 flex-1">
                   <button
                     type="button"
                     onClick={() => setBottomTab('agent')}
                     className={cn(
-                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-3 font-bold text-xs capitalize transition-colors',
+                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-2 font-bold text-xs capitalize transition-colors',
                       bottomTab === 'agent'
                         ? 'text-foreground'
                         : 'text-muted-foreground'
@@ -1956,7 +1956,7 @@ export function MarketsTradingTerminal({
                     type="button"
                     onClick={() => setBottomTab('social')}
                     className={cn(
-                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-3 font-bold text-xs capitalize transition-colors',
+                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-2 font-bold text-xs capitalize transition-colors',
                       bottomTab === 'social'
                         ? 'text-foreground'
                         : 'text-muted-foreground'
@@ -1971,7 +1971,7 @@ export function MarketsTradingTerminal({
                     type="button"
                     onClick={() => setBottomTab('positions')}
                     className={cn(
-                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-3 font-bold text-xs capitalize transition-colors',
+                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-2 font-bold text-xs capitalize transition-colors',
                       bottomTab === 'positions'
                         ? 'text-foreground'
                         : 'text-muted-foreground'
@@ -1986,7 +1986,7 @@ export function MarketsTradingTerminal({
                     type="button"
                     onClick={() => setBottomTab('trades')}
                     className={cn(
-                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-3 font-bold text-xs capitalize transition-colors',
+                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-2 font-bold text-xs capitalize transition-colors',
                       bottomTab === 'trades'
                         ? 'text-foreground'
                         : 'text-muted-foreground'

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -397,9 +397,7 @@ export function MarketsTradingTerminal({
 
     const filtered = combined.filter((row) => {
       if (filter === 'favorites') {
-        const id =
-          row.key.kind === 'perp' ? row.key.id.toUpperCase() : row.key.id;
-        if (!favoritesSet.has(`${row.key.kind}:${id}`)) return false;
+        if (!isFavorite(row.key)) return false;
       } else if (filter !== 'all' && row.kind !== filter) {
         return false;
       }
@@ -444,7 +442,7 @@ export function MarketsTradingTerminal({
     filter,
     sortBy,
     sortDesc,
-    favoritesSet,
+    isFavorite,
   ]);
 
   // Ensure a default selection

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -172,7 +172,9 @@ function computeYesPctFromShares(
   return (yes / total) * 100;
 }
 
-export function MarketsTradingTerminal({ onRequestBuyPoints }: MarketsTradingTerminalProps) {
+export function MarketsTradingTerminal({
+  onRequestBuyPoints,
+}: MarketsTradingTerminalProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -218,7 +220,9 @@ export function MarketsTradingTerminal({ onRequestBuyPoints }: MarketsTradingTer
   const [filter, setFilter] = useState<MarketsFilter>(() =>
     parseFilter(searchParams)
   );
-  const [sortBy, setSortBy] = useState<MarketsSort>(() => parseSort(searchParams));
+  const [sortBy, setSortBy] = useState<MarketsSort>(() =>
+    parseSort(searchParams)
+  );
   const [sortDesc, setSortDesc] = useState(() => parseSortDesc(searchParams));
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState<MarketKey | null>(() =>
@@ -372,7 +376,8 @@ export function MarketsTradingTerminal({ onRequestBuyPoints }: MarketsTradingTer
 
     const filtered = combined.filter((row) => {
       if (filter === 'favorites') {
-        const id = row.key.kind === 'perp' ? row.key.id.toUpperCase() : row.key.id;
+        const id =
+          row.key.kind === 'perp' ? row.key.id.toUpperCase() : row.key.id;
         if (!favoritesSet.has(`${row.key.kind}:${id}`)) return false;
       } else if (filter !== 'all' && row.kind !== filter) {
         return false;
@@ -775,12 +780,12 @@ export function MarketsTradingTerminal({ onRequestBuyPoints }: MarketsTradingTer
             Markets
           </div>
           <div className="flex items-center gap-1">
-            <div className="relative" ref={marketsMenuRef}>
+            <div ref={marketsMenuRef}>
               <button
                 type="button"
                 onClick={() => setShowMarketsMenu((v) => !v)}
                 aria-expanded={showMarketsMenu}
-                aria-haspopup="menu"
+                aria-controls="markets-filter-sort"
                 className={cn(
                   'rounded p-1.5 transition-colors hover:bg-muted/20',
                   showMarketsMenu ||
@@ -795,85 +800,6 @@ export function MarketsTradingTerminal({ onRequestBuyPoints }: MarketsTradingTer
               >
                 <Filter size={14} />
               </button>
-
-              {showMarketsMenu && (
-                <div className="absolute top-full right-0 z-50 mt-1 w-56 rounded-md border border-white/10 bg-background/95 py-1 shadow-lg backdrop-blur-md">
-                  <div className="px-3 py-2 font-bold text-[10px] text-muted-foreground uppercase tracking-wider">
-                    Type
-                  </div>
-                  {(
-                    [
-                      { id: 'all', label: 'All Markets' },
-                      { id: 'favorites', label: 'Favorites' },
-                      { id: 'perp', label: 'Perps' },
-                      { id: 'prediction', label: 'Prediction' },
-                    ] as const
-                  ).map((opt) => (
-                    <button
-                      key={opt.id}
-                      type="button"
-                      className="flex w-full items-center justify-between px-3 py-1.5 text-left text-xs hover:bg-muted/20"
-                      onClick={() => {
-                        handleFilterChange(opt.id);
-                        setShowMarketsMenu(false);
-                      }}
-                    >
-                      <span
-                        className={cn(
-                          opt.id === filter
-                            ? 'font-medium text-primary'
-                            : 'text-foreground'
-                        )}
-                      >
-                        {opt.label}
-                      </span>
-                      {opt.id === filter && (
-                        <Check size={12} className="text-primary" />
-                      )}
-                    </button>
-                  ))}
-
-                  <div className="my-1 border-white/10 border-t" />
-
-                  <div className="px-3 py-2 font-bold text-[10px] text-muted-foreground uppercase tracking-wider">
-                    Sort By
-                  </div>
-                  {(
-                    [
-                      { id: 'volume', label: 'Volume' },
-                      { id: 'change', label: '24h Change' },
-                      { id: 'openInterest', label: 'Open Interest' },
-                      { id: 'name', label: 'Name' },
-                    ] as const
-                  ).map((opt) => (
-                    <button
-                      key={opt.id}
-                      type="button"
-                      className="flex w-full items-center justify-between px-3 py-1.5 text-left text-xs hover:bg-muted/20"
-                      onClick={() => handleSortChange(opt.id)}
-                    >
-                      <span
-                        className={cn(
-                          opt.id === sortBy
-                            ? 'font-medium text-primary'
-                            : 'text-foreground'
-                        )}
-                      >
-                        {opt.label}
-                      </span>
-                      {opt.id === sortBy && (
-                        <ArrowUpDown
-                          size={12}
-                          className={cn(
-                            'text-primary transition-transform',
-                            sortDesc ? 'rotate-0' : 'rotate-180'
-                          )}
-                        />
-                      )}
-                    </button>
-                  ))}
-                </div>
-              )}
             </div>
 
             <button
@@ -886,6 +812,88 @@ export function MarketsTradingTerminal({ onRequestBuyPoints }: MarketsTradingTer
             </button>
           </div>
         </div>
+
+        {showMarketsMenu && (
+          <div
+            id="markets-filter-sort"
+            className="fade-in-0 animate-in rounded-md border border-white/10 bg-background/40 py-1 shadow-sm duration-150"
+          >
+            <div className="px-3 py-2 font-bold text-[10px] text-muted-foreground uppercase tracking-wider">
+              Type
+            </div>
+            {(
+              [
+                { id: 'all', label: 'All Markets' },
+                { id: 'favorites', label: 'Favorites' },
+                { id: 'perp', label: 'Perps' },
+                { id: 'prediction', label: 'Prediction' },
+              ] as const
+            ).map((opt) => (
+              <button
+                key={opt.id}
+                type="button"
+                className="flex w-full items-center justify-between px-3 py-1.5 text-left text-xs hover:bg-muted/20"
+                onClick={() => {
+                  handleFilterChange(opt.id);
+                  setShowMarketsMenu(false);
+                }}
+              >
+                <span
+                  className={cn(
+                    opt.id === filter
+                      ? 'font-medium text-primary'
+                      : 'text-foreground'
+                  )}
+                >
+                  {opt.label}
+                </span>
+                {opt.id === filter && (
+                  <Check size={12} className="text-primary" />
+                )}
+              </button>
+            ))}
+
+            <div className="my-1 border-white/10 border-t" />
+
+            <div className="px-3 py-2 font-bold text-[10px] text-muted-foreground uppercase tracking-wider">
+              Sort By
+            </div>
+            {(
+              [
+                { id: 'volume', label: 'Volume' },
+                { id: 'change', label: '24h Change' },
+                { id: 'openInterest', label: 'Open Interest' },
+                { id: 'name', label: 'Name' },
+              ] as const
+            ).map((opt) => (
+              <button
+                key={opt.id}
+                type="button"
+                className="flex w-full items-center justify-between px-3 py-1.5 text-left text-xs hover:bg-muted/20"
+                onClick={() => handleSortChange(opt.id)}
+              >
+                <span
+                  className={cn(
+                    opt.id === sortBy
+                      ? 'font-medium text-primary'
+                      : 'text-foreground'
+                  )}
+                >
+                  {opt.label}
+                </span>
+                {opt.id === sortBy && (
+                  <ArrowUpDown
+                    size={12}
+                    className={cn(
+                      'text-primary transition-transform',
+                      sortDesc ? 'rotate-0' : 'rotate-180'
+                    )}
+                  />
+                )}
+              </button>
+            ))}
+          </div>
+        )}
 
         <div className="relative">
           <Search

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -276,6 +276,7 @@ export function MarketsTradingTerminal({
   // Mobile UI state
   const [isMobileMarketListOpen, setIsMobileMarketListOpen] = useState(false);
   const [isMobileTradeSheetOpen, setIsMobileTradeSheetOpen] = useState(false);
+  const [isMobileChartFullscreen, setIsMobileChartFullscreen] = useState(false);
 
   useEffect(() => {
     if (!isFullscreen) return undefined;
@@ -1797,52 +1798,10 @@ export function MarketsTradingTerminal({
 
       {/* Mobile */}
       <div className="relative flex h-full flex-col overflow-hidden overscroll-none md:hidden">
-        <div className="shrink-0 border-white/5 border-b bg-background">
-          <div className="flex h-14 items-center justify-between px-4">
-            <div className="font-bold text-lg tracking-tight">Markets</div>
-            <div className="flex items-center gap-2">
-              <button
-                type="button"
-                onClick={() => setIsMobileMarketListOpen(true)}
-                className="flex items-center gap-2 rounded-full bg-muted px-3 py-1.5"
-              >
-                <span className="max-w-[180px] truncate font-bold text-sm">
-                  {selected?.kind === 'perp'
-                    ? selected.id
-                    : (predictionState?.text ?? 'Select')}
-                </span>
-                <span className="text-muted-foreground text-xs">▼</span>
-              </button>
-              <button
-                type="button"
-                onClick={toggleFullscreen}
-                aria-pressed={isFullscreen}
-                aria-label={
-                  isFullscreen
-                    ? 'Exit fullscreen terminal view'
-                    : 'Enter fullscreen terminal view'
-                }
-                title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
-                className={cn(
-                  'inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-background/70 text-muted-foreground shadow-sm backdrop-blur-md',
-                  'transition-colors hover:bg-muted/40 hover:text-foreground',
-                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30'
-                )}
-              >
-                {isFullscreen ? (
-                  <Minimize2 size={18} />
-                ) : (
-                  <Maximize2 size={18} />
-                )}
-              </button>
-            </div>
-          </div>
-        </div>
-
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
           <div className="min-h-0 flex-1 overflow-hidden">
             <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-              <div className="flex h-[40%] w-full shrink-0 flex-col border-white/5 border-b">
+              <div className="relative flex h-[40%] w-full shrink-0 flex-col border-white/5 border-b">
                 {selected?.kind === 'prediction' ? (
                   <>
                     <div className="shrink-0 space-y-2 border-white/5 border-b bg-background/40 px-4 py-3 backdrop-blur-md">
@@ -1956,6 +1915,23 @@ export function MarketsTradingTerminal({
                   <div className="flex h-full items-center justify-center text-muted-foreground">
                     Select a market
                   </div>
+                )}
+
+                {selected && (
+                  <button
+                    type="button"
+                    onClick={() => setIsMobileChartFullscreen(true)}
+                    className={cn(
+                      'absolute right-3 bottom-3 z-20 inline-flex h-10 w-10 items-center justify-center rounded-full',
+                      'border border-white/10 bg-background/70 text-muted-foreground shadow-sm backdrop-blur-md',
+                      'transition-colors hover:bg-muted/40 hover:text-foreground',
+                      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30'
+                    )}
+                    aria-label="Open chart fullscreen"
+                    title="Fullscreen chart"
+                  >
+                    <Maximize2 size={18} />
+                  </button>
                 )}
               </div>
 
@@ -2184,6 +2160,141 @@ export function MarketsTradingTerminal({
                 <div className="min-h-0 flex-1 overflow-y-auto">
                   {rightPanel}
                 </div>
+              </div>
+            </div>
+          )}
+
+          {isMobileChartFullscreen && (
+            <div className="fixed inset-0 z-[60] bg-background">
+              <button
+                type="button"
+                aria-label="Close fullscreen chart"
+                onClick={() => setIsMobileChartFullscreen(false)}
+                className={cn(
+                  'absolute top-[calc(12px+env(safe-area-inset-top))] right-[calc(12px+env(safe-area-inset-right))] z-20 inline-flex h-10 w-10 items-center justify-center rounded-full',
+                  'border border-white/10 bg-background/70 text-muted-foreground shadow-sm backdrop-blur-md',
+                  'transition-colors hover:bg-muted/40 hover:text-foreground',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30'
+                )}
+              >
+                <X size={18} />
+              </button>
+
+              <div className="flex h-full flex-col pt-safe pb-safe">
+                {selected?.kind === 'prediction' ? (
+                  <>
+                    <div className="shrink-0 space-y-2 border-white/5 border-b bg-background/40 px-4 py-3 backdrop-blur-md">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="whitespace-normal break-words font-bold text-sm leading-snug">
+                            {predictionState?.text ?? 'Prediction market'}
+                          </div>
+                          <div className="mt-1 whitespace-normal break-words text-muted-foreground text-xs">
+                            {predictionState?.resolutionDescription?.trim()
+                              ? predictionState.resolutionDescription
+                              : `Scenario ${predictionState?.scenario ?? ''}`}
+                          </div>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => setPredictionDetailsOpen(true)}
+                          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded border border-white/10 bg-background/30 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+                          aria-label="View market details"
+                          title="Details"
+                        >
+                          <Info size={14} />
+                        </button>
+                      </div>
+
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <div className="flex items-center gap-2">
+                          <div className="rounded-full bg-blue-500/10 px-2 py-1 font-bold text-[10px] text-blue-400 tabular-nums">
+                            YES {formatYesPct(predictionYesPct)}
+                          </div>
+                          <div className="rounded-full bg-violet-500/10 px-2 py-1 font-bold text-[10px] text-violet-400 tabular-nums">
+                            NO {formatYesPct(100 - predictionYesPct)}
+                          </div>
+                        </div>
+
+                        <div className="flex items-center gap-1 rounded-md bg-muted/20 p-1 font-semibold text-xs">
+                          {MARKET_TIME_RANGES.map((range) => (
+                            <button
+                              key={range}
+                              type="button"
+                              onClick={() => setPredictionTimeRange(range)}
+                              className={cn(
+                                'rounded px-2 py-1 transition-colors',
+                                predictionTimeRange === range
+                                  ? 'bg-foreground text-background'
+                                  : 'text-muted-foreground hover:text-foreground'
+                              )}
+                            >
+                              {range}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                    </div>
+
+                    <div className="min-h-0 flex-1 p-2">
+                      <PredictionProbabilityChart
+                        data={predictionHistory}
+                        marketId={selectedPredictionId ?? 'unknown'}
+                        timeRange={predictionTimeRange}
+                        onTimeRangeChange={setPredictionTimeRange}
+                        showHeader={false}
+                      />
+                    </div>
+                  </>
+                ) : selectedPerp ? (
+                  <>
+                    <div className="flex shrink-0 items-start justify-between gap-3 border-white/5 border-b bg-background/40 px-4 py-3 backdrop-blur-md">
+                      <div className="min-w-0">
+                        <div className="font-bold text-foreground text-sm">
+                          ${selectedPerp.ticker}
+                        </div>
+                        <div className="truncate text-muted-foreground text-xs">
+                          {selectedPerp.name}
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-1 rounded-md bg-muted/20 p-1 font-semibold text-xs">
+                        {MARKET_TIME_RANGES.map((range) => (
+                          <button
+                            key={range}
+                            type="button"
+                            onClick={() => setPerpTimeRange(range)}
+                            className={cn(
+                              'rounded px-2 py-1 transition-colors',
+                              perpTimeRange === range
+                                ? 'bg-foreground text-background'
+                                : 'text-muted-foreground hover:text-foreground'
+                            )}
+                          >
+                            {range}
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                    <div className="min-h-0 flex-1 p-2">
+                      <PerpPriceChart
+                        data={perpHistory.map((p) => ({
+                          time: p.time,
+                          price: p.price,
+                        }))}
+                        currentPrice={selectedPerp.currentPrice}
+                        ticker={selectedPerp.ticker}
+                        timeRange={perpTimeRange}
+                        onTimeRangeChange={setPerpTimeRange}
+                        showHeader={false}
+                        className="h-full"
+                      />
+                    </div>
+                  </>
+                ) : (
+                  <div className="flex h-full items-center justify-center text-muted-foreground">
+                    Select a market
+                  </div>
+                )}
               </div>
             </div>
           )}

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -1839,7 +1839,7 @@ export function MarketsTradingTerminal({
           </div>
         </div>
 
-        <div className="flex min-h-0 flex-1 flex-col overflow-hidden pb-[calc(128px+env(safe-area-inset-bottom))]">
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden pb-[calc(72px+env(safe-area-inset-bottom))]">
           <div className="min-h-0 flex-1 overflow-hidden">
             <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
               <div className="flex h-[42vh] w-full shrink-0 flex-col border-white/5 border-b">
@@ -2104,7 +2104,7 @@ export function MarketsTradingTerminal({
             </div>
           </div>
 
-          <div className="fixed bottom-[calc(56px+env(safe-area-inset-bottom))] left-0 z-40 flex h-[72px] w-full select-none items-center justify-between rounded-t-[20px] border-white/5 border-t bg-background px-2 pb-safe font-medium text-[10px] text-muted-foreground shadow-[0_-5px_15px_rgba(0,0,0,0.12)]">
+          <div className="fixed bottom-0 left-0 z-50 flex h-[72px] w-full select-none items-center justify-between rounded-t-[20px] border-white/5 border-t bg-background px-2 pb-safe font-medium text-[10px] text-muted-foreground shadow-[0_-5px_15px_rgba(0,0,0,0.12)]">
             {/* Minimal bottom nav */}
             <button
               type="button"

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -190,6 +190,11 @@ function formatDate(dateStr: string | undefined | null): string {
 function computeYesPctFromShares(
   market: PredictionMarketTerminalState
 ): number {
+  // Prefer CPMM-derived probability from SSE when available
+  if (market.yesProbability != null) {
+    return market.yesProbability * 100;
+  }
+  // Fallback to share-ratio calculation
   const yes = Number(market.yesShares ?? 0);
   const no = Number(market.noShares ?? 0);
   const total = yes + no;
@@ -583,8 +588,12 @@ export function MarketsTradingTerminal({
       }
 
       if (sortBy === 'change') {
-        const valA = a.change24hPct ?? Number.NEGATIVE_INFINITY;
-        const valB = b.change24hPct ?? Number.NEGATIVE_INFINITY;
+        // Use direction-aware sentinel so nulls always sort last
+        const sentinel = sortDesc
+          ? Number.NEGATIVE_INFINITY
+          : Number.POSITIVE_INFINITY;
+        const valA = a.change24hPct ?? sentinel;
+        const valB = b.change24hPct ?? sentinel;
         const byChange = compareNumbers(valA, valB);
         if (byChange !== 0) return byChange;
       } else if (sortBy === 'openInterest') {

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -288,7 +288,9 @@ function PredictionMarketHeader({
       <div
         className={cn(
           'flex items-center gap-2',
-          isCompact ? 'flex-wrap justify-between' : 'flex-col gap-2 lg:items-end'
+          isCompact
+            ? 'flex-wrap justify-between'
+            : 'flex-col gap-2 lg:items-end'
         )}
       >
         <div className="flex items-center gap-2">
@@ -607,11 +609,26 @@ export function MarketsTradingTerminal({
     isFavorite,
   ]);
 
-  // Ensure a default selection
+  // Ensure a default selection and sync URL when auto-selecting
   useEffect(() => {
     if (rows.length === 0) return;
+
+    const selectAndUpdateUrl = (key: MarketKey | null) => {
+      setSelected(key);
+      if (key) {
+        const next = new URLSearchParams(searchParams.toString());
+        next.set('marketKind', key.kind);
+        next.set('marketId', key.id);
+        next.set('filter', filter);
+        next.delete('tab');
+        next.delete('tabs');
+        next.delete('side');
+        router.replace(`/markets?${next.toString()}`, { scroll: false });
+      }
+    };
+
     if (!selected) {
-      setSelected(rows[0]?.key ?? null);
+      selectAndUpdateUrl(rows[0]?.key ?? null);
       return;
     }
     const stillVisible = rows.some(
@@ -619,8 +636,8 @@ export function MarketsTradingTerminal({
         row.key.kind === selected.kind &&
         row.key.id.toString() === selected.id.toString()
     );
-    if (!stillVisible) setSelected(rows[0]?.key ?? null);
-  }, [selected, rows]);
+    if (!stillVisible) selectAndUpdateUrl(rows[0]?.key ?? null);
+  }, [selected, rows, router, searchParams, filter]);
 
   const selectedPerp = useMemo(() => {
     if (!selected || selected.kind !== 'perp') return null;
@@ -888,6 +905,10 @@ export function MarketsTradingTerminal({
     if (predictionTradeMode === 'buy') {
       if (predictionAmountNum < 1) {
         toast.error(`Minimum bet is ${BABYLON_POINTS_SYMBOL}1`);
+        return;
+      }
+      if (!predictionBuyCalculation) {
+        toast.error('Unable to calculate buy quote.');
         return;
       }
     } else {
@@ -1316,7 +1337,10 @@ export function MarketsTradingTerminal({
                   {predictionState?.resolutionDescription?.trim()
                     ? predictionState.resolutionDescription
                     : `Scenario ${predictionState?.scenario ?? ''}${
-                        formatDate(predictionState?.endDate ?? predictionState?.resolutionDate)
+                        formatDate(
+                          predictionState?.endDate ??
+                            predictionState?.resolutionDate
+                        )
                           ? ` • Ends ${formatDate(predictionState?.endDate ?? predictionState?.resolutionDate)}`
                           : ''
                       }`}
@@ -1669,7 +1693,7 @@ export function MarketsTradingTerminal({
                 predictionSubmitting ||
                 (predictionTradeMode === 'buy' &&
                   authenticated &&
-                  predictionAmountNum < 1) ||
+                  (predictionAmountNum < 1 || !predictionBuyCalculation)) ||
                 (predictionTradeMode === 'sell' &&
                   authenticated &&
                   (maxSellShares <= 0 ||
@@ -1684,7 +1708,7 @@ export function MarketsTradingTerminal({
                 (predictionSubmitting ||
                   (predictionTradeMode === 'buy' &&
                     authenticated &&
-                    predictionAmountNum < 1) ||
+                    (predictionAmountNum < 1 || !predictionBuyCalculation)) ||
                   (predictionTradeMode === 'sell' &&
                     authenticated &&
                     (maxSellShares <= 0 ||
@@ -2372,11 +2396,16 @@ export function MarketsTradingTerminal({
                   {predictionState?.scenario ?? '—'}
                 </span>
               </div>
-              {formatDate(predictionState?.endDate ?? predictionState?.resolutionDate) && (
+              {formatDate(
+                predictionState?.endDate ?? predictionState?.resolutionDate
+              ) && (
                 <div className="mt-2 flex items-center justify-between">
                   <span className="text-muted-foreground">Ends</span>
                   <span className="font-mono text-foreground tabular-nums">
-                    {formatDate(predictionState?.endDate ?? predictionState?.resolutionDate)}
+                    {formatDate(
+                      predictionState?.endDate ??
+                        predictionState?.resolutionDate
+                    )}
                   </span>
                 </div>
               )}

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -243,7 +243,6 @@ export function MarketsTradingTerminal({
   );
 
   const [leftCollapsed, setLeftCollapsed] = useState(false);
-  const [rightCollapsed, setRightCollapsed] = useState(false);
   const [bottomCollapsed, setBottomCollapsed] = useState(false);
   const [bottomTab, setBottomTab] = useState<'positions' | 'trades'>(
     'positions'
@@ -1267,14 +1266,6 @@ export function MarketsTradingTerminal({
         <div className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
           Trade
         </div>
-        <button
-          type="button"
-          onClick={() => setRightCollapsed(true)}
-          className="rounded p-1.5 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground"
-          aria-label="Collapse trade panel"
-        >
-          ▶
-        </button>
       </div>
 
       {selected?.kind === 'prediction' ? (
@@ -1715,32 +1706,15 @@ export function MarketsTradingTerminal({
                     {centerPanel}
                   </Panel>
 
-                  {!rightCollapsed && (
-                    <>
-                      <PanelResizeHandle className="w-1 bg-white/5 hover:bg-primary/40" />
-                      <Panel
-                        defaultSize={22}
-                        minSize={18}
-                        maxSize={32}
-                        className="min-h-0 border-white/5 border-l bg-background/20"
-                      >
-                        {rightPanel}
-                      </Panel>
-                    </>
-                  )}
-
-                  {rightCollapsed && (
-                    <button
-                      type="button"
-                      onClick={() => setRightCollapsed(false)}
-                      className="w-9 shrink-0 border-white/5 border-l bg-background/30 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground"
-                      aria-label="Open trade panel"
-                    >
-                      <span className="writing-vertical-lr rotate-180 font-semibold text-[10px] tracking-wider">
-                        TRADE
-                      </span>
-                    </button>
-                  )}
+                  <PanelResizeHandle className="w-1 bg-white/5 hover:bg-primary/40" />
+                  <Panel
+                    defaultSize={22}
+                    minSize={18}
+                    maxSize={32}
+                    className="min-h-0 border-white/5 border-l bg-background/20"
+                  >
+                    {rightPanel}
+                  </Panel>
                 </PanelGroup>
               </Panel>
 

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -1839,10 +1839,10 @@ export function MarketsTradingTerminal({
           </div>
         </div>
 
-        <div className="flex min-h-0 flex-1 flex-col overflow-hidden pb-[calc(72px+env(safe-area-inset-bottom))]">
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
           <div className="min-h-0 flex-1 overflow-hidden">
             <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-              <div className="flex h-[42vh] w-full shrink-0 flex-col border-white/5 border-b">
+              <div className="flex h-[45%] w-full shrink-0 flex-col border-white/5 border-b">
                 {selected?.kind === 'prediction' ? (
                   <>
                     <div className="shrink-0 space-y-2 border-white/5 border-b bg-background/40 px-4 py-3 backdrop-blur-md">
@@ -2104,7 +2104,7 @@ export function MarketsTradingTerminal({
             </div>
           </div>
 
-          <div className="fixed bottom-0 left-0 z-50 flex h-[72px] w-full select-none items-center justify-between rounded-t-[20px] border-white/5 border-t bg-background px-2 pb-safe font-medium text-[10px] text-muted-foreground shadow-[0_-5px_15px_rgba(0,0,0,0.12)]">
+          <div className="sticky bottom-0 z-40 flex h-[72px] w-full select-none items-center justify-between rounded-t-[20px] border-white/5 border-t bg-background px-2 pb-safe font-medium text-[10px] text-muted-foreground shadow-[0_-5px_15px_rgba(0,0,0,0.12)]">
             {/* Minimal bottom nav */}
             <button
               type="button"

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -5,7 +5,7 @@ import {
   PredictionPricing,
 } from '@babylon/core/markets/prediction/client';
 import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
-import { Star, X } from 'lucide-react';
+import { Maximize2, Minimize2, Star, X } from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
@@ -142,6 +142,13 @@ export function MarketsTradingTerminal({
   const router = useRouter();
   const searchParams = useSearchParams();
 
+  const terminalRootRef = useRef<HTMLDivElement | null>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const previousOverflowRef = useRef<{
+    body: string;
+    html: string;
+  } | null>(null);
+
   const { user, authenticated, login, getAccessToken } = useAuth();
   const userId = authenticated ? (user?.id ?? null) : null;
 
@@ -206,6 +213,37 @@ export function MarketsTradingTerminal({
   // Mobile UI state
   const [isMobileMarketListOpen, setIsMobileMarketListOpen] = useState(false);
   const [isMobileTradeSheetOpen, setIsMobileTradeSheetOpen] = useState(false);
+
+  useEffect(() => {
+    if (!isFullscreen) return undefined;
+
+    previousOverflowRef.current = {
+      body: document.body.style.overflow,
+      html: document.documentElement.style.overflow,
+    };
+    document.body.style.overflow = 'hidden';
+    document.documentElement.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = previousOverflowRef.current?.body ?? '';
+      document.documentElement.style.overflow =
+        previousOverflowRef.current?.html ?? '';
+      previousOverflowRef.current = null;
+    };
+  }, [isFullscreen]);
+
+  useEffect(() => {
+    if (!isFullscreen) return undefined;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setIsFullscreen(false);
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [isFullscreen]);
+
+  const toggleFullscreen = useCallback(() => {
+    setIsFullscreen((prev) => !prev);
+  }, []);
 
   // One-way sync from URL → local UI state
   useEffect(() => {
@@ -1091,7 +1129,13 @@ export function MarketsTradingTerminal({
   );
 
   return (
-    <div className="relative flex h-full w-full flex-col overflow-hidden bg-background text-foreground">
+    <div
+      ref={terminalRootRef}
+      className={cn(
+        'relative flex h-full w-full flex-col overflow-hidden bg-background text-foreground',
+        isFullscreen && 'fixed inset-0 z-[45] h-[100dvh] w-[100dvw] pt-safe'
+      )}
+    >
       {/* Desktop */}
       <div className="hidden min-h-0 flex-1 flex-col md:flex">
         {terminalHeader}
@@ -1200,6 +1244,26 @@ export function MarketsTradingTerminal({
           </div>
         </div>
       </div>
+
+      <button
+        type="button"
+        onClick={toggleFullscreen}
+        aria-pressed={isFullscreen}
+        aria-label={
+          isFullscreen
+            ? 'Exit fullscreen terminal view'
+            : 'Enter fullscreen terminal view'
+        }
+        title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+        className={cn(
+          'absolute z-40 hidden h-11 w-11 items-center justify-center rounded-full border border-white/10 bg-background/70 text-muted-foreground shadow-lg backdrop-blur-md md:inline-flex',
+          'right-[calc(16px+env(safe-area-inset-right))] bottom-[calc(16px+env(safe-area-inset-bottom))]',
+          'transition-colors hover:bg-muted/40 hover:text-foreground',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30'
+        )}
+      >
+        {isFullscreen ? <Minimize2 size={18} /> : <Maximize2 size={18} />}
+      </button>
 
       {/* Mobile */}
       <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden md:hidden">
@@ -1390,14 +1454,34 @@ export function MarketsTradingTerminal({
             <div className="h-28 shrink-0" />
           </div>
 
-          <div className="pointer-events-none absolute bottom-[calc(72px+env(safe-area-inset-bottom)+24px)] left-0 z-30 flex w-full justify-center px-4">
+          <div className="pointer-events-none absolute bottom-[calc(72px+env(safe-area-inset-bottom)+24px)] left-0 z-30 flex w-full items-center px-4">
+            <div className="h-11 w-11 shrink-0" aria-hidden />
             <button
               type="button"
               onClick={() => setIsMobileTradeSheetOpen(true)}
-              className="pointer-events-auto w-full max-w-sm rounded-full bg-foreground py-3.5 font-bold text-background shadow-lg transition-transform active:scale-95"
+              className="pointer-events-auto mx-auto w-full max-w-sm rounded-full bg-foreground py-3.5 font-bold text-background shadow-lg transition-transform active:scale-95"
               disabled={!selected}
             >
               Trade
+            </button>
+            <button
+              type="button"
+              onClick={toggleFullscreen}
+              aria-pressed={isFullscreen}
+              aria-label={
+                isFullscreen
+                  ? 'Exit fullscreen terminal view'
+                  : 'Enter fullscreen terminal view'
+              }
+              title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+              className={cn(
+                'pointer-events-auto inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-white/10 bg-background/80 text-muted-foreground shadow-lg backdrop-blur-md',
+                'ml-3',
+                'transition-colors hover:bg-muted/40 hover:text-foreground',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30'
+              )}
+            >
+              {isFullscreen ? <Minimize2 size={18} /> : <Maximize2 size={18} />}
             </button>
           </div>
 

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -81,11 +81,14 @@ import type {
   TradeSide,
 } from '@/types/markets';
 import { MARKET_TIME_RANGES } from '@/types/markets';
-import { PerpsOrderEntryPanel } from '../perps-terminal/PerpsOrderEntryPanel';
 import { formatBalance } from '../../_lib/formatters';
+import { PerpsOrderEntryPanel } from '../perps-terminal/PerpsOrderEntryPanel';
+import { TerminalAgentsChat } from './TerminalAgentsChat';
+import { TerminalSocialFeed } from './TerminalSocialFeed';
 
 type MarketsFilter = 'all' | 'favorites' | 'perp' | 'prediction';
 type MarketsSort = 'volume' | 'change' | 'openInterest' | 'name';
+type BottomTab = 'agent' | 'social' | 'positions' | 'trades';
 
 interface MarketsTradingTerminalProps {
   onRequestBuyPoints?: () => void;
@@ -246,9 +249,7 @@ export function MarketsTradingTerminal({
 
   const [leftCollapsed, setLeftCollapsed] = useState(false);
   const [bottomCollapsed, setBottomCollapsed] = useState(false);
-  const [bottomTab, setBottomTab] = useState<'positions' | 'trades'>(
-    'positions'
-  );
+  const [bottomTab, setBottomTab] = useState<BottomTab>('agent');
 
   const [showMarketsMenu, setShowMarketsMenu] = useState(false);
   const marketsMenuRef = useRef<HTMLDivElement | null>(null);
@@ -1550,6 +1551,18 @@ export function MarketsTradingTerminal({
       <div className="flex items-center justify-between border-white/5 border-b bg-background/30 px-2">
         <div className="scrollbar-hide flex min-w-0 flex-1 overflow-x-auto">
           <TabButton
+            active={bottomTab === 'agent'}
+            onClick={() => setBottomTab('agent')}
+          >
+            Agents
+          </TabButton>
+          <TabButton
+            active={bottomTab === 'social'}
+            onClick={() => setBottomTab('social')}
+          >
+            Social
+          </TabButton>
+          <TabButton
             active={bottomTab === 'positions'}
             onClick={() => setBottomTab('positions')}
           >
@@ -1579,12 +1592,16 @@ export function MarketsTradingTerminal({
       </div>
 
       <div className="min-h-0 flex-1 overflow-hidden">
-        {!authenticated ? (
-          <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
-            Log in to view positions.
-          </div>
+        {bottomTab === 'agent' ? (
+          <TerminalAgentsChat />
+        ) : bottomTab === 'social' ? (
+          <TerminalSocialFeed />
         ) : bottomTab === 'positions' ? (
-          selected?.kind === 'prediction' ? (
+          !authenticated ? (
+            <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
+              Log in to view positions.
+            </div>
+          ) : selected?.kind === 'prediction' ? (
             <div className="h-full overflow-auto">
               {selectedPredictionPositions.length > 0 ? (
                 <PredictionPositionsList
@@ -1745,7 +1762,13 @@ export function MarketsTradingTerminal({
                 )}
               >
                 <span className="font-semibold text-[10px] tracking-widest">
-                  POSITIONS & TRADES
+                  {bottomTab === 'agent'
+                    ? 'AGENTS'
+                    : bottomTab === 'social'
+                      ? 'SOCIAL'
+                      : bottomTab === 'positions'
+                        ? 'POSITIONS'
+                        : 'TRADES'}
                 </span>
                 <span className="text-[10px]">▲</span>
               </button>
@@ -1914,50 +1937,86 @@ export function MarketsTradingTerminal({
             </div>
 
             <div className="sticky top-0 z-30 flex h-12 shrink-0 items-center border-white/5 border-b bg-background px-2 shadow-sm">
-              <button
-                type="button"
-                onClick={() => setBottomTab('positions')}
-                className={cn(
-                  'relative flex h-full min-w-[88px] flex-1 items-center justify-center py-3 font-bold text-sm capitalize transition-colors',
-                  bottomTab === 'positions'
-                    ? 'text-foreground'
-                    : 'text-muted-foreground'
-                )}
-              >
-                Positions
-                {bottomTab === 'positions' && (
-                  <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
-                )}
-              </button>
-              <button
-                type="button"
-                onClick={() => setBottomTab('trades')}
-                className={cn(
-                  'relative flex h-full min-w-[88px] flex-1 items-center justify-center py-3 font-bold text-sm capitalize transition-colors',
-                  bottomTab === 'trades'
-                    ? 'text-foreground'
-                    : 'text-muted-foreground'
-                )}
-              >
-                Trades
-                {bottomTab === 'trades' && (
-                  <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
-                )}
-              </button>
-              <button
-                type="button"
-                disabled
-                className="flex h-full min-w-[88px] flex-1 cursor-not-allowed items-center justify-center py-3 font-bold text-muted-foreground text-sm capitalize opacity-60"
-              >
-                Orders
-                <span className="ml-2 rounded-full bg-muted/20 px-2 py-0.5 text-[10px] text-muted-foreground uppercase tracking-wider">
-                  Soon
-                </span>
-              </button>
+              <div className="scrollbar-hide flex min-w-0 flex-1 overflow-x-auto">
+                <button
+                  type="button"
+                  onClick={() => setBottomTab('agent')}
+                  className={cn(
+                    'relative flex h-full min-w-[88px] flex-none items-center justify-center py-3 font-bold text-sm capitalize transition-colors',
+                    bottomTab === 'agent'
+                      ? 'text-foreground'
+                      : 'text-muted-foreground'
+                  )}
+                >
+                  Agents
+                  {bottomTab === 'agent' && (
+                    <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
+                  )}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setBottomTab('social')}
+                  className={cn(
+                    'relative flex h-full min-w-[88px] flex-none items-center justify-center py-3 font-bold text-sm capitalize transition-colors',
+                    bottomTab === 'social'
+                      ? 'text-foreground'
+                      : 'text-muted-foreground'
+                  )}
+                >
+                  Social
+                  {bottomTab === 'social' && (
+                    <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
+                  )}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setBottomTab('positions')}
+                  className={cn(
+                    'relative flex h-full min-w-[88px] flex-none items-center justify-center py-3 font-bold text-sm capitalize transition-colors',
+                    bottomTab === 'positions'
+                      ? 'text-foreground'
+                      : 'text-muted-foreground'
+                  )}
+                >
+                  Positions
+                  {bottomTab === 'positions' && (
+                    <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
+                  )}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setBottomTab('trades')}
+                  className={cn(
+                    'relative flex h-full min-w-[88px] flex-none items-center justify-center py-3 font-bold text-sm capitalize transition-colors',
+                    bottomTab === 'trades'
+                      ? 'text-foreground'
+                      : 'text-muted-foreground'
+                  )}
+                >
+                  Trades
+                  {bottomTab === 'trades' && (
+                    <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
+                  )}
+                </button>
+                <button
+                  type="button"
+                  disabled
+                  className="flex h-full min-w-[88px] flex-none cursor-not-allowed items-center justify-center py-3 font-bold text-muted-foreground text-sm capitalize opacity-60"
+                >
+                  Orders
+                  <span className="ml-2 rounded-full bg-muted/20 px-2 py-0.5 text-[10px] text-muted-foreground uppercase tracking-wider">
+                    Soon
+                  </span>
+                </button>
+              </div>
             </div>
 
             <div className="min-h-[320px] flex-1">
-              {bottomTab === 'positions' ? (
+              {bottomTab === 'agent' ? (
+                <TerminalAgentsChat />
+              ) : bottomTab === 'social' ? (
+                <TerminalSocialFeed />
+              ) : bottomTab === 'positions' ? (
                 !authenticated ? (
                   <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
                     Log in to view positions.

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -1164,10 +1164,10 @@ export function MarketsTradingTerminal({
 
               <div className="flex flex-col gap-2 lg:items-end">
                 <div className="flex items-center gap-2">
-                  <div className="rounded-full bg-green-600/10 px-2 py-1 font-bold text-[10px] text-green-500 tabular-nums">
+                  <div className="rounded-full bg-blue-500/10 px-2 py-1 font-bold text-[10px] text-blue-400 tabular-nums">
                     YES {formatYesPct(predictionYesPct)}
                   </div>
-                  <div className="rounded-full bg-red-600/10 px-2 py-1 font-bold text-[10px] text-red-500 tabular-nums">
+                  <div className="rounded-full bg-violet-500/10 px-2 py-1 font-bold text-[10px] text-violet-400 tabular-nums">
                     NO {formatYesPct(100 - predictionYesPct)}
                   </div>
                   <button
@@ -1847,10 +1847,10 @@ export function MarketsTradingTerminal({
 
                     <div className="flex flex-wrap items-center justify-between gap-2">
                       <div className="flex items-center gap-2">
-                        <div className="rounded-full bg-green-600/10 px-2 py-1 font-bold text-[10px] text-green-500 tabular-nums">
+                        <div className="rounded-full bg-blue-500/10 px-2 py-1 font-bold text-[10px] text-blue-400 tabular-nums">
                           YES {formatYesPct(predictionYesPct)}
                         </div>
-                        <div className="rounded-full bg-red-600/10 px-2 py-1 font-bold text-[10px] text-red-500 tabular-nums">
+                        <div className="rounded-full bg-violet-500/10 px-2 py-1 font-bold text-[10px] text-violet-400 tabular-nums">
                           NO {formatYesPct(100 - predictionYesPct)}
                         </div>
                       </div>

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -1549,7 +1549,7 @@ export function MarketsTradingTerminal({
   const bottomPanel = (
     <div className="flex h-full min-h-0 flex-col bg-background/20">
       <div className="flex items-center justify-between border-white/5 border-b bg-background/30 px-2">
-        <div className="scrollbar-hide flex min-w-0 flex-1 overflow-x-auto">
+        <div className="flex min-w-0 flex-1">
           <TabButton
             active={bottomTab === 'agent'}
             onClick={() => setBottomTab('agent')}
@@ -1574,12 +1574,6 @@ export function MarketsTradingTerminal({
           >
             Trades
           </TabButton>
-          <TabButton active={false} onClick={() => {}} disabled soon>
-            Orders
-          </TabButton>
-          <TabButton active={false} onClick={() => {}} disabled soon>
-            PnL
-          </TabButton>
         </div>
         <button
           type="button"
@@ -1595,7 +1589,11 @@ export function MarketsTradingTerminal({
         {bottomTab === 'agent' ? (
           <TerminalAgentsChat />
         ) : bottomTab === 'social' ? (
-          <TerminalSocialFeed />
+          <TerminalSocialFeed
+            perpTicker={
+              selected?.kind === 'perp' ? (selectedPerp?.ticker ?? null) : null
+            }
+          />
         ) : bottomTab === 'positions' ? (
           !authenticated ? (
             <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
@@ -1937,12 +1935,12 @@ export function MarketsTradingTerminal({
             </div>
 
             <div className="sticky top-0 z-30 flex h-12 shrink-0 items-center border-white/5 border-b bg-background px-2 shadow-sm">
-              <div className="scrollbar-hide flex min-w-0 flex-1 overflow-x-auto">
+              <div className="flex min-w-0 flex-1">
                 <button
                   type="button"
                   onClick={() => setBottomTab('agent')}
                   className={cn(
-                    'relative flex h-full min-w-[88px] flex-none items-center justify-center py-3 font-bold text-sm capitalize transition-colors',
+                    'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-3 font-bold text-xs capitalize transition-colors',
                     bottomTab === 'agent'
                       ? 'text-foreground'
                       : 'text-muted-foreground'
@@ -1957,7 +1955,7 @@ export function MarketsTradingTerminal({
                   type="button"
                   onClick={() => setBottomTab('social')}
                   className={cn(
-                    'relative flex h-full min-w-[88px] flex-none items-center justify-center py-3 font-bold text-sm capitalize transition-colors',
+                    'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-3 font-bold text-xs capitalize transition-colors',
                     bottomTab === 'social'
                       ? 'text-foreground'
                       : 'text-muted-foreground'
@@ -1972,7 +1970,7 @@ export function MarketsTradingTerminal({
                   type="button"
                   onClick={() => setBottomTab('positions')}
                   className={cn(
-                    'relative flex h-full min-w-[88px] flex-none items-center justify-center py-3 font-bold text-sm capitalize transition-colors',
+                    'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-3 font-bold text-xs capitalize transition-colors',
                     bottomTab === 'positions'
                       ? 'text-foreground'
                       : 'text-muted-foreground'
@@ -1987,7 +1985,7 @@ export function MarketsTradingTerminal({
                   type="button"
                   onClick={() => setBottomTab('trades')}
                   className={cn(
-                    'relative flex h-full min-w-[88px] flex-none items-center justify-center py-3 font-bold text-sm capitalize transition-colors',
+                    'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-3 font-bold text-xs capitalize transition-colors',
                     bottomTab === 'trades'
                       ? 'text-foreground'
                       : 'text-muted-foreground'
@@ -1998,16 +1996,6 @@ export function MarketsTradingTerminal({
                     <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
                   )}
                 </button>
-                <button
-                  type="button"
-                  disabled
-                  className="flex h-full min-w-[88px] flex-none cursor-not-allowed items-center justify-center py-3 font-bold text-muted-foreground text-sm capitalize opacity-60"
-                >
-                  Orders
-                  <span className="ml-2 rounded-full bg-muted/20 px-2 py-0.5 text-[10px] text-muted-foreground uppercase tracking-wider">
-                    Soon
-                  </span>
-                </button>
               </div>
             </div>
 
@@ -2015,7 +2003,13 @@ export function MarketsTradingTerminal({
               {bottomTab === 'agent' ? (
                 <TerminalAgentsChat />
               ) : bottomTab === 'social' ? (
-                <TerminalSocialFeed />
+                <TerminalSocialFeed
+                  perpTicker={
+                    selected?.kind === 'perp'
+                      ? (selectedPerp?.ticker ?? null)
+                      : null
+                  }
+                />
               ) : bottomTab === 'positions' ? (
                 !authenticated ? (
                   <div className="flex h-full items-center justify-center text-muted-foreground text-sm">

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -1308,7 +1308,7 @@ export function MarketsTradingTerminal({
             </div>
           </div>
 
-          <div className="min-h-0 flex-1 overflow-auto p-4 pb-[calc(72px+env(safe-area-inset-bottom)+24px)]">
+          <div className="min-h-0 flex-1 overflow-auto p-4 pb-[calc(env(safe-area-inset-bottom)+24px)]">
             <div className="flex items-center justify-between">
               <div className="font-semibold text-sm">Place Order</div>
               <div className="rounded bg-muted/20 px-2 py-1 text-[10px] text-muted-foreground uppercase tracking-wider">
@@ -1800,68 +1800,134 @@ export function MarketsTradingTerminal({
         <div className="shrink-0 border-white/5 border-b bg-background">
           <div className="flex h-14 items-center justify-between px-4">
             <div className="font-bold text-lg tracking-tight">Markets</div>
-            <button
-              type="button"
-              onClick={() => setIsMobileMarketListOpen(true)}
-              className="flex items-center gap-2 rounded-full bg-muted px-3 py-1.5"
-            >
-              <span className="max-w-[180px] truncate font-bold text-sm">
-                {selected?.kind === 'perp'
-                  ? selected.id
-                  : (predictionState?.text ?? 'Select')}
-              </span>
-              <span className="text-muted-foreground text-xs">▼</span>
-            </button>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setIsMobileMarketListOpen(true)}
+                className="flex items-center gap-2 rounded-full bg-muted px-3 py-1.5"
+              >
+                <span className="max-w-[180px] truncate font-bold text-sm">
+                  {selected?.kind === 'perp'
+                    ? selected.id
+                    : (predictionState?.text ?? 'Select')}
+                </span>
+                <span className="text-muted-foreground text-xs">▼</span>
+              </button>
+              <button
+                type="button"
+                onClick={toggleFullscreen}
+                aria-pressed={isFullscreen}
+                aria-label={
+                  isFullscreen
+                    ? 'Exit fullscreen terminal view'
+                    : 'Enter fullscreen terminal view'
+                }
+                title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+                className={cn(
+                  'inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 bg-background/70 text-muted-foreground shadow-sm backdrop-blur-md',
+                  'transition-colors hover:bg-muted/40 hover:text-foreground',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30'
+                )}
+              >
+                {isFullscreen ? (
+                  <Minimize2 size={18} />
+                ) : (
+                  <Maximize2 size={18} />
+                )}
+              </button>
+            </div>
           </div>
         </div>
 
-        <div className="min-h-0 flex-1 overflow-hidden">
-          <div className="hide-scrollbar flex h-full flex-col overflow-y-auto overflow-x-hidden">
-            <div className="flex h-[45vh] w-full shrink-0 flex-col border-white/5 border-b">
-              {selected?.kind === 'prediction' ? (
-                <>
-                  <div className="shrink-0 space-y-2 border-white/5 border-b bg-background/40 px-4 py-3 backdrop-blur-md">
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <div className="whitespace-normal break-words font-bold text-sm leading-snug">
-                          {predictionState?.text ?? 'Prediction market'}
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+          <div className="min-h-0 flex-1 overflow-hidden">
+            <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+              <div className="flex h-[42vh] w-full shrink-0 flex-col border-white/5 border-b">
+                {selected?.kind === 'prediction' ? (
+                  <>
+                    <div className="shrink-0 space-y-2 border-white/5 border-b bg-background/40 px-4 py-3 backdrop-blur-md">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                          <div className="whitespace-normal break-words font-bold text-sm leading-snug">
+                            {predictionState?.text ?? 'Prediction market'}
+                          </div>
+                          <div className="mt-1 whitespace-normal break-words text-muted-foreground text-xs">
+                            {predictionState?.resolutionDescription?.trim()
+                              ? predictionState.resolutionDescription
+                              : `Scenario ${predictionState?.scenario ?? ''}`}
+                          </div>
                         </div>
-                        <div className="mt-1 whitespace-normal break-words text-muted-foreground text-xs">
-                          {predictionState?.resolutionDescription?.trim()
-                            ? predictionState.resolutionDescription
-                            : `Scenario ${predictionState?.scenario ?? ''}`}
+                        <button
+                          type="button"
+                          onClick={() => setPredictionDetailsOpen(true)}
+                          className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded border border-white/10 bg-background/30 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
+                          aria-label="View market details"
+                          title="Details"
+                        >
+                          <Info size={14} />
+                        </button>
+                      </div>
+
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <div className="flex items-center gap-2">
+                          <div className="rounded-full bg-blue-500/10 px-2 py-1 font-bold text-[10px] text-blue-400 tabular-nums">
+                            YES {formatYesPct(predictionYesPct)}
+                          </div>
+                          <div className="rounded-full bg-violet-500/10 px-2 py-1 font-bold text-[10px] text-violet-400 tabular-nums">
+                            NO {formatYesPct(100 - predictionYesPct)}
+                          </div>
+                        </div>
+
+                        <div className="flex items-center gap-1 rounded-md bg-muted/20 p-1 font-semibold text-xs">
+                          {MARKET_TIME_RANGES.map((range) => (
+                            <button
+                              key={range}
+                              type="button"
+                              onClick={() => setPredictionTimeRange(range)}
+                              className={cn(
+                                'rounded px-2 py-1 transition-colors',
+                                predictionTimeRange === range
+                                  ? 'bg-foreground text-background'
+                                  : 'text-muted-foreground hover:text-foreground'
+                              )}
+                            >
+                              {range}
+                            </button>
+                          ))}
                         </div>
                       </div>
-                      <button
-                        type="button"
-                        onClick={() => setPredictionDetailsOpen(true)}
-                        className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded border border-white/10 bg-background/30 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
-                        aria-label="View market details"
-                        title="Details"
-                      >
-                        <Info size={14} />
-                      </button>
                     </div>
 
-                    <div className="flex flex-wrap items-center justify-between gap-2">
-                      <div className="flex items-center gap-2">
-                        <div className="rounded-full bg-blue-500/10 px-2 py-1 font-bold text-[10px] text-blue-400 tabular-nums">
-                          YES {formatYesPct(predictionYesPct)}
+                    <div className="min-h-0 flex-1 p-3">
+                      <PredictionProbabilityChart
+                        data={predictionHistory}
+                        marketId={selectedPredictionId ?? 'unknown'}
+                        timeRange={predictionTimeRange}
+                        onTimeRangeChange={setPredictionTimeRange}
+                        showHeader={false}
+                      />
+                    </div>
+                  </>
+                ) : selectedPerp ? (
+                  <>
+                    <div className="flex shrink-0 items-start justify-between gap-3 border-white/5 border-b bg-background/40 px-4 py-3 backdrop-blur-md">
+                      <div className="min-w-0">
+                        <div className="font-bold text-foreground text-sm">
+                          ${selectedPerp.ticker}
                         </div>
-                        <div className="rounded-full bg-violet-500/10 px-2 py-1 font-bold text-[10px] text-violet-400 tabular-nums">
-                          NO {formatYesPct(100 - predictionYesPct)}
+                        <div className="truncate text-muted-foreground text-xs">
+                          {selectedPerp.name}
                         </div>
                       </div>
-
                       <div className="flex items-center gap-1 rounded-md bg-muted/20 p-1 font-semibold text-xs">
                         {MARKET_TIME_RANGES.map((range) => (
                           <button
                             key={range}
                             type="button"
-                            onClick={() => setPredictionTimeRange(range)}
+                            onClick={() => setPerpTimeRange(range)}
                             className={cn(
                               'rounded px-2 py-1 transition-colors',
-                              predictionTimeRange === range
+                              perpTimeRange === range
                                 ? 'bg-foreground text-background'
                                 : 'text-muted-foreground hover:text-foreground'
                             )}
@@ -1871,256 +1937,210 @@ export function MarketsTradingTerminal({
                         ))}
                       </div>
                     </div>
+                    <div className="min-h-0 flex-1 p-3">
+                      <PerpPriceChart
+                        data={perpHistory.map((p) => ({
+                          time: p.time,
+                          price: p.price,
+                        }))}
+                        currentPrice={selectedPerp.currentPrice}
+                        ticker={selectedPerp.ticker}
+                        timeRange={perpTimeRange}
+                        onTimeRangeChange={setPerpTimeRange}
+                        showHeader={false}
+                        className="h-full"
+                      />
+                    </div>
+                  </>
+                ) : (
+                  <div className="flex h-full items-center justify-center text-muted-foreground">
+                    Select a market
                   </div>
+                )}
+              </div>
 
-                  <div className="min-h-0 flex-1 p-3">
-                    <PredictionProbabilityChart
-                      data={predictionHistory}
-                      marketId={selectedPredictionId ?? 'unknown'}
-                      timeRange={predictionTimeRange}
-                      onTimeRangeChange={setPredictionTimeRange}
-                      showHeader={false}
-                    />
-                  </div>
-                </>
-              ) : selectedPerp ? (
-                <>
-                  <div className="flex shrink-0 items-start justify-between gap-3 border-white/5 border-b bg-background/40 px-4 py-3 backdrop-blur-md">
-                    <div className="min-w-0">
-                      <div className="font-bold text-foreground text-sm">
-                        ${selectedPerp.ticker}
-                      </div>
-                      <div className="truncate text-muted-foreground text-xs">
-                        {selectedPerp.name}
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-1 rounded-md bg-muted/20 p-1 font-semibold text-xs">
-                      {MARKET_TIME_RANGES.map((range) => (
-                        <button
-                          key={range}
-                          type="button"
-                          onClick={() => setPerpTimeRange(range)}
-                          className={cn(
-                            'rounded px-2 py-1 transition-colors',
-                            perpTimeRange === range
-                              ? 'bg-foreground text-background'
-                              : 'text-muted-foreground hover:text-foreground'
-                          )}
-                        >
-                          {range}
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                  <div className="min-h-0 flex-1 p-3">
-                    <PerpPriceChart
-                      data={perpHistory.map((p) => ({
-                        time: p.time,
-                        price: p.price,
-                      }))}
-                      currentPrice={selectedPerp.currentPrice}
-                      ticker={selectedPerp.ticker}
-                      timeRange={perpTimeRange}
-                      onTimeRangeChange={setPerpTimeRange}
-                      showHeader={false}
-                      className="h-full"
-                    />
-                  </div>
-                </>
-              ) : (
-                <div className="flex h-full items-center justify-center text-muted-foreground">
-                  Select a market
+              <div className="sticky top-0 z-30 flex h-12 shrink-0 items-center border-white/5 border-b bg-background px-2 shadow-sm">
+                <div className="flex min-w-0 flex-1">
+                  <button
+                    type="button"
+                    onClick={() => setBottomTab('agent')}
+                    className={cn(
+                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-3 font-bold text-xs capitalize transition-colors',
+                      bottomTab === 'agent'
+                        ? 'text-foreground'
+                        : 'text-muted-foreground'
+                    )}
+                  >
+                    Agents
+                    {bottomTab === 'agent' && (
+                      <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setBottomTab('social')}
+                    className={cn(
+                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-3 font-bold text-xs capitalize transition-colors',
+                      bottomTab === 'social'
+                        ? 'text-foreground'
+                        : 'text-muted-foreground'
+                    )}
+                  >
+                    Social
+                    {bottomTab === 'social' && (
+                      <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setBottomTab('positions')}
+                    className={cn(
+                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-3 font-bold text-xs capitalize transition-colors',
+                      bottomTab === 'positions'
+                        ? 'text-foreground'
+                        : 'text-muted-foreground'
+                    )}
+                  >
+                    Positions
+                    {bottomTab === 'positions' && (
+                      <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setBottomTab('trades')}
+                    className={cn(
+                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-3 font-bold text-xs capitalize transition-colors',
+                      bottomTab === 'trades'
+                        ? 'text-foreground'
+                        : 'text-muted-foreground'
+                    )}
+                  >
+                    Trades
+                    {bottomTab === 'trades' && (
+                      <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
+                    )}
+                  </button>
                 </div>
-              )}
-            </div>
+              </div>
 
-            <div className="sticky top-0 z-30 flex h-12 shrink-0 items-center border-white/5 border-b bg-background px-2 shadow-sm">
-              <div className="flex min-w-0 flex-1">
-                <button
-                  type="button"
-                  onClick={() => setBottomTab('agent')}
-                  className={cn(
-                    'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-3 font-bold text-xs capitalize transition-colors',
-                    bottomTab === 'agent'
-                      ? 'text-foreground'
-                      : 'text-muted-foreground'
-                  )}
-                >
-                  Agents
-                  {bottomTab === 'agent' && (
-                    <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
-                  )}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setBottomTab('social')}
-                  className={cn(
-                    'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-3 font-bold text-xs capitalize transition-colors',
-                    bottomTab === 'social'
-                      ? 'text-foreground'
-                      : 'text-muted-foreground'
-                  )}
-                >
-                  Social
-                  {bottomTab === 'social' && (
-                    <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
-                  )}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setBottomTab('positions')}
-                  className={cn(
-                    'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-3 font-bold text-xs capitalize transition-colors',
-                    bottomTab === 'positions'
-                      ? 'text-foreground'
-                      : 'text-muted-foreground'
-                  )}
-                >
-                  Positions
-                  {bottomTab === 'positions' && (
-                    <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
-                  )}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setBottomTab('trades')}
-                  className={cn(
-                    'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-3 font-bold text-xs capitalize transition-colors',
-                    bottomTab === 'trades'
-                      ? 'text-foreground'
-                      : 'text-muted-foreground'
-                  )}
-                >
-                  Trades
-                  {bottomTab === 'trades' && (
-                    <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
-                  )}
-                </button>
+              <div className="min-h-0 flex-1 overflow-hidden">
+                {bottomTab === 'agent' ? (
+                  <TerminalAgentsChat />
+                ) : bottomTab === 'social' ? (
+                  <TerminalSocialFeed
+                    perpTicker={
+                      selected?.kind === 'perp'
+                        ? (selectedPerp?.ticker ?? null)
+                        : null
+                    }
+                  />
+                ) : bottomTab === 'positions' ? (
+                  !authenticated ? (
+                    <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
+                      Log in to view positions.
+                    </div>
+                  ) : selected?.kind === 'prediction' ? (
+                    <div className="h-full overflow-auto">
+                      <PredictionPositionsList
+                        positions={selectedPredictionPositions}
+                        onPositionSold={async () => {
+                          invalidateUserPositions();
+                          invalidateWalletBalance();
+                          await Promise.all([
+                            refreshPredictionPositions(),
+                            refreshPerpPositions(),
+                            refreshWalletBalance(),
+                            refreshPredictionHistory(),
+                          ]);
+                        }}
+                      />
+                    </div>
+                  ) : (
+                    <div className="h-full overflow-auto">
+                      <PerpPositionsList
+                        positions={selectedPerpPositions}
+                        onPositionClosed={async () => {
+                          invalidateUserPositions();
+                          invalidateWalletBalance();
+                          await Promise.all([
+                            refreshPerpPositions(),
+                            refreshPredictionPositions(),
+                            refreshWalletBalance(),
+                            refreshPerpHistory(),
+                          ]);
+                        }}
+                      />
+                    </div>
+                  )
+                ) : selected?.kind === 'prediction' ? (
+                  <div
+                    ref={mobileTradesContainerRef}
+                    className="h-full overflow-auto"
+                  >
+                    <AssetTradesFeed
+                      marketType="prediction"
+                      assetId={selected.id}
+                      containerRef={mobileTradesContainerRef}
+                    />
+                  </div>
+                ) : selectedPerp ? (
+                  <div
+                    ref={mobileTradesContainerRef}
+                    className="h-full overflow-auto"
+                  >
+                    <AssetTradesFeed
+                      marketType="perp"
+                      assetId={selectedPerp.ticker}
+                      containerRef={mobileTradesContainerRef}
+                    />
+                  </div>
+                ) : (
+                  <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
+                    Select a market to see trades.
+                  </div>
+                )}
               </div>
             </div>
-
-            <div className="min-h-[320px] flex-1">
-              {bottomTab === 'agent' ? (
-                <TerminalAgentsChat />
-              ) : bottomTab === 'social' ? (
-                <TerminalSocialFeed
-                  perpTicker={
-                    selected?.kind === 'perp'
-                      ? (selectedPerp?.ticker ?? null)
-                      : null
-                  }
-                />
-              ) : bottomTab === 'positions' ? (
-                !authenticated ? (
-                  <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
-                    Log in to view positions.
-                  </div>
-                ) : selected?.kind === 'prediction' ? (
-                  <PredictionPositionsList
-                    positions={selectedPredictionPositions}
-                    onPositionSold={async () => {
-                      invalidateUserPositions();
-                      invalidateWalletBalance();
-                      await Promise.all([
-                        refreshPredictionPositions(),
-                        refreshPerpPositions(),
-                        refreshWalletBalance(),
-                        refreshPredictionHistory(),
-                      ]);
-                    }}
-                  />
-                ) : (
-                  <PerpPositionsList
-                    positions={selectedPerpPositions}
-                    onPositionClosed={async () => {
-                      invalidateUserPositions();
-                      invalidateWalletBalance();
-                      await Promise.all([
-                        refreshPerpPositions(),
-                        refreshPredictionPositions(),
-                        refreshWalletBalance(),
-                        refreshPerpHistory(),
-                      ]);
-                    }}
-                  />
-                )
-              ) : selected?.kind === 'prediction' ? (
-                <div
-                  ref={mobileTradesContainerRef}
-                  className="h-full overflow-auto"
-                >
-                  <AssetTradesFeed
-                    marketType="prediction"
-                    assetId={selected.id}
-                    containerRef={mobileTradesContainerRef}
-                  />
-                </div>
-              ) : selectedPerp ? (
-                <div
-                  ref={mobileTradesContainerRef}
-                  className="h-full overflow-auto"
-                >
-                  <AssetTradesFeed
-                    marketType="perp"
-                    assetId={selectedPerp.ticker}
-                    containerRef={mobileTradesContainerRef}
-                  />
-                </div>
-              ) : (
-                <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
-                  Select a market to see trades.
-                </div>
-              )}
-            </div>
-
-            <div className="h-28 shrink-0" />
-          </div>
-
-          <div className="pointer-events-none absolute bottom-[calc(72px+env(safe-area-inset-bottom)+24px)] left-0 z-30 flex w-full items-center px-4">
-            <div className="h-11 w-11 shrink-0" aria-hidden />
-            <button
-              type="button"
-              onClick={() => setIsMobileTradeSheetOpen(true)}
-              className="pointer-events-auto mx-auto w-full max-w-sm rounded-full bg-foreground py-3.5 font-bold text-background shadow-lg transition-transform active:scale-95"
-              disabled={!selected}
-            >
-              Trade
-            </button>
-            <button
-              type="button"
-              onClick={toggleFullscreen}
-              aria-pressed={isFullscreen}
-              aria-label={
-                isFullscreen
-                  ? 'Exit fullscreen terminal view'
-                  : 'Enter fullscreen terminal view'
-              }
-              title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
-              className={cn(
-                'pointer-events-auto inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-white/10 bg-background/80 text-muted-foreground shadow-lg backdrop-blur-md',
-                'ml-3',
-                'transition-colors hover:bg-muted/40 hover:text-foreground',
-                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30'
-              )}
-            >
-              {isFullscreen ? <Minimize2 size={18} /> : <Maximize2 size={18} />}
-            </button>
           </div>
 
           <div className="relative z-40 flex h-[72px] select-none items-center justify-between rounded-t-[20px] border-white/5 border-t bg-background px-2 pb-safe font-medium text-[10px] text-muted-foreground shadow-[0_-5px_15px_rgba(0,0,0,0.12)]">
             {/* Minimal bottom nav */}
             <button
               type="button"
+              onClick={() => setIsMobileMarketListOpen(true)}
               className="flex flex-1 flex-col items-center justify-center gap-1 py-1 font-bold text-foreground"
             >
               Markets
             </button>
             <button
               type="button"
+              onClick={() => setIsMobileTradeSheetOpen(true)}
+              disabled={!selected}
+              className={cn(
+                'mx-2 inline-flex h-10 flex-[1.5] items-center justify-center rounded-full px-4 font-bold text-sm transition-all',
+                selected
+                  ? 'bg-foreground text-background active:scale-95'
+                  : 'cursor-not-allowed bg-muted/40 text-muted-foreground'
+              )}
+            >
+              Trade
+            </button>
+            <button
+              type="button"
               onClick={authenticated ? onRequestBuyPoints : login}
               className="flex flex-1 flex-col items-center justify-center gap-1 py-1 transition-colors hover:text-foreground"
             >
-              {authenticated ? 'Balance' : 'Log in'}
+              {authenticated ? (
+                <>
+                  <span className="font-semibold">Balance</span>
+                  <span className="font-mono text-[11px] tabular-nums">
+                    {balanceLoading ? '—' : formatBalance(balance)}
+                  </span>
+                </>
+              ) : (
+                'Log in'
+              )}
             </button>
           </div>
 

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -1842,7 +1842,7 @@ export function MarketsTradingTerminal({
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
           <div className="min-h-0 flex-1 overflow-hidden">
             <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-              <div className="flex h-[45%] w-full shrink-0 flex-col border-white/5 border-b">
+              <div className="flex h-[40%] w-full shrink-0 flex-col border-white/5 border-b">
                 {selected?.kind === 'prediction' ? (
                   <>
                     <div className="shrink-0 space-y-2 border-white/5 border-b bg-background/40 px-4 py-3 backdrop-blur-md">
@@ -1898,7 +1898,7 @@ export function MarketsTradingTerminal({
                       </div>
                     </div>
 
-                    <div className="min-h-0 flex-1 p-3">
+                    <div className="min-h-0 flex-1 p-2">
                       <PredictionProbabilityChart
                         data={predictionHistory}
                         marketId={selectedPredictionId ?? 'unknown'}
@@ -1937,7 +1937,7 @@ export function MarketsTradingTerminal({
                         ))}
                       </div>
                     </div>
-                    <div className="min-h-0 flex-1 p-3">
+                    <div className="min-h-0 flex-1 p-2">
                       <PerpPriceChart
                         data={perpHistory.map((p) => ({
                           time: p.time,

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -1329,7 +1329,7 @@ export function MarketsTradingTerminal({
                 className={cn(
                   'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
                   predictionSide === 'yes'
-                    ? 'bg-blue-600 text-white'
+                    ? 'bg-blue-500 text-white'
                     : 'text-muted-foreground hover:text-foreground'
                 )}
               >
@@ -1341,7 +1341,7 @@ export function MarketsTradingTerminal({
                 className={cn(
                   'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
                   predictionSide === 'no'
-                    ? 'bg-pink-600 text-white'
+                    ? 'bg-violet-500 text-white'
                     : 'text-muted-foreground hover:text-foreground'
                 )}
               >

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -5,7 +5,16 @@ import {
   PredictionPricing,
 } from '@babylon/core/markets/prediction/client';
 import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
-import { Maximize2, Minimize2, Star, X } from 'lucide-react';
+import {
+  ArrowUpDown,
+  Check,
+  Filter,
+  Maximize2,
+  Minimize2,
+  Search,
+  Star,
+  X,
+} from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
@@ -60,7 +69,8 @@ import type {
 import { MARKET_TIME_RANGES } from '@/types/markets';
 import { PerpsOrderEntryPanel } from '../perps-terminal/PerpsOrderEntryPanel';
 
-type MarketsFilter = 'all' | 'perp' | 'prediction';
+type MarketsFilter = 'all' | 'favorites' | 'perp' | 'prediction';
+type MarketsSort = 'volume' | 'change' | 'openInterest' | 'name';
 
 interface MarketsTradingTerminalProps {
   onRequestBuyPoints?: () => void;
@@ -83,6 +93,7 @@ interface UnifiedRow {
   valueSecondary?: string;
   change24hPct?: number | null;
   sortVolume: number;
+  sortOpenInterest: number;
   sortName: string;
   perpMarket?: PerpMarket;
   predictionMarket?: PredictionMarket;
@@ -90,13 +101,38 @@ interface UnifiedRow {
 
 function parseFilter(params: URLSearchParams): MarketsFilter {
   const filter = params.get('filter');
-  if (filter === 'perp' || filter === 'prediction' || filter === 'all') {
+  if (
+    filter === 'perp' ||
+    filter === 'prediction' ||
+    filter === 'favorites' ||
+    filter === 'all'
+  ) {
     return filter;
   }
   const tab = params.get('tab') ?? params.get('tabs');
   if (tab === 'perps') return 'perp';
   if (tab === 'predictions') return 'prediction';
   return 'all';
+}
+
+function parseSort(params: URLSearchParams): MarketsSort {
+  const sort = params.get('sort');
+  if (
+    sort === 'volume' ||
+    sort === 'change' ||
+    sort === 'openInterest' ||
+    sort === 'name'
+  ) {
+    return sort;
+  }
+  return 'volume';
+}
+
+function parseSortDesc(params: URLSearchParams): boolean {
+  const dir = params.get('sortDir');
+  if (dir === 'asc') return false;
+  if (dir === 'desc') return true;
+  return true;
 }
 
 function parseSelected(params: URLSearchParams): MarketKey | null {
@@ -136,9 +172,7 @@ function computeYesPctFromShares(
   return (yes / total) * 100;
 }
 
-export function MarketsTradingTerminal({
-  onRequestBuyPoints,
-}: MarketsTradingTerminalProps) {
+export function MarketsTradingTerminal({ onRequestBuyPoints }: MarketsTradingTerminalProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -184,6 +218,8 @@ export function MarketsTradingTerminal({
   const [filter, setFilter] = useState<MarketsFilter>(() =>
     parseFilter(searchParams)
   );
+  const [sortBy, setSortBy] = useState<MarketsSort>(() => parseSort(searchParams));
+  const [sortDesc, setSortDesc] = useState(() => parseSortDesc(searchParams));
   const [query, setQuery] = useState('');
   const [selected, setSelected] = useState<MarketKey | null>(() =>
     parseSelected(searchParams)
@@ -195,6 +231,9 @@ export function MarketsTradingTerminal({
   const [bottomTab, setBottomTab] = useState<'positions' | 'trades'>(
     'positions'
   );
+
+  const [showMarketsMenu, setShowMarketsMenu] = useState(false);
+  const marketsMenuRef = useRef<HTMLDivElement | null>(null);
 
   const [predictionSide, setPredictionSide] = useState<'yes' | 'no'>(
     () => parsePredictionSide(searchParams) ?? 'yes'
@@ -245,11 +284,37 @@ export function MarketsTradingTerminal({
     setIsFullscreen((prev) => !prev);
   }, []);
 
+  useEffect(() => {
+    if (!showMarketsMenu) return undefined;
+
+    const onMouseDown = (event: MouseEvent) => {
+      if (
+        marketsMenuRef.current &&
+        !marketsMenuRef.current.contains(event.target as Node)
+      ) {
+        setShowMarketsMenu(false);
+      }
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setShowMarketsMenu(false);
+    };
+
+    document.addEventListener('mousedown', onMouseDown);
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown);
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, [showMarketsMenu]);
+
   // One-way sync from URL → local UI state
   useEffect(() => {
     const nextFilter = parseFilter(searchParams);
     setFilter(nextFilter);
     setSelected(parseSelected(searchParams));
+    setSortBy(parseSort(searchParams));
+    setSortDesc(parseSortDesc(searchParams));
 
     const nextPerpSide = parsePerpSide(searchParams);
     const nextPredSide = parsePredictionSide(searchParams);
@@ -261,7 +326,7 @@ export function MarketsTradingTerminal({
     if (nextPredSide) setPredictionSide(nextPredSide);
   }, [searchParams]);
 
-  const favorites = useMarketWatchlistStore((s) => s.favorites);
+  const favoritesSet = useMarketWatchlistStore((s) => s.favoritesSet);
   const toggleFavorite = useMarketWatchlistStore((s) => s.toggleFavorite);
   const isFavorite = useMarketWatchlistStore((s) => s.isFavorite);
 
@@ -277,6 +342,7 @@ export function MarketsTradingTerminal({
       valueSecondary: `Vol ${Math.round(m.volume24h).toLocaleString()}`,
       change24hPct: m.changePercent24h,
       sortVolume: m.volume24h ?? 0,
+      sortOpenInterest: m.openInterest ?? 0,
       sortName: m.ticker.toLowerCase(),
       perpMarket: m,
     }));
@@ -296,6 +362,7 @@ export function MarketsTradingTerminal({
           m.status !== 'active' ? m.status.toUpperCase() : undefined,
         change24hPct: null,
         sortVolume: vol,
+        sortOpenInterest: 0,
         sortName: m.text.toLowerCase(),
         predictionMarket: m,
       };
@@ -304,7 +371,12 @@ export function MarketsTradingTerminal({
     const combined = [...perps, ...preds];
 
     const filtered = combined.filter((row) => {
-      if (filter !== 'all' && row.kind !== filter) return false;
+      if (filter === 'favorites') {
+        const id = row.key.kind === 'perp' ? row.key.id.toUpperCase() : row.key.id;
+        if (!favoritesSet.has(`${row.key.kind}:${id}`)) return false;
+      } else if (filter !== 'all' && row.kind !== filter) {
+        return false;
+      }
       if (q.length === 0) return true;
       return (
         row.title.toLowerCase().includes(q) ||
@@ -314,25 +386,55 @@ export function MarketsTradingTerminal({
     });
 
     return filtered.sort((a, b) => {
-      if (b.sortVolume !== a.sortVolume) return b.sortVolume - a.sortVolume;
+      const compareNumbers = (valA: number, valB: number) =>
+        sortDesc ? valB - valA : valA - valB;
+
+      if (sortBy === 'name') {
+        const byName = a.sortName.localeCompare(b.sortName);
+        return sortDesc ? -byName : byName;
+      }
+
+      if (sortBy === 'change') {
+        const valA = a.change24hPct ?? Number.NEGATIVE_INFINITY;
+        const valB = b.change24hPct ?? Number.NEGATIVE_INFINITY;
+        const byChange = compareNumbers(valA, valB);
+        if (byChange !== 0) return byChange;
+      } else if (sortBy === 'openInterest') {
+        const byOI = compareNumbers(a.sortOpenInterest, b.sortOpenInterest);
+        if (byOI !== 0) return byOI;
+      } else {
+        const byVol = compareNumbers(a.sortVolume, b.sortVolume);
+        if (byVol !== 0) return byVol;
+      }
+
+      const byVolFallback = compareNumbers(a.sortVolume, b.sortVolume);
+      if (byVolFallback !== 0) return byVolFallback;
       return a.sortName.localeCompare(b.sortName);
     });
-  }, [perpMarkets, predictionMarkets, query, filter]);
+  }, [
+    perpMarkets,
+    predictionMarkets,
+    query,
+    filter,
+    sortBy,
+    sortDesc,
+    favoritesSet,
+  ]);
 
   // Ensure a default selection
   useEffect(() => {
-    if (selected) return;
     if (rows.length === 0) return;
-    setSelected(rows[0]?.key ?? null);
+    if (!selected) {
+      setSelected(rows[0]?.key ?? null);
+      return;
+    }
+    const stillVisible = rows.some(
+      (row) =>
+        row.key.kind === selected.kind &&
+        row.key.id.toString() === selected.id.toString()
+    );
+    if (!stillVisible) setSelected(rows[0]?.key ?? null);
   }, [selected, rows]);
-
-  // Keep selection consistent with the active filter (avoids hidden-selection confusion).
-  useEffect(() => {
-    if (!selected) return;
-    if (filter === 'all') return;
-    if (selected.kind === filter) return;
-    setSelected(rows[0]?.key ?? null);
-  }, [filter, rows, selected]);
 
   const selectedPerp = useMemo(() => {
     if (!selected || selected.kind !== 'perp') return null;
@@ -481,6 +583,25 @@ export function MarketsTradingTerminal({
     [router, searchParams]
   );
 
+  const handleSortChange = useCallback(
+    (nextSort: MarketsSort) => {
+      const next = new URLSearchParams(searchParams.toString());
+      if (sortBy === nextSort) {
+        const nextDesc = !sortDesc;
+        setSortDesc(nextDesc);
+        next.set('sort', nextSort);
+        next.set('sortDir', nextDesc ? 'desc' : 'asc');
+      } else {
+        setSortBy(nextSort);
+        setSortDesc(true);
+        next.set('sort', nextSort);
+        next.set('sortDir', 'desc');
+      }
+      router.replace(`/markets?${next.toString()}`, { scroll: false });
+    },
+    [router, searchParams, sortBy, sortDesc]
+  );
+
   const predictionAmountNum = Number.parseFloat(predictionAmount) || 0;
 
   const predictionCalculation = useMemo(() => {
@@ -616,33 +737,9 @@ export function MarketsTradingTerminal({
 
   const terminalHeader = (
     <div className="flex h-11 shrink-0 items-center justify-between border-white/5 border-b bg-background/40 px-3 backdrop-blur-md">
-      <div className="flex min-w-0 flex-1 items-center gap-3">
-        <div className="flex shrink-0 rounded-md bg-muted/20 p-1 font-semibold text-xs">
-          {(['all', 'perp', 'prediction'] as const).map((f) => (
-            <button
-              key={f}
-              type="button"
-              onClick={() => handleFilterChange(f)}
-              className={cn(
-                'rounded px-2.5 py-1 transition-colors',
-                filter === f
-                  ? 'bg-foreground text-background'
-                  : 'text-muted-foreground hover:text-foreground'
-              )}
-            >
-              {f === 'all' ? 'All' : f === 'perp' ? 'Perps' : 'Predictions'}
-            </button>
-          ))}
-        </div>
-
-        <div className="relative min-w-0 flex-1">
-          <input
-            type="search"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search markets…"
-            className="w-full rounded border border-white/10 bg-background/40 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30"
-          />
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <div className="truncate font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+          Terminal
         </div>
       </div>
 
@@ -672,18 +769,137 @@ export function MarketsTradingTerminal({
 
   const listPanel = (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="flex items-center justify-between border-white/5 border-b px-3 py-2">
-        <div className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
-          Markets
+      <div className="shrink-0 space-y-3 border-white/5 border-b p-3">
+        <div className="flex items-center justify-between">
+          <div className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+            Markets
+          </div>
+          <div className="flex items-center gap-1">
+            <div className="relative" ref={marketsMenuRef}>
+              <button
+                type="button"
+                onClick={() => setShowMarketsMenu((v) => !v)}
+                aria-expanded={showMarketsMenu}
+                aria-haspopup="menu"
+                className={cn(
+                  'rounded p-1.5 transition-colors hover:bg-muted/20',
+                  showMarketsMenu ||
+                    filter !== 'all' ||
+                    sortBy !== 'volume' ||
+                    sortDesc !== true
+                    ? 'bg-muted/20 text-primary'
+                    : 'text-muted-foreground'
+                )}
+                aria-label="Filter and sort markets"
+                title="Filter & Sort"
+              >
+                <Filter size={14} />
+              </button>
+
+              {showMarketsMenu && (
+                <div className="absolute top-full right-0 z-50 mt-1 w-56 rounded-md border border-white/10 bg-background/95 py-1 shadow-lg backdrop-blur-md">
+                  <div className="px-3 py-2 font-bold text-[10px] text-muted-foreground uppercase tracking-wider">
+                    Type
+                  </div>
+                  {(
+                    [
+                      { id: 'all', label: 'All Markets' },
+                      { id: 'favorites', label: 'Favorites' },
+                      { id: 'perp', label: 'Perps' },
+                      { id: 'prediction', label: 'Prediction' },
+                    ] as const
+                  ).map((opt) => (
+                    <button
+                      key={opt.id}
+                      type="button"
+                      className="flex w-full items-center justify-between px-3 py-1.5 text-left text-xs hover:bg-muted/20"
+                      onClick={() => {
+                        handleFilterChange(opt.id);
+                        setShowMarketsMenu(false);
+                      }}
+                    >
+                      <span
+                        className={cn(
+                          opt.id === filter
+                            ? 'font-medium text-primary'
+                            : 'text-foreground'
+                        )}
+                      >
+                        {opt.label}
+                      </span>
+                      {opt.id === filter && (
+                        <Check size={12} className="text-primary" />
+                      )}
+                    </button>
+                  ))}
+
+                  <div className="my-1 border-white/10 border-t" />
+
+                  <div className="px-3 py-2 font-bold text-[10px] text-muted-foreground uppercase tracking-wider">
+                    Sort By
+                  </div>
+                  {(
+                    [
+                      { id: 'volume', label: 'Volume' },
+                      { id: 'change', label: '24h Change' },
+                      { id: 'openInterest', label: 'Open Interest' },
+                      { id: 'name', label: 'Name' },
+                    ] as const
+                  ).map((opt) => (
+                    <button
+                      key={opt.id}
+                      type="button"
+                      className="flex w-full items-center justify-between px-3 py-1.5 text-left text-xs hover:bg-muted/20"
+                      onClick={() => handleSortChange(opt.id)}
+                    >
+                      <span
+                        className={cn(
+                          opt.id === sortBy
+                            ? 'font-medium text-primary'
+                            : 'text-foreground'
+                        )}
+                      >
+                        {opt.label}
+                      </span>
+                      {opt.id === sortBy && (
+                        <ArrowUpDown
+                          size={12}
+                          className={cn(
+                            'text-primary transition-transform',
+                            sortDesc ? 'rotate-0' : 'rotate-180'
+                          )}
+                        />
+                      )}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            <button
+              type="button"
+              onClick={() => setLeftCollapsed(true)}
+              className="hidden rounded p-1.5 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground md:inline-flex"
+              aria-label="Collapse markets panel"
+            >
+              ◀
+            </button>
+          </div>
         </div>
-        <button
-          type="button"
-          onClick={() => setLeftCollapsed(true)}
-          className="rounded p-1.5 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground"
-          aria-label="Collapse markets panel"
-        >
-          ◀
-        </button>
+
+        <div className="relative">
+          <Search
+            className="-translate-y-1/2 absolute top-1/2 left-2 text-muted-foreground"
+            size={14}
+          />
+          <input
+            type="search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search…"
+            className="w-full rounded border border-white/10 bg-background/40 py-2 pr-3 pl-8 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30"
+          />
+        </div>
       </div>
 
       <div className="min-h-0 flex-1 overflow-auto">
@@ -796,9 +1012,9 @@ export function MarketsTradingTerminal({
         )}
       </div>
 
-      {favorites.length > 0 && (
+      {favoritesSet.size > 0 && (
         <div className="border-white/5 border-t p-2 text-[10px] text-muted-foreground">
-          Favorites: {favorites.length}
+          Favorites: {favoritesSet.size}
         </div>
       )}
     </div>
@@ -1282,35 +1498,6 @@ export function MarketsTradingTerminal({
               </span>
               <span className="text-muted-foreground text-xs">▼</span>
             </button>
-          </div>
-          <div className="px-3 pb-3">
-            {/* Filter + search */}
-            <div className="flex items-center gap-2">
-              <div className="flex shrink-0 rounded-md bg-muted/20 p-1 font-semibold text-xs">
-                {(['all', 'perp', 'prediction'] as const).map((f) => (
-                  <button
-                    key={f}
-                    type="button"
-                    onClick={() => handleFilterChange(f)}
-                    className={cn(
-                      'rounded px-2.5 py-1 transition-colors',
-                      filter === f
-                        ? 'bg-foreground text-background'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                  >
-                    {f === 'all' ? 'All' : f === 'perp' ? 'Perps' : 'Pred'}
-                  </button>
-                ))}
-              </div>
-              <input
-                type="search"
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                placeholder="Search…"
-                className="w-full rounded border border-white/10 bg-background/40 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30"
-              />
-            </div>
           </div>
         </div>
 

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -1442,7 +1442,7 @@ export function MarketsTradingTerminal({
                 <div className="mt-2 flex items-center justify-between">
                   <span className="text-muted-foreground">Avg price</span>
                   <span className="font-mono text-foreground tabular-nums">
-                    {(predictionBuyCalculation.avgPrice * 100).toFixed(1)}%
+                    ${predictionBuyCalculation.avgPrice.toFixed(3)}
                   </span>
                 </div>
                 <div className="mt-2 flex items-center justify-between">

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -1839,7 +1839,7 @@ export function MarketsTradingTerminal({
           </div>
         </div>
 
-        <div className="flex min-h-0 flex-1 flex-col overflow-hidden pb-[calc(72px+env(safe-area-inset-bottom))]">
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden pb-[calc(128px+env(safe-area-inset-bottom))]">
           <div className="min-h-0 flex-1 overflow-hidden">
             <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
               <div className="flex h-[42vh] w-full shrink-0 flex-col border-white/5 border-b">
@@ -2104,7 +2104,7 @@ export function MarketsTradingTerminal({
             </div>
           </div>
 
-          <div className="fixed bottom-0 left-0 z-40 flex h-[72px] w-full select-none items-center justify-between rounded-t-[20px] border-white/5 border-t bg-background px-2 pb-safe font-medium text-[10px] text-muted-foreground shadow-[0_-5px_15px_rgba(0,0,0,0.12)]">
+          <div className="fixed bottom-[calc(56px+env(safe-area-inset-bottom))] left-0 z-40 flex h-[72px] w-full select-none items-center justify-between rounded-t-[20px] border-white/5 border-t bg-background px-2 pb-safe font-medium text-[10px] text-muted-foreground shadow-[0_-5px_15px_rgba(0,0,0,0.12)]">
             {/* Minimal bottom nav */}
             <button
               type="button"

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -650,13 +650,17 @@ export function MarketsTradingTerminal({
   const predictionBuyCalculation = useMemo(() => {
     if (!predictionEffectiveShares) return null;
     if (predictionAmountNum <= 0) return null;
-    return PredictionPricing.calculateBuyWithFees(
-      predictionEffectiveShares.yesShares,
-      predictionEffectiveShares.noShares,
-      predictionSide,
-      predictionAmountNum,
-      FEE_CONFIG.TRADING_FEE_RATE
-    );
+    try {
+      return PredictionPricing.calculateBuyWithFees(
+        predictionEffectiveShares.yesShares,
+        predictionEffectiveShares.noShares,
+        predictionSide,
+        predictionAmountNum,
+        FEE_CONFIG.TRADING_FEE_RATE
+      );
+    } catch {
+      return null;
+    }
   }, [predictionEffectiveShares, predictionSide, predictionAmountNum]);
 
   const sellPosition = useMemo(() => {
@@ -682,13 +686,17 @@ export function MarketsTradingTerminal({
     if (!predictionEffectiveShares) return null;
     if (!sellPosition) return null;
     if (clampedSellShares <= 0) return null;
-    return PredictionPricing.calculateSellWithFees(
-      predictionEffectiveShares.yesShares,
-      predictionEffectiveShares.noShares,
-      predictionSide,
-      clampedSellShares,
-      FEE_CONFIG.TRADING_FEE_RATE
-    );
+    try {
+      return PredictionPricing.calculateSellWithFees(
+        predictionEffectiveShares.yesShares,
+        predictionEffectiveShares.noShares,
+        predictionSide,
+        clampedSellShares,
+        FEE_CONFIG.TRADING_FEE_RATE
+      );
+    } catch {
+      return null;
+    }
   }, [
     predictionEffectiveShares,
     predictionSide,
@@ -729,6 +737,10 @@ export function MarketsTradingTerminal({
         toast.error('Minimum sell is 0.01 shares');
         return;
       }
+      if (!predictionSellCalculation) {
+        toast.error('Unable to calculate sell quote.');
+        return;
+      }
     }
     setConfirmDialogOpen(true);
   };
@@ -746,6 +758,10 @@ export function MarketsTradingTerminal({
       }
       if (clampedSellShares < 0.01) {
         toast.error('Minimum sell is 0.01 shares');
+        return;
+      }
+      if (!predictionSellCalculation) {
+        toast.error('Unable to calculate sell quote.');
         return;
       }
     }
@@ -1502,7 +1518,9 @@ export function MarketsTradingTerminal({
                   predictionAmountNum < 1) ||
                 (predictionTradeMode === 'sell' &&
                   authenticated &&
-                  (maxSellShares <= 0 || clampedSellShares < 0.01))
+                  (maxSellShares <= 0 ||
+                    clampedSellShares < 0.01 ||
+                    !predictionSellCalculation))
               }
               className={cn(
                 'mt-5 w-full rounded py-3 font-bold text-sm text-white shadow transition-all',
@@ -1515,7 +1533,9 @@ export function MarketsTradingTerminal({
                     predictionAmountNum < 1) ||
                   (predictionTradeMode === 'sell' &&
                     authenticated &&
-                    (maxSellShares <= 0 || clampedSellShares < 0.01))) &&
+                    (maxSellShares <= 0 ||
+                      clampedSellShares < 0.01 ||
+                      !predictionSellCalculation))) &&
                   'cursor-not-allowed opacity-50'
               )}
             >

--- a/apps/web/src/app/markets/_components/terminal/TerminalAgentsChat.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalAgentsChat.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { TeamChatView } from '@/components/chats';
+import { useAuth } from '@/hooks/useAuth';
+import { useTeamChat } from '@/hooks/useTeamChat';
+
+export function TerminalAgentsChat() {
+  const { authenticated, user, login } = useAuth();
+  const {
+    teamChat,
+    chatDetails,
+    sending,
+    error,
+    sseConnected,
+    isLoadingMore,
+    hasMore,
+    messageInput,
+    handleInputChange,
+    typingUsers,
+    thinkingAgents,
+    sendError,
+    messagesEndRef,
+    topSentinelRef,
+    sendMessage,
+    handleScroll,
+    selectedAgentIds,
+    processingAgentIds,
+    toggleAgentSelection,
+  } = useTeamChat();
+
+  if (!authenticated) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-center">
+        <div className="max-w-md text-muted-foreground text-sm">
+          <div className="mb-3 font-semibold text-foreground">
+            Log in to chat with your agents
+          </div>
+          <button
+            type="button"
+            onClick={login}
+            className="mt-2 rounded bg-foreground px-4 py-2 font-semibold text-background text-sm transition-colors hover:opacity-90"
+          >
+            Log In
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-muted-foreground text-sm">
+        {error}
+      </div>
+    );
+  }
+
+  return (
+    <TeamChatView
+      chatDetails={chatDetails}
+      currentUserId={user?.id}
+      authenticated={authenticated}
+      sseConnected={sseConnected}
+      hideHeader
+      loading={false}
+      isLoadingMore={isLoadingMore}
+      hasMore={hasMore}
+      messageInput={messageInput}
+      sending={sending}
+      sendError={sendError}
+      topSentinelRef={topSentinelRef}
+      messagesEndRef={messagesEndRef}
+      onMessageChange={handleInputChange}
+      onSendMessage={sendMessage}
+      agents={[
+        ...(user
+          ? [
+              {
+                id: user.id,
+                username: user.username || null,
+                displayName: user.displayName || user.username || 'You',
+                profileImageUrl: user.profileImageUrl || null,
+              },
+            ]
+          : []),
+        ...(teamChat?.agents.map((agent) => ({
+          id: agent.id,
+          username: agent.username,
+          displayName: agent.displayName,
+          profileImageUrl: agent.profileImageUrl,
+        })) || []),
+      ]}
+      typingUsers={typingUsers}
+      thinkingAgents={thinkingAgents}
+      onScroll={handleScroll}
+      selectedAgents={
+        teamChat?.agents
+          .filter((a) => selectedAgentIds.has(a.id))
+          .map((a) => ({
+            id: a.id,
+            displayName: a.displayName || a.username || 'Agent',
+            profileImageUrl: a.profileImageUrl,
+            isProcessing: processingAgentIds.has(a.id),
+          })) || []
+      }
+      onRemoveSelectedAgent={toggleAgentSelection}
+      hasProcessingSelected={
+        selectedAgentIds.size > 0 &&
+        Array.from(selectedAgentIds).some((id) => processingAgentIds.has(id))
+      }
+    />
+  );
+}

--- a/apps/web/src/app/markets/_components/terminal/TerminalAgentsChat.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalAgentsChat.tsx
@@ -56,7 +56,7 @@ export function TerminalAgentsChat() {
   }
 
   return (
-    <div className="h-full min-h-0">
+    <div className="flex h-full min-h-0 flex-col">
       <TeamChatView
         chatDetails={chatDetails}
         currentUserId={user?.id}

--- a/apps/web/src/app/markets/_components/terminal/TerminalAgentsChat.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalAgentsChat.tsx
@@ -9,6 +9,7 @@ export function TerminalAgentsChat() {
   const {
     teamChat,
     chatDetails,
+    loading,
     sending,
     error,
     sseConnected,
@@ -63,7 +64,7 @@ export function TerminalAgentsChat() {
         authenticated={authenticated}
         sseConnected={sseConnected}
         hideHeader
-        loading={false}
+        loading={loading}
         isLoadingMore={isLoadingMore}
         hasMore={hasMore}
         messageInput={messageInput}

--- a/apps/web/src/app/markets/_components/terminal/TerminalAgentsChat.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalAgentsChat.tsx
@@ -56,58 +56,60 @@ export function TerminalAgentsChat() {
   }
 
   return (
-    <TeamChatView
-      chatDetails={chatDetails}
-      currentUserId={user?.id}
-      authenticated={authenticated}
-      sseConnected={sseConnected}
-      hideHeader
-      loading={false}
-      isLoadingMore={isLoadingMore}
-      hasMore={hasMore}
-      messageInput={messageInput}
-      sending={sending}
-      sendError={sendError}
-      topSentinelRef={topSentinelRef}
-      messagesEndRef={messagesEndRef}
-      onMessageChange={handleInputChange}
-      onSendMessage={sendMessage}
-      agents={[
-        ...(user
-          ? [
-              {
-                id: user.id,
-                username: user.username || null,
-                displayName: user.displayName || user.username || 'You',
-                profileImageUrl: user.profileImageUrl || null,
-              },
-            ]
-          : []),
-        ...(teamChat?.agents.map((agent) => ({
-          id: agent.id,
-          username: agent.username,
-          displayName: agent.displayName,
-          profileImageUrl: agent.profileImageUrl,
-        })) || []),
-      ]}
-      typingUsers={typingUsers}
-      thinkingAgents={thinkingAgents}
-      onScroll={handleScroll}
-      selectedAgents={
-        teamChat?.agents
-          .filter((a) => selectedAgentIds.has(a.id))
-          .map((a) => ({
-            id: a.id,
-            displayName: a.displayName || a.username || 'Agent',
-            profileImageUrl: a.profileImageUrl,
-            isProcessing: processingAgentIds.has(a.id),
-          })) || []
-      }
-      onRemoveSelectedAgent={toggleAgentSelection}
-      hasProcessingSelected={
-        selectedAgentIds.size > 0 &&
-        Array.from(selectedAgentIds).some((id) => processingAgentIds.has(id))
-      }
-    />
+    <div className="h-full min-h-0">
+      <TeamChatView
+        chatDetails={chatDetails}
+        currentUserId={user?.id}
+        authenticated={authenticated}
+        sseConnected={sseConnected}
+        hideHeader
+        loading={false}
+        isLoadingMore={isLoadingMore}
+        hasMore={hasMore}
+        messageInput={messageInput}
+        sending={sending}
+        sendError={sendError}
+        topSentinelRef={topSentinelRef}
+        messagesEndRef={messagesEndRef}
+        onMessageChange={handleInputChange}
+        onSendMessage={sendMessage}
+        agents={[
+          ...(user
+            ? [
+                {
+                  id: user.id,
+                  username: user.username || null,
+                  displayName: user.displayName || user.username || 'You',
+                  profileImageUrl: user.profileImageUrl || null,
+                },
+              ]
+            : []),
+          ...(teamChat?.agents.map((agent) => ({
+            id: agent.id,
+            username: agent.username,
+            displayName: agent.displayName,
+            profileImageUrl: agent.profileImageUrl,
+          })) || []),
+        ]}
+        typingUsers={typingUsers}
+        thinkingAgents={thinkingAgents}
+        onScroll={handleScroll}
+        selectedAgents={
+          teamChat?.agents
+            .filter((a) => selectedAgentIds.has(a.id))
+            .map((a) => ({
+              id: a.id,
+              displayName: a.displayName || a.username || 'Agent',
+              profileImageUrl: a.profileImageUrl,
+              isProcessing: processingAgentIds.has(a.id),
+            })) || []
+        }
+        onRemoveSelectedAgent={toggleAgentSelection}
+        hasProcessingSelected={
+          selectedAgentIds.size > 0 &&
+          Array.from(selectedAgentIds).some((id) => processingAgentIds.has(id))
+        }
+      />
+    </div>
   );
 }

--- a/apps/web/src/app/markets/_components/terminal/TerminalSocialFeed.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalSocialFeed.tsx
@@ -1,13 +1,7 @@
 'use client';
 
 import { cn, type FeedPost } from '@babylon/shared';
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { PostList } from '@/app/feed/components/PostList';
 import { useFeedPosts } from '@/app/feed/hooks/useFeedPosts';
 import { FeedSkeleton } from '@/components/shared/Skeleton';
@@ -91,6 +85,11 @@ export function TerminalSocialFeed({ perpTicker }: TerminalSocialFeedProps) {
         { signal: controller.signal }
       ).catch(() => null);
 
+      // Guard: if this request was superseded by a newer one, bail out
+      if (inFlightTagRef.current !== controller || controller.signal.aborted) {
+        return;
+      }
+
       if (!response) {
         setTagLoading(false);
         setTagLoadingMore(false);
@@ -120,6 +119,11 @@ export function TerminalSocialFeed({ perpTicker }: TerminalSocialFeedProps) {
         posts?: FeedPost[];
         total?: number;
       };
+
+      // Guard again after async json parsing
+      if (inFlightTagRef.current !== controller || controller.signal.aborted) {
+        return;
+      }
 
       if (!data.success) {
         setTagLoading(false);

--- a/apps/web/src/app/markets/_components/terminal/TerminalSocialFeed.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalSocialFeed.tsx
@@ -169,43 +169,48 @@ export function TerminalSocialFeed({ perpTicker }: TerminalSocialFeedProps) {
   const hasMore = tagMode ? tagHasMore : globalHasMore;
 
   return (
-    <div className="h-full overflow-auto px-2 py-3">
+    <div className="flex h-full min-h-0 flex-col">
       {tagMode && (
-        <div
-          className={cn(
-            'mb-3 flex items-center justify-between rounded-md border border-white/5 bg-background/40 px-3 py-2 text-muted-foreground text-xs'
-          )}
-        >
-          <span className="min-w-0 truncate">
-            Showing posts for{' '}
-            <span className="font-semibold text-foreground">
-              {tagInfo?.displayName ?? perpTicker}
-            </span>
-          </span>
-          <button
-            type="button"
-            onClick={() => setTagNotFound(true)}
-            className="shrink-0 rounded px-2 py-1 font-semibold text-foreground/80 hover:bg-muted/20 hover:text-foreground"
+        <div className="shrink-0 px-2 pt-3">
+          <div
+            className={cn(
+              'flex items-center justify-between rounded-md border border-white/5 bg-background/40 px-3 py-2 text-muted-foreground text-xs'
+            )}
           >
-            Show all
-          </button>
+            <span className="min-w-0 truncate">
+              Showing posts for{' '}
+              <span className="font-semibold text-foreground">
+                {tagInfo?.displayName ?? perpTicker}
+              </span>
+            </span>
+            <button
+              type="button"
+              onClick={() => setTagNotFound(true)}
+              className="shrink-0 rounded px-2 py-1 font-semibold text-foreground/80 hover:bg-muted/20 hover:text-foreground"
+            >
+              Show all
+            </button>
+          </div>
         </div>
       )}
-      {loading ? (
-        <FeedSkeleton count={6} />
-      ) : posts.length === 0 ? (
-        <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
-          No posts yet.
-        </div>
-      ) : (
-        <PostList
-          posts={posts as FeedPost[]}
-          actorNames={actorNames}
-          hasMore={hasMore}
-          loadingMore={loadingMore}
-          onLoadMore={onLoadMore}
-        />
-      )}
+
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-2 py-3">
+        {loading ? (
+          <FeedSkeleton count={6} />
+        ) : posts.length === 0 ? (
+          <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
+            No posts yet.
+          </div>
+        ) : (
+          <PostList
+            posts={posts as FeedPost[]}
+            actorNames={actorNames}
+            hasMore={hasMore}
+            loadingMore={loadingMore}
+            onLoadMore={onLoadMore}
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/markets/_components/terminal/TerminalSocialFeed.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalSocialFeed.tsx
@@ -170,12 +170,16 @@ export function TerminalSocialFeed({ perpTicker }: TerminalSocialFeedProps) {
       void fetchTagPosts({ append: true });
       return;
     }
+    // Guard for global mode to avoid duplicate fetches
+    if (!globalHasMore || globalLoadingMore) return;
     if (!globalCursor) return;
     void fetchGlobalPosts(globalCursor, true);
   }, [
     fetchGlobalPosts,
     fetchTagPosts,
     globalCursor,
+    globalHasMore,
+    globalLoadingMore,
     tagHasMore,
     tagLoadingMore,
     tagMode,

--- a/apps/web/src/app/markets/_components/terminal/TerminalSocialFeed.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalSocialFeed.tsx
@@ -1,7 +1,13 @@
 'use client';
 
 import { cn, type FeedPost } from '@babylon/shared';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { PostList } from '@/app/feed/components/PostList';
 import { useFeedPosts } from '@/app/feed/hooks/useFeedPosts';
 import { FeedSkeleton } from '@/components/shared/Skeleton';
@@ -43,8 +49,12 @@ export function TerminalSocialFeed({ perpTicker }: TerminalSocialFeedProps) {
   } = useFeedPosts({ enabled: !tagMode });
 
   useEffect(() => {
+    const controller = new AbortController();
     const loadActorNames = async () => {
-      const response = await fetch('/api/actors');
+      const response = await fetch('/api/actors', {
+        signal: controller.signal,
+      }).catch(() => null);
+      if (!response) return;
       if (!response.ok) return;
       const data = (await response.json()) as {
         actors?: Array<{ id: string; name: string }>;
@@ -56,7 +66,11 @@ export function TerminalSocialFeed({ perpTicker }: TerminalSocialFeedProps) {
       setActorNames(nameMap);
     };
     void loadActorNames();
+    return () => controller.abort();
   }, []);
+
+  const tagOffsetRef = useRef(tagOffset);
+  tagOffsetRef.current = tagOffset;
 
   const fetchTagPosts = useCallback(
     async ({ append }: { append: boolean }) => {
@@ -70,7 +84,7 @@ export function TerminalSocialFeed({ perpTicker }: TerminalSocialFeedProps) {
       inFlightTagRef.current = controller;
 
       const limit = 20;
-      const offset = append ? tagOffset : 0;
+      const offset = append ? tagOffsetRef.current : 0;
 
       const response = await fetch(
         `/api/trending/${encodeURIComponent(tag)}?limit=${limit}&offset=${offset}`,
@@ -133,7 +147,7 @@ export function TerminalSocialFeed({ perpTicker }: TerminalSocialFeedProps) {
       setTagLoading(false);
       setTagLoadingMore(false);
     },
-    [tag, tagOffset]
+    [tag]
   );
 
   useEffect(() => {
@@ -203,7 +217,7 @@ export function TerminalSocialFeed({ perpTicker }: TerminalSocialFeedProps) {
           </div>
         ) : (
           <PostList
-            posts={posts as FeedPost[]}
+            posts={posts}
             actorNames={actorNames}
             hasMore={hasMore}
             loadingMore={loadingMore}

--- a/apps/web/src/app/markets/_components/terminal/TerminalSocialFeed.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalSocialFeed.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import type { FeedPost } from '@babylon/shared';
+import { useCallback, useEffect, useState } from 'react';
+import { PostList } from '@/app/feed/components/PostList';
+import { useFeedPosts } from '@/app/feed/hooks/useFeedPosts';
+import { FeedSkeleton } from '@/components/shared/Skeleton';
+
+export function TerminalSocialFeed() {
+  const [actorNames, setActorNames] = useState<Map<string, string>>(new Map());
+  const { posts, loading, loadingMore, hasMore, cursor, fetchPosts } =
+    useFeedPosts();
+
+  useEffect(() => {
+    const loadActorNames = async () => {
+      const response = await fetch('/api/actors');
+      if (!response.ok) return;
+      const data = (await response.json()) as {
+        actors?: Array<{ id: string; name: string }>;
+      };
+      const nameMap = new Map<string, string>();
+      data.actors?.forEach((actor) => {
+        nameMap.set(actor.id, actor.name);
+      });
+      setActorNames(nameMap);
+    };
+    void loadActorNames();
+  }, []);
+
+  const onLoadMore = useCallback(() => {
+    if (!cursor) return;
+    void fetchPosts(cursor, true);
+  }, [cursor, fetchPosts]);
+
+  return (
+    <div className="h-full overflow-auto px-2 py-3">
+      {loading ? (
+        <FeedSkeleton count={6} />
+      ) : posts.length === 0 ? (
+        <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
+          No posts yet.
+        </div>
+      ) : (
+        <PostList
+          posts={posts as FeedPost[]}
+          actorNames={actorNames}
+          hasMore={hasMore}
+          loadingMore={loadingMore}
+          onLoadMore={onLoadMore}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/markets/_components/terminal/TerminalSocialFeed.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalSocialFeed.tsx
@@ -1,15 +1,46 @@
 'use client';
 
-import type { FeedPost } from '@babylon/shared';
-import { useCallback, useEffect, useState } from 'react';
+import { cn, type FeedPost } from '@babylon/shared';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { PostList } from '@/app/feed/components/PostList';
 import { useFeedPosts } from '@/app/feed/hooks/useFeedPosts';
 import { FeedSkeleton } from '@/components/shared/Skeleton';
 
-export function TerminalSocialFeed() {
+interface TerminalSocialFeedProps {
+  perpTicker?: string | null;
+}
+
+export function TerminalSocialFeed({ perpTicker }: TerminalSocialFeedProps) {
   const [actorNames, setActorNames] = useState<Map<string, string>>(new Map());
-  const { posts, loading, loadingMore, hasMore, cursor, fetchPosts } =
-    useFeedPosts();
+  const tag = useMemo(() => {
+    const t = perpTicker?.trim();
+    if (!t) return null;
+    return t.replace(/^\$/, '').toLowerCase();
+  }, [perpTicker]);
+
+  const [tagPosts, setTagPosts] = useState<FeedPost[]>([]);
+  const [tagInfo, setTagInfo] = useState<{
+    name: string;
+    displayName: string;
+    category?: string | null;
+  } | null>(null);
+  const [tagLoading, setTagLoading] = useState(false);
+  const [tagLoadingMore, setTagLoadingMore] = useState(false);
+  const [tagHasMore, setTagHasMore] = useState(true);
+  const [tagOffset, setTagOffset] = useState(0);
+  const [tagNotFound, setTagNotFound] = useState(false);
+  const inFlightTagRef = useRef<AbortController | null>(null);
+
+  const tagMode = tag != null && !tagNotFound;
+
+  const {
+    posts: globalPosts,
+    loading: globalLoading,
+    loadingMore: globalLoadingMore,
+    hasMore: globalHasMore,
+    cursor: globalCursor,
+    fetchPosts: fetchGlobalPosts,
+  } = useFeedPosts({ enabled: !tagMode });
 
   useEffect(() => {
     const loadActorNames = async () => {
@@ -27,13 +58,139 @@ export function TerminalSocialFeed() {
     void loadActorNames();
   }, []);
 
+  const fetchTagPosts = useCallback(
+    async ({ append }: { append: boolean }) => {
+      if (!tag) return;
+
+      if (append) setTagLoadingMore(true);
+      else setTagLoading(true);
+
+      inFlightTagRef.current?.abort();
+      const controller = new AbortController();
+      inFlightTagRef.current = controller;
+
+      const limit = 20;
+      const offset = append ? tagOffset : 0;
+
+      const response = await fetch(
+        `/api/trending/${encodeURIComponent(tag)}?limit=${limit}&offset=${offset}`,
+        { signal: controller.signal }
+      ).catch(() => null);
+
+      if (!response) {
+        setTagLoading(false);
+        setTagLoadingMore(false);
+        return;
+      }
+
+      if (response.status === 404) {
+        setTagNotFound(true);
+        setTagPosts([]);
+        setTagInfo(null);
+        setTagHasMore(true);
+        setTagOffset(0);
+        setTagLoading(false);
+        setTagLoadingMore(false);
+        return;
+      }
+
+      if (!response.ok) {
+        setTagLoading(false);
+        setTagLoadingMore(false);
+        return;
+      }
+
+      const data = (await response.json()) as {
+        success: boolean;
+        tag?: { name: string; displayName: string; category?: string | null };
+        posts?: FeedPost[];
+        total?: number;
+      };
+
+      if (!data.success) {
+        setTagLoading(false);
+        setTagLoadingMore(false);
+        return;
+      }
+
+      if (data.tag) setTagInfo(data.tag);
+      const newPosts = data.posts ?? [];
+
+      setTagPosts((prev) => {
+        const combined = append ? [...prev, ...newPosts] : newPosts;
+        const unique = new Map<string, FeedPost>();
+        combined.forEach((p) => unique.set(p.id, p));
+        return Array.from(unique.values()).sort((a, b) => {
+          const aTime = new Date(a.timestamp ?? 0).getTime();
+          const bTime = new Date(b.timestamp ?? 0).getTime();
+          return bTime - aTime;
+        });
+      });
+
+      const nextOffset = offset + newPosts.length;
+      setTagOffset(nextOffset);
+      setTagHasMore(newPosts.length === limit);
+      setTagLoading(false);
+      setTagLoadingMore(false);
+    },
+    [tag, tagOffset]
+  );
+
+  useEffect(() => {
+    setTagNotFound(false);
+    setTagPosts([]);
+    setTagInfo(null);
+    setTagHasMore(true);
+    setTagOffset(0);
+    if (!tag) return;
+    void fetchTagPosts({ append: false });
+  }, [tag, fetchTagPosts]);
+
   const onLoadMore = useCallback(() => {
-    if (!cursor) return;
-    void fetchPosts(cursor, true);
-  }, [cursor, fetchPosts]);
+    if (tagMode) {
+      if (!tagHasMore || tagLoadingMore) return;
+      void fetchTagPosts({ append: true });
+      return;
+    }
+    if (!globalCursor) return;
+    void fetchGlobalPosts(globalCursor, true);
+  }, [
+    fetchGlobalPosts,
+    fetchTagPosts,
+    globalCursor,
+    tagHasMore,
+    tagLoadingMore,
+    tagMode,
+  ]);
+
+  const posts = tagMode ? tagPosts : globalPosts;
+  const loading = tagMode ? tagLoading : globalLoading;
+  const loadingMore = tagMode ? tagLoadingMore : globalLoadingMore;
+  const hasMore = tagMode ? tagHasMore : globalHasMore;
 
   return (
     <div className="h-full overflow-auto px-2 py-3">
+      {tagMode && (
+        <div
+          className={cn(
+            'mb-3 flex items-center justify-between rounded-md border border-white/5 bg-background/40 px-3 py-2 text-muted-foreground text-xs'
+          )}
+        >
+          <span className="min-w-0 truncate">
+            Showing posts for{' '}
+            <span className="font-semibold text-foreground">
+              {tagInfo?.displayName ?? perpTicker}
+            </span>
+          </span>
+          <button
+            type="button"
+            onClick={() => setTagNotFound(true)}
+            className="shrink-0 rounded px-2 py-1 font-semibold text-foreground/80 hover:bg-muted/20 hover:text-foreground"
+          >
+            Show all
+          </button>
+        </div>
+      )}
       {loading ? (
         <FeedSkeleton count={6} />
       ) : posts.length === 0 ? (

--- a/apps/web/src/app/markets/_lib/formatters.ts
+++ b/apps/web/src/app/markets/_lib/formatters.ts
@@ -16,13 +16,16 @@ export function formatPrice(price: number): string {
 }
 
 /**
- * Formats a Babylon points balance as an integer (no decimals) with separators.
+ * Formats a Babylon points balance with 2 decimals and separators.
  *
  * @param balance - The balance to format
- * @returns Formatted balance string (e.g., "ƀ12,345")
+ * @returns Formatted balance string (e.g., "ƀ12,345.00")
  */
 export function formatBalance(balance: number): string {
-  return `${BABYLON_POINTS_SYMBOL}${Math.floor(balance).toLocaleString()}`;
+  return `${BABYLON_POINTS_SYMBOL}${balance.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
 }
 
 /**

--- a/apps/web/src/app/markets/_lib/formatters.ts
+++ b/apps/web/src/app/markets/_lib/formatters.ts
@@ -16,6 +16,16 @@ export function formatPrice(price: number): string {
 }
 
 /**
+ * Formats a Babylon points balance as an integer (no decimals) with separators.
+ *
+ * @param balance - The balance to format
+ * @returns Formatted balance string (e.g., "ƀ12,345")
+ */
+export function formatBalance(balance: number): string {
+  return `${BABYLON_POINTS_SYMBOL}${Math.floor(balance).toLocaleString()}`;
+}
+
+/**
  * Formats a volume value with appropriate suffix (K, M, B).
  * Values under ƀ1,000 are displayed without suffix.
  *

--- a/apps/web/src/app/markets/page.tsx
+++ b/apps/web/src/app/markets/page.tsx
@@ -79,7 +79,7 @@ export default function MarketsPage() {
   return (
     <PageContainer
       noPadding
-      className="flex h-[calc(100vh-theme(spacing.16))] flex-col"
+      className="flex h-[calc(100dvh-112px)] flex-col overflow-hidden md:h-dvh"
     >
       <div className="flex flex-1 overflow-hidden bg-background/20">
         <MarketsTradingTerminal

--- a/apps/web/src/components/charts/LightweightChartBase.tsx
+++ b/apps/web/src/components/charts/LightweightChartBase.tsx
@@ -142,11 +142,11 @@ export const LINE_STYLES = {
     crosshairMarkerBorderWidth: 2,
   } satisfies DeepPartial<LineSeriesOptions>,
   violetPastel: {
-    color: '#a78bfa', // violet-400
+    color: '#8b5cf6', // violet-500 (a bit less pastel)
     lineWidth: 2,
     crosshairMarkerVisible: true,
     crosshairMarkerRadius: 4,
-    crosshairMarkerBackgroundColor: '#a78bfa',
+    crosshairMarkerBackgroundColor: '#8b5cf6',
     crosshairMarkerBorderColor: '#ffffff',
     crosshairMarkerBorderWidth: 2,
   } satisfies DeepPartial<LineSeriesOptions>,

--- a/apps/web/src/components/charts/LightweightChartBase.tsx
+++ b/apps/web/src/components/charts/LightweightChartBase.tsx
@@ -106,6 +106,17 @@ export const AREA_STYLES = {
     crosshairMarkerBorderColor: '#ffffff',
     crosshairMarkerBorderWidth: 2,
   } satisfies DeepPartial<AreaSeriesOptions>,
+  bluePastel: {
+    lineColor: '#60a5fa', // blue-400
+    topColor: 'rgba(96, 165, 250, 0.22)',
+    bottomColor: 'rgba(96, 165, 250, 0.02)',
+    lineWidth: 2,
+    crosshairMarkerVisible: true,
+    crosshairMarkerRadius: 4,
+    crosshairMarkerBackgroundColor: '#60a5fa',
+    crosshairMarkerBorderColor: '#ffffff',
+    crosshairMarkerBorderWidth: 2,
+  } satisfies DeepPartial<AreaSeriesOptions>,
 };
 
 /**
@@ -127,6 +138,15 @@ export const LINE_STYLES = {
     crosshairMarkerVisible: true,
     crosshairMarkerRadius: 4,
     crosshairMarkerBackgroundColor: '#ef4444',
+    crosshairMarkerBorderColor: '#ffffff',
+    crosshairMarkerBorderWidth: 2,
+  } satisfies DeepPartial<LineSeriesOptions>,
+  violetPastel: {
+    color: '#a78bfa', // violet-400
+    lineWidth: 2,
+    crosshairMarkerVisible: true,
+    crosshairMarkerRadius: 4,
+    crosshairMarkerBackgroundColor: '#a78bfa',
     crosshairMarkerBorderColor: '#ffffff',
     crosshairMarkerBorderWidth: 2,
   } satisfies DeepPartial<LineSeriesOptions>,

--- a/apps/web/src/components/chats/TeamChatView.tsx
+++ b/apps/web/src/components/chats/TeamChatView.tsx
@@ -98,6 +98,8 @@ interface TeamChatViewProps {
   currentUserId: string | undefined;
   authenticated: boolean;
   sseConnected: boolean;
+  /** When embedding in another container that already has a header (e.g. terminal tabs). */
+  hideHeader?: boolean;
   loading: boolean;
   isLoadingMore: boolean;
   hasMore: boolean;
@@ -136,6 +138,7 @@ export function TeamChatView({
   currentUserId,
   authenticated,
   sseConnected,
+  hideHeader = false,
   loading,
   isLoadingMore,
   hasMore,
@@ -171,47 +174,49 @@ export function TeamChatView({
   return (
     <div className="flex h-full flex-col">
       {/* Chat Header - Fixed */}
-      <div className="shrink-0">
-        <div className="flex items-center justify-between px-4 py-3">
-          <div>
-            <h2 className="font-semibold text-foreground text-lg">Agents</h2>
-            <p className="text-muted-foreground text-sm">
-              {chatDetails.participants.length} member
-              {chatDetails.participants.length !== 1 ? 's' : ''}
-            </p>
-          </div>
-          <div className="flex items-center gap-3">
-            {/* Mobile members button */}
-            {onShowMembers && (
-              <button
-                onClick={onShowMembers}
-                className="rounded-lg p-2 transition-colors hover:bg-muted lg:hidden"
-                aria-label="Show team members"
-              >
-                <Users className="h-5 w-5 text-muted-foreground" />
-              </button>
-            )}
-            {/* Connection status */}
-            <div className="flex items-center gap-2">
-              <Radio
-                className={
-                  sseConnected
-                    ? 'h-4 w-4 text-green-500'
-                    : 'h-4 w-4 text-muted-foreground'
-                }
-              />
-              <span className="text-muted-foreground text-sm">
-                {sseConnected ? 'Live' : 'Connecting...'}
-              </span>
+      {!hideHeader && (
+        <div className="shrink-0">
+          <div className="flex items-center justify-between px-4 py-3">
+            <div>
+              <h2 className="font-semibold text-foreground text-lg">Agents</h2>
+              <p className="text-muted-foreground text-sm">
+                {chatDetails.participants.length} member
+                {chatDetails.participants.length !== 1 ? 's' : ''}
+              </p>
+            </div>
+            <div className="flex items-center gap-3">
+              {/* Mobile members button */}
+              {onShowMembers && (
+                <button
+                  onClick={onShowMembers}
+                  className="rounded-lg p-2 transition-colors hover:bg-muted lg:hidden"
+                  aria-label="Show team members"
+                >
+                  <Users className="h-5 w-5 text-muted-foreground" />
+                </button>
+              )}
+              {/* Connection status */}
+              <div className="flex items-center gap-2">
+                <Radio
+                  className={
+                    sseConnected
+                      ? 'h-4 w-4 text-green-500'
+                      : 'h-4 w-4 text-muted-foreground'
+                  }
+                />
+                <span className="text-muted-foreground text-sm">
+                  {sseConnected ? 'Live' : 'Connecting...'}
+                </span>
+              </div>
             </div>
           </div>
-        </div>
 
-        {/* Header Separator */}
-        <div className="px-4">
-          <Separator />
+          {/* Header Separator */}
+          <div className="px-4">
+            <Separator />
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Messages - Scrollable */}
       <div

--- a/apps/web/src/components/markets/PredictionProbabilityChart.tsx
+++ b/apps/web/src/components/markets/PredictionProbabilityChart.tsx
@@ -160,7 +160,7 @@ export function PredictionProbabilityChart({
       setChartInitError(null);
 
       const yesOptions = {
-        ...AREA_STYLES.green,
+        ...AREA_STYLES.bluePastel,
         priceFormat: {
           type: 'custom' as const,
           formatter: (price: number) => `${price.toFixed(1)}%`,
@@ -169,7 +169,7 @@ export function PredictionProbabilityChart({
       };
 
       const noOptions = {
-        ...LINE_STYLES.red,
+        ...LINE_STYLES.violetPastel,
         priceFormat: {
           type: 'custom' as const,
           formatter: (price: number) => `${price.toFixed(1)}%`,
@@ -287,13 +287,13 @@ export function PredictionProbabilityChart({
         <div className="flex flex-wrap items-center justify-between gap-3 px-1">
           <div className="flex items-center gap-4">
             <div className="flex items-center gap-2">
-              <div className="h-3 w-3 rounded-full bg-green-600" />
+              <div className="h-3 w-3 rounded-full bg-blue-400" />
               <span className="font-semibold text-sm">
                 YES {currentProbability.toFixed(1)}%
               </span>
             </div>
             <div className="flex items-center gap-2">
-              <div className="h-3 w-3 rounded-full bg-red-600" />
+              <div className="h-3 w-3 rounded-full bg-violet-400" />
               <span className="font-semibold text-sm">
                 NO {(100 - currentProbability).toFixed(1)}%
               </span>
@@ -345,14 +345,14 @@ export function PredictionProbabilityChart({
         <div className="flex items-center gap-2">
           <div
             className="h-0.5 w-4 rounded"
-            style={{ backgroundColor: '#22c55e' }}
+            style={{ backgroundColor: '#60a5fa' }}
           />
           <span>YES Probability</span>
         </div>
         <div className="flex items-center gap-2">
           <div
             className="h-0.5 w-4 rounded"
-            style={{ backgroundColor: '#ef4444' }}
+            style={{ backgroundColor: '#a78bfa' }}
           />
           <span>NO Probability</span>
         </div>

--- a/apps/web/src/components/markets/PredictionProbabilityChart.tsx
+++ b/apps/web/src/components/markets/PredictionProbabilityChart.tsx
@@ -47,6 +47,8 @@ interface PredictionProbabilityChartProps {
   onTimeRangeChange: (range: MarketTimeRange) => void;
   /** Whether to show brush selector (unused, for future) */
   showBrush?: boolean;
+  /** Whether to show the built-in header (probabilities + range controls). Defaults to true. */
+  showHeader?: boolean;
 }
 
 /**
@@ -72,6 +74,7 @@ export function PredictionProbabilityChart({
   marketId,
   timeRange,
   onTimeRangeChange,
+  showHeader = true,
 }: PredictionProbabilityChartProps) {
   const [chartInitError, setChartInitError] = useState<string | null>(null);
   const yesSeries = useRef<ISeriesApi<'Area'> | null>(null);
@@ -279,41 +282,41 @@ export function PredictionProbabilityChart({
   }
 
   return (
-    <div className="w-full space-y-3" key={marketId}>
-      {/* Header with probabilities and time range selector */}
-      <div className="flex flex-wrap items-center justify-between gap-3 px-1">
-        <div className="flex items-center gap-4">
-          <div className="flex items-center gap-2">
-            <div className="h-3 w-3 rounded-full bg-green-600" />
-            <span className="font-semibold text-sm">
-              YES {currentProbability.toFixed(1)}%
-            </span>
+    <div className={showHeader ? 'w-full space-y-3' : 'w-full'} key={marketId}>
+      {showHeader && (
+        <div className="flex flex-wrap items-center justify-between gap-3 px-1">
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-2">
+              <div className="h-3 w-3 rounded-full bg-green-600" />
+              <span className="font-semibold text-sm">
+                YES {currentProbability.toFixed(1)}%
+              </span>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="h-3 w-3 rounded-full bg-red-600" />
+              <span className="font-semibold text-sm">
+                NO {(100 - currentProbability).toFixed(1)}%
+              </span>
+            </div>
           </div>
-          <div className="flex items-center gap-2">
-            <div className="h-3 w-3 rounded-full bg-red-600" />
-            <span className="font-semibold text-sm">
-              NO {(100 - currentProbability).toFixed(1)}%
-            </span>
-          </div>
-        </div>
 
-        {/* Time range selector */}
-        <div className="flex items-center gap-1 rounded-md bg-muted/30 p-1">
-          {MARKET_TIME_RANGES.map((range) => (
-            <button
-              key={range}
-              onClick={() => onTimeRangeChange(range)}
-              className={`cursor-pointer rounded px-2 py-1 text-xs transition-colors ${
-                timeRange === range
-                  ? 'bg-primary text-primary-foreground'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              {range}
-            </button>
-          ))}
+          <div className="flex items-center gap-1 rounded-md bg-muted/30 p-1">
+            {MARKET_TIME_RANGES.map((range) => (
+              <button
+                key={range}
+                onClick={() => onTimeRangeChange(range)}
+                className={`cursor-pointer rounded px-2 py-1 text-xs transition-colors ${
+                  timeRange === range
+                    ? 'bg-primary text-primary-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+              >
+                {range}
+              </button>
+            ))}
+          </div>
         </div>
-      </div>
+      )}
 
       {/* Chart container */}
       <div className="relative">

--- a/apps/web/src/components/markets/PredictionProbabilityChart.tsx
+++ b/apps/web/src/components/markets/PredictionProbabilityChart.tsx
@@ -293,7 +293,7 @@ export function PredictionProbabilityChart({
               </span>
             </div>
             <div className="flex items-center gap-2">
-              <div className="h-3 w-3 rounded-full bg-violet-400" />
+              <div className="h-3 w-3 rounded-full bg-violet-500" />
               <span className="font-semibold text-sm">
                 NO {(100 - currentProbability).toFixed(1)}%
               </span>
@@ -352,7 +352,7 @@ export function PredictionProbabilityChart({
         <div className="flex items-center gap-2">
           <div
             className="h-0.5 w-4 rounded"
-            style={{ backgroundColor: '#a78bfa' }}
+            style={{ backgroundColor: '#8b5cf6' }}
           />
           <span>NO Probability</span>
         </div>

--- a/apps/web/src/components/shared/BottomNav.tsx
+++ b/apps/web/src/components/shared/BottomNav.tsx
@@ -27,7 +27,9 @@ function BottomNavContent() {
   // Hide bottom nav when WAITLIST_MODE is enabled on home page
   const isWaitlistMode = process.env.NEXT_PUBLIC_WAITLIST_MODE === 'true';
   const isHomePage = pathname === '/';
-  const shouldHide = isWaitlistMode && isHomePage;
+  const isMarketsPage =
+    pathname === '/markets' || pathname.startsWith('/markets/');
+  const shouldHide = (isWaitlistMode && isHomePage) || isMarketsPage;
 
   // Poll for unread notifications
   useEffect(() => {

--- a/apps/web/src/components/shared/BottomNav.tsx
+++ b/apps/web/src/components/shared/BottomNav.tsx
@@ -27,9 +27,7 @@ function BottomNavContent() {
   // Hide bottom nav when WAITLIST_MODE is enabled on home page
   const isWaitlistMode = process.env.NEXT_PUBLIC_WAITLIST_MODE === 'true';
   const isHomePage = pathname === '/';
-  const isMarketsPage =
-    pathname === '/markets' || pathname.startsWith('/markets/');
-  const shouldHide = (isWaitlistMode && isHomePage) || isMarketsPage;
+  const shouldHide = isWaitlistMode && isHomePage;
 
   // Poll for unread notifications
   useEffect(() => {

--- a/apps/web/src/stores/marketWatchlistStore.ts
+++ b/apps/web/src/stores/marketWatchlistStore.ts
@@ -50,7 +50,10 @@ export const useMarketWatchlistStore = create<MarketWatchlistState>()(
       partialize: (state) => ({ favorites: state.favorites }),
       onRehydrateStorage: () => (state) => {
         if (!state) return;
-        state.favoritesSet = new Set(state.favorites ?? []);
+        // Use setState to properly notify subscribers after rehydration
+        useMarketWatchlistStore.setState({
+          favoritesSet: new Set(state.favorites ?? []),
+        });
       },
     }
   )

--- a/apps/web/src/types/markets.ts
+++ b/apps/web/src/types/markets.ts
@@ -82,17 +82,24 @@ export interface PerpMarket {
 export interface PredictionMarket {
   id: number | string;
   text: string;
+  /** Alias sometimes returned by API routes */
+  question?: string;
   status: 'active' | 'resolved' | 'cancelled';
   createdDate?: string;
   resolutionDate?: string;
+  endDate?: string | null;
   resolvedOutcome?: boolean;
   scenario: number;
   yesShares?: number;
   noShares?: number;
+  yesProbability?: number;
+  noProbability?: number;
   tradeCount?: number;
   oracleCommitTxHash?: string | null;
   oracleRevealTxHash?: string | null;
   oraclePublishedAt?: string | null;
+  resolutionProofUrl?: string | null;
+  resolutionDescription?: string | null;
 }
 
 /**

--- a/packages/testing/unit/mcp/tool-handlers.test.ts
+++ b/packages/testing/unit/mcp/tool-handlers.test.ts
@@ -196,8 +196,8 @@ describe('MCP Tool Handlers - Validation Logic', () => {
     });
 
     it('should allow transfer to different user', () => {
-      const senderId = 'user-123';
-      const recipientId = 'user-456';
+      const senderId: string = 'user-123';
+      const recipientId: string = 'user-456';
 
       const isSelfTransfer = senderId === recipientId;
       expect(isSelfTransfer).toBe(false);


### PR DESCRIPTION
## Summary
- Polish and unify the Markets trading terminal UI (perps + prediction markets) to improve coherence, discoverability, and trading UX.
- Add missing terminal features (fullscreen modes, Agents/Social tabs, richer market filtering) and fix multiple mobile layout/scroll issues.

## Type
- [x] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: UI/UX polish

## Context / Links
- Babylon terminal UI polish + alignment with `./Babylontradingterminal` reference.

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`) (prediction sell support)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [x] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- Add terminal "fullscreen" mode on desktop and a chart-only fullscreen on mobile.
- Replace scattered market list pills with a combined Filter + Sort dropdown (incl. Favorites filter + URL sync).
- Restore bottom tabs (Agents default + Social) and align bottom panel behavior.
- Unify prediction/perps visual language:
  - Remove duplicated timeframe selector; unify headers.
  - Prediction titles/conditions are readable + details modal.
  - Prediction trade panel redesigned to match perps and support YES/NO + BUY/SELL with consistent colors.
- Make trade panel always visible (no collapse).
- Balance UX cleanup:
  - Remove duplicate balance in header; keep balance in trade panel with consistent formatting (2 decimals).
  - Fix prediction avg price display to use $.
- Mobile layout polish:
  - Remove redundant mobile header; rely on bottom bar.
  - Keep the terminal layout contained (no page scrolling) while allowing inner lists (Agents/Social/Positions/Trades) to scroll.

## Review guide
**Start here**
- `apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- This is intentionally a UI/UX coherence sweep scoped to the Markets terminal.
- Mobile work focused on fixing nested scroll containment and keeping the terminal UI stable.

## Test plan
**Commands run**
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [ ] `bun run check` (Biome format)
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Desktop: open `/markets`, verify fullscreen toggle works and Escape exits.
2. Desktop: verify market list Filter/Sort menu (incl. Favorites) and URL sync.
3. Desktop: verify prediction vs perps headers/time range selector coherence; prediction details modal.
4. Desktop: verify trade panel cannot be collapsed; balance shown in trade panel; avg price shown in $.
5. Mobile: verify bottom bar (Markets/Trade/Balance) is present and terminal UI does not require page scroll.
6. Mobile: open Agents tab and send a message (input visible); Social tab scrolls.
7. Mobile: open chart fullscreen and close.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: —
- Changed: —
- Removed: —

**DB / data migration**
- Migration(s): —
- Backfill/seed: —

**Rollout / rollback plan**
- Rollout: merge to `staging`.
- Rollback: revert PR.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option A: Visual demo

| Feature | Before | After |
|---------|--------|-------|
| Markets terminal polish | N/A | Please record the flow below |

*Demo script (for recording):*
1. Desktop `/markets`: toggle terminal fullscreen on/off.
2. Open Filter/Sort dropdown; switch to Favorites-only; change sort.
3. Open a prediction market: show readable title/conditions + details modal; show YES/NO colors and trade toggles.
4. Mobile `/markets`: show bottom bar + tabs; scroll Social; open Agents and focus input; open chart fullscreen and close.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Buy button on order entry to purchase points
  * Full buy/sell prediction flow with fee-aware calculations, net/gross/proceeds display, max-sell and buy/sell toggle
  * New terminal components: Agents chat and Social feed
  * Expanded market metadata (question, end date, probabilities, resolution info)

* **UI/Style**
  * Balance display uses points-aware formatter
  * New chart color presets and optional chart headers
  * Responsive layout and reduced bottom padding

* **Bug Fixes**
  * Watchlist rehydration now correctly updates favorites state

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR significantly enhances the Markets trading terminal with UI/UX polish and mobile layout improvements. The changes successfully unify prediction and perps terminal experiences, add prediction sell functionality, and fix mobile scrolling issues.

## Key Changes

- **Terminal fullscreen mode**: Desktop fullscreen with Escape key support, mobile chart-only fullscreen
- **Market filtering & sorting**: Combined Filter + Sort dropdown with Favorites filter, URL state sync, and sort by volume/change/open interest/name
- **Bottom tabs restoration**: Added Agents (default) and Social tabs alongside Positions/Trades
- **Prediction sell support**: New BUY/SELL toggle, shares input with max button, gross/net proceeds calculation using `PredictionPricing.calculateSellWithFees()`
- **Visual unification**: Prediction chart colors changed from green/red to blue/violet, removed duplicate timeframe selectors, trade panel always visible
- **Mobile layout**: Uses `dvh` for viewport height, removes redundant header, contains terminal layout to prevent page scroll while allowing inner list scrolling
- **Balance display**: Consistent 2-decimal formatting using `formatBalance()`, removed duplicate header balance

## Issues Found

- **Logic error** in `computeYesPctFromShares()` (line 183): Uses simple share ratio `(yes / total) * 100` instead of CPMM pricing `PredictionPricing.getCurrentPrice()`. This causes incorrect probability displays in the market list and affects the unified rows sorting/display logic.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the CPMM pricing calculation in computeYesPctFromShares
- The PR successfully implements comprehensive UI/UX improvements with good code organization and proper error handling. One critical logic error exists in probability calculation that will cause incorrect market probability displays, but it's isolated and has a clear fix. The mobile layout changes use modern viewport units appropriately, and the prediction sell implementation follows existing patterns correctly.
- apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx requires fixing the computeYesPctFromShares function to use CPMM pricing instead of simple ratios

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx | Major UI overhaul adding fullscreen mode, filter/sort menu, Agents/Social tabs, prediction sell support, and mobile layout fixes |
| apps/web/src/types/markets.ts | Added SellSharesSuccessResponse type for prediction sell API responses |
| apps/web/src/app/markets/_lib/formatters.ts | No issues found - clean utility functions for formatting prices and balances |
| apps/web/src/components/markets/PredictionProbabilityChart.tsx | Added showHeader prop and changed colors from green/red to blue/violet for better visual consistency |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Terminal as MarketsTradingTerminal
    participant API as /api/markets/predictions/:id/sell
    participant Store as userPositionsStore
    participant Wallet as walletBalanceStore

    User->>Terminal: Select prediction market
    Terminal->>Store: Load user positions
    Store-->>Terminal: Return positions for market
    
    User->>Terminal: Toggle to SELL mode
    Terminal->>Terminal: Filter positions by side (YES/NO)
    Terminal->>Terminal: Select position with most shares
    Terminal-->>User: Show max shares available
    
    User->>Terminal: Enter shares amount
    Terminal->>Terminal: Clamp to maxSellShares
    Terminal->>Terminal: Calculate sell with PredictionPricing.calculateSellWithFees()
    Terminal-->>User: Show gross proceeds, fee, net proceeds
    
    User->>Terminal: Click SELL button
    Terminal->>Terminal: Validate shares >= 0.01
    Terminal-->>User: Show confirmation dialog
    
    User->>Terminal: Confirm trade
    Terminal->>API: POST { shares, positionId }
    API-->>Terminal: { pnl }
    Terminal->>Store: Invalidate positions cache
    Terminal->>Wallet: Invalidate balance cache
    Terminal->>Store: Refresh positions
    Terminal->>Wallet: Refresh balance
    Terminal-->>User: Show success toast with shares sold
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->