### PR TITLE
fix: exclude transfers from portfolio baseline

### DIFF
--- a/apps/web/src/app/api/users/[userId]/portfolio-breakdown/route.ts
+++ b/apps/web/src/app/api/users/[userId]/portfolio-breakdown/route.ts
@@ -8,7 +8,7 @@
  * Returns a canonical portfolio breakdown for consistent P/L across the app.
  * This includes wallet balance, agents-held balance, open positions value, and
  * a unified Total P/L computed as:
- *   (Agents + Positions + Wallet) - Original Amount (net deposits/withdrawals + transfers)
+ *   (Agents + Positions + Wallet) - Original Amount
  */
 
 import {

--- a/apps/web/src/app/api/users/[userId]/portfolio-breakdown/route.ts
+++ b/apps/web/src/app/api/users/[userId]/portfolio-breakdown/route.ts
@@ -8,7 +8,7 @@
  * Returns a canonical portfolio breakdown for consistent P/L across the app.
  * This includes wallet balance, agents-held balance, open positions value, and
  * a unified Total P/L computed as:
- *   (Agents + Positions + Wallet) - Original Amount
+ *   (Agents + Positions + Wallet) - Original Amount (net deposits/withdrawals + transfers)
  */
 
 import {

--- a/packages/engine/src/services/portfolio-breakdown.ts
+++ b/packages/engine/src/services/portfolio-breakdown.ts
@@ -3,15 +3,8 @@
  */
 
 import { PredictionPricing } from '@babylon/core/markets/prediction';
-import {
-  db,
-  markets,
-  perpPositions,
-  pointsTransactions,
-  positions,
-  users,
-} from '@babylon/db';
-import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
+import { db, markets, perpPositions, positions, users } from '@babylon/db';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
 import { FEE_CONFIG } from '../config/fees';
 
 export interface PortfolioBreakdownSnapshot {
@@ -92,7 +85,6 @@ function calculatePredictionPositionValue(position: {
  *
  * Total P/L formula:
  *   totalPnL = (agents + positions + wallet) - originalAmount
- * where originalAmount includes net peer transfers.
  */
 export async function calculatePortfolioBreakdown(
   userId: string
@@ -185,26 +177,7 @@ export async function calculatePortfolioBreakdown(
 
   const totalDeposited = toNumber(user.totalDeposited);
   const totalWithdrawn = toNumber(user.totalWithdrawn);
-
-  // Exclude peer-to-peer point transfers from PnL baseline.
-  const transferResult = await db
-    .select({
-      netTransfers: sql<number>`COALESCE(SUM(${pointsTransactions.amount}), 0)`,
-    })
-    .from(pointsTransactions)
-    .where(
-      and(
-        eq(pointsTransactions.userId, userId),
-        inArray(pointsTransactions.reason, [
-          'transfer_sent',
-          'transfer_received',
-        ])
-      )
-    )
-    .limit(1);
-
-  const netTransfers = toNumber(transferResult[0]?.netTransfers);
-  const originalAmount = totalDeposited - totalWithdrawn + netTransfers;
+  const originalAmount = totalDeposited - totalWithdrawn;
 
   const available = wallet + agents;
   const totalAssets = wallet + agents + positionsValue;

--- a/packages/engine/src/services/portfolio-breakdown.ts
+++ b/packages/engine/src/services/portfolio-breakdown.ts
@@ -3,8 +3,15 @@
  */
 
 import { PredictionPricing } from '@babylon/core/markets/prediction';
-import { db, markets, perpPositions, positions, users } from '@babylon/db';
-import { and, eq, inArray, isNull } from 'drizzle-orm';
+import {
+  db,
+  markets,
+  perpPositions,
+  pointsTransactions,
+  positions,
+  users,
+} from '@babylon/db';
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 import { FEE_CONFIG } from '../config/fees';
 
 export interface PortfolioBreakdownSnapshot {
@@ -85,6 +92,7 @@ function calculatePredictionPositionValue(position: {
  *
  * Total P/L formula:
  *   totalPnL = (agents + positions + wallet) - originalAmount
+ * where originalAmount includes net peer transfers.
  */
 export async function calculatePortfolioBreakdown(
   userId: string
@@ -177,7 +185,26 @@ export async function calculatePortfolioBreakdown(
 
   const totalDeposited = toNumber(user.totalDeposited);
   const totalWithdrawn = toNumber(user.totalWithdrawn);
-  const originalAmount = totalDeposited - totalWithdrawn;
+
+  // Exclude peer-to-peer point transfers from PnL baseline.
+  const transferResult = await db
+    .select({
+      netTransfers: sql<number>`COALESCE(SUM(${pointsTransactions.amount}), 0)`,
+    })
+    .from(pointsTransactions)
+    .where(
+      and(
+        eq(pointsTransactions.userId, userId),
+        inArray(pointsTransactions.reason, [
+          'transfer_sent',
+          'transfer_received',
+        ])
+      )
+    )
+    .limit(1);
+
+  const netTransfers = toNumber(transferResult[0]?.netTransfers);
+  const originalAmount = totalDeposited - totalWithdrawn + netTransfers;
 
   const available = wallet + agents;
   const totalAssets = wallet + agents + positionsValue;


### PR DESCRIPTION
## Summary
- Adjust portfolio breakdown baseline to offset net point transfers so P&L reflects trading performance.
- Keep markets-tick route helpers internal to satisfy Next.js route type checks.
- Align markets-tick integration test requests with `NextRequest` typing.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- …

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [ ] Drive‑by refactors are excluded or split into a separate PR
- [ ] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- Add net transfer adjustment to the portfolio breakdown baseline.
- Make `MARKET_STRUCTURE` and `inferGranularTimeframe` internal to the markets-tick route.
- Use `NextRequest` for markets-tick integration test requests.
- Biome formatting cleanup in NPC investment manager + tests (pre-commit).

## Review guide
**Start here**
- `packages/engine/src/services/portfolio-breakdown.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- Biome auto-formatted two NPC PnL files during pre-commit.

## Test plan
**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Pre-push hooks ran `turbo typecheck`, `turbo lint`, `turbo build`.
2. Tests skipped (DATABASE_URL not set).

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: none
- Changed: none
- Removed: none

**DB / data migration**
- Migration(s): none
- Backfill/seed: none

**Rollout / rollback plan**
- Rollout: standard deploy
- Rollback: revert PR

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- …

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- …

### Database
- …

### Contracts / on-chain
- …

### Docs
- …

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes
- Reason: Backend-only change, no UI impact.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

Made with [Cursor](https://cursor.com)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR correctly adjusts the portfolio P&L calculation to exclude peer-to-peer point transfers from the baseline, ensuring that `totalPnL` reflects only trading performance. Previously, if a user transferred points to another user, their P&L would incorrectly show a loss even though no trading occurred.

**Key changes:**
- Added query for `transfer_sent` (negative amounts) and `transfer_received` (positive amounts) transactions
- Modified baseline formula: `originalAmount = totalDeposited - totalWithdrawn + netTransfers`
- This correctly adjusts the baseline so that net outgoing transfers reduce the baseline (making P&L neutral), and net incoming transfers increase it
- Removed `export` keywords from `MARKET_STRUCTURE` and `inferGranularTimeframe` in markets-tick route to satisfy Next.js internal route type requirements
- Updated test files to use `NextRequest` instead of `Request` for proper typing
- Biome auto-formatted two NPC-related files during pre-commit

**Logic verification:**
Example: User deposits 1000 points, transfers out 100 points (netTransfers = -100), has 900 in wallet.
- Old: originalAmount = 1000, totalPnL = 900 - 1000 = -100 (incorrect - looks like trading loss)
- New: originalAmount = 1000 + (-100) = 900, totalPnL = 900 - 900 = 0 (correct - no trading activity)

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no blocking issues found
- The transfer adjustment logic is mathematically correct and well-tested in production transfer flows. The markets-tick changes are purely cosmetic (removing exports that weren't being used externally). Test updates properly align with Next.js typing requirements. All changes are focused and low-risk.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/engine/src/services/portfolio-breakdown.ts | Adds net transfer adjustment to P&L baseline calculation to exclude peer-to-peer transfers from trading performance metrics |
| apps/web/src/app/api/cron/markets-tick/route.ts | Removes `export` keywords from MARKET_STRUCTURE and inferGranularTimeframe to keep them internal per Next.js route type requirements |
| packages/testing/integration/markets-tick.integration.test.ts | Updates test requests to use NextRequest instead of Request for proper Next.js route handler typing |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant API as Portfolio API
    participant Service as portfolio-breakdown.ts
    participant DB as Database
    
    Client->>API: GET /api/users/{userId}/portfolio-breakdown
    API->>Service: calculatePortfolioBreakdown(userId)
    
    Service->>DB: Query user (totalDeposited, totalWithdrawn, virtualBalance)
    DB-->>Service: User data
    
    Service->>DB: Query user's agents (virtualBalance)
    DB-->>Service: Agent balances
    
    Service->>DB: Query open perp positions (size, leverage, unrealizedPnL)
    DB-->>Service: Perp positions
    
    Service->>DB: Query open prediction positions (shares, avgPrice, side)
    DB-->>Service: Prediction positions
    
    Note over Service: NEW: Query transfer transactions
    Service->>DB: Query pointsTransactions<br/>(transfer_sent, transfer_received)
    DB-->>Service: Transfer transactions
    
    Note over Service: Calculate values
    Service->>Service: wallet = user.virtualBalance
    Service->>Service: agents = sum(agent.virtualBalance)
    Service->>Service: positionsValue = perpsValue + predictionsValue
    Service->>Service: netTransfers = sum(transfer amounts)
    
    Note over Service: NEW: Adjust baseline for transfers
    Service->>Service: originalAmount = totalDeposited - totalWithdrawn + netTransfers
    Service->>Service: totalAssets = wallet + agents + positionsValue
    Service->>Service: totalPnL = totalAssets - originalAmount
    
    Service-->>API: PortfolioBreakdownSnapshot
    API-->>Client: Portfolio breakdown JSON
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->