### PR TITLE
feat: comprehensive UI redesign (v2) — settings, rewards, profile, terminal, chat

### DIFF
--- a/apps/web/src/app/agents/loading.tsx
+++ b/apps/web/src/app/agents/loading.tsx
@@ -1,50 +1,28 @@
-/**
- * Agents Loading Component
- *
- * @description Loading skeleton for the agents page, displaying skeleton loaders
- * for the header, filter tabs, and agent cards grid.
- *
- * @returns {JSX.Element} Agents loading skeleton
- */
-import { Card } from '@/components/ui/card';
+import { Skeleton } from '@/components/shared/Skeleton';
 
 export default function AgentsLoading() {
   return (
-    <div className="container mx-auto max-w-7xl p-6">
-      <div className="mb-8 flex items-center justify-between">
-        <div>
-          <div className="mb-2 h-8 w-48 animate-pulse rounded bg-gray-700" />
-          <div className="h-4 w-96 animate-pulse rounded bg-gray-700" />
-        </div>
-        <div className="h-10 w-32 animate-pulse rounded bg-gray-700" />
-      </div>
-
-      <div className="mb-6 flex gap-2">
-        {[1, 2, 3].map((i) => (
-          <div key={i} className="h-8 w-16 animate-pulse rounded bg-gray-700" />
-        ))}
-      </div>
-
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-        {[1, 2, 3].map((i) => (
-          <Card key={i} className="animate-pulse p-6">
-            <div className="mb-4 flex items-center gap-4">
-              <div className="h-12 w-12 rounded-full bg-gray-700" />
-              <div className="flex-1">
-                <div className="mb-2 h-4 w-24 rounded bg-gray-700" />
-                <div className="h-3 w-16 rounded bg-gray-700" />
+    <div className="flex h-[calc(100dvh-112px)] flex-col md:h-dvh">
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        {/* Member sidebar skeleton */}
+        <div className="hidden w-64 flex-col border-border border-r p-4 lg:flex">
+          <Skeleton className="mb-4 h-8 w-32" />
+          <div className="space-y-3">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="flex items-center gap-3">
+                <Skeleton className="h-10 w-10 rounded-full" />
+                <Skeleton className="h-4 w-24" />
               </div>
-            </div>
-            <div className="mb-4 space-y-2">
-              <div className="h-3 rounded bg-gray-700" />
-              <div className="h-3 w-3/4 rounded bg-gray-700" />
-            </div>
-            <div className="grid grid-cols-2 gap-4 border-border border-t pt-4">
-              <div className="h-12 rounded bg-gray-700" />
-              <div className="h-12 rounded bg-gray-700" />
-            </div>
-          </Card>
-        ))}
+            ))}
+          </div>
+        </div>
+        {/* Chat area skeleton */}
+        <div className="flex flex-1 flex-col">
+          <div className="p-4">
+            <Skeleton className="h-8 w-48" />
+          </div>
+          <div className="flex-1" />
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/app/agents/team/page.tsx
+++ b/apps/web/src/app/agents/team/page.tsx
@@ -496,7 +496,7 @@ export default function TeamChatPage() {
       <div className="flex h-[calc(100dvh-112px)] flex-col md:h-dvh">
         <div className="flex min-h-0 flex-1 overflow-hidden">
           {/* Member sidebar skeleton */}
-          <div className="hidden w-64 flex-col border-border border-r p-4 lg:flex">
+          <div className="hidden w-80 flex-col border-border border-r p-4 lg:flex">
             <Skeleton className="mb-4 h-8 w-32" />
             <div className="space-y-3">
               {[1, 2, 3].map((i) => (
@@ -539,7 +539,7 @@ export default function TeamChatPage() {
   return (
     <div
       data-command-center-container
-      className="relative flex h-[calc(100dvh-112px)] flex-col overflow-hidden md:h-dvh"
+      className="relative flex h-[calc(100dvh-112px)] flex-col overflow-hidden border-border md:h-dvh lg:border-l"
     >
       {/* Mobile Tab Navigation - visible on small screens only */}
       <div className="flex h-12 shrink-0 items-center justify-around border-border border-b bg-background lg:hidden">
@@ -790,7 +790,7 @@ export default function TeamChatPage() {
         {/* Member Sidebar - visible on lg+ when not collapsed */}
         {!leftSidebarCollapsed && (
           <>
-            <div className="flex w-64 shrink-0 flex-col border-border border-r">
+            <div className="flex w-80 shrink-0 flex-col border-border border-r">
               {/* Conversations Section */}
               <div className="p-3">
                 <ConversationList
@@ -828,13 +828,11 @@ export default function TeamChatPage() {
                 onViewSettings={handleViewSettings}
               />
             </div>
-
-            <Separator orientation="vertical" className="hidden lg:block" />
           </>
         )}
 
         {/* Chat Content - min-width ensures chat doesn't get too small on desktop */}
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background md:min-w-[400px]">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-background">
           <TeamChatView
             chatDetails={chatDetails}
             currentUserId={user?.id}

--- a/apps/web/src/app/article/[id]/page.tsx
+++ b/apps/web/src/app/article/[id]/page.tsx
@@ -78,7 +78,7 @@ export default function ArticlePage({ params }: ArticlePageProps) {
     return (
       <PageContainer noPadding className="flex w-full flex-col">
         <div className="relative flex min-h-screen flex-1">
-          <div className="flex min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:border-r lg:border-l">
+          <div className="flex min-w-0 flex-1 flex-col border-border lg:border-r lg:border-l">
             <div className="sticky top-0 z-10 shrink-0 bg-background shadow-sm">
               <div className="px-6 py-4">
                 <div className="flex items-center gap-4">
@@ -107,7 +107,7 @@ export default function ArticlePage({ params }: ArticlePageProps) {
     return (
       <PageContainer noPadding className="flex w-full flex-col">
         <div className="relative flex min-h-screen flex-1">
-          <div className="flex min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:border-r lg:border-l">
+          <div className="flex min-w-0 flex-1 flex-col border-border lg:border-r lg:border-l">
             <div className="flex flex-1 flex-col items-center justify-center bg-background">
               <div className="text-center">
                 <h1 className="mb-2 font-bold text-2xl">Article Not Found</h1>
@@ -138,7 +138,7 @@ export default function ArticlePage({ params }: ArticlePageProps) {
     <PageContainer noPadding className="flex w-full flex-col">
       <div className="relative flex min-h-screen flex-1">
         {/* Desktop: Article content area */}
-        <div className="hidden min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:flex lg:border-r lg:border-l">
+        <div className="hidden min-w-0 flex-1 flex-col border-border lg:flex lg:border-r lg:border-l">
           {/* Desktop: Top bar with back button */}
           <div className="sticky top-0 z-10 shrink-0 bg-background shadow-sm">
             <div className="px-6 py-4">

--- a/apps/web/src/app/chats/loading.tsx
+++ b/apps/web/src/app/chats/loading.tsx
@@ -1,4 +1,3 @@
-import { Separator } from '@/components/shared/Separator';
 import { ChatListSkeleton, Skeleton } from '@/components/shared/Skeleton';
 
 export default function ChatsLoading() {
@@ -6,7 +5,7 @@ export default function ChatsLoading() {
     <div className="flex h-[calc(100dvh-var(--header-height,112px))] flex-col overflow-hidden md:h-dvh">
       <div className="flex min-h-0 flex-1 overflow-hidden">
         {/* Left column: Chat list */}
-        <div className="flex w-full flex-col bg-background xl:w-96">
+        <div className="flex w-full flex-col border-border bg-background xl:w-80 xl:border-r">
           {/* Header */}
           <div className="px-4 py-3">
             <div className="mb-4 flex items-center justify-between">
@@ -36,12 +35,6 @@ export default function ChatsLoading() {
             <ChatListSkeleton count={10} />
           </div>
         </div>
-
-        {/* Separator */}
-        <Separator
-          orientation="vertical"
-          className="hidden shrink-0 xl:block"
-        />
 
         {/* Right column: Empty state */}
         <div className="hidden min-h-0 min-w-0 flex-1 bg-background xl:block">

--- a/apps/web/src/app/chats/page.tsx
+++ b/apps/web/src/app/chats/page.tsx
@@ -13,7 +13,6 @@ import {
 } from '@/components/chats';
 import { CreateGroupModal } from '@/components/groups/CreateGroupModal';
 import { GroupManagementModal } from '@/components/groups/GroupManagementModal';
-import { Separator } from '@/components/shared/Separator';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -149,18 +148,18 @@ export default function ChatsPage() {
       {/* Use fixed viewport heights to ensure proper scroll containment */}
       {/* Mobile: 100dvh - 56px (MobileHeader pt-14) - 56px (BottomNav pb-14) = 112px */}
       {/* Desktop: full viewport height (no header/nav padding) */}
-      <div className="flex h-[calc(100dvh-112px)] flex-col overflow-hidden md:h-dvh">
+      <div className="flex h-[calc(100dvh-112px)] flex-col overflow-hidden border-border md:h-dvh lg:border-l">
         <div className="flex min-h-0 flex-1 overflow-hidden">
           {/* Left Column: Chat List */}
           {/* Mobile: full width when no chat selected, hidden when chat selected */}
-          {/* Tablet (lg): w-96 sidebar when chat selected */}
-          {/* Desktop (xl): always visible w-96 sidebar */}
+          {/* Tablet (lg): w-80 sidebar when chat selected */}
+          {/* Desktop (xl): always visible w-80 sidebar */}
           <div
             className={cn(
-              'h-full min-h-0 flex-col bg-background',
+              'h-full min-h-0 flex-col border-border bg-background',
               selectedChatId
-                ? 'hidden w-96 lg:flex' // Hide on mobile, show as sidebar on lg+
-                : 'flex w-full xl:w-96' // Full width on mobile, sidebar width on xl
+                ? 'hidden w-80 border-r lg:flex' // Hide on mobile, show as sidebar on lg+
+                : 'flex w-full xl:w-80 xl:border-r' // Full width on mobile, sidebar width on xl
             )}
           >
             <ChatHeader
@@ -184,15 +183,6 @@ export default function ChatsPage() {
               />
             </div>
           </div>
-
-          {/* Vertical Separator - visible on lg+ when chat selected */}
-          <Separator
-            orientation="vertical"
-            className={cn(
-              'shrink-0',
-              selectedChatId ? 'hidden lg:block' : 'hidden xl:block'
-            )}
-          />
 
           {/* Right Column: Chat View */}
           {/* Mobile/Tablet: only shown when chat selected */}

--- a/apps/web/src/app/comment/[id]/page.tsx
+++ b/apps/web/src/app/comment/[id]/page.tsx
@@ -571,7 +571,7 @@ export default function CommentPage({ params }: CommentPageProps) {
       <PageContainer noPadding className="flex w-full flex-col">
         <div className="relative flex min-h-screen flex-1">
           {/* Desktop loading */}
-          <div className="hidden min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:flex lg:border-r lg:border-l">
+          <div className="hidden min-w-0 flex-1 flex-col border-border lg:flex lg:border-r lg:border-l">
             <div className="sticky top-0 z-10 shrink-0 bg-background shadow-sm">
               <div className="px-6 py-4">
                 <div className="flex items-center gap-4">
@@ -615,7 +615,7 @@ export default function CommentPage({ params }: CommentPageProps) {
       <PageContainer noPadding className="flex w-full flex-col">
         <div className="relative flex min-h-screen flex-1">
           {/* Desktop error */}
-          <div className="hidden min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:flex lg:border-r lg:border-l">
+          <div className="hidden min-w-0 flex-1 flex-col border-border lg:flex lg:border-r lg:border-l">
             <div className="flex flex-1 flex-col items-center justify-center bg-background">
               <div className="text-center">
                 <h1 className="mb-2 font-bold text-2xl">Comment Not Found</h1>
@@ -863,7 +863,7 @@ export default function CommentPage({ params }: CommentPageProps) {
     <PageContainer noPadding className="flex w-full flex-col">
       <div className="relative flex min-h-screen flex-1">
         {/* Desktop: Thread content area */}
-        <div className="hidden min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:flex lg:border-r lg:border-l">
+        <div className="hidden min-w-0 flex-1 flex-col border-border lg:flex lg:border-r lg:border-l">
           {/* Desktop: Top bar with back button */}
           <div className="sticky top-0 z-10 shrink-0 bg-background shadow-sm">
             <div className="px-6 py-4">

--- a/apps/web/src/app/feed/FeedClient.tsx
+++ b/apps/web/src/app/feed/FeedClient.tsx
@@ -294,10 +294,12 @@ export function FeedClient() {
     <PageContainer noPadding className="flex w-full flex-col">
       <div ref={scrollContainerRef} className="relative flex flex-1">
         {/* Feed area */}
-        <div className="flex min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:border-r lg:border-l">
+        <div className="flex min-w-0 flex-1 flex-col border-border lg:border-r lg:border-l">
           {/* Header with tabs */}
           <div className="sticky top-0 z-10 flex-shrink-0 bg-background shadow-sm">
-            <FeedToggle activeTab={tab} onTabChange={setTab} />
+            <div className="w-full lg:mx-auto lg:max-w-[700px]">
+              <FeedToggle activeTab={tab} onTabChange={setTab} />
+            </div>
           </div>
 
           {/* Feed content */}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -79,7 +79,7 @@
   --accent-foreground: #0066FF;
   --destructive: #f4212e;
   --destructive-foreground: #ffffff;
-  --border: #2f3336;
+  --border: #393d41;
   --input: #22303c;
   --ring: #0066FF;
   --chart-1: #0066FF;
@@ -93,7 +93,7 @@
   --sidebar-primary-foreground: #ffffff;
   --sidebar-accent: #2a2a2a;
   --sidebar-accent-foreground: #0066FF;
-  --sidebar-border: #2f3336;
+  --sidebar-border: #393d41;
   --sidebar-ring: #0066FF;
   --scrollbar-track: #000000;
   --scrollbar-thumb: #0066FF;
@@ -379,16 +379,11 @@ button:disabled {
 }
 
 .message-input {
-  box-shadow: inset 3px 3px 5px rgba(0, 0, 0, 0.15), inset -3px -3px 5px rgba(255, 255, 255, 0.05);
-  transition: all 0.3s ease;
-}
-
-.message-input:focus {
-  box-shadow: inset 3px 3px 5px var(--primary-glow, rgba(0, 102, 255, 0.2)), inset -3px -3px 5px var(--primary-glow-secondary, rgba(0, 102, 255, 0.1));
+  box-shadow: none;
 }
 
 .message-bubble {
-  box-shadow: 3px 3px 8px rgba(0, 0, 0, 0.15), -3px -3px 8px rgba(255, 255, 255, 0.05);
+  box-shadow: none;
 }
 
 .chat-tab {
@@ -410,11 +405,11 @@ button:disabled {
 }
 
 .dark .message-input {
-  box-shadow: inset 3px 3px 5px rgba(0, 0, 0, 0.3), inset -3px -3px 5px rgba(255, 255, 255, 0.02);
+  box-shadow: none;
 }
 
 .dark .message-bubble {
-  box-shadow: 3px 3px 8px rgba(0, 0, 0, 0.3), -3px -3px 8px rgba(255, 255, 255, 0.02);
+  box-shadow: none;
 }
 
 .dark .chat-tab {

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -126,7 +126,7 @@ export default function RootLayout({
               <MobileHeader />
             </Suspense>
 
-            <div className="mx-auto flex min-h-screen max-w-screen-xl bg-sidebar">
+            <div className="mark mx-auto flex min-h-screen max-w-7xl bg-sidebar">
               {/* Desktop Sidebar - Sticky, not affected by pull-to-refresh */}
               <Suspense fallback={null}>
                 <Sidebar />

--- a/apps/web/src/app/leaderboard/loading.tsx
+++ b/apps/web/src/app/leaderboard/loading.tsx
@@ -11,7 +11,7 @@ export default function LeaderboardLoading() {
       {/* Desktop (xl+): 2-column with sidebar */}
       <div className="hidden flex-1 overflow-hidden xl:flex">
         {/* Main content */}
-        <div className="flex min-w-0 flex-1 flex-col overflow-hidden border-[rgba(120,120,120,0.15)] lg:border-r lg:border-l">
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden border-border lg:border-r lg:border-l">
           {/* Sticky header with tab toggle */}
           <div className="sticky top-0 z-10 flex-shrink-0 bg-background shadow-sm">
             <div className="flex w-full items-center border-border border-b">

--- a/apps/web/src/app/leaderboard/page.tsx
+++ b/apps/web/src/app/leaderboard/page.tsx
@@ -586,7 +586,7 @@ export default function LeaderboardPage() {
       {/* Desktop: Content + Widgets layout */}
       <div className="hidden flex-1 overflow-hidden xl:flex">
         {/* Main content */}
-        <div className="flex min-w-0 flex-1 flex-col overflow-hidden border-[rgba(120,120,120,0.15)] lg:border-r lg:border-l">
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden border-border lg:border-r lg:border-l">
           {/* Header with tabs */}
           <div className="sticky top-0 z-10 flex-shrink-0 bg-background shadow-sm">
             <LeaderboardToggle

--- a/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
+++ b/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
@@ -276,7 +276,7 @@ export function PerpsOrderEntryPanel({
   if (!market) {
     return (
       <div className="flex h-full flex-col p-4">
-        <div className="flex flex-1 flex-col items-center justify-center rounded-lg border border-white/5 bg-background/20 p-6 text-center">
+        <div className="flex flex-1 flex-col items-center justify-center rounded-lg p-6 text-center">
           <div className="font-semibold text-muted-foreground">Trade</div>
           <div className="mt-1 text-muted-foreground/70 text-sm">
             Select a market to place an order.
@@ -287,65 +287,67 @@ export function PerpsOrderEntryPanel({
   }
 
   return (
-    <div className="flex h-full min-h-0 flex-col bg-background/10">
+    <div className="flex h-full min-h-0 flex-col bg-background">
       {/* Account summary */}
-      <div className="border-white/5 border-b bg-muted/10 p-4">
+      <div className="border-border border-b px-3 py-3">
         <div className="flex items-start justify-between">
           <div className="space-y-1">
-            <div className="text-[10px] text-muted-foreground uppercase tracking-wider">
+            <div className="text-muted-foreground text-xs">
               Available Balance
             </div>
-            <div className="flex items-center gap-2 font-mono text-foreground text-lg tabular-nums">
+            <div className="flex items-center gap-2 font-mono text-base text-foreground tabular-nums">
               <Wallet size={14} className="text-muted-foreground" />
               {balanceLoading ? (
                 <Skeleton className="h-5 w-20" />
               ) : (
                 formatBalance(balance)
               )}
-              {onRequestBuyPoints && (
-                <button
-                  type="button"
-                  onClick={onRequestBuyPoints}
-                  className="ml-2 rounded bg-muted/20 px-2 py-1 font-sans text-[10px] text-muted-foreground uppercase tracking-wider transition-colors hover:bg-muted/30 hover:text-foreground"
-                >
-                  Buy
-                </button>
-              )}
             </div>
           </div>
-          {existingPosition && (
-            <div className="text-right">
-              <div className="text-[10px] text-muted-foreground uppercase tracking-wider">
-                Open Position
+          <div className="flex flex-col items-end gap-1">
+            {onRequestBuyPoints && (
+              <button
+                type="button"
+                onClick={onRequestBuyPoints}
+                className="rounded bg-primary px-3 py-1 font-sans font-semibold text-primary-foreground text-xs transition-colors hover:bg-primary/90"
+              >
+                Buy
+              </button>
+            )}
+            {existingPosition && (
+              <div className="text-right">
+                <div className="text-muted-foreground text-xs">
+                  Open Position
+                </div>
+                <div className="font-mono text-foreground text-xs">
+                  {existingPosition.leverage}x{' '}
+                  {existingPosition.side.toUpperCase()} •{' '}
+                  {formatPrice(existingPosition.size)}
+                </div>
               </div>
-              <div className="font-mono text-foreground text-xs">
-                {existingPosition.leverage}x{' '}
-                {existingPosition.side.toUpperCase()} •{' '}
-                {formatPrice(existingPosition.size)}
-              </div>
-            </div>
-          )}
+            )}
+          </div>
         </div>
       </div>
 
       {/* Order form */}
       <div className="min-h-0 flex-1 overflow-auto p-4 pb-[calc(env(safe-area-inset-bottom)+24px)]">
         <div className="flex items-center justify-between">
-          <div className="font-semibold text-sm">Place Order</div>
-          <div className="rounded bg-muted/20 px-2 py-1 text-[10px] text-muted-foreground uppercase tracking-wider">
+          <div className="font-medium text-sm">Place Order</div>
+          <div className="rounded bg-muted px-2 py-0.5 text-muted-foreground text-xs">
             Standard
           </div>
         </div>
 
-        <div className="mt-3 flex rounded-md bg-muted/20 p-1">
+        <div className="mt-3 flex gap-1 rounded bg-muted p-1">
           <button
             type="button"
             onClick={() => setSide('long')}
             className={cn(
-              'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
+              'flex-1 rounded py-2 font-semibold text-xs transition-colors',
               side === 'long'
-                ? 'bg-green-600 text-white'
-                : 'text-muted-foreground hover:text-foreground'
+                ? 'bg-green-600 text-white shadow-sm'
+                : 'text-muted-foreground hover:bg-muted/80 hover:text-foreground'
             )}
           >
             LONG
@@ -354,10 +356,10 @@ export function PerpsOrderEntryPanel({
             type="button"
             onClick={() => setSide('short')}
             className={cn(
-              'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
+              'flex-1 rounded py-2 font-semibold text-xs transition-colors',
               side === 'short'
-                ? 'bg-red-600 text-white'
-                : 'text-muted-foreground hover:text-foreground'
+                ? 'bg-red-600 text-white shadow-sm'
+                : 'text-muted-foreground hover:bg-muted/80 hover:text-foreground'
             )}
           >
             SHORT
@@ -387,7 +389,7 @@ export function PerpsOrderEntryPanel({
               disabled
             />
             Limit
-            <span className="ml-1 rounded bg-muted/20 px-1 py-0.5 text-[10px] text-muted-foreground">
+            <span className="ml-1 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
               soon
             </span>
           </label>
@@ -396,12 +398,12 @@ export function PerpsOrderEntryPanel({
         <div className="mt-4 space-y-4">
           <div>
             <div className="mb-1 flex items-center justify-between">
-              <label className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+              <label className="font-medium text-muted-foreground text-xs">
                 Size (USD)
               </label>
-              <span className="text-[10px] text-muted-foreground">
+              <span className="text-muted-foreground text-xs">
                 Min {BABYLON_POINTS_SYMBOL}
-                {market.minOrderSize} • Max {market.maxLeverage}x
+                {market.minOrderSize}
               </span>
             </div>
             <input
@@ -410,17 +412,17 @@ export function PerpsOrderEntryPanel({
               onChange={(e) => setSize(e.target.value)}
               min={market.minOrderSize}
               step="10"
-              className="w-full rounded border border-white/10 bg-background/30 px-3 py-2 font-mono text-sm tabular-nums focus:border-primary/40 focus:outline-none focus:ring-2 focus:ring-primary/20"
+              className="w-full rounded border border-border bg-input px-3 py-2.5 font-mono text-sm tabular-nums placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
               placeholder="0.00"
             />
           </div>
 
           <div>
             <div className="mb-1 flex items-center justify-between">
-              <label className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+              <label className="font-medium text-muted-foreground text-xs">
                 Leverage
               </label>
-              <span className="font-mono text-foreground text-xs">
+              <span className="font-medium font-mono text-foreground text-sm">
                 {clampedLeverage}x
               </span>
             </div>
@@ -430,32 +432,32 @@ export function PerpsOrderEntryPanel({
               max={market.maxLeverage}
               value={clampedLeverage}
               onChange={(e) => setLeverage(Number.parseInt(e.target.value))}
-              className="h-1.5 w-full cursor-pointer appearance-none rounded-full bg-muted accent-primary"
+              className="h-2 w-full cursor-pointer appearance-none rounded-full bg-border accent-primary"
             />
           </div>
 
-          <div className="rounded border border-white/10 bg-muted/10 p-3 text-xs">
+          <div className="space-y-2 rounded bg-muted/50 p-3 text-xs">
             <Row label="Margin" value={formatPrice(baseMargin)} />
             <Row label="Fees" value={formatPrice(estimatedFee)} />
-            <div className="my-2 border-white/10 border-t" />
+            <div className="border-border border-t" />
             <Row label="Total" value={formatPrice(totalRequired)} strong />
           </div>
 
           {showBalanceWarning && (
-            <div className="rounded border border-red-500/20 bg-red-500/10 p-2 text-[10px] text-red-400">
+            <div className="rounded bg-red-500/10 p-3 text-red-400 text-xs">
               Insufficient balance ({formatPrice(balance)})
             </div>
           )}
 
           {positionsLoading && authenticated && (
-            <div className="text-[10px] text-muted-foreground">
+            <div className="text-muted-foreground text-xs">
               Syncing positions…
             </div>
           )}
         </div>
 
         {rebalanceInfo && (
-          <div className="mt-4 rounded border border-white/10 bg-muted/10 p-3 text-xs">
+          <div className="mt-4 rounded bg-muted/50 p-3 text-xs">
             <div className="flex items-center justify-between">
               <span className="font-semibold text-muted-foreground">
                 {rebalanceInfo.label}
@@ -464,7 +466,7 @@ export function PerpsOrderEntryPanel({
                 {formatPrice(rebalanceInfo.newSize)}
               </span>
             </div>
-            <div className="mt-1 text-[10px] text-muted-foreground">
+            <div className="mt-1 text-muted-foreground text-xs">
               {rebalanceInfo.description}
             </div>
           </div>
@@ -473,14 +475,18 @@ export function PerpsOrderEntryPanel({
         <button
           type="button"
           onClick={handleSubmit}
-          disabled={submitting || (authenticated && showBalanceWarning)}
+          disabled={
+            submitting ||
+            (authenticated &&
+              (showBalanceWarning ||
+                sizeNum <= 0 ||
+                sizeNum < (market?.minOrderSize ?? 0)))
+          }
           className={cn(
-            'mt-5 w-full rounded py-3 font-bold text-sm text-white shadow transition-all',
+            'mt-5 w-full rounded py-3 font-semibold text-sm text-white transition-colors disabled:cursor-not-allowed disabled:opacity-40',
             side === 'long'
-              ? 'bg-green-600 hover:brightness-110'
-              : 'bg-red-600 hover:brightness-110',
-            (submitting || (authenticated && showBalanceWarning)) &&
-              'cursor-not-allowed opacity-50'
+              ? 'bg-green-600 hover:bg-green-700'
+              : 'bg-red-600 hover:bg-red-700'
           )}
         >
           {submitLabel}
@@ -524,12 +530,12 @@ function Row({
   strong?: boolean;
 }) {
   return (
-    <div className="flex items-center justify-between">
+    <div className="flex items-center justify-between py-0.5">
       <span className="text-muted-foreground">{label}</span>
       <span
         className={cn(
           'font-mono tabular-nums',
-          strong ? 'font-bold text-foreground' : 'text-foreground/90'
+          strong ? 'font-semibold text-foreground' : 'text-foreground'
         )}
       >
         {value}

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -9,6 +9,7 @@ import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
 import {
   ArrowUpDown,
   Check,
+  ChevronDown,
   Filter,
   Info,
   Maximize2,
@@ -505,7 +506,8 @@ export function MarketsTradingTerminal({
     parseSelected(searchParams)
   );
 
-  const [leftCollapsed, setLeftCollapsed] = useState(false);
+  const [marketDropdownOpen, setMarketDropdownOpen] = useState(false);
+  const marketDropdownRef = useRef<HTMLDivElement | null>(null);
   const [bottomCollapsed, setBottomCollapsed] = useState(false);
   const [bottomTab, setBottomTab] = useState<BottomTab>('agent');
 
@@ -744,6 +746,34 @@ export function MarketsTradingTerminal({
     };
   }, [showMarketsMenu]);
 
+  // Click-outside + Escape handler for market dropdown overlay
+  useEffect(() => {
+    if (!marketDropdownOpen) return undefined;
+
+    const onMouseDown = (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+      // Ignore clicks on the dropdown trigger buttons to avoid close-then-reopen
+      if (target.closest?.('[data-market-dropdown-trigger]')) return;
+      if (
+        marketDropdownRef.current &&
+        !marketDropdownRef.current.contains(target)
+      ) {
+        setMarketDropdownOpen(false);
+      }
+    };
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setMarketDropdownOpen(false);
+    };
+
+    document.addEventListener('mousedown', onMouseDown);
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown);
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, [marketDropdownOpen]);
+
   // One-way sync from URL → local UI state
   useEffect(() => {
     const nextFilter = parseFilter(searchParams);
@@ -890,6 +920,8 @@ export function MarketsTradingTerminal({
     if (!stillVisible) selectAndUpdateUrl(rows[0]?.key ?? null);
   }, [selected, rows, router, searchParams, filter]);
 
+  // Removed: auto-open dropdown — keep it closed by default
+
   const selectedPerp = useMemo(() => {
     if (!selected || selected.kind !== 'perp') return null;
     return (
@@ -1019,6 +1051,7 @@ export function MarketsTradingTerminal({
       next.delete('tabs');
       next.delete('side');
       router.replace(`/markets?${next.toString()}`, { scroll: false });
+      setMarketDropdownOpen(false);
       setIsMobileMarketListOpen(false);
     },
     [router, searchParams, filter]
@@ -1349,68 +1382,45 @@ export function MarketsTradingTerminal({
   const desktopTradesContainerRef = useRef<HTMLDivElement | null>(null);
   const mobileTradesContainerRef = useRef<HTMLDivElement | null>(null);
 
-  const terminalHeader = (
-    <div className="flex h-11 shrink-0 items-center justify-between border-white/5 border-b bg-background/40 px-3 backdrop-blur-md">
-      <div className="flex min-w-0 flex-1 items-center gap-2">
-        <div className="truncate font-semibold text-muted-foreground text-xs uppercase tracking-wider">
-          Terminal
-        </div>
-      </div>
-
-      <div className="ml-3 flex items-center gap-2 text-xs">
-        {!authenticated && (
-          <button
-            type="button"
-            onClick={login}
-            className="rounded bg-foreground px-3 py-1 font-semibold text-background"
-          >
-            Log in
-          </button>
-        )}
-      </div>
-    </div>
-  );
-
   const listPanel = (
     <div className="flex h-full min-h-0 flex-col">
       <div
         ref={marketsMenuRef}
-        className="shrink-0 space-y-3 border-white/5 border-b p-3"
+        className="shrink-0 space-y-2 border-white/5 border-b p-3"
       >
-        <div className="flex items-center justify-between">
-          <div className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
-            Markets
+        <div className="flex items-center gap-2">
+          <div className="relative min-w-0 flex-1">
+            <Search
+              className="-translate-y-1/2 absolute top-1/2 left-2 text-muted-foreground"
+              size={14}
+            />
+            <input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search…"
+              className="w-full rounded border border-border bg-background/40 py-2 pr-3 pl-8 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30"
+            />
           </div>
-          <div className="flex items-center gap-1">
-            <button
-              type="button"
-              onClick={() => setShowMarketsMenu((v) => !v)}
-              aria-expanded={showMarketsMenu}
-              aria-controls="markets-filter-sort"
-              className={cn(
-                'rounded p-1.5 transition-colors hover:bg-muted/20',
-                showMarketsMenu ||
-                  filter !== 'all' ||
-                  sortBy !== 'volume' ||
-                  sortDesc !== true
-                  ? 'bg-muted/20 text-primary'
-                  : 'text-muted-foreground'
-              )}
-              aria-label="Filter and sort markets"
-              title="Filter & Sort"
-            >
-              <Filter size={14} />
-            </button>
-
-            <button
-              type="button"
-              onClick={() => setLeftCollapsed(true)}
-              className="hidden rounded p-1.5 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground md:inline-flex"
-              aria-label="Collapse markets panel"
-            >
-              ◀
-            </button>
-          </div>
+          <button
+            type="button"
+            onClick={() => setShowMarketsMenu((v) => !v)}
+            aria-expanded={showMarketsMenu}
+            aria-controls="markets-filter-sort"
+            className={cn(
+              'shrink-0 rounded p-2 transition-colors hover:bg-muted/20',
+              showMarketsMenu ||
+                filter !== 'all' ||
+                sortBy !== 'volume' ||
+                sortDesc !== true
+                ? 'bg-muted/20 text-primary'
+                : 'text-muted-foreground'
+            )}
+            aria-label="Filter and sort markets"
+            title="Filter & Sort"
+          >
+            <Filter size={14} />
+          </button>
         </div>
 
         {showMarketsMenu && (
@@ -1494,28 +1504,24 @@ export function MarketsTradingTerminal({
             ))}
           </div>
         )}
-
-        <div className="relative">
-          <Search
-            className="-translate-y-1/2 absolute top-1/2 left-2 text-muted-foreground"
-            size={14}
-          />
-          <input
-            type="search"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search…"
-            className="w-full rounded border border-white/10 bg-background/40 py-2 pr-3 pl-8 text-sm focus:outline-none focus:ring-2 focus:ring-primary/30"
-          />
-        </div>
       </div>
 
       <div className="min-h-0 flex-1 overflow-auto">
         {(perpLoading || predictionLoading) && rows.length === 0 ? (
-          <div className="space-y-2 p-3">
-            <Skeleton className="h-10 w-full" />
-            <Skeleton className="h-10 w-full" />
-            <Skeleton className="h-10 w-full" />
+          <div className="divide-y divide-white/5">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-2 px-3 py-2">
+                <Skeleton className="h-3.5 w-3.5 shrink-0" />
+                <div className="min-w-0 flex-1 space-y-1">
+                  <Skeleton className="h-3.5 w-3/4" />
+                  <Skeleton className="h-2.5 w-1/2" />
+                </div>
+                <div className="space-y-1 text-right">
+                  <Skeleton className="ml-auto h-3.5 w-12" />
+                </div>
+                <Skeleton className="h-5 w-14 rounded-full" />
+              </div>
+            ))}
           </div>
         ) : perpError || predictionError ? (
           <div className="p-4 text-muted-foreground text-sm">
@@ -1567,25 +1573,25 @@ export function MarketsTradingTerminal({
                     </td>
                     <td className="px-2 py-2">
                       <div className="flex min-w-0 flex-col">
-                        <div className="truncate font-bold text-foreground">
+                        <div className="line-clamp-2 font-bold text-foreground">
                           {row.title}
                         </div>
-                        <div className="truncate text-[10px] text-muted-foreground">
+                        <div className="truncate text-[10px] text-foreground/50">
                           {row.subtitle}
                         </div>
                       </div>
                     </td>
-                    <td className="px-2 py-2 text-right">
-                      <div className="font-mono text-foreground/90 tabular-nums">
+                    <td className="whitespace-nowrap px-2 py-2 text-right">
+                      <div className="font-mono font-semibold text-foreground text-xs tabular-nums">
                         {row.valuePrimary}
                       </div>
                       {row.valueSecondary && (
-                        <div className="font-mono text-[9px] text-muted-foreground tabular-nums">
+                        <div className="font-mono font-semibold text-[11px] text-foreground/80 tabular-nums">
                           {row.valueSecondary}
                         </div>
                       )}
                     </td>
-                    <td className="px-3 py-2 text-right">
+                    <td className="whitespace-nowrap px-3 py-2 text-right">
                       {row.kind === 'perp' && change != null ? (
                         <div
                           className={cn(
@@ -1633,17 +1639,76 @@ export function MarketsTradingTerminal({
     return computeYesPctFromShares(predictionState);
   }, [predictionState]);
 
+  const marketDropdown = marketDropdownOpen ? (
+    <div
+      ref={marketDropdownRef}
+      className="fade-in-0 zoom-in-95 absolute top-full left-0 z-50 flex max-h-[60vh] w-96 animate-in flex-col rounded-br-lg border-border border-t border-r border-b bg-background/95 shadow-lg backdrop-blur-md duration-150"
+    >
+      <div className="min-h-0 flex-1 overflow-auto">{listPanel}</div>
+    </div>
+  ) : null;
+
   const centerPanel = (
     <div className="flex h-full min-h-0 flex-col bg-background/10">
       {selected?.kind === 'prediction' ? (
         <>
-          <div className="shrink-0 border-white/5 border-b px-4 py-3">
-            <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-              <div className="min-w-0">
-                <div className="whitespace-normal break-words font-bold text-foreground text-lg leading-snug">
+          <div className="relative shrink-0 border-white/5 border-b px-4 py-2.5">
+            {/* Row 1: Title + action buttons */}
+            <div className="flex items-start gap-3">
+              <button
+                type="button"
+                data-market-dropdown-trigger
+                onClick={() => setMarketDropdownOpen((v) => !v)}
+                className="group inline-flex min-w-0 items-start gap-1.5 text-left"
+              >
+                <span className="mt-[3px] inline-flex shrink-0 items-center justify-center rounded bg-muted/40 p-1 text-foreground transition-colors group-hover:bg-muted/60">
+                  <ChevronDown
+                    size={14}
+                    className={cn(
+                      'transition-transform',
+                      marketDropdownOpen && 'rotate-180'
+                    )}
+                  />
+                </span>
+                <span className="line-clamp-2 text-balance font-semibold text-foreground text-sm leading-snug">
                   {predictionState?.text ?? 'Prediction market'}
-                </div>
-                <div className="mt-1 whitespace-normal break-words text-muted-foreground text-xs">
+                </span>
+              </button>
+              <div className="flex shrink-0 items-center gap-1.5">
+                <button
+                  type="button"
+                  onClick={() => setPredictionDetailsOpen(true)}
+                  className="inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted/30 hover:text-foreground"
+                  aria-label="View market details"
+                  title="Details"
+                >
+                  <Info size={14} />
+                </button>
+                <button
+                  type="button"
+                  onClick={toggleFullscreen}
+                  aria-pressed={isFullscreen}
+                  aria-label={
+                    isFullscreen
+                      ? 'Exit fullscreen terminal view'
+                      : 'Enter fullscreen terminal view'
+                  }
+                  title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+                  className="inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted/30 hover:text-foreground"
+                >
+                  {isFullscreen ? (
+                    <Minimize2 size={14} />
+                  ) : (
+                    <Maximize2 size={14} />
+                  )}
+                </button>
+              </div>
+            </div>
+
+            {/* Row 2: Metadata + YES/NO + time range */}
+            <div className="mt-1.5 flex items-center justify-between gap-3">
+              <div className="flex min-w-0 items-center gap-2">
+                <div className="truncate text-muted-foreground text-xs">
                   {predictionState?.resolutionDescription?.trim()
                     ? predictionState.resolutionDescription
                     : `Scenario ${predictionState?.scenario ?? ''}${
@@ -1655,46 +1720,35 @@ export function MarketsTradingTerminal({
                           : ''
                       }`}
                 </div>
-              </div>
-
-              <div className="flex flex-col gap-2 lg:items-end">
-                <div className="flex items-center gap-2">
-                  <div className="rounded-full bg-blue-500/10 px-2 py-1 font-bold text-[10px] text-blue-400 tabular-nums">
+                <div className="flex shrink-0 items-center gap-1.5">
+                  <div className="rounded-full bg-blue-500/10 px-2 py-0.5 font-bold text-[10px] text-blue-400 tabular-nums">
                     YES {formatYesPct(predictionYesPct)}
                   </div>
-                  <div className="rounded-full bg-violet-500/10 px-2 py-1 font-bold text-[10px] text-violet-400 tabular-nums">
+                  <div className="rounded-full bg-violet-500/10 px-2 py-0.5 font-bold text-[10px] text-violet-400 tabular-nums">
                     NO {formatYesPct(100 - predictionYesPct)}
                   </div>
-                  <button
-                    type="button"
-                    onClick={() => setPredictionDetailsOpen(true)}
-                    className="inline-flex h-8 w-8 items-center justify-center rounded border border-white/10 bg-background/30 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30"
-                    aria-label="View market details"
-                    title="Details"
-                  >
-                    <Info size={14} />
-                  </button>
-                </div>
-
-                <div className="flex items-center gap-1 rounded-md bg-muted/20 p-1 font-semibold text-xs">
-                  {MARKET_TIME_RANGES.map((range) => (
-                    <button
-                      key={range}
-                      type="button"
-                      onClick={() => setPredictionTimeRange(range)}
-                      className={cn(
-                        'rounded px-2 py-1 transition-colors',
-                        predictionTimeRange === range
-                          ? 'bg-foreground text-background'
-                          : 'text-muted-foreground hover:text-foreground'
-                      )}
-                    >
-                      {range}
-                    </button>
-                  ))}
                 </div>
               </div>
+
+              <div className="flex shrink-0 items-center gap-1 rounded-md bg-muted/20 p-0.5 font-semibold text-[11px]">
+                {MARKET_TIME_RANGES.map((range) => (
+                  <button
+                    key={range}
+                    type="button"
+                    onClick={() => setPredictionTimeRange(range)}
+                    className={cn(
+                      'rounded px-1.5 py-0.5 transition-colors',
+                      predictionTimeRange === range
+                        ? 'bg-foreground text-background'
+                        : 'text-muted-foreground hover:text-foreground'
+                    )}
+                  >
+                    {range}
+                  </button>
+                ))}
+              </div>
             </div>
+            {marketDropdown}
           </div>
 
           <div className="min-h-0 flex-1 p-4">
@@ -1710,32 +1764,67 @@ export function MarketsTradingTerminal({
         </>
       ) : selectedPerp ? (
         <>
-          <div className="flex shrink-0 items-start justify-between gap-3 border-white/5 border-b px-4 py-3">
-            <div className="min-w-0">
-              <div className="font-bold text-foreground text-lg">
-                ${selectedPerp.ticker}
-              </div>
-              <div className="truncate text-muted-foreground text-xs">
-                {selectedPerp.name}
-              </div>
-            </div>
-            <div className="flex items-center gap-1 rounded-md bg-muted/20 p-1 font-semibold text-xs">
-              {MARKET_TIME_RANGES.map((range) => (
-                <button
-                  key={range}
-                  type="button"
-                  onClick={() => setPerpTimeRange(range)}
+          <div className="relative flex shrink-0 items-center justify-between gap-3 border-white/5 border-b px-4 py-2.5">
+            <button
+              type="button"
+              data-market-dropdown-trigger
+              onClick={() => setMarketDropdownOpen((v) => !v)}
+              className="group flex min-w-0 items-baseline gap-2"
+            >
+              <span className="inline-flex shrink-0 items-center justify-center self-center rounded bg-muted/40 p-1 text-foreground transition-colors group-hover:bg-muted/60">
+                <ChevronDown
+                  size={14}
                   className={cn(
-                    'rounded px-2 py-1 transition-colors',
-                    perpTimeRange === range
-                      ? 'bg-foreground text-background'
-                      : 'text-muted-foreground hover:text-foreground'
+                    'transition-transform',
+                    marketDropdownOpen && 'rotate-180'
                   )}
-                >
-                  {range}
-                </button>
-              ))}
+                />
+              </span>
+              <span className="font-semibold text-foreground text-sm">
+                ${selectedPerp.ticker}
+              </span>
+              <span className="truncate text-muted-foreground text-xs">
+                {selectedPerp.name}
+              </span>
+            </button>
+            <div className="flex shrink-0 items-center gap-1.5">
+              <div className="flex items-center gap-1 rounded-md bg-muted/20 p-0.5 font-semibold text-[11px]">
+                {MARKET_TIME_RANGES.map((range) => (
+                  <button
+                    key={range}
+                    type="button"
+                    onClick={() => setPerpTimeRange(range)}
+                    className={cn(
+                      'rounded px-1.5 py-0.5 transition-colors',
+                      perpTimeRange === range
+                        ? 'bg-foreground text-background'
+                        : 'text-muted-foreground hover:text-foreground'
+                    )}
+                  >
+                    {range}
+                  </button>
+                ))}
+              </div>
+              <button
+                type="button"
+                onClick={toggleFullscreen}
+                aria-pressed={isFullscreen}
+                aria-label={
+                  isFullscreen
+                    ? 'Exit fullscreen terminal view'
+                    : 'Enter fullscreen terminal view'
+                }
+                title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+                className="inline-flex h-7 w-7 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-muted/30 hover:text-foreground"
+              >
+                {isFullscreen ? (
+                  <Minimize2 size={14} />
+                ) : (
+                  <Maximize2 size={14} />
+                )}
+              </button>
             </div>
+            {marketDropdown}
           </div>
           <div className="min-h-0 flex-1 p-4">
             <PerpPriceChart
@@ -1751,77 +1840,84 @@ export function MarketsTradingTerminal({
           </div>
         </>
       ) : (
-        <div className="flex h-full items-center justify-center text-muted-foreground">
-          Select a market
+        <div className="relative flex h-full flex-col">
+          <button
+            type="button"
+            data-market-dropdown-trigger
+            onClick={() => setMarketDropdownOpen(true)}
+            className="flex h-full w-full items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Select a market
+            <ChevronDown size={16} className="ml-1.5" />
+          </button>
+          {marketDropdown}
         </div>
       )}
     </div>
   );
 
   const rightPanel = (
-    <div className="flex h-full min-h-0 flex-col bg-background/20">
-      <div className="flex items-center justify-between border-white/5 border-b px-3 py-2">
-        <div className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
-          Trade
-        </div>
-      </div>
-
+    <div className="flex h-full min-h-0 flex-col overflow-auto bg-background">
       {selected?.kind === 'prediction' ? (
-        <div className="flex h-full min-h-0 flex-col bg-background/10">
-          <div className="border-white/5 border-b bg-muted/10 p-4">
+        <div className="flex min-h-0 flex-col">
+          <div className="border-border border-b px-3 py-3">
             <div className="flex items-start justify-between gap-3">
               <div className="space-y-1">
-                <div className="text-[10px] text-muted-foreground uppercase tracking-wider">
+                <div className="text-muted-foreground text-xs">
                   Available Balance
                 </div>
-                <div className="flex items-center gap-2 font-mono text-foreground text-lg tabular-nums">
+                <div className="flex items-center gap-2 font-mono text-base text-foreground tabular-nums">
                   <Wallet size={14} className="text-muted-foreground" />
                   {balanceLoading ? (
                     <Skeleton className="h-5 w-20" />
                   ) : (
                     formatBalance(balance)
                   )}
-                  {onRequestBuyPoints && (
-                    <button
-                      type="button"
-                      onClick={onRequestBuyPoints}
-                      className="ml-2 rounded bg-muted/20 px-2 py-1 font-sans text-[10px] text-muted-foreground uppercase tracking-wider transition-colors hover:bg-muted/30 hover:text-foreground"
-                    >
-                      Buy
-                    </button>
-                  )}
                 </div>
               </div>
-              {selectedPredictionPositions.length > 0 && (
-                <div className="text-right">
-                  <div className="text-[10px] text-muted-foreground uppercase tracking-wider">
-                    Open Position
+              <div className="flex flex-col items-end gap-1">
+                {onRequestBuyPoints && (
+                  <button
+                    type="button"
+                    onClick={onRequestBuyPoints}
+                    className="rounded bg-primary px-3 py-1 font-sans font-semibold text-primary-foreground text-xs transition-colors hover:bg-primary/90"
+                  >
+                    Buy
+                  </button>
+                )}
+                {selectedPredictionPositions.length > 0 && (
+                  <div className="text-right">
+                    <div className="text-muted-foreground text-xs">
+                      Open Position
+                    </div>
+                    <div className="text-xs">
+                      {(['YES', 'NO'] as const)
+                        .map((side) => {
+                          const total = selectedPredictionPositions
+                            .filter((p) => p.side === side)
+                            .reduce((sum, p) => sum + p.shares, 0);
+                          return total > 0
+                            ? `${side} ${total.toFixed(2)}`
+                            : null;
+                        })
+                        .filter(Boolean)
+                        .join(' • ')}
+                    </div>
                   </div>
-                  <div className="text-xs">
-                    {(['YES', 'NO'] as const)
-                      .map((side) => {
-                        const total = selectedPredictionPositions
-                          .filter((p) => p.side === side)
-                          .reduce((sum, p) => sum + p.shares, 0);
-                        return total > 0 ? `${side} ${total.toFixed(2)}` : null;
-                      })
-                      .filter(Boolean)
-                      .join(' • ')}
-                  </div>
-                </div>
-              )}
+                )}
+              </div>
             </div>
           </div>
 
-          <div className="min-h-0 flex-1 overflow-auto p-4 pb-[calc(env(safe-area-inset-bottom)+24px)]">
+          <div className="p-4">
             <div className="flex items-center justify-between">
-              <div className="font-semibold text-sm">Place Order</div>
-              <div className="rounded bg-muted/20 px-2 py-1 text-[10px] text-muted-foreground uppercase tracking-wider">
+              <div className="font-medium text-sm">Place Order</div>
+              <div className="rounded bg-muted px-2 py-0.5 text-muted-foreground text-xs">
                 Standard
               </div>
             </div>
 
-            <div className="mt-3 flex rounded-md bg-muted/20 p-1">
+            <div className="mt-3 flex gap-1 rounded bg-muted p-1">
               <button
                 type="button"
                 onClick={() => setPredictionSide('yes')}
@@ -1831,14 +1927,14 @@ export function MarketsTradingTerminal({
                   !sellablePositions.hasSellableYes
                 }
                 className={cn(
-                  'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
+                  'flex-1 rounded py-2 font-semibold text-xs transition-colors',
                   predictionTradeMode === 'sell' &&
                     canSellPrediction &&
                     !sellablePositions.hasSellableYes &&
                     'cursor-not-allowed opacity-50 hover:text-muted-foreground',
                   predictionSide === 'yes'
-                    ? 'bg-blue-500 text-white'
-                    : 'text-muted-foreground hover:text-foreground'
+                    ? 'bg-blue-500 text-white shadow-sm'
+                    : 'text-muted-foreground hover:bg-muted/80 hover:text-foreground'
                 )}
               >
                 YES
@@ -1852,14 +1948,14 @@ export function MarketsTradingTerminal({
                   !sellablePositions.hasSellableNo
                 }
                 className={cn(
-                  'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
+                  'flex-1 rounded py-2 font-semibold text-xs transition-colors',
                   predictionTradeMode === 'sell' &&
                     canSellPrediction &&
                     !sellablePositions.hasSellableNo &&
                     'cursor-not-allowed opacity-50 hover:text-muted-foreground',
                   predictionSide === 'no'
-                    ? 'bg-violet-500 text-white'
-                    : 'text-muted-foreground hover:text-foreground'
+                    ? 'bg-violet-500 text-white shadow-sm'
+                    : 'text-muted-foreground hover:bg-muted/80 hover:text-foreground'
                 )}
               >
                 NO
@@ -1867,15 +1963,15 @@ export function MarketsTradingTerminal({
             </div>
 
             {canSellPrediction && (
-              <div className="mt-3 flex rounded-md bg-muted/20 p-1">
+              <div className="mt-3 flex gap-1 rounded bg-muted p-1">
                 <button
                   type="button"
                   onClick={() => setPredictionTradeMode('buy')}
                   className={cn(
-                    'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
+                    'flex-1 rounded py-2 font-semibold text-xs transition-colors',
                     predictionTradeMode === 'buy'
-                      ? 'bg-green-600 text-white'
-                      : 'text-muted-foreground hover:text-foreground'
+                      ? 'bg-green-600 text-white shadow-sm'
+                      : 'text-muted-foreground hover:bg-muted/80 hover:text-foreground'
                   )}
                 >
                   BUY
@@ -1884,10 +1980,10 @@ export function MarketsTradingTerminal({
                   type="button"
                   onClick={() => setPredictionTradeMode('sell')}
                   className={cn(
-                    'flex-1 rounded-sm py-2 font-bold text-xs transition-colors',
+                    'flex-1 rounded py-2 font-semibold text-xs transition-colors',
                     predictionTradeMode === 'sell'
-                      ? 'bg-red-600 text-white'
-                      : 'text-muted-foreground hover:text-foreground'
+                      ? 'bg-red-600 text-white shadow-sm'
+                      : 'text-muted-foreground hover:bg-muted/80 hover:text-foreground'
                   )}
                 >
                   SELL
@@ -1898,10 +1994,10 @@ export function MarketsTradingTerminal({
             {predictionTradeMode === 'buy' ? (
               <div className={cn('mt-4', !canSellPrediction && 'mt-3')}>
                 <div className="mb-1 flex items-center justify-between">
-                  <label className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+                  <label className="font-medium text-muted-foreground text-xs">
                     Amount
                   </label>
-                  <span className="text-[10px] text-muted-foreground">
+                  <span className="text-muted-foreground text-xs">
                     Min {BABYLON_POINTS_SYMBOL}1
                   </span>
                 </div>
@@ -1911,17 +2007,17 @@ export function MarketsTradingTerminal({
                   onChange={(e) => setPredictionAmount(e.target.value)}
                   min={1}
                   step="1"
-                  className="w-full rounded border border-white/10 bg-background/30 px-3 py-2 font-mono text-sm tabular-nums focus:border-primary/40 focus:outline-none focus:ring-2 focus:ring-primary/20"
+                  className="w-full rounded border border-border bg-input px-3 py-2.5 font-mono text-sm tabular-nums placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
                   placeholder="10"
                 />
               </div>
             ) : (
               <div className={cn('mt-4', !canSellPrediction && 'mt-3')}>
                 <div className="mb-1 flex items-center justify-between">
-                  <label className="font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+                  <label className="font-medium text-muted-foreground text-xs">
                     Shares
                   </label>
-                  <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
+                  <div className="flex items-center gap-2 text-muted-foreground text-xs">
                     <span>Min {MIN_SELLABLE_SHARES}</span>
                     <button
                       type="button"
@@ -1930,7 +2026,7 @@ export function MarketsTradingTerminal({
                           maxSellShares > 0 ? maxSellShares.toFixed(2) : ''
                         )
                       }
-                      className="rounded bg-muted/20 px-2 py-0.5 hover:bg-muted/30"
+                      className="rounded bg-muted px-2 py-0.5 hover:bg-muted/80"
                       disabled={maxSellShares <= 0}
                     >
                       Max
@@ -1943,14 +2039,14 @@ export function MarketsTradingTerminal({
                   onChange={(e) => setPredictionSellShares(e.target.value)}
                   min={MIN_SELLABLE_SHARES}
                   step="0.01"
-                  className="w-full rounded border border-white/10 bg-background/30 px-3 py-2 font-mono text-sm tabular-nums focus:border-primary/40 focus:outline-none focus:ring-2 focus:ring-primary/20"
+                  className="w-full rounded border border-border bg-input px-3 py-2.5 font-mono text-sm tabular-nums placeholder:text-muted-foreground/50 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/20"
                   placeholder={
                     maxSellShares > 0 ? maxSellShares.toFixed(2) : '0.00'
                   }
                   disabled={maxSellShares <= 0}
                 />
                 {maxSellShares <= 0 && (
-                  <div className="mt-2 text-[10px] text-muted-foreground">
+                  <div className="mt-2 text-muted-foreground text-xs">
                     No sellable position for this side.
                   </div>
                 )}
@@ -1958,27 +2054,27 @@ export function MarketsTradingTerminal({
             )}
 
             {predictionTradeMode === 'buy' && predictionBuyCalculation && (
-              <div className="mt-4 rounded border border-white/10 bg-muted/10 p-3 text-xs">
-                <div className="flex items-center justify-between">
+              <div className="mt-4 space-y-2 rounded bg-muted/50 p-3 text-xs">
+                <div className="flex items-center justify-between py-0.5">
                   <span className="text-muted-foreground">Shares</span>
                   <span className="font-mono text-foreground tabular-nums">
                     {predictionBuyCalculation.sharesBought.toFixed(2)}
                   </span>
                 </div>
-                <div className="mt-2 flex items-center justify-between">
+                <div className="flex items-center justify-between py-0.5">
                   <span className="text-muted-foreground">Avg price</span>
                   <span className="font-mono text-foreground tabular-nums">
                     ${predictionBuyCalculation.avgPrice.toFixed(3)}
                   </span>
                 </div>
-                <div className="mt-2 flex items-center justify-between">
+                <div className="flex items-center justify-between py-0.5">
                   <span className="text-muted-foreground">Fee</span>
-                  <span className="font-mono text-muted-foreground tabular-nums">
+                  <span className="font-mono text-foreground tabular-nums">
                     {BABYLON_POINTS_SYMBOL}
                     {predictionBuyCalculation.fee?.toFixed(2) ?? '0.00'}
                   </span>
                 </div>
-                <div className="mt-2 flex items-center justify-between">
+                <div className="flex items-center justify-between py-0.5">
                   <span className="text-muted-foreground">Expected payout</span>
                   <span className="font-mono text-foreground tabular-nums">
                     {BABYLON_POINTS_SYMBOL}
@@ -1989,22 +2085,22 @@ export function MarketsTradingTerminal({
             )}
 
             {predictionTradeMode === 'sell' && predictionSellCalculation && (
-              <div className="mt-4 rounded border border-white/10 bg-muted/10 p-3 text-xs">
-                <div className="flex items-center justify-between">
+              <div className="mt-4 space-y-2 rounded bg-muted/50 p-3 text-xs">
+                <div className="flex items-center justify-between py-0.5">
                   <span className="text-muted-foreground">Gross proceeds</span>
                   <span className="font-mono text-foreground tabular-nums">
                     {BABYLON_POINTS_SYMBOL}
                     {predictionSellCalculation.totalCost.toFixed(2)}
                   </span>
                 </div>
-                <div className="mt-2 flex items-center justify-between">
+                <div className="flex items-center justify-between py-0.5">
                   <span className="text-muted-foreground">Fee</span>
-                  <span className="font-mono text-muted-foreground tabular-nums">
+                  <span className="font-mono text-foreground tabular-nums">
                     {BABYLON_POINTS_SYMBOL}
                     {predictionSellCalculation.fee?.toFixed(2) ?? '0.00'}
                   </span>
                 </div>
-                <div className="mt-2 flex items-center justify-between font-semibold">
+                <div className="flex items-center justify-between py-0.5 font-semibold">
                   <span className="text-muted-foreground">Net proceeds</span>
                   <span className="font-mono text-foreground tabular-nums">
                     {BABYLON_POINTS_SYMBOL}
@@ -2033,20 +2129,10 @@ export function MarketsTradingTerminal({
                     !predictionSellCalculation))
               }
               className={cn(
-                'mt-5 w-full rounded py-3 font-bold text-sm text-white shadow transition-all',
+                'mt-5 w-full rounded py-3 font-semibold text-sm text-white transition-colors disabled:cursor-not-allowed disabled:opacity-40',
                 predictionTradeMode === 'buy'
-                  ? 'bg-green-600 hover:brightness-110'
-                  : 'bg-red-600 hover:brightness-110',
-                (predictionSubmitting ||
-                  (predictionTradeMode === 'buy' &&
-                    authenticated &&
-                    (predictionAmountNum < 1 || !predictionBuyCalculation)) ||
-                  (predictionTradeMode === 'sell' &&
-                    authenticated &&
-                    (maxSellShares <= 0 ||
-                      clampedSellShares < MIN_SELLABLE_SHARES ||
-                      !predictionSellCalculation))) &&
-                  'cursor-not-allowed opacity-50'
+                  ? 'bg-green-600 hover:bg-green-700'
+                  : 'bg-red-600 hover:bg-red-700'
               )}
             >
               {predictionSubmitting
@@ -2076,8 +2162,8 @@ export function MarketsTradingTerminal({
   );
 
   const bottomPanel = (
-    <div className="flex h-full min-h-0 flex-col bg-background/20">
-      <div className="flex items-center justify-between border-white/5 border-b bg-background/30 px-2">
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      <div className="flex items-center justify-between border-border border-b bg-background px-2">
         <div className="flex min-w-0 flex-1">
           <TabButton
             active={bottomTab === 'agent'}
@@ -2132,7 +2218,6 @@ export function MarketsTradingTerminal({
         ) : bottomTab === 'portfolio' ? (
           <TerminalPortfolio
             authenticated={authenticated}
-            onLogin={login}
             onRequestBuyPoints={onRequestBuyPoints ?? null}
             balance={balance}
             balanceLoading={balanceLoading}
@@ -2148,7 +2233,7 @@ export function MarketsTradingTerminal({
           />
         ) : bottomTab === 'positions' ? (
           !authenticated ? (
-            <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
+            <div className="flex h-full justify-center pt-6 text-muted-foreground text-sm">
               Log in to view positions.
             </div>
           ) : selected?.kind === 'prediction' ? (
@@ -2243,21 +2328,7 @@ export function MarketsTradingTerminal({
     >
       {/* Desktop */}
       <div className="hidden min-h-0 flex-1 flex-col md:flex">
-        {terminalHeader}
         <div className="flex min-h-0 flex-1 overflow-hidden">
-          {leftCollapsed && (
-            <button
-              type="button"
-              onClick={() => setLeftCollapsed(false)}
-              className="w-9 shrink-0 border-white/5 border-r bg-background/30 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground"
-              aria-label="Open markets panel"
-            >
-              <span className="writing-vertical-lr rotate-180 font-semibold text-[10px] tracking-wider">
-                MARKETS
-              </span>
-            </button>
-          )}
-
           <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
             <PanelGroup direction="vertical" className="flex min-h-0 flex-1">
               <Panel
@@ -2266,34 +2337,16 @@ export function MarketsTradingTerminal({
                 className="min-h-0"
               >
                 <PanelGroup direction="horizontal" className="min-h-0">
-                  {!leftCollapsed && (
-                    <>
-                      <Panel
-                        defaultSize={22}
-                        minSize={15}
-                        maxSize={32}
-                        className="min-h-0 border-white/5 border-r"
-                      >
-                        {listPanel}
-                      </Panel>
-                      <PanelResizeHandle className="w-1 bg-white/5 hover:bg-primary/40" />
-                    </>
-                  )}
-
-                  <Panel
-                    defaultSize={leftCollapsed ? 72 : 56}
-                    minSize={40}
-                    className="min-h-0"
-                  >
+                  <Panel defaultSize={70} minSize={30} className="min-h-0">
                     {centerPanel}
                   </Panel>
 
                   <PanelResizeHandle className="w-1 bg-white/5 hover:bg-primary/40" />
                   <Panel
-                    defaultSize={22}
-                    minSize={18}
-                    maxSize={32}
-                    className="min-h-0 border-white/5 border-l bg-background/20"
+                    defaultSize={30}
+                    minSize={22}
+                    maxSize={40}
+                    className="min-h-0 border-border border-l bg-background"
                   >
                     {rightPanel}
                   </Panel>
@@ -2302,11 +2355,11 @@ export function MarketsTradingTerminal({
 
               {!bottomCollapsed && (
                 <>
-                  <PanelResizeHandle className="h-1 bg-white/5 hover:bg-primary/40" />
+                  <PanelResizeHandle className="h-1 bg-border hover:bg-primary/40" />
                   <Panel
                     defaultSize={30}
                     minSize={12}
-                    className="min-h-0 border-white/5 border-t bg-background/20"
+                    className="min-h-0 border-border border-t bg-background"
                   >
                     {bottomPanel}
                   </Panel>
@@ -2319,7 +2372,7 @@ export function MarketsTradingTerminal({
                 type="button"
                 onClick={() => setBottomCollapsed(false)}
                 className={cn(
-                  'flex h-7 shrink-0 items-center justify-between border-white/5 border-t bg-background/40 px-4 text-muted-foreground',
+                  'flex h-7 shrink-0 items-center justify-between border-border border-t bg-background px-4 text-muted-foreground',
                   'transition-colors hover:bg-muted/20 hover:text-foreground'
                 )}
               >
@@ -2340,26 +2393,6 @@ export function MarketsTradingTerminal({
           </div>
         </div>
       </div>
-
-      <button
-        type="button"
-        onClick={toggleFullscreen}
-        aria-pressed={isFullscreen}
-        aria-label={
-          isFullscreen
-            ? 'Exit fullscreen terminal view'
-            : 'Enter fullscreen terminal view'
-        }
-        title={isFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
-        className={cn(
-          'absolute z-40 hidden h-11 w-11 items-center justify-center rounded-full border border-white/10 bg-background/70 text-muted-foreground shadow-lg backdrop-blur-md md:inline-flex',
-          'right-[calc(16px+env(safe-area-inset-right))] bottom-[calc(16px+env(safe-area-inset-bottom))]',
-          'transition-colors hover:bg-muted/40 hover:text-foreground',
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30'
-        )}
-      >
-        {isFullscreen ? <Minimize2 size={18} /> : <Maximize2 size={18} />}
-      </button>
 
       {/* Mobile */}
       <div className="relative flex h-full flex-col overflow-hidden overscroll-none md:hidden">
@@ -2534,7 +2567,6 @@ export function MarketsTradingTerminal({
                 ) : bottomTab === 'portfolio' ? (
                   <TerminalPortfolio
                     authenticated={authenticated}
-                    onLogin={login}
                     onRequestBuyPoints={onRequestBuyPoints ?? null}
                     balance={balance}
                     balanceLoading={balanceLoading}
@@ -2550,7 +2582,7 @@ export function MarketsTradingTerminal({
                   />
                 ) : bottomTab === 'positions' ? (
                   !authenticated ? (
-                    <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
+                    <div className="flex h-full justify-center pt-6 text-muted-foreground text-sm">
                       Log in to view positions.
                     </div>
                   ) : selected?.kind === 'prediction' ? (

--- a/apps/web/src/app/markets/_components/terminal/TerminalAgentsChat.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalAgentsChat.tsx
@@ -5,7 +5,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { useTeamChat } from '@/hooks/useTeamChat';
 
 export function TerminalAgentsChat() {
-  const { authenticated, user, login } = useAuth();
+  const { authenticated, user } = useAuth();
   const {
     teamChat,
     chatDetails,
@@ -28,19 +28,8 @@ export function TerminalAgentsChat() {
 
   if (!authenticated) {
     return (
-      <div className="flex h-full items-center justify-center p-6 text-center">
-        <div className="max-w-md text-muted-foreground text-sm">
-          <div className="mb-3 font-semibold text-foreground">
-            Log in to chat with your agents
-          </div>
-          <button
-            type="button"
-            onClick={login}
-            className="mt-2 rounded bg-foreground px-4 py-2 font-semibold text-background text-sm transition-colors hover:opacity-90"
-          >
-            Log In
-          </button>
-        </div>
+      <div className="flex h-full justify-center pt-6 text-muted-foreground text-sm">
+        Log in to chat with your agents.
       </div>
     );
   }

--- a/apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx
@@ -23,7 +23,6 @@ function formatSignedBalance(value: number): string {
 /** Props for the TerminalPortfolio component */
 interface TerminalPortfolioProps {
   authenticated: boolean;
-  onLogin: () => void;
   onRequestBuyPoints?: (() => void) | null;
   balance: number;
   balanceLoading: boolean;
@@ -76,7 +75,6 @@ function StatCard({
 
 export function TerminalPortfolio({
   authenticated,
-  onLogin,
   onRequestBuyPoints,
   balance,
   balanceLoading,
@@ -92,19 +90,8 @@ export function TerminalPortfolio({
 }: TerminalPortfolioProps) {
   if (!authenticated) {
     return (
-      <div className="flex h-full items-center justify-center p-6 text-center">
-        <div className="max-w-md text-muted-foreground text-sm">
-          <div className="mb-3 font-semibold text-foreground">
-            Log in to view your portfolio
-          </div>
-          <button
-            type="button"
-            onClick={onLogin}
-            className="mt-2 rounded bg-foreground px-4 py-2 font-semibold text-background text-sm transition-colors hover:opacity-90"
-          >
-            Log In
-          </button>
-        </div>
+      <div className="flex h-full justify-center pt-6 text-muted-foreground text-sm">
+        Log in to view your portfolio.
       </div>
     );
   }

--- a/apps/web/src/app/markets/page.tsx
+++ b/apps/web/src/app/markets/page.tsx
@@ -81,7 +81,7 @@ export default function MarketsPage() {
       noPadding
       className="flex h-[calc(100dvh-112px)] flex-col overflow-hidden md:h-dvh"
     >
-      <div className="flex flex-1 overflow-hidden bg-background/20">
+      <div className="flex flex-1 overflow-hidden border-border bg-background/20 lg:border-l">
         <MarketsTradingTerminal
           onRequestBuyPoints={() => setShowBuyPointsModal(true)}
         />

--- a/apps/web/src/app/notifications/loading.tsx
+++ b/apps/web/src/app/notifications/loading.tsx
@@ -7,7 +7,7 @@ import {
 export default function NotificationsLoading() {
   return (
     <PageContainer noPadding className="!overflow-visible flex w-full flex-col">
-      <div className="flex min-w-0 flex-1 flex-col overflow-hidden border-[rgba(120,120,120,0.15)] lg:border-r lg:border-l">
+      <div className="flex min-w-0 flex-1 flex-col overflow-hidden border-border lg:border-r lg:border-l">
         {/* Sticky header */}
         <div className="sticky top-0 z-10 border-border border-b bg-background/95 backdrop-blur-sm">
           <div className="px-4 py-3 lg:px-6">

--- a/apps/web/src/app/notifications/page.tsx
+++ b/apps/web/src/app/notifications/page.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from '@babylon/shared';
 import { Bell } from 'lucide-react';
+import dynamic from 'next/dynamic';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
@@ -12,6 +13,17 @@ import { PageContainer } from '@/components/shared/PageContainer';
 import { PullToRefreshIndicator } from '@/components/shared/PullToRefreshIndicator';
 import { useAuth } from '@/hooks/useAuth';
 import { usePullToRefresh } from '@/hooks/usePullToRefresh';
+
+const WidgetSidebar = dynamic(
+  () =>
+    import('@/components/shared/WidgetSidebar').then((m) => ({
+      default: m.WidgetSidebar,
+    })),
+  {
+    ssr: false,
+    loading: () => <div className="hidden w-96 flex-none xl:block" />,
+  }
+);
 
 interface Notification {
   id: string;
@@ -352,162 +364,165 @@ export default function NotificationsPage() {
   }
 
   return (
-    <PageContainer noPadding className="!overflow-visible flex w-full flex-col">
-      <div className="flex min-w-0 flex-1 flex-col overflow-hidden border-[rgba(120,120,120,0.15)] lg:border-r lg:border-l">
-        {/* Header */}
-        <div className="sticky top-0 z-10 border-border border-b bg-background/95 backdrop-blur-sm">
-          <div className="px-4 py-3 lg:px-6">
-            <h1 className="font-bold text-xl">Notifications</h1>
-            {unreadCount > 0 && (
-              <p className="text-muted-foreground text-sm">
-                {unreadCount} unread
-              </p>
-            )}
+    <PageContainer noPadding className="flex w-full flex-col">
+      <div ref={containerRef} className="relative flex flex-1">
+        {/* Notifications area */}
+        <div className="flex min-w-0 flex-1 flex-col border-border lg:border-r lg:border-l">
+          {/* Header */}
+          <div className="sticky top-0 z-10 flex-shrink-0 bg-background shadow-sm">
+            <div className="w-full px-4 py-3 lg:mx-auto lg:max-w-[700px] lg:px-6">
+              <h1 className="font-bold text-xl">Notifications</h1>
+              {unreadCount > 0 && (
+                <p className="text-muted-foreground text-sm">
+                  {unreadCount} unread
+                </p>
+              )}
+            </div>
           </div>
-        </div>
 
-        {/* Content */}
-        <div ref={containerRef} className="relative flex-1 overflow-y-auto">
-          {/* Pull to refresh indicator */}
-          <PullToRefreshIndicator
-            pullDistance={pullDistance}
-            isRefreshing={isRefreshing}
-          />
-          {loading ? (
-            <div className="flex flex-col items-center justify-center py-12">
-              <div className="text-muted-foreground">
-                Loading notifications...
-              </div>
-            </div>
-          ) : notifications.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-12">
-              <Bell className="mb-4 h-12 w-12 text-muted-foreground opacity-50" />
-              <h2 className="mb-2 font-semibold text-xl">
-                No notifications yet
-              </h2>
-              <p className="px-4 text-center text-muted-foreground">
-                When you get comments, reactions, follows, or mentions,
-                they&apos;ll show up here.
-              </p>
-            </div>
-          ) : (
-            <div className="space-y-0">
-              {/* Group Invites Section */}
-              {groupInvites.length > 0 && (
-                <div className="space-y-3 px-4 py-4 lg:px-6">
-                  <h3 className="font-semibold text-muted-foreground text-sm">
-                    Pending Group Invites
-                  </h3>
-                  {groupInvites.map((invite) => (
-                    <GroupInviteCard
-                      key={invite.inviteId}
-                      inviteId={invite.inviteId}
-                      groupId={invite.groupId}
-                      groupName={invite.groupName}
-                      groupDescription={invite.groupDescription}
-                      memberCount={invite.memberCount}
-                      invitedAt={invite.invitedAt}
-                      onAccepted={(_groupId, chatId) => {
-                        // Refresh invites list
-                        fetchNotifications(false, true);
-                        toast.success('Joined group!');
-                        // Navigate to chat if available
-                        if (chatId) {
-                          router.push(`/chats?chat=${chatId}`);
-                        }
-                      }}
-                      onDeclined={() => {
-                        // Refresh invites list
-                        fetchNotifications(false, true);
-                        toast.success('Invite declined');
-                      }}
-                    />
+          {/* Content */}
+          <div className="flex-1 bg-background">
+            <div className="w-full lg:mx-auto lg:max-w-[700px]">
+              <PullToRefreshIndicator
+                pullDistance={pullDistance}
+                isRefreshing={isRefreshing}
+              />
+              {loading ? (
+                <div className="flex flex-col items-center justify-center py-12">
+                  <div className="text-muted-foreground">
+                    Loading notifications...
+                  </div>
+                </div>
+              ) : notifications.length === 0 ? (
+                <div className="flex flex-col items-center justify-center py-12">
+                  <Bell className="mb-4 h-12 w-12 text-muted-foreground opacity-50" />
+                  <h2 className="mb-2 font-semibold text-xl">
+                    No notifications yet
+                  </h2>
+                  <p className="px-4 text-center text-muted-foreground">
+                    When you get comments, reactions, follows, or mentions,
+                    they&apos;ll show up here.
+                  </p>
+                </div>
+              ) : (
+                <div className="space-y-0">
+                  {/* Group Invites Section */}
+                  {groupInvites.length > 0 && (
+                    <div className="space-y-3 px-4 py-4 lg:px-6">
+                      <h3 className="font-semibold text-muted-foreground text-sm">
+                        Pending Group Invites
+                      </h3>
+                      {groupInvites.map((invite) => (
+                        <GroupInviteCard
+                          key={invite.inviteId}
+                          inviteId={invite.inviteId}
+                          groupId={invite.groupId}
+                          groupName={invite.groupName}
+                          groupDescription={invite.groupDescription}
+                          memberCount={invite.memberCount}
+                          invitedAt={invite.invitedAt}
+                          onAccepted={(_groupId, chatId) => {
+                            fetchNotifications(false, true);
+                            toast.success('Joined group!');
+                            if (chatId) {
+                              router.push(`/chats?chat=${chatId}`);
+                            }
+                          }}
+                          onDeclined={() => {
+                            fetchNotifications(false, true);
+                            toast.success('Invite declined');
+                          }}
+                        />
+                      ))}
+                    </div>
+                  )}
+
+                  {/* Regular Notifications */}
+                  {notifications.map((notification) => (
+                    <Link
+                      key={notification.id}
+                      href={getNotificationLink(notification)}
+                      onClick={() =>
+                        markAsRead(notification.id, notification.read)
+                      }
+                      data-notification-id={notification.id}
+                      className={cn(
+                        'block border-border border-b px-4 py-4 lg:px-6',
+                        'transition-colors hover:bg-muted/30',
+                        !notification.read && 'bg-primary/5'
+                      )}
+                    >
+                      <div className="flex items-start gap-3">
+                        {/* Unread Indicator */}
+                        {!notification.read && (
+                          <div className="mt-2 h-2 w-2 shrink-0 rounded-full bg-primary" />
+                        )}
+
+                        {/* Actor Avatar */}
+                        {notification.actor ? (
+                          <Avatar
+                            id={notification.actor.id}
+                            name={notification.actor.displayName}
+                            size="md"
+                            className="shrink-0"
+                          />
+                        ) : (
+                          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full">
+                            {notification.type === 'system' ? (
+                              <span className="text-xl">
+                                {getNotificationIcon(notification.type)}
+                              </span>
+                            ) : (
+                              <Bell className="h-5 w-5 text-muted-foreground" />
+                            )}
+                          </div>
+                        )}
+
+                        {/* Content */}
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-start gap-3">
+                            <div className="flex-1">
+                              {notification.type === 'system' ? (
+                                <p className="text-foreground leading-relaxed">
+                                  {notification.message}{' '}
+                                  <time className="text-muted-foreground/70 text-xs">
+                                    {formatTimeAgo(notification.createdAt)}
+                                  </time>
+                                </p>
+                              ) : (
+                                <p className="text-foreground leading-relaxed">
+                                  <span className="font-semibold">
+                                    {notification.actor?.displayName ||
+                                      'Someone'}
+                                  </span>{' '}
+                                  <span className="text-muted-foreground">
+                                    {getNotificationIcon(notification.type)}{' '}
+                                    {notification.message
+                                      .replace(
+                                        notification.actor?.displayName || '',
+                                        ''
+                                      )
+                                      .replace(/^:\s*/, '')}
+                                  </span>{' '}
+                                  <time className="text-muted-foreground/70 text-xs">
+                                    {formatTimeAgo(notification.createdAt)}
+                                  </time>
+                                </p>
+                              )}
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </Link>
                   ))}
                 </div>
               )}
-
-              {/* Regular Notifications */}
-              {notifications.map((notification) => (
-                <Link
-                  key={notification.id}
-                  href={getNotificationLink(notification)}
-                  onClick={() => markAsRead(notification.id, notification.read)}
-                  data-notification-id={notification.id}
-                  className={cn(
-                    'block border-border border-b px-4 py-4 lg:px-6',
-                    'transition-colors hover:bg-muted/30',
-                    !notification.read && 'bg-primary/5'
-                  )}
-                >
-                  <div className="flex items-start gap-3">
-                    {/* Unread Indicator - moved to left */}
-                    {!notification.read && (
-                      <div className="mt-2 h-2 w-2 shrink-0 rounded-full bg-primary" />
-                    )}
-
-                    {/* Actor Avatar */}
-                    {notification.actor ? (
-                      <Avatar
-                        id={notification.actor.id}
-                        name={notification.actor.displayName}
-                        size="md"
-                        className="shrink-0"
-                      />
-                    ) : (
-                      <div
-                        className={cn(
-                          'flex h-10 w-10 shrink-0 items-center justify-center rounded-full',
-                          notification.type === 'system'
-                            ? 'bg-primary/10'
-                            : 'bg-muted'
-                        )}
-                      >
-                        {notification.type === 'system' ? (
-                          <span className="text-xl">
-                            {getNotificationIcon(notification.type)}
-                          </span>
-                        ) : (
-                          <Bell className="h-5 w-5 text-muted-foreground" />
-                        )}
-                      </div>
-                    )}
-
-                    {/* Content */}
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-start gap-3">
-                        <div className="flex-1">
-                          {notification.type === 'system' ? (
-                            <p className="text-foreground leading-relaxed">
-                              {notification.message}
-                            </p>
-                          ) : (
-                            <p className="text-foreground leading-relaxed">
-                              <span className="font-semibold">
-                                {notification.actor?.displayName || 'Someone'}
-                              </span>{' '}
-                              <span className="text-muted-foreground">
-                                {getNotificationIcon(notification.type)}{' '}
-                                {notification.message
-                                  .replace(
-                                    notification.actor?.displayName || '',
-                                    ''
-                                  )
-                                  .replace(/^:\s*/, '')}
-                              </span>
-                            </p>
-                          )}
-                          <time className="mt-1 block text-muted-foreground text-sm">
-                            {formatTimeAgo(notification.createdAt)}
-                          </time>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </Link>
-              ))}
             </div>
-          )}
+          </div>
         </div>
+
+        {/* Widget sidebar - lazy loaded, desktop only */}
+        <WidgetSidebar />
       </div>
     </PageContainer>
   );

--- a/apps/web/src/app/post/[id]/loading.tsx
+++ b/apps/web/src/app/post/[id]/loading.tsx
@@ -7,7 +7,7 @@ export default function PostDetailLoading() {
       {/* Desktop */}
       <div className="hidden flex-1 lg:flex">
         {/* Main Content */}
-        <div className="flex min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] border-r border-l">
+        <div className="flex min-w-0 flex-1 flex-col border-border border-r border-l">
           <div className="flex-1 overflow-y-auto">
             <div className="mx-auto w-full max-w-[700px]">
               {/* Post Detail */}

--- a/apps/web/src/app/post/[id]/page.tsx
+++ b/apps/web/src/app/post/[id]/page.tsx
@@ -193,7 +193,7 @@ export default function PostPage({ params }: PostPageProps) {
       >
         <div className="relative flex min-h-screen flex-1">
           {/* Desktop loading */}
-          <div className="hidden min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:flex lg:border-r lg:border-l">
+          <div className="hidden min-w-0 flex-1 flex-col border-border lg:flex lg:border-r lg:border-l">
             <div className="flex-1 bg-background">
               <div className="w-full lg:mx-auto lg:max-w-[700px]">
                 <div className="space-y-4 px-4 py-6">
@@ -226,7 +226,7 @@ export default function PostPage({ params }: PostPageProps) {
       >
         <div className="relative flex min-h-screen flex-1">
           {/* Desktop error */}
-          <div className="hidden min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:flex lg:border-r lg:border-l">
+          <div className="hidden min-w-0 flex-1 flex-col border-border lg:flex lg:border-r lg:border-l">
             <div className="flex flex-1 flex-col items-center justify-center bg-background">
               <div className="text-center">
                 <h1 className="mb-2 font-bold text-2xl">Post Not Found</h1>
@@ -267,7 +267,7 @@ export default function PostPage({ params }: PostPageProps) {
     <PageContainer noPadding className="!overflow-visible flex w-full flex-col">
       <div className="relative flex min-h-screen flex-1">
         {/* Desktop: Post content area */}
-        <div className="hidden min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:flex lg:border-r lg:border-l">
+        <div className="hidden min-w-0 flex-1 flex-col border-border lg:flex lg:border-r lg:border-l">
           {/* Desktop: Top bar with back button */}
           <div className="sticky top-0 z-10 shrink-0 bg-background shadow-sm">
             <div className="px-6 py-4">

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -958,9 +958,9 @@ export default function ProfilePage() {
       {/* Main layout - responsive with optional sidebar on xl screens */}
       <div className="flex flex-1 overflow-hidden">
         {/* Main content */}
-        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden border-border lg:border-r lg:border-l">
           {/* Header */}
-          <div className="sticky top-0 z-10 bg-background/95 backdrop-blur-sm">
+          <div className="sticky top-0 z-10 flex-shrink-0 bg-background shadow-sm">
             <div className="flex items-center gap-4 px-4 py-3">
               <Link
                 href="/feed"

--- a/apps/web/src/app/rewards/page.tsx
+++ b/apps/web/src/app/rewards/page.tsx
@@ -488,7 +488,7 @@ export default function RewardsPage() {
                 <h2 className="font-bold text-base text-foreground">
                   Referral Link
                 </h2>
-                <span className="text-muted-foreground text-xs">
+                <span className="ml-auto text-muted-foreground text-xs">
                   +{POINTS.REFERRAL_SIGNUP} points per signup (max 10/week)
                 </span>
               </div>

--- a/apps/web/src/app/rewards/page.tsx
+++ b/apps/web/src/app/rewards/page.tsx
@@ -6,14 +6,26 @@ import {
   getReferralUrl,
   POINTS,
 } from '@babylon/shared';
-import { Check, Copy, ExternalLink, Share2 } from 'lucide-react';
+import {
+  Award,
+  Check,
+  Copy,
+  ExternalLink,
+  Gift,
+  Link as LinkIcon,
+  Share2,
+  TrendingUp,
+  Twitter,
+  UserPlus,
+  Users,
+  Wallet,
+} from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { DailyStreakCard } from '@/components/daily-login';
 import { LinkSocialAccountsModal } from '@/components/profile/LinkSocialAccountsModal';
 import { RewardsSkeleton } from '@/components/rewards/RewardsSkeleton';
-import { RewardTaskList } from '@/components/rewards/RewardTaskList';
 import { Avatar } from '@/components/shared/Avatar';
 import { ExternalShareButton } from '@/components/shared/ExternalShareButton';
 import { PageContainer } from '@/components/shared/PageContainer';
@@ -167,24 +179,10 @@ export default function RewardsPage() {
 
   const handleCopyUrl = async () => {
     if (!referralData?.user.referralCode) return;
-
-    // Guard against environments where clipboard API is not available
-    if (!navigator.clipboard?.writeText) {
-      toast.error('Clipboard not available in this browser');
-      return;
-    }
-
     const referralUrl = getReferralUrl(referralData.user.referralCode);
-    const success = await navigator.clipboard
-      .writeText(referralUrl)
-      .then(() => true)
-      .catch(() => false);
-    if (success) {
-      setCopiedUrl(true);
-      setTimeout(() => setCopiedUrl(false), 2000);
-    } else {
-      toast.error('Failed to copy referral link');
-    }
+    await navigator.clipboard.writeText(referralUrl);
+    setCopiedUrl(true);
+    setTimeout(() => setCopiedUrl(false), 2000);
   };
 
   // Calculate total points earned from all sources
@@ -216,7 +214,7 @@ export default function RewardsPage() {
           title: 'Complete Profile',
           description: (() => {
             if (referralData.user.pointsAwardedForProfile) {
-              return 'Username, image, and bio complete!';
+              return 'Username, image, and bio complete! ✓';
             }
             const missing = [];
             if (!referralData.user.username) missing.push('username');
@@ -228,6 +226,8 @@ export default function RewardsPage() {
           points: POINTS.PROFILE_COMPLETION,
           completed: referralData.user.pointsAwardedForProfile,
           action: 'profile-settings',
+          icon: UserPlus,
+          color: 'text-purple-500',
         },
         {
           id: 'twitter',
@@ -238,6 +238,8 @@ export default function RewardsPage() {
           points: POINTS.TWITTER_LINK,
           completed: referralData.user.pointsAwardedForTwitter,
           action: 'link-social',
+          icon: Twitter,
+          color: 'text-blue-400',
         },
         {
           id: 'farcaster',
@@ -248,6 +250,8 @@ export default function RewardsPage() {
           points: POINTS.FARCASTER_LINK,
           completed: referralData.user.pointsAwardedForFarcaster,
           action: 'link-social',
+          icon: LinkIcon,
+          color: 'text-purple-400',
         },
         {
           id: 'wallet',
@@ -258,6 +262,8 @@ export default function RewardsPage() {
           points: POINTS.WALLET_CONNECT,
           completed: referralData.user.pointsAwardedForWallet,
           action: 'wallet-connect',
+          icon: Wallet,
+          color: 'text-orange-500',
         },
       ]
     : [];
@@ -300,10 +306,10 @@ export default function RewardsPage() {
       {authenticated && !loading && !error && referralData && (
         <div className="hidden flex-1 overflow-hidden xl:flex">
           {/* Main Content Column */}
-          <div className="min-w-0 flex-1 space-y-4 overflow-y-auto overflow-x-hidden p-4 sm:p-6">
+          <div className="min-w-0 flex-1 space-y-4 overflow-y-auto overflow-x-hidden border-border p-4 sm:p-6 lg:border-l">
             {/* Header */}
             <div className="mb-4">
-              <h1 className="mb-2 font-bold text-2xl text-foreground">
+              <h1 className="mb-2 font-bold text-foreground text-xl">
                 Rewards
               </h1>
               <p className="text-muted-foreground">
@@ -313,169 +319,298 @@ export default function RewardsPage() {
 
             {/* Stats Row */}
             <div className="grid grid-cols-3 gap-4">
-              <div className="text-center">
-                <div className="text-muted-foreground text-sm">
-                  Total Earned
+              {/* Total Earned */}
+              <div className="rounded-lg border border-border p-4">
+                <div className="mb-2 flex items-center gap-2">
+                  <Award className="h-5 w-5 text-yellow-500" />
+                  <h2 className="font-medium text-muted-foreground text-sm">
+                    Total Earned
+                  </h2>
                 </div>
-                <div className="font-bold text-2xl text-foreground">
+                <div className="font-bold text-3xl text-yellow-500">
                   {calculateTotalEarned().toLocaleString()}
                 </div>
               </div>
-              <div className="text-center">
-                <div className="text-muted-foreground text-sm">
-                  Total Points
+
+              {/* Total Points */}
+              <div className="rounded-lg border border-border p-4">
+                <div className="mb-2 flex items-center gap-2">
+                  <TrendingUp className="h-5 w-5 text-[#0066FF]" />
+                  <h2 className="font-medium text-muted-foreground text-sm">
+                    Total Points
+                  </h2>
                 </div>
-                <div className="font-bold text-2xl text-foreground">
+                <div className="font-bold text-3xl text-[#0066FF]">
                   {referralData.user.totalPoints.toLocaleString()}
                 </div>
               </div>
-              <div className="text-center">
-                <div className="text-muted-foreground text-sm">Referrals</div>
-                <div className="font-bold text-2xl text-foreground">
-                  {referralData.stats.totalReferrals}
-                  {referralData.stats.weeklyReferralCount !== undefined &&
-                    referralData.stats.weeklyLimit !== undefined && (
-                      <span className="ml-1 font-normal text-muted-foreground text-sm">
-                        ({referralData.stats.weeklyReferralCount}/
-                        {referralData.stats.weeklyLimit} this week)
-                      </span>
-                    )}
+
+              {/* Total Referrals */}
+              <div className="rounded-lg border border-border p-4">
+                <div className="mb-2 flex items-center gap-2">
+                  <Users className="h-5 w-5 text-[#0066FF]" />
+                  <h2 className="font-medium text-muted-foreground text-sm">
+                    Total Referrals
+                  </h2>
                 </div>
+                <div className="font-bold text-3xl text-foreground">
+                  {referralData.stats.totalReferrals}
+                </div>
+                {referralData.stats.weeklyReferralCount !== undefined &&
+                  referralData.stats.weeklyLimit !== undefined && (
+                    <div className="mt-2 border-border border-t pt-2">
+                      <div className="mb-1 flex items-center justify-between text-xs">
+                        <span className="text-muted-foreground">This Week</span>
+                        <span
+                          className={`font-semibold ${
+                            referralData.stats.weeklyReferralCount >=
+                            referralData.stats.weeklyLimit
+                              ? 'text-red-500'
+                              : referralData.stats.weeklyReferralCount >=
+                                  referralData.stats.weeklyLimit * 0.8
+                                ? 'text-yellow-500'
+                                : 'text-foreground'
+                          }`}
+                        >
+                          {referralData.stats.weeklyReferralCount}/
+                          {referralData.stats.weeklyLimit}
+                        </span>
+                      </div>
+                      <div className="h-1.5 w-full rounded-full bg-background">
+                        <div
+                          className={`h-1.5 rounded-full transition-all ${
+                            referralData.stats.weeklyReferralCount >=
+                            referralData.stats.weeklyLimit
+                              ? 'bg-red-500'
+                              : referralData.stats.weeklyReferralCount >=
+                                  referralData.stats.weeklyLimit * 0.8
+                                ? 'bg-yellow-500'
+                                : 'bg-[#0066FF]'
+                          }`}
+                          style={{
+                            width: `${Math.min(100, (referralData.stats.weeklyReferralCount / referralData.stats.weeklyLimit) * 100)}%`,
+                          }}
+                        />
+                      </div>
+                    </div>
+                  )}
               </div>
             </div>
 
             {/* Daily Rewards */}
             <DailyStreakCard />
 
+            {/* Reward Tasks */}
+            <div className="rounded-lg border border-border p-4">
+              <div className="mb-4 flex items-center gap-2">
+                <TrendingUp className="h-5 w-5 text-[#0066FF]" />
+                <h2 className="font-bold text-base text-foreground">
+                  Earn Points
+                </h2>
+              </div>
+
+              <div className="grid gap-3">
+                {rewardTasks.map((task) => {
+                  const Icon = task.icon;
+                  return (
+                    <button
+                      key={task.id}
+                      onClick={() => handleTaskClick(task.id, task.action)}
+                      className={`flex w-full items-center gap-4 rounded-lg border p-4 text-left transition-all ${
+                        task.completed
+                          ? 'border-green-500/30 bg-green-500/10'
+                          : 'cursor-pointer border-border hover:bg-muted/50'
+                      }`}
+                    >
+                      <div className={`shrink-0 ${task.color}`}>
+                        <Icon className="h-6 w-6" />
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <h3 className="font-semibold text-foreground text-sm">
+                            {task.title}
+                          </h3>
+                          {task.completed && (
+                            <Check className="h-4 w-4 text-green-500" />
+                          )}
+                        </div>
+                        <p className="truncate text-muted-foreground text-xs">
+                          {task.description}
+                        </p>
+                      </div>
+                      <div className="shrink-0 text-right">
+                        <div
+                          className={`font-bold text-sm ${task.completed ? 'text-green-500' : 'text-yellow-500'}`}
+                        >
+                          {task.completed ? '✓ ' : '+'}
+                          {task.points}
+                        </div>
+                        <div className="text-muted-foreground text-xs">
+                          points
+                        </div>
+                      </div>
+                    </button>
+                  );
+                })}
+
+                {/* Share & Earn */}
+                <button
+                  onClick={() => setShowShareModal(true)}
+                  className="flex w-full cursor-pointer items-center gap-4 rounded-lg border border-border p-4 text-left transition-all hover:bg-muted/50"
+                >
+                  <div className="shrink-0 text-[#0066FF]">
+                    <Share2 className="h-6 w-6" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <h3 className="font-semibold text-foreground text-sm">
+                      Share & Earn
+                    </h3>
+                    <p className="truncate text-muted-foreground text-xs">
+                      Share content to earn points (one-time reward)
+                    </p>
+                  </div>
+                  <div className="shrink-0 text-right">
+                    <div className="font-bold text-sm text-yellow-500">
+                      +{POINTS.SHARE_ACTION}
+                    </div>
+                    <div className="text-muted-foreground text-xs">points</div>
+                  </div>
+                </button>
+              </div>
+            </div>
+
+            <Separator />
+
             {/* Referral Link */}
-            <div>
-              <div className="mb-2 flex items-baseline justify-between">
-                <h2 className="font-semibold text-foreground">Referral Link</h2>
-                <span className="text-muted-foreground text-sm">
+            <div className="rounded-lg border border-border p-4">
+              <div className="mb-3 flex items-center gap-2">
+                <Gift className="h-5 w-5 text-[#0066FF]" />
+                <h2 className="font-bold text-base text-foreground">
+                  Referral Link
+                </h2>
+                <span className="text-muted-foreground text-xs">
                   +{POINTS.REFERRAL_SIGNUP} points per signup (max 10/week)
                 </span>
               </div>
-              <div className="flex gap-2">
-                <div className="flex-1 truncate rounded-md border border-border bg-muted/30 px-3 py-2 text-foreground text-sm">
-                  {referralData.user.referralCode
-                    ? getReferralUrl(referralData.user.referralCode)
-                    : 'Generating your referral link...'}
+
+              <div className="space-y-3">
+                {/* URL Display */}
+                <div className="flex gap-2">
+                  <div className="flex-1 truncate rounded-lg border border-border px-3 py-2 text-foreground text-sm">
+                    {referralData.user.referralCode
+                      ? getReferralUrl(referralData.user.referralCode)
+                      : 'Generating your referral link...'}
+                  </div>
+                  <button
+                    onClick={handleCopyUrl}
+                    disabled={!referralData.user.referralCode}
+                    className="flex w-[84px] shrink-0 items-center justify-center gap-1.5 rounded-lg border border-border py-2 text-foreground transition-colors hover:bg-muted/50 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    {copiedUrl ? (
+                      <>
+                        <Check className="h-4 w-4 text-green-500" />
+                        <span className="text-xs">Copied!</span>
+                      </>
+                    ) : (
+                      <>
+                        <Copy className="h-4 w-4" />
+                        <span className="text-xs">Copy</span>
+                      </>
+                    )}
+                  </button>
                 </div>
-                <button
-                  onClick={handleCopyUrl}
-                  disabled={!referralData.user.referralCode}
-                  className="flex items-center gap-1.5 rounded-md border border-border px-3 py-2 text-foreground transition-colors hover:bg-muted/50 disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  {copiedUrl ? (
-                    <>
-                      <Check className="h-4 w-4 text-green-500" />
-                      <span className="text-sm">Copied</span>
-                    </>
-                  ) : (
-                    <>
-                      <Copy className="h-4 w-4" />
-                      <span className="text-sm">Copy</span>
-                    </>
-                  )}
-                </button>
-              </div>
-              {referralData.user.referralCode && (
-                <div className="mt-2">
+
+                {/* Share Button */}
+                {referralData.user.referralCode && (
                   <ExternalShareButton
                     contentType="referral"
                     text={getReferralShareText(referralData.user.referralCode)}
                     url={getReferralUrl(referralData.user.referralCode)}
                     className="w-full"
+                    inline
                   />
-                </div>
-              )}
-            </div>
+                )}
 
-            <Separator />
-
-            {/* One-Time Tasks */}
-            <div>
-              <h2 className="mb-3 font-semibold text-foreground">
-                Earn Points
-              </h2>
-              <RewardTaskList
-                tasks={rewardTasks}
-                onTaskClick={handleTaskClick}
-                variant="desktop"
-              />
-            </div>
-
-            {/* Share & Earn */}
-            <div className="flex items-center justify-between">
-              <div>
-                <h2 className="font-semibold text-foreground">Share & Earn</h2>
-                <p className="text-muted-foreground text-sm">
-                  Share content to earn +{POINTS.SHARE_ACTION} points (one-time)
-                </p>
+                {!referralData.user.referralCode && (
+                  <p className="text-muted-foreground text-xs">
+                    Sign in to get your referral link
+                  </p>
+                )}
               </div>
-              <button
-                onClick={() => setShowShareModal(true)}
-                className="flex items-center gap-2 rounded-md bg-[#0066FF] px-4 py-2 font-medium text-sm text-white transition-colors hover:bg-[#0066FF]/90"
-              >
-                <Share2 className="h-4 w-4" />
-                Share
-              </button>
             </div>
 
             {/* Referred Users List */}
-            {referralData.referredUsers.length > 0 && (
-              <div>
-                <h2 className="mb-3 font-semibold text-foreground">
+            <div>
+              <div className="mb-3 flex items-center justify-between">
+                <h2 className="flex items-center gap-1.5 font-bold text-base text-foreground">
+                  <Users className="h-4 w-4 text-[#0066FF]" />
                   Your Referrals
                 </h2>
+              </div>
+
+              {referralData.referredUsers.length === 0 ? (
+                <div className="rounded-lg border border-border py-8 text-center">
+                  <Users className="mx-auto mb-3 h-12 w-12 text-muted-foreground opacity-50" />
+                  <h3 className="mb-1 font-semibold text-base text-foreground">
+                    No referrals yet
+                  </h3>
+                  <p className="text-muted-foreground text-xs">
+                    Share your referral link to start earning points
+                  </p>
+                </div>
+              ) : (
                 <div className="space-y-2">
                   {referralData.referredUsers.map((referredUser) => (
                     <div
                       key={referredUser.id}
-                      className="flex items-center gap-3 rounded-md border border-border px-3 py-2 transition-colors hover:bg-muted/30"
+                      className="flex items-center gap-3 rounded-lg border border-border p-3 transition-colors hover:bg-muted/50"
                     >
+                      {/* Avatar */}
                       <Avatar
-                        id={referredUser.id}
-                        name={
+                        src={referredUser.profileImageUrl || undefined}
+                        alt={
                           referredUser.displayName ||
                           referredUser.username ||
                           'User'
                         }
-                        src={referredUser.profileImageUrl || undefined}
                         size="sm"
                       />
+
+                      {/* User Info */}
                       <div className="min-w-0 flex-1">
-                        <span className="font-medium text-foreground text-sm">
+                        <h3 className="truncate font-semibold text-foreground text-sm">
                           {referredUser.displayName ||
                             referredUser.username ||
                             'Anonymous'}
-                        </span>
+                        </h3>
                         {referredUser.username && (
-                          <span className="ml-2 text-muted-foreground text-xs">
+                          <p className="truncate text-muted-foreground text-xs">
                             @{referredUser.username}
-                          </span>
+                          </p>
                         )}
+                        <p className="mt-0.5 text-muted-foreground text-xs">
+                          {new Date(
+                            referredUser.joinedAt || referredUser.createdAt
+                          ).toLocaleDateString()}
+                        </p>
                       </div>
-                      <span className="text-muted-foreground text-xs">
-                        {new Date(
-                          referredUser.joinedAt || referredUser.createdAt
-                        ).toLocaleDateString()}
-                      </span>
+
+                      {/* View Profile */}
                       <a
                         href={getProfileUrl(
                           referredUser.id,
                           referredUser.username
                         )}
-                        className="text-muted-foreground transition-colors hover:text-foreground"
+                        className="p-1.5 text-muted-foreground transition-colors hover:text-foreground"
                         aria-label="View profile"
                       >
-                        <ExternalLink className="h-4 w-4" />
+                        <ExternalLink className="h-3.5 w-3.5" />
                       </a>
                     </div>
                   ))}
                 </div>
-              </div>
-            )}
+              )}
+            </div>
           </div>
 
           {/* Rewards Widget Column */}
@@ -487,11 +622,11 @@ export default function RewardsPage() {
 
       {/* Mobile/Tablet View */}
       {authenticated && !loading && !error && referralData && (
-        <div className="flex w-full flex-1 flex-col overflow-y-auto xl:hidden">
+        <div className="flex w-full flex-1 flex-col overflow-y-auto border-border lg:border-l xl:hidden">
           <div className="w-full space-y-4 px-4 py-4 sm:space-y-6 sm:px-6 sm:py-6">
             {/* Header */}
             <div>
-              <h1 className="mb-2 font-bold text-2xl text-foreground">
+              <h1 className="mb-2 font-bold text-foreground text-xl">
                 Rewards
               </h1>
               <p className="text-muted-foreground">
@@ -500,111 +635,249 @@ export default function RewardsPage() {
             </div>
 
             {/* Stats Row */}
-            <div className="grid grid-cols-3 gap-3 text-center">
-              <div>
-                <div className="text-muted-foreground text-xs">Earned</div>
-                <div className="font-bold text-foreground text-xl">
+            <div className="grid grid-cols-3 gap-2 sm:gap-3">
+              {/* Total Earned */}
+              <div className="rounded-lg border border-border p-3">
+                <div className="mb-1 flex items-center gap-1">
+                  <Award className="h-4 w-4 text-yellow-500" />
+                  <h2 className="font-medium text-muted-foreground text-xs">
+                    Earned
+                  </h2>
+                </div>
+                <div className="font-bold text-2xl text-yellow-500">
                   {calculateTotalEarned().toLocaleString()}
                 </div>
               </div>
-              <div>
-                <div className="text-muted-foreground text-xs">Total</div>
-                <div className="font-bold text-foreground text-xl">
+
+              {/* Total Points */}
+              <div className="rounded-lg border border-border p-3">
+                <div className="mb-1 flex items-center gap-1">
+                  <TrendingUp className="h-4 w-4 text-[#0066FF]" />
+                  <h2 className="font-medium text-muted-foreground text-xs">
+                    Total Points
+                  </h2>
+                </div>
+                <div className="font-bold text-2xl text-[#0066FF]">
                   {referralData.user.totalPoints.toLocaleString()}
                 </div>
               </div>
-              <div>
-                <div className="text-muted-foreground text-xs">Referrals</div>
-                <div className="font-bold text-foreground text-xl">
+
+              {/* Total Referrals */}
+              <div className="rounded-lg border border-border p-3">
+                <div className="mb-1 flex items-center gap-1">
+                  <Users className="h-4 w-4 text-[#0066FF]" />
+                  <h2 className="font-medium text-muted-foreground text-xs">
+                    Referrals
+                  </h2>
+                </div>
+                <div className="font-bold text-2xl text-foreground">
                   {referralData.stats.totalReferrals}
                 </div>
+                {referralData.stats.weeklyReferralCount !== undefined &&
+                  referralData.stats.weeklyLimit !== undefined && (
+                    <div className="mt-1.5 border-border border-t pt-1.5">
+                      <div className="mb-0.5 flex items-center justify-between text-xs">
+                        <span className="text-muted-foreground">Week</span>
+                        <span
+                          className={`font-semibold ${
+                            referralData.stats.weeklyReferralCount >=
+                            referralData.stats.weeklyLimit
+                              ? 'text-red-500'
+                              : referralData.stats.weeklyReferralCount >=
+                                  referralData.stats.weeklyLimit * 0.8
+                                ? 'text-yellow-500'
+                                : 'text-foreground'
+                          }`}
+                        >
+                          {referralData.stats.weeklyReferralCount}/
+                          {referralData.stats.weeklyLimit}
+                        </span>
+                      </div>
+                      <div className="h-1 w-full rounded-full bg-background">
+                        <div
+                          className={`h-1 rounded-full transition-all ${
+                            referralData.stats.weeklyReferralCount >=
+                            referralData.stats.weeklyLimit
+                              ? 'bg-red-500'
+                              : referralData.stats.weeklyReferralCount >=
+                                  referralData.stats.weeklyLimit * 0.8
+                                ? 'bg-yellow-500'
+                                : 'bg-[#0066FF]'
+                          }`}
+                          style={{
+                            width: `${Math.min(100, (referralData.stats.weeklyReferralCount / referralData.stats.weeklyLimit) * 100)}%`,
+                          }}
+                        />
+                      </div>
+                    </div>
+                  )}
               </div>
             </div>
 
             {/* Daily Rewards */}
             <DailyStreakCard />
 
-            {/* Referral Link */}
-            <div>
-              <div className="mb-2 flex items-baseline justify-between">
-                <h2 className="font-semibold text-foreground">Referral Link</h2>
-                <span className="text-muted-foreground text-xs">
-                  +{POINTS.REFERRAL_SIGNUP}/signup
-                </span>
-              </div>
-              <div className="flex gap-2">
-                <div className="min-w-0 flex-1 truncate rounded-md border border-border bg-muted/30 px-3 py-2 text-foreground text-sm">
-                  {referralData.user.referralCode
-                    ? getReferralUrl(referralData.user.referralCode)
-                    : 'Generating...'}
-                </div>
+            {/* Reward Tasks */}
+            <div className="space-y-3">
+              <h2 className="flex items-center gap-2 font-bold text-foreground text-lg">
+                <TrendingUp className="h-5 w-5 text-[#0066FF]" />
+                Earn Points
+              </h2>
+
+              <div className="space-y-2">
+                {rewardTasks.map((task) => {
+                  const Icon = task.icon;
+                  return (
+                    <button
+                      key={task.id}
+                      onClick={() => handleTaskClick(task.id, task.action)}
+                      className={`flex w-full items-center gap-3 rounded-lg border p-3 text-left transition-all ${
+                        task.completed
+                          ? 'border-green-500/30 bg-green-500/10'
+                          : 'cursor-pointer border-border hover:bg-muted/50'
+                      }`}
+                    >
+                      <div className={`shrink-0 ${task.color}`}>
+                        <Icon className="h-5 w-5" />
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2">
+                          <h3 className="font-semibold text-foreground text-sm">
+                            {task.title}
+                          </h3>
+                          {task.completed && (
+                            <Check className="h-4 w-4 text-green-500" />
+                          )}
+                        </div>
+                        <p className="truncate text-muted-foreground text-xs">
+                          {task.description}
+                        </p>
+                      </div>
+                      <div className="shrink-0 font-bold text-sm">
+                        <span
+                          className={
+                            task.completed
+                              ? 'text-green-500'
+                              : 'text-yellow-500'
+                          }
+                        >
+                          {task.completed ? '✓' : '+'}
+                          {task.points}
+                        </span>
+                      </div>
+                    </button>
+                  );
+                })}
+
+                {/* Share & Earn */}
                 <button
-                  onClick={handleCopyUrl}
-                  disabled={!referralData.user.referralCode}
-                  className="flex shrink-0 items-center gap-1.5 rounded-md border border-border px-3 py-2 text-foreground transition-colors hover:bg-muted/50 disabled:cursor-not-allowed disabled:opacity-50"
+                  onClick={() => setShowShareModal(true)}
+                  className="flex w-full cursor-pointer items-center gap-3 rounded-lg border border-border p-3 text-left transition-all hover:bg-muted/50"
                 >
-                  {copiedUrl ? (
-                    <Check className="h-4 w-4 text-green-500" />
-                  ) : (
-                    <Copy className="h-4 w-4" />
-                  )}
+                  <div className="shrink-0 text-[#0066FF]">
+                    <Share2 className="h-5 w-5" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <h3 className="font-semibold text-foreground text-sm">
+                      Share & Earn
+                    </h3>
+                    <p className="truncate text-muted-foreground text-xs">
+                      Share content to earn points (one-time)
+                    </p>
+                  </div>
+                  <div className="shrink-0 font-bold text-sm">
+                    <span className="text-yellow-500">
+                      +{POINTS.SHARE_ACTION}
+                    </span>
+                  </div>
                 </button>
               </div>
-              {referralData.user.referralCode && (
-                <div className="mt-2">
+            </div>
+
+            <Separator />
+
+            {/* Referral Link */}
+            <div className="rounded-lg border border-border p-4">
+              <div className="mb-3">
+                <div className="flex items-center gap-2">
+                  <Gift className="h-5 w-5 text-[#0066FF]" />
+                  <h2 className="font-bold text-base text-foreground">
+                    Referral Link
+                  </h2>
+                </div>
+                <p className="mt-1 text-muted-foreground text-xs">
+                  +{POINTS.REFERRAL_SIGNUP} points per signup (max 10/week)
+                </p>
+              </div>
+
+              <div className="space-y-3">
+                {/* URL Display */}
+                <div className="flex gap-2">
+                  <div className="min-w-0 flex-1 break-all rounded-lg border border-border px-3 py-2 text-foreground text-sm">
+                    {referralData.user.referralCode
+                      ? getReferralUrl(referralData.user.referralCode)
+                      : 'Generating your referral link...'}
+                  </div>
+                  <button
+                    onClick={handleCopyUrl}
+                    disabled={!referralData.user.referralCode}
+                    className="flex shrink-0 items-center justify-center rounded-lg border border-border px-3 py-2 text-foreground transition-colors hover:bg-muted/50 disabled:cursor-not-allowed disabled:opacity-50"
+                    aria-label="Copy referral link"
+                  >
+                    {copiedUrl ? (
+                      <Check className="h-5 w-5 text-green-500" />
+                    ) : (
+                      <Copy className="h-5 w-5" />
+                    )}
+                  </button>
+                </div>
+
+                {/* Share Button */}
+                {referralData.user.referralCode && (
                   <ExternalShareButton
                     contentType="referral"
                     text={getReferralShareText(referralData.user.referralCode)}
                     url={getReferralUrl(referralData.user.referralCode)}
                     className="w-full"
+                    inline
                   />
-                </div>
-              )}
-            </div>
+                )}
 
-            <Separator />
-
-            {/* One-Time Tasks */}
-            <div>
-              <h2 className="mb-3 font-semibold text-foreground">
-                Earn Points
-              </h2>
-              <RewardTaskList
-                tasks={rewardTasks}
-                onTaskClick={handleTaskClick}
-                variant="mobile"
-              />
-            </div>
-
-            {/* Share & Earn */}
-            <div className="flex items-center justify-between">
-              <div>
-                <h2 className="font-semibold text-foreground">Share & Earn</h2>
-                <p className="text-muted-foreground text-sm">
-                  +{POINTS.SHARE_ACTION} points (one-time)
-                </p>
+                {!referralData.user.referralCode && (
+                  <p className="text-muted-foreground text-xs">
+                    Sign in to get your referral link
+                  </p>
+                )}
               </div>
-              <button
-                onClick={() => setShowShareModal(true)}
-                className="flex items-center gap-2 rounded-md bg-[#0066FF] px-4 py-2 font-medium text-sm text-white transition-colors hover:bg-[#0066FF]/90"
-              >
-                <Share2 className="h-4 w-4" />
-                Share
-              </button>
             </div>
 
             {/* Referred Users List */}
-            {referralData.referredUsers.length > 0 && (
-              <div>
-                <h2 className="mb-3 font-semibold text-foreground">
+            <div>
+              <div className="mb-3 flex items-center justify-between">
+                <h2 className="flex items-center gap-2 font-bold text-base text-foreground">
+                  <Users className="h-5 w-5 text-[#0066FF]" />
                   Your Referrals
                 </h2>
-                <div className="space-y-2">
+              </div>
+
+              {referralData.referredUsers.length === 0 ? (
+                <div className="rounded-lg border border-border py-12 text-center">
+                  <Users className="mx-auto mb-4 h-12 w-12 text-muted-foreground opacity-50" />
+                  <h3 className="mb-2 font-semibold text-foreground text-lg">
+                    No referrals yet
+                  </h3>
+                  <p className="px-4 text-muted-foreground text-sm">
+                    Share your referral link to start earning points
+                  </p>
+                </div>
+              ) : (
+                <div className="space-y-3">
                   {referralData.referredUsers.map((referredUser) => (
                     <div
                       key={referredUser.id}
-                      className="flex items-center gap-3 rounded-md border border-border px-3 py-2 transition-colors hover:bg-muted/30"
+                      className="flex items-center gap-3 rounded-lg border border-border p-3 transition-colors hover:bg-muted/50"
                     >
+                      {/* Avatar */}
                       <Avatar
                         id={referredUser.id}
                         name={
@@ -615,29 +888,33 @@ export default function RewardsPage() {
                         src={referredUser.profileImageUrl || undefined}
                         size="sm"
                       />
+
+                      {/* User Info */}
                       <div className="min-w-0 flex-1">
-                        <span className="font-medium text-foreground text-sm">
+                        <h3 className="truncate font-semibold text-foreground text-sm">
                           {referredUser.displayName ||
                             referredUser.username ||
                             'Anonymous'}
-                        </span>
+                        </h3>
                         {referredUser.username && (
-                          <span className="ml-2 text-muted-foreground text-xs">
+                          <p className="truncate text-muted-foreground text-xs">
                             @{referredUser.username}
-                          </span>
+                          </p>
                         )}
+                        <p className="mt-0.5 text-muted-foreground text-xs">
+                          {new Date(
+                            referredUser.joinedAt || referredUser.createdAt
+                          ).toLocaleDateString()}
+                        </p>
                       </div>
-                      <span className="text-muted-foreground text-xs">
-                        {new Date(
-                          referredUser.joinedAt || referredUser.createdAt
-                        ).toLocaleDateString()}
-                      </span>
+
+                      {/* View Profile */}
                       <a
                         href={getProfileUrl(
                           referredUser.id,
                           referredUser.username
                         )}
-                        className="text-muted-foreground transition-colors hover:text-foreground"
+                        className="p-2 text-muted-foreground transition-colors hover:text-foreground"
                         aria-label="View profile"
                       >
                         <ExternalLink className="h-4 w-4" />
@@ -645,8 +922,8 @@ export default function RewardsPage() {
                     </div>
                   ))}
                 </div>
-              </div>
-            )}
+              )}
+            </div>
           </div>
         </div>
       )}

--- a/apps/web/src/app/rewards/page.tsx
+++ b/apps/web/src/app/rewards/page.tsx
@@ -335,12 +335,12 @@ export default function RewardsPage() {
               {/* Total Points */}
               <div className="rounded-lg border border-border p-4">
                 <div className="mb-2 flex items-center gap-2">
-                  <TrendingUp className="h-5 w-5 text-[#0066FF]" />
+                  <TrendingUp className="h-5 w-5 text-primary" />
                   <h2 className="font-medium text-muted-foreground text-sm">
                     Total Points
                   </h2>
                 </div>
-                <div className="font-bold text-3xl text-[#0066FF]">
+                <div className="font-bold text-3xl text-primary">
                   {referralData.user.totalPoints.toLocaleString()}
                 </div>
               </div>
@@ -348,7 +348,7 @@ export default function RewardsPage() {
               {/* Total Referrals */}
               <div className="rounded-lg border border-border p-4">
                 <div className="mb-2 flex items-center gap-2">
-                  <Users className="h-5 w-5 text-[#0066FF]" />
+                  <Users className="h-5 w-5 text-primary" />
                   <h2 className="font-medium text-muted-foreground text-sm">
                     Total Referrals
                   </h2>
@@ -385,7 +385,7 @@ export default function RewardsPage() {
                               : referralData.stats.weeklyReferralCount >=
                                   referralData.stats.weeklyLimit * 0.8
                                 ? 'bg-yellow-500'
-                                : 'bg-[#0066FF]'
+                                : 'bg-primary'
                           }`}
                           style={{
                             width: `${Math.min(100, (referralData.stats.weeklyReferralCount / referralData.stats.weeklyLimit) * 100)}%`,
@@ -403,7 +403,7 @@ export default function RewardsPage() {
             {/* Reward Tasks */}
             <div className="rounded-lg border border-border p-4">
               <div className="mb-4 flex items-center gap-2">
-                <TrendingUp className="h-5 w-5 text-[#0066FF]" />
+                <TrendingUp className="h-5 w-5 text-primary" />
                 <h2 className="font-bold text-base text-foreground">
                   Earn Points
                 </h2>
@@ -458,7 +458,7 @@ export default function RewardsPage() {
                   onClick={() => setShowShareModal(true)}
                   className="flex w-full cursor-pointer items-center gap-4 rounded-lg border border-border p-4 text-left transition-all hover:bg-muted/50"
                 >
-                  <div className="shrink-0 text-[#0066FF]">
+                  <div className="shrink-0 text-primary">
                     <Share2 className="h-6 w-6" />
                   </div>
                   <div className="min-w-0 flex-1">
@@ -484,7 +484,7 @@ export default function RewardsPage() {
             {/* Referral Link */}
             <div className="rounded-lg border border-border p-4">
               <div className="mb-3 flex items-center gap-2">
-                <Gift className="h-5 w-5 text-[#0066FF]" />
+                <Gift className="h-5 w-5 text-primary" />
                 <h2 className="font-bold text-base text-foreground">
                   Referral Link
                 </h2>
@@ -543,7 +543,7 @@ export default function RewardsPage() {
             <div>
               <div className="mb-3 flex items-center justify-between">
                 <h2 className="flex items-center gap-1.5 font-bold text-base text-foreground">
-                  <Users className="h-4 w-4 text-[#0066FF]" />
+                  <Users className="h-4 w-4 text-primary" />
                   Your Referrals
                 </h2>
               </div>
@@ -652,12 +652,12 @@ export default function RewardsPage() {
               {/* Total Points */}
               <div className="rounded-lg border border-border p-3">
                 <div className="mb-1 flex items-center gap-1">
-                  <TrendingUp className="h-4 w-4 text-[#0066FF]" />
+                  <TrendingUp className="h-4 w-4 text-primary" />
                   <h2 className="font-medium text-muted-foreground text-xs">
                     Total Points
                   </h2>
                 </div>
-                <div className="font-bold text-2xl text-[#0066FF]">
+                <div className="font-bold text-2xl text-primary">
                   {referralData.user.totalPoints.toLocaleString()}
                 </div>
               </div>
@@ -665,7 +665,7 @@ export default function RewardsPage() {
               {/* Total Referrals */}
               <div className="rounded-lg border border-border p-3">
                 <div className="mb-1 flex items-center gap-1">
-                  <Users className="h-4 w-4 text-[#0066FF]" />
+                  <Users className="h-4 w-4 text-primary" />
                   <h2 className="font-medium text-muted-foreground text-xs">
                     Referrals
                   </h2>
@@ -702,7 +702,7 @@ export default function RewardsPage() {
                               : referralData.stats.weeklyReferralCount >=
                                   referralData.stats.weeklyLimit * 0.8
                                 ? 'bg-yellow-500'
-                                : 'bg-[#0066FF]'
+                                : 'bg-primary'
                           }`}
                           style={{
                             width: `${Math.min(100, (referralData.stats.weeklyReferralCount / referralData.stats.weeklyLimit) * 100)}%`,
@@ -720,7 +720,7 @@ export default function RewardsPage() {
             {/* Reward Tasks */}
             <div className="space-y-3">
               <h2 className="flex items-center gap-2 font-bold text-foreground text-lg">
-                <TrendingUp className="h-5 w-5 text-[#0066FF]" />
+                <TrendingUp className="h-5 w-5 text-primary" />
                 Earn Points
               </h2>
 
@@ -774,7 +774,7 @@ export default function RewardsPage() {
                   onClick={() => setShowShareModal(true)}
                   className="flex w-full cursor-pointer items-center gap-3 rounded-lg border border-border p-3 text-left transition-all hover:bg-muted/50"
                 >
-                  <div className="shrink-0 text-[#0066FF]">
+                  <div className="shrink-0 text-primary">
                     <Share2 className="h-5 w-5" />
                   </div>
                   <div className="min-w-0 flex-1">
@@ -800,7 +800,7 @@ export default function RewardsPage() {
             <div className="rounded-lg border border-border p-4">
               <div className="mb-3">
                 <div className="flex items-center gap-2">
-                  <Gift className="h-5 w-5 text-[#0066FF]" />
+                  <Gift className="h-5 w-5 text-primary" />
                   <h2 className="font-bold text-base text-foreground">
                     Referral Link
                   </h2>
@@ -855,7 +855,7 @@ export default function RewardsPage() {
             <div>
               <div className="mb-3 flex items-center justify-between">
                 <h2 className="flex items-center gap-2 font-bold text-base text-foreground">
-                  <Users className="h-5 w-5 text-[#0066FF]" />
+                  <Users className="h-5 w-5 text-primary" />
                   Your Referrals
                 </h2>
               </div>

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -2,12 +2,16 @@
 
 import { cn, logger } from '@babylon/shared';
 import {
-  ArrowLeft,
+  AlertCircle,
+  CheckCircle2,
   Key,
+  Monitor,
+  Moon,
   Palette,
   Receipt,
   Save,
   Shield,
+  Sun,
   User,
 } from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
@@ -30,6 +34,27 @@ import { useAuthStore } from '@/stores/authStore';
 function isBillingEnabled(): boolean {
   return process.env.NEXT_PUBLIC_BILLING_ENABLED === 'true';
 }
+
+const themeOptions = [
+  {
+    value: 'light',
+    label: 'Light',
+    description: 'Light background with dark text',
+    icon: Sun,
+  },
+  {
+    value: 'dark',
+    label: 'Dark',
+    description: 'Dark background with light text',
+    icon: Moon,
+  },
+  {
+    value: 'system',
+    label: 'System',
+    description: 'Match your system settings',
+    icon: Monitor,
+  },
+] as const;
 
 export default function SettingsPage() {
   const router = useRouter();
@@ -211,32 +236,38 @@ export default function SettingsPage() {
 
   if (!ready) {
     return (
-      <PageContainer>
-        <div className="mx-auto w-full max-w-2xl space-y-6 px-4 sm:px-0">
-          <div className="space-y-2">
-            <Skeleton className="h-8 w-32 max-w-full" />
-            <Skeleton className="h-4 w-64 max-w-full" />
-          </div>
-          {Array.from({ length: 3 }).map((_, i) => (
-            <div
-              key={i}
-              className="space-y-4 rounded-lg border border-border bg-card/50 px-4 py-3 backdrop-blur sm:px-6 sm:py-4"
-            >
-              <Skeleton className="mb-4 h-6 w-40 max-w-full" />
-              {Array.from({ length: 2 }).map((_, j) => (
-                <div
-                  key={j}
-                  className="flex items-center justify-between gap-3 border-border/5 border-b py-3 last:border-0"
-                >
-                  <div className="min-w-0 flex-1 space-y-2">
-                    <Skeleton className="h-4 w-32 max-w-full" />
-                    <Skeleton className="h-3 w-48 max-w-full" />
-                  </div>
-                  <Skeleton className="h-8 w-16 shrink-0 rounded-full" />
-                </div>
-              ))}
+      <PageContainer noPadding className="flex w-full flex-col">
+        <div className="flex min-w-0 flex-1 flex-col border-border lg:border-r lg:border-l">
+          {/* Header skeleton */}
+          <div className="sticky top-0 z-10 flex-shrink-0 bg-background/95 backdrop-blur-sm">
+            <div className="mx-auto w-full max-w-4xl px-4 md:px-6">
+              <div className="flex items-center gap-4 py-3">
+                <Skeleton className="h-6 w-24" />
+              </div>
+              {/* Tab navigation skeleton */}
+              <div className="flex gap-1 border-border border-b">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <Skeleton key={i} className="h-10 w-20" />
+                ))}
+              </div>
             </div>
-          ))}
+          </div>
+          <div className="mx-auto w-full max-w-4xl px-4 md:px-6">
+            {/* Form fields skeleton */}
+            <div className="pt-6">
+              <div className="space-y-5 rounded-lg border border-border p-5">
+                {Array.from({ length: 3 }).map((_, i) => (
+                  <div key={i} className="space-y-2">
+                    <Skeleton className="h-4 w-28" />
+                    <Skeleton className="h-11 w-full rounded-lg" />
+                  </div>
+                ))}
+                <div className="border-border border-t pt-5">
+                  <Skeleton className="h-11 w-36 rounded-full" />
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </PageContainer>
     );
@@ -244,217 +275,232 @@ export default function SettingsPage() {
 
   if (!authenticated) {
     return (
-      <PageContainer>
-        <div className="mx-auto max-w-2xl py-12 text-center">
-          <h1 className="mb-4 font-bold text-3xl">Settings</h1>
-          <p className="mb-8 text-muted-foreground">
-            Please sign in to access your settings.
-          </p>
-          <LoginButton />
+      <PageContainer noPadding className="flex w-full flex-col">
+        <div className="flex min-w-0 flex-1 flex-col border-border lg:border-r lg:border-l">
+          <div className="sticky top-0 z-10 flex-shrink-0 bg-background/95 backdrop-blur-sm">
+            <div className="mx-auto w-full max-w-4xl px-4 py-3 md:px-6">
+              <h1 className="font-bold text-xl">Settings</h1>
+            </div>
+          </div>
+          <div className="mx-auto max-w-2xl px-4 py-12 text-center md:px-6">
+            <p className="mb-8 text-muted-foreground">
+              Please sign in to access your settings.
+            </p>
+            <LoginButton />
+          </div>
         </div>
       </PageContainer>
     );
   }
 
   return (
-    <PageContainer>
-      <div className="mx-auto max-w-4xl pb-24">
-        {/* Header */}
-        <div className="mb-8">
-          <button
-            onClick={() => router.back()}
-            className="mb-4 flex items-center gap-3 text-muted-foreground transition-colors hover:text-foreground"
-          >
-            <ArrowLeft className="h-5 w-5" />
-            <span>Back</span>
-          </button>
-          <h1 className="font-bold text-3xl">Settings</h1>
-        </div>
-
-        {/* Tab Navigation */}
-        <div className="mb-8 flex gap-1 overflow-x-auto border-border border-b">
-          {tabs.map((tab) => {
-            const Icon = tab.icon;
-            return (
-              <button
-                key={tab.id}
-                onClick={() => handleTabChange(tab.id)}
-                className={cn(
-                  'flex items-center gap-2 whitespace-nowrap border-b-2 px-4 py-3 transition-all',
-                  activeTab === tab.id
-                    ? 'border-[#0066FF] text-[#0066FF]'
-                    : 'border-transparent text-muted-foreground hover:text-foreground'
-                )}
-              >
-                <Icon className="h-4 w-4" />
-                <span className="font-medium">{tab.label}</span>
-              </button>
-            );
-          })}
-        </div>
-
-        {/* Tab Content */}
-        <div className="space-y-6 pb-8">
-          {activeTab === 'profile' && (
-            <div className="space-y-6">
-              <div>
-                <label
-                  htmlFor="displayName"
-                  className="mb-2 block font-medium text-sm"
-                >
-                  Display Name
-                </label>
-                <input
-                  id="displayName"
-                  type="text"
-                  value={displayName}
-                  onChange={(e) => setDisplayName(e.target.value)}
-                  className="w-full rounded-lg border border-border bg-muted px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#0066FF]"
-                  placeholder="Enter your display name"
-                />
-              </div>
-
-              <div>
-                <label
-                  htmlFor="username"
-                  className="mb-2 block font-medium text-sm"
-                >
-                  Username
-                </label>
-                <input
-                  id="username"
-                  type="text"
-                  value={username}
-                  onChange={(e) => setUsername(e.target.value)}
-                  disabled={Boolean(
-                    usernameChangeLimit && !usernameChangeLimit.canChange
-                  )}
-                  className="w-full rounded-lg border border-border bg-muted px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#0066FF] disabled:cursor-not-allowed disabled:opacity-50"
-                  placeholder="Enter your username"
-                />
-                {usernameChangeLimit && !usernameChangeLimit.canChange ? (
-                  <p className="mt-1 text-xs text-yellow-500">
-                    Username can only be changed once every 24 hours. Please
-                    wait {usernameChangeLimit.hours}h{' '}
-                    {usernameChangeLimit.minutes}m before changing again.
-                  </p>
-                ) : (
-                  <p className="mt-1 text-muted-foreground text-xs">
-                    Username can be changed once every 24 hours. Changing your
-                    username will update your referral code.
-                  </p>
-                )}
-              </div>
-
-              <div>
-                <label htmlFor="bio" className="mb-2 block font-medium text-sm">
-                  Bio
-                </label>
-                <textarea
-                  id="bio"
-                  value={bio}
-                  onChange={(e) => setBio(e.target.value)}
-                  rows={4}
-                  className="w-full resize-none rounded-lg border border-border bg-muted px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#0066FF]"
-                  placeholder="Tell us about yourself..."
-                />
-              </div>
+    <PageContainer noPadding className="flex w-full flex-col">
+      <div className="flex min-w-0 flex-1 flex-col border-border lg:border-r lg:border-l">
+        {/* Sticky Header + Tab Navigation */}
+        <div className="sticky top-0 z-10 flex-shrink-0 bg-background/95 backdrop-blur-sm">
+          <div className="mx-auto w-full max-w-4xl px-4 md:px-6">
+            <div className="py-3">
+              <h1 className="font-bold text-xl">Settings</h1>
             </div>
-          )}
+            <div className="flex gap-1 overflow-x-auto border-border border-b">
+              {tabs.map((tab) => {
+                const Icon = tab.icon;
+                return (
+                  <button
+                    key={tab.id}
+                    onClick={() => handleTabChange(tab.id)}
+                    className={cn(
+                      'flex items-center gap-2 whitespace-nowrap border-b-2 px-4 py-3 font-semibold text-sm transition-all',
+                      activeTab === tab.id
+                        ? 'border-primary text-primary'
+                        : 'border-transparent text-muted-foreground hover:bg-muted/30 hover:text-foreground'
+                    )}
+                  >
+                    <Icon className="h-4 w-4" />
+                    <span>{tab.label}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </div>
 
-          {activeTab === 'theme' && (
-            <div className="space-y-6">
-              <div>
-                <h3 className="mb-4 font-medium">Theme Preference</h3>
+        <div className="mx-auto w-full max-w-4xl px-4 pb-24 md:px-6">
+          {/* Tab Content */}
+          <div className="pt-6">
+            {activeTab === 'profile' && (
+              <div className="rounded-lg border border-border p-5">
+                <div className="space-y-5">
+                  <div>
+                    <label
+                      htmlFor="displayName"
+                      className="mb-2 block font-medium text-muted-foreground text-sm"
+                    >
+                      Display Name
+                    </label>
+                    <input
+                      id="displayName"
+                      type="text"
+                      value={displayName}
+                      onChange={(e) => setDisplayName(e.target.value)}
+                      className="min-h-[44px] w-full rounded-lg border border-border px-4 py-3 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+                      placeholder="Enter your display name"
+                    />
+                  </div>
+
+                  <div>
+                    <label
+                      htmlFor="username"
+                      className="mb-2 block font-medium text-muted-foreground text-sm"
+                    >
+                      Username
+                    </label>
+                    <input
+                      id="username"
+                      type="text"
+                      value={username}
+                      onChange={(e) => setUsername(e.target.value)}
+                      disabled={Boolean(
+                        usernameChangeLimit && !usernameChangeLimit.canChange
+                      )}
+                      className="min-h-[44px] w-full rounded-lg border border-border px-4 py-3 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30 disabled:cursor-not-allowed disabled:opacity-50"
+                      placeholder="Enter your username"
+                    />
+                    {usernameChangeLimit && !usernameChangeLimit.canChange ? (
+                      <div className="mt-2 flex items-start gap-2 rounded-lg border border-yellow-500/20 bg-yellow-500/10 p-3">
+                        <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-yellow-500" />
+                        <p className="text-xs text-yellow-500">
+                          Username can only be changed once every 24 hours.
+                          Please wait {usernameChangeLimit.hours}h{' '}
+                          {usernameChangeLimit.minutes}m before changing again.
+                        </p>
+                      </div>
+                    ) : (
+                      <p className="mt-1 text-muted-foreground text-xs">
+                        Username can be changed once every 24 hours. Changing
+                        your username will update your referral code.
+                      </p>
+                    )}
+                  </div>
+
+                  <div>
+                    <label
+                      htmlFor="bio"
+                      className="mb-2 block font-medium text-muted-foreground text-sm"
+                    >
+                      Bio
+                    </label>
+                    <textarea
+                      id="bio"
+                      value={bio}
+                      onChange={(e) => setBio(e.target.value)}
+                      rows={4}
+                      className="min-h-[44px] w-full resize-none rounded-lg border border-border px-4 py-3 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-primary/30"
+                      placeholder="Tell us about yourself..."
+                    />
+                  </div>
+                </div>
+
+                {/* Save area */}
+                <div className="mt-3">
+                  {errorMessage && (
+                    <div className="mb-3 flex items-start gap-2 rounded-lg border border-red-500/20 bg-red-500/10 p-3">
+                      <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-500" />
+                      <p className="text-red-500 text-sm">{errorMessage}</p>
+                    </div>
+                  )}
+                  {user?.onChainRegistered !== true && !errorMessage && (
+                    <div className="mb-3 flex items-start gap-2 rounded-lg border border-yellow-500/20 bg-yellow-500/10 p-3">
+                      <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-yellow-500" />
+                      <p className="text-sm text-yellow-500">
+                        Complete your on-chain registration before editing your
+                        profile.
+                      </p>
+                    </div>
+                  )}
+                  <div className="flex justify-end">
+                    <button
+                      onClick={handleSave}
+                      disabled={saving || user?.onChainRegistered !== true}
+                      className={cn(
+                        'flex min-h-[44px] items-center gap-2 px-6 py-3 font-medium transition-all',
+                        'bg-primary text-primary-foreground hover:bg-primary/90',
+                        'disabled:cursor-not-allowed disabled:opacity-50'
+                      )}
+                    >
+                      <Save className="h-4 w-4" />
+                      <span>
+                        {saving
+                          ? 'Saving...'
+                          : saved
+                            ? 'Saved!'
+                            : 'Save Changes'}
+                      </span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {activeTab === 'theme' && (
+              <div className="space-y-5">
                 {!mounted ? (
                   <div className="flex items-center justify-center py-8">
                     <Skeleton className="h-32 w-full" />
                   </div>
                 ) : (
-                  <div className="space-y-2">
-                    {['light', 'dark', 'system'].map((themeOption) => (
-                      <label
-                        key={themeOption}
-                        className="flex cursor-pointer items-center gap-3 rounded-lg border border-border p-3 transition-colors hover:bg-muted"
-                      >
-                        <input
-                          type="radio"
-                          name="theme"
-                          value={themeOption}
-                          checked={theme === themeOption}
-                          onChange={() => setTheme(themeOption)}
-                          className="h-4 w-4 text-[#0066FF]"
-                        />
-                        <div>
-                          <p className="font-medium capitalize">
-                            {themeOption}
-                          </p>
-                          <p className="text-muted-foreground text-sm">
-                            {themeOption === 'light' &&
-                              'Light background with dark text'}
-                            {themeOption === 'dark' &&
-                              'Dark background with light text'}
-                            {themeOption === 'system' &&
-                              'Match your system settings'}
-                          </p>
-                        </div>
-                      </label>
-                    ))}
-                  </div>
+                  <>
+                    <div className="grid gap-3">
+                      {themeOptions.map((option) => {
+                        const Icon = option.icon;
+                        const isSelected = theme === option.value;
+                        return (
+                          <button
+                            key={option.value}
+                            type="button"
+                            onClick={() => setTheme(option.value)}
+                            className={cn(
+                              'flex items-center gap-3 rounded-lg border p-4 text-left transition-all',
+                              isSelected
+                                ? 'border-primary bg-primary/5'
+                                : 'border-border hover:bg-muted/30'
+                            )}
+                          >
+                            <Icon className="h-5 w-5 shrink-0 text-muted-foreground" />
+                            <div className="flex-1">
+                              <p className="font-medium">{option.label}</p>
+                              <p className="text-muted-foreground text-sm">
+                                {option.description}
+                              </p>
+                            </div>
+                            {isSelected && (
+                              <CheckCircle2 className="h-5 w-5 shrink-0 text-primary" />
+                            )}
+                          </button>
+                        );
+                      })}
+                    </div>
+                    <p className="text-muted-foreground text-xs">
+                      Theme preference is saved automatically and applied
+                      immediately.
+                    </p>
+                  </>
                 )}
               </div>
-            </div>
-          )}
+            )}
 
-          {/* Billing Tab - Feature Flagged */}
-          {activeTab === 'billing' && billingEnabled && <BillingTab />}
+            {/* Billing Tab - Feature Flagged */}
+            {activeTab === 'billing' && billingEnabled && <BillingTab />}
 
-          {/* Security Tab */}
-          {activeTab === 'security' && <SecurityTab />}
+            {/* Security Tab */}
+            {activeTab === 'security' && <SecurityTab />}
 
-          {/* Privacy Tab */}
-          {activeTab === 'privacy' && <PrivacyTab />}
+            {/* Privacy Tab */}
+            {activeTab === 'privacy' && <PrivacyTab />}
 
-          {/* API Keys Tab */}
-          {activeTab === 'api' && <ApiKeysTab />}
-
-          {/* Save Button - Only show for profile tab (theme saves automatically) */}
-          {activeTab === 'profile' && (
-            <div className="border-border border-t pt-6">
-              {errorMessage && (
-                <p className="mb-4 text-red-500 text-sm">{errorMessage}</p>
-              )}
-              {user?.onChainRegistered !== true && !errorMessage && (
-                <p className="mb-4 text-sm text-yellow-500">
-                  Complete your on-chain registration before editing your
-                  profile.
-                </p>
-              )}
-              <button
-                onClick={handleSave}
-                disabled={saving || user?.onChainRegistered !== true}
-                className={cn(
-                  'flex items-center gap-2 rounded-lg px-6 py-3 font-medium transition-all',
-                  'bg-[#0066FF] text-primary-foreground hover:bg-[#2952d9]',
-                  'disabled:cursor-not-allowed disabled:opacity-50'
-                )}
-              >
-                <Save className="h-4 w-4" />
-                <span>
-                  {saving ? 'Saving...' : saved ? 'Saved!' : 'Save Changes'}
-                </span>
-              </button>
-            </div>
-          )}
-
-          {/* Theme saves automatically, show confirmation */}
-          {activeTab === 'theme' && mounted && (
-            <div className="border-border border-t pt-6">
-              <p className="text-muted-foreground text-sm">
-                Theme preference is saved automatically and applied immediately.
-              </p>
-            </div>
-          )}
+            {/* API Keys Tab */}
+            {activeTab === 'api' && <ApiKeysTab />}
+          </div>
         </div>
       </div>
     </PageContainer>

--- a/apps/web/src/app/trending/[tag]/loading.tsx
+++ b/apps/web/src/app/trending/[tag]/loading.tsx
@@ -6,7 +6,7 @@ export default function TrendingTagLoading() {
     <PageContainer noPadding className="flex w-full flex-col">
       <div className="relative flex min-h-screen flex-1">
         {/* Desktop */}
-        <div className="hidden min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:flex lg:border-r lg:border-l">
+        <div className="hidden min-w-0 flex-1 flex-col border-border lg:flex lg:border-r lg:border-l">
           {/* Header */}
           <div className="sticky top-0 z-10 shrink-0 bg-background shadow-sm">
             <div className="px-6 py-4">

--- a/apps/web/src/app/trending/[tag]/page.tsx
+++ b/apps/web/src/app/trending/[tag]/page.tsx
@@ -183,7 +183,7 @@ export default function TrendingTagPage() {
     <PageContainer noPadding className="flex w-full flex-col">
       <div className="relative flex min-h-screen flex-1">
         {/* Desktop: Content area */}
-        <div className="hidden min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:flex lg:border-r lg:border-l">
+        <div className="hidden min-w-0 flex-1 flex-col border-border lg:flex lg:border-r lg:border-l">
           {/* Desktop header */}
           <div className="sticky top-0 z-10 shrink-0 bg-background shadow-sm">
             <div className="px-6 py-4">

--- a/apps/web/src/app/trending/[tag]/page.tsx
+++ b/apps/web/src/app/trending/[tag]/page.tsx
@@ -196,7 +196,7 @@ export default function TrendingTagPage() {
                   <ArrowLeft size={20} />
                 </button>
                 <div className="flex items-center gap-2">
-                  <TrendingUp className="h-5 w-5 text-[#0066FF]" />
+                  <TrendingUp className="h-5 w-5 text-primary" />
                   <h1 className="font-bold text-xl">{headerTitle}</h1>
                 </div>
                 {headerCategory && (
@@ -232,7 +232,7 @@ export default function TrendingTagPage() {
                 <ArrowLeft size={20} />
               </button>
               <div className="flex items-center gap-2">
-                <TrendingUp className="h-5 w-5 text-[#0066FF]" />
+                <TrendingUp className="h-5 w-5 text-primary" />
                 <h1 className="font-bold text-xl">{headerTitle}</h1>
               </div>
               {headerCategory && (

--- a/apps/web/src/app/trending/group/page.tsx
+++ b/apps/web/src/app/trending/group/page.tsx
@@ -137,7 +137,7 @@ export default function GroupedTrendingPage() {
     <PageContainer noPadding className="flex w-full flex-col">
       <div className="relative flex min-h-screen flex-1">
         {/* Desktop: Content area */}
-        <div className="hidden min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:flex lg:border-r lg:border-l">
+        <div className="hidden min-w-0 flex-1 flex-col border-border lg:flex lg:border-r lg:border-l">
           {/* Desktop header */}
           <div className="sticky top-0 z-10 shrink-0 bg-background shadow-sm">
             <div className="px-6 py-4">

--- a/apps/web/src/app/trending/group/page.tsx
+++ b/apps/web/src/app/trending/group/page.tsx
@@ -150,7 +150,7 @@ export default function GroupedTrendingPage() {
                   <ArrowLeft size={20} />
                 </button>
                 <div className="flex items-center gap-2">
-                  <TrendingUp className="h-5 w-5 text-[#0066FF]" />
+                  <TrendingUp className="h-5 w-5 text-primary" />
                   <h1 className="font-bold text-xl">{headerTitle}</h1>
                 </div>
                 {headerCategory && (
@@ -186,7 +186,7 @@ export default function GroupedTrendingPage() {
                 <ArrowLeft size={20} />
               </button>
               <div className="flex items-center gap-2">
-                <TrendingUp className="h-5 w-5 text-[#0066FF]" />
+                <TrendingUp className="h-5 w-5 text-primary" />
                 <h1 className="font-bold text-xl">{headerTitle}</h1>
               </div>
               {headerCategory && (

--- a/apps/web/src/components/agents/AgentChat.tsx
+++ b/apps/web/src/components/agents/AgentChat.tsx
@@ -547,11 +547,6 @@ export function AgentChat({
           </div>
         )}
 
-        {/* Input Separator */}
-        <div className="px-4">
-          <Separator />
-        </div>
-
         {/* Message Input - with mention support */}
         <MessageInput
           value={input}

--- a/apps/web/src/components/auth/FeedAuthBanner.tsx
+++ b/apps/web/src/components/auth/FeedAuthBanner.tsx
@@ -51,7 +51,7 @@ function FeedAuthBannerContent() {
         'border-border border-t-2'
       )}
     >
-      <div className="mx-auto max-w-7xl px-4 py-4">
+      <div className="mark mx-auto max-w-7xl px-4 py-4 md:pl-20 lg:pl-64 xl:pr-96">
         <div className="flex items-center justify-between gap-4">
           <div className="flex-1">
             <h3 className="mb-1 font-bold text-lg">Join the conversation.</h3>

--- a/apps/web/src/components/auth/UserMenu.tsx
+++ b/apps/web/src/components/auth/UserMenu.tsx
@@ -1,7 +1,15 @@
 'use client';
 
 import { getDisplayReferralUrl, getReferralUrl } from '@babylon/shared';
-import { BookOpen, Check, Copy, Key, LogOut, Settings } from 'lucide-react';
+import {
+  BookOpen,
+  Check,
+  Copy,
+  Key,
+  LogOut,
+  MoreHorizontal,
+  Settings,
+} from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import { useGameGuide } from '@/components/providers/GameGuideProvider';
@@ -224,7 +232,7 @@ export function UserMenu() {
   const trigger = (
     <div
       data-testid="user-menu"
-      className="flex cursor-pointer items-center gap-3 rounded-full px-3 py-2.5 transition-colors hover:bg-sidebar-accent"
+      className="group flex w-full cursor-pointer items-center gap-3 px-4 py-3 transition-colors duration-200 hover:bg-sidebar-accent"
     >
       <Avatar
         id={user.id}
@@ -235,13 +243,14 @@ export function UserMenu() {
         imageUrl={user.profileImageUrl || undefined}
       />
       <div className="min-w-0 flex-1">
-        <p className="truncate font-semibold text-[15px] text-sidebar-foreground leading-5">
+        <p className="truncate text-lg text-sidebar-foreground leading-5 group-hover:text-black dark:group-hover:text-white">
           {displayName}
         </p>
-        <p className="truncate text-[13px] text-muted-foreground leading-4">
+        <p className="truncate text-muted-foreground text-xs leading-4">
           @{username}
         </p>
       </div>
+      <MoreHorizontal className="h-5 w-5 shrink-0 text-muted-foreground" />
     </div>
   );
 
@@ -250,20 +259,23 @@ export function UserMenu() {
   const tradingBalanceValue = tradingBalance ?? 0;
 
   return (
-    <Dropdown trigger={trigger} placement="top-right" width="default">
+    <Dropdown
+      trigger={trigger}
+      placement="top-left"
+      width="sidebar"
+      popoverClassName="border-r-0 rounded-r-none"
+    >
       {/* Points Display */}
-      <div className="border-sidebar-accent border-b px-5 py-4">
+      <div className="border-sidebar-accent border-b px-4 py-3">
         <div className="flex items-center justify-between">
-          <span className="font-semibold text-muted-foreground text-sm">
-            Total Points
-          </span>
-          <span className="font-bold text-foreground text-xl">
+          <span className="text-muted-foreground text-sm">Total Points</span>
+          <span className="font-semibold text-lg text-sidebar-foreground">
             {totalPointsValue.toLocaleString()}
           </span>
         </div>
-        <div className="mt-2 flex items-center justify-between">
+        <div className="mt-1 flex items-center justify-between">
           <span className="text-muted-foreground text-xs">Trading Balance</span>
-          <span className="font-semibold text-foreground text-sm">
+          <span className="text-sidebar-foreground text-sm">
             {tradingBalanceValue.toLocaleString()}
           </span>
         </div>
@@ -271,62 +283,53 @@ export function UserMenu() {
 
       {user?.referralCode && (
         <DropdownItem onClick={handleCopyReferralCode}>
-          <div className="flex items-center gap-3 py-2">
+          <div className="flex items-center gap-3">
             {copiedCode ? (
-              <>
-                <Check className="h-5 w-5 text-green-500" />
-                <span className="font-semibold text-green-500 text-sm">
-                  Link Copied!
-                </span>
-              </>
+              <Check className="h-6 w-6 text-green-500" />
             ) : (
-              <>
-                <Copy className="h-5 w-5" style={{ color: '#0066FF' }} />
-                <div className="flex min-w-0 flex-1 flex-col">
-                  <span className="font-semibold text-foreground text-sm">
-                    Copy Referral Link
-                  </span>
-                  <span className="truncate font-mono text-muted-foreground text-xs">
-                    {getDisplayReferralUrl(user.referralCode)}
-                  </span>
-                </div>
-              </>
+              <Copy className="h-6 w-6 text-sidebar-foreground" />
             )}
+            <div className="flex min-w-0 flex-1 flex-col">
+              <span
+                className={
+                  copiedCode ? 'text-green-500' : 'text-sidebar-foreground'
+                }
+              >
+                {copiedCode ? 'Link Copied!' : 'Copy Referral Link'}
+              </span>
+              <span className="truncate font-mono text-muted-foreground text-xs">
+                {getDisplayReferralUrl(user.referralCode)}
+              </span>
+            </div>
           </div>
         </DropdownItem>
       )}
 
       <DropdownItem onClick={() => router.push('/settings')}>
-        <div className="flex items-center gap-3 py-2">
-          <Settings className="h-5 w-5" style={{ color: '#0066FF' }} />
-          <span className="font-semibold text-foreground text-sm">
-            Settings
-          </span>
+        <div className="flex items-center gap-3">
+          <Settings className="h-6 w-6 text-sidebar-foreground" />
+          <span className="text-sidebar-foreground">Settings</span>
         </div>
       </DropdownItem>
 
       <DropdownItem onClick={openGuide}>
-        <div className="flex items-center gap-3 py-2">
-          <BookOpen className="h-5 w-5" style={{ color: '#0066FF' }} />
-          <span className="font-semibold text-foreground text-sm">
-            Game Guide
-          </span>
+        <div className="flex items-center gap-3">
+          <BookOpen className="h-6 w-6 text-sidebar-foreground" />
+          <span className="text-sidebar-foreground">Game Guide</span>
         </div>
       </DropdownItem>
 
       <DropdownItem onClick={() => router.push('/settings?tab=api')}>
-        <div className="flex items-center gap-3 py-2">
-          <Key className="h-5 w-5" style={{ color: '#0066FF' }} />
-          <span className="font-semibold text-foreground text-sm">
-            API Keys
-          </span>
+        <div className="flex items-center gap-3">
+          <Key className="h-6 w-6 text-sidebar-foreground" />
+          <span className="text-sidebar-foreground">API Keys</span>
         </div>
       </DropdownItem>
 
       <DropdownItem onClick={logout}>
-        <div className="flex items-center gap-3 py-2 text-destructive hover:text-destructive/90">
-          <LogOut className="h-5 w-5" />
-          <span className="font-semibold">Logout</span>
+        <div className="flex items-center gap-3 text-destructive">
+          <LogOut className="h-6 w-6" />
+          <span>Logout</span>
         </div>
       </DropdownItem>
     </Dropdown>

--- a/apps/web/src/components/chats/ChatView.tsx
+++ b/apps/web/src/components/chats/ChatView.tsx
@@ -144,11 +144,6 @@ export function ChatView({
           />
         )}
 
-        {/* Input Separator */}
-        <div className="px-4">
-          <Separator />
-        </div>
-
         {/* Message Input with mention support */}
         <MessageInput
           value={messageInput}

--- a/apps/web/src/components/chats/ChatViewHeader.tsx
+++ b/apps/web/src/components/chats/ChatViewHeader.tsx
@@ -38,8 +38,8 @@ export function ChatViewHeader({
   onLeaveChat,
 }: ChatViewHeaderProps) {
   return (
-    <div className="bg-background px-4 py-4">
-      <div className="flex items-center gap-3">
+    <div className="overflow-hidden bg-background px-4 py-4">
+      <div className="flex min-w-0 items-center gap-3">
         {showBackButton && (
           <button
             onClick={onBack}
@@ -73,21 +73,23 @@ export function ChatViewHeader({
         )}
 
         {/* Chat name and status */}
-        <div className="flex-1">
-          <div className="flex items-center gap-2">
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-2">
             {chatDetails.chat.isGroup ? (
-              <h3 className="font-bold text-foreground text-lg">
+              <h3 className="truncate font-bold text-foreground text-lg">
                 {chatDetails.chat.name || 'Chat'}
               </h3>
             ) : chatDetails.chat.otherUser ? (
               <Link
                 href={getProfilePath(chatDetails.chat.otherUser)}
-                className="font-bold text-foreground text-lg transition-colors hover:text-primary"
+                className="truncate font-bold text-foreground text-lg transition-colors hover:text-primary"
               >
                 {chatDetails.chat.otherUser.displayName || 'Chat'}
               </Link>
             ) : (
-              <h3 className="font-bold text-foreground text-lg">Chat</h3>
+              <h3 className="truncate font-bold text-foreground text-lg">
+                Chat
+              </h3>
             )}
 
             {/* SSE status */}

--- a/apps/web/src/components/chats/MessageInput.tsx
+++ b/apps/web/src/components/chats/MessageInput.tsx
@@ -1,8 +1,14 @@
 'use client';
 
 import { cn } from '@babylon/shared';
-import { Send } from 'lucide-react';
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import { ArrowUp } from 'lucide-react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { LoginButton } from '@/components/auth/LoginButton';
 import { Skeleton } from '@/components/shared/Skeleton';
 import {
@@ -497,6 +503,10 @@ export function MessageInput({
   const placeholderText = placeholder || 'Type a message...';
   const compact = density === 'compact';
 
+  const [isFocused, setIsFocused] = useState(false);
+  const hasContent = value.trim().length > 0;
+  const canSend = hasContent && !sending && !disabled;
+
   if (!authenticated) {
     return (
       <div className={cn('bg-background', compact ? 'px-3 py-2' : 'px-4 py-3')}>
@@ -511,13 +521,7 @@ export function MessageInput({
   }
 
   return (
-    <div
-      ref={containerRef}
-      className={cn(
-        'relative bg-background',
-        compact ? 'px-3 py-2' : 'px-4 py-3'
-      )}
-    >
+    <div ref={containerRef} className={cn('relative', compact ? 'p-3' : 'p-4')}>
       {/* Mention autocomplete dropdown */}
       {mentionsEnabled && (
         <MentionAutocomplete
@@ -531,95 +535,101 @@ export function MessageInput({
         />
       )}
 
-      {/* Input container with send button inside */}
-      <div className="relative">
-        {/* Textarea with optional highlight overlay for mentions */}
-        {mentionsEnabled ? (
-          <>
-            {/* Highlight overlay - renders mentions with styling */}
-            <div
-              ref={highlightRef}
-              className={cn(
-                'pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words rounded-xl pr-14',
-                compact
-                  ? 'px-3 py-2.5 text-sm md:text-xs'
-                  : 'px-4 py-4 text-sm',
-                'text-foreground'
-              )}
-              aria-hidden="true"
-            >
-              <HighlightedText
-                text={value}
-                validUsernames={validMentionHandles}
+      {/* Composer shell */}
+      <div
+        className={cn(
+          'flex items-center gap-2 rounded-xl border border-border px-3 py-2 transition-shadow duration-200',
+          isFocused && 'shadow-sm',
+          (sending || disabled) && 'opacity-60'
+        )}
+      >
+        {/* Input area */}
+        <div className="relative min-w-0 flex-1">
+          {mentionsEnabled ? (
+            <>
+              {/* Highlight overlay */}
+              <div
+                ref={highlightRef}
+                className={cn(
+                  'pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words py-[5px]',
+                  'text-[15px] leading-[22px]',
+                  'text-foreground'
+                )}
+                aria-hidden="true"
+              >
+                <HighlightedText
+                  text={value}
+                  validUsernames={validMentionHandles}
+                />
+              </div>
+              <textarea
+                ref={textareaRef}
+                value={value}
+                onChange={handleChange}
+                onKeyDown={handleKeyDown}
+                onScroll={handleScroll}
+                onSelect={handleSelect}
+                onFocus={() => setIsFocused(true)}
+                onBlur={() => setIsFocused(false)}
+                aria-label="Message input, use @ to mention members"
+                placeholder={placeholderText}
+                disabled={sending || disabled}
+                rows={1}
+                spellCheck={false}
+                autoComplete="off"
+                autoCorrect="off"
+                autoCapitalize="off"
+                className={cn(
+                  'relative z-10 max-h-40 w-full resize-none overflow-y-auto bg-transparent py-[5px]',
+                  compact
+                    ? 'min-h-[32px] text-sm leading-[22px] md:text-xs'
+                    : 'min-h-[32px] text-sm leading-[22px]',
+                  'text-transparent caret-foreground placeholder:text-muted-foreground/40',
+                  'outline-none',
+                  'disabled:cursor-not-allowed'
+                )}
               />
-            </div>
-            {/* Actual textarea - text is transparent, caret visible */}
+            </>
+          ) : (
             <textarea
               ref={textareaRef}
               value={value}
               onChange={handleChange}
               onKeyDown={handleKeyDown}
-              onScroll={handleScroll}
-              onSelect={handleSelect}
-              aria-label="Message input, use @ to mention members"
+              onFocus={() => setIsFocused(true)}
+              onBlur={() => setIsFocused(false)}
               placeholder={placeholderText}
               disabled={sending || disabled}
               rows={1}
-              spellCheck={false}
-              autoComplete="off"
-              autoCorrect="off"
-              autoCapitalize="off"
               className={cn(
-                'relative z-10 max-h-40 w-full resize-none overflow-y-auto rounded-xl pr-14',
+                'max-h-40 w-full resize-none overflow-y-auto bg-transparent py-[5px]',
                 compact
-                  ? 'min-h-[48px] px-3 py-2.5 text-sm md:text-xs'
-                  : 'min-h-[56px] px-4 py-4 text-sm',
-                'message-input bg-sidebar-accent/50',
-                'text-transparent caret-foreground placeholder:text-muted-foreground',
-                'outline-none focus:ring-2 focus:ring-primary/50',
-                'disabled:cursor-not-allowed disabled:opacity-50'
+                  ? 'min-h-[32px] text-sm leading-[22px] md:text-xs'
+                  : 'min-h-[32px] text-sm leading-[22px]',
+                'text-foreground placeholder:text-muted-foreground/40',
+                'outline-none',
+                'disabled:cursor-not-allowed'
               )}
             />
-          </>
-        ) : (
-          /* Simple textarea without highlight overlay */
-          <textarea
-            ref={textareaRef}
-            value={value}
-            onChange={handleChange}
-            onKeyDown={handleKeyDown}
-            placeholder={placeholderText}
-            disabled={sending || disabled}
-            rows={1}
-            className={cn(
-              'max-h-40 w-full resize-none overflow-y-auto rounded-xl pr-14',
-              compact
-                ? 'min-h-[48px] px-3 py-2.5 text-sm md:text-xs'
-                : 'min-h-[56px] px-4 py-4 text-sm',
-              'message-input bg-sidebar-accent/50',
-              'text-foreground placeholder:text-muted-foreground',
-              'outline-none focus:ring-2 focus:ring-primary/50',
-              'disabled:cursor-not-allowed disabled:opacity-50'
-            )}
-          />
-        )}
+          )}
+        </div>
 
-        {/* Send button - positioned inside input, vertically centered */}
+        {/* Send button */}
         <button
           type="button"
           onClick={onSend}
-          disabled={!value.trim() || sending || disabled}
+          disabled={!canSend}
           className={cn(
-            '-translate-y-1/2 absolute top-1/2 right-3 z-20 flex h-8 w-8 items-center justify-center rounded-lg',
-            'text-primary transition-all duration-200',
-            'hover:bg-muted',
-            'disabled:cursor-not-allowed disabled:text-muted-foreground disabled:opacity-50'
+            'flex h-8 w-8 shrink-0 items-center justify-center rounded-lg transition-all duration-150',
+            canSend
+              ? 'bg-primary text-primary-foreground hover:bg-primary/90 active:scale-95'
+              : 'text-muted-foreground'
           )}
         >
           {sending ? (
-            <Skeleton className="h-5 w-5 rounded" />
+            <Skeleton className="h-4 w-4 rounded" />
           ) : (
-            <Send className="h-5 w-5" />
+            <ArrowUp className="h-4 w-4" strokeWidth={2.5} />
           )}
         </button>
       </div>

--- a/apps/web/src/components/chats/TeamChatView.tsx
+++ b/apps/web/src/components/chats/TeamChatView.tsx
@@ -207,12 +207,12 @@ export function TeamChatView({
       {!hideHeader && (
         <div className="shrink-0">
           <div className="flex items-center justify-between px-4 py-3">
-            <div className="flex items-center gap-3">
+            <div className="flex min-w-0 flex-1 items-center gap-3">
               {/* Left sidebar toggle - desktop only */}
               {onToggleLeftSidebar && (
                 <button
                   onClick={onToggleLeftSidebar}
-                  className="hidden rounded-lg p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground lg:block"
+                  className="hidden shrink-0 rounded-lg p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground lg:block"
                   aria-label={
                     leftSidebarCollapsed ? 'Show sidebar' : 'Hide sidebar'
                   }
@@ -220,13 +220,13 @@ export function TeamChatView({
                   <PanelLeft className="h-4 w-4" strokeWidth={1.5} />
                 </button>
               )}
-              <div>
-                <h2 className="font-semibold text-foreground text-lg">
+              <div className="min-w-0">
+                <h2 className="truncate font-semibold text-foreground text-lg">
                   {chatDetails.chat.name || 'Agents'}
                 </h2>
               </div>
             </div>
-            <div className="flex items-center gap-3">
+            <div className="flex shrink-0 items-center gap-3">
               {/* Mobile members button */}
               {onShowMembers && (
                 <button
@@ -313,11 +313,6 @@ export function TeamChatView({
         {authenticated && (
           <FeedbackMessages error={sendError} warning={null} success={false} />
         )}
-
-        {/* Input Separator */}
-        <div className={compact ? 'px-3' : 'px-4'}>
-          <Separator />
-        </div>
 
         {/* Message Input with @mention support */}
         <MessageInput

--- a/apps/web/src/components/posts/PostCard.tsx
+++ b/apps/web/src/components/posts/PostCard.tsx
@@ -357,7 +357,7 @@ export const PostCard = memo(function PostCard({
                 </h2>
                 {!isDetail && (
                   <button
-                    className="inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-lg bg-[#0066FF] px-3 py-2 font-semibold text-primary-foreground text-sm transition-colors hover:bg-[#2952d9]"
+                    className="inline-flex shrink-0 items-center gap-2 whitespace-nowrap rounded-lg bg-primary px-3 py-2 font-semibold text-primary-foreground text-sm transition-colors hover:bg-primary/90"
                     onClick={handleCardClick}
                   >
                     Read Full Article →

--- a/apps/web/src/components/posts/PostCard.tsx
+++ b/apps/web/src/components/posts/PostCard.tsx
@@ -303,48 +303,48 @@ export const PostCard = memo(function PostCard({
         <div className="min-w-0 flex-1">
           {/* Header: Name/Handle on left, Timestamp and Menu on right */}
           <div className="mb-2 flex items-center justify-between gap-3">
-              {/* Name and Handle inline */}
-              <div className="flex min-w-0 flex-1 items-center gap-1.5">
-                <Link
-                  href={getProfileUrl(displayAuthorId, displayAuthorUsername)}
-                  className="truncate font-semibold text-[15px] text-foreground hover:underline"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  {displayAuthorName}
-                </Link>
-                {showVerifiedBadge && <VerifiedBadge size="sm" />}
-                <Link
-                  href={getProfileUrl(displayAuthorId, displayAuthorUsername)}
-                  className="truncate text-[15px] text-muted-foreground hover:underline"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  @{displayAuthorUsername || displayAuthorId}
-                </Link>
-              </div>
-              {/* Timestamp and Menu - Right aligned */}
-              <div className="flex shrink-0 items-center gap-2">
-                <time
-                  className="text-[15px] text-muted-foreground"
-                  title={postDate.toLocaleString()}
-                >
-                  {timeAgo}
-                </time>
-                {user && user.id !== displayAuthorId && (
-                  <div onClick={(e) => e.stopPropagation()}>
-                    <ModerationMenu
-                      targetUserId={displayAuthorId}
-                      targetUsername={displayAuthorUsername || undefined}
-                      targetDisplayName={displayAuthorName}
-                      targetProfileImageUrl={
-                        displayAuthorProfileImageUrl || undefined
-                      }
-                      postId={post.id}
-                      isNPC={authorIsNPC}
-                    />
-                  </div>
-                )}
-              </div>
+            {/* Name and Handle inline */}
+            <div className="flex min-w-0 flex-1 items-center gap-1.5">
+              <Link
+                href={getProfileUrl(displayAuthorId, displayAuthorUsername)}
+                className="truncate font-semibold text-[15px] text-foreground hover:underline"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {displayAuthorName}
+              </Link>
+              {showVerifiedBadge && <VerifiedBadge size="sm" />}
+              <Link
+                href={getProfileUrl(displayAuthorId, displayAuthorUsername)}
+                className="truncate text-[15px] text-muted-foreground hover:underline"
+                onClick={(e) => e.stopPropagation()}
+              >
+                @{displayAuthorUsername || displayAuthorId}
+              </Link>
             </div>
+            {/* Timestamp and Menu - Right aligned */}
+            <div className="flex shrink-0 items-center gap-2">
+              <time
+                className="text-[15px] text-muted-foreground"
+                title={postDate.toLocaleString()}
+              >
+                {timeAgo}
+              </time>
+              {user && user.id !== displayAuthorId && (
+                <div onClick={(e) => e.stopPropagation()}>
+                  <ModerationMenu
+                    targetUserId={displayAuthorId}
+                    targetUsername={displayAuthorUsername || undefined}
+                    targetDisplayName={displayAuthorName}
+                    targetProfileImageUrl={
+                      displayAuthorProfileImageUrl || undefined
+                    }
+                    postId={post.id}
+                    isNPC={authorIsNPC}
+                  />
+                </div>
+              )}
+            </div>
+          </div>
 
           {/* Post Content */}
           {post.type === 'article' ? (

--- a/apps/web/src/components/posts/PostCard.tsx
+++ b/apps/web/src/components/posts/PostCard.tsx
@@ -254,7 +254,7 @@ export const PostCard = memo(function PostCard({
     >
       {/* Repost Indicator - Only show for simple reposts (not quote posts) */}
       {isSimpleRepost && (
-        <div className="mb-2 flex items-center gap-3 pl-12 text-muted-foreground text-sm">
+        <div className="mb-1 flex items-center gap-2 pl-12 text-muted-foreground text-xs">
           <Repeat2 size={14} className="text-green-600" />
           <span>
             Reposted by{' '}
@@ -276,36 +276,33 @@ export const PostCard = memo(function PostCard({
       {/* Two-column layout: Avatar | Content */}
       <div className="flex gap-3">
         {/* Left column: Avatar + Connecting Line */}
-        {!isSimpleRepost && (
-          <div className="flex flex-col items-center">
-            <Link
-              href={getProfileUrl(displayAuthorId, displayAuthorUsername)}
-              className="shrink-0 transition-opacity hover:opacity-80"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <Avatar
-                id={displayAuthorId}
-                name={displayAuthorName}
-                type={post.type === 'article' ? 'business' : 'actor'}
-                size="md"
-                src={displayAuthorProfileImageUrl || undefined}
-                scaleFactor={fontSize}
-              />
-            </Link>
-            {/* Connecting line to comments */}
-            {showCommentPreviews &&
-              !isDetail &&
-              (post.commentPreviews?.length ?? 0) > 0 && (
-                <div className="mt-2 w-0.5 flex-1 bg-border" />
-              )}
-          </div>
-        )}
+        <div className="flex flex-col items-center">
+          <Link
+            href={getProfileUrl(displayAuthorId, displayAuthorUsername)}
+            className="shrink-0 transition-opacity hover:opacity-80"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Avatar
+              id={displayAuthorId}
+              name={displayAuthorName}
+              type={post.type === 'article' ? 'business' : 'actor'}
+              size="md"
+              src={displayAuthorProfileImageUrl || undefined}
+              scaleFactor={fontSize}
+            />
+          </Link>
+          {/* Connecting line to comments */}
+          {showCommentPreviews &&
+            !isDetail &&
+            (post.commentPreviews?.length ?? 0) > 0 && (
+              <div className="mt-2 w-0.5 flex-1 bg-border" />
+            )}
+        </div>
 
         {/* Right column: All content */}
         <div className="min-w-0 flex-1">
           {/* Header: Name/Handle on left, Timestamp and Menu on right */}
-          {!isSimpleRepost && (
-            <div className="mb-2 flex items-center justify-between gap-3">
+          <div className="mb-2 flex items-center justify-between gap-3">
               {/* Name and Handle inline */}
               <div className="flex min-w-0 flex-1 items-center gap-1.5">
                 <Link
@@ -348,7 +345,6 @@ export const PostCard = memo(function PostCard({
                 )}
               </div>
             </div>
-          )}
 
           {/* Post Content */}
           {post.type === 'article' ? (
@@ -379,8 +375,32 @@ export const PostCard = memo(function PostCard({
                 {post.content}
               </div>
             </div>
+          ) : post.isRepost && isSimpleRepost ? (
+            // Simple repost - show original content directly (no border/card)
+            <div className="post-content mb-3 w-full whitespace-pre-wrap break-words text-[15px] text-foreground leading-normal">
+              {post.originalPost ? (
+                <TaggedText
+                  text={post.originalPost.content}
+                  onTagClick={(tag) => {
+                    if (tag.startsWith('@')) {
+                      const username = tag.slice(1);
+                      router.push(getProfileUrl('', username));
+                    } else if (tag.startsWith('$')) {
+                      const symbol = tag.slice(1);
+                      router.push(
+                        `/markets?search=${encodeURIComponent(symbol)}`
+                      );
+                    }
+                  }}
+                />
+              ) : (
+                <span className="text-foreground/50 italic">
+                  This post has been deleted
+                </span>
+              )}
+            </div>
           ) : post.isRepost ? (
-            // Repost (with or without quote comment) - show embedded card
+            // Quote post - show quote comment + embedded original in card
             <div className="mb-4 w-full">
               {/* Quote comment (if present) */}
               {post.quoteComment && (
@@ -389,11 +409,9 @@ export const PostCard = memo(function PostCard({
                     text={post.quoteComment}
                     onTagClick={(tag) => {
                       if (tag.startsWith('@')) {
-                        // Handle @mentions - route to profile
                         const username = tag.slice(1);
                         router.push(getProfileUrl('', username));
                       } else if (tag.startsWith('$')) {
-                        // Handle $cashtags - route to markets
                         const symbol = tag.slice(1);
                         router.push(
                           `/markets?search=${encodeURIComponent(symbol)}`
@@ -477,11 +495,9 @@ export const PostCard = memo(function PostCard({
                         text={post.originalPost.content}
                         onTagClick={(tag) => {
                           if (tag.startsWith('@')) {
-                            // Handle @mentions - route to profile
                             const username = tag.slice(1);
                             router.push(getProfileUrl('', username));
                           } else if (tag.startsWith('$')) {
-                            // Handle $cashtags - route to markets
                             const symbol = tag.slice(1);
                             router.push(
                               `/markets?search=${encodeURIComponent(symbol)}`

--- a/apps/web/src/components/profile/LinkSocialAccountsModal.tsx
+++ b/apps/web/src/components/profile/LinkSocialAccountsModal.tsx
@@ -261,7 +261,7 @@ export function LinkSocialAccountsModal({
                   disabled={linking === 'farcaster'}
                   className={cn(
                     'w-full rounded-lg px-4 py-2 font-semibold transition-colors',
-                    'bg-[#8A63D2] text-foreground hover:bg-[#7952c4]',
+                    'bg-[#8A63D2] text-white hover:bg-[#7952c4]',
                     'disabled:cursor-not-allowed disabled:opacity-50',
                     'flex items-center justify-center gap-2'
                   )}

--- a/apps/web/src/components/profile/ProfileWidget.tsx
+++ b/apps/web/src/components/profile/ProfileWidget.tsx
@@ -7,7 +7,14 @@ import type {
   UserProfileStats,
 } from '@babylon/shared';
 import { cn } from '@babylon/shared';
-import { HelpCircle, TrendingDown, TrendingUp } from 'lucide-react';
+import {
+  BarChart3,
+  Coins,
+  HelpCircle,
+  TrendingDown,
+  TrendingUp,
+  Wallet,
+} from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Skeleton } from '@/components/shared/Skeleton';
@@ -306,12 +313,10 @@ export function ProfileWidget({ userId }: ProfileWidgetProps) {
   if (loading) {
     return (
       <div className="flex h-full w-full flex-col overflow-y-auto">
-        <div className="flex items-center justify-center py-8">
-          <div className="w-full space-y-3">
-            <Skeleton className="h-24 w-full" />
-            <Skeleton className="h-24 w-full" />
-            <Skeleton className="h-24 w-full" />
-          </div>
+        <div className="space-y-4">
+          <Skeleton className="h-48 w-full rounded-lg" />
+          <Skeleton className="h-32 w-full rounded-lg" />
+          <Skeleton className="h-24 w-full rounded-lg" />
         </div>
       </div>
     );
@@ -333,88 +338,101 @@ export function ProfileWidget({ userId }: ProfileWidgetProps) {
     );
   }
 
+  const StatRow = ({
+    label,
+    value,
+    valueClassName,
+  }: {
+    label: string;
+    value: string;
+    valueClassName?: string;
+  }) => (
+    <div className="flex items-center justify-between py-1.5">
+      <span className="text-muted-foreground text-sm">{label}</span>
+      <span
+        className={cn('font-medium text-foreground text-sm', valueClassName)}
+      >
+        {value}
+      </span>
+    </div>
+  );
+
   return (
-    <div className="flex h-full w-full flex-col overflow-y-auto">
+    <div className="flex h-full w-full flex-col space-y-4 overflow-y-auto">
       {/* Points Section */}
-      <div className="mb-6">
-        <h3 className="mb-3 font-bold text-foreground text-lg">Points</h3>
-        <div className="space-y-2">
-          <div className="flex items-center justify-between rounded-lg bg-[#0066FF]/10 px-2 py-1.5">
-            <span className="font-semibold text-[#0066FF] text-sm">
-              Total Points
-            </span>
-            <span className="font-bold text-[#0066FF] text-sm">
-              {formatPoints(portfolio?.totalPoints ?? 0)} pts
-            </span>
+      <div className="rounded-lg border border-border p-4">
+        <div className="mb-3 flex items-center gap-2">
+          <Coins className="h-4 w-4 text-primary" />
+          <h3 className="font-semibold text-foreground text-sm">Points</h3>
+        </div>
+
+        {/* Total Points highlight */}
+        <div className="mb-3 rounded-lg bg-primary/5 px-3 py-2.5">
+          <div className="text-primary/90 text-xs">Total Points</div>
+          <div className="font-bold text-lg text-primary">
+            {formatPoints(portfolio?.totalPoints ?? 0)}
           </div>
-          <div className="flex items-center justify-between">
-            <span className="text-muted-foreground text-sm">Available</span>
-            <span className="font-semibold text-foreground text-sm">
-              {formatPoints(portfolio?.available ?? 0)} pts
-            </span>
-          </div>
-          <div className="flex items-center justify-between">
-            <span className="text-muted-foreground text-sm">In Positions</span>
-            <span className="font-semibold text-foreground text-sm">
-              {formatPoints(portfolio?.positions ?? 0)} pts
-            </span>
-          </div>
-          <div className="flex items-center justify-between">
-            <span className="text-muted-foreground text-sm">Agents</span>
-            <span className="font-semibold text-foreground text-sm">
-              {formatPoints(portfolio?.agents ?? 0)} pts
-            </span>
-          </div>
-          <div className="flex items-center justify-between">
-            <span className="text-muted-foreground text-sm">Wallet</span>
-            <span className="font-semibold text-foreground text-sm">
-              {formatPoints(portfolio?.wallet ?? 0)} pts
-            </span>
-          </div>
-          <div className="flex items-center justify-between">
-            <span className="text-muted-foreground text-sm">Total Assets</span>
-            <span className="font-semibold text-foreground text-sm">
-              {formatPoints(portfolio?.totalAssets ?? 0)} pts
-            </span>
-          </div>
-          <div className="flex items-center justify-between border-border border-t pt-2">
-            <span className="text-muted-foreground text-sm">P&L</span>
-            <span
-              className={cn(
-                'font-semibold text-sm',
-                (portfolio?.totalPnL ?? 0) >= 0
-                  ? 'text-green-600'
-                  : 'text-red-600'
-              )}
-            >
-              {formatPoints(portfolio?.totalPnL ?? 0)} pts (
-              {formatPercent(pnlPercent)})
-            </span>
+        </div>
+
+        <div className="space-y-0">
+          <StatRow
+            label="Available"
+            value={`${formatPoints(portfolio?.available ?? 0)} pts`}
+          />
+          <StatRow
+            label="In Positions"
+            value={`${formatPoints(portfolio?.positions ?? 0)} pts`}
+          />
+          <StatRow
+            label="Agents"
+            value={`${formatPoints(portfolio?.agents ?? 0)} pts`}
+          />
+          <StatRow
+            label="Wallet"
+            value={`${formatPoints(portfolio?.wallet ?? 0)} pts`}
+          />
+          <StatRow
+            label="Total Assets"
+            value={`${formatPoints(portfolio?.totalAssets ?? 0)} pts`}
+          />
+          <div className="mt-1 border-border border-t pt-2">
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground text-sm">P&L</span>
+              <span
+                className={cn(
+                  'font-semibold text-sm',
+                  (portfolio?.totalPnL ?? 0) >= 0
+                    ? 'text-green-500'
+                    : 'text-red-500'
+                )}
+              >
+                {formatPoints(portfolio?.totalPnL ?? 0)} pts (
+                {formatPercent(pnlPercent)})
+              </span>
+            </div>
           </div>
         </div>
       </div>
 
       {/* Holdings Section */}
-      <div className="mb-6">
+      <div className="rounded-lg border border-border p-4">
         <button
           onClick={() => router.push('/markets')}
-          className="mb-3 cursor-pointer text-left font-bold text-foreground text-lg transition-colors hover:text-[#0066FF]"
+          className="mb-3 flex items-center gap-2 transition-colors hover:text-primary"
         >
-          Holdings
+          <Wallet className="h-4 w-4 text-primary" />
+          <h3 className="font-semibold text-foreground text-sm">Holdings</h3>
         </button>
 
         {/* Predictions */}
         {predictions.length > 0 && (
-          <div className="mb-4">
-            <button
-              onClick={() => router.push('/markets')}
-              className="mb-2 block cursor-pointer font-semibold text-muted-foreground text-xs uppercase transition-colors hover:text-[#0066FF]"
-            >
-              PREDICTIONS
-            </button>
-            <div className="space-y-2">
+          <div className="mb-3">
+            <div className="mb-2 font-medium text-muted-foreground text-xs uppercase tracking-wide">
+              Predictions
+            </div>
+            <div className="space-y-1">
               {predictions.slice(0, 3).map((pred) => {
-                const pnlPercent =
+                const pnlPct =
                   pred.avgPrice > 0
                     ? ((pred.currentPrice - pred.avgPrice) / pred.avgPrice) *
                       100
@@ -427,22 +445,24 @@ export function ProfileWidget({ userId }: ProfileWidgetProps) {
                       setModalType('prediction');
                       setModalOpen(true);
                     }}
-                    className="-ml-2 w-full cursor-pointer rounded p-2 text-left text-sm transition-colors hover:bg-muted/30"
+                    className="w-full rounded-lg p-2 text-left transition-colors hover:bg-muted/30"
                   >
-                    <div className="truncate font-medium text-foreground">
+                    <div className="truncate font-medium text-foreground text-sm">
                       {pred.question}
                     </div>
-                    <div className="text-muted-foreground text-xs">
-                      {pred.shares} shares {pred.side} @{' '}
-                      {formatPrice(pred.avgPrice)}
-                    </div>
-                    <div
-                      className={cn(
-                        'mt-0.5 font-medium text-xs',
-                        pnlPercent >= 0 ? 'text-green-600' : 'text-red-600'
-                      )}
-                    >
-                      {formatPercent(pnlPercent)}
+                    <div className="mt-0.5 flex items-center justify-between">
+                      <span className="text-muted-foreground text-xs">
+                        {pred.shares} shares {pred.side} @{' '}
+                        {formatPrice(pred.avgPrice)}
+                      </span>
+                      <span
+                        className={cn(
+                          'font-medium text-xs',
+                          pnlPct >= 0 ? 'text-green-500' : 'text-red-500'
+                        )}
+                      >
+                        {formatPercent(pnlPct)}
+                      </span>
                     </div>
                   </button>
                 );
@@ -453,14 +473,11 @@ export function ProfileWidget({ userId }: ProfileWidgetProps) {
 
         {/* Stocks (Perps) */}
         {perps.length > 0 && (
-          <div className="mb-4">
-            <button
-              onClick={() => router.push('/markets')}
-              className="mb-2 block cursor-pointer font-semibold text-muted-foreground text-xs uppercase transition-colors hover:text-[#0066FF]"
-            >
-              STOCKS
-            </button>
-            <div className="space-y-2">
+          <div>
+            <div className="mb-2 font-medium text-muted-foreground text-xs uppercase tracking-wide">
+              Stocks
+            </div>
+            <div className="space-y-1">
               {perps.slice(0, 3).map((perp) => (
                 <button
                   key={perp.id}
@@ -469,31 +486,33 @@ export function ProfileWidget({ userId }: ProfileWidgetProps) {
                     setModalType('perp');
                     setModalOpen(true);
                   }}
-                  className="-ml-2 w-full cursor-pointer rounded p-2 text-left text-sm transition-colors hover:bg-muted/30"
+                  className="w-full rounded-lg p-2 text-left transition-colors hover:bg-muted/30"
                 >
                   <div className="flex items-center gap-1.5">
-                    <span className="font-medium text-foreground">
+                    <span className="font-medium text-foreground text-sm">
                       {perp.ticker}
                     </span>
                     {perp.unrealizedPnLPercent >= 0 ? (
-                      <TrendingUp className="h-3 w-3 text-green-600" />
+                      <TrendingUp className="h-3 w-3 text-green-500" />
                     ) : (
-                      <TrendingDown className="h-3 w-3 text-red-600" />
+                      <TrendingDown className="h-3 w-3 text-red-500" />
                     )}
                   </div>
-                  <div className="text-muted-foreground text-xs">
-                    {formatPoints(perp.size)} pts
-                  </div>
-                  <div
-                    className={cn(
-                      'mt-0.5 font-medium text-xs',
-                      perp.unrealizedPnL >= 0
-                        ? 'text-green-600'
-                        : 'text-red-600'
-                    )}
-                  >
-                    {formatPoints(perp.unrealizedPnL)} pts (
-                    {formatPercent(perp.unrealizedPnLPercent)})
+                  <div className="mt-0.5 flex items-center justify-between">
+                    <span className="text-muted-foreground text-xs">
+                      {formatPoints(perp.size)} pts
+                    </span>
+                    <span
+                      className={cn(
+                        'font-medium text-xs',
+                        perp.unrealizedPnL >= 0
+                          ? 'text-green-500'
+                          : 'text-red-500'
+                      )}
+                    >
+                      {formatPoints(perp.unrealizedPnL)} pts (
+                      {formatPercent(perp.unrealizedPnLPercent)})
+                    </span>
                   </div>
                 </button>
               ))}
@@ -510,38 +529,30 @@ export function ProfileWidget({ userId }: ProfileWidgetProps) {
 
       {/* Stats Section */}
       {stats && (
-        <div className="mb-6">
-          <h3 className="mb-3 font-bold text-foreground text-lg">Stats</h3>
-          <div className="space-y-2">
-            <div className="flex items-center justify-between">
-              <span className="text-muted-foreground text-sm">
-                {stats.following} Following
-              </span>
-            </div>
-            <div className="flex items-center justify-between">
-              <span className="text-muted-foreground text-sm">
-                {stats.followers} Followers
-              </span>
-            </div>
-            <div className="flex items-center justify-between">
-              <span className="text-muted-foreground text-sm">
-                {stats.totalActivity} Total Activity
-              </span>
-            </div>
+        <div className="rounded-lg border border-border p-4">
+          <div className="mb-3 flex items-center gap-2">
+            <BarChart3 className="h-4 w-4 text-primary" />
+            <h3 className="font-semibold text-foreground text-sm">Stats</h3>
+          </div>
+          <div className="space-y-0">
+            <StatRow label="Following" value={String(stats.following)} />
+            <StatRow label="Followers" value={String(stats.followers)} />
+            <StatRow
+              label="Total Activity"
+              value={String(stats.totalActivity)}
+            />
             {isOwnProfile && (
-              <div className="flex items-center justify-between">
-                <span className="text-muted-foreground text-sm">My Agents</span>
-                <span className="font-semibold text-foreground text-sm">
-                  {portfolio?.agentCount ?? 0}
-                </span>
-              </div>
+              <StatRow
+                label="My Agents"
+                value={String(portfolio?.agentCount ?? 0)}
+              />
             )}
           </div>
         </div>
       )}
 
       {/* Help Icon */}
-      <div className="mt-auto flex justify-end pt-4">
+      <div className="mt-auto flex justify-end pt-2">
         <button
           type="button"
           className="text-muted-foreground transition-colors hover:text-foreground"

--- a/apps/web/src/components/rewards/RewardsSkeleton.tsx
+++ b/apps/web/src/components/rewards/RewardsSkeleton.tsx
@@ -128,7 +128,10 @@ export function RewardsSkeleton() {
                   key={i}
                   className="flex items-center gap-3 rounded-lg border border-border p-3"
                 >
-                  <SkeletonBox className="h-8 w-8 shrink-0 rounded-full" delay={i * 50} />
+                  <SkeletonBox
+                    className="h-8 w-8 shrink-0 rounded-full"
+                    delay={i * 50}
+                  />
                   <div className="min-w-0 flex-1 space-y-1.5">
                     <SkeletonText className="h-4 w-28" delay={i * 50} />
                     <SkeletonText className="h-3 w-20" delay={i * 50} />
@@ -233,7 +236,10 @@ export function RewardsSkeleton() {
                   key={i}
                   className="flex items-center gap-3 rounded-lg border border-border p-3"
                 >
-                  <SkeletonBox className="h-8 w-8 shrink-0 rounded-full" delay={i * 50} />
+                  <SkeletonBox
+                    className="h-8 w-8 shrink-0 rounded-full"
+                    delay={i * 50}
+                  />
                   <div className="min-w-0 flex-1 space-y-1.5">
                     <SkeletonText className="h-4 w-28" delay={i * 50} />
                     <SkeletonText className="h-3 w-20" delay={i * 50} />

--- a/apps/web/src/components/rewards/RewardsSkeleton.tsx
+++ b/apps/web/src/components/rewards/RewardsSkeleton.tsx
@@ -1,26 +1,5 @@
-/**
- * Rewards skeleton component for rewards page loading state.
- *
- * Provides skeleton loading UI that matches the rewards page layout to
- * prevent layout shifts during loading. Includes skeleton components
- * for stats, tasks, and referral sections.
- *
- * Features:
- * - Layout-matched skeleton
- * - Staggered animations
- * - Responsive design
- * - Accessibility support
- *
- * @returns Rewards skeleton element
- */
 import { Separator } from '@/components/shared/Separator';
 
-/**
- * Skeleton box component for placeholder rectangles.
- *
- * @param props - SkeletonBox component props
- * @returns Skeleton box element
- */
 function SkeletonBox({
   className = '',
   delay = 0,
@@ -37,12 +16,6 @@ function SkeletonBox({
   );
 }
 
-/**
- * Skeleton text component for placeholder text lines.
- *
- * @param props - SkeletonText component props
- * @returns Skeleton text element
- */
 function SkeletonText({
   className = '',
   delay = 0,
@@ -64,7 +37,7 @@ export function RewardsSkeleton() {
     <div role="status" aria-label="Loading rewards...">
       {/* Desktop Layout */}
       <div className="hidden flex-1 overflow-hidden xl:flex">
-        <div className="min-w-0 flex-1 space-y-4 overflow-y-auto overflow-x-hidden p-4 sm:p-6">
+        <div className="min-w-0 flex-1 space-y-4 overflow-y-auto overflow-x-hidden border-border p-4 sm:p-6 lg:border-l">
           {/* Header */}
           <div className="mb-4">
             <SkeletonText className="mb-2 h-8 w-32" />
@@ -73,127 +46,94 @@ export function RewardsSkeleton() {
 
           {/* Stats Row */}
           <div className="grid grid-cols-3 gap-4">
-            {/* Total Earned */}
-            <div className="rounded-lg border border-[#0066FF]/30 bg-gradient-to-r from-[#0066FF]/20 to-purple-500/20 p-4">
-              <div className="mb-2 flex items-center gap-2">
-                <SkeletonBox className="h-5 w-5" delay={50} />
-                <SkeletonText className="h-4 w-24" delay={50} />
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="rounded-lg border border-border p-4">
+                <div className="mb-2 flex items-center gap-2">
+                  <SkeletonBox className="h-5 w-5" delay={i * 50} />
+                  <SkeletonText className="h-4 w-24" delay={i * 50} />
+                </div>
+                <SkeletonText className="h-8 w-20" delay={i * 50} />
               </div>
-              <div
-                className="h-[1.875rem] w-20 animate-pulse rounded bg-muted/50"
-                style={{ animationDelay: '50ms' }}
-                aria-hidden="true"
-              />
-            </div>
-
-            {/* Current Balance */}
-            <div className="rounded-lg border border-border bg-muted/30 p-4">
-              <div className="mb-2 flex items-center gap-2">
-                <SkeletonBox className="h-5 w-5" delay={100} />
-                <SkeletonText className="h-4 w-28" delay={100} />
-              </div>
-              <div
-                className="h-[1.875rem] w-24 animate-pulse rounded bg-muted/50"
-                style={{ animationDelay: '100ms' }}
-                aria-hidden="true"
-              />
-            </div>
-
-            {/* Total Referrals */}
-            <div className="rounded-lg border border-border bg-muted/30 p-4">
-              <div className="mb-2 flex items-center gap-2">
-                <SkeletonBox className="h-5 w-5" delay={150} />
-                <SkeletonText className="h-4 w-28" delay={150} />
-              </div>
-              <div
-                className="h-[1.875rem] w-16 animate-pulse rounded bg-muted/50"
-                style={{ animationDelay: '150ms' }}
-                aria-hidden="true"
-              />
-            </div>
+            ))}
           </div>
 
-          {/* Reward Tasks */}
-          <div className="rounded-lg border border-border bg-muted/30 p-4">
+          {/* Daily Rewards placeholder */}
+          <div className="rounded-lg border border-border p-4">
+            <div className="mb-3 flex items-center gap-2">
+              <SkeletonBox className="h-5 w-5" />
+              <SkeletonText className="h-5 w-32" />
+            </div>
+            <SkeletonBox className="h-16 w-full rounded-lg" />
+          </div>
+
+          {/* Earn Points (tasks + share) */}
+          <div className="rounded-lg border border-border p-4">
             <div className="mb-4 flex items-center gap-2">
               <SkeletonBox className="h-5 w-5" />
               <SkeletonText className="h-5 w-28" />
             </div>
 
             <div className="grid gap-3">
-              {[1, 2, 3, 4].map((i) => (
+              {[0, 1, 2, 3, 4].map((i) => (
                 <div
                   key={i}
-                  className="flex items-center gap-4 rounded-lg border border-border bg-sidebar-accent/50 p-4"
+                  className="flex items-center gap-4 rounded-lg border border-border p-4"
                 >
-                  <SkeletonBox className="h-6 w-6 shrink-0" />
+                  <SkeletonBox className="h-6 w-6 shrink-0" delay={i * 50} />
                   <div className="min-w-0 flex-1 space-y-2">
-                    <SkeletonText className="h-4 w-32" />
-                    <SkeletonText className="h-3 w-48" />
+                    <SkeletonText className="h-4 w-32" delay={i * 50} />
+                    <SkeletonText className="h-3 w-48" delay={i * 50} />
                   </div>
                   <div className="shrink-0 space-y-1 text-right">
-                    <SkeletonText className="h-4 w-12" />
-                    <SkeletonText className="h-3 w-12" />
+                    <SkeletonText className="h-4 w-12" delay={i * 50} />
+                    <SkeletonText className="h-3 w-12" delay={i * 50} />
                   </div>
                 </div>
               ))}
             </div>
           </div>
 
-          {/* Share Actions */}
-          <div className="rounded-lg border border-border bg-muted/30 p-4">
-            <div className="mb-4 flex items-center gap-2">
-              <SkeletonBox className="h-5 w-5" />
-              <SkeletonText className="h-5 w-32" />
-            </div>
-
-            <div className="space-y-3">
-              <SkeletonText className="h-4 w-full" />
-              <SkeletonBox className="h-10 w-full rounded-lg" />
-            </div>
-          </div>
-
           <Separator />
 
           {/* Referral Link */}
-          <div className="rounded-lg border border-border bg-muted/30 p-4">
+          <div className="rounded-lg border border-border p-4">
             <div className="mb-3 flex items-center gap-2">
               <SkeletonBox className="h-5 w-5" />
-              <SkeletonText className="h-5 w-32" />
-              <SkeletonText className="ml-auto h-3 w-32" />
+              <SkeletonText className="h-5 w-28" />
+              <SkeletonText className="h-3 w-48" />
             </div>
 
             <div className="space-y-3">
               <div className="flex gap-2">
                 <SkeletonBox className="h-10 flex-1 rounded-lg" />
-                <SkeletonBox className="h-10 w-20 rounded-lg" />
+                <SkeletonBox className="h-10 w-[84px] rounded-lg" />
               </div>
-              <SkeletonBox className="h-10 w-full rounded-lg" />
+              <div className="flex gap-2">
+                <SkeletonBox className="h-10 flex-1 rounded-lg" />
+                <SkeletonBox className="h-10 flex-1 rounded-lg" />
+              </div>
             </div>
           </div>
 
           {/* Referred Users List */}
           <div>
-            <div className="mb-3 flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <SkeletonBox className="h-4 w-4" />
-                <SkeletonText className="h-5 w-32" />
-              </div>
+            <div className="mb-3 flex items-center gap-1.5">
+              <SkeletonBox className="h-4 w-4" />
+              <SkeletonText className="h-5 w-32" />
             </div>
 
             <div className="space-y-2">
-              {[1, 2, 3].map((i) => (
+              {[0, 1, 2].map((i) => (
                 <div
                   key={i}
-                  className="flex items-center gap-3 rounded-lg border border-border bg-muted/30 p-3"
+                  className="flex items-center gap-3 rounded-lg border border-border p-3"
                 >
-                  <SkeletonBox className="h-10 w-10 shrink-0 rounded-full" />
-                  <div className="min-w-0 flex-1 space-y-2">
-                    <SkeletonText className="h-4 w-32" />
-                    <SkeletonText className="h-3 w-24" />
-                    <SkeletonText className="h-3 w-28" />
+                  <SkeletonBox className="h-8 w-8 shrink-0 rounded-full" delay={i * 50} />
+                  <div className="min-w-0 flex-1 space-y-1.5">
+                    <SkeletonText className="h-4 w-28" delay={i * 50} />
+                    <SkeletonText className="h-3 w-20" delay={i * 50} />
                   </div>
-                  <SkeletonBox className="h-6 w-6" />
+                  <SkeletonBox className="h-4 w-4" delay={i * 50} />
                 </div>
               ))}
             </div>
@@ -202,7 +142,7 @@ export function RewardsSkeleton() {
       </div>
 
       {/* Mobile/Tablet Layout */}
-      <div className="flex w-full flex-1 flex-col overflow-y-auto xl:hidden">
+      <div className="flex w-full flex-1 flex-col overflow-y-auto border-border lg:border-l xl:hidden">
         <div className="w-full space-y-4 px-4 py-4 sm:space-y-6 sm:px-6 sm:py-6">
           {/* Header */}
           <div>
@@ -212,44 +152,27 @@ export function RewardsSkeleton() {
 
           {/* Stats Row */}
           <div className="grid grid-cols-3 gap-2 sm:gap-3">
-            {/* Total Earned */}
-            <div className="rounded-lg border border-[#0066FF]/30 bg-gradient-to-r from-[#0066FF]/20 to-purple-500/20 p-3">
-              <div className="mb-1 flex items-center gap-1">
-                <SkeletonBox className="h-4 w-4" />
-                <SkeletonText className="h-3 w-16" />
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="rounded-lg border border-border p-3">
+                <div className="mb-1 flex items-center gap-1">
+                  <SkeletonBox className="h-4 w-4" delay={i * 50} />
+                  <SkeletonText className="h-3 w-14" delay={i * 50} />
+                </div>
+                <SkeletonText className="h-7 w-14" delay={i * 50} />
               </div>
-              <div
-                className="h-[1.5rem] w-16 animate-pulse rounded bg-muted/50"
-                aria-hidden="true"
-              />
-            </div>
-
-            {/* Current Balance */}
-            <div className="rounded-lg border border-border bg-muted/30 p-3">
-              <div className="mb-1 flex items-center gap-1">
-                <SkeletonBox className="h-4 w-4" />
-                <SkeletonText className="h-3 w-16" />
-              </div>
-              <div
-                className="h-[1.5rem] w-20 animate-pulse rounded bg-muted/50"
-                aria-hidden="true"
-              />
-            </div>
-
-            {/* Total Referrals */}
-            <div className="rounded-lg border border-border bg-muted/30 p-3">
-              <div className="mb-1 flex items-center gap-1">
-                <SkeletonBox className="h-4 w-4" />
-                <SkeletonText className="h-3 w-16" />
-              </div>
-              <div
-                className="h-[1.5rem] w-12 animate-pulse rounded bg-muted/50"
-                aria-hidden="true"
-              />
-            </div>
+            ))}
           </div>
 
-          {/* Reward Tasks */}
+          {/* Daily Rewards placeholder */}
+          <div className="rounded-lg border border-border p-4">
+            <div className="mb-3 flex items-center gap-2">
+              <SkeletonBox className="h-5 w-5" />
+              <SkeletonText className="h-5 w-32" />
+            </div>
+            <SkeletonBox className="h-14 w-full rounded-lg" />
+          </div>
+
+          {/* Earn Points (tasks + share) */}
           <div className="space-y-3">
             <div className="flex items-center gap-2">
               <SkeletonBox className="h-5 w-5" />
@@ -257,73 +180,65 @@ export function RewardsSkeleton() {
             </div>
 
             <div className="space-y-2">
-              {[1, 2, 3, 4].map((i) => (
+              {[0, 1, 2, 3, 4].map((i) => (
                 <div
                   key={i}
-                  className="flex items-center gap-3 rounded-lg border border-border bg-muted/30 p-3"
+                  className="flex items-center gap-3 rounded-lg border border-border p-3"
                 >
-                  <SkeletonBox className="h-5 w-5 shrink-0" />
+                  <SkeletonBox className="h-5 w-5 shrink-0" delay={i * 50} />
                   <div className="min-w-0 flex-1 space-y-2">
-                    <SkeletonText className="h-4 w-28" />
-                    <SkeletonText className="h-3 w-40" />
+                    <SkeletonText className="h-4 w-28" delay={i * 50} />
+                    <SkeletonText className="h-3 w-40" delay={i * 50} />
                   </div>
-                  <SkeletonText className="h-4 w-12 shrink-0" />
+                  <SkeletonText className="h-4 w-12 shrink-0" delay={i * 50} />
                 </div>
               ))}
             </div>
           </div>
 
-          {/* Share Actions */}
-          <div className="space-y-3">
-            <div className="flex items-center gap-2">
-              <SkeletonBox className="h-5 w-5" />
-              <SkeletonText className="h-6 w-32" />
-            </div>
-            <SkeletonText className="h-4 w-full" />
-            <SkeletonBox className="h-10 w-full rounded-lg" />
-          </div>
-
           <Separator />
 
           {/* Referral Link */}
-          <div className="rounded-lg border border-border bg-muted/30 p-4">
-            <div className="mb-3 flex items-center gap-2">
-              <SkeletonBox className="h-5 w-5" />
-              <SkeletonText className="h-5 w-32" />
-              <SkeletonText className="ml-2 h-3 w-24" />
+          <div className="rounded-lg border border-border p-4">
+            <div className="mb-3">
+              <div className="flex items-center gap-2">
+                <SkeletonBox className="h-5 w-5" />
+                <SkeletonText className="h-5 w-28" />
+              </div>
+              <SkeletonText className="mt-1 h-3 w-48" />
             </div>
 
             <div className="space-y-3">
               <div className="flex gap-2">
                 <SkeletonBox className="h-10 min-w-0 flex-1 rounded-lg" />
-                <SkeletonBox className="h-10 w-12 shrink-0 rounded-lg" />
+                <SkeletonBox className="h-10 w-[84px] shrink-0 rounded-lg" />
               </div>
-              <SkeletonBox className="h-10 w-full rounded-lg" />
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <SkeletonBox className="h-10 flex-1 rounded-lg" />
+                <SkeletonBox className="h-10 flex-1 rounded-lg" />
+              </div>
             </div>
           </div>
 
           {/* Referred Users List */}
           <div>
-            <div className="mb-3 flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <SkeletonBox className="h-5 w-5" />
-                <SkeletonText className="h-5 w-32" />
-              </div>
+            <div className="mb-3 flex items-center gap-2">
+              <SkeletonBox className="h-5 w-5" />
+              <SkeletonText className="h-5 w-32" />
             </div>
 
             <div className="space-y-3">
-              {[1, 2, 3].map((i) => (
+              {[0, 1, 2].map((i) => (
                 <div
                   key={i}
-                  className="flex items-center gap-3 rounded-lg border border-border bg-muted/30 p-3"
+                  className="flex items-center gap-3 rounded-lg border border-border p-3"
                 >
-                  <SkeletonBox className="h-10 w-10 shrink-0 rounded-full" />
-                  <div className="min-w-0 flex-1 space-y-2">
-                    <SkeletonText className="h-4 w-32" />
-                    <SkeletonText className="h-3 w-24" />
-                    <SkeletonText className="h-3 w-28" />
+                  <SkeletonBox className="h-8 w-8 shrink-0 rounded-full" delay={i * 50} />
+                  <div className="min-w-0 flex-1 space-y-1.5">
+                    <SkeletonText className="h-4 w-28" delay={i * 50} />
+                    <SkeletonText className="h-3 w-20" delay={i * 50} />
                   </div>
-                  <SkeletonBox className="h-6 w-6" />
+                  <SkeletonBox className="h-4 w-4" delay={i * 50} />
                 </div>
               ))}
             </div>
@@ -331,7 +246,6 @@ export function RewardsSkeleton() {
         </div>
       </div>
 
-      {/* Screen reader announcement */}
       <span className="sr-only">Loading rewards content, please wait...</span>
     </div>
   );

--- a/apps/web/src/components/settings/ApiKeysTab.tsx
+++ b/apps/web/src/components/settings/ApiKeysTab.tsx
@@ -246,7 +246,7 @@ export function ApiKeysTab() {
       )}
 
       {/* Generate New Key */}
-      <div className="rounded-lg border border-border bg-muted/50 p-4">
+      <div className="rounded-lg border border-border p-4">
         <h3 className="mb-3 font-semibold">Generate New API Key</h3>
         <div className="flex gap-2">
           <input

--- a/apps/web/src/components/settings/PrivacyTab.tsx
+++ b/apps/web/src/components/settings/PrivacyTab.tsx
@@ -5,6 +5,8 @@ import {
   AlertCircle,
   Download,
   ExternalLink,
+  FileText,
+  Mail,
   Shield,
   Trash2,
 } from 'lucide-react';
@@ -117,33 +119,38 @@ export function PrivacyTab() {
 
       {/* Legal Documents */}
       <div className="space-y-3 rounded-lg border border-border p-4">
-        <h3 className="font-semibold">Legal Documents</h3>
-        <div className="space-y-2">
-          <a
-            href="https://docs.babylon.market/legal/privacy-policy"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-2 text-[#0066FF] text-sm hover:underline"
-          >
-            <ExternalLink className="h-4 w-4" />
-            Privacy Policy
-          </a>
-          <a
-            href="https://docs.babylon.market/legal/terms-of-service"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-2 text-[#0066FF] text-sm hover:underline"
-          >
-            <ExternalLink className="h-4 w-4" />
-            Terms of Service
-          </a>
+        <div className="flex items-start gap-3">
+          <FileText className="mt-0.5 h-5 w-5 text-[#0066FF]" />
+          <div className="flex-1">
+            <h3 className="font-semibold">Legal Documents</h3>
+            <div className="mt-1 space-y-2">
+              <a
+                href="https://docs.babylon.market/legal/privacy-policy"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2 text-[#0066FF] text-sm hover:underline"
+              >
+                <ExternalLink className="h-4 w-4" />
+                Privacy Policy
+              </a>
+              <a
+                href="https://docs.babylon.market/legal/terms-of-service"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2 text-[#0066FF] text-sm hover:underline"
+              >
+                <ExternalLink className="h-4 w-4" />
+                Terms of Service
+              </a>
+            </div>
+            {user?.tosAcceptedAt && (
+              <p className="mt-2 text-muted-foreground text-xs">
+                You accepted the Terms of Service on{' '}
+                {new Date(user.tosAcceptedAt).toLocaleDateString()}
+              </p>
+            )}
+          </div>
         </div>
-        {user?.tosAcceptedAt && (
-          <p className="text-muted-foreground text-xs">
-            You accepted the Terms of Service on{' '}
-            {new Date(user.tosAcceptedAt).toLocaleDateString()}
-          </p>
-        )}
       </div>
 
       {/* Data Export (GDPR Right to Access) */}
@@ -295,22 +302,27 @@ export function PrivacyTab() {
       </div>
 
       {/* Contact Information */}
-      <div className="space-y-2 rounded-lg border border-border p-4">
-        <h3 className="font-semibold">Privacy Questions?</h3>
-        <p className="text-muted-foreground text-sm">
-          For privacy-related inquiries, data subject requests, or to exercise
-          your rights, contact us at:
-        </p>
-        <a
-          href="mailto:privacy@elizas.com"
-          className="text-[#0066FF] text-sm hover:underline"
-        >
-          privacy@elizas.com
-        </a>
-        <p className="mt-2 text-muted-foreground text-xs">
-          We will respond to verified requests within 30 days (45 days for
-          complex requests) as required by GDPR and CCPA.
-        </p>
+      <div className="space-y-3 rounded-lg border border-border p-4">
+        <div className="flex items-start gap-3">
+          <Mail className="mt-0.5 h-5 w-5 text-[#0066FF]" />
+          <div className="flex-1">
+            <h3 className="font-semibold">Privacy Questions?</h3>
+            <p className="mt-1 text-muted-foreground text-sm">
+              For privacy-related inquiries, data subject requests, or to
+              exercise your rights, contact us at:
+            </p>
+            <a
+              href="mailto:privacy@elizas.com"
+              className="text-[#0066FF] text-sm hover:underline"
+            >
+              privacy@elizas.com
+            </a>
+            <p className="mt-2 text-muted-foreground text-xs">
+              We will respond to verified requests within 30 days (45 days for
+              complex requests) as required by GDPR and CCPA.
+            </p>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/settings/SecurityTab.tsx
+++ b/apps/web/src/components/settings/SecurityTab.tsx
@@ -4,6 +4,7 @@ import { logger } from '@babylon/shared';
 import { usePrivy, useWallets } from '@privy-io/react-auth';
 import {
   AlertCircle,
+  BookOpen,
   CheckCircle2,
   Copy,
   ExternalLink,
@@ -141,103 +142,108 @@ export function SecurityTab() {
       </div>
 
       {/* Connected Wallets */}
-      <div className="space-y-4 rounded-lg border border-border p-4">
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <div>
-            <h3 className="flex items-center gap-2 font-semibold">
-              <Wallet className="h-4 w-4" />
-              Connected Wallets
-            </h3>
-            <p className="mt-1 text-muted-foreground text-sm">
-              Manage your blockchain wallets and authentication methods
-            </p>
-          </div>
-          {linkWallet && (
-            <button
-              onClick={linkWallet}
-              className="rounded-lg bg-[#0066FF] px-4 py-2 font-medium text-primary-foreground text-sm hover:bg-[#0066FF]/90"
-            >
-              Link Wallet
-            </button>
-          )}
-        </div>
+      <div className="rounded-lg border border-border p-4">
+        <div className="flex items-start gap-3">
+          <Wallet className="mt-0.5 h-5 w-5 shrink-0 text-[#0066FF]" />
+          <div className="flex-1 space-y-4">
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <div>
+                <h3 className="font-semibold">Connected Wallets</h3>
+                <p className="mt-1 text-muted-foreground text-sm">
+                  Manage your blockchain wallets and authentication methods
+                </p>
+              </div>
+              {linkWallet && (
+                <button
+                  onClick={linkWallet}
+                  className="rounded-lg bg-[#0066FF] px-4 py-2 font-medium text-primary-foreground text-sm hover:bg-[#0066FF]/90"
+                >
+                  Link Wallet
+                </button>
+              )}
+            </div>
 
-        {wallets.length === 0 ? (
-          <div className="py-8 text-center text-muted-foreground">
-            <Wallet className="mx-auto mb-3 h-12 w-12 opacity-50" />
-            <p className="text-sm">No wallets connected</p>
-          </div>
-        ) : (
-          <div className="mt-4 space-y-3">
-            {wallets.map((wallet) => (
-              <div
-                key={wallet.address}
-                className="flex flex-wrap items-center justify-between gap-4 rounded-lg bg-muted p-3"
-              >
-                <div className="min-w-0 flex-1">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="font-medium text-sm">
-                      {getWalletTypeDisplay(wallet.walletClientType)}
-                    </span>
-                    {isEmbeddedWallet(wallet.walletClientType) && (
-                      <span className="rounded bg-[#0066FF]/20 px-2 py-0.5 text-[#0066FF] text-xs">
-                        Embedded
-                      </span>
-                    )}
-                    {wallet.address === user?.walletAddress && (
-                      <span className="rounded bg-green-500/20 px-2 py-0.5 text-green-500 text-xs">
-                        Primary
-                      </span>
-                    )}
+            {wallets.length === 0 ? (
+              <div className="py-8 text-center text-muted-foreground">
+                <Wallet className="mx-auto mb-3 h-12 w-12 opacity-50" />
+                <p className="text-sm">No wallets connected</p>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {wallets.map((wallet) => (
+                  <div
+                    key={wallet.address}
+                    className="flex flex-wrap items-center justify-between gap-4 rounded-lg bg-muted p-3"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-medium text-sm">
+                          {getWalletTypeDisplay(wallet.walletClientType)}
+                        </span>
+                        {isEmbeddedWallet(wallet.walletClientType) && (
+                          <span className="rounded bg-[#0066FF]/20 px-2 py-0.5 text-[#0066FF] text-xs">
+                            Embedded
+                          </span>
+                        )}
+                        {wallet.address === user?.walletAddress && (
+                          <span className="rounded bg-green-500/20 px-2 py-0.5 text-green-500 text-xs">
+                            Primary
+                          </span>
+                        )}
+                      </div>
+                      <div className="mt-1 flex items-center gap-2">
+                        <code className="text-muted-foreground text-xs">
+                          {wallet.address.slice(0, 6)}...
+                          {wallet.address.slice(-4)}
+                        </code>
+                        <button
+                          onClick={() =>
+                            copyToClipboard(wallet.address, 'Address')
+                          }
+                          className="rounded p-1 hover:bg-background"
+                          title="Copy full address"
+                        >
+                          <Copy className="h-3 w-3 text-muted-foreground" />
+                        </button>
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {isEmbeddedWallet(wallet.walletClientType) &&
+                        exportWallet && (
+                          <button
+                            onClick={exportWallet}
+                            className="flex items-center gap-1 rounded border border-border bg-background px-3 py-1.5 font-medium text-xs hover:bg-accent"
+                            title="Export wallet private key"
+                          >
+                            <Key className="h-3 w-3" />
+                            <span className="hidden sm:inline">Export</span>
+                          </button>
+                        )}
+                      {wallets.length > 1 && unlinkWallet && (
+                        <button
+                          onClick={() => unlinkWallet(wallet.address)}
+                          className="rounded px-3 py-1.5 font-medium text-red-500 text-xs hover:bg-red-500/10"
+                        >
+                          Unlink
+                        </button>
+                      )}
+                    </div>
                   </div>
-                  <div className="mt-1 flex items-center gap-2">
-                    <code className="text-muted-foreground text-xs">
-                      {wallet.address.slice(0, 6)}...{wallet.address.slice(-4)}
-                    </code>
-                    <button
-                      onClick={() => copyToClipboard(wallet.address, 'Address')}
-                      className="rounded p-1 hover:bg-background"
-                      title="Copy full address"
-                    >
-                      <Copy className="h-3 w-3 text-muted-foreground" />
-                    </button>
-                  </div>
-                </div>
-                <div className="flex items-center gap-2">
-                  {isEmbeddedWallet(wallet.walletClientType) &&
-                    exportWallet && (
-                      <button
-                        onClick={exportWallet}
-                        className="flex items-center gap-1 rounded border border-border bg-background px-3 py-1.5 font-medium text-xs hover:bg-accent"
-                        title="Export wallet private key"
-                      >
-                        <Key className="h-3 w-3" />
-                        <span className="hidden sm:inline">Export</span>
-                      </button>
-                    )}
-                  {wallets.length > 1 && unlinkWallet && (
-                    <button
-                      onClick={() => unlinkWallet(wallet.address)}
-                      className="rounded px-3 py-1.5 font-medium text-red-500 text-xs hover:bg-red-500/10"
-                    >
-                      Unlink
-                    </button>
-                  )}
+                ))}
+              </div>
+            )}
+
+            <div className="rounded-lg border border-blue-500/20 bg-blue-500/5 p-3">
+              <div className="flex items-start gap-2">
+                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-blue-500" />
+                <div className="text-muted-foreground text-sm">
+                  <strong className="text-foreground">Embedded wallets</strong>{' '}
+                  are created and managed by Privy, enabling gasless
+                  transactions. You can export your private key at any time.{' '}
+                  <strong className="text-foreground">External wallets</strong>{' '}
+                  require you to pay gas fees.
                 </div>
               </div>
-            ))}
-          </div>
-        )}
-
-        <div className="mt-4 rounded-lg border border-blue-500/20 bg-blue-500/5 p-3">
-          <div className="flex items-start gap-2">
-            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-blue-500" />
-            <div className="text-muted-foreground text-sm">
-              <strong className="text-foreground">Embedded wallets</strong> are
-              created and managed by Privy, enabling gasless transactions. You
-              can export your private key at any time.{' '}
-              <strong className="text-foreground">External wallets</strong>{' '}
-              require you to pay gas fees.
             </div>
           </div>
         </div>
@@ -265,36 +271,41 @@ export function SecurityTab() {
 
       {/* Additional Resources */}
       <div className="space-y-3 rounded-lg border border-border p-4">
-        <h3 className="font-semibold">Security Resources</h3>
-        <div className="space-y-2">
-          <a
-            href="https://docs.privy.io/guide/security"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-2 text-[#0066FF] text-sm hover:underline"
-          >
-            <ExternalLink className="h-4 w-4" />
-            Privy Security Documentation
-          </a>
-          <a
-            href="https://docs.babylon.market/security"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-2 text-[#0066FF] text-sm hover:underline"
-          >
-            <ExternalLink className="h-4 w-4" />
-            Babylon Security Best Practices
-          </a>
+        <div className="flex items-start gap-3">
+          <BookOpen className="mt-0.5 h-5 w-5 text-[#0066FF]" />
+          <div className="flex-1">
+            <h3 className="font-semibold">Security Resources</h3>
+            <div className="mt-1 space-y-2">
+              <a
+                href="https://docs.privy.io/guide/security"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2 text-[#0066FF] text-sm hover:underline"
+              >
+                <ExternalLink className="h-4 w-4" />
+                Privy Security Documentation
+              </a>
+              <a
+                href="https://docs.babylon.market/security"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2 text-[#0066FF] text-sm hover:underline"
+              >
+                <ExternalLink className="h-4 w-4" />
+                Babylon Security Best Practices
+              </a>
+            </div>
+            <p className="mt-3 text-muted-foreground text-xs">
+              For security concerns or to report vulnerabilities, contact{' '}
+              <a
+                href="mailto:security@elizas.com"
+                className="text-[#0066FF] hover:underline"
+              >
+                security@elizas.com
+              </a>
+            </p>
+          </div>
         </div>
-        <p className="mt-3 text-muted-foreground text-xs">
-          For security concerns or to report vulnerabilities, contact{' '}
-          <a
-            href="mailto:security@elizas.com"
-            className="text-[#0066FF] hover:underline"
-          >
-            security@elizas.com
-          </a>
-        </p>
       </div>
 
       {/* Privacy & Account Deletion Link */}

--- a/apps/web/src/components/shared/Dropdown.tsx
+++ b/apps/web/src/components/shared/Dropdown.tsx
@@ -26,6 +26,7 @@ interface DropdownProps {
   trigger: ReactNode;
   children: ReactNode;
   className?: string;
+  popoverClassName?: string;
   placement?: 'top-right' | 'bottom-right' | 'top-left' | 'bottom-left';
   width?: 'default' | 'sidebar';
 }
@@ -34,6 +35,7 @@ export function Dropdown({
   trigger,
   children,
   className,
+  popoverClassName,
   placement = 'bottom-right',
   width = 'default',
 }: DropdownProps) {
@@ -75,7 +77,7 @@ export function Dropdown({
       };
 
   // Determine width based on width prop
-  const widthClass = width === 'sidebar' ? 'w-64 lg:w-64 xl:w-72' : 'w-60';
+  const widthClass = width === 'sidebar' ? 'w-full' : 'w-60';
 
   return (
     <div className={cn('relative', className)} ref={dropdownRef}>
@@ -90,7 +92,8 @@ export function Dropdown({
             className={cn(
               'absolute z-50 rounded-lg border border-border bg-popover shadow-lg',
               widthClass,
-              positionClasses
+              positionClasses,
+              popoverClassName
             )}
           >
             {children}

--- a/apps/web/src/components/shared/ExternalShareButton.tsx
+++ b/apps/web/src/components/shared/ExternalShareButton.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * External share button component with tracking and points rewards.
  *

--- a/apps/web/src/components/shared/ExternalShareButton.tsx
+++ b/apps/web/src/components/shared/ExternalShareButton.tsx
@@ -42,6 +42,8 @@ interface ExternalShareButtonProps {
   url?: string;
   text?: string;
   className?: string;
+  /** Render share buttons inline (side by side) instead of a dropdown */
+  inline?: boolean;
 }
 
 /**
@@ -56,6 +58,7 @@ export function ExternalShareButton({
   url,
   text,
   className = '',
+  inline = false,
 }: ExternalShareButtonProps) {
   const { authenticated, user } = useAuth();
   const [showMenu, setShowMenu] = useState(false);
@@ -205,6 +208,41 @@ export function ExternalShareButton({
     setTimeout(() => setShared(false), 2000);
     setShowMenu(false);
   };
+
+  if (inline) {
+    return (
+      <div className={`flex flex-col gap-2 sm:flex-row ${className}`}>
+        <button
+          onClick={handleShareToTwitter}
+          className="flex flex-1 items-center justify-center gap-2 rounded-lg border border-border px-3 py-2 text-foreground transition-colors hover:bg-muted/50"
+        >
+          <Twitter className="h-4 w-4 text-blue-400" />
+          <span className="font-medium text-sm">Share to X</span>
+        </button>
+        <button
+          onClick={handleShareToFarcaster}
+          className="flex flex-1 items-center justify-center gap-2 rounded-lg border border-border px-3 py-2 text-foreground transition-colors hover:bg-muted/50"
+        >
+          <FarcasterIcon className="h-4 w-4 text-purple-400" />
+          <span className="font-medium text-sm">Share to Farcaster</span>
+        </button>
+
+        {/* Verification Modal */}
+        {showVerification && pendingVerification && user && (
+          <ShareVerificationModal
+            isOpen={showVerification}
+            onClose={() => {
+              setShowVerification(false);
+              setPendingVerification(null);
+            }}
+            shareId={pendingVerification.shareId}
+            platform={pendingVerification.platform}
+            userId={user.id}
+          />
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className="relative">

--- a/apps/web/src/components/shared/Separator.tsx
+++ b/apps/web/src/components/shared/Separator.tsx
@@ -1,21 +1,5 @@
 import { cn } from '@babylon/shared';
 
-/**
- * Separator component for visual division between content sections.
- *
- * Provides a styled separator line with gradient effect. Supports both
- * horizontal and vertical orientations. Uses a subtle blue gradient with
- * shadow for visual depth.
- *
- * @param props - Separator component props
- * @returns Separator element
- *
- * @example
- * ```tsx
- * <Separator orientation="horizontal" />
- * <Separator orientation="vertical" className="h-20" />
- * ```
- */
 interface SeparatorProps {
   className?: string;
   orientation?: 'horizontal' | 'vertical';
@@ -26,30 +10,8 @@ export function Separator({
   orientation = 'horizontal',
 }: SeparatorProps) {
   if (orientation === 'vertical') {
-    return (
-      <div className={cn('h-full w-px', className)}>
-        <div
-          className="h-full w-px rounded-full"
-          style={{
-            background:
-              'linear-gradient(180deg, transparent, rgba(28, 156, 240, 0.3), transparent)',
-            boxShadow: '1px 0 2px rgba(0, 0, 0, 0.1)',
-          }}
-        />
-      </div>
-    );
+    return <div className={cn('h-full w-px bg-border', className)} />;
   }
 
-  return (
-    <div className={cn('h-px w-full', className)}>
-      <div
-        className="h-px w-full rounded-full"
-        style={{
-          background:
-            'linear-gradient(90deg, transparent, rgba(28, 156, 240, 0.3), transparent)',
-          boxShadow: '0 1px 2px rgba(0, 0, 0, 0.1)',
-        }}
-      />
-    </div>
-  );
+  return <div className={cn('h-px w-full bg-border', className)} />;
 }

--- a/apps/web/src/components/shared/Sidebar.tsx
+++ b/apps/web/src/components/shared/Sidebar.tsx
@@ -131,14 +131,12 @@ function SidebarContent() {
       name: 'Home',
       href: '/feed',
       icon: HouseIcon,
-      color: '#0066FF',
       active: pathname === '/feed' || pathname === '/',
     },
     {
       name: 'Notifications',
       href: '/notifications',
       icon: Bell,
-      color: '#0066FF',
       active: pathname === '/notifications',
       requiresAuth: true,
     },
@@ -146,21 +144,18 @@ function SidebarContent() {
       name: 'Leaderboard',
       href: '/leaderboard',
       icon: Trophy,
-      color: '#0066FF',
       active: pathname === '/leaderboard',
     },
     {
       name: 'Terminal',
       href: '/markets',
       icon: TrendingUp,
-      color: '#0066FF',
       active: pathname === '/markets',
     },
     {
       name: 'Chats',
       href: '/chats',
       icon: MessageCircle,
-      color: '#0066FF',
       active: pathname === '/chats',
       requiresAuth: true,
     },
@@ -168,7 +163,6 @@ function SidebarContent() {
       name: 'Agents',
       href: '/agents/team',
       icon: Users,
-      color: '#0066FF',
       active: pathname === '/agents' || pathname.startsWith('/agents/'),
       requiresAuth: true,
     },
@@ -176,7 +170,6 @@ function SidebarContent() {
       name: 'Rewards',
       href: '/rewards',
       icon: Gift,
-      color: '#0066FF',
       active: pathname === '/rewards',
       requiresAuth: true,
     },
@@ -184,7 +177,6 @@ function SidebarContent() {
       name: 'Profile',
       href: '/profile',
       icon: User,
-      color: '#0066FF',
       active: pathname === '/profile',
       requiresAuth: true,
     },
@@ -195,7 +187,6 @@ function SidebarContent() {
             name: 'Admin',
             href: '/admin',
             icon: Shield,
-            color: '#f97316',
             active: pathname === '/admin',
           },
         ]
@@ -224,11 +215,14 @@ function SidebarContent() {
           <Link href="/feed" aria-label="Babylon home">
             {/* Icon-only logo for md (tablet) or collapsed */}
             <BabylonIcon
-              className={cn('h-8 w-8 text-[#06f]', !collapsed && 'lg:hidden')}
+              className={cn(
+                'h-8 w-8 text-sidebar-primary',
+                !collapsed && 'lg:hidden'
+              )}
             />
             {/* Full logo with text for lg+ (desktop) when expanded */}
             {!collapsed && (
-              <BabylonFullLogo className="hidden h-8 w-auto text-[#06f] lg:block" />
+              <BabylonFullLogo className="hidden h-8 w-auto text-sidebar-primary lg:block" />
             )}
           </Link>
           {/* Collapse toggle - only visible on lg+ when expanded */}

--- a/apps/web/src/components/shared/Sidebar.tsx
+++ b/apps/web/src/components/shared/Sidebar.tsx
@@ -4,6 +4,8 @@ import { cn, getReferralUrl } from '@babylon/shared';
 import {
   Bell,
   Check,
+  ChevronsLeft,
+  ChevronsRight,
   Copy,
   Gift,
   LogOut,
@@ -23,7 +25,6 @@ import { Avatar } from '@/components/shared/Avatar';
 import { BabylonIcon } from '@/components/shared/icons/BabylonIcon';
 import { BabylonFullLogo } from '@/components/shared/icons/BabylonLogo';
 import { HouseIcon } from '@/components/shared/icons/HouseIcon';
-import { Separator } from '@/components/shared/Separator';
 import { useAuth } from '@/hooks/useAuth';
 import { useUnreadMessages } from '@/hooks/useUnreadMessages';
 import { getAuthToken } from '@/lib/auth';
@@ -38,6 +39,7 @@ import { getAuthToken } from '@/lib/auth';
  * @returns Sidebar content element
  */
 function SidebarContent() {
+  const [collapsed, setCollapsed] = useState(false);
   const [showMdMenu, setShowMdMenu] = useState(false);
   const [copiedReferral, setCopiedReferral] = useState(false);
   const [unreadNotifications, setUnreadNotifications] = useState(0);
@@ -208,21 +210,53 @@ function SidebarContent() {
           'sticky top-0 isolate z-40 hidden h-screen md:flex md:flex-col',
           'bg-sidebar',
           'transition-all duration-300',
-          'md:w-20 lg:w-64'
+          'md:w-20',
+          !collapsed && 'lg:w-64'
         )}
       >
-        {/* Header - Logo */}
-        <div className="flex items-center justify-center p-6 lg:justify-start lg:px-4">
+        {/* Header - Logo & Collapse Toggle */}
+        <div
+          className={cn(
+            'flex items-center justify-center p-6',
+            !collapsed && 'lg:justify-start lg:px-4'
+          )}
+        >
           <Link href="/feed" aria-label="Babylon home">
-            {/* Icon-only logo for md (tablet) */}
-            <BabylonIcon className="h-8 w-8 text-[#06f] lg:hidden" />
-            {/* Full logo with text for lg+ (desktop) */}
-            <BabylonFullLogo className="hidden h-8 w-auto text-[#06f] lg:block" />
+            {/* Icon-only logo for md (tablet) or collapsed */}
+            <BabylonIcon
+              className={cn('h-8 w-8 text-[#06f]', !collapsed && 'lg:hidden')}
+            />
+            {/* Full logo with text for lg+ (desktop) when expanded */}
+            {!collapsed && (
+              <BabylonFullLogo className="hidden h-8 w-auto text-[#06f] lg:block" />
+            )}
           </Link>
+          {/* Collapse toggle - only visible on lg+ when expanded */}
+          {!collapsed && (
+            <button
+              type="button"
+              onClick={() => setCollapsed(true)}
+              className="ml-auto hidden items-center justify-center rounded-md p-1 text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-black lg:flex dark:hover:text-white"
+              aria-label="Collapse sidebar"
+            >
+              <ChevronsLeft className="h-6 w-6" />
+            </button>
+          )}
         </div>
+        {/* Expand toggle - only visible on lg+ when collapsed, styled like nav items */}
+        {collapsed && (
+          <button
+            type="button"
+            onClick={() => setCollapsed(false)}
+            className="hidden w-full items-center justify-center px-4 py-3 text-sidebar-foreground transition-colors hover:bg-sidebar-accent hover:text-black lg:flex dark:hover:text-white"
+            aria-label="Expand sidebar"
+          >
+            <ChevronsRight className="h-6 w-6" />
+          </button>
+        )}
 
-        {/* Navigation */}
-        <nav className="pointer-events-auto relative z-20 flex-1">
+        {/* Navigation - scrollable when screen is short */}
+        <nav className="pointer-events-auto relative z-20 flex-1 overflow-y-auto">
           {navItems.map((item) => {
             const Icon = item.icon;
             const hasNotificationBadge =
@@ -232,7 +266,7 @@ function SidebarContent() {
             const navContent = (
               <>
                 {/* Icon with notification indicator */}
-                <div className="relative lg:mr-3">
+                <div className={cn('relative', !collapsed && 'lg:mr-3')}>
                   <Icon
                     className={cn(
                       'h-6 w-6 flex-shrink-0',
@@ -250,7 +284,8 @@ function SidebarContent() {
                 {/* Label - hidden on tablet (md), shown on desktop (lg+) */}
                 <span
                   className={cn(
-                    'hidden lg:block',
+                    'hidden',
+                    !collapsed && 'lg:block',
                     'text-lg transition-colors duration-300',
                     item.active
                       ? 'font-semibold text-black dark:text-white'
@@ -265,7 +300,8 @@ function SidebarContent() {
             const sharedClassName = cn(
               'group pointer-events-auto relative z-10 flex items-center px-4 py-3',
               'transition-colors duration-200',
-              'md:justify-center lg:justify-start',
+              'md:justify-center',
+              !collapsed && 'lg:justify-start',
               'bg-transparent hover:bg-sidebar-accent'
             );
 
@@ -297,13 +333,8 @@ function SidebarContent() {
           })}
         </nav>
 
-        {/* Separator - only shown on desktop */}
-        <div className="hidden px-4 py-2 lg:block">
-          <Separator />
-        </div>
-
         {/* Bottom Section - Authentication (Desktop lg+) */}
-        <div className="hidden p-4 lg:block">
+        <div className={cn('hidden', !collapsed && 'lg:block')}>
           {!ready ? (
             // Skeleton loader while authentication is initializing
             <div className="flex animate-pulse items-center gap-3 p-3">
@@ -322,48 +353,45 @@ function SidebarContent() {
 
         {/* Bottom Section - User Icon (Tablet md) */}
         {authenticated && user && (
-          <div className="relative md:block lg:hidden" ref={mdMenuRef}>
-            <div className="flex justify-center p-4">
-              <button
-                onClick={() => setShowMdMenu(!showMdMenu)}
-                className="transition-opacity hover:opacity-80"
-                aria-label="Open user menu"
-              >
-                <Avatar
-                  id={user.id}
-                  name={user.displayName || user.email || 'User'}
-                  type="user"
-                  size="md"
-                  src={user.profileImageUrl || undefined}
-                  imageUrl={user.profileImageUrl || undefined}
-                />
-              </button>
-            </div>
+          <div
+            className={cn('relative md:block', !collapsed && 'lg:hidden')}
+            ref={mdMenuRef}
+          >
+            {/* User avatar button - styled like nav items */}
+            <button
+              onClick={() => setShowMdMenu(!showMdMenu)}
+              className="flex w-full items-center justify-center px-4 py-3 transition-colors duration-200 hover:bg-sidebar-accent"
+              aria-label="Open user menu"
+            >
+              <Avatar
+                id={user.id}
+                name={user.displayName || user.email || 'User'}
+                type="user"
+                size="sm"
+                src={user.profileImageUrl || undefined}
+                imageUrl={user.profileImageUrl || undefined}
+              />
+            </button>
 
-            {/* Dropdown Menu - Icon Only */}
+            {/* Dropdown Menu - styled like nav items */}
             {showMdMenu && (
-              <div className="-translate-x-1/2 absolute bottom-full left-1/2 z-50 mb-2 w-auto overflow-hidden rounded-lg border border-border bg-sidebar shadow-lg">
+              <div className="absolute bottom-full left-0 z-50 mb-2 w-full overflow-hidden bg-sidebar shadow-lg">
                 {/* Referral Code */}
                 {user.referralCode && (
                   <button
                     onClick={copyReferralCode}
-                    className="flex w-full items-center justify-center p-3 transition-colors hover:bg-sidebar-accent"
+                    className="flex w-full items-center justify-center px-4 py-3 transition-colors duration-200 hover:bg-sidebar-accent"
                     title={copiedReferral ? 'Copied!' : 'Copy Referral Link'}
                     aria-label={
                       copiedReferral ? 'Copied!' : 'Copy Referral Link'
                     }
                   >
                     {copiedReferral ? (
-                      <Check className="h-5 w-5 flex-shrink-0 text-green-500" />
+                      <Check className="h-6 w-6 flex-shrink-0 text-green-500" />
                     ) : (
-                      <Copy className="h-5 w-5 flex-shrink-0 text-sidebar-foreground" />
+                      <Copy className="h-6 w-6 flex-shrink-0 text-sidebar-foreground" />
                     )}
                   </button>
-                )}
-
-                {/* Separator */}
-                {user.referralCode && (
-                  <div className="border-border border-t" />
                 )}
 
                 {/* Logout */}
@@ -372,11 +400,11 @@ function SidebarContent() {
                     setShowMdMenu(false);
                     logout();
                   }}
-                  className="flex w-full items-center justify-center p-3 text-destructive transition-colors hover:bg-destructive/10"
+                  className="flex w-full items-center justify-center px-4 py-3 text-destructive transition-colors duration-200 hover:bg-sidebar-accent"
                   title="Logout"
                   aria-label="Logout"
                 >
-                  <LogOut className="h-5 w-5 flex-shrink-0" />
+                  <LogOut className="h-6 w-6 flex-shrink-0" />
                 </button>
               </div>
             )}

--- a/apps/web/src/components/shared/Skeleton.tsx
+++ b/apps/web/src/components/shared/Skeleton.tsx
@@ -517,7 +517,7 @@ export function FeedLayoutSkeleton() {
   return (
     <div className="relative flex flex-1">
       {/* Feed column */}
-      <div className="flex min-w-0 flex-1 flex-col border-[rgba(120,120,120,0.15)] lg:border-r lg:border-l">
+      <div className="flex min-w-0 flex-1 flex-col border-border lg:border-r lg:border-l">
         {/* Sticky header placeholder (FeedToggle) */}
         <div className="sticky top-0 z-10 flex-shrink-0 bg-background shadow-sm">
           <div className="flex w-full items-center border-border border-b">


### PR DESCRIPTION
## Summary

Comprehensive UI redesign pass across the web app to establish a consistent, modern design language. Replaces hardcoded color values with theme tokens, removes heavy backgrounds and gradients in favor of clean bordered cards, and fixes various layout/alignment issues.

## Changes

### Settings page
- Replace all hardcoded `#0066FF` with theme tokens (`text-primary`, `border-primary`, `bg-primary`)
- Add glassmorphism sticky header with `backdrop-blur`
- Wrap profile fields in bordered card container
- Redesign theme tab with visual cards (Sun/Moon/Monitor icons), horizontal layout, `CheckCircle2` selected state
- Right-align save button, remove rounded corners and divider line
- Use `AlertCircle` icon for error/warning alerts
- Remove input background colors (`bg-muted/50`)

### Settings sub-tabs
- **PrivacyTab**: add Mail icon to Privacy Questions block, FileText icon to Legal Documents block
- **SecurityTab**: add Wallet icon to Connected Wallets block, BookOpen icon to Security Resources block, align content with title not icon
- **ApiKeysTab**: remove background from Generate New API Key section

### Rewards page
- Remove all gray backgrounds (`bg-muted/30`, `bg-sidebar-accent/50`, `bg-sidebar-accent`) from stat cards, task buttons, referral link containers, and referral user cards
- Remove colored gradient/border from Total Earned and Total Points stat cards, use consistent `border-border` styling
- Merge Share & Earn section into Earn Points card as a task row
- Add inline mode to `ExternalShareButton` (Share to X + Share to Farcaster side by side, vertical on mobile)
- Fix copy button width (`w-[84px]`) to prevent layout shift between Copy/Copied states
- Stack referral link title and description on separate rows for mobile
- Right-align referral link description on desktop

### Rewards skeleton
- Rewrite `RewardsSkeleton` to match redesigned rewards page layout (no gray backgrounds, consistent `border-border` cards, merged Share & Earn into Earn Points, `DailyStreakCard` placeholder, inline share buttons, fixed-width copy button, responsive referral link header)

### Profile page
- Redesign `ProfileWidget` sidebar with consistent bordered cards for Points, Holdings, and Stats sections
- Add themed icons (Coins, Wallet, BarChart3) to section headers
- Highlight Total Points in `bg-primary/5` card with `text-primary` styling

### PostCard (simple reposts)
- Always show avatar column so content aligns with normal posts
- Always show author name/handle header row
- Move "Reposted by" indicator to its own row above avatar+header
- Render original post content directly without bordered card or duplicate avatar/name (quote posts still use embedded card)

### Notifications page
- Remove background color from notification emoji avatars

### Markets terminal
- Remove auto-open behavior for market dropdown
- Redesign market list skeleton to match real table-row UI (star, title+subtitle, value, change badge)

### Chat system
- Remove neumorphic `box-shadow` from `.message-bubble` and `.message-input` in `globals.css`
- Fix team chat title truncation (add `truncate`, `min-w-0` through flex chain)
- Fix chat content clipping when right sidebar opens (remove `md:min-w-[400px]`)
- Add overflow and truncation fixes to `ChatViewHeader`

### Theme
- Update dark mode `--border` from `#2f3336` to `#393d41`
- Update dark mode `--sidebar-border` from `#2f3336` to `#393d41`

### Auth
- `LinkSocialAccountsModal`: change Farcaster button text color to white

### Other
- Remove unused `Separator` import from `Sidebar.tsx`