### PR TITLE
feat(ui): redesign position cards, trade feed market links, activity panel

### DIFF
--- a/apps/web/src/app/agents/team/page.tsx
+++ b/apps/web/src/app/agents/team/page.tsx
@@ -215,7 +215,7 @@ export default function TeamChatPage() {
   const [activeRightTabId, setActiveRightTabId] = useState<string | null>(null);
 
   // Bottom panel state
-  const [bottomPanelOpen, setBottomPanelOpen] = useState(false);
+  const [bottomPanelOpen, setBottomPanelOpen] = useState(true);
   const [bottomPanelTab, setBottomPanelTab] =
     useState<BottomPanelTab>('activity');
   const [bottomPanelEntityId, setBottomPanelEntityId] = useState<string | null>(

--- a/apps/web/src/app/api/trades/route.ts
+++ b/apps/web/src/app/api/trades/route.ts
@@ -383,6 +383,31 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   });
   const perpUsersMap = new Map(perpUsers.map((u) => [u.id, u]));
 
+  // Fetch prediction markets for pred_buy/pred_sell balance transactions and NPC prediction trades
+  const predictionMarketIds = [
+    ...new Set([
+      ...balanceTransactions
+        .filter(
+          (tx) =>
+            (tx.type === 'pred_buy' || tx.type === 'pred_sell') && tx.relatedId
+        )
+        .map((tx) => tx.relatedId as string),
+      ...npcTrades
+        .filter((t) => t.marketType === 'prediction' && t.marketId)
+        .map((t) => t.marketId as string),
+    ]),
+  ];
+  const predictionMarkets =
+    predictionMarketIds.length > 0
+      ? await db.market.findMany({
+          where: { id: { in: predictionMarketIds } },
+          select: { id: true, question: true, resolved: true, resolution: true },
+        })
+      : [];
+  const predictionMarketsMap = new Map(
+    predictionMarkets.map((m) => [m.id, m])
+  );
+
   // Merge and sort by timestamp
   // Filter out balance transactions from NPC actors - they have npcTrades entries instead
   const allTrades = [
@@ -391,18 +416,26 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
         const user = balanceUsersMap.get(tx.userId);
         return !user?.isActor; // Exclude NPC actors
       })
-      .map((tx) => ({
-        type: 'balance' as const,
-        id: tx.id,
-        timestamp: tx.createdAt,
-        user: balanceUsersMap.get(tx.userId) || null,
-        amount: tx.amount.toString(),
-        balanceBefore: tx.balanceBefore.toString(),
-        balanceAfter: tx.balanceAfter.toString(),
-        transactionType: tx.type,
-        description: tx.description,
-        relatedId: tx.relatedId,
-      })),
+      .map((tx) => {
+        const isPrediction = tx.type === 'pred_buy' || tx.type === 'pred_sell';
+        const market =
+          isPrediction && tx.relatedId
+            ? predictionMarketsMap.get(tx.relatedId) ?? null
+            : null;
+        return {
+          type: 'balance' as const,
+          id: tx.id,
+          timestamp: tx.createdAt,
+          user: balanceUsersMap.get(tx.userId) || null,
+          amount: tx.amount.toString(),
+          balanceBefore: tx.balanceBefore.toString(),
+          balanceAfter: tx.balanceAfter.toString(),
+          transactionType: tx.type,
+          description: tx.description,
+          relatedId: tx.relatedId,
+          market,
+        };
+      }),
     ...pointTransfers.map((tx) => {
       const metadata = tx.metadata
         ? (JSON.parse(tx.metadata) as {
@@ -442,6 +475,10 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     }),
     ...npcTrades.map((trade) => {
       const actor = actorsMap.get(trade.npcActorId);
+      const npcMarket =
+        trade.marketType === 'prediction' && trade.marketId
+          ? predictionMarketsMap.get(trade.marketId) ?? null
+          : null;
       return {
         type: 'npc' as const,
         id: trade.id,
@@ -458,6 +495,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
         marketType: trade.marketType,
         ticker: trade.ticker,
         marketId: trade.marketId,
+        marketQuestion: npcMarket?.question ?? null,
         action: trade.action,
         side: trade.side,
         amount: trade.amount,

--- a/apps/web/src/app/api/trades/route.ts
+++ b/apps/web/src/app/api/trades/route.ts
@@ -401,12 +401,15 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     predictionMarketIds.length > 0
       ? await db.market.findMany({
           where: { id: { in: predictionMarketIds } },
-          select: { id: true, question: true, resolved: true, resolution: true },
+          select: {
+            id: true,
+            question: true,
+            resolved: true,
+            resolution: true,
+          },
         })
       : [];
-  const predictionMarketsMap = new Map(
-    predictionMarkets.map((m) => [m.id, m])
-  );
+  const predictionMarketsMap = new Map(predictionMarkets.map((m) => [m.id, m]));
 
   // Merge and sort by timestamp
   // Filter out balance transactions from NPC actors - they have npcTrades entries instead
@@ -420,7 +423,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
         const isPrediction = tx.type === 'pred_buy' || tx.type === 'pred_sell';
         const market =
           isPrediction && tx.relatedId
-            ? predictionMarketsMap.get(tx.relatedId) ?? null
+            ? (predictionMarketsMap.get(tx.relatedId) ?? null)
             : null;
         return {
           type: 'balance' as const,
@@ -477,7 +480,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       const actor = actorsMap.get(trade.npcActorId);
       const npcMarket =
         trade.marketType === 'prediction' && trade.marketId
-          ? predictionMarketsMap.get(trade.marketId) ?? null
+          ? (predictionMarketsMap.get(trade.marketId) ?? null)
           : null;
       return {
         type: 'npc' as const,

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -1159,14 +1159,34 @@ export function MarketsTradingTerminal({
     sellablePositions.hasSellableYes,
   ]);
 
+  const selectedPerpTickerUpper = selectedPerp?.ticker.toUpperCase() ?? null;
   const selectedPerpPositions = useMemo(() => {
-    if (!selectedPerp) return [];
+    if (!selectedPerpTickerUpper) return [];
     return perpPositions.filter(
       (p) =>
-        p.ticker.toUpperCase() === selectedPerp.ticker.toUpperCase() &&
-        !p.closedAt
+        p.ticker.toUpperCase() === selectedPerpTickerUpper && !p.closedAt
     );
-  }, [perpPositions, selectedPerp]);
+  }, [perpPositions, selectedPerpTickerUpper]);
+
+  const otherPerpPositions = useMemo(() => {
+    if (perpPositions.length === 0) return [];
+    if (selected?.kind !== 'perp' || !selectedPerpTickerUpper) {
+      return perpPositions;
+    }
+    return perpPositions.filter(
+      (p) => p.ticker.toUpperCase() !== selectedPerpTickerUpper || p.closedAt
+    );
+  }, [perpPositions, selected?.kind, selectedPerpTickerUpper]);
+
+  const otherPredictionPositions = useMemo(() => {
+    if (predictionPositions.length === 0) return [];
+    if (selected?.kind !== 'prediction' || !selectedPredictionId) {
+      return predictionPositions;
+    }
+    return predictionPositions.filter(
+      (p) => p.marketId.toString() !== selectedPredictionId
+    );
+  }, [predictionPositions, selected?.kind, selectedPredictionId]);
 
   const predictionAmountNum = Number.parseFloat(predictionAmount) || 0;
   const predictionSellSharesNum = Number.parseFloat(predictionSellShares) || 0;
@@ -2293,35 +2313,13 @@ export function MarketsTradingTerminal({
                     />
                   </div>
                 )}
-              {perpPositions.filter(
-                (p) =>
-                  selected?.kind !== 'perp' ||
-                  p.ticker.toUpperCase() !==
-                    selectedPerp?.ticker.toUpperCase() ||
-                  p.closedAt
-              ).length > 0 && (
+              {otherPerpPositions.length > 0 && (
                 <div className="rounded border border-white/10 bg-background/10 p-2">
                   <div className="px-1 pb-2 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
-                    Perps (
-                    {
-                      perpPositions.filter(
-                        (p) =>
-                          selected?.kind !== 'perp' ||
-                          p.ticker.toUpperCase() !==
-                            selectedPerp?.ticker.toUpperCase() ||
-                          p.closedAt
-                      ).length
-                    }
-                    )
+                    Perps ({otherPerpPositions.length})
                   </div>
                   <PerpPositionsList
-                    positions={perpPositions.filter(
-                      (p) =>
-                        selected?.kind !== 'perp' ||
-                        p.ticker.toUpperCase() !==
-                          selectedPerp?.ticker.toUpperCase() ||
-                        p.closedAt
-                    )}
+                    positions={otherPerpPositions}
                     density="compact"
                     onPositionClosed={handlePerpPositionClosed}
                     onPositionClick={(ticker) =>
@@ -2330,29 +2328,13 @@ export function MarketsTradingTerminal({
                   />
                 </div>
               )}
-              {predictionPositions.filter(
-                (p) =>
-                  selected?.kind !== 'prediction' ||
-                  p.marketId.toString() !== selectedPredictionId
-              ).length > 0 && (
+              {otherPredictionPositions.length > 0 && (
                 <div className="rounded border border-white/10 bg-background/10 p-2">
                   <div className="px-1 pb-2 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
-                    Predictions (
-                    {
-                      predictionPositions.filter(
-                        (p) =>
-                          selected?.kind !== 'prediction' ||
-                          p.marketId.toString() !== selectedPredictionId
-                      ).length
-                    }
-                    )
+                    Predictions ({otherPredictionPositions.length})
                   </div>
                   <PredictionPositionsList
-                    positions={predictionPositions.filter(
-                      (p) =>
-                        selected?.kind !== 'prediction' ||
-                        p.marketId.toString() !== selectedPredictionId
-                    )}
+                    positions={otherPredictionPositions}
                     density="compact"
                     onPositionSold={handlePredictionPositionSold}
                     onPositionClick={(marketId) =>
@@ -2694,25 +2676,13 @@ export function MarketsTradingTerminal({
                             />
                           </div>
                         )}
-                      {perpPositions.filter(
-                        (p) =>
-                          selected?.kind !== 'perp' ||
-                          p.ticker.toUpperCase() !==
-                            selectedPerp?.ticker.toUpperCase() ||
-                          p.closedAt
-                      ).length > 0 && (
+                      {otherPerpPositions.length > 0 && (
                         <div className="rounded border border-white/10 bg-background/10 p-2">
                           <div className="px-1 pb-2 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
                             Perps
                           </div>
                           <PerpPositionsList
-                            positions={perpPositions.filter(
-                              (p) =>
-                                selected?.kind !== 'perp' ||
-                                p.ticker.toUpperCase() !==
-                                  selectedPerp?.ticker.toUpperCase() ||
-                                p.closedAt
-                            )}
+                            positions={otherPerpPositions}
                             density="compact"
                             onPositionClosed={handlePerpPositionClosed}
                             onPositionClick={(ticker) =>
@@ -2721,21 +2691,13 @@ export function MarketsTradingTerminal({
                           />
                         </div>
                       )}
-                      {predictionPositions.filter(
-                        (p) =>
-                          selected?.kind !== 'prediction' ||
-                          p.marketId.toString() !== selectedPredictionId
-                      ).length > 0 && (
+                      {otherPredictionPositions.length > 0 && (
                         <div className="rounded border border-white/10 bg-background/10 p-2">
                           <div className="px-1 pb-2 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
                             Predictions
                           </div>
                           <PredictionPositionsList
-                            positions={predictionPositions.filter(
-                              (p) =>
-                                selected?.kind !== 'prediction' ||
-                                p.marketId.toString() !== selectedPredictionId
-                            )}
+                            positions={otherPredictionPositions}
                             density="compact"
                             onPositionSold={handlePredictionPositionSold}
                             onPositionClick={(marketId) =>

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -10,7 +10,6 @@ import {
   ArrowUpDown,
   Check,
   ChevronDown,
-  Filter,
   Info,
   Maximize2,
   Minimize2,
@@ -825,7 +824,11 @@ export function MarketsTradingTerminal({
         subtitle: `Scenario ${m.scenario}`,
         valuePrimary: `YES ${formatYesPct(yesPct)}`,
         valueSecondary:
-          m.status !== 'active' ? m.status.toUpperCase() : undefined,
+          m.status !== 'active'
+            ? m.status.toUpperCase()
+            : vol > 0
+              ? `Vol ${Math.round(vol).toLocaleString()}`
+              : undefined,
         change24hPct: null,
         sortVolume: vol,
         sortOpenInterest: 0,
@@ -1035,7 +1038,7 @@ export function MarketsTradingTerminal({
       range: predictionTimeRange,
     });
 
-  const { history: perpHistory, refresh: refreshPerpHistory } = usePerpHistory(
+  const { history: perpHistory } = usePerpHistory(
     selectedPerp?.ticker ?? null,
     { range: perpTimeRange }
   );
@@ -1410,16 +1413,15 @@ export function MarketsTradingTerminal({
             className={cn(
               'shrink-0 rounded p-2 transition-colors hover:bg-muted/20',
               showMarketsMenu ||
-                filter !== 'all' ||
                 sortBy !== 'volume' ||
                 sortDesc !== true
                 ? 'bg-muted/20 text-primary'
                 : 'text-muted-foreground'
             )}
-            aria-label="Filter and sort markets"
-            title="Filter & Sort"
+            aria-label="Sort markets"
+            title="Sort"
           >
-            <Filter size={14} />
+            <ArrowUpDown size={14} />
           </button>
         </div>
 
@@ -1428,40 +1430,31 @@ export function MarketsTradingTerminal({
             id="markets-filter-sort"
             className="fade-in-0 animate-in rounded-md border border-white/10 bg-background/40 py-1 shadow-sm duration-150"
           >
-            <div className="px-3 py-2 font-bold text-[10px] text-muted-foreground uppercase tracking-wider">
-              Type
-            </div>
-            {(
-              [
-                { id: 'all', label: 'All Markets' },
-                { id: 'favorites', label: 'Favorites' },
-                { id: 'perp', label: 'Perps' },
-                { id: 'prediction', label: 'Prediction' },
-              ] as const
-            ).map((opt) => (
-              <button
-                key={opt.id}
-                type="button"
-                className="flex w-full items-center justify-between px-3 py-1.5 text-left text-xs hover:bg-muted/20"
-                onClick={() => {
-                  handleFilterChange(opt.id);
-                  setShowMarketsMenu(false);
-                }}
-              >
-                <span
-                  className={cn(
-                    opt.id === filter
-                      ? 'font-medium text-primary'
-                      : 'text-foreground'
-                  )}
-                >
-                  {opt.label}
-                </span>
-                {opt.id === filter && (
-                  <Check size={12} className="text-primary" />
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs hover:bg-muted/20"
+              onClick={() => {
+                handleFilterChange(filter === 'favorites' ? 'all' : 'favorites');
+              }}
+            >
+              <div
+                className={cn(
+                  'flex h-3.5 w-3.5 items-center justify-center rounded-sm border transition-colors',
+                  filter === 'favorites'
+                    ? 'border-primary bg-primary'
+                    : 'border-muted-foreground/40'
                 )}
-              </button>
-            ))}
+              >
+                {filter === 'favorites' && (
+                  <Check size={10} className="text-primary-foreground" />
+                )}
+              </div>
+              <span className={cn(
+                filter === 'favorites' ? 'font-medium text-primary' : 'text-foreground'
+              )}>
+                Favorites only
+              </span>
+            </button>
 
             <div className="my-1 border-white/10 border-t" />
 
@@ -1504,6 +1497,35 @@ export function MarketsTradingTerminal({
             ))}
           </div>
         )}
+      </div>
+
+      <div className="relative flex shrink-0">
+        {(
+          [
+            { id: 'all', label: 'All' },
+            { id: 'perp', label: 'Perps' },
+            { id: 'prediction', label: 'Prediction' },
+          ] as const
+        ).map((tab) => {
+          const isActive = filter === tab.id || (tab.id === 'all' && filter === 'favorites');
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => handleFilterChange(tab.id)}
+              className={cn(
+                'relative flex-1 py-2.5 text-xs font-semibold transition-colors hover:bg-muted/20',
+                isActive ? 'bg-primary/10 text-primary' : 'text-muted-foreground'
+              )}
+            >
+              {tab.label}
+              {isActive && (
+                <div className="absolute right-0 bottom-0 left-0 h-[2px] bg-primary" />
+              )}
+            </button>
+          );
+        })}
+        <div className="absolute right-0 bottom-0 left-0 h-px bg-white/5" />
       </div>
 
       <div className="min-h-0 flex-1 overflow-auto">
@@ -2226,59 +2248,66 @@ export function MarketsTradingTerminal({
             portfolioError={portfolioError}
             onRefresh={handlePortfolioRefresh}
             refreshDisabled={refreshOnCooldown}
-            perpPositions={perpPositions}
-            predictionPositions={predictionPositions}
-            onPerpPositionClosed={handlePerpPositionClosed}
-            onPredictionPositionSold={handlePredictionPositionSold}
           />
         ) : bottomTab === 'positions' ? (
           !authenticated ? (
             <div className="flex h-full justify-center pt-6 text-muted-foreground text-sm">
               Log in to view positions.
             </div>
-          ) : selected?.kind === 'prediction' ? (
-            <div className="h-full overflow-auto">
-              {selectedPredictionPositions.length > 0 ? (
-                <PredictionPositionsList
-                  positions={selectedPredictionPositions}
-                  density="compact"
-                  onPositionSold={async () => {
-                    invalidateUserPositions();
-                    invalidateWalletBalance();
-                    await Promise.all([
-                      refreshPredictionPositions(),
-                      refreshPerpPositions(),
-                      refreshWalletBalance(),
-                      refreshPredictionHistory(),
-                    ]);
-                  }}
-                />
-              ) : (
-                <div className="flex h-full items-center justify-center text-muted-foreground text-xs">
-                  No open positions
-                </div>
-              )}
+          ) : perpPositions.length === 0 && predictionPositions.length === 0 ? (
+            <div className="flex h-full items-center justify-center text-muted-foreground text-xs">
+              No open positions
             </div>
           ) : (
-            <div className="h-full overflow-auto">
-              {selectedPerpPositions.length > 0 ? (
-                <PerpPositionsList
-                  positions={selectedPerpPositions}
-                  density="compact"
-                  onPositionClosed={async () => {
-                    invalidateUserPositions();
-                    invalidateWalletBalance();
-                    await Promise.all([
-                      refreshPerpPositions(),
-                      refreshPredictionPositions(),
-                      refreshWalletBalance(),
-                      refreshPerpHistory(),
-                    ]);
-                  }}
-                />
-              ) : (
-                <div className="flex h-full items-center justify-center text-muted-foreground text-xs">
-                  No open positions
+            <div className="h-full space-y-2 overflow-auto p-2">
+              {selected?.kind === 'prediction' && selectedPredictionPositions.length > 0 && (
+                <div className="rounded border border-primary/20 bg-primary/5 p-2">
+                  <div className="px-1 pb-2 font-semibold text-primary text-xs uppercase tracking-wider">
+                    Selected Market
+                  </div>
+                  <PredictionPositionsList
+                    positions={selectedPredictionPositions}
+                    density="compact"
+                    onPositionSold={handlePredictionPositionSold}
+                  />
+                </div>
+              )}
+              {selected?.kind === 'perp' && selectedPerpPositions.length > 0 && (
+                <div className="rounded border border-primary/20 bg-primary/5 p-2">
+                  <div className="px-1 pb-2 font-semibold text-primary text-xs uppercase tracking-wider">
+                    Selected Market
+                  </div>
+                  <PerpPositionsList
+                    positions={selectedPerpPositions}
+                    density="compact"
+                    onPositionClosed={handlePerpPositionClosed}
+                  />
+                </div>
+              )}
+              {perpPositions.filter((p) => selected?.kind !== 'perp' || p.ticker.toUpperCase() !== selectedPerp?.ticker.toUpperCase() || p.closedAt).length > 0 && (
+                <div className="rounded border border-white/10 bg-background/10 p-2">
+                  <div className="px-1 pb-2 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+                    Perps ({perpPositions.filter((p) => selected?.kind !== 'perp' || p.ticker.toUpperCase() !== selectedPerp?.ticker.toUpperCase() || p.closedAt).length})
+                  </div>
+                  <PerpPositionsList
+                    positions={perpPositions.filter((p) => selected?.kind !== 'perp' || p.ticker.toUpperCase() !== selectedPerp?.ticker.toUpperCase() || p.closedAt)}
+                    density="compact"
+                    onPositionClosed={handlePerpPositionClosed}
+                    onPositionClick={(ticker) => handleSelect({ kind: 'perp', id: ticker })}
+                  />
+                </div>
+              )}
+              {predictionPositions.filter((p) => selected?.kind !== 'prediction' || p.marketId.toString() !== selectedPredictionId).length > 0 && (
+                <div className="rounded border border-white/10 bg-background/10 p-2">
+                  <div className="px-1 pb-2 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+                    Predictions ({predictionPositions.filter((p) => selected?.kind !== 'prediction' || p.marketId.toString() !== selectedPredictionId).length})
+                  </div>
+                  <PredictionPositionsList
+                    positions={predictionPositions.filter((p) => selected?.kind !== 'prediction' || p.marketId.toString() !== selectedPredictionId)}
+                    density="compact"
+                    onPositionSold={handlePredictionPositionSold}
+                    onPositionClick={(marketId) => handleSelect({ kind: 'prediction', id: marketId })}
+                  />
                 </div>
               )}
             </div>
@@ -2575,49 +2604,68 @@ export function MarketsTradingTerminal({
                     portfolioError={portfolioError}
                     onRefresh={handlePortfolioRefresh}
                     refreshDisabled={refreshOnCooldown}
-                    perpPositions={perpPositions}
-                    predictionPositions={predictionPositions}
-                    onPerpPositionClosed={handlePerpPositionClosed}
-                    onPredictionPositionSold={handlePredictionPositionSold}
                   />
                 ) : bottomTab === 'positions' ? (
                   !authenticated ? (
                     <div className="flex h-full justify-center pt-6 text-muted-foreground text-sm">
                       Log in to view positions.
                     </div>
-                  ) : selected?.kind === 'prediction' ? (
-                    <div className="h-full overflow-auto overscroll-contain">
-                      <PredictionPositionsList
-                        positions={selectedPredictionPositions}
-                        density="compact"
-                        onPositionSold={async () => {
-                          invalidateUserPositions();
-                          invalidateWalletBalance();
-                          await Promise.all([
-                            refreshPredictionPositions(),
-                            refreshPerpPositions(),
-                            refreshWalletBalance(),
-                            refreshPredictionHistory(),
-                          ]);
-                        }}
-                      />
+                  ) : perpPositions.length === 0 && predictionPositions.length === 0 ? (
+                    <div className="flex h-full items-center justify-center text-muted-foreground text-xs">
+                      No open positions
                     </div>
                   ) : (
-                    <div className="h-full overflow-auto overscroll-contain">
-                      <PerpPositionsList
-                        positions={selectedPerpPositions}
-                        density="compact"
-                        onPositionClosed={async () => {
-                          invalidateUserPositions();
-                          invalidateWalletBalance();
-                          await Promise.all([
-                            refreshPerpPositions(),
-                            refreshPredictionPositions(),
-                            refreshWalletBalance(),
-                            refreshPerpHistory(),
-                          ]);
-                        }}
-                      />
+                    <div className="h-full space-y-2 overflow-auto overscroll-contain p-2">
+                      {selected?.kind === 'prediction' && selectedPredictionPositions.length > 0 && (
+                        <div className="rounded border border-primary/20 bg-primary/5 p-2">
+                          <div className="px-1 pb-2 font-semibold text-primary text-xs uppercase tracking-wider">
+                            Selected Market
+                          </div>
+                          <PredictionPositionsList
+                            positions={selectedPredictionPositions}
+                            density="compact"
+                            onPositionSold={handlePredictionPositionSold}
+                          />
+                        </div>
+                      )}
+                      {selected?.kind === 'perp' && selectedPerpPositions.length > 0 && (
+                        <div className="rounded border border-primary/20 bg-primary/5 p-2">
+                          <div className="px-1 pb-2 font-semibold text-primary text-xs uppercase tracking-wider">
+                            Selected Market
+                          </div>
+                          <PerpPositionsList
+                            positions={selectedPerpPositions}
+                            density="compact"
+                            onPositionClosed={handlePerpPositionClosed}
+                          />
+                        </div>
+                      )}
+                      {perpPositions.filter((p) => selected?.kind !== 'perp' || p.ticker.toUpperCase() !== selectedPerp?.ticker.toUpperCase() || p.closedAt).length > 0 && (
+                        <div className="rounded border border-white/10 bg-background/10 p-2">
+                          <div className="px-1 pb-2 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+                            Perps
+                          </div>
+                          <PerpPositionsList
+                            positions={perpPositions.filter((p) => selected?.kind !== 'perp' || p.ticker.toUpperCase() !== selectedPerp?.ticker.toUpperCase() || p.closedAt)}
+                            density="compact"
+                            onPositionClosed={handlePerpPositionClosed}
+                            onPositionClick={(ticker) => handleSelect({ kind: 'perp', id: ticker })}
+                          />
+                        </div>
+                      )}
+                      {predictionPositions.filter((p) => selected?.kind !== 'prediction' || p.marketId.toString() !== selectedPredictionId).length > 0 && (
+                        <div className="rounded border border-white/10 bg-background/10 p-2">
+                          <div className="px-1 pb-2 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
+                            Predictions
+                          </div>
+                          <PredictionPositionsList
+                            positions={predictionPositions.filter((p) => selected?.kind !== 'prediction' || p.marketId.toString() !== selectedPredictionId)}
+                            density="compact"
+                            onPositionSold={handlePredictionPositionSold}
+                            onPositionClick={(marketId) => handleSelect({ kind: 'prediction', id: marketId })}
+                          />
+                        </div>
+                      )}
                     </div>
                   )
                 ) : bottomTab === 'trades' ? (

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -1412,9 +1412,7 @@ export function MarketsTradingTerminal({
             aria-controls="markets-filter-sort"
             className={cn(
               'shrink-0 rounded p-2 transition-colors hover:bg-muted/20',
-              showMarketsMenu ||
-                sortBy !== 'volume' ||
-                sortDesc !== true
+              showMarketsMenu || sortBy !== 'volume' || sortDesc !== true
                 ? 'bg-muted/20 text-primary'
                 : 'text-muted-foreground'
             )}
@@ -1434,7 +1432,9 @@ export function MarketsTradingTerminal({
               type="button"
               className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs hover:bg-muted/20"
               onClick={() => {
-                handleFilterChange(filter === 'favorites' ? 'all' : 'favorites');
+                handleFilterChange(
+                  filter === 'favorites' ? 'all' : 'favorites'
+                );
               }}
             >
               <div
@@ -1449,9 +1449,13 @@ export function MarketsTradingTerminal({
                   <Check size={10} className="text-primary-foreground" />
                 )}
               </div>
-              <span className={cn(
-                filter === 'favorites' ? 'font-medium text-primary' : 'text-foreground'
-              )}>
+              <span
+                className={cn(
+                  filter === 'favorites'
+                    ? 'font-medium text-primary'
+                    : 'text-foreground'
+                )}
+              >
                 Favorites only
               </span>
             </button>
@@ -1507,15 +1511,18 @@ export function MarketsTradingTerminal({
             { id: 'prediction', label: 'Prediction' },
           ] as const
         ).map((tab) => {
-          const isActive = filter === tab.id || (tab.id === 'all' && filter === 'favorites');
+          const isActive =
+            filter === tab.id || (tab.id === 'all' && filter === 'favorites');
           return (
             <button
               key={tab.id}
               type="button"
               onClick={() => handleFilterChange(tab.id)}
               className={cn(
-                'relative flex-1 py-2.5 text-xs font-semibold transition-colors hover:bg-muted/20',
-                isActive ? 'bg-primary/10 text-primary' : 'text-muted-foreground'
+                'relative flex-1 py-2.5 font-semibold text-xs transition-colors hover:bg-muted/20',
+                isActive
+                  ? 'bg-primary/10 text-primary'
+                  : 'text-muted-foreground'
               )}
             >
               {tab.label}
@@ -2260,53 +2267,97 @@ export function MarketsTradingTerminal({
             </div>
           ) : (
             <div className="h-full space-y-2 overflow-auto p-2">
-              {selected?.kind === 'prediction' && selectedPredictionPositions.length > 0 && (
-                <div className="rounded border border-primary/20 bg-primary/5 p-2">
-                  <div className="px-1 pb-2 font-semibold text-primary text-xs uppercase tracking-wider">
-                    Selected Market
+              {selected?.kind === 'prediction' &&
+                selectedPredictionPositions.length > 0 && (
+                  <div className="rounded border border-primary/20 bg-primary/5 p-2">
+                    <div className="px-1 pb-2 font-semibold text-primary text-xs uppercase tracking-wider">
+                      Selected Market
+                    </div>
+                    <PredictionPositionsList
+                      positions={selectedPredictionPositions}
+                      density="compact"
+                      onPositionSold={handlePredictionPositionSold}
+                    />
                   </div>
-                  <PredictionPositionsList
-                    positions={selectedPredictionPositions}
-                    density="compact"
-                    onPositionSold={handlePredictionPositionSold}
-                  />
-                </div>
-              )}
-              {selected?.kind === 'perp' && selectedPerpPositions.length > 0 && (
-                <div className="rounded border border-primary/20 bg-primary/5 p-2">
-                  <div className="px-1 pb-2 font-semibold text-primary text-xs uppercase tracking-wider">
-                    Selected Market
+                )}
+              {selected?.kind === 'perp' &&
+                selectedPerpPositions.length > 0 && (
+                  <div className="rounded border border-primary/20 bg-primary/5 p-2">
+                    <div className="px-1 pb-2 font-semibold text-primary text-xs uppercase tracking-wider">
+                      Selected Market
+                    </div>
+                    <PerpPositionsList
+                      positions={selectedPerpPositions}
+                      density="compact"
+                      onPositionClosed={handlePerpPositionClosed}
+                    />
                   </div>
-                  <PerpPositionsList
-                    positions={selectedPerpPositions}
-                    density="compact"
-                    onPositionClosed={handlePerpPositionClosed}
-                  />
-                </div>
-              )}
-              {perpPositions.filter((p) => selected?.kind !== 'perp' || p.ticker.toUpperCase() !== selectedPerp?.ticker.toUpperCase() || p.closedAt).length > 0 && (
+                )}
+              {perpPositions.filter(
+                (p) =>
+                  selected?.kind !== 'perp' ||
+                  p.ticker.toUpperCase() !==
+                    selectedPerp?.ticker.toUpperCase() ||
+                  p.closedAt
+              ).length > 0 && (
                 <div className="rounded border border-white/10 bg-background/10 p-2">
                   <div className="px-1 pb-2 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
-                    Perps ({perpPositions.filter((p) => selected?.kind !== 'perp' || p.ticker.toUpperCase() !== selectedPerp?.ticker.toUpperCase() || p.closedAt).length})
+                    Perps (
+                    {
+                      perpPositions.filter(
+                        (p) =>
+                          selected?.kind !== 'perp' ||
+                          p.ticker.toUpperCase() !==
+                            selectedPerp?.ticker.toUpperCase() ||
+                          p.closedAt
+                      ).length
+                    }
+                    )
                   </div>
                   <PerpPositionsList
-                    positions={perpPositions.filter((p) => selected?.kind !== 'perp' || p.ticker.toUpperCase() !== selectedPerp?.ticker.toUpperCase() || p.closedAt)}
+                    positions={perpPositions.filter(
+                      (p) =>
+                        selected?.kind !== 'perp' ||
+                        p.ticker.toUpperCase() !==
+                          selectedPerp?.ticker.toUpperCase() ||
+                        p.closedAt
+                    )}
                     density="compact"
                     onPositionClosed={handlePerpPositionClosed}
-                    onPositionClick={(ticker) => handleSelect({ kind: 'perp', id: ticker })}
+                    onPositionClick={(ticker) =>
+                      handleSelect({ kind: 'perp', id: ticker })
+                    }
                   />
                 </div>
               )}
-              {predictionPositions.filter((p) => selected?.kind !== 'prediction' || p.marketId.toString() !== selectedPredictionId).length > 0 && (
+              {predictionPositions.filter(
+                (p) =>
+                  selected?.kind !== 'prediction' ||
+                  p.marketId.toString() !== selectedPredictionId
+              ).length > 0 && (
                 <div className="rounded border border-white/10 bg-background/10 p-2">
                   <div className="px-1 pb-2 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
-                    Predictions ({predictionPositions.filter((p) => selected?.kind !== 'prediction' || p.marketId.toString() !== selectedPredictionId).length})
+                    Predictions (
+                    {
+                      predictionPositions.filter(
+                        (p) =>
+                          selected?.kind !== 'prediction' ||
+                          p.marketId.toString() !== selectedPredictionId
+                      ).length
+                    }
+                    )
                   </div>
                   <PredictionPositionsList
-                    positions={predictionPositions.filter((p) => selected?.kind !== 'prediction' || p.marketId.toString() !== selectedPredictionId)}
+                    positions={predictionPositions.filter(
+                      (p) =>
+                        selected?.kind !== 'prediction' ||
+                        p.marketId.toString() !== selectedPredictionId
+                    )}
                     density="compact"
                     onPositionSold={handlePredictionPositionSold}
-                    onPositionClick={(marketId) => handleSelect({ kind: 'prediction', id: marketId })}
+                    onPositionClick={(marketId) =>
+                      handleSelect({ kind: 'prediction', id: marketId })
+                    }
                   />
                 </div>
               )}
@@ -2610,59 +2661,86 @@ export function MarketsTradingTerminal({
                     <div className="flex h-full justify-center pt-6 text-muted-foreground text-sm">
                       Log in to view positions.
                     </div>
-                  ) : perpPositions.length === 0 && predictionPositions.length === 0 ? (
+                  ) : perpPositions.length === 0 &&
+                    predictionPositions.length === 0 ? (
                     <div className="flex h-full items-center justify-center text-muted-foreground text-xs">
                       No open positions
                     </div>
                   ) : (
                     <div className="h-full space-y-2 overflow-auto overscroll-contain p-2">
-                      {selected?.kind === 'prediction' && selectedPredictionPositions.length > 0 && (
-                        <div className="rounded border border-primary/20 bg-primary/5 p-2">
-                          <div className="px-1 pb-2 font-semibold text-primary text-xs uppercase tracking-wider">
-                            Selected Market
+                      {selected?.kind === 'prediction' &&
+                        selectedPredictionPositions.length > 0 && (
+                          <div className="rounded border border-primary/20 bg-primary/5 p-2">
+                            <div className="px-1 pb-2 font-semibold text-primary text-xs uppercase tracking-wider">
+                              Selected Market
+                            </div>
+                            <PredictionPositionsList
+                              positions={selectedPredictionPositions}
+                              density="compact"
+                              onPositionSold={handlePredictionPositionSold}
+                            />
                           </div>
-                          <PredictionPositionsList
-                            positions={selectedPredictionPositions}
-                            density="compact"
-                            onPositionSold={handlePredictionPositionSold}
-                          />
-                        </div>
-                      )}
-                      {selected?.kind === 'perp' && selectedPerpPositions.length > 0 && (
-                        <div className="rounded border border-primary/20 bg-primary/5 p-2">
-                          <div className="px-1 pb-2 font-semibold text-primary text-xs uppercase tracking-wider">
-                            Selected Market
+                        )}
+                      {selected?.kind === 'perp' &&
+                        selectedPerpPositions.length > 0 && (
+                          <div className="rounded border border-primary/20 bg-primary/5 p-2">
+                            <div className="px-1 pb-2 font-semibold text-primary text-xs uppercase tracking-wider">
+                              Selected Market
+                            </div>
+                            <PerpPositionsList
+                              positions={selectedPerpPositions}
+                              density="compact"
+                              onPositionClosed={handlePerpPositionClosed}
+                            />
                           </div>
-                          <PerpPositionsList
-                            positions={selectedPerpPositions}
-                            density="compact"
-                            onPositionClosed={handlePerpPositionClosed}
-                          />
-                        </div>
-                      )}
-                      {perpPositions.filter((p) => selected?.kind !== 'perp' || p.ticker.toUpperCase() !== selectedPerp?.ticker.toUpperCase() || p.closedAt).length > 0 && (
+                        )}
+                      {perpPositions.filter(
+                        (p) =>
+                          selected?.kind !== 'perp' ||
+                          p.ticker.toUpperCase() !==
+                            selectedPerp?.ticker.toUpperCase() ||
+                          p.closedAt
+                      ).length > 0 && (
                         <div className="rounded border border-white/10 bg-background/10 p-2">
                           <div className="px-1 pb-2 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
                             Perps
                           </div>
                           <PerpPositionsList
-                            positions={perpPositions.filter((p) => selected?.kind !== 'perp' || p.ticker.toUpperCase() !== selectedPerp?.ticker.toUpperCase() || p.closedAt)}
+                            positions={perpPositions.filter(
+                              (p) =>
+                                selected?.kind !== 'perp' ||
+                                p.ticker.toUpperCase() !==
+                                  selectedPerp?.ticker.toUpperCase() ||
+                                p.closedAt
+                            )}
                             density="compact"
                             onPositionClosed={handlePerpPositionClosed}
-                            onPositionClick={(ticker) => handleSelect({ kind: 'perp', id: ticker })}
+                            onPositionClick={(ticker) =>
+                              handleSelect({ kind: 'perp', id: ticker })
+                            }
                           />
                         </div>
                       )}
-                      {predictionPositions.filter((p) => selected?.kind !== 'prediction' || p.marketId.toString() !== selectedPredictionId).length > 0 && (
+                      {predictionPositions.filter(
+                        (p) =>
+                          selected?.kind !== 'prediction' ||
+                          p.marketId.toString() !== selectedPredictionId
+                      ).length > 0 && (
                         <div className="rounded border border-white/10 bg-background/10 p-2">
                           <div className="px-1 pb-2 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
                             Predictions
                           </div>
                           <PredictionPositionsList
-                            positions={predictionPositions.filter((p) => selected?.kind !== 'prediction' || p.marketId.toString() !== selectedPredictionId)}
+                            positions={predictionPositions.filter(
+                              (p) =>
+                                selected?.kind !== 'prediction' ||
+                                p.marketId.toString() !== selectedPredictionId
+                            )}
                             density="compact"
                             onPositionSold={handlePredictionPositionSold}
-                            onPositionClick={(marketId) => handleSelect({ kind: 'prediction', id: marketId })}
+                            onPositionClick={(marketId) =>
+                              handleSelect({ kind: 'prediction', id: marketId })
+                            }
                           />
                         </div>
                       )}

--- a/apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx
@@ -1,12 +1,8 @@
 'use client';
 
-import type { UserPredictionPosition } from '@babylon/shared';
 import { cn } from '@babylon/shared';
 import { RefreshCw, Wallet } from 'lucide-react';
-import { PerpPositionsList } from '@/components/markets/PerpPositionsList';
-import { PredictionPositionsList } from '@/components/markets/PredictionPositionsList';
 import type { PortfolioBreakdownSnapshot } from '@/hooks/usePortfolioPnL';
-import type { DisplayPerpPosition } from '@/types/markets';
 import { formatBalance } from '../../_lib/formatters';
 
 /**
@@ -32,10 +28,6 @@ interface TerminalPortfolioProps {
   onRefresh: () => void;
   /** When true, disables refresh button (e.g., during cooldown) without showing loading spinner */
   refreshDisabled?: boolean;
-  perpPositions: DisplayPerpPosition[];
-  predictionPositions: UserPredictionPosition[];
-  onPerpPositionClosed: () => Promise<void>;
-  onPredictionPositionSold: () => Promise<void>;
 }
 
 /** Helper to format portfolio values with loading state */
@@ -83,10 +75,6 @@ export function TerminalPortfolio({
   portfolioError,
   onRefresh,
   refreshDisabled = false,
-  perpPositions,
-  predictionPositions,
-  onPerpPositionClosed,
-  onPredictionPositionSold,
 }: TerminalPortfolioProps) {
   if (!authenticated) {
     return (
@@ -230,43 +218,6 @@ export function TerminalPortfolio({
         </div>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-auto overscroll-contain p-3">
-        <div className="space-y-3">
-          {perpPositions.length === 0 && predictionPositions.length === 0 ? (
-            <div className="flex h-[140px] items-center justify-center rounded border border-white/10 bg-background/20 text-muted-foreground text-sm">
-              No open positions yet.
-            </div>
-          ) : (
-            <>
-              {perpPositions.length > 0 && (
-                <div className="rounded border border-white/10 bg-background/10 p-2">
-                  <div className="px-1 pb-2 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
-                    Perps ({perpPositions.length})
-                  </div>
-                  <PerpPositionsList
-                    positions={perpPositions}
-                    density="compact"
-                    onPositionClosed={onPerpPositionClosed}
-                  />
-                </div>
-              )}
-
-              {predictionPositions.length > 0 && (
-                <div className="rounded border border-white/10 bg-background/10 p-2">
-                  <div className="px-1 pb-2 font-semibold text-muted-foreground text-xs uppercase tracking-wider">
-                    Predictions ({predictionPositions.length})
-                  </div>
-                  <PredictionPositionsList
-                    positions={predictionPositions}
-                    density="compact"
-                    onPositionSold={onPredictionPositionSold}
-                  />
-                </div>
-              )}
-            </>
-          )}
-        </div>
-      </div>
     </div>
   );
 }

--- a/apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalPortfolio.tsx
@@ -217,7 +217,6 @@ export function TerminalPortfolio({
           />
         </div>
       </div>
-
     </div>
   );
 }

--- a/apps/web/src/components/markets/PerpPositionsList.tsx
+++ b/apps/web/src/components/markets/PerpPositionsList.tsx
@@ -245,7 +245,7 @@ export function PerpPositionsList({
 
               {/* Row 2: Price + Stats + Close button */}
               <div className="mt-1.5 flex items-center justify-between gap-2">
-                <div className="flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
+                <div className="flex flex-wrap items-center gap-x-2 text-muted-foreground text-xs">
                   <span className="font-medium text-foreground">
                     {formatPrice(position.entryPrice)}
                     <span className="mx-0.5 text-muted-foreground">&rarr;</span>
@@ -307,7 +307,7 @@ export function PerpPositionsList({
               {isNearLiquidation && (
                 <div className="mt-1.5 flex items-center gap-1.5 rounded bg-red-600/20 px-2 py-1">
                   <AlertTriangle className="h-3 w-3 shrink-0 text-red-600" />
-                  <p className="font-medium text-xs text-red-600">
+                  <p className="font-medium text-red-600 text-xs">
                     Near liquidation! {liquidationDistance.toFixed(2)}% away
                   </p>
                 </div>

--- a/apps/web/src/components/markets/PerpPositionsList.tsx
+++ b/apps/web/src/components/markets/PerpPositionsList.tsx
@@ -48,12 +48,14 @@ type PerpPosition = DisplayPerpPosition;
 interface PerpPositionsListProps {
   positions: PerpPosition[];
   onPositionClosed?: () => void;
+  onPositionClick?: (ticker: string) => void;
   density?: 'default' | 'compact';
 }
 
 export function PerpPositionsList({
   positions,
   onPositionClosed,
+  onPositionClick,
   density = 'default',
 }: PerpPositionsListProps) {
   const compact = density === 'compact';
@@ -155,8 +157,6 @@ export function PerpPositionsList({
     return date.toLocaleDateString('en-US', {
       month: 'short',
       day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
     });
   };
 
@@ -177,7 +177,7 @@ export function PerpPositionsList({
   }
 
   return (
-    <div className={cn(compact ? 'space-y-2' : 'space-y-3')}>
+    <div className={cn(compact ? 'space-y-1.5' : 'space-y-2')}>
       {positionsWithPnL.map(
         ({
           position,
@@ -194,158 +194,124 @@ export function PerpPositionsList({
               key={position.id}
               className={cn(
                 'rounded transition-all',
-                compact ? 'p-3' : 'p-4',
-                isNearLiquidation ? 'bg-red-600/10' : 'bg-muted/40'
+                compact ? 'p-2' : 'p-2.5',
+                isNearLiquidation ? 'bg-red-600/10' : 'bg-muted/40',
+                onPositionClick && 'cursor-pointer hover:bg-muted/60'
               )}
+              onClick={() => onPositionClick?.(position.ticker)}
             >
-              {/* Header */}
-              <div
-                className={cn(
-                  'flex items-center justify-between',
-                  compact ? 'mb-2' : 'mb-3'
-                )}
-              >
-                <div className="flex items-center gap-2">
+              {/* Row 1: Side badge, ticker, PnL */}
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-1.5">
                   <span
                     className={cn(
-                      'flex items-center gap-1 rounded px-2 py-1 font-bold text-xs',
+                      'flex shrink-0 items-center gap-0.5 rounded px-1.5 py-0.5 font-bold text-[11px]',
                       position.side === 'long'
                         ? 'bg-green-600/20 text-green-600'
                         : 'bg-red-600/20 text-red-600'
                     )}
                   >
                     {position.side === 'long' ? (
-                      <TrendingUp size={12} />
+                      <TrendingUp size={10} />
                     ) : (
-                      <TrendingDown size={12} />
+                      <TrendingDown size={10} />
                     )}
                     {position.leverage}x {position.side.toUpperCase()}
                   </span>
-                  <span className="font-bold text-foreground">
+                  <span className="font-bold text-foreground text-xs">
                     ${position.ticker}
                   </span>
-                  {/* Agent position badge */}
                   {position.isAgentPosition && (
-                    <span className="flex items-center gap-1 rounded bg-purple-600/20 px-2 py-1 font-medium text-purple-500 text-xs">
-                      <Bot size={12} />
+                    <span className="flex shrink-0 items-center gap-0.5 rounded bg-purple-600/20 px-1 py-0.5 font-medium text-[11px] text-purple-500">
+                      <Bot size={10} />
                       {position.agentName || 'Agent'}
                     </span>
                   )}
                 </div>
+                <span
+                  className={cn(
+                    'shrink-0 font-bold text-xs',
+                    pnl >= 0 ? 'text-green-600' : 'text-red-600'
+                  )}
+                >
+                  {pnl >= 0 ? '+' : ''}
+                  {formatPrice(pnl)}{' '}
+                  <span className="font-normal text-[11px]">
+                    ({pnl >= 0 ? '+' : ''}
+                    {pnlPercent.toFixed(2)}%)
+                  </span>
+                </span>
+              </div>
 
-                <div className="text-right">
-                  <div
-                    className={cn(
-                      compact ? 'font-bold text-base' : 'font-bold text-lg',
-                      pnl >= 0 ? 'text-green-600' : 'text-red-600'
-                    )}
-                  >
-                    {pnl >= 0 ? '+' : ''}
-                    {formatPrice(pnl)}
-                  </div>
-                  <div
-                    className={cn(
-                      'text-xs',
-                      pnl >= 0 ? 'text-green-600' : 'text-red-600'
-                    )}
-                  >
-                    {pnl >= 0 ? '+' : ''}
-                    {pnlPercent.toFixed(2)}%
-                  </div>
+              {/* Row 2: Price + Stats + Close button */}
+              <div className="mt-1.5 flex items-center justify-between gap-2">
+                <div className="flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
+                  <span className="font-medium text-foreground">
+                    {formatPrice(position.entryPrice)}
+                    <span className="mx-0.5 text-muted-foreground">&rarr;</span>
+                    {formatPrice(currentPrice)}
+                  </span>
+                  <span className="text-muted-foreground/40">&middot;</span>
+                  <span>
+                    Size{' '}
+                    <span className="font-medium text-foreground">
+                      {formatPrice(position.size)}
+                    </span>
+                  </span>
+                  <span className="text-muted-foreground/40">&middot;</span>
+                  <span>
+                    Liq{' '}
+                    <span className="font-medium text-red-600">
+                      {formatPrice(position.liquidationPrice)}
+                    </span>
+                  </span>
+                  <span className="text-muted-foreground/40">&middot;</span>
+                  <span>
+                    Fund{' '}
+                    <span
+                      className={cn(
+                        'font-medium',
+                        position.fundingPaid >= 0
+                          ? 'text-red-600'
+                          : 'text-green-600'
+                      )}
+                    >
+                      {position.fundingPaid >= 0 ? '-' : '+'}
+                      {formatPrice(Math.abs(position.fundingPaid))}
+                    </span>
+                  </span>
+                  <span className="text-muted-foreground/40">&middot;</span>
+                  <span className="text-foreground">
+                    {formatDate(position.openedAt)}
+                  </span>
                 </div>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleCloseClick(position, currentPrice, pnl, pnlPercent);
+                  }}
+                  disabled={isClosing}
+                  className={cn(
+                    'shrink-0 cursor-pointer rounded-full px-3 py-0.5 font-medium text-xs transition-all',
+                    isNearLiquidation
+                      ? 'bg-red-600 text-primary-foreground hover:bg-red-700'
+                      : 'bg-muted text-foreground hover:bg-muted/80',
+                    isClosing && 'cursor-not-allowed opacity-50'
+                  )}
+                >
+                  {isClosing ? 'Closing...' : 'Close'}
+                </button>
               </div>
 
               {/* Liquidation Warning */}
               {isNearLiquidation && (
-                <div
-                  className={cn(
-                    'flex items-center gap-2 rounded bg-red-600/20',
-                    compact ? 'mb-2 p-1.5' : 'mb-3 p-2'
-                  )}
-                >
-                  <AlertTriangle className="h-4 w-4 flex-shrink-0 text-red-600" />
-                  <p className="font-medium text-red-600 text-xs">
+                <div className="mt-1.5 flex items-center gap-1.5 rounded bg-red-600/20 px-2 py-1">
+                  <AlertTriangle className="h-3 w-3 shrink-0 text-red-600" />
+                  <p className="font-medium text-xs text-red-600">
                     Near liquidation! {liquidationDistance.toFixed(2)}% away
                   </p>
                 </div>
               )}
-
-              {/* Stats Grid */}
-              <div
-                className={cn(
-                  'grid grid-cols-2 text-xs',
-                  compact ? 'mb-2 gap-1.5' : 'mb-3 gap-2'
-                )}
-              >
-                <div>
-                  <div className="text-muted-foreground">Entry</div>
-                  <div className="font-medium text-foreground">
-                    {formatPrice(position.entryPrice)}
-                  </div>
-                </div>
-                <div>
-                  <div className="text-muted-foreground">Current</div>
-                  <div className="font-medium text-foreground">
-                    {formatPrice(currentPrice)}
-                  </div>
-                </div>
-                <div>
-                  <div className="text-muted-foreground">Liquidation</div>
-                  <div className="font-bold text-red-600">
-                    {formatPrice(position.liquidationPrice)}
-                  </div>
-                </div>
-                <div>
-                  <div className="text-muted-foreground">Size</div>
-                  <div className="font-medium text-foreground">
-                    {formatPrice(position.size)}
-                  </div>
-                </div>
-                <div>
-                  <div className="text-muted-foreground">Funding Paid</div>
-                  <div
-                    className={cn(
-                      'font-medium',
-                      position.fundingPaid >= 0
-                        ? 'text-red-600'
-                        : 'text-green-600'
-                    )}
-                  >
-                    {position.fundingPaid >= 0 ? '-' : '+'}
-                    {formatPrice(Math.abs(position.fundingPaid))}
-                  </div>
-                </div>
-                <div>
-                  <div className="text-muted-foreground">Opened</div>
-                  <div className="font-medium text-foreground">
-                    {formatDate(position.openedAt)}
-                  </div>
-                </div>
-              </div>
-
-              {/* Close Button */}
-              <button
-                onClick={() =>
-                  handleCloseClick(position, currentPrice, pnl, pnlPercent)
-                }
-                disabled={isClosing}
-                className={cn(
-                  'w-full cursor-pointer rounded py-2 font-medium transition-all',
-                  isNearLiquidation
-                    ? 'bg-red-600 text-primary-foreground hover:bg-red-700'
-                    : 'bg-muted text-foreground hover:bg-muted',
-                  isClosing && 'cursor-not-allowed opacity-50'
-                )}
-              >
-                {isClosing ? (
-                  <span className="flex items-center justify-center gap-2">
-                    <div className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
-                    Closing...
-                  </span>
-                ) : (
-                  'Close Position'
-                )}
-              </button>
             </div>
           );
         }

--- a/apps/web/src/components/markets/PredictionPositionsList.tsx
+++ b/apps/web/src/components/markets/PredictionPositionsList.tsx
@@ -49,12 +49,14 @@ type PredictionPosition = UserPredictionPosition;
 interface PredictionPositionsListProps {
   positions: PredictionPosition[];
   onPositionSold?: () => void;
+  onPositionClick?: (marketId: string) => void;
   density?: 'default' | 'compact';
 }
 
 export function PredictionPositionsList({
   positions,
   onPositionSold,
+  onPositionClick,
   density = 'default',
 }: PredictionPositionsListProps) {
   const { getAccessToken } = usePrivy();
@@ -171,7 +173,7 @@ export function PredictionPositionsList({
   }
 
   return (
-    <div className={cn(compact ? 'space-y-2' : 'space-y-3')}>
+    <div className={cn(compact ? 'space-y-1.5' : 'space-y-2')}>
       {positions.map((position) => {
         const currentValue =
           position.currentValue ?? position.shares * position.currentPrice;
@@ -186,143 +188,120 @@ export function PredictionPositionsList({
         return (
           <div
             key={position.id}
-            className={cn('rounded bg-muted/40', compact ? 'p-3' : 'p-4')}
+            className={cn(
+              'rounded bg-muted/40',
+              compact ? 'p-2' : 'p-2.5',
+              onPositionClick && 'cursor-pointer hover:bg-muted/60'
+            )}
+            onClick={() => onPositionClick?.(position.marketId.toString())}
           >
-            <div
-              className={cn(
-                'flex items-center justify-between',
-                compact ? 'mb-2' : 'mb-3'
-              )}
-            >
-              <div className="flex items-center gap-2">
+            {/* Row 1: Side badge, question (truncated), PnL */}
+            <div className="flex items-start justify-between gap-2">
+              <div className="flex min-w-0 items-center gap-1.5">
                 <span
                   className={cn(
-                    'flex items-center gap-1 rounded px-2 py-1 font-bold text-xs',
+                    'flex shrink-0 items-center gap-0.5 rounded px-1.5 py-0.5 font-bold text-[11px]',
                     position.side === 'YES'
                       ? 'bg-green-600/20 text-green-600'
                       : 'bg-red-600/20 text-red-600'
                   )}
                 >
                   {position.side === 'YES' ? (
-                    <CheckCircle size={12} />
+                    <CheckCircle size={10} />
                   ) : (
-                    <XCircle size={12} />
+                    <XCircle size={10} />
                   )}
                   {position.side}
                 </span>
-                {/* Agent position badge */}
                 {position.isAgentPosition && (
-                  <span className="flex items-center gap-1 rounded bg-purple-600/20 px-2 py-1 font-medium text-purple-500 text-xs">
-                    <Bot size={12} />
+                  <span className="flex shrink-0 items-center gap-0.5 rounded bg-purple-600/20 px-1 py-0.5 font-medium text-[11px] text-purple-500">
+                    <Bot size={10} />
                     {position.agentName || 'Agent'}
                   </span>
                 )}
-              </div>
-
-              <div className="text-right">
-                <div
-                  className={cn(
-                    compact ? 'font-bold text-base' : 'font-bold text-lg',
-                    unrealizedPnL >= 0 ? 'text-green-600' : 'text-red-600'
-                  )}
-                >
-                  {unrealizedPnL >= 0 ? '+' : ''}
-                  {formatPrice(unrealizedPnL)}
-                </div>
-                <div
-                  className={cn(
-                    'text-xs',
-                    unrealizedPnL >= 0 ? 'text-green-600' : 'text-red-600'
-                  )}
-                >
-                  {unrealizedPnL >= 0 ? '+' : ''}
-                  {pnlPercent.toFixed(2)}%
-                </div>
-              </div>
-            </div>
-
-            <p
-              className={cn(
-                'font-medium text-foreground',
-                compact
-                  ? 'mb-2 text-sm leading-snug md:text-xs'
-                  : 'mb-3 text-sm'
-              )}
-            >
-              {position.question}
-            </p>
-
-            <div
-              className={cn(
-                'grid grid-cols-2 text-xs',
-                compact ? 'mb-2 gap-1.5' : 'mb-3 gap-2'
-              )}
-            >
-              <div>
-                <div className="text-muted-foreground">Shares</div>
-                <div className="font-medium text-foreground">
-                  {position.shares.toFixed(2)}
-                </div>
-              </div>
-              <div>
-                <div className="text-muted-foreground">Avg Cost</div>
-                <div className="font-medium text-foreground">
-                  {formatPrice(position.avgPrice)}
-                </div>
-              </div>
-              <div>
-                <div className="text-muted-foreground">Current Price</div>
-                <div className="font-medium text-foreground">
-                  {formatPrice(position.currentPrice)}
-                </div>
-              </div>
-              <div>
-                <div className="text-muted-foreground">Value</div>
-                <div className="font-medium text-foreground">
-                  {formatPrice(currentValue)}
-                </div>
-              </div>
-            </div>
-
-            {!position.resolved ? (
-              <button
-                onClick={() =>
-                  handleSellClick(
-                    position,
-                    currentValue,
-                    unrealizedPnL,
-                    pnlPercent
-                  )
-                }
-                disabled={isSelling || position.shares < 0.01}
-                className={cn(
-                  'w-full cursor-pointer rounded bg-muted font-medium text-foreground transition-all hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50',
-                  compact ? 'py-1.5 text-sm md:text-xs' : 'py-2 text-sm'
-                )}
-              >
-                {isSelling
-                  ? 'Selling...'
-                  : position.shares < 0.01
-                    ? 'Position Too Small'
-                    : 'Sell Shares'}
-              </button>
-            ) : (
-              <div
-                className={cn(
-                  'py-2 text-center font-medium',
-                  compact ? 'text-sm md:text-xs' : 'text-sm'
-                )}
-              >
-                <span className="text-muted-foreground">Resolved: </span>
-                <span
-                  className={
-                    position.resolution ? 'text-green-600' : 'text-red-600'
-                  }
-                >
-                  {position.resolution ? 'YES' : 'NO'}
+                <span className="truncate text-xs font-medium text-foreground">
+                  {position.question}
                 </span>
               </div>
-            )}
+              <span
+                className={cn(
+                  'shrink-0 font-bold text-xs',
+                  unrealizedPnL >= 0 ? 'text-green-600' : 'text-red-600'
+                )}
+              >
+                {unrealizedPnL >= 0 ? '+' : ''}
+                {formatPrice(unrealizedPnL)}{' '}
+                <span className="font-normal text-[11px]">
+                  ({unrealizedPnL >= 0 ? '+' : ''}
+                  {pnlPercent.toFixed(2)}%)
+                </span>
+              </span>
+            </div>
+
+            {/* Row 2: Stats + Sell/Resolved */}
+            <div className="mt-1.5 flex items-center justify-between gap-2">
+              <div className="flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
+                <span>
+                  {position.shares.toFixed(2)}{' '}
+                  <span className="font-medium text-foreground">shares</span>
+                </span>
+                <span className="text-muted-foreground/40">&middot;</span>
+                <span>
+                  Avg{' '}
+                  <span className="font-medium text-foreground">
+                    {formatPrice(position.avgPrice)}
+                  </span>
+                </span>
+                <span className="text-muted-foreground/40">&middot;</span>
+                <span>
+                  Now{' '}
+                  <span className="font-medium text-foreground">
+                    {formatPrice(position.currentPrice)}
+                  </span>
+                </span>
+                <span className="text-muted-foreground/40">&middot;</span>
+                <span>
+                  Val{' '}
+                  <span className="font-medium text-foreground">
+                    {formatPrice(currentValue)}
+                  </span>
+                </span>
+              </div>
+              {!position.resolved ? (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleSellClick(
+                      position,
+                      currentValue,
+                      unrealizedPnL,
+                      pnlPercent
+                    );
+                  }}
+                  disabled={isSelling || position.shares < 0.01}
+                  className={cn(
+                    'shrink-0 cursor-pointer rounded-full bg-muted px-3 py-0.5 font-medium text-xs text-foreground transition-all hover:bg-muted/80 disabled:cursor-not-allowed disabled:opacity-50'
+                  )}
+                >
+                  {isSelling
+                    ? 'Selling...'
+                    : position.shares < 0.01
+                      ? 'Too Small'
+                      : 'Sell'}
+                </button>
+              ) : (
+                <span className="shrink-0 text-xs font-medium text-muted-foreground">
+                  Resolved:{' '}
+                  <span
+                    className={
+                      position.resolution ? 'text-green-600' : 'text-red-600'
+                    }
+                  >
+                    {position.resolution ? 'YES' : 'NO'}
+                  </span>
+                </span>
+              )}
+            </div>
           </div>
         );
       })}

--- a/apps/web/src/components/markets/PredictionPositionsList.tsx
+++ b/apps/web/src/components/markets/PredictionPositionsList.tsx
@@ -219,7 +219,7 @@ export function PredictionPositionsList({
                     {position.agentName || 'Agent'}
                   </span>
                 )}
-                <span className="truncate text-xs font-medium text-foreground">
+                <span className="truncate font-medium text-foreground text-xs">
                   {position.question}
                 </span>
               </div>
@@ -240,7 +240,7 @@ export function PredictionPositionsList({
 
             {/* Row 2: Stats + Sell/Resolved */}
             <div className="mt-1.5 flex items-center justify-between gap-2">
-              <div className="flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
+              <div className="flex flex-wrap items-center gap-x-2 text-muted-foreground text-xs">
                 <span>
                   {position.shares.toFixed(2)}{' '}
                   <span className="font-medium text-foreground">shares</span>
@@ -280,7 +280,7 @@ export function PredictionPositionsList({
                   }}
                   disabled={isSelling || position.shares < 0.01}
                   className={cn(
-                    'shrink-0 cursor-pointer rounded-full bg-muted px-3 py-0.5 font-medium text-xs text-foreground transition-all hover:bg-muted/80 disabled:cursor-not-allowed disabled:opacity-50'
+                    'shrink-0 cursor-pointer rounded-full bg-muted px-3 py-0.5 font-medium text-foreground text-xs transition-all hover:bg-muted/80 disabled:cursor-not-allowed disabled:opacity-50'
                   )}
                 >
                   {isSelling
@@ -290,7 +290,7 @@ export function PredictionPositionsList({
                       : 'Sell'}
                 </button>
               ) : (
-                <span className="shrink-0 text-xs font-medium text-muted-foreground">
+                <span className="shrink-0 font-medium text-muted-foreground text-xs">
                   Resolved:{' '}
                   <span
                     className={

--- a/apps/web/src/components/profile/ProfilePageClient.tsx
+++ b/apps/web/src/components/profile/ProfilePageClient.tsx
@@ -19,7 +19,7 @@ import {
   Search,
 } from 'lucide-react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import {
   useCallback,
   useEffect,
@@ -81,9 +81,13 @@ export function ProfilePageClient({
         ? extractUsername(identifier)
         : identifier;
 
+  const searchParams = useSearchParams();
   const { user, authenticated, getAccessToken } = useAuth();
   const [searchQuery, setSearchQuery] = useState('');
-  const [tab, setTab] = useState<'posts' | 'replies' | 'trades'>('posts');
+  const initialTab = searchParams.get('tab');
+  const [tab, setTab] = useState<'posts' | 'replies' | 'trades'>(
+    initialTab === 'trades' || initialTab === 'replies' ? initialTab : 'posts'
+  );
   const { allGames } = useGameStore();
   const [optimisticFollowerCount, setOptimisticFollowerCount] = useState<
     number | null

--- a/apps/web/src/components/shared/ComingSoon.tsx
+++ b/apps/web/src/components/shared/ComingSoon.tsx
@@ -2594,9 +2594,7 @@ export function ComingSoon() {
                         </button>
                         <button
                           type="submit"
-                          disabled={
-                            isSavingProfile || !isProfileFormValid()
-                          }
+                          disabled={isSavingProfile || !isProfileFormValid()}
                           className="min-h-[44px] flex-1 rounded-lg bg-primary px-4 py-2 font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
                         >
                           {isSavingProfile
@@ -4088,9 +4086,7 @@ export function ComingSoon() {
                     </button>
                     <button
                       type="submit"
-                      disabled={
-                        isSavingProfile || !isProfileFormValid()
-                      }
+                      disabled={isSavingProfile || !isProfileFormValid()}
                       className="min-h-[44px] flex-1 rounded-lg bg-primary px-4 py-2 font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:cursor-not-allowed disabled:opacity-50"
                     >
                       {isSavingProfile

--- a/apps/web/src/components/trades/TradeCard.tsx
+++ b/apps/web/src/components/trades/TradeCard.tsx
@@ -204,17 +204,27 @@ export function TradeCard({ trade }: TradeCardProps) {
     e.stopPropagation();
 
     if (trade.type === 'balance' && trade.market) {
-      router.push(`/markets?filter=prediction&marketKind=prediction&marketId=${encodeURIComponent(trade.market.id)}`);
+      router.push(
+        `/markets?filter=prediction&marketKind=prediction&marketId=${encodeURIComponent(trade.market.id)}`
+      );
     } else if (trade.type === 'npc') {
       if (trade.marketType === 'perp' && trade.ticker) {
-        router.push(`/markets?filter=perp&marketKind=perp&marketId=${encodeURIComponent(trade.ticker)}`);
+        router.push(
+          `/markets?filter=perp&marketKind=perp&marketId=${encodeURIComponent(trade.ticker)}`
+        );
       } else if (trade.marketType === 'prediction' && trade.marketId) {
-        router.push(`/markets?filter=prediction&marketKind=prediction&marketId=${encodeURIComponent(trade.marketId)}`);
+        router.push(
+          `/markets?filter=prediction&marketKind=prediction&marketId=${encodeURIComponent(trade.marketId)}`
+        );
       }
     } else if (trade.type === 'position' && trade.market) {
-      router.push(`/markets?filter=prediction&marketKind=prediction&marketId=${encodeURIComponent(trade.market.id)}`);
+      router.push(
+        `/markets?filter=prediction&marketKind=prediction&marketId=${encodeURIComponent(trade.market.id)}`
+      );
     } else if (trade.type === 'perp') {
-      router.push(`/markets?filter=perp&marketKind=perp&marketId=${encodeURIComponent(trade.ticker)}`);
+      router.push(
+        `/markets?filter=perp&marketKind=perp&marketId=${encodeURIComponent(trade.ticker)}`
+      );
     }
   };
 

--- a/apps/web/src/components/trades/TradeCard.tsx
+++ b/apps/web/src/components/trades/TradeCard.tsx
@@ -4,7 +4,7 @@ import {
   cn,
   formatCompactCurrency,
   getActorProfileUrl,
-  getProfileUrl,
+  getUserProfileUrl,
 } from '@babylon/shared';
 import {
   ArrowDownRight,
@@ -15,7 +15,9 @@ import {
   TrendingUp,
 } from 'lucide-react';
 import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { Avatar } from '@/components/shared/Avatar';
 
 /**
  * Trade type discriminator for trade card display.
@@ -49,6 +51,12 @@ interface BalanceTrade extends BaseTrade {
   transactionType: string;
   description: string | null;
   relatedId: string | null;
+  market: {
+    id: string;
+    question: string;
+    resolved: boolean;
+    resolution: boolean | null;
+  } | null;
 }
 
 /**
@@ -59,6 +67,7 @@ interface NPCTrade extends BaseTrade {
   marketType: string;
   ticker: string | null;
   marketId: string | null;
+  marketQuestion: string | null;
   action: string;
   side: string | null;
   amount: number;
@@ -194,22 +203,38 @@ export function TradeCard({ trade }: TradeCardProps) {
   const handleAssetClick = (e: React.MouseEvent) => {
     e.stopPropagation();
 
-    if (trade.type === 'npc') {
+    if (trade.type === 'balance' && trade.market) {
+      router.push(`/markets?filter=prediction&marketKind=prediction&marketId=${encodeURIComponent(trade.market.id)}`);
+    } else if (trade.type === 'npc') {
       if (trade.marketType === 'perp' && trade.ticker) {
-        router.push(`/markets/perps/${trade.ticker}`);
+        router.push(`/markets?filter=perp&marketKind=perp&marketId=${encodeURIComponent(trade.ticker)}`);
       } else if (trade.marketType === 'prediction' && trade.marketId) {
-        router.push(`/markets/predictions/${trade.marketId}`);
+        router.push(`/markets?filter=prediction&marketKind=prediction&marketId=${encodeURIComponent(trade.marketId)}`);
       }
     } else if (trade.type === 'position' && trade.market) {
-      router.push(`/markets/predictions/${trade.market.id}`);
+      router.push(`/markets?filter=prediction&marketKind=prediction&marketId=${encodeURIComponent(trade.market.id)}`);
     } else if (trade.type === 'perp') {
-      router.push(`/markets/perps/${trade.ticker}`);
+      router.push(`/markets?filter=perp&marketKind=perp&marketId=${encodeURIComponent(trade.ticker)}`);
     }
   };
+
+  const profileUrl = trade.user.isActor
+    ? `${getActorProfileUrl(trade.user.id)}?tab=trades`
+    : `${getUserProfileUrl(trade.user.id, trade.user.username)}?tab=trades`;
 
   return (
     <div className="border-border border-b p-4 transition-colors hover:bg-muted/30">
       <div className="flex items-start gap-3">
+        {/* User Avatar */}
+        <Link href={profileUrl} className="shrink-0">
+          <Avatar
+            id={trade.user.id}
+            name={trade.user.displayName || trade.user.username || 'User'}
+            type={trade.user.isActor ? 'actor' : undefined}
+            size="sm"
+            src={trade.user.profileImageUrl || undefined}
+          />
+        </Link>
         {/* Trade Content */}
         <div className="min-w-0 flex-1">
           {/* Trade Details */}
@@ -297,13 +322,19 @@ function BalanceTradeContent({
           {timestamp}
         </span>
       </div>
-      {trade.description && (
+      {trade.market ? (
         <p
-          className="line-clamp-2 cursor-pointer text-foreground text-sm hover:underline"
+          className="line-clamp-2 cursor-pointer font-medium text-foreground text-sm hover:underline"
           onClick={onAssetClick}
         >
-          {trade.description}
+          {trade.market.question}
         </p>
+      ) : (
+        trade.description && (
+          <p className="line-clamp-2 text-muted-foreground text-sm">
+            {trade.description}
+          </p>
+        )
       )}
     </div>
   );
@@ -360,6 +391,14 @@ function NPCTradeContent({
           {timestamp}
         </span>
       </div>
+      {trade.marketQuestion && (
+        <p
+          className="cursor-pointer font-medium text-foreground text-sm hover:underline"
+          onClick={onAssetClick}
+        >
+          {trade.marketQuestion}
+        </p>
+      )}
       <div className="flex items-center gap-3 text-muted-foreground text-sm">
         <span>Amount: {formatCurrency(trade.amount)}</span>
         <span>Price: {formatCurrency(trade.price)}</span>
@@ -516,7 +555,7 @@ function TransferTradeContent({
     if (trade.otherParty) {
       const href = trade.otherParty.isActor
         ? getActorProfileUrl(trade.otherParty.id)
-        : getProfileUrl(trade.otherParty.id, trade.otherParty.username);
+        : getUserProfileUrl(trade.otherParty.id, trade.otherParty.username);
       router.push(href);
     }
   };


### PR DESCRIPTION
## Summary
- Redesign perp and prediction position cards into compact 2-row layout with inline dot-separated stats and pill-style close/sell buttons
- Add prediction market info (question + link) to trade feed for both user balance trades (`pred_buy`/`pred_sell`) and NPC prediction trades
- Fix `getProfileUrl` → `getUserProfileUrl` bug in TradeCard transfer content
- Default team page activity panel to expanded