### PR TITLE
fix: support cookie auth for NFT mint

### DIFF
--- a/apps/web/src/hooks/useNftMint.ts
+++ b/apps/web/src/hooks/useNftMint.ts
@@ -58,31 +58,33 @@ export function useNftMint(): UseNftMintResult {
       setError(null);
 
       try {
-        const token = await getAccessToken();
+        // In production we may rely on Privy's HttpOnly cookie auth. In that setup,
+        // `getAccessToken()` can be unavailable/undefined in the browser, but the
+        // cookie still authenticates same-origin requests.
+        const token = await getAccessToken().catch(() => null);
 
         // Check if aborted before continuing
         if (signal?.aborted) return;
 
-        if (!token) {
-          setEligibility(notAuthenticated);
-          setFlowState('idle');
-          setIsCheckingEligibility(false);
-          return;
-        }
-
         const response = await fetch('/api/nft/eligibility', {
-          headers: { Authorization: `Bearer ${token}` },
+          headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+          credentials: 'include',
           signal, // Pass abort signal to fetch
         });
 
         // Check if aborted before updating state
         if (signal?.aborted) return;
 
+        if (response.status === 401) {
+          setEligibility(notAuthenticated);
+          setFlowState('idle');
+          return;
+        }
+
         if (!response.ok) {
           const errorData = await response.json().catch(() => ({}));
           setError(errorData.error ?? 'Failed to check eligibility');
           setFlowState('error');
-          setIsCheckingEligibility(false);
           return;
         }
 
@@ -148,13 +150,12 @@ export function useNftMint(): UseNftMintResult {
     setFlowState('minting');
 
     try {
+      // `getAccessToken()` refreshes Privy's session, but the app can still work without
+      // an explicit token when HttpOnly cookies are enabled (server action reads cookie).
       const userJwt = await getAccessToken().catch(() => null);
-      if (!userJwt) {
-        handleError('Authentication failed');
-        return;
-      }
-
-      const result = await mintNftAction({ userJwt });
+      const result = userJwt
+        ? await mintNftAction({ userJwt })
+        : await mintNftAction();
 
       if (result.status === 'error') {
         console.error('[NFT Mint Error]', {

--- a/packages/api/src/services/points-service.ts
+++ b/packages/api/src/services/points-service.ts
@@ -1504,18 +1504,14 @@ export class PointsService {
       );
     }
 
-    const sortField:
-      | 'allPoints'
-      | 'earnedPoints'
-      | 'invitePoints'
-      | 'totalPoints' =
-      pointsCategory === 'total'
-        ? 'totalPoints'
-        : pointsCategory === 'all'
-          ? 'allPoints'
-          : pointsCategory === 'earned'
-            ? 'earnedPoints'
-            : 'invitePoints';
+    // `pointsCategory === 'total'` returns early above, so at this point the union
+    // is narrowed to 'all' | 'earned' | 'referral'.
+    const sortField: 'allPoints' | 'earnedPoints' | 'invitePoints' =
+      pointsCategory === 'all'
+        ? 'allPoints'
+        : pointsCategory === 'earned'
+          ? 'earnedPoints'
+          : 'invitePoints';
 
     combined.sort((a, b) => {
       const comparison = b[sortField] - a[sortField];


### PR DESCRIPTION
## Summary

- Fix NFT eligibility + mint flow to work with Privy HttpOnly cookie auth even when `getAccessToken()` is unavailable/returns null.
- Remove an unreachable `pointsCategory === 'total'` comparison that was breaking `bun run typecheck` on `staging`.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Follow-up after #1045: production reports still seeing mint/eligibility issues under HttpOnly cookie auth.

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] API infra (`packages/api`) (tiny fix to restore typecheck)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- `apps/web/src/hooks/useNftMint.ts`: stop hard-failing when `getAccessToken()` is missing; rely on same-origin cookies and only attach `Authorization` when available.
- `packages/api/src/services/points-service.ts`: remove unreachable `pointsCategory === 'total'` branch after an early return.

## Review guide

**Start here**
- `apps/web/src/hooks/useNftMint.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- This makes the mint flow compatible with cookie-only auth (production configuration).

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [ ] `bun run test` (unit + integration) (skipped: `DATABASE_URL` not set; runs in CI)

**Manual verification**
1. With Privy HttpOnly cookies enabled, run eligibility + mint without relying on an access token.
2. Verify eligibility still works when an access token is present (Authorization header still sent).

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates
- [ ] Requires DB migration

## Breaking changes

- [x] None

## Security / privacy

- [x] No security impact

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Behavior-only change; UI visuals unchanged.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
