### PR TITLE
Mobile Markets: move tabs to top + add Chart tab

### DIFF
--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -564,7 +564,14 @@ export function MarketsTradingTerminal({
       setIsMobileChartFullscreen(false);
 
       if (tab === 'chart') {
-        setMobileChartAnimationKey((k) => k + 1);
+        // Only remount chart when returning from a non-chart surface
+        const wasOnChart =
+          !isMobilePanelOpen &&
+          !isMobileMarketListOpen &&
+          !isMobileTradeSheetOpen;
+        if (!wasOnChart) {
+          setMobileChartAnimationKey((k) => k + 1);
+        }
         setIsMobilePanelOpen(false);
         setIsMobileMarketListOpen(false);
         setIsMobileTradeSheetOpen(false);
@@ -573,7 +580,7 @@ export function MarketsTradingTerminal({
 
       openMobilePanel(tab);
     },
-    [openMobilePanel]
+    [openMobilePanel, isMobilePanelOpen, isMobileMarketListOpen, isMobileTradeSheetOpen]
   );
 
   // Shared handlers for TerminalPortfolio (used in both desktop and mobile)

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -144,17 +144,20 @@ function MobileTabBar({
             type="button"
             onClick={() => onSelect(tab)}
             className={cn(
-              'relative flex h-9 shrink-0 items-center justify-center rounded-xl px-3 font-bold text-[11px] transition-colors',
+              'relative flex h-9 shrink-0 items-center justify-center rounded-xl px-3 font-bold text-[11px] transition-colors duration-200',
               activeTab === tab
                 ? 'bg-muted/20 text-foreground'
                 : 'text-muted-foreground hover:text-foreground'
             )}
             aria-current={activeTab === tab ? 'page' : undefined}
           >
-            {MOBILE_TAB_LABELS[tab]}
-            {activeTab === tab && (
-              <div className="absolute right-2 bottom-0 left-2 h-0.5 rounded-full bg-foreground" />
-            )}
+              {MOBILE_TAB_LABELS[tab]}
+            <div
+              className={cn(
+                'absolute right-2 bottom-0 left-2 h-0.5 origin-center rounded-full bg-foreground transition-transform duration-200',
+                activeTab === tab ? 'scale-x-100' : 'scale-x-0'
+              )}
+            />
           </button>
         ))}
       </div>
@@ -534,6 +537,7 @@ export function MarketsTradingTerminal({
   const [isMobileChartFullscreen, setIsMobileChartFullscreen] = useState(false);
   const [isMobilePanelOpen, setIsMobilePanelOpen] = useState(false);
   const [mobileBottomNavHeight, setMobileBottomNavHeight] = useState(56);
+  const [mobileChartAnimationKey, setMobileChartAnimationKey] = useState(0);
 
   // Cooldown state to prevent refresh spam (protects backend at scale)
   const [refreshOnCooldown, setRefreshOnCooldown] = useState(false);
@@ -560,6 +564,7 @@ export function MarketsTradingTerminal({
       setIsMobileChartFullscreen(false);
 
       if (tab === 'chart') {
+        setMobileChartAnimationKey((k) => k + 1);
         setIsMobilePanelOpen(false);
         setIsMobileMarketListOpen(false);
         setIsMobileTradeSheetOpen(false);
@@ -2380,7 +2385,10 @@ export function MarketsTradingTerminal({
                 ) : null}
 
                 {selected?.kind === 'prediction' ? (
-                  <div className="min-h-0 flex-1 p-2">
+                  <div
+                    key={mobileChartAnimationKey}
+                    className="min-h-0 flex-1 p-2"
+                  >
                     <PredictionProbabilityChart
                       data={predictionHistory}
                       marketId={selectedPredictionId ?? 'unknown'}
@@ -2391,7 +2399,10 @@ export function MarketsTradingTerminal({
                     />
                   </div>
                 ) : selectedPerp ? (
-                  <div className="min-h-0 flex-1 p-2">
+                  <div
+                    key={mobileChartAnimationKey}
+                    className="min-h-0 flex-1 p-2"
+                  >
                     <PerpPriceChart
                       data={perpHistory.map((p) => ({
                         time: p.time,

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -151,7 +151,7 @@ function MobileTabBar({
             )}
             aria-current={activeTab === tab ? 'page' : undefined}
           >
-              {MOBILE_TAB_LABELS[tab]}
+            {MOBILE_TAB_LABELS[tab]}
             <div
               className={cn(
                 'absolute right-2 bottom-0 left-2 h-0.5 origin-center rounded-full bg-foreground transition-transform duration-200',

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -9,7 +9,6 @@ import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
 import {
   ArrowUpDown,
   Check,
-  ChevronUp,
   Filter,
   Info,
   Maximize2,
@@ -92,6 +91,7 @@ import { TerminalSocialFeed } from './TerminalSocialFeed';
 type MarketsFilter = 'all' | 'favorites' | 'perp' | 'prediction';
 type MarketsSort = 'volume' | 'change' | 'openInterest' | 'name';
 type BottomTab = 'agent' | 'social' | 'portfolio' | 'positions' | 'trades';
+type MobileTab = 'chart' | BottomTab;
 
 /** Base height of the bottom nav (matches app layout's pb-14) */
 const BOTTOM_NAV_BASE_HEIGHT = 56;
@@ -113,6 +113,54 @@ const BOTTOM_TAB_LABELS: Record<BottomTab, string> = {
   positions: 'Positions',
   trades: 'Trades',
 };
+
+const MOBILE_TAB_LABELS: Record<MobileTab, string> = {
+  chart: 'Chart',
+  ...BOTTOM_TAB_LABELS,
+};
+
+const MOBILE_TABS: readonly MobileTab[] = [
+  'chart',
+  'agent',
+  'social',
+  'portfolio',
+  'positions',
+  'trades',
+];
+
+function MobileTabBar({
+  activeTab,
+  onSelect,
+}: {
+  activeTab: MobileTab;
+  onSelect: (tab: MobileTab) => void;
+}) {
+  return (
+    <div className="hide-scrollbar min-w-0 flex-1 overflow-x-auto">
+      <div className="flex w-max min-w-full items-center justify-center gap-1 px-1">
+        {MOBILE_TABS.map((tab) => (
+          <button
+            key={tab}
+            type="button"
+            onClick={() => onSelect(tab)}
+            className={cn(
+              'relative flex h-9 shrink-0 items-center justify-center rounded-xl px-3 font-bold text-[11px] transition-colors',
+              activeTab === tab
+                ? 'bg-muted/20 text-foreground'
+                : 'text-muted-foreground hover:text-foreground'
+            )}
+            aria-current={activeTab === tab ? 'page' : undefined}
+          >
+            {MOBILE_TAB_LABELS[tab]}
+            {activeTab === tab && (
+              <div className="absolute right-2 bottom-0 left-2 h-0.5 rounded-full bg-foreground" />
+            )}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
 
 /*
  * Z-INDEX STACKING CONTEXT (documentation only - Tailwind requires static class names)
@@ -506,6 +554,22 @@ export function MarketsTradingTerminal({
     setIsMobileMarketListOpen(false);
     setIsMobileTradeSheetOpen(false);
   }, []);
+
+  const handleMobileTabSelect = useCallback(
+    (tab: MobileTab) => {
+      setIsMobileChartFullscreen(false);
+
+      if (tab === 'chart') {
+        setIsMobilePanelOpen(false);
+        setIsMobileMarketListOpen(false);
+        setIsMobileTradeSheetOpen(false);
+        return;
+      }
+
+      openMobilePanel(tab);
+    },
+    [openMobilePanel]
+  );
 
   // Shared handlers for TerminalPortfolio (used in both desktop and mobile)
   const handlePortfolioRefresh = useCallback(() => {
@@ -2286,53 +2350,64 @@ export function MarketsTradingTerminal({
           <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
             <div className="contents">
               <div className="relative flex min-h-0 w-full flex-1 flex-col border-white/5 border-b">
+                <div className="border-white/5 border-b bg-background/60 px-2 py-2 shadow-sm backdrop-blur-md">
+                  <MobileTabBar
+                    activeTab={
+                      isMobilePanelOpen
+                        ? (bottomTab as MobileTab)
+                        : ('chart' as const)
+                    }
+                    onSelect={handleMobileTabSelect}
+                  />
+                </div>
+
                 {selected?.kind === 'prediction' ? (
-                  <>
-                    <PredictionMarketHeader
-                      predictionState={predictionState}
-                      yesPct={predictionYesPct}
+                  <PredictionMarketHeader
+                    predictionState={predictionState}
+                    yesPct={predictionYesPct}
+                    timeRange={predictionTimeRange}
+                    onTimeRangeChange={setPredictionTimeRange}
+                    onDetailsClick={() => setPredictionDetailsOpen(true)}
+                    variant="compact"
+                  />
+                ) : selectedPerp ? (
+                  <PerpMarketHeader
+                    selectedPerp={selectedPerp}
+                    timeRange={perpTimeRange}
+                    onTimeRangeChange={setPerpTimeRange}
+                    variant="compact"
+                  />
+                ) : null}
+
+                {selected?.kind === 'prediction' ? (
+                  <div className="min-h-0 flex-1 p-2">
+                    <PredictionProbabilityChart
+                      data={predictionHistory}
+                      marketId={selectedPredictionId ?? 'unknown'}
                       timeRange={predictionTimeRange}
                       onTimeRangeChange={setPredictionTimeRange}
-                      onDetailsClick={() => setPredictionDetailsOpen(true)}
-                      variant="compact"
+                      showHeader={false}
+                      height="fill"
                     />
-                    <div className="min-h-0 flex-1 p-2">
-                      <PredictionProbabilityChart
-                        data={predictionHistory}
-                        marketId={selectedPredictionId ?? 'unknown'}
-                        timeRange={predictionTimeRange}
-                        onTimeRangeChange={setPredictionTimeRange}
-                        showHeader={false}
-                        height="fill"
-                      />
-                    </div>
-                  </>
+                  </div>
                 ) : selectedPerp ? (
-                  <>
-                    <PerpMarketHeader
-                      selectedPerp={selectedPerp}
+                  <div className="min-h-0 flex-1 p-2">
+                    <PerpPriceChart
+                      data={perpHistory.map((p) => ({
+                        time: p.time,
+                        price: p.price,
+                      }))}
+                      currentPrice={selectedPerp.currentPrice}
+                      ticker={selectedPerp.ticker}
                       timeRange={perpTimeRange}
                       onTimeRangeChange={setPerpTimeRange}
-                      variant="compact"
+                      showHeader={false}
+                      height="fill"
+                      className="h-full"
                     />
-                    <div className="min-h-0 flex-1 p-2">
-                      <PerpPriceChart
-                        data={perpHistory.map((p) => ({
-                          time: p.time,
-                          price: p.price,
-                        }))}
-                        currentPrice={selectedPerp.currentPrice}
-                        ticker={selectedPerp.ticker}
-                        timeRange={perpTimeRange}
-                        onTimeRangeChange={setPerpTimeRange}
-                        showHeader={false}
-                        height="fill"
-                        className="h-full"
-                      />
-                    </div>
-                  </>
+                  </div>
                 ) : (
-                  <div className="flex h-full items-center justify-center text-muted-foreground">
+                  <div className="flex min-h-0 flex-1 items-center justify-center text-muted-foreground">
                     Select a market
                   </div>
                 )}
@@ -2361,107 +2436,6 @@ export function MarketsTradingTerminal({
             className="sticky z-40 w-full select-none overflow-hidden rounded-t-[20px] border-white/5 border-t bg-background shadow-[0_-5px_15px_rgba(0,0,0,0.12)]"
             style={{ bottom: mobileBottomDockOffset }}
           >
-            <div className="border-white/5 border-b bg-background/70 px-2 py-2 shadow-sm backdrop-blur-md">
-              <div className="flex items-center gap-1 rounded-2xl border border-white/10 bg-background/40 p-1">
-                <div className="flex min-w-0 flex-1">
-                  <button
-                    type="button"
-                    onClick={() => openMobilePanel('agent')}
-                    className={cn(
-                      'relative flex h-9 min-w-0 flex-1 items-center justify-center px-2 font-bold text-[11px] transition-colors',
-                      bottomTab === 'agent'
-                        ? 'text-foreground'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                    aria-label="Open Agents panel"
-                  >
-                    Agents
-                    {bottomTab === 'agent' && (
-                      <div className="absolute right-2 bottom-0 left-2 h-0.5 rounded-full bg-foreground" />
-                    )}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => openMobilePanel('social')}
-                    className={cn(
-                      'relative flex h-9 min-w-0 flex-1 items-center justify-center px-2 font-bold text-[11px] transition-colors',
-                      bottomTab === 'social'
-                        ? 'text-foreground'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                    aria-label="Open Social panel"
-                  >
-                    Social
-                    {bottomTab === 'social' && (
-                      <div className="absolute right-2 bottom-0 left-2 h-0.5 rounded-full bg-foreground" />
-                    )}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => openMobilePanel('portfolio')}
-                    className={cn(
-                      'relative flex h-9 min-w-0 flex-1 items-center justify-center px-2 font-bold text-[11px] transition-colors',
-                      bottomTab === 'portfolio'
-                        ? 'text-foreground'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                    aria-label="Open Portfolio panel"
-                  >
-                    Portf.
-                    {bottomTab === 'portfolio' && (
-                      <div className="absolute right-2 bottom-0 left-2 h-0.5 rounded-full bg-foreground" />
-                    )}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => openMobilePanel('positions')}
-                    className={cn(
-                      'relative flex h-9 min-w-0 flex-1 items-center justify-center px-2 font-bold text-[11px] transition-colors',
-                      bottomTab === 'positions'
-                        ? 'text-foreground'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                    aria-label="Open Positions panel"
-                  >
-                    Pos.
-                    {bottomTab === 'positions' && (
-                      <div className="absolute right-2 bottom-0 left-2 h-0.5 rounded-full bg-foreground" />
-                    )}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => openMobilePanel('trades')}
-                    className={cn(
-                      'relative flex h-9 min-w-0 flex-1 items-center justify-center px-2 font-bold text-[11px] transition-colors',
-                      bottomTab === 'trades'
-                        ? 'text-foreground'
-                        : 'text-muted-foreground hover:text-foreground'
-                    )}
-                    aria-label="Open Trades panel"
-                  >
-                    Trades
-                    {bottomTab === 'trades' && (
-                      <div className="absolute right-2 bottom-0 left-2 h-0.5 rounded-full bg-foreground" />
-                    )}
-                  </button>
-                </div>
-
-                <button
-                  type="button"
-                  onClick={() => openMobilePanel()}
-                  className={cn(
-                    'inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-xl',
-                    'text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground',
-                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30'
-                  )}
-                  aria-label="Open panel"
-                  title="Open panel"
-                >
-                  <ChevronUp size={18} />
-                </button>
-              </div>
-            </div>
-
             <div className="flex h-[72px] items-center justify-between px-2 pb-2 font-medium text-[10px] text-muted-foreground">
               {/* Minimal bottom nav */}
               <button
@@ -2513,98 +2487,11 @@ export function MarketsTradingTerminal({
 
           {isMobilePanelOpen && (
             <div className="fade-in slide-in-from-bottom-2 absolute inset-0 z-[70] flex animate-in flex-col bg-background pt-safe pb-safe duration-200">
-              <div className="flex items-center justify-between border-white/5 border-b p-4">
-                <h2 className="font-bold text-lg">
-                  {BOTTOM_TAB_LABELS[bottomTab]} Panel
-                </h2>
-                <button
-                  type="button"
-                  onClick={() => setIsMobilePanelOpen(false)}
-                  className="rounded-full p-2 transition-colors hover:bg-muted/20"
-                  aria-label="Close panel"
-                >
-                  <X size={20} />
-                </button>
-              </div>
-
-              <div className="flex h-11 shrink-0 items-center border-white/5 border-b bg-background px-2 shadow-sm">
-                <div className="flex min-w-0 flex-1">
-                  <button
-                    type="button"
-                    onClick={() => setBottomTab('agent')}
-                    className={cn(
-                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-2 font-bold text-xs capitalize transition-colors',
-                      bottomTab === 'agent'
-                        ? 'text-foreground'
-                        : 'text-muted-foreground'
-                    )}
-                  >
-                    Agents
-                    {bottomTab === 'agent' && (
-                      <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
-                    )}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setBottomTab('social')}
-                    className={cn(
-                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-2 font-bold text-xs capitalize transition-colors',
-                      bottomTab === 'social'
-                        ? 'text-foreground'
-                        : 'text-muted-foreground'
-                    )}
-                  >
-                    Social
-                    {bottomTab === 'social' && (
-                      <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
-                    )}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setBottomTab('portfolio')}
-                    className={cn(
-                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-2 font-bold text-xs capitalize transition-colors',
-                      bottomTab === 'portfolio'
-                        ? 'text-foreground'
-                        : 'text-muted-foreground'
-                    )}
-                  >
-                    Portfolio
-                    {bottomTab === 'portfolio' && (
-                      <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
-                    )}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setBottomTab('positions')}
-                    className={cn(
-                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-2 font-bold text-xs capitalize transition-colors',
-                      bottomTab === 'positions'
-                        ? 'text-foreground'
-                        : 'text-muted-foreground'
-                    )}
-                  >
-                    Positions
-                    {bottomTab === 'positions' && (
-                      <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
-                    )}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setBottomTab('trades')}
-                    className={cn(
-                      'relative flex h-full min-w-0 flex-1 items-center justify-center px-2 py-2 font-bold text-xs capitalize transition-colors',
-                      bottomTab === 'trades'
-                        ? 'text-foreground'
-                        : 'text-muted-foreground'
-                    )}
-                  >
-                    Trades
-                    {bottomTab === 'trades' && (
-                      <div className="absolute bottom-0 left-0 h-0.5 w-full rounded-t-full bg-foreground" />
-                    )}
-                  </button>
-                </div>
+              <div className="flex items-center gap-2 border-white/5 border-b bg-background/70 px-2 py-2 shadow-sm backdrop-blur-md">
+                <MobileTabBar
+                  activeTab={bottomTab as MobileTab}
+                  onSelect={handleMobileTabSelect}
+                />
               </div>
 
               <div className="min-h-0 flex-1 overflow-hidden">

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -2387,7 +2387,7 @@ export function MarketsTradingTerminal({
                 {selected?.kind === 'prediction' ? (
                   <div
                     key={mobileChartAnimationKey}
-                    className="min-h-0 flex-1 p-2"
+                    className="fade-in min-h-0 flex-1 animate-in p-2 duration-200"
                   >
                     <PredictionProbabilityChart
                       data={predictionHistory}
@@ -2401,7 +2401,7 @@ export function MarketsTradingTerminal({
                 ) : selectedPerp ? (
                   <div
                     key={mobileChartAnimationKey}
-                    className="min-h-0 flex-1 p-2"
+                    className="fade-in min-h-0 flex-1 animate-in p-2 duration-200"
                   >
                     <PerpPriceChart
                       data={perpHistory.map((p) => ({
@@ -2505,7 +2505,10 @@ export function MarketsTradingTerminal({
                 />
               </div>
 
-              <div className="min-h-0 flex-1 overflow-hidden">
+              <div
+                key={bottomTab}
+                className="fade-in min-h-0 flex-1 animate-in overflow-hidden duration-150"
+              >
                 {bottomTab === 'agent' ? (
                   <TerminalAgentsChat />
                 ) : bottomTab === 'social' ? (


### PR DESCRIPTION
## Summary

- Updates the **Markets** mobile UI to match the designer mock: move the terminal tabs to the top and add a dedicated **Chart** tab.
- Keeps the bottom dock focused on **Markets / Trade / Balance** (no more terminal tabs down there).
- Adds lightweight polish animations (tab underline + content fade + chart remount on returning to Chart).

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Designer reference: https://venue-data-39407163.figma.site/

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Non-goals / follow-ups**
- Desktop terminal UI changes (intentionally untouched).
- Deeper chart “draw” animation inside lightweight-charts (would require changes in chart components / data streaming).

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- Mobile-only: add a top tab bar for `Chart / Agent / Social / Portfolio / Positions / Trades`.
- Add `Chart` tab to return to the chart view.
- Remove the old terminal tab strip from the bottom dock.
- Add subtle switch animations (underline transition + fade-in for content; chart remount on returning to Chart).

## Review guide

**Start here**
- `apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- Changes are intentionally scoped to the mobile layout (`md:hidden` branch). Desktop UI is unchanged.

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Open `/markets` on a mobile viewport.
2. Select a market.
3. Verify the tab bar is at the top and switching tabs works.
4. Tap `Chart` to return to the chart.
5. Verify bottom dock still shows `Markets / Trade / Balance` only.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- None

**DB / data migration**
- None

**Rollout / rollback plan**
- Rollout: standard deploy
- Rollback: revert this PR

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- N/A

### Database
- N/A

### Contracts / on-chain
- N/A

### Docs
- N/A

</details>

## Screenshots / recordings (UI)

### Option A: Visual demo

| Feature | Before | After |
|---------|--------|-------|
| Markets mobile tabs placement | Tabs were in the bottom dock above `Markets/Trade/Balance` | Tabs are at the top with a `Chart` tab |

*Demo script (for recording):*
1. Open `/markets` on mobile.
2. Select any market.
3. Tap `Agent → Social → Portfolio → Trades`.
4. Tap `Chart` to return to the chart.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a mobile tab navigation bar to the trading terminal, letting users switch between chart and trading panels with a single, scrollable control.
  * Chart and panel views now remount predictably when switching tabs, improving animation and state consistency on mobile.

* **Style**
  * Minor layout and styling adjustments to accommodate the new mobile tab surface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Refactored the mobile Markets terminal UI to move tabs to the top and add a dedicated Chart tab. The bottom dock now only shows Markets/Trade/Balance, while Agent/Social/Portfolio/Positions/Trades tabs appear at the top alongside the new Chart tab.

**Key Changes:**
- Added `MobileTab` type and `MobileTabBar` component for unified tab navigation
- Implemented `handleMobileTabSelect` to manage tab switching with proper state cleanup
- Added `mobileChartAnimationKey` state to trigger chart remount animations when returning to Chart tab
- Removed old terminal tab strip from bottom dock (100+ lines)
- Applied fade-in animations to tab content transitions
- Maintained desktop UI unchanged (scoped to `md:hidden`)

**Implementation:**
- Chart tab closes all panels and increments animation key for smooth remount
- Other tabs delegate to existing `openMobilePanel` function
- Tab bar appears in both main view and panel overlay for consistent navigation
- Charts wrapped in keyed divs with `fade-in` animations for polish

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean refactor focused on mobile UI reorganization with no logical errors, proper state management, and no security concerns. Changes are well-scoped to mobile viewport, maintain existing functionality, and add polish animations.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx | Refactored mobile UI to move terminal tabs to top and add Chart tab with smooth animations |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant MobileTabBar
    participant handleMobileTabSelect
    participant State
    participant ChartComponent

    User->>MobileTabBar: Click Chart tab
    MobileTabBar->>handleMobileTabSelect: onSelect('chart')
    handleMobileTabSelect->>State: setIsMobileChartFullscreen(false)
    handleMobileTabSelect->>State: setMobileChartAnimationKey(k => k + 1)
    handleMobileTabSelect->>State: setIsMobilePanelOpen(false)
    handleMobileTabSelect->>State: setIsMobileMarketListOpen(false)
    handleMobileTabSelect->>State: setIsMobileTradeSheetOpen(false)
    State->>ChartComponent: Remount with new key
    ChartComponent-->>User: Display chart with fade-in animation

    User->>MobileTabBar: Click Agent/Social/Portfolio/Positions/Trades tab
    MobileTabBar->>handleMobileTabSelect: onSelect(tab)
    handleMobileTabSelect->>State: setIsMobileChartFullscreen(false)
    handleMobileTabSelect->>State: openMobilePanel(tab)
    State->>State: setBottomTab(tab)
    State->>State: setIsMobilePanelOpen(true)
    State->>State: setIsMobileMarketListOpen(false)
    State->>State: setIsMobileTradeSheetOpen(false)
    State-->>User: Display panel overlay with selected tab content
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->