### PR TITLE
feat(leaderboard): redesign leaderboard page

### DIFF
--- a/apps/web/src/app/leaderboard/loading.tsx
+++ b/apps/web/src/app/leaderboard/loading.tsx
@@ -15,7 +15,7 @@ export default function LeaderboardLoading() {
           {/* Sticky header with tab toggle */}
           <div className="sticky top-0 z-10 flex-shrink-0 bg-background shadow-sm">
             <div className="flex w-full items-center border-border border-b">
-              {['All Points', 'Earned', 'Referral'].map((label) => (
+              {['Total', 'Reputation', 'Earned', 'Referral'].map((label) => (
                 <div key={label} className="flex-1 py-3.5 text-center">
                   <Skeleton className="mx-auto h-4 w-20" />
                 </div>
@@ -46,7 +46,7 @@ export default function LeaderboardLoading() {
         {/* Sticky header with tab toggle */}
         <div className="sticky top-0 z-10 flex-shrink-0 bg-background shadow-sm">
           <div className="flex w-full items-center border-border border-b">
-            {['All Points', 'Earned', 'Referral'].map((label) => (
+            {['Total', 'Reputation', 'Earned', 'Referral'].map((label) => (
               <div key={label} className="flex-1 py-3.5 text-center">
                 <Skeleton className="mx-auto h-4 w-20" />
               </div>

--- a/apps/web/src/app/leaderboard/page.tsx
+++ b/apps/web/src/app/leaderboard/page.tsx
@@ -1,9 +1,6 @@
 'use client';
 
-import {
-  getActorProfileUrl,
-  getProfileUrl,
-} from '@babylon/shared';
+import { getActorProfileUrl, getProfileUrl } from '@babylon/shared';
 import { ChevronLeft, ChevronRight, Trophy } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import Link from 'next/link';
@@ -315,13 +312,10 @@ export default function LeaderboardPage() {
                       />
                       {authenticated && !isCurrentUser && (
                         <div
-                          className="absolute -bottom-0.5 -right-1"
+                          className="-bottom-0.5 -right-1 absolute"
                           onClick={(e) => e.stopPropagation()}
                         >
-                          <FollowButton
-                            userId={player.id}
-                            variant="circle"
-                          />
+                          <FollowButton userId={player.id} variant="circle" />
                         </div>
                       )}
                     </div>
@@ -387,11 +381,8 @@ export default function LeaderboardPage() {
                         src={player.profileImageUrl || undefined}
                       />
                       {authenticated && !isCurrentUser && (
-                        <div className="absolute -bottom-0.5 -right-1">
-                          <FollowButton
-                            userId={player.id}
-                            variant="circle"
-                          />
+                        <div className="-bottom-0.5 -right-1 absolute">
+                          <FollowButton userId={player.id} variant="circle" />
                         </div>
                       )}
                     </div>
@@ -419,7 +410,9 @@ export default function LeaderboardPage() {
                         <span className="font-bold text-foreground">
                           {formattedPoints} pts
                         </span>
-                        <span className="text-muted-foreground">{activePointsLabel}</span>
+                        <span className="text-muted-foreground">
+                          {activePointsLabel}
+                        </span>
                       </div>
                     </div>
                   </div>

--- a/apps/web/src/app/leaderboard/page.tsx
+++ b/apps/web/src/app/leaderboard/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import {
-  formatCurrency,
   getActorProfileUrl,
   getProfileUrl,
 } from '@babylon/shared';
@@ -16,7 +15,7 @@ import { Avatar } from '@/components/shared/Avatar';
 import type { LeaderboardTab } from '@/components/shared/LeaderboardToggle';
 import { LeaderboardToggle } from '@/components/shared/LeaderboardToggle';
 import { PageContainer } from '@/components/shared/PageContainer';
-import { RankBadge, RankNumber } from '@/components/shared/RankBadge';
+import { RankNumber } from '@/components/shared/RankBadge';
 import { LeaderboardSkeleton } from '@/components/shared/Skeleton';
 import { VerifiedBadge } from '@/components/shared/VerifiedBadge';
 import { useAuth } from '@/hooks/useAuth';
@@ -273,18 +272,6 @@ export default function LeaderboardPage() {
                     ? player.earnedPoints
                     : player.invitePoints;
             const formattedPoints = (displayPoints ?? 0).toLocaleString();
-            const absolutePnL = Math.abs(player.lifetimePnL);
-            const formattedPnL = formatCurrency(absolutePnL);
-            const pnlDisplay =
-              player.lifetimePnL === 0
-                ? formatCurrency(0)
-                : `${player.lifetimePnL > 0 ? '+' : '-'}${formattedPnL}`;
-            const pnlColor =
-              player.lifetimePnL === 0
-                ? 'text-muted-foreground'
-                : player.lifetimePnL > 0
-                  ? 'text-green-500'
-                  : 'text-red-500';
 
             return (
               <div key={player.id} className="flex items-stretch">
@@ -308,9 +295,9 @@ export default function LeaderboardPage() {
                   }
                   className={`hidden flex-1 cursor-pointer px-4 py-3 text-left transition-colors xl:block ${
                     isSelected
-                      ? 'border-[#0066FF] border-l-4 bg-[#0066FF]/20'
+                      ? 'border-l-4 border-l-foreground bg-muted/30'
                       : isCurrentUser
-                        ? 'border-l-4 border-l-[#0066FF] bg-[#0066FF]/10 hover:bg-muted/30'
+                        ? 'border-l-4 border-l-foreground bg-muted/20 hover:bg-muted/30'
                         : 'border-l-4 border-l-transparent hover:bg-muted/30'
                   }`}
                 >
@@ -318,7 +305,7 @@ export default function LeaderboardPage() {
                     <div className="shrink-0">
                       <RankNumber rank={player.rank} size="md" />
                     </div>
-                    <div className="shrink-0">
+                    <div className="relative shrink-0">
                       <Avatar
                         id={player.id}
                         name={player.displayName || player.username || 'User'}
@@ -326,6 +313,17 @@ export default function LeaderboardPage() {
                         size="md"
                         src={player.profileImageUrl || undefined}
                       />
+                      {authenticated && !isCurrentUser && (
+                        <div
+                          className="absolute -bottom-0.5 -right-1"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <FollowButton
+                            userId={player.id}
+                            variant="circle"
+                          />
+                        </div>
+                      )}
                     </div>
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-1.5">
@@ -342,7 +340,7 @@ export default function LeaderboardPage() {
                           />
                         )}
                         {isCurrentUser && (
-                          <span className="rounded bg-[#0066FF] px-2 py-0.5 font-semibold text-primary-foreground text-xs">
+                          <span className="rounded bg-foreground px-2 py-0.5 font-semibold text-background text-xs">
                             YOU
                           </span>
                         )}
@@ -354,88 +352,14 @@ export default function LeaderboardPage() {
                       )}
                     </div>
                     <div className="shrink-0 text-right">
-                      <div className="flex items-center gap-3">
-                        <div>
-                          <div className="font-bold text-foreground text-lg">
-                            {formattedPoints}
-                          </div>
-                          <div className="text-muted-foreground text-xs">
-                            {activePointsLabel}
-                          </div>
-                        </div>
-                        {authenticated && !isCurrentUser && (
-                          <div
-                            className="shrink-0"
-                            onClick={(e) => e.stopPropagation()}
-                          >
-                            <FollowButton
-                              userId={player.id}
-                              size="sm"
-                              variant="icon"
-                            />
-                          </div>
-                        )}
+                      <div className="font-bold text-foreground text-lg">
+                        {formattedPoints}
+                      </div>
+                      <div className="text-muted-foreground text-xs">
+                        {activePointsLabel}
                       </div>
                     </div>
                   </div>
-                  {!player.isActor &&
-                    (player.invitePoints > 0 ||
-                      player.earnedPoints !== 0 ||
-                      player.bonusPoints > 0 ||
-                      player.lifetimePnL !== 0 ||
-                      player.referralCount > 0) && (
-                      <div className="mt-2 ml-16 flex gap-4 text-xs">
-                        <div className="flex items-center gap-1">
-                          <span className="text-muted-foreground">P&L:</span>
-                          <span className={`font-semibold ${pnlColor}`}>
-                            {pnlDisplay}
-                          </span>
-                        </div>
-                        {player.invitePoints > 0 && (
-                          <div className="flex items-center gap-1">
-                            <span className="text-muted-foreground">
-                              Invite:
-                            </span>
-                            <span className="font-semibold text-primary">
-                              {player.invitePoints}
-                            </span>
-                          </div>
-                        )}
-                        {player.earnedPoints !== 0 && (
-                          <div className="flex items-center gap-1">
-                            <span className="text-muted-foreground">
-                              Earned:
-                            </span>
-                            <span
-                              className={`font-semibold ${player.earnedPoints > 0 ? 'text-green-500' : 'text-red-500'}`}
-                            >
-                              {player.earnedPoints > 0 ? '+' : ''}
-                              {player.earnedPoints}
-                            </span>
-                          </div>
-                        )}
-                        {player.bonusPoints > 0 && (
-                          <div className="flex items-center gap-1">
-                            <span className="text-muted-foreground">
-                              Bonus:
-                            </span>
-                            <span className="font-semibold text-yellow-500">
-                              {player.bonusPoints}
-                            </span>
-                          </div>
-                        )}
-                        {player.referralCount > 0 && (
-                          <div className="flex items-center gap-1">
-                            <span className="text-muted-foreground">
-                              Referrals:
-                            </span>
-                            <span className="font-semibold text-primary">
-                              {player.referralCount}
-                            </span>
-                          </div>
-                        )}
-                      </div>
-                    )}
                 </div>
 
                 {/* Mobile/Tablet: Direct link to profile */}
@@ -444,20 +368,17 @@ export default function LeaderboardPage() {
                   data-testid={
                     player.isActor ? 'npc-entry' : 'leaderboard-entry'
                   }
-                  className={`block flex-1 px-4 py-3 transition-colors xl:hidden ${
+                  className={`block flex-1 px-4 py-1.5 transition-colors xl:hidden ${
                     isCurrentUser
-                      ? 'border-l-4 bg-[#0066FF]/20'
+                      ? 'border-l-4 border-l-foreground bg-muted/20'
                       : 'hover:bg-muted/30'
                   }`}
-                  style={{
-                    borderLeftColor: isCurrentUser ? '#0066FF' : 'transparent',
-                  }}
                 >
                   <div className="flex items-center gap-2 sm:gap-4">
                     <div className="shrink-0">
                       <RankNumber rank={player.rank} size="md" />
                     </div>
-                    <div className="shrink-0">
+                    <div className="relative shrink-0">
                       <Avatar
                         id={player.id}
                         name={player.displayName || player.username || 'User'}
@@ -465,6 +386,14 @@ export default function LeaderboardPage() {
                         size="md"
                         src={player.profileImageUrl || undefined}
                       />
+                      {authenticated && !isCurrentUser && (
+                        <div className="absolute -bottom-0.5 -right-1">
+                          <FollowButton
+                            userId={player.id}
+                            variant="circle"
+                          />
+                        </div>
+                      )}
                     </div>
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-1.5">
@@ -481,75 +410,20 @@ export default function LeaderboardPage() {
                           />
                         )}
                         {isCurrentUser && (
-                          <span className="shrink-0 rounded bg-[#0066FF]/20 px-2 py-0.5 text-[#0066FF] text-xs">
+                          <span className="shrink-0 rounded bg-foreground px-2 py-0.5 text-background text-xs">
                             You
                           </span>
                         )}
                       </div>
-                      {player.username && (
-                        <p className="mb-1 truncate text-muted-foreground text-xs">
-                          @{player.username}
-                        </p>
-                      )}
-                      <div className="flex items-center gap-2 text-muted-foreground text-xs sm:gap-3 sm:text-sm">
-                        <span className="font-semibold text-foreground">
+                      <div className="flex items-center gap-2 text-xs sm:text-sm">
+                        <span className="font-bold text-foreground">
                           {formattedPoints} pts
                         </span>
-                        <span>{activePointsLabel}</span>
-                        {player.rank <= 3 && <RankBadge rank={player.rank} />}
+                        <span className="text-muted-foreground">{activePointsLabel}</span>
                       </div>
-                      {!player.isActor && (
-                        <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-muted-foreground text-xs sm:text-sm">
-                          <span className={`${pnlColor} font-semibold`}>
-                            P&L: {pnlDisplay}
-                          </span>
-                          {player.invitePoints > 0 && (
-                            <span>
-                              Invite:{' '}
-                              <span className="font-semibold text-primary">
-                                {player.invitePoints}
-                              </span>
-                            </span>
-                          )}
-                          {player.earnedPoints !== 0 && (
-                            <span>
-                              Earned:{' '}
-                              <span
-                                className={`font-semibold ${player.earnedPoints > 0 ? 'text-green-500' : 'text-red-500'}`}
-                              >
-                                {player.earnedPoints > 0 ? '+' : ''}
-                                {player.earnedPoints}
-                              </span>
-                            </span>
-                          )}
-                          {player.bonusPoints > 0 && (
-                            <span>
-                              Bonus:{' '}
-                              <span className="font-semibold text-yellow-500">
-                                {player.bonusPoints}
-                              </span>
-                            </span>
-                          )}
-                          {player.referralCount > 0 && (
-                            <span>
-                              Referrals:{' '}
-                              <span className="font-semibold text-primary">
-                                {player.referralCount}
-                              </span>
-                            </span>
-                          )}
-                        </div>
-                      )}
                     </div>
                   </div>
                 </Link>
-
-                {/* Mobile Follow Button */}
-                {authenticated && !isCurrentUser && (
-                  <div className="flex shrink-0 items-center self-center pr-3 xl:hidden">
-                    <FollowButton userId={player.id} size="sm" variant="icon" />
-                  </div>
-                )}
               </div>
             );
           })}

--- a/apps/web/src/components/interactions/FollowButton.tsx
+++ b/apps/web/src/components/interactions/FollowButton.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { cn, logger } from '@babylon/shared';
-import { UserMinus, UserPlus } from 'lucide-react';
+import { Minus, Plus, UserMinus, UserPlus } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { Skeleton } from '@/components/shared/Skeleton';
@@ -32,7 +32,7 @@ interface FollowButtonProps {
   userId: string;
   initialFollowing?: boolean;
   size?: 'sm' | 'md' | 'lg';
-  variant?: 'button' | 'icon';
+  variant?: 'button' | 'icon' | 'circle';
   className?: string;
   onFollowChange?: (isFollowing: boolean) => void;
   onFollowerCountChange?: (delta: number) => void; // +1 for follow, -1 for unfollow
@@ -220,6 +220,33 @@ export function FollowButton({
     md: 'p-2',
     lg: 'p-2.5',
   };
+
+  if (variant === 'circle') {
+    if (isChecking) return null;
+
+    return (
+      <button
+        onClick={handleFollow}
+        disabled={isLoading}
+        className={cn(
+          'flex items-center justify-center rounded-full border-2 border-background transition-colors',
+          isFollowing
+            ? 'bg-red-500 hover:bg-red-600'
+            : 'bg-primary hover:bg-primary/80',
+          isLoading && 'cursor-not-allowed opacity-50',
+          'h-5 w-5',
+          className
+        )}
+        aria-label={isFollowing ? 'Unfollow' : 'Follow'}
+      >
+        {isFollowing ? (
+          <Minus className="h-3 w-3 text-white" />
+        ) : (
+          <Plus className="h-3 w-3 text-white" />
+        )}
+      </button>
+    );
+  }
 
   if (variant === 'icon') {
     // Show subtle skeleton during loading to prevent layout shift

--- a/apps/web/src/components/leaderboard/LeaderboardWidgetSidebar.tsx
+++ b/apps/web/src/components/leaderboard/LeaderboardWidgetSidebar.tsx
@@ -5,13 +5,12 @@ import {
   getActorProfileUrl,
   getProfileUrl,
 } from '@babylon/shared';
-import { ExternalLink, TrendingUp, Trophy, Users } from 'lucide-react';
+import { ExternalLink } from 'lucide-react';
 import Link from 'next/link';
 import { useEffect, useRef } from 'react';
 import { FollowButton } from '@/components/interactions/FollowButton';
 import { OnChainBadge } from '@/components/profile/OnChainBadge';
 import { Avatar } from '@/components/shared/Avatar';
-import { RankBadge, RankNumber } from '@/components/shared/RankBadge';
 import { VerifiedBadge } from '@/components/shared/VerifiedBadge';
 import { useAuth } from '@/hooks/useAuth';
 
@@ -48,7 +47,6 @@ interface LeaderboardWidgetSidebarProps {
  */
 export function LeaderboardWidgetSidebar({
   selectedUser,
-  pointsCategory,
 }: LeaderboardWidgetSidebarProps) {
   const { authenticated, user } = useAuth();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -137,31 +135,6 @@ export function LeaderboardWidgetSidebar({
     };
   }, []);
 
-  const getDisplayPoints = (user: SelectedUser) => {
-    switch (pointsCategory) {
-      case 'total':
-        return user.totalPoints ?? 0;
-      case 'all':
-        return user.allPoints;
-      case 'earned':
-        return user.earnedPoints;
-      case 'referral':
-        return user.invitePoints;
-    }
-  };
-
-  const getPointsLabel = () => {
-    switch (pointsCategory) {
-      case 'total':
-        return 'Total Points';
-      case 'all':
-        return 'Reputation';
-      case 'earned':
-        return 'Earned Points';
-      case 'referral':
-        return 'Referral Points';
-    }
-  };
 
   return (
     <div
@@ -170,14 +143,8 @@ export function LeaderboardWidgetSidebar({
     >
       <div ref={innerRef} className="mr-28 flex flex-col gap-6 px-4 py-6">
         {/* Selected User Widget */}
-        <div className="rounded-lg border border-border bg-card/50 p-4 backdrop-blur">
-          <h3 className="mb-4 flex items-center gap-2 font-semibold text-foreground">
-            <Trophy className="h-5 w-5 text-[#0066FF]" />
-            Selected Player
-          </h3>
-
-          {selectedUser ? (
-            <div className="space-y-4">
+        {selectedUser && (
+          <div className="space-y-4">
               {/* User Header */}
               <div className="flex items-center gap-3">
                 <Avatar
@@ -186,7 +153,7 @@ export function LeaderboardWidgetSidebar({
                     selectedUser.displayName || selectedUser.username || 'User'
                   }
                   type={selectedUser.isActor ? 'actor' : undefined}
-                  size="lg"
+                  size="md"
                   src={selectedUser.profileImageUrl || undefined}
                 />
                 <div className="min-w-0 flex-1">
@@ -212,32 +179,24 @@ export function LeaderboardWidgetSidebar({
                     </p>
                   )}
                 </div>
+                {authenticated && user && selectedUser.id !== user.id && (
+                  <FollowButton
+                    userId={selectedUser.id}
+                    size="sm"
+                    variant="button"
+                    className="w-20"
+                  />
+                )}
               </div>
 
-              {/* Rank Display */}
-              <div className="flex items-center justify-between rounded-lg bg-muted/30 p-3">
-                <div className="flex items-center gap-3">
-                  <RankNumber rank={selectedUser.rank} size="lg" />
-                  <div>
-                    <div className="font-bold text-foreground text-xl">
-                      {getDisplayPoints(selectedUser).toLocaleString()}
-                    </div>
-                    <div className="text-muted-foreground text-xs">
-                      {getPointsLabel()}
-                    </div>
-                  </div>
-                </div>
-                <RankBadge rank={selectedUser.rank} size="lg" showLabel />
-              </div>
 
               {/* Total Points (primary metric) */}
               {selectedUser.totalPoints !== undefined && (
-                <div className="rounded-lg bg-[#0066FF]/10 p-3">
-                  <div className="flex items-center gap-1 text-muted-foreground text-xs">
-                    <Trophy className="h-3 w-3" />
+                <div className="border-border border-b pb-3">
+                  <div className="text-muted-foreground text-xs">
                     Total Points
                   </div>
-                  <div className="font-bold text-[#0066FF] text-xl">
+                  <div className="font-bold text-foreground text-xl">
                     {selectedUser.totalPoints.toLocaleString()}
                   </div>
                 </div>
@@ -246,9 +205,8 @@ export function LeaderboardWidgetSidebar({
               {/* Stats Grid */}
               <div className="grid grid-cols-2 gap-3">
                 {/* P&L */}
-                <div className="rounded-lg bg-muted/30 p-3">
-                  <div className="flex items-center gap-1 text-muted-foreground text-xs">
-                    <TrendingUp className="h-3 w-3" />
+                <div>
+                  <div className="text-muted-foreground text-xs">
                     Lifetime P&L
                   </div>
                   <div
@@ -267,9 +225,8 @@ export function LeaderboardWidgetSidebar({
                 </div>
 
                 {/* Referrals */}
-                <div className="rounded-lg bg-muted/30 p-3">
-                  <div className="flex items-center gap-1 text-muted-foreground text-xs">
-                    <Users className="h-3 w-3" />
+                <div>
+                  <div className="text-muted-foreground text-xs">
                     Referrals
                   </div>
                   <div className="font-bold text-foreground">
@@ -278,8 +235,8 @@ export function LeaderboardWidgetSidebar({
                 </div>
 
                 {/* All Points Breakdown */}
-                {selectedUser.allPoints > 0 && (
-                  <div className="col-span-2 rounded-lg bg-muted/30 p-3">
+                {(selectedUser.earnedPoints !== 0 || selectedUser.invitePoints > 0 || selectedUser.bonusPoints > 0) && (
+                  <div className="col-span-2 border-border border-t pt-3">
                     <div className="mb-2 text-muted-foreground text-xs">
                       Points Breakdown
                     </div>
@@ -300,7 +257,7 @@ export function LeaderboardWidgetSidebar({
                           <span className="text-muted-foreground">
                             Referral
                           </span>
-                          <span className="font-semibold text-primary">
+                          <span className="font-semibold text-foreground">
                             +{selectedUser.invitePoints.toLocaleString()}
                           </span>
                         </div>
@@ -308,7 +265,7 @@ export function LeaderboardWidgetSidebar({
                       {selectedUser.bonusPoints > 0 && (
                         <div className="flex justify-between">
                           <span className="text-muted-foreground">Bonus</span>
-                          <span className="font-semibold text-yellow-500">
+                          <span className="font-semibold text-foreground">
                             +{selectedUser.bonusPoints.toLocaleString()}
                           </span>
                         </div>
@@ -326,37 +283,18 @@ export function LeaderboardWidgetSidebar({
                       ? getActorProfileUrl(selectedUser.id)
                       : getProfileUrl(selectedUser.id, selectedUser.username)
                   }
-                  className="flex w-full items-center justify-center gap-2 rounded-lg bg-[#0066FF] px-4 py-3 font-semibold text-primary-foreground transition-colors hover:bg-[#2952d9]"
+                  className="flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-4 py-3 font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
                 >
                   View Profile
                   <ExternalLink className="h-4 w-4" />
                 </Link>
-                {authenticated && user && selectedUser.id !== user.id && (
-                  <FollowButton
-                    userId={selectedUser.id}
-                    size="md"
-                    className="w-full justify-center"
-                  />
-                )}
               </div>
-            </div>
-          ) : (
-            <div className="flex flex-col items-center justify-center py-8 text-center">
-              <Trophy className="mb-3 h-12 w-12 text-muted-foreground/50" />
-              <p className="mb-1 font-medium text-muted-foreground">
-                No Player Selected
-              </p>
-              <p className="text-muted-foreground text-sm">
-                Click on a player in the leaderboard to view their stats
-              </p>
-            </div>
-          )}
-        </div>
+          </div>
+        )}
 
         {/* Leaderboard Info */}
-        <div className="rounded-lg border border-border bg-card/50 p-4 backdrop-blur">
-          <h3 className="mb-3 flex items-center gap-2 font-semibold text-foreground">
-            <TrendingUp className="h-5 w-5 text-purple-500" />
+        <div>
+          <h3 className="mb-3 font-semibold text-foreground">
             How Points Work
           </h3>
           <div className="space-y-2 text-muted-foreground text-sm">

--- a/apps/web/src/components/leaderboard/LeaderboardWidgetSidebar.tsx
+++ b/apps/web/src/components/leaderboard/LeaderboardWidgetSidebar.tsx
@@ -135,7 +135,6 @@ export function LeaderboardWidgetSidebar({
     };
   }, []);
 
-
   return (
     <div
       ref={containerRef}
@@ -145,150 +144,147 @@ export function LeaderboardWidgetSidebar({
         {/* Selected User Widget */}
         {selectedUser && (
           <div className="space-y-4">
-              {/* User Header */}
-              <div className="flex items-center gap-3">
-                <Avatar
-                  id={selectedUser.id}
-                  name={
-                    selectedUser.displayName || selectedUser.username || 'User'
-                  }
-                  type={selectedUser.isActor ? 'actor' : undefined}
-                  size="md"
-                  src={selectedUser.profileImageUrl || undefined}
-                />
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
-                    <h4 className="truncate font-semibold text-foreground">
-                      {selectedUser.displayName ||
-                        selectedUser.username ||
-                        'Anonymous'}
-                    </h4>
-                    {selectedUser.isActor ? (
-                      <VerifiedBadge size="sm" />
-                    ) : (
-                      <OnChainBadge
-                        isRegistered={selectedUser.onChainRegistered ?? false}
-                        nftTokenId={selectedUser.nftTokenId ?? null}
-                        size="sm"
-                      />
-                    )}
-                  </div>
-                  {selectedUser.username && (
-                    <p className="truncate text-muted-foreground text-sm">
-                      @{selectedUser.username}
-                    </p>
+            {/* User Header */}
+            <div className="flex items-center gap-3">
+              <Avatar
+                id={selectedUser.id}
+                name={
+                  selectedUser.displayName || selectedUser.username || 'User'
+                }
+                type={selectedUser.isActor ? 'actor' : undefined}
+                size="md"
+                src={selectedUser.profileImageUrl || undefined}
+              />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <h4 className="truncate font-semibold text-foreground">
+                    {selectedUser.displayName ||
+                      selectedUser.username ||
+                      'Anonymous'}
+                  </h4>
+                  {selectedUser.isActor ? (
+                    <VerifiedBadge size="sm" />
+                  ) : (
+                    <OnChainBadge
+                      isRegistered={selectedUser.onChainRegistered ?? false}
+                      nftTokenId={selectedUser.nftTokenId ?? null}
+                      size="sm"
+                    />
                   )}
                 </div>
-                {authenticated && user && selectedUser.id !== user.id && (
-                  <FollowButton
-                    userId={selectedUser.id}
-                    size="sm"
-                    variant="button"
-                    className="w-20"
-                  />
+                {selectedUser.username && (
+                  <p className="truncate text-muted-foreground text-sm">
+                    @{selectedUser.username}
+                  </p>
                 )}
               </div>
+              {authenticated && user && selectedUser.id !== user.id && (
+                <FollowButton
+                  userId={selectedUser.id}
+                  size="sm"
+                  variant="button"
+                  className="w-20"
+                />
+              )}
+            </div>
 
+            {/* Total Points (primary metric) */}
+            {selectedUser.totalPoints !== undefined && (
+              <div className="border-border border-b pb-3">
+                <div className="text-muted-foreground text-xs">
+                  Total Points
+                </div>
+                <div className="font-bold text-foreground text-xl">
+                  {selectedUser.totalPoints.toLocaleString()}
+                </div>
+              </div>
+            )}
 
-              {/* Total Points (primary metric) */}
-              {selectedUser.totalPoints !== undefined && (
-                <div className="border-border border-b pb-3">
-                  <div className="text-muted-foreground text-xs">
-                    Total Points
+            {/* Stats Grid */}
+            <div className="grid grid-cols-2 gap-3">
+              {/* P&L */}
+              <div>
+                <div className="text-muted-foreground text-xs">
+                  Lifetime P&L
+                </div>
+                <div
+                  className={`font-bold ${
+                    selectedUser.lifetimePnL === 0
+                      ? 'text-muted-foreground'
+                      : selectedUser.lifetimePnL > 0
+                        ? 'text-green-500'
+                        : 'text-red-500'
+                  }`}
+                >
+                  {selectedUser.lifetimePnL === 0
+                    ? formatCurrency(0)
+                    : `${selectedUser.lifetimePnL > 0 ? '+' : '-'}${formatCurrency(Math.abs(selectedUser.lifetimePnL))}`}
+                </div>
+              </div>
+
+              {/* Referrals */}
+              <div>
+                <div className="text-muted-foreground text-xs">Referrals</div>
+                <div className="font-bold text-foreground">
+                  {selectedUser.referralCount}
+                </div>
+              </div>
+
+              {/* All Points Breakdown */}
+              {(selectedUser.earnedPoints !== 0 ||
+                selectedUser.invitePoints > 0 ||
+                selectedUser.bonusPoints > 0) && (
+                <div className="col-span-2 border-border border-t pt-3">
+                  <div className="mb-2 text-muted-foreground text-xs">
+                    Points Breakdown
                   </div>
-                  <div className="font-bold text-foreground text-xl">
-                    {selectedUser.totalPoints.toLocaleString()}
+                  <div className="space-y-1 text-sm">
+                    {selectedUser.earnedPoints !== 0 && (
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">Earned</span>
+                        <span
+                          className={`font-semibold ${selectedUser.earnedPoints > 0 ? 'text-green-500' : 'text-red-500'}`}
+                        >
+                          {selectedUser.earnedPoints > 0 ? '+' : ''}
+                          {selectedUser.earnedPoints.toLocaleString()}
+                        </span>
+                      </div>
+                    )}
+                    {selectedUser.invitePoints > 0 && (
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">Referral</span>
+                        <span className="font-semibold text-foreground">
+                          +{selectedUser.invitePoints.toLocaleString()}
+                        </span>
+                      </div>
+                    )}
+                    {selectedUser.bonusPoints > 0 && (
+                      <div className="flex justify-between">
+                        <span className="text-muted-foreground">Bonus</span>
+                        <span className="font-semibold text-foreground">
+                          +{selectedUser.bonusPoints.toLocaleString()}
+                        </span>
+                      </div>
+                    )}
                   </div>
                 </div>
               )}
+            </div>
 
-              {/* Stats Grid */}
-              <div className="grid grid-cols-2 gap-3">
-                {/* P&L */}
-                <div>
-                  <div className="text-muted-foreground text-xs">
-                    Lifetime P&L
-                  </div>
-                  <div
-                    className={`font-bold ${
-                      selectedUser.lifetimePnL === 0
-                        ? 'text-muted-foreground'
-                        : selectedUser.lifetimePnL > 0
-                          ? 'text-green-500'
-                          : 'text-red-500'
-                    }`}
-                  >
-                    {selectedUser.lifetimePnL === 0
-                      ? formatCurrency(0)
-                      : `${selectedUser.lifetimePnL > 0 ? '+' : '-'}${formatCurrency(Math.abs(selectedUser.lifetimePnL))}`}
-                  </div>
-                </div>
-
-                {/* Referrals */}
-                <div>
-                  <div className="text-muted-foreground text-xs">
-                    Referrals
-                  </div>
-                  <div className="font-bold text-foreground">
-                    {selectedUser.referralCount}
-                  </div>
-                </div>
-
-                {/* All Points Breakdown */}
-                {(selectedUser.earnedPoints !== 0 || selectedUser.invitePoints > 0 || selectedUser.bonusPoints > 0) && (
-                  <div className="col-span-2 border-border border-t pt-3">
-                    <div className="mb-2 text-muted-foreground text-xs">
-                      Points Breakdown
-                    </div>
-                    <div className="space-y-1 text-sm">
-                      {selectedUser.earnedPoints !== 0 && (
-                        <div className="flex justify-between">
-                          <span className="text-muted-foreground">Earned</span>
-                          <span
-                            className={`font-semibold ${selectedUser.earnedPoints > 0 ? 'text-green-500' : 'text-red-500'}`}
-                          >
-                            {selectedUser.earnedPoints > 0 ? '+' : ''}
-                            {selectedUser.earnedPoints.toLocaleString()}
-                          </span>
-                        </div>
-                      )}
-                      {selectedUser.invitePoints > 0 && (
-                        <div className="flex justify-between">
-                          <span className="text-muted-foreground">
-                            Referral
-                          </span>
-                          <span className="font-semibold text-foreground">
-                            +{selectedUser.invitePoints.toLocaleString()}
-                          </span>
-                        </div>
-                      )}
-                      {selectedUser.bonusPoints > 0 && (
-                        <div className="flex justify-between">
-                          <span className="text-muted-foreground">Bonus</span>
-                          <span className="font-semibold text-foreground">
-                            +{selectedUser.bonusPoints.toLocaleString()}
-                          </span>
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                )}
-              </div>
-
-              {/* Action Buttons */}
-              <div className="flex flex-col gap-2">
-                <Link
-                  href={
-                    selectedUser.isActor
-                      ? getActorProfileUrl(selectedUser.id)
-                      : getProfileUrl(selectedUser.id, selectedUser.username)
-                  }
-                  className="flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-4 py-3 font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
-                >
-                  View Profile
-                  <ExternalLink className="h-4 w-4" />
-                </Link>
-              </div>
+            {/* Action Buttons */}
+            <div className="flex flex-col gap-2">
+              <Link
+                href={
+                  selectedUser.isActor
+                    ? getActorProfileUrl(selectedUser.id)
+                    : getProfileUrl(selectedUser.id, selectedUser.username)
+                }
+                className="flex w-full items-center justify-center gap-2 rounded-lg bg-primary px-4 py-3 font-semibold text-primary-foreground transition-colors hover:bg-primary/90"
+              >
+                View Profile
+                <ExternalLink className="h-4 w-4" />
+              </Link>
+            </div>
           </div>
         )}
 

--- a/apps/web/src/components/profile/OnChainBadge.tsx
+++ b/apps/web/src/components/profile/OnChainBadge.tsx
@@ -71,10 +71,13 @@ export function OnChainBadge({
           </span>
         )}
         {showTooltip && (
-          <div className="-translate-x-1/2 absolute bottom-full left-1/2 z-50 mb-2 whitespace-nowrap rounded-lg border border-border bg-popover px-3 py-2 shadow-lg">
+          <div className="-translate-x-1/2 absolute top-full left-1/2 z-50 mt-2 whitespace-nowrap rounded-lg border border-border bg-popover px-3 py-2 shadow-lg">
+            <div className="-translate-x-1/2 -mb-[1px] absolute bottom-full left-1/2">
+              <div className="border-4 border-transparent border-b-border" />
+            </div>
             <div className="space-y-1 text-xs">
               <p className="font-semibold text-green-500">
-                ✓ Verified On-Chain
+                Verified On-Chain
               </p>
               <p className="text-muted-foreground">
                 NFT Token ID: #{nftTokenId}
@@ -82,9 +85,6 @@ export function OnChainBadge({
               <p className="text-muted-foreground">
                 Blockchain identity verified
               </p>
-            </div>
-            <div className="-translate-x-1/2 -mt-[1px] absolute top-full left-1/2">
-              <div className="border-4 border-transparent border-t-border" />
             </div>
           </div>
         )}
@@ -108,18 +108,18 @@ export function OnChainBadge({
         </span>
       )}
       {showTooltip && (
-        <div className="-translate-x-1/2 absolute bottom-full left-1/2 z-50 mb-2 whitespace-nowrap rounded-lg border border-border bg-popover px-3 py-2 shadow-lg">
+        <div className="-translate-x-1/2 absolute top-full left-1/2 z-50 mt-2 whitespace-nowrap rounded-lg border border-border bg-popover px-3 py-2 shadow-lg">
+          <div className="-translate-x-1/2 -mb-[1px] absolute bottom-full left-1/2">
+            <div className="border-4 border-transparent border-b-border" />
+          </div>
           <div className="space-y-1 text-xs">
             <p className="font-semibold text-muted-foreground">
-              ⚠ Not Verified On-Chain
+              Not Verified On-Chain
             </p>
             <p className="text-muted-foreground/70">No blockchain identity</p>
             <p className="text-muted-foreground/70">
               Limited reputation features
             </p>
-          </div>
-          <div className="-translate-x-1/2 -mt-[1px] absolute top-full left-1/2">
-            <div className="border-4 border-transparent border-t-border" />
           </div>
         </div>
       )}

--- a/apps/web/src/components/profile/OnChainBadge.tsx
+++ b/apps/web/src/components/profile/OnChainBadge.tsx
@@ -76,9 +76,7 @@ export function OnChainBadge({
               <div className="border-4 border-transparent border-b-border" />
             </div>
             <div className="space-y-1 text-xs">
-              <p className="font-semibold text-green-500">
-                Verified On-Chain
-              </p>
+              <p className="font-semibold text-green-500">Verified On-Chain</p>
               <p className="text-muted-foreground">
                 NFT Token ID: #{nftTokenId}
               </p>

--- a/apps/web/src/components/shared/LeaderboardToggle.tsx
+++ b/apps/web/src/components/shared/LeaderboardToggle.tsx
@@ -39,7 +39,7 @@ export function LeaderboardToggle({
           activeTab === 'total' ? 'text-foreground' : 'text-muted-foreground'
         )}
       >
-        Total Points
+        Total
         {activeTab === 'total' && (
           <div className="absolute right-0 bottom-0 left-0 h-[3px] bg-primary" />
         )}

--- a/apps/web/src/components/shared/RankBadge.tsx
+++ b/apps/web/src/components/shared/RankBadge.tsx
@@ -41,22 +41,18 @@ export function RankBadge({
   let BadgeIcon: typeof Trophy | typeof Medal | typeof Award;
   let badgeColor: string;
   let badgeLabel: string;
-  let glowColor: string;
 
   if (rank === 1) {
     BadgeIcon = Trophy;
-    badgeColor = 'text-yellow-500';
-    glowColor = 'shadow-yellow-500/50';
+    badgeColor = 'text-foreground';
     badgeLabel = '1st Place';
   } else if (rank <= 3) {
     BadgeIcon = Medal;
-    badgeColor = 'text-gray-400';
-    glowColor = 'shadow-gray-400/50';
+    badgeColor = 'text-muted-foreground';
     badgeLabel = `${rank}${rank === 2 ? 'nd' : 'rd'} Place`;
   } else {
     BadgeIcon = Award;
-    badgeColor = 'text-amber-700';
-    glowColor = 'shadow-amber-700/50';
+    badgeColor = 'text-muted-foreground';
     badgeLabel = `Top ${rank}`;
   }
 
@@ -77,18 +73,10 @@ export function RankBadge({
     <div className={`flex items-center gap-2 ${className}`}>
       <div className={`relative ${sizeClasses[size]}`}>
         <BadgeIcon
-          className={`${sizeClasses[size]} ${badgeColor} drop-shadow-lg ${glowColor}`}
+          className={`${sizeClasses[size]} ${badgeColor}`}
           fill="currentColor"
           strokeWidth={1.5}
         />
-        {rank === 1 && (
-          <div className="absolute inset-0 animate-pulse">
-            <BadgeIcon
-              className={`${sizeClasses[size]} ${badgeColor} opacity-50`}
-              fill="currentColor"
-            />
-          </div>
-        )}
       </div>
       {showLabel && (
         <span
@@ -135,18 +123,15 @@ export function RankNumber({
     lg: 'w-10 h-10 text-base',
   };
 
-  let bgColor = 'bg-gray-700';
-  let textColor = 'text-gray-300';
+  let bgColor = 'bg-muted';
+  let textColor = 'text-muted-foreground';
 
-  if (rank === 1) {
-    bgColor = 'bg-gradient-to-br from-yellow-500 to-yellow-600';
-    textColor = 'text-primary-foreground';
-  } else if (rank <= 3) {
-    bgColor = 'bg-gradient-to-br from-gray-400 to-gray-500';
-    textColor = 'text-primary-foreground';
+  if (rank <= 3) {
+    bgColor = 'bg-foreground';
+    textColor = 'text-background';
   } else if (rank <= 10) {
-    bgColor = 'bg-gradient-to-br from-amber-700 to-amber-800';
-    textColor = 'text-primary-foreground';
+    bgColor = 'bg-muted';
+    textColor = 'text-foreground';
   }
 
   return (

--- a/apps/web/src/components/shared/Skeleton.tsx
+++ b/apps/web/src/components/shared/Skeleton.tsx
@@ -308,17 +308,18 @@ export function ProfileHeaderSkeleton() {
  */
 export function LeaderboardItemSkeleton() {
   return (
-    <div className="p-3 sm:p-4">
+    <div className="px-4 py-1.5 xl:py-3">
       <div className="flex items-center gap-2 sm:gap-4">
-        <Skeleton className="h-8 w-8 shrink-0 rounded" />
-        <Skeleton className="h-10 w-10 shrink-0 rounded-full sm:h-12 sm:w-12" />
-        <div className="min-w-0 flex-1 space-y-2">
+        <Skeleton className="h-8 w-8 shrink-0 rounded-full" />
+        <Skeleton className="h-10 w-10 shrink-0 rounded-full" />
+        <div className="min-w-0 flex-1 space-y-1.5">
           <Skeleton className="h-4 w-24 max-w-full sm:w-32" />
-          <Skeleton className="h-3 w-20 max-w-full sm:w-24" />
+          <Skeleton className="h-3 w-20 max-w-full xl:hidden" />
+          <Skeleton className="hidden h-3 w-20 max-w-full xl:block" />
         </div>
-        <div className="shrink-0 space-y-2 text-right">
-          <Skeleton className="h-4 w-16 sm:h-5 sm:w-20" />
-          <Skeleton className="h-3 w-10 sm:w-12" />
+        <div className="hidden shrink-0 space-y-1.5 text-right xl:block">
+          <Skeleton className="h-5 w-20" />
+          <Skeleton className="h-3 w-12" />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Flatten leaderboard rows: remove inline stats (P&L, invite, earned, bonus, referrals), consolidate into selected player sidebar
- Add circle follow/unfollow button overlay on avatar (blue + / red -)
- Simplify sidebar: remove empty state, rank badge, inline follow button next to name
- Neutralize colors to match homepage minimal design (foreground/muted-foreground only, green/red for P&L only)
- Mobile: remove username from rows, show points inline below name, reduce row padding
- Fix loading skeleton to match real UI (4 tabs, correct layout)
- Move OnChainBadge tooltip below icon
- Rename "Total Points" tab to "Total"