### PR TITLE
fix: bypass NFT gate for admin users

### DIFF
--- a/apps/web/src/app/api/nft/access/route.ts
+++ b/apps/web/src/app/api/nft/access/route.ts
@@ -6,6 +6,13 @@ import type { NftAccessResponse } from '@/types/nft';
 export const GET = withErrorHandling(async (request: NextRequest) => {
   const user = await authenticate(request);
 
+  if (user.isAdmin) {
+    return successResponse({
+      success: true,
+      data: { hasAccess: true, degraded: false },
+    } satisfies NftAccessResponse);
+  }
+
   let allowed: boolean;
   let degraded: boolean;
   try {


### PR DESCRIPTION
## Summary
- add server-side admin bypass in API nft access
- return hasAccess true for admin users so middleware no longer redirects them to waitlist

## Why
- frontend already bypassed admins, but middleware enforces server gating via API nft access
- this aligns server behavior with expected admin access

## Validation
- bun run lint
- bun x turbo run build --filter=web
- bun run typecheck currently fails on pre-existing repo issues unrelated to this change