### PR TITLE
feat(groups): assign default alpha groups on whitelist access + fix migration script

### DIFF
--- a/packages/api/src/__tests__/whitelist-group-assignment.test.ts
+++ b/packages/api/src/__tests__/whitelist-group-assignment.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Unit Tests: Whitelist → Default Alpha Group Assignment
+ *
+ * Verifies that when a user is added to the whitelist via addToWhitelist(),
+ * UserAlphaGroupAssignmentService.assignDefaultGroups() is called for new
+ * entries but NOT for already-existing entries.
+ *
+ * Run with: bun test packages/api/src/__tests__/whitelist-group-assignment.test.ts
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  type Mock,
+  mock,
+} from 'bun:test';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be set up BEFORE importing the module under test
+// ---------------------------------------------------------------------------
+
+const mockAssignDefaultGroups = mock(() =>
+  Promise.resolve({
+    success: true,
+    groupsAssigned: 3,
+    assignments: [
+      {
+        npcId: 'npc-1',
+        npcName: 'NPC Alpha',
+        tier: 3 as const,
+        groupId: 'g1',
+        chatId: 'c1',
+      },
+      {
+        npcId: 'npc-2',
+        npcName: 'NPC Beta',
+        tier: 3 as const,
+        groupId: 'g2',
+        chatId: 'c2',
+      },
+      {
+        npcId: 'npc-3',
+        npcName: 'NPC Gamma',
+        tier: 3 as const,
+        groupId: 'g3',
+        chatId: 'c3',
+      },
+    ],
+    errors: [],
+  })
+);
+
+const mockLoggerInfo = mock();
+const mockLoggerError = mock();
+
+// Track what the DB insert returns — controls whether addToWhitelist thinks
+// the entry is new or already exists.
+const mockInsertReturnId = 'new-id';
+
+// We need a unique ID that nanoid will generate so we can compare
+let capturedNanoid = '';
+const mockNanoid = mock(() => {
+  capturedNanoid = `mock-nanoid-${Date.now()}`;
+  return capturedNanoid;
+});
+
+// Mock DB — simplified chain that supports .insert().values().onConflictDoUpdate().returning()
+const mockReturning = mock(() => Promise.resolve([{ id: mockInsertReturnId }]));
+const mockOnConflictDoUpdate = mock(() => ({ returning: mockReturning }));
+const mockValues = mock(() => ({ onConflictDoUpdate: mockOnConflictDoUpdate }));
+const mockInsert = mock(() => ({ values: mockValues }));
+const mockDb = { insert: mockInsert };
+
+// Mock modules BEFORE importing the service
+mock.module('@babylon/db', () => ({
+  db: mockDb,
+  and: (...args: unknown[]) => args,
+  desc: (col: unknown) => col,
+  eq: (a: unknown, b: unknown) => [a, b],
+  inArray: (a: unknown, b: unknown) => [a, b],
+  isNull: (a: unknown) => a,
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings,
+    values,
+  }),
+  users: { id: 'id' },
+  whitelist: {
+    id: 'id',
+    userId: 'userId',
+    source: 'source',
+    reason: 'reason',
+    grantedBy: 'grantedBy',
+    grantedAt: 'grantedAt',
+    revokedAt: 'revokedAt',
+  },
+  whitelistConfig: {},
+  nftSnapshot: { userId: 'userId' },
+}));
+
+mock.module('@babylon/engine', () => ({
+  UserAlphaGroupAssignmentService: {
+    assignDefaultGroups: mockAssignDefaultGroups,
+  },
+}));
+
+mock.module('@babylon/shared', () => ({
+  logger: {
+    info: mockLoggerInfo,
+    warn: mock(),
+    error: mockLoggerError,
+    debug: mock(),
+  },
+}));
+
+mock.module('nanoid', () => ({
+  nanoid: mockNanoid,
+}));
+
+// Also mock PointsService since whitelist-service imports it
+mock.module('../services/points-service', () => ({
+  PointsService: {},
+}));
+
+// NOW import the function under test
+const { addToWhitelist } = await import('../services/whitelist-service');
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('addToWhitelist → group assignment', () => {
+  beforeEach(() => {
+    mockAssignDefaultGroups.mockClear();
+    mockLoggerInfo.mockClear();
+    mockLoggerError.mockClear();
+    mockInsert.mockClear();
+    mockReturning.mockClear();
+  });
+
+  it('should call assignDefaultGroups for a NEW whitelist entry', async () => {
+    // When the returned id matches nanoid's output, the entry is new
+    mockReturning.mockImplementation(() => {
+      // Return the same id that nanoid generated → new entry
+      return Promise.resolve([{ id: capturedNanoid }]);
+    });
+
+    const result = await addToWhitelist({
+      userId: 'user-123',
+      source: 'admin_manual',
+      reason: 'Testing',
+      grantedBy: 'admin-1',
+    });
+
+    expect(result.alreadyExists).toBe(false);
+
+    // assignDefaultGroups is fire-and-forget, so we need to flush microtasks
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(mockAssignDefaultGroups).toHaveBeenCalledTimes(1);
+    expect(mockAssignDefaultGroups).toHaveBeenCalledWith('user-123');
+  });
+
+  it('should NOT call assignDefaultGroups for an ALREADY EXISTING entry', async () => {
+    // When the returned id differs from nanoid's output, the entry already exists
+    mockReturning.mockImplementation(() => {
+      return Promise.resolve([{ id: 'some-other-existing-id' }]);
+    });
+
+    const result = await addToWhitelist({
+      userId: 'user-456',
+      source: 'admin_manual',
+    });
+
+    expect(result.alreadyExists).toBe(true);
+
+    // Wait for any potential async calls
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(mockAssignDefaultGroups).toHaveBeenCalledTimes(0);
+  });
+
+  it('should log success when groups are assigned', async () => {
+    mockReturning.mockImplementation(() => {
+      return Promise.resolve([{ id: capturedNanoid }]);
+    });
+
+    mockAssignDefaultGroups.mockImplementation(() =>
+      Promise.resolve({
+        success: true,
+        groupsAssigned: 3,
+        assignments: [],
+        errors: [],
+      })
+    );
+
+    await addToWhitelist({
+      userId: 'user-789',
+      source: 'leaderboard',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(mockAssignDefaultGroups).toHaveBeenCalledTimes(1);
+    expect(mockLoggerInfo).toHaveBeenCalled();
+
+    // Find the specific log call about group assignment
+    const groupAssignmentLog = mockLoggerInfo.mock.calls.find(
+      (call: unknown[]) =>
+        typeof call[0] === 'string' &&
+        call[0].includes('Assigned default alpha groups to whitelisted user')
+    );
+    expect(groupAssignmentLog).toBeDefined();
+  });
+
+  it('should log error if assignDefaultGroups throws', async () => {
+    mockReturning.mockImplementation(() => {
+      return Promise.resolve([{ id: capturedNanoid }]);
+    });
+
+    mockAssignDefaultGroups.mockImplementation(() =>
+      Promise.reject(new Error('DB connection failed'))
+    );
+
+    // Should NOT throw — error is caught internally
+    const result = await addToWhitelist({
+      userId: 'user-error',
+      source: 'admin_manual',
+    });
+
+    expect(result.alreadyExists).toBe(false);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(mockLoggerError).toHaveBeenCalled();
+    const errorLog = mockLoggerError.mock.calls.find(
+      (call: unknown[]) =>
+        typeof call[0] === 'string' &&
+        call[0].includes('Failed to assign default alpha groups')
+    );
+    expect(errorLog).toBeDefined();
+  });
+
+  it('should not block the whitelist response if group assignment is slow', async () => {
+    mockReturning.mockImplementation(() => {
+      return Promise.resolve([{ id: capturedNanoid }]);
+    });
+
+    // Simulate a slow assignDefaultGroups (500ms)
+    mockAssignDefaultGroups.mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(
+            () =>
+              resolve({
+                success: true,
+                groupsAssigned: 3,
+                assignments: [],
+                errors: [],
+              }),
+            500
+          )
+        )
+    );
+
+    const startTime = Date.now();
+    const result = await addToWhitelist({
+      userId: 'user-slow',
+      source: 'admin_manual',
+    });
+    const elapsed = Date.now() - startTime;
+
+    // addToWhitelist should return immediately (fire-and-forget)
+    expect(result.alreadyExists).toBe(false);
+    expect(elapsed).toBeLessThan(200); // Should not wait for the 500ms assignment
+  });
+});

--- a/packages/api/src/__tests__/whitelist-group-assignment.test.ts
+++ b/packages/api/src/__tests__/whitelist-group-assignment.test.ts
@@ -8,15 +8,7 @@
  * Run with: bun test packages/api/src/__tests__/whitelist-group-assignment.test.ts
  */
 
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  type Mock,
-  mock,
-} from 'bun:test';
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
 
 // ---------------------------------------------------------------------------
 // Mocks — must be set up BEFORE importing the module under test

--- a/packages/api/src/services/whitelist-service.ts
+++ b/packages/api/src/services/whitelist-service.ts
@@ -11,6 +11,8 @@ import {
   whitelist,
   whitelistConfig,
 } from '@babylon/db';
+import { UserAlphaGroupAssignmentService } from '@babylon/engine';
+import { logger } from '@babylon/shared';
 import { nanoid } from 'nanoid';
 import { PointsService } from './points-service';
 
@@ -164,7 +166,36 @@ export async function addToWhitelist({
 
   // If the returned id matches what we tried to insert, it's a new/replaced row.
   // If it doesn't match, the row was already active and untouched.
-  return { id: result.id, alreadyExists: result.id !== id };
+  const alreadyExists = result.id !== id;
+
+  // Assign default alpha groups when granting new access (async, non-blocking)
+  // This ensures whitelisted users get NPC group chats immediately.
+  // assignDefaultGroups is safe to call even if user already has groups or profile is incomplete.
+  if (!alreadyExists) {
+    UserAlphaGroupAssignmentService.assignDefaultGroups(userId)
+      .then((assignmentResult) => {
+        if (assignmentResult.groupsAssigned > 0) {
+          logger.info(
+            'Assigned default alpha groups to whitelisted user',
+            {
+              userId,
+              groupsAssigned: assignmentResult.groupsAssigned,
+              source,
+            },
+            'addToWhitelist'
+          );
+        }
+      })
+      .catch((error) => {
+        logger.error(
+          'Failed to assign default alpha groups to whitelisted user',
+          { userId, error: String(error) },
+          'addToWhitelist'
+        );
+      });
+  }
+
+  return { id: result.id, alreadyExists };
 }
 
 /**

--- a/scripts/migrate-users-to-default-groups.ts
+++ b/scripts/migrate-users-to-default-groups.ts
@@ -19,7 +19,19 @@
  *   --user=<id>    Only process a specific user (for testing)
  */
 
-import { and, count, db, eq, groupMembers, groups, users } from '@babylon/db';
+import {
+  and,
+  count,
+  db,
+  eq,
+  groupMembers,
+  groups,
+  inArray,
+  isNull,
+  nftSnapshot,
+  users,
+  whitelist,
+} from '@babylon/db';
 import { UserAlphaGroupAssignmentService } from '@babylon/engine';
 import { logger } from '@babylon/shared';
 
@@ -128,11 +140,64 @@ async function main() {
   } else {
     // Batch mode - get all eligible users
     // This query gets users with fewer than 3 NPC group memberships
+    // Get user IDs that have actual platform access:
+    // 1. Users in NftSnapshot (top of leaderboard, eligible to mint)
+    // 2. Users in Whitelist (manually granted access)
+    // 3. Admin users
+    const [snapshotUsers, whitelistedUsers, adminUsers] = await Promise.all([
+      db
+        .select({ userId: nftSnapshot.userId })
+        .from(nftSnapshot),
+      db
+        .select({ userId: whitelist.userId })
+        .from(whitelist)
+        .where(isNull(whitelist.revokedAt)),
+      db
+        .select({ id: users.id })
+        .from(users)
+        .where(
+          and(
+            eq(users.isAdmin, true),
+            eq(users.isActor, false),
+            eq(users.isAgent, false)
+          )
+        ),
+    ]);
+
+    const accessUserIds = new Set([
+      ...snapshotUsers.map((u) => u.userId),
+      ...whitelistedUsers.map((u) => u.userId),
+      ...adminUsers.map((u) => u.id),
+    ]);
+
+    logger.info(
+      'Access-granted users found',
+      {
+        nftSnapshot: snapshotUsers.length,
+        whitelisted: whitelistedUsers.length,
+        admins: adminUsers.length,
+        uniqueTotal: accessUserIds.size,
+      },
+      'migrate-default-groups'
+    );
+
+    if (accessUserIds.size === 0) {
+      logger.error(
+        'No access-granted users found. Aborting.',
+        {},
+        'migrate-default-groups'
+      );
+      process.exit(1);
+    }
+
+    // Only process users who have platform access
+    const accessUserIdArray = [...accessUserIds];
     usersToProcess = await db
       .select({ id: users.id, username: users.username })
       .from(users)
       .where(
         and(
+          inArray(users.id, accessUserIdArray),
           eq(users.isActor, false),
           eq(users.isAgent, false),
           eq(users.isBanned, false),

--- a/scripts/migrate-users-to-default-groups.ts
+++ b/scripts/migrate-users-to-default-groups.ts
@@ -145,9 +145,7 @@ async function main() {
     // 2. Users in Whitelist (manually granted access)
     // 3. Admin users
     const [snapshotUsers, whitelistedUsers, adminUsers] = await Promise.all([
-      db
-        .select({ userId: nftSnapshot.userId })
-        .from(nftSnapshot),
+      db.select({ userId: nftSnapshot.userId }).from(nftSnapshot),
       db
         .select({ userId: whitelist.userId })
         .from(whitelist)


### PR DESCRIPTION
## Summary

- Automatically assign 3 default Tier 3 (Followers) NPC groups when a user is granted whitelist access, so they see group chats immediately on `/chats`
- Fix migration script to only process users with actual platform access (NftSnapshot + Whitelist + admins) instead of all 498k users with `profileComplete = true`

## Type

- [x] Bug fix
- [x] Feature

## Context / Links

- Users on the new prod deployment were not seeing any alpha group chats
- Root cause: `bootstrap-alpha-groups.ts` had not been run, and the migration script had no access-gate filter
- The `addToWhitelist` service did not trigger group assignment, so whitelisted users had no groups

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] API infra (`packages/api`)
- [x] Other: `scripts/`

## Changes

- **`packages/api/src/services/whitelist-service.ts`**: After inserting a new whitelist entry, call `UserAlphaGroupAssignmentService.assignDefaultGroups()` (async, non-blocking, fire-and-forget with error logging). Skipped for re-adds (`alreadyExists`).
- **`scripts/migrate-users-to-default-groups.ts`**: Instead of querying all users with `profileComplete = true` (498k), now queries `NftSnapshot` (top of leaderboard), `Whitelist` (manually granted), and `isAdmin = true` users to build the eligible set (~100 users). Logs access breakdown before processing.

## Review guide

**Start here**
- `packages/api/src/services/whitelist-service.ts` — the core change (group assignment on whitelist)

**Risk**
- [x] Low

**Notes for reviewers**
- `assignDefaultGroups` is already safe: handles missing users, agents, banned users, already-has-groups, and incomplete profiles gracefully
- The async fire-and-forget pattern matches the existing signup flow at `apps/web/src/app/api/users/signup/route.ts:713`
- No circular dependency: `@babylon/api` already depends on `@babylon/engine`

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [x] `bun run test` (unit + integration)

**Manual verification**
1. Ran `bootstrap-alpha-groups.ts` on prod to create tier groups
2. Ran updated `migrate-users-to-default-groups.ts` on prod — processed 115 access-granted users, assigned 321 groups, 0 errors
3. Verified individual users see groups on `/chats` after restore

## Ops / Migration / Deployment

- [x] No deploy impact
- After deploying, run `bun run scripts/bootstrap-alpha-groups.ts` on any new environment to create tier groups
- Future whitelist additions will auto-assign groups (no manual intervention needed)

**Rollout / rollback plan**
- Rollout: Deploy normally. New whitelist grants will auto-assign groups.
- Rollback: Revert the commit. Users already assigned groups keep them (no harm).

## Breaking changes

- [x] None

## Security / privacy

- [x] No security impact

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend-only change — whitelist service and migration script, no UI impact

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

