### PR TITLE
[1/6] Privy Offline: Enforce server-side config guardrails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,10 +66,15 @@ POSTGRES_URL=
 # Get these from https://dashboard.privy.io
 NEXT_PUBLIC_PRIVY_APP_ID=your_privy_app_id_here
 PRIVY_APP_SECRET=your_privy_app_secret_here
-# Optional: base64-encoded PKCS8 P-256 private key (no PEM headers).
-# Needed only if you configure Privy controls that require app authorization signatures
-# for wallet actions (owners/signers/quorums/policies). Keep in a secret manager.
-# PRIVY_AUTHORIZATION_PRIVATE_KEY=
+# Optional explicit server app ID override. If unset, server falls back to NEXT_PUBLIC_PRIVY_APP_ID.
+# PRIVY_APP_ID=
+# Offline-first required: base64-encoded PKCS8 P-256 private key (no PEM headers).
+# Used by backend to sign delegated wallet requests via Privy authorization context.
+PRIVY_AUTHORIZATION_PRIVATE_KEY=
+# Offline-first required: key quorum ID configured as signer for delegated wallet actions.
+PRIVY_OFFLINE_SIGNER_ID=
+# Offline-first required: policy ID attached to the delegated signer.
+PRIVY_OFFLINE_POLICY_ID=
 # Buffer (in seconds) before JWT expiration at which wallet operations are rejected.
 # Prevents stale tokens from failing at Privy's API with cryptic 400 errors. Default: 30
 # PRIVY_JWT_EXPIRY_BUFFER_SECONDS=30

--- a/packages/api/src/services/privy/__tests__/evm-send-transaction.test.ts
+++ b/packages/api/src/services/privy/__tests__/evm-send-transaction.test.ts
@@ -200,7 +200,11 @@ describe('sendSponsoredEvmTransaction – JWT pre-flight checks', () => {
 
   beforeEach(() => {
     mockSendTransaction.mockClear();
-    delete process.env.PRIVY_APP_ID;
+    process.env.PRIVY_APP_ID = 'test-app-id';
+    process.env.PRIVY_APP_SECRET = 'test-secret';
+    process.env.PRIVY_AUTHORIZATION_PRIVATE_KEY = 'test-authorization-key';
+    process.env.PRIVY_OFFLINE_SIGNER_ID = 'test-offline-signer-id';
+    process.env.PRIVY_OFFLINE_POLICY_ID = 'test-offline-policy-id';
     delete process.env.NEXT_PUBLIC_PRIVY_APP_ID;
     delete process.env.PRIVY_JWT_EXPIRY_BUFFER_SECONDS;
   });
@@ -324,17 +328,21 @@ describe('sendSponsoredEvmTransaction – JWT pre-flight checks', () => {
     expect(mockSendTransaction).toHaveBeenCalled();
   });
 
-  it('skips audience check when PRIVY_APP_ID is not configured', async () => {
-    // Neither env var set → should skip audience validation
+  it('fails fast when offline configuration is incomplete', async () => {
+    delete process.env.PRIVY_APP_ID;
+    delete process.env.NEXT_PUBLIC_PRIVY_APP_ID;
+
     const token = buildJwt({ ...VALID_PAYLOAD, aud: 'any-audience' });
 
-    await sendSponsoredEvmTransaction({
-      userJwt: token,
-      walletId: 'wallet-1',
-      to: validAddress,
-    });
-
-    expect(mockSendTransaction).toHaveBeenCalled();
+    await expect(
+      sendSponsoredEvmTransaction({
+        userJwt: token,
+        walletId: 'wallet-1',
+        to: validAddress,
+      })
+    ).rejects.toThrow(
+      'Privy offline configuration is incomplete: missing PRIVY_APP_ID (or NEXT_PUBLIC_PRIVY_APP_ID)'
+    );
   });
 
   it('retries with a fallback token when Privy rejects the primary JWT at the wallet endpoint', async () => {

--- a/packages/api/src/services/privy/evm-send-transaction.ts
+++ b/packages/api/src/services/privy/evm-send-transaction.ts
@@ -3,6 +3,7 @@ import type { AuthorizationContext } from '@privy-io/node';
 import { decodeJwt, decodeProtectedHeader } from 'jose';
 import type { Address, Hex } from 'viem';
 import { z } from 'zod';
+import { getPrivyOfflineConfig } from './offline-config';
 import { getPrivyNodeClient } from './privy-node';
 
 export type SendSponsoredEvmTransactionInput = {
@@ -130,8 +131,8 @@ export async function sendSponsoredEvmTransaction({
     throw new Error('Missing Privy user JWT');
   }
 
-  const appId =
-    process.env.PRIVY_APP_ID ?? process.env.NEXT_PUBLIC_PRIVY_APP_ID;
+  const offlineConfig = getPrivyOfflineConfig();
+  const appId = offlineConfig.appId;
 
   // Pre-flight validate candidates (decode-only) so we can skip obviously-invalid tokens
   // without paying for a wallet API call.
@@ -238,21 +239,8 @@ export async function sendSponsoredEvmTransaction({
     'sendSponsoredEvmTransaction'
   );
 
-  if (!appId) {
-    logger.warn(
-      'PRIVY_APP_ID is not configured — skipping JWT audience validation. Set PRIVY_APP_ID or NEXT_PUBLIC_PRIVY_APP_ID to enable.',
-      {},
-      'sendSponsoredEvmTransaction'
-    );
-  }
-
   const privy = getPrivyNodeClient();
-
-  // Optional: If you configure Privy controls that require an authorization signature
-  // from an app authorization key (P-256), provide the private key via env var.
-  // This is a base64-encoded PKCS8 P-256 private key with no PEM headers.
-  const authorizationPrivateKey =
-    process.env.PRIVY_AUTHORIZATION_PRIVATE_KEY?.trim();
+  const authorizationPrivateKey = offlineConfig.authorizationPrivateKey;
 
   // VALUE FIELD HANDLING:
   // We omit the value field entirely for zero-value transactions rather than sending "0x0".
@@ -289,9 +277,7 @@ export async function sendSponsoredEvmTransaction({
     const { token } = candidate;
     const authorizationContext: AuthorizationContext = {
       user_jwts: [token],
-      ...(authorizationPrivateKey
-        ? { authorization_private_keys: [authorizationPrivateKey] }
-        : {}),
+      authorization_private_keys: [authorizationPrivateKey],
     };
 
     try {

--- a/packages/api/src/services/privy/offline-config.ts
+++ b/packages/api/src/services/privy/offline-config.ts
@@ -1,0 +1,59 @@
+export type PrivyOfflineConfig = {
+  appId: string;
+  appSecret: string;
+  authorizationPrivateKey: string;
+  offlineSignerId: string;
+  offlinePolicyId: string;
+};
+
+function getTrimmedEnv(name: string): string | undefined {
+  const value = process.env[name];
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function getPrivyAppId(): string | undefined {
+  return (
+    getTrimmedEnv('PRIVY_APP_ID') ?? getTrimmedEnv('NEXT_PUBLIC_PRIVY_APP_ID')
+  );
+}
+
+function formatMissingFields(missing: string[]): string {
+  return missing.join(', ');
+}
+
+export function getPrivyOfflineConfig(): PrivyOfflineConfig {
+  const appId = getPrivyAppId();
+  const appSecret = getTrimmedEnv('PRIVY_APP_SECRET');
+  const authorizationPrivateKey = getTrimmedEnv(
+    'PRIVY_AUTHORIZATION_PRIVATE_KEY'
+  );
+  const offlineSignerId = getTrimmedEnv('PRIVY_OFFLINE_SIGNER_ID');
+  const offlinePolicyId = getTrimmedEnv('PRIVY_OFFLINE_POLICY_ID');
+
+  const missing: string[] = [];
+  if (!appId) missing.push('PRIVY_APP_ID (or NEXT_PUBLIC_PRIVY_APP_ID)');
+  if (!appSecret) missing.push('PRIVY_APP_SECRET');
+  if (!authorizationPrivateKey) missing.push('PRIVY_AUTHORIZATION_PRIVATE_KEY');
+  if (!offlineSignerId) missing.push('PRIVY_OFFLINE_SIGNER_ID');
+  if (!offlinePolicyId) missing.push('PRIVY_OFFLINE_POLICY_ID');
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Privy offline configuration is incomplete: missing ${formatMissingFields(missing)}`
+    );
+  }
+
+  return {
+    appId: appId!,
+    appSecret: appSecret!,
+    authorizationPrivateKey: authorizationPrivateKey!,
+    offlineSignerId: offlineSignerId!,
+    offlinePolicyId: offlinePolicyId!,
+  };
+}
+
+export function assertPrivyOfflineConfig(): void {
+  getPrivyOfflineConfig();
+}

--- a/packages/api/src/services/privy/privy-node.ts
+++ b/packages/api/src/services/privy/privy-node.ts
@@ -1,17 +1,12 @@
 import { PrivyClient } from '@privy-io/node';
+import { getPrivyOfflineConfig } from './offline-config';
 
 let privyNodeClient: PrivyClient | null = null;
 
 export function getPrivyNodeClient(): PrivyClient {
   if (privyNodeClient) return privyNodeClient;
 
-  const appId =
-    process.env.PRIVY_APP_ID ?? process.env.NEXT_PUBLIC_PRIVY_APP_ID;
-  const appSecret = process.env.PRIVY_APP_SECRET;
-
-  if (!appId || !appSecret) {
-    throw new Error('Privy credentials not configured');
-  }
+  const { appId, appSecret } = getPrivyOfflineConfig();
 
   privyNodeClient = new PrivyClient({ appId, appSecret });
   return privyNodeClient;


### PR DESCRIPTION
## Summary

- Enforces strict Privy offline configuration requirements at runtime for server-side wallet transactions.
- Fails fast when required env vars are missing, with actionable error messages.
- Updates sender/client wiring and tests to align with offline delegated transaction prerequisites.

## Type

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [x] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Offline-first Privy transaction stack PR `1/6`.
- Base: `staging`
- Next PR in stack: `feat/offline-pr2-wallet-provisioning`

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- Added strict offline config resolver and validator for Privy server-side flow.
- Updated Privy node client initialization to require validated offline config.
- Updated sponsored tx sender to enforce offline auth key config availability.
- Updated unit tests for offline config expectations.
- Updated `.env.example` with required offline env vars.

## Review guide

**Start here**
- `packages/api/src/services/privy/offline-config.ts`
- `packages/api/src/services/privy/privy-node.ts`
- `packages/api/src/services/privy/evm-send-transaction.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- This PR is intentionally guardrail-only. It does not change onboarding/provisioning logic yet.
- Follow-up provisioning and flow migration happen in PRs `2/6+`.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Verified fail-fast behavior when required offline env vars are missing.
2. Ran targeted checks:
   - `bun run --cwd packages/api typecheck`
   - `bun test packages/api/src/services/privy/__tests__/evm-send-transaction.test.ts`

## Ops / Migration / Deployment

- [ ] No deploy impact
- [x] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `PRIVY_AUTHORIZATION_PRIVATE_KEY`, `PRIVY_OFFLINE_SIGNER_ID`, `PRIVY_OFFLINE_POLICY_ID`
- Changed: `PRIVY_APP_ID` now explicitly supported/required server-side for offline flow
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: Configure required env vars in each environment, deploy, verify startup + tx submission path.
- Rollback: Revert this PR or restore previous env-dependent behavior branch.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- N/A

## Security / privacy

- [ ] No security impact
- [x] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- No API contract changes.

### Database
- No DB changes.

### Contracts / on-chain
- No contract changes.

### Docs
- `.env.example` updated.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend-only configuration guardrails; no UI impact.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
