### PR TITLE
Waitlist: reuse profile modal

### DIFF
--- a/apps/web/src/components/shared/ComingSoon.tsx
+++ b/apps/web/src/components/shared/ComingSoon.tsx
@@ -3756,8 +3756,10 @@ export function ComingSoon() {
         </div>
       </section>
 
+      {profileCompletionModal}
+
       {/* Profile Completion Modal */}
-      {showProfileModal && (
+      {false && (
         <>
           <div
             className="fixed inset-0 z-[100] bg-black/70 backdrop-blur-sm transition-opacity duration-300"


### PR DESCRIPTION
Follow-up: reuse the extracted profileCompletionModal in the main waitlist view (and dead-code the legacy inline block) to avoid duplication.