### PR TITLE
fix: Replace GPT-OSS-20B with Llama 3.3 70B for agent free tier

### DIFF
--- a/packages/shared/src/constants/models.ts
+++ b/packages/shared/src/constants/models.ts
@@ -39,12 +39,12 @@ export interface GroqModelConfig {
  * To change models, update the modelId values here.
  */
 export const GROQ_MODELS = {
-  /** Free tier model - fast and efficient */
+  /** Free tier model - versatile with tool calling support */
   FREE: {
-    displayName: 'GPT-OSS 20B',
-    modelId: 'openai/gpt-oss-20b',
+    displayName: 'Llama 70B',
+    modelId: 'llama-3.3-70b-versatile',
     tier: 'free',
-    description: 'Fast and efficient for everyday tasks',
+    description: 'Fast and capable with tool calling support',
   },
   /** Pro tier model - more capable */
   PRO: {


### PR DESCRIPTION
## Summary
Fixes tool calling errors where GPT-OSS-20B would call tools even when `tool_choice` was set to 'none'. This was causing intermittent failures on the first agent message.

## Changes
- Replace `openai/gpt-oss-20b` with `llama-3.3-70b-versatile` for free tier
- Simplify displayName to "Llama 70B" for cleaner UI
- Llama 3.3 70B has native tool calling support (Llama 3.x capability)
- Model is in production on Groq and already has token limits configured (131K)
- Keeps Kimi K2 for pro tier

## Why
The GPT-OSS-20B model has a known bug where it calls tools even when instructed not to:
https://community.groq.com/t/gpt-oss-20b-calling-tools-unasked/650/2

Llama 3.3 70B Versatile is a production model with native function calling support and no known tool calling bugs. The originally planned Llama 3 Groq Tool Use models are no longer available on GroqCloud.

## Test plan
- [x] Verify model is available on Groq production API
- [x] Verify token limits are configured correctly
- [ ] Test agents can send messages without tool calling errors
- [ ] Test both free and pro tier agents
- [ ] Verify tool calling works correctly when intended

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Free tier AI model updated to Llama 70B (Llama 3.3 series) — now more versatile, fast, and includes tool-calling support for improved task handling and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Replaced GPT-OSS-20B with Llama 3.3 70B Versatile for free tier agents to resolve a critical tool calling bug where GPT-OSS-20B would invoke tools even when `tool_choice` was set to 'none', causing intermittent failures on first agent messages.

**Key Changes:**
- Updated `GROQ_MODELS.FREE.modelId` from `openai/gpt-oss-20b` to `llama-3.3-70b-versatile`
- Simplified display name to "Llama 70B" for cleaner UI
- Updated description to highlight native tool calling support
- Model already has token limits configured (131K input context)

**Technical Context:**
The change is isolated to the centralized model configuration in `packages/shared/src/constants/models.ts`, which serves as the single source of truth for model selection. All consumers (groq plugin, agent runtime, API routes) automatically pick up the new model through the `GROQ_MODELS.FREE` reference.

**Verification:**
- ✅ Model is available in Groq production API
- ✅ Token limits already configured in token-counter utilities (131,072 tokens)
- ✅ Model has native Llama 3.x tool calling support
- ✅ No breaking changes to API contracts or interfaces

**Minor Issues:**
- Example comments in the file still reference outdated model names ("Groq 8B") and should be updated to reflect current model names

<h3>Confidence Score: 4.5/5</h3>

- Safe to merge after updating example comments - fixes critical production bug with minimal risk
- High confidence due to isolated change in centralized config, pre-existing token limit configuration, and production-ready replacement model. Minor deduction for outdated example comments that should be updated for documentation accuracy.
- No files require special attention - straightforward model swap with proper infrastructure already in place

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/shared/src/constants/models.ts | Replaces GPT-OSS-20B with Llama 3.3 70B for free tier to fix tool calling bug |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Agent as Free Tier Agent
    participant Plugin as Groq Plugin
    participant Config as GROQ_MODELS Config
    participant Groq as Groq API
    
    Agent->>Plugin: Request TEXT_SMALL generation
    Plugin->>Config: Read GROQ_MODELS.FREE.modelId
    Config-->>Plugin: llama-3.3-70b-versatile
    Note over Config: Previously: openai/gpt-oss-20b<br/>Now: llama-3.3-70b-versatile
    Plugin->>Groq: Generate text with model
    Note over Groq: Llama 3.3 70B respects<br/>tool_choice='none' setting
    Groq-->>Plugin: Response (no unwanted tools)
    Plugin-->>Agent: Generated text
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->