### PR TITLE
fix: unify NFT chain config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -543,7 +543,8 @@ LINEAR_GAME_FEEDBACK_LABEL_ID=
 # Contract address for the Top 100 NFT collection (required for minting to work)
 # Must be a valid Ethereum address. Minting is disabled if not set.
 NFT_CONTRACT_ADDRESS=
-# Chain ID where the NFT contract is deployed (defaults to 1 = Ethereum mainnet)
+# NFT chain ID is derived from `NEXT_PUBLIC_CHAIN_ID`/`CHAIN_ID` (single-chain per environment).
+# `NFT_CHAIN_ID` is kept for backwards compatibility; if set, it must match the configured chain id.
 NFT_CHAIN_ID=1
 # Envio hosted GraphQL endpoint for on-chain NFT ownership checks (required for on-chain gating / secondary transfers).
 # Example: https://indexer.dev.hyperindex.xyz/<project>/v1/graphql

--- a/README.md
+++ b/README.md
@@ -200,7 +200,8 @@ forge script script/DeployProtoMonkeysNFT.s.sol:DeployProtoMonkeysNFTLocal \
 
 # 3. Set the deployed address in .env
 NFT_CONTRACT_ADDRESS=<deployed_address>
-NFT_CHAIN_ID=31337
+NEXT_PUBLIC_CHAIN_ID=31337
+NFT_CHAIN_ID=31337 # (legacy, optional) must match NEXT_PUBLIC_CHAIN_ID/CHAIN_ID
 NFT_SIGNER_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
 # 4. Seed NFT collection and snapshots
@@ -213,7 +214,8 @@ bun run scripts/seed-nft-snapshot-local.ts
 ```bash
 # NFT Contract Configuration
 NFT_CONTRACT_ADDRESS=0x...          # Set after deployment
-NFT_CHAIN_ID=1                      # 1 = Mainnet, 11155111 = Sepolia, 31337 = Local
+NEXT_PUBLIC_CHAIN_ID=1              # 1 = Mainnet, 11155111 = Sepolia, 31337 = Local
+NFT_CHAIN_ID=1                      # (legacy, optional) must match NEXT_PUBLIC_CHAIN_ID/CHAIN_ID
 NFT_SIGNER_PRIVATE_KEY=0x...        # Backend signer private key (NEVER COMMIT)
 NFT_SIGNER_ADDRESS=0x...            # Public address of signer
 NFT_BASE_URI=https://babylon.market/api/nft/metadata/
@@ -236,7 +238,8 @@ forge script script/DeployProtoMonkeysNFT.s.sol:DeployProtoMonkeysNFT \
 
 # Update environment
 NFT_CONTRACT_ADDRESS=<deployed_address>
-NFT_CHAIN_ID=11155111
+NEXT_PUBLIC_CHAIN_ID=11155111
+NFT_CHAIN_ID=11155111 # (legacy, optional) must match NEXT_PUBLIC_CHAIN_ID/CHAIN_ID
 ```
 
 ### Ethereum Mainnet
@@ -251,7 +254,8 @@ forge script script/DeployProtoMonkeysNFT.s.sol:DeployProtoMonkeysNFT \
 
 # Update environment
 NFT_CONTRACT_ADDRESS=<deployed_address>
-NFT_CHAIN_ID=1
+NEXT_PUBLIC_CHAIN_ID=1
+NFT_CHAIN_ID=1 # (legacy, optional) must match NEXT_PUBLIC_CHAIN_ID/CHAIN_ID
 ```
 
 ### Post-Deployment Setup

--- a/packages/api/src/services/nft-indexer-service.ts
+++ b/packages/api/src/services/nft-indexer-service.ts
@@ -1,5 +1,6 @@
 import { db, eq, inArray, nftOwnership, users } from '@babylon/db';
 import { ValidationError } from '@babylon/shared';
+import { getNftChainId } from './nft/nft-chain';
 
 type JsonPrimitive = string | number | boolean | null;
 type JsonValue = JsonPrimitive | JsonObject | JsonValue[];
@@ -28,25 +29,9 @@ function getNftIndexerGraphqlUrl(): string | null {
 }
 
 export function getNftCollectionIdFromEnv(): string {
-  const chainIdRaw = process.env.NFT_CHAIN_ID?.trim();
   const contractAddressRaw = process.env.NFT_CONTRACT_ADDRESS?.trim();
 
-  if (!chainIdRaw) {
-    throw new ValidationError(
-      'NFT_CHAIN_ID not configured',
-      ['NFT_CHAIN_ID'],
-      [{ field: 'NFT_CHAIN_ID', message: 'Must be set' }]
-    );
-  }
-
-  const chainId = Number.parseInt(chainIdRaw, 10);
-  if (!Number.isFinite(chainId) || chainId <= 0) {
-    throw new ValidationError(
-      'NFT_CHAIN_ID is invalid',
-      ['NFT_CHAIN_ID'],
-      [{ field: 'NFT_CHAIN_ID', message: 'Must be a positive integer' }]
-    );
-  }
+  const chainId = getNftChainId();
 
   if (!contractAddressRaw) {
     throw new ValidationError(

--- a/packages/api/src/services/nft-mint-service.ts
+++ b/packages/api/src/services/nft-mint-service.ts
@@ -41,11 +41,11 @@ import {
 } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 import { getPrivyClient } from '../auth-middleware';
+import { getNftChainId } from './nft/nft-chain';
 import {
   type PrivyUserWalletsLite,
   pickEmbeddedEvmWallet,
 } from './privy/user-wallets';
-import { getNftChainId } from './nft/nft-chain';
 
 // ============================================================================
 // Types

--- a/packages/api/src/services/nft-mint-service.ts
+++ b/packages/api/src/services/nft-mint-service.ts
@@ -45,6 +45,7 @@ import {
   type PrivyUserWalletsLite,
   pickEmbeddedEvmWallet,
 } from './privy/user-wallets';
+import { getNftChainId } from './nft/nft-chain';
 
 // ============================================================================
 // Types
@@ -177,9 +178,7 @@ function getPublicClient(chainId: number) {
 
 function getConfig() {
   const contractAddress = process.env.NFT_CONTRACT_ADDRESS as Hex | undefined;
-  const chainId = process.env.NFT_CHAIN_ID
-    ? parseInt(process.env.NFT_CHAIN_ID, 10)
-    : undefined;
+  const chainId = getNftChainId();
   const signerPrivateKey = process.env.NFT_SIGNER_PRIVATE_KEY as
     | Hex
     | undefined;
@@ -202,11 +201,17 @@ function validateConfig(): {
     );
   }
 
-  if (!chainId || Number.isNaN(chainId)) {
+  if (!Number.isFinite(chainId) || chainId <= 0) {
     throw new ValidationError(
       'NFT chain not configured',
       ['chainId'],
-      [{ field: 'chainId', message: 'NFT_CHAIN_ID not set' }]
+      [
+        {
+          field: 'chainId',
+          message:
+            'Chain ID not configured. Set NEXT_PUBLIC_CHAIN_ID (or CHAIN_ID) to the chain where the NFT contract is deployed.',
+        },
+      ]
     );
   }
 

--- a/packages/api/src/services/nft/__tests__/nft-chain.test.ts
+++ b/packages/api/src/services/nft/__tests__/nft-chain.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test';
+import { CHAIN_ID } from '@babylon/shared';
+
+async function withEnv<T>(
+  env: Record<string, string | undefined>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const prev: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(env)) {
+    prev[k] = process.env[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const [k, v] of Object.entries(prev)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+describe('getNftChainId', () => {
+  test('uses CHAIN_ID when NFT_CHAIN_ID is unset', async () => {
+    const value = await withEnv(
+      { NFT_CHAIN_ID: undefined },
+      async () => {
+        const mod = await import(`../nft-chain.ts?t=${Date.now()}`);
+        return mod.getNftChainId();
+      },
+    );
+
+    expect(value).toBe(CHAIN_ID);
+  });
+
+  test('throws if legacy NFT_CHAIN_ID mismatches configured CHAIN_ID', async () => {
+    const mismatched = CHAIN_ID === 1 ? 11155111 : 1;
+    await expect(
+      withEnv({ NFT_CHAIN_ID: String(mismatched) }, async () => {
+        const mod = await import(`../nft-chain.ts?t=${Date.now()}`);
+        return mod.getNftChainId();
+      }),
+    ).rejects.toThrow('NFT_CHAIN_ID must match');
+  });
+});

--- a/packages/api/src/services/nft/__tests__/nft-chain.test.ts
+++ b/packages/api/src/services/nft/__tests__/nft-chain.test.ts
@@ -3,7 +3,7 @@ import { CHAIN_ID } from '@babylon/shared';
 
 async function withEnv<T>(
   env: Record<string, string | undefined>,
-  fn: () => Promise<T>,
+  fn: () => Promise<T>
 ): Promise<T> {
   const prev: Record<string, string | undefined> = {};
   for (const [k, v] of Object.entries(env)) {
@@ -23,13 +23,10 @@ async function withEnv<T>(
 
 describe('getNftChainId', () => {
   test('uses CHAIN_ID when NFT_CHAIN_ID is unset', async () => {
-    const value = await withEnv(
-      { NFT_CHAIN_ID: undefined },
-      async () => {
-        const mod = await import(`../nft-chain.ts?t=${Date.now()}`);
-        return mod.getNftChainId();
-      },
-    );
+    const value = await withEnv({ NFT_CHAIN_ID: undefined }, async () => {
+      const mod = await import(`../nft-chain.ts?t=${Date.now()}`);
+      return mod.getNftChainId();
+    });
 
     expect(value).toBe(CHAIN_ID);
   });
@@ -40,7 +37,7 @@ describe('getNftChainId', () => {
       withEnv({ NFT_CHAIN_ID: String(mismatched) }, async () => {
         const mod = await import(`../nft-chain.ts?t=${Date.now()}`);
         return mod.getNftChainId();
-      }),
+      })
     ).rejects.toThrow('NFT_CHAIN_ID must match');
   });
 });

--- a/packages/api/src/services/nft/nft-chain.ts
+++ b/packages/api/src/services/nft/nft-chain.ts
@@ -1,0 +1,46 @@
+import { CHAIN_ID, ValidationError } from '@babylon/shared';
+
+function parsePositiveInt(value: string): number | null {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return parsed;
+}
+
+/**
+ * Babylon runs the NFT flow on a single chain per environment.
+ *
+ * Source of truth: `NEXT_PUBLIC_CHAIN_ID` (or `CHAIN_ID` on the server).
+ *
+ * `NFT_CHAIN_ID` is treated as a legacy env var:
+ * - if set, it must parse as a positive integer
+ * - and it must match `CHAIN_ID` to prevent hard-to-debug chain drift
+ */
+export function getNftChainId(): number {
+  const legacyRaw = process.env.NFT_CHAIN_ID?.trim();
+  if (!legacyRaw) return CHAIN_ID;
+
+  const legacyParsed = parsePositiveInt(legacyRaw);
+  if (!legacyParsed) {
+    throw new ValidationError(
+      'NFT_CHAIN_ID is invalid',
+      ['NFT_CHAIN_ID'],
+      [{ field: 'NFT_CHAIN_ID', message: 'Must be a positive integer' }]
+    );
+  }
+
+  if (legacyParsed !== CHAIN_ID) {
+    throw new ValidationError(
+      'NFT_CHAIN_ID must match NEXT_PUBLIC_CHAIN_ID/CHAIN_ID',
+      ['NFT_CHAIN_ID', 'NEXT_PUBLIC_CHAIN_ID', 'CHAIN_ID'],
+      [
+        {
+          field: 'NFT_CHAIN_ID',
+          message: `Expected ${CHAIN_ID} but got ${legacyParsed}`,
+        },
+      ]
+    );
+  }
+
+  return CHAIN_ID;
+}
+

--- a/packages/api/src/services/nft/nft-chain.ts
+++ b/packages/api/src/services/nft/nft-chain.ts
@@ -43,4 +43,3 @@ export function getNftChainId(): number {
 
   return CHAIN_ID;
 }
-

--- a/packages/testing/integration/nft-mint.integration.test.ts
+++ b/packages/testing/integration/nft-mint.integration.test.ts
@@ -124,6 +124,13 @@ async function createSnapshotEntry(
 }
 
 async function createTestNftCollection(): Promise<void> {
+  const envChainId =
+    process.env.NEXT_PUBLIC_CHAIN_ID ||
+    process.env.CHAIN_ID ||
+    process.env.NFT_CHAIN_ID ||
+    '31337';
+  const chainId = parseInt(envChainId, 10);
+
   // Create 100 test NFTs
   for (let tokenId = 1; tokenId <= 100; tokenId++) {
     const id = nanoid();
@@ -137,7 +144,7 @@ async function createTestNftCollection(): Promise<void> {
       contractAddress:
         process.env.NFT_CONTRACT_ADDRESS ??
         '0x0000000000000000000000000000000000000000',
-      chainId: parseInt(process.env.NFT_CHAIN_ID ?? '31337', 10),
+      chainId,
       updatedAt: new Date(),
     });
     testCollectionIds.push(id);

--- a/scripts/seed-nft-collection.ts
+++ b/scripts/seed-nft-collection.ts
@@ -34,8 +34,10 @@ const TOTAL_NFTS = 100;
 const NFT_CONTRACT_ADDRESS =
   process.env.NFT_CONTRACT_ADDRESS ??
   '0x0000000000000000000000000000000000000000';
-const NFT_CHAIN_ID = process.env.NFT_CHAIN_ID
-  ? parseInt(process.env.NFT_CHAIN_ID, 10)
+const configuredChainIdRaw =
+  process.env.NEXT_PUBLIC_CHAIN_ID || process.env.CHAIN_ID || process.env.NFT_CHAIN_ID;
+const NFT_CHAIN_ID = configuredChainIdRaw
+  ? parseInt(configuredChainIdRaw, 10)
   : 31337; // Default to local Hardhat
 
 /** IPFS CID for NFT metadata (contains {tokenId}.json files, required) */

--- a/scripts/seed-nft-collection.ts
+++ b/scripts/seed-nft-collection.ts
@@ -35,7 +35,9 @@ const NFT_CONTRACT_ADDRESS =
   process.env.NFT_CONTRACT_ADDRESS ??
   '0x0000000000000000000000000000000000000000';
 const configuredChainIdRaw =
-  process.env.NEXT_PUBLIC_CHAIN_ID || process.env.CHAIN_ID || process.env.NFT_CHAIN_ID;
+  process.env.NEXT_PUBLIC_CHAIN_ID ||
+  process.env.CHAIN_ID ||
+  process.env.NFT_CHAIN_ID;
 const NFT_CHAIN_ID = configuredChainIdRaw
   ? parseInt(configuredChainIdRaw, 10)
   : 31337; // Default to local Hardhat

--- a/scripts/wait-for-hardhat-and-deploy.ts
+++ b/scripts/wait-for-hardhat-and-deploy.ts
@@ -210,6 +210,7 @@ async function deployNftContract(): Promise<void> {
     updateEnvFile(envPath, {
       NFT_CONTRACT_ADDRESS: nftContractAddress,
       NFT_CHAIN_ID: '31337',
+      NEXT_PUBLIC_CHAIN_ID: '31337',
       NFT_SIGNER_PRIVATE_KEY: HARDHAT_ACCOUNT_0_PRIVATE_KEY,
       NFT_SIGNER_ADDRESS: HARDHAT_ACCOUNT_0,
       NFT_BASE_URI: 'http://localhost:3000/api/nft/metadata/',
@@ -218,6 +219,7 @@ async function deployNftContract(): Promise<void> {
     // Set environment variables for current process
     process.env.NFT_CONTRACT_ADDRESS = nftContractAddress;
     process.env.NFT_CHAIN_ID = '31337';
+    process.env.NEXT_PUBLIC_CHAIN_ID = '31337';
     process.env.NFT_SIGNER_PRIVATE_KEY = HARDHAT_ACCOUNT_0_PRIVATE_KEY;
     process.env.NFT_SIGNER_ADDRESS = HARDHAT_ACCOUNT_0;
     process.env.NFT_BASE_URI = 'http://localhost:3000/api/nft/metadata/';
@@ -268,6 +270,7 @@ async function seedNftData(contractAddress: string): Promise<void> {
       ...process.env,
       NFT_CONTRACT_ADDRESS: contractAddress,
       NFT_CHAIN_ID: '31337',
+      NEXT_PUBLIC_CHAIN_ID: '31337',
     };
 
     // Run the NFT collection seeder


### PR DESCRIPTION
## Summary

- Unify NFT chain selection to the single per-environment chain (`NEXT_PUBLIC_CHAIN_ID` / `CHAIN_ID`).
- Treat `NFT_CHAIN_ID` as a legacy env var: if set, it must match the configured chain id to prevent chain drift.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Goal: one chain per environment (staging/local = Sepolia, prod = mainnet), defined once via `NEXT_PUBLIC_CHAIN_ID`.

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [x] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: scripts/docs

## Changes

- Add `packages/api/src/services/nft/nft-chain.ts` with `getNftChainId()`.
- `packages/api/src/services/nft-mint-service.ts`: derive NFT chain id via `getNftChainId()`.
- `packages/api/src/services/nft-indexer-service.ts`: derive collection id chain id via `getNftChainId()`.
- `scripts/wait-for-hardhat-and-deploy.ts`: ensure `NEXT_PUBLIC_CHAIN_ID=31337` is set alongside legacy `NFT_CHAIN_ID` in local deploy flow.
- `scripts/seed-nft-collection.ts`: read chain id from `NEXT_PUBLIC_CHAIN_ID`/`CHAIN_ID` first, then legacy `NFT_CHAIN_ID`.
- Docs: clarify legacy status for `NFT_CHAIN_ID` in `.env.example` and `README.md`.

## Review guide

**Start here**
- `packages/api/src/services/nft/nft-chain.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- This intentionally keeps `NFT_CHAIN_ID` working, but prevents mismatches.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [ ] `bun run test` (unit + integration)

**Manual verification**
1. `bun test packages/api/src/services/nft/__tests__/nft-chain.test.ts`

## Ops / Migration / Deployment

- [ ] No deploy impact
- [x] Requires env var updates (listed below + `.env.example` updated)

**Env vars (added/changed/removed)**
- Added: none
- Changed: `NFT_CHAIN_ID` is now legacy/optional and must match `NEXT_PUBLIC_CHAIN_ID`/`CHAIN_ID` if present.
- Removed: none

**Rollout / rollback plan**
- Rollout: Ensure `NEXT_PUBLIC_CHAIN_ID` is correctly set per environment.
- Rollback: revert PR.

## Breaking changes

- [ ] None
- [x] Yes (describe + migration guide below)

**Migration guide**
- Set `NEXT_PUBLIC_CHAIN_ID` (or `CHAIN_ID` on server-only contexts) to the chain where the NFT contract is deployed.
- If `NFT_CHAIN_ID` is still set, make sure it matches (or remove it).

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: backend config + scripts + docs only.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
