### PR TITLE
fix: retry Privy sponsored tx with fallback JWT

### DIFF
--- a/apps/web/src/app/_actions/nft.ts
+++ b/apps/web/src/app/_actions/nft.ts
@@ -12,7 +12,7 @@ import {
 import { logger, ValidationError } from '@babylon/shared';
 import type { Address, Hex } from 'viem';
 
-import { requirePrivyToken } from './utils';
+import { requirePrivyTokenBundle } from './utils';
 
 /**
  * Result of the NFT mint action.
@@ -56,8 +56,11 @@ export async function mintNftAction(input?: {
 }): Promise<MintNftActionResult> {
   // Step 1: Auth
   let privyToken: string;
+  let fallbackPrivyToken: string | undefined;
   try {
-    privyToken = await requirePrivyToken(input?.userJwt);
+    const bundle = await requirePrivyTokenBundle(input?.userJwt);
+    privyToken = bundle.primary;
+    fallbackPrivyToken = bundle.fallback;
   } catch (e) {
     const msg = e instanceof Error ? e.message : 'Auth failed';
     return { status: 'error', error: msg, step: 'auth' };
@@ -86,6 +89,8 @@ export async function mintNftAction(input?: {
   try {
     const result = await sendSponsoredEvmTransaction({
       userJwt: privyToken,
+      userJwtFallbacks: fallbackPrivyToken ? [fallbackPrivyToken] : [],
+      expectedPrivyUserId: ctx.privyId,
       walletId: ctx.privyWalletId,
       to: prepare.contractAddress as Address,
       data: prepare.encodedData,

--- a/apps/web/src/app/_actions/onchain.ts
+++ b/apps/web/src/app/_actions/onchain.ts
@@ -21,7 +21,7 @@ import {
 } from 'viem';
 import type { AgentProfileMetadata } from '@/hooks/useUpdateAgentProfileTx';
 
-import { requirePrivyToken } from './utils';
+import { requirePrivyTokenBundle } from './utils';
 
 function marketIdToBytes32(marketId: string): `0x${string}` {
   const bigintValue = BigInt(marketId);
@@ -62,7 +62,8 @@ export async function buySharesOnchainAction(input: {
   numShares: number;
   userJwt?: string;
 }): Promise<{ txHash: Hex }> {
-  const privyToken = await requirePrivyToken(input.userJwt);
+  const bundle = await requirePrivyTokenBundle(input.userJwt);
+  const privyToken = bundle.primary;
   const ctx = await getAuthedUserContextFromPrivyToken(privyToken);
 
   const marketIdBytes32 = marketIdToBytes32(input.marketId);
@@ -77,6 +78,8 @@ export async function buySharesOnchainAction(input: {
 
   const { hash } = await sendSponsoredEvmTransaction({
     userJwt: privyToken,
+    userJwtFallbacks: bundle.fallback ? [bundle.fallback] : [],
+    expectedPrivyUserId: ctx.privyId,
     walletId: ctx.privyWalletId,
     to: DIAMOND_ADDRESS as Address,
     data,
@@ -94,7 +97,8 @@ export async function sellSharesOnchainAction(input: {
   numShares: number;
   userJwt?: string;
 }): Promise<{ txHash: Hex }> {
-  const privyToken = await requirePrivyToken(input.userJwt);
+  const bundle = await requirePrivyTokenBundle(input.userJwt);
+  const privyToken = bundle.primary;
   const ctx = await getAuthedUserContextFromPrivyToken(privyToken);
 
   const marketIdBytes32 = marketIdToBytes32(input.marketId);
@@ -109,6 +113,8 @@ export async function sellSharesOnchainAction(input: {
 
   const { hash } = await sendSponsoredEvmTransaction({
     userJwt: privyToken,
+    userJwtFallbacks: bundle.fallback ? [bundle.fallback] : [],
+    expectedPrivyUserId: ctx.privyId,
     walletId: ctx.privyWalletId,
     to: DIAMOND_ADDRESS as Address,
     data,
@@ -125,7 +131,8 @@ export async function sendSponsoredEthTransferAction(input: {
   amountWei: string;
   userJwt?: string;
 }): Promise<{ txHash: Hex }> {
-  const privyToken = await requirePrivyToken(input.userJwt);
+  const bundle = await requirePrivyTokenBundle(input.userJwt);
+  const privyToken = bundle.primary;
   const ctx = await getAuthedUserContextFromPrivyToken(privyToken);
 
   if (!isAddress(input.to)) {
@@ -135,6 +142,8 @@ export async function sendSponsoredEthTransferAction(input: {
 
   const { hash } = await sendSponsoredEvmTransaction({
     userJwt: privyToken,
+    userJwtFallbacks: bundle.fallback ? [bundle.fallback] : [],
+    expectedPrivyUserId: ctx.privyId,
     walletId: ctx.privyWalletId,
     to: input.to.toLowerCase() as Address,
     valueWei,
@@ -150,7 +159,8 @@ export async function updateAgentProfileOnchainAction(input: {
   endpoint?: string;
   userJwt?: string;
 }): Promise<{ txHash: Hex }> {
-  const privyToken = await requirePrivyToken(input.userJwt);
+  const bundle = await requirePrivyTokenBundle(input.userJwt);
+  const privyToken = bundle.primary;
   const ctx = await getAuthedUserContextFromPrivyToken(privyToken);
 
   const registryAddress = getIdentityRegistryAddress();
@@ -178,6 +188,8 @@ export async function updateAgentProfileOnchainAction(input: {
 
   const { hash } = await sendSponsoredEvmTransaction({
     userJwt: privyToken,
+    userJwtFallbacks: bundle.fallback ? [bundle.fallback] : [],
+    expectedPrivyUserId: ctx.privyId,
     walletId: ctx.privyWalletId,
     to: registryAddress,
     data,

--- a/apps/web/src/app/_actions/utils.ts
+++ b/apps/web/src/app/_actions/utils.ts
@@ -2,6 +2,20 @@
 
 import { cookies } from 'next/headers';
 
+type PrivyTokenBundle = {
+  /** Token we should use for auth/user context. */
+  primary: string;
+  /**
+   * Optional fallback token (typically the other source: cookie vs explicit).
+   * Used to retry wallet operations when Privy rejects a token as invalid/revoked.
+   */
+  fallback?: string;
+};
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
 /**
  * Retrieves the Privy authentication token, preferring an explicit (fresh) token
  * over the HttpOnly cookie.
@@ -26,6 +40,36 @@ export async function requirePrivyToken(
   const cookieStore = await cookies();
   const cookieToken = cookieStore.get('privy-token')?.value;
   if (cookieToken) return cookieToken;
+
+  throw new Error(
+    'Authentication required: no Privy token found. Please sign in and try again.'
+  );
+}
+
+/**
+ * Retrieves both the explicit Privy token (if provided) and the HttpOnly cookie token.
+ *
+ * Why:
+ * - The explicit token is generally fresher (comes from `getAccessToken()`).
+ * - In rare cases, Privy can rotate/revoke tokens such that a previously-valid token still
+ *   passes basic verification but is rejected by wallet endpoints with
+ *   "Invalid JWT token provided".
+ * - Having a fallback lets server actions retry once with the other token source.
+ */
+export async function requirePrivyTokenBundle(
+  explicitToken?: string
+): Promise<PrivyTokenBundle> {
+  const cookieStore = await cookies();
+  const cookieToken = cookieStore.get('privy-token')?.value;
+
+  const explicit = isNonEmptyString(explicitToken) ? explicitToken : undefined;
+  const cookie = isNonEmptyString(cookieToken) ? cookieToken : undefined;
+
+  if (explicit && cookie && explicit !== cookie) {
+    return { primary: explicit, fallback: cookie };
+  }
+  if (explicit) return { primary: explicit };
+  if (cookie) return { primary: cookie };
 
   throw new Error(
     'Authentication required: no Privy token found. Please sign in and try again.'

--- a/apps/web/src/app/_actions/utils.ts
+++ b/apps/web/src/app/_actions/utils.ts
@@ -27,25 +27,9 @@ function isNonEmptyString(value: unknown): value is string {
  * "400 Invalid JWT token provided" even though basic `verifyAuthToken` passes.
  *
  * @param explicitToken - Fresh token from `getAccessToken()` (preferred)
- * @returns The Privy JWT token
+ * @returns The Privy JWT token bundle
  * @throws Error with descriptive message if no token is found
  */
-export async function requirePrivyToken(
-  explicitToken?: string
-): Promise<string> {
-  // Prefer the explicit token — it comes from getAccessToken() and is always fresh.
-  // The privy-token cookie may be stale or out-of-sync with the latest refresh.
-  if (explicitToken) return explicitToken;
-
-  const cookieStore = await cookies();
-  const cookieToken = cookieStore.get('privy-token')?.value;
-  if (cookieToken) return cookieToken;
-
-  throw new Error(
-    'Authentication required: no Privy token found. Please sign in and try again.'
-  );
-}
-
 /**
  * Retrieves both the explicit Privy token (if provided) and the HttpOnly cookie token.
  *

--- a/apps/web/src/app/api/users/onboarding/onchain/route.ts
+++ b/apps/web/src/app/api/users/onboarding/onchain/route.ts
@@ -84,6 +84,10 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
   // this cookie contains the user's access token (JWT) and is the most reliable source.
   // Fall back to the Authorization header for external clients/agents.
   const userJwt = cookieToken ?? headerToken ?? null;
+  const userJwtFallbacks =
+    cookieToken && headerToken && cookieToken !== headerToken
+      ? [headerToken]
+      : [];
 
   const authUser = await authenticate(request);
   const body = (await request.json()) as
@@ -158,6 +162,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
   const onchainResult = await processOnchainRegistration({
     user: authUser,
     userJwt,
+    userJwtFallbacks,
     walletAddress,
     username: dbUser.username,
     displayName: dbUser.displayName,

--- a/packages/api/src/services/onchain-service.ts
+++ b/packages/api/src/services/onchain-service.ts
@@ -113,6 +113,11 @@ export interface OnchainRegistrationInput {
    * Required when Babylon needs to submit a transaction from the user's embedded wallet.
    */
   userJwt?: string | null;
+  /**
+   * Optional fallback JWTs (e.g. cookie token vs Authorization header token).
+   * Used only if Privy rejects the primary token at the wallet endpoint.
+   */
+  userJwtFallbacks?: string[];
   walletAddress?: string | null;
   username?: string | null;
   displayName?: string | null;
@@ -136,6 +141,7 @@ export interface OnchainRegistrationResult {
 export async function processOnchainRegistration({
   user,
   userJwt,
+  userJwtFallbacks,
   walletAddress,
   username,
   displayName,
@@ -621,6 +627,8 @@ export async function processOnchainRegistration({
 
     const { hash } = await sendSponsoredEvmTransaction({
       userJwt,
+      userJwtFallbacks,
+      expectedPrivyUserId: user.privyId,
       walletId: dbUser.privyWalletId,
       to: IDENTITY_REGISTRY,
       data,

--- a/packages/api/src/services/privy/__tests__/evm-send-transaction.test.ts
+++ b/packages/api/src/services/privy/__tests__/evm-send-transaction.test.ts
@@ -343,7 +343,11 @@ describe('sendSponsoredEvmTransaction – JWT pre-flight checks', () => {
 
     mockSendTransaction
       .mockImplementationOnce(() =>
-        Promise.reject(new Error('400 {"error":"Invalid JWT token provided","code":"invalid_data"}'))
+        Promise.reject(
+          new Error(
+            '400 {"error":"Invalid JWT token provided","code":"invalid_data"}'
+          )
+        )
       )
       .mockImplementationOnce(() =>
         Promise.resolve({ hash: '0xdef', caip2: 'eip155:1' })

--- a/packages/api/src/services/privy/__tests__/evm-send-transaction.test.ts
+++ b/packages/api/src/services/privy/__tests__/evm-send-transaction.test.ts
@@ -336,4 +336,27 @@ describe('sendSponsoredEvmTransaction – JWT pre-flight checks', () => {
 
     expect(mockSendTransaction).toHaveBeenCalled();
   });
+
+  it('retries with a fallback token when Privy rejects the primary JWT at the wallet endpoint', async () => {
+    const primary = buildJwt(VALID_PAYLOAD);
+    const fallback = buildJwt({ ...VALID_PAYLOAD, sid: 'fallback-session' });
+
+    mockSendTransaction
+      .mockImplementationOnce(() =>
+        Promise.reject(new Error('400 {"error":"Invalid JWT token provided","code":"invalid_data"}'))
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({ hash: '0xdef', caip2: 'eip155:1' })
+      );
+
+    const result = await sendSponsoredEvmTransaction({
+      userJwt: primary,
+      userJwtFallbacks: [fallback],
+      walletId: 'wallet-1',
+      to: validAddress,
+    });
+
+    expect(result.hash).toBe('0xdef');
+    expect(mockSendTransaction).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/api/src/services/privy/__tests__/evm-send-transaction.test.ts
+++ b/packages/api/src/services/privy/__tests__/evm-send-transaction.test.ts
@@ -363,4 +363,33 @@ describe('sendSponsoredEvmTransaction – JWT pre-flight checks', () => {
     expect(result.hash).toBe('0xdef');
     expect(mockSendTransaction).toHaveBeenCalledTimes(2);
   });
+
+  it('does not use fallback tokens whose subject does not match expectedPrivyUserId', async () => {
+    const primary = buildJwt(VALID_PAYLOAD);
+    const fallbackWrongUser = buildJwt({
+      ...VALID_PAYLOAD,
+      sub: 'did:privy:someone-else',
+    });
+
+    mockSendTransaction.mockImplementationOnce(() =>
+      Promise.reject(
+        new Error(
+          '400 {"error":"Invalid JWT token provided","code":"invalid_data"}'
+        )
+      )
+    );
+
+    await expect(
+      sendSponsoredEvmTransaction({
+        userJwt: primary,
+        userJwtFallbacks: [fallbackWrongUser],
+        expectedPrivyUserId: VALID_PAYLOAD.sub,
+        walletId: 'wallet-1',
+        to: validAddress,
+      })
+    ).rejects.toThrow('Invalid JWT token provided');
+
+    // Only the primary token should be attempted; fallback is filtered out by pre-flight validation.
+    expect(mockSendTransaction).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/api/src/services/privy/evm-send-transaction.ts
+++ b/packages/api/src/services/privy/evm-send-transaction.ts
@@ -208,6 +208,10 @@ export async function sendSponsoredEvmTransaction({
   // Debug: Log JWT header + claims to diagnose auth issues (no sensitive identifiers).
   // Only log for the first candidate we will try.
   const first = candidates[0];
+  // Satisfy `noUncheckedIndexedAccess`: even with length checks, TS keeps index access as possibly-undefined.
+  if (!first) {
+    throw new Error('Invalid Privy user JWT: no usable token candidates');
+  }
   const jwtHeader = safeDecodeJwtHeader(first.token);
   logger.debug(
     'Privy JWT diagnostics',

--- a/packages/api/src/services/privy/evm-send-transaction.ts
+++ b/packages/api/src/services/privy/evm-send-transaction.ts
@@ -273,7 +273,10 @@ export async function sendSponsoredEvmTransaction({
   );
 
   let lastError: unknown;
-  for (const { token } of candidates) {
+  for (let i = 0; i < candidates.length; i += 1) {
+    const candidate = candidates[i];
+    if (!candidate) continue;
+    const { token } = candidate;
     const authorizationContext: AuthorizationContext = {
       user_jwts: [token],
     };
@@ -313,6 +316,13 @@ export async function sendSponsoredEvmTransaction({
       // Only retry on the specific auth failure we expect for token rotation/revocation.
       if (!isInvalidPrivyWalletJwtError(error)) {
         throw error;
+      }
+      if (i < candidates.length - 1) {
+        logger.debug(
+          'Privy wallet rejected JWT, trying fallback token',
+          { candidateIndex: i, candidatesCount: candidates.length },
+          'sendSponsoredEvmTransaction'
+        );
       }
       // Continue to next candidate (if any).
     }

--- a/packages/api/src/services/privy/evm-send-transaction.ts
+++ b/packages/api/src/services/privy/evm-send-transaction.ts
@@ -7,6 +7,16 @@ import { getPrivyNodeClient } from './privy-node';
 
 export type SendSponsoredEvmTransactionInput = {
   userJwt: string;
+  /**
+   * Optional fallback tokens (e.g. cookie token vs freshly-refreshed token).
+   * These are tried only if the primary token is rejected by Privy's wallet endpoint.
+   */
+  userJwtFallbacks?: string[];
+  /**
+   * Optional safety check: require that the JWT subject matches the expected Privy user id.
+   * Use this when the caller already verified auth and knows the `privyId`.
+   */
+  expectedPrivyUserId?: string;
   walletId: string;
   to: Address;
   data?: Hex;
@@ -65,6 +75,27 @@ export function safeDecodeJwtPayload(token: string): PrivyJwtPayload | null {
   }
 }
 
+function isInvalidPrivyWalletJwtError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  // Privy wallet endpoints currently surface this message for invalid/revoked JWTs.
+  // Keep the match strict to avoid retrying on unrelated failures.
+  return error.message.toLowerCase().includes('invalid jwt token provided');
+}
+
+function dedupeNonEmptyStrings(values: Array<string | undefined>): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const v of values) {
+    if (typeof v !== 'string') continue;
+    const trimmed = v.trim();
+    if (trimmed.length === 0) continue;
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
+}
+
 /**
  * Sends a sponsored EVM transaction on behalf of a user via Privy's server-side wallet flow.
  *
@@ -82,6 +113,8 @@ export function safeDecodeJwtPayload(token: string): PrivyJwtPayload | null {
  */
 export async function sendSponsoredEvmTransaction({
   userJwt,
+  userJwtFallbacks,
+  expectedPrivyUserId,
   walletId,
   to,
   data,
@@ -89,80 +122,123 @@ export async function sendSponsoredEvmTransaction({
   caip2 = `eip155:${CHAIN.id}`,
   chainId = CHAIN.id,
 }: SendSponsoredEvmTransactionInput): Promise<{ hash: Hex; caip2: string }> {
-  const payload = safeDecodeJwtPayload(userJwt);
-  if (!payload) {
-    throw new Error(
-      'Invalid Privy user JWT: token must be a valid JWT with the expected Privy claims (aud, sub, iss, iat, exp)'
-    );
+  const jwtCandidates = dedupeNonEmptyStrings([
+    userJwt,
+    ...(userJwtFallbacks ?? []),
+  ]);
+  if (jwtCandidates.length === 0) {
+    throw new Error('Missing Privy user JWT');
   }
 
   const appId =
     process.env.PRIVY_APP_ID ?? process.env.NEXT_PUBLIC_PRIVY_APP_ID;
 
-  // Debug: Log JWT header + claims to diagnose auth issues (no sensitive identifiers)
-  const jwtHeader = safeDecodeJwtHeader(userJwt);
+  // Pre-flight validate candidates (decode-only) so we can skip obviously-invalid tokens
+  // without paying for a wallet API call.
+  const parsedBuffer = Number(process.env.PRIVY_JWT_EXPIRY_BUFFER_SECONDS);
+  const expiryBuffer =
+    Number.isFinite(parsedBuffer) && parsedBuffer > 0 ? parsedBuffer : 30;
+
+  const invalidJwtError = new Error(
+    'Invalid Privy user JWT: token must be a valid JWT with the expected Privy claims (aud, sub, iss, iat, exp)'
+  );
+
+  const candidates: Array<{ token: string; payload: PrivyJwtPayload }> = [];
+  let firstValidationError: Error | undefined;
+  let lastValidationError: Error | undefined;
+  for (const token of jwtCandidates) {
+    const payload = safeDecodeJwtPayload(token);
+    if (!payload) {
+      // Preserve the previous error message semantics for single-token calls.
+      lastValidationError = invalidJwtError;
+      if (!firstValidationError) firstValidationError = invalidJwtError;
+      continue;
+    }
+
+    if (expectedPrivyUserId && payload.sub !== expectedPrivyUserId) {
+      const err = new Error(
+        'Privy token subject mismatch: token does not match the authenticated user'
+      );
+      lastValidationError = err;
+      if (!firstValidationError) firstValidationError = err;
+      continue;
+    }
+
+    if (!payload.exp) {
+      const err = new Error(
+        'Privy JWT is missing an expiration claim (exp). Cannot authorize wallet operations without a verifiable token lifetime.'
+      );
+      lastValidationError = err;
+      if (!firstValidationError) firstValidationError = err;
+      continue;
+    }
+
+    if (payload.exp < Date.now() / 1000 + expiryBuffer) {
+      const err = new Error(
+        `Privy JWT is expired or about to expire (exp: ${new Date(payload.exp * 1000).toISOString()}). Please refresh your session.`
+      );
+      lastValidationError = err;
+      if (!firstValidationError) firstValidationError = err;
+      continue;
+    }
+
+    if (appId) {
+      const tokenAud = payload.aud;
+      const audMatches =
+        tokenAud === appId ||
+        (Array.isArray(tokenAud) && tokenAud.includes(appId));
+      if (!audMatches) {
+        const err = new Error(
+          `Privy token audience mismatch: token audience "${tokenAud}" does not match app ID "${appId}"`
+        );
+        lastValidationError = err;
+        if (!firstValidationError) firstValidationError = err;
+        continue;
+      }
+    }
+
+    candidates.push({ token, payload });
+  }
+
+  if (candidates.length === 0) {
+    // Preserve clear, single-cause error semantics for callers/tests.
+    throw firstValidationError ?? lastValidationError ?? invalidJwtError;
+  }
+
+  // Debug: Log JWT header + claims to diagnose auth issues (no sensitive identifiers).
+  // Only log for the first candidate we will try.
+  const first = candidates[0];
+  const jwtHeader = safeDecodeJwtHeader(first.token);
   logger.debug(
     'Privy JWT diagnostics',
     {
       alg: jwtHeader?.alg,
       typ: jwtHeader?.typ,
       kid: jwtHeader?.kid,
-      iss: payload.iss,
-      aud: payload.aud,
-      iat: payload.iat,
-      exp: payload.exp,
-      isExpired: payload.exp ? payload.exp < Date.now() / 1000 : 'no-exp',
+      iss: first.payload.iss,
+      aud: first.payload.aud,
+      iat: first.payload.iat,
+      exp: first.payload.exp,
+      isExpired: first.payload.exp
+        ? first.payload.exp < Date.now() / 1000
+        : 'no-exp',
       configuredAppId: appId,
-      jwtLength: userJwt.length,
+      candidatesCount: candidates.length,
+      jwtLength: first.token.length,
+      expectedPrivyUserId: expectedPrivyUserId ? 'provided' : 'not-provided',
     },
     'sendSponsoredEvmTransaction'
   );
 
-  // Wallet operations are security-sensitive — reject tokens that lack an
-  // expiration claim. While `exp` is optional per RFC 7519, Privy tokens
-  // always include it, so a missing `exp` indicates a malformed or tampered token.
-  if (!payload.exp) {
-    throw new Error(
-      'Privy JWT is missing an expiration claim (exp). Cannot authorize wallet operations without a verifiable token lifetime.'
-    );
-  }
-
-  // Reject tokens that are expired or about to expire.
-  // The buffer is configurable via PRIVY_JWT_EXPIRY_BUFFER_SECONDS (default: 30s).
-  // This catches stale tokens early with a clear error instead of letting them
-  // fail at Privy's wallet API with a cryptic "400 Invalid JWT token".
-  const parsedBuffer = Number(process.env.PRIVY_JWT_EXPIRY_BUFFER_SECONDS);
-  const expiryBuffer =
-    Number.isFinite(parsedBuffer) && parsedBuffer > 0 ? parsedBuffer : 30;
-  if (payload.exp < Date.now() / 1000 + expiryBuffer) {
-    throw new Error(
-      `Privy JWT is expired or about to expire (exp: ${new Date(payload.exp * 1000).toISOString()}). Please refresh your session.`
-    );
-  }
-
-  const tokenAud = payload.aud;
   if (!appId) {
     logger.warn(
       'PRIVY_APP_ID is not configured — skipping JWT audience validation. Set PRIVY_APP_ID or NEXT_PUBLIC_PRIVY_APP_ID to enable.',
       {},
       'sendSponsoredEvmTransaction'
     );
-  } else if (typeof appId === 'string') {
-    const audMatches =
-      tokenAud === appId ||
-      (Array.isArray(tokenAud) && tokenAud.includes(appId));
-    if (!audMatches) {
-      throw new Error(
-        `Privy token audience mismatch: token audience "${tokenAud}" does not match app ID "${appId}"`
-      );
-    }
   }
 
   const privy = getPrivyNodeClient();
-
-  const authorizationContext: AuthorizationContext = {
-    user_jwts: [userJwt],
-  };
 
   // VALUE FIELD HANDLING:
   // We omit the value field entirely for zero-value transactions rather than sending "0x0".
@@ -192,33 +268,53 @@ export async function sendSponsoredEvmTransaction({
     'sendSponsoredEvmTransaction'
   );
 
-  const response = await privy
-    .wallets()
-    .ethereum()
-    .sendTransaction(walletId, {
-      caip2,
-      sponsor: true,
-      authorization_context: authorizationContext,
-      params: {
-        transaction: {
+  let lastError: unknown;
+  for (const { token } of candidates) {
+    const authorizationContext: AuthorizationContext = {
+      user_jwts: [token],
+    };
+
+    try {
+      const response = await privy
+        .wallets()
+        .ethereum()
+        .sendTransaction(walletId, {
+          caip2,
+          sponsor: true,
+          authorization_context: authorizationContext,
+          params: {
+            transaction: {
+              to,
+              chain_id: chainId,
+              ...(valueHex ? { value: valueHex } : {}),
+              ...(data ? { data } : {}),
+            },
+          },
+        });
+
+      logger.info(
+        'Sponsored transaction submitted successfully',
+        {
+          txHash: response.hash,
+          caip2: response.caip2,
+          walletId,
           to,
-          chain_id: chainId,
-          ...(valueHex ? { value: valueHex } : {}),
-          ...(data ? { data } : {}),
         },
-      },
-    });
+        'sendSponsoredEvmTransaction'
+      );
 
-  logger.info(
-    'Sponsored transaction submitted successfully',
-    {
-      txHash: response.hash,
-      caip2: response.caip2,
-      walletId,
-      to,
-    },
-    'sendSponsoredEvmTransaction'
-  );
+      return { hash: response.hash as Hex, caip2: response.caip2 };
+    } catch (error) {
+      lastError = error;
+      // Only retry on the specific auth failure we expect for token rotation/revocation.
+      if (!isInvalidPrivyWalletJwtError(error)) {
+        throw error;
+      }
+      // Continue to next candidate (if any).
+    }
+  }
 
-  return { hash: response.hash as Hex, caip2: response.caip2 };
+  throw lastError instanceof Error
+    ? lastError
+    : new Error('Failed to submit sponsored transaction via Privy');
 }


### PR DESCRIPTION
## Summary

- Fix intermittent Privy wallet tx failures by retrying once with a fallback user JWT when Privy rejects the primary token as invalid.
- Centralize the retry + validation logic inside the Privy adapter (`sendSponsoredEvmTransaction`) to keep app-layer wiring thin.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- User reports: `Mint failed at send_transaction: 400 {"error":"Invalid JWT token provided","code":"invalid_data"}`

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web API routes / SSE / A2A (`apps/web`)
- [x] API infra (`packages/api`)
- [ ] Web UI (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- Add `userJwtFallbacks` + `expectedPrivyUserId` support to `sendSponsoredEvmTransaction` and perform a strict one-time retry only on Privy wallet auth failures.
- Keep server actions thin by passing token bundle to the API adapter instead of implementing retry logic in `apps/web`.
- Add unit test coverage for the retry behavior.

## Review guide

**Start here**
- `packages/api/src/services/privy/evm-send-transaction.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- Retry is strictly gated on the error message `Invalid JWT token provided` and is single-attempt.
- `expectedPrivyUserId` prevents accidental cross-user token usage when multiple token sources exist.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Additional**
- `bun test packages/api/src/services/privy/__tests__/evm-send-transaction.test.ts`

**Manual verification**
1. Mint NFT with a valid session (happy path)
2. If you can reproduce the stale token scenario: confirm mint retries once and succeeds without user-facing failure.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: none
- Changed: none
- Removed: none

**Rollout / rollback plan**
- Rollout: normal deploy.
- Rollback: revert PR.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: backend / server-action + API adapter change, no UI changes.

## Checklist (author)

- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
