### PR TITLE
Fix profile image validation for preset assets

### DIFF
--- a/packages/shared/src/validation/schemas/common.ts
+++ b/packages/shared/src/validation/schemas/common.ts
@@ -136,6 +136,30 @@ export const URLSchema = z.string().url({
 });
 
 /**
+ * Public asset path OR http(s) URL schema.
+ *
+ * Used for user-facing images where we support preset local assets (e.g. /assets/*)
+ * as well as uploaded assets (e.g. /uploads/*) and remote URLs.
+ */
+export const AssetOrUrlSchema = z.string().refine(
+  (val) => {
+    const value = val.trim();
+    if (value.length === 0) return true;
+    if (value.startsWith('/assets/') || value.startsWith('/uploads/')) {
+      return true;
+    }
+
+    try {
+      const parsed = new URL(value);
+      return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    } catch {
+      return false;
+    }
+  },
+  { message: 'Invalid URL format' }
+);
+
+/**
  * Phone number validation (basic international format)
  */
 export const PhoneNumberSchema = z

--- a/packages/shared/src/validation/schemas/onboarding.ts
+++ b/packages/shared/src/validation/schemas/onboarding.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { UsernameSchema } from './common';
+import { AssetOrUrlSchema, UsernameSchema } from './common';
 
 export const OnboardingProfileSchema = z.object({
   username: UsernameSchema,
@@ -15,14 +15,18 @@ export const OnboardingProfileSchema = z.object({
     .optional()
     .or(z.literal('').transform(() => undefined)),
   profileImageUrl: z
-    .string()
-    .url('Profile image must be a valid URL')
+    .preprocess(
+      (val) => (typeof val === 'string' ? val.trim() : val),
+      AssetOrUrlSchema
+    )
     .optional()
     .or(z.literal('').transform(() => undefined))
     .nullable(),
   coverImageUrl: z
-    .string()
-    .url('Cover image must be a valid URL')
+    .preprocess(
+      (val) => (typeof val === 'string' ? val.trim() : val),
+      AssetOrUrlSchema
+    )
     .optional()
     .or(z.literal('').transform(() => undefined))
     .nullable(),

--- a/packages/shared/src/validation/schemas/user.ts
+++ b/packages/shared/src/validation/schemas/user.ts
@@ -4,6 +4,7 @@
 
 import { z } from 'zod';
 import {
+  AssetOrUrlSchema,
   createTrimmedStringSchema,
   EmailSchema,
   PaginationSchema,
@@ -23,8 +24,8 @@ export const CreateUserSchema = z
     username: UsernameSchema.optional(),
     displayName: createTrimmedStringSchema(undefined, 100).optional(),
     bio: createTrimmedStringSchema(undefined, 500).optional(),
-    profileImageUrl: URLSchema.optional(),
-    coverImageUrl: URLSchema.optional(),
+    profileImageUrl: AssetOrUrlSchema.optional(),
+    coverImageUrl: AssetOrUrlSchema.optional(),
   })
   .refine((data) => data.walletAddress || data.email, {
     message: 'Either wallet address or email is required',
@@ -37,8 +38,8 @@ export const UpdateUserSchema = z.object({
   username: UsernameSchema.optional(),
   displayName: createTrimmedStringSchema(undefined, 100).optional(),
   bio: createTrimmedStringSchema(undefined, 500).optional(),
-  profileImageUrl: URLSchema.optional(),
-  coverImageUrl: URLSchema.optional(),
+  profileImageUrl: AssetOrUrlSchema.optional(),
+  coverImageUrl: AssetOrUrlSchema.optional(),
   showTwitterPublic: z.boolean().optional(),
   showFarcasterPublic: z.boolean().optional(),
   showWalletPublic: z.boolean().optional(),


### PR DESCRIPTION
Allow preset image paths like /assets/user-profiles/* and /assets/user-banners/* (and /uploads/*), not just absolute http(s) URLs, so update-profile works from the waitlist/profile modal.