### PR TITLE
fix: complete profile modal not opening on click

### DIFF
--- a/apps/web/src/components/shared/ComingSoon.tsx
+++ b/apps/web/src/components/shared/ComingSoon.tsx
@@ -24,6 +24,7 @@ import {
 import Image from 'next/image';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { toast } from 'sonner';
 import { LinkSocialAccountsModal } from '@/components/profile/LinkSocialAccountsModal';
 import { Avatar } from '@/components/shared/Avatar';
@@ -2282,32 +2283,329 @@ export function ComingSoon() {
   // Authenticated but not onboarded yet: don't show an infinite waitlist loader.
   if (!dbUser.profileComplete || !dbUser.username) {
     return (
-      <div className="fixed inset-0 z-[110] flex items-center justify-center bg-background">
-        <div className="mx-auto w-full max-w-md px-6 text-center">
-          <h2 className="mb-2 font-semibold text-foreground text-xl">
-            Complete your profile to continue
-          </h2>
-          <p className="mb-6 text-muted-foreground">
-            We need a username before we can show your waitlist position.
-          </p>
-          <div className="flex items-center justify-center gap-3">
-            <button
-              type="button"
-              onClick={() => setShowProfileModal(true)}
-              className="rounded-lg bg-primary px-4 py-2 font-semibold text-primary-foreground transition-opacity hover:opacity-90"
-            >
-              Complete profile
-            </button>
-            <button
-              type="button"
-              onClick={() => void logout()}
-              className="rounded-lg border border-border px-4 py-2 font-semibold text-foreground transition-colors hover:bg-muted"
-            >
-              Logout
-            </button>
+      <>
+        <div className="fixed inset-0 z-[110] flex items-center justify-center bg-background">
+          <div className="mx-auto w-full max-w-md px-6 text-center">
+            <h2 className="mb-2 font-semibold text-foreground text-xl">
+              Complete your profile to continue
+            </h2>
+            <p className="mb-6 text-muted-foreground">
+              We need a username before we can show your waitlist position.
+            </p>
+            <div className="flex items-center justify-center gap-3">
+              <button
+                type="button"
+                onClick={() => setShowProfileModal(true)}
+                className="rounded-lg bg-primary px-4 py-2 font-semibold text-primary-foreground transition-opacity hover:opacity-90"
+              >
+                Complete profile
+              </button>
+              <button
+                type="button"
+                onClick={() => void logout()}
+                className="rounded-lg border border-border px-4 py-2 font-semibold text-foreground transition-colors hover:bg-muted"
+              >
+                Logout
+              </button>
+            </div>
           </div>
         </div>
-      </div>
+        {showProfileModal &&
+          createPortal(
+            <>
+              <div
+                className="fixed inset-0 z-[100] bg-black/70 backdrop-blur-sm transition-opacity duration-300"
+                onClick={() =>
+                  !isSavingProfile && setShowProfileModal(false)
+                }
+                style={{ pointerEvents: 'auto' }}
+              />
+              <div className="pointer-events-none fixed inset-0 z-[100] flex items-center justify-center overflow-y-auto p-4">
+                <div
+                  className="pointer-events-auto my-8 w-full max-w-2xl rounded-lg border border-border bg-background shadow-xl transition-all duration-300"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <div className="flex items-center justify-between border-border border-b p-6">
+                    <div className="flex items-center gap-3">
+                      <div className="rounded-lg bg-primary/10 p-2">
+                        <User className="h-6 w-6 text-primary" />
+                      </div>
+                      <div>
+                        <h2 className="font-bold text-2xl">
+                          {dbUser?.profileComplete
+                            ? 'Edit Profile'
+                            : 'Complete Profile'}
+                        </h2>
+                        {!dbUser?.profileComplete ? (
+                          <p className="text-muted-foreground text-sm">
+                            Earn{' '}
+                            <span className="font-semibold text-primary">
+                              +{POINTS.PROFILE_COMPLETION} points
+                            </span>{' '}
+                            when complete
+                          </p>
+                        ) : (
+                          <p className="text-muted-foreground text-sm">
+                            Update your profile information
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => setShowProfileModal(false)}
+                      disabled={isSavingProfile}
+                      className="rounded-lg p-2 transition-colors hover:bg-muted disabled:opacity-50"
+                    >
+                      <X className="h-5 w-5" />
+                    </button>
+                  </div>
+                  <form
+                    onSubmit={(e) => {
+                      e.preventDefault()
+                      handleSaveProfile()
+                    }}
+                    className="space-y-6 p-6"
+                  >
+                    {!dbUser?.profileComplete && (
+                      <div className="rounded-lg border border-primary/20 bg-primary/10 p-4">
+                        <p className="text-foreground text-sm leading-relaxed">
+                          <span className="font-semibold">💡 Pro Tip:</span>{' '}
+                          Complete all fields below to earn{' '}
+                          <span className="font-bold text-primary">
+                            {POINTS.PROFILE_COMPLETION} points
+                          </span>{' '}
+                          and personalize your Babylon experience!
+                        </p>
+                      </div>
+                    )}
+                    <div className="space-y-2">
+                      <label className="block font-medium text-sm">
+                        Profile Banner
+                      </label>
+                      <div className="group relative h-40 overflow-hidden rounded-lg bg-muted">
+                        <Image
+                          src={
+                            uploadedBanner ||
+                            profileForm.coverImageUrl ||
+                            `/assets/user-banners/banner-${bannerIndex}.jpg`
+                          }
+                          alt="Profile banner"
+                          fill
+                          className="object-cover"
+                          unoptimized
+                        />
+                        <div className="absolute inset-0 flex items-center justify-center gap-2 bg-black/50 opacity-0 transition-opacity group-hover:opacity-100">
+                          <button
+                            type="button"
+                            onClick={() => cycleBanner('prev')}
+                            className="rounded-lg bg-background/80 p-2 transition-colors hover:bg-background"
+                            title="Previous banner"
+                          >
+                            <ChevronLeft className="h-5 w-5" />
+                          </button>
+                          <label
+                            className="cursor-pointer rounded-lg bg-background/80 p-2 transition-colors hover:bg-background"
+                            title="Upload banner"
+                          >
+                            <Upload className="h-5 w-5" />
+                            <input
+                              type="file"
+                              accept="image/*"
+                              onChange={handleBannerUpload}
+                              className="hidden"
+                              disabled={isSavingProfile}
+                            />
+                          </label>
+                          <button
+                            type="button"
+                            onClick={() => cycleBanner('next')}
+                            className="rounded-lg bg-background/80 p-2 transition-colors hover:bg-background"
+                            title="Next banner"
+                          >
+                            <ChevronRight className="h-5 w-5" />
+                          </button>
+                        </div>
+                      </div>
+                      <p className="text-muted-foreground text-xs">
+                        Click to cycle through banners or upload your own
+                      </p>
+                    </div>
+                    <div className="flex items-start gap-4">
+                      <div className="group relative h-24 w-24 shrink-0 overflow-hidden rounded-full bg-muted">
+                        <Image
+                          src={
+                            uploadedProfileImage ||
+                            profileForm.profileImageUrl ||
+                            `/assets/user-profiles/profile-${profilePictureIndex}.jpg`
+                          }
+                          alt="Profile picture"
+                          fill
+                          className="object-cover"
+                          unoptimized
+                        />
+                        <div className="absolute inset-0 flex items-center justify-center gap-1 bg-black/50 opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100">
+                          <button
+                            type="button"
+                            onClick={() => cycleProfilePicture('prev')}
+                            className="rounded-lg bg-background/80 p-1.5 transition-colors hover:bg-background"
+                            title="Previous picture"
+                          >
+                            <ChevronLeft className="h-4 w-4" />
+                          </button>
+                          <label
+                            className="cursor-pointer rounded-lg bg-background/80 p-1.5 transition-colors hover:bg-background"
+                            title="Upload picture"
+                          >
+                            <Upload className="h-4 w-4" />
+                            <input
+                              type="file"
+                              accept="image/*"
+                              onChange={handleProfileImageUpload}
+                              className="hidden"
+                              disabled={isSavingProfile}
+                            />
+                          </label>
+                          <button
+                            type="button"
+                            onClick={() => cycleProfilePicture('next')}
+                            className="rounded-lg bg-background/80 p-1.5 transition-colors hover:bg-background"
+                            title="Next picture"
+                          >
+                            <ChevronRight className="h-4 w-4" />
+                          </button>
+                        </div>
+                      </div>
+                      <div className="flex-1 space-y-4">
+                        <div className="space-y-2">
+                          <label className="block font-medium text-sm">
+                            Display Name *
+                          </label>
+                          <input
+                            type="text"
+                            value={profileForm.displayName}
+                            onChange={(e) =>
+                              setProfileForm((prev) => ({
+                                ...prev,
+                                displayName: e.target.value,
+                              }))
+                            }
+                            placeholder="Your display name"
+                            className="w-full rounded-lg border border-border bg-muted px-3 py-2 transition-colors focus:outline-none focus:ring-2 focus:ring-primary"
+                            disabled={isSavingProfile}
+                            maxLength={50}
+                          />
+                        </div>
+                        <div className="space-y-2">
+                          <label className="block font-medium text-sm">
+                            Username *
+                          </label>
+                          <div className="relative">
+                            <span className="-translate-y-1/2 absolute top-1/2 left-3 text-muted-foreground">
+                              @
+                            </span>
+                            <input
+                              type="text"
+                              value={profileForm.username}
+                              onChange={(e) =>
+                                setProfileForm((prev) => ({
+                                  ...prev,
+                                  username: e.target.value,
+                                }))
+                              }
+                              placeholder="Choose a username"
+                              className="w-full rounded-lg border border-border bg-muted py-2 pr-10 pl-8 transition-colors focus:outline-none focus:ring-2 focus:ring-primary"
+                              disabled={isSavingProfile}
+                              maxLength={20}
+                            />
+                            {isCheckingUsername && (
+                              <div className="-translate-y-1/2 absolute top-1/2 right-3">
+                                <div className="h-4 w-4 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+                              </div>
+                            )}
+                            {usernameStatus === 'available' &&
+                              !isCheckingUsername && (
+                                <Check className="-translate-y-1/2 absolute top-1/2 right-3 h-4 w-4 text-green-500" />
+                              )}
+                            {usernameStatus === 'taken' && !isCheckingUsername && (
+                              <X className="-translate-y-1/2 absolute top-1/2 right-3 h-4 w-4 text-red-500" />
+                            )}
+                          </div>
+                          {usernameStatus === 'taken' && usernameSuggestion && (
+                            <p className="text-muted-foreground text-xs">
+                              Suggestion:{' '}
+                              <button
+                                type="button"
+                                className="text-primary underline hover:text-primary/80"
+                                onClick={() =>
+                                  setProfileForm((prev) => ({
+                                    ...prev,
+                                    username: usernameSuggestion ?? '',
+                                  }))
+                                }
+                              >
+                                {usernameSuggestion}
+                              </button>
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                    <div className="space-y-2">
+                      <label className="block font-medium text-sm">Bio</label>
+                      <textarea
+                        value={profileForm.bio}
+                        onChange={(e) =>
+                          setProfileForm((prev) => ({
+                            ...prev,
+                            bio: e.target.value,
+                          }))
+                        }
+                        placeholder="Tell us about yourself..."
+                        rows={3}
+                        maxLength={280}
+                        className="w-full resize-none rounded-lg border border-border bg-muted px-3 py-2 transition-colors focus:outline-none focus:ring-2 focus:ring-primary"
+                        disabled={isSavingProfile}
+                      />
+                      <p className="text-right text-muted-foreground text-xs">
+                        {profileForm.bio.length}/280
+                      </p>
+                    </div>
+                    <div className="flex gap-3 pt-4">
+                      <button
+                        type="button"
+                        onClick={() => setShowProfileModal(false)}
+                        disabled={isSavingProfile}
+                        className="flex-1 rounded-lg border border-border bg-sidebar px-4 py-2 font-semibold transition-colors hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="submit"
+                        disabled={(() => {
+                          const username =
+                            profileForm.username?.trim() || ''
+                          const displayName =
+                            profileForm.displayName?.trim() || ''
+                          return (
+                            isSavingProfile || !username || !displayName
+                          )
+                        })()}
+                        className="min-h-[44px] flex-1 rounded-lg bg-primary px-4 py-2 font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        {isSavingProfile
+                          ? 'Saving...'
+                          : dbUser?.profileComplete
+                            ? 'Save Changes'
+                            : 'Save & Earn Points'}
+                      </button>
+                    </div>
+                  </form>
+                </div>
+              </div>
+            </>,
+            document.body,
+          )}
+      </>
     );
   }
 


### PR DESCRIPTION
## Summary
- The "Complete profile" button on the profile-incomplete screen did nothing when clicked
- Root cause: the `createPortal()` call had malformed closing syntax — the fragment closing tag `</>` and `document.body` argument were placed outside the function call parentheses, causing a silent parse error
- Fix: corrected the `createPortal(JSX, document.body)` closing syntax so the modal renders properly

## Test plan
- [ ] Log in with a user that has no username/profile completed
- [ ] Verify the "Complete your profile to continue" screen appears
- [ ] Click "Complete profile" button — modal should now open
- [ ] Fill in username + display name and submit — profile should save
- [ ] Verify "Logout" button still works