### PR TITLE
fix: replace hardcoded $ with ƀ (BABYLON_POINTS_SYMBOL) for in-game prices

### DIFF
--- a/apps/web/src/components/admin/AgentsTab.tsx
+++ b/apps/web/src/components/admin/AgentsTab.tsx
@@ -680,7 +680,8 @@ export function AgentsTab() {
                             : 'text-red-500'
                         )}
                       >
-                        {agent.lifetimePnL >= 0 ? '+' : ''}{BABYLON_POINTS_SYMBOL}
+                        {agent.lifetimePnL >= 0 ? '+' : ''}
+                        {BABYLON_POINTS_SYMBOL}
                         {agent.lifetimePnL.toFixed(2)}
                       </div>
                     </div>

--- a/apps/web/src/components/admin/AgentsTab.tsx
+++ b/apps/web/src/components/admin/AgentsTab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { cn, logger } from '@babylon/shared';
+import { BABYLON_POINTS_SYMBOL, cn, logger } from '@babylon/shared';
 import {
   Activity,
   AlertCircle,
@@ -680,7 +680,7 @@ export function AgentsTab() {
                             : 'text-red-500'
                         )}
                       >
-                        {agent.lifetimePnL >= 0 ? '+' : ''}$
+                        {agent.lifetimePnL >= 0 ? '+' : ''}{BABYLON_POINTS_SYMBOL}
                         {agent.lifetimePnL.toFixed(2)}
                       </div>
                     </div>

--- a/apps/web/src/components/admin/TrainingDataTab.tsx
+++ b/apps/web/src/components/admin/TrainingDataTab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { cn } from '@babylon/shared';
+import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
 import {
   AlertCircle,
   CheckCircle,
@@ -235,7 +235,7 @@ export function TrainingDataTab() {
                   : 'text-red-500'
               )}
             >
-              ${data.qualityMetrics.avgPnl.toFixed(2)}
+              {BABYLON_POINTS_SYMBOL}{data.qualityMetrics.avgPnl.toFixed(2)}
             </div>
           </div>
         </div>
@@ -268,7 +268,7 @@ export function TrainingDataTab() {
                         window.avgPnl >= 0 ? 'text-green-500' : 'text-red-500'
                       )}
                     >
-                      {window.avgPnl >= 0 ? '+' : ''}${window.avgPnl.toFixed(2)}
+                      {window.avgPnl >= 0 ? '+' : ''}{BABYLON_POINTS_SYMBOL}{window.avgPnl.toFixed(2)}
                     </div>
                     <div className="text-muted-foreground text-xs">avg P&L</div>
                   </div>
@@ -317,7 +317,7 @@ export function TrainingDataTab() {
                           traj.finalPnL >= 0 ? 'text-green-500' : 'text-red-500'
                         )}
                       >
-                        {traj.finalPnL >= 0 ? '+' : ''}$
+                        {traj.finalPnL >= 0 ? '+' : ''}{BABYLON_POINTS_SYMBOL}
                         {traj.finalPnL.toFixed(2)}
                       </div>
                     )}

--- a/apps/web/src/components/admin/TrainingDataTab.tsx
+++ b/apps/web/src/components/admin/TrainingDataTab.tsx
@@ -235,7 +235,8 @@ export function TrainingDataTab() {
                   : 'text-red-500'
               )}
             >
-              {BABYLON_POINTS_SYMBOL}{data.qualityMetrics.avgPnl.toFixed(2)}
+              {BABYLON_POINTS_SYMBOL}
+              {data.qualityMetrics.avgPnl.toFixed(2)}
             </div>
           </div>
         </div>
@@ -268,7 +269,9 @@ export function TrainingDataTab() {
                         window.avgPnl >= 0 ? 'text-green-500' : 'text-red-500'
                       )}
                     >
-                      {window.avgPnl >= 0 ? '+' : ''}{BABYLON_POINTS_SYMBOL}{window.avgPnl.toFixed(2)}
+                      {window.avgPnl >= 0 ? '+' : ''}
+                      {BABYLON_POINTS_SYMBOL}
+                      {window.avgPnl.toFixed(2)}
                     </div>
                     <div className="text-muted-foreground text-xs">avg P&L</div>
                   </div>
@@ -317,7 +320,8 @@ export function TrainingDataTab() {
                           traj.finalPnL >= 0 ? 'text-green-500' : 'text-red-500'
                         )}
                       >
-                        {traj.finalPnL >= 0 ? '+' : ''}{BABYLON_POINTS_SYMBOL}
+                        {traj.finalPnL >= 0 ? '+' : ''}
+                        {BABYLON_POINTS_SYMBOL}
                         {traj.finalPnL.toFixed(2)}
                       </div>
                     )}

--- a/apps/web/src/components/agents/AgentChat.tsx
+++ b/apps/web/src/components/agents/AgentChat.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { logger } from '@babylon/shared';
+import { BABYLON_POINTS_SYMBOL, logger } from '@babylon/shared';
 import { Wallet } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
@@ -486,14 +486,14 @@ export function AgentChat({
         {agent.virtualBalance !== undefined && (
           <div
             className="flex items-center justify-between border-border border-b bg-muted/30 px-4 py-2"
-            aria-label={`Agent balance: $${agent.virtualBalance.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
+            aria-label={`Agent balance: ${BABYLON_POINTS_SYMBOL}${agent.virtualBalance.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
           >
             <div className="flex items-center gap-2 text-muted-foreground text-sm">
               <Wallet className="h-4 w-4" aria-hidden="true" />
               <span>Agent Balance</span>
             </div>
             <span className="font-medium font-mono text-sm">
-              {'$'}
+              {BABYLON_POINTS_SYMBOL}
               {agent.virtualBalance.toLocaleString(undefined, {
                 minimumFractionDigits: 2,
                 maximumFractionDigits: 2,

--- a/apps/web/src/components/feed/MarketsPanel.tsx
+++ b/apps/web/src/components/feed/MarketsPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { cn } from '@babylon/shared';
+import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
 import { TrendingDown, TrendingUp } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useState } from 'react';
@@ -220,7 +220,7 @@ export function MarketsPanel() {
                         </p>
                         <div className="mt-0.5 flex items-center justify-between gap-1">
                           <span className="truncate text-muted-foreground text-xs">
-                            $
+                            {BABYLON_POINTS_SYMBOL}
                             {token.currentPrice.toLocaleString('en-US', {
                               minimumFractionDigits: 2,
                               maximumFractionDigits: 2,
@@ -263,7 +263,7 @@ export function MarketsPanel() {
                         </p>
                         <div className="mt-0.5 flex items-center justify-between gap-1">
                           <span className="truncate text-muted-foreground text-xs">
-                            $
+                            {BABYLON_POINTS_SYMBOL}
                             {token.currentPrice.toLocaleString('en-US', {
                               minimumFractionDigits: 2,
                               maximumFractionDigits: 2,
@@ -315,7 +315,7 @@ export function MarketsPanel() {
                         </div>
                         {market.volume > 0 && (
                           <span className="text-muted-foreground text-xs">
-                            Vol ${Math.round(market.volume).toLocaleString()}
+                            Vol {BABYLON_POINTS_SYMBOL}{Math.round(market.volume).toLocaleString()}
                           </span>
                         )}
                       </div>

--- a/apps/web/src/components/feed/MarketsPanel.tsx
+++ b/apps/web/src/components/feed/MarketsPanel.tsx
@@ -315,7 +315,8 @@ export function MarketsPanel() {
                         </div>
                         {market.volume > 0 && (
                           <span className="text-muted-foreground text-xs">
-                            Vol {BABYLON_POINTS_SYMBOL}{Math.round(market.volume).toLocaleString()}
+                            Vol {BABYLON_POINTS_SYMBOL}
+                            {Math.round(market.volume).toLocaleString()}
                           </span>
                         )}
                       </div>

--- a/apps/web/src/components/npc/NPCLeaderboard.tsx
+++ b/apps/web/src/components/npc/NPCLeaderboard.tsx
@@ -29,12 +29,7 @@
 'use client';
 
 import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
-import {
-  Activity,
-  TrendingDown,
-  TrendingUp,
-  Trophy,
-} from 'lucide-react';
+import { Activity, TrendingDown, TrendingUp, Trophy } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 /**
@@ -243,7 +238,8 @@ export function NPCLeaderboard({
                       : 'text-red-500'
                   )}
                 >
-                  {entry.performance.unrealizedPnL >= 0 ? '+' : ''}{BABYLON_POINTS_SYMBOL}
+                  {entry.performance.unrealizedPnL >= 0 ? '+' : ''}
+                  {BABYLON_POINTS_SYMBOL}
                   {Math.abs(entry.performance.unrealizedPnL).toLocaleString()}
                 </div>
                 <div className="text-muted-foreground text-xs">Unrealized</div>
@@ -273,7 +269,8 @@ export function NPCLeaderboard({
       {/* Footer */}
       {data.leaderboard.length === data.metadata.limit && (
         <div className="border-border border-t pt-2 text-center text-muted-foreground text-xs">
-          Showing top {data.metadata.limit} NPCs. Minimum portfolio value: {BABYLON_POINTS_SYMBOL}
+          Showing top {data.metadata.limit} NPCs. Minimum portfolio value:{' '}
+          {BABYLON_POINTS_SYMBOL}
           {data.metadata.minValue.toLocaleString()}
         </div>
       )}

--- a/apps/web/src/components/npc/NPCLeaderboard.tsx
+++ b/apps/web/src/components/npc/NPCLeaderboard.tsx
@@ -28,10 +28,9 @@
  */
 'use client';
 
-import { cn } from '@babylon/shared';
+import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
 import {
   Activity,
-  DollarSign,
   TrendingDown,
   TrendingUp,
   Trophy,
@@ -207,7 +206,7 @@ export function NPCLeaderboard({
               {/* Portfolio Value */}
               <div className="text-right">
                 <div className="flex items-center gap-1 font-bold text-foreground text-sm">
-                  <DollarSign className="h-3 w-3" />
+                  <span className="h-3 w-3">{BABYLON_POINTS_SYMBOL}</span>
                   {entry.performance.totalValue.toLocaleString()}
                 </div>
                 <div className="text-muted-foreground text-xs">Value</div>
@@ -244,7 +243,7 @@ export function NPCLeaderboard({
                       : 'text-red-500'
                   )}
                 >
-                  {entry.performance.unrealizedPnL >= 0 ? '+' : ''}$
+                  {entry.performance.unrealizedPnL >= 0 ? '+' : ''}{BABYLON_POINTS_SYMBOL}
                   {Math.abs(entry.performance.unrealizedPnL).toLocaleString()}
                 </div>
                 <div className="text-muted-foreground text-xs">Unrealized</div>
@@ -274,7 +273,7 @@ export function NPCLeaderboard({
       {/* Footer */}
       {data.leaderboard.length === data.metadata.limit && (
         <div className="border-border border-t pt-2 text-center text-muted-foreground text-xs">
-          Showing top {data.metadata.limit} NPCs. Minimum portfolio value: $
+          Showing top {data.metadata.limit} NPCs. Minimum portfolio value: {BABYLON_POINTS_SYMBOL}
           {data.metadata.minValue.toLocaleString()}
         </div>
       )}

--- a/apps/web/src/components/npc/NPCPortfolioCard.tsx
+++ b/apps/web/src/components/npc/NPCPortfolioCard.tsx
@@ -28,7 +28,7 @@
  */
 'use client';
 
-import { cn } from '@babylon/shared';
+import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
 import {
   Activity,
   AlertCircle,
@@ -176,7 +176,7 @@ export function NPCPortfolioCard({
           Total Portfolio Value
         </div>
         <div className="font-bold text-3xl text-foreground">
-          ${portfolio.totalValue.toLocaleString()}
+          {BABYLON_POINTS_SYMBOL}{portfolio.totalValue.toLocaleString()}
         </div>
         <div className="mt-2 flex items-center gap-4">
           <div className="flex items-center gap-1 text-sm">
@@ -190,7 +190,7 @@ export function NPCPortfolioCard({
                 portfolio.unrealizedPnL >= 0 ? 'text-green-500' : 'text-red-500'
               }
             >
-              ${Math.abs(portfolio.unrealizedPnL).toLocaleString()}
+              {BABYLON_POINTS_SYMBOL}{Math.abs(portfolio.unrealizedPnL).toLocaleString()}
             </span>
             <span className="text-muted-foreground text-xs">unrealized</span>
           </div>
@@ -201,7 +201,7 @@ export function NPCPortfolioCard({
                   portfolio.realizedPnL >= 0 ? 'text-green-500' : 'text-red-500'
                 }
               >
-                ${Math.abs(portfolio.realizedPnL).toLocaleString()}
+                {BABYLON_POINTS_SYMBOL}{Math.abs(portfolio.realizedPnL).toLocaleString()}
               </span>
               <span className="text-xs">realized</span>
             </div>
@@ -215,7 +215,7 @@ export function NPCPortfolioCard({
         <div className="rounded-lg bg-muted/30 p-3">
           <div className="mb-1 text-muted-foreground text-xs">Available</div>
           <div className="font-bold text-foreground text-lg">
-            ${portfolio.availableBalance.toLocaleString()}
+            {BABYLON_POINTS_SYMBOL}{portfolio.availableBalance.toLocaleString()}
           </div>
         </div>
 
@@ -271,7 +271,7 @@ export function NPCPortfolioCard({
                 </div>
                 <div className="flex items-center gap-3">
                   <span className="text-muted-foreground">
-                    ${position.size.toLocaleString()}
+                    {BABYLON_POINTS_SYMBOL}{position.size.toLocaleString()}
                   </span>
                   {position.leverage && position.leverage > 1 && (
                     <span className="text-yellow-500">
@@ -285,7 +285,7 @@ export function NPCPortfolioCard({
                         : 'text-red-500'
                     }
                   >
-                    {position.unrealizedPnL >= 0 ? '+' : ''}$
+                    {position.unrealizedPnL >= 0 ? '+' : ''}{BABYLON_POINTS_SYMBOL}
                     {position.unrealizedPnL.toLocaleString()}
                   </span>
                 </div>

--- a/apps/web/src/components/npc/NPCPortfolioCard.tsx
+++ b/apps/web/src/components/npc/NPCPortfolioCard.tsx
@@ -176,7 +176,8 @@ export function NPCPortfolioCard({
           Total Portfolio Value
         </div>
         <div className="font-bold text-3xl text-foreground">
-          {BABYLON_POINTS_SYMBOL}{portfolio.totalValue.toLocaleString()}
+          {BABYLON_POINTS_SYMBOL}
+          {portfolio.totalValue.toLocaleString()}
         </div>
         <div className="mt-2 flex items-center gap-4">
           <div className="flex items-center gap-1 text-sm">
@@ -190,7 +191,8 @@ export function NPCPortfolioCard({
                 portfolio.unrealizedPnL >= 0 ? 'text-green-500' : 'text-red-500'
               }
             >
-              {BABYLON_POINTS_SYMBOL}{Math.abs(portfolio.unrealizedPnL).toLocaleString()}
+              {BABYLON_POINTS_SYMBOL}
+              {Math.abs(portfolio.unrealizedPnL).toLocaleString()}
             </span>
             <span className="text-muted-foreground text-xs">unrealized</span>
           </div>
@@ -201,7 +203,8 @@ export function NPCPortfolioCard({
                   portfolio.realizedPnL >= 0 ? 'text-green-500' : 'text-red-500'
                 }
               >
-                {BABYLON_POINTS_SYMBOL}{Math.abs(portfolio.realizedPnL).toLocaleString()}
+                {BABYLON_POINTS_SYMBOL}
+                {Math.abs(portfolio.realizedPnL).toLocaleString()}
               </span>
               <span className="text-xs">realized</span>
             </div>
@@ -215,7 +218,8 @@ export function NPCPortfolioCard({
         <div className="rounded-lg bg-muted/30 p-3">
           <div className="mb-1 text-muted-foreground text-xs">Available</div>
           <div className="font-bold text-foreground text-lg">
-            {BABYLON_POINTS_SYMBOL}{portfolio.availableBalance.toLocaleString()}
+            {BABYLON_POINTS_SYMBOL}
+            {portfolio.availableBalance.toLocaleString()}
           </div>
         </div>
 
@@ -271,7 +275,8 @@ export function NPCPortfolioCard({
                 </div>
                 <div className="flex items-center gap-3">
                   <span className="text-muted-foreground">
-                    {BABYLON_POINTS_SYMBOL}{position.size.toLocaleString()}
+                    {BABYLON_POINTS_SYMBOL}
+                    {position.size.toLocaleString()}
                   </span>
                   {position.leverage && position.leverage > 1 && (
                     <span className="text-yellow-500">
@@ -285,7 +290,8 @@ export function NPCPortfolioCard({
                         : 'text-red-500'
                     }
                   >
-                    {position.unrealizedPnL >= 0 ? '+' : ''}{BABYLON_POINTS_SYMBOL}
+                    {position.unrealizedPnL >= 0 ? '+' : ''}
+                    {BABYLON_POINTS_SYMBOL}
                     {position.unrealizedPnL.toLocaleString()}
                   </span>
                 </div>

--- a/apps/web/src/components/profile/ProfileWidget.tsx
+++ b/apps/web/src/components/profile/ProfileWidget.tsx
@@ -6,7 +6,7 @@ import type {
   PredictionPosition,
   UserProfileStats,
 } from '@babylon/shared';
-import { cn } from '@babylon/shared';
+import { BABYLON_POINTS_SYMBOL, cn } from '@babylon/shared';
 import {
   BarChart3,
   Coins,
@@ -34,7 +34,7 @@ const formatPercent = (value: number) => {
 };
 
 const formatPrice = (price: number) => {
-  return `$${price.toFixed(2)}`;
+  return `${BABYLON_POINTS_SYMBOL}${price.toFixed(2)}`;
 };
 
 function toNumber(value: unknown, fallback = 0): number {


### PR DESCRIPTION
## Summary
- Replaced hardcoded `$` with `BABYLON_POINTS_SYMBOL` (`ƀ`) across 7 components that display in-game Babylon Points prices, balances, and PnL
- Removed unused `DollarSign` lucide-react import from NPCLeaderboard
- Real USD/ETH contexts (Stripe checkout, ETH sends, appeal stakes) and cashtag tickers (`$BTC`, `$ETH`) are intentionally unchanged

## Files changed
- `MarketsPanel.tsx` — gainer/loser prices, market volume
- `AgentChat.tsx` — agent balance display + aria-label
- `NPCPortfolioCard.tsx` — total value, unrealized/realized PnL, available balance, position size/PnL
- `NPCLeaderboard.tsx` — portfolio value icon, unrealized PnL, footer min value
- `AgentsTab.tsx` — lifetime PnL
- `TrainingDataTab.tsx` — avg PnL, window avg PnL, final PnL
- `ProfileWidget.tsx` — `formatPrice()` helper