### PR TITLE
fix(chats): filter out DMs with user's own agents from chat list

### DIFF
--- a/apps/web/src/app/api/chats/route.ts
+++ b/apps/web/src/app/api/chats/route.ts
@@ -179,7 +179,6 @@ import {
 } from '@babylon/api/services/nft-chat-gating-service';
 // Import from new Drizzle client
 import {
-  agentMessages,
   and,
   asSystem,
   asUser,
@@ -594,38 +593,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
         }
 
         // Get last message for this chat
-        // If the other user is an agent owned by the current user, get from agentMessages
-        let lastMessage = messagesByChatId.get(chat.id)?.[0] || null;
-
-        if (
-          otherUserDetails.isAgent &&
-          otherUserDetails.managedBy === user.userId
-        ) {
-          // Fetch last message from agentMessages table for owned agents
-          const [agentLastMsg] = await dbClient
-            .select({
-              id: agentMessages.id,
-              content: agentMessages.content,
-              createdAt: agentMessages.createdAt,
-            })
-            .from(agentMessages)
-            .where(eq(agentMessages.agentUserId, otherUserDetails.id))
-            .orderBy(desc(agentMessages.createdAt))
-            .limit(1);
-
-          if (agentLastMsg) {
-            lastMessage = {
-              id: agentLastMsg.id,
-              content: agentLastMsg.content,
-              chatId: chat.id,
-              senderId: otherUserDetails.id,
-              type: 'user' as const,
-              createdAt: agentLastMsg.createdAt,
-              targetIds: null, // Not applicable for DM messages
-              metadata: null, // Not applicable for DM messages
-            };
-          }
-        }
+        const lastMessage = messagesByChatId.get(chat.id)?.[0] || null;
 
         return {
           id: chat.id,

--- a/apps/web/src/app/api/chats/route.ts
+++ b/apps/web/src/app/api/chats/route.ts
@@ -583,6 +583,16 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
           return null;
         }
 
+        // Filter out DMs with the user's own agents
+        // These legacy conversations should be hidden - agent-owner communication
+        // now happens through the team chat at /agents/team
+        if (
+          otherUserDetails.isAgent &&
+          otherUserDetails.managedBy === user.userId
+        ) {
+          return null;
+        }
+
         // Get last message for this chat
         // If the other user is an agent owned by the current user, get from agentMessages
         let lastMessage = messagesByChatId.get(chat.id)?.[0] || null;

--- a/apps/web/src/components/chats/hooks/useChatPage.ts
+++ b/apps/web/src/components/chats/hooks/useChatPage.ts
@@ -130,9 +130,25 @@ export function useChatPage() {
       return new Date(bTime).getTime() - new Date(aTime).getTime();
     });
 
-    setAllChats(combined);
+    // Client-side fallback: filter out DMs with the user's own agents
+    // This guards against any edge cases where API-level filtering didn't catch them
+    // Agent-owner communication should happen through /agents/team instead
+    const filteredCombined = combined.filter((chat) => {
+      // Only filter DMs (not group chats)
+      if (chat.isGroup) return true;
+      // Check if the other user is an agent managed by the current user
+      const otherUser = chat.otherUser as
+        | { isAgent?: boolean; managedBy?: string | null }
+        | undefined;
+      if (otherUser?.isAgent && otherUser?.managedBy === user?.id) {
+        return false;
+      }
+      return true;
+    });
+
+    setAllChats(filteredCombined);
     setLoading(false);
-  }, [getAccessToken, isDebugMode, ready, authenticated]);
+  }, [getAccessToken, isDebugMode, ready, authenticated, user?.id]);
 
   // Load chat details
   const loadChatDetails = useCallback(

--- a/apps/web/src/components/chats/hooks/useChatPage.ts
+++ b/apps/web/src/components/chats/hooks/useChatPage.ts
@@ -137,10 +137,7 @@ export function useChatPage() {
       // Only filter DMs (not group chats)
       if (chat.isGroup) return true;
       // Check if the other user is an agent managed by the current user
-      const otherUser = chat.otherUser as
-        | { isAgent?: boolean; managedBy?: string | null }
-        | undefined;
-      if (otherUser?.isAgent && otherUser?.managedBy === user?.id) {
+      if (chat.otherUser?.isAgent && chat.otherUser?.managedBy === user?.id) {
         return false;
       }
       return true;


### PR DESCRIPTION
## Summary

- Filter out legacy DM conversations between users and their own agents from the `/chats` page
- These DMs were created before the team chat implementation; new agent-owner DMs are now blocked at the `executeDirectMessage` level
- Agent-owner communication is now handled exclusively through `/agents/team`

## Changes

- **API-level filtering** (`/api/chats`): Exclude DMs where the other participant is an agent managed by the current user
- **Client-side fallback** (`useChatPage.ts`): Additional guard to filter any edge cases that slip through

## Test plan

- [x] Legacy agent-owner DM chats no longer appear in the chat list
- [x] DMs with other users remain visible
- [x] Group chats are unaffected