### PR TITLE
fix(ui): dynamically calculate widget sidebar banner offset

### DIFF
--- a/apps/web/src/components/shared/WidgetSidebar.tsx
+++ b/apps/web/src/components/shared/WidgetSidebar.tsx
@@ -67,9 +67,11 @@ export function WidgetSidebar({
       // Check if sidebar fits in viewport
       const fitsInViewport = sidebarHeight <= viewportHeight;
 
-      // Check if NFT promo banner is visible (not dismissed)
-      const bannerDismissed = localStorage.getItem('nft-banner-dismissed');
-      const bannerOffset = bannerDismissed ? 0 : 40;
+      // Calculate banner offset dynamically from the container's viewport position.
+      // When the NFT promo banner (in document flow) is visible, the container
+      // starts below it; as the user scrolls past the banner it reaches 0.
+      const containerTop = container.getBoundingClientRect().top;
+      const bannerOffset = Math.max(0, containerTop);
 
       if (fitsInViewport) {
         // Sidebar fits - simple sticky to top (below banner)


### PR DESCRIPTION
## Summary
- Fixes the widget sidebar (search bar, latest news, trending, markets) overlapping the NFT promo banner on desktop
- The sidebar was using a hardcoded 40px offset tied to a `localStorage` check for the old dismissible banner. Now that the banner is always visible and in document flow (from #1024), the offset is calculated dynamically from the container's actual viewport position
- The sidebar now correctly sits below the banner at page load and adjusts seamlessly as the banner scrolls away

## Test plan
- [ ] Verify the search bar and widget sidebar no longer overlap the NFT promo banner on desktop
- [ ] Verify the sidebar tracks correctly as the banner scrolls out of view
- [ ] Verify sidebar behavior on XL+ screens with tall content (smart scroll)