### PR TITLE
fix: whitelist Date serialization in raw SQL templates

### DIFF
--- a/apps/web/src/app/api/admin/nft-snapshot/route.ts
+++ b/apps/web/src/app/api/admin/nft-snapshot/route.ts
@@ -8,7 +8,7 @@
  */
 
 import { requireAdmin, successResponse, withErrorHandling } from '@babylon/api';
-import { db, eq, nftSnapshot, users } from '@babylon/db';
+import { db, eq, nftSnapshot, or, sql, users } from '@babylon/db';
 import { nanoid } from 'nanoid';
 import { type NextRequest, NextResponse } from 'next/server';
 
@@ -60,7 +60,9 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
     return NextResponse.json({ error: 'userId is required' }, { status: 400 });
   }
 
-  // Check if user exists
+  // Strip leading @ and resolve by userId or username
+  const identifier = userId.trim().replace(/^@/, '');
+
   const [user] = await db
     .select({
       id: users.id,
@@ -68,7 +70,12 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
       walletAddress: users.walletAddress,
     })
     .from(users)
-    .where(eq(users.id, userId))
+    .where(
+      or(
+        eq(users.id, identifier),
+        sql`lower(${users.username}) = lower(${identifier})`
+      )
+    )
     .limit(1);
 
   if (!user) {
@@ -79,7 +86,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
   const [existing] = await db
     .select({ id: nftSnapshot.id })
     .from(nftSnapshot)
-    .where(eq(nftSnapshot.userId, userId))
+    .where(eq(nftSnapshot.userId, user.id))
     .limit(1);
 
   if (existing) {
@@ -100,7 +107,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
 
   const newEntry = {
     id: nanoid(),
-    userId,
+    userId: user.id,
     walletAddress: user.walletAddress ?? null,
     rank: rank ?? maxRank + 1,
     points: points ?? 0,

--- a/apps/web/src/app/api/admin/whitelist/route.ts
+++ b/apps/web/src/app/api/admin/whitelist/route.ts
@@ -15,7 +15,7 @@ import {
   listWhitelistEntries,
   removeFromWhitelist,
 } from '@babylon/api/services/whitelist-service';
-import { db, eq, users } from '@babylon/db';
+import { db, eq, or, sql, users } from '@babylon/db';
 import { type NextRequest, NextResponse } from 'next/server';
 
 export const GET = withErrorHandling(async (request: NextRequest) => {
@@ -52,11 +52,18 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
     return NextResponse.json({ error: 'userId is required' }, { status: 400 });
   }
 
-  // Verify user exists
+  // Strip leading @ and resolve by userId or username
+  const identifier = userId.trim().replace(/^@/, '');
+
   const [user] = await db
     .select({ id: users.id, username: users.username })
     .from(users)
-    .where(eq(users.id, userId))
+    .where(
+      or(
+        eq(users.id, identifier),
+        sql`lower(${users.username}) = lower(${identifier})`
+      )
+    )
     .limit(1);
 
   if (!user) {
@@ -64,7 +71,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
   }
 
   const result = await addToWhitelist({
-    userId,
+    userId: user.id,
     source: source ?? 'admin_manual',
     reason,
     grantedBy: admin.dbUserId ?? undefined,

--- a/apps/web/src/components/admin/NftWhitelistTab.tsx
+++ b/apps/web/src/components/admin/NftWhitelistTab.tsx
@@ -211,7 +211,7 @@ export function NftWhitelistTab() {
               onKeyDown={(e) => {
                 if (e.key === 'Enter') handleAddUser();
               }}
-              placeholder="User ID to add..."
+              placeholder="Username or User ID..."
               className="h-9 rounded-lg border border-border bg-background px-3 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary"
             />
             <button

--- a/apps/web/src/components/admin/WhitelistTab.tsx
+++ b/apps/web/src/components/admin/WhitelistTab.tsx
@@ -438,7 +438,7 @@ export function WhitelistTab() {
               onKeyDown={(e) => {
                 if (e.key === 'Enter') handleAddUser();
               }}
-              placeholder="User ID to whitelist..."
+              placeholder="Username or User ID..."
               className="h-9 rounded-lg border border-border bg-background px-3 text-sm outline-none focus:border-primary focus:ring-1 focus:ring-primary"
             />
             <input

--- a/packages/api/src/services/whitelist-service.ts
+++ b/packages/api/src/services/whitelist-service.ts
@@ -131,6 +131,7 @@ export async function addToWhitelist({
 }: AddToWhitelistParams): Promise<{ id: string; alreadyExists: boolean }> {
   const id = nanoid();
   const now = new Date();
+  const nowISO = now.toISOString();
 
   const [result] = await db
     .insert(whitelist)
@@ -150,11 +151,14 @@ export async function addToWhitelist({
         source: sql`CASE WHEN ${whitelist.revokedAt} IS NOT NULL THEN ${source} ELSE ${whitelist.source} END`,
         reason: sql`CASE WHEN ${whitelist.revokedAt} IS NOT NULL THEN ${reason ?? null} ELSE ${whitelist.reason} END`,
         grantedBy: sql`CASE WHEN ${whitelist.revokedAt} IS NOT NULL THEN ${grantedBy ?? null} ELSE ${whitelist.grantedBy} END`,
-        grantedAt: sql`CASE WHEN ${whitelist.revokedAt} IS NOT NULL THEN ${now} ELSE ${whitelist.grantedAt} END`,
+        grantedAt: sql`CASE WHEN ${whitelist.revokedAt} IS NOT NULL THEN ${nowISO}::timestamp ELSE ${whitelist.grantedAt} END`,
         revokedAt: sql`CASE WHEN ${whitelist.revokedAt} IS NOT NULL THEN NULL ELSE ${whitelist.revokedAt} END`,
       },
     })
-    .returning({ id: whitelist.id, revokedAt: whitelist.revokedAt });
+    .returning({ id: whitelist.id });
+
+  // An upsert always returns a row — but guard just in case.
+  if (!result) throw new Error('Whitelist upsert returned no rows');
 
   // If the returned id matches what we tried to insert, it's a new/replaced row.
   // If it doesn't match, the row was already active and untouched.
@@ -351,6 +355,7 @@ export async function importFirst100FromSnapshot(grantedBy?: string) {
     for (const entry of snapshotEntries) {
       const id = nanoid();
       const now = new Date();
+      const nowISO = now.toISOString();
 
       const [row] = await tx
         .insert(whitelist)
@@ -370,11 +375,13 @@ export async function importFirst100FromSnapshot(grantedBy?: string) {
             source: sql`CASE WHEN ${whitelist.revokedAt} IS NOT NULL THEN 'snapshot_first_100' ELSE ${whitelist.source} END`,
             reason: sql`CASE WHEN ${whitelist.revokedAt} IS NOT NULL THEN ${'Imported from NFT snapshot (rank #' + entry.rank + ')'} ELSE ${whitelist.reason} END`,
             grantedBy: sql`CASE WHEN ${whitelist.revokedAt} IS NOT NULL THEN ${grantedBy ?? null} ELSE ${whitelist.grantedBy} END`,
-            grantedAt: sql`CASE WHEN ${whitelist.revokedAt} IS NOT NULL THEN ${now} ELSE ${whitelist.grantedAt} END`,
+            grantedAt: sql`CASE WHEN ${whitelist.revokedAt} IS NOT NULL THEN ${nowISO}::timestamp ELSE ${whitelist.grantedAt} END`,
             revokedAt: sql`CASE WHEN ${whitelist.revokedAt} IS NOT NULL THEN NULL ELSE ${whitelist.revokedAt} END`,
           },
         })
         .returning({ id: whitelist.id });
+
+      if (!row) throw new Error('Whitelist upsert returned no rows');
 
       if (row.id === id) {
         imported++;


### PR DESCRIPTION
## Summary

- Fix `TypeError: Received an instance of Date` error when using the whitelist import feature on staging
- The postgres driver rejects `Date` objects in raw `sql` template literals — convert to ISO string and cast with `::timestamp`
- Add guard clauses for potentially undefined `.returning()` results

## Context

Follow-up fix to PR #995 (whitelisting system). The `ON CONFLICT DO UPDATE` clauses passed JavaScript `Date` objects directly into Drizzle's `sql` template literals, which the postgres driver cannot serialize. Drizzle auto-converts `Date` in `values()` but not in raw `sql` expressions.

## Changes

- `packages/api/src/services/whitelist-service.ts`: Convert `new Date()` to `.toISOString()` + `::timestamp` cast in all `ON CONFLICT` SET clauses (both `addToWhitelist` and `importFirst100FromSnapshot`)

## Test Plan

- [ ] Verify Import First 100 works on staging admin panel
- [ ] Verify manual whitelist add works on staging admin panel
- [ ] Verify whitelist revoke + re-add works correctly