### PR TITLE
feat(groups): reorganize member search tabs and fix NPC avatar display

### DIFF
--- a/apps/web/src/app/api/groups/[groupId]/route.ts
+++ b/apps/web/src/app/api/groups/[groupId]/route.ts
@@ -87,11 +87,14 @@ export const GET = withErrorHandling(
         updatedAt: group.updatedAt,
         members: memberUsers.map((u) => {
           const membership = members.find((m) => m.userId === u.id);
+          // Determine member type: NPC (isActor), Agent (isAgent), or User
+          const memberType = u.isActor ? 'npc' : u.isAgent ? 'agent' : 'user';
           return {
             id: u.id,
             displayName: u.displayName,
             username: u.username,
             profileImageUrl: u.profileImageUrl,
+            memberType,
             role: membership?.role ?? 'member',
             isAdmin:
               membership?.role === 'admin' || membership?.role === 'owner',

--- a/apps/web/src/app/api/users/search/route.ts
+++ b/apps/web/src/app/api/users/search/route.ts
@@ -77,6 +77,9 @@
  *                         type: string
  *                       bio:
  *                         type: string
+ *                       isAgent:
+ *                         type: boolean
+ *                         description: Present when includeAgents=true, indicates if this is a user-created agent
  *       401:
  *         description: Unauthorized
  *
@@ -189,6 +192,8 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
         username: true,
         profileImageUrl: true,
         bio: true,
+        // Include isAgent when agents are included to distinguish them from humans
+        ...(includeAgents && { isAgent: true }),
       },
       take: 20, // Limit results
       orderBy: [

--- a/apps/web/src/components/groups/CreateGroupModal.tsx
+++ b/apps/web/src/components/groups/CreateGroupModal.tsx
@@ -15,7 +15,6 @@ import {
 import { useEffect, useState } from 'react';
 import { Avatar } from '@/components/shared/Avatar';
 import { useAuthStore } from '@/stores/authStore';
-import { MemberTypeBadge } from './MemberTypeBadge';
 
 /**
  * Member structure for group creation modal.
@@ -367,7 +366,6 @@ export function CreateGroupModal({
                       <span className="text-sm">
                         {member.displayName || member.username || 'Unknown'}
                       </span>
-                      <MemberTypeBadge type={member.type} />
                       <button
                         onClick={() => handleRemoveMember(member.id)}
                         className="ml-1 text-muted-foreground hover:text-foreground"

--- a/apps/web/src/components/groups/CreateGroupModal.tsx
+++ b/apps/web/src/components/groups/CreateGroupModal.tsx
@@ -29,18 +29,20 @@ interface Member {
   type: 'user' | 'agent' | 'npc';
 }
 
-type SearchTab = 'users' | 'agents';
+type SearchTab = 'users' | 'npcs';
 
 /**
  * Create group modal component for creating new user groups.
  *
  * Provides a form interface for creating groups with name input and
- * member selection. Includes tabbed search for users and agents/NPCs.
- * Creates both group and associated chat on creation.
+ * member selection. Includes tabbed search for users (including user-created
+ * agents) and NPCs. Creates both group and associated chat on creation.
  *
  * Features:
  * - Group name input
- * - Tabbed search (Users / Agents & NPCs)
+ * - Tabbed search (Users / NPCs)
+ * - Users tab includes human users and user-created agents
+ * - NPCs tab includes only system NPCs
  * - Member selection with type badges
  * - Auto-generated group names
  * - Form validation
@@ -93,7 +95,7 @@ export function CreateGroupModal({
     }
   }, [isOpen]);
 
-  // Search for users or agents based on active tab
+  // Search for users or NPCs based on active tab
   useEffect(() => {
     if (!searchQuery.trim() || searchQuery.length < 2) {
       setSearchResults([]);
@@ -106,9 +108,11 @@ export function CreateGroupModal({
         const token = await getAccessToken();
 
         // Use different endpoint based on active tab
+        // Users tab includes human users + user-created agents
+        // NPCs tab only includes NPCs
         const endpoint =
           activeTab === 'users'
-            ? `/api/users/search?q=${encodeURIComponent(searchQuery)}`
+            ? `/api/users/search?q=${encodeURIComponent(searchQuery)}&includeAgents=true`
             : `/api/agents/search?q=${encodeURIComponent(searchQuery)}`;
 
         const response = await fetch(endpoint, {
@@ -127,26 +131,34 @@ export function CreateGroupModal({
                     displayName: string | null;
                     username: string | null;
                     profileImageUrl: string | null;
+                    isAgent?: boolean;
                   }) => ({
-                    ...u,
-                    type: 'user' as const,
+                    id: u.id,
+                    displayName: u.displayName,
+                    username: u.username,
+                    profileImageUrl: u.profileImageUrl,
+                    // Distinguish between human users and user-created agents
+                    type: u.isAgent ? ('agent' as const) : ('user' as const),
                   })
                 )
-              : (data.agents || []).map(
-                  (a: {
-                    id: string;
-                    displayName: string | null;
-                    username: string | null;
-                    profileImageUrl: string | null;
-                    type: 'agent' | 'npc';
-                  }) => ({
-                    id: a.id,
-                    displayName: a.displayName,
-                    username: a.username,
-                    profileImageUrl: a.profileImageUrl,
-                    type: a.type,
-                  })
-                );
+              : // Filter to only include NPCs (not user-created agents)
+                (data.agents || [])
+                  .filter((a: { type: 'agent' | 'npc' }) => a.type === 'npc')
+                  .map(
+                    (a: {
+                      id: string;
+                      displayName: string | null;
+                      username: string | null;
+                      profileImageUrl: string | null;
+                      type: 'agent' | 'npc';
+                    }) => ({
+                      id: a.id,
+                      displayName: a.displayName,
+                      username: a.username,
+                      profileImageUrl: a.profileImageUrl,
+                      type: a.type,
+                    })
+                  );
           setSearchResults(results);
         } else {
           setSearchResults([]);
@@ -346,8 +358,10 @@ export function CreateGroupModal({
                       className="flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1.5"
                     >
                       <Avatar
-                        imageUrl={member.profileImageUrl || undefined}
+                        id={member.id}
+                        src={member.profileImageUrl || undefined}
                         name={member.username || member.displayName || '?'}
+                        type={member.type === 'npc' ? 'actor' : 'user'}
                         size="sm"
                       />
                       <span className="text-sm">
@@ -385,16 +399,16 @@ export function CreateGroupModal({
                   Users
                 </button>
                 <button
-                  onClick={() => handleTabChange('agents')}
+                  onClick={() => handleTabChange('npcs')}
                   className={cn(
                     'flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-2 text-sm transition-colors',
-                    activeTab === 'agents'
+                    activeTab === 'npcs'
                       ? 'bg-background font-medium text-foreground shadow-sm'
                       : 'text-muted-foreground hover:text-foreground'
                   )}
                 >
                   <Bot className="h-4 w-4" />
-                  Agents & NPCs
+                  NPCs
                 </button>
               </div>
 
@@ -406,7 +420,7 @@ export function CreateGroupModal({
                   placeholder={
                     activeTab === 'users'
                       ? 'Search users by name...'
-                      : 'Search agents and NPCs...'
+                      : 'Search NPCs by name...'
                   }
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
@@ -438,14 +452,15 @@ export function CreateGroupModal({
                       disabled={!!isSelected}
                     >
                       <Avatar
-                        imageUrl={member.profileImageUrl || undefined}
+                        id={member.id}
+                        src={member.profileImageUrl || undefined}
                         name={member.username || member.displayName || '?'}
+                        type={member.type === 'npc' ? 'actor' : 'user'}
                         size="sm"
                       />
                       <div className="min-w-0 flex-1">
-                        <div className="flex items-center truncate font-medium text-sm">
+                        <div className="truncate font-medium text-sm">
                           {member.displayName || member.username || 'Unknown'}
-                          <MemberTypeBadge type={member.type} />
                         </div>
                         {member.username && (
                           <div className="truncate text-muted-foreground text-xs">
@@ -466,15 +481,14 @@ export function CreateGroupModal({
               searchResults.length === 0 &&
               !searching && (
                 <div className="py-4 text-center text-muted-foreground text-sm">
-                  No {activeTab === 'users' ? 'users' : 'agents or NPCs'} found
+                  No {activeTab === 'users' ? 'users' : 'NPCs'} found
                 </div>
               )}
 
             {!searchQuery && selectedMembers.length === 0 && (
               <div className="rounded-lg border border-border border-dashed bg-sidebar py-4 text-center text-muted-foreground text-sm">
                 <p>
-                  Search for{' '}
-                  {activeTab === 'users' ? 'users' : 'agents and NPCs'} to add
+                  Search for {activeTab === 'users' ? 'users' : 'NPCs'} to add
                   to your group
                 </p>
                 <p className="mt-1 text-xs">

--- a/apps/web/src/components/groups/GroupManagementModal.tsx
+++ b/apps/web/src/components/groups/GroupManagementModal.tsx
@@ -20,7 +20,7 @@ import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { Avatar } from '@/components/shared/Avatar';
 import { useAuthStore } from '@/stores/authStore';
-import { GroupTypeBadge, MemberTypeBadge } from './MemberTypeBadge';
+import { GroupTypeBadge } from './MemberTypeBadge';
 
 /**
  * Member structure for group management modal.
@@ -30,6 +30,7 @@ interface Member {
   displayName: string | null;
   username: string | null;
   profileImageUrl: string | null;
+  memberType: 'user' | 'agent' | 'npc';
   isAdmin: boolean;
   joinedAt: Date | string;
 }
@@ -59,18 +60,20 @@ interface SearchResult {
   type: 'user' | 'agent' | 'npc';
 }
 
-type SearchTab = 'users' | 'agents';
+type SearchTab = 'users' | 'npcs';
 
 /**
  * Group management modal component for managing group members and settings.
  *
  * Provides comprehensive group management interface including member list,
- * adding/removing members with tabbed search (users and agents/NPCs),
- * promoting/demoting admins, and deleting groups.
+ * adding/removing members with tabbed search (users including user-created
+ * agents, and NPCs), promoting/demoting admins, and deleting groups.
  *
  * Features:
  * - Member list display with type badges
- * - Tabbed search for adding members (Users / Agents & NPCs)
+ * - Tabbed search for adding members (Users / NPCs)
+ * - Users tab includes human users and user-created agents
+ * - NPCs tab includes only system NPCs
  * - Remove member functionality
  * - Promote/demote admin functionality
  * - Delete group functionality
@@ -149,7 +152,7 @@ export function GroupManagementModal({
     loadGroupDetails();
   }, [isOpen, groupId, getAccessToken]);
 
-  // Search for users or agents based on active tab
+  // Search for users or NPCs based on active tab
   useEffect(() => {
     if (!searchQuery.trim() || searchQuery.length < 2) {
       setSearchResults([]);
@@ -162,9 +165,11 @@ export function GroupManagementModal({
         const token = await getAccessToken();
 
         // Use different endpoint based on active tab
+        // Users tab includes human users + user-created agents
+        // NPCs tab only includes NPCs
         const endpoint =
           activeTab === 'users'
-            ? `/api/users/search?q=${encodeURIComponent(searchQuery)}`
+            ? `/api/users/search?q=${encodeURIComponent(searchQuery)}&includeAgents=true`
             : `/api/agents/search?q=${encodeURIComponent(searchQuery)}`;
 
         const response = await fetch(endpoint, {
@@ -190,14 +195,21 @@ export function GroupManagementModal({
                       displayName: string | null;
                       username: string | null;
                       profileImageUrl: string | null;
+                      isAgent?: boolean;
                     }) => ({
-                      ...u,
-                      type: 'user' as const,
+                      id: u.id,
+                      displayName: u.displayName,
+                      username: u.username,
+                      profileImageUrl: u.profileImageUrl,
+                      // Distinguish between human users and user-created agents
+                      type: u.isAgent ? ('agent' as const) : ('user' as const),
                     })
                   )
-              : (data.agents || [])
+              : // Filter to only include NPCs (not user-created agents)
+                (data.agents || [])
                   .filter(
-                    (a: { id: string }) => !existingMemberIds.includes(a.id)
+                    (a: { id: string; type: 'agent' | 'npc' }) =>
+                      !existingMemberIds.includes(a.id) && a.type === 'npc'
                   )
                   .map(
                     (a: {
@@ -622,16 +634,16 @@ export function GroupManagementModal({
                           Users
                         </button>
                         <button
-                          onClick={() => handleTabChange('agents')}
+                          onClick={() => handleTabChange('npcs')}
                           className={cn(
                             'flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-sm transition-colors',
-                            activeTab === 'agents'
+                            activeTab === 'npcs'
                               ? 'bg-sidebar font-medium text-foreground shadow-sm'
                               : 'text-muted-foreground hover:text-foreground'
                           )}
                         >
                           <Bot className="h-3.5 w-3.5" />
-                          Agents & NPCs
+                          NPCs
                         </button>
                       </div>
 
@@ -643,7 +655,7 @@ export function GroupManagementModal({
                           placeholder={
                             activeTab === 'users'
                               ? 'Search users...'
-                              : 'Search agents and NPCs...'
+                              : 'Search NPCs...'
                           }
                           value={searchQuery}
                           onChange={(e) => setSearchQuery(e.target.value)}
@@ -665,18 +677,19 @@ export function GroupManagementModal({
                               className="flex w-full items-center gap-2 p-2.5 text-left transition-colors hover:bg-sidebar disabled:opacity-50"
                             >
                               <Avatar
-                                imageUrl={result.profileImageUrl || undefined}
+                                id={result.id}
+                                src={result.profileImageUrl || undefined}
                                 name={
                                   result.username || result.displayName || '?'
                                 }
+                                type={result.type === 'npc' ? 'actor' : 'user'}
                                 size="sm"
                               />
                               <div className="min-w-0 flex-1">
-                                <div className="flex items-center truncate font-medium text-sm">
+                                <div className="truncate font-medium text-sm">
                                   {result.displayName ||
                                     result.username ||
                                     'Unknown'}
-                                  <MemberTypeBadge type={result.type} />
                                 </div>
                                 {result.username && (
                                   <div className="truncate text-muted-foreground text-xs">
@@ -696,9 +709,7 @@ export function GroupManagementModal({
                         searchResults.length === 0 &&
                         !searching && (
                           <div className="py-2 text-center text-muted-foreground text-sm">
-                            No{' '}
-                            {activeTab === 'users' ? 'users' : 'agents or NPCs'}{' '}
-                            found
+                            No {activeTab === 'users' ? 'users' : 'NPCs'} found
                           </div>
                         )}
                     </div>
@@ -714,8 +725,12 @@ export function GroupManagementModal({
                           className="flex items-center gap-3 rounded-lg border border-border bg-sidebar p-3 transition-colors hover:bg-sidebar/80"
                         >
                           <Avatar
-                            imageUrl={member.profileImageUrl || undefined}
+                            id={member.id}
+                            src={member.profileImageUrl || undefined}
                             name={member.username || member.displayName || '?'}
+                            type={
+                              member.memberType === 'npc' ? 'actor' : 'user'
+                            }
                             size="md"
                           />
                           <div className="min-w-0 flex-1">


### PR DESCRIPTION
- Change tabs from "Users / Agents & NPCs" to "Users / NPCs"
- Users tab now includes human users AND user-created agents (via includeAgents=true)
- NPCs tab only shows system NPCs (filtered by type === 'npc')
- Fix Avatar component usage to pass id and type props for proper NPC image loading
- Add memberType field to group details API for member type identification




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Group member data now includes a visible memberType (User, Agent, NPC); avatars render to reflect NPCs as actors.
  * Member search tabs renamed to "Users" and "NPCs": Users shows humans and user-created agents; NPCs shows system NPCs only.
  * Search placeholders, button labels, and no-results messages updated for NPC-focused wording.

* **Refactor**
  * Group creation and management flows reorganized to separate NPCs from other member types and clarify add-member behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates group member search UX by splitting the add-member tabs into **Users** (now including user-created agents via `includeAgents=true`) and **NPCs** (system NPCs only, filtered by `type === 'npc'`). It also fixes NPC avatar rendering by passing `id` and `type` into the shared `Avatar` component (so NPCs can resolve the static `/images/actors/{id}.jpg` path), and extends the group details API to return a `memberType` field per member for downstream UI decisions.

<h3>Confidence Score: 4/5</h3>

- This PR is generally safe to merge; changes are localized to group member search UI and group details response shape.
- No obvious runtime errors in the updated UI logic, and the `Avatar` prop change aligns with the shared Avatar component API. Main risk is semantic correctness of `memberType` derivation if user records can have overlapping `isActor`/`isAgent` flags or if other consumers of the group details endpoint assume a fixed member shape.
- apps/web/src/app/api/groups/[groupId]/route.ts (memberType derivation and API response shape changes)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/api/groups/[groupId]/route.ts | Adds `memberType` to group members based on `isActor`/`isAgent` flags; watch for ambiguous classification if both flags could be true. |
| apps/web/src/components/groups/CreateGroupModal.tsx | Renames tabs to Users/NPCs, includes agents in user search via `includeAgents=true`, filters NPC results, and updates Avatar props to pass `id/src/type`. |
| apps/web/src/components/groups/GroupManagementModal.tsx | Updates add-member search tabs to Users/NPCs, includes agents in user search, filters NPCs, adds `memberType` to member interface, and fixes Avatar props for NPC rendering. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant UI as Create/Manage Group UI
  participant UsersAPI as /api/users/search
  participant AgentsAPI as /api/agents/search
  participant GroupAPI as /api/groups/[groupId]

  alt Users tab (humans + user-created agents)
    UI->>UsersAPI: GET ?q=...&includeAgents=true
    UsersAPI-->>UI: { users: [...] }
  else NPCs tab (system NPCs only)
    UI->>AgentsAPI: GET ?q=...
    AgentsAPI-->>UI: { agents: [...] }
    UI->>UI: filter agents where type == 'npc'
  end

  UI->>GroupAPI: GET /api/groups/{groupId}
  GroupAPI-->>UI: group.members[] includes memberType
  UI->>UI: Avatar uses {id, src, type: (memberType=='npc' ? 'actor' : 'user')}
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->