### PR TITLE
Terminal UI polish (mobile dock, portfolio tab, charts)

### DIFF
--- a/apps/web/src/app/feed/components/PostList.tsx
+++ b/apps/web/src/app/feed/components/PostList.tsx
@@ -15,6 +15,7 @@ interface PostListProps {
   hasMore: boolean;
   loadingMore: boolean;
   onLoadMore: () => void;
+  density?: 'default' | 'compact';
 }
 
 /**
@@ -32,6 +33,7 @@ export const PostList = memo(function PostList({
   hasMore,
   loadingMore,
   onLoadMore,
+  density = 'default',
 }: PostListProps) {
   const router = useRouter();
   const { user } = useAuthStore();
@@ -144,10 +146,11 @@ export const PostList = memo(function PostList({
         return (
           <div key={`post-wrapper-${post.id}-${i}`}>
             {postData.type === 'article' ? (
-              <ArticleCard post={postData} />
+              <ArticleCard post={postData} density={density} />
             ) : (
               <PostCard
                 post={postData}
+                density={density}
                 showCommentInputBar={false}
                 onCommentClick={() => {
                   router.push(`/post/${post.id}`);

--- a/apps/web/src/app/markets/_components/perps-terminal/PerpsTerminalBottomPanel.tsx
+++ b/apps/web/src/app/markets/_components/perps-terminal/PerpsTerminalBottomPanel.tsx
@@ -150,6 +150,7 @@ export function PerpsTerminalBottomPanel({
             {filteredPositions.length > 0 ? (
               <PerpPositionsList
                 positions={filteredPositions}
+                density="compact"
                 onPositionClosed={handlePositionClosed}
               />
             ) : (
@@ -164,6 +165,7 @@ export function PerpsTerminalBottomPanel({
               marketType="perp"
               assetId={ticker}
               containerRef={containerRef}
+              density="compact"
             />
           </div>
         ) : (

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -984,7 +984,12 @@ export function MarketsTradingTerminal({
     if (canSellPrediction) return;
     setPredictionTradeMode('buy');
     setPredictionSellShares('');
-  }, [canSellPrediction, predictionTradeMode, setPredictionTradeMode, setPredictionSellShares]);
+  }, [
+    canSellPrediction,
+    predictionTradeMode,
+    setPredictionTradeMode,
+    setPredictionSellShares,
+  ]);
 
   useEffect(() => {
     if (predictionTradeMode !== 'sell') return;

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -1807,14 +1807,14 @@ export function MarketsTradingTerminal({
             </div>
           ) : selected?.kind === 'prediction' ? (
             <div className="h-full overflow-auto">
-	              {selectedPredictionPositions.length > 0 ? (
-	                <PredictionPositionsList
-	                  positions={selectedPredictionPositions}
-	                  density="compact"
-	                  onPositionSold={async () => {
-	                    invalidateUserPositions();
-	                    invalidateWalletBalance();
-	                    await Promise.all([
+              {selectedPredictionPositions.length > 0 ? (
+                <PredictionPositionsList
+                  positions={selectedPredictionPositions}
+                  density="compact"
+                  onPositionSold={async () => {
+                    invalidateUserPositions();
+                    invalidateWalletBalance();
+                    await Promise.all([
                       refreshPredictionPositions(),
                       refreshPerpPositions(),
                       refreshWalletBalance(),
@@ -1830,14 +1830,14 @@ export function MarketsTradingTerminal({
             </div>
           ) : (
             <div className="h-full overflow-auto">
-	              {selectedPerpPositions.length > 0 ? (
-	                <PerpPositionsList
-	                  positions={selectedPerpPositions}
-	                  density="compact"
-	                  onPositionClosed={async () => {
-	                    invalidateUserPositions();
-	                    invalidateWalletBalance();
-	                    await Promise.all([
+              {selectedPerpPositions.length > 0 ? (
+                <PerpPositionsList
+                  positions={selectedPerpPositions}
+                  density="compact"
+                  onPositionClosed={async () => {
+                    invalidateUserPositions();
+                    invalidateWalletBalance();
+                    await Promise.all([
                       refreshPerpPositions(),
                       refreshPredictionPositions(),
                       refreshWalletBalance(),
@@ -1853,23 +1853,23 @@ export function MarketsTradingTerminal({
             </div>
           )
         ) : selected?.kind === 'prediction' ? (
-	          <div ref={desktopTradesContainerRef} className="h-full overflow-auto">
-	            <AssetTradesFeed
-	              marketType="prediction"
-	              assetId={selected.id}
-	              containerRef={desktopTradesContainerRef}
-	              density="compact"
-	            />
-	          </div>
-	        ) : selectedPerp ? (
-	          <div ref={desktopTradesContainerRef} className="h-full overflow-auto">
-	            <AssetTradesFeed
-	              marketType="perp"
-	              assetId={selectedPerp.ticker}
-	              containerRef={desktopTradesContainerRef}
-	              density="compact"
-	            />
-	          </div>
+          <div ref={desktopTradesContainerRef} className="h-full overflow-auto">
+            <AssetTradesFeed
+              marketType="prediction"
+              assetId={selected.id}
+              containerRef={desktopTradesContainerRef}
+              density="compact"
+            />
+          </div>
+        ) : selectedPerp ? (
+          <div ref={desktopTradesContainerRef} className="h-full overflow-auto">
+            <AssetTradesFeed
+              marketType="perp"
+              assetId={selectedPerp.ticker}
+              containerRef={desktopTradesContainerRef}
+              density="compact"
+            />
+          </div>
         ) : (
           <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
             Select a market to see trades.
@@ -2160,14 +2160,14 @@ export function MarketsTradingTerminal({
                       Log in to view positions.
                     </div>
                   ) : selected?.kind === 'prediction' ? (
-	                    <div className="h-full overflow-auto overscroll-contain">
-	                      <PredictionPositionsList
-	                        positions={selectedPredictionPositions}
-	                        density="compact"
-	                        onPositionSold={async () => {
-	                          invalidateUserPositions();
-	                          invalidateWalletBalance();
-	                          await Promise.all([
+                    <div className="h-full overflow-auto overscroll-contain">
+                      <PredictionPositionsList
+                        positions={selectedPredictionPositions}
+                        density="compact"
+                        onPositionSold={async () => {
+                          invalidateUserPositions();
+                          invalidateWalletBalance();
+                          await Promise.all([
                             refreshPredictionPositions(),
                             refreshPerpPositions(),
                             refreshWalletBalance(),
@@ -2177,14 +2177,14 @@ export function MarketsTradingTerminal({
                       />
                     </div>
                   ) : (
-	                    <div className="h-full overflow-auto overscroll-contain">
-	                      <PerpPositionsList
-	                        positions={selectedPerpPositions}
-	                        density="compact"
-	                        onPositionClosed={async () => {
-	                          invalidateUserPositions();
-	                          invalidateWalletBalance();
-	                          await Promise.all([
+                    <div className="h-full overflow-auto overscroll-contain">
+                      <PerpPositionsList
+                        positions={selectedPerpPositions}
+                        density="compact"
+                        onPositionClosed={async () => {
+                          invalidateUserPositions();
+                          invalidateWalletBalance();
+                          await Promise.all([
                             refreshPerpPositions(),
                             refreshPredictionPositions(),
                             refreshWalletBalance(),
@@ -2198,26 +2198,26 @@ export function MarketsTradingTerminal({
                   <div
                     ref={mobileTradesContainerRef}
                     className="h-full overflow-auto overscroll-contain"
-	                  >
-	                    <AssetTradesFeed
-	                      marketType="prediction"
-	                      assetId={selected.id}
-	                      containerRef={mobileTradesContainerRef}
-	                      density="compact"
-	                    />
-	                  </div>
-	                ) : selectedPerp ? (
+                  >
+                    <AssetTradesFeed
+                      marketType="prediction"
+                      assetId={selected.id}
+                      containerRef={mobileTradesContainerRef}
+                      density="compact"
+                    />
+                  </div>
+                ) : selectedPerp ? (
                   <div
                     ref={mobileTradesContainerRef}
                     className="h-full overflow-auto overscroll-contain"
-	                  >
-	                    <AssetTradesFeed
-	                      marketType="perp"
-	                      assetId={selectedPerp.ticker}
-	                      containerRef={mobileTradesContainerRef}
-	                      density="compact"
-	                    />
-	                  </div>
+                  >
+                    <AssetTradesFeed
+                      marketType="perp"
+                      assetId={selectedPerp.ticker}
+                      containerRef={mobileTradesContainerRef}
+                      density="compact"
+                    />
+                  </div>
                 ) : (
                   <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
                     Select a market to see trades.

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -44,8 +44,8 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { useAuth } from '@/hooks/useAuth';
-import { usePortfolioPnL } from '@/hooks/usePortfolioPnL';
 import { usePerpHistory } from '@/hooks/usePerpHistory';
+import { usePortfolioPnL } from '@/hooks/usePortfolioPnL';
 import { usePredictionHistory } from '@/hooks/usePredictionHistory';
 import type {
   PredictionResolutionSSE,
@@ -1805,144 +1805,144 @@ export function MarketsTradingTerminal({
         </button>
       </div>
 
-	      <div className="min-h-0 flex-1 overflow-hidden">
-	        {bottomTab === 'agent' ? (
-	          <TerminalAgentsChat />
-	        ) : bottomTab === 'social' ? (
-	          <TerminalSocialFeed
-	            perpTicker={
-	              selected?.kind === 'perp' ? (selectedPerp?.ticker ?? null) : null
-	            }
-	          />
-	        ) : bottomTab === 'portfolio' ? (
-	          <TerminalPortfolio
-	            authenticated={authenticated}
-	            onLogin={login}
-	            onRequestBuyPoints={onRequestBuyPoints ?? null}
-	            balance={balance}
-	            balanceLoading={balanceLoading}
-	            portfolio={portfolioPnL}
-	            portfolioLoading={portfolioLoading}
-	            portfolioError={portfolioError}
-		            onRefresh={() => {
-		              invalidateUserPositions();
-		              invalidateWalletBalance();
-		              void Promise.allSettled([
-		                refreshPortfolio(),
-		                refreshPredictionPositions(),
-		                refreshPerpPositions(),
-		                refreshWalletBalance(),
-		              ]);
-		            }}
-	            perpPositions={perpPositions}
-	            predictionPositions={predictionPositions}
-	            onPerpPositionClosed={async () => {
-	              invalidateUserPositions();
-	              invalidateWalletBalance();
-	              await Promise.all([
-	                refreshPerpPositions(),
-	                refreshPredictionPositions(),
-	                refreshWalletBalance(),
-	                refreshPortfolio(),
-	              ]);
-	            }}
-	            onPredictionPositionSold={async () => {
-	              invalidateUserPositions();
-	              invalidateWalletBalance();
-	              await Promise.all([
-	                refreshPredictionPositions(),
-	                refreshPerpPositions(),
-	                refreshWalletBalance(),
-	                refreshPortfolio(),
-	              ]);
-	            }}
-	          />
-	        ) : bottomTab === 'positions' ? (
-	          !authenticated ? (
-	            <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
-	              Log in to view positions.
-	            </div>
-	          ) : selected?.kind === 'prediction' ? (
-	            <div className="h-full overflow-auto">
-	              {selectedPredictionPositions.length > 0 ? (
-	                <PredictionPositionsList
-	                  positions={selectedPredictionPositions}
-	                  density="compact"
-	                  onPositionSold={async () => {
-	                    invalidateUserPositions();
-	                    invalidateWalletBalance();
-	                    await Promise.all([
-	                      refreshPredictionPositions(),
-	                      refreshPerpPositions(),
-	                      refreshWalletBalance(),
-	                      refreshPredictionHistory(),
-	                    ]);
-	                  }}
-	                />
-	              ) : (
-	                <div className="flex h-full items-center justify-center text-muted-foreground text-xs">
-	                  No open positions
-	                </div>
-	              )}
-	            </div>
-	          ) : (
-	            <div className="h-full overflow-auto">
-	              {selectedPerpPositions.length > 0 ? (
-	                <PerpPositionsList
-	                  positions={selectedPerpPositions}
-	                  density="compact"
-	                  onPositionClosed={async () => {
-	                    invalidateUserPositions();
-	                    invalidateWalletBalance();
-	                    await Promise.all([
-	                      refreshPerpPositions(),
-	                      refreshPredictionPositions(),
-	                      refreshWalletBalance(),
-	                      refreshPerpHistory(),
-	                    ]);
-	                  }}
-	                />
-	              ) : (
-	                <div className="flex h-full items-center justify-center text-muted-foreground text-xs">
-	                  No open positions
-	                </div>
-	              )}
-	            </div>
-	          )
-	        ) : bottomTab === 'trades' ? (
-	          selected?.kind === 'prediction' ? (
-	            <div
-	              ref={desktopTradesContainerRef}
-	              className="h-full overflow-auto"
-	            >
-	              <AssetTradesFeed
-	                marketType="prediction"
-	                assetId={selected.id}
-	                containerRef={desktopTradesContainerRef}
-	                density="compact"
-	              />
-	            </div>
-	          ) : selectedPerp ? (
-	            <div
-	              ref={desktopTradesContainerRef}
-	              className="h-full overflow-auto"
-	            >
-	              <AssetTradesFeed
-	                marketType="perp"
-	                assetId={selectedPerp.ticker}
-	                containerRef={desktopTradesContainerRef}
-	                density="compact"
-	              />
-	            </div>
-	          ) : (
-	            <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
-	              Select a market to see trades.
-	            </div>
-	          )
-	        ) : null}
-	      </div>
-	    </div>
-	  );
+      <div className="min-h-0 flex-1 overflow-hidden">
+        {bottomTab === 'agent' ? (
+          <TerminalAgentsChat />
+        ) : bottomTab === 'social' ? (
+          <TerminalSocialFeed
+            perpTicker={
+              selected?.kind === 'perp' ? (selectedPerp?.ticker ?? null) : null
+            }
+          />
+        ) : bottomTab === 'portfolio' ? (
+          <TerminalPortfolio
+            authenticated={authenticated}
+            onLogin={login}
+            onRequestBuyPoints={onRequestBuyPoints ?? null}
+            balance={balance}
+            balanceLoading={balanceLoading}
+            portfolio={portfolioPnL}
+            portfolioLoading={portfolioLoading}
+            portfolioError={portfolioError}
+            onRefresh={() => {
+              invalidateUserPositions();
+              invalidateWalletBalance();
+              void Promise.allSettled([
+                refreshPortfolio(),
+                refreshPredictionPositions(),
+                refreshPerpPositions(),
+                refreshWalletBalance(),
+              ]);
+            }}
+            perpPositions={perpPositions}
+            predictionPositions={predictionPositions}
+            onPerpPositionClosed={async () => {
+              invalidateUserPositions();
+              invalidateWalletBalance();
+              await Promise.all([
+                refreshPerpPositions(),
+                refreshPredictionPositions(),
+                refreshWalletBalance(),
+                refreshPortfolio(),
+              ]);
+            }}
+            onPredictionPositionSold={async () => {
+              invalidateUserPositions();
+              invalidateWalletBalance();
+              await Promise.all([
+                refreshPredictionPositions(),
+                refreshPerpPositions(),
+                refreshWalletBalance(),
+                refreshPortfolio(),
+              ]);
+            }}
+          />
+        ) : bottomTab === 'positions' ? (
+          !authenticated ? (
+            <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
+              Log in to view positions.
+            </div>
+          ) : selected?.kind === 'prediction' ? (
+            <div className="h-full overflow-auto">
+              {selectedPredictionPositions.length > 0 ? (
+                <PredictionPositionsList
+                  positions={selectedPredictionPositions}
+                  density="compact"
+                  onPositionSold={async () => {
+                    invalidateUserPositions();
+                    invalidateWalletBalance();
+                    await Promise.all([
+                      refreshPredictionPositions(),
+                      refreshPerpPositions(),
+                      refreshWalletBalance(),
+                      refreshPredictionHistory(),
+                    ]);
+                  }}
+                />
+              ) : (
+                <div className="flex h-full items-center justify-center text-muted-foreground text-xs">
+                  No open positions
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="h-full overflow-auto">
+              {selectedPerpPositions.length > 0 ? (
+                <PerpPositionsList
+                  positions={selectedPerpPositions}
+                  density="compact"
+                  onPositionClosed={async () => {
+                    invalidateUserPositions();
+                    invalidateWalletBalance();
+                    await Promise.all([
+                      refreshPerpPositions(),
+                      refreshPredictionPositions(),
+                      refreshWalletBalance(),
+                      refreshPerpHistory(),
+                    ]);
+                  }}
+                />
+              ) : (
+                <div className="flex h-full items-center justify-center text-muted-foreground text-xs">
+                  No open positions
+                </div>
+              )}
+            </div>
+          )
+        ) : bottomTab === 'trades' ? (
+          selected?.kind === 'prediction' ? (
+            <div
+              ref={desktopTradesContainerRef}
+              className="h-full overflow-auto"
+            >
+              <AssetTradesFeed
+                marketType="prediction"
+                assetId={selected.id}
+                containerRef={desktopTradesContainerRef}
+                density="compact"
+              />
+            </div>
+          ) : selectedPerp ? (
+            <div
+              ref={desktopTradesContainerRef}
+              className="h-full overflow-auto"
+            >
+              <AssetTradesFeed
+                marketType="perp"
+                assetId={selectedPerp.ticker}
+                containerRef={desktopTradesContainerRef}
+                density="compact"
+              />
+            </div>
+          ) : (
+            <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
+              Select a market to see trades.
+            </div>
+          )
+        ) : null}
+      </div>
+    </div>
+  );
 
   return (
     <div
@@ -2034,17 +2034,17 @@ export function MarketsTradingTerminal({
                   'transition-colors hover:bg-muted/20 hover:text-foreground'
                 )}
               >
-	                <span className="font-semibold text-[10px] tracking-widest">
-	                  {bottomTab === 'agent'
-	                    ? 'AGENTS'
-	                    : bottomTab === 'social'
-	                      ? 'SOCIAL'
-	                      : bottomTab === 'portfolio'
-	                        ? 'PORTFOLIO'
-	                      : bottomTab === 'positions'
-	                        ? 'POSITIONS'
-	                        : 'TRADES'}
-	                </span>
+                <span className="font-semibold text-[10px] tracking-widest">
+                  {bottomTab === 'agent'
+                    ? 'AGENTS'
+                    : bottomTab === 'social'
+                      ? 'SOCIAL'
+                      : bottomTab === 'portfolio'
+                        ? 'PORTFOLIO'
+                        : bottomTab === 'positions'
+                          ? 'POSITIONS'
+                          : 'TRADES'}
+                </span>
                 <span className="text-[10px]">▲</span>
               </button>
             )}
@@ -2162,41 +2162,41 @@ export function MarketsTradingTerminal({
                       <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
                     )}
                   </button>
-	                  <button
-	                    type="button"
-	                    onClick={() => setBottomTab('social')}
-	                    className={cn(
-	                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-2 font-bold text-xs capitalize transition-colors',
+                  <button
+                    type="button"
+                    onClick={() => setBottomTab('social')}
+                    className={cn(
+                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-2 font-bold text-xs capitalize transition-colors',
                       bottomTab === 'social'
                         ? 'text-foreground'
                         : 'text-muted-foreground'
-	                    )}
-	                  >
-	                    Social
-	                    {bottomTab === 'social' && (
-	                      <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
-	                    )}
-	                  </button>
-	                  <button
-	                    type="button"
-	                    onClick={() => setBottomTab('portfolio')}
-	                    className={cn(
-	                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-2 font-bold text-xs capitalize transition-colors',
-	                      bottomTab === 'portfolio'
-	                        ? 'text-foreground'
-	                        : 'text-muted-foreground'
-	                    )}
-	                  >
-	                    Portfolio
-	                    {bottomTab === 'portfolio' && (
-	                      <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
-	                    )}
-	                  </button>
-	                  <button
-	                    type="button"
-	                    onClick={() => setBottomTab('positions')}
-	                    className={cn(
-	                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-2 font-bold text-xs capitalize transition-colors',
+                    )}
+                  >
+                    Social
+                    {bottomTab === 'social' && (
+                      <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setBottomTab('portfolio')}
+                    className={cn(
+                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-2 font-bold text-xs capitalize transition-colors',
+                      bottomTab === 'portfolio'
+                        ? 'text-foreground'
+                        : 'text-muted-foreground'
+                    )}
+                  >
+                    Portfolio
+                    {bottomTab === 'portfolio' && (
+                      <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setBottomTab('positions')}
+                    className={cn(
+                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-2 font-bold text-xs capitalize transition-colors',
                       bottomTab === 'positions'
                         ? 'text-foreground'
                         : 'text-muted-foreground'
@@ -2225,132 +2225,132 @@ export function MarketsTradingTerminal({
                 </div>
               </div>
 
-	              <div className="min-h-0 flex-1 overflow-hidden">
-	                {bottomTab === 'agent' ? (
-	                  <TerminalAgentsChat />
-	                ) : bottomTab === 'social' ? (
-	                  <TerminalSocialFeed
-	                    perpTicker={
-	                      selected?.kind === 'perp'
-	                        ? (selectedPerp?.ticker ?? null)
-	                        : null
-	                    }
-	                  />
-	                ) : bottomTab === 'portfolio' ? (
-	                  <TerminalPortfolio
-	                    authenticated={authenticated}
-	                    onLogin={login}
-	                    onRequestBuyPoints={onRequestBuyPoints ?? null}
-	                    balance={balance}
-	                    balanceLoading={balanceLoading}
-	                    portfolio={portfolioPnL}
-	                    portfolioLoading={portfolioLoading}
-	                    portfolioError={portfolioError}
-	                    onRefresh={() => {
-	                      invalidateUserPositions();
-	                      invalidateWalletBalance();
-	                      void Promise.allSettled([
-	                        refreshPortfolio(),
-	                        refreshPredictionPositions(),
-	                        refreshPerpPositions(),
-	                        refreshWalletBalance(),
-	                      ]);
-	                    }}
-	                    perpPositions={perpPositions}
-	                    predictionPositions={predictionPositions}
-	                    onPerpPositionClosed={async () => {
-	                      invalidateUserPositions();
-	                      invalidateWalletBalance();
-	                      await Promise.all([
-	                        refreshPerpPositions(),
-	                        refreshPredictionPositions(),
-	                        refreshWalletBalance(),
-	                        refreshPortfolio(),
-	                      ]);
-	                    }}
-	                    onPredictionPositionSold={async () => {
-	                      invalidateUserPositions();
-	                      invalidateWalletBalance();
-	                      await Promise.all([
-	                        refreshPredictionPositions(),
-	                        refreshPerpPositions(),
-	                        refreshWalletBalance(),
-	                        refreshPortfolio(),
-	                      ]);
-	                    }}
-	                  />
-	                ) : bottomTab === 'positions' ? (
-	                  !authenticated ? (
-	                    <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
-	                      Log in to view positions.
-	                    </div>
-	                  ) : selected?.kind === 'prediction' ? (
-	                    <div className="h-full overflow-auto overscroll-contain">
-	                      <PredictionPositionsList
-	                        positions={selectedPredictionPositions}
-	                        density="compact"
-	                        onPositionSold={async () => {
-	                          invalidateUserPositions();
-	                          invalidateWalletBalance();
-	                          await Promise.all([
-	                            refreshPredictionPositions(),
-	                            refreshPerpPositions(),
-	                            refreshWalletBalance(),
-	                            refreshPredictionHistory(),
-	                          ]);
-	                        }}
-	                      />
-	                    </div>
-	                  ) : (
-	                    <div className="h-full overflow-auto overscroll-contain">
-	                      <PerpPositionsList
-	                        positions={selectedPerpPositions}
-	                        density="compact"
-	                        onPositionClosed={async () => {
-	                          invalidateUserPositions();
-	                          invalidateWalletBalance();
-	                          await Promise.all([
-	                            refreshPerpPositions(),
-	                            refreshPredictionPositions(),
-	                            refreshWalletBalance(),
-	                            refreshPerpHistory(),
-	                          ]);
-	                        }}
-	                      />
-	                    </div>
-	                  )
-	                ) : bottomTab === 'trades' ? (
-	                  selected?.kind === 'prediction' ? (
-	                    <div
-	                      ref={mobileTradesContainerRef}
-	                      className="h-full overflow-auto overscroll-contain"
-	                    >
-	                      <AssetTradesFeed
-	                        marketType="prediction"
-	                        assetId={selected.id}
-	                        containerRef={mobileTradesContainerRef}
-	                        density="compact"
-	                      />
-	                    </div>
-	                  ) : selectedPerp ? (
-	                    <div
-	                      ref={mobileTradesContainerRef}
-	                      className="h-full overflow-auto overscroll-contain"
-	                    >
-	                      <AssetTradesFeed
-	                        marketType="perp"
-	                        assetId={selectedPerp.ticker}
-	                        containerRef={mobileTradesContainerRef}
-	                        density="compact"
-	                      />
-	                    </div>
-	                  ) : (
-	                    <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
-	                      Select a market to see trades.
-	                    </div>
-	                  )
-	                ) : null}
-	              </div>
+              <div className="min-h-0 flex-1 overflow-hidden">
+                {bottomTab === 'agent' ? (
+                  <TerminalAgentsChat />
+                ) : bottomTab === 'social' ? (
+                  <TerminalSocialFeed
+                    perpTicker={
+                      selected?.kind === 'perp'
+                        ? (selectedPerp?.ticker ?? null)
+                        : null
+                    }
+                  />
+                ) : bottomTab === 'portfolio' ? (
+                  <TerminalPortfolio
+                    authenticated={authenticated}
+                    onLogin={login}
+                    onRequestBuyPoints={onRequestBuyPoints ?? null}
+                    balance={balance}
+                    balanceLoading={balanceLoading}
+                    portfolio={portfolioPnL}
+                    portfolioLoading={portfolioLoading}
+                    portfolioError={portfolioError}
+                    onRefresh={() => {
+                      invalidateUserPositions();
+                      invalidateWalletBalance();
+                      void Promise.allSettled([
+                        refreshPortfolio(),
+                        refreshPredictionPositions(),
+                        refreshPerpPositions(),
+                        refreshWalletBalance(),
+                      ]);
+                    }}
+                    perpPositions={perpPositions}
+                    predictionPositions={predictionPositions}
+                    onPerpPositionClosed={async () => {
+                      invalidateUserPositions();
+                      invalidateWalletBalance();
+                      await Promise.all([
+                        refreshPerpPositions(),
+                        refreshPredictionPositions(),
+                        refreshWalletBalance(),
+                        refreshPortfolio(),
+                      ]);
+                    }}
+                    onPredictionPositionSold={async () => {
+                      invalidateUserPositions();
+                      invalidateWalletBalance();
+                      await Promise.all([
+                        refreshPredictionPositions(),
+                        refreshPerpPositions(),
+                        refreshWalletBalance(),
+                        refreshPortfolio(),
+                      ]);
+                    }}
+                  />
+                ) : bottomTab === 'positions' ? (
+                  !authenticated ? (
+                    <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
+                      Log in to view positions.
+                    </div>
+                  ) : selected?.kind === 'prediction' ? (
+                    <div className="h-full overflow-auto overscroll-contain">
+                      <PredictionPositionsList
+                        positions={selectedPredictionPositions}
+                        density="compact"
+                        onPositionSold={async () => {
+                          invalidateUserPositions();
+                          invalidateWalletBalance();
+                          await Promise.all([
+                            refreshPredictionPositions(),
+                            refreshPerpPositions(),
+                            refreshWalletBalance(),
+                            refreshPredictionHistory(),
+                          ]);
+                        }}
+                      />
+                    </div>
+                  ) : (
+                    <div className="h-full overflow-auto overscroll-contain">
+                      <PerpPositionsList
+                        positions={selectedPerpPositions}
+                        density="compact"
+                        onPositionClosed={async () => {
+                          invalidateUserPositions();
+                          invalidateWalletBalance();
+                          await Promise.all([
+                            refreshPerpPositions(),
+                            refreshPredictionPositions(),
+                            refreshWalletBalance(),
+                            refreshPerpHistory(),
+                          ]);
+                        }}
+                      />
+                    </div>
+                  )
+                ) : bottomTab === 'trades' ? (
+                  selected?.kind === 'prediction' ? (
+                    <div
+                      ref={mobileTradesContainerRef}
+                      className="h-full overflow-auto overscroll-contain"
+                    >
+                      <AssetTradesFeed
+                        marketType="prediction"
+                        assetId={selected.id}
+                        containerRef={mobileTradesContainerRef}
+                        density="compact"
+                      />
+                    </div>
+                  ) : selectedPerp ? (
+                    <div
+                      ref={mobileTradesContainerRef}
+                      className="h-full overflow-auto overscroll-contain"
+                    >
+                      <AssetTradesFeed
+                        marketType="perp"
+                        assetId={selectedPerp.ticker}
+                        containerRef={mobileTradesContainerRef}
+                        density="compact"
+                      />
+                    </div>
+                  ) : (
+                    <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
+                      Select a market to see trades.
+                    </div>
+                  )
+                ) : null}
+              </div>
             </div>
           </div>
 

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -102,7 +102,10 @@ const MIN_SELLABLE_SHARES = 0.01;
 /** Cooldown period between portfolio refreshes to prevent API spam (ms) */
 const REFRESH_COOLDOWN_MS = 5000;
 
-/** Labels for each bottom tab for accessibility */
+/**
+ * Labels for each bottom tab - used for dynamic mobile panel title and accessibility.
+ * Centralizing these ensures consistency between button labels and panel headers.
+ */
 const BOTTOM_TAB_LABELS: Record<BottomTab, string> = {
   agent: 'Agents',
   social: 'Social',
@@ -110,6 +113,14 @@ const BOTTOM_TAB_LABELS: Record<BottomTab, string> = {
   positions: 'Positions',
   trades: 'Trades',
 };
+
+/*
+ * Z-INDEX STACKING CONTEXT (documentation only - Tailwind requires static class names)
+ * ─────────────────────────────────────────────────────────────────────────────────────
+ * z-40:   Mobile bottom dock bar
+ * z-[70]: Mobile panel overlay (above dock), trade sheet, market list
+ * z-[80]: Modal dialogs and fullscreen chart overlay
+ */
 
 interface MarketsTradingTerminalProps {
   onRequestBuyPoints?: () => void;
@@ -523,7 +534,8 @@ export function MarketsTradingTerminal({
     refreshWalletBalance,
   ]);
 
-  const handlePerpPositionClosed = useCallback(async () => {
+  // Shared helper to refresh all position-related data after a trade/close action
+  const refreshAllPositionData = useCallback(async () => {
     invalidateUserPositions();
     invalidateWalletBalance();
     await Promise.all([
@@ -539,21 +551,13 @@ export function MarketsTradingTerminal({
     refreshPortfolio,
   ]);
 
+  const handlePerpPositionClosed = useCallback(async () => {
+    await refreshAllPositionData();
+  }, [refreshAllPositionData]);
+
   const handlePredictionPositionSold = useCallback(async () => {
-    invalidateUserPositions();
-    invalidateWalletBalance();
-    await Promise.all([
-      refreshPredictionPositions(),
-      refreshPerpPositions(),
-      refreshWalletBalance(),
-      refreshPortfolio(),
-    ]);
-  }, [
-    refreshPredictionPositions,
-    refreshPerpPositions,
-    refreshWalletBalance,
-    refreshPortfolio,
-  ]);
+    await refreshAllPositionData();
+  }, [refreshAllPositionData]);
 
   const mobileBottomDockOffset = useMemo(() => {
     // The app layout uses `pb-14` (56px) to reserve space for the fixed BottomNav.
@@ -561,21 +565,37 @@ export function MarketsTradingTerminal({
     return Math.max(0, mobileBottomNavHeight - BOTTOM_NAV_BASE_HEIGHT);
   }, [mobileBottomNavHeight]);
 
+  // Track the height of the app's fixed BottomNav to properly position the mobile dock.
+  // We use DOM query because BottomNav is rendered in the app layout outside this component's
+  // React tree, so we can't use props/context. The 'app-bottom-nav' ID is set in BottomNav.tsx.
   useEffect(() => {
-    const bottomNav = document.getElementById('app-bottom-nav');
-    if (!bottomNav) {
-      setMobileBottomNavHeight(0);
-      return undefined;
+    // SSR safety: ensure we're in browser environment
+    if (typeof window === 'undefined') {
+      return () => {};
     }
 
+    const bottomNav = document.getElementById('app-bottom-nav');
+
+    // Define update function outside conditional for consistent cleanup
     const updateHeight = () => {
-      setMobileBottomNavHeight(bottomNav.getBoundingClientRect().height);
+      if (bottomNav) {
+        setMobileBottomNavHeight(bottomNav.getBoundingClientRect().height);
+      } else {
+        setMobileBottomNavHeight(0);
+      }
     };
 
+    // Initial measurement
     updateHeight();
 
+    // If no bottomNav found, still return cleanup (currently no-op but consistent pattern)
+    if (!bottomNav) {
+      return () => {};
+    }
+
+    // SSR safety for ResizeObserver
     const resizeObserver =
-      typeof ResizeObserver !== 'undefined'
+      typeof window !== 'undefined' && typeof ResizeObserver !== 'undefined'
         ? new ResizeObserver(() => updateHeight())
         : null;
 
@@ -964,20 +984,27 @@ export function MarketsTradingTerminal({
     );
   }, [predictionPositions, selectedPredictionId]);
 
-  const selectedPredictionShares = useMemo(() => {
-    let yesShares = 0;
-    let noShares = 0;
-    for (const position of selectedPredictionPositions) {
-      if (position.side === 'YES') yesShares += position.shares;
-      if (position.side === 'NO') noShares += position.shares;
-    }
-    return { yesShares, noShares };
+  // Compute sellable positions per side - only positions with shares >= MIN_SELLABLE_SHARES
+  // are actually sellable. We check individual positions, not aggregated totals, because
+  // a user might have multiple small positions that sum above threshold but none are sellable.
+  const sellablePositions = useMemo(() => {
+    const sellableYes = selectedPredictionPositions.filter(
+      (p) => p.side === 'YES' && p.shares >= MIN_SELLABLE_SHARES
+    );
+    const sellableNo = selectedPredictionPositions.filter(
+      (p) => p.side === 'NO' && p.shares >= MIN_SELLABLE_SHARES
+    );
+    return {
+      hasSellableYes: sellableYes.length > 0,
+      hasSellableNo: sellableNo.length > 0,
+      sellableYesCount: sellableYes.length,
+      sellableNoCount: sellableNo.length,
+    };
   }, [selectedPredictionPositions]);
 
   const canSellPrediction =
     authenticated &&
-    (selectedPredictionShares.yesShares >= MIN_SELLABLE_SHARES ||
-      selectedPredictionShares.noShares >= MIN_SELLABLE_SHARES);
+    (sellablePositions.hasSellableYes || sellablePositions.hasSellableNo);
 
   useEffect(() => {
     if (predictionTradeMode !== 'sell') return;
@@ -994,15 +1021,16 @@ export function MarketsTradingTerminal({
   useEffect(() => {
     if (predictionTradeMode !== 'sell') return;
     if (!canSellPrediction) return;
+    // Check if current side has any sellable positions (not just aggregated shares)
     const canSellThisSide =
       predictionSide === 'yes'
-        ? selectedPredictionShares.yesShares >= MIN_SELLABLE_SHARES
-        : selectedPredictionShares.noShares >= MIN_SELLABLE_SHARES;
+        ? sellablePositions.hasSellableYes
+        : sellablePositions.hasSellableNo;
     if (canSellThisSide) return;
     const canSellOtherSide =
       predictionSide === 'yes'
-        ? selectedPredictionShares.noShares >= MIN_SELLABLE_SHARES
-        : selectedPredictionShares.yesShares >= MIN_SELLABLE_SHARES;
+        ? sellablePositions.hasSellableNo
+        : sellablePositions.hasSellableYes;
     if (!canSellOtherSide) return;
     setPredictionSide((prev) => (prev === 'yes' ? 'no' : 'yes'));
     setPredictionSellShares('');
@@ -1010,8 +1038,8 @@ export function MarketsTradingTerminal({
     canSellPrediction,
     predictionSide,
     predictionTradeMode,
-    selectedPredictionShares.noShares,
-    selectedPredictionShares.yesShares,
+    sellablePositions.hasSellableNo,
+    sellablePositions.hasSellableYes,
   ]);
 
   const selectedPerpPositions = useMemo(() => {
@@ -1719,13 +1747,13 @@ export function MarketsTradingTerminal({
                 disabled={
                   predictionTradeMode === 'sell' &&
                   canSellPrediction &&
-                  selectedPredictionShares.yesShares < MIN_SELLABLE_SHARES
+                  !sellablePositions.hasSellableYes
                 }
                 className={cn(
                   'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
                   predictionTradeMode === 'sell' &&
                     canSellPrediction &&
-                    selectedPredictionShares.yesShares < MIN_SELLABLE_SHARES &&
+                    !sellablePositions.hasSellableYes &&
                     'cursor-not-allowed opacity-50 hover:text-muted-foreground',
                   predictionSide === 'yes'
                     ? 'bg-blue-500 text-white'
@@ -1740,13 +1768,13 @@ export function MarketsTradingTerminal({
                 disabled={
                   predictionTradeMode === 'sell' &&
                   canSellPrediction &&
-                  selectedPredictionShares.noShares < MIN_SELLABLE_SHARES
+                  !sellablePositions.hasSellableNo
                 }
                 className={cn(
                   'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
                   predictionTradeMode === 'sell' &&
                     canSellPrediction &&
-                    selectedPredictionShares.noShares < MIN_SELLABLE_SHARES &&
+                    !sellablePositions.hasSellableNo &&
                     'cursor-not-allowed opacity-50 hover:text-muted-foreground',
                   predictionSide === 'no'
                     ? 'bg-violet-500 text-white'

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -9,6 +9,7 @@ import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
 import {
   ArrowUpDown,
   Check,
+  ChevronUp,
   Filter,
   Info,
   Maximize2,
@@ -2156,33 +2157,104 @@ export function MarketsTradingTerminal({
               </div>
 
               <div className="shrink-0 border-white/5 border-t bg-background/70 px-2 py-2 shadow-sm backdrop-blur-md">
-                <button
-                  type="button"
-                  onClick={() => openMobilePanel()}
-                  className={cn(
-                    'flex w-full items-center gap-2 rounded-full border border-white/10 bg-background/40 px-4 py-2',
-                    'text-left text-foreground text-sm transition-colors hover:bg-muted/20',
-                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30'
-                  )}
-                  aria-label="Open panel"
-                >
-                  <span className="font-bold">Panel</span>
-                  <span className="text-muted-foreground">
-                    •{' '}
-                    {bottomTab === 'agent'
-                      ? 'Agents'
-                      : bottomTab === 'social'
-                        ? 'Social'
-                        : bottomTab === 'portfolio'
-                          ? 'Portfolio'
-                          : bottomTab === 'positions'
-                            ? 'Positions'
-                            : 'Trades'}
-                  </span>
-                  <span className="ml-auto font-semibold text-muted-foreground text-xs uppercase tracking-wider">
-                    Open
-                  </span>
-                </button>
+                <div className="flex items-center gap-1 rounded-2xl border border-white/10 bg-background/40 p-1">
+                  <div className="flex min-w-0 flex-1">
+                    <button
+                      type="button"
+                      onClick={() => openMobilePanel('agent')}
+                      className={cn(
+                        'relative flex h-9 min-w-0 flex-1 items-center justify-center px-2 font-bold text-[11px] transition-colors',
+                        bottomTab === 'agent'
+                          ? 'text-foreground'
+                          : 'text-muted-foreground hover:text-foreground'
+                      )}
+                      aria-label="Open Agents panel"
+                    >
+                      Agents
+                      {bottomTab === 'agent' && (
+                        <div className="absolute right-2 bottom-0 left-2 h-0.5 rounded-full bg-foreground" />
+                      )}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => openMobilePanel('social')}
+                      className={cn(
+                        'relative flex h-9 min-w-0 flex-1 items-center justify-center px-2 font-bold text-[11px] transition-colors',
+                        bottomTab === 'social'
+                          ? 'text-foreground'
+                          : 'text-muted-foreground hover:text-foreground'
+                      )}
+                      aria-label="Open Social panel"
+                    >
+                      Social
+                      {bottomTab === 'social' && (
+                        <div className="absolute right-2 bottom-0 left-2 h-0.5 rounded-full bg-foreground" />
+                      )}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => openMobilePanel('portfolio')}
+                      className={cn(
+                        'relative flex h-9 min-w-0 flex-1 items-center justify-center px-2 font-bold text-[11px] transition-colors',
+                        bottomTab === 'portfolio'
+                          ? 'text-foreground'
+                          : 'text-muted-foreground hover:text-foreground'
+                      )}
+                      aria-label="Open Portfolio panel"
+                    >
+                      Portf.
+                      {bottomTab === 'portfolio' && (
+                        <div className="absolute right-2 bottom-0 left-2 h-0.5 rounded-full bg-foreground" />
+                      )}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => openMobilePanel('positions')}
+                      className={cn(
+                        'relative flex h-9 min-w-0 flex-1 items-center justify-center px-2 font-bold text-[11px] transition-colors',
+                        bottomTab === 'positions'
+                          ? 'text-foreground'
+                          : 'text-muted-foreground hover:text-foreground'
+                      )}
+                      aria-label="Open Positions panel"
+                    >
+                      Pos.
+                      {bottomTab === 'positions' && (
+                        <div className="absolute right-2 bottom-0 left-2 h-0.5 rounded-full bg-foreground" />
+                      )}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => openMobilePanel('trades')}
+                      className={cn(
+                        'relative flex h-9 min-w-0 flex-1 items-center justify-center px-2 font-bold text-[11px] transition-colors',
+                        bottomTab === 'trades'
+                          ? 'text-foreground'
+                          : 'text-muted-foreground hover:text-foreground'
+                      )}
+                      aria-label="Open Trades panel"
+                    >
+                      Trades
+                      {bottomTab === 'trades' && (
+                        <div className="absolute right-2 bottom-0 left-2 h-0.5 rounded-full bg-foreground" />
+                      )}
+                    </button>
+                  </div>
+
+                  <button
+                    type="button"
+                    onClick={() => openMobilePanel()}
+                    className={cn(
+                      'inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl',
+                      'text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground',
+                      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30'
+                    )}
+                    aria-label="Open panel"
+                    title="Open panel"
+                  >
+                    <ChevronUp size={18} />
+                  </button>
+                </div>
               </div>
             </div>
           </div>

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -593,9 +593,9 @@ export function MarketsTradingTerminal({
       return () => {};
     }
 
-    // SSR safety for ResizeObserver
+    // ResizeObserver may not exist in older browsers
     const resizeObserver =
-      typeof window !== 'undefined' && typeof ResizeObserver !== 'undefined'
+      typeof ResizeObserver !== 'undefined'
         ? new ResizeObserver(() => updateHeight())
         : null;
 
@@ -1006,34 +1006,34 @@ export function MarketsTradingTerminal({
     authenticated &&
     (sellablePositions.hasSellableYes || sellablePositions.hasSellableNo);
 
+  // Consolidated sell mode effect - handles both mode switching and side switching
+  // to prevent cascading state updates from separate effects
   useEffect(() => {
     if (predictionTradeMode !== 'sell') return;
-    if (canSellPrediction) return;
-    setPredictionTradeMode('buy');
-    setPredictionSellShares('');
-  }, [
-    canSellPrediction,
-    predictionTradeMode,
-    setPredictionTradeMode,
-    setPredictionSellShares,
-  ]);
 
-  useEffect(() => {
-    if (predictionTradeMode !== 'sell') return;
-    if (!canSellPrediction) return;
-    // Check if current side has any sellable positions (not just aggregated shares)
+    // If can't sell at all, switch to buy mode
+    if (!canSellPrediction) {
+      setPredictionTradeMode('buy');
+      setPredictionSellShares('');
+      return;
+    }
+
+    // If can sell but not on current side, switch to the other side
     const canSellThisSide =
       predictionSide === 'yes'
         ? sellablePositions.hasSellableYes
         : sellablePositions.hasSellableNo;
-    if (canSellThisSide) return;
-    const canSellOtherSide =
-      predictionSide === 'yes'
-        ? sellablePositions.hasSellableNo
-        : sellablePositions.hasSellableYes;
-    if (!canSellOtherSide) return;
-    setPredictionSide((prev) => (prev === 'yes' ? 'no' : 'yes'));
-    setPredictionSellShares('');
+
+    if (!canSellThisSide) {
+      const canSellOtherSide =
+        predictionSide === 'yes'
+          ? sellablePositions.hasSellableNo
+          : sellablePositions.hasSellableYes;
+      if (canSellOtherSide) {
+        setPredictionSide((prev) => (prev === 'yes' ? 'no' : 'yes'));
+        setPredictionSellShares('');
+      }
+    }
   }, [
     canSellPrediction,
     predictionSide,

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -1807,13 +1807,14 @@ export function MarketsTradingTerminal({
             </div>
           ) : selected?.kind === 'prediction' ? (
             <div className="h-full overflow-auto">
-              {selectedPredictionPositions.length > 0 ? (
-                <PredictionPositionsList
-                  positions={selectedPredictionPositions}
-                  onPositionSold={async () => {
-                    invalidateUserPositions();
-                    invalidateWalletBalance();
-                    await Promise.all([
+	              {selectedPredictionPositions.length > 0 ? (
+	                <PredictionPositionsList
+	                  positions={selectedPredictionPositions}
+	                  density="compact"
+	                  onPositionSold={async () => {
+	                    invalidateUserPositions();
+	                    invalidateWalletBalance();
+	                    await Promise.all([
                       refreshPredictionPositions(),
                       refreshPerpPositions(),
                       refreshWalletBalance(),
@@ -1829,13 +1830,14 @@ export function MarketsTradingTerminal({
             </div>
           ) : (
             <div className="h-full overflow-auto">
-              {selectedPerpPositions.length > 0 ? (
-                <PerpPositionsList
-                  positions={selectedPerpPositions}
-                  onPositionClosed={async () => {
-                    invalidateUserPositions();
-                    invalidateWalletBalance();
-                    await Promise.all([
+	              {selectedPerpPositions.length > 0 ? (
+	                <PerpPositionsList
+	                  positions={selectedPerpPositions}
+	                  density="compact"
+	                  onPositionClosed={async () => {
+	                    invalidateUserPositions();
+	                    invalidateWalletBalance();
+	                    await Promise.all([
                       refreshPerpPositions(),
                       refreshPredictionPositions(),
                       refreshWalletBalance(),
@@ -1851,21 +1853,23 @@ export function MarketsTradingTerminal({
             </div>
           )
         ) : selected?.kind === 'prediction' ? (
-          <div ref={desktopTradesContainerRef} className="h-full overflow-auto">
-            <AssetTradesFeed
-              marketType="prediction"
-              assetId={selected.id}
-              containerRef={desktopTradesContainerRef}
-            />
-          </div>
-        ) : selectedPerp ? (
-          <div ref={desktopTradesContainerRef} className="h-full overflow-auto">
-            <AssetTradesFeed
-              marketType="perp"
-              assetId={selectedPerp.ticker}
-              containerRef={desktopTradesContainerRef}
-            />
-          </div>
+	          <div ref={desktopTradesContainerRef} className="h-full overflow-auto">
+	            <AssetTradesFeed
+	              marketType="prediction"
+	              assetId={selected.id}
+	              containerRef={desktopTradesContainerRef}
+	              density="compact"
+	            />
+	          </div>
+	        ) : selectedPerp ? (
+	          <div ref={desktopTradesContainerRef} className="h-full overflow-auto">
+	            <AssetTradesFeed
+	              marketType="perp"
+	              assetId={selectedPerp.ticker}
+	              containerRef={desktopTradesContainerRef}
+	              density="compact"
+	            />
+	          </div>
         ) : (
           <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
             Select a market to see trades.
@@ -2156,13 +2160,14 @@ export function MarketsTradingTerminal({
                       Log in to view positions.
                     </div>
                   ) : selected?.kind === 'prediction' ? (
-                    <div className="h-full overflow-auto overscroll-contain">
-                      <PredictionPositionsList
-                        positions={selectedPredictionPositions}
-                        onPositionSold={async () => {
-                          invalidateUserPositions();
-                          invalidateWalletBalance();
-                          await Promise.all([
+	                    <div className="h-full overflow-auto overscroll-contain">
+	                      <PredictionPositionsList
+	                        positions={selectedPredictionPositions}
+	                        density="compact"
+	                        onPositionSold={async () => {
+	                          invalidateUserPositions();
+	                          invalidateWalletBalance();
+	                          await Promise.all([
                             refreshPredictionPositions(),
                             refreshPerpPositions(),
                             refreshWalletBalance(),
@@ -2172,13 +2177,14 @@ export function MarketsTradingTerminal({
                       />
                     </div>
                   ) : (
-                    <div className="h-full overflow-auto overscroll-contain">
-                      <PerpPositionsList
-                        positions={selectedPerpPositions}
-                        onPositionClosed={async () => {
-                          invalidateUserPositions();
-                          invalidateWalletBalance();
-                          await Promise.all([
+	                    <div className="h-full overflow-auto overscroll-contain">
+	                      <PerpPositionsList
+	                        positions={selectedPerpPositions}
+	                        density="compact"
+	                        onPositionClosed={async () => {
+	                          invalidateUserPositions();
+	                          invalidateWalletBalance();
+	                          await Promise.all([
                             refreshPerpPositions(),
                             refreshPredictionPositions(),
                             refreshWalletBalance(),
@@ -2192,24 +2198,26 @@ export function MarketsTradingTerminal({
                   <div
                     ref={mobileTradesContainerRef}
                     className="h-full overflow-auto overscroll-contain"
-                  >
-                    <AssetTradesFeed
-                      marketType="prediction"
-                      assetId={selected.id}
-                      containerRef={mobileTradesContainerRef}
-                    />
-                  </div>
-                ) : selectedPerp ? (
+	                  >
+	                    <AssetTradesFeed
+	                      marketType="prediction"
+	                      assetId={selected.id}
+	                      containerRef={mobileTradesContainerRef}
+	                      density="compact"
+	                    />
+	                  </div>
+	                ) : selectedPerp ? (
                   <div
                     ref={mobileTradesContainerRef}
                     className="h-full overflow-auto overscroll-contain"
-                  >
-                    <AssetTradesFeed
-                      marketType="perp"
-                      assetId={selectedPerp.ticker}
-                      containerRef={mobileTradesContainerRef}
-                    />
-                  </div>
+	                  >
+	                    <AssetTradesFeed
+	                      marketType="perp"
+	                      assetId={selectedPerp.ticker}
+	                      containerRef={mobileTradesContainerRef}
+	                      density="compact"
+	                    />
+	                  </div>
                 ) : (
                   <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
                     Select a market to see trades.

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -456,12 +456,46 @@ export function MarketsTradingTerminal({
   const [isMobileTradeSheetOpen, setIsMobileTradeSheetOpen] = useState(false);
   const [isMobileChartFullscreen, setIsMobileChartFullscreen] = useState(false);
   const [isMobilePanelOpen, setIsMobilePanelOpen] = useState(false);
+  const [mobileBottomNavHeight, setMobileBottomNavHeight] = useState(56);
 
   const openMobilePanel = useCallback((tab?: BottomTab) => {
     if (tab) setBottomTab(tab);
     setIsMobilePanelOpen(true);
     setIsMobileMarketListOpen(false);
     setIsMobileTradeSheetOpen(false);
+  }, []);
+
+  const mobileBottomDockOffset = useMemo(() => {
+    // The app layout uses `pb-14` (56px) to reserve space for the fixed BottomNav.
+    // We only need to offset by the *extra* height beyond 56px (e.g. iOS safe-area).
+    return Math.max(0, mobileBottomNavHeight - 56);
+  }, [mobileBottomNavHeight]);
+
+  useEffect(() => {
+    const bottomNav = document.getElementById('app-bottom-nav');
+    if (!bottomNav) {
+      setMobileBottomNavHeight(0);
+      return;
+    }
+
+    const updateHeight = () => {
+      setMobileBottomNavHeight(bottomNav.getBoundingClientRect().height);
+    };
+
+    updateHeight();
+
+    const resizeObserver =
+      typeof ResizeObserver !== 'undefined'
+        ? new ResizeObserver(() => updateHeight())
+        : null;
+
+    resizeObserver?.observe(bottomNav);
+    window.addEventListener('resize', updateHeight, { passive: true });
+
+    return () => {
+      resizeObserver?.disconnect();
+      window.removeEventListener('resize', updateHeight);
+    };
   }, []);
 
   useEffect(() => {
@@ -2220,156 +2254,161 @@ export function MarketsTradingTerminal({
                   </button>
                 )}
               </div>
-
-              <div className="shrink-0 border-white/5 border-t bg-background/70 px-2 py-2 shadow-sm backdrop-blur-md">
-                <div className="flex items-center gap-1 rounded-2xl border border-white/10 bg-background/40 p-1">
-                  <div className="flex min-w-0 flex-1">
-                    <button
-                      type="button"
-                      onClick={() => openMobilePanel('agent')}
-                      className={cn(
-                        'relative flex h-9 min-w-0 flex-1 items-center justify-center px-2 font-bold text-[11px] transition-colors',
-                        bottomTab === 'agent'
-                          ? 'text-foreground'
-                          : 'text-muted-foreground hover:text-foreground'
-                      )}
-                      aria-label="Open Agents panel"
-                    >
-                      Agents
-                      {bottomTab === 'agent' && (
-                        <div className="absolute right-2 bottom-0 left-2 h-0.5 rounded-full bg-foreground" />
-                      )}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => openMobilePanel('social')}
-                      className={cn(
-                        'relative flex h-9 min-w-0 flex-1 items-center justify-center px-2 font-bold text-[11px] transition-colors',
-                        bottomTab === 'social'
-                          ? 'text-foreground'
-                          : 'text-muted-foreground hover:text-foreground'
-                      )}
-                      aria-label="Open Social panel"
-                    >
-                      Social
-                      {bottomTab === 'social' && (
-                        <div className="absolute right-2 bottom-0 left-2 h-0.5 rounded-full bg-foreground" />
-                      )}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => openMobilePanel('portfolio')}
-                      className={cn(
-                        'relative flex h-9 min-w-0 flex-1 items-center justify-center px-2 font-bold text-[11px] transition-colors',
-                        bottomTab === 'portfolio'
-                          ? 'text-foreground'
-                          : 'text-muted-foreground hover:text-foreground'
-                      )}
-                      aria-label="Open Portfolio panel"
-                    >
-                      Portf.
-                      {bottomTab === 'portfolio' && (
-                        <div className="absolute right-2 bottom-0 left-2 h-0.5 rounded-full bg-foreground" />
-                      )}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => openMobilePanel('positions')}
-                      className={cn(
-                        'relative flex h-9 min-w-0 flex-1 items-center justify-center px-2 font-bold text-[11px] transition-colors',
-                        bottomTab === 'positions'
-                          ? 'text-foreground'
-                          : 'text-muted-foreground hover:text-foreground'
-                      )}
-                      aria-label="Open Positions panel"
-                    >
-                      Pos.
-                      {bottomTab === 'positions' && (
-                        <div className="absolute right-2 bottom-0 left-2 h-0.5 rounded-full bg-foreground" />
-                      )}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => openMobilePanel('trades')}
-                      className={cn(
-                        'relative flex h-9 min-w-0 flex-1 items-center justify-center px-2 font-bold text-[11px] transition-colors',
-                        bottomTab === 'trades'
-                          ? 'text-foreground'
-                          : 'text-muted-foreground hover:text-foreground'
-                      )}
-                      aria-label="Open Trades panel"
-                    >
-                      Trades
-                      {bottomTab === 'trades' && (
-                        <div className="absolute right-2 bottom-0 left-2 h-0.5 rounded-full bg-foreground" />
-                      )}
-                    </button>
-                  </div>
-
-                  <button
-                    type="button"
-                    onClick={() => openMobilePanel()}
-                    className={cn(
-                      'inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl',
-                      'text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground',
-                      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30'
-                    )}
-                    aria-label="Open panel"
-                    title="Open panel"
-                  >
-                    <ChevronUp size={18} />
-                  </button>
-                </div>
-              </div>
             </div>
           </div>
 
-          <div className="sticky bottom-14 z-40 flex h-[72px] w-full select-none items-center justify-between rounded-t-[20px] border-white/5 border-t bg-background px-2 pb-2 font-medium text-[10px] text-muted-foreground shadow-[0_-5px_15px_rgba(0,0,0,0.12)]">
-            {/* Minimal bottom nav */}
-            <button
-              type="button"
-              onClick={() => {
-                setIsMobilePanelOpen(false);
-                setIsMobileTradeSheetOpen(false);
-                setIsMobileMarketListOpen(true);
-              }}
-              className="flex flex-1 flex-col items-center justify-center gap-1 py-1 font-bold text-foreground"
-            >
-              Markets
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                setIsMobilePanelOpen(false);
-                setIsMobileMarketListOpen(false);
-                setIsMobileTradeSheetOpen(true);
-              }}
-              disabled={!selected}
-              className={cn(
-                'mx-2 inline-flex h-10 flex-[1.5] items-center justify-center rounded-full px-4 font-bold text-sm transition-all',
-                selected
-                  ? 'bg-foreground text-background active:scale-95'
-                  : 'cursor-not-allowed bg-muted/40 text-muted-foreground'
-              )}
-            >
-              Trade
-            </button>
-            <button
-              type="button"
-              onClick={authenticated ? onRequestBuyPoints : login}
-              className="flex flex-1 flex-col items-center justify-center gap-1 py-1 transition-colors hover:text-foreground"
-            >
-              {authenticated ? (
-                <>
-                  <span className="font-semibold">Balance</span>
-                  <span className="font-mono text-[11px] tabular-nums">
-                    {balanceLoading ? '—' : formatBalance(balance)}
-                  </span>
-                </>
-              ) : (
-                'Log in'
-              )}
-            </button>
+          <div
+            className="sticky z-40 w-full select-none overflow-hidden rounded-t-[20px] border-white/5 border-t bg-background shadow-[0_-5px_15px_rgba(0,0,0,0.12)]"
+            style={{ bottom: mobileBottomDockOffset }}
+          >
+            <div className="border-white/5 border-b bg-background/70 px-2 py-2 shadow-sm backdrop-blur-md">
+              <div className="flex items-center gap-1 rounded-2xl border border-white/10 bg-background/40 p-1">
+                <div className="flex min-w-0 flex-1">
+                  <button
+                    type="button"
+                    onClick={() => openMobilePanel('agent')}
+                    className={cn(
+                      'relative flex h-9 min-w-0 flex-1 items-center justify-center px-2 font-bold text-[11px] transition-colors',
+                      bottomTab === 'agent'
+                        ? 'text-foreground'
+                        : 'text-muted-foreground hover:text-foreground'
+                    )}
+                    aria-label="Open Agents panel"
+                  >
+                    Agents
+                    {bottomTab === 'agent' && (
+                      <div className="absolute right-2 bottom-0 left-2 h-0.5 rounded-full bg-foreground" />
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => openMobilePanel('social')}
+                    className={cn(
+                      'relative flex h-9 min-w-0 flex-1 items-center justify-center px-2 font-bold text-[11px] transition-colors',
+                      bottomTab === 'social'
+                        ? 'text-foreground'
+                        : 'text-muted-foreground hover:text-foreground'
+                    )}
+                    aria-label="Open Social panel"
+                  >
+                    Social
+                    {bottomTab === 'social' && (
+                      <div className="absolute right-2 bottom-0 left-2 h-0.5 rounded-full bg-foreground" />
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => openMobilePanel('portfolio')}
+                    className={cn(
+                      'relative flex h-9 min-w-0 flex-1 items-center justify-center px-2 font-bold text-[11px] transition-colors',
+                      bottomTab === 'portfolio'
+                        ? 'text-foreground'
+                        : 'text-muted-foreground hover:text-foreground'
+                    )}
+                    aria-label="Open Portfolio panel"
+                  >
+                    Portf.
+                    {bottomTab === 'portfolio' && (
+                      <div className="absolute right-2 bottom-0 left-2 h-0.5 rounded-full bg-foreground" />
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => openMobilePanel('positions')}
+                    className={cn(
+                      'relative flex h-9 min-w-0 flex-1 items-center justify-center px-2 font-bold text-[11px] transition-colors',
+                      bottomTab === 'positions'
+                        ? 'text-foreground'
+                        : 'text-muted-foreground hover:text-foreground'
+                    )}
+                    aria-label="Open Positions panel"
+                  >
+                    Pos.
+                    {bottomTab === 'positions' && (
+                      <div className="absolute right-2 bottom-0 left-2 h-0.5 rounded-full bg-foreground" />
+                    )}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => openMobilePanel('trades')}
+                    className={cn(
+                      'relative flex h-9 min-w-0 flex-1 items-center justify-center px-2 font-bold text-[11px] transition-colors',
+                      bottomTab === 'trades'
+                        ? 'text-foreground'
+                        : 'text-muted-foreground hover:text-foreground'
+                    )}
+                    aria-label="Open Trades panel"
+                  >
+                    Trades
+                    {bottomTab === 'trades' && (
+                      <div className="absolute right-2 bottom-0 left-2 h-0.5 rounded-full bg-foreground" />
+                    )}
+                  </button>
+                </div>
+
+                <button
+                  type="button"
+                  onClick={() => openMobilePanel()}
+                  className={cn(
+                    'inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl',
+                    'text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground',
+                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30'
+                  )}
+                  aria-label="Open panel"
+                  title="Open panel"
+                >
+                  <ChevronUp size={18} />
+                </button>
+              </div>
+            </div>
+
+            <div className="flex h-[72px] items-center justify-between px-2 pb-2 font-medium text-[10px] text-muted-foreground">
+              {/* Minimal bottom nav */}
+              <button
+                type="button"
+                onClick={() => {
+                  setIsMobilePanelOpen(false);
+                  setIsMobileTradeSheetOpen(false);
+                  setIsMobileMarketListOpen(true);
+                }}
+                className="flex flex-1 flex-col items-center justify-center gap-1 py-1 font-bold text-foreground"
+              >
+                Markets
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setIsMobilePanelOpen(false);
+                  setIsMobileMarketListOpen(false);
+                  setIsMobileTradeSheetOpen(true);
+                }}
+                disabled={!selected}
+                className={cn(
+                  'mx-2 inline-flex h-10 flex-[1.5] items-center justify-center rounded-full px-4 font-bold text-sm transition-all',
+                  selected
+                    ? 'bg-foreground text-background active:scale-95'
+                    : 'cursor-not-allowed bg-muted/40 text-muted-foreground'
+                )}
+              >
+                Trade
+              </button>
+              <button
+                type="button"
+                onClick={authenticated ? onRequestBuyPoints : login}
+                className="flex flex-1 flex-col items-center justify-center gap-1 py-1 transition-colors hover:text-foreground"
+              >
+                {authenticated ? (
+                  <>
+                    <span className="font-semibold">Balance</span>
+                    <span className="font-mono text-[11px] tabular-nums">
+                      {balanceLoading ? '—' : formatBalance(balance)}
+                    </span>
+                  </>
+                ) : (
+                  'Log in'
+                )}
+              </button>
+            </div>
           </div>
 
           {isMobilePanelOpen && (

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -93,6 +93,24 @@ type MarketsFilter = 'all' | 'favorites' | 'perp' | 'prediction';
 type MarketsSort = 'volume' | 'change' | 'openInterest' | 'name';
 type BottomTab = 'agent' | 'social' | 'portfolio' | 'positions' | 'trades';
 
+/** Base height of the bottom nav (matches app layout's pb-14) */
+const BOTTOM_NAV_BASE_HEIGHT = 56;
+
+/** Minimum shares threshold for sellable positions */
+const MIN_SELLABLE_SHARES = 0.01;
+
+/** Cooldown period between portfolio refreshes to prevent API spam (ms) */
+const REFRESH_COOLDOWN_MS = 5000;
+
+/** Labels for each bottom tab for accessibility */
+const BOTTOM_TAB_LABELS: Record<BottomTab, string> = {
+  agent: 'Agents',
+  social: 'Social',
+  portfolio: 'Portfolio',
+  positions: 'Positions',
+  trades: 'Trades',
+};
+
 interface MarketsTradingTerminalProps {
   onRequestBuyPoints?: () => void;
 }
@@ -458,6 +476,19 @@ export function MarketsTradingTerminal({
   const [isMobilePanelOpen, setIsMobilePanelOpen] = useState(false);
   const [mobileBottomNavHeight, setMobileBottomNavHeight] = useState(56);
 
+  // Cooldown state to prevent refresh spam (protects backend at scale)
+  const [refreshOnCooldown, setRefreshOnCooldown] = useState(false);
+  const refreshCooldownRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Cleanup cooldown timer on unmount
+  useEffect(() => {
+    return () => {
+      if (refreshCooldownRef.current) {
+        clearTimeout(refreshCooldownRef.current);
+      }
+    };
+  }, []);
+
   const openMobilePanel = useCallback((tab?: BottomTab) => {
     if (tab) setBottomTab(tab);
     setIsMobilePanelOpen(true);
@@ -467,6 +498,9 @@ export function MarketsTradingTerminal({
 
   // Shared handlers for TerminalPortfolio (used in both desktop and mobile)
   const handlePortfolioRefresh = useCallback(() => {
+    // Prevent refresh if on cooldown
+    if (refreshOnCooldown) return;
+
     invalidateUserPositions();
     invalidateWalletBalance();
     void Promise.allSettled([
@@ -475,7 +509,14 @@ export function MarketsTradingTerminal({
       refreshPerpPositions(),
       refreshWalletBalance(),
     ]);
+
+    // Start cooldown to prevent rapid successive refreshes
+    setRefreshOnCooldown(true);
+    refreshCooldownRef.current = setTimeout(() => {
+      setRefreshOnCooldown(false);
+    }, REFRESH_COOLDOWN_MS);
   }, [
+    refreshOnCooldown,
     refreshPortfolio,
     refreshPredictionPositions,
     refreshPerpPositions,
@@ -516,15 +557,15 @@ export function MarketsTradingTerminal({
 
   const mobileBottomDockOffset = useMemo(() => {
     // The app layout uses `pb-14` (56px) to reserve space for the fixed BottomNav.
-    // We only need to offset by the *extra* height beyond 56px (e.g. iOS safe-area).
-    return Math.max(0, mobileBottomNavHeight - 56);
+    // We only need to offset by the *extra* height beyond that (e.g. iOS safe-area).
+    return Math.max(0, mobileBottomNavHeight - BOTTOM_NAV_BASE_HEIGHT);
   }, [mobileBottomNavHeight]);
 
   useEffect(() => {
     const bottomNav = document.getElementById('app-bottom-nav');
     if (!bottomNav) {
       setMobileBottomNavHeight(0);
-      return;
+      return undefined;
     }
 
     const updateHeight = () => {
@@ -935,28 +976,28 @@ export function MarketsTradingTerminal({
 
   const canSellPrediction =
     authenticated &&
-    (selectedPredictionShares.yesShares >= 0.01 ||
-      selectedPredictionShares.noShares >= 0.01);
+    (selectedPredictionShares.yesShares >= MIN_SELLABLE_SHARES ||
+      selectedPredictionShares.noShares >= MIN_SELLABLE_SHARES);
 
   useEffect(() => {
     if (predictionTradeMode !== 'sell') return;
     if (canSellPrediction) return;
     setPredictionTradeMode('buy');
     setPredictionSellShares('');
-  }, [canSellPrediction, predictionTradeMode]);
+  }, [canSellPrediction, predictionTradeMode, setPredictionTradeMode, setPredictionSellShares]);
 
   useEffect(() => {
     if (predictionTradeMode !== 'sell') return;
     if (!canSellPrediction) return;
     const canSellThisSide =
       predictionSide === 'yes'
-        ? selectedPredictionShares.yesShares >= 0.01
-        : selectedPredictionShares.noShares >= 0.01;
+        ? selectedPredictionShares.yesShares >= MIN_SELLABLE_SHARES
+        : selectedPredictionShares.noShares >= MIN_SELLABLE_SHARES;
     if (canSellThisSide) return;
     const canSellOtherSide =
       predictionSide === 'yes'
-        ? selectedPredictionShares.noShares >= 0.01
-        : selectedPredictionShares.yesShares >= 0.01;
+        ? selectedPredictionShares.noShares >= MIN_SELLABLE_SHARES
+        : selectedPredictionShares.yesShares >= MIN_SELLABLE_SHARES;
     if (!canSellOtherSide) return;
     setPredictionSide((prev) => (prev === 'yes' ? 'no' : 'yes'));
     setPredictionSellShares('');
@@ -999,7 +1040,7 @@ export function MarketsTradingTerminal({
   const sellPosition = useMemo(() => {
     const wantedSide = predictionSide.toUpperCase() as 'YES' | 'NO';
     const candidates = selectedPredictionPositions.filter(
-      (p) => p.side === wantedSide && p.shares >= 0.01
+      (p) => p.side === wantedSide && p.shares >= MIN_SELLABLE_SHARES
     );
     if (candidates.length === 0) return null;
     const first = candidates[0];
@@ -1070,8 +1111,8 @@ export function MarketsTradingTerminal({
         toast.error('No sellable position for this side.');
         return;
       }
-      if (clampedSellShares < 0.01) {
-        toast.error('Minimum sell is 0.01 shares');
+      if (clampedSellShares < MIN_SELLABLE_SHARES) {
+        toast.error(`Minimum sell is ${MIN_SELLABLE_SHARES} shares`);
         return;
       }
       if (!predictionSellCalculation) {
@@ -1093,8 +1134,8 @@ export function MarketsTradingTerminal({
         toast.error('No sellable position for this side.');
         return;
       }
-      if (clampedSellShares < 0.01) {
-        toast.error('Minimum sell is 0.01 shares');
+      if (clampedSellShares < MIN_SELLABLE_SHARES) {
+        toast.error(`Minimum sell is ${MIN_SELLABLE_SHARES} shares`);
         return;
       }
       if (!predictionSellCalculation) {
@@ -1180,6 +1221,7 @@ export function MarketsTradingTerminal({
         refreshPerpPositions(),
         refreshWalletBalance(),
         refreshPredictionHistory(),
+        refreshPortfolio(),
       ]);
     } catch (error) {
       const message =
@@ -1672,13 +1714,13 @@ export function MarketsTradingTerminal({
                 disabled={
                   predictionTradeMode === 'sell' &&
                   canSellPrediction &&
-                  selectedPredictionShares.yesShares < 0.01
+                  selectedPredictionShares.yesShares < MIN_SELLABLE_SHARES
                 }
                 className={cn(
                   'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
                   predictionTradeMode === 'sell' &&
                     canSellPrediction &&
-                    selectedPredictionShares.yesShares < 0.01 &&
+                    selectedPredictionShares.yesShares < MIN_SELLABLE_SHARES &&
                     'cursor-not-allowed opacity-50 hover:text-muted-foreground',
                   predictionSide === 'yes'
                     ? 'bg-blue-500 text-white'
@@ -1693,13 +1735,13 @@ export function MarketsTradingTerminal({
                 disabled={
                   predictionTradeMode === 'sell' &&
                   canSellPrediction &&
-                  selectedPredictionShares.noShares < 0.01
+                  selectedPredictionShares.noShares < MIN_SELLABLE_SHARES
                 }
                 className={cn(
                   'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
                   predictionTradeMode === 'sell' &&
                     canSellPrediction &&
-                    selectedPredictionShares.noShares < 0.01 &&
+                    selectedPredictionShares.noShares < MIN_SELLABLE_SHARES &&
                     'cursor-not-allowed opacity-50 hover:text-muted-foreground',
                   predictionSide === 'no'
                     ? 'bg-violet-500 text-white'
@@ -1766,7 +1808,7 @@ export function MarketsTradingTerminal({
                     Shares
                   </label>
                   <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
-                    <span>Min 0.01</span>
+                    <span>Min {MIN_SELLABLE_SHARES}</span>
                     <button
                       type="button"
                       onClick={() =>
@@ -1785,7 +1827,7 @@ export function MarketsTradingTerminal({
                   type="number"
                   value={predictionSellShares}
                   onChange={(e) => setPredictionSellShares(e.target.value)}
-                  min={0.01}
+                  min={MIN_SELLABLE_SHARES}
                   step="0.01"
                   className="w-full rounded border border-white/10 bg-background/30 px-3 py-2 font-mono text-sm tabular-nums focus:border-primary/40 focus:outline-none focus:ring-2 focus:ring-primary/20"
                   placeholder={
@@ -1873,7 +1915,7 @@ export function MarketsTradingTerminal({
                 (predictionTradeMode === 'sell' &&
                   authenticated &&
                   (maxSellShares <= 0 ||
-                    clampedSellShares < 0.01 ||
+                    clampedSellShares < MIN_SELLABLE_SHARES ||
                     !predictionSellCalculation))
               }
               className={cn(
@@ -1888,7 +1930,7 @@ export function MarketsTradingTerminal({
                   (predictionTradeMode === 'sell' &&
                     authenticated &&
                     (maxSellShares <= 0 ||
-                      clampedSellShares < 0.01 ||
+                      clampedSellShares < MIN_SELLABLE_SHARES ||
                       !predictionSellCalculation))) &&
                   'cursor-not-allowed opacity-50'
               )}
@@ -1984,6 +2026,7 @@ export function MarketsTradingTerminal({
             portfolioLoading={portfolioLoading}
             portfolioError={portfolioError}
             onRefresh={handlePortfolioRefresh}
+            refreshDisabled={refreshOnCooldown}
             perpPositions={perpPositions}
             predictionPositions={predictionPositions}
             onPerpPositionClosed={handlePerpPositionClosed}
@@ -2438,7 +2481,9 @@ export function MarketsTradingTerminal({
           {isMobilePanelOpen && (
             <div className="fade-in slide-in-from-bottom-2 absolute inset-0 z-[70] flex animate-in flex-col bg-background pt-safe pb-safe duration-200">
               <div className="flex items-center justify-between border-white/5 border-b p-4">
-                <h2 className="font-bold text-lg">Panel</h2>
+                <h2 className="font-bold text-lg">
+                  {BOTTOM_TAB_LABELS[bottomTab]} Panel
+                </h2>
                 <button
                   type="button"
                   onClick={() => setIsMobilePanelOpen(false)}
@@ -2551,6 +2596,7 @@ export function MarketsTradingTerminal({
                     portfolioLoading={portfolioLoading}
                     portfolioError={portfolioError}
                     onRefresh={handlePortfolioRefresh}
+                    refreshDisabled={refreshOnCooldown}
                     perpPositions={perpPositions}
                     predictionPositions={predictionPositions}
                     onPerpPositionClosed={handlePerpPositionClosed}

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -1540,6 +1540,7 @@ export function MarketsTradingTerminal({
               timeRange={perpTimeRange}
               onTimeRangeChange={setPerpTimeRange}
               showHeader={false}
+              height="fill"
               className="h-full"
             />
           </div>
@@ -2227,6 +2228,7 @@ export function MarketsTradingTerminal({
                         timeRange={perpTimeRange}
                         onTimeRangeChange={setPerpTimeRange}
                         showHeader={false}
+                        height="fill"
                         className="h-full"
                       />
                     </div>
@@ -2735,6 +2737,7 @@ export function MarketsTradingTerminal({
                         timeRange={perpTimeRange}
                         onTimeRangeChange={setPerpTimeRange}
                         showHeader={false}
+                        height="fill"
                         className="h-full"
                       />
                     </div>

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -44,6 +44,7 @@ import {
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
 import { useAuth } from '@/hooks/useAuth';
+import { usePortfolioPnL } from '@/hooks/usePortfolioPnL';
 import { usePerpHistory } from '@/hooks/usePerpHistory';
 import { usePredictionHistory } from '@/hooks/usePredictionHistory';
 import type {
@@ -84,11 +85,12 @@ import { MARKET_TIME_RANGES } from '@/types/markets';
 import { formatBalance } from '../../_lib/formatters';
 import { PerpsOrderEntryPanel } from '../perps-terminal/PerpsOrderEntryPanel';
 import { TerminalAgentsChat } from './TerminalAgentsChat';
+import { TerminalPortfolio } from './TerminalPortfolio';
 import { TerminalSocialFeed } from './TerminalSocialFeed';
 
 type MarketsFilter = 'all' | 'favorites' | 'perp' | 'prediction';
 type MarketsSort = 'volume' | 'change' | 'openInterest' | 'name';
-type BottomTab = 'agent' | 'social' | 'positions' | 'trades';
+type BottomTab = 'agent' | 'social' | 'portfolio' | 'positions' | 'trades';
 
 interface MarketsTradingTerminalProps {
   onRequestBuyPoints?: () => void;
@@ -403,6 +405,12 @@ export function MarketsTradingTerminal({
     positions: predictionPositions,
     refresh: refreshPredictionPositions,
   } = usePredictionPositions(userId);
+  const {
+    data: portfolioPnL,
+    loading: portfolioLoading,
+    error: portfolioError,
+    refresh: refreshPortfolio,
+  } = usePortfolioPnL();
 
   const [filter, setFilter] = useState<MarketsFilter>(() =>
     parseFilter(searchParams)
@@ -1769,6 +1777,12 @@ export function MarketsTradingTerminal({
             Social
           </TabButton>
           <TabButton
+            active={bottomTab === 'portfolio'}
+            onClick={() => setBottomTab('portfolio')}
+          >
+            Portfolio
+          </TabButton>
+          <TabButton
             active={bottomTab === 'positions'}
             onClick={() => setBottomTab('positions')}
           >
@@ -1791,93 +1805,144 @@ export function MarketsTradingTerminal({
         </button>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-hidden">
-        {bottomTab === 'agent' ? (
-          <TerminalAgentsChat />
-        ) : bottomTab === 'social' ? (
-          <TerminalSocialFeed
-            perpTicker={
-              selected?.kind === 'perp' ? (selectedPerp?.ticker ?? null) : null
-            }
-          />
-        ) : bottomTab === 'positions' ? (
-          !authenticated ? (
-            <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
-              Log in to view positions.
-            </div>
-          ) : selected?.kind === 'prediction' ? (
-            <div className="h-full overflow-auto">
-              {selectedPredictionPositions.length > 0 ? (
-                <PredictionPositionsList
-                  positions={selectedPredictionPositions}
-                  density="compact"
-                  onPositionSold={async () => {
-                    invalidateUserPositions();
-                    invalidateWalletBalance();
-                    await Promise.all([
-                      refreshPredictionPositions(),
-                      refreshPerpPositions(),
-                      refreshWalletBalance(),
-                      refreshPredictionHistory(),
-                    ]);
-                  }}
-                />
-              ) : (
-                <div className="flex h-full items-center justify-center text-muted-foreground text-xs">
-                  No open positions
-                </div>
-              )}
-            </div>
-          ) : (
-            <div className="h-full overflow-auto">
-              {selectedPerpPositions.length > 0 ? (
-                <PerpPositionsList
-                  positions={selectedPerpPositions}
-                  density="compact"
-                  onPositionClosed={async () => {
-                    invalidateUserPositions();
-                    invalidateWalletBalance();
-                    await Promise.all([
-                      refreshPerpPositions(),
-                      refreshPredictionPositions(),
-                      refreshWalletBalance(),
-                      refreshPerpHistory(),
-                    ]);
-                  }}
-                />
-              ) : (
-                <div className="flex h-full items-center justify-center text-muted-foreground text-xs">
-                  No open positions
-                </div>
-              )}
-            </div>
-          )
-        ) : selected?.kind === 'prediction' ? (
-          <div ref={desktopTradesContainerRef} className="h-full overflow-auto">
-            <AssetTradesFeed
-              marketType="prediction"
-              assetId={selected.id}
-              containerRef={desktopTradesContainerRef}
-              density="compact"
-            />
-          </div>
-        ) : selectedPerp ? (
-          <div ref={desktopTradesContainerRef} className="h-full overflow-auto">
-            <AssetTradesFeed
-              marketType="perp"
-              assetId={selectedPerp.ticker}
-              containerRef={desktopTradesContainerRef}
-              density="compact"
-            />
-          </div>
-        ) : (
-          <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
-            Select a market to see trades.
-          </div>
-        )}
-      </div>
-    </div>
-  );
+	      <div className="min-h-0 flex-1 overflow-hidden">
+	        {bottomTab === 'agent' ? (
+	          <TerminalAgentsChat />
+	        ) : bottomTab === 'social' ? (
+	          <TerminalSocialFeed
+	            perpTicker={
+	              selected?.kind === 'perp' ? (selectedPerp?.ticker ?? null) : null
+	            }
+	          />
+	        ) : bottomTab === 'portfolio' ? (
+	          <TerminalPortfolio
+	            authenticated={authenticated}
+	            onLogin={login}
+	            onRequestBuyPoints={onRequestBuyPoints ?? null}
+	            balance={balance}
+	            balanceLoading={balanceLoading}
+	            portfolio={portfolioPnL}
+	            portfolioLoading={portfolioLoading}
+	            portfolioError={portfolioError}
+		            onRefresh={() => {
+		              invalidateUserPositions();
+		              invalidateWalletBalance();
+		              void Promise.allSettled([
+		                refreshPortfolio(),
+		                refreshPredictionPositions(),
+		                refreshPerpPositions(),
+		                refreshWalletBalance(),
+		              ]);
+		            }}
+	            perpPositions={perpPositions}
+	            predictionPositions={predictionPositions}
+	            onPerpPositionClosed={async () => {
+	              invalidateUserPositions();
+	              invalidateWalletBalance();
+	              await Promise.all([
+	                refreshPerpPositions(),
+	                refreshPredictionPositions(),
+	                refreshWalletBalance(),
+	                refreshPortfolio(),
+	              ]);
+	            }}
+	            onPredictionPositionSold={async () => {
+	              invalidateUserPositions();
+	              invalidateWalletBalance();
+	              await Promise.all([
+	                refreshPredictionPositions(),
+	                refreshPerpPositions(),
+	                refreshWalletBalance(),
+	                refreshPortfolio(),
+	              ]);
+	            }}
+	          />
+	        ) : bottomTab === 'positions' ? (
+	          !authenticated ? (
+	            <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
+	              Log in to view positions.
+	            </div>
+	          ) : selected?.kind === 'prediction' ? (
+	            <div className="h-full overflow-auto">
+	              {selectedPredictionPositions.length > 0 ? (
+	                <PredictionPositionsList
+	                  positions={selectedPredictionPositions}
+	                  density="compact"
+	                  onPositionSold={async () => {
+	                    invalidateUserPositions();
+	                    invalidateWalletBalance();
+	                    await Promise.all([
+	                      refreshPredictionPositions(),
+	                      refreshPerpPositions(),
+	                      refreshWalletBalance(),
+	                      refreshPredictionHistory(),
+	                    ]);
+	                  }}
+	                />
+	              ) : (
+	                <div className="flex h-full items-center justify-center text-muted-foreground text-xs">
+	                  No open positions
+	                </div>
+	              )}
+	            </div>
+	          ) : (
+	            <div className="h-full overflow-auto">
+	              {selectedPerpPositions.length > 0 ? (
+	                <PerpPositionsList
+	                  positions={selectedPerpPositions}
+	                  density="compact"
+	                  onPositionClosed={async () => {
+	                    invalidateUserPositions();
+	                    invalidateWalletBalance();
+	                    await Promise.all([
+	                      refreshPerpPositions(),
+	                      refreshPredictionPositions(),
+	                      refreshWalletBalance(),
+	                      refreshPerpHistory(),
+	                    ]);
+	                  }}
+	                />
+	              ) : (
+	                <div className="flex h-full items-center justify-center text-muted-foreground text-xs">
+	                  No open positions
+	                </div>
+	              )}
+	            </div>
+	          )
+	        ) : bottomTab === 'trades' ? (
+	          selected?.kind === 'prediction' ? (
+	            <div
+	              ref={desktopTradesContainerRef}
+	              className="h-full overflow-auto"
+	            >
+	              <AssetTradesFeed
+	                marketType="prediction"
+	                assetId={selected.id}
+	                containerRef={desktopTradesContainerRef}
+	                density="compact"
+	              />
+	            </div>
+	          ) : selectedPerp ? (
+	            <div
+	              ref={desktopTradesContainerRef}
+	              className="h-full overflow-auto"
+	            >
+	              <AssetTradesFeed
+	                marketType="perp"
+	                assetId={selectedPerp.ticker}
+	                containerRef={desktopTradesContainerRef}
+	                density="compact"
+	              />
+	            </div>
+	          ) : (
+	            <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
+	              Select a market to see trades.
+	            </div>
+	          )
+	        ) : null}
+	      </div>
+	    </div>
+	  );
 
   return (
     <div
@@ -1969,15 +2034,17 @@ export function MarketsTradingTerminal({
                   'transition-colors hover:bg-muted/20 hover:text-foreground'
                 )}
               >
-                <span className="font-semibold text-[10px] tracking-widest">
-                  {bottomTab === 'agent'
-                    ? 'AGENTS'
-                    : bottomTab === 'social'
-                      ? 'SOCIAL'
-                      : bottomTab === 'positions'
-                        ? 'POSITIONS'
-                        : 'TRADES'}
-                </span>
+	                <span className="font-semibold text-[10px] tracking-widest">
+	                  {bottomTab === 'agent'
+	                    ? 'AGENTS'
+	                    : bottomTab === 'social'
+	                      ? 'SOCIAL'
+	                      : bottomTab === 'portfolio'
+	                        ? 'PORTFOLIO'
+	                      : bottomTab === 'positions'
+	                        ? 'POSITIONS'
+	                        : 'TRADES'}
+	                </span>
                 <span className="text-[10px]">▲</span>
               </button>
             )}
@@ -2095,26 +2162,41 @@ export function MarketsTradingTerminal({
                       <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
                     )}
                   </button>
-                  <button
-                    type="button"
-                    onClick={() => setBottomTab('social')}
-                    className={cn(
-                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-2 font-bold text-xs capitalize transition-colors',
+	                  <button
+	                    type="button"
+	                    onClick={() => setBottomTab('social')}
+	                    className={cn(
+	                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-2 font-bold text-xs capitalize transition-colors',
                       bottomTab === 'social'
                         ? 'text-foreground'
                         : 'text-muted-foreground'
-                    )}
-                  >
-                    Social
-                    {bottomTab === 'social' && (
-                      <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
-                    )}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setBottomTab('positions')}
-                    className={cn(
-                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-2 font-bold text-xs capitalize transition-colors',
+	                    )}
+	                  >
+	                    Social
+	                    {bottomTab === 'social' && (
+	                      <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
+	                    )}
+	                  </button>
+	                  <button
+	                    type="button"
+	                    onClick={() => setBottomTab('portfolio')}
+	                    className={cn(
+	                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-2 font-bold text-xs capitalize transition-colors',
+	                      bottomTab === 'portfolio'
+	                        ? 'text-foreground'
+	                        : 'text-muted-foreground'
+	                    )}
+	                  >
+	                    Portfolio
+	                    {bottomTab === 'portfolio' && (
+	                      <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
+	                    )}
+	                  </button>
+	                  <button
+	                    type="button"
+	                    onClick={() => setBottomTab('positions')}
+	                    className={cn(
+	                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-2 font-bold text-xs capitalize transition-colors',
                       bottomTab === 'positions'
                         ? 'text-foreground'
                         : 'text-muted-foreground'
@@ -2143,87 +2225,132 @@ export function MarketsTradingTerminal({
                 </div>
               </div>
 
-              <div className="min-h-0 flex-1 overflow-hidden">
-                {bottomTab === 'agent' ? (
-                  <TerminalAgentsChat />
-                ) : bottomTab === 'social' ? (
-                  <TerminalSocialFeed
-                    perpTicker={
-                      selected?.kind === 'perp'
-                        ? (selectedPerp?.ticker ?? null)
-                        : null
-                    }
-                  />
-                ) : bottomTab === 'positions' ? (
-                  !authenticated ? (
-                    <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
-                      Log in to view positions.
-                    </div>
-                  ) : selected?.kind === 'prediction' ? (
-                    <div className="h-full overflow-auto overscroll-contain">
-                      <PredictionPositionsList
-                        positions={selectedPredictionPositions}
-                        density="compact"
-                        onPositionSold={async () => {
-                          invalidateUserPositions();
-                          invalidateWalletBalance();
-                          await Promise.all([
-                            refreshPredictionPositions(),
-                            refreshPerpPositions(),
-                            refreshWalletBalance(),
-                            refreshPredictionHistory(),
-                          ]);
-                        }}
-                      />
-                    </div>
-                  ) : (
-                    <div className="h-full overflow-auto overscroll-contain">
-                      <PerpPositionsList
-                        positions={selectedPerpPositions}
-                        density="compact"
-                        onPositionClosed={async () => {
-                          invalidateUserPositions();
-                          invalidateWalletBalance();
-                          await Promise.all([
-                            refreshPerpPositions(),
-                            refreshPredictionPositions(),
-                            refreshWalletBalance(),
-                            refreshPerpHistory(),
-                          ]);
-                        }}
-                      />
-                    </div>
-                  )
-                ) : selected?.kind === 'prediction' ? (
-                  <div
-                    ref={mobileTradesContainerRef}
-                    className="h-full overflow-auto overscroll-contain"
-                  >
-                    <AssetTradesFeed
-                      marketType="prediction"
-                      assetId={selected.id}
-                      containerRef={mobileTradesContainerRef}
-                      density="compact"
-                    />
-                  </div>
-                ) : selectedPerp ? (
-                  <div
-                    ref={mobileTradesContainerRef}
-                    className="h-full overflow-auto overscroll-contain"
-                  >
-                    <AssetTradesFeed
-                      marketType="perp"
-                      assetId={selectedPerp.ticker}
-                      containerRef={mobileTradesContainerRef}
-                      density="compact"
-                    />
-                  </div>
-                ) : (
-                  <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
-                    Select a market to see trades.
-                  </div>
-                )}
-              </div>
+	              <div className="min-h-0 flex-1 overflow-hidden">
+	                {bottomTab === 'agent' ? (
+	                  <TerminalAgentsChat />
+	                ) : bottomTab === 'social' ? (
+	                  <TerminalSocialFeed
+	                    perpTicker={
+	                      selected?.kind === 'perp'
+	                        ? (selectedPerp?.ticker ?? null)
+	                        : null
+	                    }
+	                  />
+	                ) : bottomTab === 'portfolio' ? (
+	                  <TerminalPortfolio
+	                    authenticated={authenticated}
+	                    onLogin={login}
+	                    onRequestBuyPoints={onRequestBuyPoints ?? null}
+	                    balance={balance}
+	                    balanceLoading={balanceLoading}
+	                    portfolio={portfolioPnL}
+	                    portfolioLoading={portfolioLoading}
+	                    portfolioError={portfolioError}
+	                    onRefresh={() => {
+	                      invalidateUserPositions();
+	                      invalidateWalletBalance();
+	                      void Promise.allSettled([
+	                        refreshPortfolio(),
+	                        refreshPredictionPositions(),
+	                        refreshPerpPositions(),
+	                        refreshWalletBalance(),
+	                      ]);
+	                    }}
+	                    perpPositions={perpPositions}
+	                    predictionPositions={predictionPositions}
+	                    onPerpPositionClosed={async () => {
+	                      invalidateUserPositions();
+	                      invalidateWalletBalance();
+	                      await Promise.all([
+	                        refreshPerpPositions(),
+	                        refreshPredictionPositions(),
+	                        refreshWalletBalance(),
+	                        refreshPortfolio(),
+	                      ]);
+	                    }}
+	                    onPredictionPositionSold={async () => {
+	                      invalidateUserPositions();
+	                      invalidateWalletBalance();
+	                      await Promise.all([
+	                        refreshPredictionPositions(),
+	                        refreshPerpPositions(),
+	                        refreshWalletBalance(),
+	                        refreshPortfolio(),
+	                      ]);
+	                    }}
+	                  />
+	                ) : bottomTab === 'positions' ? (
+	                  !authenticated ? (
+	                    <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
+	                      Log in to view positions.
+	                    </div>
+	                  ) : selected?.kind === 'prediction' ? (
+	                    <div className="h-full overflow-auto overscroll-contain">
+	                      <PredictionPositionsList
+	                        positions={selectedPredictionPositions}
+	                        density="compact"
+	                        onPositionSold={async () => {
+	                          invalidateUserPositions();
+	                          invalidateWalletBalance();
+	                          await Promise.all([
+	                            refreshPredictionPositions(),
+	                            refreshPerpPositions(),
+	                            refreshWalletBalance(),
+	                            refreshPredictionHistory(),
+	                          ]);
+	                        }}
+	                      />
+	                    </div>
+	                  ) : (
+	                    <div className="h-full overflow-auto overscroll-contain">
+	                      <PerpPositionsList
+	                        positions={selectedPerpPositions}
+	                        density="compact"
+	                        onPositionClosed={async () => {
+	                          invalidateUserPositions();
+	                          invalidateWalletBalance();
+	                          await Promise.all([
+	                            refreshPerpPositions(),
+	                            refreshPredictionPositions(),
+	                            refreshWalletBalance(),
+	                            refreshPerpHistory(),
+	                          ]);
+	                        }}
+	                      />
+	                    </div>
+	                  )
+	                ) : bottomTab === 'trades' ? (
+	                  selected?.kind === 'prediction' ? (
+	                    <div
+	                      ref={mobileTradesContainerRef}
+	                      className="h-full overflow-auto overscroll-contain"
+	                    >
+	                      <AssetTradesFeed
+	                        marketType="prediction"
+	                        assetId={selected.id}
+	                        containerRef={mobileTradesContainerRef}
+	                        density="compact"
+	                      />
+	                    </div>
+	                  ) : selectedPerp ? (
+	                    <div
+	                      ref={mobileTradesContainerRef}
+	                      className="h-full overflow-auto overscroll-contain"
+	                    >
+	                      <AssetTradesFeed
+	                        marketType="perp"
+	                        assetId={selectedPerp.ticker}
+	                        containerRef={mobileTradesContainerRef}
+	                        density="compact"
+	                      />
+	                    </div>
+	                  ) : (
+	                    <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
+	                      Select a market to see trades.
+	                    </div>
+	                  )
+	                ) : null}
+	              </div>
             </div>
           </div>
 

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -840,6 +840,51 @@ export function MarketsTradingTerminal({
     );
   }, [predictionPositions, selectedPredictionId]);
 
+  const selectedPredictionShares = useMemo(() => {
+    let yesShares = 0;
+    let noShares = 0;
+    for (const position of selectedPredictionPositions) {
+      if (position.side === 'YES') yesShares += position.shares;
+      if (position.side === 'NO') noShares += position.shares;
+    }
+    return { yesShares, noShares };
+  }, [selectedPredictionPositions]);
+
+  const canSellPrediction =
+    authenticated &&
+    (selectedPredictionShares.yesShares >= 0.01 ||
+      selectedPredictionShares.noShares >= 0.01);
+
+  useEffect(() => {
+    if (predictionTradeMode !== 'sell') return;
+    if (canSellPrediction) return;
+    setPredictionTradeMode('buy');
+    setPredictionSellShares('');
+  }, [canSellPrediction, predictionTradeMode]);
+
+  useEffect(() => {
+    if (predictionTradeMode !== 'sell') return;
+    if (!canSellPrediction) return;
+    const canSellThisSide =
+      predictionSide === 'yes'
+        ? selectedPredictionShares.yesShares >= 0.01
+        : selectedPredictionShares.noShares >= 0.01;
+    if (canSellThisSide) return;
+    const canSellOtherSide =
+      predictionSide === 'yes'
+        ? selectedPredictionShares.noShares >= 0.01
+        : selectedPredictionShares.yesShares >= 0.01;
+    if (!canSellOtherSide) return;
+    setPredictionSide((prev) => (prev === 'yes' ? 'no' : 'yes'));
+    setPredictionSellShares('');
+  }, [
+    canSellPrediction,
+    predictionSide,
+    predictionTradeMode,
+    selectedPredictionShares.noShares,
+    selectedPredictionShares.yesShares,
+  ]);
+
   const selectedPerpPositions = useMemo(() => {
     if (!selectedPerp) return [];
     return perpPositions.filter(
@@ -1540,8 +1585,17 @@ export function MarketsTradingTerminal({
               <button
                 type="button"
                 onClick={() => setPredictionSide('yes')}
+                disabled={
+                  predictionTradeMode === 'sell' &&
+                  canSellPrediction &&
+                  selectedPredictionShares.yesShares < 0.01
+                }
                 className={cn(
                   'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
+                  predictionTradeMode === 'sell' &&
+                    canSellPrediction &&
+                    selectedPredictionShares.yesShares < 0.01 &&
+                    'cursor-not-allowed opacity-50 hover:text-muted-foreground',
                   predictionSide === 'yes'
                     ? 'bg-blue-500 text-white'
                     : 'text-muted-foreground hover:text-foreground'
@@ -1552,8 +1606,17 @@ export function MarketsTradingTerminal({
               <button
                 type="button"
                 onClick={() => setPredictionSide('no')}
+                disabled={
+                  predictionTradeMode === 'sell' &&
+                  canSellPrediction &&
+                  selectedPredictionShares.noShares < 0.01
+                }
                 className={cn(
                   'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
+                  predictionTradeMode === 'sell' &&
+                    canSellPrediction &&
+                    selectedPredictionShares.noShares < 0.01 &&
+                    'cursor-not-allowed opacity-50 hover:text-muted-foreground',
                   predictionSide === 'no'
                     ? 'bg-violet-500 text-white'
                     : 'text-muted-foreground hover:text-foreground'
@@ -1563,35 +1626,37 @@ export function MarketsTradingTerminal({
               </button>
             </div>
 
-            <div className="mt-3 flex rounded-md bg-muted/20 p-1">
-              <button
-                type="button"
-                onClick={() => setPredictionTradeMode('buy')}
-                className={cn(
-                  'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
-                  predictionTradeMode === 'buy'
-                    ? 'bg-green-600 text-white'
-                    : 'text-muted-foreground hover:text-foreground'
-                )}
-              >
-                BUY
-              </button>
-              <button
-                type="button"
-                onClick={() => setPredictionTradeMode('sell')}
-                className={cn(
-                  'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
-                  predictionTradeMode === 'sell'
-                    ? 'bg-red-600 text-white'
-                    : 'text-muted-foreground hover:text-foreground'
-                )}
-              >
-                SELL
-              </button>
-            </div>
+            {canSellPrediction && (
+              <div className="mt-3 flex rounded-md bg-muted/20 p-1">
+                <button
+                  type="button"
+                  onClick={() => setPredictionTradeMode('buy')}
+                  className={cn(
+                    'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
+                    predictionTradeMode === 'buy'
+                      ? 'bg-green-600 text-white'
+                      : 'text-muted-foreground hover:text-foreground'
+                  )}
+                >
+                  BUY
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setPredictionTradeMode('sell')}
+                  className={cn(
+                    'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
+                    predictionTradeMode === 'sell'
+                      ? 'bg-red-600 text-white'
+                      : 'text-muted-foreground hover:text-foreground'
+                  )}
+                >
+                  SELL
+                </button>
+              </div>
+            )}
 
             {predictionTradeMode === 'buy' ? (
-              <div className="mt-4">
+              <div className={cn('mt-4', !canSellPrediction && 'mt-3')}>
                 <div className="mb-1 flex items-center justify-between">
                   <label className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
                     Amount
@@ -1611,7 +1676,7 @@ export function MarketsTradingTerminal({
                 />
               </div>
             ) : (
-              <div className="mt-4">
+              <div className={cn('mt-4', !canSellPrediction && 'mt-3')}>
                 <div className="mb-1 flex items-center justify-between">
                   <label className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
                     Shares

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -2324,7 +2324,7 @@ export function MarketsTradingTerminal({
             </div>
           </div>
 
-          <div className="sticky bottom-0 z-40 flex h-[72px] w-full select-none items-center justify-between rounded-t-[20px] border-white/5 border-t bg-background px-2 pb-safe font-medium text-[10px] text-muted-foreground shadow-[0_-5px_15px_rgba(0,0,0,0.12)]">
+          <div className="sticky bottom-[calc(56px+env(safe-area-inset-bottom))] z-40 flex h-[72px] w-full select-none items-center justify-between rounded-t-[20px] border-white/5 border-t bg-background px-2 pb-2 font-medium text-[10px] text-muted-foreground shadow-[0_-5px_15px_rgba(0,0,0,0.12)]">
             {/* Minimal bottom nav */}
             <button
               type="button"
@@ -2373,7 +2373,7 @@ export function MarketsTradingTerminal({
           </div>
 
           {isMobilePanelOpen && (
-            <div className="fade-in slide-in-from-bottom-2 absolute inset-0 z-50 flex animate-in flex-col bg-background pt-safe pb-safe duration-200">
+            <div className="fade-in slide-in-from-bottom-2 absolute inset-0 z-[70] flex animate-in flex-col bg-background pt-safe pb-safe duration-200">
               <div className="flex items-center justify-between border-white/5 border-b p-4">
                 <h2 className="font-bold text-lg">Panel</h2>
                 <button
@@ -2596,7 +2596,7 @@ export function MarketsTradingTerminal({
           )}
 
           {isMobileMarketListOpen && (
-            <div className="fade-in slide-in-from-bottom-2 absolute inset-0 z-50 flex animate-in flex-col bg-background duration-200">
+            <div className="fade-in slide-in-from-bottom-2 absolute inset-0 z-[70] flex animate-in flex-col bg-background duration-200">
               <div className="flex items-center justify-between border-white/5 border-b p-4">
                 <h2 className="font-bold text-lg">Markets</h2>
                 <button
@@ -2613,7 +2613,7 @@ export function MarketsTradingTerminal({
           )}
 
           {isMobileTradeSheetOpen && (
-            <div className="fixed inset-0 z-50 flex flex-col justify-end">
+            <div className="fixed inset-0 z-[70] flex flex-col justify-end">
               <button
                 type="button"
                 aria-label="Close trade sheet"
@@ -2640,7 +2640,7 @@ export function MarketsTradingTerminal({
           )}
 
           {isMobileChartFullscreen && (
-            <div className="fixed inset-0 z-[60] bg-background">
+            <div className="fixed inset-0 z-[80] bg-background">
               <button
                 type="button"
                 aria-label="Close fullscreen chart"

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -454,6 +454,14 @@ export function MarketsTradingTerminal({
   const [isMobileMarketListOpen, setIsMobileMarketListOpen] = useState(false);
   const [isMobileTradeSheetOpen, setIsMobileTradeSheetOpen] = useState(false);
   const [isMobileChartFullscreen, setIsMobileChartFullscreen] = useState(false);
+  const [isMobilePanelOpen, setIsMobilePanelOpen] = useState(false);
+
+  const openMobilePanel = useCallback((tab?: BottomTab) => {
+    if (tab) setBottomTab(tab);
+    setIsMobilePanelOpen(true);
+    setIsMobileMarketListOpen(false);
+    setIsMobileTradeSheetOpen(false);
+  }, []);
 
   useEffect(() => {
     if (!isFullscreen) return undefined;
@@ -1411,6 +1419,7 @@ export function MarketsTradingTerminal({
               timeRange={predictionTimeRange}
               onTimeRangeChange={setPredictionTimeRange}
               showHeader={false}
+              height="fill"
             />
           </div>
         </>
@@ -2075,9 +2084,9 @@ export function MarketsTradingTerminal({
       {/* Mobile */}
       <div className="relative flex h-full flex-col overflow-hidden overscroll-none md:hidden">
         <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-          <div className="min-h-0 flex-1 overflow-hidden">
-            <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-              <div className="relative flex w-full shrink-0 basis-[34%] flex-col border-white/5 border-b">
+          <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+            <div className="contents">
+              <div className="relative flex min-h-0 w-full flex-1 flex-col border-white/5 border-b">
                 {selected?.kind === 'prediction' ? (
                   <>
                     <PredictionMarketHeader
@@ -2095,6 +2104,7 @@ export function MarketsTradingTerminal({
                         timeRange={predictionTimeRange}
                         onTimeRangeChange={setPredictionTimeRange}
                         showHeader={false}
+                        height="fill"
                       />
                     </div>
                   </>
@@ -2145,7 +2155,101 @@ export function MarketsTradingTerminal({
                 )}
               </div>
 
-              <div className="sticky top-0 z-30 flex h-11 shrink-0 items-center border-white/5 border-b bg-background px-2 shadow-sm">
+              <div className="shrink-0 border-white/5 border-t bg-background/70 px-2 py-2 shadow-sm backdrop-blur-md">
+                <button
+                  type="button"
+                  onClick={() => openMobilePanel()}
+                  className={cn(
+                    'flex w-full items-center gap-2 rounded-full border border-white/10 bg-background/40 px-4 py-2',
+                    'text-left text-foreground text-sm transition-colors hover:bg-muted/20',
+                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30'
+                  )}
+                  aria-label="Open panel"
+                >
+                  <span className="font-bold">Panel</span>
+                  <span className="text-muted-foreground">
+                    •{' '}
+                    {bottomTab === 'agent'
+                      ? 'Agents'
+                      : bottomTab === 'social'
+                        ? 'Social'
+                        : bottomTab === 'portfolio'
+                          ? 'Portfolio'
+                          : bottomTab === 'positions'
+                            ? 'Positions'
+                            : 'Trades'}
+                  </span>
+                  <span className="ml-auto font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+                    Open
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div className="sticky bottom-0 z-40 flex h-[72px] w-full select-none items-center justify-between rounded-t-[20px] border-white/5 border-t bg-background px-2 pb-safe font-medium text-[10px] text-muted-foreground shadow-[0_-5px_15px_rgba(0,0,0,0.12)]">
+            {/* Minimal bottom nav */}
+            <button
+              type="button"
+              onClick={() => {
+                setIsMobilePanelOpen(false);
+                setIsMobileTradeSheetOpen(false);
+                setIsMobileMarketListOpen(true);
+              }}
+              className="flex flex-1 flex-col items-center justify-center gap-1 py-1 font-bold text-foreground"
+            >
+              Markets
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setIsMobilePanelOpen(false);
+                setIsMobileMarketListOpen(false);
+                setIsMobileTradeSheetOpen(true);
+              }}
+              disabled={!selected}
+              className={cn(
+                'mx-2 inline-flex h-10 flex-[1.5] items-center justify-center rounded-full px-4 font-bold text-sm transition-all',
+                selected
+                  ? 'bg-foreground text-background active:scale-95'
+                  : 'cursor-not-allowed bg-muted/40 text-muted-foreground'
+              )}
+            >
+              Trade
+            </button>
+            <button
+              type="button"
+              onClick={authenticated ? onRequestBuyPoints : login}
+              className="flex flex-1 flex-col items-center justify-center gap-1 py-1 transition-colors hover:text-foreground"
+            >
+              {authenticated ? (
+                <>
+                  <span className="font-semibold">Balance</span>
+                  <span className="font-mono text-[11px] tabular-nums">
+                    {balanceLoading ? '—' : formatBalance(balance)}
+                  </span>
+                </>
+              ) : (
+                'Log in'
+              )}
+            </button>
+          </div>
+
+          {isMobilePanelOpen && (
+            <div className="fade-in slide-in-from-bottom-2 absolute inset-0 z-50 flex animate-in flex-col bg-background pt-safe pb-safe duration-200">
+              <div className="flex items-center justify-between border-white/5 border-b p-4">
+                <h2 className="font-bold text-lg">Panel</h2>
+                <button
+                  type="button"
+                  onClick={() => setIsMobilePanelOpen(false)}
+                  className="rounded-full p-2 transition-colors hover:bg-muted/20"
+                  aria-label="Close panel"
+                >
+                  <X size={20} />
+                </button>
+              </div>
+
+              <div className="flex h-11 shrink-0 items-center border-white/5 border-b bg-background px-2 shadow-sm">
                 <div className="flex min-w-0 flex-1">
                   <button
                     type="button"
@@ -2352,47 +2456,7 @@ export function MarketsTradingTerminal({
                 ) : null}
               </div>
             </div>
-          </div>
-
-          <div className="sticky bottom-0 z-40 flex h-[72px] w-full select-none items-center justify-between rounded-t-[20px] border-white/5 border-t bg-background px-2 pb-safe font-medium text-[10px] text-muted-foreground shadow-[0_-5px_15px_rgba(0,0,0,0.12)]">
-            {/* Minimal bottom nav */}
-            <button
-              type="button"
-              onClick={() => setIsMobileMarketListOpen(true)}
-              className="flex flex-1 flex-col items-center justify-center gap-1 py-1 font-bold text-foreground"
-            >
-              Markets
-            </button>
-            <button
-              type="button"
-              onClick={() => setIsMobileTradeSheetOpen(true)}
-              disabled={!selected}
-              className={cn(
-                'mx-2 inline-flex h-10 flex-[1.5] items-center justify-center rounded-full px-4 font-bold text-sm transition-all',
-                selected
-                  ? 'bg-foreground text-background active:scale-95'
-                  : 'cursor-not-allowed bg-muted/40 text-muted-foreground'
-              )}
-            >
-              Trade
-            </button>
-            <button
-              type="button"
-              onClick={authenticated ? onRequestBuyPoints : login}
-              className="flex flex-1 flex-col items-center justify-center gap-1 py-1 transition-colors hover:text-foreground"
-            >
-              {authenticated ? (
-                <>
-                  <span className="font-semibold">Balance</span>
-                  <span className="font-mono text-[11px] tabular-nums">
-                    {balanceLoading ? '—' : formatBalance(balance)}
-                  </span>
-                </>
-              ) : (
-                'Log in'
-              )}
-            </button>
-          </div>
+          )}
 
           {isMobileMarketListOpen && (
             <div className="fade-in slide-in-from-bottom-2 absolute inset-0 z-50 flex animate-in flex-col bg-background duration-200">
@@ -2472,6 +2536,7 @@ export function MarketsTradingTerminal({
                         timeRange={predictionTimeRange}
                         onTimeRangeChange={setPredictionTimeRange}
                         showHeader={false}
+                        height="fill"
                       />
                     </div>
                   </>

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -1222,15 +1222,15 @@ export function MarketsTradingTerminal({
           </div>
         ) : (
           <table className="w-full text-left text-xs">
-            <thead className="sticky top-0 z-10 bg-background/70 text-muted-foreground backdrop-blur-md">
+            <thead className="sr-only">
               <tr className="border-white/5 border-b">
-                <th className="w-10 px-3 py-2" />
+                <th className="w-10 px-3 py-2">Favorite</th>
                 <th className="px-2 py-2">Market</th>
                 <th className="px-2 py-2 text-right">Value</th>
                 <th className="px-3 py-2 text-right">24h</th>
               </tr>
             </thead>
-            <tbody>
+            <tbody className="border-white/5 border-t">
               {rows.map((row) => {
                 const active =
                   selected?.kind === row.key.kind &&

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -465,6 +465,55 @@ export function MarketsTradingTerminal({
     setIsMobileTradeSheetOpen(false);
   }, []);
 
+  // Shared handlers for TerminalPortfolio (used in both desktop and mobile)
+  const handlePortfolioRefresh = useCallback(() => {
+    invalidateUserPositions();
+    invalidateWalletBalance();
+    void Promise.allSettled([
+      refreshPortfolio(),
+      refreshPredictionPositions(),
+      refreshPerpPositions(),
+      refreshWalletBalance(),
+    ]);
+  }, [
+    refreshPortfolio,
+    refreshPredictionPositions,
+    refreshPerpPositions,
+    refreshWalletBalance,
+  ]);
+
+  const handlePerpPositionClosed = useCallback(async () => {
+    invalidateUserPositions();
+    invalidateWalletBalance();
+    await Promise.all([
+      refreshPerpPositions(),
+      refreshPredictionPositions(),
+      refreshWalletBalance(),
+      refreshPortfolio(),
+    ]);
+  }, [
+    refreshPerpPositions,
+    refreshPredictionPositions,
+    refreshWalletBalance,
+    refreshPortfolio,
+  ]);
+
+  const handlePredictionPositionSold = useCallback(async () => {
+    invalidateUserPositions();
+    invalidateWalletBalance();
+    await Promise.all([
+      refreshPredictionPositions(),
+      refreshPerpPositions(),
+      refreshWalletBalance(),
+      refreshPortfolio(),
+    ]);
+  }, [
+    refreshPredictionPositions,
+    refreshPerpPositions,
+    refreshWalletBalance,
+    refreshPortfolio,
+  ]);
+
   const mobileBottomDockOffset = useMemo(() => {
     // The app layout uses `pb-14` (56px) to reserve space for the fixed BottomNav.
     // We only need to offset by the *extra* height beyond 56px (e.g. iOS safe-area).
@@ -1934,38 +1983,11 @@ export function MarketsTradingTerminal({
             portfolio={portfolioPnL}
             portfolioLoading={portfolioLoading}
             portfolioError={portfolioError}
-            onRefresh={() => {
-              invalidateUserPositions();
-              invalidateWalletBalance();
-              void Promise.allSettled([
-                refreshPortfolio(),
-                refreshPredictionPositions(),
-                refreshPerpPositions(),
-                refreshWalletBalance(),
-              ]);
-            }}
+            onRefresh={handlePortfolioRefresh}
             perpPositions={perpPositions}
             predictionPositions={predictionPositions}
-            onPerpPositionClosed={async () => {
-              invalidateUserPositions();
-              invalidateWalletBalance();
-              await Promise.all([
-                refreshPerpPositions(),
-                refreshPredictionPositions(),
-                refreshWalletBalance(),
-                refreshPortfolio(),
-              ]);
-            }}
-            onPredictionPositionSold={async () => {
-              invalidateUserPositions();
-              invalidateWalletBalance();
-              await Promise.all([
-                refreshPredictionPositions(),
-                refreshPerpPositions(),
-                refreshWalletBalance(),
-                refreshPortfolio(),
-              ]);
-            }}
+            onPerpPositionClosed={handlePerpPositionClosed}
+            onPredictionPositionSold={handlePredictionPositionSold}
           />
         ) : bottomTab === 'positions' ? (
           !authenticated ? (
@@ -2528,38 +2550,11 @@ export function MarketsTradingTerminal({
                     portfolio={portfolioPnL}
                     portfolioLoading={portfolioLoading}
                     portfolioError={portfolioError}
-                    onRefresh={() => {
-                      invalidateUserPositions();
-                      invalidateWalletBalance();
-                      void Promise.allSettled([
-                        refreshPortfolio(),
-                        refreshPredictionPositions(),
-                        refreshPerpPositions(),
-                        refreshWalletBalance(),
-                      ]);
-                    }}
+                    onRefresh={handlePortfolioRefresh}
                     perpPositions={perpPositions}
                     predictionPositions={predictionPositions}
-                    onPerpPositionClosed={async () => {
-                      invalidateUserPositions();
-                      invalidateWalletBalance();
-                      await Promise.all([
-                        refreshPerpPositions(),
-                        refreshPredictionPositions(),
-                        refreshWalletBalance(),
-                        refreshPortfolio(),
-                      ]);
-                    }}
-                    onPredictionPositionSold={async () => {
-                      invalidateUserPositions();
-                      invalidateWalletBalance();
-                      await Promise.all([
-                        refreshPredictionPositions(),
-                        refreshPerpPositions(),
-                        refreshWalletBalance(),
-                        refreshPortfolio(),
-                      ]);
-                    }}
+                    onPerpPositionClosed={handlePerpPositionClosed}
+                    onPredictionPositionSold={handlePredictionPositionSold}
                   />
                 ) : bottomTab === 'positions' ? (
                   !authenticated ? (

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -2324,7 +2324,7 @@ export function MarketsTradingTerminal({
             </div>
           </div>
 
-          <div className="sticky bottom-[calc(56px+env(safe-area-inset-bottom))] z-40 flex h-[72px] w-full select-none items-center justify-between rounded-t-[20px] border-white/5 border-t bg-background px-2 pb-2 font-medium text-[10px] text-muted-foreground shadow-[0_-5px_15px_rgba(0,0,0,0.12)]">
+          <div className="sticky bottom-14 z-40 flex h-[72px] w-full select-none items-center justify-between rounded-t-[20px] border-white/5 border-t bg-background px-2 pb-2 font-medium text-[10px] text-muted-foreground shadow-[0_-5px_15px_rgba(0,0,0,0.12)]">
             {/* Minimal bottom nav */}
             <button
               type="button"

--- a/apps/web/src/app/markets/_components/terminal/TerminalAgentsChat.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalAgentsChat.tsx
@@ -61,6 +61,7 @@ export function TerminalAgentsChat() {
         authenticated={authenticated}
         sseConnected={sseConnected}
         hideHeader
+        density="compact"
         loading={loading}
         isLoadingMore={isLoadingMore}
         hasMore={hasMore}

--- a/apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx
@@ -3,8 +3,8 @@
 import type { UserPredictionPosition } from '@babylon/shared';
 import { cn } from '@babylon/shared';
 import { RefreshCw, Wallet } from 'lucide-react';
-import { PredictionPositionsList } from '@/components/markets/PredictionPositionsList';
 import { PerpPositionsList } from '@/components/markets/PerpPositionsList';
+import { PredictionPositionsList } from '@/components/markets/PredictionPositionsList';
 import type { PortfolioBreakdownSnapshot } from '@/hooks/usePortfolioPnL';
 import type { DisplayPerpPosition } from '@/types/markets';
 import { formatBalance } from '../../_lib/formatters';
@@ -29,7 +29,9 @@ function StatCard({
       <div className="text-[10px] text-muted-foreground uppercase tracking-wider">
         {label}
       </div>
-      <div className={cn('mt-1 font-mono text-sm tabular-nums', valueClassName)}>
+      <div
+        className={cn('mt-1 font-mono text-sm tabular-nums', valueClassName)}
+      >
         {value}
       </div>
     </div>
@@ -122,7 +124,10 @@ export function TerminalPortfolio({
               title="Refresh"
             >
               <RefreshCw
-                className={cn('h-3.5 w-3.5', portfolioLoading && 'animate-spin')}
+                className={cn(
+                  'h-3.5 w-3.5',
+                  portfolioLoading && 'animate-spin'
+                )}
               />
               Refresh
             </button>
@@ -152,13 +157,17 @@ export function TerminalPortfolio({
           <StatCard
             label="Total Assets"
             value={
-              portfolioLoading || !portfolio ? '—' : formatBalance(portfolio.totalAssets)
+              portfolioLoading || !portfolio
+                ? '—'
+                : formatBalance(portfolio.totalAssets)
             }
           />
           <StatCard
             label="Available"
             value={
-              portfolioLoading || !portfolio ? '—' : formatBalance(portfolio.available)
+              portfolioLoading || !portfolio
+                ? '—'
+                : formatBalance(portfolio.available)
             }
           />
         </div>
@@ -166,12 +175,18 @@ export function TerminalPortfolio({
         <div className="mt-2 grid grid-cols-2 gap-2 lg:grid-cols-4">
           <StatCard
             label="Agents"
-            value={portfolioLoading || !portfolio ? '—' : formatBalance(portfolio.agents)}
+            value={
+              portfolioLoading || !portfolio
+                ? '—'
+                : formatBalance(portfolio.agents)
+            }
           />
           <StatCard
             label="Positions"
             value={
-              portfolioLoading || !portfolio ? '—' : formatBalance(portfolio.positions)
+              portfolioLoading || !portfolio
+                ? '—'
+                : formatBalance(portfolio.positions)
             }
           />
           <StatCard

--- a/apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx
@@ -130,12 +130,16 @@ export function TerminalPortfolio({
             )}
             <button
               type="button"
-              onClick={onRefresh}
+              onClick={!portfolioLoading ? onRefresh : undefined}
+              disabled={portfolioLoading}
               className={cn(
-                'inline-flex items-center gap-1 rounded bg-muted/20 px-2 py-1 font-semibold text-[10px] uppercase tracking-wider transition-colors hover:bg-muted/30',
-                portfolioLoading ? 'text-muted-foreground' : 'text-foreground'
+                'inline-flex items-center gap-1 rounded bg-muted/20 px-2 py-1 font-semibold text-[10px] uppercase tracking-wider transition-colors',
+                portfolioLoading
+                  ? 'cursor-not-allowed text-muted-foreground opacity-50'
+                  : 'text-foreground hover:bg-muted/30'
               )}
               aria-label="Refresh portfolio"
+              aria-busy={portfolioLoading}
               title="Refresh"
             >
               <RefreshCw

--- a/apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import type { UserPredictionPosition } from '@babylon/shared';
+import { cn } from '@babylon/shared';
+import { RefreshCw, Wallet } from 'lucide-react';
+import { PredictionPositionsList } from '@/components/markets/PredictionPositionsList';
+import { PerpPositionsList } from '@/components/markets/PerpPositionsList';
+import type { PortfolioBreakdownSnapshot } from '@/hooks/usePortfolioPnL';
+import type { DisplayPerpPosition } from '@/types/markets';
+import { formatBalance } from '../../_lib/formatters';
+
+function formatSignedBalance(value: number): string {
+  if (value === 0) return formatBalance(0);
+  const sign = value > 0 ? '+' : '-';
+  return `${sign}${formatBalance(Math.abs(value))}`;
+}
+
+function StatCard({
+  label,
+  value,
+  valueClassName,
+}: {
+  label: string;
+  value: string;
+  valueClassName?: string;
+}) {
+  return (
+    <div className="rounded-md border border-white/10 bg-background/30 px-3 py-2">
+      <div className="text-[10px] text-muted-foreground uppercase tracking-wider">
+        {label}
+      </div>
+      <div className={cn('mt-1 font-mono text-sm tabular-nums', valueClassName)}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+export function TerminalPortfolio({
+  authenticated,
+  onLogin,
+  onRequestBuyPoints,
+  balance,
+  balanceLoading,
+  portfolio,
+  portfolioLoading,
+  portfolioError,
+  onRefresh,
+  perpPositions,
+  predictionPositions,
+  onPerpPositionClosed,
+  onPredictionPositionSold,
+}: {
+  authenticated: boolean;
+  onLogin: () => void;
+  onRequestBuyPoints?: (() => void) | null;
+  balance: number;
+  balanceLoading: boolean;
+  portfolio: PortfolioBreakdownSnapshot | null;
+  portfolioLoading: boolean;
+  portfolioError: string | null;
+  onRefresh: () => void;
+  perpPositions: DisplayPerpPosition[];
+  predictionPositions: UserPredictionPosition[];
+  onPerpPositionClosed: () => Promise<void>;
+  onPredictionPositionSold: () => Promise<void>;
+}) {
+  if (!authenticated) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-center">
+        <div className="max-w-md text-muted-foreground text-sm">
+          <div className="mb-3 font-semibold text-foreground">
+            Log in to view your portfolio
+          </div>
+          <button
+            type="button"
+            onClick={onLogin}
+            className="mt-2 rounded bg-foreground px-4 py-2 font-semibold text-background text-sm transition-colors hover:opacity-90"
+          >
+            Log In
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const pnlValueClass =
+    (portfolio?.totalPnL ?? 0) >= 0 ? 'text-green-500' : 'text-red-500';
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="shrink-0 border-white/5 border-b bg-background/20 p-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 font-semibold text-foreground text-sm">
+              <Wallet className="h-4 w-4 text-muted-foreground" />
+              Portfolio
+            </div>
+            <div className="mt-0.5 text-muted-foreground text-xs">
+              Balance, PnL, positions
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2">
+            {onRequestBuyPoints && (
+              <button
+                type="button"
+                onClick={onRequestBuyPoints}
+                className="rounded bg-muted/20 px-2 py-1 font-semibold text-[10px] text-muted-foreground uppercase tracking-wider transition-colors hover:bg-muted/30 hover:text-foreground"
+              >
+                Buy
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onRefresh}
+              className={cn(
+                'inline-flex items-center gap-1 rounded bg-muted/20 px-2 py-1 font-semibold text-[10px] uppercase tracking-wider transition-colors hover:bg-muted/30',
+                portfolioLoading ? 'text-muted-foreground' : 'text-foreground'
+              )}
+              aria-label="Refresh portfolio"
+              title="Refresh"
+            >
+              <RefreshCw
+                className={cn('h-3.5 w-3.5', portfolioLoading && 'animate-spin')}
+              />
+              Refresh
+            </button>
+          </div>
+        </div>
+
+        {portfolioError && (
+          <div className="mt-2 rounded border border-red-500/20 bg-red-500/10 px-3 py-2 text-red-200 text-xs">
+            {portfolioError}
+          </div>
+        )}
+
+        <div className="mt-3 grid grid-cols-2 gap-2 lg:grid-cols-4">
+          <StatCard
+            label="Wallet (spendable)"
+            value={balanceLoading ? '—' : formatBalance(balance)}
+          />
+          <StatCard
+            label="Total PnL"
+            value={
+              portfolioLoading || !portfolio
+                ? '—'
+                : formatSignedBalance(portfolio.totalPnL)
+            }
+            valueClassName={pnlValueClass}
+          />
+          <StatCard
+            label="Total Assets"
+            value={
+              portfolioLoading || !portfolio ? '—' : formatBalance(portfolio.totalAssets)
+            }
+          />
+          <StatCard
+            label="Available"
+            value={
+              portfolioLoading || !portfolio ? '—' : formatBalance(portfolio.available)
+            }
+          />
+        </div>
+
+        <div className="mt-2 grid grid-cols-2 gap-2 lg:grid-cols-4">
+          <StatCard
+            label="Agents"
+            value={portfolioLoading || !portfolio ? '—' : formatBalance(portfolio.agents)}
+          />
+          <StatCard
+            label="Positions"
+            value={
+              portfolioLoading || !portfolio ? '—' : formatBalance(portfolio.positions)
+            }
+          />
+          <StatCard
+            label="Agent Count"
+            value={
+              portfolioLoading || !portfolio
+                ? '—'
+                : portfolio.agentCount.toLocaleString()
+            }
+          />
+          <StatCard
+            label="Original"
+            value={
+              portfolioLoading || !portfolio
+                ? '—'
+                : formatBalance(portfolio.originalAmount)
+            }
+          />
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto overscroll-contain p-3">
+        <div className="space-y-3">
+          {perpPositions.length === 0 && predictionPositions.length === 0 ? (
+            <div className="flex h-[140px] items-center justify-center rounded border border-white/10 bg-background/20 text-muted-foreground text-sm">
+              No open positions yet.
+            </div>
+          ) : (
+            <>
+              {perpPositions.length > 0 && (
+                <div className="rounded border border-white/10 bg-background/10 p-2">
+                  <div className="px-1 pb-2 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+                    Perps ({perpPositions.length})
+                  </div>
+                  <PerpPositionsList
+                    positions={perpPositions}
+                    density="compact"
+                    onPositionClosed={onPerpPositionClosed}
+                  />
+                </div>
+              )}
+
+              {predictionPositions.length > 0 && (
+                <div className="rounded border border-white/10 bg-background/10 p-2">
+                  <div className="px-1 pb-2 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+                    Predictions ({predictionPositions.length})
+                  </div>
+                  <PredictionPositionsList
+                    positions={predictionPositions}
+                    density="compact"
+                    onPositionSold={onPredictionPositionSold}
+                  />
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx
@@ -145,7 +145,11 @@ export function TerminalPortfolio({
               )}
               aria-label="Refresh portfolio"
               aria-busy={portfolioLoading}
-              title={refreshDisabled ? 'Please wait before refreshing again' : 'Refresh'}
+              title={
+                refreshDisabled
+                  ? 'Please wait before refreshing again'
+                  : 'Refresh'
+              }
             >
               <RefreshCw
                 className={cn(

--- a/apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx
@@ -15,6 +15,35 @@ function formatSignedBalance(value: number): string {
   return `${sign}${formatBalance(Math.abs(value))}`;
 }
 
+/** Props for the TerminalPortfolio component */
+interface TerminalPortfolioProps {
+  authenticated: boolean;
+  onLogin: () => void;
+  onRequestBuyPoints?: (() => void) | null;
+  balance: number;
+  balanceLoading: boolean;
+  portfolio: PortfolioBreakdownSnapshot | null;
+  portfolioLoading: boolean;
+  portfolioError: string | null;
+  onRefresh: () => void;
+  perpPositions: DisplayPerpPosition[];
+  predictionPositions: UserPredictionPosition[];
+  onPerpPositionClosed: () => Promise<void>;
+  onPredictionPositionSold: () => Promise<void>;
+}
+
+/** Helper to format portfolio values with loading state */
+function formatPortfolioValue(
+  isLoading: boolean,
+  portfolio: PortfolioBreakdownSnapshot | null,
+  getValue: (p: PortfolioBreakdownSnapshot) => number | string,
+  formatter: (v: number) => string = formatBalance
+): string {
+  if (isLoading || !portfolio) return '—';
+  const value = getValue(portfolio);
+  return typeof value === 'number' ? formatter(value) : value;
+}
+
 function StatCard({
   label,
   value,
@@ -52,21 +81,7 @@ export function TerminalPortfolio({
   predictionPositions,
   onPerpPositionClosed,
   onPredictionPositionSold,
-}: {
-  authenticated: boolean;
-  onLogin: () => void;
-  onRequestBuyPoints?: (() => void) | null;
-  balance: number;
-  balanceLoading: boolean;
-  portfolio: PortfolioBreakdownSnapshot | null;
-  portfolioLoading: boolean;
-  portfolioError: string | null;
-  onRefresh: () => void;
-  perpPositions: DisplayPerpPosition[];
-  predictionPositions: UserPredictionPosition[];
-  onPerpPositionClosed: () => Promise<void>;
-  onPredictionPositionSold: () => Promise<void>;
-}) {
+}: TerminalPortfolioProps) {
   if (!authenticated) {
     return (
       <div className="flex h-full items-center justify-center p-6 text-center">
@@ -147,63 +162,64 @@ export function TerminalPortfolio({
           />
           <StatCard
             label="Total PnL"
-            value={
-              portfolioLoading || !portfolio
-                ? '—'
-                : formatSignedBalance(portfolio.totalPnL)
-            }
+            value={formatPortfolioValue(
+              portfolioLoading,
+              portfolio,
+              (p) => p.totalPnL,
+              formatSignedBalance
+            )}
             valueClassName={pnlValueClass}
           />
           <StatCard
             label="Total Assets"
-            value={
-              portfolioLoading || !portfolio
-                ? '—'
-                : formatBalance(portfolio.totalAssets)
-            }
+            value={formatPortfolioValue(
+              portfolioLoading,
+              portfolio,
+              (p) => p.totalAssets
+            )}
           />
           <StatCard
             label="Available"
-            value={
-              portfolioLoading || !portfolio
-                ? '—'
-                : formatBalance(portfolio.available)
-            }
+            value={formatPortfolioValue(
+              portfolioLoading,
+              portfolio,
+              (p) => p.available
+            )}
           />
         </div>
 
         <div className="mt-2 grid grid-cols-2 gap-2 lg:grid-cols-4">
           <StatCard
             label="Agents"
-            value={
-              portfolioLoading || !portfolio
-                ? '—'
-                : formatBalance(portfolio.agents)
-            }
+            value={formatPortfolioValue(
+              portfolioLoading,
+              portfolio,
+              (p) => p.agents
+            )}
           />
           <StatCard
             label="Positions"
-            value={
-              portfolioLoading || !portfolio
-                ? '—'
-                : formatBalance(portfolio.positions)
-            }
+            value={formatPortfolioValue(
+              portfolioLoading,
+              portfolio,
+              (p) => p.positions
+            )}
           />
           <StatCard
             label="Agent Count"
-            value={
-              portfolioLoading || !portfolio
-                ? '—'
-                : portfolio.agentCount.toLocaleString()
-            }
+            value={formatPortfolioValue(
+              portfolioLoading,
+              portfolio,
+              (p) => p.agentCount.toLocaleString()
+            )}
           />
           <StatCard
             label="Original"
-            value={
-              portfolioLoading || !portfolio
-                ? '—'
-                : formatBalance(portfolio.originalAmount)
-            }
+            value={formatPortfolioValue(
+              portfolioLoading,
+              portfolio,
+              (p) => p.originalAmount
+            )}
           />
         </div>
       </div>

--- a/apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx
@@ -109,8 +109,13 @@ export function TerminalPortfolio({
     );
   }
 
+  // Use neutral color when portfolio data is not yet loaded
   const pnlValueClass =
-    (portfolio?.totalPnL ?? 0) >= 0 ? 'text-green-500' : 'text-red-500';
+    portfolio?.totalPnL == null
+      ? 'text-muted-foreground'
+      : portfolio.totalPnL >= 0
+        ? 'text-green-500'
+        : 'text-red-500';
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -138,9 +143,7 @@ export function TerminalPortfolio({
             )}
             <button
               type="button"
-              onClick={
-                !portfolioLoading && !refreshDisabled ? onRefresh : undefined
-              }
+              onClick={onRefresh}
               disabled={portfolioLoading || refreshDisabled}
               className={cn(
                 'inline-flex items-center gap-1 rounded bg-muted/20 px-2 py-1 font-semibold text-[10px] uppercase tracking-wider transition-colors',

--- a/apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx
@@ -207,10 +207,8 @@ export function TerminalPortfolio({
           />
           <StatCard
             label="Agent Count"
-            value={formatPortfolioValue(
-              portfolioLoading,
-              portfolio,
-              (p) => p.agentCount.toLocaleString()
+            value={formatPortfolioValue(portfolioLoading, portfolio, (p) =>
+              p.agentCount.toLocaleString()
             )}
           />
           <StatCard

--- a/apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx
@@ -26,6 +26,8 @@ interface TerminalPortfolioProps {
   portfolioLoading: boolean;
   portfolioError: string | null;
   onRefresh: () => void;
+  /** When true, disables refresh button (e.g., during cooldown) without showing loading spinner */
+  refreshDisabled?: boolean;
   perpPositions: DisplayPerpPosition[];
   predictionPositions: UserPredictionPosition[];
   onPerpPositionClosed: () => Promise<void>;
@@ -77,6 +79,7 @@ export function TerminalPortfolio({
   portfolioLoading,
   portfolioError,
   onRefresh,
+  refreshDisabled = false,
   perpPositions,
   predictionPositions,
   onPerpPositionClosed,
@@ -130,17 +133,19 @@ export function TerminalPortfolio({
             )}
             <button
               type="button"
-              onClick={!portfolioLoading ? onRefresh : undefined}
-              disabled={portfolioLoading}
+              onClick={
+                !portfolioLoading && !refreshDisabled ? onRefresh : undefined
+              }
+              disabled={portfolioLoading || refreshDisabled}
               className={cn(
                 'inline-flex items-center gap-1 rounded bg-muted/20 px-2 py-1 font-semibold text-[10px] uppercase tracking-wider transition-colors',
-                portfolioLoading
+                portfolioLoading || refreshDisabled
                   ? 'cursor-not-allowed text-muted-foreground opacity-50'
                   : 'text-foreground hover:bg-muted/30'
               )}
               aria-label="Refresh portfolio"
               aria-busy={portfolioLoading}
-              title="Refresh"
+              title={refreshDisabled ? 'Please wait before refreshing again' : 'Refresh'}
             >
               <RefreshCw
                 className={cn(

--- a/apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx
@@ -9,6 +9,11 @@ import type { PortfolioBreakdownSnapshot } from '@/hooks/usePortfolioPnL';
 import type { DisplayPerpPosition } from '@/types/markets';
 import { formatBalance } from '../../_lib/formatters';
 
+/**
+ * Formats a balance with explicit +/- sign prefix.
+ * Uses Math.abs() to ensure formatBalance receives a positive value,
+ * then manually prepends the sign to avoid double-negative display.
+ */
 function formatSignedBalance(value: number): string {
   if (value === 0) return formatBalance(0);
   const sign = value > 0 ? '+' : '-';

--- a/apps/web/src/app/markets/_components/terminal/TerminalSocialFeed.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalSocialFeed.tsx
@@ -220,7 +220,7 @@ export function TerminalSocialFeed({ perpTicker }: TerminalSocialFeedProps) {
         {loading ? (
           <FeedSkeleton count={6} />
         ) : posts.length === 0 ? (
-          <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
+          <div className="flex h-full items-center justify-center text-muted-foreground text-xs">
             No posts yet.
           </div>
         ) : (
@@ -230,6 +230,7 @@ export function TerminalSocialFeed({ perpTicker }: TerminalSocialFeedProps) {
             hasMore={hasMore}
             loadingMore={loadingMore}
             onLoadMore={onLoadMore}
+            density="compact"
           />
         )}
       </div>

--- a/apps/web/src/components/articles/ArticleCard.tsx
+++ b/apps/web/src/components/articles/ArticleCard.tsx
@@ -28,15 +28,18 @@ const _ArticleCardPostSchema = z.object({
 export type ArticleCardProps = {
   post: z.infer<typeof _ArticleCardPostSchema>;
   className?: string;
+  density?: 'default' | 'compact';
   onClick?: () => void;
 };
 
 export const ArticleCard = memo(function ArticleCard({
   post,
   className,
+  density = 'default',
   onClick,
 }: ArticleCardProps) {
   const router = useRouter();
+  const compact = density === 'compact';
   const publishedDate = new Date(post.timestamp);
   const now = new Date();
   const diffMs = now.getTime() - publishedDate.getTime();
@@ -72,7 +75,7 @@ export const ArticleCard = memo(function ArticleCard({
   return (
     <article
       className={cn(
-        'px-4 py-4',
+        compact ? 'px-3 py-3' : 'px-4 py-4',
         'cursor-pointer transition-all duration-200 hover:bg-muted/30',
         'w-full overflow-hidden',
         'border-border border-b',
@@ -100,7 +103,12 @@ export const ArticleCard = memo(function ArticleCard({
         {/* Right column: All content */}
         <div className="min-w-0 flex-1">
           {/* Author row: Name · @handle · Category | timeAgo right-aligned */}
-          <div className="mb-2 flex items-center justify-between gap-1.5 text-[15px] leading-tight">
+          <div
+            className={cn(
+              'flex items-center justify-between gap-1.5 leading-tight',
+              compact ? 'mb-1 text-[15px] md:text-[13px]' : 'mb-2 text-[15px]'
+            )}
+          >
             <div className="flex min-w-0 items-center gap-1.5">
               <Link
                 href={`/profile/${post.authorId}`}
@@ -128,7 +136,10 @@ export const ArticleCard = memo(function ArticleCard({
               )}
             </div>
             <time
-              className="shrink-0 text-[15px] text-muted-foreground"
+              className={cn(
+                'shrink-0 text-muted-foreground',
+                compact ? 'text-[15px] md:text-[13px]' : 'text-[15px]'
+              )}
               title={publishedDate.toLocaleString()}
             >
               {timeAgo}
@@ -149,12 +160,24 @@ export const ArticleCard = memo(function ArticleCard({
           )}
 
           {/* Article Title */}
-          <h2 className="mb-1.5 line-clamp-2 font-bold text-foreground text-lg leading-tight">
+          <h2
+            className={cn(
+              'line-clamp-2 font-bold text-foreground leading-tight',
+              compact ? 'mb-1 text-lg md:text-base' : 'mb-1.5 text-lg'
+            )}
+          >
             {post.articleTitle || 'Untitled Article'}
           </h2>
 
           {/* Summary */}
-          <p className="mb-3 line-clamp-2 text-muted-foreground text-sm leading-relaxed">
+          <p
+            className={cn(
+              'line-clamp-2 text-muted-foreground',
+              compact
+                ? 'mb-2 text-sm leading-snug md:text-xs'
+                : 'mb-3 text-sm leading-relaxed'
+            )}
+          >
             {post.content}
           </p>
 
@@ -165,7 +188,14 @@ export const ArticleCard = memo(function ArticleCard({
                 {post.byline}
               </span>
             )}
-            <span className="text-[#0066FF] text-sm">Read Full Article →</span>
+            <span
+              className={cn(
+                'text-[#0066FF]',
+                compact ? 'text-sm md:text-xs' : 'text-sm'
+              )}
+            >
+              Read Full Article →
+            </span>
           </div>
         </div>
       </div>

--- a/apps/web/src/components/chats/MessageBubble.tsx
+++ b/apps/web/src/components/chats/MessageBubble.tsx
@@ -55,6 +55,7 @@ interface MessageBubbleProps {
   validMentions?: string[];
   /** Whether this message is showing "Thinking..." placeholder state */
   isThinking?: boolean;
+  density?: 'default' | 'compact';
   /** Callback when a tag is clicked - opens sidebar with tag data */
   onTagClick?: (tag: MessageTag, messageId: string) => void;
 }
@@ -65,15 +66,18 @@ export function MessageBubble({
   isCurrentUser,
   validMentions,
   isThinking,
+  density = 'default',
   onTagClick,
 }: MessageBubbleProps) {
   const msgDate = new Date(message.createdAt);
   const senderName = sender?.displayName || 'Unknown';
+  const compact = density === 'compact';
 
   return (
     <div
       className={cn(
-        'flex gap-3',
+        'flex',
+        compact ? 'gap-2' : 'gap-3',
         isCurrentUser ? 'justify-end' : 'items-start'
       )}
     >
@@ -86,13 +90,18 @@ export function MessageBubble({
             id={sender.id}
             name={senderName}
             type="user"
-            size="md"
+            size={compact ? 'sm' : 'md'}
             imageUrl={sender.profileImageUrl}
           />
         </Link>
       )}
       {!isCurrentUser && !sender && (
-        <Avatar id={message.senderId} name={senderName} type="user" size="md" />
+        <Avatar
+          id={message.senderId}
+          name={senderName}
+          type="user"
+          size={compact ? 'sm' : 'md'}
+        />
       )}
       <div
         className={cn(
@@ -104,13 +113,21 @@ export function MessageBubble({
           {!isCurrentUser && sender && (
             <Link
               href={getProfilePath(sender)}
-              className="font-bold text-foreground text-sm transition-colors hover:text-primary"
+              className={cn(
+                'font-bold text-foreground transition-colors hover:text-primary',
+                compact ? 'text-sm md:text-xs' : 'text-sm'
+              )}
             >
               {senderName}
             </Link>
           )}
           {!isCurrentUser && !sender && (
-            <span className="font-bold text-foreground text-sm">
+            <span
+              className={cn(
+                'font-bold text-foreground',
+                compact ? 'text-sm md:text-xs' : 'text-sm'
+              )}
+            >
               {senderName}
             </span>
           )}
@@ -129,7 +146,8 @@ export function MessageBubble({
         </div>
         <div
           className={cn(
-            'message-bubble max-w-full overflow-x-auto break-words rounded-2xl px-4 py-3 text-sm',
+            'message-bubble max-w-full overflow-x-auto break-words rounded-2xl',
+            compact ? 'px-3 py-2 text-sm md:text-xs' : 'px-4 py-3 text-sm',
             isCurrentUser
               ? 'rounded-tr-sm bg-primary/20'
               : 'rounded-tl-sm bg-sidebar-accent/50'

--- a/apps/web/src/components/chats/MessageInput.tsx
+++ b/apps/web/src/components/chats/MessageInput.tsx
@@ -87,6 +87,7 @@ export interface MessageInputProps {
   onSend: () => void;
   sending: boolean;
   authenticated: boolean;
+  density?: 'default' | 'compact';
   /** Additional disabled condition (e.g., insufficient points for agent chat) */
   disabled?: boolean;
   /** Custom placeholder text */
@@ -107,6 +108,7 @@ export function MessageInput({
   onSend,
   sending,
   authenticated,
+  density = 'default',
   disabled = false,
   placeholder,
   mentionableMembers,
@@ -293,10 +295,11 @@ export function MessageInput({
 
   // Determine placeholder text
   const placeholderText = placeholder || 'Type a message...';
+  const compact = density === 'compact';
 
   if (!authenticated) {
     return (
-      <div className="bg-background px-4 py-3">
+      <div className={cn('bg-background', compact ? 'px-3 py-2' : 'px-4 py-3')}>
         <div className="text-center">
           <p className="mb-3 text-muted-foreground text-sm">
             Log in to send messages
@@ -308,7 +311,10 @@ export function MessageInput({
   }
 
   return (
-    <div ref={containerRef} className="relative bg-background px-4 py-3">
+    <div
+      ref={containerRef}
+      className={cn('relative bg-background', compact ? 'px-3 py-2' : 'px-4 py-3')}
+    >
       {/* Mention autocomplete dropdown */}
       {mentionsEnabled && (
         <MentionAutocomplete
@@ -331,7 +337,8 @@ export function MessageInput({
             <div
               ref={highlightRef}
               className={cn(
-                'pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words rounded-xl px-4 py-4 pr-14 text-sm',
+                'pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words rounded-xl pr-14',
+                compact ? 'px-3 py-2.5 text-sm md:text-xs' : 'px-4 py-4 text-sm',
                 'text-foreground'
               )}
               aria-hidden="true"
@@ -354,14 +361,17 @@ export function MessageInput({
               rows={1}
               spellCheck={false}
               autoComplete="off"
-              autoCorrect="off"
-              autoCapitalize="off"
-              className={cn(
-                'relative z-10 max-h-40 min-h-[56px] w-full resize-none overflow-y-auto rounded-xl px-4 py-4 pr-14 text-sm',
-                'message-input bg-sidebar-accent/50',
-                'text-transparent caret-foreground placeholder:text-muted-foreground',
-                'outline-none focus:ring-2 focus:ring-primary/50',
-                'disabled:cursor-not-allowed disabled:opacity-50'
+	              autoCorrect="off"
+	              autoCapitalize="off"
+	              className={cn(
+	                'relative z-10 max-h-40 w-full resize-none overflow-y-auto rounded-xl pr-14',
+	                compact
+	                  ? 'min-h-[48px] px-3 py-2.5 text-sm md:text-xs'
+	                  : 'min-h-[56px] px-4 py-4 text-sm',
+	                'message-input bg-sidebar-accent/50',
+	                'text-transparent caret-foreground placeholder:text-muted-foreground',
+	                'outline-none focus:ring-2 focus:ring-primary/50',
+	                'disabled:cursor-not-allowed disabled:opacity-50'
               )}
             />
           </>
@@ -374,13 +384,16 @@ export function MessageInput({
             onKeyDown={handleKeyDown}
             placeholder={placeholderText}
             disabled={sending || disabled}
-            rows={1}
-            className={cn(
-              'max-h-40 min-h-[56px] w-full resize-none overflow-y-auto rounded-xl px-4 py-4 pr-14 text-sm',
-              'message-input bg-sidebar-accent/50',
-              'text-foreground placeholder:text-muted-foreground',
-              'outline-none focus:ring-2 focus:ring-primary/50',
-              'disabled:cursor-not-allowed disabled:opacity-50'
+	            rows={1}
+	            className={cn(
+	              'max-h-40 w-full resize-none overflow-y-auto rounded-xl pr-14',
+	              compact
+	                ? 'min-h-[48px] px-3 py-2.5 text-sm md:text-xs'
+	                : 'min-h-[56px] px-4 py-4 text-sm',
+	              'message-input bg-sidebar-accent/50',
+	              'text-foreground placeholder:text-muted-foreground',
+	              'outline-none focus:ring-2 focus:ring-primary/50',
+	              'disabled:cursor-not-allowed disabled:opacity-50'
             )}
           />
         )}

--- a/apps/web/src/components/chats/MessageInput.tsx
+++ b/apps/web/src/components/chats/MessageInput.tsx
@@ -313,7 +313,10 @@ export function MessageInput({
   return (
     <div
       ref={containerRef}
-      className={cn('relative bg-background', compact ? 'px-3 py-2' : 'px-4 py-3')}
+      className={cn(
+        'relative bg-background',
+        compact ? 'px-3 py-2' : 'px-4 py-3'
+      )}
     >
       {/* Mention autocomplete dropdown */}
       {mentionsEnabled && (
@@ -338,7 +341,9 @@ export function MessageInput({
               ref={highlightRef}
               className={cn(
                 'pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words rounded-xl pr-14',
-                compact ? 'px-3 py-2.5 text-sm md:text-xs' : 'px-4 py-4 text-sm',
+                compact
+                  ? 'px-3 py-2.5 text-sm md:text-xs'
+                  : 'px-4 py-4 text-sm',
                 'text-foreground'
               )}
               aria-hidden="true"
@@ -361,17 +366,17 @@ export function MessageInput({
               rows={1}
               spellCheck={false}
               autoComplete="off"
-	              autoCorrect="off"
-	              autoCapitalize="off"
-	              className={cn(
-	                'relative z-10 max-h-40 w-full resize-none overflow-y-auto rounded-xl pr-14',
-	                compact
-	                  ? 'min-h-[48px] px-3 py-2.5 text-sm md:text-xs'
-	                  : 'min-h-[56px] px-4 py-4 text-sm',
-	                'message-input bg-sidebar-accent/50',
-	                'text-transparent caret-foreground placeholder:text-muted-foreground',
-	                'outline-none focus:ring-2 focus:ring-primary/50',
-	                'disabled:cursor-not-allowed disabled:opacity-50'
+              autoCorrect="off"
+              autoCapitalize="off"
+              className={cn(
+                'relative z-10 max-h-40 w-full resize-none overflow-y-auto rounded-xl pr-14',
+                compact
+                  ? 'min-h-[48px] px-3 py-2.5 text-sm md:text-xs'
+                  : 'min-h-[56px] px-4 py-4 text-sm',
+                'message-input bg-sidebar-accent/50',
+                'text-transparent caret-foreground placeholder:text-muted-foreground',
+                'outline-none focus:ring-2 focus:ring-primary/50',
+                'disabled:cursor-not-allowed disabled:opacity-50'
               )}
             />
           </>
@@ -384,16 +389,16 @@ export function MessageInput({
             onKeyDown={handleKeyDown}
             placeholder={placeholderText}
             disabled={sending || disabled}
-	            rows={1}
-	            className={cn(
-	              'max-h-40 w-full resize-none overflow-y-auto rounded-xl pr-14',
-	              compact
-	                ? 'min-h-[48px] px-3 py-2.5 text-sm md:text-xs'
-	                : 'min-h-[56px] px-4 py-4 text-sm',
-	              'message-input bg-sidebar-accent/50',
-	              'text-foreground placeholder:text-muted-foreground',
-	              'outline-none focus:ring-2 focus:ring-primary/50',
-	              'disabled:cursor-not-allowed disabled:opacity-50'
+            rows={1}
+            className={cn(
+              'max-h-40 w-full resize-none overflow-y-auto rounded-xl pr-14',
+              compact
+                ? 'min-h-[48px] px-3 py-2.5 text-sm md:text-xs'
+                : 'min-h-[56px] px-4 py-4 text-sm',
+              'message-input bg-sidebar-accent/50',
+              'text-foreground placeholder:text-muted-foreground',
+              'outline-none focus:ring-2 focus:ring-primary/50',
+              'disabled:cursor-not-allowed disabled:opacity-50'
             )}
           />
         )}

--- a/apps/web/src/components/chats/MessageList.tsx
+++ b/apps/web/src/components/chats/MessageList.tsx
@@ -43,6 +43,7 @@ interface MessageListProps {
   authenticated: boolean;
   topSentinelRef: React.RefObject<HTMLDivElement | null>;
   messagesEndRef: React.RefObject<HTMLDivElement | null>;
+  density?: 'default' | 'compact';
   /** Callback when a message tag is clicked */
   onTagClick?: (tag: MessageTag, messageId: string) => void;
 }
@@ -57,6 +58,7 @@ export function MessageList({
   authenticated,
   topSentinelRef,
   messagesEndRef,
+  density = 'default',
   onTagClick,
 }: MessageListProps) {
   // Extract usernames from participants for @mention formatting
@@ -128,6 +130,7 @@ export function MessageList({
                 isCurrentUser={false}
                 validMentions={validMentions}
                 isThinking={msg.isThinking}
+                density={density}
                 onTagClick={onTagClick}
               />
             );
@@ -148,6 +151,7 @@ export function MessageList({
                 isCurrentUser={isCurrentUser}
                 validMentions={validMentions}
                 isThinking={msg.isThinking}
+                density={density}
                 onTagClick={onTagClick}
               />
             );

--- a/apps/web/src/components/chats/TeamChatView.tsx
+++ b/apps/web/src/components/chats/TeamChatView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { MessageTag } from '@babylon/shared';
+import { cn, type MessageTag } from '@babylon/shared';
 import {
   Brain,
   MessageCircle,
@@ -31,7 +31,13 @@ interface ThinkingAgentInfo {
 }
 
 /** Typing indicator component - shows bouncing dots for users typing */
-function TypingIndicator({ typingUsers }: { typingUsers: TypingUserInfo[] }) {
+function TypingIndicator({
+  typingUsers,
+  density,
+}: {
+  typingUsers: TypingUserInfo[];
+  density: 'default' | 'compact';
+}) {
   const first = typingUsers[0];
   const second = typingUsers[1];
 
@@ -45,7 +51,14 @@ function TypingIndicator({ typingUsers }: { typingUsers: TypingUserInfo[] }) {
         : `${first.displayName} and ${typingUsers.length - 1} others are typing...`;
 
   return (
-    <div className="flex items-center gap-2 px-4 py-2 text-muted-foreground text-sm">
+    <div
+      className={cn(
+        'flex items-center gap-2 text-muted-foreground',
+        density === 'compact'
+          ? 'px-3 py-1.5 text-sm md:text-xs'
+          : 'px-4 py-2 text-sm'
+      )}
+    >
       <span className="flex gap-1">
         <span className="animate-bounce" style={{ animationDelay: '0ms' }}>
           •
@@ -68,17 +81,27 @@ function TypingIndicator({ typingUsers }: { typingUsers: TypingUserInfo[] }) {
  */
 function ThinkingIndicator({
   thinkingAgents,
+  density,
 }: {
   thinkingAgents: ThinkingAgentInfo[];
+  density: 'default' | 'compact';
 }) {
   if (thinkingAgents.length === 0) return null;
 
   return (
-    <div className="space-y-1 px-4 py-2">
+    <div
+      className={cn(
+        'space-y-1',
+        density === 'compact' ? 'px-3 py-1.5' : 'px-4 py-2'
+      )}
+    >
       {thinkingAgents.map((agent) => (
         <div
           key={agent.agentId}
-          className="flex items-center gap-2 text-blue-500 text-sm"
+          className={cn(
+            'flex items-center gap-2 text-blue-500',
+            density === 'compact' ? 'text-sm md:text-xs' : 'text-sm'
+          )}
         >
           <Brain className="h-4 w-4 animate-pulse" />
           <span className="font-medium">{agent.agentName}</span>
@@ -98,6 +121,7 @@ interface TeamChatViewProps {
   sseConnected: boolean;
   /** When embedding in another container that already has a header (e.g. terminal tabs). */
   hideHeader?: boolean;
+  density?: 'default' | 'compact';
   loading: boolean;
   isLoadingMore: boolean;
   hasMore: boolean;
@@ -141,6 +165,7 @@ export function TeamChatView({
   authenticated,
   sseConnected,
   hideHeader = false,
+  density = 'default',
   loading,
   isLoadingMore,
   hasMore,
@@ -162,6 +187,7 @@ export function TeamChatView({
   onToggleRightSidebar,
   onTagClick,
 }: TeamChatViewProps) {
+  const compact = density === 'compact';
   // Empty state when no chat selected
   if (!chatDetails) {
     return (
@@ -247,7 +273,10 @@ export function TeamChatView({
       {/* Messages - Scrollable */}
       <div
         data-chat-messages-container
-        className="relative min-h-0 min-w-0 flex-1 space-y-4 overflow-y-auto overflow-x-hidden px-4 py-3"
+        className={cn(
+          'relative min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden',
+          compact ? 'space-y-2 px-3 py-2' : 'space-y-4 px-4 py-3'
+        )}
         onScroll={(e) => onScroll?.(e.currentTarget)}
       >
         <MessageList
@@ -260,6 +289,7 @@ export function TeamChatView({
           authenticated={authenticated}
           topSentinelRef={topSentinelRef}
           messagesEndRef={messagesEndRef}
+          density={density}
           onTagClick={onTagClick}
         />
       </div>
@@ -268,12 +298,12 @@ export function TeamChatView({
       <div className="shrink-0">
         {/* Thinking Indicator - shown when agents are processing complex queries */}
         {thinkingAgents.length > 0 && (
-          <ThinkingIndicator thinkingAgents={thinkingAgents} />
+          <ThinkingIndicator thinkingAgents={thinkingAgents} density={density} />
         )}
 
         {/* Typing Indicator - shown when users/agents are typing simple responses */}
         {typingUsers.length > 0 && (
-          <TypingIndicator typingUsers={typingUsers} />
+          <TypingIndicator typingUsers={typingUsers} density={density} />
         )}
 
         {/* Feedback Messages */}
@@ -282,7 +312,7 @@ export function TeamChatView({
         )}
 
         {/* Input Separator */}
-        <div className="px-4">
+        <div className={compact ? 'px-3' : 'px-4'}>
           <Separator />
         </div>
 
@@ -293,6 +323,7 @@ export function TeamChatView({
           onSend={onSendMessage}
           sending={sending}
           authenticated={authenticated}
+          density={density}
           placeholder="Ask the swarm...(Type @ to mention agents)"
           mentionableMembers={agents}
         />

--- a/apps/web/src/components/chats/TeamChatView.tsx
+++ b/apps/web/src/components/chats/TeamChatView.tsx
@@ -298,7 +298,10 @@ export function TeamChatView({
       <div className="shrink-0">
         {/* Thinking Indicator - shown when agents are processing complex queries */}
         {thinkingAgents.length > 0 && (
-          <ThinkingIndicator thinkingAgents={thinkingAgents} density={density} />
+          <ThinkingIndicator
+            thinkingAgents={thinkingAgents}
+            density={density}
+          />
         )}
 
         {/* Typing Indicator - shown when users/agents are typing simple responses */}

--- a/apps/web/src/components/markets/AssetTradesFeed.tsx
+++ b/apps/web/src/components/markets/AssetTradesFeed.tsx
@@ -149,13 +149,16 @@ interface AssetTradesFeedProps {
   marketType: 'prediction' | 'perp';
   assetId: string; // marketId for predictions, ticker for perps
   containerRef?: React.RefObject<HTMLDivElement | null>;
+  density?: 'default' | 'compact';
 }
 
 export function AssetTradesFeed({
   marketType,
   assetId,
   containerRef,
+  density = 'default',
 }: AssetTradesFeedProps) {
+  const compact = density === 'compact';
   const [trades, setTrades] = useState<Trade[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -375,11 +378,16 @@ export function AssetTradesFeed({
 
   if (loading) {
     return (
-      <div className="space-y-3">
+      <div className={cn(compact ? 'space-y-2' : 'space-y-3')}>
         {[...Array(5)].map((_, i) => (
-          <div key={i} className="rounded-lg bg-muted/30 p-4">
-            <div className="flex items-start gap-3">
-              <Skeleton className="h-10 w-10 rounded-full" />
+          <div
+            key={i}
+            className={cn('rounded-lg bg-muted/30', compact ? 'p-3' : 'p-4')}
+          >
+            <div className={cn('flex items-start', compact ? 'gap-2' : 'gap-3')}>
+              <Skeleton
+                className={cn(compact ? 'h-8 w-8' : 'h-10 w-10', 'rounded-full')}
+              />
               <div className="flex-1 space-y-2">
                 <Skeleton className="h-4 w-32" />
                 <Skeleton className="h-4 w-full" />
@@ -421,13 +429,15 @@ export function AssetTradesFeed({
   if (trades.length === 0) {
     return (
       <div className="py-12 text-center">
-        <p className="text-muted-foreground">No trades yet for this market</p>
+        <p className={cn('text-muted-foreground', compact ? 'text-xs' : 'text-sm')}>
+          No trades yet for this market
+        </p>
       </div>
     );
   }
 
   return (
-    <div className="space-y-3">
+    <div className={cn(compact ? 'space-y-2' : 'space-y-3')}>
       {needsRefresh && !isAtTop && (
         <button
           type="button"
@@ -446,6 +456,7 @@ export function AssetTradesFeed({
           trade={trade}
           formatCurrency={formatCurrency}
           formatTime={formatTime}
+          density={density}
         />
       ))}
 
@@ -473,10 +484,12 @@ interface TradeCardProps {
   trade: Trade;
   formatCurrency: (value: string | number) => string;
   formatTime: (timestamp: string) => string;
+  density: 'default' | 'compact';
 }
 
-function TradeCard({ trade, formatCurrency, formatTime }: TradeCardProps) {
+function TradeCard({ trade, formatCurrency, formatTime, density }: TradeCardProps) {
   const user = trade.user;
+  const compact = density === 'compact';
   const profileUrl = user?.isActor
     ? `/profile/${user.id}`
     : user?.username
@@ -484,19 +497,29 @@ function TradeCard({ trade, formatCurrency, formatTime }: TradeCardProps) {
       : '#';
 
   return (
-    <div className="rounded-lg bg-muted/30 p-4 transition-colors hover:bg-muted/50">
-      <div className="flex items-start gap-3">
+    <div
+      className={cn(
+        'rounded-lg bg-muted/30 transition-colors hover:bg-muted/50',
+        compact ? 'p-3' : 'p-4'
+      )}
+    >
+      <div className={cn('flex items-start', compact ? 'gap-2' : 'gap-3')}>
         {/* User Avatar */}
         <Link href={user ? profileUrl : '#'} className="flex-shrink-0">
           {user?.profileImageUrl ? (
             <img
               src={user.profileImageUrl}
               alt={user.displayName || user.username || 'User'}
-              className="h-10 w-10 rounded-full"
+              className={cn(compact ? 'h-8 w-8' : 'h-10 w-10', 'rounded-full')}
             />
           ) : (
-            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/20">
-              <UserIcon className="h-5 w-5 text-primary" />
+            <div
+              className={cn(
+                'flex items-center justify-center rounded-full bg-primary/20',
+                compact ? 'h-8 w-8' : 'h-10 w-10'
+              )}
+            >
+              <UserIcon className={cn(compact ? 'h-4 w-4' : 'h-5 w-5', 'text-primary')} />
             </div>
           )}
         </Link>
@@ -507,7 +530,10 @@ function TradeCard({ trade, formatCurrency, formatTime }: TradeCardProps) {
           <div className="mb-1 flex items-center gap-2">
             <Link
               href={user ? profileUrl : '#'}
-              className="truncate font-medium text-sm hover:underline"
+              className={cn(
+                'truncate font-medium hover:underline',
+                compact ? 'text-sm md:text-xs' : 'text-sm'
+              )}
             >
               {user?.displayName || user?.username || 'Unknown'}
             </Link>
@@ -527,18 +553,24 @@ function TradeCard({ trade, formatCurrency, formatTime }: TradeCardProps) {
             <PositionTradeContent
               trade={trade}
               formatCurrency={formatCurrency}
+              density={density}
             />
           )}
           {trade.type === 'perp' && (
-            <PerpTradeContent trade={trade} formatCurrency={formatCurrency} />
+            <PerpTradeContent
+              trade={trade}
+              formatCurrency={formatCurrency}
+              density={density}
+            />
           )}
           {trade.type === 'npc' && (
-            <NPCTradeContent trade={trade} formatCurrency={formatCurrency} />
+            <NPCTradeContent trade={trade} formatCurrency={formatCurrency} density={density} />
           )}
           {trade.type === 'balance' && (
             <BalanceTradeContent
               trade={trade}
               formatCurrency={formatCurrency}
+              density={density}
             />
           )}
         </div>
@@ -550,14 +582,17 @@ function TradeCard({ trade, formatCurrency, formatTime }: TradeCardProps) {
 function PositionTradeContent({
   trade,
   formatCurrency,
+  density,
 }: {
   trade: PositionTrade;
   formatCurrency: (v: number) => string;
+  density: 'default' | 'compact';
 }) {
   const isYes = trade.side === 'YES';
+  const compact = density === 'compact';
 
   return (
-    <div className="text-sm">
+    <div className={cn(compact ? 'text-sm md:text-xs' : 'text-sm')}>
       <div className="mb-1 flex items-center gap-2">
         <span
           className={cn(
@@ -583,15 +618,18 @@ function PositionTradeContent({
 function PerpTradeContent({
   trade,
   formatCurrency,
+  density,
 }: {
   trade: PerpTrade;
   formatCurrency: (v: number) => string;
+  density: 'default' | 'compact';
 }) {
   const isLong = trade.side === 'long';
   const isProfitable = trade.unrealizedPnL >= 0;
+  const compact = density === 'compact';
 
   return (
-    <div className="text-sm">
+    <div className={cn(compact ? 'text-sm md:text-xs' : 'text-sm')}>
       <div className="mb-1 flex items-center gap-2">
         <span
           className={cn(
@@ -642,12 +680,15 @@ function PerpTradeContent({
 function NPCTradeContent({
   trade,
   formatCurrency,
+  density,
 }: {
   trade: NPCTrade;
   formatCurrency: (v: number) => string;
+  density: 'default' | 'compact';
 }) {
+  const compact = density === 'compact';
   return (
-    <div className="text-sm">
+    <div className={cn(compact ? 'text-sm md:text-xs' : 'text-sm')}>
       <div className="mb-1 flex items-center gap-2">
         <span className="font-medium">{trade.action}</span>
         <ArrowUpDown className="h-3 w-3 text-muted-foreground" />
@@ -685,10 +726,13 @@ function NPCTradeContent({
 function BalanceTradeContent({
   trade,
   formatCurrency,
+  density,
 }: {
   trade: BalanceTrade;
   formatCurrency: (v: number) => string;
+  density: 'default' | 'compact';
 }) {
+  const compact = density === 'compact';
   const getActionLabel = (type: string) => {
     switch (type) {
       case 'pred_buy':
@@ -707,7 +751,7 @@ function BalanceTradeContent({
   };
 
   return (
-    <div className="text-sm">
+    <div className={cn(compact ? 'text-sm md:text-xs' : 'text-sm')}>
       <div className="mb-1">
         <span className="font-medium">
           {getActionLabel(trade.transactionType)}

--- a/apps/web/src/components/markets/AssetTradesFeed.tsx
+++ b/apps/web/src/components/markets/AssetTradesFeed.tsx
@@ -384,9 +384,14 @@ export function AssetTradesFeed({
             key={i}
             className={cn('rounded-lg bg-muted/30', compact ? 'p-3' : 'p-4')}
           >
-            <div className={cn('flex items-start', compact ? 'gap-2' : 'gap-3')}>
+            <div
+              className={cn('flex items-start', compact ? 'gap-2' : 'gap-3')}
+            >
               <Skeleton
-                className={cn(compact ? 'h-8 w-8' : 'h-10 w-10', 'rounded-full')}
+                className={cn(
+                  compact ? 'h-8 w-8' : 'h-10 w-10',
+                  'rounded-full'
+                )}
               />
               <div className="flex-1 space-y-2">
                 <Skeleton className="h-4 w-32" />
@@ -429,7 +434,12 @@ export function AssetTradesFeed({
   if (trades.length === 0) {
     return (
       <div className="py-12 text-center">
-        <p className={cn('text-muted-foreground', compact ? 'text-xs' : 'text-sm')}>
+        <p
+          className={cn(
+            'text-muted-foreground',
+            compact ? 'text-xs' : 'text-sm'
+          )}
+        >
           No trades yet for this market
         </p>
       </div>
@@ -487,7 +497,12 @@ interface TradeCardProps {
   density: 'default' | 'compact';
 }
 
-function TradeCard({ trade, formatCurrency, formatTime, density }: TradeCardProps) {
+function TradeCard({
+  trade,
+  formatCurrency,
+  formatTime,
+  density,
+}: TradeCardProps) {
   const user = trade.user;
   const compact = density === 'compact';
   const profileUrl = user?.isActor
@@ -519,7 +534,9 @@ function TradeCard({ trade, formatCurrency, formatTime, density }: TradeCardProp
                 compact ? 'h-8 w-8' : 'h-10 w-10'
               )}
             >
-              <UserIcon className={cn(compact ? 'h-4 w-4' : 'h-5 w-5', 'text-primary')} />
+              <UserIcon
+                className={cn(compact ? 'h-4 w-4' : 'h-5 w-5', 'text-primary')}
+              />
             </div>
           )}
         </Link>
@@ -564,7 +581,11 @@ function TradeCard({ trade, formatCurrency, formatTime, density }: TradeCardProp
             />
           )}
           {trade.type === 'npc' && (
-            <NPCTradeContent trade={trade} formatCurrency={formatCurrency} density={density} />
+            <NPCTradeContent
+              trade={trade}
+              formatCurrency={formatCurrency}
+              density={density}
+            />
           )}
           {trade.type === 'balance' && (
             <BalanceTradeContent

--- a/apps/web/src/components/markets/AssetTradesFeed.tsx
+++ b/apps/web/src/components/markets/AssetTradesFeed.tsx
@@ -14,7 +14,7 @@ import {
   User as UserIcon,
 } from 'lucide-react';
 import Link from 'next/link';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Skeleton } from '@/components/shared/Skeleton';
 import { usePredictionMarketStream } from '@/hooks/usePredictionMarketStream';
 
@@ -497,7 +497,8 @@ interface TradeCardProps {
   density: 'default' | 'compact';
 }
 
-function TradeCard({
+/** Memoized trade card to prevent unnecessary re-renders in large lists */
+const TradeCard = memo(function TradeCard({
   trade,
   formatCurrency,
   formatTime,
@@ -598,7 +599,7 @@ function TradeCard({
       </div>
     </div>
   );
-}
+});
 
 function PositionTradeContent({
   trade,

--- a/apps/web/src/components/markets/PerpPositionsList.tsx
+++ b/apps/web/src/components/markets/PerpPositionsList.tsx
@@ -162,7 +162,12 @@ export function PerpPositionsList({
 
   if (positions.length === 0) {
     return (
-      <div className={cn('text-center text-muted-foreground', compact ? 'py-6' : 'py-8')}>
+      <div
+        className={cn(
+          'text-center text-muted-foreground',
+          compact ? 'py-6' : 'py-8'
+        )}
+      >
         <p>No open positions</p>
         <p className={cn(compact ? 'mt-1 text-xs' : 'mt-1 text-sm')}>
           Open a long or short position to get started

--- a/apps/web/src/components/markets/PerpPositionsList.tsx
+++ b/apps/web/src/components/markets/PerpPositionsList.tsx
@@ -48,12 +48,15 @@ type PerpPosition = DisplayPerpPosition;
 interface PerpPositionsListProps {
   positions: PerpPosition[];
   onPositionClosed?: () => void;
+  density?: 'default' | 'compact';
 }
 
 export function PerpPositionsList({
   positions,
   onPositionClosed,
+  density = 'default',
 }: PerpPositionsListProps) {
+  const compact = density === 'compact';
   const [closingId, setClosingId] = useState<string | null>(null);
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
   const [pendingClose, setPendingClose] = useState<{
@@ -159,9 +162,9 @@ export function PerpPositionsList({
 
   if (positions.length === 0) {
     return (
-      <div className="py-8 text-center text-muted-foreground">
+      <div className={cn('text-center text-muted-foreground', compact ? 'py-6' : 'py-8')}>
         <p>No open positions</p>
-        <p className="mt-1 text-sm">
+        <p className={cn(compact ? 'mt-1 text-xs' : 'mt-1 text-sm')}>
           Open a long or short position to get started
         </p>
       </div>
@@ -169,7 +172,7 @@ export function PerpPositionsList({
   }
 
   return (
-    <div className="space-y-3">
+    <div className={cn(compact ? 'space-y-2' : 'space-y-3')}>
       {positionsWithPnL.map(
         ({
           position,
@@ -185,12 +188,18 @@ export function PerpPositionsList({
             <div
               key={position.id}
               className={cn(
-                'rounded p-4 transition-all',
+                'rounded transition-all',
+                compact ? 'p-3' : 'p-4',
                 isNearLiquidation ? 'bg-red-600/10' : 'bg-muted/40'
               )}
             >
               {/* Header */}
-              <div className="mb-3 flex items-center justify-between">
+              <div
+                className={cn(
+                  'flex items-center justify-between',
+                  compact ? 'mb-2' : 'mb-3'
+                )}
+              >
                 <div className="flex items-center gap-2">
                   <span
                     className={cn(
@@ -222,7 +231,7 @@ export function PerpPositionsList({
                 <div className="text-right">
                   <div
                     className={cn(
-                      'font-bold text-lg',
+                      compact ? 'font-bold text-base' : 'font-bold text-lg',
                       pnl >= 0 ? 'text-green-600' : 'text-red-600'
                     )}
                   >
@@ -243,7 +252,12 @@ export function PerpPositionsList({
 
               {/* Liquidation Warning */}
               {isNearLiquidation && (
-                <div className="mb-3 flex items-center gap-2 rounded bg-red-600/20 p-2">
+                <div
+                  className={cn(
+                    'flex items-center gap-2 rounded bg-red-600/20',
+                    compact ? 'mb-2 p-1.5' : 'mb-3 p-2'
+                  )}
+                >
                   <AlertTriangle className="h-4 w-4 flex-shrink-0 text-red-600" />
                   <p className="font-medium text-red-600 text-xs">
                     Near liquidation! {liquidationDistance.toFixed(2)}% away
@@ -252,7 +266,12 @@ export function PerpPositionsList({
               )}
 
               {/* Stats Grid */}
-              <div className="mb-3 grid grid-cols-2 gap-2 text-xs">
+              <div
+                className={cn(
+                  'grid grid-cols-2 text-xs',
+                  compact ? 'mb-2 gap-1.5' : 'mb-3 gap-2'
+                )}
+              >
                 <div>
                   <div className="text-muted-foreground">Entry</div>
                   <div className="font-medium text-foreground">

--- a/apps/web/src/components/markets/PerpPriceChart.tsx
+++ b/apps/web/src/components/markets/PerpPriceChart.tsx
@@ -99,6 +99,9 @@ export function PerpPriceChart({
     },
   });
 
+  const hasData = data.length > 0;
+  const unavailableReason = chartInitError ?? chartBaseError;
+
   // Filter and prepare data based on time range
   const chartData = useMemo(() => {
     if (!data.length) return [];
@@ -282,39 +285,6 @@ export function PerpPriceChart({
     }
   }, [currentPrice]);
 
-  // Loading state when no data
-  if (!data.length) {
-    return (
-      <div className="flex h-[400px] items-center justify-center text-muted-foreground">
-        <div className="text-center">
-          <div className="text-sm">Loading chart data...</div>
-        </div>
-      </div>
-    );
-  }
-
-  if (chartInitError) {
-    return (
-      <div className="flex h-[400px] items-center justify-center text-muted-foreground">
-        <div className="text-center">
-          <div className="text-sm">Chart unavailable</div>
-          <div className="mt-1 text-xs">{chartInitError}</div>
-        </div>
-      </div>
-    );
-  }
-
-  if (chartBaseError) {
-    return (
-      <div className="flex h-[400px] items-center justify-center text-muted-foreground">
-        <div className="text-center">
-          <div className="text-sm">Chart unavailable</div>
-          <div className="mt-1 text-xs">{chartBaseError}</div>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div
       className={cn(
@@ -371,14 +341,29 @@ export function PerpPriceChart({
           ref={chartContainerRef}
           className="h-[400px] w-full rounded-lg bg-muted/10"
         />
-        {!chart && (
+        {!chart && !unavailableReason && (
           <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
             <div className="rounded-lg bg-card/90 px-4 py-2 text-muted-foreground text-sm">
               Initializing chart…
             </div>
           </div>
         )}
-        {chartData.length === 0 && data.length > 0 && (
+        {!hasData && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+            <div className="rounded-lg bg-card/90 px-4 py-2 text-muted-foreground text-sm">
+              Loading chart data…
+            </div>
+          </div>
+        )}
+        {unavailableReason && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+            <div className="rounded-lg bg-card/90 px-4 py-2 text-center text-muted-foreground text-sm">
+              <div className="font-semibold">Chart unavailable</div>
+              <div className="mt-1 text-xs">{unavailableReason}</div>
+            </div>
+          </div>
+        )}
+        {chartData.length === 0 && hasData && (
           <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
             <div className="rounded-lg bg-card/90 px-4 py-2 text-muted-foreground text-sm">
               No data in selected time range

--- a/apps/web/src/components/markets/PerpPriceChart.tsx
+++ b/apps/web/src/components/markets/PerpPriceChart.tsx
@@ -48,6 +48,12 @@ interface PerpPriceChartProps {
   showBrush?: boolean;
   /** Whether to show the header (price + range controls). Defaults to true. */
   showHeader?: boolean;
+  /**
+   * Chart sizing behavior.
+   * - fixed: uses a fixed-height chart (good for pages)
+   * - fill: stretches to the available parent height (good for flex layouts like the terminal)
+   */
+  height?: 'fixed' | 'fill';
   /** Optional className for the container */
   className?: string;
 }
@@ -77,6 +83,7 @@ export function PerpPriceChart({
   timeRange,
   onTimeRangeChange,
   showHeader = true,
+  height = 'fixed',
   className,
 }: PerpPriceChartProps) {
   const [chartInitError, setChartInitError] = useState<string | null>(null);
@@ -99,6 +106,7 @@ export function PerpPriceChart({
     },
   });
 
+  const fillHeight = height === 'fill';
   const hasData = data.length > 0;
   const unavailableReason = chartInitError ?? chartBaseError;
 
@@ -288,14 +296,15 @@ export function PerpPriceChart({
   return (
     <div
       className={cn(
-        'flex h-full w-full flex-col',
-        showHeader ? 'space-y-3' : '',
+        'flex w-full',
+        fillHeight ? 'h-full min-h-0 flex-col gap-3' : 'h-full flex-col',
+        showHeader && !fillHeight ? 'space-y-3' : '',
         className
       )}
     >
       {/* Header with price info and time range selector */}
       {showHeader && (
-        <div className="flex flex-shrink-0 flex-wrap items-center justify-between gap-3 px-1">
+        <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 px-1">
           <div className="flex items-center gap-3">
             <div>
               <div className="font-bold text-2xl">
@@ -336,10 +345,13 @@ export function PerpPriceChart({
       )}
 
       {/* Chart container */}
-      <div className="relative">
+      <div className={cn('relative', fillHeight && 'min-h-0 flex-1')}>
         <div
           ref={chartContainerRef}
-          className="h-[400px] w-full rounded-lg bg-muted/10"
+          className={cn(
+            'w-full rounded-lg bg-muted/10',
+            fillHeight ? 'h-full min-h-[240px]' : 'h-[400px]'
+          )}
         />
         {!chart && !unavailableReason && (
           <div className="pointer-events-none absolute inset-0 flex items-center justify-center">

--- a/apps/web/src/components/markets/PerpPriceChart.tsx
+++ b/apps/web/src/components/markets/PerpPriceChart.tsx
@@ -353,35 +353,33 @@ export function PerpPriceChart({
             fillHeight ? 'h-full min-h-[240px]' : 'h-[400px]'
           )}
         />
-        {!chart && !unavailableReason && (
-          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-            <div className="rounded-lg bg-card/90 px-4 py-2 text-muted-foreground text-sm">
-              Initializing chart…
-            </div>
-          </div>
-        )}
-        {!hasData && (
-          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-            <div className="rounded-lg bg-card/90 px-4 py-2 text-muted-foreground text-sm">
-              Loading chart data…
-            </div>
-          </div>
-        )}
-        {unavailableReason && (
+        {/* Overlay states are mutually exclusive - priority: unavailable > loading > initializing > empty */}
+        {unavailableReason ? (
           <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
             <div className="rounded-lg bg-card/90 px-4 py-2 text-center text-muted-foreground text-sm">
               <div className="font-semibold">Chart unavailable</div>
               <div className="mt-1 text-xs">{unavailableReason}</div>
             </div>
           </div>
-        )}
-        {chartData.length === 0 && hasData && (
+        ) : !hasData ? (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+            <div className="rounded-lg bg-card/90 px-4 py-2 text-muted-foreground text-sm">
+              Loading chart data…
+            </div>
+          </div>
+        ) : !chart ? (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+            <div className="rounded-lg bg-card/90 px-4 py-2 text-muted-foreground text-sm">
+              Initializing chart…
+            </div>
+          </div>
+        ) : chartData.length === 0 ? (
           <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
             <div className="rounded-lg bg-card/90 px-4 py-2 text-muted-foreground text-sm">
               No data in selected time range
             </div>
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/apps/web/src/components/markets/PredictionPositionsList.tsx
+++ b/apps/web/src/components/markets/PredictionPositionsList.tsx
@@ -49,13 +49,16 @@ type PredictionPosition = UserPredictionPosition;
 interface PredictionPositionsListProps {
   positions: PredictionPosition[];
   onPositionSold?: () => void;
+  density?: 'default' | 'compact';
 }
 
 export function PredictionPositionsList({
   positions,
   onPositionSold,
+  density = 'default',
 }: PredictionPositionsListProps) {
   const { getAccessToken } = usePrivy();
+  const compact = density === 'compact';
   const [sellingId, setSellingId] = useState<string | null>(null);
   const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
   const [pendingSell, setPendingSell] = useState<{
@@ -153,15 +156,17 @@ export function PredictionPositionsList({
 
   if (positions.length === 0) {
     return (
-      <div className="py-8 text-center text-muted-foreground">
+      <div className={cn('text-center text-muted-foreground', compact ? 'py-6' : 'py-8')}>
         <p>No prediction positions</p>
-        <p className="mt-1 text-sm">Buy YES or NO shares to start betting</p>
+        <p className={cn(compact ? 'mt-1 text-xs' : 'mt-1 text-sm')}>
+          Buy YES or NO shares to start betting
+        </p>
       </div>
     );
   }
 
   return (
-    <div className="space-y-3">
+    <div className={cn(compact ? 'space-y-2' : 'space-y-3')}>
       {positions.map((position) => {
         const currentValue =
           position.currentValue ?? position.shares * position.currentPrice;
@@ -174,8 +179,11 @@ export function PredictionPositionsList({
         const isSelling = sellingId === position.id;
 
         return (
-          <div key={position.id} className="rounded bg-muted/40 p-4">
-            <div className="mb-3 flex items-center justify-between">
+          <div
+            key={position.id}
+            className={cn('rounded bg-muted/40', compact ? 'p-3' : 'p-4')}
+          >
+            <div className={cn('flex items-center justify-between', compact ? 'mb-2' : 'mb-3')}>
               <div className="flex items-center gap-2">
                 <span
                   className={cn(
@@ -204,7 +212,7 @@ export function PredictionPositionsList({
               <div className="text-right">
                 <div
                   className={cn(
-                    'font-bold text-lg',
+                    compact ? 'font-bold text-base' : 'font-bold text-lg',
                     unrealizedPnL >= 0 ? 'text-green-600' : 'text-red-600'
                   )}
                 >
@@ -223,11 +231,21 @@ export function PredictionPositionsList({
               </div>
             </div>
 
-            <p className="mb-3 font-medium text-foreground text-sm">
+            <p
+              className={cn(
+                'font-medium text-foreground',
+                compact ? 'mb-2 text-sm leading-snug md:text-xs' : 'mb-3 text-sm'
+              )}
+            >
               {position.question}
             </p>
 
-            <div className="mb-3 grid grid-cols-2 gap-2 text-xs">
+            <div
+              className={cn(
+                'grid grid-cols-2 text-xs',
+                compact ? 'mb-2 gap-1.5' : 'mb-3 gap-2'
+              )}
+            >
               <div>
                 <div className="text-muted-foreground">Shares</div>
                 <div className="font-medium text-foreground">
@@ -254,8 +272,8 @@ export function PredictionPositionsList({
               </div>
             </div>
 
-            {!position.resolved ? (
-              <button
+	            {!position.resolved ? (
+	              <button
                 onClick={() =>
                   handleSellClick(
                     position,
@@ -263,19 +281,27 @@ export function PredictionPositionsList({
                     unrealizedPnL,
                     pnlPercent
                   )
-                }
-                disabled={isSelling || position.shares < 0.01}
-                className="w-full cursor-pointer rounded bg-muted py-2 font-medium text-foreground transition-all hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-              >
+	                }
+	                disabled={isSelling || position.shares < 0.01}
+	                className={cn(
+	                  'w-full cursor-pointer rounded bg-muted font-medium text-foreground transition-all hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50',
+	                  compact ? 'py-1.5 text-sm md:text-xs' : 'py-2 text-sm'
+	                )}
+	              >
                 {isSelling
                   ? 'Selling...'
                   : position.shares < 0.01
                     ? 'Position Too Small'
                     : 'Sell Shares'}
               </button>
-            ) : (
-              <div className="py-2 text-center font-medium text-sm">
-                <span className="text-muted-foreground">Resolved: </span>
+	            ) : (
+	              <div
+	                className={cn(
+	                  'py-2 text-center font-medium',
+	                  compact ? 'text-sm md:text-xs' : 'text-sm'
+	                )}
+	              >
+	                <span className="text-muted-foreground">Resolved: </span>
                 <span
                   className={
                     position.resolution ? 'text-green-600' : 'text-red-600'

--- a/apps/web/src/components/markets/PredictionPositionsList.tsx
+++ b/apps/web/src/components/markets/PredictionPositionsList.tsx
@@ -156,7 +156,12 @@ export function PredictionPositionsList({
 
   if (positions.length === 0) {
     return (
-      <div className={cn('text-center text-muted-foreground', compact ? 'py-6' : 'py-8')}>
+      <div
+        className={cn(
+          'text-center text-muted-foreground',
+          compact ? 'py-6' : 'py-8'
+        )}
+      >
         <p>No prediction positions</p>
         <p className={cn(compact ? 'mt-1 text-xs' : 'mt-1 text-sm')}>
           Buy YES or NO shares to start betting
@@ -183,7 +188,12 @@ export function PredictionPositionsList({
             key={position.id}
             className={cn('rounded bg-muted/40', compact ? 'p-3' : 'p-4')}
           >
-            <div className={cn('flex items-center justify-between', compact ? 'mb-2' : 'mb-3')}>
+            <div
+              className={cn(
+                'flex items-center justify-between',
+                compact ? 'mb-2' : 'mb-3'
+              )}
+            >
               <div className="flex items-center gap-2">
                 <span
                   className={cn(
@@ -234,7 +244,9 @@ export function PredictionPositionsList({
             <p
               className={cn(
                 'font-medium text-foreground',
-                compact ? 'mb-2 text-sm leading-snug md:text-xs' : 'mb-3 text-sm'
+                compact
+                  ? 'mb-2 text-sm leading-snug md:text-xs'
+                  : 'mb-3 text-sm'
               )}
             >
               {position.question}
@@ -272,8 +284,8 @@ export function PredictionPositionsList({
               </div>
             </div>
 
-	            {!position.resolved ? (
-	              <button
+            {!position.resolved ? (
+              <button
                 onClick={() =>
                   handleSellClick(
                     position,
@@ -281,27 +293,27 @@ export function PredictionPositionsList({
                     unrealizedPnL,
                     pnlPercent
                   )
-	                }
-	                disabled={isSelling || position.shares < 0.01}
-	                className={cn(
-	                  'w-full cursor-pointer rounded bg-muted font-medium text-foreground transition-all hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50',
-	                  compact ? 'py-1.5 text-sm md:text-xs' : 'py-2 text-sm'
-	                )}
-	              >
+                }
+                disabled={isSelling || position.shares < 0.01}
+                className={cn(
+                  'w-full cursor-pointer rounded bg-muted font-medium text-foreground transition-all hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50',
+                  compact ? 'py-1.5 text-sm md:text-xs' : 'py-2 text-sm'
+                )}
+              >
                 {isSelling
                   ? 'Selling...'
                   : position.shares < 0.01
                     ? 'Position Too Small'
                     : 'Sell Shares'}
               </button>
-	            ) : (
-	              <div
-	                className={cn(
-	                  'py-2 text-center font-medium',
-	                  compact ? 'text-sm md:text-xs' : 'text-sm'
-	                )}
-	              >
-	                <span className="text-muted-foreground">Resolved: </span>
+            ) : (
+              <div
+                className={cn(
+                  'py-2 text-center font-medium',
+                  compact ? 'text-sm md:text-xs' : 'text-sm'
+                )}
+              >
+                <span className="text-muted-foreground">Resolved: </span>
                 <span
                   className={
                     position.resolution ? 'text-green-600' : 'text-red-600'

--- a/apps/web/src/components/markets/PredictionProbabilityChart.tsx
+++ b/apps/web/src/components/markets/PredictionProbabilityChart.tsx
@@ -90,7 +90,11 @@ export function PredictionProbabilityChart({
   const seriesInitialized = useRef(false);
   const fillHeight = height === 'fill';
 
-  const { chartContainerRef, chart } = useLightweightChart({
+  const {
+    chartContainerRef,
+    chart,
+    error: chartBaseError,
+  } = useLightweightChart({
     rightPriceScale: {
       scaleMargins: { top: 0.1, bottom: 0.1 },
       autoScale: true,
@@ -160,6 +164,9 @@ export function PredictionProbabilityChart({
     const latest = sorted[0];
     return latest ? latest.yesPrice * 100 : 50;
   }, [data]);
+
+  const hasData = data.length > 0;
+  const unavailableReason = chartInitError ?? chartBaseError;
 
   // Initialize series when chart is ready
   useEffect(() => {
@@ -268,46 +275,14 @@ export function PredictionProbabilityChart({
     }
   }, [chart, chartData]);
 
-  // Loading state when no data
-  if (!data.length) {
-    return (
-      <div
-        className={cn(
-          'flex items-center justify-center text-muted-foreground',
-          fillHeight ? 'h-full min-h-[240px]' : 'h-[400px]'
-        )}
-      >
-        <div className="text-center">
-          <div className="text-sm">Loading chart data...</div>
-        </div>
-      </div>
-    );
-  }
-
-  if (chartInitError) {
-    return (
-      <div
-        className={cn(
-          'flex items-center justify-center text-muted-foreground',
-          fillHeight ? 'h-full min-h-[240px]' : 'h-[400px]'
-        )}
-      >
-        <div className="text-center">
-          <div className="text-sm">Chart unavailable</div>
-          <div className="mt-1 text-xs">{chartInitError}</div>
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div
+      data-market-id={marketId}
       className={cn(
         'w-full',
         showHeader && !fillHeight && 'space-y-3',
         fillHeight && 'flex h-full min-h-0 flex-col gap-3'
       )}
-      key={marketId}
     >
       {showHeader && (
         <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 px-1">
@@ -353,14 +328,29 @@ export function PredictionProbabilityChart({
             fillHeight ? 'h-full min-h-[240px]' : 'h-[400px]'
           )}
         />
-        {!chart && (
+        {!chart && !unavailableReason && (
           <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
             <div className="rounded-lg bg-card/90 px-4 py-2 text-muted-foreground text-sm">
               Initializing chart…
             </div>
           </div>
         )}
-        {chartData.yes.length === 0 && data.length > 0 && (
+        {!hasData && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+            <div className="rounded-lg bg-card/90 px-4 py-2 text-muted-foreground text-sm">
+              Loading chart data…
+            </div>
+          </div>
+        )}
+        {unavailableReason && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+            <div className="rounded-lg bg-card/90 px-4 py-2 text-center text-muted-foreground text-sm">
+              <div className="font-semibold">Chart unavailable</div>
+              <div className="mt-1 text-xs">{unavailableReason}</div>
+            </div>
+          </div>
+        )}
+        {chartData.yes.length === 0 && hasData && (
           <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
             <div className="rounded-lg bg-card/90 px-4 py-2 text-muted-foreground text-sm">
               No data in selected time range

--- a/apps/web/src/components/markets/PredictionProbabilityChart.tsx
+++ b/apps/web/src/components/markets/PredictionProbabilityChart.tsx
@@ -328,35 +328,33 @@ export function PredictionProbabilityChart({
             fillHeight ? 'h-full min-h-[240px]' : 'h-[400px]'
           )}
         />
-        {!chart && !unavailableReason && (
-          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-            <div className="rounded-lg bg-card/90 px-4 py-2 text-muted-foreground text-sm">
-              Initializing chart…
-            </div>
-          </div>
-        )}
-        {!hasData && (
-          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-            <div className="rounded-lg bg-card/90 px-4 py-2 text-muted-foreground text-sm">
-              Loading chart data…
-            </div>
-          </div>
-        )}
-        {unavailableReason && (
+        {/* Overlay states are mutually exclusive - priority: unavailable > loading > initializing > empty */}
+        {unavailableReason ? (
           <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
             <div className="rounded-lg bg-card/90 px-4 py-2 text-center text-muted-foreground text-sm">
               <div className="font-semibold">Chart unavailable</div>
               <div className="mt-1 text-xs">{unavailableReason}</div>
             </div>
           </div>
-        )}
-        {chartData.yes.length === 0 && hasData && (
+        ) : !hasData ? (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+            <div className="rounded-lg bg-card/90 px-4 py-2 text-muted-foreground text-sm">
+              Loading chart data…
+            </div>
+          </div>
+        ) : !chart ? (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+            <div className="rounded-lg bg-card/90 px-4 py-2 text-muted-foreground text-sm">
+              Initializing chart…
+            </div>
+          </div>
+        ) : chartData.yes.length === 0 ? (
           <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
             <div className="rounded-lg bg-card/90 px-4 py-2 text-muted-foreground text-sm">
               No data in selected time range
             </div>
           </div>
-        )}
+        ) : null}
       </div>
 
       {/* Legend */}

--- a/apps/web/src/components/markets/PredictionProbabilityChart.tsx
+++ b/apps/web/src/components/markets/PredictionProbabilityChart.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { cn } from '@babylon/shared';
 import type { ISeriesApi, Time } from 'lightweight-charts';
 import { AreaSeries, LineSeries } from 'lightweight-charts';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -49,6 +50,12 @@ interface PredictionProbabilityChartProps {
   showBrush?: boolean;
   /** Whether to show the built-in header (probabilities + range controls). Defaults to true. */
   showHeader?: boolean;
+  /**
+   * Chart sizing behavior.
+   * - fixed: uses a fixed-height chart (good for pages)
+   * - fill: stretches to the available parent height (good for flex layouts like the terminal)
+   */
+  height?: 'fixed' | 'fill';
 }
 
 /**
@@ -75,11 +82,13 @@ export function PredictionProbabilityChart({
   timeRange,
   onTimeRangeChange,
   showHeader = true,
+  height = 'fixed',
 }: PredictionProbabilityChartProps) {
   const [chartInitError, setChartInitError] = useState<string | null>(null);
   const yesSeries = useRef<ISeriesApi<'Area'> | null>(null);
   const noSeries = useRef<ISeriesApi<'Line'> | null>(null);
   const seriesInitialized = useRef(false);
+  const fillHeight = height === 'fill';
 
   const { chartContainerRef, chart } = useLightweightChart({
     rightPriceScale: {
@@ -262,7 +271,12 @@ export function PredictionProbabilityChart({
   // Loading state when no data
   if (!data.length) {
     return (
-      <div className="flex h-[400px] items-center justify-center text-muted-foreground">
+      <div
+        className={cn(
+          'flex items-center justify-center text-muted-foreground',
+          fillHeight ? 'h-full min-h-[240px]' : 'h-[400px]'
+        )}
+      >
         <div className="text-center">
           <div className="text-sm">Loading chart data...</div>
         </div>
@@ -272,7 +286,12 @@ export function PredictionProbabilityChart({
 
   if (chartInitError) {
     return (
-      <div className="flex h-[400px] items-center justify-center text-muted-foreground">
+      <div
+        className={cn(
+          'flex items-center justify-center text-muted-foreground',
+          fillHeight ? 'h-full min-h-[240px]' : 'h-[400px]'
+        )}
+      >
         <div className="text-center">
           <div className="text-sm">Chart unavailable</div>
           <div className="mt-1 text-xs">{chartInitError}</div>
@@ -282,9 +301,16 @@ export function PredictionProbabilityChart({
   }
 
   return (
-    <div className={showHeader ? 'w-full space-y-3' : 'w-full'} key={marketId}>
+    <div
+      className={cn(
+        'w-full',
+        showHeader && !fillHeight && 'space-y-3',
+        fillHeight && 'flex h-full min-h-0 flex-col gap-3'
+      )}
+      key={marketId}
+    >
       {showHeader && (
-        <div className="flex flex-wrap items-center justify-between gap-3 px-1">
+        <div className="flex shrink-0 flex-wrap items-center justify-between gap-3 px-1">
           <div className="flex items-center gap-4">
             <div className="flex items-center gap-2">
               <div className="h-3 w-3 rounded-full bg-blue-400" />
@@ -319,10 +345,13 @@ export function PredictionProbabilityChart({
       )}
 
       {/* Chart container */}
-      <div className="relative">
+      <div className={cn('relative', fillHeight && 'min-h-0 flex-1')}>
         <div
           ref={chartContainerRef}
-          className="h-[400px] w-full rounded-lg bg-muted/10"
+          className={cn(
+            'w-full rounded-lg bg-muted/10',
+            fillHeight ? 'h-full min-h-[240px]' : 'h-[400px]'
+          )}
         />
         {!chart && (
           <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
@@ -341,7 +370,7 @@ export function PredictionProbabilityChart({
       </div>
 
       {/* Legend */}
-      <div className="flex items-center justify-center gap-6 px-1 text-muted-foreground text-xs">
+      <div className="flex shrink-0 items-center justify-center gap-6 px-1 text-muted-foreground text-xs">
         <div className="flex items-center gap-2">
           <div
             className="h-0.5 w-4 rounded"

--- a/apps/web/src/components/markets/PredictionProbabilityChart.tsx
+++ b/apps/web/src/components/markets/PredictionProbabilityChart.tsx
@@ -280,7 +280,8 @@ export function PredictionProbabilityChart({
       data-market-id={marketId}
       className={cn(
         'w-full',
-        showHeader && !fillHeight && 'space-y-3',
+        ((showHeader && !fillHeight) || (!showHeader && fillHeight)) &&
+          'space-y-3',
         fillHeight && 'flex h-full min-h-0 flex-col gap-3'
       )}
     >

--- a/apps/web/src/components/posts/PostCard.tsx
+++ b/apps/web/src/components/posts/PostCard.tsx
@@ -89,6 +89,7 @@ export interface PostCardProps {
     commentPreviews?: CommentPreviewData[];
   };
   className?: string;
+  density?: 'default' | 'compact';
   onCommentClick?: () => void;
   showInteractions?: boolean;
   showCommentPreviews?: boolean;
@@ -99,6 +100,7 @@ export interface PostCardProps {
 export const PostCard = memo(function PostCard({
   post,
   className,
+  density = 'default',
   onCommentClick,
   showInteractions = true,
   showCommentPreviews = true,
@@ -108,6 +110,8 @@ export const PostCard = memo(function PostCard({
   const router = useRouter();
   const { fontSize } = useFontSize();
   const { user } = useAuth();
+  const compact = density === 'compact';
+  const densityScale = compact ? 0.9 : 1;
 
   const postDate = new Date(post.timestamp);
   const now = new Date();
@@ -220,7 +224,7 @@ export const PostCard = memo(function PostCard({
     return (
       <article
         className={cn(
-          'px-4 py-3',
+          compact ? 'px-3 py-2' : 'px-4 py-3',
           'w-full overflow-hidden',
           'border-border border-b',
           className
@@ -236,7 +240,7 @@ export const PostCard = memo(function PostCard({
   return (
     <article
       className={cn(
-        'px-4 py-4',
+        compact ? 'px-3 py-3' : 'px-4 py-4',
         !isDetail &&
           'cursor-pointer transition-all duration-200 hover:bg-muted/30',
         'w-full overflow-hidden',
@@ -244,7 +248,7 @@ export const PostCard = memo(function PostCard({
         className
       )}
       style={{
-        fontSize: `${fontSize}rem`,
+        fontSize: `${fontSize * densityScale}rem`,
       }}
       onClick={!isDetail ? handleCardClick : undefined}
     >

--- a/apps/web/src/components/shared/BottomNav.tsx
+++ b/apps/web/src/components/shared/BottomNav.tsx
@@ -109,7 +109,11 @@ function BottomNavContent() {
   ];
 
   return (
-    <nav className="fixed right-0 bottom-0 bottom-nav-rounded left-0 z-50 border-border border-t bg-sidebar md:hidden">
+    <nav
+      id="app-bottom-nav"
+      data-bottom-nav
+      className="fixed right-0 bottom-0 bottom-nav-rounded left-0 z-50 border-border border-t bg-sidebar md:hidden"
+    >
       {/* Navigation Items */}
       <div className="safe-area-bottom flex h-14 items-center justify-between px-4">
         <div className="flex flex-1 items-center justify-around">


### PR DESCRIPTION
## Summary
- Polish the Markets trading terminal UI (desktop + mobile) to improve clarity and ergonomics.
- Add a new Portfolio tab with real data (PnL, balances, positions).
- Stabilize chart rendering/initialization for Perps and Prediction markets.

## Type

- [x] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [x] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: UI polish

## Context / Links
- Terminal UI polish feedback (internal).

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- Remove duplicated Markets header in the left panel.
- Make tab content more compact and add a Portfolio tab (PnL, balances, positions) using real sources.
- Rework mobile terminal panel ergonomics (dock with visible tabs + full-screen panel), and align the dock with the app BottomNav.
- Prediction trade UX: hide BUY/SELL selector when user has no sellable shares; force BUY default; disable invalid sides when selling.
- Stabilize chart init (always render container; show loading/unavailable overlays); make Perp chart support `height="fill"` and use it in the terminal for mobile parity.

## Review guide

**Start here**
- `apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx`
- `apps/web/src/components/markets/PredictionProbabilityChart.tsx`
- `apps/web/src/components/markets/PerpPriceChart.tsx`
- `apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- No new env vars.
- Mobile dock alignment accounts for the global `pb-14` and only offsets extra safe-area beyond 56px.

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Mobile: open terminal, verify dock is aligned above BottomNav; open panel, switch tabs.
2. Prediction market: verify BUY/SELL selector is hidden when no shares; SELL appears when shares exist.
3. Perp + prediction charts: verify charts initialize consistently (no stuck "Initializing…" / missing ref error).

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: —
- Changed: —
- Removed: —

**DB / data migration**
- Migration(s): —
- Backfill/seed: —

**Rollout / rollback plan**
- Rollout: standard deploy
- Rollback: revert PR

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option A: Visual demo

| Feature | Before | After |
|---------|--------|-------|
| Mobile terminal panel + dock | N/A | Dock aligned above BottomNav; tabs visible; panel opens full-screen |
| Portfolio tab | N/A | Shows real balances/PnL/positions |
| Chart init stability | N/A | Charts initialize without ref-missing / stuck init |

*Demo script (for recording):*
1. Open `/markets` on mobile.
2. Verify bottom dock tabs (Agents/Social/Portfolio/Positions/Trades) and open the panel.
3. Switch to Portfolio and confirm PnL/balances render.
4. Select a Prediction market: confirm BUY/SELL behavior with/without shares; confirm chart loads.
5. Select a Perp market: confirm chart fills available space and initializes.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Portfolio tab & dashboard added to trading terminal (wallet, PnL, open positions, refresh, buy).

* **New Features**
  * Global "compact" density mode added across feeds, posts, chats, position lists, and trade lists.

* **UI Improvements**
  * Charts now support flexible "fill" height for responsive panels; mobile panel/dock updated for portfolio and tabbed panels.

* **Behavior**
  * Minimum sellable-shares threshold enforced in buy/sell validation and messaging; portfolio refreshes integrated with trade actions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Polished the Markets trading terminal UI for both desktop and mobile, adding a new Portfolio tab with real PnL data and stabilizing chart initialization.

**Major changes:**
- Added Portfolio tab showing wallet balance, total PnL, agent balances, positions breakdown, and open positions list (Perps + Predictions)
- Stabilized chart rendering by always rendering the container (even when data is unavailable) and showing proper loading/error overlays instead of early returns
- Added `height="fill"` mode to both Perp and Prediction charts for better terminal integration (stretches to available parent height in flex layouts)
- Redesigned mobile terminal UX with a visible dock (tabs always visible) that sits above the app BottomNav, accounting for safe-area insets
- Improved Prediction trade UX: hides BUY/SELL selector when user has no shares, forces BUY as default, and auto-switches to valid side when selling
- Added `density="compact"` mode to AssetTradesFeed and positions lists for tighter spacing in terminal views

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minor manual testing recommended for mobile dock alignment across different devices
- The changes are well-structured UI improvements with defensive coding patterns (chart stability fixes, proper error handling, null checks). The mobile dock offset calculation is thoughtful (accounting for safe-area beyond base 56px). Prediction trade UX improvements have proper guards with useEffect cleanup. The new Portfolio tab fetches data correctly with abort controller cleanup. Main concern is the mobile dock alignment relying on runtime DOM queries which should be manually tested on iOS devices with different safe-area insets.
- Test `MarketsTradingTerminal.tsx` mobile dock alignment on iOS devices with varying safe-area insets to ensure proper positioning above BottomNav

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx | Added Portfolio tab, mobile dock with safe-area alignment, improved chart initialization with height="fill" prop |
| apps/web/src/components/markets/PerpPriceChart.tsx | Stabilized chart initialization with always-rendered container, added height="fill" mode, improved loading/error overlays |
| apps/web/src/components/markets/PredictionProbabilityChart.tsx | Stabilized chart initialization with always-rendered container, added height="fill" mode, improved loading/error overlays |
| apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx | New Portfolio tab component showing balances, PnL, positions using real data from usePortfolioPnL hook |
| apps/web/src/components/shared/BottomNav.tsx | Added id and data attribute to enable terminal dock alignment calculations |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Terminal as MarketsTradingTerminal
    participant BottomNav as App BottomNav
    participant Dock as Mobile Terminal Dock
    participant Panel as Mobile Panel
    participant Portfolio as TerminalPortfolio
    participant Chart as PerpPriceChart/PredictionChart
    participant API as Portfolio API

    Note over User,API: Mobile Terminal Initialization
    User->>Terminal: Open /markets on mobile
    Terminal->>BottomNav: Query #app-bottom-nav height
    BottomNav-->>Terminal: Return actual height (56px + safe-area)
    Terminal->>Terminal: Calculate mobileBottomDockOffset<br/>(height - 56px)
    Terminal->>Dock: Render dock at bottom + offset
    Note over Dock: Visible tabs: Agents, Social,<br/>Portfolio, Positions, Trades

    Note over User,API: Portfolio Tab Interaction
    User->>Dock: Tap "Portfolio" tab
    Dock->>Panel: openMobilePanel('portfolio')
    Panel->>Panel: setIsMobilePanelOpen(true)
    Panel->>Portfolio: Render TerminalPortfolio
    Portfolio->>API: GET /api/users/{id}/portfolio-breakdown
    API-->>Portfolio: Return breakdown data<br/>(wallet, agents, positions, PnL)
    Portfolio->>User: Display balances, PnL, positions

    Note over User,API: Chart Rendering Flow
    User->>Terminal: Select market (Perp or Prediction)
    Terminal->>Chart: Render with height="fill"
    Chart->>Chart: Always render container (even without data)
    Chart->>Chart: Show "Initializing chart..." overlay
    Chart->>Chart: Initialize lightweight-charts
    alt Chart init success
        Chart->>Chart: Hide overlay, render data
    else Chart init error
        Chart->>Chart: Show "Chart unavailable" overlay
    end
    Chart->>User: Display chart or error state

    Note over User,API: Prediction Trade UX
    User->>Terminal: Select Prediction market
    Terminal->>Terminal: Check user positions<br/>(selectedPredictionShares)
    alt User has no shares
        Terminal->>Terminal: Hide BUY/SELL selector<br/>Force predictionTradeMode='buy'
    else User has shares
        Terminal->>Terminal: Show BUY/SELL selector<br/>Enable SELL mode
        alt Selling with invalid side
            Terminal->>Terminal: Auto-switch to valid side<br/>(YES if has yesShares, NO if has noShares)
        end
    end
    Terminal->>User: Display appropriate trade UI
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->