### PR TITLE
fix: team chat

### DIFF
--- a/apps/web/src/app/agents/team/AgentPnL.tsx
+++ b/apps/web/src/app/agents/team/AgentPnL.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import { cn, logger } from '@babylon/shared';
+import {
+  BABYLON_POINTS_SYMBOL,
+  cn,
+  formatCompactCurrency,
+  logger,
+} from '@babylon/shared';
 import { ChevronDown, Loader2, TrendingDown, TrendingUp } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
@@ -202,7 +207,7 @@ function UserPnL({
             <TrendingDown className="h-3 w-3" />
           )}
           {totalPnL >= 0 ? '+' : ''}
-          {totalPnL.toFixed(2)}
+          {formatCompactCurrency(totalPnL)}
         </div>
       </div>
 
@@ -219,7 +224,7 @@ function UserPnL({
               )}
             >
               {totalPnL >= 0 ? '+' : ''}
-              {totalPnL.toFixed(2)}
+              {formatCompactCurrency(totalPnL)}
             </span>
           </div>
           <div className="flex items-center justify-between text-xs">
@@ -231,7 +236,7 @@ function UserPnL({
               )}
             >
               {realizedPnL >= 0 ? '+' : ''}
-              {realizedPnL.toFixed(2)}
+              {formatCompactCurrency(realizedPnL)}
             </span>
           </div>
           <div className="flex items-center justify-between text-xs">
@@ -243,14 +248,14 @@ function UserPnL({
               )}
             >
               {unrealizedPnL >= 0 ? '+' : ''}
-              {unrealizedPnL.toFixed(2)}
+              {formatCompactCurrency(unrealizedPnL)}
             </span>
           </div>
           <div className="border-border border-t pt-2">
             <div className="flex items-center justify-between text-xs">
               <span className="text-muted-foreground">In Positions</span>
               <span className="font-medium">
-                {positionsValue.toFixed(2)} pts
+                {formatCompactCurrency(positionsValue)}
               </span>
             </div>
           </div>
@@ -260,7 +265,9 @@ function UserPnL({
         <div className="grid grid-cols-2 gap-2">
           <div className="rounded-lg bg-muted/30 p-2 text-center">
             <div className="text-[10px] text-muted-foreground">Balance</div>
-            <div className="font-semibold text-sm">{balance.toFixed(0)}</div>
+            <div className="font-semibold text-sm">
+              {formatCompactCurrency(balance, 0)}
+            </div>
           </div>
           <div className="rounded-lg bg-muted/30 p-2 text-center">
             <div className="text-[10px] text-muted-foreground">Positions</div>
@@ -335,7 +342,7 @@ function UserPnL({
                           )}
                         >
                           {Number(pos.unrealizedPnL) >= 0 ? '+' : ''}
-                          {Number(pos.unrealizedPnL).toFixed(2)}
+                          {formatCompactCurrency(Number(pos.unrealizedPnL))}
                         </span>
                       )}
                     </button>
@@ -377,7 +384,10 @@ function UserPnL({
                           </span>
                           <span>Size: {Number(pos.size).toFixed(4)}</span>
                           {pos.entryPrice && (
-                            <span>@ ${Number(pos.entryPrice).toFixed(2)}</span>
+                            <span>
+                              @ {BABYLON_POINTS_SYMBOL}
+                              {Number(pos.entryPrice).toFixed(2)}
+                            </span>
                           )}
                         </div>
                       </div>
@@ -391,7 +401,7 @@ function UserPnL({
                           )}
                         >
                           {Number(pos.unrealizedPnL) >= 0 ? '+' : ''}
-                          {Number(pos.unrealizedPnL).toFixed(2)}
+                          {formatCompactCurrency(Number(pos.unrealizedPnL))}
                         </span>
                       )}
                     </button>
@@ -549,7 +559,7 @@ function AgentPnLView({
           )}
           {positionsLoading
             ? '...'
-            : `${totalPnL >= 0 ? '+' : ''}${totalPnL.toFixed(2)}`}
+            : `${totalPnL >= 0 ? '+' : ''}${formatCompactCurrency(totalPnL)}`}
         </div>
       </div>
 
@@ -567,7 +577,7 @@ function AgentPnLView({
             >
               {positionsLoading
                 ? '...'
-                : `${totalPnL >= 0 ? '+' : ''}${totalPnL.toFixed(2)}`}
+                : `${totalPnL >= 0 ? '+' : ''}${formatCompactCurrency(totalPnL)}`}
             </span>
           </div>
           <div className="flex items-center justify-between text-xs">
@@ -579,7 +589,7 @@ function AgentPnLView({
               )}
             >
               {realizedPnL >= 0 ? '+' : ''}
-              {realizedPnL.toFixed(2)}
+              {formatCompactCurrency(realizedPnL)}
             </span>
           </div>
           <div className="flex items-center justify-between text-xs">
@@ -592,14 +602,16 @@ function AgentPnLView({
             >
               {positionsLoading
                 ? '...'
-                : `${unrealizedPnL >= 0 ? '+' : ''}${unrealizedPnL.toFixed(2)}`}
+                : `${unrealizedPnL >= 0 ? '+' : ''}${formatCompactCurrency(unrealizedPnL)}`}
             </span>
           </div>
           <div className="border-border border-t pt-2">
             <div className="flex items-center justify-between text-xs">
               <span className="text-muted-foreground">In Positions</span>
               <span className="font-medium">
-                {positionsLoading ? '...' : pointsInPositions.toFixed(2)} pts
+                {positionsLoading
+                  ? '...'
+                  : formatCompactCurrency(pointsInPositions)}
               </span>
             </div>
           </div>
@@ -694,7 +706,7 @@ function AgentPnLView({
                           )}
                         >
                           {Number(pos.unrealizedPnL) >= 0 ? '+' : ''}
-                          {Number(pos.unrealizedPnL).toFixed(2)}
+                          {formatCompactCurrency(Number(pos.unrealizedPnL))}
                         </span>
                       )}
                     </button>
@@ -736,7 +748,10 @@ function AgentPnLView({
                           </span>
                           <span>Size: {Number(pos.size).toFixed(4)}</span>
                           {pos.entryPrice && (
-                            <span>@ ${Number(pos.entryPrice).toFixed(2)}</span>
+                            <span>
+                              @ {BABYLON_POINTS_SYMBOL}
+                              {Number(pos.entryPrice).toFixed(2)}
+                            </span>
                           )}
                         </div>
                       </div>
@@ -750,7 +765,7 @@ function AgentPnLView({
                           )}
                         >
                           {Number(pos.unrealizedPnL) >= 0 ? '+' : ''}
-                          {Number(pos.unrealizedPnL).toFixed(2)}
+                          {formatCompactCurrency(Number(pos.unrealizedPnL))}
                         </span>
                       )}
                     </button>

--- a/apps/web/src/app/agents/team/AgentPortfolio.tsx
+++ b/apps/web/src/app/agents/team/AgentPortfolio.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { cn, logger } from '@babylon/shared';
+import { cn, formatCompactCurrency, logger } from '@babylon/shared';
 import {
   ArrowDownToLine,
   ArrowUpFromLine,
@@ -108,7 +108,7 @@ function UserWallet({
               Your Balance
             </div>
             <div className="mt-1 font-bold text-2xl">
-              {balance.toFixed(2)} pts
+              {formatCompactCurrency(balance)}
             </div>
           </div>
           <div className="text-right">
@@ -120,7 +120,7 @@ function UserWallet({
               )}
             >
               {lifetimePnL >= 0 ? '+' : ''}
-              {lifetimePnL.toFixed(2)}
+              {formatCompactCurrency(lifetimePnL)}
             </div>
           </div>
         </div>
@@ -210,13 +210,13 @@ function AgentWallet({
 
     if (action === 'deposit' && amountNum > balanceInfo.userBalance) {
       toast.error(
-        `Insufficient balance. You have ${balanceInfo.userBalance.toFixed(2)} pts`
+        `Insufficient balance. You have ${formatCompactCurrency(balanceInfo.userBalance)}`
       );
       return;
     }
     if (action === 'withdraw' && amountNum > balanceInfo.agentBalance) {
       toast.error(
-        `Insufficient agent balance. Agent has ${balanceInfo.agentBalance.toFixed(2)} pts`
+        `Insufficient agent balance. Agent has ${formatCompactCurrency(balanceInfo.agentBalance)}`
       );
       return;
     }
@@ -292,13 +292,13 @@ function AgentWallet({
               Agent Balance
             </div>
             <div className="mt-1 font-bold text-2xl">
-              {balanceInfo.agentBalance.toFixed(2)} pts
+              {formatCompactCurrency(balanceInfo.agentBalance)}
             </div>
           </div>
           <div className="text-right">
             <div className="text-muted-foreground text-xs">Your Balance</div>
             <div className="mt-1 font-semibold text-lg">
-              {balanceInfo.userBalance.toFixed(2)} pts
+              {formatCompactCurrency(balanceInfo.userBalance)}
             </div>
           </div>
         </div>
@@ -424,7 +424,7 @@ function AgentWallet({
                         )}
                       >
                         {tx.amount > 0 ? '+' : ''}
-                        {tx.amount.toFixed(2)}
+                        {formatCompactCurrency(tx.amount)}
                       </span>
                     </button>
 
@@ -447,7 +447,7 @@ function AgentWallet({
                               Balance After:
                             </span>
                             <span className="font-medium">
-                              {tx.balanceAfter.toFixed(2)} pts
+                              {formatCompactCurrency(tx.balanceAfter)}
                             </span>
                           </div>
                           <div className="flex justify-between">

--- a/apps/web/src/app/agents/team/AgentPortfolio.tsx
+++ b/apps/web/src/app/agents/team/AgentPortfolio.tsx
@@ -7,10 +7,12 @@ import {
   ChevronDown,
   History,
   Loader2,
+  Sparkles,
   Wallet,
 } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
+import { BuyPointsModal } from '@/components/points/BuyPointsModal';
 import { Input } from '@/components/ui/input';
 import { useAuth } from '@/hooks/useAuth';
 import { useWalletBalance } from '@/hooks/useWalletBalance';
@@ -87,7 +89,13 @@ function UserWallet({
   userId: string;
   entityName: string;
 }) {
-  const { balance, lifetimePnL, loading } = useWalletBalance(userId);
+  const { balance, lifetimePnL, loading, refresh } = useWalletBalance(userId);
+  const [buyPointsOpen, setBuyPointsOpen] = useState(false);
+
+  const handleBuyPointsSuccess = useCallback(() => {
+    refresh();
+    toast.success('Points purchased successfully!');
+  }, [refresh]);
 
   if (loading) {
     return (
@@ -126,6 +134,23 @@ function UserWallet({
         </div>
         <div className="mt-2 text-muted-foreground text-xs">{entityName}</div>
       </div>
+
+      {/* Buy Points Button */}
+      <button
+        type="button"
+        onClick={() => setBuyPointsOpen(true)}
+        className="flex items-center justify-center gap-2 rounded-lg bg-[#0066FF] px-4 py-2.5 font-medium text-white transition-all hover:bg-[#0055DD]"
+      >
+        <Sparkles className="h-4 w-4" />
+        Buy Points
+      </button>
+
+      {/* Buy Points Modal */}
+      <BuyPointsModal
+        isOpen={buyPointsOpen}
+        onClose={() => setBuyPointsOpen(false)}
+        onSuccess={handleBuyPointsSuccess}
+      />
     </div>
   );
 }

--- a/apps/web/src/app/agents/team/BottomPanel.tsx
+++ b/apps/web/src/app/agents/team/BottomPanel.tsx
@@ -107,9 +107,9 @@ export function BottomPanel({
     { id: 'pnl', label: 'PnL' },
     { id: 'logs', label: 'Logs' },
   ];
-  // Hide Logs and Activity tabs for user
+  // Hide Logs tab for user (Activity is now available for users)
   const tabs = isUserSelected
-    ? allTabs.filter((t) => t.id !== 'logs' && t.id !== 'activity')
+    ? allTabs.filter((t) => t.id !== 'logs')
     : allTabs;
 
   // Handle tab click - if clicking active tab while open, collapse

--- a/apps/web/src/app/agents/team/UserActivity.tsx
+++ b/apps/web/src/app/agents/team/UserActivity.tsx
@@ -1,0 +1,463 @@
+'use client';
+
+import { cn, formatCompactCurrency } from '@babylon/shared';
+import { Activity } from 'lucide-react';
+import { memo, useCallback, useEffect, useState } from 'react';
+import { useAuth } from '@/hooks/useAuth';
+
+/** Activity types from the API */
+interface TradeActivity {
+  type: 'trade';
+  id: string;
+  timestamp: string;
+  data: {
+    tradeType: string; // pred_buy, pred_sell, perp_open, perp_close
+    marketId: string | null;
+    marketQuestion: string | null;
+    amount: number;
+    description: string | null;
+  };
+}
+
+interface PointsActivity {
+  type: 'points';
+  id: string;
+  timestamp: string;
+  data: {
+    amount: number;
+    pointsBefore: number;
+    pointsAfter: number;
+    reason: string;
+    paymentProvider: string | null;
+  };
+}
+
+interface PostActivity {
+  type: 'post';
+  id: string;
+  timestamp: string;
+  data: {
+    postId: string;
+    contentPreview: string;
+  };
+}
+
+interface CommentActivity {
+  type: 'comment';
+  id: string;
+  timestamp: string;
+  data: {
+    commentId: string;
+    postId: string;
+    contentPreview: string;
+    parentCommentId: string | null;
+  };
+}
+
+type UserActivityItem =
+  | TradeActivity
+  | PointsActivity
+  | PostActivity
+  | CommentActivity;
+
+interface UserActivityProps {
+  userId: string;
+  className?: string;
+}
+
+/**
+ * Get human-readable reason label for points transactions
+ */
+function getReasonLabel(reason: string): string {
+  const labels: Record<string, string> = {
+    purchase: 'Purchased points',
+    purchase_refund: 'Received refund',
+    purchase_dispute: 'Dispute deduction',
+    purchase_dispute_won: 'Dispute won',
+    trading_pnl: 'Trading P&L',
+    transfer_sent: 'Transferred to agent',
+    transfer_received: 'Withdrew from agent',
+    referral_signup: 'Referral bonus',
+    referral_qualified: 'Qualified referral bonus',
+    profile_completion: 'Profile completion bonus',
+    farcaster_link: 'Linked Farcaster',
+    twitter_link: 'Linked Twitter',
+    discord_link: 'Linked Discord',
+    wallet_connect: 'Connected wallet',
+    admin_award: 'Admin award',
+    admin_deduction: 'Admin deduction',
+    report_reward: 'Report reward',
+    agent_deposit: 'Deposited to agent',
+    agent_withdrawal: 'Withdrew from agent',
+  };
+  return (
+    labels[reason] ||
+    reason.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+  );
+}
+
+/**
+ * Get trade title based on trade type
+ */
+function getTradeTitle(tradeType: string): string {
+  const titles: Record<string, string> = {
+    pred_buy: 'Bought prediction position',
+    pred_sell: 'Sold prediction position',
+    perp_open: 'Opened perp position',
+    perp_close: 'Closed perp position',
+    perp_liquidation: 'Position liquidated',
+  };
+  return titles[tradeType] || 'Trade';
+}
+
+/**
+ * Get activity title
+ */
+function getActivityTitle(activity: UserActivityItem): string {
+  if (activity.type === 'trade') {
+    return getTradeTitle(activity.data.tradeType);
+  }
+  if (activity.type === 'points') {
+    return getReasonLabel(activity.data.reason);
+  }
+  if (activity.type === 'post') {
+    return 'Created a post';
+  }
+  if (activity.type === 'comment') {
+    return activity.data.parentCommentId
+      ? 'Replied to a comment'
+      : 'Commented on a post';
+  }
+  return 'Activity';
+}
+
+/**
+ * Format time ago (matches AgentActivityCard)
+ */
+function getTimeAgo(date: Date): string {
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+
+  // Handle future dates (clock skew)
+  if (diffMs < 0) return 'just now';
+
+  const diffSec = Math.floor(diffMs / 1000);
+  const diffMin = Math.floor(diffSec / 60);
+  const diffHour = Math.floor(diffMin / 60);
+  const diffDay = Math.floor(diffHour / 24);
+
+  if (diffSec < 60) return 'just now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHour < 24) return `${diffHour}h ago`;
+  if (diffDay === 1) return 'yesterday';
+  if (diffDay < 7) return `${diffDay}d ago`;
+
+  return date.toLocaleDateString();
+}
+
+/**
+ * Amount badge component for points
+ */
+function AmountBadge({ amount }: { amount: number }) {
+  const isPositive = amount >= 0;
+  return (
+    <div
+      className={cn(
+        'shrink-0 rounded-md px-2.5 py-1 font-medium font-mono text-sm',
+        isPositive
+          ? 'border border-emerald-300 bg-emerald-100 text-emerald-700 dark:border-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400'
+          : 'border border-red-300 bg-red-100 text-red-700 dark:border-red-800 dark:bg-red-900/30 dark:text-red-400'
+      )}
+    >
+      {isPositive ? '+' : ''}
+      {formatCompactCurrency(amount)}
+    </div>
+  );
+}
+
+/**
+ * Activity card component (matches AgentActivityCard style)
+ */
+const ActivityCard = memo(function ActivityCard({
+  activity,
+}: {
+  activity: UserActivityItem;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const timestamp = new Date(activity.timestamp);
+  const timeAgo = getTimeAgo(timestamp);
+  const title = getActivityTitle(activity);
+  const content = renderActivityContent(activity, expanded);
+
+  // Determine which badge to show
+  let badge = null;
+  if (activity.type === 'points') {
+    badge = <AmountBadge amount={activity.data.amount} />;
+  }
+
+  return (
+    <div
+      className={cn(
+        'group relative cursor-pointer rounded-lg border border-border p-4 transition-colors hover:border-border/80',
+        'bg-card/50 hover:bg-card/80'
+      )}
+      onClick={() => setExpanded((prev) => !prev)}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          setExpanded((prev) => !prev);
+        }
+      }}
+      role="button"
+      tabIndex={0}
+      aria-expanded={expanded}
+      aria-label={`${title}. Click to ${expanded ? 'collapse' : 'expand'} details.`}
+    >
+      <div className="flex items-start gap-3">
+        <div className="min-w-0 flex-1">
+          {/* Header Row */}
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-medium text-foreground text-sm">{title}</span>
+            <span className="text-muted-foreground text-xs">{timeAgo}</span>
+          </div>
+
+          {/* Activity-specific content */}
+          {content && <div className="mt-2">{content}</div>}
+        </div>
+
+        {/* Badge */}
+        {badge}
+      </div>
+    </div>
+  );
+});
+
+/**
+ * Get subtitle for points activity (matches agent trade subtitle style)
+ */
+function getPointsSubtitle(
+  reason: string,
+  paymentProvider: string | null
+): string | null {
+  // Show payment provider for purchases
+  if (reason === 'purchase' && paymentProvider) {
+    return `via ${paymentProvider}`;
+  }
+  // Show context for other transaction types
+  if (reason.includes('transfer')) {
+    return 'Agent funding';
+  }
+  if (reason.includes('referral')) {
+    return 'Referral program';
+  }
+  if (
+    reason.includes('link') ||
+    reason.includes('connect') ||
+    reason.includes('profile')
+  ) {
+    return 'Onboarding reward';
+  }
+  if (reason === 'trading_pnl') {
+    return 'Position settlement';
+  }
+  return null;
+}
+
+/**
+ * Render activity-specific content
+ */
+function renderActivityContent(activity: UserActivityItem, expanded: boolean) {
+  if (activity.type === 'trade') {
+    const { tradeType, amount, marketQuestion } = activity.data;
+    const isPrediction = tradeType.startsWith('pred_');
+    const typeLabel = isPrediction ? 'Prediction' : 'Perpetual';
+
+    return (
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          <span className="text-muted-foreground">{typeLabel}</span>
+          <span className="text-muted-foreground/60">•</span>
+          <span className="font-mono text-foreground">
+            ${amount.toLocaleString()}
+          </span>
+        </div>
+
+        {marketQuestion && (
+          <p
+            className={cn(
+              'text-muted-foreground text-sm',
+              expanded ? '' : 'line-clamp-2'
+            )}
+          >
+            {marketQuestion}
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  if (activity.type === 'points') {
+    const { reason, paymentProvider } = activity.data;
+    const subtitle = getPointsSubtitle(reason, paymentProvider);
+
+    // Only show subtitle if we have one (matching agent trade style)
+    if (!subtitle) return null;
+
+    return (
+      <div className="flex flex-wrap items-center gap-2 text-sm">
+        <span className="text-muted-foreground">{subtitle}</span>
+      </div>
+    );
+  }
+
+  if (activity.type === 'post') {
+    return (
+      <p
+        className={cn(
+          'text-muted-foreground text-sm',
+          expanded ? '' : 'line-clamp-2'
+        )}
+      >
+        {activity.data.contentPreview}
+      </p>
+    );
+  }
+
+  if (activity.type === 'comment') {
+    return (
+      <p
+        className={cn(
+          'text-muted-foreground text-sm',
+          expanded ? '' : 'line-clamp-2'
+        )}
+      >
+        {activity.data.contentPreview}
+      </p>
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Loading skeleton (matches AgentActivityFeed exactly)
+ */
+function ActivitySkeleton() {
+  return (
+    <div className="animate-pulse rounded-lg border border-border p-4">
+      <div className="flex items-start gap-3">
+        <div className="h-9 w-9 shrink-0 rounded-full bg-muted" />
+        <div className="flex-1 space-y-2">
+          <div className="h-4 w-48 rounded bg-muted" />
+          <div className="h-3 w-32 rounded bg-muted" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Empty state (matches AgentActivityFeed exactly)
+ */
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-center">
+      <Activity className="mb-4 h-12 w-12 text-muted-foreground opacity-50" />
+      <p className="font-semibold text-lg">No activity yet</p>
+      <p className="mt-1 max-w-sm text-muted-foreground text-sm">
+        Your trades, points, and posts will appear here
+      </p>
+    </div>
+  );
+}
+
+/**
+ * User Activity component - displays user's activity feed
+ * (matches AgentActivityFeed structure exactly)
+ */
+export function UserActivity({ userId, className }: UserActivityProps) {
+  const { getAccessToken } = useAuth();
+  const [activities, setActivities] = useState<UserActivityItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const refresh = useCallback(async () => {
+    const token = await getAccessToken();
+    if (!token) {
+      setError(new Error('Not authenticated'));
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetch(`/api/users/${userId}/activity?limit=50`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({}));
+        const errorMessage =
+          errorData.error || errorData.message || `Server error: ${res.status}`;
+        throw new Error(errorMessage);
+      }
+
+      const data = await res.json();
+      setActivities(data.activities || []);
+    } catch (err) {
+      console.error('Activity fetch error:', err);
+      setError(
+        err instanceof Error ? err : new Error('Failed to load activity')
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [userId, getAccessToken]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return (
+    <div className={cn('flex flex-col', className)}>
+      {/* Error state with retry button */}
+      {error && (
+        <div className="mb-4 flex items-center justify-between rounded-lg border border-destructive/50 bg-destructive/10 p-3">
+          <p className="text-destructive text-sm">
+            Failed to load activity: {error.message}
+          </p>
+          <button
+            onClick={() => void refresh()}
+            disabled={isLoading}
+            className="ml-3 shrink-0 rounded-md bg-destructive/20 px-3 py-1 text-destructive text-sm transition-colors hover:bg-destructive/30 disabled:opacity-50"
+          >
+            {isLoading ? 'Retrying...' : 'Retry'}
+          </button>
+        </div>
+      )}
+
+      {/* Loading skeleton */}
+      {isLoading && activities.length === 0 && (
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <ActivitySkeleton key={i} />
+          ))}
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!isLoading && activities.length === 0 && !error && <EmptyState />}
+
+      {/* Activity list */}
+      {activities.length > 0 && (
+        <div className="space-y-3">
+          {activities.map((activity) => (
+            <ActivityCard key={activity.id} activity={activity} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/agents/team/page.tsx
+++ b/apps/web/src/app/agents/team/page.tsx
@@ -114,12 +114,35 @@ const AgentActivityFeed = dynamic(
     loading: () => (
       <div className="animate-pulse space-y-3">
         {[1, 2, 3].map((i) => (
-          <div key={i} className="rounded-lg border border-zinc-800 p-4">
+          <div key={i} className="rounded-lg border border-border p-4">
             <div className="flex items-start gap-3">
-              <div className="h-9 w-9 shrink-0 rounded-full bg-zinc-800" />
+              <div className="h-9 w-9 shrink-0 rounded-full bg-muted" />
               <div className="flex-1 space-y-2">
-                <div className="h-4 w-48 rounded bg-zinc-800" />
-                <div className="h-3 w-32 rounded bg-zinc-800" />
+                <div className="h-4 w-48 rounded bg-muted" />
+                <div className="h-3 w-32 rounded bg-muted" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    ),
+  }
+);
+
+// Lazy load user activity feed for performance
+const UserActivity = dynamic(
+  () => import('./UserActivity').then((m) => ({ default: m.UserActivity })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="animate-pulse space-y-3">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="rounded-lg border border-border p-4">
+            <div className="flex items-start gap-3">
+              <div className="h-9 w-9 shrink-0 rounded-full bg-muted" />
+              <div className="flex-1 space-y-2">
+                <div className="h-4 w-48 rounded bg-muted" />
+                <div className="h-3 w-32 rounded bg-muted" />
               </div>
             </div>
           </div>
@@ -218,8 +241,7 @@ export default function TeamChatPage() {
     if (!bottomPanelEntityId && user?.id) {
       setBottomPanelEntityId(user.id);
       setBottomPanelEntityType('user');
-      // Set default tab to 'wallet' for user (activity/logs not available)
-      setBottomPanelTab('wallet');
+      // Keep current tab - activity is now available for users
       return;
     }
 
@@ -232,27 +254,32 @@ export default function TeamChatPage() {
         if (user?.id) {
           setBottomPanelEntityId(user.id);
           setBottomPanelEntityType('user');
-          // Set default tab to 'wallet' for user (activity/logs not available)
-          setBottomPanelTab('wallet');
+          // Switch to activity if on logs (logs not available for users)
+          if (bottomPanelTab === 'logs') {
+            setBottomPanelTab('activity');
+          }
         } else {
           setBottomPanelEntityId(null);
           setBottomPanelEntityType(null);
         }
       }
     }
-  }, [teamChat?.agents, bottomPanelEntityId, bottomPanelEntityType, user?.id]);
+  }, [
+    teamChat?.agents,
+    bottomPanelEntityId,
+    bottomPanelEntityType,
+    user?.id,
+    bottomPanelTab,
+  ]);
 
   // Handle entity change from bottom panel
   const handleBottomPanelEntityChange = useCallback(
     (id: string, type: EntityType) => {
       setBottomPanelEntityId(id);
       setBottomPanelEntityType(type);
-      // If switching to user and on logs or activity tab, switch to wallet
-      if (
-        type === 'user' &&
-        (bottomPanelTab === 'logs' || bottomPanelTab === 'activity')
-      ) {
-        setBottomPanelTab('wallet');
+      // If switching to user and on logs tab, switch to activity (logs not available for users)
+      if (type === 'user' && bottomPanelTab === 'logs') {
+        setBottomPanelTab('activity');
       }
     },
     [bottomPanelTab]
@@ -886,19 +913,26 @@ export default function TeamChatPage() {
       >
         {bottomPanelEntityId && bottomPanelEntityType && (
           <>
-            {/* Activity Tab - only for agents */}
-            {bottomPanelTab === 'activity' &&
-              bottomPanelEntityType === 'agent' && (
-                <div className="p-4">
-                  <AgentActivityFeed
-                    agentId={bottomPanelEntityId}
-                    limit={20}
-                    showAgent={false}
-                    showConnectionStatus={false}
-                    emptyMessage="No activity from this agent yet."
-                  />
-                </div>
-              )}
+            {/* Activity Tab */}
+            {bottomPanelTab === 'activity' && (
+              <div className="min-h-0 flex-1 overflow-y-auto">
+                {bottomPanelEntityType === 'agent' ? (
+                  <div className="p-4">
+                    <AgentActivityFeed
+                      agentId={bottomPanelEntityId}
+                      limit={20}
+                      showAgent={false}
+                      showConnectionStatus={false}
+                      emptyMessage="No activity from this agent yet."
+                    />
+                  </div>
+                ) : (
+                  <div className="p-4">
+                    <UserActivity userId={bottomPanelEntityId} />
+                  </div>
+                )}
+              </div>
+            )}
 
             {/* Wallet Tab */}
             {bottomPanelTab === 'wallet' &&

--- a/apps/web/src/app/agents/team/panels/PnlPanel.tsx
+++ b/apps/web/src/app/agents/team/panels/PnlPanel.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { PnlTagData } from '@babylon/shared';
-import { cn } from '@babylon/shared';
+import { cn, formatCompactCurrency } from '@babylon/shared';
 import { TrendingDown, TrendingUp } from 'lucide-react';
 import { PanelViewMoreLink } from './PanelViewMoreLink';
 
@@ -40,7 +40,9 @@ export function PnlPanel({ data, type }: PnlPanelProps) {
       <div className="grid grid-cols-2 gap-3">
         <div className="rounded-lg border border-border bg-card p-3">
           <p className="text-muted-foreground text-xs">Balance</p>
-          <p className="mt-1 font-bold text-lg">${balance.toFixed(2)}</p>
+          <p className="mt-1 font-bold text-lg">
+            {formatCompactCurrency(balance)}
+          </p>
         </div>
         <div className="rounded-lg border border-border bg-card p-3">
           <p className="text-muted-foreground text-xs">Lifetime P&L</p>
@@ -55,7 +57,7 @@ export function PnlPanel({ data, type }: PnlPanelProps) {
             ) : (
               <TrendingDown className="h-4 w-4" />
             )}
-            ${Math.abs(lifetimePnL).toFixed(2)}
+            {formatCompactCurrency(Math.abs(lifetimePnL))}
           </p>
         </div>
       </div>
@@ -113,7 +115,7 @@ export function PnlPanel({ data, type }: PnlPanelProps) {
               <div className="mt-1.5 flex items-center justify-between text-muted-foreground text-xs">
                 <span>Size: {pos.size.toFixed(4)}</span>
                 {pos.entryPrice != null && (
-                  <span>Entry: ${pos.entryPrice.toFixed(2)}</span>
+                  <span>Entry: {formatCompactCurrency(pos.entryPrice)}</span>
                 )}
               </div>
             </div>
@@ -132,7 +134,7 @@ export function PnlPanel({ data, type }: PnlPanelProps) {
             >
               <span className="font-medium">{trade.action}</span>
               <span className="text-muted-foreground">{trade.ticker}</span>
-              <span>${trade.amount.toFixed(2)}</span>
+              <span>{formatCompactCurrency(trade.amount)}</span>
               {trade.pnl !== null && (
                 <span
                   className={cn(
@@ -140,7 +142,8 @@ export function PnlPanel({ data, type }: PnlPanelProps) {
                     trade.pnl >= 0 ? 'text-green-500' : 'text-red-500'
                   )}
                 >
-                  {trade.pnl >= 0 ? '+' : ''}${trade.pnl.toFixed(2)}
+                  {trade.pnl >= 0 ? '+' : ''}
+                  {formatCompactCurrency(trade.pnl)}
                 </span>
               )}
             </div>

--- a/apps/web/src/app/api/users/[userId]/activity/route.ts
+++ b/apps/web/src/app/api/users/[userId]/activity/route.ts
@@ -1,0 +1,317 @@
+/**
+ * User Activity API
+ *
+ * @route GET /api/users/[userId]/activity - Get user activity (trades, points, posts, comments)
+ * @access Authenticated (owner only)
+ *
+ * @description
+ * Returns recent activity for a user including trades, points transactions, posts, and comments.
+ * Used for the Activity feed in the team chat bottom panel.
+ */
+
+import {
+  AuthorizationError,
+  authenticate,
+  requireUserByIdentifier,
+  successResponse,
+  withErrorHandling,
+} from '@babylon/api';
+import {
+  balanceTransactions,
+  comments,
+  db,
+  desc,
+  eq,
+  inArray,
+  markets,
+  pointsTransactions,
+  posts,
+} from '@babylon/db';
+import { UserIdParamSchema } from '@babylon/shared';
+import type { NextRequest } from 'next/server';
+import { z } from 'zod';
+
+const QuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).optional().default(50),
+  type: z
+    .enum(['all', 'points', 'post', 'comment', 'trade'])
+    .optional()
+    .default('all'),
+});
+
+interface TradeActivity {
+  type: 'trade';
+  id: string;
+  timestamp: string;
+  data: {
+    tradeType: string; // pred_buy, pred_sell, perp_open, perp_close
+    marketId: string | null;
+    marketQuestion: string | null;
+    amount: number;
+    description: string | null;
+  };
+}
+
+interface PointsActivity {
+  type: 'points';
+  id: string;
+  timestamp: string;
+  data: {
+    amount: number;
+    pointsBefore: number;
+    pointsAfter: number;
+    reason: string;
+    paymentProvider: string | null;
+  };
+}
+
+interface PostActivity {
+  type: 'post';
+  id: string;
+  timestamp: string;
+  data: {
+    postId: string;
+    contentPreview: string;
+  };
+}
+
+interface CommentActivity {
+  type: 'comment';
+  id: string;
+  timestamp: string;
+  data: {
+    commentId: string;
+    postId: string;
+    contentPreview: string;
+    parentCommentId: string | null;
+  };
+}
+
+type UserActivity =
+  | TradeActivity
+  | PointsActivity
+  | PostActivity
+  | CommentActivity;
+
+/**
+ * GET /api/users/[userId]/activity
+ * Get user's activity feed
+ */
+export const GET = withErrorHandling(
+  async (
+    request: NextRequest,
+    context: { params: Promise<{ userId: string }> }
+  ) => {
+    // Authenticate user
+    const authUser = await authenticate(request);
+    const { userId } = UserIdParamSchema.parse(await context.params);
+
+    // Check if the authenticated user has a database record
+    if (!authUser.dbUserId) {
+      throw new AuthorizationError(
+        'User profile not found. Please complete onboarding first.',
+        'activity',
+        'read'
+      );
+    }
+
+    const targetUser = await requireUserByIdentifier(userId, { id: true });
+    const canonicalUserId = targetUser.id;
+
+    // Verify user is getting their own activity
+    if (authUser.dbUserId !== canonicalUserId) {
+      throw new AuthorizationError(
+        'You can only view your own activity',
+        'activity',
+        'read'
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const { limit, type } = QuerySchema.parse({
+      limit: searchParams.get('limit') ?? undefined,
+      type: searchParams.get('type') ?? undefined,
+    });
+
+    const activities: UserActivity[] = [];
+
+    // Fetch trades from balanceTransactions (individual trade events)
+    if (type === 'all' || type === 'trade') {
+      const tradeTypes = [
+        'pred_buy',
+        'pred_sell',
+        'perp_open',
+        'perp_close',
+        'perp_liquidation',
+      ];
+
+      const userTrades = await db
+        .select({
+          id: balanceTransactions.id,
+          type: balanceTransactions.type,
+          amount: balanceTransactions.amount,
+          relatedId: balanceTransactions.relatedId,
+          description: balanceTransactions.description,
+          createdAt: balanceTransactions.createdAt,
+        })
+        .from(balanceTransactions)
+        .where(eq(balanceTransactions.userId, canonicalUserId))
+        .orderBy(desc(balanceTransactions.createdAt))
+        .limit(limit * 2); // Fetch more to filter
+
+      // Filter to only trade types
+      const filteredTrades = userTrades.filter((t) =>
+        tradeTypes.includes(t.type)
+      );
+
+      // Get market info for trades that have relatedId (marketId)
+      const marketIds = [
+        ...new Set(
+          filteredTrades
+            .filter((t) => t.relatedId && t.type.startsWith('pred_'))
+            .map((t) => t.relatedId as string)
+        ),
+      ];
+
+      let marketsMap: Map<string, string> = new Map();
+      if (marketIds.length > 0) {
+        const marketData = await db
+          .select({
+            id: markets.id,
+            question: markets.question,
+          })
+          .from(markets)
+          .where(inArray(markets.id, marketIds));
+
+        marketsMap = new Map(marketData.map((m) => [m.id, m.question]));
+      }
+
+      for (const trade of filteredTrades.slice(0, limit)) {
+        activities.push({
+          type: 'trade',
+          id: trade.id,
+          timestamp: trade.createdAt.toISOString(),
+          data: {
+            tradeType: trade.type,
+            marketId: trade.relatedId,
+            marketQuestion: trade.relatedId
+              ? marketsMap.get(trade.relatedId) || null
+              : null,
+            amount: Math.abs(Number(trade.amount)),
+            description: trade.description,
+          },
+        });
+      }
+    }
+
+    // Fetch points transactions if requested (excluding trading_pnl since we show trades separately)
+    if (type === 'all' || type === 'points') {
+      const transactions = await db
+        .select({
+          id: pointsTransactions.id,
+          amount: pointsTransactions.amount,
+          pointsBefore: pointsTransactions.pointsBefore,
+          pointsAfter: pointsTransactions.pointsAfter,
+          reason: pointsTransactions.reason,
+          paymentProvider: pointsTransactions.paymentProvider,
+          createdAt: pointsTransactions.createdAt,
+        })
+        .from(pointsTransactions)
+        .where(eq(pointsTransactions.userId, canonicalUserId))
+        .orderBy(desc(pointsTransactions.createdAt))
+        .limit(limit);
+
+      for (const tx of transactions) {
+        // Skip trading_pnl since we show trades from balanceTransactions
+        if (tx.reason === 'trading_pnl') continue;
+
+        activities.push({
+          type: 'points',
+          id: tx.id,
+          timestamp: tx.createdAt.toISOString(),
+          data: {
+            amount: tx.amount,
+            pointsBefore: tx.pointsBefore,
+            pointsAfter: tx.pointsAfter,
+            reason: tx.reason,
+            paymentProvider: tx.paymentProvider,
+          },
+        });
+      }
+    }
+
+    // Fetch posts if requested
+    if (type === 'all' || type === 'post') {
+      const userPosts = await db
+        .select({
+          id: posts.id,
+          content: posts.content,
+          createdAt: posts.createdAt,
+        })
+        .from(posts)
+        .where(eq(posts.authorId, canonicalUserId))
+        .orderBy(desc(posts.createdAt))
+        .limit(limit);
+
+      for (const post of userPosts) {
+        activities.push({
+          type: 'post',
+          id: post.id,
+          timestamp: post.createdAt.toISOString(),
+          data: {
+            postId: post.id,
+            contentPreview: post.content.substring(0, 200),
+          },
+        });
+      }
+    }
+
+    // Fetch comments if requested
+    if (type === 'all' || type === 'comment') {
+      const userComments = await db
+        .select({
+          id: comments.id,
+          postId: comments.postId,
+          content: comments.content,
+          parentCommentId: comments.parentCommentId,
+          createdAt: comments.createdAt,
+        })
+        .from(comments)
+        .where(eq(comments.authorId, canonicalUserId))
+        .orderBy(desc(comments.createdAt))
+        .limit(limit);
+
+      for (const comment of userComments) {
+        activities.push({
+          type: 'comment',
+          id: comment.id,
+          timestamp: comment.createdAt.toISOString(),
+          data: {
+            commentId: comment.id,
+            postId: comment.postId,
+            contentPreview: comment.content.substring(0, 200),
+            parentCommentId: comment.parentCommentId,
+          },
+        });
+      }
+    }
+
+    // Sort all activities by timestamp (newest first)
+    activities.sort(
+      (a, b) =>
+        new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime()
+    );
+
+    const limitedActivities = activities.slice(0, limit);
+
+    return successResponse({
+      userId: canonicalUserId,
+      activities: limitedActivities,
+      pagination: {
+        limit,
+        count: limitedActivities.length,
+        hasMore: activities.length > limit,
+      },
+    });
+  }
+);

--- a/apps/web/src/hooks/useChatMessages.ts
+++ b/apps/web/src/hooks/useChatMessages.ts
@@ -427,7 +427,16 @@ export function useChatMessages(chatId: string | null) {
   }, [isConnected, chatId]);
 
   const addMessage = useCallback((message: ChatMessage) => {
-    setMessages((prev) => replaceOptimisticMessage(prev, message));
+    // Optimistic/thinking messages should be appended directly without replacement logic
+    // Only confirmed messages (from SSE) should go through replacement to match their optimistic
+    if (
+      message.id.startsWith('pending-') ||
+      message.id.startsWith('thinking-')
+    ) {
+      setMessages((prev) => [...prev, message]);
+    } else {
+      setMessages((prev) => replaceOptimisticMessage(prev, message));
+    }
   }, []);
 
   const updateMessage = useCallback(


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Buy Points feature to user wallet interface
  * Introduced user activity feed displaying trades, points, posts, and comments

* **Improvements**
  * Enhanced currency formatting across portfolio and P&L displays for improved readability

* **Bug Fixes**
  * Fixed Activity tab to display correctly for user profiles

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR extends the team chat bottom panel to support a user-facing Activity tab by adding a new `UserActivity` client component and a new authenticated API endpoint `GET /api/users/[userId]/activity` that aggregates trades, points transactions, posts, and comments. It also tweaks message handling in `useChatMessages` for optimistic/thinking messages and updates several UI panels to use `formatCompactCurrency`/ƀ symbol formatting.

Key things to double-check are the new activity aggregation semantics (trade amount sign/direction, points filtering vs limit/pagination) and the adjusted optimistic-message insertion logic to ensure it doesn’t create duplicate placeholders.

<h3>Confidence Score: 3/5</h3>

- This PR is likely safe to merge, but there are a couple data/UX correctness concerns in the new activity endpoint and optimistic message handling.
- Main changes are additive (new API + new feed UI) and formatting tweaks, but the activity aggregation currently (1) filters points transactions after limiting, which can underfill results, and (2) normalizes trade amounts to absolute values, which may misrepresent direction. Separately, `addMessage` now appends pending/thinking messages without dedupe, which can reintroduce duplicate optimistic placeholders depending on caller behavior.
- apps/web/src/app/api/users/[userId]/activity/route.ts, apps/web/src/hooks/useChatMessages.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/agents/team/AgentPnL.tsx | Formats P&L/balances with formatCompactCurrency and uses ƀ symbol; possible UX/data-format inconsistency for points vs dollars but no obvious functional breakage. |
| apps/web/src/app/agents/team/AgentPortfolio.tsx | Adds Buy Points modal/button in user wallet and switches number formatting; potential balance refresh/toast timing issues but logic is straightforward. |
| apps/web/src/app/agents/team/BottomPanel.tsx | Allows Activity tab for users by only hiding Logs; behavior change appears consistent with page.tsx updates. |
| apps/web/src/app/agents/team/UserActivity.tsx | New user activity feed UI and fetch logic; likely mismatch in amount formatting/symbols and some data fields unused; error handling OK. |
| apps/web/src/app/agents/team/page.tsx | Adds lazy-loaded UserActivity and changes bottom panel default tab logic; may cause extra effect reruns due to dependency changes but should work. |
| apps/web/src/app/agents/team/panels/PnlPanel.tsx | Switches to formatCompactCurrency but may drop currency/points symbol semantics and shows abs(lifetimePnL) without sign; potential incorrect display. |
| apps/web/src/app/api/users/[userId]/activity/route.ts | Adds new authenticated activity endpoint; possible data correctness issues (trade amounts, market mapping, pagination hasMore) and performance from multiple queries. |
| apps/web/src/hooks/useChatMessages.ts | Changes addMessage to append pending/thinking directly; potential for duplicate optimistic messages and bypassing stableKey/replacement flow. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant U as User
  participant Page as TeamChatPage (apps/web/src/app/agents/team/page.tsx)
  participant BP as BottomPanel (apps/web/src/app/agents/team/BottomPanel.tsx)
  participant UA as UserActivity (apps/web/src/app/agents/team/UserActivity.tsx)
  participant API as GET /api/users/:userId/activity
  participant DB as DB (balanceTransactions, pointsTransactions, posts, comments)

  U->>Page: Open /agents/team
  Page->>BP: Render bottom panel (default tab/activity)
  alt Selected entity is user
    BP->>UA: Render <UserActivity userId>
    UA->>UA: getAccessToken()
    UA->>API: fetch /api/users/:userId/activity (Bearer token)
    API->>DB: Query balanceTransactions (trade types)
    API->>DB: Query pointsTransactions (limit N, filter trading_pnl in code)
    API->>DB: Query posts (limit N)
    API->>DB: Query comments (limit N)
    API-->>UA: activities[] (sorted + sliced)
    UA-->>BP: Render activity cards
  else Selected entity is agent
    BP->>Page: Render AgentActivityFeed
  end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->