### PR TITLE
Fix: redirect repost-of-repost to original

### DIFF
--- a/apps/web/src/app/api/cron/markets-tick/route.ts
+++ b/apps/web/src/app/api/cron/markets-tick/route.ts
@@ -160,8 +160,6 @@ const SYSTEM_MARKET_FEES = {
 /**
  * Market structure configuration - maintains exactly 10 active markets
  * with staggered timeframes for constant activity.
- *
- * Exported for testing purposes.
  */
 const MARKET_STRUCTURE: Record<
   string,
@@ -1930,8 +1928,6 @@ function mapTimeframeToDbType(timeframe: string): MarketTimeframe {
  * allowing accurate gap-filling with correct durations.
  *
  * Uses threshold-based matching with 10% tolerance to handle minor variations.
- *
- * Exported for testing purposes.
  */
 function inferGranularTimeframe(durationMs: number): string {
   // Sort entries by duration ascending to find the best match

--- a/apps/web/src/app/api/posts/[id]/share/route.ts
+++ b/apps/web/src/app/api/posts/[id]/share/route.ts
@@ -189,6 +189,7 @@ export const POST = withErrorHandling(
     const [post] = await db
       .select({
         id: posts.id,
+        content: posts.content,
         deletedAt: posts.deletedAt,
         authorId: posts.authorId,
         timestamp: posts.timestamp,
@@ -244,7 +245,7 @@ export const POST = withErrorHandling(
       throw new BusinessLogicError('Cannot share deleted post', 'POST_DELETED');
     }
 
-    if (post?.originalPostId) {
+    if (post && post.originalPostId && post.content.trim().length === 0) {
       throw new BusinessLogicError(
         'Cannot repost a repost. Please repost the original post.',
         'CANNOT_REPOST_REPOST'

--- a/apps/web/src/app/api/posts/[id]/share/route.ts
+++ b/apps/web/src/app/api/posts/[id]/share/route.ts
@@ -199,14 +199,43 @@ export const POST = withErrorHandling(
       .where(eq(posts.id, postId))
       .limit(1);
 
-    if (post && post.timestamp > now) {
-      throw new NotFoundError('Post', postId);
+    const isPureRepost =
+      !!post &&
+      typeof post.originalPostId === 'string' &&
+      post.originalPostId.trim().length > 0 &&
+      post.content.trim().length === 0;
+    const shareTargetPostId = isPureRepost ? post!.originalPostId! : postId;
+    let shareTargetPost = post;
+
+    if (post && isPureRepost) {
+      const [resolvedPost] = await db
+        .select({
+          id: posts.id,
+          content: posts.content,
+          deletedAt: posts.deletedAt,
+          authorId: posts.authorId,
+          timestamp: posts.timestamp,
+          originalPostId: posts.originalPostId,
+        })
+        .from(posts)
+        .where(eq(posts.id, shareTargetPostId))
+        .limit(1);
+
+      if (!resolvedPost) {
+        throw new NotFoundError('Post', shareTargetPostId);
+      }
+
+      shareTargetPost = resolvedPost;
     }
 
-    if (post) {
+    if (shareTargetPost && shareTargetPost.timestamp > now) {
+      throw new NotFoundError('Post', shareTargetPostId);
+    }
+
+    if (shareTargetPost) {
       const [isBlocked, hasBlockedMe] = await Promise.all([
-        hasBlocked(post.authorId, canonicalUserId),
-        hasBlocked(canonicalUserId, post.authorId),
+        hasBlocked(shareTargetPost.authorId, canonicalUserId),
+        hasBlocked(canonicalUserId, shareTargetPost.authorId),
       ]);
 
       if (isBlocked || hasBlockedMe) {
@@ -241,34 +270,46 @@ export const POST = withErrorHandling(
           timestamp,
         });
       }
-    } else if (post.deletedAt) {
+    } else if (shareTargetPost?.deletedAt) {
       throw new BusinessLogicError('Cannot share deleted post', 'POST_DELETED');
-    }
-
-    if (post && post.originalPostId && post.content.trim().length === 0) {
-      throw new BusinessLogicError(
-        'Cannot repost a repost. Please repost the original post.',
-        'CANNOT_REPOST_REPOST'
-      );
     }
 
     const [existingShare] = await db
       .select({ id: shares.id })
       .from(shares)
-      .where(and(eq(shares.userId, canonicalUserId), eq(shares.postId, postId)))
+      .where(
+        and(
+          eq(shares.userId, canonicalUserId),
+          eq(shares.postId, shareTargetPostId)
+        )
+      )
       .limit(1);
 
     if (existingShare) {
       throw new BusinessLogicError('Post already shared', 'ALREADY_SHARED');
     }
 
+    if (isPureRepost && shareTargetPostId !== postId) {
+      const [existingRepostShare] = await db
+        .select({ id: shares.id })
+        .from(shares)
+        .where(
+          and(eq(shares.userId, canonicalUserId), eq(shares.postId, postId))
+        )
+        .limit(1);
+
+      if (existingRepostShare) {
+        throw new BusinessLogicError('Post already shared', 'ALREADY_SHARED');
+      }
+    }
+
     await db.insert(shares).values({
       id: await generateSnowflakeId(),
       userId: canonicalUserId,
-      postId,
+      postId: shareTargetPostId,
     });
 
-    await NPCInteractionTracker.trackShare(canonicalUserId, postId);
+    await NPCInteractionTracker.trackShare(canonicalUserId, shareTargetPostId);
 
     const repostId = await generateSnowflakeId();
 
@@ -279,11 +320,11 @@ export const POST = withErrorHandling(
         timestamp: posts.timestamp,
       })
       .from(posts)
-      .where(eq(posts.id, postId))
+      .where(eq(posts.id, shareTargetPostId))
       .limit(1);
 
     if (originalPost && originalPost.timestamp > now) {
-      throw new NotFoundError('Post', postId);
+      throw new NotFoundError('Post', shareTargetPostId);
     }
 
     let repostPostData = null;
@@ -326,7 +367,7 @@ export const POST = withErrorHandling(
           content: repostContent,
           authorId: canonicalUserId,
           timestamp: new Date(),
-          originalPostId: postId,
+          originalPostId: shareTargetPostId,
         })
         .returning();
 
@@ -351,9 +392,9 @@ export const POST = withErrorHandling(
         timestamp: createdRepost.timestamp.toISOString(),
         isRepost: true,
         isQuote: !!quoteComment,
-        originalPostId: postId,
+        originalPostId: shareTargetPostId,
         originalPost: {
-          id: postId,
+          id: shareTargetPostId,
           content: originalPost.content,
           authorId: originalPost.authorId,
           authorName: originalAuthorName,
@@ -378,7 +419,7 @@ export const POST = withErrorHandling(
       });
       logger.info(
         'Broadcast repost to feed channel',
-        { repostId, postId },
+        { repostId, postId: shareTargetPostId },
         'POST /api/posts/[id]/share'
       );
     }
@@ -386,7 +427,7 @@ export const POST = withErrorHandling(
     const [postAuthor] = await db
       .select({ authorId: posts.authorId })
       .from(posts)
-      .where(eq(posts.id, postId))
+      .where(eq(posts.id, shareTargetPostId))
       .limit(1);
 
     if (
@@ -401,24 +442,28 @@ export const POST = withErrorHandling(
         .limit(1);
 
       if (postAuthorUser) {
-        await notifyShare(postAuthor.authorId, canonicalUserId, postId);
+        await notifyShare(
+          postAuthor.authorId,
+          canonicalUserId,
+          shareTargetPostId
+        );
       }
     }
 
     const [shareCountResult] = await db
       .select({ count: count() })
       .from(shares)
-      .where(eq(shares.postId, postId));
+      .where(eq(shares.postId, shareTargetPostId));
     const shareCount = Number(shareCountResult?.count ?? 0);
 
     logger.info(
       'Post shared successfully',
-      { postId, userId: canonicalUserId, shareCount },
+      { postId: shareTargetPostId, userId: canonicalUserId, shareCount },
       'POST /api/posts/[id]/share'
     );
 
     trackServerEvent(canonicalUserId, 'post_shared', {
-      postId,
+      postId: shareTargetPostId,
       ...(postAuthor?.authorId && { originalAuthorId: postAuthor.authorId }),
       shareCount,
       ...(repostId && { repostId }),

--- a/apps/web/src/app/api/posts/[id]/share/route.ts
+++ b/apps/web/src/app/api/posts/[id]/share/route.ts
@@ -135,6 +135,7 @@ import {
 } from '@babylon/engine';
 import {
   generateSnowflakeId,
+  isPureRepost,
   logger,
   PostIdParamSchema,
   SharePostSchema,
@@ -199,15 +200,11 @@ export const POST = withErrorHandling(
       .where(eq(posts.id, postId))
       .limit(1);
 
-    const isPureRepost =
-      !!post &&
-      typeof post.originalPostId === 'string' &&
-      post.originalPostId.trim().length > 0 &&
-      post.content.trim().length === 0;
-    const shareTargetPostId = isPureRepost ? post!.originalPostId! : postId;
+    let shareTargetPostId = postId;
     let shareTargetPost = post;
 
-    if (post && isPureRepost) {
+    if (post && isPureRepost(post)) {
+      shareTargetPostId = post.originalPostId;
       const [resolvedPost] = await db
         .select({
           id: posts.id,
@@ -289,7 +286,7 @@ export const POST = withErrorHandling(
       throw new BusinessLogicError('Post already shared', 'ALREADY_SHARED');
     }
 
-    if (isPureRepost && shareTargetPostId !== postId) {
+    if (post && isPureRepost(post) && shareTargetPostId !== postId) {
       const [existingRepostShare] = await db
         .select({ id: shares.id })
         .from(shares)
@@ -529,14 +526,8 @@ export const DELETE = withErrorHandling(
         .where(eq(posts.id, postId))
         .limit(1);
 
-      const isPureRepost =
-        !!post &&
-        typeof post.originalPostId === 'string' &&
-        post.originalPostId.trim().length > 0 &&
-        post.content.trim().length === 0;
-
-      if (isPureRepost) {
-        shareTargetPostId = post.originalPostId!;
+      if (post && isPureRepost(post)) {
+        shareTargetPostId = post.originalPostId;
         const [redirectedShare] = await db
           .select({ id: shares.id })
           .from(shares)

--- a/apps/web/src/app/api/posts/[id]/share/route.ts
+++ b/apps/web/src/app/api/posts/[id]/share/route.ts
@@ -192,6 +192,7 @@ export const POST = withErrorHandling(
         deletedAt: posts.deletedAt,
         authorId: posts.authorId,
         timestamp: posts.timestamp,
+        originalPostId: posts.originalPostId,
       })
       .from(posts)
       .where(eq(posts.id, postId))
@@ -241,6 +242,13 @@ export const POST = withErrorHandling(
       }
     } else if (post.deletedAt) {
       throw new BusinessLogicError('Cannot share deleted post', 'POST_DELETED');
+    }
+
+    if (post?.originalPostId) {
+      throw new BusinessLogicError(
+        'Cannot repost a repost. Please repost the original post.',
+        'CANNOT_REPOST_REPOST'
+      );
     }
 
     const [existingShare] = await db

--- a/apps/web/src/app/api/posts/[id]/share/route.ts
+++ b/apps/web/src/app/api/posts/[id]/share/route.ts
@@ -511,11 +511,45 @@ export const DELETE = withErrorHandling(
     await ensureUserForAuth(user, { displayName: fallbackDisplayName });
     const canonicalUserId = getCanonicalUserId(user);
 
-    const [share] = await db
+    let shareTargetPostId = postId;
+    let [share] = await db
       .select({ id: shares.id })
       .from(shares)
       .where(and(eq(shares.userId, canonicalUserId), eq(shares.postId, postId)))
       .limit(1);
+
+    if (!share) {
+      const [post] = await db
+        .select({
+          id: posts.id,
+          content: posts.content,
+          originalPostId: posts.originalPostId,
+        })
+        .from(posts)
+        .where(eq(posts.id, postId))
+        .limit(1);
+
+      const isPureRepost =
+        !!post &&
+        typeof post.originalPostId === 'string' &&
+        post.originalPostId.trim().length > 0 &&
+        post.content.trim().length === 0;
+
+      if (isPureRepost) {
+        shareTargetPostId = post.originalPostId!;
+        const [redirectedShare] = await db
+          .select({ id: shares.id })
+          .from(shares)
+          .where(
+            and(
+              eq(shares.userId, canonicalUserId),
+              eq(shares.postId, shareTargetPostId)
+            )
+          )
+          .limit(1);
+        share = redirectedShare;
+      }
+    }
 
     if (!share) {
       throw new NotFoundError('Share', `${postId}-${canonicalUserId}`);
@@ -527,7 +561,7 @@ export const DELETE = withErrorHandling(
       .where(
         and(
           eq(posts.authorId, canonicalUserId),
-          eq(posts.originalPostId, postId),
+          eq(posts.originalPostId, shareTargetPostId),
           isNull(posts.deletedAt)
         )
       )
@@ -537,13 +571,17 @@ export const DELETE = withErrorHandling(
       await db.delete(posts).where(eq(posts.id, repostPost.id));
       logger.info(
         'Deleted repost post',
-        { repostPostId: repostPost.id, originalPostId: postId },
+        {
+          repostPostId: repostPost.id,
+          originalPostId: shareTargetPostId,
+          requestedPostId: postId,
+        },
         'DELETE /api/posts/[id]/share'
       );
     } else {
       logger.warn(
         'No repost post found to delete',
-        { postId, userId: canonicalUserId },
+        { postId: shareTargetPostId, userId: canonicalUserId },
         'DELETE /api/posts/[id]/share'
       );
     }
@@ -553,25 +591,25 @@ export const DELETE = withErrorHandling(
     const [shareCountResult] = await db
       .select({ count: count() })
       .from(shares)
-      .where(eq(shares.postId, postId));
+      .where(eq(shares.postId, shareTargetPostId));
     const shareCount = Number(shareCountResult?.count ?? 0);
 
     await cachedDb.invalidatePostsCache();
     await cachedDb.invalidateActorPostsCache(canonicalUserId);
     logger.info(
       'Invalidated post caches after unshare',
-      { postId },
+      { postId: shareTargetPostId, requestedPostId: postId },
       'DELETE /api/posts/[id]/share'
     );
 
     logger.info(
       'Post unshared successfully',
-      { postId, userId: canonicalUserId, shareCount },
+      { postId: shareTargetPostId, userId: canonicalUserId, shareCount },
       'DELETE /api/posts/[id]/share'
     );
 
     trackServerEvent(canonicalUserId, 'post_unshared', {
-      postId,
+      postId: shareTargetPostId,
       shareCount,
     });
 

--- a/apps/web/src/app/api/posts/[id]/share/route.ts
+++ b/apps/web/src/app/api/posts/[id]/share/route.ts
@@ -286,6 +286,7 @@ export const POST = withErrorHandling(
       throw new BusinessLogicError('Post already shared', 'ALREADY_SHARED');
     }
 
+    // Backfill safety: legacy shares may still point at repost IDs
     if (post && isPureRepost(post) && shareTargetPostId !== postId) {
       const [existingRepostShare] = await db
         .select({ id: shares.id })

--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -1701,7 +1701,7 @@ export async function executeDirectRepost(
     return { success: false, error: 'Cannot repost own content' };
   }
 
-  if (post.originalPostId) {
+  if (post.originalPostId && post.content.trim().length === 0) {
     return {
       success: false,
       error: 'Cannot repost a repost. Please repost the original post.',

--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -20,6 +20,7 @@ import {
   PredictionDbAdapter,
   PredictionMarketService,
 } from '@babylon/core/markets/prediction';
+import { isPureRepost } from '@babylon/shared';
 import {
   actorState,
   aliasedTable,
@@ -1696,14 +1697,10 @@ export async function executeDirectRepost(
     return { success: false, error: `Post not found: ${postId}` };
   }
 
-  const isPureRepost =
-    typeof post.originalPostId === 'string' &&
-    post.originalPostId.trim().length > 0 &&
-    post.content.trim().length === 0;
   let targetPost = post;
   let targetPostId = postId;
 
-  if (isPureRepost) {
+  if (isPureRepost(post)) {
     const [resolvedPost] = await db
       .select({
         id: posts.id,
@@ -1712,7 +1709,7 @@ export async function executeDirectRepost(
         originalPostId: posts.originalPostId,
       })
       .from(posts)
-      .where(eq(posts.id, post.originalPostId!))
+      .where(eq(posts.id, post.originalPostId))
       .limit(1);
 
     if (!resolvedPost) {

--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -1715,7 +1715,7 @@ export async function executeDirectRepost(
     if (!resolvedPost) {
       return {
         success: false,
-        error: `Post not found: ${post.originalPostId}`,
+        error: 'Original post no longer exists',
       };
     }
 

--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -1682,7 +1682,12 @@ export async function executeDirectRepost(
 
   // Verify post exists
   const [post] = await db
-    .select({ id: posts.id, authorId: posts.authorId, content: posts.content })
+    .select({
+      id: posts.id,
+      authorId: posts.authorId,
+      content: posts.content,
+      originalPostId: posts.originalPostId,
+    })
     .from(posts)
     .where(eq(posts.id, postId))
     .limit(1);
@@ -1694,6 +1699,13 @@ export async function executeDirectRepost(
   // Don't let agents repost their own content
   if (post.authorId === agentUserId) {
     return { success: false, error: 'Cannot repost own content' };
+  }
+
+  if (post.originalPostId) {
+    return {
+      success: false,
+      error: 'Cannot repost a repost. Please repost the original post.',
+    };
   }
 
   // Note: We rely on the transaction's unique constraint handling to detect duplicates.

--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -1696,24 +1696,47 @@ export async function executeDirectRepost(
     return { success: false, error: `Post not found: ${postId}` };
   }
 
-  // Don't let agents repost their own content
-  if (post.authorId === agentUserId) {
-    return { success: false, error: 'Cannot repost own content' };
+  const isPureRepost =
+    typeof post.originalPostId === 'string' &&
+    post.originalPostId.trim().length > 0 &&
+    post.content.trim().length === 0;
+  let targetPost = post;
+  let targetPostId = postId;
+
+  if (isPureRepost) {
+    const [resolvedPost] = await db
+      .select({
+        id: posts.id,
+        authorId: posts.authorId,
+        content: posts.content,
+        originalPostId: posts.originalPostId,
+      })
+      .from(posts)
+      .where(eq(posts.id, post.originalPostId!))
+      .limit(1);
+
+    if (!resolvedPost) {
+      return {
+        success: false,
+        error: `Post not found: ${post.originalPostId}`,
+      };
+    }
+
+    targetPost = resolvedPost;
+    targetPostId = resolvedPost.id;
   }
 
-  if (post.originalPostId && post.content.trim().length === 0) {
-    return {
-      success: false,
-      error: 'Cannot repost a repost. Please repost the original post.',
-    };
+  // Don't let agents repost their own content
+  if (targetPost.authorId === agentUserId) {
+    return { success: false, error: 'Cannot repost own content' };
   }
 
   // Note: We rely on the transaction's unique constraint handling to detect duplicates.
   // The pre-check was removed to avoid TOCTOU race conditions.
 
   logger.info(
-    `[DirectExecutor] Reposting post ${postId}`,
-    { agentUserId, hasComment: !!comment },
+    `[DirectExecutor] Reposting post ${targetPostId}`,
+    { agentUserId, hasComment: !!comment, requestedPostId: postId },
     'DirectExecutors'
   );
 
@@ -1731,7 +1754,7 @@ export async function executeDirectRepost(
       await tx.insert(shares).values({
         id: shareId,
         userId: agentUserId,
-        postId,
+        postId: targetPostId,
         createdAt: now,
       });
 
@@ -1741,7 +1764,7 @@ export async function executeDirectRepost(
           id: quotePostId,
           content: comment!.trim(),
           authorId: agentUserId,
-          originalPostId: postId,
+          originalPostId: targetPostId,
           type: 'repost',
           timestamp: now,
           createdAt: now,
@@ -1750,7 +1773,7 @@ export async function executeDirectRepost(
     });
 
     logger.info(
-      `[DirectExecutor] Post reposted: ${postId} -> share ${shareId}${quotePostId ? ` with quote ${quotePostId}` : ''}`,
+      `[DirectExecutor] Post reposted: ${targetPostId} -> share ${shareId}${quotePostId ? ` with quote ${quotePostId}` : ''}`,
       undefined,
       'DirectExecutors'
     );
@@ -1773,7 +1796,9 @@ export async function executeDirectRepost(
       const [share] = await db
         .select({ id: shares.id })
         .from(shares)
-        .where(and(eq(shares.postId, postId), eq(shares.userId, agentUserId)))
+        .where(
+          and(eq(shares.postId, targetPostId), eq(shares.userId, agentUserId))
+        )
         .limit(1);
 
       if (!share?.id) {

--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -20,7 +20,6 @@ import {
   PredictionDbAdapter,
   PredictionMarketService,
 } from '@babylon/core/markets/prediction';
-import { isPureRepost } from '@babylon/shared';
 import {
   actorState,
   aliasedTable,
@@ -54,6 +53,7 @@ import {
   storeTagsForPost,
   WalletService,
 } from '@babylon/engine';
+import { isPureRepost } from '@babylon/shared';
 import { agentPnLService } from '../services/AgentPnLService';
 import { logger } from '../shared/logger';
 import { generateSnowflakeId } from '../shared/snowflake';

--- a/packages/agents/src/autonomous/__tests__/direct-repost.test.ts
+++ b/packages/agents/src/autonomous/__tests__/direct-repost.test.ts
@@ -15,9 +15,7 @@ const mockDb = {
       })),
     })),
   })),
-  transaction: mock(async () => {
-    throw new Error('transaction should not run for repost-of-repost');
-  }),
+  transaction: mock(async () => undefined),
 };
 
 mock.module('@babylon/db', () => ({
@@ -109,16 +107,48 @@ mock.module('../utils/resolvePerpTicker', () => ({
 const { executeDirectRepost } = await import('../DirectExecutors');
 
 describe('executeDirectRepost', () => {
-  test('rejects reposting a repost', async () => {
+  test('reposts the original when given a repost', async () => {
+    const originalPost = {
+      id: 'post-0',
+      authorId: 'user-9',
+      content: 'Original content',
+      originalPostId: null,
+    };
+    let selectCallCount = 0;
+    mockDb.select = mock(() => ({
+      from: mock(() => ({
+        where: mock(() => ({
+          limit: mock(async () => {
+            selectCallCount += 1;
+            return selectCallCount === 1 ? [mockPost] : [originalPost];
+          }),
+        })),
+      })),
+    }));
+
+    let sharedPostId: string | undefined;
+    mockDb.transaction = mock(
+      async (callback: (tx: unknown) => Promise<void>) => {
+        await callback({
+          insert: mock(() => ({
+            values: mock(async (values: { postId: string }) => {
+              sharedPostId = values.postId;
+            }),
+          })),
+        });
+        return undefined;
+      }
+    ) as typeof mockDb.transaction;
+
     const result = await executeDirectRepost({
       agentUserId: 'user-2',
       postId: 'post-1',
       comment: undefined,
     });
 
-    expect(result.success).toBe(false);
-    expect(result.error).toContain('Cannot repost a repost');
-    expect(mockDb.transaction).not.toHaveBeenCalled();
+    expect(result.success).toBe(true);
+    expect(mockDb.transaction).toHaveBeenCalled();
+    expect(sharedPostId).toBe(originalPost.id);
   });
 
   test('allows reposting an original post', async () => {

--- a/packages/agents/src/autonomous/__tests__/direct-repost.test.ts
+++ b/packages/agents/src/autonomous/__tests__/direct-repost.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+const mockPost = {
+  id: 'post-1',
+  authorId: 'user-1',
+  content: 'original content',
+  originalPostId: 'post-0',
+};
+
+const mockDb = {
+  select: mock(() => ({
+    from: mock(() => ({
+      where: mock(() => ({
+        limit: mock(async () => [mockPost]),
+      })),
+    })),
+  })),
+  transaction: mock(async () => {
+    throw new Error('transaction should not run for repost-of-repost');
+  }),
+};
+
+mock.module('@babylon/db', () => ({
+  actorState: {},
+  aliasedTable: mock(() => ({})),
+  and: (...args: unknown[]) => args,
+  asSystem: () => ({}),
+  asUser: () => ({}),
+  chatParticipants: {},
+  chats: {},
+  comments: {},
+  db: mockDb,
+  dmAcceptances: {},
+  eq: (a: unknown, b: unknown) => ({ a, b }),
+  gte: (...args: unknown[]) => args,
+  isNull: (...args: unknown[]) => args,
+  messages: {},
+  perpPositions: {},
+  posts: {
+    id: 'id',
+    authorId: 'authorId',
+    content: 'content',
+    originalPostId: 'originalPostId',
+  },
+  reactions: {},
+  shares: { id: 'id', postId: 'postId', userId: 'userId' },
+  sql: {},
+  users: { id: 'id' },
+}));
+
+mock.module('@babylon/api', () => ({
+  broadcastAgentActivity: mock(async () => undefined),
+  broadcastChatMessage: mock(async () => undefined),
+  broadcastToChannel: mock(async () => undefined),
+}));
+
+mock.module('@babylon/core/markets/perps', () => ({
+  PerpDbAdapter: class {},
+  PerpMarketService: class {},
+}));
+
+mock.module('@babylon/core/markets/prediction', () => ({
+  PredictionDbAdapter: class {},
+  PredictionMarketService: class {},
+}));
+
+mock.module('@babylon/engine', () => ({
+  FEE_CONFIG: {
+    TRADING_FEE_RATE: 0,
+    PLATFORM_SHARE: 0,
+    REFERRER_SHARE: 0,
+    MIN_FEE_AMOUNT: 0,
+    FEE_TYPES: {},
+  },
+  FeeService: { processTradingFee: mock(async () => ({ feeCharged: 0 })) },
+  generateTagsFromPost: mock(async () => []),
+  invalidateAfterPredictionTrade: mock(async () => undefined),
+  PredictionPricing: {},
+  StaticDataRegistry: { getActor: mock(() => null) },
+  storeTagsForPost: mock(async () => undefined),
+  WalletService: class {},
+}));
+
+mock.module('../../shared/logger', () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    debug: mock(() => undefined),
+    error: mock(() => undefined),
+  },
+}));
+
+mock.module('../../shared/snowflake', () => ({
+  generateSnowflakeId: mock(async () => 'snowflake-id'),
+}));
+
+mock.module('../../services/AgentPnLService', () => ({
+  agentPnLService: { recordTrade: mock(async () => undefined) },
+}));
+
+mock.module('../TopicDiversityService', () => ({
+  topicDiversityService: { trackPostTopics: mock(async () => undefined) },
+}));
+
+mock.module('../utils/resolvePerpTicker', () => ({
+  resolvePerpTicker: mock(() => null),
+}));
+
+const { executeDirectRepost } = await import('../DirectExecutors');
+
+describe('executeDirectRepost', () => {
+  test('rejects reposting a repost', async () => {
+    const result = await executeDirectRepost({
+      agentUserId: 'user-2',
+      postId: 'post-1',
+      comment: undefined,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Cannot repost a repost');
+    expect(mockDb.transaction).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agents/src/autonomous/__tests__/direct-repost.test.ts
+++ b/packages/agents/src/autonomous/__tests__/direct-repost.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, mock, test } from 'bun:test';
 const mockPost = {
   id: 'post-1',
   authorId: 'user-1',
-  content: 'original content',
+  content: '',
   originalPostId: 'post-0',
 };
 
@@ -119,5 +119,54 @@ describe('executeDirectRepost', () => {
     expect(result.success).toBe(false);
     expect(result.error).toContain('Cannot repost a repost');
     expect(mockDb.transaction).not.toHaveBeenCalled();
+  });
+
+  test('allows reposting an original post', async () => {
+    // Create a mock for an original post (no originalPostId)
+    const originalPost = {
+      id: 'post-original',
+      authorId: 'user-1',
+      content: 'Original content',
+      originalPostId: null,
+    };
+
+    // Override the select mock for this test to return original post
+    const mockDbSuccess = {
+      select: mock(() => ({
+        from: mock(() => ({
+          where: mock(() => ({
+            limit: mock(async () => [originalPost]),
+          })),
+        })),
+      })),
+      transaction: mock(async (callback: (tx: unknown) => Promise<void>) => {
+        // Simulate successful transaction
+        await callback({
+          insert: mock(() => ({ values: mock(async () => undefined) })),
+        });
+        return undefined;
+      }),
+    };
+
+    // Temporarily replace the db mock
+    const originalSelect = mockDb.select;
+    const originalTransaction = mockDb.transaction;
+    mockDb.select = mockDbSuccess.select;
+    mockDb.transaction = mockDbSuccess.transaction as typeof mockDb.transaction;
+
+    try {
+      const result = await executeDirectRepost({
+        agentUserId: 'user-2',
+        postId: 'post-original',
+        comment: undefined,
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockDbSuccess.transaction).toHaveBeenCalled();
+    } finally {
+      // Restore original mocks
+      mockDb.select = originalSelect;
+      mockDb.transaction = originalTransaction;
+    }
   });
 });

--- a/packages/agents/src/autonomous/__tests__/direct-repost.test.ts
+++ b/packages/agents/src/autonomous/__tests__/direct-repost.test.ts
@@ -199,4 +199,44 @@ describe('executeDirectRepost', () => {
       mockDb.transaction = originalTransaction;
     }
   });
+
+  test('does not redirect quote reposts', async () => {
+    const quotePost = {
+      id: 'post-quote',
+      authorId: 'user-3',
+      content: 'My take on this',
+      originalPostId: 'post-0',
+    };
+
+    mockDb.select = mock(() => ({
+      from: mock(() => ({
+        where: mock(() => ({
+          limit: mock(async () => [quotePost]),
+        })),
+      })),
+    }));
+
+    let sharedPostId: string | undefined;
+    mockDb.transaction = mock(
+      async (callback: (tx: unknown) => Promise<void>) => {
+        await callback({
+          insert: mock(() => ({
+            values: mock(async (values: { postId: string }) => {
+              sharedPostId = values.postId;
+            }),
+          })),
+        });
+        return undefined;
+      }
+    ) as typeof mockDb.transaction;
+
+    const result = await executeDirectRepost({
+      agentUserId: 'user-2',
+      postId: 'post-quote',
+      comment: undefined,
+    });
+
+    expect(result.success).toBe(true);
+    expect(sharedPostId).toBe(quotePost.id);
+  });
 });

--- a/packages/engine/src/services/npc-social-engagement-service.ts
+++ b/packages/engine/src/services/npc-social-engagement-service.ts
@@ -10,7 +10,7 @@
 
 import { db } from '@babylon/db';
 import type { JsonValue } from '@babylon/shared';
-import { generateSnowflakeId, logger } from '@babylon/shared';
+import { generateSnowflakeId, isPureRepost, logger } from '@babylon/shared';
 import {
   NPC_DIVERSITY_CONFIG,
   NPC_ENGAGEMENT_CONFIG,
@@ -319,11 +319,7 @@ export async function processNPCSocialEngagements(
     const postIds = recentPosts.map((p) => p.id);
     const shareTargetPostIds = new Set(postIds);
     for (const post of recentPosts) {
-      if (
-        typeof post.originalPostId === 'string' &&
-        post.originalPostId.trim().length > 0 &&
-        post.content.trim().length === 0
-      ) {
+      if (isPureRepost(post)) {
         shareTargetPostIds.add(post.originalPostId);
       }
     }
@@ -467,11 +463,9 @@ export async function processNPCSocialEngagements(
         const key = `${post.id}-${actor.id}`;
         const probs = calculateEngagementProbability(actor, post, random);
         // If this is a pure repost, share the original instead of the repost itself
-        const isPureRepost =
-          typeof post.originalPostId === 'string' &&
-          post.originalPostId.trim().length > 0 &&
-          post.content.trim().length === 0;
-        const shareTargetPostId = isPureRepost ? post.originalPostId! : post.id;
+        const shareTargetPostId = isPureRepost(post)
+          ? post.originalPostId
+          : post.id;
         const shareKey = `${shareTargetPostId}-${actor.id}`;
 
         // LIKE

--- a/packages/engine/src/services/npc-social-engagement-service.ts
+++ b/packages/engine/src/services/npc-social-engagement-service.ts
@@ -456,12 +456,12 @@ export async function processNPCSocialEngagements(
 
         const key = `${post.id}-${actor.id}`;
         const probs = calculateEngagementProbability(actor, post, random);
-        // Only skip sharing pure reposts (type='repost'), not quote posts
-        // Quote posts have originalPostId but are distinct content worth sharing
+        // Only skip sharing pure reposts (originalPostId + empty content), not quote posts
+        // Quote posts have originalPostId but include content worth sharing
         const isRepostTarget =
-          post.type === 'repost' &&
           typeof post.originalPostId === 'string' &&
-          post.originalPostId.trim().length > 0;
+          post.originalPostId.trim().length > 0 &&
+          post.content.trim().length === 0;
 
         // LIKE
         // Skip if global likes quota reached (other actors may still process shares/comments)

--- a/packages/engine/src/services/npc-social-engagement-service.ts
+++ b/packages/engine/src/services/npc-social-engagement-service.ts
@@ -317,13 +317,23 @@ export async function processNPCSocialEngagements(
 
     // Get existing engagements
     const postIds = recentPosts.map((p) => p.id);
+    const shareTargetPostIds = new Set(postIds);
+    for (const post of recentPosts) {
+      if (
+        typeof post.originalPostId === 'string' &&
+        post.originalPostId.trim().length > 0 &&
+        post.content.trim().length === 0
+      ) {
+        shareTargetPostIds.add(post.originalPostId);
+      }
+    }
     const [existingReactions, existingShares] = await Promise.all([
       db.reaction.findMany({
         where: { postId: { in: postIds } },
         select: { postId: true, userId: true },
       }),
       db.share.findMany({
-        where: { postId: { in: postIds } },
+        where: { postId: { in: Array.from(shareTargetPostIds) } },
         select: { postId: true, userId: true },
       }),
     ]);
@@ -456,12 +466,13 @@ export async function processNPCSocialEngagements(
 
         const key = `${post.id}-${actor.id}`;
         const probs = calculateEngagementProbability(actor, post, random);
-        // Only skip sharing pure reposts (originalPostId + empty content), not quote posts
-        // Quote posts have originalPostId but include content worth sharing
-        const isRepostTarget =
+        // If this is a pure repost, share the original instead of the repost itself
+        const isPureRepost =
           typeof post.originalPostId === 'string' &&
           post.originalPostId.trim().length > 0 &&
           post.content.trim().length === 0;
+        const shareTargetPostId = isPureRepost ? post.originalPostId! : post.id;
+        const shareKey = `${shareTargetPostId}-${actor.id}`;
 
         // LIKE
         // Skip if global likes quota reached (other actors may still process shares/comments)
@@ -503,8 +514,7 @@ export async function processNPCSocialEngagements(
         // SHARE (creates both a Share record AND a visible repost Post)
         // Skip if diversity tracker says too many consecutive shares
         if (
-          !isRepostTarget &&
-          !shareSet.has(key) &&
+          !shareSet.has(shareKey) &&
           result.sharesCreated < NPC_ENGAGEMENT_CONFIG.maxSharesPerTick &&
           !diversityTracker.shouldSkipForDiversity('share')
         ) {
@@ -515,7 +525,7 @@ export async function processNPCSocialEngagements(
                 await tx.share.create({
                   data: {
                     id: await generateSnowflakeId(),
-                    postId: post.id,
+                    postId: shareTargetPostId,
                     userId: actor.id,
                   },
                 });
@@ -529,7 +539,7 @@ export async function processNPCSocialEngagements(
                     content: '',
                     authorId: actor.id,
                     timestamp: getStaggeredTimestamp(), // Staggered for organic feel
-                    originalPostId: post.id,
+                    originalPostId: shareTargetPostId,
                     type: 'repost', // Explicit type for query filtering
                   },
                 });
@@ -537,7 +547,7 @@ export async function processNPCSocialEngagements(
 
               result.sharesCreated++;
               engagedActors.add(actor.id);
-              shareSet.add(key); // Only mark on success - allows retry on failure
+              shareSet.add(shareKey); // Only mark on success - allows retry on failure
               diversityTracker.recordAction('share');
             } catch (error) {
               // Unique constraint or other error - don't mark as processed, allows retry

--- a/packages/engine/src/services/npc-social-engagement-service.ts
+++ b/packages/engine/src/services/npc-social-engagement-service.ts
@@ -456,6 +456,9 @@ export async function processNPCSocialEngagements(
 
         const key = `${post.id}-${actor.id}`;
         const probs = calculateEngagementProbability(actor, post, random);
+        const isRepostTarget =
+          typeof post.originalPostId === 'string' &&
+          post.originalPostId.trim().length > 0;
 
         // LIKE
         // Skip if global likes quota reached (other actors may still process shares/comments)
@@ -497,6 +500,7 @@ export async function processNPCSocialEngagements(
         // SHARE (creates both a Share record AND a visible repost Post)
         // Skip if diversity tracker says too many consecutive shares
         if (
+          !isRepostTarget &&
           !shareSet.has(key) &&
           result.sharesCreated < NPC_ENGAGEMENT_CONFIG.maxSharesPerTick &&
           !diversityTracker.shouldSkipForDiversity('share')

--- a/packages/engine/src/services/npc-social-engagement-service.ts
+++ b/packages/engine/src/services/npc-social-engagement-service.ts
@@ -456,7 +456,10 @@ export async function processNPCSocialEngagements(
 
         const key = `${post.id}-${actor.id}`;
         const probs = calculateEngagementProbability(actor, post, random);
+        // Only skip sharing pure reposts (type='repost'), not quote posts
+        // Quote posts have originalPostId but are distinct content worth sharing
         const isRepostTarget =
+          post.type === 'repost' &&
           typeof post.originalPostId === 'string' &&
           post.originalPostId.trim().length > 0;
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -58,6 +58,8 @@ export * from './utils/logger';
 export * from './utils/name-replacement';
 // OASF skill mapper (pure functions)
 export * from './utils/oasf-skill-mapper';
+// Post utilities (pure functions)
+export * from './utils/post-utils';
 // Profile utilities (pure functions)
 export * from './utils/profile';
 // Retry utilities (pure functions)

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -18,6 +18,7 @@ export * from './json-parser';
 export * from './logger';
 export * from './name-replacement';
 export * from './oasf-skill-mapper';
+export * from './post-utils';
 export * from './profile';
 export * from './retry';
 export * from './singleton';

--- a/packages/shared/src/utils/post-utils.ts
+++ b/packages/shared/src/utils/post-utils.ts
@@ -1,0 +1,10 @@
+export function isPureRepost(post: {
+  originalPostId?: string | null;
+  content: string;
+}): post is { originalPostId: string; content: string } {
+  return (
+    typeof post.originalPostId === 'string' &&
+    post.originalPostId.trim().length > 0 &&
+    post.content.trim().length === 0
+  );
+}

--- a/packages/testing/integration/markets-tick.integration.test.ts
+++ b/packages/testing/integration/markets-tick.integration.test.ts
@@ -21,6 +21,10 @@ import {
   test,
 } from 'bun:test';
 import { NextRequest } from 'next/server';
+import type {
+  GET as MarketsTickGet,
+  POST as MarketsTickPost,
+} from '@/app/api/cron/markets-tick/route';
 
 // Set test environment first (before any imports)
 process.env.NODE_ENV = 'test';
@@ -582,10 +586,9 @@ describe('Idempotency Check Logic', () => {
 // These tests exercise the actual HTTP endpoint behavior with a test database
 
 describe('POST Handler Integration', () => {
-  type MarketTickRoute = typeof import('@/app/api/cron/markets-tick/route');
   // Import the POST handler dynamically to ensure mocks are applied
-  let POST: MarketTickRoute['POST'];
-  let GET: MarketTickRoute['GET'];
+  let POST: typeof MarketsTickPost;
+  let GET: typeof MarketsTickGet;
 
   beforeAll(async () => {
     // Dynamic import after mocks are set up
@@ -636,7 +639,10 @@ describe('POST Handler Integration', () => {
     if (!data.skipped) {
       expect(data).toHaveProperty('metrics');
       if (data.metrics) {
-        expect(typeof data.metrics.totalMs).toBe('number');
+        expect(typeof data.metrics.getActiveMarketsMs).toBe('number');
+        expect(typeof data.metrics.resolutionMs).toBe('number');
+        expect(typeof data.metrics.creationMs).toBe('number');
+        expect(typeof data.metrics.subMarketCreationMs).toBe('number');
       }
     }
   });
@@ -659,8 +665,7 @@ describe('POST Handler Integration', () => {
 
     // Response should always include some timing information
     // Either in metrics.totalMs or as durationMs for skipped responses
-    const hasTiming =
-      data.metrics?.totalMs !== undefined || data.durationMs !== undefined;
+    const hasTiming = data.durationMs !== undefined;
     expect(hasTiming || data.skipped).toBe(true);
   });
 
@@ -749,9 +754,16 @@ describe('POST Handler Integration', () => {
     // If execution completed (not skipped), verify metrics structure
     if (!data.skipped && data.metrics) {
       // Check for expected metric fields
-      expect(data.metrics).toHaveProperty('totalMs');
-      expect(typeof data.metrics.totalMs).toBe('number');
-      expect(data.metrics.totalMs).toBeGreaterThanOrEqual(0);
+      expect(typeof data.metrics.getActiveMarketsMs).toBe('number');
+      expect(typeof data.metrics.resolutionMs).toBe('number');
+      expect(typeof data.metrics.creationMs).toBe('number');
+      expect(typeof data.metrics.subMarketCreationMs).toBe('number');
+    }
+
+    // Check for top-level durationMs (present in all responses, skipped or not)
+    if (!data.skipped) {
+      expect(typeof data.durationMs).toBe('number');
+      expect(data.durationMs).toBeGreaterThanOrEqual(0);
     }
   });
 });

--- a/packages/testing/integration/markets-tick.integration.test.ts
+++ b/packages/testing/integration/markets-tick.integration.test.ts
@@ -20,6 +20,7 @@ import {
   setDefaultTimeout,
   test,
 } from 'bun:test';
+import { NextRequest } from 'next/server';
 
 // Set test environment first (before any imports)
 process.env.NODE_ENV = 'test';
@@ -600,7 +601,7 @@ describe('POST Handler Integration', () => {
     }
 
     // Create a request with valid cron authorization header
-    const request = new Request('http://localhost/api/cron/markets-tick', {
+    const request = new NextRequest('http://localhost/api/cron/markets-tick', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${process.env.CRON_SECRET || 'test-secret'}`,
@@ -621,7 +622,7 @@ describe('POST Handler Integration', () => {
       return;
     }
 
-    const request = new Request('http://localhost/api/cron/markets-tick', {
+    const request = new NextRequest('http://localhost/api/cron/markets-tick', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${process.env.CRON_SECRET || 'test-secret'}`,
@@ -646,7 +647,7 @@ describe('POST Handler Integration', () => {
       return;
     }
 
-    const request = new Request('http://localhost/api/cron/markets-tick', {
+    const request = new NextRequest('http://localhost/api/cron/markets-tick', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${process.env.CRON_SECRET || 'test-secret'}`,
@@ -673,15 +674,21 @@ describe('POST Handler Integration', () => {
       Authorization: `Bearer ${process.env.CRON_SECRET || 'test-secret'}`,
     };
 
-    const getRequest = new Request('http://localhost/api/cron/markets-tick', {
-      method: 'GET',
-      headers,
-    });
+    const getRequest = new NextRequest(
+      'http://localhost/api/cron/markets-tick',
+      {
+        method: 'GET',
+        headers,
+      }
+    );
 
-    const postRequest = new Request('http://localhost/api/cron/markets-tick', {
-      method: 'POST',
-      headers,
-    });
+    const postRequest = new NextRequest(
+      'http://localhost/api/cron/markets-tick',
+      {
+        method: 'POST',
+        headers,
+      }
+    );
 
     const getResponse = await GET(getRequest);
     const postResponse = await POST(postRequest);
@@ -703,7 +710,7 @@ describe('POST Handler Integration', () => {
 
     // This test relies on the game state in the database
     // If there's no running game, the response should indicate skipped
-    const request = new Request('http://localhost/api/cron/markets-tick', {
+    const request = new NextRequest('http://localhost/api/cron/markets-tick', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${process.env.CRON_SECRET || 'test-secret'}`,
@@ -727,7 +734,7 @@ describe('POST Handler Integration', () => {
       return;
     }
 
-    const request = new Request('http://localhost/api/cron/markets-tick', {
+    const request = new NextRequest('http://localhost/api/cron/markets-tick', {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${process.env.CRON_SECRET || 'test-secret'}`,

--- a/packages/testing/integration/markets-tick.integration.test.ts
+++ b/packages/testing/integration/markets-tick.integration.test.ts
@@ -587,13 +587,9 @@ describe('POST Handler Integration', () => {
 
   beforeAll(async () => {
     // Dynamic import after mocks are set up
-    const routeModule = await import(
-      '@babylon/web/src/app/api/cron/markets-tick/route'
-    );
-    POST = routeModule.POST as unknown as (
-      request: Request
-    ) => Promise<Response>;
-    GET = routeModule.GET as unknown as (request: Request) => Promise<Response>;
+    const routeModule = await import('@/app/api/cron/markets-tick/route');
+    POST = routeModule.POST;
+    GET = routeModule.GET;
   });
 
   test('should return valid JSON response structure', async () => {

--- a/packages/testing/integration/markets-tick.integration.test.ts
+++ b/packages/testing/integration/markets-tick.integration.test.ts
@@ -581,9 +581,10 @@ describe('Idempotency Check Logic', () => {
 // These tests exercise the actual HTTP endpoint behavior with a test database
 
 describe('POST Handler Integration', () => {
+  type MarketTickRoute = typeof import('@/app/api/cron/markets-tick/route');
   // Import the POST handler dynamically to ensure mocks are applied
-  let POST: (request: Request) => Promise<Response>;
-  let GET: (request: Request) => Promise<Response>;
+  let POST: MarketTickRoute['POST'];
+  let GET: MarketTickRoute['GET'];
 
   beforeAll(async () => {
     // Dynamic import after mocks are set up

--- a/scripts/postinstall-solidity-deps.ts
+++ b/scripts/postinstall-solidity-deps.ts
@@ -20,15 +20,15 @@ interface SoldeerPackage {
 const PACKAGES: SoldeerPackage[] = [
   {
     name: 'forge-std',
-    version: '1.9.4',
-    folderName: 'forge-std-1.9.4',
-    url: 'https://soldeer-revisions.s3.amazonaws.com/forge-std/1_9_4_25-10-2024_14:36:59_forge-std-1.9.zip',
+    version: '1.9.7',
+    folderName: 'forge-std-1.9.7',
+    url: 'https://soldeer-revisions.s3.amazonaws.com/forge-std/1_9_7_28-04-2025_15:55:08_forge-std-1.9.zip',
   },
   {
     name: '@openzeppelin-contracts',
-    version: '5.2.0',
-    folderName: '@openzeppelin-contracts-5.2.0',
-    url: 'https://soldeer-revisions.s3.amazonaws.com/@openzeppelin-contracts/5_2_0_11-01-2025_09:30:20_contracts.zip',
+    version: '5.4.0',
+    folderName: '@openzeppelin-contracts-5.4.0',
+    url: 'https://soldeer-revisions.s3.amazonaws.com/@openzeppelin-contracts/5_4_0_19-07-2025_08:59:41_contracts.zip',
   },
 ];
 


### PR DESCRIPTION
## Summary
- Redirect repost-of-repost attempts to the original post (no hard error)
- Keep quote posts shareable by treating pure reposts as empty-content originals
- Align NPC sharing + agent repost behavior with the same redirect rule
- Fix unshare to resolve redirected reposts correctly
- Extract `isPureRepost` into shared helper to avoid duplication
- Fix markets-tick test assertions to match actual route response
- Align markets-tick test imports and handler typing

## Changes

### Repost-of-Repost Handling (Redirect to Original)
- **Web API** (`/api/posts/[id]/share`): If the target is a pure repost (originalPostId + empty content), share the original instead
- **Agent Executor** (`executeDirectRepost`): Resolves pure reposts to the original before sharing
- **NPC Service**: Shares the original when a feed item is a pure repost; de-dupes against original IDs
- **Unshare** (`DELETE /api/posts/[id]/share`): Resolves pure reposts to the original share record before deleting

### Refactor
- **Shared helper**: `isPureRepost` added to `@babylon/shared` and used across API, agent, and NPC flows

### Code Review Fixes
1. **Quote Posts Remain Shareable**
   - Pure reposts are identified by `originalPostId` + empty content only
   - Quote posts (originalPostId + commentary) are not blocked

2. **Markets-Tick Test Fixes**
   - Fixed incorrect `data.metrics.totalMs` assertions (doesn't exist in response)
   - Updated to check actual metric fields: `getActiveMarketsMs`, `resolutionMs`, `creationMs`, `subMarketCreationMs`
   - Fixed TypeScript types: use `typeof` for route handler imports

3. **Test Coverage**
   - Added unit test verifying repost-of-repost redirects to original
   - Keeps success case for direct repost of original

## Test plan
- [x] Unit tests updated for redirect behavior
- [x] TypeCheck, lint, and build pass
- [ ] Manual testing in staging (if needed)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Improvements
  - Repost handling now resolves pure reposts to their original post so shares, notifications, analytics, and logs operate on the true target and avoid duplicate shares.
  - NPC/social engagement logic updated to consider repost targets.
  - Cron timing fields renamed for clearer metrics.

- Bug Fixes
  - Sharing/unshare flows correctly handle pure reposts and fail cleanly if the original cannot be resolved.

- Tests
  - Added unit and integration tests for repost-of-repost and cron timing flows.

- Chores
  - Updated Solidity deps.

- New Features
  - Added a public utility to detect pure reposts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->