### PR TITLE
fix(auth): use NEXT_PUBLIC_WAITLIST_URL for OAuth redirect URLs

### DIFF
--- a/apps/web/src/app/api/auth/discord/callback/route.ts
+++ b/apps/web/src/app/api/auth/discord/callback/route.ts
@@ -32,7 +32,10 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   );
 
   // Use the app URL as base for all redirects
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || request.nextUrl.origin;
+  const baseUrl =
+    process.env.NEXT_PUBLIC_WAITLIST_URL ||
+    process.env.NEXT_PUBLIC_APP_URL ||
+    request.nextUrl.origin;
 
   if (!parsed.success) {
     return NextResponse.redirect(
@@ -157,7 +160,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
         client_secret: process.env.DISCORD_CLIENT_SECRET!,
         grant_type: 'authorization_code',
         code,
-        redirect_uri: `${process.env.NEXT_PUBLIC_APP_URL}/api/auth/discord/callback`,
+        redirect_uri: `${process.env.NEXT_PUBLIC_WAITLIST_URL || process.env.NEXT_PUBLIC_APP_URL}/api/auth/discord/callback`,
       }),
     }
   );

--- a/apps/web/src/app/api/auth/discord/initiate/route.ts
+++ b/apps/web/src/app/api/auth/discord/initiate/route.ts
@@ -51,7 +51,7 @@ export async function GET(request: NextRequest) {
   authUrl.searchParams.set('client_id', process.env.DISCORD_CLIENT_ID!);
   authUrl.searchParams.set(
     'redirect_uri',
-    `${process.env.NEXT_PUBLIC_APP_URL}/api/auth/discord/callback`
+    `${process.env.NEXT_PUBLIC_WAITLIST_URL || process.env.NEXT_PUBLIC_APP_URL}/api/auth/discord/callback`
   );
   authUrl.searchParams.set('scope', 'identify guilds');
   authUrl.searchParams.set('state', state);

--- a/apps/web/src/app/api/auth/twitter/callback/route.ts
+++ b/apps/web/src/app/api/auth/twitter/callback/route.ts
@@ -80,7 +80,10 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   );
 
   // Use the app URL as base for all redirects
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || request.nextUrl.origin;
+  const baseUrl =
+    process.env.NEXT_PUBLIC_WAITLIST_URL ||
+    process.env.NEXT_PUBLIC_APP_URL ||
+    request.nextUrl.origin;
 
   if (!parsed.success) {
     return NextResponse.redirect(
@@ -223,7 +226,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     body: new URLSearchParams({
       code,
       grant_type: 'authorization_code',
-      redirect_uri: `${process.env.NEXT_PUBLIC_APP_URL}/api/auth/twitter/callback`,
+      redirect_uri: `${process.env.NEXT_PUBLIC_WAITLIST_URL || process.env.NEXT_PUBLIC_APP_URL}/api/auth/twitter/callback`,
       code_verifier: oauthState.codeVerifier,
     }),
   });

--- a/apps/web/src/app/api/auth/twitter/initiate/route.ts
+++ b/apps/web/src/app/api/auth/twitter/initiate/route.ts
@@ -95,7 +95,7 @@ export async function GET(request: NextRequest) {
   authUrl.searchParams.set('client_id', process.env.TWITTER_CLIENT_ID!);
   authUrl.searchParams.set(
     'redirect_uri',
-    `${process.env.NEXT_PUBLIC_APP_URL}/api/auth/twitter/callback`
+    `${process.env.NEXT_PUBLIC_WAITLIST_URL || process.env.NEXT_PUBLIC_APP_URL}/api/auth/twitter/callback`
   );
   authUrl.searchParams.set(
     'scope',


### PR DESCRIPTION
Use NEXT_PUBLIC_WAITLIST_URL as primary URL for Twitter and Discord OAuth redirects, falling back to NEXT_PUBLIC_APP_URL. This ensures users accessing from babylon.market stay on that domain instead of being redirected to play.babylon.market after OAuth.

