### PR TITLE
fix: sidebar user bar visibility and mobile NFT banner spacing

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -137,7 +137,7 @@ export default async function RootLayout({
                 </Suspense>
 
                 {/* Main Content Area - Scrollable content with pull-to-refresh */}
-                <main className="min-h-screen min-w-0 flex-1 bg-background pt-14 pb-14 md:pt-0 md:pb-0">
+                <main className="min-h-screen min-w-0 flex-1 bg-background pb-14 md:pb-0">
                   {children}
                 </main>
 

--- a/apps/web/src/components/shared/Sidebar.tsx
+++ b/apps/web/src/components/shared/Sidebar.tsx
@@ -43,6 +43,7 @@ function SidebarContent() {
   const [showMdMenu, setShowMdMenu] = useState(false);
   const [copiedReferral, setCopiedReferral] = useState(false);
   const [unreadNotifications, setUnreadNotifications] = useState(0);
+  const asideRef = useRef<HTMLElement>(null);
   const mdMenuRef = useRef<HTMLDivElement>(null);
   const pathname = usePathname();
   const { ready, authenticated, user, logout, login } = useAuth();
@@ -111,6 +112,27 @@ function SidebarContent() {
     const interval = setInterval(fetchUnreadCount, 60000); // 60 seconds = 1 minute
     return () => clearInterval(interval);
   }, [authenticated, user]);
+
+  // Adjust sidebar height to account for elements above it (e.g. NFT banner)
+  // so the user profile bar at the bottom is always visible
+  useEffect(() => {
+    let rafId: number;
+    const updateHeight = () => {
+      rafId = requestAnimationFrame(() => {
+        if (!asideRef.current) return;
+        const top = Math.max(0, asideRef.current.getBoundingClientRect().top);
+        asideRef.current.style.height = `calc(100vh - ${top}px)`;
+      });
+    };
+    updateHeight();
+    window.addEventListener('scroll', updateHeight, { passive: true });
+    window.addEventListener('resize', updateHeight, { passive: true });
+    return () => {
+      cancelAnimationFrame(rafId);
+      window.removeEventListener('scroll', updateHeight);
+      window.removeEventListener('resize', updateHeight);
+    };
+  }, []);
 
   const copyReferralCode = async () => {
     if (!user?.referralCode) return;
@@ -197,6 +219,7 @@ function SidebarContent() {
     <>
       {/* Responsive sidebar: icons only on tablet (md), icons + names on desktop (lg+) */}
       <aside
+        ref={asideRef}
         className={cn(
           'sticky top-0 isolate z-40 hidden h-screen md:flex md:flex-col',
           'bg-sidebar',


### PR DESCRIPTION
## Summary
- **Desktop sidebar**: Dynamically adjust sidebar height to account for the NFT promo banner, so the user profile bar at the bottom is always visible without scrolling
- **Mobile**: Remove redundant `pt-14` on `<main>` that caused a 56px gap between the NFT banner and page content