### PR TITLE
fix(agents): use messageId for unique sidebar tab IDs

### DIFF
--- a/apps/web/src/app/agents/team/page.tsx
+++ b/apps/web/src/app/agents/team/page.tsx
@@ -299,12 +299,14 @@ export default function TeamChatPage() {
   }, []);
 
   // Handle tag click from message bubble - opens panel in right sidebar
-  // Reuses existing tab if same type (and entityId for single-item views)
-  const handleTagClick = useCallback((tag: MessageTag) => {
-    // Compute the expected tab ID
+  // Uses messageId to create unique tabs for list views from different messages
+  const handleTagClick = useCallback((tag: MessageTag, messageId: string) => {
+    // Compute the tab ID
+    // - For single-item views (with entityId): share tab across messages (e.g., same market)
+    // - For list views (no entityId): unique per message to prevent overwrites
     const tabId = tag.entityId
       ? `${tag.type}-id-${tag.entityId}`
-      : `${tag.type}-list`;
+      : `${tag.type}-list-${messageId}`;
 
     setRightSidebarTabs((prev) => {
       // Check if a matching tab already exists

--- a/apps/web/src/components/chats/MessageBubble.tsx
+++ b/apps/web/src/components/chats/MessageBubble.tsx
@@ -56,7 +56,7 @@ interface MessageBubbleProps {
   /** Whether this message is showing "Thinking..." placeholder state */
   isThinking?: boolean;
   /** Callback when a tag is clicked - opens sidebar with tag data */
-  onTagClick?: (tag: MessageTag) => void;
+  onTagClick?: (tag: MessageTag, messageId: string) => void;
 }
 
 export function MessageBubble({
@@ -176,7 +176,7 @@ export function MessageBubble({
                       <button
                         key={`${tag.type}-${tag.entityId ?? i}`}
                         type="button"
-                        onClick={() => onTagClick?.(tag)}
+                        onClick={() => onTagClick?.(tag, message.id)}
                         className="group flex items-center gap-1.5 rounded-full border border-primary/20 bg-primary/5 px-3 py-1 font-medium text-primary text-xs transition-all hover:border-primary/40 hover:bg-primary/10"
                       >
                         {IconComponent && (

--- a/apps/web/src/components/chats/MessageList.tsx
+++ b/apps/web/src/components/chats/MessageList.tsx
@@ -44,7 +44,7 @@ interface MessageListProps {
   topSentinelRef: React.RefObject<HTMLDivElement | null>;
   messagesEndRef: React.RefObject<HTMLDivElement | null>;
   /** Callback when a message tag is clicked */
-  onTagClick?: (tag: MessageTag) => void;
+  onTagClick?: (tag: MessageTag, messageId: string) => void;
 }
 
 export function MessageList({

--- a/apps/web/src/components/chats/TeamChatView.tsx
+++ b/apps/web/src/components/chats/TeamChatView.tsx
@@ -125,7 +125,7 @@ interface TeamChatViewProps {
   /** Callback to toggle right sidebar */
   onToggleRightSidebar?: () => void;
   /** Callback when a message tag is clicked */
-  onTagClick?: (tag: MessageTag) => void;
+  onTagClick?: (tag: MessageTag, messageId: string) => void;
 }
 
 /**


### PR DESCRIPTION
Previously, list view tags from different messages shared the same tab ID (e.g., "predictions-list"), causing them to overwrite each other when multiple agents returned prediction lists.

Now:
- Single-item views (with entityId): share tab (e.g., same market = same tab)
- List views (no entityId): unique per message using messageId

This allows users to open multiple prediction/perp list tabs from different agent responses without overwriting.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated tag interaction handling in team chat to include message context, ensuring tag actions on different messages maintain separate views and prevent unintended overwrites.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed tab ID collision for list view tags by incorporating `messageId` into the tab identifier. Previously, multiple agent responses with list tags (e.g., predictions lists, perp lists) would share the same tab ID and overwrite each other. 

The fix intelligently distinguishes between:
- **Single-item views** (with `entityId`): Continue sharing tabs across messages (e.g., same market = same tab)
- **List views** (no `entityId`): Create unique tabs per message using `messageId` suffix

This allows users to keep multiple list views open from different agent responses without losing data, while still preserving the expected behavior of consolidating single-entity views.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The change is minimal, focused, and follows a clear pattern. The implementation correctly threads the messageId parameter through all necessary components without altering any other logic. The tab ID generation logic appropriately handles both entity-specific and list views. No breaking changes or edge cases detected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/agents/team/page.tsx | Added messageId parameter to handleTagClick to generate unique tab IDs for list views while preserving shared tabs for entity-specific views |
| apps/web/src/components/chats/MessageBubble.tsx | Updated onTagClick signature to accept messageId and passes message.id when tags are clicked |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant MessageBubble
    participant TeamChatPage
    participant RightSidebar

    User->>MessageBubble: Click tag on message
    MessageBubble->>MessageBubble: Extract tag and message.id
    MessageBubble->>TeamChatPage: onTagClick(tag, messageId)
    TeamChatPage->>TeamChatPage: Check tag.entityId
    alt Has entityId (single-item view)
        TeamChatPage->>TeamChatPage: Generate tabId = `${type}-id-${entityId}`
        Note over TeamChatPage: Shared across messages<br/>e.g., "predictions-id-123"
    else No entityId (list view)
        TeamChatPage->>TeamChatPage: Generate tabId = `${type}-list-${messageId}`
        Note over TeamChatPage: Unique per message<br/>e.g., "predictions-list-msg456"
    end
    TeamChatPage->>TeamChatPage: Check if tab exists
    alt Tab exists
        TeamChatPage->>TeamChatPage: Update existing tab data
    else New tab
        TeamChatPage->>TeamChatPage: Create new tab
    end
    TeamChatPage->>RightSidebar: Set active tab and open sidebar
    RightSidebar->>User: Display tab content
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->