### PR TITLE
fix: leaderboard total points

### DIFF
--- a/apps/web/src/app/api/cron/points-recompute/route.ts
+++ b/apps/web/src/app/api/cron/points-recompute/route.ts
@@ -45,6 +45,10 @@ export async function POST(request: NextRequest) {
   logger.info('Points recompute started', { isMidnight }, 'PointsRecompute');
 
   try {
+    // Self-heal: mark users with totalPoints=0 as dirty so recompute can backfill.
+    const markedZeroTotalPoints =
+      await TotalPointsService.markZeroTotalPointsDirty();
+
     // Incremental: only recompute users marked dirty
     const recomputeResult = await TotalPointsService.recomputeDirtyUsers();
 
@@ -58,6 +62,7 @@ export async function POST(request: NextRequest) {
 
     const result = {
       success: true,
+      markedZeroTotalPoints,
       recomputed: recomputeResult,
       snapshot: snapshotResult,
       isMidnight,

--- a/packages/api/src/services/points-service.ts
+++ b/packages/api/src/services/points-service.ts
@@ -16,15 +16,19 @@ import {
   eq,
   gt,
   gte,
+  markets,
   isNull,
   type JsonValue,
   ne,
+  perpPositions,
   pointsTransactions,
+  positions,
   referrals,
   sql,
   users,
 } from '@babylon/db';
-import { StaticDataRegistry } from '@babylon/engine';
+import { PredictionPricing } from '@babylon/core/markets/prediction';
+import { FEE_CONFIG, StaticDataRegistry } from '@babylon/engine';
 import {
   generateSnowflakeId,
   logger,
@@ -45,6 +49,71 @@ const UNQUALIFIED_REFERRAL_LIMIT = 10;
  * @description Categories for filtering leaderboard results.
  */
 type LeaderboardCategory = 'all' | 'earned' | 'referral' | 'total';
+
+function toNumber(value: unknown, fallback = 0): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+  return fallback;
+}
+
+function clampFeeRate(rate: number): number {
+  return rate > 0 && rate < 1 ? rate : 0;
+}
+
+function calculatePerpPositionValue(position: {
+  size: unknown;
+  leverage: unknown;
+  unrealizedPnL: unknown;
+}): number {
+  const size = toNumber(position.size);
+  const leverage = toNumber(position.leverage);
+  const unrealizedPnL = toNumber(position.unrealizedPnL);
+
+  const effectiveLeverage =
+    Number.isFinite(leverage) && leverage > 0 ? leverage : 1;
+  const margin = Math.abs(size / effectiveLeverage);
+  return margin + unrealizedPnL;
+}
+
+function calculatePredictionPositionValue(position: {
+  shares: unknown;
+  avgPrice: unknown;
+  side: boolean | null;
+  marketYesShares: unknown;
+  marketNoShares: unknown;
+}): number {
+  const shares = toNumber(position.shares);
+  const avgPrice = toNumber(position.avgPrice);
+
+  const yesShares = toNumber(position.marketYesShares);
+  const noShares = toNumber(position.marketNoShares);
+
+  const feeRate = clampFeeRate(FEE_CONFIG.TRADING_FEE_RATE);
+  const costBasisNet = shares * avgPrice;
+  const costBasis = feeRate > 0 ? costBasisNet / (1 - feeRate) : costBasisNet;
+
+  if (shares <= 0 || yesShares <= 0 || noShares <= 0) {
+    return costBasis;
+  }
+
+  const sideKey = position.side ? 'yes' : 'no';
+  try {
+    const sellPreview = PredictionPricing.calculateSellWithFees(
+      yesShares,
+      noShares,
+      sideKey,
+      shares,
+      feeRate
+    );
+    return sellPreview.netProceeds ?? sellPreview.totalCost;
+  } catch {
+    // Fall back to cost basis when sell preview fails (e.g. invalid market state)
+    return costBasis;
+  }
+}
 
 /**
  * Result of awarding points to a user
@@ -1358,22 +1427,11 @@ export class PointsService {
     // Build users query based on category
     // All modes exclude actors (isActor=false) AND agents (isAgent=false)
     let usersResult;
-    let totalCountForTotal: number | null = null;
     if (pointsCategory === 'total') {
-      // Use DB-level ordering and pagination for 'total' mode
-      const [countResult] = await db
-        .select({ count: count() })
-        .from(users)
-        .where(and(eq(users.isActor, false), eq(users.isAgent, false)));
-      totalCountForTotal = countResult?.count ?? 0;
-
       usersResult = await db
         .select(userSelectFields)
         .from(users)
-        .where(and(eq(users.isActor, false), eq(users.isAgent, false)))
-        .orderBy(desc(users.totalPoints))
-        .limit(pageSize)
-        .offset(skip);
+        .where(and(eq(users.isActor, false), eq(users.isAgent, false)));
     } else if (pointsCategory === 'all') {
       usersResult = await db
         .select(userSelectFields)
@@ -1409,6 +1467,83 @@ export class PointsService {
         );
     }
 
+    const totalPointsByUserId = new Map<string, number>();
+    if (pointsCategory === 'total') {
+      const [perpRows, predictionRows] = await Promise.all([
+        db
+          .select({
+            userId: perpPositions.userId,
+            size: perpPositions.size,
+            leverage: perpPositions.leverage,
+            unrealizedPnL: perpPositions.unrealizedPnL,
+          })
+          .from(perpPositions)
+          .innerJoin(users, eq(perpPositions.userId, users.id))
+          .where(
+            and(
+              isNull(perpPositions.closedAt),
+              eq(users.isActor, false),
+              eq(users.isAgent, false)
+            )
+          ),
+        db
+          .select({
+            userId: positions.userId,
+            shares: positions.shares,
+            avgPrice: positions.avgPrice,
+            side: positions.side,
+            marketYesShares: markets.yesShares,
+            marketNoShares: markets.noShares,
+          })
+          .from(positions)
+          .innerJoin(markets, eq(positions.marketId, markets.id))
+          .innerJoin(users, eq(positions.userId, users.id))
+          .where(
+            and(
+              eq(markets.resolved, false),
+              gt(positions.shares, '0'),
+              eq(users.isActor, false),
+              eq(users.isAgent, false)
+            )
+          ),
+      ]);
+
+      const perpsValueByUserId = new Map<string, number>();
+      for (const row of perpRows) {
+        const prev = perpsValueByUserId.get(row.userId) ?? 0;
+        perpsValueByUserId.set(
+          row.userId,
+          prev +
+            calculatePerpPositionValue({
+              size: row.size,
+              leverage: row.leverage,
+              unrealizedPnL: row.unrealizedPnL,
+            })
+        );
+      }
+
+      const predictionsValueByUserId = new Map<string, number>();
+      for (const row of predictionRows) {
+        const prev = predictionsValueByUserId.get(row.userId) ?? 0;
+        // Use the same liquidation-value approximation as portfolio-breakdown/total-points.
+        const value = calculatePredictionPositionValue({
+          shares: row.shares,
+          avgPrice: row.avgPrice,
+          side: row.side,
+          marketYesShares: row.marketYesShares,
+          marketNoShares: row.marketNoShares,
+        });
+        predictionsValueByUserId.set(row.userId, prev + value);
+      }
+
+      for (const user of usersResult) {
+        const wallet = toNumber(user.virtualBalance);
+        const perpsValue = perpsValueByUserId.get(user.id) ?? 0;
+        const predictionsValue = predictionsValueByUserId.get(user.id) ?? 0;
+        totalPointsByUserId.set(user.id, wallet + perpsValue + predictionsValue);
+      }
+    }
+
     const combined = [
       ...usersResult.map((user) => ({
         id: user.id,
@@ -1419,7 +1554,10 @@ export class PointsService {
         invitePoints: user.invitePoints,
         earnedPoints: user.earnedPoints,
         bonusPoints: user.bonusPoints,
-        totalPoints: Number(user.totalPoints ?? 0),
+        totalPoints:
+          pointsCategory === 'total'
+            ? (totalPointsByUserId.get(user.id) ?? 0)
+            : Number(user.totalPoints ?? 0),
         referralCount: user.referralCount,
         balance: Number(user.virtualBalance ?? 0),
         lifetimePnL: Number(user.lifetimePnL ?? 0),
@@ -1486,38 +1624,31 @@ export class PointsService {
             ? 'earnedPoints'
             : 'invitePoints';
 
-    // For 'total' mode, DB already handled ordering and pagination
-    if (pointsCategory !== 'total') {
-      combined.sort((a, b) => {
-        const comparison = b[sortField] - a[sortField];
-        if (comparison !== 0) {
-          return comparison;
+    combined.sort((a, b) => {
+      const comparison = b[sortField] - a[sortField];
+      if (comparison !== 0) {
+        return comparison;
+      }
+
+      if (pointsCategory === 'referral') {
+        const referralComparison = b.referralCount - a.referralCount;
+        if (referralComparison !== 0) {
+          return referralComparison;
         }
+      }
 
-        if (pointsCategory === 'referral') {
-          const referralComparison = b.referralCount - a.referralCount;
-          if (referralComparison !== 0) {
-            return referralComparison;
-          }
+      if (pointsCategory === 'earned') {
+        const pnlComparison = b.lifetimePnL - a.lifetimePnL;
+        if (pnlComparison !== 0) {
+          return pnlComparison;
         }
+      }
 
-        if (pointsCategory === 'earned') {
-          const pnlComparison = b.lifetimePnL - a.lifetimePnL;
-          if (pnlComparison !== 0) {
-            return pnlComparison;
-          }
-        }
+      return b.allPoints - a.allPoints;
+    });
 
-        return b.allPoints - a.allPoints;
-      });
-    }
-
-    const totalCount =
-      pointsCategory === 'total' ? (totalCountForTotal ?? 0) : combined.length;
-    const paginatedResults =
-      pointsCategory === 'total'
-        ? combined
-        : combined.slice(skip, skip + pageSize);
+    const totalCount = combined.length;
+    const paginatedResults = combined.slice(skip, skip + pageSize);
 
     const resultsWithRank = paginatedResults.map((entry, index) => ({
       ...entry,

--- a/packages/api/src/services/points-service.ts
+++ b/packages/api/src/services/points-service.ts
@@ -5,6 +5,8 @@
  * Tracks all point transactions and ensures no duplicate awards. Handles different
  * point types (reputation, invite, bonus) and provides leaderboard functionality.
  */
+
+import { PredictionPricing } from '@babylon/core/markets/prediction';
 import {
   actorState,
   and,
@@ -16,9 +18,9 @@ import {
   eq,
   gt,
   gte,
-  markets,
   isNull,
   type JsonValue,
+  markets,
   ne,
   perpPositions,
   pointsTransactions,
@@ -27,7 +29,6 @@ import {
   sql,
   users,
 } from '@babylon/db';
-import { PredictionPricing } from '@babylon/core/markets/prediction';
 import { FEE_CONFIG, StaticDataRegistry } from '@babylon/engine';
 import {
   generateSnowflakeId,
@@ -1540,7 +1541,10 @@ export class PointsService {
         const wallet = toNumber(user.virtualBalance);
         const perpsValue = perpsValueByUserId.get(user.id) ?? 0;
         const predictionsValue = predictionsValueByUserId.get(user.id) ?? 0;
-        totalPointsByUserId.set(user.id, wallet + perpsValue + predictionsValue);
+        totalPointsByUserId.set(
+          user.id,
+          wallet + perpsValue + predictionsValue
+        );
       }
     }
 

--- a/packages/api/src/services/points-service.ts
+++ b/packages/api/src/services/points-service.ts
@@ -6,7 +6,6 @@
  * point types (reputation, invite, bonus) and provides leaderboard functionality.
  */
 
-import { PredictionPricing } from '@babylon/core/markets/prediction';
 import {
   actorState,
   and,
@@ -20,16 +19,13 @@ import {
   gte,
   isNull,
   type JsonValue,
-  markets,
   ne,
-  perpPositions,
   pointsTransactions,
-  positions,
   referrals,
   sql,
   users,
 } from '@babylon/db';
-import { FEE_CONFIG, StaticDataRegistry } from '@babylon/engine';
+import { StaticDataRegistry } from '@babylon/engine';
 import {
   generateSnowflakeId,
   logger,
@@ -50,71 +46,6 @@ const UNQUALIFIED_REFERRAL_LIMIT = 10;
  * @description Categories for filtering leaderboard results.
  */
 type LeaderboardCategory = 'all' | 'earned' | 'referral' | 'total';
-
-function toNumber(value: unknown, fallback = 0): number {
-  if (typeof value === 'number' && Number.isFinite(value)) return value;
-  if (typeof value === 'string') {
-    const parsed = Number.parseFloat(value);
-    return Number.isFinite(parsed) ? parsed : fallback;
-  }
-  return fallback;
-}
-
-function clampFeeRate(rate: number): number {
-  return rate > 0 && rate < 1 ? rate : 0;
-}
-
-function calculatePerpPositionValue(position: {
-  size: unknown;
-  leverage: unknown;
-  unrealizedPnL: unknown;
-}): number {
-  const size = toNumber(position.size);
-  const leverage = toNumber(position.leverage);
-  const unrealizedPnL = toNumber(position.unrealizedPnL);
-
-  const effectiveLeverage =
-    Number.isFinite(leverage) && leverage > 0 ? leverage : 1;
-  const margin = Math.abs(size / effectiveLeverage);
-  return margin + unrealizedPnL;
-}
-
-function calculatePredictionPositionValue(position: {
-  shares: unknown;
-  avgPrice: unknown;
-  side: boolean | null;
-  marketYesShares: unknown;
-  marketNoShares: unknown;
-}): number {
-  const shares = toNumber(position.shares);
-  const avgPrice = toNumber(position.avgPrice);
-
-  const yesShares = toNumber(position.marketYesShares);
-  const noShares = toNumber(position.marketNoShares);
-
-  const feeRate = clampFeeRate(FEE_CONFIG.TRADING_FEE_RATE);
-  const costBasisNet = shares * avgPrice;
-  const costBasis = feeRate > 0 ? costBasisNet / (1 - feeRate) : costBasisNet;
-
-  if (shares <= 0 || yesShares <= 0 || noShares <= 0) {
-    return costBasis;
-  }
-
-  const sideKey = position.side ? 'yes' : 'no';
-  try {
-    const sellPreview = PredictionPricing.calculateSellWithFees(
-      yesShares,
-      noShares,
-      sideKey,
-      shares,
-      feeRate
-    );
-    return sellPreview.netProceeds ?? sellPreview.totalCost;
-  } catch {
-    // Fall back to cost basis when sell preview fails (e.g. invalid market state)
-    return costBasis;
-  }
-}
 
 /**
  * Result of awarding points to a user
@@ -1428,11 +1359,52 @@ export class PointsService {
     // Build users query based on category
     // All modes exclude actors (isActor=false) AND agents (isAgent=false)
     let usersResult;
+    let totalCountForTotal: number | null = null;
     if (pointsCategory === 'total') {
+      // DB-level ordering and pagination for scalable leaderboard queries.
+      const [countResult] = await db
+        .select({ count: count() })
+        .from(users)
+        .where(and(eq(users.isActor, false), eq(users.isAgent, false)));
+      totalCountForTotal = countResult?.count ?? 0;
+
       usersResult = await db
         .select(userSelectFields)
         .from(users)
-        .where(and(eq(users.isActor, false), eq(users.isAgent, false)));
+        .where(and(eq(users.isActor, false), eq(users.isAgent, false)))
+        .orderBy(desc(users.totalPoints))
+        .limit(pageSize)
+        .offset(skip);
+
+      const usersWithRank = usersResult.map((user, index) => ({
+        id: user.id,
+        username: user.username,
+        displayName: user.displayName,
+        profileImageUrl: user.profileImageUrl,
+        allPoints: user.reputationPoints,
+        invitePoints: user.invitePoints,
+        earnedPoints: user.earnedPoints,
+        bonusPoints: user.bonusPoints,
+        totalPoints: Number(user.totalPoints ?? 0),
+        referralCount: user.referralCount,
+        balance: Number(user.virtualBalance ?? 0),
+        lifetimePnL: Number(user.lifetimePnL ?? 0),
+        createdAt: user.createdAt,
+        isActor: false,
+        tier: null as string | null,
+        onChainRegistered: user.onChainRegistered,
+        nftTokenId: user.nftTokenId,
+        rank: skip + index + 1,
+      }));
+
+      return {
+        users: usersWithRank,
+        totalCount: totalCountForTotal,
+        page,
+        pageSize,
+        totalPages: Math.ceil((totalCountForTotal ?? 0) / pageSize),
+        pointsCategory,
+      };
     } else if (pointsCategory === 'all') {
       usersResult = await db
         .select(userSelectFields)
@@ -1468,86 +1440,6 @@ export class PointsService {
         );
     }
 
-    const totalPointsByUserId = new Map<string, number>();
-    if (pointsCategory === 'total') {
-      const [perpRows, predictionRows] = await Promise.all([
-        db
-          .select({
-            userId: perpPositions.userId,
-            size: perpPositions.size,
-            leverage: perpPositions.leverage,
-            unrealizedPnL: perpPositions.unrealizedPnL,
-          })
-          .from(perpPositions)
-          .innerJoin(users, eq(perpPositions.userId, users.id))
-          .where(
-            and(
-              isNull(perpPositions.closedAt),
-              eq(users.isActor, false),
-              eq(users.isAgent, false)
-            )
-          ),
-        db
-          .select({
-            userId: positions.userId,
-            shares: positions.shares,
-            avgPrice: positions.avgPrice,
-            side: positions.side,
-            marketYesShares: markets.yesShares,
-            marketNoShares: markets.noShares,
-          })
-          .from(positions)
-          .innerJoin(markets, eq(positions.marketId, markets.id))
-          .innerJoin(users, eq(positions.userId, users.id))
-          .where(
-            and(
-              eq(markets.resolved, false),
-              gt(positions.shares, '0'),
-              eq(users.isActor, false),
-              eq(users.isAgent, false)
-            )
-          ),
-      ]);
-
-      const perpsValueByUserId = new Map<string, number>();
-      for (const row of perpRows) {
-        const prev = perpsValueByUserId.get(row.userId) ?? 0;
-        perpsValueByUserId.set(
-          row.userId,
-          prev +
-            calculatePerpPositionValue({
-              size: row.size,
-              leverage: row.leverage,
-              unrealizedPnL: row.unrealizedPnL,
-            })
-        );
-      }
-
-      const predictionsValueByUserId = new Map<string, number>();
-      for (const row of predictionRows) {
-        const prev = predictionsValueByUserId.get(row.userId) ?? 0;
-        // Use the same liquidation-value approximation as portfolio-breakdown/total-points.
-        const value = calculatePredictionPositionValue({
-          shares: row.shares,
-          avgPrice: row.avgPrice,
-          side: row.side,
-          marketYesShares: row.marketYesShares,
-          marketNoShares: row.marketNoShares,
-        });
-        predictionsValueByUserId.set(row.userId, prev + value);
-      }
-
-      for (const user of usersResult) {
-        const wallet = toNumber(user.virtualBalance);
-        const perpsValue = perpsValueByUserId.get(user.id) ?? 0;
-        const predictionsValue = predictionsValueByUserId.get(user.id) ?? 0;
-        totalPointsByUserId.set(
-          user.id,
-          wallet + perpsValue + predictionsValue
-        );
-      }
-    }
-
     const combined = [
       ...usersResult.map((user) => ({
         id: user.id,
@@ -1558,10 +1450,7 @@ export class PointsService {
         invitePoints: user.invitePoints,
         earnedPoints: user.earnedPoints,
         bonusPoints: user.bonusPoints,
-        totalPoints:
-          pointsCategory === 'total'
-            ? (totalPointsByUserId.get(user.id) ?? 0)
-            : Number(user.totalPoints ?? 0),
+        totalPoints: Number(user.totalPoints ?? 0),
         referralCount: user.referralCount,
         balance: Number(user.virtualBalance ?? 0),
         lifetimePnL: Number(user.lifetimePnL ?? 0),

--- a/packages/api/src/users/ensure-user.ts
+++ b/packages/api/src/users/ensure-user.ts
@@ -127,6 +127,10 @@ export async function ensureUserForAuth(
     id: user.dbUserId ?? user.userId,
     privyId,
     isActor: options.isActor ?? false,
+    // New users start with the default virtual balance (see db schema).
+    // Keep totalPoints consistent so leaderboard doesn't show 0 until the cron recompute runs.
+    totalPoints: '1000',
+    totalPointsDirtyAt: new Date(),
     updatedAt: new Date(),
   };
 

--- a/packages/engine/src/services/total-points-service.ts
+++ b/packages/engine/src/services/total-points-service.ts
@@ -15,7 +15,7 @@ import {
   users,
 } from '@babylon/db';
 import { generateSnowflakeId, logger } from '@babylon/shared';
-import { and, eq, gt, isNotNull, isNull, lte } from 'drizzle-orm';
+import { and, eq, gt, inArray, isNotNull, isNull, lte, or } from 'drizzle-orm';
 import { FEE_CONFIG } from '../config/fees';
 
 // ---------------------------------------------------------------------------
@@ -99,9 +99,13 @@ export const TotalPointsService = {
    */
   async recomputeTotalPoints(userId: string): Promise<number> {
     const userResult = await db
-      .select({ virtualBalance: users.virtualBalance })
+      .select({
+        id: users.id,
+        privyId: users.privyId,
+        virtualBalance: users.virtualBalance,
+      })
       .from(users)
-      .where(eq(users.id, userId))
+      .where(or(eq(users.id, userId), eq(users.privyId, userId)))
       .limit(1);
 
     const user = userResult[0];
@@ -115,6 +119,10 @@ export const TotalPointsService = {
     }
 
     const wallet = toNumber(user.virtualBalance);
+    const canonicalUserId = user.id;
+    const positionUserIds = Array.from(
+      new Set([canonicalUserId, user.privyId].filter(Boolean))
+    ) as string[];
 
     const [perpRows, predictionRows] = await Promise.all([
       db
@@ -125,7 +133,10 @@ export const TotalPointsService = {
         })
         .from(perpPositions)
         .where(
-          and(eq(perpPositions.userId, userId), isNull(perpPositions.closedAt))
+          and(
+            inArray(perpPositions.userId, positionUserIds),
+            isNull(perpPositions.closedAt)
+          )
         ),
       db
         .select({
@@ -137,7 +148,13 @@ export const TotalPointsService = {
         })
         .from(positions)
         .innerJoin(markets, eq(positions.marketId, markets.id))
-        .where(and(eq(positions.userId, userId), eq(markets.resolved, false))),
+        .where(
+          and(
+            inArray(positions.userId, positionUserIds),
+            eq(markets.resolved, false),
+            gt(positions.shares, '0')
+          )
+        ),
     ]);
 
     const perpsValue = perpRows.reduce(
@@ -163,7 +180,7 @@ export const TotalPointsService = {
     await db
       .update(users)
       .set({ totalPoints: totalPoints.toFixed(2) })
-      .where(eq(users.id, userId));
+      .where(eq(users.id, canonicalUserId));
 
     return totalPoints;
   },
@@ -176,7 +193,38 @@ export const TotalPointsService = {
     await db
       .update(users)
       .set({ totalPointsDirtyAt: new Date() })
-      .where(eq(users.id, userId));
+      .where(or(eq(users.id, userId), eq(users.privyId, userId)));
+  },
+
+  /**
+   * Backfill helper: mark users with totalPoints=0 as dirty, so the cron can
+   * recompute them incrementally. This is bounded and safe to run repeatedly.
+   */
+  async markZeroTotalPointsDirty(batchSize = 1000): Promise<number> {
+    const safeBatchSize = Math.min(Math.max(1, batchSize), 10_000);
+    const candidates = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(
+        and(
+          eq(users.isAgent, false),
+          eq(users.isActor, false),
+          eq(users.totalPoints, '0'),
+          isNull(users.totalPointsDirtyAt)
+        )
+      )
+      .orderBy(users.id)
+      .limit(safeBatchSize);
+
+    if (candidates.length === 0) return 0;
+
+    const ids = candidates.map((c) => c.id);
+    await db
+      .update(users)
+      .set({ totalPointsDirtyAt: new Date() })
+      .where(inArray(users.id, ids));
+
+    return candidates.length;
   },
 
   /**


### PR DESCRIPTION
## What
- Restores a scalable Total leaderboard: `pointsType=total` uses DB ordering/pagination on `users.totalPoints` (indexed).
- Fixes totalPoints computation to include positions under both `users.id` and `users.privyId` (aliasing), matching `portfolio-breakdown`.
- Adds a bounded self-heal backfill: `/api/cron/points-recompute` now marks users with `totalPoints=0` as dirty (`TotalPointsService.markZeroTotalPointsDirty`) so the existing 15-min cron can recompute incrementally.
- Ensures new users start with `totalPoints=1000` and are marked dirty (existing change).

## Why
`users.totalPoints` defaults to 0 while `virtualBalance` defaults to 1000. If the recompute cron never ran (or users were never marked dirty), the Total leaderboard showed 0 for everyone.

## How It Heals Existing Data
After deploy, the next `/api/cron/points-recompute` runs will:
- Mark a bounded batch of users with `totalPoints=0` as dirty
- Recompute dirty users (wallet + open perps + open predictions)
- Repeat every 15 minutes until backfilled

## Checks
- `bun run lint --filter=@babylon/api --filter=@babylon/engine --filter=web` OK
- `bun run build --filter=web` OK
- `bun test packages/testing/unit/total-points-service.test.ts` OK
- `turbo typecheck` currently fails due to pre-existing errors in `packages/api` / `packages/training` unrelated to this PR.