### PR TITLE
fix: correct NPC portfolio PnL aggregates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ dist/
 # local env files
 .env*.local
 .env
+.staging-cookies.txt
 
 # Symlinked env files in apps
 apps/*/.env

--- a/REALIZED_PNL_FIX.md
+++ b/REALIZED_PNL_FIX.md
@@ -68,24 +68,30 @@ You provided a curl command for agent `273508387734421504` (Lumen Oracle) and me
    }, 0);
    ```
 
-3. **Calculate realized PnL from perp positions**:
+3. **Include open perp positions in aggregates**:
    ```typescript
-   const allPerpPositions = await db
-     .select()
+   const openPerpPositions = await db
+     .select({ id: perpPositions.id, unrealizedPnL: perpPositions.unrealizedPnL })
      .from(perpPositions)
-     .where(eq(perpPositions.userId, poolId));
+     .where(and(eq(perpPositions.userId, poolId), isNull(perpPositions.closedAt)));
+   ```
 
-   const closedPerps = allPerpPositions.filter((p) => p.closedAt !== null);
+4. **Calculate realized PnL from closed perp positions**:
+   ```typescript
+   const closedPerpPositions = await db
+     .select({ realizedPnL: perpPositions.realizedPnL })
+     .from(perpPositions)
+     .where(and(eq(perpPositions.userId, poolId), isNotNull(perpPositions.closedAt)));
 
-   const realizedPnLFromPerp = closedPerps.reduce((sum, pos) => {
+   const realizedPnLFromPerp = closedPerpPositions.reduce((sum, pos) => {
      return sum + Number.parseFloat(pos.realizedPnL?.toString() || '0');
    }, 0);
    ```
 
-4. **Return combined realized PnL**:
+5. **Return combined realized PnL**:
    ```typescript
    const realizedPnL = realizedPnLFromPool + realizedPnLFromPerp;
-   
+
    return {
      // ...
      realizedPnL,  // ✅ Now properly calculated
@@ -134,7 +140,7 @@ Expected response should now include non-zero `realizedPnL` for agents with clos
 Check closed positions directly:
 ```sql
 -- Pool positions
-SELECT 
+SELECT
   "poolId",
   COUNT(*) as closed_count,
   SUM("realizedPnL") as total_realized_pnl
@@ -144,7 +150,7 @@ GROUP BY "poolId"
 HAVING COUNT(*) > 0;
 
 -- Perp positions
-SELECT 
+SELECT
   "userId",
   COUNT(*) as closed_count,
   SUM("realizedPnL") as total_realized_pnl

--- a/REALIZED_PNL_FIX.md
+++ b/REALIZED_PNL_FIX.md
@@ -1,0 +1,228 @@
+# Realized PnL Bug Fix - Complete Analysis & Solution
+
+## Executive Summary
+
+**Bug**: All NPC agents (including user-controlled agents) were reporting `realizedPnL: 0` regardless of their actual closed position profits/losses.
+
+**Root Cause**: Hardcoded value in `NPCInvestmentManager.getPortfolioMetrics()` - the `realizedPnL` field was never implemented, just set to 0 with a TODO comment.
+
+**Impact**: Portfolio metrics, performance dashboards, leaderboards, and agent analytics were showing incomplete P&L data.
+
+**Status**: ✅ **FIXED** - Realized PnL is now correctly calculated from closed positions.
+
+---
+
+## The Investigation
+
+### Starting Point
+
+You provided a curl command for agent `273508387734421504` (Lumen Oracle) and mentioned:
+> "I think pnl calc is mostly right but realized/unrealized may be wrong"
+
+### What I Found
+
+1. **Database Schema**: Both `poolPositions` and `perpPositions` tables have `realizedPnL` fields that ARE being populated correctly when positions close
+
+2. **Trade Execution**: The `TradeExecutionService` correctly sets `realizedPnL` when closing positions:
+   ```typescript
+   await tx.update(poolPositions).set({
+     closedAt: now,
+     realizedPnL,  // ✅ This was working
+     unrealizedPnL: 0,
+     // ...
+   })
+   ```
+
+3. **Portfolio Metrics**: The `getPortfolioMetrics()` function was hardcoded:
+   ```typescript
+   return {
+     // ...
+     realizedPnL: 0, // ❌ This was the bug
+   }
+   ```
+
+### Key Insight: NPC vs User Architecture
+
+- **Regular Users**: Have `users.lifetimePnL` field that accumulates via `WalletService.recordPnL()`
+- **NPCs**: Don't have `lifetimePnL` in `actorState` - must calculate from closed positions
+
+---
+
+## The Fix
+
+### File Changed
+`packages/engine/src/npc/npc-investment-manager.ts`
+
+### Changes Made
+
+1. **Track closed positions**:
+   ```typescript
+   const openPositions = positionResults.filter((p) => p.closedAt === null);
+   const closedPositions = positionResults.filter((p) => p.closedAt !== null);
+   ```
+
+2. **Calculate realized PnL from pool positions**:
+   ```typescript
+   const realizedPnLFromPool = closedPositions.reduce((sum, pos) => {
+     return sum + Number.parseFloat(pos.realizedPnL?.toString() || '0');
+   }, 0);
+   ```
+
+3. **Calculate realized PnL from perp positions**:
+   ```typescript
+   const allPerpPositions = await db
+     .select()
+     .from(perpPositions)
+     .where(eq(perpPositions.userId, poolId));
+
+   const closedPerps = allPerpPositions.filter((p) => p.closedAt !== null);
+
+   const realizedPnLFromPerp = closedPerps.reduce((sum, pos) => {
+     return sum + Number.parseFloat(pos.realizedPnL?.toString() || '0');
+   }, 0);
+   ```
+
+4. **Return combined realized PnL**:
+   ```typescript
+   const realizedPnL = realizedPnLFromPool + realizedPnLFromPerp;
+   
+   return {
+     // ...
+     realizedPnL,  // ✅ Now properly calculated
+   }
+   ```
+
+---
+
+## Verification
+
+### 1. Unit Tests
+
+Created comprehensive test suite at:
+`packages/testing/unit/npc-investment-manager-pnl.test.ts`
+
+Tests cover:
+- No positions (should return 0)
+- Only closed pool positions
+- Only closed perp positions
+- Mix of open and closed positions
+- Null handling
+
+Run tests:
+```bash
+bun test packages/testing/unit/npc-investment-manager-pnl.test.ts
+```
+
+### 2. API Testing
+
+Use the provided verification script:
+```bash
+./scripts/verify-pnl-fix.sh
+```
+
+Or manually test with curl:
+```bash
+curl 'https://staging.babylon.market/api/npc/273508387734421504/portfolio' \
+  -H 'accept: */*' \
+  -b 'privy-token=...; privy-id-token=...'
+```
+
+Expected response should now include non-zero `realizedPnL` for agents with closed positions.
+
+### 3. Database Verification
+
+Check closed positions directly:
+```sql
+-- Pool positions
+SELECT 
+  "poolId",
+  COUNT(*) as closed_count,
+  SUM("realizedPnL") as total_realized_pnl
+FROM "PoolPosition"
+WHERE "closedAt" IS NOT NULL
+GROUP BY "poolId"
+HAVING COUNT(*) > 0;
+
+-- Perp positions
+SELECT 
+  "userId",
+  COUNT(*) as closed_count,
+  SUM("realizedPnL") as total_realized_pnl
+FROM "PerpPosition"
+WHERE "closedAt" IS NOT NULL
+GROUP BY "userId"
+HAVING COUNT(*) > 0;
+```
+
+---
+
+## Impact Analysis
+
+### APIs Affected
+- ✅ `/api/npc/[actorId]/portfolio` - Now returns correct realized PnL
+- ✅ All internal calls to `NPCInvestmentManager.getPortfolioMetrics()`
+
+### Components Affected
+- Portfolio displays
+- Agent performance dashboards
+- Leaderboards
+- Trading analytics
+- Performance metrics
+
+### No Breaking Changes
+- The fix only changes the **value** of `realizedPnL` from 0 to the correct calculation
+- The API shape remains the same
+- No migration required (data was already in the database)
+
+---
+
+## Future Improvements
+
+### Short Term
+1. **Add monitoring**: Alert when realized/unrealized PnL calculations fail
+2. **Performance**: Consider caching closed position totals
+3. **Validation**: Add sanity checks (realized PnL shouldn't exceed total invested)
+
+### Long Term
+1. **Unify PnL tracking**: Add `lifetimePnL` field to `actorState` table
+2. **Historical analysis**: Track realized PnL changes over time
+3. **Performance optimization**: Index closed positions for faster queries
+4. **Real-time updates**: Invalidate portfolio caches when positions close
+
+---
+
+## Files Modified
+
+- ✅ `packages/engine/src/npc/npc-investment-manager.ts` - Main fix
+
+## Files Created
+
+- 📄 `docs/pnl-fix-summary.md` - Detailed technical documentation
+- 🧪 `packages/testing/unit/npc-investment-manager-pnl.test.ts` - Test suite
+- 🔧 `scripts/verify-pnl-fix.sh` - Verification script
+- 📋 `REALIZED_PNL_FIX.md` - This file
+
+---
+
+## Checklist for Deployment
+
+- [x] Code fixed
+- [x] Tests written
+- [x] Documentation created
+- [ ] Tests passing
+- [ ] Code reviewed
+- [ ] Deployed to staging
+- [ ] Verified on staging
+- [ ] Deployed to production
+- [ ] Verified on production
+- [ ] Monitoring enabled
+
+---
+
+## Questions?
+
+For technical details, see `docs/pnl-fix-summary.md`
+
+For testing, run `bun test packages/testing/unit/npc-investment-manager-pnl.test.ts`
+
+For verification, run `./scripts/verify-pnl-fix.sh` after deployment

--- a/REALIZED_PNL_FIX.md
+++ b/REALIZED_PNL_FIX.md
@@ -68,21 +68,27 @@ You provided a curl command for agent `273508387734421504` (Lumen Oracle) and me
    }, 0);
    ```
 
-3. **Include open perp positions in aggregates**:
+3. **Query perp positions once and split open/closed**:
    ```typescript
-   const openPerpPositions = await db
-     .select({ id: perpPositions.id, unrealizedPnL: perpPositions.unrealizedPnL })
+   const perpPositionsResult = await db
+     .select({
+       id: perpPositions.id,
+       realizedPnL: perpPositions.realizedPnL,
+       closedAt: perpPositions.closedAt,
+     })
      .from(perpPositions)
-     .where(and(eq(perpPositions.userId, poolId), isNull(perpPositions.closedAt)));
+     .where(eq(perpPositions.userId, poolId));
+
+   const openPerpPositions = perpPositionsResult.filter(
+     (p) => p.closedAt === null
+   );
+   const closedPerpPositions = perpPositionsResult.filter(
+     (p) => p.closedAt !== null
+   );
    ```
 
 4. **Calculate realized PnL from closed perp positions**:
    ```typescript
-   const closedPerpPositions = await db
-     .select({ realizedPnL: perpPositions.realizedPnL })
-     .from(perpPositions)
-     .where(and(eq(perpPositions.userId, poolId), isNotNull(perpPositions.closedAt)));
-
    const realizedPnLFromPerp = closedPerpPositions.reduce((sum, pos) => {
      return sum + Number.parseFloat(pos.realizedPnL?.toString() || '0');
    }, 0);

--- a/docs/pnl-fix-summary.md
+++ b/docs/pnl-fix-summary.md
@@ -28,9 +28,10 @@ The fix updates `getPortfolioMetrics()` to:
 
 1. **Query pool positions** and exclude any perps that already exist in `perpPositions`
 2. **Sum up `realizedPnL`** from all closed pool positions
-3. **Query open perp positions** for unrealized, invested, and position counts
-4. **Sum up `realizedPnL`** from all closed perp positions
-5. **Return the total** realized PnL (pool + perp) and updated aggregates
+3. **Query perp positions once** and split into open/closed in memory
+4. **Use open perps** for unrealized, invested, and position counts
+5. **Sum up `realizedPnL`** from all closed perp positions
+6. **Return the total** realized PnL (pool + perp) and updated aggregates
 
 ### Code Changes
 
@@ -51,15 +52,21 @@ const positionResults = await db
   .from(poolPositions)
   .where(eq(poolPositions.poolId, poolId));
 
-const openPerpPositions = await db
-  .select({ id: perpPositions.id })
+const perpPositionsResult = await db
+  .select({
+    id: perpPositions.id,
+    realizedPnL: perpPositions.realizedPnL,
+    closedAt: perpPositions.closedAt,
+  })
   .from(perpPositions)
-  .where(and(eq(perpPositions.userId, poolId), isNull(perpPositions.closedAt)));
+  .where(eq(perpPositions.userId, poolId));
 
-const closedPerpPositions = await db
-  .select({ id: perpPositions.id, realizedPnL: perpPositions.realizedPnL })
-  .from(perpPositions)
-  .where(and(eq(perpPositions.userId, poolId), isNotNull(perpPositions.closedAt)));
+const openPerpPositions = perpPositionsResult.filter(
+  (p) => p.closedAt === null
+);
+const closedPerpPositions = perpPositionsResult.filter(
+  (p) => p.closedAt !== null
+);
 
 const perpPositionIds = new Set([
   ...openPerpPositions.map((p) => p.id),
@@ -86,12 +93,6 @@ realizedPnL: 0, // Could track from trade history
 const realizedPnLFromPool = closedPositions.reduce((sum, pos) => {
   return sum + Number.parseFloat(pos.realizedPnL?.toString() || '0');
 }, 0);
-
-// Get closed perp positions for this actor (userId = poolId for NPCs)
-const closedPerpPositions = await db
-  .select({ realizedPnL: perpPositions.realizedPnL })
-  .from(perpPositions)
-  .where(and(eq(perpPositions.userId, poolId), isNotNull(perpPositions.closedAt)));
 
 // Calculate realized PnL from closed perp positions
 const realizedPnLFromPerp = closedPerpPositions.reduce((sum, pos) => {

--- a/docs/pnl-fix-summary.md
+++ b/docs/pnl-fix-summary.md
@@ -1,0 +1,162 @@
+# PnL Calculation Bug Fix
+
+## Issue Summary
+
+The realized P&L (Profit & Loss) for all NPC agents was **always returning 0**, regardless of whether they had closed positions with actual realized profits or losses. This affected all user-controlled and autonomous agents using the NPC portfolio system.
+
+## Root Cause
+
+In `packages/engine/src/npc/npc-investment-manager.ts`, the `getPortfolioMetrics()` function had a hardcoded value:
+
+```typescript
+realizedPnL: 0, // Could track from trade history
+```
+
+This was a TODO comment that was never implemented. The function was calculating unrealized PnL correctly from open positions, but ignoring realized PnL from closed positions.
+
+## Impact
+
+- **Portfolio API**: The `/api/npc/[actorId]/portfolio` endpoint returned `realizedPnL: 0` for all agents
+- **Agent Performance**: Agents' total P&L was understated by the amount of their realized gains/losses
+- **Reporting**: Dashboards, leaderboards, and performance metrics showed incomplete P&L data
+
+## The Fix
+
+### What Changed
+
+The fix updates `getPortfolioMetrics()` to:
+
+1. **Query closed pool positions** in addition to open positions
+2. **Sum up `realizedPnL`** from all closed pool positions
+3. **Query all perp positions** for the actor/pool
+4. **Sum up `realizedPnL`** from all closed perp positions  
+5. **Return the total** realized PnL (pool + perp)
+
+### Code Changes
+
+**File**: `packages/engine/src/npc/npc-investment-manager.ts`
+
+```typescript
+// Before: Line 90
+const positionResults = await db
+  .select()
+  .from(poolPositions)
+  .where(eq(poolPositions.poolId, poolId));
+
+const openPositions = positionResults.filter((p) => p.closedAt === null);
+
+// After: Lines 87-92
+const positionResults = await db
+  .select()
+  .from(poolPositions)
+  .where(eq(poolPositions.poolId, poolId));
+
+const openPositions = positionResults.filter((p) => p.closedAt === null);
+const closedPositions = positionResults.filter((p) => p.closedAt !== null);
+```
+
+```typescript
+// Before: Line 140
+realizedPnL: 0, // Could track from trade history
+
+// After: Lines 125-145
+// Calculate realized PnL from closed pool positions
+const realizedPnLFromPool = closedPositions.reduce((sum, pos) => {
+  return sum + Number.parseFloat(pos.realizedPnL?.toString() || '0');
+}, 0);
+
+// Get all perp positions for this actor (userId = poolId for NPCs)
+const allPerpPositions = await db
+  .select()
+  .from(perpPositions)
+  .where(eq(perpPositions.userId, poolId));
+
+// Filter for closed perp positions
+const closedPerps = allPerpPositions.filter((p) => p.closedAt !== null);
+
+// Calculate realized PnL from closed perp positions
+const realizedPnLFromPerp = closedPerps.reduce((sum, pos) => {
+  return sum + Number.parseFloat(pos.realizedPnL?.toString() || '0');
+}, 0);
+
+// Total realized PnL
+const realizedPnL = realizedPnLFromPool + realizedPnLFromPerp;
+
+// ... later in return statement:
+realizedPnL, // Now properly calculated
+```
+
+## Technical Details
+
+### Database Schema
+
+Both `poolPositions` and `perpPositions` tables have:
+- `realizedPnL: doublePrecision` - Set when position is closed
+- `closedAt: timestamp` - Set when position is closed
+
+### Position Closing Flow
+
+When a position is closed via `TradeExecutionService.closePoolPosition()`:
+
+```typescript
+await tx
+  .update(poolPositions)
+  .set({
+    closedAt: now,
+    currentPrice,
+    unrealizedPnL: 0,  // Zero out unrealized
+    realizedPnL,       // Set realized PnL
+    updatedAt: now,
+  })
+  .where(eq(poolPositions.id, decision.positionId!));
+```
+
+This data was being written correctly, just not being read by `getPortfolioMetrics()`.
+
+### NPC vs Regular Users
+
+- **Regular Users**: Use `users.lifetimePnL` field which is accumulated via `WalletService.recordPnL()`
+- **NPCs**: Don't have a `lifetimePnL` field in `actorState` table, so we must calculate from closed positions
+
+## Verification
+
+### Testing the Fix
+
+1. **API Test**: Call the portfolio endpoint for an agent with closed positions
+   ```bash
+   curl 'https://staging.babylon.market/api/npc/[actorId]/portfolio' \
+     -H 'Cookie: ...'
+   ```
+   
+   Expected: `realizedPnL` should show the sum of all closed position P&L, not 0
+
+2. **Database Query**: Check agent's closed positions directly
+   ```sql
+   SELECT COUNT(*), SUM(realized_pnl) as total_realized
+   FROM "PoolPosition"
+   WHERE "poolId" = 'AGENT_ID' AND "closedAt" IS NOT NULL;
+   
+   SELECT COUNT(*), SUM(realized_pnl) as total_realized
+   FROM "PerpPosition"
+   WHERE "userId" = 'AGENT_ID' AND "closedAt" IS NOT NULL;
+   ```
+
+### Known Agent IDs to Test
+
+- Agent ID from original report: `273508387734421504` (Lumen Oracle)
+- Any user-controlled agent that has closed positions
+
+## Future Improvements
+
+1. **Add `lifetimePnL` to `actorState`**: Track accumulated realized PnL like regular users do
+2. **Performance optimization**: Cache closed position totals instead of recalculating each time
+3. **Historical tracking**: Add realized PnL to `npcTrades` table for historical analysis
+4. **Monitoring**: Add alerts when realized/unrealized PnL calculations fail
+
+## Related Files
+
+- `packages/engine/src/npc/npc-investment-manager.ts` - Main fix
+- `packages/engine/src/services/trade-execution-service.ts` - Sets `realizedPnL` when closing
+- `packages/db/src/schema/pools.ts` - Schema for `poolPositions`
+- `packages/db/src/schema/markets.ts` - Schema for `perpPositions`
+- `apps/web/src/app/api/npc/[actorId]/portfolio/route.ts` - API that calls fixed function

--- a/docs/pnl-fix-summary.md
+++ b/docs/pnl-fix-summary.md
@@ -123,6 +123,7 @@ This data was being written correctly, just not being read by `getPortfolioMetri
 ### Testing the Fix
 
 1. **API Test**: Call the portfolio endpoint for an agent with closed positions
+
    ```bash
    curl 'https://staging.babylon.market/api/npc/[actorId]/portfolio' \
      -H 'Cookie: ...'
@@ -131,6 +132,7 @@ This data was being written correctly, just not being read by `getPortfolioMetri
    Expected: `realizedPnL` should show the sum of all closed position P&L, not 0
 
 2. **Database Query**: Check agent's closed positions directly
+
    ```sql
    SELECT COUNT(*), SUM(realized_pnl) as total_realized
    FROM "PoolPosition"

--- a/docs/pnl-fix-summary.md
+++ b/docs/pnl-fix-summary.md
@@ -26,18 +26,18 @@ This was a TODO comment that was never implemented. The function was calculating
 
 The fix updates `getPortfolioMetrics()` to:
 
-1. **Query closed pool positions** in addition to open positions
+1. **Query pool positions** and exclude any perps that already exist in `perpPositions`
 2. **Sum up `realizedPnL`** from all closed pool positions
-3. **Query all perp positions** for the actor/pool
-4. **Sum up `realizedPnL`** from all closed perp positions  
-5. **Return the total** realized PnL (pool + perp)
+3. **Query open perp positions** for unrealized, invested, and position counts
+4. **Sum up `realizedPnL`** from all closed perp positions
+5. **Return the total** realized PnL (pool + perp) and updated aggregates
 
 ### Code Changes
 
 **File**: `packages/engine/src/npc/npc-investment-manager.ts`
 
 ```typescript
-// Before: Line 90
+// Before
 const positionResults = await db
   .select()
   .from(poolPositions)
@@ -45,37 +45,56 @@ const positionResults = await db
 
 const openPositions = positionResults.filter((p) => p.closedAt === null);
 
-// After: Lines 87-92
+// After
 const positionResults = await db
   .select()
   .from(poolPositions)
   .where(eq(poolPositions.poolId, poolId));
 
-const openPositions = positionResults.filter((p) => p.closedAt === null);
-const closedPositions = positionResults.filter((p) => p.closedAt !== null);
+const openPerpPositions = await db
+  .select({ id: perpPositions.id })
+  .from(perpPositions)
+  .where(and(eq(perpPositions.userId, poolId), isNull(perpPositions.closedAt)));
+
+const closedPerpPositions = await db
+  .select({ id: perpPositions.id, realizedPnL: perpPositions.realizedPnL })
+  .from(perpPositions)
+  .where(and(eq(perpPositions.userId, poolId), isNotNull(perpPositions.closedAt)));
+
+const perpPositionIds = new Set([
+  ...openPerpPositions.map((p) => p.id),
+  ...closedPerpPositions.map((p) => p.id),
+]);
+
+const shouldIncludePoolPosition = (position) =>
+  position.marketType !== 'perp' || !perpPositionIds.has(position.id);
+
+const openPositions = positionResults.filter(
+  (p) => p.closedAt === null && shouldIncludePoolPosition(p)
+);
+const closedPositions = positionResults.filter(
+  (p) => p.closedAt !== null && shouldIncludePoolPosition(p)
+);
 ```
 
 ```typescript
-// Before: Line 140
+// Before
 realizedPnL: 0, // Could track from trade history
 
-// After: Lines 125-145
+// After
 // Calculate realized PnL from closed pool positions
 const realizedPnLFromPool = closedPositions.reduce((sum, pos) => {
   return sum + Number.parseFloat(pos.realizedPnL?.toString() || '0');
 }, 0);
 
-// Get all perp positions for this actor (userId = poolId for NPCs)
-const allPerpPositions = await db
-  .select()
+// Get closed perp positions for this actor (userId = poolId for NPCs)
+const closedPerpPositions = await db
+  .select({ realizedPnL: perpPositions.realizedPnL })
   .from(perpPositions)
-  .where(eq(perpPositions.userId, poolId));
-
-// Filter for closed perp positions
-const closedPerps = allPerpPositions.filter((p) => p.closedAt !== null);
+  .where(and(eq(perpPositions.userId, poolId), isNotNull(perpPositions.closedAt)));
 
 // Calculate realized PnL from closed perp positions
-const realizedPnLFromPerp = closedPerps.reduce((sum, pos) => {
+const realizedPnLFromPerp = closedPerpPositions.reduce((sum, pos) => {
   return sum + Number.parseFloat(pos.realizedPnL?.toString() || '0');
 }, 0);
 
@@ -128,7 +147,7 @@ This data was being written correctly, just not being read by `getPortfolioMetri
    curl 'https://staging.babylon.market/api/npc/[actorId]/portfolio' \
      -H 'Cookie: ...'
    ```
-   
+
    Expected: `realizedPnL` should show the sum of all closed position P&L, not 0
 
 2. **Database Query**: Check agent's closed positions directly
@@ -137,7 +156,7 @@ This data was being written correctly, just not being read by `getPortfolioMetri
    SELECT COUNT(*), SUM(realized_pnl) as total_realized
    FROM "PoolPosition"
    WHERE "poolId" = 'AGENT_ID' AND "closedAt" IS NOT NULL;
-   
+
    SELECT COUNT(*), SUM(realized_pnl) as total_realized
    FROM "PerpPosition"
    WHERE "userId" = 'AGENT_ID' AND "closedAt" IS NOT NULL;

--- a/packages/engine/src/npc/npc-investment-manager.ts
+++ b/packages/engine/src/npc/npc-investment-manager.ts
@@ -83,13 +83,14 @@ export class NPCInvestmentManager {
       throw new Error(`Actor state not found: ${poolId} (poolId = actorId)`);
     }
 
-    // Get open positions (closedAt is null)
+    // Get all positions (both open and closed) for this pool
     const positionResults = await db
       .select()
       .from(poolPositions)
       .where(eq(poolPositions.poolId, poolId));
 
     const openPositions = positionResults.filter((p) => p.closedAt === null);
+    const closedPositions = positionResults.filter((p) => p.closedAt !== null);
     // Map database PoolPosition to PortfolioPosition interface
     const positions: PortfolioPosition[] = openPositions.map((p) => ({
       id: p.id,
@@ -121,6 +122,28 @@ export class NPCInvestmentManager {
       return sum + Number.parseFloat(pos.unrealizedPnL?.toString() || '0');
     }, 0);
 
+    // Calculate realized PnL from closed pool positions
+    const realizedPnLFromPool = closedPositions.reduce((sum, pos) => {
+      return sum + Number.parseFloat(pos.realizedPnL?.toString() || '0');
+    }, 0);
+
+    // Get all perp positions for this actor (userId = poolId for NPCs)
+    const allPerpPositions = await db
+      .select()
+      .from(perpPositions)
+      .where(eq(perpPositions.userId, poolId));
+
+    // Filter for closed perp positions
+    const closedPerps = allPerpPositions.filter((p) => p.closedAt !== null);
+
+    // Calculate realized PnL from closed perp positions
+    const realizedPnLFromPerp = closedPerps.reduce((sum, pos) => {
+      return sum + Number.parseFloat(pos.realizedPnL?.toString() || '0');
+    }, 0);
+
+    // Total realized PnL
+    const realizedPnL = realizedPnLFromPool + realizedPnLFromPerp;
+
     // Calculate total portfolio value
     const totalValue = availableBalance + totalInvested + unrealizedPnL;
 
@@ -137,7 +160,7 @@ export class NPCInvestmentManager {
       totalValue,
       availableBalance,
       unrealizedPnL,
-      realizedPnL: 0, // Could track from trade history
+      realizedPnL,
       positionCount: positions.length,
       utilization,
       riskScore,

--- a/packages/engine/src/npc/npc-investment-manager.ts
+++ b/packages/engine/src/npc/npc-investment-manager.ts
@@ -90,25 +90,6 @@ export class NPCInvestmentManager {
       .from(poolPositions)
       .where(eq(poolPositions.poolId, poolId));
 
-    const openPositions = positionResults.filter((p) => p.closedAt === null);
-    const closedPositions = positionResults.filter((p) => p.closedAt !== null);
-    // Map database PoolPosition to PortfolioPosition interface
-    const positions: PortfolioPosition[] = openPositions.map((p) => ({
-      id: p.id,
-      poolId: p.poolId,
-      marketType:
-        p.marketType === 'perp' || p.marketType === 'prediction'
-          ? p.marketType
-          : 'prediction',
-      ticker: p.ticker ?? undefined,
-      marketId: p.marketId ?? undefined,
-      side: p.side,
-      size: Number(p.size),
-      entryPrice: Number(p.entryPrice),
-      currentPrice: Number(p.currentPrice),
-      unrealizedPnL: Number(p.unrealizedPnL),
-      leverage: p.leverage ?? undefined,
-    }));
     const availableBalance = Number.parseFloat(
       actorBalance.tradingBalance?.toString() ?? '0'
     );
@@ -130,6 +111,49 @@ export class NPCInvestmentManager {
         and(eq(perpPositions.userId, poolId), isNull(perpPositions.closedAt))
       );
 
+    // Query closed perp positions only (future optimization: use SQL aggregation)
+    const closedPerpPositions = await db
+      .select({ id: perpPositions.id, realizedPnL: perpPositions.realizedPnL })
+      .from(perpPositions)
+      .where(
+        and(eq(perpPositions.userId, poolId), isNotNull(perpPositions.closedAt))
+      );
+
+    const perpPositionIds = new Set([
+      ...openPerpPositions.map((p) => p.id),
+      ...closedPerpPositions.map((p) => p.id),
+    ]);
+
+    // poolPositions may contain legacy perps; avoid double counting when perps
+    // already exist in perpPositions.
+    const shouldIncludePoolPosition = (position: typeof positionResults[0]) =>
+      position.marketType !== 'perp' || !perpPositionIds.has(position.id);
+
+    const openPositions = positionResults.filter(
+      (p) => p.closedAt === null && shouldIncludePoolPosition(p)
+    );
+    const closedPositions = positionResults.filter(
+      (p) => p.closedAt !== null && shouldIncludePoolPosition(p)
+    );
+
+    // Map database PoolPosition to PortfolioPosition interface
+    const positions: PortfolioPosition[] = openPositions.map((p) => ({
+      id: p.id,
+      poolId: p.poolId,
+      marketType:
+        p.marketType === 'perp' || p.marketType === 'prediction'
+          ? p.marketType
+          : 'prediction',
+      ticker: p.ticker ?? undefined,
+      marketId: p.marketId ?? undefined,
+      side: p.side,
+      size: Number(p.size),
+      entryPrice: Number(p.entryPrice),
+      currentPrice: Number(p.currentPrice),
+      unrealizedPnL: Number(p.unrealizedPnL),
+      leverage: p.leverage ?? undefined,
+    }));
+
     const perpPortfolioPositions: PortfolioPosition[] = openPerpPositions.map(
       (p) => ({
         id: p.id,
@@ -147,7 +171,14 @@ export class NPCInvestmentManager {
 
     // Calculate total invested capital (pool positions only)
     const poolInvested = positions.reduce((sum, pos) => {
-      return sum + Number.parseFloat(pos.size?.toString() || '0');
+      const size = Number.parseFloat(pos.size?.toString() || '0');
+      if (pos.marketType === 'perp') {
+        const leverage = Number.parseFloat(pos.leverage?.toString() || '1');
+        const effectiveLeverage =
+          Number.isFinite(leverage) && leverage > 0 ? leverage : 1;
+        return sum + Math.abs(size / effectiveLeverage);
+      }
+      return sum + Math.abs(size);
     }, 0);
 
     const perpInvested = openPerpPositions.reduce((sum, pos) => {
@@ -175,14 +206,6 @@ export class NPCInvestmentManager {
     const realizedPnLFromPool = closedPositions.reduce((sum, pos) => {
       return sum + Number.parseFloat(pos.realizedPnL?.toString() || '0');
     }, 0);
-
-    // Query closed perp positions only (future optimization: use SQL aggregation)
-    const closedPerpPositions = await db
-      .select({ realizedPnL: perpPositions.realizedPnL })
-      .from(perpPositions)
-      .where(
-        and(eq(perpPositions.userId, poolId), isNotNull(perpPositions.closedAt))
-      );
 
     // Calculate realized PnL from closed perp positions
     const realizedPnLFromPerp = closedPerpPositions.reduce((sum, pos) => {

--- a/packages/engine/src/npc/npc-investment-manager.ts
+++ b/packages/engine/src/npc/npc-investment-manager.ts
@@ -13,7 +13,6 @@ import {
   actorState,
   and,
   db,
-  isNotNull,
   isNull,
   organizationState,
   perpPositions,
@@ -94,8 +93,8 @@ export class NPCInvestmentManager {
       actorBalance.tradingBalance?.toString() ?? '0'
     );
 
-    // Get open perp positions (stored in perpPositions table)
-    const openPerpPositions = await db
+    // Get perp positions once and split into open/closed in memory.
+    const perpPositionsResult = await db
       .select({
         id: perpPositions.id,
         ticker: perpPositions.ticker,
@@ -105,19 +104,18 @@ export class NPCInvestmentManager {
         currentPrice: perpPositions.currentPrice,
         unrealizedPnL: perpPositions.unrealizedPnL,
         leverage: perpPositions.leverage,
+        realizedPnL: perpPositions.realizedPnL,
+        closedAt: perpPositions.closedAt,
       })
       .from(perpPositions)
-      .where(
-        and(eq(perpPositions.userId, poolId), isNull(perpPositions.closedAt))
-      );
+      .where(eq(perpPositions.userId, poolId));
 
-    // Query closed perp positions only (future optimization: use SQL aggregation)
-    const closedPerpPositions = await db
-      .select({ id: perpPositions.id, realizedPnL: perpPositions.realizedPnL })
-      .from(perpPositions)
-      .where(
-        and(eq(perpPositions.userId, poolId), isNotNull(perpPositions.closedAt))
-      );
+    const openPerpPositions = perpPositionsResult.filter(
+      (p) => p.closedAt === null
+    );
+    const closedPerpPositions = perpPositionsResult.filter(
+      (p) => p.closedAt !== null
+    );
 
     const perpPositionIds = new Set([
       ...openPerpPositions.map((p) => p.id),

--- a/packages/engine/src/npc/npc-investment-manager.ts
+++ b/packages/engine/src/npc/npc-investment-manager.ts
@@ -13,6 +13,7 @@ import {
   actorState,
   and,
   db,
+  isNotNull,
   isNull,
   organizationState,
   perpPositions,
@@ -127,17 +128,16 @@ export class NPCInvestmentManager {
       return sum + Number.parseFloat(pos.realizedPnL?.toString() || '0');
     }, 0);
 
-    // Get all perp positions for this actor (userId = poolId for NPCs)
-    const allPerpPositions = await db
-      .select()
+    // Query closed perp positions only (future optimization: use SQL aggregation)
+    const closedPerpPositions = await db
+      .select({ realizedPnL: perpPositions.realizedPnL })
       .from(perpPositions)
-      .where(eq(perpPositions.userId, poolId));
-
-    // Filter for closed perp positions
-    const closedPerps = allPerpPositions.filter((p) => p.closedAt !== null);
+      .where(
+        and(eq(perpPositions.userId, poolId), isNotNull(perpPositions.closedAt))
+      );
 
     // Calculate realized PnL from closed perp positions
-    const realizedPnLFromPerp = closedPerps.reduce((sum, pos) => {
+    const realizedPnLFromPerp = closedPerpPositions.reduce((sum, pos) => {
       return sum + Number.parseFloat(pos.realizedPnL?.toString() || '0');
     }, 0);
 

--- a/packages/engine/src/npc/npc-investment-manager.ts
+++ b/packages/engine/src/npc/npc-investment-manager.ts
@@ -113,15 +113,63 @@ export class NPCInvestmentManager {
       actorBalance.tradingBalance?.toString() ?? '0'
     );
 
-    // Calculate total invested capital (sum of all open position entry values)
-    const totalInvested = positions.reduce((sum, pos) => {
+    // Get open perp positions (stored in perpPositions table)
+    const openPerpPositions = await db
+      .select({
+        id: perpPositions.id,
+        ticker: perpPositions.ticker,
+        side: perpPositions.side,
+        size: perpPositions.size,
+        entryPrice: perpPositions.entryPrice,
+        currentPrice: perpPositions.currentPrice,
+        unrealizedPnL: perpPositions.unrealizedPnL,
+        leverage: perpPositions.leverage,
+      })
+      .from(perpPositions)
+      .where(
+        and(eq(perpPositions.userId, poolId), isNull(perpPositions.closedAt))
+      );
+
+    const perpPortfolioPositions: PortfolioPosition[] = openPerpPositions.map(
+      (p) => ({
+        id: p.id,
+        poolId,
+        marketType: 'perp',
+        ticker: p.ticker ?? undefined,
+        side: p.side,
+        size: Number(p.size),
+        entryPrice: Number(p.entryPrice),
+        currentPrice: Number(p.currentPrice),
+        unrealizedPnL: Number(p.unrealizedPnL),
+        leverage: p.leverage ?? undefined,
+      })
+    );
+
+    // Calculate total invested capital (pool positions only)
+    const poolInvested = positions.reduce((sum, pos) => {
       return sum + Number.parseFloat(pos.size?.toString() || '0');
     }, 0);
 
+    const perpInvested = openPerpPositions.reduce((sum, pos) => {
+      const size = Number.parseFloat(pos.size?.toString() || '0');
+      const leverage = Number.parseFloat(pos.leverage?.toString() || '1');
+      const effectiveLeverage =
+        Number.isFinite(leverage) && leverage > 0 ? leverage : 1;
+      return sum + Math.abs(size / effectiveLeverage);
+    }, 0);
+
+    const totalInvested = poolInvested + perpInvested;
+
     // Calculate unrealized PnL from open positions
-    const unrealizedPnL = positions.reduce((sum, pos) => {
+    const poolUnrealizedPnL = positions.reduce((sum, pos) => {
       return sum + Number.parseFloat(pos.unrealizedPnL?.toString() || '0');
     }, 0);
+
+    const perpUnrealizedPnL = openPerpPositions.reduce((sum, pos) => {
+      return sum + Number.parseFloat(pos.unrealizedPnL?.toString() || '0');
+    }, 0);
+
+    const unrealizedPnL = poolUnrealizedPnL + perpUnrealizedPnL;
 
     // Calculate realized PnL from closed pool positions
     const realizedPnLFromPool = closedPositions.reduce((sum, pos) => {
@@ -150,9 +198,11 @@ export class NPCInvestmentManager {
     // Calculate utilization (how much capital is deployed)
     const utilization = totalValue > 0 ? (totalInvested / totalValue) * 100 : 0;
 
+    const allOpenPositions = [...positions, ...perpPortfolioPositions];
+
     // Calculate risk score based on leverage and concentration
     const riskScore = NPCInvestmentManager.calculateRiskScore(
-      positions,
+      allOpenPositions,
       totalValue
     );
 
@@ -161,7 +211,7 @@ export class NPCInvestmentManager {
       availableBalance,
       unrealizedPnL,
       realizedPnL,
-      positionCount: positions.length,
+      positionCount: allOpenPositions.length,
       utilization,
       riskScore,
     };

--- a/packages/testing/unit/npc-investment-manager-pnl.test.ts
+++ b/packages/testing/unit/npc-investment-manager-pnl.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Test for NPCInvestmentManager.getPortfolioMetrics() realized PnL calculation
+ *
+ * This test verifies the fix for the bug where realizedPnL was always returning 0
+ * instead of calculating the sum of realized PnL from closed positions.
+ */
+
+import { describe, expect, test, beforeAll, afterAll } from 'bun:test';
+import {
+  db,
+  actorState,
+  poolPositions,
+  perpPositions,
+  eq,
+  sql,
+} from '@babylon/db';
+import { NPCInvestmentManager } from '@babylon/engine';
+import { generateSnowflakeId } from '@babylon/shared';
+
+describe('NPCInvestmentManager - Realized PnL Calculation', () => {
+  const TEST_ACTOR_ID = 'test-actor-pnl-' + Date.now();
+  const INITIAL_BALANCE = 10000;
+
+  beforeAll(async () => {
+    // Create test actor state
+    await db.insert(actorState).values({
+      id: TEST_ACTOR_ID,
+      tradingBalance: String(INITIAL_BALANCE),
+      reputationPoints: 1000,
+      hasPool: true,
+      updatedAt: new Date(),
+    });
+  });
+
+  afterAll(async () => {
+    // Clean up test data
+    await db
+      .delete(poolPositions)
+      .where(eq(poolPositions.poolId, TEST_ACTOR_ID));
+    await db
+      .delete(perpPositions)
+      .where(eq(perpPositions.userId, TEST_ACTOR_ID));
+    await db.delete(actorState).where(eq(actorState.id, TEST_ACTOR_ID));
+  });
+
+  test('should return 0 realized PnL when no positions exist', async () => {
+    const metrics = await NPCInvestmentManager.getPortfolioMetrics(
+      TEST_ACTOR_ID
+    );
+
+    expect(metrics.realizedPnL).toBe(0);
+    expect(metrics.unrealizedPnL).toBe(0);
+    expect(metrics.positionCount).toBe(0);
+  });
+
+  test('should calculate realized PnL from closed pool positions', async () => {
+    const pos1Id = await generateSnowflakeId();
+    const pos2Id = await generateSnowflakeId();
+
+    // Create closed positions with realized PnL
+    await db.insert(poolPositions).values([
+      {
+        id: pos1Id,
+        poolId: TEST_ACTOR_ID,
+        marketType: 'prediction',
+        marketId: 'test-market-1',
+        side: 'YES',
+        entryPrice: 50,
+        currentPrice: 60,
+        size: 100,
+        unrealizedPnL: 0, // Closed positions have 0 unrealized
+        realizedPnL: 150, // Profit of $150
+        openedAt: new Date(Date.now() - 3600000),
+        closedAt: new Date(Date.now() - 1800000), // Closed 30 min ago
+        updatedAt: new Date(),
+      },
+      {
+        id: pos2Id,
+        poolId: TEST_ACTOR_ID,
+        marketType: 'prediction',
+        marketId: 'test-market-2',
+        side: 'NO',
+        entryPrice: 40,
+        currentPrice: 30,
+        size: 200,
+        unrealizedPnL: 0,
+        realizedPnL: -75, // Loss of $75
+        openedAt: new Date(Date.now() - 7200000),
+        closedAt: new Date(Date.now() - 3600000), // Closed 1 hr ago
+        updatedAt: new Date(),
+      },
+    ]);
+
+    const metrics = await NPCInvestmentManager.getPortfolioMetrics(
+      TEST_ACTOR_ID
+    );
+
+    // Total realized should be 150 + (-75) = 75
+    expect(metrics.realizedPnL).toBe(75);
+    expect(metrics.unrealizedPnL).toBe(0);
+    expect(metrics.positionCount).toBe(0); // No open positions
+
+    // Clean up
+    await db
+      .delete(poolPositions)
+      .where(eq(poolPositions.poolId, TEST_ACTOR_ID));
+  });
+
+  test('should calculate realized PnL from closed perp positions', async () => {
+    const perpPos1Id = await generateSnowflakeId();
+    const perpPos2Id = await generateSnowflakeId();
+
+    // Create closed perp positions
+    await db.insert(perpPositions).values([
+      {
+        id: perpPos1Id,
+        userId: TEST_ACTOR_ID,
+        organizationId: 'org-1',
+        ticker: 'ACME',
+        side: 'long',
+        entryPrice: 100,
+        size: 500,
+        leverage: 2,
+        liquidationPrice: 50,
+        unrealizedPnL: 0,
+        unrealizedPnLPercent: 0,
+        realizedPnL: 250, // Profit of $250
+        openedAt: new Date(Date.now() - 7200000),
+        closedAt: new Date(Date.now() - 3600000),
+        lastUpdated: new Date(),
+      },
+      {
+        id: perpPos2Id,
+        userId: TEST_ACTOR_ID,
+        organizationId: 'org-2',
+        ticker: 'BETA',
+        side: 'short',
+        entryPrice: 200,
+        size: 300,
+        leverage: 1,
+        liquidationPrice: 400,
+        unrealizedPnL: 0,
+        unrealizedPnLPercent: 0,
+        realizedPnL: -100, // Loss of $100
+        openedAt: new Date(Date.now() - 5400000),
+        closedAt: new Date(Date.now() - 1800000),
+        lastUpdated: new Date(),
+      },
+    ]);
+
+    const metrics = await NPCInvestmentManager.getPortfolioMetrics(
+      TEST_ACTOR_ID
+    );
+
+    // Total realized should be 250 + (-100) = 150
+    expect(metrics.realizedPnL).toBe(150);
+    expect(metrics.unrealizedPnL).toBe(0);
+    expect(metrics.positionCount).toBe(0);
+
+    // Clean up
+    await db
+      .delete(perpPositions)
+      .where(eq(perpPositions.userId, TEST_ACTOR_ID));
+  });
+
+  test('should calculate both realized and unrealized PnL correctly', async () => {
+    const openPosId = await generateSnowflakeId();
+    const closedPosId = await generateSnowflakeId();
+    const openPerpId = await generateSnowflakeId();
+    const closedPerpId = await generateSnowflakeId();
+
+    // Create mix of open and closed positions
+    await db.insert(poolPositions).values([
+      {
+        id: openPosId,
+        poolId: TEST_ACTOR_ID,
+        marketType: 'prediction',
+        marketId: 'test-market-3',
+        side: 'YES',
+        entryPrice: 50,
+        currentPrice: 55,
+        size: 100,
+        unrealizedPnL: 50, // Open position with unrealized profit
+        realizedPnL: null,
+        openedAt: new Date(Date.now() - 1800000),
+        closedAt: null,
+        updatedAt: new Date(),
+      },
+      {
+        id: closedPosId,
+        poolId: TEST_ACTOR_ID,
+        marketType: 'prediction',
+        marketId: 'test-market-4',
+        side: 'NO',
+        entryPrice: 60,
+        currentPrice: 50,
+        size: 200,
+        unrealizedPnL: 0,
+        realizedPnL: 200, // Closed with profit
+        openedAt: new Date(Date.now() - 7200000),
+        closedAt: new Date(Date.now() - 3600000),
+        updatedAt: new Date(),
+      },
+    ]);
+
+    await db.insert(perpPositions).values([
+      {
+        id: openPerpId,
+        userId: TEST_ACTOR_ID,
+        organizationId: 'org-3',
+        ticker: 'GAMMA',
+        side: 'long',
+        entryPrice: 100,
+        size: 300,
+        leverage: 1,
+        liquidationPrice: 50,
+        unrealizedPnL: -25, // Open position with unrealized loss
+        unrealizedPnLPercent: -8.33,
+        realizedPnL: null,
+        openedAt: new Date(Date.now() - 1800000),
+        closedAt: null,
+        lastUpdated: new Date(),
+      },
+      {
+        id: closedPerpId,
+        userId: TEST_ACTOR_ID,
+        organizationId: 'org-4',
+        ticker: 'DELTA',
+        side: 'short',
+        entryPrice: 150,
+        size: 400,
+        leverage: 2,
+        liquidationPrice: 300,
+        unrealizedPnL: 0,
+        unrealizedPnLPercent: 0,
+        realizedPnL: 350, // Closed with profit
+        openedAt: new Date(Date.now() - 5400000),
+        closedAt: new Date(Date.now() - 1800000),
+        lastUpdated: new Date(),
+      },
+    ]);
+
+    const metrics = await NPCInvestmentManager.getPortfolioMetrics(
+      TEST_ACTOR_ID
+    );
+
+    // Unrealized: 50 (pool) + (-25) (perp) = 25
+    expect(metrics.unrealizedPnL).toBe(25);
+
+    // Realized: 200 (pool) + 350 (perp) = 550
+    expect(metrics.realizedPnL).toBe(550);
+
+    // Open positions: 1 pool + 1 perp = 2
+    expect(metrics.positionCount).toBe(2);
+
+    // Total value should include unrealized PnL
+    const expectedTotalValue =
+      INITIAL_BALANCE + // 10000
+      300 + // openPoolPos.size
+      300 + // openPerpPos.size
+      25; // unrealizedPnL
+    expect(metrics.totalValue).toBe(expectedTotalValue);
+
+    // Clean up
+    await db
+      .delete(poolPositions)
+      .where(eq(poolPositions.poolId, TEST_ACTOR_ID));
+    await db
+      .delete(perpPositions)
+      .where(eq(perpPositions.userId, TEST_ACTOR_ID));
+  });
+
+  test('should handle null realizedPnL gracefully', async () => {
+    const posId = await generateSnowflakeId();
+
+    // Create a closed position with null realizedPnL (shouldn't happen, but defensive)
+    await db.insert(poolPositions).values({
+      id: posId,
+      poolId: TEST_ACTOR_ID,
+      marketType: 'prediction',
+      marketId: 'test-market-5',
+      side: 'YES',
+      entryPrice: 50,
+      currentPrice: 50,
+      size: 100,
+      unrealizedPnL: 0,
+      realizedPnL: null, // null instead of 0
+      openedAt: new Date(Date.now() - 3600000),
+      closedAt: new Date(Date.now() - 1800000),
+      updatedAt: new Date(),
+    });
+
+    const metrics = await NPCInvestmentManager.getPortfolioMetrics(
+      TEST_ACTOR_ID
+    );
+
+    // Should treat null as 0
+    expect(metrics.realizedPnL).toBe(0);
+
+    // Clean up
+    await db
+      .delete(poolPositions)
+      .where(eq(poolPositions.poolId, TEST_ACTOR_ID));
+  });
+});

--- a/packages/testing/unit/npc-investment-manager-pnl.test.ts
+++ b/packages/testing/unit/npc-investment-manager-pnl.test.ts
@@ -12,7 +12,6 @@ import {
   poolPositions,
   perpPositions,
   eq,
-  sql,
 } from '@babylon/db';
 import { NPCInvestmentManager } from '@babylon/engine';
 import { generateSnowflakeId } from '@babylon/shared';
@@ -158,6 +157,60 @@ describe('NPCInvestmentManager - Realized PnL Calculation', () => {
     expect(metrics.positionCount).toBe(0);
 
     // Clean up
+    await db
+      .delete(perpPositions)
+      .where(eq(perpPositions.userId, TEST_ACTOR_ID));
+  });
+
+  test('should sum realized PnL from closed pool and perp positions', async () => {
+    const poolPosId = await generateSnowflakeId();
+    const perpPosId = await generateSnowflakeId();
+
+    await db.insert(poolPositions).values({
+      id: poolPosId,
+      poolId: TEST_ACTOR_ID,
+      marketType: 'prediction',
+      marketId: 'test-market-3b',
+      side: 'YES',
+      entryPrice: 50,
+      currentPrice: 55,
+      size: 120,
+      unrealizedPnL: 0,
+      realizedPnL: 120, // Profit of $120
+      openedAt: new Date(Date.now() - 7200000),
+      closedAt: new Date(Date.now() - 3600000),
+      updatedAt: new Date(),
+    });
+
+    await db.insert(perpPositions).values({
+      id: perpPosId,
+      userId: TEST_ACTOR_ID,
+      organizationId: 'org-2b',
+      ticker: 'OMEGA',
+      side: 'short',
+      entryPrice: 200,
+      size: 300,
+      leverage: 1,
+      liquidationPrice: 400,
+      unrealizedPnL: 0,
+      unrealizedPnLPercent: 0,
+      realizedPnL: -30, // Loss of $30
+      openedAt: new Date(Date.now() - 5400000),
+      closedAt: new Date(Date.now() - 1800000),
+      lastUpdated: new Date(),
+    });
+
+    const metrics = await NPCInvestmentManager.getPortfolioMetrics(
+      TEST_ACTOR_ID
+    );
+
+    expect(metrics.realizedPnL).toBe(90);
+    expect(metrics.unrealizedPnL).toBe(0);
+    expect(metrics.positionCount).toBe(0);
+
+    await db
+      .delete(poolPositions)
+      .where(eq(poolPositions.poolId, TEST_ACTOR_ID));
     await db
       .delete(perpPositions)
       .where(eq(perpPositions.userId, TEST_ACTOR_ID));

--- a/packages/testing/unit/npc-investment-manager-pnl.test.ts
+++ b/packages/testing/unit/npc-investment-manager-pnl.test.ts
@@ -309,8 +309,8 @@ describe('NPCInvestmentManager - Realized PnL Calculation', () => {
     // Total value should include unrealized PnL
     const expectedTotalValue =
       INITIAL_BALANCE + // 10000
-      300 + // openPoolPos.size
-      300 + // openPerpPos.size
+      100 + // openPoolPos.size
+      300 + // openPerpPos.size (margin at 1x leverage)
       25; // unrealizedPnL
     expect(metrics.totalValue).toBe(expectedTotalValue);
 

--- a/packages/testing/unit/npc-investment-manager-pnl.test.ts
+++ b/packages/testing/unit/npc-investment-manager-pnl.test.ts
@@ -5,7 +5,15 @@
  * instead of calculating the sum of realized PnL from closed positions.
  */
 
-import { describe, expect, test, beforeAll, afterAll } from 'bun:test';
+import {
+  describe,
+  expect,
+  test,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+} from 'bun:test';
 import {
   db,
   actorState,
@@ -29,6 +37,24 @@ describe('NPCInvestmentManager - Realized PnL Calculation', () => {
       hasPool: true,
       updatedAt: new Date(),
     });
+  });
+
+  beforeEach(async () => {
+    await db
+      .delete(poolPositions)
+      .where(eq(poolPositions.poolId, TEST_ACTOR_ID));
+    await db
+      .delete(perpPositions)
+      .where(eq(perpPositions.userId, TEST_ACTOR_ID));
+  });
+
+  afterEach(async () => {
+    await db
+      .delete(poolPositions)
+      .where(eq(poolPositions.poolId, TEST_ACTOR_ID));
+    await db
+      .delete(perpPositions)
+      .where(eq(perpPositions.userId, TEST_ACTOR_ID));
   });
 
   afterAll(async () => {
@@ -118,6 +144,7 @@ describe('NPCInvestmentManager - Realized PnL Calculation', () => {
         ticker: 'ACME',
         side: 'long',
         entryPrice: 100,
+        currentPrice: 110,
         size: 500,
         leverage: 2,
         liquidationPrice: 50,
@@ -135,6 +162,7 @@ describe('NPCInvestmentManager - Realized PnL Calculation', () => {
         ticker: 'BETA',
         side: 'short',
         entryPrice: 200,
+        currentPrice: 190,
         size: 300,
         leverage: 1,
         liquidationPrice: 400,
@@ -189,6 +217,7 @@ describe('NPCInvestmentManager - Realized PnL Calculation', () => {
       ticker: 'OMEGA',
       side: 'short',
       entryPrice: 200,
+      currentPrice: 190,
       size: 300,
       leverage: 1,
       liquidationPrice: 400,
@@ -264,6 +293,7 @@ describe('NPCInvestmentManager - Realized PnL Calculation', () => {
         ticker: 'GAMMA',
         side: 'long',
         entryPrice: 100,
+        currentPrice: 95,
         size: 300,
         leverage: 1,
         liquidationPrice: 50,
@@ -281,6 +311,7 @@ describe('NPCInvestmentManager - Realized PnL Calculation', () => {
         ticker: 'DELTA',
         side: 'short',
         entryPrice: 150,
+        currentPrice: 140,
         size: 400,
         leverage: 2,
         liquidationPrice: 300,

--- a/scripts/verify-pnl-fix.sh
+++ b/scripts/verify-pnl-fix.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Verify PnL fix for all user-controlled agents on staging
+
+echo "🔍 Verifying PnL fix for user-controlled agents..."
+echo ""
+
+# Check if cookies file exists
+if [ ! -f ".staging-cookies.txt" ]; then
+  echo "⚠️  Create .staging-cookies.txt with your auth cookies first"
+  echo "Example format:"
+  echo "privy-token=eyJ...; privy-id-token=eyJ...; privy-session=t"
+  exit 1
+fi
+
+COOKIES=$(cat .staging-cookies.txt)
+BASE_URL="https://staging.babylon.market"
+
+# Array of known user-controlled agent IDs (update with actual IDs)
+AGENT_IDS=(
+  "273508387734421504"  # Lumen Oracle
+  # Add more agent IDs here
+)
+
+echo "Testing ${#AGENT_IDS[@]} agents..."
+echo ""
+
+for AGENT_ID in "${AGENT_IDS[@]}"; do
+  echo "📊 Agent: $AGENT_ID"
+  
+  RESPONSE=$(curl -s "$BASE_URL/api/npc/$AGENT_ID/portfolio" \
+    -H "accept: */*" \
+    -b "$COOKIES")
+  
+  # Extract realizedPnL using jq
+  REALIZED_PNL=$(echo "$RESPONSE" | jq -r '.portfolio.realizedPnL // "null"')
+  UNREALIZED_PNL=$(echo "$RESPONSE" | jq -r '.portfolio.unrealizedPnL // "null"')
+  POSITION_COUNT=$(echo "$RESPONSE" | jq -r '.portfolio.positionCount // 0')
+  
+  if [ "$REALIZED_PNL" = "null" ]; then
+    echo "   ❌ Failed to fetch data"
+  elif [ "$REALIZED_PNL" = "0" ] && [ "$POSITION_COUNT" = "0" ]; then
+    echo "   ✅ realizedPnL: \$0.00 (no positions - expected)"
+  else
+    echo "   ✅ realizedPnL: \$$REALIZED_PNL"
+    echo "      unrealizedPnL: \$$UNREALIZED_PNL"
+    echo "      positions: $POSITION_COUNT"
+  fi
+  echo ""
+done
+
+echo "✅ Verification complete!"
+echo ""
+echo "If all agents show realizedPnL != 0 when they have closed positions, the fix is working!"

--- a/scripts/verify-pnl-fix.sh
+++ b/scripts/verify-pnl-fix.sh
@@ -16,6 +16,9 @@ COOKIES=$(cat .staging-cookies.txt)
 BASE_URL="https://staging.babylon.market"
 
 # Array of known user-controlled agent IDs (update with actual IDs)
+# To find agents with closed positions, query:
+#   SELECT DISTINCT "poolId" FROM "PoolPosition" WHERE "closedAt" IS NOT NULL LIMIT 10;
+#   SELECT DISTINCT "userId" FROM "PerpPosition" WHERE "closedAt" IS NOT NULL LIMIT 10;
 AGENT_IDS=(
   "273508387734421504"  # Lumen Oracle
   # Add more agent IDs here


### PR DESCRIPTION
## Summary
- Fix NPC portfolio PnL aggregation so realized PnL isn’t hardcoded and open perps are included.
- Avoid double counting perps when legacy `poolPositions` overlap with `perpPositions`.
- Harden tests and update docs/verification guidance.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [x] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- User report: Agent `273508387734421504` (Lumen Oracle)
- PR: #920

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Non‑goals / follow‑ups**
- Add `lifetimePnL` to `actorState` and backfill.
- SQL aggregation for realized PnL.
- DB index changes for closed position lookups.

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [x] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- Aggregate realized PnL from closed pool + perp positions
- Include open perps in invested/unrealized/position count/risk
- De‑dup legacy pool perps that overlap with `perpPositions`
- Test isolation + required `currentPrice` fields
- Docs/verification updates and `.staging-cookies.txt` ignored

## Review guide
**Start here**
- `packages/engine/src/npc/npc-investment-manager.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- Perp de‑dup logic uses position IDs to exclude legacy pool perps.
- Margin assumption: perps contribute `abs(size / leverage)` to invested capital.

## Test plan
**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Not run (DB‑dependent). Recommend `bun test packages/testing/unit/npc-investment-manager-pnl.test.ts` and `scripts/verify-pnl-fix.sh` on staging.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: none
- Changed: none
- Removed: none

**DB / data migration**
- Migration(s): none
- Backfill/seed: none

**Rollout / rollback plan**
- Rollout: standard deploy
- Rollback: revert PR

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- N/A

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- NPC portfolio metrics now include open perps in aggregates.

### Database
- No schema changes.

### Contracts / on-chain
- N/A

### Docs
- Updated `docs/pnl-fix-summary.md` and `REALIZED_PNL_FIX.md`.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes
- Reason: Backend-only change, no UI impact.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)