### PR TITLE
fix: sanitize NFT mint errors

### DIFF
--- a/apps/web/src/app/_actions/nft.ts
+++ b/apps/web/src/app/_actions/nft.ts
@@ -21,9 +21,32 @@ type MintStep =
   | 'send_transaction'
   | 'confirm';
 
+function redactJwtLikeTokens(text: string): string {
+  // Redact JWT-like strings (base64url.base64url.base64url).
+  // This avoids accidentally logging auth tokens if they show up in an error message/stack.
+  const jwtLike =
+    /(?<![A-Za-z0-9_-])([A-Za-z0-9_-]{10,})\.([A-Za-z0-9_-]{10,})\.([A-Za-z0-9_-]{10,})(?![A-Za-z0-9_-])/g;
+  return text.replace(jwtLike, '[REDACTED_JWT]');
+}
+
 function errorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
   return typeof error === 'string' ? error : 'Unknown error';
+}
+
+function toSafeLogError(error: unknown): {
+  name?: string;
+  message: string;
+  stack?: string;
+} {
+  if (error instanceof Error) {
+    return {
+      name: error.name,
+      message: redactJwtLikeTokens(error.message),
+      stack: error.stack ? redactJwtLikeTokens(error.stack) : undefined,
+    };
+  }
+  return { message: redactJwtLikeTokens(errorMessage(error)) };
 }
 
 function toUserSafeMintError(step: MintStep, error: unknown): string {
@@ -110,7 +133,7 @@ export async function mintNftAction(input?: {
     const errorId = crypto.randomUUID();
     logger.warn(
       'NFT mint auth failed',
-      { errorId, step, error: e },
+      { errorId, step, error: toSafeLogError(e) },
       'mintNftAction'
     );
     return {
@@ -130,7 +153,7 @@ export async function mintNftAction(input?: {
     const errorId = crypto.randomUUID();
     logger.warn(
       'NFT mint user context failed',
-      { errorId, step, error: e },
+      { errorId, step, error: toSafeLogError(e) },
       'mintNftAction'
     );
     return {
@@ -150,7 +173,7 @@ export async function mintNftAction(input?: {
     const errorId = crypto.randomUUID();
     logger.error(
       'NFT mint prepare failed',
-      { errorId, step, userId: ctx.dbUserId, error: e },
+      { errorId, step, userId: ctx.dbUserId, error: toSafeLogError(e) },
       'mintNftAction'
     );
     return {
@@ -187,7 +210,7 @@ export async function mintNftAction(input?: {
         userId: ctx.dbUserId,
         privyId: ctx.privyId,
         walletId: ctx.privyWalletId,
-        error: e,
+        error: toSafeLogError(e),
       },
       'mintNftAction'
     );
@@ -217,7 +240,13 @@ export async function mintNftAction(input?: {
       const errorId = crypto.randomUUID();
       logger.error(
         'NFT mint confirm failed',
-        { errorId, step, userId: ctx.dbUserId, txHash: hash, error },
+        {
+          errorId,
+          step,
+          userId: ctx.dbUserId,
+          txHash: hash,
+          error: toSafeLogError(error),
+        },
         'mintNftAction'
       );
       return {

--- a/apps/web/src/app/_actions/nft.ts
+++ b/apps/web/src/app/_actions/nft.ts
@@ -14,7 +14,12 @@ import type { Address, Hex } from 'viem';
 
 import { requirePrivyTokenBundle } from './utils';
 
-type MintStep = 'auth' | 'user_context' | 'prepare' | 'send_transaction' | 'confirm';
+type MintStep =
+  | 'auth'
+  | 'user_context'
+  | 'prepare'
+  | 'send_transaction'
+  | 'confirm';
 
 function errorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;

--- a/apps/web/src/app/_actions/nft.ts
+++ b/apps/web/src/app/_actions/nft.ts
@@ -14,6 +14,45 @@ import type { Address, Hex } from 'viem';
 
 import { requirePrivyTokenBundle } from './utils';
 
+type MintStep = 'auth' | 'user_context' | 'prepare' | 'send_transaction' | 'confirm';
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return typeof error === 'string' ? error : 'Unknown error';
+}
+
+function toUserSafeMintError(step: MintStep, error: unknown): string {
+  const msg = errorMessage(error).toLowerCase();
+
+  // Wallet + auth errors: keep messaging user-friendly (no internal details).
+  const isAuthy =
+    msg.includes('invalid jwt token provided') ||
+    msg.includes('expired') ||
+    msg.includes('missing privy token') ||
+    msg.includes('authentication required');
+  if (isAuthy || step === 'auth' || step === 'user_context') {
+    return 'Your session has expired. Please sign in again and try minting.';
+  }
+
+  if (msg.includes('embedded wallet not ready')) {
+    return 'Your wallet is still initializing. Please wait a few seconds and try again.';
+  }
+
+  if (step === 'prepare') {
+    return 'Mint is temporarily unavailable. Please try again shortly.';
+  }
+
+  if (step === 'send_transaction') {
+    return 'We could not submit the transaction. Please try again.';
+  }
+
+  if (step === 'confirm') {
+    return 'Transaction submitted, but confirmation is taking longer than expected. Please check again shortly.';
+  }
+
+  return 'Mint failed. Please try again.';
+}
+
 /**
  * Result of the NFT mint action.
  * - `status: 'confirmed'`: Transaction confirmed and NFT data available
@@ -23,7 +62,7 @@ import { requirePrivyTokenBundle } from './utils';
 export type MintNftActionResult =
   | ({ status: 'confirmed'; txHash: Hex } & ConfirmResult)
   | { status: 'pending'; txHash: Hex; message: string }
-  | { status: 'error'; error: string; step: string };
+  | { status: 'error'; error: string; step: MintStep; errorId: string };
 
 /**
  * Exponential backoff sleep with jitter for polling.
@@ -62,8 +101,19 @@ export async function mintNftAction(input?: {
     privyToken = bundle.primary;
     fallbackPrivyToken = bundle.fallback;
   } catch (e) {
-    const msg = e instanceof Error ? e.message : 'Auth failed';
-    return { status: 'error', error: msg, step: 'auth' };
+    const step: MintStep = 'auth';
+    const errorId = crypto.randomUUID();
+    logger.warn(
+      'NFT mint auth failed',
+      { errorId, step, error: e },
+      'mintNftAction'
+    );
+    return {
+      status: 'error',
+      error: toUserSafeMintError(step, e),
+      step,
+      errorId,
+    };
   }
 
   // Step 2: User context
@@ -71,8 +121,19 @@ export async function mintNftAction(input?: {
   try {
     ctx = await getAuthedUserContextFromPrivyToken(privyToken);
   } catch (e) {
-    const msg = e instanceof Error ? e.message : 'User context failed';
-    return { status: 'error', error: msg, step: 'user_context' };
+    const step: MintStep = 'user_context';
+    const errorId = crypto.randomUUID();
+    logger.warn(
+      'NFT mint user context failed',
+      { errorId, step, error: e },
+      'mintNftAction'
+    );
+    return {
+      status: 'error',
+      error: toUserSafeMintError(step, e),
+      step,
+      errorId,
+    };
   }
 
   // Step 3: Prepare mint
@@ -80,8 +141,19 @@ export async function mintNftAction(input?: {
   try {
     prepare = await prepareMint(ctx.dbUserId);
   } catch (e) {
-    const msg = e instanceof Error ? e.message : 'Prepare failed';
-    return { status: 'error', error: msg, step: 'prepare' };
+    const step: MintStep = 'prepare';
+    const errorId = crypto.randomUUID();
+    logger.error(
+      'NFT mint prepare failed',
+      { errorId, step, userId: ctx.dbUserId, error: e },
+      'mintNftAction'
+    );
+    return {
+      status: 'error',
+      error: toUserSafeMintError(step, e),
+      step,
+      errorId,
+    };
   }
 
   // Step 4: Send transaction via Privy
@@ -100,8 +172,26 @@ export async function mintNftAction(input?: {
     });
     hash = result.hash;
   } catch (e) {
-    const msg = e instanceof Error ? e.message : 'Send transaction failed';
-    return { status: 'error', error: msg, step: 'send_transaction' };
+    const step: MintStep = 'send_transaction';
+    const errorId = crypto.randomUUID();
+    logger.error(
+      'NFT mint send transaction failed',
+      {
+        errorId,
+        step,
+        userId: ctx.dbUserId,
+        privyId: ctx.privyId,
+        walletId: ctx.privyWalletId,
+        error: e,
+      },
+      'mintNftAction'
+    );
+    return {
+      status: 'error',
+      error: toUserSafeMintError(step, e),
+      step,
+      errorId,
+    };
   }
 
   // Step 5: Poll for confirmation
@@ -118,8 +208,19 @@ export async function mintNftAction(input?: {
         await backoffSleep(attempt);
         continue;
       }
-      const msg = error instanceof Error ? error.message : 'Confirm failed';
-      return { status: 'error', error: msg, step: 'confirm' };
+      const step: MintStep = 'confirm';
+      const errorId = crypto.randomUUID();
+      logger.error(
+        'NFT mint confirm failed',
+        { errorId, step, userId: ctx.dbUserId, txHash: hash, error },
+        'mintNftAction'
+      );
+      return {
+        status: 'error',
+        error: toUserSafeMintError(step, error),
+        step,
+        errorId,
+      };
     }
   }
 

--- a/apps/web/src/hooks/useNftMint.ts
+++ b/apps/web/src/hooks/useNftMint.ts
@@ -125,9 +125,10 @@ export function useNftMint(): UseNftMintResult {
   );
 
   const startMint = useCallback(async () => {
-    const handleError = (message: string) => {
-      setError(message);
-      toast.error(message);
+    const handleError = (message: string, errorId?: string) => {
+      const uiMessage = errorId ? `${message} (Ref: ${errorId})` : message;
+      setError(uiMessage);
+      toast.error(uiMessage);
       setFlowState('error');
     };
 
@@ -161,7 +162,7 @@ export function useNftMint(): UseNftMintResult {
           errorId: result.errorId,
           message: result.error,
         });
-        handleError(result.error);
+        handleError(result.error, result.errorId);
         return;
       }
 

--- a/apps/web/src/hooks/useNftMint.ts
+++ b/apps/web/src/hooks/useNftMint.ts
@@ -156,8 +156,12 @@ export function useNftMint(): UseNftMintResult {
       const result = await mintNftAction({ userJwt });
 
       if (result.status === 'error') {
-        console.error('[NFT Mint Error]', result.step, result.error);
-        handleError(`Mint failed at ${result.step}: ${result.error}`);
+        console.error('[NFT Mint Error]', {
+          step: result.step,
+          errorId: result.errorId,
+          message: result.error,
+        });
+        handleError(result.error);
         return;
       }
 

--- a/pr-1045-changelog.md
+++ b/pr-1045-changelog.md
@@ -1,0 +1,7 @@
+**PR:** https://github.com/BabylonSocial/babylon/pull/1045
+
+### NFT Mint Error Sanitization + Debug Reference
+- Stop leaking raw internal mint errors to the user (ex: Privy `Invalid JWT token provided`, HTTP payloads, stacks).
+- Return a stable `errorId` + mint `step` so support can correlate user reports with server logs.
+- Redact JWT-like tokens from error messages/stacks before logging to reduce risk of credential leakage.
+- UI surfaces user-safe messaging and includes `Ref: <errorId>` for faster triage.


### PR DESCRIPTION
## Summary

- Stop leaking raw internal mint errors to the UI (ex: "Mint failed at send_transaction: 400 {…Invalid JWT…}").
- Keep full diagnostics server-side with a stable `errorId` + `step` for support/debugging.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Related: #1044 (Privy JWT fallback retry)

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- Return user-safe mint error messages (by step) + include an `errorId` for support triage.
- Log the original error server-side with `{ errorId, step }` (no JWTs in logs).

## Review guide

**Start here**
- `apps/web/src/app/_actions/nft.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- Intentional behavior change: UI no longer shows raw backend error strings.
- Non-goal: changing the underlying mint/onchain flow (handled in #1044).

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [ ] `bun run test` (unit + integration) (skipped: `DATABASE_URL` not set; runs in CI)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Force a mint failure (ex: logged out / missing privy token, or invalid tx) and verify the toast/error is user-safe.
2. Confirm server logs include the `errorId` + `step` and the original error details.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `…`
- Changed: `…`
- Removed: `…`

**DB / data migration**
- Migration(s): `…`
- Backfill/seed: `…`

**Rollout / rollback plan**
- Rollout: normal deploy.
- Rollback: revert PR.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy

- [ ] No security impact
- [x] Needs extra review (describe)

- User-facing errors are now sanitized; detailed errors remain available in server logs keyed by `errorId`.

## Screenshots / recordings (UI)

### Option A: Visual demo

| Feature | Before | After |
|---------|--------|-------|
| Mint error toast/message | `Mint failed at send_transaction: 400 {…Invalid JWT…}` | User-safe message + `Ref: <errorId>` |

*Demo script (for recording):*
1. Trigger a mint failure (ex: sign out, then attempt mint).
2. Observe the user-safe error message.
3. Locate matching `{ errorId }` in server logs.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
