### PR TITLE
fix: unify cron relay fan-out across environments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -480,6 +480,12 @@ PHALA_ENDPOINT=
 
 # Cron job security token (generate with: openssl rand -hex 32)
 CRON_SECRET=your_random_secret_here_replace_with_actual_secret
+# Mirror cron calls from production to staging (optional, default: false)
+REDIRECT_CRON_STAGING=false
+# Staging base URL used when REDIRECT_CRON_STAGING=true (optional)
+CRON_STAGING_URL=https://staging.babylon.market
+# Enable internal scheduler outside production or force it explicitly (optional, default: false)
+ENABLE_INTERNAL_CRON_SCHEDULER=false
 # NFT revalidation cron job timeout in milliseconds (default: 50000 = 50s, allows 10s buffer for Vercel 60s limit)
 NFT_REVALIDATE_TIMEOUT_MS=50000
 

--- a/apps/web/src/app/api/cron/agent-tick/route.ts
+++ b/apps/web/src/app/api/cron/agent-tick/route.ts
@@ -155,25 +155,17 @@ export async function POST(_req: NextRequest) {
   const processId = `agent-tick-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
   logger.info('Agent tick started', { processId }, 'AgentTick');
 
-  // 1. Relay to staging if REDIRECT_CRON_STAGING is enabled
+  // 1. Relay to staging if REDIRECT_CRON_STAGING is enabled (fan-out)
   const relayResult = await relayCronToStaging(_req, 'agent-tick');
   if (relayResult.forwarded) {
     logger.info(
-      'Cron execution relayed to staging - skipping local execution',
+      'Cron execution relayed to staging (fan-out: continuing local execution)',
       {
         status: relayResult.status,
         error: relayResult.error,
       },
       'AgentTick'
     );
-    return NextResponse.json({
-      success: true,
-      skipped: true,
-      reason: 'Relayed to staging environment',
-      relayStatus: relayResult.status,
-      processed: 0,
-      skippedLocked: 0,
-    });
   }
 
   // 1.5 Acquire global lock to prevent overlapping cron invocations

--- a/apps/web/src/app/api/cron/article-tick/route.ts
+++ b/apps/web/src/app/api/cron/article-tick/route.ts
@@ -241,21 +241,14 @@ export async function POST(_req: NextRequest) {
   const processId = `article-tick-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
   logger.info('Article tick started', { processId }, 'ArticleTick');
 
-  // Relay to staging if configured
+  // Relay to staging if configured (fan-out)
   const relayResult = await relayCronToStaging(_req, 'article-tick');
   if (relayResult.forwarded) {
     logger.info(
-      'Cron execution relayed to staging - skipping local execution',
+      'Cron execution relayed to staging (fan-out: continuing local execution)',
       { status: relayResult.status, error: relayResult.error },
       'ArticleTick'
     );
-    return NextResponse.json({
-      success: true,
-      skipped: true,
-      reason: 'Relayed to staging environment',
-      relayStatus: relayResult.status,
-      articlesCreated: 0,
-    });
   }
 
   // Acquire global lock to prevent overlapping cron invocations

--- a/apps/web/src/app/api/cron/game-tick/route.ts
+++ b/apps/web/src/app/api/cron/game-tick/route.ts
@@ -104,23 +104,17 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
   const startTime = Date.now();
   const lockId = `tick-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
 
-  // 1.5. Relay to staging if REDIRECT_CRON_STAGING is enabled
+  // 1.5. Relay to staging if REDIRECT_CRON_STAGING is enabled (fan-out)
   const relayResult = await relayCronToStaging(request, 'game-tick');
   if (relayResult.forwarded) {
     logger.info(
-      'Cron execution relayed to staging - skipping local execution',
+      'Cron execution relayed to staging (fan-out: continuing local execution)',
       {
         status: relayResult.status,
         error: relayResult.error,
       },
       'Cron'
     );
-    return successResponse({
-      success: true,
-      skipped: true,
-      reason: 'Relayed to staging environment',
-      relayStatus: relayResult.status,
-    });
   }
 
   // 1.6. Check GAME_START environment variable (manual override)

--- a/apps/web/src/app/api/cron/markets-tick/route.ts
+++ b/apps/web/src/app/api/cron/markets-tick/route.ts
@@ -452,20 +452,14 @@ export async function POST(_req: NextRequest) {
   const processId = `markets-tick-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
   logger.info('Markets tick started', { processId }, 'MarketsTick');
 
-  // Relay to staging if configured
+  // Relay to staging if configured (fan-out)
   const relayResult = await relayCronToStaging(_req, 'markets-tick');
   if (relayResult.forwarded) {
     logger.info(
-      'Cron execution relayed to staging - skipping local execution',
+      'Cron execution relayed to staging (fan-out: continuing local execution)',
       { status: relayResult.status, error: relayResult.error },
       'MarketsTick'
     );
-    return NextResponse.json({
-      success: true,
-      skipped: true,
-      reason: 'Relayed to staging environment',
-      relayStatus: relayResult.status,
-    });
   }
 
   // Acquire global lock to prevent overlapping cron invocations

--- a/apps/web/src/app/api/cron/npc-tick/route.ts
+++ b/apps/web/src/app/api/cron/npc-tick/route.ts
@@ -147,21 +147,14 @@ export async function POST(_req: NextRequest) {
   const processId = `npc-tick-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
   logger.info('NPC tick started', { processId }, 'NPCTick');
 
-  // Relay to staging if configured
+  // Relay to staging if configured (fan-out)
   const relayResult = await relayCronToStaging(_req, 'npc-tick');
   if (relayResult.forwarded) {
     logger.info(
-      'Cron execution relayed to staging - skipping local execution',
+      'Cron execution relayed to staging (fan-out: continuing local execution)',
       { status: relayResult.status, error: relayResult.error },
       'NPCTick'
     );
-    return NextResponse.json({
-      success: true,
-      skipped: true,
-      reason: 'Relayed to staging environment',
-      relayStatus: relayResult.status,
-      processed: 0,
-    });
   }
 
   // Acquire global lock to prevent overlapping cron invocations

--- a/apps/web/src/app/api/cron/organization-tick/route.ts
+++ b/apps/web/src/app/api/cron/organization-tick/route.ts
@@ -169,21 +169,14 @@ export async function POST(_req: NextRequest) {
   const processId = `org-tick-${Date.now()}-${crypto.randomUUID().slice(0, 8)}`;
   logger.info('Organization tick started', { processId }, 'OrganizationTick');
 
-  // Relay to staging if configured
+  // Relay to staging if configured (fan-out)
   const relayResult = await relayCronToStaging(_req, 'organization-tick');
   if (relayResult.forwarded) {
     logger.info(
-      'Cron execution relayed to staging - skipping local execution',
+      'Cron execution relayed to staging (fan-out: continuing local execution)',
       { status: relayResult.status, error: relayResult.error },
       'OrganizationTick'
     );
-    return NextResponse.json({
-      success: true,
-      skipped: true,
-      reason: 'Relayed to staging environment',
-      relayStatus: relayResult.status,
-      processed: 0,
-    });
   }
 
   // Acquire global lock to prevent overlapping cron invocations

--- a/packages/api/src/services/cron-relay-service.ts
+++ b/packages/api/src/services/cron-relay-service.ts
@@ -49,24 +49,57 @@ export async function relayCronToStaging(
   const { pathname, search } = new URL(request.url);
   const targetUrl = `${stagingBaseUrl}${pathname}${search}`;
 
-  const res = await fetch(targetUrl, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${cronSecret}`,
-      'x-cron-relay': routeName,
-    },
-    cache: 'no-store',
-  });
+  try {
+    const res = await fetch(targetUrl, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${cronSecret}`,
+        'x-cron-relay': routeName,
+      },
+      cache: 'no-store',
+      signal: AbortSignal.timeout(10000),
+    });
 
-  logger.info(
-    'Relayed cron execution to staging',
-    {
-      routeName,
-      targetUrl,
-      status: res.status,
-    },
-    'CronRelay'
-  );
+    if (!res.ok) {
+      logger.warn(
+        'Cron relay to staging returned non-2xx status',
+        {
+          routeName,
+          targetUrl,
+          status: res.status,
+          statusText: res.statusText,
+        },
+        'CronRelay'
+      );
+      return {
+        forwarded: false,
+        status: res.status,
+        error: `Relay failed with HTTP ${res.status}`,
+      };
+    }
 
-  return { forwarded: true, status: res.status };
+    logger.info(
+      'Relayed cron execution to staging',
+      {
+        routeName,
+        targetUrl,
+        status: res.status,
+      },
+      'CronRelay'
+    );
+
+    return { forwarded: true, status: res.status };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logger.warn(
+      'Cron relay to staging failed',
+      {
+        routeName,
+        targetUrl,
+        error: message,
+      },
+      'CronRelay'
+    );
+    return { forwarded: false, error: message };
+  }
 }


### PR DESCRIPTION
## Summary
- make cron relay best-effort with timeout and explicit non-2xx handling
- switch cron routes from relay+skip to consistent fan-out (relay + local execution)
- document relay env vars in .env.example

## Validation
- bun run lint
- bun run build
- bun run typecheck (fails on pre-existing agent0 typing issues unrelated to this change)