### PR TITLE
feat(admin): add NFT whitelist management tab

### DIFF
--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -53,6 +53,7 @@ import {
   Shield,
   ShieldCheck,
   Sparkles,
+  Star,
   TrendingUp,
   Users,
 } from 'lucide-react';
@@ -80,6 +81,7 @@ import { StatsTab } from '@/components/admin/StatsTab';
 import { SystemHealthTab } from '@/components/admin/SystemHealthTab';
 import { TradingFeedTab } from '@/components/admin/TradingFeedTab';
 import { TrainingDataTab } from '@/components/admin/TrainingDataTab';
+import { NftWhitelistTab } from '@/components/admin/NftWhitelistTab';
 import { UserManagementTab } from '@/components/admin/UserManagementTab';
 import { PageContainer } from '@/components/shared/PageContainer';
 import { Skeleton } from '@/components/shared/Skeleton';
@@ -112,7 +114,8 @@ type Tab =
   | 'agents'
   | 'escrow'
   | 'audit-logs'
-  | 'alpha-groups';
+  | 'alpha-groups'
+  | 'nft-whitelist';
 
 /**
  * Admin Dashboard Component
@@ -254,6 +257,7 @@ export default function AdminDashboard() {
         { id: 'groups' as const, label: 'Groups', icon: MessageSquare },
         { id: 'alpha-groups' as const, label: 'Alpha Groups', icon: Crown },
         { id: 'notifications' as const, label: 'Notifications', icon: Bell },
+        { id: 'nft-whitelist' as const, label: 'NFT Whitelist', icon: Star },
       ],
     },
     {
@@ -408,6 +412,7 @@ export default function AdminDashboard() {
         {activeTab === 'escrow' && <EscrowManagementTab />}
         {activeTab === 'audit-logs' && <AuditLogsTab />}
         {activeTab === 'alpha-groups' && <AlphaGroupsTab />}
+        {activeTab === 'nft-whitelist' && <NftWhitelistTab />}
       </div>
     </PageContainer>
   );

--- a/apps/web/src/app/api/admin/nft-snapshot/refresh/route.ts
+++ b/apps/web/src/app/api/admin/nft-snapshot/refresh/route.ts
@@ -1,0 +1,107 @@
+/**
+ * Admin NFT Snapshot Refresh API
+ *
+ * @route POST /api/admin/nft-snapshot/refresh - Manually trigger snapshot from leaderboard
+ * @access Admin
+ */
+
+import {
+  PointsService,
+  requireAdmin,
+  successResponse,
+  withErrorHandling,
+} from '@babylon/api'
+import { db, eq, inArray, nftSnapshot, users } from '@babylon/db'
+import { nanoid } from 'nanoid'
+import type { NextRequest } from 'next/server'
+
+export const POST = withErrorHandling(async (request: NextRequest) => {
+  await requireAdmin(request)
+
+  const snapshotTime = new Date()
+  const { users: topUsers } = await PointsService.getLeaderboard(
+    1,
+    100,
+    0,
+    'all'
+  )
+
+  const existingSnapshots = await db
+    .select({
+      userId: nftSnapshot.userId,
+      hasMinted: nftSnapshot.hasMinted,
+      mintedTokenId: nftSnapshot.mintedTokenId,
+      mintedAt: nftSnapshot.mintedAt,
+      mintTxHash: nftSnapshot.mintTxHash,
+    })
+    .from(nftSnapshot)
+
+  const existingMap = new Map(existingSnapshots.map((s) => [s.userId, s]))
+
+  const userIds = topUsers.map((u) => u.id)
+  const walletMap = new Map<string, string | null>()
+
+  if (userIds.length > 0) {
+    const wallets = await db
+      .select({ id: users.id, walletAddress: users.walletAddress })
+      .from(users)
+      .where(inArray(users.id, userIds))
+
+    for (const w of wallets) {
+      walletMap.set(w.id, w.walletAddress)
+    }
+  }
+
+  let newlyEligible = 0
+  let updated = 0
+
+  for (let i = 0; i < topUsers.length; i++) {
+    const user = topUsers[i]!
+    const rank = i + 1
+    const existing = existingMap.get(user.id)
+    const walletAddress = walletMap.get(user.id) ?? null
+
+    if (existing) {
+      await db
+        .update(nftSnapshot)
+        .set({
+          rank,
+          points: user.allPoints,
+          walletAddress,
+          snapshotTakenAt: snapshotTime,
+        })
+        .where(eq(nftSnapshot.userId, user.id))
+      updated++
+    } else {
+      await db.insert(nftSnapshot).values({
+        id: nanoid(),
+        userId: user.id,
+        walletAddress,
+        rank,
+        points: user.allPoints,
+        snapshotTakenAt: snapshotTime,
+        hasMinted: false,
+      })
+      newlyEligible++
+    }
+
+    existingMap.delete(user.id)
+  }
+
+  let removed = 0
+  for (const [userId, snapshot] of existingMap) {
+    if (!snapshot.hasMinted) {
+      await db.delete(nftSnapshot).where(eq(nftSnapshot.userId, userId))
+      removed++
+    }
+  }
+
+  return successResponse({
+    success: true,
+    snapshotTakenAt: snapshotTime.toISOString(),
+    usersInSnapshot: topUsers.length,
+    newlyEligible,
+    updated,
+    removed,
+  })
+})

--- a/apps/web/src/app/api/admin/nft-snapshot/refresh/route.ts
+++ b/apps/web/src/app/api/admin/nft-snapshot/refresh/route.ts
@@ -15,6 +15,8 @@ import { db, eq, inArray, nftSnapshot, users } from '@babylon/db'
 import { nanoid } from 'nanoid'
 import type { NextRequest } from 'next/server'
 
+export const maxDuration = 60
+
 export const POST = withErrorHandling(async (request: NextRequest) => {
   await requireAdmin(request)
 

--- a/apps/web/src/app/api/admin/nft-snapshot/route.ts
+++ b/apps/web/src/app/api/admin/nft-snapshot/route.ts
@@ -14,7 +14,7 @@ import {
 } from '@babylon/api'
 import { db, eq, nftSnapshot, users } from '@babylon/db'
 import { nanoid } from 'nanoid'
-import type { NextRequest } from 'next/server'
+import { NextResponse, type NextRequest } from 'next/server'
 
 export const GET = withErrorHandling(async (request: NextRequest) => {
   await requireAdmin(request)
@@ -61,10 +61,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
   }
 
   if (!userId || typeof userId !== 'string') {
-    return new Response(
-      JSON.stringify({ error: 'userId is required' }),
-      { status: 400, headers: { 'Content-Type': 'application/json' } }
-    )
+    return NextResponse.json({ error: 'userId is required' }, { status: 400 })
   }
 
   // Check if user exists
@@ -75,10 +72,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
     .limit(1)
 
   if (!user) {
-    return new Response(
-      JSON.stringify({ error: 'User not found' }),
-      { status: 404, headers: { 'Content-Type': 'application/json' } }
-    )
+    return NextResponse.json({ error: 'User not found' }, { status: 404 })
   }
 
   // Check if user is already in snapshot
@@ -89,9 +83,9 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
     .limit(1)
 
   if (existing) {
-    return new Response(
-      JSON.stringify({ error: 'User is already in the snapshot' }),
-      { status: 409, headers: { 'Content-Type': 'application/json' } }
+    return NextResponse.json(
+      { error: 'User is already in the snapshot' },
+      { status: 409 }
     )
   }
 
@@ -130,10 +124,7 @@ export const DELETE = withErrorHandling(async (request: NextRequest) => {
   const { userId } = body as { userId: string }
 
   if (!userId || typeof userId !== 'string') {
-    return new Response(
-      JSON.stringify({ error: 'userId is required' }),
-      { status: 400, headers: { 'Content-Type': 'application/json' } }
-    )
+    return NextResponse.json({ error: 'userId is required' }, { status: 400 })
   }
 
   // Check if entry exists and hasn't minted
@@ -144,16 +135,16 @@ export const DELETE = withErrorHandling(async (request: NextRequest) => {
     .limit(1)
 
   if (!existing) {
-    return new Response(
-      JSON.stringify({ error: 'User not found in snapshot' }),
-      { status: 404, headers: { 'Content-Type': 'application/json' } }
+    return NextResponse.json(
+      { error: 'User not found in snapshot' },
+      { status: 404 }
     )
   }
 
   if (existing.hasMinted) {
-    return new Response(
-      JSON.stringify({ error: 'Cannot remove a user who has already minted' }),
-      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    return NextResponse.json(
+      { error: 'Cannot remove a user who has already minted' },
+      { status: 400 }
     )
   }
 

--- a/apps/web/src/app/api/admin/nft-snapshot/route.ts
+++ b/apps/web/src/app/api/admin/nft-snapshot/route.ts
@@ -1,0 +1,163 @@
+/**
+ * Admin NFT Snapshot Management API
+ *
+ * @route GET /api/admin/nft-snapshot - List all snapshot entries
+ * @route POST /api/admin/nft-snapshot - Add a user to the snapshot
+ * @route DELETE /api/admin/nft-snapshot - Remove a user from the snapshot
+ * @access Admin
+ */
+
+import {
+  requireAdmin,
+  successResponse,
+  withErrorHandling,
+} from '@babylon/api'
+import { db, eq, nftSnapshot, users } from '@babylon/db'
+import { nanoid } from 'nanoid'
+import type { NextRequest } from 'next/server'
+
+export const GET = withErrorHandling(async (request: NextRequest) => {
+  await requireAdmin(request)
+
+  const snapshots = await db
+    .select({
+      id: nftSnapshot.id,
+      userId: nftSnapshot.userId,
+      walletAddress: nftSnapshot.walletAddress,
+      rank: nftSnapshot.rank,
+      points: nftSnapshot.points,
+      snapshotTakenAt: nftSnapshot.snapshotTakenAt,
+      hasMinted: nftSnapshot.hasMinted,
+      mintedTokenId: nftSnapshot.mintedTokenId,
+      mintedAt: nftSnapshot.mintedAt,
+      mintTxHash: nftSnapshot.mintTxHash,
+      username: users.username,
+    })
+    .from(nftSnapshot)
+    .leftJoin(users, eq(nftSnapshot.userId, users.id))
+    .orderBy(nftSnapshot.rank)
+
+  const totalEligible = snapshots.length
+  const totalMinted = snapshots.filter((s) => s.hasMinted).length
+
+  return successResponse({
+    snapshots,
+    stats: {
+      totalEligible,
+      totalMinted,
+      remaining: totalEligible - totalMinted,
+    },
+  })
+})
+
+export const POST = withErrorHandling(async (request: NextRequest) => {
+  await requireAdmin(request)
+
+  const body = await request.json()
+  const { userId, rank, points } = body as {
+    userId: string
+    rank?: number
+    points?: number
+  }
+
+  if (!userId || typeof userId !== 'string') {
+    return new Response(
+      JSON.stringify({ error: 'userId is required' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+
+  // Check if user exists
+  const [user] = await db
+    .select({ id: users.id, username: users.username, walletAddress: users.walletAddress })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1)
+
+  if (!user) {
+    return new Response(
+      JSON.stringify({ error: 'User not found' }),
+      { status: 404, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+
+  // Check if user is already in snapshot
+  const [existing] = await db
+    .select({ id: nftSnapshot.id })
+    .from(nftSnapshot)
+    .where(eq(nftSnapshot.userId, userId))
+    .limit(1)
+
+  if (existing) {
+    return new Response(
+      JSON.stringify({ error: 'User is already in the snapshot' }),
+      { status: 409, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+
+  // Get current max rank for default
+  const allSnapshots = await db
+    .select({ rank: nftSnapshot.rank })
+    .from(nftSnapshot)
+    .orderBy(nftSnapshot.rank)
+
+  const maxRank = allSnapshots.length > 0
+    ? Math.max(...allSnapshots.map((s) => s.rank))
+    : 0
+
+  const newEntry = {
+    id: nanoid(),
+    userId,
+    walletAddress: user.walletAddress ?? null,
+    rank: rank ?? maxRank + 1,
+    points: points ?? 0,
+    snapshotTakenAt: new Date(),
+    hasMinted: false,
+  }
+
+  await db.insert(nftSnapshot).values(newEntry)
+
+  return successResponse({
+    success: true,
+    entry: { ...newEntry, username: user.username },
+  })
+})
+
+export const DELETE = withErrorHandling(async (request: NextRequest) => {
+  await requireAdmin(request)
+
+  const body = await request.json()
+  const { userId } = body as { userId: string }
+
+  if (!userId || typeof userId !== 'string') {
+    return new Response(
+      JSON.stringify({ error: 'userId is required' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+
+  // Check if entry exists and hasn't minted
+  const [existing] = await db
+    .select({ id: nftSnapshot.id, hasMinted: nftSnapshot.hasMinted })
+    .from(nftSnapshot)
+    .where(eq(nftSnapshot.userId, userId))
+    .limit(1)
+
+  if (!existing) {
+    return new Response(
+      JSON.stringify({ error: 'User not found in snapshot' }),
+      { status: 404, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+
+  if (existing.hasMinted) {
+    return new Response(
+      JSON.stringify({ error: 'Cannot remove a user who has already minted' }),
+      { status: 400, headers: { 'Content-Type': 'application/json' } }
+    )
+  }
+
+  await db.delete(nftSnapshot).where(eq(nftSnapshot.userId, userId))
+
+  return successResponse({ success: true, removedUserId: userId })
+})

--- a/apps/web/src/components/admin/NftWhitelistTab.tsx
+++ b/apps/web/src/components/admin/NftWhitelistTab.tsx
@@ -9,7 +9,7 @@ import {
   Trash2,
   Users,
 } from 'lucide-react'
-import { useCallback, useEffect, useState, useTransition } from 'react'
+import { useCallback, useEffect, useMemo, useState, useTransition } from 'react'
 import { toast } from 'sonner'
 import { Skeleton } from '@/components/shared/Skeleton'
 
@@ -38,9 +38,26 @@ export function NftWhitelistTab() {
   const [stats, setStats] = useState<SnapshotStats | null>(null)
   const [loading, setLoading] = useState(true)
   const [addUserId, setAddUserId] = useState('')
+  const [searchQuery, setSearchQuery] = useState('')
   const [isPending, startTransition] = useTransition()
   const [refreshing, setRefreshing] = useState(false)
   const [removingUserId, setRemovingUserId] = useState<string | null>(null)
+
+  const filteredSnapshots = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase()
+    if (!query) return snapshots
+
+    return snapshots.filter((entry) => {
+      const username = (entry.username ?? '').toLowerCase()
+      const userId = entry.userId.toLowerCase()
+      const walletAddress = (entry.walletAddress ?? '').toLowerCase()
+      return (
+        username.includes(query) ||
+        userId.includes(query) ||
+        walletAddress.includes(query)
+      )
+    })
+  }, [searchQuery, snapshots])
 
   const fetchSnapshots = useCallback(async () => {
     try {
@@ -178,31 +195,41 @@ export function NftWhitelistTab() {
 
       {/* Actions Row */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        {/* Add User Form */}
-        <div className="flex items-center gap-2">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+          {/* Add User Form */}
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={addUserId}
+              onChange={(e) => setAddUserId(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleAddUser() }}
+              placeholder="User ID to add..."
+              className="h-9 rounded-lg border border-border bg-background px-3 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary"
+            />
+            <button
+              onClick={handleAddUser}
+              disabled={isPending || !addUserId.trim()}
+              className={cn(
+                'flex h-9 items-center gap-1.5 rounded-lg bg-primary px-3 font-medium text-primary-foreground text-sm transition-colors',
+                'hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50'
+              )}
+            >
+              {isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Plus className="h-4 w-4" />
+              )}
+              Add
+            </button>
+          </div>
+
           <input
             type="text"
-            value={addUserId}
-            onChange={(e) => setAddUserId(e.target.value)}
-            onKeyDown={(e) => { if (e.key === 'Enter') handleAddUser() }}
-            placeholder="User ID to add..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search by user, ID, or wallet..."
             className="h-9 rounded-lg border border-border bg-background px-3 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary"
           />
-          <button
-            onClick={handleAddUser}
-            disabled={isPending || !addUserId.trim()}
-            className={cn(
-              'flex h-9 items-center gap-1.5 rounded-lg bg-primary px-3 font-medium text-primary-foreground text-sm transition-colors',
-              'hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50'
-            )}
-          >
-            {isPending ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <Plus className="h-4 w-4" />
-            )}
-            Add
-          </button>
         </div>
 
         {/* Refresh Button */}
@@ -236,18 +263,27 @@ export function NftWhitelistTab() {
             </tr>
           </thead>
           <tbody>
-            {snapshots.length === 0 ? (
+            {filteredSnapshots.length === 0 ? (
               <tr>
                 <td
                   colSpan={7}
                   className="px-4 py-8 text-center text-muted-foreground"
                 >
-                  No snapshot entries. Click &quot;Refresh from Leaderboard&quot;
-                  to populate, or add users manually.
+                  {snapshots.length === 0
+                    ? (
+                      <>
+                        No snapshot entries. Click
+                        {' '}
+                        &quot;Refresh from Leaderboard&quot;
+                        {' '}
+                        to populate, or add users manually.
+                      </>
+                    )
+                    : 'No entries match your search.'}
                 </td>
               </tr>
             ) : (
-              snapshots.map((entry) => (
+              filteredSnapshots.map((entry) => (
                 <tr
                   key={entry.id}
                   className="border-border border-b last:border-b-0 hover:bg-muted/30"

--- a/apps/web/src/components/admin/NftWhitelistTab.tsx
+++ b/apps/web/src/components/admin/NftWhitelistTab.tsx
@@ -1,0 +1,316 @@
+'use client'
+
+import { cn } from '@babylon/shared'
+import {
+  CheckCircle,
+  Loader2,
+  Plus,
+  RefreshCw,
+  Trash2,
+  Users,
+} from 'lucide-react'
+import { useCallback, useEffect, useState, useTransition } from 'react'
+import { toast } from 'sonner'
+import { Skeleton } from '@/components/shared/Skeleton'
+
+interface SnapshotEntry {
+  id: string
+  userId: string
+  walletAddress: string | null
+  rank: number
+  points: number
+  snapshotTakenAt: string
+  hasMinted: boolean
+  mintedTokenId: number | null
+  mintedAt: string | null
+  mintTxHash: string | null
+  username: string | null
+}
+
+interface SnapshotStats {
+  totalEligible: number
+  totalMinted: number
+  remaining: number
+}
+
+export function NftWhitelistTab() {
+  const [snapshots, setSnapshots] = useState<SnapshotEntry[]>([])
+  const [stats, setStats] = useState<SnapshotStats | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [addUserId, setAddUserId] = useState('')
+  const [isPending, startTransition] = useTransition()
+  const [refreshing, setRefreshing] = useState(false)
+  const [removingUserId, setRemovingUserId] = useState<string | null>(null)
+
+  const fetchSnapshots = useCallback(async () => {
+    try {
+      const res = await fetch('/api/admin/nft-snapshot')
+      if (!res.ok) throw new Error('Failed to fetch snapshots')
+      const data = await res.json()
+      setSnapshots(data.snapshots ?? [])
+      setStats(data.stats ?? null)
+    } catch (err) {
+      toast.error('Failed to load NFT snapshot data')
+      console.error(err)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchSnapshots()
+  }, [fetchSnapshots])
+
+  function handleAddUser() {
+    if (!addUserId.trim()) return
+
+    startTransition(async () => {
+      try {
+        const res = await fetch('/api/admin/nft-snapshot', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ userId: addUserId.trim() }),
+        })
+
+        const data = await res.json()
+
+        if (!res.ok) {
+          toast.error(data.error ?? 'Failed to add user')
+          return
+        }
+
+        toast.success('User added to snapshot')
+        setAddUserId('')
+        await fetchSnapshots()
+      } catch {
+        toast.error('Failed to add user')
+      }
+    })
+  }
+
+  async function handleRemoveUser(userId: string) {
+    setRemovingUserId(userId)
+    try {
+      const res = await fetch('/api/admin/nft-snapshot', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId }),
+      })
+
+      const data = await res.json()
+
+      if (!res.ok) {
+        toast.error(data.error ?? 'Failed to remove user')
+        return
+      }
+
+      toast.success('User removed from snapshot')
+      await fetchSnapshots()
+    } catch {
+      toast.error('Failed to remove user')
+    } finally {
+      setRemovingUserId(null)
+    }
+  }
+
+  async function handleRefreshSnapshot() {
+    setRefreshing(true)
+    try {
+      const res = await fetch('/api/admin/nft-snapshot/refresh', {
+        method: 'POST',
+      })
+
+      const data = await res.json()
+
+      if (!res.ok) {
+        toast.error(data.error ?? 'Failed to refresh snapshot')
+        return
+      }
+
+      toast.success(
+        `Snapshot refreshed: ${data.newlyEligible} new, ${data.updated} updated, ${data.removed} removed`
+      )
+      await fetchSnapshots()
+    } catch {
+      toast.error('Failed to refresh snapshot')
+    } finally {
+      setRefreshing(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Stats Row */}
+      {stats && (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div className="rounded-xl border border-border bg-card p-4">
+            <div className="flex items-center gap-2 text-muted-foreground text-sm">
+              <Users className="h-4 w-4" />
+              Total Eligible
+            </div>
+            <p className="mt-1 font-bold text-2xl">{stats.totalEligible}</p>
+          </div>
+          <div className="rounded-xl border border-border bg-card p-4">
+            <div className="flex items-center gap-2 text-muted-foreground text-sm">
+              <CheckCircle className="h-4 w-4" />
+              Minted
+            </div>
+            <p className="mt-1 font-bold text-2xl">{stats.totalMinted}</p>
+          </div>
+          <div className="rounded-xl border border-border bg-card p-4">
+            <div className="flex items-center gap-2 text-muted-foreground text-sm">
+              <Users className="h-4 w-4" />
+              Remaining
+            </div>
+            <p className="mt-1 font-bold text-2xl">{stats.remaining}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Actions Row */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        {/* Add User Form */}
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            value={addUserId}
+            onChange={(e) => setAddUserId(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') handleAddUser() }}
+            placeholder="User ID to add..."
+            className="h-9 rounded-lg border border-border bg-background px-3 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary"
+          />
+          <button
+            onClick={handleAddUser}
+            disabled={isPending || !addUserId.trim()}
+            className={cn(
+              'flex h-9 items-center gap-1.5 rounded-lg bg-primary px-3 font-medium text-primary-foreground text-sm transition-colors',
+              'hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50'
+            )}
+          >
+            {isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Plus className="h-4 w-4" />
+            )}
+            Add
+          </button>
+        </div>
+
+        {/* Refresh Button */}
+        <button
+          onClick={handleRefreshSnapshot}
+          disabled={refreshing}
+          className={cn(
+            'flex h-9 items-center gap-1.5 rounded-lg border border-border bg-card px-3 font-medium text-sm transition-colors',
+            'hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50'
+          )}
+        >
+          <RefreshCw
+            className={cn('h-4 w-4', refreshing && 'animate-spin')}
+          />
+          Refresh from Leaderboard
+        </button>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto rounded-xl border border-border">
+        <table className="w-full text-left text-sm">
+          <thead>
+            <tr className="border-border border-b bg-muted/50">
+              <th className="px-4 py-3 font-medium text-muted-foreground">Rank</th>
+              <th className="px-4 py-3 font-medium text-muted-foreground">User</th>
+              <th className="px-4 py-3 font-medium text-muted-foreground">Wallet</th>
+              <th className="px-4 py-3 font-medium text-muted-foreground">Points</th>
+              <th className="px-4 py-3 font-medium text-muted-foreground">Status</th>
+              <th className="px-4 py-3 font-medium text-muted-foreground">Token ID</th>
+              <th className="px-4 py-3 font-medium text-muted-foreground">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {snapshots.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={7}
+                  className="px-4 py-8 text-center text-muted-foreground"
+                >
+                  No snapshot entries. Click &quot;Refresh from Leaderboard&quot;
+                  to populate, or add users manually.
+                </td>
+              </tr>
+            ) : (
+              snapshots.map((entry) => (
+                <tr
+                  key={entry.id}
+                  className="border-border border-b last:border-b-0 hover:bg-muted/30"
+                >
+                  <td className="px-4 py-3 font-medium">#{entry.rank}</td>
+                  <td className="px-4 py-3">
+                    <div>
+                      <span className="font-medium">
+                        {entry.username ?? 'Unknown'}
+                      </span>
+                      <span className="ml-1 text-muted-foreground text-xs">
+                        {entry.userId.slice(0, 8)}...
+                      </span>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 font-mono text-xs">
+                    {entry.walletAddress
+                      ? `${entry.walletAddress.slice(0, 6)}...${entry.walletAddress.slice(-4)}`
+                      : '—'}
+                  </td>
+                  <td className="px-4 py-3">
+                    {entry.points.toLocaleString()}
+                  </td>
+                  <td className="px-4 py-3">
+                    {entry.hasMinted ? (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-green-500/10 px-2 py-0.5 font-medium text-green-500 text-xs">
+                        <CheckCircle className="h-3 w-3" />
+                        Minted
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center rounded-full bg-yellow-500/10 px-2 py-0.5 font-medium text-xs text-yellow-500">
+                        Eligible
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground">
+                    {entry.mintedTokenId != null ? `#${entry.mintedTokenId}` : '—'}
+                  </td>
+                  <td className="px-4 py-3">
+                    <button
+                      onClick={() => handleRemoveUser(entry.userId)}
+                      disabled={entry.hasMinted || removingUserId === entry.userId}
+                      title={entry.hasMinted ? 'Cannot remove — already minted' : 'Remove from whitelist'}
+                      className={cn(
+                        'flex h-7 w-7 items-center justify-center rounded-lg transition-colors',
+                        entry.hasMinted
+                          ? 'cursor-not-allowed text-muted-foreground/30'
+                          : 'text-red-500 hover:bg-red-500/10'
+                      )}
+                    >
+                      {removingUserId === entry.userId ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <Trash2 className="h-4 w-4" />
+                      )}
+                    </button>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Add **NFT Whitelist** tab to the admin panel under the Platform category
- Admin API routes at `/api/admin/nft-snapshot` for listing, adding, and removing snapshot entries
- Manual snapshot refresh endpoint at `/api/admin/nft-snapshot/refresh` (mirrors cron logic)
- UI with stats cards, searchable table, add/remove controls, and one-click leaderboard refresh

## Test plan

- [ ] Navigate to Admin Dashboard > Platform > NFT Whitelist
- [ ] Verify stats cards show correct counts
- [ ] Add a user by pasting their user ID
- [ ] Remove a non-minted user from the list
- [ ] Click "Refresh from Leaderboard" and verify snapshot updates
- [ ] Confirm minted users cannot be removed (button disabled)