### PR TITLE
fix: prevent message reordering during real-time updates

### DIFF
--- a/apps/web/src/hooks/useChatMessages.ts
+++ b/apps/web/src/hooks/useChatMessages.ts
@@ -50,13 +50,6 @@ function formatMessage(msg: RawApiMessage, chatId: string): ChatMessage {
   };
 }
 
-/** Sort messages by createdAt timestamp */
-function sortByTime(messages: ChatMessage[]): ChatMessage[] {
-  return [...messages].sort(
-    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-  );
-}
-
 /**
  * Time window (ms) for matching optimistic messages to confirmed messages.
  * If a confirmed message arrives within this window of an optimistic message
@@ -121,7 +114,9 @@ function replaceOptimisticMessage(
     );
   }
 
-  return sortByTime([...messages, confirmed]);
+  // Don't sort - just append. This preserves visual order during real-time chat.
+  // Messages are already sorted when loaded from API.
+  return [...messages, confirmed];
 }
 
 /** Polling interval - less aggressive since SSE is primary */
@@ -392,18 +387,21 @@ export function useChatMessages(chatId: string | null) {
               const pending = updated.find((m) => isMatchingOptimistic(m, msg));
               if (pending) {
                 const idx = updated.indexOf(pending);
+                // Preserve original timestamp to maintain visual order
                 updated[idx] = {
                   ...msg,
                   stableKey: pending.stableKey || pending.id,
+                  createdAt: pending.createdAt,
                 };
                 changed = true;
               } else {
+                // Just append new messages, don't sort
                 updated.push(msg);
                 changed = true;
               }
             }
 
-            return changed ? sortByTime(updated) : prev;
+            return changed ? updated : prev;
           });
 
           hasLoadedRef.current.add(chatId);


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message ordering to preserve the visual sequence as loaded from the server, preventing messages from rearranging during updates or confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR completes the fix for message reordering issues by removing all sorting operations during real-time updates. Building on the previous commit that preserved timestamps when replacing optimistic messages, this change ensures messages maintain their visual position throughout the entire lifecycle.

**Key Changes:**
- Removed `sortByTime()` helper function entirely
- Updated `replaceOptimisticMessage()` to append new messages without sorting
- Modified polling fallback to append messages without sorting
- Added inline comments explaining the rationale for preserving insertion order

**How It Works:**
Messages are sorted once when initially loaded from the API. During real-time updates, new messages are simply appended to maintain the order users see. When optimistic messages are replaced with confirmed ones, the original `createdAt` timestamp is preserved (from the previous commit), keeping the message in its original position. This prevents visual reordering that occurs when server timestamps differ from client timestamps due to network latency.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with one consideration about message ordering guarantees
- The change successfully addresses the visual reordering issue by removing sorting during real-time updates. However, the approach assumes that: (1) the API always returns properly sorted messages on initial load, (2) messages arrive via SSE/polling in chronological order, and (3) clock skew between client/server is minimal. The code relies on insertion order being correct, which works well for real-time chat but could cause issues if messages arrive out of order due to network delays or multi-server race conditions.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/hooks/useChatMessages.ts | Removed sortByTime calls to prevent message reordering during real-time updates, preserving insertion order |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant UI
    participant useChatMessages
    participant API
    participant SSE
    
    Note over User,SSE: Initial Load
    User->>UI: Opens chat
    UI->>useChatMessages: useChatMessages(chatId)
    useChatMessages->>API: GET /api/chats/:chatId
    API-->>useChatMessages: Sorted messages
    useChatMessages->>SSE: Subscribe to chat:chatId
    SSE-->>useChatMessages: Connection established
    useChatMessages-->>UI: Display messages
    
    Note over User,SSE: User Sends Message (Optimistic Update)
    User->>UI: Types & sends message
    UI->>API: POST /api/chats/:chatId/message
    UI->>useChatMessages: addMessage(optimistic)
    useChatMessages->>useChatMessages: replaceOptimisticMessage()
    Note right of useChatMessages: Append without sorting<br/>to preserve visual order
    useChatMessages-->>UI: Update messages
    
    Note over User,SSE: Real-time Confirmation
    API-->>SSE: Broadcast new_message
    SSE->>useChatMessages: handleChatUpdate(confirmed)
    useChatMessages->>useChatMessages: replaceOptimisticMessage()
    Note right of useChatMessages: Replace optimistic with confirmed<br/>Preserve createdAt from optimistic<br/>No sorting - maintain position
    useChatMessages-->>UI: Update messages (same position)
    
    Note over User,SSE: Polling Fallback
    loop Every 15 seconds
        useChatMessages->>API: GET /api/chats/:chatId (poll)
        API-->>useChatMessages: Latest messages
        useChatMessages->>useChatMessages: Deduplicate & append new
        Note right of useChatMessages: No sorting - preserve order
        useChatMessages-->>UI: Update if changed
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->