### PR TITLE
feat: keep sidebar and nav on waitlist/coming-soon pages

### DIFF
--- a/apps/web/src/app/api/activity/heartbeat/route.ts
+++ b/apps/web/src/app/api/activity/heartbeat/route.ts
@@ -255,7 +255,8 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
   // Higher probability ensures timely cleanup during low-traffic periods
   if (Math.random() < 0.25) {
     closeStaleSessionsInternal().catch((error) => {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
       logger.warn(
         'Opportunistic stale-session cleanup failed',
         { errorMessage },

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -110,50 +110,48 @@ export default async function RootLayout({
             <GlobalLoginModal />
           </Suspense>
 
-          {isWaitlistHost ? (
-            children
-          ) : (
-            <>
-              <Suspense fallback={null}>
-                <NftAccessGate enabled={nftGatingEnabled} />
-              </Suspense>
-
-              {/* NFT Collection Promo Banner - at the very top */}
-              <Suspense fallback={null}>
-                <NftPromoBanner />
-              </Suspense>
-
-              {/* Mobile Header - Fixed, not affected by pull-to-refresh */}
-              <Suspense fallback={null}>
-                <MobileHeader />
-              </Suspense>
-
-              <div className="mark mx-auto flex min-h-screen max-w-7xl bg-sidebar">
-                {/* Desktop Sidebar - Sticky, not affected by pull-to-refresh */}
-                <Suspense fallback={null}>
-                  <Sidebar />
-                </Suspense>
-
-                {/* Main Content Area - Scrollable content with pull-to-refresh */}
-                <main className="min-h-screen min-w-0 flex-1 bg-background pt-14 pb-14 md:pt-0 md:pb-0">
-                  {children}
-                </main>
-
-                {/* Mobile Bottom Navigation - Fixed, not affected by pull-to-refresh */}
-                <Suspense fallback={null}>
-                  <BottomNav />
-                </Suspense>
-              </div>
-
-              {/* Auth Banner - shows on all pages when not authenticated */}
-              <Suspense fallback={null}>
-                <FeedAuthBanner />
-              </Suspense>
-
-              {/* Floating Feedback Button - shows on all pages when authenticated */}
-              <FeedbackButton />
-            </>
+          {!isWaitlistHost && (
+            <Suspense fallback={null}>
+              <NftAccessGate enabled={nftGatingEnabled} />
+            </Suspense>
           )}
+
+          {!isWaitlistHost && (
+            /* NFT Collection Promo Banner - at the very top */
+            <Suspense fallback={null}>
+              <NftPromoBanner />
+            </Suspense>
+          )}
+
+          {/* Mobile Header - Fixed, not affected by pull-to-refresh */}
+          <Suspense fallback={null}>
+            <MobileHeader />
+          </Suspense>
+
+          <div className="mark mx-auto flex min-h-screen max-w-7xl bg-sidebar">
+            {/* Desktop Sidebar - Sticky, not affected by pull-to-refresh */}
+            <Suspense fallback={null}>
+              <Sidebar />
+            </Suspense>
+
+            {/* Main Content Area - Scrollable content with pull-to-refresh */}
+            <main className="min-h-screen min-w-0 flex-1 bg-background pt-14 pb-14 md:pt-0 md:pb-0">
+              {children}
+            </main>
+
+            {/* Mobile Bottom Navigation - Fixed, not affected by pull-to-refresh */}
+            <Suspense fallback={null}>
+              <BottomNav />
+            </Suspense>
+          </div>
+
+          {/* Auth Banner - shows on all pages when not authenticated */}
+          <Suspense fallback={null}>
+            <FeedAuthBanner />
+          </Suspense>
+
+          {/* Floating Feedback Button - shows on all pages when authenticated */}
+          <FeedbackButton />
         </Providers>
         <Analytics />
         <SpeedInsights />

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -125,13 +125,13 @@ export default async function RootLayout({
 
           {/* Mobile Header - Fixed, not affected by pull-to-refresh */}
           <Suspense fallback={null}>
-            <MobileHeader />
+            <MobileHeader isWaitlistHost={isWaitlistHost} />
           </Suspense>
 
           <div className="mark mx-auto flex min-h-screen max-w-7xl bg-sidebar">
             {/* Desktop Sidebar - Sticky, not affected by pull-to-refresh */}
             <Suspense fallback={null}>
-              <Sidebar />
+              <Sidebar isWaitlistHost={isWaitlistHost} />
             </Suspense>
 
             {/* Main Content Area - Scrollable content with pull-to-refresh */}
@@ -141,7 +141,7 @@ export default async function RootLayout({
 
             {/* Mobile Bottom Navigation - Fixed, not affected by pull-to-refresh */}
             <Suspense fallback={null}>
-              <BottomNav />
+              <BottomNav isWaitlistHost={isWaitlistHost} />
             </Suspense>
           </div>
 

--- a/apps/web/src/components/admin/ActivityHeatmap.tsx
+++ b/apps/web/src/components/admin/ActivityHeatmap.tsx
@@ -11,7 +11,13 @@
 
 import { cn, formatNumber } from '@babylon/shared';
 import { Calendar, Clock, RefreshCw } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState, useTransition } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+} from 'react';
 import { Skeleton } from '@/components/shared/Skeleton';
 
 type HeatmapType = 'hourly' | 'calendar';

--- a/apps/web/src/components/admin/GrowthMetricsTab.tsx
+++ b/apps/web/src/components/admin/GrowthMetricsTab.tsx
@@ -27,7 +27,13 @@ import {
   Users,
   Zap,
 } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState, useTransition } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+} from 'react';
 import {
   Area,
   AreaChart,
@@ -269,8 +275,7 @@ export function GrowthMetricsTab() {
       {
         label: 'First Command',
         value: commandedWithin24h,
-        pct:
-          signups > 0 ? Math.round((commandedWithin24h / signups) * 100) : 0,
+        pct: signups > 0 ? Math.round((commandedWithin24h / signups) * 100) : 0,
       },
       {
         label: 'Activated',

--- a/apps/web/src/components/providers/Providers.tsx
+++ b/apps/web/src/components/providers/Providers.tsx
@@ -301,16 +301,16 @@ export function Providers({ children }: { children: React.ReactNode }) {
                       {/* <OnboardingProvider> */}
                       {/* Session heartbeat for engagement metrics */}
                       <SessionHeartbeatProvider>
-                      {/* Game guide provider for first-time tutorial */}
-                      <GameGuideProvider>
-                        <WidgetRefreshProvider>
-                          {mounted ? (
-                            <Fragment>{children}</Fragment>
-                          ) : (
-                            <div className="min-h-screen bg-sidebar" />
-                          )}
-                        </WidgetRefreshProvider>
-                      </GameGuideProvider>
+                        {/* Game guide provider for first-time tutorial */}
+                        <GameGuideProvider>
+                          <WidgetRefreshProvider>
+                            {mounted ? (
+                              <Fragment>{children}</Fragment>
+                            ) : (
+                              <div className="min-h-screen bg-sidebar" />
+                            )}
+                          </WidgetRefreshProvider>
+                        </GameGuideProvider>
                       </SessionHeartbeatProvider>
                       {/* </OnboardingProvider> */}
                     </FarcasterMiniAppProvider>

--- a/apps/web/src/components/shared/BottomNav.tsx
+++ b/apps/web/src/components/shared/BottomNav.tsx
@@ -18,14 +18,15 @@ import { getAuthToken } from '@/lib/auth';
  *
  * @returns Bottom navigation element or null if hidden
  */
-function BottomNavContent() {
+function BottomNavContent({ isWaitlistHost }: { isWaitlistHost?: boolean }) {
   const pathname = usePathname();
   const { authenticated, user } = useAuth();
   const [unreadNotifications, setUnreadNotifications] = useState(0);
   const { totalUnread: unreadMessages } = useUnreadMessages();
 
-  // Hide bottom nav when WAITLIST_MODE is enabled on home page
-  const isWaitlistMode = process.env.NEXT_PUBLIC_WAITLIST_MODE === 'true';
+  // Hide bottom nav on home page for waitlist hosts
+  const isWaitlistMode =
+    isWaitlistHost || process.env.NEXT_PUBLIC_WAITLIST_MODE === 'true';
   const isHomePage = pathname === '/';
   const shouldHide = isWaitlistMode && isHomePage;
 
@@ -165,6 +166,6 @@ function BottomNavContent() {
  *
  * @returns Bottom navigation element or null if hidden
  */
-export function BottomNav() {
-  return <BottomNavContent />;
+export function BottomNav({ isWaitlistHost }: { isWaitlistHost?: boolean }) {
+  return <BottomNavContent isWaitlistHost={isWaitlistHost} />;
 }

--- a/apps/web/src/components/shared/MobileHeader.tsx
+++ b/apps/web/src/components/shared/MobileHeader.tsx
@@ -32,7 +32,7 @@ import { useAuthStore } from '@/stores/authStore';
  *
  * @returns Mobile header element or null if hidden
  */
-function MobileHeaderContent() {
+function MobileHeaderContent({ isWaitlistHost }: { isWaitlistHost?: boolean }) {
   const { authenticated, logout } = useAuth();
   const { user, setUser } = useAuthStore();
   const [showSideMenu, setShowSideMenu] = useState(false);
@@ -44,8 +44,9 @@ function MobileHeaderContent() {
   const [unreadNotifications, setUnreadNotifications] = useState(0);
   const pathname = usePathname();
 
-  // Hide mobile header when WAITLIST_MODE is enabled on home page
-  const isWaitlistMode = process.env.NEXT_PUBLIC_WAITLIST_MODE === 'true';
+  // Hide mobile header on home page for waitlist hosts
+  const isWaitlistMode =
+    isWaitlistHost || process.env.NEXT_PUBLIC_WAITLIST_MODE === 'true';
   const isHomePage = pathname === '/';
   const shouldHide = isWaitlistMode && isHomePage;
 
@@ -464,6 +465,6 @@ function MobileHeaderContent() {
  *
  * @returns Mobile header element or null if hidden
  */
-export function MobileHeader() {
-  return <MobileHeaderContent />;
+export function MobileHeader({ isWaitlistHost }: { isWaitlistHost?: boolean }) {
+  return <MobileHeaderContent isWaitlistHost={isWaitlistHost} />;
 }

--- a/apps/web/src/components/shared/Sidebar.tsx
+++ b/apps/web/src/components/shared/Sidebar.tsx
@@ -38,7 +38,7 @@ import { getAuthToken } from '@/lib/auth';
  *
  * @returns Sidebar content element
  */
-function SidebarContent() {
+function SidebarContent({ isWaitlistHost }: { isWaitlistHost?: boolean }) {
   const [collapsed, setCollapsed] = useState(false);
   const [showMdMenu, setShowMdMenu] = useState(false);
   const [copiedReferral, setCopiedReferral] = useState(false);
@@ -48,8 +48,9 @@ function SidebarContent() {
   const { ready, authenticated, user, logout, login } = useAuth();
   const { totalUnread: unreadMessages } = useUnreadMessages();
 
-  // Hide sidebar when WAITLIST_MODE is enabled on home page
-  const isWaitlistMode = process.env.NEXT_PUBLIC_WAITLIST_MODE === 'true';
+  // Hide sidebar on home page for waitlist hosts
+  const isWaitlistMode =
+    isWaitlistHost || process.env.NEXT_PUBLIC_WAITLIST_MODE === 'true';
   const isHomePage = pathname === '/';
   const shouldHideSidebar = isWaitlistMode && isHomePage;
 
@@ -418,6 +419,6 @@ function SidebarContent() {
  *
  * @returns Sidebar element or null if hidden
  */
-export function Sidebar() {
-  return <SidebarContent />;
+export function Sidebar({ isWaitlistHost }: { isWaitlistHost?: boolean }) {
+  return <SidebarContent isWaitlistHost={isWaitlistHost} />;
 }

--- a/apps/web/src/lib/host-routing.ts
+++ b/apps/web/src/lib/host-routing.ts
@@ -2,6 +2,7 @@ const DEFAULT_WAITLIST_HOSTS = [
   'babylon.market',
   'www.babylon.market',
   'staging.babylon.market',
+  'localhost',
 ] as const;
 
 export function getWaitlistHostnames(): Set<string> {

--- a/apps/web/src/lib/stripe/server.ts
+++ b/apps/web/src/lib/stripe/server.ts
@@ -30,7 +30,7 @@ export function getStripeInstance(): Stripe {
       throw new Error('STRIPE_SECRET_KEY environment variable is required');
     }
     _stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-      apiVersion: '2025-12-15.clover',
+      apiVersion: '2026-01-28.clover',
       typescript: true,
     });
   }


### PR DESCRIPTION
## Summary
- Always render sidebar, mobile header, and bottom nav on waitlist hosts instead of stripping them
- ComingSoon content is already handled at the page level (`app/page.tsx`), so the layout-level bypass was redundant
- NFT gating and promo banner remain skipped on waitlist hosts
- Add localhost to waitlist hosts for local testing
- Fix Stripe API version mismatch