### PR TITLE
feat(admin): Separate SUPER_ADMIN and ADMIN roles with granular permissions

### DIFF
--- a/packages/api/src/__tests__/admin-middleware.test.ts
+++ b/packages/api/src/__tests__/admin-middleware.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+const mockSelect = mock();
+const mockLoggerInfo = mock();
+const mockLoggerWarn = mock();
+
+const adminRolesTable = { table: 'adminRoles' };
+const usersTable = { table: 'users' };
+
+mock.module('@babylon/db', () => ({
+  adminRoles: adminRolesTable,
+  and: (...conditions: unknown[]) => ({ conditions }),
+  db: {
+    select: mockSelect,
+  },
+  eq: (left: unknown, right: unknown) => ({ left, right }),
+  isNull: (value: unknown) => ({ value }),
+  notInArray: (left: unknown, right: unknown[]) => ({ left, right }),
+  ROLE_PERMISSIONS: {
+    SUPER_ADMIN: ['manage_admins', 'manage_game', 'manage_escrow'],
+    ADMIN: ['view_stats', 'manage_users'],
+    VIEWER: ['view_stats'],
+  },
+  users: usersTable,
+}));
+
+mock.module('@babylon/shared', () => ({
+  checkForAdminEmail: () => ({ adminEmail: null, allVerifiedEmails: [] }),
+  logger: {
+    info: mockLoggerInfo,
+    warn: mockLoggerWarn,
+  },
+}));
+
+mock.module('../auth-middleware', () => ({
+  authenticate: mock(),
+  getPrivyClient: () => ({
+    getUser: mock(),
+  }),
+}));
+
+import { ROLE_PERMISSIONS } from '@babylon/db';
+import { getAdminRole, getAllAdmins } from '../admin-middleware';
+
+describe('admin-middleware role mapping', () => {
+  beforeEach(() => {
+    mockSelect.mockReset();
+    mockLoggerInfo.mockReset();
+    mockLoggerWarn.mockReset();
+    process.env.ADMIN_EMAIL_DOMAIN = '';
+  });
+
+  it('maps legacy isAdmin users to ADMIN in getAdminRole', async () => {
+    mockSelect
+      .mockImplementationOnce(() => ({
+        from: (table: unknown) => {
+          expect(table).toBe(adminRolesTable);
+          return {
+            where: () => ({
+              limit: async () => [],
+            }),
+          };
+        },
+      }))
+      .mockImplementationOnce(() => ({
+        from: (table: unknown) => {
+          expect(table).toBe(usersTable);
+          return {
+            where: () => ({
+              limit: async () => [{ isAdmin: true, privyId: null }],
+            }),
+          };
+        },
+      }));
+
+    const result = await getAdminRole('legacy-user-id');
+
+    expect(result.role).toBe('ADMIN');
+    expect(result.permissions).toEqual(ROLE_PERMISSIONS.ADMIN);
+  });
+
+  it('maps legacy isAdmin users to ADMIN in getAllAdmins', async () => {
+    mockSelect
+      .mockImplementationOnce(() => ({
+        from: (table: unknown) => {
+          expect(table).toBe(adminRolesTable);
+          return {
+            innerJoin: () => ({
+              where: async () => [],
+            }),
+          };
+        },
+      }))
+      .mockImplementationOnce(() => ({
+        from: (table: unknown) => {
+          expect(table).toBe(usersTable);
+          return {
+            where: async () => [
+              {
+                id: 'legacy-user-id',
+                username: 'legacy-user',
+                displayName: 'Legacy User',
+                profileImageUrl: null,
+                createdAt: new Date('2026-01-01T00:00:00.000Z'),
+              },
+            ],
+          };
+        },
+      }));
+
+    const result = await getAllAdmins();
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.role).toBe('ADMIN');
+    expect(result[0]?.permissions).toEqual(ROLE_PERMISSIONS.ADMIN);
+  });
+});

--- a/packages/api/src/admin-middleware.ts
+++ b/packages/api/src/admin-middleware.ts
@@ -84,8 +84,10 @@ export async function getAdminRole(
     .limit(1);
 
   // Backward compatibility: Check isAdmin flag for legacy admins
+  // NOTE: isAdmin flag now grants ADMIN role, not SUPER_ADMIN
+  // SUPER_ADMIN must be explicitly granted via AdminRole table
   if (user?.isAdmin) {
-    return { role: 'SUPER_ADMIN', permissions: ROLE_PERMISSIONS.SUPER_ADMIN };
+    return { role: 'ADMIN', permissions: ROLE_PERMISSIONS.ADMIN };
   }
 
   // Check admin email domain - fetch verified email directly from Privy for security
@@ -103,7 +105,7 @@ export async function getAdminRole(
 
     if (adminEmail) {
       logger.info(
-        'Auto-promoting user to SUPER_ADMIN via verified Privy email domain',
+        'Auto-promoting user to ADMIN via verified Privy email domain',
         {
           userId,
           emailDomain: adminEmail.split('@')[1] ?? null,
@@ -112,7 +114,9 @@ export async function getAdminRole(
         },
         'getAdminRole'
       );
-      return { role: 'SUPER_ADMIN', permissions: ROLE_PERMISSIONS.SUPER_ADMIN };
+      // Grant ADMIN role (not SUPER_ADMIN) for email domain matches
+      // SUPER_ADMIN must be explicitly granted via AdminRole table
+      return { role: 'ADMIN', permissions: ROLE_PERMISSIONS.ADMIN };
     }
   }
 

--- a/packages/api/src/admin-middleware.ts
+++ b/packages/api/src/admin-middleware.ts
@@ -381,8 +381,8 @@ export async function getAllAdmins(): Promise<
       username: legacy.username,
       displayName: legacy.displayName,
       profileImageUrl: legacy.profileImageUrl,
-      role: 'SUPER_ADMIN',
-      permissions: ROLE_PERMISSIONS.SUPER_ADMIN,
+      role: 'ADMIN',
+      permissions: ROLE_PERMISSIONS.ADMIN,
       grantedAt: legacy.createdAt,
       grantedBy: legacy.id, // Self-granted for legacy
     });

--- a/packages/db/src/schema/admin.ts
+++ b/packages/db/src/schema/admin.ts
@@ -44,6 +44,10 @@ export type AdminPermission = (typeof ADMIN_PERMISSIONS)[number];
 
 /**
  * Default permissions by role
+ *
+ * SUPER_ADMIN: Full access - can manage admins, escrow, and game controls
+ * ADMIN: Standard admin - can view everything, manage users/reports, but NOT escrow/game/admins
+ * VIEWER: Read-only access to dashboards
  */
 export const ROLE_PERMISSIONS: Record<AdminRoleType, AdminPermission[]> = {
   SUPER_ADMIN: [...ADMIN_PERMISSIONS],
@@ -54,12 +58,11 @@ export const ROLE_PERMISSIONS: Record<AdminRoleType, AdminPermission[]> = {
     'view_trading',
     'view_system',
     'give_feedback',
-    'manage_game',
     'view_reports',
     'resolve_reports',
-    'manage_escrow',
     'view_alpha_groups',
     'manage_alpha_groups',
+    // NOTE: manage_game, manage_escrow, manage_admins are SUPER_ADMIN only
   ],
   VIEWER: [
     'view_stats',

--- a/packages/testing/integration/admin-dashboard-rbac.integration.test.ts
+++ b/packages/testing/integration/admin-dashboard-rbac.integration.test.ts
@@ -2,7 +2,7 @@
 // Run: bun test integration/admin-dashboard-rbac.integration.test.ts --preload ./integration/preload.ts
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { getDevCredentials } from '@babylon/api';
+import { getAllAdmins, getDevCredentials } from '@babylon/api';
 import {
   ADMIN_PERMISSIONS,
   ADMIN_ROLES,
@@ -189,8 +189,10 @@ describe('Admin Dashboard RBAC Integration Tests', () => {
     });
 
     test('ROLE_PERMISSIONS assigns correct permissions to ADMIN', () => {
-      // ADMIN should not have manage_admins
+      // ADMIN should not have super-admin-only permissions
       expect(ROLE_PERMISSIONS.ADMIN).not.toContain('manage_admins');
+      expect(ROLE_PERMISSIONS.ADMIN).not.toContain('manage_game');
+      expect(ROLE_PERMISSIONS.ADMIN).not.toContain('manage_escrow');
       expect(ROLE_PERMISSIONS.ADMIN).toContain('view_stats');
       expect(ROLE_PERMISSIONS.ADMIN).toContain('manage_users');
       expect(ROLE_PERMISSIONS.ADMIN).toContain('resolve_reports');
@@ -267,6 +269,16 @@ describe('Admin Dashboard RBAC Integration Tests', () => {
 
       expect(user).toBeDefined();
       expect(user!.isAdmin).toBe(true);
+    });
+
+    test('legacy isAdmin users are exposed as ADMIN in getAllAdmins', async () => {
+      const userId = await createTestUser({ isAdmin: true });
+      const admins = await getAllAdmins();
+      const legacyAdmin = admins.find((admin) => admin.userId === userId);
+
+      expect(legacyAdmin).toBeDefined();
+      expect(legacyAdmin!.role).toBe('ADMIN');
+      expect(legacyAdmin!.permissions).toEqual(ROLE_PERMISSIONS.ADMIN);
     });
 
     test('user can have role without legacy isAdmin', async () => {


### PR DESCRIPTION
## Summary
<!-- 1–3 bullets: what changed + why (user impact / business goal). -->

- Restrict sensitive permissions (`manage_game`, `manage_escrow`, `manage_admins`) to SUPER_ADMIN only
- Auto-promoted users via `ADMIN_EMAIL_DOMAIN` now receive ADMIN role instead of SUPER_ADMIN
- SUPER_ADMIN must be explicitly granted via the AdminRole table, preventing accidental full access

## Type
<!-- Helps triage + release notes. -->

- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
<!-- Link issues, Linear tickets, docs, prior PRs. -->

- Team discussion: Need to prevent all admins from having game shutdown and escrow control permissions
- Core team members should retain full SUPER_ADMIN access

## Scope (keep it focused)
<!-- If you had to touch multiple areas, explain why and what you intentionally left out. -->

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [x] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
<!-- List the notable changes (what is new/removed/modified). Link key files if it helps. -->

- **`packages/db/src/schema/admin.ts`**: Updated `ROLE_PERMISSIONS.ADMIN` to remove `manage_game`, `manage_escrow`, and `manage_admins`
- **`packages/api/src/admin-middleware.ts`**: 
  - Changed `isAdmin` flag interpretation from SUPER_ADMIN → ADMIN
  - Changed email domain auto-promotion from SUPER_ADMIN → ADMIN

## Review guide
<!-- Help reviewers go fast: where to start, what to ignore, tricky bits, key decisions. -->

**Start here**
- `packages/db/src/schema/admin.ts` - See the updated ROLE_PERMISSIONS
- `packages/api/src/admin-middleware.ts` - See the getAdminRole function changes

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- This is a permission reduction, not expansion - safer direction
- Existing SUPER_ADMINs in AdminRole table are unaffected
- Users with only `isAdmin: true` flag will lose `manage_game`, `manage_escrow`, `manage_admins` permissions

## Test plan
<!-- Tick what you ran. Add manual steps for anything user-facing. -->

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Login as with admini user → should have ADMIN role, NOT SUPER_ADMIN
2. Verify ADMIN users cannot access game control / escrow management features
3. Verify users in AdminRole table with SUPER_ADMIN still have full access

## Ops / Migration / Deployment
<!-- Anything that impacts deploys, data, cron, config, or rollouts. -->

- [ ] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [x] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- None

**DB / data migration**
- Migration(s): None (schema change is in TypeScript constants only)

**Rollout / rollback plan**
- Rollout: Deploy normally, permissions take effect immediately on next login
- Rollback: Revert commit and redeploy; optionally restore ADMIN permissions in schema

## Breaking changes

- [ ] None
- [x] Yes (describe + migration guide below)

**Migration guide**
- Users who previously had SUPER_ADMIN via `isAdmin: true` will now have ADMIN role
- To restore SUPER_ADMIN for specific users, add them to the AdminRole table with role='SUPER_ADMIN'

## Security / privacy
<!-- Authn/authz, secrets handling, PII, prompt injection surfaces, etc. -->

- [x] No security impact
- [ ] Needs extra review (describe)

This is a permission restriction (reducing access), which is the safer direction for security.

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
<!-- New/changed endpoints, SSE event payloads, shared types. -->
- No API changes, only permission logic changes

### Database
<!-- Tables/columns/indexes, perf implications, how to verify. -->
- No schema changes
- AdminRole table entries for SUPER_ADMIN users added manually

### Contracts / on-chain
<!-- Network(s), addresses, upgrade/migration notes, how to verify. -->
- N/A

### Docs
<!-- If you touched generated vendor docs, regenerate via `bun run docs:generate`. -->
- N/A

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend permission logic change only. No UI changes. Admin dashboard UI will behave the same, but certain actions will be forbidden for ADMIN users (handled by existing permission checks).

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

