### PR TITLE
Premium chat: holders-only (live indexer)

### DIFF
--- a/apps/web/src/app/api/chats/route.ts
+++ b/apps/web/src/app/api/chats/route.ts
@@ -332,7 +332,6 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   const canAccessNftGatedChat =
     !nftChatGatingConfig.enabled ||
     !gatedChatId ||
-    user.isAgent === true ||
     (await canAccessNftChatGate(user.dbUserId ?? user.userId, gatedChatId));
 
   logger.info(

--- a/packages/api/src/__tests__/nft-chat-gating-service.test.ts
+++ b/packages/api/src/__tests__/nft-chat-gating-service.test.ts
@@ -14,6 +14,7 @@ import { beforeEach, describe, expect, it, mock } from 'bun:test';
 
 // Mock tables
 const chatsTable = { id: 'id', isGroup: 'isGroup', groupId: 'groupId' };
+const usersTable = { id: 'id', walletAddress: 'walletAddress' };
 const groupMembersTable = {
   id: 'id',
   groupId: 'groupId',
@@ -29,7 +30,7 @@ const chatParticipantsTable = {
 
 // Mock functions
 const mockIsUserAdmin = mock();
-const mockHasNftAccess = mock();
+const mockHasOnchainNftAccess = mock();
 const mockDbSelect = mock();
 const mockDbInsert = mock();
 const mockDbUpdate = mock();
@@ -42,8 +43,14 @@ const mockLogger = {
 };
 
 // Mock dependencies - use paths relative to the module being tested
-mock.module('../services/nft-access-service', () => ({
-  hasNftAccess: mockHasNftAccess,
+mock.module('../services/nft-indexer-service', () => ({
+  hasOnchainNftAccess: mockHasOnchainNftAccess,
+  NftIndexerUnavailableError: class NftIndexerUnavailableError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = 'NftIndexerUnavailableError';
+    }
+  },
 }));
 
 mock.module('../admin-middleware', () => ({
@@ -60,6 +67,7 @@ mock.module('@babylon/db', () => ({
   eq: (field: unknown, value: unknown) => ({ type: 'eq', field, value }),
   and: (...conditions: unknown[]) => ({ type: 'and', conditions }),
   chats: chatsTable,
+  users: usersTable,
   groupMembers: groupMembersTable,
   chatParticipants: chatParticipantsTable,
 }));
@@ -120,7 +128,7 @@ describe('NFT Chat Gating Service', () => {
   beforeEach(() => {
     // Reset all mocks
     mockIsUserAdmin.mockReset();
-    mockHasNftAccess.mockReset();
+    mockHasOnchainNftAccess.mockReset();
     mockDbSelect.mockReset();
     mockDbInsert.mockReset();
     mockDbUpdate.mockReset();
@@ -228,7 +236,7 @@ describe('NFT Chat Gating Service', () => {
       const result = await canAccessNftChatGate('user-123', 'regular-chat');
       expect(result).toBe(true);
       expect(mockIsUserAdmin).not.toHaveBeenCalled();
-      expect(mockHasNftAccess).not.toHaveBeenCalled();
+      expect(mockHasOnchainNftAccess).not.toHaveBeenCalled();
     });
 
     it('should return true for admins on gated chat', async () => {
@@ -237,22 +245,50 @@ describe('NFT Chat Gating Service', () => {
       const result = await canAccessNftChatGate('admin-user', 'gated-chat');
       expect(result).toBe(true);
       expect(mockIsUserAdmin).toHaveBeenCalledWith('admin-user');
-      expect(mockHasNftAccess).not.toHaveBeenCalled();
+      expect(mockHasOnchainNftAccess).not.toHaveBeenCalled();
     });
 
     it('should check NFT access for non-admin on gated chat', async () => {
       mockIsUserAdmin.mockResolvedValue(false);
-      mockHasNftAccess.mockResolvedValue(true);
+      mockHasOnchainNftAccess.mockResolvedValue(true);
+      mockDbSelect.mockImplementation(() => ({
+        from: (table: unknown) => {
+          if (table === usersTable) {
+            return {
+              where: () => ({
+                limit: () => Promise.resolve([{ walletAddress: '0xabc' }]),
+              }),
+            };
+          }
+          throw new Error('Unexpected select table');
+        },
+      }));
 
       const result = await canAccessNftChatGate('regular-user', 'gated-chat');
       expect(result).toBe(true);
       expect(mockIsUserAdmin).toHaveBeenCalledWith('regular-user');
-      expect(mockHasNftAccess).toHaveBeenCalledWith('regular-user');
+      expect(mockHasOnchainNftAccess).toHaveBeenCalledWith('0xabc', {
+        cacheScope: 'premium_chat',
+        positiveTtlMs: 10000,
+        negativeTtlMs: 10000,
+      });
     });
 
     it('should return false for non-admin without NFT access', async () => {
       mockIsUserAdmin.mockResolvedValue(false);
-      mockHasNftAccess.mockResolvedValue(false);
+      mockHasOnchainNftAccess.mockResolvedValue(false);
+      mockDbSelect.mockImplementation(() => ({
+        from: (table: unknown) => {
+          if (table === usersTable) {
+            return {
+              where: () => ({
+                limit: () => Promise.resolve([{ walletAddress: '0xabc' }]),
+              }),
+            };
+          }
+          throw new Error('Unexpected select table');
+        },
+      }));
 
       const result = await canAccessNftChatGate('regular-user', 'gated-chat');
       expect(result).toBe(false);
@@ -282,7 +318,19 @@ describe('NFT Chat Gating Service', () => {
 
     it('should not throw when user has access', async () => {
       mockIsUserAdmin.mockResolvedValue(false);
-      mockHasNftAccess.mockResolvedValue(true);
+      mockHasOnchainNftAccess.mockResolvedValue(true);
+      mockDbSelect.mockImplementation(() => ({
+        from: (table: unknown) => {
+          if (table === usersTable) {
+            return {
+              where: () => ({
+                limit: () => Promise.resolve([{ walletAddress: '0xabc' }]),
+              }),
+            };
+          }
+          throw new Error('Unexpected select table');
+        },
+      }));
 
       const user = { userId: 'user-123', dbUserId: 'db-user-123' };
       await expect(
@@ -292,7 +340,19 @@ describe('NFT Chat Gating Service', () => {
 
     it('should throw AuthorizationError when user lacks access', async () => {
       mockIsUserAdmin.mockResolvedValue(false);
-      mockHasNftAccess.mockResolvedValue(false);
+      mockHasOnchainNftAccess.mockResolvedValue(false);
+      mockDbSelect.mockImplementation(() => ({
+        from: (table: unknown) => {
+          if (table === usersTable) {
+            return {
+              where: () => ({
+                limit: () => Promise.resolve([{ walletAddress: '0xabc' }]),
+              }),
+            };
+          }
+          throw new Error('Unexpected select table');
+        },
+      }));
 
       const user = { userId: 'user-123' };
       await expect(requireNftChatAccess(user, 'gated-chat')).rejects.toThrow(
@@ -302,23 +362,55 @@ describe('NFT Chat Gating Service', () => {
 
     it('should prefer dbUserId over userId for access check', async () => {
       mockIsUserAdmin.mockResolvedValue(false);
-      mockHasNftAccess.mockResolvedValue(true);
+      mockHasOnchainNftAccess.mockResolvedValue(true);
+      mockDbSelect.mockImplementation(() => ({
+        from: (table: unknown) => {
+          if (table === usersTable) {
+            return {
+              where: () => ({
+                limit: () => Promise.resolve([{ walletAddress: '0xabc' }]),
+              }),
+            };
+          }
+          throw new Error('Unexpected select table');
+        },
+      }));
 
       const user = { userId: 'privy-id', dbUserId: 'db-user-123' };
       await requireNftChatAccess(user, 'gated-chat');
 
       // Should call with dbUserId, not userId
-      expect(mockHasNftAccess).toHaveBeenCalledWith('db-user-123');
+      expect(mockHasOnchainNftAccess).toHaveBeenCalledWith('0xabc', {
+        cacheScope: 'premium_chat',
+        positiveTtlMs: 10000,
+        negativeTtlMs: 10000,
+      });
     });
 
     it('should fallback to userId when dbUserId is not available', async () => {
       mockIsUserAdmin.mockResolvedValue(false);
-      mockHasNftAccess.mockResolvedValue(true);
+      mockHasOnchainNftAccess.mockResolvedValue(true);
+      mockDbSelect.mockImplementation(() => ({
+        from: (table: unknown) => {
+          if (table === usersTable) {
+            return {
+              where: () => ({
+                limit: () => Promise.resolve([{ walletAddress: '0xabc' }]),
+              }),
+            };
+          }
+          throw new Error('Unexpected select table');
+        },
+      }));
 
       const user = { userId: 'user-123' };
       await requireNftChatAccess(user, 'gated-chat');
 
-      expect(mockHasNftAccess).toHaveBeenCalledWith('user-123');
+      expect(mockHasOnchainNftAccess).toHaveBeenCalledWith('0xabc', {
+        cacheScope: 'premium_chat',
+        positiveTtlMs: 10000,
+        negativeTtlMs: 10000,
+      });
     });
   });
 
@@ -346,7 +438,19 @@ describe('NFT Chat Gating Service', () => {
 
     it('should throw AuthorizationError when user lacks NFT access', async () => {
       mockIsUserAdmin.mockResolvedValue(false);
-      mockHasNftAccess.mockResolvedValue(false);
+      mockHasOnchainNftAccess.mockResolvedValue(false);
+      mockDbSelect.mockImplementation(() => ({
+        from: (table: unknown) => {
+          if (table === usersTable) {
+            return {
+              where: () => ({
+                limit: () => Promise.resolve([{ walletAddress: '0xabc' }]),
+              }),
+            };
+          }
+          throw new Error('Unexpected select table');
+        },
+      }));
 
       await expect(ensureNftChatMembership('user-123')).rejects.toThrow(
         'NFT chat access required'
@@ -355,18 +459,30 @@ describe('NFT Chat Gating Service', () => {
 
     it('should allow admin access without NFT', async () => {
       mockIsUserAdmin.mockResolvedValue(true);
-      mockHasNftAccess.mockResolvedValue(false);
+      mockHasOnchainNftAccess.mockResolvedValue(false);
 
       // Mock db.select for chat lookup
       mockDbSelect.mockImplementation(() => ({
-        from: () => ({
-          where: () => ({
-            limit: () =>
-              Promise.resolve([
-                { id: 'gated-chat', isGroup: true, groupId: 'group-123' },
-              ]),
-          }),
-        }),
+        from: (table: unknown) => {
+          if (table === chatsTable) {
+            return {
+              where: () => ({
+                limit: () =>
+                  Promise.resolve([
+                    { id: 'gated-chat', isGroup: true, groupId: 'group-123' },
+                  ]),
+              }),
+            };
+          }
+          if (table === usersTable) {
+            return {
+              where: () => ({
+                limit: () => Promise.resolve([]),
+              }),
+            };
+          }
+          throw new Error('Unexpected select table');
+        },
       }));
 
       // Mock transaction
@@ -389,15 +505,27 @@ describe('NFT Chat Gating Service', () => {
 
     it('should throw NotFoundError when chat does not exist', async () => {
       mockIsUserAdmin.mockResolvedValue(false);
-      mockHasNftAccess.mockResolvedValue(true);
+      mockHasOnchainNftAccess.mockResolvedValue(true);
 
       // Mock db.select returning empty
       mockDbSelect.mockImplementation(() => ({
-        from: () => ({
-          where: () => ({
-            limit: () => Promise.resolve([]),
-          }),
-        }),
+        from: (table: unknown) => {
+          if (table === usersTable) {
+            return {
+              where: () => ({
+                limit: () => Promise.resolve([{ walletAddress: '0xabc' }]),
+              }),
+            };
+          }
+          if (table === chatsTable) {
+            return {
+              where: () => ({
+                limit: () => Promise.resolve([]),
+              }),
+            };
+          }
+          throw new Error('Unexpected select table');
+        },
       }));
 
       await expect(ensureNftChatMembership('user-123')).rejects.toThrow(
@@ -407,18 +535,30 @@ describe('NFT Chat Gating Service', () => {
 
     it('should throw ValidationError when chat is not a group chat', async () => {
       mockIsUserAdmin.mockResolvedValue(false);
-      mockHasNftAccess.mockResolvedValue(true);
+      mockHasOnchainNftAccess.mockResolvedValue(true);
 
       // Mock db.select returning non-group chat
       mockDbSelect.mockImplementation(() => ({
-        from: () => ({
-          where: () => ({
-            limit: () =>
-              Promise.resolve([
-                { id: 'gated-chat', isGroup: false, groupId: null },
-              ]),
-          }),
-        }),
+        from: (table: unknown) => {
+          if (table === usersTable) {
+            return {
+              where: () => ({
+                limit: () => Promise.resolve([{ walletAddress: '0xabc' }]),
+              }),
+            };
+          }
+          if (table === chatsTable) {
+            return {
+              where: () => ({
+                limit: () =>
+                  Promise.resolve([
+                    { id: 'gated-chat', isGroup: false, groupId: null },
+                  ]),
+              }),
+            };
+          }
+          throw new Error('Unexpected select table');
+        },
       }));
 
       await expect(ensureNftChatMembership('user-123')).rejects.toThrow(
@@ -428,17 +568,29 @@ describe('NFT Chat Gating Service', () => {
 
     it('should create membership records for eligible user', async () => {
       mockIsUserAdmin.mockResolvedValue(false);
-      mockHasNftAccess.mockResolvedValue(true);
+      mockHasOnchainNftAccess.mockResolvedValue(true);
 
       mockDbSelect.mockImplementation(() => ({
-        from: () => ({
-          where: () => ({
-            limit: () =>
-              Promise.resolve([
-                { id: 'gated-chat', isGroup: true, groupId: 'group-123' },
-              ]),
-          }),
-        }),
+        from: (table: unknown) => {
+          if (table === usersTable) {
+            return {
+              where: () => ({
+                limit: () => Promise.resolve([{ walletAddress: '0xabc' }]),
+              }),
+            };
+          }
+          if (table === chatsTable) {
+            return {
+              where: () => ({
+                limit: () =>
+                  Promise.resolve([
+                    { id: 'gated-chat', isGroup: true, groupId: 'group-123' },
+                  ]),
+              }),
+            };
+          }
+          throw new Error('Unexpected select table');
+        },
       }));
 
       let insertCalls = 0;
@@ -500,7 +652,19 @@ describe('NFT Chat Gating Service', () => {
 
     it('should not revoke if user still has NFT access', async () => {
       mockIsUserAdmin.mockResolvedValue(false);
-      mockHasNftAccess.mockResolvedValue(true);
+      mockHasOnchainNftAccess.mockResolvedValue(true);
+      mockDbSelect.mockImplementation(() => ({
+        from: (table: unknown) => {
+          if (table === usersTable) {
+            return {
+              where: () => ({
+                limit: () => Promise.resolve([{ walletAddress: '0xabc' }]),
+              }),
+            };
+          }
+          throw new Error('Unexpected select table');
+        },
+      }));
 
       await revokeNftChatMembershipIfNeeded(
         'user-123',
@@ -513,15 +677,27 @@ describe('NFT Chat Gating Service', () => {
 
     it('should revoke membership when user loses NFT access', async () => {
       mockIsUserAdmin.mockResolvedValue(false);
-      mockHasNftAccess.mockResolvedValue(false);
+      mockHasOnchainNftAccess.mockResolvedValue(false);
 
       // Mock db.select for chat lookup
       mockDbSelect.mockImplementation(() => ({
-        from: () => ({
-          where: () => ({
-            limit: () => Promise.resolve([{ groupId: 'group-123' }]),
-          }),
-        }),
+        from: (table: unknown) => {
+          if (table === usersTable) {
+            return {
+              where: () => ({
+                limit: () => Promise.resolve([{ walletAddress: '0xabc' }]),
+              }),
+            };
+          }
+          if (table === chatsTable) {
+            return {
+              where: () => ({
+                limit: () => Promise.resolve([{ groupId: 'group-123' }]),
+              }),
+            };
+          }
+          throw new Error('Unexpected select table');
+        },
       }));
 
       let updateCalls = 0;
@@ -561,15 +737,27 @@ describe('NFT Chat Gating Service', () => {
 
     it('should only update chatParticipants when chat has no groupId', async () => {
       mockIsUserAdmin.mockResolvedValue(false);
-      mockHasNftAccess.mockResolvedValue(false);
+      mockHasOnchainNftAccess.mockResolvedValue(false);
 
       // Mock db.select returning chat without groupId
       mockDbSelect.mockImplementation(() => ({
-        from: () => ({
-          where: () => ({
-            limit: () => Promise.resolve([{ groupId: null }]),
-          }),
-        }),
+        from: (table: unknown) => {
+          if (table === usersTable) {
+            return {
+              where: () => ({
+                limit: () => Promise.resolve([{ walletAddress: '0xabc' }]),
+              }),
+            };
+          }
+          if (table === chatsTable) {
+            return {
+              where: () => ({
+                limit: () => Promise.resolve([{ groupId: null }]),
+              }),
+            };
+          }
+          throw new Error('Unexpected select table');
+        },
       }));
 
       let updateCalls = 0;
@@ -602,7 +790,7 @@ describe('NFT Chat Gating Service', () => {
 describe('NFT Chat Gating - Integration Scenarios', () => {
   beforeEach(() => {
     mockIsUserAdmin.mockReset();
-    mockHasNftAccess.mockReset();
+    mockHasOnchainNftAccess.mockReset();
     delete process.env.NFT_CHAT_GATING_ENABLED;
     delete process.env.NFT_CHAT_GATING_CHAT_ID;
   });
@@ -613,7 +801,19 @@ describe('NFT Chat Gating - Integration Scenarios', () => {
       process.env.NFT_CHAT_GATING_CHAT_ID = 'fd-alpha-chat';
 
       mockIsUserAdmin.mockResolvedValue(false);
-      mockHasNftAccess.mockResolvedValue(true);
+      mockHasOnchainNftAccess.mockResolvedValue(true);
+      mockDbSelect.mockImplementation(() => ({
+        from: (table: unknown) => {
+          if (table === usersTable) {
+            return {
+              where: () => ({
+                limit: () => Promise.resolve([{ walletAddress: '0xabc' }]),
+              }),
+            };
+          }
+          throw new Error('Unexpected select table');
+        },
+      }));
 
       // Step 1: Check if chat is gated
       const isGated = isNftChatGatedChat('fd-alpha-chat');
@@ -637,7 +837,19 @@ describe('NFT Chat Gating - Integration Scenarios', () => {
       process.env.NFT_CHAT_GATING_CHAT_ID = 'fd-alpha-chat';
 
       mockIsUserAdmin.mockResolvedValue(false);
-      mockHasNftAccess.mockResolvedValue(false);
+      mockHasOnchainNftAccess.mockResolvedValue(false);
+      mockDbSelect.mockImplementation(() => ({
+        from: (table: unknown) => {
+          if (table === usersTable) {
+            return {
+              where: () => ({
+                limit: () => Promise.resolve([{ walletAddress: '0xabc' }]),
+              }),
+            };
+          }
+          throw new Error('Unexpected select table');
+        },
+      }));
 
       // Step 1: Check if chat is gated
       const isGated = isNftChatGatedChat('fd-alpha-chat');
@@ -659,7 +871,7 @@ describe('NFT Chat Gating - Integration Scenarios', () => {
 
       // Even without NFT access, regular chats should be accessible
       mockIsUserAdmin.mockResolvedValue(false);
-      mockHasNftAccess.mockResolvedValue(false);
+      mockHasOnchainNftAccess.mockResolvedValue(false);
 
       // Step 1: Check if chat is gated
       const isGated = isNftChatGatedChat('regular-chat');
@@ -668,7 +880,7 @@ describe('NFT Chat Gating - Integration Scenarios', () => {
       // Step 2: Check access (should return true without checking NFT)
       const canAccess = await canAccessNftChatGate('user-123', 'regular-chat');
       expect(canAccess).toBe(true);
-      expect(mockHasNftAccess).not.toHaveBeenCalled();
+      expect(mockHasOnchainNftAccess).not.toHaveBeenCalled();
 
       // Step 3: Require access (should not throw)
       await expect(
@@ -687,7 +899,7 @@ describe('NFT Chat Gating - Integration Scenarios', () => {
 
       const canAccess = await canAccessNftChatGate('user-123', 'fd-alpha-chat');
       expect(canAccess).toBe(true);
-      expect(mockHasNftAccess).not.toHaveBeenCalled();
+      expect(mockHasOnchainNftAccess).not.toHaveBeenCalled();
     });
 
     it('should handle missing chat ID gracefully', async () => {
@@ -708,14 +920,14 @@ describe('NFT Chat Gating - Integration Scenarios', () => {
 
       mockIsUserAdmin.mockResolvedValue(true);
       // NFT access check should not even be called for admins
-      mockHasNftAccess.mockResolvedValue(false);
+      mockHasOnchainNftAccess.mockResolvedValue(false);
 
       const canAccess = await canAccessNftChatGate(
         'admin-user',
         'fd-alpha-chat'
       );
       expect(canAccess).toBe(true);
-      expect(mockHasNftAccess).not.toHaveBeenCalled();
+      expect(mockHasOnchainNftAccess).not.toHaveBeenCalled();
     });
   });
 
@@ -733,7 +945,7 @@ describe('NFT Chat Gating - Integration Scenarios', () => {
 
       // Should not have checked admin status or NFT access
       expect(mockIsUserAdmin).not.toHaveBeenCalled();
-      expect(mockHasNftAccess).not.toHaveBeenCalled();
+      expect(mockHasOnchainNftAccess).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/api/src/__tests__/nft-chat-gating-service.test.ts
+++ b/packages/api/src/__tests__/nft-chat-gating-service.test.ts
@@ -308,12 +308,25 @@ describe('NFT Chat Gating Service', () => {
       ).resolves.toBeUndefined();
     });
 
-    it('should not throw for agents', async () => {
+    it('should throw for agents on gated chats', async () => {
+      mockIsUserAdmin.mockResolvedValue(false);
+      mockDbSelect.mockImplementation(() => ({
+        from: (table: unknown) => {
+          if (table === usersTable) {
+            return {
+              where: () => ({
+                limit: () => Promise.resolve([]),
+              }),
+            };
+          }
+          throw new Error('Unexpected select table');
+        },
+      }));
+
       const user = { userId: 'agent-123', isAgent: true };
-      await expect(
-        requireNftChatAccess(user, 'gated-chat')
-      ).resolves.toBeUndefined();
-      expect(mockIsUserAdmin).not.toHaveBeenCalled();
+      await expect(requireNftChatAccess(user, 'gated-chat')).rejects.toThrow(
+        'NFT chat access required'
+      );
     });
 
     it('should not throw when user has access', async () => {
@@ -932,20 +945,28 @@ describe('NFT Chat Gating - Integration Scenarios', () => {
   });
 
   describe('Agent Bypass Scenarios', () => {
-    it('should always allow agents to access gated chats', async () => {
+    it('should not allow agents to access gated chats', async () => {
       process.env.NFT_CHAT_GATING_ENABLED = 'true';
       process.env.NFT_CHAT_GATING_CHAT_ID = 'fd-alpha-chat';
 
-      // Agent should bypass all checks
+      mockIsUserAdmin.mockResolvedValue(false);
+      mockDbSelect.mockImplementation(() => ({
+        from: (table: unknown) => {
+          if (table === usersTable) {
+            return {
+              where: () => ({
+                limit: () => Promise.resolve([]),
+              }),
+            };
+          }
+          throw new Error('Unexpected select table');
+        },
+      }));
+
       const user = { userId: 'agent-123', isAgent: true };
-
-      await expect(
-        requireNftChatAccess(user, 'fd-alpha-chat')
-      ).resolves.toBeUndefined();
-
-      // Should not have checked admin status or NFT access
-      expect(mockIsUserAdmin).not.toHaveBeenCalled();
-      expect(mockHasOnchainNftAccess).not.toHaveBeenCalled();
+      await expect(requireNftChatAccess(user, 'fd-alpha-chat')).rejects.toThrow(
+        'NFT chat access required'
+      );
     });
   });
 });

--- a/packages/api/src/services/nft-chat-gating-service.ts
+++ b/packages/api/src/services/nft-chat-gating-service.ts
@@ -115,7 +115,6 @@ export async function requireNftChatAccess(
   chatId: string
 ): Promise<void> {
   if (!isNftChatGatedChat(chatId)) return;
-  if (user.isAgent) return;
 
   // Prefer dbUserId for NFT access check (hasNftAccess expects database user ID).
   // Falls back to userId for backwards compatibility (userId === dbUserId when user exists in DB).

--- a/packages/api/src/services/nft-chat-gating-service.ts
+++ b/packages/api/src/services/nft-chat-gating-service.ts
@@ -5,12 +5,16 @@ import {
   db,
   eq,
   groupMembers,
+  users,
 } from '@babylon/db';
 import { generateSnowflakeId, logger, ValidationError } from '@babylon/shared';
 import { sql } from 'drizzle-orm';
 import { isUserAdmin } from '../admin-middleware';
 import { AuthorizationError, NotFoundError } from '../errors';
-import { hasNftAccess } from './nft-access-service';
+import {
+  hasOnchainNftAccess,
+  NftIndexerUnavailableError,
+} from './nft-indexer-service';
 
 export interface NftChatGatingConfig {
   enabled: boolean;
@@ -69,6 +73,31 @@ export function isNftChatGatedChat(chatId: string): boolean {
   return enabled && gatedChatId !== null && chatId === gatedChatId;
 }
 
+async function hasPremiumChatHolderAccess(dbUserId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ walletAddress: users.walletAddress })
+    .from(users)
+    .where(eq(users.id, dbUserId))
+    .limit(1);
+
+  const walletAddress = row?.walletAddress ?? null;
+  if (!walletAddress) return false;
+
+  try {
+    // Premium chat is holders-only. We keep negative TTL short to avoid
+    // delaying access after a user acquires an NFT.
+    return await hasOnchainNftAccess(walletAddress, {
+      cacheScope: 'premium_chat',
+      positiveTtlMs: 10_000,
+      negativeTtlMs: 10_000,
+    });
+  } catch (error: unknown) {
+    // Fail closed if the indexer is unavailable/misconfigured.
+    if (error instanceof NftIndexerUnavailableError) return false;
+    throw error;
+  }
+}
+
 export async function canAccessNftChatGate(
   dbUserId: string,
   chatId: string
@@ -78,7 +107,7 @@ export async function canAccessNftChatGate(
   const isAdmin = await isUserAdmin(dbUserId);
   if (isAdmin) return true;
 
-  return hasNftAccess(dbUserId);
+  return hasPremiumChatHolderAccess(dbUserId);
 }
 
 export async function requireNftChatAccess(
@@ -107,7 +136,7 @@ export async function ensureNftChatMembership(userId: string): Promise<{
   const chatId = assertChatIdConfigured(config);
 
   const isAdmin = await isUserAdmin(userId);
-  const allowed = isAdmin ? true : await hasNftAccess(userId);
+  const allowed = isAdmin ? true : await hasPremiumChatHolderAccess(userId);
 
   if (!allowed) {
     throw new AuthorizationError('NFT chat access required', 'chat', 'join', {
@@ -210,7 +239,7 @@ export async function revokeNftChatMembershipIfNeeded(
   const isAdmin = await isUserAdmin(userId);
   if (isAdmin) return;
 
-  const allowed = await hasNftAccess(userId);
+  const allowed = await hasPremiumChatHolderAccess(userId);
   if (allowed) return;
 
   const [chat] = await db

--- a/packages/api/src/services/nft-indexer-service.ts
+++ b/packages/api/src/services/nft-indexer-service.ts
@@ -75,6 +75,24 @@ const DEFAULT_POSITIVE_TTL_MS = 10_000;
 const DEFAULT_NEGATIVE_TTL_MS = 60_000;
 const DEFAULT_TIMEOUT_MS = 2_500;
 const MAX_CACHE_ENTRIES = 10_000;
+const MAX_TTL_MS = 5 * 60_000;
+
+export type HasOnchainNftAccessOptions = {
+  /**
+   * Cache scope to prevent one call site from affecting another.
+   * Example: "premium_chat" vs "default".
+   */
+  cacheScope?: string;
+  /**
+   * Overrides the internal in-memory cache TTLs. Values are clamped.
+   */
+  positiveTtlMs?: number;
+  negativeTtlMs?: number;
+  /**
+   * When true, bypasses the in-memory cache entirely.
+   */
+  bypassCache?: boolean;
+};
 
 /**
  * Evicts expired entries and enforces size cap on the cache.
@@ -96,11 +114,19 @@ function evictExpiredCacheEntries(nowMs: number): void {
   }
 }
 
-function getCacheTtls(): { positiveTtlMs: number; negativeTtlMs: number } {
-  // Keep this intentionally simple: TTLs are internal defaults for now.
+function normalizeTtlMs(value: number | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  if (!Number.isFinite(value) || value <= 0) return fallback;
+  return Math.min(Math.floor(value), MAX_TTL_MS);
+}
+
+function getCacheTtls(opts?: HasOnchainNftAccessOptions): {
+  positiveTtlMs: number;
+  negativeTtlMs: number;
+} {
   return {
-    positiveTtlMs: DEFAULT_POSITIVE_TTL_MS,
-    negativeTtlMs: DEFAULT_NEGATIVE_TTL_MS,
+    positiveTtlMs: normalizeTtlMs(opts?.positiveTtlMs, DEFAULT_POSITIVE_TTL_MS),
+    negativeTtlMs: normalizeTtlMs(opts?.negativeTtlMs, DEFAULT_NEGATIVE_TTL_MS),
   };
 }
 
@@ -194,7 +220,8 @@ export async function getNftHolderBalanceFromIndexer(
 }
 
 export async function hasOnchainNftAccess(
-  walletAddress: string
+  walletAddress: string,
+  opts?: HasOnchainNftAccessOptions
 ): Promise<boolean> {
   let collectionId: string;
   try {
@@ -209,7 +236,13 @@ export async function hasOnchainNftAccess(
     throw error;
   }
   const address = normalizeHexAddress(walletAddress);
-  const cacheKey = `${collectionId}:${address}`;
+  const cacheScope = opts?.cacheScope?.trim() || 'default';
+  const cacheKey = `${cacheScope}:${collectionId}:${address}`;
+
+  if (opts?.bypassCache === true) {
+    const balance = await getNftHolderBalanceFromIndexer(address);
+    return balance > 0n;
+  }
 
   const nowMs = Date.now();
   const cached = accessCache.get(cacheKey);
@@ -224,7 +257,7 @@ export async function hasOnchainNftAccess(
   const balance = await getNftHolderBalanceFromIndexer(address);
   const allowed = balance > 0n;
 
-  const { positiveTtlMs, negativeTtlMs } = getCacheTtls();
+  const { positiveTtlMs, negativeTtlMs } = getCacheTtls(opts);
   const ttlMs = allowed ? positiveTtlMs : negativeTtlMs;
   accessCache.set(cacheKey, { allowed, expiresAtMs: nowMs + ttlMs });
 


### PR DESCRIPTION
## Summary
- Makes the single “premium” NFT chat (`NFT_CHAT_GATING_CHAT_ID`) **holders-only at time T** using the NFT indexer live balance check (no admin bypass).
- Removes coupling to `hasNftAccess` (no snapshot/whitelist/top100 access path for this chat).
- Adds a scoped, short-TTL in-memory cache option for indexer holder checks to keep access near-real-time without hammering the indexer.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: N/A

## Context / Links
- N/A

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web API routes / SSE / A2A (`apps/web`)
- [x] API infra (`packages/api`)
- [ ] Other: N/A

## Changes
- Premium chat access check now resolves to:
  - require wallet + `hasOnchainNftAccess(...)` via indexer (fail-closed if indexer unavailable)
- `/api/chats` will only surface the premium chat for current holders (reconcile + filter).
- `hasOnchainNftAccess(wallet, opts)` now supports `cacheScope` + TTL overrides.

## Review guide
**Start here**
- `packages/api/src/services/nft-chat-gating-service.ts`
- `packages/api/src/services/nft-indexer-service.ts`
- `apps/web/src/app/api/chats/route.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- Premium chat holder checks use a dedicated cache scope (`premium_chat`) with 10s positive/negative TTL.

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [x] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)

**Tests run**
- `bun test packages/api/src/__tests__/nft-chat-gating-service.test.ts`

**Notes**
- `bun run typecheck` currently fails due to pre-existing `packages/agents` / `agent0-sdk` API mismatches (unrelated to this PR).

**Manual verification**
1. Set `NFT_CHAT_GATING_ENABLED=true` and `NFT_CHAT_GATING_CHAT_ID=<chatId>`.
2. Non-holder user cannot read/write the premium chat (403) and it does not appear in `/api/chats`.
3. Holder user can access; after transfer out, access is revoked on the next request (subject to short TTL).

## Ops / Migration / Deployment
- [ ] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: None
- Changed: None
- Removed: None

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option B: No visual changes
- Reason: Backend/API-only gating behavior change.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
