### PR TITLE
fix(web): handle network failures in Settings uploads

### DIFF
--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -310,11 +310,23 @@ export default function SettingsPage() {
       const formData = new FormData();
       formData.append('file', profileImage.file);
       formData.append('type', 'profile');
-      const uploadResponse = await fetch('/api/upload/image', {
-        method: 'POST',
-        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-        body: formData,
-      });
+      let uploadResponse: Response;
+      try {
+        uploadResponse = await fetch('/api/upload/image', {
+          method: 'POST',
+          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+          body: formData,
+        });
+      } catch (err) {
+        logger.error(
+          'Profile image upload request failed',
+          { error: err },
+          'SettingsPage'
+        );
+        setErrorMessage('Failed to upload profile image.');
+        setSaving(false);
+        return;
+      }
       const uploadPayload = (await uploadResponse.json().catch(() => ({}))) as {
         url?: string;
       };
@@ -330,11 +342,23 @@ export default function SettingsPage() {
       const formData = new FormData();
       formData.append('file', coverImage.file);
       formData.append('type', 'cover');
-      const uploadResponse = await fetch('/api/upload/image', {
-        method: 'POST',
-        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-        body: formData,
-      });
+      let uploadResponse: Response;
+      try {
+        uploadResponse = await fetch('/api/upload/image', {
+          method: 'POST',
+          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+          body: formData,
+        });
+      } catch (err) {
+        logger.error(
+          'Cover image upload request failed',
+          { error: err },
+          'SettingsPage'
+        );
+        setErrorMessage('Failed to upload cover image.');
+        setSaving(false);
+        return;
+      }
       const uploadPayload = (await uploadResponse.json().catch(() => ({}))) as {
         url?: string;
       };
@@ -346,22 +370,34 @@ export default function SettingsPage() {
       nextCoverImageUrl = uploadPayload.url;
     }
 
-    const response = await fetch(
-      `/api/users/${encodeURIComponent(user.id)}/update-profile`,
-      {
-        method: 'POST',
-        headers,
-        body: JSON.stringify({
-          displayName: trimmedDisplayName,
-          username: trimmedUsername,
-          bio: trimmedBio,
-          ...(nextProfileImageUrl
-            ? { profileImageUrl: nextProfileImageUrl }
-            : {}),
-          ...(nextCoverImageUrl ? { coverImageUrl: nextCoverImageUrl } : {}),
-        }),
-      }
-    );
+    let response: Response;
+    try {
+      response = await fetch(
+        `/api/users/${encodeURIComponent(user.id)}/update-profile`,
+        {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({
+            displayName: trimmedDisplayName,
+            username: trimmedUsername,
+            bio: trimmedBio,
+            ...(nextProfileImageUrl
+              ? { profileImageUrl: nextProfileImageUrl }
+              : {}),
+            ...(nextCoverImageUrl ? { coverImageUrl: nextCoverImageUrl } : {}),
+          }),
+        }
+      );
+    } catch (err) {
+      logger.error(
+        'Profile update request failed',
+        { error: err },
+        'SettingsPage'
+      );
+      setErrorMessage('Unable to save your changes.');
+      setSaving(false);
+      return;
+    }
 
     const payload = await response.json().catch(() => ({}));
     if (!response.ok) {


### PR DESCRIPTION
## Summary
- Add explicit network-error handling for Settings profile image uploads and profile updates.
- This prevents unhandled promise rejections and provides consistent user-facing error messages.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Follow-up from PR #989 review notes (network failure handling in Settings upload flow).

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- Wrap Settings upload + update requests in targeted `try/catch` blocks.
- Log failures and surface a stable error message via `setErrorMessage(...)`.

## Review guide
**Start here**
- `apps/web/src/app/settings/page.tsx`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- Only catches network/request failures at the UI boundary; server-side behavior is unchanged.

## Test plan
**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Settings -> Profile tab: try saving changes while offline / blocking requests; confirm an error is shown and no crash occurs.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: none
- Changed: none
- Removed: none

**DB / data migration**
- Migration(s): none
- Backfill/seed: none

**Rollout / rollback plan**
- Rollout: normal deploy.
- Rollback: revert this PR.

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option B: No visual changes
- Reason: UI behavior change only for error states (network failures); primary UI remains unchanged.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
