### PR TITLE
feat: Whitelisting System - First 100, Leaderboard, and Ad-Hoc Admin Controls

### DIFF
--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -83,6 +83,7 @@ import { SystemHealthTab } from '@/components/admin/SystemHealthTab';
 import { TradingFeedTab } from '@/components/admin/TradingFeedTab';
 import { TrainingDataTab } from '@/components/admin/TrainingDataTab';
 import { UserManagementTab } from '@/components/admin/UserManagementTab';
+import { WhitelistTab } from '@/components/admin/WhitelistTab';
 import { PageContainer } from '@/components/shared/PageContainer';
 import { Skeleton } from '@/components/shared/Skeleton';
 import { useAuth } from '@/hooks/useAuth';
@@ -115,7 +116,8 @@ type Tab =
   | 'escrow'
   | 'audit-logs'
   | 'alpha-groups'
-  | 'nft-whitelist';
+  | 'nft-whitelist'
+  | 'whitelist';
 
 /**
  * Admin Dashboard Component
@@ -258,6 +260,7 @@ export default function AdminDashboard() {
         { id: 'alpha-groups' as const, label: 'Alpha Groups', icon: Crown },
         { id: 'notifications' as const, label: 'Notifications', icon: Bell },
         { id: 'nft-whitelist' as const, label: 'NFT Whitelist', icon: Star },
+        { id: 'whitelist' as const, label: 'Access Whitelist', icon: Shield },
       ],
     },
     {
@@ -413,6 +416,7 @@ export default function AdminDashboard() {
         {activeTab === 'audit-logs' && <AuditLogsTab />}
         {activeTab === 'alpha-groups' && <AlphaGroupsTab />}
         {activeTab === 'nft-whitelist' && <NftWhitelistTab />}
+        {activeTab === 'whitelist' && <WhitelistTab />}
       </div>
     </PageContainer>
   );

--- a/apps/web/src/app/api/admin/users/route.ts
+++ b/apps/web/src/app/api/admin/users/route.ts
@@ -100,6 +100,7 @@ import {
   eq,
   follows,
   inArray,
+  isNull,
   positions,
   reactions,
   reports,
@@ -108,6 +109,7 @@ import {
   userBlocks,
   userMutes,
   users,
+  whitelist,
 } from '@babylon/db';
 import { logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
@@ -253,6 +255,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     blocksReceived,
     mutesReceived,
     reportsSent,
+    whitelistedUsers,
   ] =
     userIds.length > 0
       ? await Promise.all([
@@ -310,8 +313,20 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
             .from(reports)
             .where(inArray(reports.reporterId, userIds))
             .groupBy(reports.reporterId),
+          // Whitelist status (active entries only).
+          // Wrapped in catch so a missing Whitelist table doesn't break the admin endpoint.
+          db
+            .select({ userId: whitelist.userId })
+            .from(whitelist)
+            .where(
+              and(
+                inArray(whitelist.userId, userIds),
+                isNull(whitelist.revokedAt)
+              )
+            )
+            .catch(() => [] as { userId: string }[]),
         ])
-      : [[], [], [], [], [], [], [], [], []];
+      : [[], [], [], [], [], [], [], [], [], []];
 
   // Build lookup maps
   const commentCountMap = new Map(
@@ -341,6 +356,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   const reportsSentMap = new Map(
     reportsSent.filter((r) => r.userId).map((r) => [r.userId!, r.count])
   );
+  const whitelistedSet = new Set(whitelistedUsers.map((w) => w.userId));
 
   // Calculate moderation metrics and bad user scores
   const usersWithMetrics = usersResult.map((user) => {
@@ -363,6 +379,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
 
     return {
       ...user,
+      isWhitelisted: whitelistedSet.has(user.id),
       _count: {
         comments: commentCountMap.get(user.id) || 0,
         reactions: reactionCountMap.get(user.id) || 0,

--- a/apps/web/src/app/api/admin/whitelist/config/route.ts
+++ b/apps/web/src/app/api/admin/whitelist/config/route.ts
@@ -52,6 +52,21 @@ export const PUT = withErrorHandling(async (request: NextRequest) => {
     );
   }
 
+  const VALID_CATEGORIES = ['all', 'trading', 'social', 'reputation'] as const;
+  if (
+    leaderboardCategory !== undefined &&
+    !VALID_CATEGORIES.includes(
+      leaderboardCategory as (typeof VALID_CATEGORIES)[number]
+    )
+  ) {
+    return NextResponse.json(
+      {
+        error: `leaderboardCategory must be one of: ${VALID_CATEGORIES.join(', ')}`,
+      },
+      { status: 400 }
+    );
+  }
+
   await updateWhitelistConfig({
     leaderboardRankThreshold,
     leaderboardCategory,

--- a/apps/web/src/app/api/admin/whitelist/config/route.ts
+++ b/apps/web/src/app/api/admin/whitelist/config/route.ts
@@ -1,0 +1,64 @@
+/**
+ * Admin Whitelist Config API
+ *
+ * @route GET /api/admin/whitelist/config - Get current whitelist configuration
+ * @route PUT /api/admin/whitelist/config - Update whitelist configuration
+ * @access Admin
+ */
+
+import { requireAdmin, successResponse, withErrorHandling } from '@babylon/api';
+import {
+  getWhitelistConfig,
+  updateWhitelistConfig,
+} from '@babylon/api/services/whitelist-service';
+import { type NextRequest, NextResponse } from 'next/server';
+
+export const GET = withErrorHandling(async (request: NextRequest) => {
+  await requireAdmin(request);
+
+  const config = await getWhitelistConfig();
+
+  return successResponse({
+    config: config ?? {
+      leaderboardRankThreshold: null,
+      leaderboardCategory: 'all',
+      updatedAt: null,
+      updatedBy: null,
+    },
+  });
+});
+
+export const PUT = withErrorHandling(async (request: NextRequest) => {
+  const admin = await requireAdmin(request);
+
+  const body = await request.json();
+  const { leaderboardRankThreshold, leaderboardCategory } = body as {
+    leaderboardRankThreshold: number | null;
+    leaderboardCategory?: string;
+  };
+
+  if (
+    leaderboardRankThreshold !== null &&
+    (typeof leaderboardRankThreshold !== 'number' ||
+      leaderboardRankThreshold < 0 ||
+      !Number.isInteger(leaderboardRankThreshold))
+  ) {
+    return NextResponse.json(
+      {
+        error:
+          'leaderboardRankThreshold must be a non-negative integer or null',
+      },
+      { status: 400 }
+    );
+  }
+
+  await updateWhitelistConfig({
+    leaderboardRankThreshold,
+    leaderboardCategory,
+    updatedBy: admin.dbUserId ?? undefined,
+  });
+
+  const config = await getWhitelistConfig();
+
+  return successResponse({ success: true, config });
+});

--- a/apps/web/src/app/api/admin/whitelist/import-first-100/route.ts
+++ b/apps/web/src/app/api/admin/whitelist/import-first-100/route.ts
@@ -1,0 +1,23 @@
+/**
+ * Admin Whitelist Import First 100 API
+ *
+ * @route POST /api/admin/whitelist/import-first-100 - Import users from NftSnapshot
+ * @access Admin
+ */
+
+import { requireAdmin, successResponse, withErrorHandling } from '@babylon/api';
+import { importFirst100FromSnapshot } from '@babylon/api/services/whitelist-service';
+import type { NextRequest } from 'next/server';
+
+export const POST = withErrorHandling(async (request: NextRequest) => {
+  const admin = await requireAdmin(request);
+
+  const result = await importFirst100FromSnapshot(admin.dbUserId ?? undefined);
+
+  return successResponse({
+    success: true,
+    imported: result.imported,
+    skipped: result.skipped,
+    total: result.total,
+  });
+});

--- a/apps/web/src/app/api/admin/whitelist/route.ts
+++ b/apps/web/src/app/api/admin/whitelist/route.ts
@@ -1,0 +1,107 @@
+/**
+ * Admin Whitelist Management API
+ *
+ * @route GET /api/admin/whitelist - List whitelisted users with stats
+ * @route POST /api/admin/whitelist - Add a user to the whitelist
+ * @route DELETE /api/admin/whitelist - Remove (revoke) a user from the whitelist
+ * @access Admin
+ */
+
+import { requireAdmin, successResponse, withErrorHandling } from '@babylon/api';
+import type { WhitelistSource } from '@babylon/api/services/whitelist-service';
+import {
+  addToWhitelist,
+  getWhitelistStats,
+  listWhitelistEntries,
+  removeFromWhitelist,
+} from '@babylon/api/services/whitelist-service';
+import { db, eq, users } from '@babylon/db';
+import { type NextRequest, NextResponse } from 'next/server';
+
+export const GET = withErrorHandling(async (request: NextRequest) => {
+  await requireAdmin(request);
+
+  const { searchParams } = new URL(request.url);
+  const source = searchParams.get('source') as WhitelistSource | null;
+  const search = searchParams.get('search') ?? undefined;
+  const includeRevoked = searchParams.get('includeRevoked') === 'true';
+
+  const [entries, stats] = await Promise.all([
+    listWhitelistEntries({
+      source: source ?? undefined,
+      search,
+      includeRevoked,
+    }),
+    getWhitelistStats(),
+  ]);
+
+  return successResponse({ entries, stats });
+});
+
+export const POST = withErrorHandling(async (request: NextRequest) => {
+  const admin = await requireAdmin(request);
+
+  const body = await request.json();
+  const { userId, source, reason } = body as {
+    userId: string;
+    source?: WhitelistSource;
+    reason?: string;
+  };
+
+  if (!userId || typeof userId !== 'string') {
+    return NextResponse.json({ error: 'userId is required' }, { status: 400 });
+  }
+
+  // Verify user exists
+  const [user] = await db
+    .select({ id: users.id, username: users.username })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 });
+  }
+
+  const result = await addToWhitelist({
+    userId,
+    source: source ?? 'admin_manual',
+    reason,
+    grantedBy: admin.dbUserId ?? undefined,
+  });
+
+  if (result.alreadyExists) {
+    return NextResponse.json(
+      { error: 'User is already whitelisted' },
+      { status: 409 }
+    );
+  }
+
+  return successResponse({
+    success: true,
+    id: result.id,
+    username: user.username,
+  });
+});
+
+export const DELETE = withErrorHandling(async (request: NextRequest) => {
+  await requireAdmin(request);
+
+  const body = await request.json();
+  const { userId } = body as { userId: string };
+
+  if (!userId || typeof userId !== 'string') {
+    return NextResponse.json({ error: 'userId is required' }, { status: 400 });
+  }
+
+  const result = await removeFromWhitelist(userId);
+
+  if (!result.removed) {
+    return NextResponse.json(
+      { error: 'User not found in whitelist or already revoked' },
+      { status: 404 }
+    );
+  }
+
+  return successResponse({ success: true, removedUserId: userId });
+});

--- a/apps/web/src/components/admin/UserManagementTab.tsx
+++ b/apps/web/src/components/admin/UserManagementTab.tsx
@@ -32,6 +32,7 @@ const UserSchema = z.object({
   isActor: z.boolean(),
   isAdmin: z.boolean(),
   isBanned: z.boolean(),
+  isWhitelisted: z.boolean().optional(),
   bannedAt: z.string().nullable(),
   bannedReason: z.string().nullable(),
   bannedBy: z.string().nullable(),
@@ -132,6 +133,9 @@ export function UserManagementTab() {
   const [isScammer, setIsScammer] = useState(false);
   const [isCSAM, setIsCSAM] = useState(false);
   const [isBanning, startBanning] = useTransition();
+  const [whitelistingUserId, setWhitelistingUserId] = useState<string | null>(
+    null
+  );
 
   const fetchUsers = useCallback(
     (showRefreshing = false) => {
@@ -205,6 +209,34 @@ export function UserManagementTab() {
     });
   };
 
+  const handleWhitelistUser = async (userId: string) => {
+    setWhitelistingUserId(userId);
+    try {
+      const res = await fetch('/api/admin/whitelist', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId, source: 'admin_manual' }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        if (res.status === 409) {
+          toast.info('User is already whitelisted');
+        } else {
+          toast.error(data.error ?? 'Failed to whitelist user');
+        }
+        return;
+      }
+
+      toast.success('User whitelisted successfully');
+    } catch {
+      toast.error('Failed to whitelist user');
+    } finally {
+      setWhitelistingUserId(null);
+    }
+  };
+
   /** Use shared formatCompactCurrency for currency formatting */
   const formatCurrency = (value: string) => {
     const num = parseFloat(value);
@@ -261,6 +293,12 @@ export function UserManagementTab() {
               {user.onChainRegistered && (
                 <span className="rounded bg-green-500/20 px-2 py-0.5 text-green-500 text-xs">
                   On-chain
+                </span>
+              )}
+              {user.isWhitelisted && (
+                <span className="flex items-center gap-1 rounded bg-emerald-500/20 px-2 py-0.5 text-emerald-500 text-xs">
+                  <Shield className="h-3 w-3" />
+                  Whitelisted
                 </span>
               )}
             </div>
@@ -422,6 +460,19 @@ export function UserManagementTab() {
               >
                 <Ban className="h-4 w-4" />
                 Block
+              </button>
+              <button
+                onClick={() => handleWhitelistUser(user.id)}
+                disabled={whitelistingUserId === user.id}
+                className="flex items-center gap-1 rounded bg-emerald-500/20 px-3 py-1.5 font-medium text-emerald-500 text-sm transition-colors hover:bg-emerald-500/30 disabled:opacity-50"
+                title="Whitelist user — allow them to bypass gating"
+              >
+                {whitelistingUserId === user.id ? (
+                  <RefreshCw className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Shield className="h-4 w-4" />
+                )}
+                Whitelist
               </button>
               {user.isBanned ? (
                 <button

--- a/apps/web/src/components/admin/WhitelistTab.tsx
+++ b/apps/web/src/components/admin/WhitelistTab.tsx
@@ -194,6 +194,15 @@ export function WhitelistTab() {
   }
 
   async function handleRemoveUser(userId: string) {
+    const entry = entries.find((e) => e.userId === userId);
+    const label = entry?.displayName ?? entry?.username ?? userId.slice(0, 12);
+    if (
+      !window.confirm(
+        `Revoke whitelist access for "${label}"? They will be subject to NFT gating again.`
+      )
+    )
+      return;
+
     setRemovingUserId(userId);
     try {
       const res = await fetch('/api/admin/whitelist', {
@@ -257,6 +266,13 @@ export function WhitelistTab() {
   }
 
   async function handleImportFirst100() {
+    if (
+      !window.confirm(
+        'Import all users from the NFT snapshot as whitelisted? This is a bulk operation and cannot be easily undone.'
+      )
+    )
+      return;
+
     setIsImporting(true);
     try {
       const res = await fetch('/api/admin/whitelist/import-first-100', {

--- a/apps/web/src/components/admin/WhitelistTab.tsx
+++ b/apps/web/src/components/admin/WhitelistTab.tsx
@@ -1,0 +1,635 @@
+'use client';
+
+import { cn } from '@babylon/shared';
+import {
+  CheckCircle,
+  Download,
+  Loader2,
+  Plus,
+  Search,
+  Settings,
+  Shield,
+  Trash2,
+  Trophy,
+  UserPlus,
+  Users,
+  X,
+} from 'lucide-react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+} from 'react';
+import { toast } from 'sonner';
+import { Skeleton } from '@/components/shared/Skeleton';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type WhitelistSource = 'snapshot_first_100' | 'admin_manual' | 'leaderboard';
+
+interface WhitelistEntry {
+  id: string;
+  userId: string;
+  source: WhitelistSource;
+  reason: string | null;
+  grantedBy: string | null;
+  grantedAt: string;
+  revokedAt: string | null;
+  username: string | null;
+  displayName: string | null;
+  walletAddress: string | null;
+  profileImageUrl: string | null;
+}
+
+interface WhitelistStats {
+  total: number;
+  snapshot_first_100: number;
+  admin_manual: number;
+  leaderboard: number;
+}
+
+interface WhitelistConfig {
+  leaderboardRankThreshold: number | null;
+  leaderboardCategory: string;
+  updatedAt: string | null;
+  updatedBy: string | null;
+}
+
+type FilterSource = 'all' | WhitelistSource;
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function WhitelistTab() {
+  // Data state
+  const [entries, setEntries] = useState<WhitelistEntry[]>([]);
+  const [stats, setStats] = useState<WhitelistStats | null>(null);
+  const [config, setConfig] = useState<WhitelistConfig | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  // Filter & search
+  const [filterSource, setFilterSource] = useState<FilterSource>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // Add user form
+  const [addUserId, setAddUserId] = useState('');
+  const [addReason, setAddReason] = useState('');
+  const [isPending, startTransition] = useTransition();
+
+  // Leaderboard config
+  const [rankThreshold, setRankThreshold] = useState('');
+  const [isSavingConfig, setIsSavingConfig] = useState(false);
+
+  // Import
+  const [isImporting, setIsImporting] = useState(false);
+
+  // Remove
+  const [removingUserId, setRemovingUserId] = useState<string | null>(null);
+
+  // -------------------------------------------------------------------------
+  // Filtered entries
+  // -------------------------------------------------------------------------
+
+  const filteredEntries = useMemo(() => {
+    let result = entries;
+
+    if (filterSource !== 'all') {
+      result = result.filter((e) => e.source === filterSource);
+    }
+
+    if (searchQuery.trim()) {
+      const q = searchQuery.trim().toLowerCase();
+      result = result.filter(
+        (e) =>
+          e.username?.toLowerCase().includes(q) ||
+          e.userId.toLowerCase().includes(q) ||
+          e.walletAddress?.toLowerCase().includes(q) ||
+          e.displayName?.toLowerCase().includes(q)
+      );
+    }
+
+    return result;
+  }, [entries, filterSource, searchQuery]);
+
+  // -------------------------------------------------------------------------
+  // Data fetching
+  // -------------------------------------------------------------------------
+
+  const fetchEntries = useCallback(async () => {
+    try {
+      const res = await fetch('/api/admin/whitelist');
+      if (!res.ok) throw new Error('Failed to fetch whitelist');
+      const data = await res.json();
+      setEntries(data.entries ?? []);
+      setStats(data.stats ?? null);
+    } catch (err) {
+      toast.error('Failed to load whitelist data');
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const fetchConfig = useCallback(async () => {
+    try {
+      const res = await fetch('/api/admin/whitelist/config');
+      if (!res.ok) throw new Error('Failed to fetch config');
+      const data = await res.json();
+      const cfg = data.config ?? null;
+      setConfig(cfg);
+      setRankThreshold(
+        cfg?.leaderboardRankThreshold != null
+          ? String(cfg.leaderboardRankThreshold)
+          : ''
+      );
+    } catch (err) {
+      console.error(err);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchEntries();
+    fetchConfig();
+  }, [fetchEntries, fetchConfig]);
+
+  // -------------------------------------------------------------------------
+  // Actions
+  // -------------------------------------------------------------------------
+
+  function handleAddUser() {
+    if (!addUserId.trim()) return;
+
+    startTransition(async () => {
+      try {
+        const res = await fetch('/api/admin/whitelist', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            userId: addUserId.trim(),
+            source: 'admin_manual',
+            reason: addReason.trim() || undefined,
+          }),
+        });
+
+        const data = await res.json();
+
+        if (!res.ok) {
+          toast.error(data.error ?? 'Failed to add user');
+          return;
+        }
+
+        toast.success(`User ${data.username ?? addUserId.trim()} whitelisted`);
+        setAddUserId('');
+        setAddReason('');
+        await fetchEntries();
+      } catch {
+        toast.error('Failed to add user');
+      }
+    });
+  }
+
+  async function handleRemoveUser(userId: string) {
+    setRemovingUserId(userId);
+    try {
+      const res = await fetch('/api/admin/whitelist', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        toast.error(data.error ?? 'Failed to remove user');
+        return;
+      }
+
+      toast.success('User removed from whitelist');
+      await fetchEntries();
+    } catch {
+      toast.error('Failed to remove user');
+    } finally {
+      setRemovingUserId(null);
+    }
+  }
+
+  async function handleSaveConfig() {
+    setIsSavingConfig(true);
+    try {
+      const threshold = rankThreshold.trim()
+        ? Number.parseInt(rankThreshold.trim(), 10)
+        : null;
+
+      if (threshold !== null && (Number.isNaN(threshold) || threshold < 0)) {
+        toast.error('Rank threshold must be a non-negative number or empty');
+        return;
+      }
+
+      const res = await fetch('/api/admin/whitelist/config', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ leaderboardRankThreshold: threshold }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        toast.error(data.error ?? 'Failed to save config');
+        return;
+      }
+
+      toast.success(
+        threshold !== null
+          ? `Leaderboard whitelist enabled for top ${threshold} users`
+          : 'Leaderboard whitelist disabled'
+      );
+      setConfig(data.config ?? null);
+    } catch {
+      toast.error('Failed to save config');
+    } finally {
+      setIsSavingConfig(false);
+    }
+  }
+
+  async function handleImportFirst100() {
+    setIsImporting(true);
+    try {
+      const res = await fetch('/api/admin/whitelist/import-first-100', {
+        method: 'POST',
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        toast.error(data.error ?? 'Failed to import');
+        return;
+      }
+
+      toast.success(
+        `Imported ${data.imported ?? 0} users, ${data.skipped ?? 0} skipped`
+      );
+      await fetchEntries();
+    } catch {
+      toast.error('Failed to import first 100');
+    } finally {
+      setIsImporting(false);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Render helpers
+  // -------------------------------------------------------------------------
+
+  function sourceLabel(source: WhitelistSource) {
+    switch (source) {
+      case 'snapshot_first_100':
+        return 'First 100';
+      case 'admin_manual':
+        return 'Admin';
+      case 'leaderboard':
+        return 'Leaderboard';
+    }
+  }
+
+  function sourceBadgeClasses(source: WhitelistSource) {
+    switch (source) {
+      case 'snapshot_first_100':
+        return 'bg-blue-500/10 text-blue-500';
+      case 'admin_manual':
+        return 'bg-purple-500/10 text-purple-500';
+      case 'leaderboard':
+        return 'bg-amber-500/10 text-amber-500';
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Loading state
+  // -------------------------------------------------------------------------
+
+  if (loading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-24 w-full" />
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Main render
+  // -------------------------------------------------------------------------
+
+  return (
+    <div className="space-y-6">
+      {/* Stats Row */}
+      {stats && (
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+          <div className="rounded-xl border border-border bg-card p-4">
+            <div className="flex items-center gap-2 text-muted-foreground text-sm">
+              <Shield className="h-4 w-4" />
+              Total Whitelisted
+            </div>
+            <p className="mt-1 font-bold text-2xl">{stats.total}</p>
+          </div>
+          <div className="rounded-xl border border-border bg-card p-4">
+            <div className="flex items-center gap-2 text-muted-foreground text-sm">
+              <Trophy className="h-4 w-4" />
+              First 100
+            </div>
+            <p className="mt-1 font-bold text-2xl">
+              {stats.snapshot_first_100}
+            </p>
+          </div>
+          <div className="rounded-xl border border-border bg-card p-4">
+            <div className="flex items-center gap-2 text-muted-foreground text-sm">
+              <Users className="h-4 w-4" />
+              Leaderboard
+            </div>
+            <p className="mt-1 font-bold text-2xl">
+              {config?.leaderboardRankThreshold != null
+                ? `Top ${config.leaderboardRankThreshold}`
+                : 'Disabled'}
+            </p>
+          </div>
+          <div className="rounded-xl border border-border bg-card p-4">
+            <div className="flex items-center gap-2 text-muted-foreground text-sm">
+              <UserPlus className="h-4 w-4" />
+              Admin Manual
+            </div>
+            <p className="mt-1 font-bold text-2xl">{stats.admin_manual}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Leaderboard Config Section */}
+      <div className="rounded-xl border border-border bg-card p-4">
+        <div className="mb-3 flex items-center gap-2 font-medium text-sm">
+          <Settings className="h-4 w-4 text-muted-foreground" />
+          Leaderboard Whitelist Configuration
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+          <div className="flex-1">
+            <label className="mb-1 block text-muted-foreground text-xs">
+              Rank Threshold (users ranked 1 to N are whitelisted)
+            </label>
+            <input
+              type="number"
+              min="0"
+              value={rankThreshold}
+              onChange={(e) => setRankThreshold(e.target.value)}
+              placeholder="e.g. 500 (leave empty to disable)"
+              className="h-9 w-full rounded-lg border border-border bg-background px-3 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary"
+            />
+          </div>
+          <button
+            onClick={handleSaveConfig}
+            disabled={isSavingConfig}
+            className={cn(
+              'flex h-9 items-center gap-1.5 rounded-lg bg-primary px-4 font-medium text-primary-foreground text-sm transition-colors',
+              'hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50'
+            )}
+          >
+            {isSavingConfig ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <CheckCircle className="h-4 w-4" />
+            )}
+            Save
+          </button>
+        </div>
+        <p className="mt-2 text-muted-foreground text-xs">
+          When set, any user ranked within this threshold on the leaderboard
+          automatically bypasses gating. This is dynamic and updates as rankings
+          change.
+        </p>
+      </div>
+
+      {/* Import + Add User Actions */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        {/* Add User Form */}
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              value={addUserId}
+              onChange={(e) => setAddUserId(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleAddUser();
+              }}
+              placeholder="User ID to whitelist..."
+              className="h-9 rounded-lg border border-border bg-background px-3 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary"
+            />
+            <input
+              type="text"
+              value={addReason}
+              onChange={(e) => setAddReason(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleAddUser();
+              }}
+              placeholder="Reason (optional)"
+              className="h-9 rounded-lg border border-border bg-background px-3 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary"
+            />
+            <button
+              onClick={handleAddUser}
+              disabled={isPending || !addUserId.trim()}
+              className={cn(
+                'flex h-9 items-center gap-1.5 rounded-lg bg-primary px-3 font-medium text-primary-foreground text-sm transition-colors',
+                'hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50'
+              )}
+            >
+              {isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Plus className="h-4 w-4" />
+              )}
+              Add
+            </button>
+          </div>
+        </div>
+
+        {/* Import Button */}
+        <button
+          onClick={handleImportFirst100}
+          disabled={isImporting}
+          className={cn(
+            'flex h-9 items-center gap-1.5 rounded-lg border border-border bg-card px-3 font-medium text-sm transition-colors',
+            'hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50'
+          )}
+        >
+          {isImporting ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Download className="h-4 w-4" />
+          )}
+          Import First 100 from Snapshot
+        </button>
+      </div>
+
+      {/* Filter Tabs + Search */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex gap-2">
+          {(
+            [
+              { key: 'all', label: 'All' },
+              { key: 'snapshot_first_100', label: 'First 100' },
+              { key: 'leaderboard', label: 'Leaderboard' },
+              { key: 'admin_manual', label: 'Admin' },
+            ] as const
+          ).map(({ key, label }) => (
+            <button
+              key={key}
+              onClick={() => setFilterSource(key)}
+              className={cn(
+                'rounded-lg px-3 py-1.5 font-medium text-sm transition-colors',
+                filterSource === key
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-muted text-muted-foreground hover:bg-muted/80'
+              )}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        <div className="relative">
+          <Search className="-translate-y-1/2 absolute top-1/2 left-3 h-4 w-4 text-muted-foreground" />
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search by user, ID, or wallet..."
+            className="h-9 rounded-lg border border-border bg-background pr-3 pl-9 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary"
+          />
+          {searchQuery && (
+            <button
+              onClick={() => setSearchQuery('')}
+              className="-translate-y-1/2 absolute top-1/2 right-2 text-muted-foreground hover:text-foreground"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto rounded-xl border border-border">
+        <table className="w-full text-left text-sm">
+          <thead>
+            <tr className="border-border border-b bg-muted/50">
+              <th className="px-4 py-3 font-medium text-muted-foreground">
+                User
+              </th>
+              <th className="px-4 py-3 font-medium text-muted-foreground">
+                Source
+              </th>
+              <th className="px-4 py-3 font-medium text-muted-foreground">
+                Reason
+              </th>
+              <th className="px-4 py-3 font-medium text-muted-foreground">
+                Granted At
+              </th>
+              <th className="px-4 py-3 font-medium text-muted-foreground">
+                Status
+              </th>
+              <th className="px-4 py-3 font-medium text-muted-foreground">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredEntries.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="px-4 py-8 text-center text-muted-foreground"
+                >
+                  {entries.length === 0
+                    ? 'No whitelist entries yet. Add users manually or import from snapshot.'
+                    : 'No entries match your search/filter.'}
+                </td>
+              </tr>
+            ) : (
+              filteredEntries.map((entry) => (
+                <tr
+                  key={entry.id}
+                  className="border-border border-b last:border-b-0 hover:bg-muted/30"
+                >
+                  <td className="px-4 py-3">
+                    <div>
+                      <span className="font-medium">
+                        {entry.displayName ?? entry.username ?? 'Unknown'}
+                      </span>
+                      {entry.username && entry.displayName && (
+                        <span className="ml-1 text-muted-foreground text-xs">
+                          @{entry.username}
+                        </span>
+                      )}
+                      <div className="text-muted-foreground text-xs">
+                        {entry.userId.slice(0, 12)}...
+                      </div>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={cn(
+                        'inline-flex items-center rounded-full px-2 py-0.5 font-medium text-xs',
+                        sourceBadgeClasses(entry.source)
+                      )}
+                    >
+                      {sourceLabel(entry.source)}
+                    </span>
+                  </td>
+                  <td className="max-w-[200px] truncate px-4 py-3 text-muted-foreground text-xs">
+                    {entry.reason ?? '—'}
+                  </td>
+                  <td className="px-4 py-3 text-muted-foreground text-xs">
+                    {new Date(entry.grantedAt).toLocaleDateString()}
+                  </td>
+                  <td className="px-4 py-3">
+                    {entry.revokedAt ? (
+                      <span className="inline-flex items-center rounded-full bg-red-500/10 px-2 py-0.5 font-medium text-red-500 text-xs">
+                        Revoked
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center gap-1 rounded-full bg-green-500/10 px-2 py-0.5 font-medium text-green-500 text-xs">
+                        <CheckCircle className="h-3 w-3" />
+                        Active
+                      </span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    {!entry.revokedAt && (
+                      <button
+                        onClick={() => handleRemoveUser(entry.userId)}
+                        disabled={removingUserId === entry.userId}
+                        title="Revoke whitelist access"
+                        className="flex h-7 w-7 items-center justify-center rounded-lg text-red-500 transition-colors hover:bg-red-500/10"
+                      >
+                        {removingUserId === entry.userId ? (
+                          <Loader2 className="h-4 w-4 animate-spin" />
+                        ) : (
+                          <Trash2 className="h-4 w-4" />
+                        )}
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Count footer */}
+      <div className="text-muted-foreground text-xs">
+        Showing {filteredEntries.length} of {entries.length} entries
+      </div>
+    </div>
+  );
+}

--- a/packages/api/src/services/nft-access-service.ts
+++ b/packages/api/src/services/nft-access-service.ts
@@ -3,6 +3,7 @@ import {
   hasOnchainNftAccess,
   NftIndexerUnavailableError,
 } from './nft-indexer-service';
+import { checkWhitelistAccess } from './whitelist-service';
 
 async function hasDbNftOrClaimAccessFallback(
   dbUserId: string
@@ -33,6 +34,15 @@ async function hasDbNftOrClaimAccessFallback(
  * avoids hard failures if the indexer is temporarily unavailable).
  */
 export async function hasNftAccess(dbUserId: string): Promise<boolean> {
+  // Check whitelist first (fastest path for whitelisted users).
+  // Wrapped in try-catch so a missing Whitelist table doesn't block NFT checks.
+  try {
+    const wl = await checkWhitelistAccess(dbUserId);
+    if (wl.allowed) return true;
+  } catch {
+    // Whitelist table may not exist yet — continue with NFT checks
+  }
+
   const [dbUser] = await db
     .select({ walletAddress: users.walletAddress })
     .from(users)
@@ -57,6 +67,17 @@ export async function hasNftAccessForAuthUser(user: {
   dbUserId?: string | null;
   walletAddress?: string | null;
 }): Promise<boolean> {
+  // Check whitelist first.
+  // Wrapped in try-catch so a missing Whitelist table doesn't block NFT checks.
+  if (user.dbUserId) {
+    try {
+      const wl = await checkWhitelistAccess(user.dbUserId);
+      if (wl.allowed) return true;
+    } catch {
+      // Whitelist table may not exist yet — continue with NFT checks
+    }
+  }
+
   const walletAddress = user.walletAddress ?? null;
   if (walletAddress) {
     try {
@@ -76,6 +97,17 @@ export async function getNftAccessStatusForAuthUser(user: {
   dbUserId?: string | null;
   walletAddress?: string | null;
 }): Promise<{ allowed: boolean; degraded: boolean }> {
+  // Check whitelist first — whitelisted users bypass all NFT checks.
+  // Wrapped in try-catch so a missing Whitelist table doesn't block NFT checks.
+  if (user.dbUserId) {
+    try {
+      const wl = await checkWhitelistAccess(user.dbUserId);
+      if (wl.allowed) return { allowed: true, degraded: false };
+    } catch {
+      // Whitelist table may not exist yet — continue with NFT checks
+    }
+  }
+
   const walletAddress = user.walletAddress ?? null;
   if (walletAddress) {
     try {

--- a/packages/api/src/services/nft-access-service.ts
+++ b/packages/api/src/services/nft-access-service.ts
@@ -1,4 +1,5 @@
 import { db, eq, nftOwnership, nftSnapshot, users } from '@babylon/db';
+import { logger } from '@babylon/shared';
 import {
   hasOnchainNftAccess,
   NftIndexerUnavailableError,
@@ -26,6 +27,38 @@ async function hasDbNftOrClaimAccessFallback(
 }
 
 /**
+ * Check if a user is whitelisted, with graceful fallback if the Whitelist
+ * table doesn't exist yet (safe for rolling deployments).
+ *
+ * Only swallows "relation does not exist" errors (PG code 42P01).
+ * All other errors are logged and re-thrown so they surface in production.
+ */
+async function isWhitelistOverride(
+  dbUserId: string | null | undefined
+): Promise<boolean> {
+  if (!dbUserId) return false;
+  try {
+    const wl = await checkWhitelistAccess(dbUserId);
+    return wl.allowed;
+  } catch (error: unknown) {
+    // PostgreSQL "undefined_table" — table doesn't exist yet during rolling deploy.
+    const pgCode =
+      error && typeof error === 'object' && 'code' in error
+        ? (error as { code: string }).code
+        : undefined;
+    if (pgCode === '42P01') return false;
+
+    // Any other error is unexpected — log it and continue with NFT checks so
+    // a whitelist bug doesn't block user access entirely.
+    logger.error('Whitelist access check failed', {
+      dbUserId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return false;
+  }
+}
+
+/**
  * Returns true if the user currently holds at least one NFT from the configured
  * Top 100 collection.
  *
@@ -35,13 +68,7 @@ async function hasDbNftOrClaimAccessFallback(
  */
 export async function hasNftAccess(dbUserId: string): Promise<boolean> {
   // Check whitelist first (fastest path for whitelisted users).
-  // Wrapped in try-catch so a missing Whitelist table doesn't block NFT checks.
-  try {
-    const wl = await checkWhitelistAccess(dbUserId);
-    if (wl.allowed) return true;
-  } catch {
-    // Whitelist table may not exist yet — continue with NFT checks
-  }
+  if (await isWhitelistOverride(dbUserId)) return true;
 
   const [dbUser] = await db
     .select({ walletAddress: users.walletAddress })
@@ -67,16 +94,7 @@ export async function hasNftAccessForAuthUser(user: {
   dbUserId?: string | null;
   walletAddress?: string | null;
 }): Promise<boolean> {
-  // Check whitelist first.
-  // Wrapped in try-catch so a missing Whitelist table doesn't block NFT checks.
-  if (user.dbUserId) {
-    try {
-      const wl = await checkWhitelistAccess(user.dbUserId);
-      if (wl.allowed) return true;
-    } catch {
-      // Whitelist table may not exist yet — continue with NFT checks
-    }
-  }
+  if (await isWhitelistOverride(user.dbUserId)) return true;
 
   const walletAddress = user.walletAddress ?? null;
   if (walletAddress) {
@@ -97,16 +115,8 @@ export async function getNftAccessStatusForAuthUser(user: {
   dbUserId?: string | null;
   walletAddress?: string | null;
 }): Promise<{ allowed: boolean; degraded: boolean }> {
-  // Check whitelist first — whitelisted users bypass all NFT checks.
-  // Wrapped in try-catch so a missing Whitelist table doesn't block NFT checks.
-  if (user.dbUserId) {
-    try {
-      const wl = await checkWhitelistAccess(user.dbUserId);
-      if (wl.allowed) return { allowed: true, degraded: false };
-    } catch {
-      // Whitelist table may not exist yet — continue with NFT checks
-    }
-  }
+  if (await isWhitelistOverride(user.dbUserId))
+    return { allowed: true, degraded: false };
 
   const walletAddress = user.walletAddress ?? null;
   if (walletAddress) {

--- a/packages/api/src/services/whitelist-service.ts
+++ b/packages/api/src/services/whitelist-service.ts
@@ -118,8 +118,10 @@ export async function checkWhitelistAccess(
 // ---------------------------------------------------------------------------
 
 /**
- * Add a user to the whitelist. If the user was previously revoked,
- * removes the old entry and creates a fresh one.
+ * Add a user to the whitelist. Uses INSERT ... ON CONFLICT for idempotency.
+ *
+ * If the user has an active (non-revoked) entry, returns alreadyExists: true.
+ * If the user has a revoked entry, replaces it with a fresh active entry.
  */
 export async function addToWhitelist({
   userId,
@@ -127,33 +129,36 @@ export async function addToWhitelist({
   reason,
   grantedBy,
 }: AddToWhitelistParams): Promise<{ id: string; alreadyExists: boolean }> {
-  // Check for existing active entry
-  const [existing] = await db
-    .select({ id: whitelist.id, revokedAt: whitelist.revokedAt })
-    .from(whitelist)
-    .where(eq(whitelist.userId, userId))
-    .limit(1);
-
-  if (existing && !existing.revokedAt) {
-    return { id: existing.id, alreadyExists: true };
-  }
-
-  // Remove revoked entry if exists, then create fresh
-  if (existing) {
-    await db.delete(whitelist).where(eq(whitelist.userId, userId));
-  }
-
   const id = nanoid();
-  await db.insert(whitelist).values({
-    id,
-    userId,
-    source,
-    reason: reason ?? null,
-    grantedBy: grantedBy ?? null,
-    grantedAt: new Date(),
-  });
+  const now = new Date();
 
-  return { id, alreadyExists: false };
+  const [result] = await db
+    .insert(whitelist)
+    .values({
+      id,
+      userId,
+      source,
+      reason: reason ?? null,
+      grantedBy: grantedBy ?? null,
+      grantedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: whitelist.userId,
+      // Only overwrite if the existing row is revoked; otherwise leave it.
+      set: {
+        id: sql`CASE WHEN ${whitelist.revokedAt} IS NOT NULL THEN ${id} ELSE ${whitelist.id} END`,
+        source: sql`CASE WHEN ${whitelist.revokedAt} IS NOT NULL THEN ${source} ELSE ${whitelist.source} END`,
+        reason: sql`CASE WHEN ${whitelist.revokedAt} IS NOT NULL THEN ${reason ?? null} ELSE ${whitelist.reason} END`,
+        grantedBy: sql`CASE WHEN ${whitelist.revokedAt} IS NOT NULL THEN ${grantedBy ?? null} ELSE ${whitelist.grantedBy} END`,
+        grantedAt: sql`CASE WHEN ${whitelist.revokedAt} IS NOT NULL THEN ${now} ELSE ${whitelist.grantedAt} END`,
+        revokedAt: sql`CASE WHEN ${whitelist.revokedAt} IS NOT NULL THEN NULL ELSE ${whitelist.revokedAt} END`,
+      },
+    })
+    .returning({ id: whitelist.id, revokedAt: whitelist.revokedAt });
+
+  // If the returned id matches what we tried to insert, it's a new/replaced row.
+  // If it doesn't match, the row was already active and untouched.
+  return { id: result.id, alreadyExists: result.id !== id };
 }
 
 /**
@@ -323,6 +328,7 @@ export async function updateWhitelistConfig({
 
 /**
  * Import users from the NftSnapshot table as 'snapshot_first_100' whitelist entries.
+ * Runs inside a transaction for atomicity — either all entries are imported or none.
  * Skips users who are already whitelisted (active).
  */
 export async function importFirst100FromSnapshot(grantedBy?: string) {
@@ -334,23 +340,55 @@ export async function importFirst100FromSnapshot(grantedBy?: string) {
     .from(nftSnapshot)
     .orderBy(nftSnapshot.rank);
 
-  let imported = 0;
-  let skipped = 0;
-
-  for (const entry of snapshotEntries) {
-    const result = await addToWhitelist({
-      userId: entry.userId,
-      source: 'snapshot_first_100',
-      reason: `Imported from NFT snapshot (rank #${entry.rank})`,
-      grantedBy,
-    });
-
-    if (result.alreadyExists) {
-      skipped++;
-    } else {
-      imported++;
-    }
+  if (snapshotEntries.length === 0) {
+    return { imported: 0, skipped: 0, total: 0 };
   }
 
-  return { imported, skipped, total: snapshotEntries.length };
+  const result = await db.transaction(async (tx) => {
+    let imported = 0;
+    let skipped = 0;
+
+    for (const entry of snapshotEntries) {
+      const id = nanoid();
+      const now = new Date();
+
+      const [row] = await tx
+        .insert(whitelist)
+        .values({
+          id,
+          userId: entry.userId,
+          source: 'snapshot_first_100' as WhitelistSource,
+          reason: `Imported from NFT snapshot (rank #${entry.rank})`,
+          grantedBy: grantedBy ?? null,
+          grantedAt: now,
+        })
+        .onConflictDoUpdate({
+          target: whitelist.userId,
+          // Only overwrite revoked entries; leave active entries untouched.
+          set: {
+            id: sql`CASE WHEN ${whitelist.revokedAt} IS NOT NULL THEN ${id} ELSE ${whitelist.id} END`,
+            source: sql`CASE WHEN ${whitelist.revokedAt} IS NOT NULL THEN 'snapshot_first_100' ELSE ${whitelist.source} END`,
+            reason: sql`CASE WHEN ${whitelist.revokedAt} IS NOT NULL THEN ${'Imported from NFT snapshot (rank #' + entry.rank + ')'} ELSE ${whitelist.reason} END`,
+            grantedBy: sql`CASE WHEN ${whitelist.revokedAt} IS NOT NULL THEN ${grantedBy ?? null} ELSE ${whitelist.grantedBy} END`,
+            grantedAt: sql`CASE WHEN ${whitelist.revokedAt} IS NOT NULL THEN ${now} ELSE ${whitelist.grantedAt} END`,
+            revokedAt: sql`CASE WHEN ${whitelist.revokedAt} IS NOT NULL THEN NULL ELSE ${whitelist.revokedAt} END`,
+          },
+        })
+        .returning({ id: whitelist.id });
+
+      if (row.id === id) {
+        imported++;
+      } else {
+        skipped++;
+      }
+    }
+
+    return { imported, skipped };
+  });
+
+  return {
+    imported: result.imported,
+    skipped: result.skipped,
+    total: snapshotEntries.length,
+  };
 }

--- a/packages/api/src/services/whitelist-service.ts
+++ b/packages/api/src/services/whitelist-service.ts
@@ -1,0 +1,356 @@
+import {
+  and,
+  db,
+  desc,
+  eq,
+  isNull,
+  nftSnapshot,
+  sql,
+  users,
+  whitelist,
+  whitelistConfig,
+} from '@babylon/db';
+import { nanoid } from 'nanoid';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type WhitelistSource =
+  | 'snapshot_first_100'
+  | 'admin_manual'
+  | 'leaderboard';
+
+interface AddToWhitelistParams {
+  userId: string;
+  source: WhitelistSource;
+  reason?: string;
+  grantedBy?: string;
+}
+
+interface UpdateWhitelistConfigParams {
+  leaderboardRankThreshold: number | null;
+  leaderboardCategory?: string;
+  updatedBy?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Access checks
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if a user has an active (non-revoked) entry in the Whitelist table.
+ */
+export async function isUserWhitelisted(userId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ id: whitelist.id })
+    .from(whitelist)
+    .where(and(eq(whitelist.userId, userId), isNull(whitelist.revokedAt)))
+    .limit(1);
+
+  return Boolean(row);
+}
+
+/**
+ * Check if a user qualifies for whitelist access via the leaderboard
+ * rank threshold configured in WhitelistConfig.
+ *
+ * Computes the user's rank on-the-fly by counting users with higher
+ * reputation points. Returns false if the threshold is disabled (null).
+ */
+export async function isUserWhitelistedByLeaderboard(
+  userId: string
+): Promise<boolean> {
+  const config = await getWhitelistConfig();
+  if (!config?.leaderboardRankThreshold) return false;
+
+  const threshold = config.leaderboardRankThreshold;
+
+  // Get the user's reputation points
+  const [user] = await db
+    .select({ reputationPoints: users.reputationPoints })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  if (!user) return false;
+
+  // Count how many non-actor, non-agent users have strictly more points
+  const [result] = await db
+    .select({ rank: sql<number>`count(*) + 1` })
+    .from(users)
+    .where(
+      and(
+        sql`${users.reputationPoints} > ${user.reputationPoints}`,
+        eq(users.isActor, false),
+        eq(users.isAgent, false)
+      )
+    );
+
+  const rank = Number(result?.rank ?? 0);
+  return rank <= threshold;
+}
+
+/**
+ * Combined whitelist access check: direct whitelist entry OR leaderboard rank.
+ */
+export async function checkWhitelistAccess(
+  userId: string
+): Promise<{ allowed: boolean; source: string | null }> {
+  // 1. Check direct whitelist entry first (fast)
+  const [directEntry] = await db
+    .select({ source: whitelist.source })
+    .from(whitelist)
+    .where(and(eq(whitelist.userId, userId), isNull(whitelist.revokedAt)))
+    .limit(1);
+
+  if (directEntry) return { allowed: true, source: directEntry.source };
+
+  // 2. Check leaderboard rank threshold
+  const leaderboardAllowed = await isUserWhitelistedByLeaderboard(userId);
+  if (leaderboardAllowed) return { allowed: true, source: 'leaderboard' };
+
+  return { allowed: false, source: null };
+}
+
+// ---------------------------------------------------------------------------
+// CRUD operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Add a user to the whitelist. If the user was previously revoked,
+ * removes the old entry and creates a fresh one.
+ */
+export async function addToWhitelist({
+  userId,
+  source,
+  reason,
+  grantedBy,
+}: AddToWhitelistParams): Promise<{ id: string; alreadyExists: boolean }> {
+  // Check for existing active entry
+  const [existing] = await db
+    .select({ id: whitelist.id, revokedAt: whitelist.revokedAt })
+    .from(whitelist)
+    .where(eq(whitelist.userId, userId))
+    .limit(1);
+
+  if (existing && !existing.revokedAt) {
+    return { id: existing.id, alreadyExists: true };
+  }
+
+  // Remove revoked entry if exists, then create fresh
+  if (existing) {
+    await db.delete(whitelist).where(eq(whitelist.userId, userId));
+  }
+
+  const id = nanoid();
+  await db.insert(whitelist).values({
+    id,
+    userId,
+    source,
+    reason: reason ?? null,
+    grantedBy: grantedBy ?? null,
+    grantedAt: new Date(),
+  });
+
+  return { id, alreadyExists: false };
+}
+
+/**
+ * Soft-revoke a user from the whitelist by setting revokedAt.
+ */
+export async function removeFromWhitelist(
+  userId: string
+): Promise<{ removed: boolean }> {
+  const [entry] = await db
+    .select({ id: whitelist.id, revokedAt: whitelist.revokedAt })
+    .from(whitelist)
+    .where(eq(whitelist.userId, userId))
+    .limit(1);
+
+  if (!entry) return { removed: false };
+  if (entry.revokedAt) return { removed: false }; // already revoked
+
+  await db
+    .update(whitelist)
+    .set({ revokedAt: new Date() })
+    .where(eq(whitelist.id, entry.id));
+
+  return { removed: true };
+}
+
+/**
+ * List all whitelist entries, optionally filtered by source.
+ * Includes user info (username, walletAddress, displayName).
+ */
+export async function listWhitelistEntries(options?: {
+  source?: WhitelistSource;
+  includeRevoked?: boolean;
+  search?: string;
+}) {
+  const conditions = [];
+
+  if (options?.source) {
+    conditions.push(eq(whitelist.source, options.source));
+  }
+
+  if (!options?.includeRevoked) {
+    conditions.push(isNull(whitelist.revokedAt));
+  }
+
+  let query = db
+    .select({
+      id: whitelist.id,
+      userId: whitelist.userId,
+      source: whitelist.source,
+      reason: whitelist.reason,
+      grantedBy: whitelist.grantedBy,
+      grantedAt: whitelist.grantedAt,
+      revokedAt: whitelist.revokedAt,
+      username: users.username,
+      displayName: users.displayName,
+      walletAddress: users.walletAddress,
+      profileImageUrl: users.profileImageUrl,
+    })
+    .from(whitelist)
+    .leftJoin(users, eq(whitelist.userId, users.id))
+    .$dynamic();
+
+  if (conditions.length > 0) {
+    query = query.where(and(...conditions));
+  }
+
+  const results = await query.orderBy(desc(whitelist.grantedAt));
+
+  // Apply search filter in-memory (username, userId, walletAddress)
+  if (options?.search) {
+    const q = options.search.toLowerCase();
+    return results.filter(
+      (r) =>
+        r.username?.toLowerCase().includes(q) ||
+        r.userId.toLowerCase().includes(q) ||
+        r.walletAddress?.toLowerCase().includes(q) ||
+        r.displayName?.toLowerCase().includes(q)
+    );
+  }
+
+  return results;
+}
+
+/**
+ * Get whitelist stats grouped by source.
+ */
+export async function getWhitelistStats() {
+  const entries = await db
+    .select({
+      source: whitelist.source,
+      count: sql<number>`count(*)`,
+    })
+    .from(whitelist)
+    .where(isNull(whitelist.revokedAt))
+    .groupBy(whitelist.source);
+
+  const stats = {
+    total: 0,
+    snapshot_first_100: 0,
+    admin_manual: 0,
+    leaderboard: 0,
+  };
+
+  for (const entry of entries) {
+    const count = Number(entry.count);
+    stats.total += count;
+    if (entry.source in stats) {
+      stats[entry.source as WhitelistSource] = count;
+    }
+  }
+
+  return stats;
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const CONFIG_ID = 'default';
+
+/**
+ * Get the whitelist configuration (leaderboard threshold, etc.).
+ */
+export async function getWhitelistConfig() {
+  const [config] = await db
+    .select()
+    .from(whitelistConfig)
+    .where(eq(whitelistConfig.id, CONFIG_ID))
+    .limit(1);
+
+  return config ?? null;
+}
+
+/**
+ * Upsert the whitelist configuration.
+ */
+export async function updateWhitelistConfig({
+  leaderboardRankThreshold,
+  leaderboardCategory,
+  updatedBy,
+}: UpdateWhitelistConfigParams) {
+  const now = new Date();
+
+  await db
+    .insert(whitelistConfig)
+    .values({
+      id: CONFIG_ID,
+      leaderboardRankThreshold,
+      leaderboardCategory: leaderboardCategory ?? 'all',
+      updatedAt: now,
+      updatedBy: updatedBy ?? null,
+    })
+    .onConflictDoUpdate({
+      target: whitelistConfig.id,
+      set: {
+        leaderboardRankThreshold,
+        ...(leaderboardCategory !== undefined && { leaderboardCategory }),
+        updatedAt: now,
+        updatedBy: updatedBy ?? null,
+      },
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Import First 100
+// ---------------------------------------------------------------------------
+
+/**
+ * Import users from the NftSnapshot table as 'snapshot_first_100' whitelist entries.
+ * Skips users who are already whitelisted (active).
+ */
+export async function importFirst100FromSnapshot(grantedBy?: string) {
+  const snapshotEntries = await db
+    .select({
+      userId: nftSnapshot.userId,
+      rank: nftSnapshot.rank,
+    })
+    .from(nftSnapshot)
+    .orderBy(nftSnapshot.rank);
+
+  let imported = 0;
+  let skipped = 0;
+
+  for (const entry of snapshotEntries) {
+    const result = await addToWhitelist({
+      userId: entry.userId,
+      source: 'snapshot_first_100',
+      reason: `Imported from NFT snapshot (rank #${entry.rank})`,
+      grantedBy,
+    });
+
+    if (result.alreadyExists) {
+      skipped++;
+    } else {
+      imported++;
+    }
+  }
+
+  return { imported, skipped, total: snapshotEntries.length };
+}

--- a/packages/db/drizzle/migrations/0039_unique_fantastic_four.sql
+++ b/packages/db/drizzle/migrations/0039_unique_fantastic_four.sql
@@ -1,0 +1,38 @@
+-- Migration: Add Whitelist and WhitelistConfig tables
+-- Purpose: Whitelisting system for game access gating bypass
+--
+-- Three whitelist sources:
+-- 1. snapshot_first_100: End-of-year top-100 user snapshot
+-- 2. admin_manual: Ad-hoc admin whitelisting
+-- 3. leaderboard: Leaderboard rank-based whitelisting
+
+CREATE TABLE IF NOT EXISTS "Whitelist" (
+	"id" text PRIMARY KEY NOT NULL,
+	"userId" text NOT NULL,
+	"source" text NOT NULL,
+	"reason" text,
+	"grantedBy" text,
+	"grantedAt" timestamp DEFAULT now() NOT NULL,
+	"revokedAt" timestamp,
+	CONSTRAINT "Whitelist_userId_unique" UNIQUE("userId")
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "WhitelistConfig" (
+	"id" text PRIMARY KEY NOT NULL,
+	"leaderboardRankThreshold" integer,
+	"leaderboardCategory" text DEFAULT 'all' NOT NULL,
+	"updatedAt" timestamp DEFAULT now() NOT NULL,
+	"updatedBy" text
+);
+--> statement-breakpoint
+ALTER TABLE "Whitelist" ADD CONSTRAINT "Whitelist_userId_User_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "Whitelist" ADD CONSTRAINT "Whitelist_grantedBy_User_id_fk" FOREIGN KEY ("grantedBy") REFERENCES "public"."User"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "WhitelistConfig" ADD CONSTRAINT "WhitelistConfig_updatedBy_User_id_fk" FOREIGN KEY ("updatedBy") REFERENCES "public"."User"("id") ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "Whitelist_userId_idx" ON "Whitelist" USING btree ("userId");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "Whitelist_source_idx" ON "Whitelist" USING btree ("source");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "Whitelist_revokedAt_idx" ON "Whitelist" USING btree ("revokedAt");

--- a/packages/db/drizzle/migrations/meta/0039_snapshot.json
+++ b/packages/db/drizzle/migrations/meta/0039_snapshot.json
@@ -1,0 +1,17660 @@
+{
+  "id": "17489a57-06f2-4391-80cf-8e866c5a82e7",
+  "prevId": "bc4302ed-f12d-4daf-9b60-ce69484a7988",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.ActorState": {
+      "name": "ActorState",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tradingBalance": {
+          "name": "tradingBalance",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'10000'"
+        },
+        "reputationPoints": {
+          "name": "reputationPoints",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10000
+        },
+        "hasPool": {
+          "name": "hasPool",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastPostAt": {
+          "name": "lastPostAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastActiveAt": {
+          "name": "lastActiveAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postsToday": {
+          "name": "postsToday",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "postsTodayResetAt": {
+          "name": "postsTodayResetAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currentMood": {
+          "name": "currentMood",
+          "type": "numeric(4, 3)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'0'"
+        },
+        "recentMemories": {
+          "name": "recentMemories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "relationships": {
+          "name": "relationships",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ActorState_hasPool_idx": {
+          "name": "ActorState_hasPool_idx",
+          "columns": [
+            {
+              "expression": "hasPool",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ActorState_reputationPoints_idx": {
+          "name": "ActorState_reputationPoints_idx",
+          "columns": [
+            {
+              "expression": "reputationPoints",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ActorState_lastPostAt_idx": {
+          "name": "ActorState_lastPostAt_idx",
+          "columns": [
+            {
+              "expression": "lastPostAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ActorState_lastActiveAt_idx": {
+          "name": "ActorState_lastActiveAt_idx",
+          "columns": [
+            {
+              "expression": "lastActiveAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "positive_trading_balance": {
+          "name": "positive_trading_balance",
+          "value": "\"ActorState\".\"tradingBalance\" >= 0"
+        },
+        "current_mood_bounds": {
+          "name": "current_mood_bounds",
+          "value": "\"ActorState\".\"currentMood\" >= -1 AND \"ActorState\".\"currentMood\" <= 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.ActorFollow": {
+      "name": "ActorFollow",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "followerId": {
+          "name": "followerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "followingId": {
+          "name": "followingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "isMutual": {
+          "name": "isMutual",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "ActorFollow_followerId_idx": {
+          "name": "ActorFollow_followerId_idx",
+          "columns": [
+            {
+              "expression": "followerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ActorFollow_followingId_idx": {
+          "name": "ActorFollow_followingId_idx",
+          "columns": [
+            {
+              "expression": "followingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ActorFollow_isMutual_idx": {
+          "name": "ActorFollow_isMutual_idx",
+          "columns": [
+            {
+              "expression": "isMutual",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ActorRelationship": {
+      "name": "ActorRelationship",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor1Id": {
+          "name": "actor1Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor2Id": {
+          "name": "actor2Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relationshipType": {
+          "name": "relationshipType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strength": {
+          "name": "strength",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isPublic": {
+          "name": "isPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "history": {
+          "name": "history",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affects": {
+          "name": "affects",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastInteraction": {
+          "name": "lastInteraction",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interactionCount": {
+          "name": "interactionCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "evolutionCount": {
+          "name": "evolutionCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "ActorRelationship_actor1Id_idx": {
+          "name": "ActorRelationship_actor1Id_idx",
+          "columns": [
+            {
+              "expression": "actor1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ActorRelationship_actor2Id_idx": {
+          "name": "ActorRelationship_actor2Id_idx",
+          "columns": [
+            {
+              "expression": "actor2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ActorRelationship_relationshipType_idx": {
+          "name": "ActorRelationship_relationshipType_idx",
+          "columns": [
+            {
+              "expression": "relationshipType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ActorRelationship_sentiment_idx": {
+          "name": "ActorRelationship_sentiment_idx",
+          "columns": [
+            {
+              "expression": "sentiment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ActorRelationship_strength_idx": {
+          "name": "ActorRelationship_strength_idx",
+          "columns": [
+            {
+              "expression": "strength",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ActorRelationship_lastInteraction_idx": {
+          "name": "ActorRelationship_lastInteraction_idx",
+          "columns": [
+            {
+              "expression": "lastInteraction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.NPCInteraction": {
+      "name": "NPCInteraction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor1Id": {
+          "name": "actor1Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor2Id": {
+          "name": "actor2Id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interactionType": {
+          "name": "interactionType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "NPCInteraction_actor1Id_actor2Id_timestamp_idx": {
+          "name": "NPCInteraction_actor1Id_actor2Id_timestamp_idx",
+          "columns": [
+            {
+              "expression": "actor1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "NPCInteraction_timestamp_idx": {
+          "name": "NPCInteraction_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "NPCInteraction_actor1Id_idx": {
+          "name": "NPCInteraction_actor1Id_idx",
+          "columns": [
+            {
+              "expression": "actor1Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "NPCInteraction_actor2Id_idx": {
+          "name": "NPCInteraction_actor2Id_idx",
+          "columns": [
+            {
+              "expression": "actor2Id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "NPCInteraction_interactionType_idx": {
+          "name": "NPCInteraction_interactionType_idx",
+          "columns": [
+            {
+              "expression": "interactionType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.NPCTrade": {
+      "name": "NPCTrade",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "npcActorId": {
+          "name": "npcActorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poolId": {
+          "name": "poolId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marketType": {
+          "name": "marketType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticker": {
+          "name": "ticker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marketId": {
+          "name": "marketId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postId": {
+          "name": "postId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executedAt": {
+          "name": "executedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "NPCTrade_executedAt_idx": {
+          "name": "NPCTrade_executedAt_idx",
+          "columns": [
+            {
+              "expression": "executedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "NPCTrade_marketType_marketId_executedAt_idx": {
+          "name": "NPCTrade_marketType_marketId_executedAt_idx",
+          "columns": [
+            {
+              "expression": "marketType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "marketId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "executedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "NPCTrade_marketType_ticker_idx": {
+          "name": "NPCTrade_marketType_ticker_idx",
+          "columns": [
+            {
+              "expression": "marketType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ticker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "NPCTrade_npcActorId_executedAt_idx": {
+          "name": "NPCTrade_npcActorId_executedAt_idx",
+          "columns": [
+            {
+              "expression": "npcActorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "executedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "NPCTrade_poolId_executedAt_idx": {
+          "name": "NPCTrade_poolId_executedAt_idx",
+          "columns": [
+            {
+              "expression": "poolId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "executedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AdminRole": {
+      "name": "AdminRole",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grantedBy": {
+          "name": "grantedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grantedAt": {
+          "name": "grantedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "AdminRole_role_idx": {
+          "name": "AdminRole_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AdminRole_userId_idx": {
+          "name": "AdminRole_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AdminRole_grantedAt_idx": {
+          "name": "AdminRole_grantedAt_idx",
+          "columns": [
+            {
+              "expression": "grantedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AdminRole_revokedAt_idx": {
+          "name": "AdminRole_revokedAt_idx",
+          "columns": [
+            {
+              "expression": "revokedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "AdminRole_userId_User_id_fk": {
+          "name": "AdminRole_userId_User_id_fk",
+          "tableFrom": "AdminRole",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "AdminRole_grantedBy_User_id_fk": {
+          "name": "AdminRole_grantedBy_User_id_fk",
+          "tableFrom": "AdminRole",
+          "tableTo": "User",
+          "columnsFrom": [
+            "grantedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "AdminRole_userId_unique": {
+          "name": "AdminRole_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SystemMetricsSnapshot": {
+      "name": "SystemMetricsSnapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalUsers": {
+          "name": "totalUsers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activeUsers": {
+          "name": "activeUsers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "newSignups": {
+          "name": "newSignups",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tradingVolume": {
+          "name": "tradingVolume",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activeMarkets": {
+          "name": "activeMarkets",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "openPositions": {
+          "name": "openPositions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "perpVolume": {
+          "name": "perpVolume",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "activePerpPositions": {
+          "name": "activePerpPositions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "postsCreated": {
+          "name": "postsCreated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "commentsCreated": {
+          "name": "commentsCreated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reactionsCreated": {
+          "name": "reactionsCreated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalVirtualBalance": {
+          "name": "totalVirtualBalance",
+          "type": "numeric(20, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feesCollectedHourly": {
+          "name": "feesCollectedHourly",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "apiUptime": {
+          "name": "apiUptime",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avgResponseTime": {
+          "name": "avgResponseTime",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "errorRate": {
+          "name": "errorRate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cronJobsHealthy": {
+          "name": "cronJobsHealthy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cronJobsUnhealthy": {
+          "name": "cronJobsUnhealthy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "extendedMetrics": {
+          "name": "extendedMetrics",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshotDurationMs": {
+          "name": "snapshotDurationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "SystemMetricsSnapshot_timestamp_environment_unique_idx": {
+          "name": "SystemMetricsSnapshot_timestamp_environment_unique_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "environment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SystemMetricsSnapshot_environment_timestamp_idx": {
+          "name": "SystemMetricsSnapshot_environment_timestamp_idx",
+          "columns": [
+            {
+              "expression": "environment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SystemMetricsSnapshot_createdAt_idx": {
+          "name": "SystemMetricsSnapshot_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AgentCapability": {
+      "name": "AgentCapability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agentRegistryId": {
+          "name": "agentRegistryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strategies": {
+          "name": "strategies",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "markets": {
+          "name": "markets",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "actions": {
+          "name": "actions",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0.0'"
+        },
+        "x402Support": {
+          "name": "x402Support",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userType": {
+          "name": "userType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gameNetworkChainId": {
+          "name": "gameNetworkChainId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gameNetworkRpcUrl": {
+          "name": "gameNetworkRpcUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gameNetworkExplorerUrl": {
+          "name": "gameNetworkExplorerUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skills": {
+          "name": "skills",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "domains": {
+          "name": "domains",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "a2aEndpoint": {
+          "name": "a2aEndpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcpEndpoint": {
+          "name": "mcpEndpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "AgentCapability_agentRegistryId_idx": {
+          "name": "AgentCapability_agentRegistryId_idx",
+          "columns": [
+            {
+              "expression": "agentRegistryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "AgentCapability_agentRegistryId_unique": {
+          "name": "AgentCapability_agentRegistryId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agentRegistryId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AgentGoalAction": {
+      "name": "AgentGoalAction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "goalId": {
+          "name": "goalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentUserId": {
+          "name": "agentUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actionType": {
+          "name": "actionType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actionId": {
+          "name": "actionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impact": {
+          "name": "impact",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AgentGoalAction_goalId_idx": {
+          "name": "AgentGoalAction_goalId_idx",
+          "columns": [
+            {
+              "expression": "goalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentGoalAction_agentUserId_createdAt_idx": {
+          "name": "AgentGoalAction_agentUserId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "agentUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentGoalAction_actionType_idx": {
+          "name": "AgentGoalAction_actionType_idx",
+          "columns": [
+            {
+              "expression": "actionType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AgentGoal": {
+      "name": "AgentGoal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agentUserId": {
+          "name": "agentUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target": {
+          "name": "target",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "progress": {
+          "name": "progress",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "AgentGoal_agentUserId_status_idx": {
+          "name": "AgentGoal_agentUserId_status_idx",
+          "columns": [
+            {
+              "expression": "agentUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentGoal_priority_idx": {
+          "name": "AgentGoal_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentGoal_status_idx": {
+          "name": "AgentGoal_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentGoal_createdAt_idx": {
+          "name": "AgentGoal_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AgentLog": {
+      "name": "AgentLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion": {
+          "name": "completion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thinking": {
+          "name": "thinking",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "agentUserId": {
+          "name": "agentUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "AgentLog_agentUserId_createdAt_idx": {
+          "name": "AgentLog_agentUserId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "agentUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentLog_level_idx": {
+          "name": "AgentLog_level_idx",
+          "columns": [
+            {
+              "expression": "level",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentLog_type_createdAt_idx": {
+          "name": "AgentLog_type_createdAt_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AgentMessage": {
+      "name": "AgentMessage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelUsed": {
+          "name": "modelUsed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pointsCost": {
+          "name": "pointsCost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "agentUserId": {
+          "name": "agentUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "AgentMessage_agentUserId_createdAt_idx": {
+          "name": "AgentMessage_agentUserId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "agentUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentMessage_role_idx": {
+          "name": "AgentMessage_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AgentPerformanceMetrics": {
+      "name": "AgentPerformanceMetrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gamesPlayed": {
+          "name": "gamesPlayed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "gamesWon": {
+          "name": "gamesWon",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "averageGameScore": {
+          "name": "averageGameScore",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastGameScore": {
+          "name": "lastGameScore",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastGamePlayedAt": {
+          "name": "lastGamePlayedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalizedPnL": {
+          "name": "normalizedPnL",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "totalTrades": {
+          "name": "totalTrades",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "profitableTrades": {
+          "name": "profitableTrades",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "winRate": {
+          "name": "winRate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "averageROI": {
+          "name": "averageROI",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sharpeRatio": {
+          "name": "sharpeRatio",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalFeedbackCount": {
+          "name": "totalFeedbackCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "averageFeedbackScore": {
+          "name": "averageFeedbackScore",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 70
+        },
+        "intelFeedbackCount": {
+          "name": "intelFeedbackCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "averageIntelScore": {
+          "name": "averageIntelScore",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "averageRating": {
+          "name": "averageRating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "positiveCount": {
+          "name": "positiveCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "neutralCount": {
+          "name": "neutralCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "negativeCount": {
+          "name": "negativeCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reputationScore": {
+          "name": "reputationScore",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 70
+        },
+        "trustLevel": {
+          "name": "trustLevel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UNRATED'"
+        },
+        "confidenceScore": {
+          "name": "confidenceScore",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "onChainReputationSync": {
+          "name": "onChainReputationSync",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastSyncedAt": {
+          "name": "lastSyncedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onChainTrustScore": {
+          "name": "onChainTrustScore",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onChainAccuracyScore": {
+          "name": "onChainAccuracyScore",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "firstActivityAt": {
+          "name": "firstActivityAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastActivityAt": {
+          "name": "lastActivityAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalInteractions": {
+          "name": "totalInteractions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "AgentPerformanceMetrics_gamesPlayed_idx": {
+          "name": "AgentPerformanceMetrics_gamesPlayed_idx",
+          "columns": [
+            {
+              "expression": "gamesPlayed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentPerformanceMetrics_normalizedPnL_idx": {
+          "name": "AgentPerformanceMetrics_normalizedPnL_idx",
+          "columns": [
+            {
+              "expression": "normalizedPnL",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentPerformanceMetrics_reputationScore_idx": {
+          "name": "AgentPerformanceMetrics_reputationScore_idx",
+          "columns": [
+            {
+              "expression": "reputationScore",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentPerformanceMetrics_trustLevel_idx": {
+          "name": "AgentPerformanceMetrics_trustLevel_idx",
+          "columns": [
+            {
+              "expression": "trustLevel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentPerformanceMetrics_updatedAt_idx": {
+          "name": "AgentPerformanceMetrics_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "AgentPerformanceMetrics_userId_unique": {
+          "name": "AgentPerformanceMetrics_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AgentPointsTransaction": {
+      "name": "AgentPointsTransaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balanceBefore": {
+          "name": "balanceBefore",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balanceAfter": {
+          "name": "balanceAfter",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relatedId": {
+          "name": "relatedId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "agentUserId": {
+          "name": "agentUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "managerUserId": {
+          "name": "managerUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "AgentPointsTransaction_agentUserId_createdAt_idx": {
+          "name": "AgentPointsTransaction_agentUserId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "agentUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentPointsTransaction_managerUserId_createdAt_idx": {
+          "name": "AgentPointsTransaction_managerUserId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "managerUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentPointsTransaction_type_idx": {
+          "name": "AgentPointsTransaction_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AgentRegistry": {
+      "name": "AgentRegistry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "AgentType",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "AgentStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'REGISTERED'"
+        },
+        "trustLevel": {
+          "name": "trustLevel",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "systemPrompt": {
+          "name": "systemPrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discoveryCardVersion": {
+          "name": "discoveryCardVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discoveryEndpointA2a": {
+          "name": "discoveryEndpointA2a",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discoveryEndpointMcp": {
+          "name": "discoveryEndpointMcp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discoveryEndpointRpc": {
+          "name": "discoveryEndpointRpc",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discoveryAuthRequired": {
+          "name": "discoveryAuthRequired",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "discoveryAuthMethods": {
+          "name": "discoveryAuthMethods",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "discoveryRateLimit": {
+          "name": "discoveryRateLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discoveryCostPerAction": {
+          "name": "discoveryCostPerAction",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onChainTokenId": {
+          "name": "onChainTokenId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onChainTxHash": {
+          "name": "onChainTxHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onChainServerWallet": {
+          "name": "onChainServerWallet",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onChainReputationScore": {
+          "name": "onChainReputationScore",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "onChainChainId": {
+          "name": "onChainChainId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onChainIdentityRegistry": {
+          "name": "onChainIdentityRegistry",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onChainReputationSystem": {
+          "name": "onChainReputationSystem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent0TokenId": {
+          "name": "agent0TokenId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent0MetadataCID": {
+          "name": "agent0MetadataCID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent0SubgraphOwner": {
+          "name": "agent0SubgraphOwner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent0SubgraphMetadataURI": {
+          "name": "agent0SubgraphMetadataURI",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent0SubgraphTimestamp": {
+          "name": "agent0SubgraphTimestamp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent0DiscoveryEndpoint": {
+          "name": "agent0DiscoveryEndpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtimeInstanceId": {
+          "name": "runtimeInstanceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registeredAt": {
+          "name": "registeredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastActiveAt": {
+          "name": "lastActiveAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "terminatedAt": {
+          "name": "terminatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "AgentRegistry_type_status_idx": {
+          "name": "AgentRegistry_type_status_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentRegistry_trustLevel_idx": {
+          "name": "AgentRegistry_trustLevel_idx",
+          "columns": [
+            {
+              "expression": "trustLevel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentRegistry_userId_idx": {
+          "name": "AgentRegistry_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentRegistry_actorId_idx": {
+          "name": "AgentRegistry_actorId_idx",
+          "columns": [
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentRegistry_status_lastActiveAt_idx": {
+          "name": "AgentRegistry_status_lastActiveAt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastActiveAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentRegistry_type_trustLevel_idx": {
+          "name": "AgentRegistry_type_trustLevel_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "trustLevel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "AgentRegistry_agentId_unique": {
+          "name": "AgentRegistry_agentId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agentId"
+          ]
+        },
+        "AgentRegistry_userId_unique": {
+          "name": "AgentRegistry_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        },
+        "AgentRegistry_actorId_unique": {
+          "name": "AgentRegistry_actorId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "actorId"
+          ]
+        },
+        "AgentRegistry_runtimeInstanceId_unique": {
+          "name": "AgentRegistry_runtimeInstanceId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "runtimeInstanceId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AgentTrade": {
+      "name": "AgentTrade",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "marketType": {
+          "name": "marketType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "marketId": {
+          "name": "marketId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticker": {
+          "name": "ticker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pnl": {
+          "name": "pnl",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "executedAt": {
+          "name": "executedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "agentUserId": {
+          "name": "agentUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "AgentTrade_agentUserId_executedAt_idx": {
+          "name": "AgentTrade_agentUserId_executedAt_idx",
+          "columns": [
+            {
+              "expression": "agentUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "executedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentTrade_marketType_marketId_idx": {
+          "name": "AgentTrade_marketType_marketId_idx",
+          "columns": [
+            {
+              "expression": "marketType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "marketId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AgentTrade_ticker_idx": {
+          "name": "AgentTrade_ticker_idx",
+          "columns": [
+            {
+              "expression": "ticker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ExternalAgentConnection": {
+      "name": "ExternalAgentConnection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agentRegistryId": {
+          "name": "agentRegistryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "externalId": {
+          "name": "externalId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "protocol": {
+          "name": "protocol",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authType": {
+          "name": "authType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "authCredentials": {
+          "name": "authCredentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentCardJson": {
+          "name": "agentCardJson",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isHealthy": {
+          "name": "isHealthy",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "lastHealthCheck": {
+          "name": "lastHealthCheck",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastConnected": {
+          "name": "lastConnected",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registeredByUserId": {
+          "name": "registeredByUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedBy": {
+          "name": "revokedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ExternalAgentConnection_agentRegistryId_idx": {
+          "name": "ExternalAgentConnection_agentRegistryId_idx",
+          "columns": [
+            {
+              "expression": "agentRegistryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ExternalAgentConnection_externalId_idx": {
+          "name": "ExternalAgentConnection_externalId_idx",
+          "columns": [
+            {
+              "expression": "externalId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ExternalAgentConnection_protocol_idx": {
+          "name": "ExternalAgentConnection_protocol_idx",
+          "columns": [
+            {
+              "expression": "protocol",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ExternalAgentConnection_isHealthy_idx": {
+          "name": "ExternalAgentConnection_isHealthy_idx",
+          "columns": [
+            {
+              "expression": "isHealthy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ExternalAgentConnection_revokedAt_idx": {
+          "name": "ExternalAgentConnection_revokedAt_idx",
+          "columns": [
+            {
+              "expression": "revokedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ExternalAgentConnection_agentRegistryId_unique": {
+          "name": "ExternalAgentConnection_agentRegistryId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "agentRegistryId"
+          ]
+        },
+        "ExternalAgentConnection_externalId_unique": {
+          "name": "ExternalAgentConnection_externalId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "externalId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Market": {
+      "name": "Market",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gameId": {
+          "name": "gameId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dayNumber": {
+          "name": "dayNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yesShares": {
+          "name": "yesShares",
+          "type": "numeric(18, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "noShares": {
+          "name": "noShares",
+          "type": "numeric(18, 6)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "liquidity": {
+          "name": "liquidity",
+          "type": "numeric(18, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endDate": {
+          "name": "endDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onChainMarketId": {
+          "name": "onChainMarketId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onChainResolutionTxHash": {
+          "name": "onChainResolutionTxHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onChainResolved": {
+          "name": "onChainResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "oracleAddress": {
+          "name": "oracleAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolutionProofUrl": {
+          "name": "resolutionProofUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolutionDescription": {
+          "name": "resolutionDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Market_createdAt_idx": {
+          "name": "Market_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Market_gameId_dayNumber_idx": {
+          "name": "Market_gameId_dayNumber_idx",
+          "columns": [
+            {
+              "expression": "gameId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dayNumber",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Market_onChainMarketId_idx": {
+          "name": "Market_onChainMarketId_idx",
+          "columns": [
+            {
+              "expression": "onChainMarketId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Market_resolved_endDate_idx": {
+          "name": "Market_resolved_endDate_idx",
+          "columns": [
+            {
+              "expression": "resolved",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Organization": {
+      "name": "Organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticker": {
+          "name": "ticker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canBeInvolved": {
+          "name": "canBeInvolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "initialPrice": {
+          "name": "initialPrice",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currentPrice": {
+          "name": "currentPrice",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Organization_currentPrice_idx": {
+          "name": "Organization_currentPrice_idx",
+          "columns": [
+            {
+              "expression": "currentPrice",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Organization_type_idx": {
+          "name": "Organization_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Organization_ticker_idx": {
+          "name": "Organization_ticker_idx",
+          "columns": [
+            {
+              "expression": "ticker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PerpMarketSnapshot": {
+      "name": "PerpMarketSnapshot",
+      "schema": "",
+      "columns": {
+        "ticker": {
+          "name": "ticker",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "currentPrice": {
+          "name": "currentPrice",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price24hAgo": {
+          "name": "price24hAgo",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "price24hAgoUpdatedAt": {
+          "name": "price24hAgoUpdatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics24hResetAt": {
+          "name": "metrics24hResetAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change24h": {
+          "name": "change24h",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "changePercent24h": {
+          "name": "changePercent24h",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "high24h": {
+          "name": "high24h",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "low24h": {
+          "name": "low24h",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume24h": {
+          "name": "volume24h",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "openInterest": {
+          "name": "openInterest",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "fundingRate": {
+          "name": "fundingRate",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "maxLeverage": {
+          "name": "maxLeverage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "minOrderSize": {
+          "name": "minOrderSize",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "markPrice": {
+          "name": "markPrice",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "indexPrice": {
+          "name": "indexPrice",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "PerpMarketSnapshot_orgId_idx": {
+          "name": "PerpMarketSnapshot_orgId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PerpPosition": {
+      "name": "PerpPosition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticker": {
+          "name": "ticker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryPrice": {
+          "name": "entryPrice",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPrice": {
+          "name": "currentPrice",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leverage": {
+          "name": "leverage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "liquidationPrice": {
+          "name": "liquidationPrice",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unrealizedPnL": {
+          "name": "unrealizedPnL",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unrealizedPnLPercent": {
+          "name": "unrealizedPnLPercent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fundingPaid": {
+          "name": "fundingPaid",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "openedAt": {
+          "name": "openedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lastUpdated": {
+          "name": "lastUpdated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "realizedPnL": {
+          "name": "realizedPnL",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settledAt": {
+          "name": "settledAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settledToChain": {
+          "name": "settledToChain",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settlementTxHash": {
+          "name": "settlementTxHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "PerpPosition_organizationId_idx": {
+          "name": "PerpPosition_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PerpPosition_settledToChain_idx": {
+          "name": "PerpPosition_settledToChain_idx",
+          "columns": [
+            {
+              "expression": "settledToChain",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PerpPosition_ticker_idx": {
+          "name": "PerpPosition_ticker_idx",
+          "columns": [
+            {
+              "expression": "ticker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PerpPosition_userId_closedAt_idx": {
+          "name": "PerpPosition_userId_closedAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Position": {
+      "name": "Position",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "marketId": {
+          "name": "marketId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side": {
+          "name": "side",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shares": {
+          "name": "shares",
+          "type": "numeric(18, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avgPrice": {
+          "name": "avgPrice",
+          "type": "numeric(18, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pnl": {
+          "name": "pnl",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questionId": {
+          "name": "questionId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        }
+      },
+      "indexes": {
+        "Position_marketId_idx": {
+          "name": "Position_marketId_idx",
+          "columns": [
+            {
+              "expression": "marketId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Position_questionId_idx": {
+          "name": "Position_questionId_idx",
+          "columns": [
+            {
+              "expression": "questionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Position_status_idx": {
+          "name": "Position_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Position_userId_idx": {
+          "name": "Position_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Position_userId_marketId_idx": {
+          "name": "Position_userId_marketId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "marketId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Position_userId_status_idx": {
+          "name": "Position_userId_status_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PredictionPriceHistory": {
+      "name": "PredictionPriceHistory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "marketId": {
+          "name": "marketId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "yesPrice": {
+          "name": "yesPrice",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "noPrice": {
+          "name": "noPrice",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "yesShares": {
+          "name": "yesShares",
+          "type": "numeric(24, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "noShares": {
+          "name": "noShares",
+          "type": "numeric(24, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "liquidity": {
+          "name": "liquidity",
+          "type": "numeric(24, 8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "PredictionPriceHistory_marketId_createdAt_idx": {
+          "name": "PredictionPriceHistory_marketId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "marketId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Question": {
+      "name": "Question",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "questionNumber": {
+          "name": "questionNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scenarioId": {
+          "name": "scenarioId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdDate": {
+          "name": "createdDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "resolutionDate": {
+          "name": "resolutionDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "resolvedOutcome": {
+          "name": "resolvedOutcome",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oracleCommitBlock": {
+          "name": "oracleCommitBlock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oracleCommitTxHash": {
+          "name": "oracleCommitTxHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oracleCommitment": {
+          "name": "oracleCommitment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oracleError": {
+          "name": "oracleError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oraclePublishedAt": {
+          "name": "oraclePublishedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oracleRevealBlock": {
+          "name": "oracleRevealBlock",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oracleRevealTxHash": {
+          "name": "oracleRevealTxHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oracleSaltEncrypted": {
+          "name": "oracleSaltEncrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oracleSessionId": {
+          "name": "oracleSessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolutionProofUrl": {
+          "name": "resolutionProofUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolutionDescription": {
+          "name": "resolutionDescription",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolutionConfidence": {
+          "name": "resolutionConfidence",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requiresManualReview": {
+          "name": "requiresManualReview",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "resolutionReviewStatus": {
+          "name": "resolutionReviewStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolutionReviewedAt": {
+          "name": "resolutionReviewedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolutionReviewedBy": {
+          "name": "resolutionReviewedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Question_createdDate_idx": {
+          "name": "Question_createdDate_idx",
+          "columns": [
+            {
+              "expression": "createdDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Question_oraclePublishedAt_idx": {
+          "name": "Question_oraclePublishedAt_idx",
+          "columns": [
+            {
+              "expression": "oraclePublishedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Question_oracleSessionId_idx": {
+          "name": "Question_oracleSessionId_idx",
+          "columns": [
+            {
+              "expression": "oracleSessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Question_status_resolutionDate_idx": {
+          "name": "Question_status_resolutionDate_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resolutionDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Question_requiresManualReview_status_idx": {
+          "name": "Question_requiresManualReview_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "requiresManualReview",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resolutionReviewStatus",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Question_questionNumber_unique": {
+          "name": "Question_questionNumber_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "questionNumber"
+          ]
+        },
+        "Question_oracleSessionId_unique": {
+          "name": "Question_oracleSessionId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "oracleSessionId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.StockPrice": {
+      "name": "StockPrice",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organizationId": {
+          "name": "organizationId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change": {
+          "name": "change",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changePercent": {
+          "name": "changePercent",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "isSnapshot": {
+          "name": "isSnapshot",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "openPrice": {
+          "name": "openPrice",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "highPrice": {
+          "name": "highPrice",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lowPrice": {
+          "name": "lowPrice",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume": {
+          "name": "volume",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "StockPrice_isSnapshot_timestamp_idx": {
+          "name": "StockPrice_isSnapshot_timestamp_idx",
+          "columns": [
+            {
+              "expression": "isSnapshot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "StockPrice_organizationId_timestamp_idx": {
+          "name": "StockPrice_organizationId_timestamp_idx",
+          "columns": [
+            {
+              "expression": "organizationId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "StockPrice_timestamp_idx": {
+          "name": "StockPrice_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ChatParticipant": {
+      "name": "ChatParticipant",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joinedAt": {
+          "name": "joinedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "addedBy": {
+          "name": "addedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ChatParticipant_chatId_idx": {
+          "name": "ChatParticipant_chatId_idx",
+          "columns": [
+            {
+              "expression": "chatId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatParticipant_userId_idx": {
+          "name": "ChatParticipant_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatParticipant_chatId_isActive_idx": {
+          "name": "ChatParticipant_chatId_isActive_idx",
+          "columns": [
+            {
+              "expression": "chatId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ChatParticipant_userId_isActive_idx": {
+          "name": "ChatParticipant_userId_isActive_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ChatParticipant_chatId_userId_key": {
+          "name": "ChatParticipant_chatId_userId_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chatId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Chat": {
+      "name": "Chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isGroup": {
+          "name": "isGroup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdBy": {
+          "name": "createdBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gameId": {
+          "name": "gameId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dayNumber": {
+          "name": "dayNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relatedQuestion": {
+          "name": "relatedQuestion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "groupId": {
+          "name": "groupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requiredNftContractAddress": {
+          "name": "requiredNftContractAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requiredNftTokenId": {
+          "name": "requiredNftTokenId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requiredNftChainId": {
+          "name": "requiredNftChainId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nftGated": {
+          "name": "nftGated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "lastNftRevalidatedAt": {
+          "name": "lastNftRevalidatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Chat_gameId_dayNumber_idx": {
+          "name": "Chat_gameId_dayNumber_idx",
+          "columns": [
+            {
+              "expression": "gameId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dayNumber",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Chat_groupId_idx": {
+          "name": "Chat_groupId_idx",
+          "columns": [
+            {
+              "expression": "groupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Chat_isGroup_idx": {
+          "name": "Chat_isGroup_idx",
+          "columns": [
+            {
+              "expression": "isGroup",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Chat_createdBy_idx": {
+          "name": "Chat_createdBy_idx",
+          "columns": [
+            {
+              "expression": "createdBy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Chat_relatedQuestion_idx": {
+          "name": "Chat_relatedQuestion_idx",
+          "columns": [
+            {
+              "expression": "relatedQuestion",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Chat_nftGated_idx": {
+          "name": "Chat_nftGated_idx",
+          "columns": [
+            {
+              "expression": "nftGated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Chat_requiredNftContractAddress_idx": {
+          "name": "Chat_requiredNftContractAddress_idx",
+          "columns": [
+            {
+              "expression": "requiredNftContractAddress",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.DMAcceptance": {
+      "name": "DMAcceptance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "otherUserId": {
+          "name": "otherUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "acceptedAt": {
+          "name": "acceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejectedAt": {
+          "name": "rejectedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "DMAcceptance_status_createdAt_idx": {
+          "name": "DMAcceptance_status_createdAt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "DMAcceptance_userId_status_idx": {
+          "name": "DMAcceptance_userId_status_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "DMAcceptance_chatId_unique": {
+          "name": "DMAcceptance_chatId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "chatId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.GroupInvite": {
+      "name": "GroupInvite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "groupId": {
+          "name": "groupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitedUserId": {
+          "name": "invitedUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invitedBy": {
+          "name": "invitedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invitedAt": {
+          "name": "invitedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "respondedAt": {
+          "name": "respondedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "declineCount": {
+          "name": "declineCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastDeclinedAt": {
+          "name": "lastDeclinedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nextEligibleAt": {
+          "name": "nextEligibleAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "GroupInvite_groupId_idx": {
+          "name": "GroupInvite_groupId_idx",
+          "columns": [
+            {
+              "expression": "groupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "GroupInvite_invitedUserId_status_idx": {
+          "name": "GroupInvite_invitedUserId_status_idx",
+          "columns": [
+            {
+              "expression": "invitedUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "GroupInvite_status_idx": {
+          "name": "GroupInvite_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "GroupInvite_invitedUserId_status_declineCount_idx": {
+          "name": "GroupInvite_invitedUserId_status_declineCount_idx",
+          "columns": [
+            {
+              "expression": "invitedUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "declineCount",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "GroupInvite_nextEligibleAt_idx": {
+          "name": "GroupInvite_nextEligibleAt_idx",
+          "columns": [
+            {
+              "expression": "nextEligibleAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "GroupInvite_groupId_invitedUserId_key": {
+          "name": "GroupInvite_groupId_invitedUserId_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "groupId",
+            "invitedUserId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.GroupMember": {
+      "name": "GroupMember",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "groupId": {
+          "name": "groupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "joinedAt": {
+          "name": "joinedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "addedBy": {
+          "name": "addedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "lastMessageAt": {
+          "name": "lastMessageAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messageCount": {
+          "name": "messageCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "qualityScore": {
+          "name": "qualityScore",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "kickedAt": {
+          "name": "kickedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kickReason": {
+          "name": "kickReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tier": {
+          "name": "tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promotedAt": {
+          "name": "promotedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "demotedAt": {
+          "name": "demotedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previousTier": {
+          "name": "previousTier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isGrandfathered": {
+          "name": "isGrandfathered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "grandfatheredAt": {
+          "name": "grandfatheredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "GroupMember_groupId_idx": {
+          "name": "GroupMember_groupId_idx",
+          "columns": [
+            {
+              "expression": "groupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "GroupMember_userId_idx": {
+          "name": "GroupMember_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "GroupMember_groupId_isActive_idx": {
+          "name": "GroupMember_groupId_isActive_idx",
+          "columns": [
+            {
+              "expression": "groupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "GroupMember_userId_isActive_idx": {
+          "name": "GroupMember_userId_isActive_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "GroupMember_lastMessageAt_idx": {
+          "name": "GroupMember_lastMessageAt_idx",
+          "columns": [
+            {
+              "expression": "lastMessageAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "GroupMember_role_idx": {
+          "name": "GroupMember_role_idx",
+          "columns": [
+            {
+              "expression": "role",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "GroupMember_tier_idx": {
+          "name": "GroupMember_tier_idx",
+          "columns": [
+            {
+              "expression": "tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "GroupMember_userId_isActive_tier_idx": {
+          "name": "GroupMember_userId_isActive_tier_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "GroupMember_isActive_tier_idx": {
+          "name": "GroupMember_isActive_tier_idx",
+          "columns": [
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "GroupMember_isGrandfathered_idx": {
+          "name": "GroupMember_isGrandfathered_idx",
+          "columns": [
+            {
+              "expression": "isGrandfathered",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "GroupMember_groupId_userId_key": {
+          "name": "GroupMember_groupId_userId_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "groupId",
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Group": {
+      "name": "Group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "group_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerId": {
+          "name": "ownerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdById": {
+          "name": "createdById",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tier": {
+          "name": "tier",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maxMembers": {
+          "name": "maxMembers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parentGroupId": {
+          "name": "parentGroupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activeChatId": {
+          "name": "activeChatId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Group_type_idx": {
+          "name": "Group_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Group_ownerId_idx": {
+          "name": "Group_ownerId_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Group_createdById_idx": {
+          "name": "Group_createdById_idx",
+          "columns": [
+            {
+              "expression": "createdById",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Group_createdAt_idx": {
+          "name": "Group_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Group_tier_idx": {
+          "name": "Group_tier_idx",
+          "columns": [
+            {
+              "expression": "tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Group_ownerId_tier_idx": {
+          "name": "Group_ownerId_tier_idx",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Group_parentGroupId_idx": {
+          "name": "Group_parentGroupId_idx",
+          "columns": [
+            {
+              "expression": "parentGroupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Group_team_ownerId_unique": {
+          "name": "Group_team_ownerId_unique",
+          "columns": [
+            {
+              "expression": "ownerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"Group\".\"type\" = 'team'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Message": {
+      "name": "Message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "senderId": {
+          "name": "senderId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "message_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "targetIds": {
+          "name": "targetIds",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Message_chatId_createdAt_idx": {
+          "name": "Message_chatId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "chatId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_senderId_idx": {
+          "name": "Message_senderId_idx",
+          "columns": [
+            {
+              "expression": "senderId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_type_idx": {
+          "name": "Message_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Message_targetIds_idx": {
+          "name": "Message_targetIds_idx",
+          "columns": [
+            {
+              "expression": "targetIds",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Notification": {
+      "name": "Notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postId": {
+          "name": "postId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commentId": {
+          "name": "commentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "groupId": {
+          "name": "groupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inviteId": {
+          "name": "inviteId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Notification_chatId_idx": {
+          "name": "Notification_chatId_idx",
+          "columns": [
+            {
+              "expression": "chatId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Notification_groupId_idx": {
+          "name": "Notification_groupId_idx",
+          "columns": [
+            {
+              "expression": "groupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Notification_inviteId_idx": {
+          "name": "Notification_inviteId_idx",
+          "columns": [
+            {
+              "expression": "inviteId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Notification_read_idx": {
+          "name": "Notification_read_idx",
+          "columns": [
+            {
+              "expression": "read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Notification_userId_createdAt_idx": {
+          "name": "Notification_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Notification_userId_read_createdAt_idx": {
+          "name": "Notification_userId_read_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Notification_userId_type_read_idx": {
+          "name": "Notification_userId_type_read_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AdminAuditLog": {
+      "name": "AdminAuditLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "adminId": {
+          "name": "adminId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceType": {
+          "name": "resourceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resourceId": {
+          "name": "resourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previousValue": {
+          "name": "previousValue",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "newValue": {
+          "name": "newValue",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AdminAuditLog_adminId_idx": {
+          "name": "AdminAuditLog_adminId_idx",
+          "columns": [
+            {
+              "expression": "adminId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AdminAuditLog_action_idx": {
+          "name": "AdminAuditLog_action_idx",
+          "columns": [
+            {
+              "expression": "action",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AdminAuditLog_resourceType_idx": {
+          "name": "AdminAuditLog_resourceType_idx",
+          "columns": [
+            {
+              "expression": "resourceType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AdminAuditLog_resourceId_idx": {
+          "name": "AdminAuditLog_resourceId_idx",
+          "columns": [
+            {
+              "expression": "resourceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AdminAuditLog_createdAt_idx": {
+          "name": "AdminAuditLog_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AdminAuditLog_adminId_createdAt_idx": {
+          "name": "AdminAuditLog_adminId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "adminId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.AnalyticsDailySnapshot": {
+      "name": "AnalyticsDailySnapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalUsers": {
+          "name": "totalUsers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "newUsers": {
+          "name": "newUsers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "activeUsers": {
+          "name": "activeUsers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bannedUsers": {
+          "name": "bannedUsers",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalPosts": {
+          "name": "totalPosts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "newPosts": {
+          "name": "newPosts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalComments": {
+          "name": "totalComments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "newComments": {
+          "name": "newComments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalReactions": {
+          "name": "totalReactions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "newReactions": {
+          "name": "newReactions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalMarkets": {
+          "name": "totalMarkets",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "activeMarkets": {
+          "name": "activeMarkets",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalTrades": {
+          "name": "totalTrades",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "newTrades": {
+          "name": "newTrades",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalFollows": {
+          "name": "totalFollows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "newFollows": {
+          "name": "newFollows",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalReferrals": {
+          "name": "totalReferrals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "newReferrals": {
+          "name": "newReferrals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalReports": {
+          "name": "totalReports",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "newReports": {
+          "name": "newReports",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolvedReports": {
+          "name": "resolvedReports",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "AnalyticsDailySnapshot_date_idx": {
+          "name": "AnalyticsDailySnapshot_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "AnalyticsDailySnapshot_createdAt_idx": {
+          "name": "AnalyticsDailySnapshot_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "AnalyticsDailySnapshot_date_unique": {
+          "name": "AnalyticsDailySnapshot_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.GameConfig": {
+      "name": "GameConfig",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "GameConfig_key_idx": {
+          "name": "GameConfig_key_idx",
+          "columns": [
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "GameConfig_key_unique": {
+          "name": "GameConfig_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Game": {
+      "name": "Game",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currentDay": {
+          "name": "currentDay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "currentDate": {
+          "name": "currentDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "isRunning": {
+          "name": "isRunning",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isContinuous": {
+          "name": "isContinuous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "speed": {
+          "name": "speed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 60000
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pausedAt": {
+          "name": "pausedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastTickAt": {
+          "name": "lastTickAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastSnapshotAt": {
+          "name": "lastSnapshotAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "activeQuestions": {
+          "name": "activeQuestions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Game_isContinuous_idx": {
+          "name": "Game_isContinuous_idx",
+          "columns": [
+            {
+              "expression": "isContinuous",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Game_isRunning_idx": {
+          "name": "Game_isRunning_idx",
+          "columns": [
+            {
+              "expression": "isRunning",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.GenerationLock": {
+      "name": "GenerationLock",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'game-tick-lock'"
+        },
+        "lockedBy": {
+          "name": "lockedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lockedAt": {
+          "name": "lockedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'game-tick'"
+        }
+      },
+      "indexes": {
+        "GenerationLock_expiresAt_idx": {
+          "name": "GenerationLock_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OAuthState": {
+      "name": "OAuthState",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "codeVerifier": {
+          "name": "codeVerifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "returnPath": {
+          "name": "returnPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OAuthState_expiresAt_idx": {
+          "name": "OAuthState_expiresAt_idx",
+          "columns": [
+            {
+              "expression": "expiresAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OAuthState_state_idx": {
+          "name": "OAuthState_state_idx",
+          "columns": [
+            {
+              "expression": "state",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "OAuthState_state_unique": {
+          "name": "OAuthState_state_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "state"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OracleCommitment": {
+      "name": "OracleCommitment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "questionId": {
+          "name": "questionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saltEncrypted": {
+          "name": "saltEncrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commitment": {
+          "name": "commitment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "OracleCommitment_createdAt_idx": {
+          "name": "OracleCommitment_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OracleCommitment_questionId_idx": {
+          "name": "OracleCommitment_questionId_idx",
+          "columns": [
+            {
+              "expression": "questionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OracleCommitment_sessionId_idx": {
+          "name": "OracleCommitment_sessionId_idx",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "OracleCommitment_questionId_unique": {
+          "name": "OracleCommitment_questionId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "questionId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OracleTransaction": {
+      "name": "OracleTransaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "questionId": {
+          "name": "questionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "txType": {
+          "name": "txType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "txHash": {
+          "name": "txHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blockNumber": {
+          "name": "blockNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gasUsed": {
+          "name": "gasUsed",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gasPrice": {
+          "name": "gasPrice",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retryCount": {
+          "name": "retryCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "confirmedAt": {
+          "name": "confirmedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "OracleTransaction_questionId_idx": {
+          "name": "OracleTransaction_questionId_idx",
+          "columns": [
+            {
+              "expression": "questionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OracleTransaction_status_createdAt_idx": {
+          "name": "OracleTransaction_status_createdAt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OracleTransaction_txHash_idx": {
+          "name": "OracleTransaction_txHash_idx",
+          "columns": [
+            {
+              "expression": "txHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OracleTransaction_txType_idx": {
+          "name": "OracleTransaction_txType_idx",
+          "columns": [
+            {
+              "expression": "txType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "OracleTransaction_txHash_unique": {
+          "name": "OracleTransaction_txHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "txHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ParodyHeadline": {
+      "name": "ParodyHeadline",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "originalHeadlineId": {
+          "name": "originalHeadlineId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalTitle": {
+          "name": "originalTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "originalSource": {
+          "name": "originalSource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parodyTitle": {
+          "name": "parodyTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parodyContent": {
+          "name": "parodyContent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "characterMappings": {
+          "name": "characterMappings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organizationMappings": {
+          "name": "organizationMappings",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generatedAt": {
+          "name": "generatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isUsed": {
+          "name": "isUsed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "usedAt": {
+          "name": "usedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ParodyHeadline_isUsed_generatedAt_idx": {
+          "name": "ParodyHeadline_isUsed_generatedAt_idx",
+          "columns": [
+            {
+              "expression": "isUsed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ParodyHeadline_generatedAt_idx": {
+          "name": "ParodyHeadline_generatedAt_idx",
+          "columns": [
+            {
+              "expression": "generatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ParodyHeadline_originalHeadlineId_unique": {
+          "name": "ParodyHeadline_originalHeadlineId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "originalHeadlineId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RealtimeOutbox": {
+      "name": "RealtimeOutbox",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'v1'"
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "RealtimeOutboxStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "RealtimeOutbox_status_createdAt_idx": {
+          "name": "RealtimeOutbox_status_createdAt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RealtimeOutbox_channel_status_idx": {
+          "name": "RealtimeOutbox_channel_status_idx",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RSSFeedSource": {
+      "name": "RSSFeedSource",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedUrl": {
+          "name": "feedUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "lastFetched": {
+          "name": "lastFetched",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetchErrors": {
+          "name": "fetchErrors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "RSSFeedSource_isActive_lastFetched_idx": {
+          "name": "RSSFeedSource_isActive_lastFetched_idx",
+          "columns": [
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lastFetched",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RSSFeedSource_category_idx": {
+          "name": "RSSFeedSource_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.RSSHeadline": {
+      "name": "RSSHeadline",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "sourceId": {
+          "name": "sourceId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "publishedAt": {
+          "name": "publishedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rawData": {
+          "name": "rawData",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetchedAt": {
+          "name": "fetchedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "RSSHeadline_sourceId_publishedAt_idx": {
+          "name": "RSSHeadline_sourceId_publishedAt_idx",
+          "columns": [
+            {
+              "expression": "sourceId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "publishedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "RSSHeadline_publishedAt_idx": {
+          "name": "RSSHeadline_publishedAt_idx",
+          "columns": [
+            {
+              "expression": "publishedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SystemSettings": {
+      "name": "SystemSettings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'system'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TickTokenStats": {
+      "name": "TickTokenStats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tickId": {
+          "name": "tickId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tickStartedAt": {
+          "name": "tickStartedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tickCompletedAt": {
+          "name": "tickCompletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tickDurationMs": {
+          "name": "tickDurationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalCalls": {
+          "name": "totalCalls",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalInputTokens": {
+          "name": "totalInputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalOutputTokens": {
+          "name": "totalOutputTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalTokens": {
+          "name": "totalTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byPromptType": {
+          "name": "byPromptType",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "byModel": {
+          "name": "byModel",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "TickTokenStats_tickStartedAt_idx": {
+          "name": "TickTokenStats_tickStartedAt_idx",
+          "columns": [
+            {
+              "expression": "tickStartedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TickTokenStats_tickId_idx": {
+          "name": "TickTokenStats_tickId_idx",
+          "columns": [
+            {
+              "expression": "tickId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TickTokenStats_createdAt_idx": {
+          "name": "TickTokenStats_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WidgetCache": {
+      "name": "WidgetCache",
+      "schema": "",
+      "columns": {
+        "widget": {
+          "name": "widget",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "WidgetCache_widget_updatedAt_idx": {
+          "name": "WidgetCache_widget_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "widget",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorldEvent": {
+      "name": "WorldEvent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actors": {
+          "name": "actors",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "relatedQuestion": {
+          "name": "relatedQuestion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pointsToward": {
+          "name": "pointsToward",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "gameId": {
+          "name": "gameId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dayNumber": {
+          "name": "dayNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "WorldEvent_gameId_dayNumber_idx": {
+          "name": "WorldEvent_gameId_dayNumber_idx",
+          "columns": [
+            {
+              "expression": "gameId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dayNumber",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorldEvent_relatedQuestion_idx": {
+          "name": "WorldEvent_relatedQuestion_idx",
+          "columns": [
+            {
+              "expression": "relatedQuestion",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorldEvent_timestamp_idx": {
+          "name": "WorldEvent_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WorldFact": {
+      "name": "WorldFact",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastUpdated": {
+          "name": "lastUpdated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "WorldFact_category_isActive_idx": {
+          "name": "WorldFact_category_isActive_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorldFact_priority_idx": {
+          "name": "WorldFact_priority_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorldFact_lastUpdated_idx": {
+          "name": "WorldFact_lastUpdated_idx",
+          "columns": [
+            {
+              "expression": "lastUpdated",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "WorldFact_source_createdAt_idx": {
+          "name": "WorldFact_source_createdAt_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"createdAt\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ArcState": {
+      "name": "ArcState",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "questionId": {
+          "name": "questionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentState": {
+          "name": "currentState",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stateEnteredAt": {
+          "name": "stateEnteredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventsGenerated": {
+          "name": "eventsGenerated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastEventAt": {
+          "name": "lastEventAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pendingTransitions": {
+          "name": "pendingTransitions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ArcState_currentState_idx": {
+          "name": "ArcState_currentState_idx",
+          "columns": [
+            {
+              "expression": "currentState",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ArcState_questionId_Question_id_fk": {
+          "name": "ArcState_questionId_Question_id_fk",
+          "tableFrom": "ArcState",
+          "tableTo": "Question",
+          "columnsFrom": [
+            "questionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ArcState_questionId_unique": {
+          "name": "ArcState_questionId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "questionId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.QuestionArcPlan": {
+      "name": "QuestionArcPlan",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "questionId": {
+          "name": "questionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uncertaintyPeakDay": {
+          "name": "uncertaintyPeakDay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "clarityOnsetDay": {
+          "name": "clarityOnsetDay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verificationDay": {
+          "name": "verificationDay",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "insiderActorIds": {
+          "name": "insiderActorIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "deceiverActorIds": {
+          "name": "deceiverActorIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "phaseRatios": {
+          "name": "phaseRatios",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventSchedule": {
+          "name": "eventSchedule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "QuestionArcPlan_questionId_idx": {
+          "name": "QuestionArcPlan_questionId_idx",
+          "columns": [
+            {
+              "expression": "questionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "QuestionArcPlan_questionId_Question_id_fk": {
+          "name": "QuestionArcPlan_questionId_Question_id_fk",
+          "tableFrom": "QuestionArcPlan",
+          "tableTo": "Question",
+          "columnsFrom": [
+            "questionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.SubMarketSpawnLog": {
+      "name": "SubMarketSpawnLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parentMarketId": {
+          "name": "parentMarketId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sourceEventId": {
+          "name": "sourceEventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spawnedMarketId": {
+          "name": "spawnedMarketId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wasSpawned": {
+          "name": "wasSpawned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skipReason": {
+          "name": "skipReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "questionTemplate": {
+          "name": "questionTemplate",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generatedQuestion": {
+          "name": "generatedQuestion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "childTimeframe": {
+          "name": "childTimeframe",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "SubMarketSpawnLog_parentMarketId_idx": {
+          "name": "SubMarketSpawnLog_parentMarketId_idx",
+          "columns": [
+            {
+              "expression": "parentMarketId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SubMarketSpawnLog_spawnedMarketId_idx": {
+          "name": "SubMarketSpawnLog_spawnedMarketId_idx",
+          "columns": [
+            {
+              "expression": "spawnedMarketId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SubMarketSpawnLog_eventType_idx": {
+          "name": "SubMarketSpawnLog_eventType_idx",
+          "columns": [
+            {
+              "expression": "eventType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "SubMarketSpawnLog_createdAt_idx": {
+          "name": "SubMarketSpawnLog_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "SubMarketSpawnLog_parentMarketId_TimeframedMarket_id_fk": {
+          "name": "SubMarketSpawnLog_parentMarketId_TimeframedMarket_id_fk",
+          "tableFrom": "SubMarketSpawnLog",
+          "tableTo": "TimeframedMarket",
+          "columnsFrom": [
+            "parentMarketId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "SubMarketSpawnLog_spawnedMarketId_TimeframedMarket_id_fk": {
+          "name": "SubMarketSpawnLog_spawnedMarketId_TimeframedMarket_id_fk",
+          "tableFrom": "SubMarketSpawnLog",
+          "tableTo": "TimeframedMarket",
+          "columnsFrom": [
+            "spawnedMarketId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TimeframedMarket": {
+      "name": "TimeframedMarket",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "questionId": {
+          "name": "questionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timeframe": {
+          "name": "timeframe",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'general'"
+        },
+        "granularTimeframe": {
+          "name": "granularTimeframe",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parentMarketId": {
+          "name": "parentMarketId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rootMarketId": {
+          "name": "rootMarketId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arcState": {
+          "name": "arcState",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'setup'"
+        },
+        "arcStateEnteredAt": {
+          "name": "arcStateEnteredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isResolved": {
+          "name": "isResolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "triggerData": {
+          "name": "triggerData",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "affiliatedOrgIds": {
+          "name": "affiliatedOrgIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "affiliatedActorIds": {
+          "name": "affiliatedActorIds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "childMarketCount": {
+          "name": "childMarketCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "eventsGenerated": {
+          "name": "eventsGenerated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastEventAt": {
+          "name": "lastEventAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "TimeframedMarket_questionId_idx": {
+          "name": "TimeframedMarket_questionId_idx",
+          "columns": [
+            {
+              "expression": "questionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimeframedMarket_parentMarketId_idx": {
+          "name": "TimeframedMarket_parentMarketId_idx",
+          "columns": [
+            {
+              "expression": "parentMarketId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimeframedMarket_rootMarketId_idx": {
+          "name": "TimeframedMarket_rootMarketId_idx",
+          "columns": [
+            {
+              "expression": "rootMarketId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimeframedMarket_timeframe_idx": {
+          "name": "TimeframedMarket_timeframe_idx",
+          "columns": [
+            {
+              "expression": "timeframe",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimeframedMarket_category_idx": {
+          "name": "TimeframedMarket_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimeframedMarket_granularTimeframe_idx": {
+          "name": "TimeframedMarket_granularTimeframe_idx",
+          "columns": [
+            {
+              "expression": "granularTimeframe",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimeframedMarket_isActive_idx": {
+          "name": "TimeframedMarket_isActive_idx",
+          "columns": [
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimeframedMarket_endTime_idx": {
+          "name": "TimeframedMarket_endTime_idx",
+          "columns": [
+            {
+              "expression": "endTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TimeframedMarket_startTime_endTime_idx": {
+          "name": "TimeframedMarket_startTime_endTime_idx",
+          "columns": [
+            {
+              "expression": "startTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "TimeframedMarket_questionId_Question_id_fk": {
+          "name": "TimeframedMarket_questionId_Question_id_fk",
+          "tableFrom": "TimeframedMarket",
+          "tableTo": "Question",
+          "columnsFrom": [
+            "questionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "TimeframedMarket_parentMarketId_TimeframedMarket_id_fk": {
+          "name": "TimeframedMarket_parentMarketId_TimeframedMarket_id_fk",
+          "tableFrom": "TimeframedMarket",
+          "tableTo": "TimeframedMarket",
+          "columnsFrom": [
+            "parentMarketId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "TimeframedMarket_rootMarketId_TimeframedMarket_id_fk": {
+          "name": "TimeframedMarket_rootMarketId_TimeframedMarket_id_fk",
+          "tableFrom": "TimeframedMarket",
+          "tableTo": "TimeframedMarket",
+          "columnsFrom": [
+            "rootMarketId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.NftClaim": {
+      "name": "NftClaim",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenId": {
+          "name": "tokenId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimerUserId": {
+          "name": "claimerUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimerAddress": {
+          "name": "claimerAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimedAt": {
+          "name": "claimedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "txHash": {
+          "name": "txHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshotRank": {
+          "name": "snapshotRank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "snapshotPoints": {
+          "name": "snapshotPoints",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "NftClaim_claimerUserId_idx": {
+          "name": "NftClaim_claimerUserId_idx",
+          "columns": [
+            {
+              "expression": "claimerUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "NftClaim_claimerAddress_idx": {
+          "name": "NftClaim_claimerAddress_idx",
+          "columns": [
+            {
+              "expression": "claimerAddress",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "NftClaim_tokenId_key": {
+          "name": "NftClaim_tokenId_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.NftCollection": {
+      "name": "NftCollection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenId": {
+          "name": "tokenId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnailUrl": {
+          "name": "thumbnailUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imageCid": {
+          "name": "imageCid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storyTitle": {
+          "name": "storyTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storyContent": {
+          "name": "storyContent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadataUri": {
+          "name": "metadataUri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contractAddress": {
+          "name": "contractAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chainId": {
+          "name": "chainId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "NftCollection_tokenId_idx": {
+          "name": "NftCollection_tokenId_idx",
+          "columns": [
+            {
+              "expression": "tokenId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "NftCollection_contractAddress_idx": {
+          "name": "NftCollection_contractAddress_idx",
+          "columns": [
+            {
+              "expression": "contractAddress",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "NftCollection_tokenId_unique": {
+          "name": "NftCollection_tokenId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.NftOwnership": {
+      "name": "NftOwnership",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tokenId": {
+          "name": "tokenId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ownerAddress": {
+          "name": "ownerAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acquiredAt": {
+          "name": "acquiredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "txHash": {
+          "name": "txHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blockNumber": {
+          "name": "blockNumber",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "NftOwnership_ownerAddress_idx": {
+          "name": "NftOwnership_ownerAddress_idx",
+          "columns": [
+            {
+              "expression": "ownerAddress",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "NftOwnership_userId_idx": {
+          "name": "NftOwnership_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "NftOwnership_updatedAt_idx": {
+          "name": "NftOwnership_updatedAt_idx",
+          "columns": [
+            {
+              "expression": "updatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "NftOwnership_tokenId_key": {
+          "name": "NftOwnership_tokenId_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tokenId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.NftSnapshot": {
+      "name": "NftSnapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "walletAddress": {
+          "name": "walletAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "snapshotTakenAt": {
+          "name": "snapshotTakenAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hasMinted": {
+          "name": "hasMinted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mintedTokenId": {
+          "name": "mintedTokenId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mintedAt": {
+          "name": "mintedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mintTxHash": {
+          "name": "mintTxHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "NftSnapshot_walletAddress_idx": {
+          "name": "NftSnapshot_walletAddress_idx",
+          "columns": [
+            {
+              "expression": "walletAddress",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "NftSnapshot_hasMinted_idx": {
+          "name": "NftSnapshot_hasMinted_idx",
+          "columns": [
+            {
+              "expression": "hasMinted",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "NftSnapshot_rank_idx": {
+          "name": "NftSnapshot_rank_idx",
+          "columns": [
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "NftSnapshot_userId_key": {
+          "name": "NftSnapshot_userId_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OrganizationState": {
+      "name": "OrganizationState",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "currentPrice": {
+          "name": "currentPrice",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "basePrice": {
+          "name": "basePrice",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "activeModifiers": {
+          "name": "activeModifiers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "OrganizationState_currentPrice_idx": {
+          "name": "OrganizationState_currentPrice_idx",
+          "columns": [
+            {
+              "expression": "currentPrice",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OrganizationState_sentiment_idx": {
+          "name": "OrganizationState_sentiment_idx",
+          "columns": [
+            {
+              "expression": "sentiment",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "sentiment_range": {
+          "name": "sentiment_range",
+          "value": "\"OrganizationState\".\"sentiment\" >= -100 AND \"OrganizationState\".\"sentiment\" <= 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.PoolDeposit": {
+      "name": "PoolDeposit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "poolId": {
+          "name": "poolId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shares": {
+          "name": "shares",
+          "type": "numeric(18, 6)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentValue": {
+          "name": "currentValue",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unrealizedPnL": {
+          "name": "unrealizedPnL",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "depositedAt": {
+          "name": "depositedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "withdrawnAt": {
+          "name": "withdrawnAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "withdrawnAmount": {
+          "name": "withdrawnAmount",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "PoolDeposit_poolId_userId_idx": {
+          "name": "PoolDeposit_poolId_userId_idx",
+          "columns": [
+            {
+              "expression": "poolId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PoolDeposit_poolId_withdrawnAt_idx": {
+          "name": "PoolDeposit_poolId_withdrawnAt_idx",
+          "columns": [
+            {
+              "expression": "poolId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "withdrawnAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PoolDeposit_userId_depositedAt_idx": {
+          "name": "PoolDeposit_userId_depositedAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "depositedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PoolPosition": {
+      "name": "PoolPosition",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "poolId": {
+          "name": "poolId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "marketType": {
+          "name": "marketType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ticker": {
+          "name": "ticker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marketId": {
+          "name": "marketId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "side": {
+          "name": "side",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entryPrice": {
+          "name": "entryPrice",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPrice": {
+          "name": "currentPrice",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shares": {
+          "name": "shares",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leverage": {
+          "name": "leverage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "liquidationPrice": {
+          "name": "liquidationPrice",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "unrealizedPnL": {
+          "name": "unrealizedPnL",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "openedAt": {
+          "name": "openedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "realizedPnL": {
+          "name": "realizedPnL",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "PoolPosition_marketType_marketId_idx": {
+          "name": "PoolPosition_marketType_marketId_idx",
+          "columns": [
+            {
+              "expression": "marketType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "marketId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PoolPosition_marketType_ticker_idx": {
+          "name": "PoolPosition_marketType_ticker_idx",
+          "columns": [
+            {
+              "expression": "marketType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "ticker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PoolPosition_poolId_closedAt_idx": {
+          "name": "PoolPosition_poolId_closedAt_idx",
+          "columns": [
+            {
+              "expression": "poolId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "closedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Pool": {
+      "name": "Pool",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "npcActorId": {
+          "name": "npcActorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalValue": {
+          "name": "totalValue",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "totalDeposits": {
+          "name": "totalDeposits",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "availableBalance": {
+          "name": "availableBalance",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "lifetimePnL": {
+          "name": "lifetimePnL",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "performanceFeeRate": {
+          "name": "performanceFeeRate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.05
+        },
+        "totalFeesCollected": {
+          "name": "totalFeesCollected",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "openedAt": {
+          "name": "openedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "closedAt": {
+          "name": "closedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentPrice": {
+          "name": "currentPrice",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "priceChange24h": {
+          "name": "priceChange24h",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+        "tvl": {
+          "name": "tvl",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume24h": {
+          "name": "volume24h",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Pool_isActive_idx": {
+          "name": "Pool_isActive_idx",
+          "columns": [
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Pool_npcActorId_idx": {
+          "name": "Pool_npcActorId_idx",
+          "columns": [
+            {
+              "expression": "npcActorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Pool_status_idx": {
+          "name": "Pool_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Pool_totalValue_idx": {
+          "name": "Pool_totalValue_idx",
+          "columns": [
+            {
+              "expression": "totalValue",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Pool_volume24h_idx": {
+          "name": "Pool_volume24h_idx",
+          "columns": [
+            {
+              "expression": "volume24h",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Comment": {
+      "name": "Comment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postId": {
+          "name": "postId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parentCommentId": {
+          "name": "parentCommentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Comment_authorId_idx": {
+          "name": "Comment_authorId_idx",
+          "columns": [
+            {
+              "expression": "authorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Comment_deletedAt_idx": {
+          "name": "Comment_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Comment_parentCommentId_idx": {
+          "name": "Comment_parentCommentId_idx",
+          "columns": [
+            {
+              "expression": "parentCommentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Comment_postId_createdAt_idx": {
+          "name": "Comment_postId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "postId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Comment_postId_deletedAt_idx": {
+          "name": "Comment_postId_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "postId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PostTag": {
+      "name": "PostTag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "postId": {
+          "name": "postId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "PostTag_postId_idx": {
+          "name": "PostTag_postId_idx",
+          "columns": [
+            {
+              "expression": "postId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PostTag_tagId_createdAt_idx": {
+          "name": "PostTag_tagId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "tagId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PostTag_tagId_idx": {
+          "name": "PostTag_tagId_idx",
+          "columns": [
+            {
+              "expression": "tagId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "PostTag_postId_tagId_key": {
+          "name": "PostTag_postId_tagId_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "postId",
+            "tagId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Post": {
+      "name": "Post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gameId": {
+          "name": "gameId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dayNumber": {
+          "name": "dayNumber",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "articleTitle": {
+          "name": "articleTitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "biasScore": {
+          "name": "biasScore",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "byline": {
+          "name": "byline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fullContent": {
+          "name": "fullContent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slant": {
+          "name": "slant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "imageUrl": {
+          "name": "imageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'post'"
+        },
+        "deletedAt": {
+          "name": "deletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commentOnPostId": {
+          "name": "commentOnPostId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parentCommentId": {
+          "name": "parentCommentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "originalPostId": {
+          "name": "originalPostId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relatedQuestion": {
+          "name": "relatedQuestion",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Post_authorId_timestamp_idx": {
+          "name": "Post_authorId_timestamp_idx",
+          "columns": [
+            {
+              "expression": "authorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Post_authorId_type_timestamp_idx": {
+          "name": "Post_authorId_type_timestamp_idx",
+          "columns": [
+            {
+              "expression": "authorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Post_commentOnPostId_idx": {
+          "name": "Post_commentOnPostId_idx",
+          "columns": [
+            {
+              "expression": "commentOnPostId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Post_deletedAt_idx": {
+          "name": "Post_deletedAt_idx",
+          "columns": [
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Post_gameId_dayNumber_idx": {
+          "name": "Post_gameId_dayNumber_idx",
+          "columns": [
+            {
+              "expression": "gameId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dayNumber",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Post_parentCommentId_idx": {
+          "name": "Post_parentCommentId_idx",
+          "columns": [
+            {
+              "expression": "parentCommentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Post_originalPostId_idx": {
+          "name": "Post_originalPostId_idx",
+          "columns": [
+            {
+              "expression": "originalPostId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Post_timestamp_idx": {
+          "name": "Post_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Post_type_deletedAt_timestamp_idx": {
+          "name": "Post_type_deletedAt_timestamp_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deletedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Post_type_timestamp_idx": {
+          "name": "Post_type_timestamp_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Post_relatedQuestion_idx": {
+          "name": "Post_relatedQuestion_idx",
+          "columns": [
+            {
+              "expression": "relatedQuestion",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Reaction": {
+      "name": "Reaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "postId": {
+          "name": "postId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "commentId": {
+          "name": "commentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'like'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Reaction_commentId_idx": {
+          "name": "Reaction_commentId_idx",
+          "columns": [
+            {
+              "expression": "commentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Reaction_postId_idx": {
+          "name": "Reaction_postId_idx",
+          "columns": [
+            {
+              "expression": "postId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Reaction_userId_idx": {
+          "name": "Reaction_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Reaction_commentId_userId_type_key": {
+          "name": "Reaction_commentId_userId_type_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "commentId",
+            "userId",
+            "type"
+          ]
+        },
+        "Reaction_postId_userId_type_key": {
+          "name": "Reaction_postId_userId_type_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "postId",
+            "userId",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ShareAction": {
+      "name": "ShareAction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentType": {
+          "name": "contentType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contentId": {
+          "name": "contentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pointsAwarded": {
+          "name": "pointsAwarded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "verificationDetails": {
+          "name": "verificationDetails",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verifiedAt": {
+          "name": "verifiedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "ShareAction_contentType_idx": {
+          "name": "ShareAction_contentType_idx",
+          "columns": [
+            {
+              "expression": "contentType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ShareAction_platform_idx": {
+          "name": "ShareAction_platform_idx",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ShareAction_userId_createdAt_idx": {
+          "name": "ShareAction_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ShareAction_verified_idx": {
+          "name": "ShareAction_verified_idx",
+          "columns": [
+            {
+              "expression": "verified",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Share": {
+      "name": "Share",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postId": {
+          "name": "postId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Share_createdAt_idx": {
+          "name": "Share_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Share_postId_idx": {
+          "name": "Share_postId_idx",
+          "columns": [
+            {
+              "expression": "postId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Share_userId_idx": {
+          "name": "Share_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Share_userId_postId_key": {
+          "name": "Share_userId_postId_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId",
+            "postId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Tag": {
+      "name": "Tag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Tag_name_idx": {
+          "name": "Tag_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Tag_name_unique": {
+          "name": "Tag_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TrendingTag": {
+      "name": "TrendingTag",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postCount": {
+          "name": "postCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calculatedAt": {
+          "name": "calculatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "windowStart": {
+          "name": "windowStart",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "windowEnd": {
+          "name": "windowEnd",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relatedContext": {
+          "name": "relatedContext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "TrendingTag_calculatedAt_idx": {
+          "name": "TrendingTag_calculatedAt_idx",
+          "columns": [
+            {
+              "expression": "calculatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TrendingTag_rank_calculatedAt_idx": {
+          "name": "TrendingTag_rank_calculatedAt_idx",
+          "columns": [
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "calculatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TrendingTag_tagId_calculatedAt_idx": {
+          "name": "TrendingTag_tagId_calculatedAt_idx",
+          "columns": [
+            {
+              "expression": "tagId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "calculatedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TradeAttempt": {
+      "name": "TradeAttempt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tradeType": {
+          "name": "tradeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "marketId": {
+          "name": "marketId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ticker": {
+          "name": "ticker",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "failureReason": {
+          "name": "failureReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failureCode": {
+          "name": "failureCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requestId": {
+          "name": "requestId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "TradeAttempt_userId_createdAt_idx": {
+          "name": "TradeAttempt_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TradeAttempt_outcome_createdAt_idx": {
+          "name": "TradeAttempt_outcome_createdAt_idx",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TradeAttempt_createdAt_idx": {
+          "name": "TradeAttempt_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TradeAttempt_tradeType_outcome_createdAt_idx": {
+          "name": "TradeAttempt_tradeType_outcome_createdAt_idx",
+          "columns": [
+            {
+              "expression": "tradeType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserActivityLog": {
+      "name": "UserActivityLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activityType": {
+          "name": "activityType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activityDate": {
+          "name": "activityDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UserActivityLog_activityDate_idx": {
+          "name": "UserActivityLog_activityDate_idx",
+          "columns": [
+            {
+              "expression": "activityDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserActivityLog_userId_activityDate_idx": {
+          "name": "UserActivityLog_userId_activityDate_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "activityDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UserActivityLog_userId_activityDate_activityType_idx": {
+          "name": "UserActivityLog_userId_activityDate_activityType_idx",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId",
+            "activityDate",
+            "activityType"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserSession": {
+      "name": "UserSession",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sessionId": {
+          "name": "sessionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lastActiveAt": {
+          "name": "lastActiveAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endedAt": {
+          "name": "endedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ipHash": {
+          "name": "ipHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pageCount": {
+          "name": "pageCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "heartbeatCount": {
+          "name": "heartbeatCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UserSession_userId_startedAt_idx": {
+          "name": "UserSession_userId_startedAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserSession_userId_endedAt_idx": {
+          "name": "UserSession_userId_endedAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserSession_startedAt_idx": {
+          "name": "UserSession_startedAt_idx",
+          "columns": [
+            {
+              "expression": "startedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserSession_lastActiveAt_idx": {
+          "name": "UserSession_lastActiveAt_idx",
+          "columns": [
+            {
+              "expression": "lastActiveAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserSession_sessionId_idx": {
+          "name": "UserSession_sessionId_idx",
+          "columns": [
+            {
+              "expression": "sessionId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.BalanceTransaction": {
+      "name": "BalanceTransaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balanceBefore": {
+          "name": "balanceBefore",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balanceAfter": {
+          "name": "balanceAfter",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "relatedId": {
+          "name": "relatedId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "BalanceTransaction_type_idx": {
+          "name": "BalanceTransaction_type_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "BalanceTransaction_userId_createdAt_idx": {
+          "name": "BalanceTransaction_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "BalanceTransaction_type_createdAt_idx": {
+          "name": "BalanceTransaction_type_createdAt_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "BalanceTransaction_userId_type_idx": {
+          "name": "BalanceTransaction_userId_type_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Feedback": {
+      "name": "Feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "fromUserId": {
+          "name": "fromUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fromAgentId": {
+          "name": "fromAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toUserId": {
+          "name": "toUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "toAgentId": {
+          "name": "toAgentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gameId": {
+          "name": "gameId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tradeId": {
+          "name": "tradeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "positionId": {
+          "name": "positionId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "interactionType": {
+          "name": "interactionType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "onChainTxHash": {
+          "name": "onChainTxHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent0TokenId": {
+          "name": "agent0TokenId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Feedback_createdAt_idx": {
+          "name": "Feedback_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Feedback_fromUserId_idx": {
+          "name": "Feedback_fromUserId_idx",
+          "columns": [
+            {
+              "expression": "fromUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Feedback_gameId_idx": {
+          "name": "Feedback_gameId_idx",
+          "columns": [
+            {
+              "expression": "gameId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Feedback_interactionType_idx": {
+          "name": "Feedback_interactionType_idx",
+          "columns": [
+            {
+              "expression": "interactionType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Feedback_score_idx": {
+          "name": "Feedback_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Feedback_toAgentId_idx": {
+          "name": "Feedback_toAgentId_idx",
+          "columns": [
+            {
+              "expression": "toAgentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Feedback_toUserId_idx": {
+          "name": "Feedback_toUserId_idx",
+          "columns": [
+            {
+              "expression": "toUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Feedback_toUserId_interactionType_idx": {
+          "name": "Feedback_toUserId_interactionType_idx",
+          "columns": [
+            {
+              "expression": "toUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "interactionType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ModerationEscrow": {
+      "name": "ModerationEscrow",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "recipientId": {
+          "name": "recipientId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adminId": {
+          "name": "adminId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amountUSD": {
+          "name": "amountUSD",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amountWei": {
+          "name": "amountWei",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paymentRequestId": {
+          "name": "paymentRequestId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paymentTxHash": {
+          "name": "paymentTxHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refundTxHash": {
+          "name": "refundTxHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refundedBy": {
+          "name": "refundedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refundedAt": {
+          "name": "refundedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "ModerationEscrow_recipientId_createdAt_idx": {
+          "name": "ModerationEscrow_recipientId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "recipientId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ModerationEscrow_adminId_idx": {
+          "name": "ModerationEscrow_adminId_idx",
+          "columns": [
+            {
+              "expression": "adminId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ModerationEscrow_status_idx": {
+          "name": "ModerationEscrow_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ModerationEscrow_paymentRequestId_idx": {
+          "name": "ModerationEscrow_paymentRequestId_idx",
+          "columns": [
+            {
+              "expression": "paymentRequestId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ModerationEscrow_paymentTxHash_idx": {
+          "name": "ModerationEscrow_paymentTxHash_idx",
+          "columns": [
+            {
+              "expression": "paymentTxHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "ModerationEscrow_createdAt_idx": {
+          "name": "ModerationEscrow_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ModerationEscrow_paymentRequestId_unique": {
+          "name": "ModerationEscrow_paymentRequestId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "paymentRequestId"
+          ]
+        },
+        "ModerationEscrow_paymentTxHash_unique": {
+          "name": "ModerationEscrow_paymentTxHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "paymentTxHash"
+          ]
+        },
+        "ModerationEscrow_refundTxHash_unique": {
+          "name": "ModerationEscrow_refundTxHash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "refundTxHash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.PointsTransaction": {
+      "name": "PointsTransaction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pointsBefore": {
+          "name": "pointsBefore",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pointsAfter": {
+          "name": "pointsAfter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "paymentAmount": {
+          "name": "paymentAmount",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paymentRequestId": {
+          "name": "paymentRequestId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paymentTxHash": {
+          "name": "paymentTxHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paymentVerified": {
+          "name": "paymentVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "paymentProvider": {
+          "name": "paymentProvider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "PointsTransaction_createdAt_idx": {
+          "name": "PointsTransaction_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PointsTransaction_paymentRequestId_idx": {
+          "name": "PointsTransaction_paymentRequestId_idx",
+          "columns": [
+            {
+              "expression": "paymentRequestId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PointsTransaction_reason_idx": {
+          "name": "PointsTransaction_reason_idx",
+          "columns": [
+            {
+              "expression": "reason",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PointsTransaction_userId_createdAt_idx": {
+          "name": "PointsTransaction_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "PointsTransaction_paymentProvider_idx": {
+          "name": "PointsTransaction_paymentProvider_idx",
+          "columns": [
+            {
+              "expression": "paymentProvider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "PointsTransaction_paymentRequestId_unique": {
+          "name": "PointsTransaction_paymentRequestId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "paymentRequestId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Report": {
+      "name": "Report",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "reporterId": {
+          "name": "reporterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reportedUserId": {
+          "name": "reportedUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reportedPostId": {
+          "name": "reportedPostId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reportedCommentId": {
+          "name": "reportedCommentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reportType": {
+          "name": "reportType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolvedBy": {
+          "name": "resolvedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolvedAt": {
+          "name": "resolvedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "Report_reporterId_idx": {
+          "name": "Report_reporterId_idx",
+          "columns": [
+            {
+              "expression": "reporterId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Report_reportedUserId_idx": {
+          "name": "Report_reportedUserId_idx",
+          "columns": [
+            {
+              "expression": "reportedUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Report_reportedPostId_idx": {
+          "name": "Report_reportedPostId_idx",
+          "columns": [
+            {
+              "expression": "reportedPostId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Report_reportedCommentId_idx": {
+          "name": "Report_reportedCommentId_idx",
+          "columns": [
+            {
+              "expression": "reportedCommentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Report_status_idx": {
+          "name": "Report_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Report_priority_status_idx": {
+          "name": "Report_priority_status_idx",
+          "columns": [
+            {
+              "expression": "priority",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Report_category_idx": {
+          "name": "Report_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Report_createdAt_idx": {
+          "name": "Report_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Report_reportedUserId_status_idx": {
+          "name": "Report_reportedUserId_status_idx",
+          "columns": [
+            {
+              "expression": "reportedUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Report_reportedPostId_status_idx": {
+          "name": "Report_reportedPostId_status_idx",
+          "columns": [
+            {
+              "expression": "reportedPostId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Report_reportedCommentId_status_idx": {
+          "name": "Report_reportedCommentId_status_idx",
+          "columns": [
+            {
+              "expression": "reportedCommentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TradingFee": {
+      "name": "TradingFee",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tradeType": {
+          "name": "tradeType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tradeId": {
+          "name": "tradeId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "marketId": {
+          "name": "marketId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feeAmount": {
+          "name": "feeAmount",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platformFee": {
+          "name": "platformFee",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referrerFee": {
+          "name": "referrerFee",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referrerId": {
+          "name": "referrerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "TradingFee_createdAt_idx": {
+          "name": "TradingFee_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TradingFee_referrerId_createdAt_idx": {
+          "name": "TradingFee_referrerId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "referrerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TradingFee_tradeType_idx": {
+          "name": "TradingFee_tradeType_idx",
+          "columns": [
+            {
+              "expression": "tradeType",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "TradingFee_userId_createdAt_idx": {
+          "name": "TradingFee_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.benchmark_results": {
+      "name": "benchmark_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "modelId": {
+          "name": "modelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmarkId": {
+          "name": "benchmarkId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmarkPath": {
+          "name": "benchmarkPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runAt": {
+          "name": "runAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "totalPnl": {
+          "name": "totalPnl",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "predictionAccuracy": {
+          "name": "predictionAccuracy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "perpWinRate": {
+          "name": "perpWinRate",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "optimalityScore": {
+          "name": "optimalityScore",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "detailedMetrics": {
+          "name": "detailedMetrics",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "baselinePnlDelta": {
+          "name": "baselinePnlDelta",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "baselineAccuracyDelta": {
+          "name": "baselineAccuracyDelta",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "improved": {
+          "name": "improved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "benchmark_results_modelId_idx": {
+          "name": "benchmark_results_modelId_idx",
+          "columns": [
+            {
+              "expression": "modelId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "benchmark_results_benchmarkId_idx": {
+          "name": "benchmark_results_benchmarkId_idx",
+          "columns": [
+            {
+              "expression": "benchmarkId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "benchmark_results_runAt_idx": {
+          "name": "benchmark_results_runAt_idx",
+          "columns": [
+            {
+              "expression": "runAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "benchmark_results_optimalityScore_idx": {
+          "name": "benchmark_results_optimalityScore_idx",
+          "columns": [
+            {
+              "expression": "optimalityScore",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.llm_call_logs": {
+      "name": "llm_call_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trajectoryId": {
+          "name": "trajectoryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stepId": {
+          "name": "stepId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "callId": {
+          "name": "callId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latencyMs": {
+          "name": "latencyMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actionType": {
+          "name": "actionType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "systemPrompt": {
+          "name": "systemPrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userPrompt": {
+          "name": "userPrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messagesJson": {
+          "name": "messagesJson",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature": {
+          "name": "temperature",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "maxTokens": {
+          "name": "maxTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topP": {
+          "name": "topP",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "promptTokens": {
+          "name": "promptTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completionTokens": {
+          "name": "completionTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalTokens": {
+          "name": "totalTokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "llm_call_logs_callId_idx": {
+          "name": "llm_call_logs_callId_idx",
+          "columns": [
+            {
+              "expression": "callId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "llm_call_logs_timestamp_idx": {
+          "name": "llm_call_logs_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "llm_call_logs_trajectoryId_idx": {
+          "name": "llm_call_logs_trajectoryId_idx",
+          "columns": [
+            {
+              "expression": "trajectoryId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "llm_call_logs_createdAt_idx": {
+          "name": "llm_call_logs_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "llm_call_logs_callId_unique": {
+          "name": "llm_call_logs_callId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "callId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.market_outcomes": {
+      "name": "market_outcomes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "windowId": {
+          "name": "windowId",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stockTicker": {
+          "name": "stockTicker",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startPrice": {
+          "name": "startPrice",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endPrice": {
+          "name": "endPrice",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changePercent": {
+          "name": "changePercent",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sentiment": {
+          "name": "sentiment",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "newsEvents": {
+          "name": "newsEvents",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "predictionMarketId": {
+          "name": "predictionMarketId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalProbability": {
+          "name": "finalProbability",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "volume": {
+          "name": "volume",
+          "type": "numeric(15, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "market_outcomes_windowId_idx": {
+          "name": "market_outcomes_windowId_idx",
+          "columns": [
+            {
+              "expression": "windowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "market_outcomes_windowId_stockTicker_idx": {
+          "name": "market_outcomes_windowId_stockTicker_idx",
+          "columns": [
+            {
+              "expression": "windowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "stockTicker",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reaction_trajectories": {
+      "name": "reaction_trajectories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "eventId": {
+          "name": "eventId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventType": {
+          "name": "eventType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "eventSeverity": {
+          "name": "eventSeverity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "npcId": {
+          "name": "npcId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "npcRole": {
+          "name": "npcRole",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "arcPhase": {
+          "name": "arcPhase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orgContextJson": {
+          "name": "orgContextJson",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actionType": {
+          "name": "actionType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actionAngle": {
+          "name": "actionAngle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actionSentiment": {
+          "name": "actionSentiment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postId": {
+          "name": "postId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tradeDetailsJson": {
+          "name": "tradeDetailsJson",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "outcomeRecordedAt": {
+          "name": "outcomeRecordedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcomeLikes": {
+          "name": "outcomeLikes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcomeComments": {
+          "name": "outcomeComments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcomeReposts": {
+          "name": "outcomeReposts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcomePriceMovement": {
+          "name": "outcomePriceMovement",
+          "type": "numeric(10, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcomeProfitLoss": {
+          "name": "outcomeProfitLoss",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcomeOtherNpcs": {
+          "name": "outcomeOtherNpcs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcomeHumans": {
+          "name": "outcomeHumans",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward": {
+          "name": "reward",
+          "type": "numeric(8, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "usedInTraining": {
+          "name": "usedInTraining",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {
+        "reaction_trajectories_eventId_idx": {
+          "name": "reaction_trajectories_eventId_idx",
+          "columns": [
+            {
+              "expression": "eventId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reaction_trajectories_npcId_idx": {
+          "name": "reaction_trajectories_npcId_idx",
+          "columns": [
+            {
+              "expression": "npcId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reaction_trajectories_createdAt_idx": {
+          "name": "reaction_trajectories_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reaction_trajectories_pendingOutcome_idx": {
+          "name": "reaction_trajectories_pendingOutcome_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "outcomeRecordedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reward_judgments": {
+      "name": "reward_judgments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trajectoryId": {
+          "name": "trajectoryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judgeModel": {
+          "name": "judgeModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judgeVersion": {
+          "name": "judgeVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overallScore": {
+          "name": "overallScore",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "componentScoresJson": {
+          "name": "componentScoresJson",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "normalizedScore": {
+          "name": "normalizedScore",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "groupId": {
+          "name": "groupId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "strengthsJson": {
+          "name": "strengthsJson",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weaknessesJson": {
+          "name": "weaknessesJson",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "criteriaJson": {
+          "name": "criteriaJson",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "judgedAt": {
+          "name": "judgedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "reward_judgments_overallScore_idx": {
+          "name": "reward_judgments_overallScore_idx",
+          "columns": [
+            {
+              "expression": "overallScore",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reward_judgments_groupId_rank_idx": {
+          "name": "reward_judgments_groupId_rank_idx",
+          "columns": [
+            {
+              "expression": "groupId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rank",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reward_judgments_trajectoryId_unique": {
+          "name": "reward_judgments_trajectoryId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trajectoryId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trained_models": {
+      "name": "trained_models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "modelId": {
+          "name": "modelId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "baseModel": {
+          "name": "baseModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trainingBatch": {
+          "name": "trainingBatch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'training'"
+        },
+        "deployedAt": {
+          "name": "deployedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archivedAt": {
+          "name": "archivedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storagePath": {
+          "name": "storagePath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "benchmarkScore": {
+          "name": "benchmarkScore",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accuracy": {
+          "name": "accuracy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avgReward": {
+          "name": "avgReward",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "evalMetrics": {
+          "name": "evalMetrics",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wandbRunId": {
+          "name": "wandbRunId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wandbArtifactId": {
+          "name": "wandbArtifactId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "huggingFaceRepo": {
+          "name": "huggingFaceRepo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agentsUsing": {
+          "name": "agentsUsing",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalInferences": {
+          "name": "totalInferences",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastBenchmarked": {
+          "name": "lastBenchmarked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmarkCount": {
+          "name": "benchmarkCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "trained_models_status_idx": {
+          "name": "trained_models_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trained_models_version_idx": {
+          "name": "trained_models_version_idx",
+          "columns": [
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trained_models_deployedAt_idx": {
+          "name": "trained_models_deployedAt_idx",
+          "columns": [
+            {
+              "expression": "deployedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trained_models_lastBenchmarked_idx": {
+          "name": "trained_models_lastBenchmarked_idx",
+          "columns": [
+            {
+              "expression": "lastBenchmarked",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trained_models_modelId_unique": {
+          "name": "trained_models_modelId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "modelId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.training_batches": {
+      "name": "training_batches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "batchId": {
+          "name": "batchId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scenarioId": {
+          "name": "scenarioId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "baseModel": {
+          "name": "baseModel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "modelVersion": {
+          "name": "modelVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trajectoryIds": {
+          "name": "trajectoryIds",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rankingsJson": {
+          "name": "rankingsJson",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewardsJson": {
+          "name": "rewardsJson",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trainingLoss": {
+          "name": "trainingLoss",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policyImprovement": {
+          "name": "policyImprovement",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "startedAt": {
+          "name": "startedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "training_batches_scenarioId_idx": {
+          "name": "training_batches_scenarioId_idx",
+          "columns": [
+            {
+              "expression": "scenarioId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "training_batches_status_createdAt_idx": {
+          "name": "training_batches_status_createdAt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "training_batches_batchId_unique": {
+          "name": "training_batches_batchId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "batchId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trajectories": {
+      "name": "trajectories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "trajectoryId": {
+          "name": "trajectoryId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agentId": {
+          "name": "agentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archetype": {
+          "name": "archetype",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "startTime": {
+          "name": "startTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endTime": {
+          "name": "endTime",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durationMs": {
+          "name": "durationMs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "windowId": {
+          "name": "windowId",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "windowHours": {
+          "name": "windowHours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "episodeId": {
+          "name": "episodeId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scenarioId": {
+          "name": "scenarioId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batchId": {
+          "name": "batchId",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stepsJson": {
+          "name": "stepsJson",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rewardComponentsJson": {
+          "name": "rewardComponentsJson",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metricsJson": {
+          "name": "metricsJson",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadataJson": {
+          "name": "metadataJson",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalReward": {
+          "name": "totalReward",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "episodeLength": {
+          "name": "episodeLength",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finalStatus": {
+          "name": "finalStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "finalBalance": {
+          "name": "finalBalance",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalPnL": {
+          "name": "finalPnL",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tradesExecuted": {
+          "name": "tradesExecuted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postsCreated": {
+          "name": "postsCreated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiJudgeReward": {
+          "name": "aiJudgeReward",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aiJudgeReasoning": {
+          "name": "aiJudgeReasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "judgedAt": {
+          "name": "judgedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isTrainingData": {
+          "name": "isTrainingData",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "isEvaluation": {
+          "name": "isEvaluation",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "usedInTraining": {
+          "name": "usedInTraining",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "trainedInBatch": {
+          "name": "trainedInBatch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "trajectories_agentId_startTime_idx": {
+          "name": "trajectories_agentId_startTime_idx",
+          "columns": [
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "startTime",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trajectories_aiJudgeReward_idx": {
+          "name": "trajectories_aiJudgeReward_idx",
+          "columns": [
+            {
+              "expression": "aiJudgeReward",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trajectories_isTrainingData_usedInTraining_idx": {
+          "name": "trajectories_isTrainingData_usedInTraining_idx",
+          "columns": [
+            {
+              "expression": "isTrainingData",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "usedInTraining",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trajectories_scenarioId_createdAt_idx": {
+          "name": "trajectories_scenarioId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "scenarioId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trajectories_trainedInBatch_idx": {
+          "name": "trajectories_trainedInBatch_idx",
+          "columns": [
+            {
+              "expression": "trainedInBatch",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trajectories_windowId_agentId_idx": {
+          "name": "trajectories_windowId_agentId_idx",
+          "columns": [
+            {
+              "expression": "windowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agentId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trajectories_windowId_idx": {
+          "name": "trajectories_windowId_idx",
+          "columns": [
+            {
+              "expression": "windowId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trajectories_archetype_idx": {
+          "name": "trajectories_archetype_idx",
+          "columns": [
+            {
+              "expression": "archetype",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "trajectories_trajectoryId_unique": {
+          "name": "trajectories_trajectoryId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "trajectoryId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserAgentConfig": {
+      "name": "UserAgentConfig",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "personality": {
+          "name": "personality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "system": {
+          "name": "system",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tradingStrategy": {
+          "name": "tradingStrategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "style": {
+          "name": "style",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "messageExamples": {
+          "name": "messageExamples",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personaPrompt": {
+          "name": "personaPrompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "goals": {
+          "name": "goals",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "directives": {
+          "name": "directives",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "constraints": {
+          "name": "constraints",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "planningHorizon": {
+          "name": "planningHorizon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'single'"
+        },
+        "riskTolerance": {
+          "name": "riskTolerance",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'medium'"
+        },
+        "maxActionsPerTick": {
+          "name": "maxActionsPerTick",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "modelTier": {
+          "name": "modelTier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'free'"
+        },
+        "autonomousPosting": {
+          "name": "autonomousPosting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "autonomousCommenting": {
+          "name": "autonomousCommenting",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "autonomousTrading": {
+          "name": "autonomousTrading",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "autonomousDMs": {
+          "name": "autonomousDMs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "autonomousGroupChats": {
+          "name": "autonomousGroupChats",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "a2aEnabled": {
+          "name": "a2aEnabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "errorMessage": {
+          "name": "errorMessage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastTickAt": {
+          "name": "lastTickAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastChatAt": {
+          "name": "lastChatAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "UserAgentConfig_userId_idx": {
+          "name": "UserAgentConfig_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserAgentConfig_status_idx": {
+          "name": "UserAgentConfig_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserAgentConfig_autonomousTrading_idx": {
+          "name": "UserAgentConfig_autonomousTrading_idx",
+          "columns": [
+            {
+              "expression": "autonomousTrading",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UserAgentConfig_userId_unique": {
+          "name": "UserAgentConfig_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Favorite": {
+      "name": "Favorite",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "targetUserId": {
+          "name": "targetUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Favorite_targetUserId_idx": {
+          "name": "Favorite_targetUserId_idx",
+          "columns": [
+            {
+              "expression": "targetUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Favorite_userId_idx": {
+          "name": "Favorite_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Favorite_userId_targetUserId_key": {
+          "name": "Favorite_userId_targetUserId_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId",
+            "targetUserId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.FollowStatus": {
+      "name": "FollowStatus",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "npcId": {
+          "name": "npcId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "followedAt": {
+          "name": "followedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "unfollowedAt": {
+          "name": "unfollowedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActive": {
+          "name": "isActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "followReason": {
+          "name": "followReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "FollowStatus_npcId_idx": {
+          "name": "FollowStatus_npcId_idx",
+          "columns": [
+            {
+              "expression": "npcId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "FollowStatus_userId_isActive_idx": {
+          "name": "FollowStatus_userId_isActive_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActive",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "FollowStatus_userId_npcId_key": {
+          "name": "FollowStatus_userId_npcId_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId",
+            "npcId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Follow": {
+      "name": "Follow",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "followerId": {
+          "name": "followerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "followingId": {
+          "name": "followingId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "Follow_followerId_idx": {
+          "name": "Follow_followerId_idx",
+          "columns": [
+            {
+              "expression": "followerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Follow_followingId_idx": {
+          "name": "Follow_followingId_idx",
+          "columns": [
+            {
+              "expression": "followingId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Follow_followerId_followingId_key": {
+          "name": "Follow_followerId_followingId_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "followerId",
+            "followingId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.GameOnboarding": {
+      "name": "GameOnboarding",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currentStep": {
+          "name": "currentStep",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'welcome'"
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"completedSteps\":[],\"currentStep\":\"welcome\",\"startedAt\":null,\"completedAt\":null,\"rewards\":[]}'::jsonb"
+        },
+        "isComplete": {
+          "name": "isComplete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "skippedAt": {
+          "name": "skippedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "GameOnboarding_isComplete_idx": {
+          "name": "GameOnboarding_isComplete_idx",
+          "columns": [
+            {
+              "expression": "isComplete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "GameOnboarding_currentStep_idx": {
+          "name": "GameOnboarding_currentStep_idx",
+          "columns": [
+            {
+              "expression": "currentStep",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "GameOnboarding_userId_User_id_fk": {
+          "name": "GameOnboarding_userId_User_id_fk",
+          "tableFrom": "GameOnboarding",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "GameOnboarding_userId_unique": {
+          "name": "GameOnboarding_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.OnboardingIntent": {
+      "name": "OnboardingIntent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "OnboardingStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING_PROFILE'"
+        },
+        "referralCode": {
+          "name": "referralCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profileApplied": {
+          "name": "profileApplied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "profileCompletedAt": {
+          "name": "profileCompletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onchainStartedAt": {
+          "name": "onchainStartedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onchainCompletedAt": {
+          "name": "onchainCompletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastError": {
+          "name": "lastError",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "OnboardingIntent_createdAt_idx": {
+          "name": "OnboardingIntent_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "OnboardingIntent_status_idx": {
+          "name": "OnboardingIntent_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "OnboardingIntent_userId_unique": {
+          "name": "OnboardingIntent_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ProfileUpdateLog": {
+      "name": "ProfileUpdateLog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changedFields": {
+          "name": "changedFields",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backendSigned": {
+          "name": "backendSigned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "txHash": {
+          "name": "txHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ProfileUpdateLog_userId_createdAt_idx": {
+          "name": "ProfileUpdateLog_userId_createdAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Referral": {
+      "name": "Referral",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "referrerId": {
+          "name": "referrerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "referredUserId": {
+          "name": "referredUserId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referralCode": {
+          "name": "referralCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completedAt": {
+          "name": "completedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "qualifiedAt": {
+          "name": "qualifiedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signupPointsAwarded": {
+          "name": "signupPointsAwarded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "suspiciousReferralFlags": {
+          "name": "suspiciousReferralFlags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Referral_referralCode_idx": {
+          "name": "Referral_referralCode_idx",
+          "columns": [
+            {
+              "expression": "referralCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Referral_referrerId_idx": {
+          "name": "Referral_referrerId_idx",
+          "columns": [
+            {
+              "expression": "referrerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Referral_referredUserId_idx": {
+          "name": "Referral_referredUserId_idx",
+          "columns": [
+            {
+              "expression": "referredUserId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Referral_status_createdAt_idx": {
+          "name": "Referral_status_createdAt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Referral_qualifiedAt_idx": {
+          "name": "Referral_qualifiedAt_idx",
+          "columns": [
+            {
+              "expression": "qualifiedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Referral_referrerId_status_qualifiedAt_signupPointsAwarded_idx": {
+          "name": "Referral_referrerId_status_qualifiedAt_signupPointsAwarded_idx",
+          "columns": [
+            {
+              "expression": "referrerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "qualifiedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "signupPointsAwarded",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Referral_referrerId_signupPointsAwarded_completedAt_idx": {
+          "name": "Referral_referrerId_signupPointsAwarded_completedAt_idx",
+          "columns": [
+            {
+              "expression": "referrerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "signupPointsAwarded",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Referral_referralCode_referredUserId_key": {
+          "name": "Referral_referralCode_referredUserId_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "referralCode",
+            "referredUserId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.TwitterOAuthToken": {
+      "name": "TwitterOAuthToken",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth1Token": {
+          "name": "oauth1Token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth1TokenSecret": {
+          "name": "oauth1TokenSecret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "screenName": {
+          "name": "screenName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "TwitterOAuthToken_userId_idx": {
+          "name": "TwitterOAuthToken_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "TwitterOAuthToken_userId_unique": {
+          "name": "TwitterOAuthToken_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserActorFollow": {
+      "name": "UserActorFollow",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actorId": {
+          "name": "actorId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UserActorFollow_actorId_idx": {
+          "name": "UserActorFollow_actorId_idx",
+          "columns": [
+            {
+              "expression": "actorId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserActorFollow_userId_idx": {
+          "name": "UserActorFollow_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UserActorFollow_userId_actorId_key": {
+          "name": "UserActorFollow_userId_actorId_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId",
+            "actorId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserApiKey": {
+      "name": "UserApiKey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keyHash": {
+          "name": "keyHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastUsedAt": {
+          "name": "lastUsedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "UserApiKey_userId_idx": {
+          "name": "UserApiKey_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserApiKey_keyHash_idx": {
+          "name": "UserApiKey_keyHash_idx",
+          "columns": [
+            {
+              "expression": "keyHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserApiKey_userId_revokedAt_idx": {
+          "name": "UserApiKey_userId_revokedAt_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revokedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserBlock": {
+      "name": "UserBlock",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "blockerId": {
+          "name": "blockerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blockedId": {
+          "name": "blockedId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UserBlock_blockerId_idx": {
+          "name": "UserBlock_blockerId_idx",
+          "columns": [
+            {
+              "expression": "blockerId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserBlock_blockedId_idx": {
+          "name": "UserBlock_blockedId_idx",
+          "columns": [
+            {
+              "expression": "blockedId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserBlock_createdAt_idx": {
+          "name": "UserBlock_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UserBlock_blockerId_blockedId_key": {
+          "name": "UserBlock_blockerId_blockedId_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "blockerId",
+            "blockedId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserInteraction": {
+      "name": "UserInteraction",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "npcId": {
+          "name": "npcId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "postId": {
+          "name": "postId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commentId": {
+          "name": "commentId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "qualityScore": {
+          "name": "qualityScore",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "wasFollowed": {
+          "name": "wasFollowed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "wasInvitedToChat": {
+          "name": "wasInvitedToChat",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "UserInteraction_npcId_timestamp_idx": {
+          "name": "UserInteraction_npcId_timestamp_idx",
+          "columns": [
+            {
+              "expression": "npcId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserInteraction_userId_npcId_timestamp_idx": {
+          "name": "UserInteraction_userId_npcId_timestamp_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "npcId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserInteraction_userId_timestamp_idx": {
+          "name": "UserInteraction_userId_timestamp_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserMute": {
+      "name": "UserMute",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "muterId": {
+          "name": "muterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mutedId": {
+          "name": "mutedId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UserMute_muterId_idx": {
+          "name": "UserMute_muterId_idx",
+          "columns": [
+            {
+              "expression": "muterId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserMute_mutedId_idx": {
+          "name": "UserMute_mutedId_idx",
+          "columns": [
+            {
+              "expression": "mutedId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserMute_createdAt_idx": {
+          "name": "UserMute_createdAt_idx",
+          "columns": [
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "UserMute_muterId_mutedId_key": {
+          "name": "UserMute_muterId_mutedId_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "muterId",
+            "mutedId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.UserPointsSnapshot": {
+      "name": "UserPointsSnapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "totalPoints": {
+          "name": "totalPoints",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "snapshotDate": {
+          "name": "snapshotDate",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daily'"
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "UserPointsSnapshot_userId_idx": {
+          "name": "UserPointsSnapshot_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserPointsSnapshot_userId_period_snapshotDate_idx": {
+          "name": "UserPointsSnapshot_userId_period_snapshotDate_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "snapshotDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "UserPointsSnapshot_snapshotDate_idx": {
+          "name": "UserPointsSnapshot_snapshotDate_idx",
+          "columns": [
+            {
+              "expression": "snapshotDate",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "UserPointsSnapshot_userId_User_id_fk": {
+          "name": "UserPointsSnapshot_userId_User_id_fk",
+          "tableFrom": "UserPointsSnapshot",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.User": {
+      "name": "User",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "privyWalletId": {
+          "name": "privyWalletId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "walletAddress": {
+          "name": "walletAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "displayName": {
+          "name": "displayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profileImageUrl": {
+          "name": "profileImageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isActor": {
+          "name": "isActor",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "personality": {
+          "name": "personality",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postStyle": {
+          "name": "postStyle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "postExample": {
+          "name": "postExample",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "virtualBalance": {
+          "name": "virtualBalance",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1000'"
+        },
+        "totalDeposited": {
+          "name": "totalDeposited",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1000'"
+        },
+        "totalWithdrawn": {
+          "name": "totalWithdrawn",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "lifetimePnL": {
+          "name": "lifetimePnL",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "profileComplete": {
+          "name": "profileComplete",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hasProfileImage": {
+          "name": "hasProfileImage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hasUsername": {
+          "name": "hasUsername",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hasBio": {
+          "name": "hasBio",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "profileSetupCompletedAt": {
+          "name": "profileSetupCompletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "farcasterUsername": {
+          "name": "farcasterUsername",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hasFarcaster": {
+          "name": "hasFarcaster",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hasTwitter": {
+          "name": "hasTwitter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "hasDiscord": {
+          "name": "hasDiscord",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "nftTokenId": {
+          "name": "nftTokenId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "onChainRegistered": {
+          "name": "onChainRegistered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pointsAwardedForFarcaster": {
+          "name": "pointsAwardedForFarcaster",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pointsAwardedForFarcasterFollow": {
+          "name": "pointsAwardedForFarcasterFollow",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pointsAwardedForProfile": {
+          "name": "pointsAwardedForProfile",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pointsAwardedForProfileImage": {
+          "name": "pointsAwardedForProfileImage",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pointsAwardedForTwitter": {
+          "name": "pointsAwardedForTwitter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pointsAwardedForTwitterFollow": {
+          "name": "pointsAwardedForTwitterFollow",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pointsAwardedForDiscord": {
+          "name": "pointsAwardedForDiscord",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pointsAwardedForDiscordJoin": {
+          "name": "pointsAwardedForDiscordJoin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pointsAwardedForUsername": {
+          "name": "pointsAwardedForUsername",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pointsAwardedForWallet": {
+          "name": "pointsAwardedForWallet",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pointsAwardedForReferralBonus": {
+          "name": "pointsAwardedForReferralBonus",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pointsAwardedForShare": {
+          "name": "pointsAwardedForShare",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pointsAwardedForPrivateGroup": {
+          "name": "pointsAwardedForPrivateGroup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pointsAwardedForPrivateChannel": {
+          "name": "pointsAwardedForPrivateChannel",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "referralCode": {
+          "name": "referralCode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referralCount": {
+          "name": "referralCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "referredBy": {
+          "name": "referredBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registrationIpHash": {
+          "name": "registrationIpHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lastReferralIpHash": {
+          "name": "lastReferralIpHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registrationTxHash": {
+          "name": "registrationTxHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reputationPoints": {
+          "name": "reputationPoints",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1000
+        },
+        "twitterUsername": {
+          "name": "twitterUsername",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bannerDismissCount": {
+          "name": "bannerDismissCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bannerLastShown": {
+          "name": "bannerLastShown",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "coverImageUrl": {
+          "name": "coverImageUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "showFarcasterPublic": {
+          "name": "showFarcasterPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "showTwitterPublic": {
+          "name": "showTwitterPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "showWalletPublic": {
+          "name": "showWalletPublic",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "usernameChangedAt": {
+          "name": "usernameChangedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent0FeedbackCount": {
+          "name": "agent0FeedbackCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent0MetadataCID": {
+          "name": "agent0MetadataCID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent0RegisteredAt": {
+          "name": "agent0RegisteredAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent0TokenId": {
+          "name": "agent0TokenId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent0TrustScore": {
+          "name": "agent0TrustScore",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bannedAt": {
+          "name": "bannedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bannedBy": {
+          "name": "bannedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bannedReason": {
+          "name": "bannedReason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "farcasterDisplayName": {
+          "name": "farcasterDisplayName",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "farcasterFid": {
+          "name": "farcasterFid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "farcasterPfpUrl": {
+          "name": "farcasterPfpUrl",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "farcasterVerifiedAt": {
+          "name": "farcasterVerifiedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isAdmin": {
+          "name": "isAdmin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isBanned": {
+          "name": "isBanned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isScammer": {
+          "name": "isScammer",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isCSAM": {
+          "name": "isCSAM",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "appealCount": {
+          "name": "appealCount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "appealStaked": {
+          "name": "appealStaked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "appealStakeAmount": {
+          "name": "appealStakeAmount",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appealStakeTxHash": {
+          "name": "appealStakeTxHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appealStatus": {
+          "name": "appealStatus",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appealSubmittedAt": {
+          "name": "appealSubmittedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "appealReviewedAt": {
+          "name": "appealReviewedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "falsePositiveHistory": {
+          "name": "falsePositiveHistory",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privyId": {
+          "name": "privyId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registrationBlockNumber": {
+          "name": "registrationBlockNumber",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registrationGasUsed": {
+          "name": "registrationGasUsed",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registrationTimestamp": {
+          "name": "registrationTimestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalFeesEarned": {
+          "name": "totalFeesEarned",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "totalFeesPaid": {
+          "name": "totalFeesPaid",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "twitterAccessToken": {
+          "name": "twitterAccessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterId": {
+          "name": "twitterId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterRefreshToken": {
+          "name": "twitterRefreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterTokenExpiresAt": {
+          "name": "twitterTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitterVerifiedAt": {
+          "name": "twitterVerifiedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discordId": {
+          "name": "discordId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discordUsername": {
+          "name": "discordUsername",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discordAccessToken": {
+          "name": "discordAccessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discordRefreshToken": {
+          "name": "discordRefreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discordTokenExpiresAt": {
+          "name": "discordTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discordVerifiedAt": {
+          "name": "discordVerifiedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tosAccepted": {
+          "name": "tosAccepted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "tosAcceptedAt": {
+          "name": "tosAcceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tosAcceptedVersion": {
+          "name": "tosAcceptedVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'2025-11-11'"
+        },
+        "privacyPolicyAccepted": {
+          "name": "privacyPolicyAccepted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "privacyPolicyAcceptedAt": {
+          "name": "privacyPolicyAcceptedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "privacyPolicyAcceptedVersion": {
+          "name": "privacyPolicyAcceptedVersion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'2025-11-11'"
+        },
+        "invitePoints": {
+          "name": "invitePoints",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "earnedPoints": {
+          "name": "earnedPoints",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "bonusPoints": {
+          "name": "bonusPoints",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "waitlistPosition": {
+          "name": "waitlistPosition",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waitlistJoinedAt": {
+          "name": "waitlistJoinedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isWaitlistActive": {
+          "name": "isWaitlistActive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "isTest": {
+          "name": "isTest",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "pointsAwardedForEmail": {
+          "name": "pointsAwardedForEmail",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "waitlistGraduatedAt": {
+          "name": "waitlistGraduatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isAgent": {
+          "name": "isAgent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "managedBy": {
+          "name": "managedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "totalPoints": {
+          "name": "totalPoints",
+          "type": "numeric(18, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "totalPointsDirtyAt": {
+          "name": "totalPointsDirtyAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gameGuideCompletedAt": {
+          "name": "gameGuideCompletedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profileChainSyncNeeded": {
+          "name": "profileChainSyncNeeded",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "profileChainSyncAt": {
+          "name": "profileChainSyncAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profileChainSyncError": {
+          "name": "profileChainSyncError",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dailyLoginStreak": {
+          "name": "dailyLoginStreak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lastDailyLogin": {
+          "name": "lastDailyLogin",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longestStreak": {
+          "name": "longestStreak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "totalDailyLogins": {
+          "name": "totalDailyLogins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "User_displayName_idx": {
+          "name": "User_displayName_idx",
+          "columns": [
+            {
+              "expression": "displayName",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_earnedPoints_idx": {
+          "name": "User_earnedPoints_idx",
+          "columns": [
+            {
+              "expression": "earnedPoints",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_invitePoints_idx": {
+          "name": "User_invitePoints_idx",
+          "columns": [
+            {
+              "expression": "invitePoints",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_isActor_idx": {
+          "name": "User_isActor_idx",
+          "columns": [
+            {
+              "expression": "isActor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_isActor_createdAt_idx": {
+          "name": "User_isActor_createdAt_idx",
+          "columns": [
+            {
+              "expression": "isActor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_isAgent_idx": {
+          "name": "User_isAgent_idx",
+          "columns": [
+            {
+              "expression": "isAgent",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_isAgent_createdAt_idx": {
+          "name": "User_isAgent_createdAt_idx",
+          "columns": [
+            {
+              "expression": "isAgent",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_isAgent_managedBy_idx": {
+          "name": "User_isAgent_managedBy_idx",
+          "columns": [
+            {
+              "expression": "isAgent",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "managedBy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_isBanned_isActor_idx": {
+          "name": "User_isBanned_isActor_idx",
+          "columns": [
+            {
+              "expression": "isBanned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "isActor",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_isScammer_idx": {
+          "name": "User_isScammer_idx",
+          "columns": [
+            {
+              "expression": "isScammer",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_isCSAM_idx": {
+          "name": "User_isCSAM_idx",
+          "columns": [
+            {
+              "expression": "isCSAM",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_managedBy_idx": {
+          "name": "User_managedBy_idx",
+          "columns": [
+            {
+              "expression": "managedBy",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_profileComplete_createdAt_idx": {
+          "name": "User_profileComplete_createdAt_idx",
+          "columns": [
+            {
+              "expression": "profileComplete",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "createdAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_referralCode_idx": {
+          "name": "User_referralCode_idx",
+          "columns": [
+            {
+              "expression": "referralCode",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_reputationPoints_idx": {
+          "name": "User_reputationPoints_idx",
+          "columns": [
+            {
+              "expression": "reputationPoints",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_totalPoints_idx": {
+          "name": "User_totalPoints_idx",
+          "columns": [
+            {
+              "expression": "totalPoints",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_username_idx": {
+          "name": "User_username_idx",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_waitlistJoinedAt_idx": {
+          "name": "User_waitlistJoinedAt_idx",
+          "columns": [
+            {
+              "expression": "waitlistJoinedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_waitlistPosition_idx": {
+          "name": "User_waitlistPosition_idx",
+          "columns": [
+            {
+              "expression": "waitlistPosition",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_walletAddress_idx": {
+          "name": "User_walletAddress_idx",
+          "columns": [
+            {
+              "expression": "walletAddress",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_registrationIpHash_idx": {
+          "name": "User_registrationIpHash_idx",
+          "columns": [
+            {
+              "expression": "registrationIpHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_lastReferralIpHash_idx": {
+          "name": "User_lastReferralIpHash_idx",
+          "columns": [
+            {
+              "expression": "lastReferralIpHash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_profileChainSyncNeeded_onChainRegistered_idx": {
+          "name": "User_profileChainSyncNeeded_onChainRegistered_idx",
+          "columns": [
+            {
+              "expression": "profileChainSyncNeeded",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "onChainRegistered",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_dailyLoginStreak_idx": {
+          "name": "User_dailyLoginStreak_idx",
+          "columns": [
+            {
+              "expression": "dailyLoginStreak",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_longestStreak_idx": {
+          "name": "User_longestStreak_idx",
+          "columns": [
+            {
+              "expression": "longestStreak",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "User_lastDailyLogin_idx": {
+          "name": "User_lastDailyLogin_idx",
+          "columns": [
+            {
+              "expression": "lastDailyLogin",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "User_walletAddress_unique": {
+          "name": "User_walletAddress_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "walletAddress"
+          ]
+        },
+        "User_username_unique": {
+          "name": "User_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        },
+        "User_nftTokenId_unique": {
+          "name": "User_nftTokenId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "nftTokenId"
+          ]
+        },
+        "User_referralCode_unique": {
+          "name": "User_referralCode_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "referralCode"
+          ]
+        },
+        "User_farcasterFid_unique": {
+          "name": "User_farcasterFid_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "farcasterFid"
+          ]
+        },
+        "User_privyId_unique": {
+          "name": "User_privyId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "privyId"
+          ]
+        },
+        "User_twitterId_unique": {
+          "name": "User_twitterId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "twitterId"
+          ]
+        },
+        "User_discordId_unique": {
+          "name": "User_discordId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discordId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.Whitelist": {
+      "name": "Whitelist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grantedBy": {
+          "name": "grantedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grantedAt": {
+          "name": "grantedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revokedAt": {
+          "name": "revokedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "Whitelist_userId_idx": {
+          "name": "Whitelist_userId_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Whitelist_source_idx": {
+          "name": "Whitelist_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "Whitelist_revokedAt_idx": {
+          "name": "Whitelist_revokedAt_idx",
+          "columns": [
+            {
+              "expression": "revokedAt",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "Whitelist_userId_User_id_fk": {
+          "name": "Whitelist_userId_User_id_fk",
+          "tableFrom": "Whitelist",
+          "tableTo": "User",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "Whitelist_grantedBy_User_id_fk": {
+          "name": "Whitelist_grantedBy_User_id_fk",
+          "tableFrom": "Whitelist",
+          "tableTo": "User",
+          "columnsFrom": [
+            "grantedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "Whitelist_userId_unique": {
+          "name": "Whitelist_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.WhitelistConfig": {
+      "name": "WhitelistConfig",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "leaderboardRankThreshold": {
+          "name": "leaderboardRankThreshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "leaderboardCategory": {
+          "name": "leaderboardCategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'all'"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updatedBy": {
+          "name": "updatedBy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "WhitelistConfig_updatedBy_User_id_fk": {
+          "name": "WhitelistConfig_updatedBy_User_id_fk",
+          "tableFrom": "WhitelistConfig",
+          "tableTo": "User",
+          "columnsFrom": [
+            "updatedBy"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.AgentStatus": {
+      "name": "AgentStatus",
+      "schema": "public",
+      "values": [
+        "REGISTERED",
+        "INITIALIZED",
+        "ACTIVE",
+        "PAUSED",
+        "TERMINATED"
+      ]
+    },
+    "public.AgentType": {
+      "name": "AgentType",
+      "schema": "public",
+      "values": [
+        "USER_CONTROLLED",
+        "NPC",
+        "EXTERNAL"
+      ]
+    },
+    "public.OnboardingStatus": {
+      "name": "OnboardingStatus",
+      "schema": "public",
+      "values": [
+        "PENDING_PROFILE",
+        "PENDING_ONCHAIN",
+        "ONCHAIN_IN_PROGRESS",
+        "ONCHAIN_FAILED",
+        "COMPLETED"
+      ]
+    },
+    "public.RealtimeOutboxStatus": {
+      "name": "RealtimeOutboxStatus",
+      "schema": "public",
+      "values": [
+        "pending",
+        "sent",
+        "failed"
+      ]
+    },
+    "public.group_type": {
+      "name": "group_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "npc",
+        "agent",
+        "team"
+      ]
+    },
+    "public.message_type": {
+      "name": "message_type",
+      "schema": "public",
+      "values": [
+        "user",
+        "system",
+        "coordinator"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/migrations/meta/_journal.json
+++ b/packages/db/drizzle/migrations/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1769566560000,
       "tag": "0027_add_system_metrics_snapshot",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1770402442392,
+      "tag": "0039_unique_fantastic_four",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -22,3 +22,4 @@ export * from './training';
 export * from './user-agent-configs';
 export * from './users';
 export * from './users-relations';
+export * from './whitelist';

--- a/packages/db/src/schema/whitelist.ts
+++ b/packages/db/src/schema/whitelist.ts
@@ -1,0 +1,83 @@
+import { relations } from 'drizzle-orm';
+import { index, integer, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { users } from './users';
+
+/**
+ * Whitelist - Stores individually whitelisted users who bypass NFT gating.
+ *
+ * Users can be whitelisted via:
+ * - `snapshot_first_100`: Imported from end-of-year top-100 snapshot
+ * - `admin_manual`: Manually added by an admin
+ * - `leaderboard`: Added via leaderboard-based bulk import
+ *
+ * Soft-revoke via `revokedAt` preserves audit trail.
+ */
+export const whitelist = pgTable(
+  'Whitelist',
+  {
+    id: text('id').primaryKey(),
+    userId: text('userId')
+      .notNull()
+      .unique()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    source: text('source')
+      .notNull()
+      .$type<'snapshot_first_100' | 'admin_manual' | 'leaderboard'>(),
+    reason: text('reason'),
+    grantedBy: text('grantedBy').references(() => users.id, {
+      onDelete: 'set null',
+    }),
+    grantedAt: timestamp('grantedAt', { mode: 'date' }).notNull().defaultNow(),
+    revokedAt: timestamp('revokedAt', { mode: 'date' }),
+  },
+  (table) => [
+    index('Whitelist_userId_idx').on(table.userId),
+    index('Whitelist_source_idx').on(table.source),
+    index('Whitelist_revokedAt_idx').on(table.revokedAt),
+  ]
+);
+
+export type WhitelistRow = typeof whitelist.$inferSelect;
+export type NewWhitelistRow = typeof whitelist.$inferInsert;
+
+/**
+ * WhitelistConfig - Singleton configuration for whitelist settings.
+ *
+ * Stores global settings such as the leaderboard rank threshold.
+ * Uses a singleton pattern (id is always 'default').
+ */
+export const whitelistConfig = pgTable('WhitelistConfig', {
+  id: text('id').primaryKey(), // always 'default'
+  leaderboardRankThreshold: integer('leaderboardRankThreshold'), // null = disabled
+  leaderboardCategory: text('leaderboardCategory').notNull().default('all'),
+  updatedAt: timestamp('updatedAt', { mode: 'date' }).notNull().defaultNow(),
+  updatedBy: text('updatedBy').references(() => users.id, {
+    onDelete: 'set null',
+  }),
+});
+
+export type WhitelistConfigRow = typeof whitelistConfig.$inferSelect;
+export type NewWhitelistConfigRow = typeof whitelistConfig.$inferInsert;
+
+// Relations
+export const whitelistRelations = relations(whitelist, ({ one }) => ({
+  user: one(users, {
+    fields: [whitelist.userId],
+    references: [users.id],
+  }),
+  granter: one(users, {
+    fields: [whitelist.grantedBy],
+    references: [users.id],
+    relationName: 'Whitelist_grantedByToUser',
+  }),
+}));
+
+export const whitelistConfigRelations = relations(
+  whitelistConfig,
+  ({ one }) => ({
+    updater: one(users, {
+      fields: [whitelistConfig.updatedBy],
+      references: [users.id],
+    }),
+  })
+);


### PR DESCRIPTION
## Summary

- Add comprehensive whitelisting system with three methods to bypass NFT gating: First 100 snapshot import, configurable leaderboard rank threshold, and ad-hoc admin whitelisting
- New `Whitelist` and `WhitelistConfig` database tables with migration, service layer, admin API routes, and full admin panel UI
- Whitelist checks are integrated at the top of the NFT access service with graceful fallback if tables don't exist yet (safe for rolling deployments)

## Changes

### Database
- `Whitelist` table: `userId` (unique), `source`, `reason`, `grantedBy`, `grantedAt`, `revokedAt` (soft revoke)
- `WhitelistConfig` table: singleton row for `leaderboardRankThreshold` setting
- Migration `0039_unique_fantastic_four.sql` (additive only, `CREATE TABLE IF NOT EXISTS`)

### Service Layer
- `whitelist-service.ts`: `checkWhitelistAccess`, `isUserWhitelisted`, `isUserWhitelistedByLeaderboard`, CRUD operations, config management, bulk import from NftSnapshot
- `nft-access-service.ts`: All three access check functions now check whitelist first, wrapped in try-catch for resilience

### Admin API
- `GET/POST/DELETE /api/admin/whitelist` - List, add, revoke whitelist entries
- `GET/PUT /api/admin/whitelist/config` - Leaderboard rank threshold configuration
- `POST /api/admin/whitelist/import-first-100` - Bulk import from existing NftSnapshot

### Admin UI
- New **Access Whitelist** tab: stats cards, leaderboard config section, import button, add user form, filter tabs, search, entry table with revoke actions
- **Whitelist** button added to UserManagementTab alongside Mute/Block/Ban
- **Whitelisted** badge on user cards
- `isWhitelisted` field added to admin users API response

## Test Plan

- [ ] Verify migration runs cleanly via `drizzle-kit push`
- [ ] Test adding a user to whitelist via admin panel
- [ ] Test leaderboard rank threshold config (set to 500, verify top 500 users bypass gating)
- [ ] Test importing first 100 from NftSnapshot
- [ ] Test revoking a whitelisted user
- [ ] Test that whitelisted users bypass the NFT access gate
- [ ] Verify admin users list shows whitelist badges correctly
- [ ] Verify existing NFT gating still works for non-whitelisted users