### PR TITLE
fix: improve NPC action dispersion and organic feed pacing

### DIFF
--- a/apps/web/src/app/api/cron/organization-tick/route.ts
+++ b/apps/web/src/app/api/cron/organization-tick/route.ts
@@ -115,9 +115,16 @@ export const dynamic = 'force-dynamic';
  * - Variable batch size feels more natural than fixed counts
  */
 const BASE_ORGS_PER_TICK = Number(process.env.ORG_TICK_BATCH_SIZE) || 3;
-// Add variance of -1, 0, or +1 for organic feel (avoids predictable batch sizes)
-const batchVariance = Math.floor(secureRandom() * 3) - 1;
-const ORGS_PER_TICK = Math.max(1, BASE_ORGS_PER_TICK + batchVariance);
+
+/**
+ * Calculate organizations per tick with random variance.
+ * Returns BASE ± 1 (range: 2-4 with default base of 3).
+ * Called per-request to ensure fresh randomness each tick.
+ */
+function getOrgsPerTick(): number {
+  const variance = Math.floor(secureRandom() * 3) - 1; // -1, 0, or +1
+  return Math.max(1, BASE_ORGS_PER_TICK + variance);
+}
 
 /**
  * Minimum time in minutes between posts from the same organization.
@@ -356,10 +363,8 @@ export async function POST(_req: NextRequest) {
 
     // Select organizations using weighted stratified sampling (from eligible orgs only)
     // This ensures a balanced mix of org types that mirrors real-world posting patterns
-    const orgsThisTick = selectWeightedOrganizations(
-      eligibleOrgs,
-      ORGS_PER_TICK
-    );
+    const orgsPerTick = getOrgsPerTick(); // Fresh randomness per request
+    const orgsThisTick = selectWeightedOrganizations(eligibleOrgs, orgsPerTick);
 
     logger.info(
       `Organization tick processing ${orgsThisTick.length} orgs`,

--- a/apps/web/src/app/api/cron/organization-tick/route.ts
+++ b/apps/web/src/app/api/cron/organization-tick/route.ts
@@ -104,15 +104,20 @@ export const maxDuration = 300; // 5 minutes max
 export const dynamic = 'force-dynamic';
 
 /**
- * Number of organizations to process per tick.
+ * Base number of organizations to process per tick.
+ * Actual count varies by ±1 for organic pacing (2-4 orgs per tick).
  * Configurable via ORG_TICK_BATCH_SIZE environment variable.
  * Each org generates 1 short post per tick.
  *
- * With 60 orgs and weighted stratified selection, 3 per tick ensures:
+ * With 60 orgs and weighted stratified selection, ~3 per tick ensures:
  * - Good type diversity (typically 2-3 different org types per tick)
  * - Each org posts roughly every 20 ticks
+ * - Variable batch size feels more natural than fixed counts
  */
-const ORGS_PER_TICK = Number(process.env.ORG_TICK_BATCH_SIZE) || 3;
+const BASE_ORGS_PER_TICK = Number(process.env.ORG_TICK_BATCH_SIZE) || 3;
+// Add variance of -1, 0, or +1 for organic feel (avoids predictable batch sizes)
+const batchVariance = Math.floor(secureRandom() * 3) - 1;
+const ORGS_PER_TICK = Math.max(1, BASE_ORGS_PER_TICK + batchVariance);
 
 /**
  * Minimum time in minutes between posts from the same organization.
@@ -451,6 +456,14 @@ export async function POST(_req: NextRequest) {
         const content = rawPost.trim();
         const now = new Date();
 
+        // Spread timestamp randomly within the NEXT 5-minute window (until next tick)
+        // Posts become visible gradually as their timestamp passes
+        // This prevents all posts from appearing at the exact same time
+        // making the feed feel more organic rather than batch-generated
+        const TICK_WINDOW_MS = 5 * 60 * 1000; // 5 minutes
+        const randomOffset = Math.floor(secureRandom() * TICK_WINDOW_MS);
+        const postTimestamp = new Date(now.getTime() + randomOffset);
+
         // Create the post in database (always type: 'post', never 'article')
         const postId = await generateSnowflakeId();
         await db.insert(posts).values({
@@ -459,8 +472,8 @@ export async function POST(_req: NextRequest) {
           authorId: org.id,
           gameId: gameState.id,
           dayNumber: gameState.currentDay ?? 1,
-          timestamp: now,
-          createdAt: now,
+          timestamp: postTimestamp, // Staggered for organic feel
+          createdAt: now, // Actual creation time
           type: 'post',
         });
 

--- a/packages/core/markets/prediction/PredictionMarketService.ts
+++ b/packages/core/markets/prediction/PredictionMarketService.ts
@@ -235,7 +235,9 @@ export class PredictionMarketService {
       .filter((p): p is NonNullable<typeof p> => !!p)
       // Only allow selling active positions (whitelist approach for security)
       // This prevents selling cancelled/voided/resolved positions that have already been settled
-      .filter((p) => (!p.status || p.status === 'active') && p.shares > MIN_SHARES);
+      .filter(
+        (p) => (!p.status || p.status === 'active') && p.shares > MIN_SHARES
+      );
 
     let pos: NonNullable<typeof yesPos> | NonNullable<typeof noPos> | null =
       null;

--- a/packages/engine/src/config/npc-activity.ts
+++ b/packages/engine/src/config/npc-activity.ts
@@ -385,12 +385,12 @@ export const NPC_ENGAGEMENT_CONFIG = {
    * Probability that a discourse interaction becomes a quote-post instead of a reply.
    * Only applies when engaging with an original post (not a reply thread).
    *
-   * @default 0.65 (65% quote-posts, 35% direct replies)
+   * @default 0.30 (30% quote-posts, 70% direct replies)
    * @env NPC_DISCOURSE_QUOTE_PROBABILITY
    */
   discourseQuoteProbability: envProbability(
     'NPC_DISCOURSE_QUOTE_PROBABILITY',
-    0.65
+    0.30
   ),
 
   /**

--- a/packages/engine/src/config/npc-activity.ts
+++ b/packages/engine/src/config/npc-activity.ts
@@ -390,7 +390,7 @@ export const NPC_ENGAGEMENT_CONFIG = {
    */
   discourseQuoteProbability: envProbability(
     'NPC_DISCOURSE_QUOTE_PROBABILITY',
-    0.30
+    0.3
   ),
 
   /**

--- a/packages/engine/src/services/npc-social-engagement-service.ts
+++ b/packages/engine/src/services/npc-social-engagement-service.ts
@@ -478,31 +478,35 @@ export async function processNPCSocialEngagements(
         ) {
           if (random() < probs.share) {
             try {
-              await db.share.create({
-                data: {
-                  id: await generateSnowflakeId(),
-                  postId: post.id,
-                  userId: actor.id,
-                },
-              });
+              // Wrap in transaction for atomicity - both succeed or both fail
+              await db.$transaction(async (tx) => {
+                await tx.share.create({
+                  data: {
+                    id: await generateSnowflakeId(),
+                    postId: post.id,
+                    userId: actor.id,
+                  },
+                });
 
-              // Also create a repost Post so it appears in the feed
-              // Empty content = simple repost (not a quote post)
-              const repostId = await generateSnowflakeId();
-              await db.post.create({
-                data: {
-                  id: repostId,
-                  content: '',
-                  authorId: actor.id,
-                  timestamp: now,
-                  originalPostId: post.id,
-                },
+                // Create visible repost Post (empty content = simple repost)
+                const repostId = await generateSnowflakeId();
+                await tx.post.create({
+                  data: {
+                    id: repostId,
+                    content: '',
+                    authorId: actor.id,
+                    timestamp: now,
+                    originalPostId: post.id,
+                    type: 'repost', // Explicit type for query filtering
+                  },
+                });
               });
 
               result.sharesCreated++;
               engagedActors.add(actor.id);
+              shareSet.add(key); // Only mark on success - allows retry on failure
             } catch (error) {
-              // Likely a unique constraint race - ignore to keep engagement loop resilient
+              // Unique constraint or other error - don't mark as processed, allows retry
               logger.debug(
                 'Failed to insert NPC share/repost (ignored)',
                 {
@@ -512,9 +516,8 @@ export async function processNPCSocialEngagements(
                 },
                 'NPCSocialEngagement'
               );
-            } finally {
-              shareSet.add(key); // Mark as processed either way
             }
+            // No finally block - shareSet only marked on success
           }
         }
 

--- a/packages/engine/src/services/npc-social-engagement-service.ts
+++ b/packages/engine/src/services/npc-social-engagement-service.ts
@@ -471,7 +471,7 @@ export async function processNPCSocialEngagements(
           }
         }
 
-        // SHARE
+        // SHARE (creates both a Share record AND a visible repost Post)
         if (
           !shareSet.has(key) &&
           result.sharesCreated < NPC_ENGAGEMENT_CONFIG.maxSharesPerTick
@@ -485,12 +485,26 @@ export async function processNPCSocialEngagements(
                   userId: actor.id,
                 },
               });
+
+              // Also create a repost Post so it appears in the feed
+              // Empty content = simple repost (not a quote post)
+              const repostId = await generateSnowflakeId();
+              await db.post.create({
+                data: {
+                  id: repostId,
+                  content: '',
+                  authorId: actor.id,
+                  timestamp: now,
+                  originalPostId: post.id,
+                },
+              });
+
               result.sharesCreated++;
               engagedActors.add(actor.id);
             } catch (error) {
               // Likely a unique constraint race - ignore to keep engagement loop resilient
               logger.debug(
-                'Failed to insert NPC share (ignored)',
+                'Failed to insert NPC share/repost (ignored)',
                 {
                   actorId: actor.id,
                   postId: post.id,


### PR DESCRIPTION
## Summary

- Fix inverted quote probability (0.65 -> 0.30) so NPCs create 70% replies and 30% quote posts instead of the opposite
- Add NPC simple repost generation so shares appear as visible feed items
- Add timestamp staggering to organization-tick (spread across 5-min window)
- Add variable batch size to organization-tick (2-4 orgs instead of fixed 3)

## Problem

The feed was dominated by quote posts and organization posts appeared batched/robotic:
- NPCs were creating 65% quote posts instead of the intended 30%
- NPC shares were invisible (only created Share records, not visible Post entries)
- Organization posts all had the same timestamp within a tick
- Organization batch size was always exactly 3 (predictable)

## Changes

### 1. Fix Quote Probability (`packages/engine/src/config/npc-activity.ts`)
- Changed `discourseQuoteProbability` from `0.65` to `0.30`
- Updated JSDoc to reflect correct 30% quote / 70% reply intention

### 2. Add NPC Simple Reposts (`packages/engine/src/services/npc-social-engagement-service.ts`)
- NPC shares now create both a Share record AND a visible repost Post
- Empty content marks it as a simple repost (not a quote post)

### 3. Organization Timestamp Staggering (`apps/web/src/app/api/cron/organization-tick/route.ts`)
- Posts now have timestamps spread across the next 5-minute window
- Posts become visible gradually as their timestamp passes

### 4. Variable Batch Size (`apps/web/src/app/api/cron/organization-tick/route.ts`)
- Changed from fixed 3 to variable 2-4 orgs per tick
- Uses secureRandom() for -1, 0, or +1 variance

## Test plan

- [ ] Verify quote posts are ~30% of NPC discourse (down from ~65%)
- [ ] Verify simple reposts appear in feed from NPC shares
- [ ] Verify organization posts have varied timestamps
- [ ] Verify organization batch sizes vary between 2-4

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NPC share actions now atomically create visible reposts alongside share records.

* **Updates**
  * NPC engagement adjusted: quote-post probability reduced from 65% to 30%.
  * Content distribution now uses randomized batch sizes and staggered post timestamps for more organic pacing.

* **Bug Fixes / Reliability**
  * Share processing now only marks shares as completed when the creation transaction succeeds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed NPC behavior to create more organic, less robotic feed content through four targeted changes.

**Key Changes:**
- Fixed inverted quote probability (0.65 → 0.30) so NPCs create 70% replies instead of 65% quote posts
- NPC shares now create visible repost Posts (not just Share records) so they appear in the feed
- Organization posts get staggered timestamps across 5-minute windows instead of identical timestamps
- Organization batch size varies between 2-4 per tick (not fixed at 3)

**Issues Found:**
- Critical logic bug: batch variance calculated at module level means same batch size for entire server lifetime (see inline comment)

<h3>Confidence Score: 3/5</h3>

- Safe to merge after fixing batch variance initialization bug
- One critical logic bug in organization-tick where batch variance is calculated at module level instead of per-request. Other changes are solid improvements to feed pacing.
- apps/web/src/app/api/cron/organization-tick/route.ts needs batch variance fix before merge

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/engine/src/config/npc-activity.ts | Changed quote probability from 0.65 to 0.30 to fix inverted logic |
| packages/engine/src/services/npc-social-engagement-service.ts | Added repost Post creation for NPC shares so they appear in feed |
| apps/web/src/app/api/cron/organization-tick/route.ts | Added timestamp staggering and variable batch size for organic feel |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Cron as Cron Job
    participant OrgTick as organization-tick
    participant NPCTick as npc-tick
    participant EngService as npc-social-engagement-service
    participant DB as Database
    participant Feed as User Feed

    Note over Cron,Feed: Organization Tick Flow (5-min intervals)
    Cron->>OrgTick: POST /api/cron/organization-tick
    OrgTick->>OrgTick: Calculate batch variance (-1, 0, +1)
    OrgTick->>OrgTick: Select 2-4 orgs (BASE ± variance)
    loop For each org
        OrgTick->>OrgTick: Generate post content via LLM
        OrgTick->>OrgTick: Calculate random offset (0-5 min)
        OrgTick->>DB: Insert post with staggered timestamp
    end
    Note over OrgTick,DB: Posts spread across next 5-min window

    Note over Cron,Feed: NPC Social Engagement Flow
    Cron->>NPCTick: POST /api/cron/npc-tick
    NPCTick->>EngService: processNPCSocialEngagements()
    EngService->>DB: Fetch recent posts (last 6h)
    loop For each NPC actor
        EngService->>EngService: Calculate engagement probability
        alt Quote or Reply (30% quote, 70% reply)
            EngService->>DB: Create reply/quote post
        end
        alt Share action
            EngService->>DB: Create Share record
            EngService->>DB: Create repost Post (empty content)
            Note over DB,Feed: Repost now visible in feed
        end
        alt Like action
            EngService->>DB: Create Reaction record
        end
    end
    DB->>Feed: Posts appear gradually as timestamps pass
    Note over DB,Feed: Organic feed pacing achieved
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->