### PR TITLE
fix(db): respect select in TableRepository

### DIFF
--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -437,6 +437,30 @@ function buildOrderBy<TTable extends PgTable>(
 }
 
 /**
+ * Build Drizzle select fields from a boolean select input.
+ *
+ * This is especially important for forward/backward DB compatibility: when callers
+ * specify a `select`, we should only query the requested columns instead of
+ * selecting the whole row.
+ */
+function buildSelectFields<TTable extends PgTable>(
+  table: TTable,
+  select: SelectInput | undefined
+): Record<string, PgColumn> | undefined {
+  if (!select) return undefined;
+
+  const tableConfig = getTableConfig(table);
+  const fields: Record<string, PgColumn> = {};
+  for (const [key, enabled] of Object.entries(select)) {
+    if (!enabled) continue;
+    const column = findColumnByName(tableConfig, key);
+    if (column) fields[key] = column;
+  }
+
+  return Object.keys(fields).length > 0 ? fields : undefined;
+}
+
+/**
  * Type representing all valid database value types including JSON columns.
  *
  * JSONB columns with custom types (e.g., NpcMemory[], PriceModifier[]) use .$type<T>()
@@ -539,6 +563,7 @@ export class TableRepository<
    */
   async findUnique(options: FindOptions<TSelect>): Promise<TSelect | null> {
     const whereClause = buildWhereClause(this.table, options.where);
+    const selectFields = buildSelectFields(this.table, options.select);
 
     // Use Drizzle's query API for relations if include is specified
     const relationalBuilder = getRelationalQueryBuilder(
@@ -554,8 +579,10 @@ export class TableRepository<
     }
 
     // Use Drizzle's typed query builder - helper ensures type safety
-    const results = await this.drizzle
-      .select()
+    const baseSelect = selectFields
+      ? this.drizzle.select(selectFields as SelectedFields)
+      : this.drizzle.select();
+    const results = await baseSelect
       .from(asDrizzleTable(this.table))
       .where(whereClause)
       .limit(1);
@@ -580,6 +607,7 @@ export class TableRepository<
   async findFirst(options: FindOptions<TSelect> = {}): Promise<TSelect | null> {
     const whereClause = buildWhereClause(this.table, options.where);
     const orderByClause = buildOrderBy(this.table, options.orderBy);
+    const selectFields = buildSelectFields(this.table, options.select);
 
     // Use Drizzle's query API for relations if include is specified
     const relationalBuilder = getRelationalQueryBuilder(
@@ -597,10 +625,10 @@ export class TableRepository<
 
     // Use Drizzle's typed query builder with $dynamic() for conditional chaining
     // Helper ensures type safety
-    let query = this.drizzle
-      .select()
-      .from(asDrizzleTable(this.table))
-      .$dynamic();
+    const baseSelect = selectFields
+      ? this.drizzle.select(selectFields as SelectedFields)
+      : this.drizzle.select();
+    let query = baseSelect.from(asDrizzleTable(this.table)).$dynamic();
     if (whereClause) query = query.where(whereClause);
     if (orderByClause.length > 0) query = query.orderBy(...orderByClause);
     if (options.skip) query = query.offset(options.skip);
@@ -626,6 +654,7 @@ export class TableRepository<
   async findMany(options: FindOptions<TSelect> = {}): Promise<TSelect[]> {
     const whereClause = buildWhereClause(this.table, options.where);
     const orderByClause = buildOrderBy(this.table, options.orderBy);
+    const selectFields = buildSelectFields(this.table, options.select);
 
     // Use Drizzle's query API for relations if include is specified
     const relationalBuilder = getRelationalQueryBuilder(
@@ -645,10 +674,10 @@ export class TableRepository<
 
     // Use Drizzle's typed query builder with $dynamic() for conditional chaining
     // Helper ensures type safety
-    let query = this.drizzle
-      .select()
-      .from(asDrizzleTable(this.table))
-      .$dynamic();
+    const baseSelect = selectFields
+      ? this.drizzle.select(selectFields as SelectedFields)
+      : this.drizzle.select();
+    let query = baseSelect.from(asDrizzleTable(this.table)).$dynamic();
     if (whereClause) query = query.where(whereClause);
     if (orderByClause.length > 0) query = query.orderBy(...orderByClause);
     if (options.take) query = query.limit(options.take);


### PR DESCRIPTION
## Summary

- Fix `TableRepository` to respect `select` in `findUnique`/`findFirst`/`findMany`, instead of always doing `SELECT *`.
- Prevents admin stats endpoints (and any other `select`-based queries) from failing when the DB schema lags behind the TypeScript schema (e.g. missing columns in a given environment).

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Admin dashboard access check relies on `GET /api/admin/stats`. When that endpoint 500s, `/admin` shows “Access Denied”.

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [x] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- `packages/db/src/client.ts`: build a column map from `select` and pass it into Drizzle `.select(fields)`.

## Review guide

**Start here**
- `packages/db/src/client.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- This aligns runtime behavior with the public repository API (callers already pass `select` expecting it to take effect).
- Follow-up (separate): repo-wide `bun run typecheck` currently fails due to `agent0-sdk` type mismatches; not caused by this change.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

(Scoped) Ran:
- `cd packages/db && bun run typecheck`
- `cd packages/db && bun run lint`

**Manual verification**
1. N/A (library change).

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: N/A
- Changed: N/A
- Removed: N/A

**DB / data migration**
- Migration(s): N/A
- Backfill/seed: N/A

**Rollout / rollback plan**
- Rollout: deploy normally.
- Rollback: revert this commit.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend/library-only change, no UI changes.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
