### PR TITLE
feat: improve profile replies and trades tab styling

### DIFF
--- a/apps/web/src/app/api/users/[userId]/posts/route.ts
+++ b/apps/web/src/app/api/users/[userId]/posts/route.ts
@@ -267,6 +267,149 @@ export const GET = withErrorHandling(
         );
       }
 
+      // Fetch interaction counts for parent posts
+      const [postLikeCounts, postCommentCounts, postShareCounts] =
+        await Promise.all([
+          db
+            .select({
+              postId: reactions.postId,
+              count: count(),
+            })
+            .from(reactions)
+            .where(
+              and(
+                inArray(reactions.postId, postIds),
+                eq(reactions.type, 'like')
+              )
+            )
+            .groupBy(reactions.postId),
+          db
+            .select({
+              postId: comments.postId,
+              count: count(),
+            })
+            .from(comments)
+            .where(inArray(comments.postId, postIds))
+            .groupBy(comments.postId),
+          db
+            .select({
+              postId: shares.postId,
+              count: count(),
+            })
+            .from(shares)
+            .where(inArray(shares.postId, postIds))
+            .groupBy(shares.postId),
+        ]);
+
+      const postLikeCountsMap = new Map(
+        postLikeCounts.map((r) => [r.postId, Number(r.count)])
+      );
+      const postCommentCountsMap = new Map(
+        postCommentCounts.map((r) => [r.postId, Number(r.count)])
+      );
+      const postShareCountsMap = new Map(
+        postShareCounts.map((r) => [r.postId, Number(r.count)])
+      );
+
+      // Fetch interaction counts for parent comments
+      let parentCommentLikeCountsMap = new Map<string, number>();
+      let parentCommentReplyCountsMap = new Map<string, number>();
+      if (parentCommentIds.length > 0) {
+        const [parentCommentLikeCounts, parentCommentReplyCounts] =
+          await Promise.all([
+            db
+              .select({
+                commentId: reactions.commentId,
+                count: count(),
+              })
+              .from(reactions)
+              .where(
+                and(
+                  inArray(reactions.commentId, parentCommentIds),
+                  eq(reactions.type, 'like')
+                )
+              )
+              .groupBy(reactions.commentId),
+            db
+              .select({
+                parentCommentId: comments.parentCommentId,
+                count: count(),
+              })
+              .from(comments)
+              .where(inArray(comments.parentCommentId, parentCommentIds))
+              .groupBy(comments.parentCommentId),
+          ]);
+
+        parentCommentLikeCountsMap = new Map(
+          parentCommentLikeCounts
+            .filter(
+              (r): r is typeof r & { commentId: string } => r.commentId !== null
+            )
+            .map((r) => [r.commentId, Number(r.count)])
+        );
+        parentCommentReplyCountsMap = new Map(
+          parentCommentReplyCounts
+            .filter(
+              (r): r is typeof r & { parentCommentId: string } =>
+                r.parentCommentId !== null
+            )
+            .map((r) => [r.parentCommentId, Number(r.count)])
+        );
+      }
+
+      // Fetch user's likes/shares on parent posts and parent comments
+      let userPostLikesSet = new Set<string>();
+      let userPostSharesSet = new Set<string>();
+      let userParentCommentLikesSet = new Set<string>();
+      if (user) {
+        const [userPostLikes, userPostShares, userParentCommentLikes] =
+          await Promise.all([
+            db
+              .select({ postId: reactions.postId })
+              .from(reactions)
+              .where(
+                and(
+                  inArray(reactions.postId, postIds),
+                  eq(reactions.userId, user.userId),
+                  eq(reactions.type, 'like')
+                )
+              ),
+            db
+              .select({ postId: shares.postId })
+              .from(shares)
+              .where(
+                and(
+                  inArray(shares.postId, postIds),
+                  eq(shares.userId, user.userId)
+                )
+              ),
+            parentCommentIds.length > 0
+              ? db
+                  .select({ commentId: reactions.commentId })
+                  .from(reactions)
+                  .where(
+                    and(
+                      inArray(reactions.commentId, parentCommentIds),
+                      eq(reactions.userId, user.userId),
+                      eq(reactions.type, 'like')
+                    )
+                  )
+              : Promise.resolve([]),
+          ]);
+
+        userPostLikesSet = new Set(
+          userPostLikes
+            .map((l) => l.postId)
+            .filter((id): id is string => id !== null)
+        );
+        userPostSharesSet = new Set(userPostShares.map((s) => s.postId));
+        userParentCommentLikesSet = new Set(
+          userParentCommentLikes
+            .map((l) => l.commentId)
+            .filter((id): id is string => id !== null)
+        );
+      }
+
       // Fetch author info for posts and parent comments
       const parentCommentAuthorIds = [
         ...new Set(
@@ -363,6 +506,11 @@ export const GET = withErrorHandling(
                 authorId: parentComment.authorId,
                 createdAt: parentComment.createdAt.toISOString(),
                 author: getAuthorInfo(parentComment.authorId),
+                likeCount:
+                  parentCommentLikeCountsMap.get(parentComment.id) ?? 0,
+                replyCount:
+                  parentCommentReplyCountsMap.get(parentComment.id) ?? 0,
+                isLiked: userParentCommentLikesSet.has(parentComment.id),
               }
             : null,
           // Original post (always included for context)
@@ -373,6 +521,11 @@ export const GET = withErrorHandling(
                 authorId: post.authorId,
                 timestamp: post.timestamp.toISOString(),
                 author: getAuthorInfo(post.authorId),
+                likeCount: postLikeCountsMap.get(post.id) ?? 0,
+                commentCount: postCommentCountsMap.get(post.id) ?? 0,
+                shareCount: postShareCountsMap.get(post.id) ?? 0,
+                isLiked: userPostLikesSet.has(post.id),
+                isShared: userPostSharesSet.has(post.id),
               }
             : null,
         };

--- a/apps/web/src/app/api/users/[userId]/posts/route.ts
+++ b/apps/web/src/app/api/users/[userId]/posts/route.ts
@@ -155,7 +155,12 @@ export const GET = withErrorHandling(
       const userComments = await db
         .select()
         .from(comments)
-        .where(eq(comments.authorId, canonicalUserId))
+        .where(
+          and(
+            eq(comments.authorId, canonicalUserId),
+            isNull(comments.deletedAt)
+          )
+        )
         .orderBy(desc(comments.createdAt))
         .limit(100);
 
@@ -209,7 +214,12 @@ export const GET = withErrorHandling(
             createdAt: comments.createdAt,
           })
           .from(comments)
-          .where(inArray(comments.id, parentCommentIds));
+          .where(
+            and(
+              inArray(comments.id, parentCommentIds),
+              isNull(comments.deletedAt)
+            )
+          );
 
         parentCommentsMap = new Map(parentCommentsData.map((c) => [c.id, c]));
       }
@@ -240,7 +250,12 @@ export const GET = withErrorHandling(
           count: count(),
         })
         .from(comments)
-        .where(inArray(comments.parentCommentId, commentIds))
+        .where(
+          and(
+            inArray(comments.parentCommentId, commentIds),
+            isNull(comments.deletedAt)
+          )
+        )
         .groupBy(comments.parentCommentId);
 
       const replyCountsMap = new Map(
@@ -269,37 +284,44 @@ export const GET = withErrorHandling(
 
       // Fetch interaction counts for parent posts
       const [postLikeCounts, postCommentCounts, postShareCounts] =
-        await Promise.all([
-          db
-            .select({
-              postId: reactions.postId,
-              count: count(),
-            })
-            .from(reactions)
-            .where(
-              and(
-                inArray(reactions.postId, postIds),
-                eq(reactions.type, 'like')
-              )
-            )
-            .groupBy(reactions.postId),
-          db
-            .select({
-              postId: comments.postId,
-              count: count(),
-            })
-            .from(comments)
-            .where(inArray(comments.postId, postIds))
-            .groupBy(comments.postId),
-          db
-            .select({
-              postId: shares.postId,
-              count: count(),
-            })
-            .from(shares)
-            .where(inArray(shares.postId, postIds))
-            .groupBy(shares.postId),
-        ]);
+        postIds.length > 0
+          ? await Promise.all([
+              db
+                .select({
+                  postId: reactions.postId,
+                  count: count(),
+                })
+                .from(reactions)
+                .where(
+                  and(
+                    inArray(reactions.postId, postIds),
+                    eq(reactions.type, 'like')
+                  )
+                )
+                .groupBy(reactions.postId),
+              db
+                .select({
+                  postId: comments.postId,
+                  count: count(),
+                })
+                .from(comments)
+                .where(
+                  and(
+                    inArray(comments.postId, postIds),
+                    isNull(comments.deletedAt)
+                  )
+                )
+                .groupBy(comments.postId),
+              db
+                .select({
+                  postId: shares.postId,
+                  count: count(),
+                })
+                .from(shares)
+                .where(inArray(shares.postId, postIds))
+                .groupBy(shares.postId),
+            ])
+          : [[], [], []];
 
       const postLikeCountsMap = new Map(
         postLikeCounts.map((r) => [r.postId, Number(r.count)])
@@ -336,7 +358,12 @@ export const GET = withErrorHandling(
                 count: count(),
               })
               .from(comments)
-              .where(inArray(comments.parentCommentId, parentCommentIds))
+              .where(
+                and(
+                  inArray(comments.parentCommentId, parentCommentIds),
+                  isNull(comments.deletedAt)
+                )
+              )
               .groupBy(comments.parentCommentId),
           ]);
 
@@ -364,25 +391,29 @@ export const GET = withErrorHandling(
       if (user) {
         const [userPostLikes, userPostShares, userParentCommentLikes] =
           await Promise.all([
-            db
-              .select({ postId: reactions.postId })
-              .from(reactions)
-              .where(
-                and(
-                  inArray(reactions.postId, postIds),
-                  eq(reactions.userId, user.userId),
-                  eq(reactions.type, 'like')
-                )
-              ),
-            db
-              .select({ postId: shares.postId })
-              .from(shares)
-              .where(
-                and(
-                  inArray(shares.postId, postIds),
-                  eq(shares.userId, user.userId)
-                )
-              ),
+            postIds.length > 0
+              ? db
+                  .select({ postId: reactions.postId })
+                  .from(reactions)
+                  .where(
+                    and(
+                      inArray(reactions.postId, postIds),
+                      eq(reactions.userId, user.userId),
+                      eq(reactions.type, 'like')
+                    )
+                  )
+              : Promise.resolve([] as Array<{ postId: string | null }>),
+            postIds.length > 0
+              ? db
+                  .select({ postId: shares.postId })
+                  .from(shares)
+                  .where(
+                    and(
+                      inArray(shares.postId, postIds),
+                      eq(shares.userId, user.userId)
+                    )
+                  )
+              : Promise.resolve([] as Array<{ postId: string }>),
             parentCommentIds.length > 0
               ? db
                   .select({ commentId: reactions.commentId })
@@ -394,7 +425,7 @@ export const GET = withErrorHandling(
                       eq(reactions.type, 'like')
                     )
                   )
-              : Promise.resolve([]),
+              : Promise.resolve([] as Array<{ commentId: string | null }>),
           ]);
 
         userPostLikesSet = new Set(
@@ -591,7 +622,7 @@ export const GET = withErrorHandling(
         count: count(),
       })
       .from(comments)
-      .where(inArray(comments.postId, postIds))
+      .where(and(inArray(comments.postId, postIds), isNull(comments.deletedAt)))
       .groupBy(comments.postId);
 
     const commentCountsMap = new Map(

--- a/apps/web/src/components/profile/ProfileReplyCard.tsx
+++ b/apps/web/src/components/profile/ProfileReplyCard.tsx
@@ -3,7 +3,7 @@
 import { getProfileUrl } from '@babylon/shared';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { CommentInput } from '@/components/interactions/CommentInput';
 import { CommentInteractionBar } from '@/components/interactions/CommentInteractionBar';
 import { InteractionBar } from '@/components/interactions/InteractionBar';
@@ -132,6 +132,56 @@ export function ProfileReplyCard({
     ? `/comment/${reply.parentComment?.id}`
     : `/post/${reply.post.id}`;
 
+  const parentPostInteractions = useMemo(
+    () => ({
+      postId: reply.post.id,
+      likeCount: reply.post.likeCount ?? 0,
+      commentCount: reply.post.commentCount ?? 0,
+      shareCount: reply.post.shareCount ?? 0,
+      isLiked: reply.post.isLiked ?? false,
+      isShared: reply.post.isShared ?? false,
+    }),
+    [
+      reply.post.commentCount,
+      reply.post.id,
+      reply.post.isLiked,
+      reply.post.isShared,
+      reply.post.likeCount,
+      reply.post.shareCount,
+    ]
+  );
+
+  const parentPostData = useMemo(
+    () => ({
+      id: reply.post.id,
+      content: reply.post.content,
+      authorId: reply.post.authorId,
+      authorName: parentAuthorName,
+      authorUsername: parentAuthorUsername,
+      authorProfileImageUrl: parentAuthorProfileImageUrl,
+      timestamp: reply.post.timestamp,
+      likeCount: reply.post.likeCount,
+      commentCount: reply.post.commentCount,
+      shareCount: reply.post.shareCount,
+      isLiked: reply.post.isLiked,
+      isShared: reply.post.isShared,
+    }),
+    [
+      parentAuthorName,
+      parentAuthorProfileImageUrl,
+      parentAuthorUsername,
+      reply.post.authorId,
+      reply.post.commentCount,
+      reply.post.content,
+      reply.post.id,
+      reply.post.isLiked,
+      reply.post.isShared,
+      reply.post.likeCount,
+      reply.post.shareCount,
+      reply.post.timestamp,
+    ]
+  );
+
   const handleTagClick = (tag: string) => {
     if (tag.startsWith('@')) {
       const username = tag.slice(1);
@@ -220,29 +270,9 @@ export function ProfileReplyCard({
             ) : (
               <InteractionBar
                 postId={reply.post.id}
-                initialInteractions={{
-                  postId: reply.post.id,
-                  likeCount: reply.post.likeCount ?? 0,
-                  commentCount: reply.post.commentCount ?? 0,
-                  shareCount: reply.post.shareCount ?? 0,
-                  isLiked: reply.post.isLiked ?? false,
-                  isShared: reply.post.isShared ?? false,
-                }}
+                initialInteractions={parentPostInteractions}
                 onCommentClick={() => router.push(`/post/${reply.post.id}`)}
-                postData={{
-                  id: reply.post.id,
-                  content: reply.post.content,
-                  authorId: reply.post.authorId,
-                  authorName: parentAuthorName,
-                  authorUsername: parentAuthorUsername,
-                  authorProfileImageUrl: parentAuthorProfileImageUrl,
-                  timestamp: reply.post.timestamp,
-                  likeCount: reply.post.likeCount,
-                  commentCount: reply.post.commentCount,
-                  shareCount: reply.post.shareCount,
-                  isLiked: reply.post.isLiked,
-                  isShared: reply.post.isShared,
-                }}
+                postData={parentPostData}
               />
             )}
           </div>

--- a/apps/web/src/components/profile/ProfileReplyCard.tsx
+++ b/apps/web/src/components/profile/ProfileReplyCard.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { cn, getProfileUrl } from '@babylon/shared';
-import { formatDistanceToNow } from 'date-fns';
-import { MessageCircle, Repeat2 } from 'lucide-react';
+import { getProfileUrl } from '@babylon/shared';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { CommentInput } from '@/components/interactions/CommentInput';
-import { LikeButton } from '@/components/interactions/LikeButton';
+import { CommentInteractionBar } from '@/components/interactions/CommentInteractionBar';
+import { InteractionBar } from '@/components/interactions/InteractionBar';
+import { formatTimeAgo } from '@/components/posts/CommentPreview';
 import { Avatar } from '@/components/shared/Avatar';
 import { TaggedText } from '@/components/shared/TaggedText';
 import {
@@ -45,6 +45,9 @@ export interface ProfileReply {
     authorId: string;
     createdAt: string;
     author?: AuthorInfo | null;
+    likeCount?: number;
+    replyCount?: number;
+    isLiked?: boolean;
   } | null;
   // Original post
   post: {
@@ -53,6 +56,11 @@ export interface ProfileReply {
     authorId: string;
     timestamp: string;
     author?: AuthorInfo | null;
+    likeCount?: number;
+    commentCount?: number;
+    shareCount?: number;
+    isLiked?: boolean;
+    isShared?: boolean;
   };
 }
 
@@ -145,60 +153,98 @@ export function ProfileReplyCard({
       {/* Parent Content - what they replied to (post or comment) */}
       <div className="relative">
         {/* Connector line - from parent avatar down to reply */}
-        <div className="absolute top-10 bottom-0 left-[1.625rem] w-0.5 bg-border sm:left-[1.875rem]" />
+        <div className="absolute top-10 bottom-0 left-[2.1875rem] w-0.5 bg-border sm:left-[2.6875rem]" />
 
         <div
           className="flex cursor-pointer gap-3 px-4 py-3 transition-colors hover:bg-muted/50 sm:px-6"
           onClick={() => router.push(parentNavigateUrl)}
         >
           {/* Parent Author Avatar */}
-          <Link
-            href={getProfileUrl(parentAuthorId, parentAuthorUsername)}
-            className="relative z-10 shrink-0 transition-opacity hover:opacity-80"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <Avatar
-              id={parentAuthorId}
-              name={parentAuthorName}
-              size="sm"
-              imageUrl={parentAuthorProfileImageUrl || undefined}
-            />
-          </Link>
+          <div className="flex flex-col items-center">
+            <Link
+              href={getProfileUrl(parentAuthorId, parentAuthorUsername)}
+              className="relative z-10 shrink-0 transition-opacity hover:opacity-80"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Avatar
+                id={parentAuthorId}
+                name={parentAuthorName}
+                size="md"
+                src={parentAuthorProfileImageUrl || undefined}
+              />
+            </Link>
+          </div>
 
           {/* Parent Content */}
           <div className="min-w-0 flex-1">
             {/* Header */}
-            <div className="mb-1 flex items-center gap-2">
-              <Link
-                href={getProfileUrl(parentAuthorId, parentAuthorUsername)}
-                className="truncate font-semibold text-sm hover:underline"
-                onClick={(e) => e.stopPropagation()}
-              >
-                {parentAuthorName}
-              </Link>
-              {parentAuthorIsNPC && (
-                <VerifiedBadge size="sm" className="-ml-1" />
+            <div className="flex items-start justify-between gap-2">
+              <div className="flex min-w-0 items-center gap-1">
+                <Link
+                  href={getProfileUrl(parentAuthorId, parentAuthorUsername)}
+                  className="truncate font-semibold text-[15px] text-foreground hover:underline"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {parentAuthorName}
+                </Link>
+                {parentAuthorIsNPC && <VerifiedBadge size="sm" />}
+                {parentAuthorUsername && (
+                  <span className="truncate text-[15px] text-muted-foreground">
+                    @{parentAuthorUsername}
+                  </span>
+                )}
+              </div>
+              {parentTimestamp && (
+                <span className="shrink-0 text-muted-foreground text-xs">
+                  {formatTimeAgo(parentTimestamp)}
+                </span>
               )}
-              <Link
-                href={getProfileUrl(parentAuthorId, parentAuthorUsername)}
-                className="truncate text-muted-foreground text-xs hover:underline"
-                onClick={(e) => e.stopPropagation()}
-              >
-                @{parentAuthorUsername || parentAuthorName}
-              </Link>
-              <span className="text-muted-foreground text-xs">·</span>
-              <span className="text-muted-foreground text-xs">
-                {parentTimestamp &&
-                  formatDistanceToNow(new Date(parentTimestamp), {
-                    addSuffix: true,
-                  })}
-              </span>
             </div>
 
             {/* Parent Content - truncated */}
-            <p className="line-clamp-3 text-foreground text-sm">
+            <p className="mt-0.5 line-clamp-3 text-foreground text-sm leading-relaxed">
               <TaggedText text={parentContent} onTagClick={handleTagClick} />
             </p>
+
+            {/* Parent Interaction Bar */}
+            {isReplyToComment ? (
+              <CommentInteractionBar
+                commentId={reply.parentComment!.id}
+                likeCount={reply.parentComment?.likeCount}
+                isLiked={reply.parentComment?.isLiked}
+                replyCount={reply.parentComment?.replyCount}
+                onReplyClick={() =>
+                  router.push(`/comment/${reply.parentComment!.id}`)
+                }
+              />
+            ) : (
+              <InteractionBar
+                postId={reply.post.id}
+                initialInteractions={{
+                  postId: reply.post.id,
+                  likeCount: reply.post.likeCount ?? 0,
+                  commentCount: reply.post.commentCount ?? 0,
+                  shareCount: reply.post.shareCount ?? 0,
+                  isLiked: reply.post.isLiked ?? false,
+                  isShared: reply.post.isShared ?? false,
+                }}
+                onCommentClick={() => router.push(`/post/${reply.post.id}`)}
+                postData={{
+                  id: reply.post.id,
+                  content: reply.post.content,
+                  authorId: reply.post.authorId,
+                  authorName: parentAuthorName,
+                  authorUsername: parentAuthorUsername,
+                  authorProfileImageUrl: parentAuthorProfileImageUrl,
+                  timestamp: reply.post.timestamp,
+                  likeCount: reply.post.likeCount,
+                  commentCount: reply.post.commentCount,
+                  shareCount: reply.post.shareCount,
+                  isLiked: reply.post.isLiked,
+                  isShared: reply.post.isShared,
+                }}
+              />
+            )}
           </div>
         </div>
       </div>
@@ -209,99 +255,58 @@ export function ProfileReplyCard({
         onClick={() => router.push(`/comment/${reply.id}`)}
       >
         {/* Reply Author Avatar */}
-        <Link
-          href={getProfileUrl(authorId, authorUsername)}
-          className="shrink-0 transition-opacity hover:opacity-80"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <Avatar
-            id={authorId}
-            name={authorName}
-            size="sm"
-            imageUrl={authorProfileImageUrl || undefined}
-          />
-        </Link>
+        <div className="flex flex-col items-center">
+          <Link
+            href={getProfileUrl(authorId, authorUsername)}
+            className="shrink-0 transition-opacity hover:opacity-80"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <Avatar
+              id={authorId}
+              name={authorName}
+              size="md"
+              src={authorProfileImageUrl || undefined}
+            />
+          </Link>
+        </div>
 
         {/* Reply Content */}
         <div className="min-w-0 flex-1">
           {/* Header */}
-          <div className="mb-1 flex items-center gap-2">
-            <Link
-              href={getProfileUrl(authorId, authorUsername)}
-              className="truncate font-semibold text-sm hover:underline"
-              onClick={(e) => e.stopPropagation()}
-            >
-              {authorName}
-            </Link>
-            {replyAuthorIsNPC && <VerifiedBadge size="sm" className="-ml-1" />}
-            <Link
-              href={getProfileUrl(authorId, authorUsername)}
-              className="truncate text-muted-foreground text-xs hover:underline"
-              onClick={(e) => e.stopPropagation()}
-            >
-              @{authorUsername || authorName}
-            </Link>
-            <span className="text-muted-foreground text-xs">·</span>
-            <span className="text-muted-foreground text-xs">
-              {formatDistanceToNow(new Date(reply.createdAt), {
-                addSuffix: true,
-              })}
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex min-w-0 items-center gap-1">
+              <Link
+                href={getProfileUrl(authorId, authorUsername)}
+                className="truncate font-semibold text-[15px] text-foreground hover:underline"
+                onClick={(e) => e.stopPropagation()}
+              >
+                {authorName}
+              </Link>
+              {replyAuthorIsNPC && <VerifiedBadge size="sm" />}
+              {authorUsername && (
+                <span className="truncate text-[15px] text-muted-foreground">
+                  @{authorUsername}
+                </span>
+              )}
+            </div>
+            <span className="shrink-0 text-muted-foreground text-xs">
+              {formatTimeAgo(reply.createdAt)}
             </span>
           </div>
 
           {/* Reply Content */}
-          <p className="mb-2 whitespace-pre-wrap break-words text-foreground text-sm">
+          <p className="mt-0.5 whitespace-pre-wrap break-words text-foreground text-sm leading-relaxed">
             <TaggedText text={reply.content} onTagClick={handleTagClick} />
           </p>
 
           {/* Action Buttons */}
-          <div
-            className="mt-2 flex w-full items-center justify-between gap-6 text-muted-foreground"
-            onClick={(e) => e.stopPropagation()}
-          >
-            {/* Reply button */}
-            <button
-              type="button"
-              onClick={() => setIsReplying(!isReplying)}
-              className={cn(
-                'flex flex-1 items-center gap-1',
-                'bg-transparent transition-all duration-200 hover:opacity-70',
-                'cursor-pointer text-muted-foreground text-xs',
-                isReplying && 'text-[#0066FF]'
-              )}
-            >
-              <MessageCircle size={18} />
-              {replyCount > 0 && (
-                <span className="font-medium tabular-nums">{replyCount}</span>
-              )}
-            </button>
-
-            {/* Repost button (placeholder) */}
-            <div className="flex-1">
-              <button
-                type="button"
-                disabled
-                className="flex cursor-default items-center gap-1 text-muted-foreground/40 text-xs"
-              >
-                <Repeat2 size={18} />
-              </button>
-            </div>
-
-            {/* Like button */}
-            <div className="flex-1">
-              <LikeButton
-                targetId={reply.id}
-                targetType="comment"
-                initialLiked={reply.isLiked}
-                initialCount={reply.likeCount}
-                size="sm"
-                showCount
-              />
-            </div>
-
-            {/* Empty spacer to match 4-column layout */}
-            <div className="flex-1" />
-          </div>
+          <CommentInteractionBar
+            commentId={reply.id}
+            likeCount={reply.likeCount}
+            isLiked={reply.isLiked}
+            replyCount={replyCount}
+            onReplyClick={() => setIsReplying(!isReplying)}
+          />
 
           {/* Inline reply input */}
           {isReplying && (

--- a/apps/web/src/components/trades/TradeCard.tsx
+++ b/apps/web/src/components/trades/TradeCard.tsx
@@ -11,7 +11,6 @@ import {
 } from 'lucide-react';
 import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
 import { useRouter } from 'next/navigation';
-import { Avatar } from '@/components/shared/Avatar';
 
 /**
  * Trade type discriminator for trade card display.
@@ -164,9 +163,6 @@ export function TradeCard({ trade }: TradeCardProps) {
   // Handle null user (should not happen, but be safe)
   if (!trade.user) return null;
 
-  const displayName =
-    trade.user.displayName || trade.user.username || 'Anonymous';
-
   const formatTime = (timestamp: Date | string) => {
     const date = new Date(timestamp);
     const now = new Date();
@@ -188,11 +184,6 @@ export function TradeCard({ trade }: TradeCardProps) {
     return formatCompactCurrency(Number.isNaN(num) ? 0 : num);
   };
 
-  const handleProfileClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    router.push(`/profile/${trade.user!.id}`);
-  };
-
   const handleAssetClick = (e: React.MouseEvent) => {
     e.stopPropagation();
 
@@ -212,46 +203,15 @@ export function TradeCard({ trade }: TradeCardProps) {
   return (
     <div className="border-border border-b p-4 transition-colors hover:bg-muted/30">
       <div className="flex items-start gap-3">
-        {/* Avatar */}
-        <div
-          className="flex-shrink-0 cursor-pointer"
-          onClick={handleProfileClick}
-        >
-          <Avatar
-            src={trade.user.profileImageUrl || undefined}
-            alt={displayName}
-            size="sm"
-          />
-        </div>
-
         {/* Trade Content */}
         <div className="min-w-0 flex-1">
-          {/* User Info */}
-          <div className="mb-1 flex items-center justify-between gap-2">
-            <div className="flex min-w-0 items-center gap-2">
-              <span
-                className="cursor-pointer truncate font-medium hover:underline"
-                onClick={handleProfileClick}
-              >
-                {displayName}
-              </span>
-              {trade.user.isActor && (
-                <span className="rounded bg-purple-500/20 px-2 py-0.5 text-purple-500 text-xs">
-                  NPC
-                </span>
-              )}
-            </div>
-            <span className="shrink-0 text-muted-foreground text-xs">
-              {formatTime(trade.timestamp)}
-            </span>
-          </div>
-
           {/* Trade Details */}
           {trade.type === 'balance' && (
             <BalanceTradeContent
               trade={trade}
               onAssetClick={handleAssetClick}
               formatCurrency={formatCurrency}
+              timestamp={formatTime(trade.timestamp)}
             />
           )}
           {trade.type === 'npc' && (
@@ -259,6 +219,7 @@ export function TradeCard({ trade }: TradeCardProps) {
               trade={trade}
               onAssetClick={handleAssetClick}
               formatCurrency={formatCurrency}
+              timestamp={formatTime(trade.timestamp)}
             />
           )}
           {trade.type === 'position' && (
@@ -266,6 +227,7 @@ export function TradeCard({ trade }: TradeCardProps) {
               trade={trade}
               onAssetClick={handleAssetClick}
               formatCurrency={formatCurrency}
+              timestamp={formatTime(trade.timestamp)}
             />
           )}
           {trade.type === 'perp' && (
@@ -273,10 +235,15 @@ export function TradeCard({ trade }: TradeCardProps) {
               trade={trade}
               onAssetClick={handleAssetClick}
               formatCurrency={formatCurrency}
+              timestamp={formatTime(trade.timestamp)}
             />
           )}
           {trade.type === 'transfer' && (
-            <TransferTradeContent trade={trade} router={router} />
+            <TransferTradeContent
+              trade={trade}
+              router={router}
+              timestamp={formatTime(trade.timestamp)}
+            />
           )}
         </div>
       </div>
@@ -288,10 +255,12 @@ function BalanceTradeContent({
   trade,
   onAssetClick,
   formatCurrency,
+  timestamp,
 }: {
   trade: BalanceTrade;
   onAssetClick: (e: React.MouseEvent) => void;
   formatCurrency: (value: string | number) => string;
+  timestamp: string;
 }) {
   const amount = Number.parseFloat(trade.amount);
   const isPositive = amount >= 0;
@@ -299,21 +268,26 @@ function BalanceTradeContent({
 
   return (
     <div className="space-y-1">
-      <div className="flex items-center gap-2">
-        {isPositive ? (
-          <ArrowUpRight className="h-4 w-4 text-green-500" />
-        ) : (
-          <ArrowDownRight className="h-4 w-4 text-red-500" />
-        )}
-        <span className="text-muted-foreground text-sm">{actionText}</span>
-        <span
-          className={cn(
-            'font-semibold text-base',
-            isPositive ? 'text-green-600' : 'text-red-600'
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          {isPositive ? (
+            <ArrowUpRight className="h-4 w-4 text-green-500" />
+          ) : (
+            <ArrowDownRight className="h-4 w-4 text-red-500" />
           )}
-        >
-          {isPositive ? '+' : ''}
-          {formatCurrency(amount)}
+          <span className="text-muted-foreground text-sm">{actionText}</span>
+          <span
+            className={cn(
+              'font-semibold text-base',
+              isPositive ? 'text-green-600' : 'text-red-600'
+            )}
+          >
+            {isPositive ? '+' : ''}
+            {formatCurrency(amount)}
+          </span>
+        </div>
+        <span className="shrink-0 text-muted-foreground text-xs">
+          {timestamp}
         </span>
       </div>
       {trade.description && (
@@ -332,45 +306,52 @@ function NPCTradeContent({
   trade,
   onAssetClick,
   formatCurrency,
+  timestamp,
 }: {
   trade: NPCTrade;
   onAssetClick: (e: React.MouseEvent) => void;
   formatCurrency: (value: string | number) => string;
+  timestamp: string;
 }) {
   const isLong = trade.side === 'long' || trade.side === 'YES';
   const action = trade.action.toUpperCase();
 
   return (
     <div className="space-y-1">
-      <div className="flex flex-wrap items-center gap-2">
-        <span
-          className={cn(
-            'rounded px-2 py-1 font-medium text-xs',
-            isLong
-              ? 'bg-green-500/20 text-green-500'
-              : 'bg-red-500/20 text-red-500'
-          )}
-        >
-          {action}
-        </span>
-        {trade.ticker && (
-          <span
-            className="cursor-pointer font-bold hover:underline"
-            onClick={onAssetClick}
-          >
-            {trade.ticker}
-          </span>
-        )}
-        {trade.side && (
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex flex-wrap items-center gap-2">
           <span
             className={cn(
-              'font-medium text-xs',
-              isLong ? 'text-green-600' : 'text-red-600'
+              'rounded px-2 py-1 font-medium text-xs',
+              isLong
+                ? 'bg-green-500/20 text-green-500'
+                : 'bg-red-500/20 text-red-500'
             )}
           >
-            {trade.side}
+            {action}
           </span>
-        )}
+          {trade.ticker && (
+            <span
+              className="cursor-pointer font-bold hover:underline"
+              onClick={onAssetClick}
+            >
+              {trade.ticker}
+            </span>
+          )}
+          {trade.side && (
+            <span
+              className={cn(
+                'font-medium text-xs',
+                isLong ? 'text-green-600' : 'text-red-600'
+              )}
+            >
+              {trade.side}
+            </span>
+          )}
+        </div>
+        <span className="shrink-0 text-muted-foreground text-xs">
+          {timestamp}
+        </span>
       </div>
       <div className="flex items-center gap-3 text-muted-foreground text-sm">
         <span>Amount: {formatCurrency(trade.amount)}</span>
@@ -389,27 +370,34 @@ function PositionTradeContent({
   trade,
   onAssetClick,
   formatCurrency,
+  timestamp,
 }: {
   trade: PositionTrade;
   onAssetClick: (e: React.MouseEvent) => void;
   formatCurrency: (value: string | number) => string;
+  timestamp: string;
 }) {
   const isYes = trade.side === 'YES';
 
   return (
     <div className="space-y-1">
-      <div className="flex items-center gap-2">
-        <span
-          className={cn(
-            'rounded px-2 py-1 font-medium text-xs',
-            isYes
-              ? 'bg-green-500/20 text-green-500'
-              : 'bg-red-500/20 text-red-500'
-          )}
-        >
-          {trade.side}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <span
+            className={cn(
+              'rounded px-2 py-1 font-medium text-xs',
+              isYes
+                ? 'bg-green-500/20 text-green-500'
+                : 'bg-red-500/20 text-red-500'
+            )}
+          >
+            {trade.side}
+          </span>
+          <span className="text-muted-foreground text-sm">Position</span>
+        </div>
+        <span className="shrink-0 text-muted-foreground text-xs">
+          {timestamp}
         </span>
-        <span className="text-muted-foreground text-sm">Position</span>
       </div>
       {trade.market && (
         <p
@@ -431,10 +419,12 @@ function PerpTradeContent({
   trade,
   onAssetClick,
   formatCurrency,
+  timestamp,
 }: {
   trade: PerpTrade;
   onAssetClick: (e: React.MouseEvent) => void;
   formatCurrency: (value: string | number) => string;
+  timestamp: string;
 }) {
   const isLong = trade.side === 'long';
   const pnl = Number.parseFloat(trade.unrealizedPnL);
@@ -443,34 +433,41 @@ function PerpTradeContent({
 
   return (
     <div className="space-y-1">
-      <div className="flex flex-wrap items-center gap-2">
-        {isLong ? (
-          <TrendingUp className="h-4 w-4 text-green-500" />
-        ) : (
-          <TrendingDown className="h-4 w-4 text-red-500" />
-        )}
-        <span
-          className={cn(
-            'rounded px-2 py-1 font-medium text-xs',
-            isLong
-              ? 'bg-green-500/20 text-green-500'
-              : 'bg-red-500/20 text-red-500'
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          {isLong ? (
+            <TrendingUp className="h-4 w-4 text-green-500" />
+          ) : (
+            <TrendingDown className="h-4 w-4 text-red-500" />
           )}
-        >
-          {trade.side.toUpperCase()}
-        </span>
-        <span
-          className="cursor-pointer font-bold hover:underline"
-          onClick={onAssetClick}
-        >
-          {trade.ticker}
-        </span>
-        <span className="text-muted-foreground text-xs">{trade.leverage}x</span>
-        {isClosed && (
-          <span className="rounded bg-muted px-2 py-0.5 text-muted-foreground text-xs">
-            CLOSED
+          <span
+            className={cn(
+              'rounded px-2 py-1 font-medium text-xs',
+              isLong
+                ? 'bg-green-500/20 text-green-500'
+                : 'bg-red-500/20 text-red-500'
+            )}
+          >
+            {trade.side.toUpperCase()}
           </span>
-        )}
+          <span
+            className="cursor-pointer font-bold hover:underline"
+            onClick={onAssetClick}
+          >
+            {trade.ticker}
+          </span>
+          <span className="text-muted-foreground text-xs">
+            {trade.leverage}x
+          </span>
+          {isClosed && (
+            <span className="rounded bg-muted px-2 py-0.5 text-muted-foreground text-xs">
+              CLOSED
+            </span>
+          )}
+        </div>
+        <span className="shrink-0 text-muted-foreground text-xs">
+          {timestamp}
+        </span>
       </div>
       <div className="flex items-center gap-3 text-muted-foreground text-sm">
         <span>Size: {formatCurrency(trade.size)}</span>
@@ -497,9 +494,11 @@ function PerpTradeContent({
 function TransferTradeContent({
   trade,
   router,
+  timestamp,
 }: {
   trade: TransferTrade;
   router: AppRouterInstance;
+  timestamp: string;
 }) {
   const isSent = trade.direction === 'sent';
   const otherPartyName =
@@ -514,20 +513,25 @@ function TransferTradeContent({
 
   return (
     <div className="space-y-1">
-      <div className="flex items-center gap-2">
-        {isSent ? (
-          <Send className="h-4 w-4 text-blue-500" />
-        ) : (
-          <Coins className="h-4 w-4 text-green-500" />
-        )}
-        <span className="text-muted-foreground text-sm">
-          {isSent ? 'Sent points to' : 'Received points from'}
-        </span>
-        <span
-          className="cursor-pointer font-medium hover:underline"
-          onClick={handleOtherPartyClick}
-        >
-          {otherPartyName}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          {isSent ? (
+            <Send className="h-4 w-4 text-blue-500" />
+          ) : (
+            <Coins className="h-4 w-4 text-green-500" />
+          )}
+          <span className="text-muted-foreground text-sm">
+            {isSent ? 'Sent points to' : 'Received points from'}
+          </span>
+          <span
+            className="cursor-pointer font-medium hover:underline"
+            onClick={handleOtherPartyClick}
+          >
+            {otherPartyName}
+          </span>
+        </div>
+        <span className="shrink-0 text-muted-foreground text-xs">
+          {timestamp}
         </span>
       </div>
       <div className="flex items-center gap-2">

--- a/apps/web/src/components/trades/TradeCard.tsx
+++ b/apps/web/src/components/trades/TradeCard.tsx
@@ -184,6 +184,8 @@ export function TradeCard({ trade }: TradeCardProps) {
     return formatCompactCurrency(Number.isNaN(num) ? 0 : num);
   };
 
+  const timestamp = formatTime(trade.timestamp);
+
   const handleAssetClick = (e: React.MouseEvent) => {
     e.stopPropagation();
 
@@ -211,7 +213,7 @@ export function TradeCard({ trade }: TradeCardProps) {
               trade={trade}
               onAssetClick={handleAssetClick}
               formatCurrency={formatCurrency}
-              timestamp={formatTime(trade.timestamp)}
+              timestamp={timestamp}
             />
           )}
           {trade.type === 'npc' && (
@@ -219,7 +221,7 @@ export function TradeCard({ trade }: TradeCardProps) {
               trade={trade}
               onAssetClick={handleAssetClick}
               formatCurrency={formatCurrency}
-              timestamp={formatTime(trade.timestamp)}
+              timestamp={timestamp}
             />
           )}
           {trade.type === 'position' && (
@@ -227,7 +229,7 @@ export function TradeCard({ trade }: TradeCardProps) {
               trade={trade}
               onAssetClick={handleAssetClick}
               formatCurrency={formatCurrency}
-              timestamp={formatTime(trade.timestamp)}
+              timestamp={timestamp}
             />
           )}
           {trade.type === 'perp' && (
@@ -235,14 +237,14 @@ export function TradeCard({ trade }: TradeCardProps) {
               trade={trade}
               onAssetClick={handleAssetClick}
               formatCurrency={formatCurrency}
-              timestamp={formatTime(trade.timestamp)}
+              timestamp={timestamp}
             />
           )}
           {trade.type === 'transfer' && (
             <TransferTradeContent
               trade={trade}
               router={router}
-              timestamp={formatTime(trade.timestamp)}
+              timestamp={timestamp}
             />
           )}
         </div>


### PR DESCRIPTION
## Summary
- **Trades tab**: Remove avatar and name row from trade cards, move timestamp inline with the trade action row for a cleaner layout
- **Replies tab**: Align ProfileReplyCard styling with feed's CommentPreview (avatar size md, header layout with justify-between, text-[15px] sizing, use shared CommentInteractionBar)
- **Replies tab**: Add interaction bar to the parent post/comment that was replied to, with full repost support for posts and like/reply for comments
- **API**: Fetch interaction counts (likes, comments, shares, isLiked, isShared) for parent posts and parent comments in the replies endpoint