### PR TITLE
[2/6] Privy Offline: Provision embedded wallets and persist readiness

### DIFF
--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -143,8 +143,10 @@
 
 import {
   authenticate,
+  BusinessLogicError,
   ConflictError,
   cachedDb,
+  ensureOfflineWalletReady,
   getPrivyClient,
   InternalServerError,
   type PrivyUserWalletsLite,
@@ -165,23 +167,12 @@ type PrivyUserWithWallets = PrivyUser &
   PrivyUserWithEmails &
   PrivyUserWalletsLite;
 
-async function resolveEmbeddedWallet(privyId: string): Promise<{
-  privyWalletId: string | null;
-  embeddedWalletAddress: string | null;
-}> {
-  const privyClient = getPrivyClient();
-  const user = (await privyClient.getUser(privyId)) as PrivyUserWithWallets;
-  const embedded = pickEmbeddedEvmWallet(user);
-  return {
-    privyWalletId: embedded?.walletId ?? null,
-    embeddedWalletAddress: embedded?.address?.toLowerCase() ?? null,
-  };
-}
-
 const userSelectFields = {
   id: users.id,
   privyId: users.privyId,
   privyWalletId: users.privyWalletId,
+  offlineWalletReady: users.offlineWalletReady,
+  offlineWalletReadyAt: users.offlineWalletReadyAt,
   username: users.username,
   displayName: users.displayName,
   bio: users.bio,
@@ -225,6 +216,8 @@ type UserSelectResult = {
   id: string;
   privyId: string | null;
   privyWalletId: string | null;
+  offlineWalletReady: boolean;
+  offlineWalletReadyAt: Date | null;
   username: string | null;
   displayName: string | null;
   bio: string | null;
@@ -271,6 +264,9 @@ function buildUserResponse(
   return {
     id: dbUser.id,
     privyId: dbUser.privyId,
+    privyWalletId: dbUser.privyWalletId,
+    offlineWalletReady: dbUser.offlineWalletReady,
+    offlineWalletReadyAt: dbUser.offlineWalletReadyAt?.toISOString() ?? null,
     username: dbUser.username,
     displayName: dbUser.displayName,
     bio: dbUser.bio,
@@ -385,6 +381,12 @@ async function updateReferrerForIncompleteUser(
 
 export const GET = withErrorHandling(async (request: NextRequest) => {
   const authUser = await authenticate(request);
+  const cookieToken = request.cookies.get('privy-token')?.value;
+  const authHeader = request.headers.get('authorization');
+  const headerToken = authHeader?.startsWith('Bearer ')
+    ? authHeader.substring(7)
+    : undefined;
+  const userJwt = cookieToken ?? headerToken ?? null;
   const privyId = authUser.privyId ?? authUser.userId;
   const canonicalUserId = authUser.dbUserId ?? authUser.userId;
   const clientEmbeddedWalletAddressRaw = request.headers.get(
@@ -818,44 +820,55 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   //
   // =====================================================================================
   const dbWalletLower = dbUser.walletAddress?.toLowerCase() ?? null;
-  const shouldBackfillWallet = !dbWalletLower || !dbUser.privyWalletId;
   const shouldResyncWallet =
     !!clientEmbeddedWalletAddress &&
     clientEmbeddedWalletAddress !== dbWalletLower;
+  const shouldEnsureOfflineWallet =
+    !dbWalletLower ||
+    !dbUser.privyWalletId ||
+    !dbUser.offlineWalletReady ||
+    shouldResyncWallet;
 
-  if (shouldBackfillWallet || shouldResyncWallet) {
-    const { privyWalletId, embeddedWalletAddress } =
-      await resolveEmbeddedWallet(privyId);
-
-    const resolvedAddress = embeddedWalletAddress?.toLowerCase() ?? null;
-
-    if (shouldResyncWallet && resolvedAddress) {
-      if (resolvedAddress !== clientEmbeddedWalletAddress) {
-        logger.warn(
-          'Client embedded wallet address mismatch; using Privy embedded wallet address',
-          {
-            userId: dbUser.id,
-            dbWalletAddress: dbUser.walletAddress,
-            clientEmbeddedWalletAddress,
-            privyEmbeddedWalletAddress: resolvedAddress,
-          },
-          'GET /api/users/me'
-        );
-      }
+  if (shouldEnsureOfflineWallet) {
+    if (!userJwt) {
+      throw new BusinessLogicError(
+        'Authentication required. Missing Privy access token for offline wallet provisioning.',
+        'AUTH_REQUIRED'
+      );
     }
 
-    if (privyWalletId || resolvedAddress) {
-      const [updated] = await db
-        .update(users)
-        .set({
-          privyWalletId: privyWalletId ?? dbUser.privyWalletId,
-          walletAddress: resolvedAddress ?? dbUser.walletAddress,
-          updatedAt: new Date(),
-        })
-        .where(eq(users.id, dbUser.id))
-        .returning(userSelectFields);
-      if (updated) dbUser = updated;
+    const offlineWallet = await ensureOfflineWalletReady({ privyId, userJwt });
+    const resolvedAddress = offlineWallet.walletAddress.toLowerCase();
+
+    if (
+      shouldResyncWallet &&
+      resolvedAddress &&
+      resolvedAddress !== clientEmbeddedWalletAddress
+    ) {
+      logger.warn(
+        'Client embedded wallet address mismatch; using Privy embedded wallet address',
+        {
+          userId: dbUser.id,
+          dbWalletAddress: dbUser.walletAddress,
+          clientEmbeddedWalletAddress,
+          privyEmbeddedWalletAddress: resolvedAddress,
+        },
+        'GET /api/users/me'
+      );
     }
+
+    const [updated] = await db
+      .update(users)
+      .set({
+        privyWalletId: offlineWallet.privyWalletId,
+        walletAddress: resolvedAddress,
+        offlineWalletReady: true,
+        offlineWalletReadyAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(users.id, dbUser.id))
+      .returning(userSelectFields);
+    if (updated) dbUser = updated;
   }
 
   // Auto-promote existing users to admin if they have a verified admin domain email

--- a/apps/web/src/app/api/users/onboarding/onchain/route.ts
+++ b/apps/web/src/app/api/users/onboarding/onchain/route.ts
@@ -60,6 +60,7 @@ import {
   authenticate,
   BusinessLogicError,
   ConflictError,
+  ensureOfflineWalletReady,
   processOnchainRegistration,
   successResponse,
   withErrorHandling,
@@ -69,7 +70,6 @@ import { logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 
 interface OnchainRequestBody {
-  walletAddress?: string | null;
   txHash?: string | null;
   referralCode?: string | null;
 }
@@ -105,10 +105,6 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
     typeof (body as OnchainRequestBody).txHash === 'string'
       ? (body as OnchainRequestBody).txHash?.trim() || null
       : null;
-  const walletOverride =
-    typeof (body as OnchainRequestBody).walletAddress === 'string'
-      ? (body as OnchainRequestBody).walletAddress?.trim() || null
-      : null;
   const referralCode =
     typeof (body as OnchainRequestBody).referralCode === 'string'
       ? (body as OnchainRequestBody).referralCode?.trim() || null
@@ -125,6 +121,8 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
       bio: users.bio,
       profileImageUrl: users.profileImageUrl,
       coverImageUrl: users.coverImageUrl,
+      privyWalletId: users.privyWalletId,
+      offlineWalletReady: users.offlineWalletReady,
       walletAddress: users.walletAddress,
       onChainRegistered: users.onChainRegistered,
       nftTokenId: users.nftTokenId,
@@ -148,15 +146,27 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
     );
   }
 
-  const walletAddress =
-    walletOverride?.toLowerCase() ??
-    dbUser.walletAddress ??
-    authUser.walletAddress;
-  if (!walletAddress) {
-    throw new BusinessLogicError(
-      'Wallet address is required for on-chain registration.',
-      'WALLET_REQUIRED'
-    );
+  const offlineWallet = await ensureOfflineWalletReady({
+    privyId: dbUser.privyId ?? authUser.privyId ?? authUser.userId,
+    userJwt,
+  });
+  const walletAddress = offlineWallet.walletAddress.toLowerCase();
+
+  if (
+    dbUser.privyWalletId !== offlineWallet.privyWalletId ||
+    dbUser.walletAddress?.toLowerCase() !== walletAddress ||
+    !dbUser.offlineWalletReady
+  ) {
+    await db
+      .update(users)
+      .set({
+        privyWalletId: offlineWallet.privyWalletId,
+        walletAddress,
+        offlineWalletReady: true,
+        offlineWalletReadyAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(users.id, canonicalUserId));
   }
 
   const onchainResult = await processOnchainRegistration({

--- a/apps/web/src/app/api/users/signup/route.ts
+++ b/apps/web/src/app/api/users/signup/route.ts
@@ -89,15 +89,15 @@
 import type { JsonValue } from '@babylon/api';
 import {
   authenticate,
+  BusinessLogicError,
   ConflictError,
+  ensureOfflineWalletReady,
   getHashedClientIp,
   getOrCreateReferralCode,
   getPrivyClient,
   InternalServerError,
   notifyNewAccount,
   PointsService,
-  type PrivyUserWalletsLite,
-  pickEmbeddedEvmWallet,
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
@@ -142,9 +142,7 @@ interface SignupRequestBody {
   privacyPolicyAccepted?: boolean;
 }
 
-type PrivyUserWithWallets = PrivyUser &
-  PrivyUserWithEmails &
-  PrivyUserWalletsLite;
+type PrivyIdentityUser = PrivyUser & PrivyUserWithEmails;
 
 const SignupSchema = OnboardingProfileSchema.extend({
   identityToken: z
@@ -157,6 +155,20 @@ const SignupSchema = OnboardingProfileSchema.extend({
 
 export const POST = withErrorHandling(async (request: NextRequest) => {
   const authUser = await authenticate(request);
+  const cookieToken = request.cookies.get('privy-token')?.value;
+  const authHeader = request.headers.get('authorization');
+  const headerToken = authHeader?.startsWith('Bearer ')
+    ? authHeader.substring(7)
+    : undefined;
+  const userJwt = cookieToken ?? headerToken ?? null;
+
+  if (!userJwt) {
+    throw new BusinessLogicError(
+      'Authentication required. Missing Privy access token.',
+      'AUTH_REQUIRED'
+    );
+  }
+
   const body = (await request.json()) as
     | SignupRequestBody
     | Record<string, JsonValue>;
@@ -192,7 +204,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
     const privyClient = getPrivyClient();
     const identityUser = (await privyClient.getUserFromIdToken(
       identityToken
-    )) as PrivyUserWithWallets;
+    )) as PrivyIdentityUser;
 
     identityFarcasterUsername = identityUser.farcaster?.username ?? undefined;
     identityTwitterUsername = identityUser.twitter?.username ?? undefined;
@@ -211,13 +223,9 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
   const importedTwitter = parsedProfile.importedFrom === 'twitter';
   const importedFarcaster = parsedProfile.importedFrom === 'farcaster';
 
-  const privyClient = getPrivyClient();
-  const privyUser = (await privyClient.getUser(
-    privyId
-  )) as PrivyUserWithWallets;
-  const embedded = pickEmbeddedEvmWallet(privyUser);
-  privyWalletId = embedded?.walletId ?? null;
-  walletAddress = embedded?.address?.toLowerCase() ?? walletAddress ?? null;
+  const offlineWallet = await ensureOfflineWalletReady({ privyId, userJwt });
+  privyWalletId = offlineWallet.privyWalletId;
+  walletAddress = offlineWallet.walletAddress;
 
   // Wrap transaction with retry logic for connection errors
   const result = await withRetry(
@@ -311,6 +319,8 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
           coverImageUrl: parsedProfile.coverImageUrl ?? null,
           privyWalletId,
           walletAddress,
+          offlineWalletReady: offlineWallet.offlineWalletReady,
+          offlineWalletReadyAt: new Date(),
           profileComplete: true,
           profileSetupCompletedAt: new Date(), // Track when profile was completed
           hasUsername: true,

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -229,6 +229,7 @@ export {
   getAuthedUserContextFromPrivyTokenBundle,
 } from './services/privy/authed-user';
 export { sendSponsoredEvmTransaction } from './services/privy/evm-send-transaction';
+export { ensureOfflineWalletReady } from './services/privy/offline-wallet-provisioning';
 // Privy (embedded wallet server-side helpers)
 export {
   type PrivyUserWalletsLite,

--- a/packages/api/src/services/privy/offline-wallet-provisioning.ts
+++ b/packages/api/src/services/privy/offline-wallet-provisioning.ts
@@ -1,0 +1,170 @@
+import { logger } from '@babylon/shared';
+import type { User as PrivyUser } from '@privy-io/server-auth';
+import { getPrivyClient } from '../../auth-middleware';
+import { getPrivyOfflineConfig } from './offline-config';
+import { getPrivyNodeClient } from './privy-node';
+import {
+  type PrivyUserWalletsLite,
+  pickEmbeddedEvmWallet,
+} from './user-wallets';
+
+type PrivyUserWithWallets = PrivyUser & PrivyUserWalletsLite;
+type WalletSigner = {
+  signer_id: string;
+  override_policy_ids?: string[];
+};
+type WalletWithSigners = {
+  additional_signers: WalletSigner[];
+};
+
+export type EnsureOfflineWalletReadyInput = {
+  privyId: string;
+  userJwt: string;
+};
+
+export type EnsureOfflineWalletReadyResult = {
+  privyWalletId: string;
+  walletAddress: string;
+  offlineWalletReady: true;
+  createdWallet: boolean;
+  updatedSigner: boolean;
+};
+
+function hasOfflineSignerPolicy(
+  wallet: WalletWithSigners,
+  signerId: string,
+  policyId: string
+): boolean {
+  const signer = wallet.additional_signers.find(
+    (s) => s.signer_id === signerId
+  );
+  if (!signer) return false;
+  return (signer.override_policy_ids ?? []).includes(policyId);
+}
+
+function buildUpdatedSigners(
+  wallet: WalletWithSigners,
+  signerId: string,
+  policyId: string
+): WalletSigner[] {
+  const withoutTarget = wallet.additional_signers.filter(
+    (s) => s.signer_id !== signerId
+  );
+  return [
+    ...withoutTarget,
+    {
+      signer_id: signerId,
+      override_policy_ids: [policyId],
+    },
+  ];
+}
+
+export async function ensureOfflineWalletReady({
+  privyId,
+  userJwt,
+}: EnsureOfflineWalletReadyInput): Promise<EnsureOfflineWalletReadyResult> {
+  const privyNode = getPrivyNodeClient();
+  const privyServer = getPrivyClient();
+  const offlineConfig = getPrivyOfflineConfig();
+
+  if (!userJwt || userJwt.trim().length === 0) {
+    throw new Error(
+      'Cannot provision offline wallet readiness without an authenticated Privy JWT'
+    );
+  }
+
+  let createdWallet = false;
+  let updatedSigner = false;
+
+  const initialPrivyUser = (await privyServer.getUser(
+    privyId
+  )) as PrivyUserWithWallets;
+  let embedded = pickEmbeddedEvmWallet(initialPrivyUser);
+
+  if (!embedded) {
+    createdWallet = true;
+    await privyServer.createWallets({
+      userId: privyId,
+      wallets: [
+        {
+          chainType: 'ethereum',
+          additionalSigners: [
+            {
+              signerId: offlineConfig.offlineSignerId,
+              policyIds: [offlineConfig.offlinePolicyId],
+            },
+          ],
+          policyIds: [],
+        },
+      ],
+    });
+
+    const refreshedPrivyUser = (await privyServer.getUser(
+      privyId
+    )) as PrivyUserWithWallets;
+    embedded = pickEmbeddedEvmWallet(refreshedPrivyUser);
+  }
+
+  if (!embedded) {
+    throw new Error(
+      'Failed to resolve embedded wallet after provisioning step'
+    );
+  }
+
+  let wallet = await privyNode.wallets().get(embedded.walletId);
+  const signerReady = hasOfflineSignerPolicy(
+    wallet,
+    offlineConfig.offlineSignerId,
+    offlineConfig.offlinePolicyId
+  );
+
+  if (!signerReady) {
+    updatedSigner = true;
+    const additionalSigners = buildUpdatedSigners(
+      wallet,
+      offlineConfig.offlineSignerId,
+      offlineConfig.offlinePolicyId
+    );
+
+    await privyNode.wallets().update(embedded.walletId, {
+      additional_signers: additionalSigners,
+      authorization_context: {
+        user_jwts: [userJwt],
+        authorization_private_keys: [offlineConfig.authorizationPrivateKey],
+      },
+    });
+
+    wallet = await privyNode.wallets().get(embedded.walletId);
+  }
+
+  const readyAfterUpdate = hasOfflineSignerPolicy(
+    wallet,
+    offlineConfig.offlineSignerId,
+    offlineConfig.offlinePolicyId
+  );
+  if (!readyAfterUpdate) {
+    throw new Error(
+      'Offline wallet provisioning failed: signer/policy not attached after update'
+    );
+  }
+
+  logger.info(
+    'Offline wallet is ready for delegated transactions',
+    {
+      privyId,
+      walletId: embedded.walletId,
+      walletAddress: embedded.address.toLowerCase(),
+      createdWallet,
+      updatedSigner,
+    },
+    'ensureOfflineWalletReady'
+  );
+
+  return {
+    privyWalletId: embedded.walletId,
+    walletAddress: embedded.address.toLowerCase(),
+    offlineWalletReady: true,
+    createdWallet,
+    updatedSigner,
+  };
+}

--- a/packages/db/drizzle/migrations/0040_add_offline_wallet_ready.sql
+++ b/packages/db/drizzle/migrations/0040_add_offline_wallet_ready.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "User"
+ADD COLUMN "offlineWalletReady" boolean DEFAULT false NOT NULL;
+
+ALTER TABLE "User"
+ADD COLUMN "offlineWalletReadyAt" timestamp;

--- a/packages/db/drizzle/migrations/0040_rollback_add_offline_wallet_ready.sql
+++ b/packages/db/drizzle/migrations/0040_rollback_add_offline_wallet_ready.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "User"
+DROP COLUMN IF EXISTS "offlineWalletReadyAt";
+
+ALTER TABLE "User"
+DROP COLUMN IF EXISTS "offlineWalletReady";

--- a/packages/db/drizzle/migrations/meta/_journal.json
+++ b/packages/db/drizzle/migrations/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1770402442392,
       "tag": "0039_unique_fantastic_four",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1770912000000,
+      "tag": "0040_add_offline_wallet_ready",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/users.ts
+++ b/packages/db/src/schema/users.ts
@@ -96,6 +96,9 @@ export const users = pgTable(
     // Privy embedded wallet id (used for server-side wallet actions).
     // This is not the Privy user id (did:privy:...), it's the wallet resource id.
     privyWalletId: text('privyWalletId'),
+    // Offline delegated wallet readiness (signer + policy attached in Privy).
+    offlineWalletReady: boolean('offlineWalletReady').notNull().default(false),
+    offlineWalletReadyAt: timestamp('offlineWalletReadyAt', { mode: 'date' }),
     walletAddress: text('walletAddress').unique(),
     username: text('username').unique(),
     displayName: text('displayName'),


### PR DESCRIPTION
## Summary

- Adds idempotent offline wallet provisioning for Privy embedded wallets.
- Persists minimal readiness state in DB (`offlineWalletReady`, `offlineWalletReadyAt`).
- Integrates provisioning/readiness updates into signup/me/onboarding routes.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [x] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Offline-first Privy transaction stack PR `2/6`.
- Parent PR: #1060
- Base: `feat/offline-pr1-config-guardrails`
- Next PR in stack: `feat/offline-pr3-offline-transaction-path`

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [x] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- Added `ensureOfflineWalletReady` service to:
  - resolve or create embedded EVM wallet,
  - attach offline signer/policy,
  - verify readiness from Privy wallet state.
- Added DB columns in `User`:
  - `offlineWalletReady` (default `false`, not null)
  - `offlineWalletReadyAt` (nullable timestamp)
- Added migration `0040_add_offline_wallet_ready.sql` (+ rollback file).
- Integrated provisioning calls + DB updates in:
  - `apps/web/src/app/api/users/signup/route.ts`
  - `apps/web/src/app/api/users/me/route.ts`
  - `apps/web/src/app/api/users/onboarding/onchain/route.ts`

## Review guide

**Start here**
- `packages/api/src/services/privy/offline-wallet-provisioning.ts`
- `packages/db/src/schema/users.ts`
- `packages/db/drizzle/migrations/0040_add_offline_wallet_ready.sql`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- This PR introduces persistent readiness gating metadata and onboarding-time provisioning.
- Transaction path is still finalized in PR `3/6`.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Verified provisioning flow on existing and missing embedded wallet cases.
2. Ran targeted checks:
   - `bun run --cwd packages/api typecheck`
   - `bun run --cwd packages/db typecheck`
   - `bun run --cwd apps/web typecheck`

## Ops / Migration / Deployment

- [ ] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [x] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `packages/db/drizzle/migrations/0040_add_offline_wallet_ready.sql`
- Backfill/seed: Optional operational audit via `bun run audit:offline-wallet-readiness`

**Rollout / rollback plan**
- Rollout: Run DB migration, deploy, monitor readiness progression.
- Rollback: Revert app changes and apply rollback migration `0040_rollback_add_offline_wallet_ready.sql` if required.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- N/A

## Security / privacy

- [ ] No security impact
- [x] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- No public API contract changes; internal onboarding behavior now auto-provisions offline readiness.

### Database
- New columns on `User` table for readiness state.

### Contracts / on-chain
- No contract changes.

### Docs
- No docs changes in this PR.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend/API/DB flow changes only.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
