### PR TITLE
fix: harden Privy auth for NFT mint

### DIFF
--- a/apps/web/src/app/_actions/nft.ts
+++ b/apps/web/src/app/_actions/nft.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import {
-  getAuthedUserContextFromPrivyToken,
+  getAuthedUserContextFromPrivyTokenBundle,
   sendSponsoredEvmTransaction,
 } from '@babylon/api';
 import {
@@ -145,9 +145,12 @@ export async function mintNftAction(input?: {
   }
 
   // Step 2: User context
-  let ctx: Awaited<ReturnType<typeof getAuthedUserContextFromPrivyToken>>;
+  let ctx: Awaited<ReturnType<typeof getAuthedUserContextFromPrivyTokenBundle>>;
   try {
-    ctx = await getAuthedUserContextFromPrivyToken(privyToken);
+    ctx = await getAuthedUserContextFromPrivyTokenBundle({
+      primary: privyToken,
+      fallback: fallbackPrivyToken,
+    });
   } catch (e) {
     const step: MintStep = 'user_context';
     const errorId = crypto.randomUUID();

--- a/apps/web/src/hooks/useNftMint.ts
+++ b/apps/web/src/hooks/useNftMint.ts
@@ -147,15 +147,28 @@ export function useNftMint(): UseNftMintResult {
     setFlowState('preparing');
     setError(null);
 
-    setFlowState('minting');
-
     try {
-      // `getAccessToken()` refreshes Privy's session, but the app can still work without
-      // an explicit token when HttpOnly cookies are enabled (server action reads cookie).
-      const userJwt = await getAccessToken().catch(() => null);
-      const result = userJwt
-        ? await mintNftAction({ userJwt })
-        : await mintNftAction();
+      setFlowState('minting');
+
+      // Per Privy cookie best practices, always refresh the session before
+      // triggering a privileged server-side action.
+      //
+      // This avoids relying on a potentially-missing/stale `privy-token` cookie
+      // on the first request after the user returns to the app.
+      let userJwt: string | null;
+      try {
+        userJwt = await getAccessToken();
+      } catch {
+        userJwt = null;
+      }
+      if (!userJwt) {
+        handleError(
+          'Your session has expired. Please sign in again and try minting.'
+        );
+        return;
+      }
+
+      const result = await mintNftAction({ userJwt });
 
       if (result.status === 'error') {
         console.error('[NFT Mint Error]', {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -225,8 +225,8 @@ export {
 export * from './services';
 export {
   type AuthedPrivyUserContext,
-  getAuthedUserContextFromPrivyTokenBundle,
   getAuthedUserContextFromPrivyToken,
+  getAuthedUserContextFromPrivyTokenBundle,
 } from './services/privy/authed-user';
 export { sendSponsoredEvmTransaction } from './services/privy/evm-send-transaction';
 // Privy (embedded wallet server-side helpers)

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -225,6 +225,7 @@ export {
 export * from './services';
 export {
   type AuthedPrivyUserContext,
+  getAuthedUserContextFromPrivyTokenBundle,
   getAuthedUserContextFromPrivyToken,
 } from './services/privy/authed-user';
 export { sendSponsoredEvmTransaction } from './services/privy/evm-send-transaction';

--- a/packages/api/src/services/privy/__tests__/authed-user.test.ts
+++ b/packages/api/src/services/privy/__tests__/authed-user.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+import { AuthenticationError } from '../../../errors';
+
+function base64url(obj: Record<string, unknown>): string {
+  return Buffer.from(JSON.stringify(obj)).toString('base64url');
+}
+
+/** Creates a minimal unsigned JWT string (header.payload.signature). */
+function buildJwt(payload: Record<string, unknown>): string {
+  const header = { alg: 'RS256', typ: 'JWT' };
+  return `${base64url(header)}.${base64url(payload)}.fake-signature`;
+}
+
+const NOW_SECONDS = Math.floor(Date.now() / 1000);
+
+const basePayload = {
+  aud: 'test-app-id',
+  iss: 'privy.io',
+  iat: NOW_SECONDS - 60,
+  exp: NOW_SECONDS + 3600,
+};
+
+const mockVerifyAuthToken = mock();
+const mockDbLimit = mock();
+
+mock.module('@babylon/shared', () => ({
+  CHAIN: { id: 1 },
+  logger: {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  },
+}));
+
+mock.module('../privy-node', () => ({
+  getPrivyNodeClient: () => ({
+    wallets: () => ({
+      ethereum: () => ({
+        sendTransaction: mock(() => Promise.resolve({ hash: '0xabc', caip2: 'eip155:1' })),
+      }),
+    }),
+  }),
+}));
+
+mock.module('../../../auth-middleware', () => ({
+  getPrivyClient: () => ({
+    verifyAuthToken: mockVerifyAuthToken,
+  }),
+}));
+
+mock.module('@babylon/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: mockDbLimit,
+        }),
+      }),
+    }),
+  },
+  eq: () => ({}),
+  users: {
+    id: 'id',
+    privyId: 'privyId',
+    privyWalletId: 'privyWalletId',
+    walletAddress: 'walletAddress',
+    isAdmin: 'isAdmin',
+  },
+}));
+
+// Dynamic import after mocks are set up.
+const {
+  getAuthedUserContextFromPrivyToken,
+  getAuthedUserContextFromPrivyTokenBundle,
+} = await import('../authed-user');
+
+describe('getAuthedUserContextFromPrivyTokenBundle', () => {
+  beforeEach(() => {
+    mockVerifyAuthToken.mockReset();
+    mockDbLimit.mockReset();
+  });
+
+  it('returns user context using the primary token', async () => {
+    mockVerifyAuthToken.mockResolvedValue({ userId: 'did:privy:primary' });
+    mockDbLimit.mockResolvedValue([
+      {
+        id: '1',
+        privyWalletId: 'wallet_1',
+        walletAddress: '0xabc',
+        isAdmin: false,
+      },
+    ]);
+
+    const primary = buildJwt({ ...basePayload, sub: 'did:privy:primary' });
+    const fallback = buildJwt({ ...basePayload, sub: 'did:privy:primary' });
+
+    const ctx = await getAuthedUserContextFromPrivyTokenBundle({
+      primary,
+      fallback,
+    });
+
+    expect(ctx.privyId).toBe('did:privy:primary');
+    expect(mockVerifyAuthToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries with fallback token when primary token is rejected as invalid/expired (same user)', async () => {
+    mockVerifyAuthToken
+      .mockRejectedValueOnce(
+        new Error('400 {"error":"Invalid JWT token provided","code":"invalid_data"}')
+      )
+      .mockResolvedValueOnce({ userId: 'did:privy:user' });
+    mockDbLimit.mockResolvedValue([
+      {
+        id: '1',
+        privyWalletId: 'wallet_1',
+        walletAddress: '0xabc',
+        isAdmin: false,
+      },
+    ]);
+
+    // Ensure tokens are different strings so the bundle path is exercised.
+    const primary = buildJwt({ ...basePayload, sub: 'did:privy:user', sid: 'p' });
+    const fallback = buildJwt({ ...basePayload, sub: 'did:privy:user', sid: 'f' });
+
+    const { safeDecodeJwtPayload } = await import('../evm-send-transaction');
+    expect(safeDecodeJwtPayload(primary)?.sub).toBe('did:privy:user');
+    expect(safeDecodeJwtPayload(fallback)?.sub).toBe('did:privy:user');
+
+    const ctx = await getAuthedUserContextFromPrivyTokenBundle({
+      primary,
+      fallback,
+    });
+
+    expect(ctx.privyId).toBe('did:privy:user');
+    expect(mockVerifyAuthToken).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry with fallback token when token subjects do not match', async () => {
+    mockVerifyAuthToken.mockRejectedValueOnce(
+      new Error('400 {"error":"Invalid JWT token provided","code":"invalid_data"}')
+    );
+
+    const primary = buildJwt({ ...basePayload, sub: 'did:privy:userA' });
+    const fallback = buildJwt({ ...basePayload, sub: 'did:privy:userB' });
+
+    await expect(
+      getAuthedUserContextFromPrivyTokenBundle({
+        primary,
+        fallback,
+      })
+    ).rejects.toThrow('Invalid JWT token provided');
+    expect(mockVerifyAuthToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry with fallback token for non-token errors', async () => {
+    mockVerifyAuthToken.mockRejectedValueOnce(new Error('network down'));
+
+    const primary = buildJwt({ ...basePayload, sub: 'did:privy:user' });
+    const fallback = buildJwt({ ...basePayload, sub: 'did:privy:user' });
+
+    await expect(
+      getAuthedUserContextFromPrivyTokenBundle({
+        primary,
+        fallback,
+      })
+    ).rejects.toThrow('network down');
+    expect(mockVerifyAuthToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws AuthenticationError when token missing (original function behavior)', async () => {
+    await expect(getAuthedUserContextFromPrivyToken('')).rejects.toBeInstanceOf(
+      AuthenticationError
+    );
+  });
+});

--- a/packages/api/src/services/privy/__tests__/authed-user.test.ts
+++ b/packages/api/src/services/privy/__tests__/authed-user.test.ts
@@ -38,7 +38,9 @@ mock.module('../privy-node', () => ({
   getPrivyNodeClient: () => ({
     wallets: () => ({
       ethereum: () => ({
-        sendTransaction: mock(() => Promise.resolve({ hash: '0xabc', caip2: 'eip155:1' })),
+        sendTransaction: mock(() =>
+          Promise.resolve({ hash: '0xabc', caip2: 'eip155:1' })
+        ),
       }),
     }),
   }),
@@ -108,7 +110,9 @@ describe('getAuthedUserContextFromPrivyTokenBundle', () => {
   it('retries with fallback token when primary token is rejected as invalid/expired (same user)', async () => {
     mockVerifyAuthToken
       .mockRejectedValueOnce(
-        new Error('400 {"error":"Invalid JWT token provided","code":"invalid_data"}')
+        new Error(
+          '400 {"error":"Invalid JWT token provided","code":"invalid_data"}'
+        )
       )
       .mockResolvedValueOnce({ userId: 'did:privy:user' });
     mockDbLimit.mockResolvedValue([
@@ -121,8 +125,16 @@ describe('getAuthedUserContextFromPrivyTokenBundle', () => {
     ]);
 
     // Ensure tokens are different strings so the bundle path is exercised.
-    const primary = buildJwt({ ...basePayload, sub: 'did:privy:user', sid: 'p' });
-    const fallback = buildJwt({ ...basePayload, sub: 'did:privy:user', sid: 'f' });
+    const primary = buildJwt({
+      ...basePayload,
+      sub: 'did:privy:user',
+      sid: 'p',
+    });
+    const fallback = buildJwt({
+      ...basePayload,
+      sub: 'did:privy:user',
+      sid: 'f',
+    });
 
     const { safeDecodeJwtPayload } = await import('../evm-send-transaction');
     expect(safeDecodeJwtPayload(primary)?.sub).toBe('did:privy:user');
@@ -139,7 +151,9 @@ describe('getAuthedUserContextFromPrivyTokenBundle', () => {
 
   it('does not retry with fallback token when token subjects do not match', async () => {
     mockVerifyAuthToken.mockRejectedValueOnce(
-      new Error('400 {"error":"Invalid JWT token provided","code":"invalid_data"}')
+      new Error(
+        '400 {"error":"Invalid JWT token provided","code":"invalid_data"}'
+      )
     );
 
     const primary = buildJwt({ ...basePayload, sub: 'did:privy:userA' });

--- a/packages/api/src/services/privy/authed-user.ts
+++ b/packages/api/src/services/privy/authed-user.ts
@@ -1,6 +1,7 @@
 import { db, eq, users } from '@babylon/db';
 import { getPrivyClient } from '../../auth-middleware';
 import { AuthenticationError } from '../../errors';
+import { safeDecodeJwtPayload } from './evm-send-transaction';
 
 export type AuthedPrivyUserContext = {
   privyId: string;
@@ -9,6 +10,23 @@ export type AuthedPrivyUserContext = {
   walletAddress: string | null;
   isAdmin: boolean;
 };
+
+type PrivyTokenBundle = {
+  primary: string;
+  fallback?: string;
+};
+
+function isInvalidPrivyAuthTokenError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const msg = error.message.toLowerCase();
+  // Keep this conservative: only retry on token-shaped failures.
+  return (
+    msg.includes('invalid jwt token provided') ||
+    msg.includes('jwt expired') ||
+    msg.includes('token expired') ||
+    msg.includes('expired')
+  );
+}
 
 export async function getAuthedUserContextFromPrivyToken(
   privyToken: string
@@ -45,4 +63,36 @@ export async function getAuthedUserContextFromPrivyToken(
     walletAddress: dbUser.walletAddress,
     isAdmin: dbUser.isAdmin ?? false,
   };
+}
+
+/**
+ * Like `getAuthedUserContextFromPrivyToken`, but retries once with a fallback token
+ * if the primary token is rejected as invalid/expired.
+ */
+export async function getAuthedUserContextFromPrivyTokenBundle({
+  primary,
+  fallback,
+}: PrivyTokenBundle): Promise<AuthedPrivyUserContext> {
+  if (fallback && fallback.trim() === primary.trim()) {
+    return getAuthedUserContextFromPrivyToken(primary);
+  }
+
+  const primarySub = safeDecodeJwtPayload(primary)?.sub ?? null;
+  const fallbackSub = fallback
+    ? (safeDecodeJwtPayload(fallback)?.sub ?? null)
+    : null;
+  const canFallback =
+    Boolean(fallback) &&
+    Boolean(primarySub) &&
+    Boolean(fallbackSub) &&
+    primarySub === fallbackSub;
+
+  try {
+    return await getAuthedUserContextFromPrivyToken(primary);
+  } catch (error) {
+    if (canFallback && fallback && isInvalidPrivyAuthTokenError(error)) {
+      return getAuthedUserContextFromPrivyToken(fallback);
+    }
+    throw error;
+  }
 }

--- a/pr-1049-changelog.md
+++ b/pr-1049-changelog.md
@@ -1,0 +1,8 @@
+**PR:** https://github.com/BabylonSocial/babylon/pull/1049
+
+### NFT Mint: Privy Session Refresh + Safe Token Fallback
+- Refresh Privy session (`getAccessToken()`) before triggering the mint server action to avoid missing/expired `privy-token` cookie on first request after a user returns.
+- Resolve mint user-context from a token bundle (primary + fallback) and retry once on token-shaped failures.
+- Guard fallback by requiring both tokens decode to the same `sub` (prevents cross-user token mixups).
+- Adds unit tests for the new token-bundle user-context resolver.
+


### PR DESCRIPTION
## Summary
- Make NFT mint proactively refresh the Privy session via `getAccessToken()` before calling the mint server action, to avoid missing/expired `privy-token` cookie on first request after a user returns.
- Harden server-side mint auth by resolving user context from a token bundle (primary + fallback) and retrying once on token-shaped failures, with a strict same-user check.
- Add unit tests for the new token-bundle user-context resolver.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- User reports: "Your session has expired. Please sign in again and try minting."
- Privy cookies docs: `docs/vendors/privy/recipes/react/cookies.md`

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- `apps/web/src/hooks/useNftMint.ts`: require a fresh access token (and thus a client-side session refresh) before triggering `mintNftAction`.
- `packages/api/src/services/privy/authed-user.ts`: add `getAuthedUserContextFromPrivyTokenBundle` with conservative fallback retry and same-subject guard.
- `apps/web/src/app/_actions/nft.ts`: use the token-bundle resolver for the `user_context` step.
- `packages/api/src/services/privy/__tests__/authed-user.test.ts`: unit tests for bundle behavior.

## Review guide
**Start here**
- `apps/web/src/hooks/useNftMint.ts`
- `packages/api/src/services/privy/authed-user.ts`
- `apps/web/src/app/_actions/nft.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- Fallback is only attempted when both tokens decode to the same `sub` (prevents cross-user fallback).

## Test plan
**Commands run**
- [ ] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Additional tests**
- `bun test packages/api/src/services/privy/__tests__/authed-user.test.ts packages/api/src/services/privy/__tests__/evm-send-transaction.test.ts`

**Manual verification**
1. Login and open the NFT mint UI.
2. Mint should refresh session and proceed without hitting the generic "session expired" error when the user is otherwise authenticated.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `-`
- Changed: `-`
- Removed: `-`

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option B: No visual changes
- Reason: Behavior-only auth/session handling change (no UI/visual changes).

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
