### PR TITLE
fix: preserve message order when replacing optimistic messages

### DIFF
--- a/apps/web/src/hooks/useChatMessages.ts
+++ b/apps/web/src/hooks/useChatMessages.ts
@@ -107,12 +107,17 @@ function replaceOptimisticMessage(
   // Replace optimistic message if found
   const pending = messages.find((msg) => isMatchingOptimistic(msg, confirmed));
   if (pending) {
-    return sortByTime(
-      messages.map((msg) =>
-        msg.id === pending.id
-          ? { ...confirmed, stableKey: pending.stableKey || pending.id }
-          : msg
-      )
+    // Preserve the optimistic message's createdAt to maintain visual order
+    // The server timestamp might differ due to network latency, but we want
+    // to keep the message in the same position the user saw it
+    return messages.map((msg) =>
+      msg.id === pending.id
+        ? {
+            ...confirmed,
+            stableKey: pending.stableKey || pending.id,
+            createdAt: pending.createdAt,
+          }
+        : msg
     );
   }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed optimistic message replacement to preserve the original client-side timestamp when the confirmed message arrives from the server. This prevents messages from jumping to a different position in the chat when the server's `createdAt` differs from the client's due to network latency.

The fix removes the `sortByTime()` call and instead preserves `pending.createdAt` when replacing optimistic messages in the SSE handler.

**Issue Found:**
- The polling fallback path (lines 393-398) still uses the server timestamp and needs the same `createdAt` preservation to prevent reordering when polling triggers instead of SSE

<h3>Confidence Score: 3/5</h3>

- Safe to merge but polling fallback has the same ordering issue that this PR fixes for SSE
- The fix correctly addresses message reordering in the SSE path, but the polling fallback code path has the same issue and wasn't updated, creating inconsistent behavior
- The polling fallback logic in `useChatMessages.ts` lines 393-398 needs the same fix

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/hooks/useChatMessages.ts | Preserves optimistic message `createdAt` timestamp to maintain visual order when replacing with confirmed message |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant UI
    participant Hook as useChatMessages
    participant API
    participant SSE as SSE Channel

    User->>UI: Send message
    UI->>Hook: addMessage(optimistic)
    Note over Hook: Creates pending-{uuid}<br/>with client timestamp
    Hook->>UI: Update with optimistic msg

    UI->>API: POST /api/messages
    API-->>SSE: Broadcast new_message
    API-->>UI: 200 OK (confirmed msg)

    SSE->>Hook: handleChatUpdate(confirmed)
    Note over Hook: replaceOptimisticMessage()<br/>finds matching pending message

    alt This PR Fix
        Hook->>Hook: Preserve pending.createdAt
        Note over Hook: Keeps original timestamp<br/>to maintain visual order
    else Before This PR
        Hook->>Hook: sortByTime() with<br/>server createdAt
        Note over Hook: Could reorder message<br/>due to network latency
    end

    Hook->>UI: Update with confirmed msg
    Note over UI: Message stays in same position
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->