### PR TITLE
[3/6] Privy Offline: Use a single authorization-key tx path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,9 +75,6 @@ PRIVY_AUTHORIZATION_PRIVATE_KEY=
 PRIVY_OFFLINE_SIGNER_ID=
 # Offline-first required: policy ID attached to the delegated signer.
 PRIVY_OFFLINE_POLICY_ID=
-# Buffer (in seconds) before JWT expiration at which wallet operations are rejected.
-# Prevents stale tokens from failing at Privy's API with cryptic 400 errors. Default: 30
-# PRIVY_JWT_EXPIRY_BUFFER_SECONDS=30
 
 # ============================================================================
 # Blockchain Configuration (Web3 Integration)

--- a/apps/web/src/app/_actions/nft.ts
+++ b/apps/web/src/app/_actions/nft.ts
@@ -191,9 +191,6 @@ export async function mintNftAction(input?: {
   let hash: Hex;
   try {
     const result = await sendSponsoredEvmTransaction({
-      userJwt: privyToken,
-      userJwtFallbacks: fallbackPrivyToken ? [fallbackPrivyToken] : [],
-      expectedPrivyUserId: ctx.privyId,
       walletId: ctx.privyWalletId,
       to: prepare.contractAddress as Address,
       data: prepare.encodedData,

--- a/apps/web/src/app/_actions/onchain.ts
+++ b/apps/web/src/app/_actions/onchain.ts
@@ -77,9 +77,6 @@ export async function buySharesOnchainAction(input: {
   });
 
   const { hash } = await sendSponsoredEvmTransaction({
-    userJwt: privyToken,
-    userJwtFallbacks: bundle.fallback ? [bundle.fallback] : [],
-    expectedPrivyUserId: ctx.privyId,
     walletId: ctx.privyWalletId,
     to: DIAMOND_ADDRESS as Address,
     data,
@@ -112,9 +109,6 @@ export async function sellSharesOnchainAction(input: {
   });
 
   const { hash } = await sendSponsoredEvmTransaction({
-    userJwt: privyToken,
-    userJwtFallbacks: bundle.fallback ? [bundle.fallback] : [],
-    expectedPrivyUserId: ctx.privyId,
     walletId: ctx.privyWalletId,
     to: DIAMOND_ADDRESS as Address,
     data,
@@ -141,9 +135,6 @@ export async function sendSponsoredEthTransferAction(input: {
   const valueWei = BigInt(input.amountWei);
 
   const { hash } = await sendSponsoredEvmTransaction({
-    userJwt: privyToken,
-    userJwtFallbacks: bundle.fallback ? [bundle.fallback] : [],
-    expectedPrivyUserId: ctx.privyId,
     walletId: ctx.privyWalletId,
     to: input.to.toLowerCase() as Address,
     valueWei,
@@ -187,9 +178,6 @@ export async function updateAgentProfileOnchainAction(input: {
   });
 
   const { hash } = await sendSponsoredEvmTransaction({
-    userJwt: privyToken,
-    userJwtFallbacks: bundle.fallback ? [bundle.fallback] : [],
-    expectedPrivyUserId: ctx.privyId,
     walletId: ctx.privyWalletId,
     to: registryAddress,
     data,

--- a/apps/web/src/app/api/users/onboarding/onchain/route.ts
+++ b/apps/web/src/app/api/users/onboarding/onchain/route.ts
@@ -84,10 +84,6 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
   // this cookie contains the user's access token (JWT) and is the most reliable source.
   // Fall back to the Authorization header for external clients/agents.
   const userJwt = cookieToken ?? headerToken ?? null;
-  const userJwtFallbacks =
-    cookieToken && headerToken && cookieToken !== headerToken
-      ? [headerToken]
-      : [];
 
   const authUser = await authenticate(request);
   const body = (await request.json()) as
@@ -171,8 +167,6 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
 
   const onchainResult = await processOnchainRegistration({
     user: authUser,
-    userJwt,
-    userJwtFallbacks,
     walletAddress,
     username: dbUser.username,
     displayName: dbUser.displayName,

--- a/packages/api/src/services/onchain-service.ts
+++ b/packages/api/src/services/onchain-service.ts
@@ -108,16 +108,6 @@ export const DEPLOYER_PRIVATE_KEY: `0x${string}` =
 
 export interface OnchainRegistrationInput {
   user: AuthenticatedUser;
-  /**
-   * Privy user auth token (JWT) for server-side user wallet actions.
-   * Required when Babylon needs to submit a transaction from the user's embedded wallet.
-   */
-  userJwt?: string | null;
-  /**
-   * Optional fallback JWTs (e.g. cookie token vs Authorization header token).
-   * Used only if Privy rejects the primary token at the wallet endpoint.
-   */
-  userJwtFallbacks?: string[];
   walletAddress?: string | null;
   username?: string | null;
   displayName?: string | null;
@@ -140,8 +130,6 @@ export interface OnchainRegistrationResult {
 
 export async function processOnchainRegistration({
   user,
-  userJwt,
-  userJwtFallbacks,
   walletAddress,
   username,
   displayName,
@@ -605,14 +593,6 @@ export async function processOnchainRegistration({
     }
   } else {
     // Non-agent: submit from the user's embedded wallet via Privy (server-side user wallet flow).
-    if (!userJwt) {
-      throw new InternalServerError(
-        'Missing Privy user token for transaction',
-        {
-          missing: 'userJwt',
-        }
-      );
-    }
     if (!dbUser.privyWalletId) {
       throw new InternalServerError('User embedded wallet id missing', {
         missing: 'users.privyWalletId',
@@ -626,9 +606,6 @@ export async function processOnchainRegistration({
     });
 
     const { hash } = await sendSponsoredEvmTransaction({
-      userJwt,
-      userJwtFallbacks,
-      expectedPrivyUserId: user.privyId,
       walletId: dbUser.privyWalletId,
       to: IDENTITY_REGISTRY,
       data,

--- a/packages/api/src/services/privy/__tests__/evm-send-transaction.test.ts
+++ b/packages/api/src/services/privy/__tests__/evm-send-transaction.test.ts
@@ -163,7 +163,7 @@ describe('PrivyJwtPayloadSchema', () => {
 });
 
 // ---------------------------------------------------------------------------
-// sendSponsoredEvmTransaction – JWT pre-flight validation
+// sendSponsoredEvmTransaction – offline delegated path
 // ---------------------------------------------------------------------------
 
 // Mock the Privy client and shared modules so we can unit-test the function
@@ -195,7 +195,7 @@ mock.module('../privy-node', () => ({
 // Dynamic import after mocks are set up
 const { sendSponsoredEvmTransaction } = await import('../evm-send-transaction');
 
-describe('sendSponsoredEvmTransaction – JWT pre-flight checks', () => {
+describe('sendSponsoredEvmTransaction – offline delegated path', () => {
   const validAddress = '0x0000000000000000000000000000000000000001' as const;
 
   beforeEach(() => {
@@ -206,137 +206,37 @@ describe('sendSponsoredEvmTransaction – JWT pre-flight checks', () => {
     process.env.PRIVY_OFFLINE_SIGNER_ID = 'test-offline-signer-id';
     process.env.PRIVY_OFFLINE_POLICY_ID = 'test-offline-policy-id';
     delete process.env.NEXT_PUBLIC_PRIVY_APP_ID;
-    delete process.env.PRIVY_JWT_EXPIRY_BUFFER_SECONDS;
   });
 
-  it('rejects a malformed JWT', async () => {
-    await expect(
-      sendSponsoredEvmTransaction({
-        userJwt: 'not-a-jwt',
-        walletId: 'wallet-1',
-        to: validAddress,
-      })
-    ).rejects.toThrow('Invalid Privy user JWT');
-  });
-
-  it('rejects a JWT missing required claims', async () => {
-    const { sub: _, ...incomplete } = VALID_PAYLOAD;
-    const token = buildJwt(incomplete);
-
-    await expect(
-      sendSponsoredEvmTransaction({
-        userJwt: token,
-        walletId: 'wallet-1',
-        to: validAddress,
-      })
-    ).rejects.toThrow('Invalid Privy user JWT');
-  });
-
-  it('rejects an expired JWT', async () => {
-    const expiredPayload = { ...VALID_PAYLOAD, exp: NOW_SECONDS - 100 };
-    const token = buildJwt(expiredPayload);
-
-    await expect(
-      sendSponsoredEvmTransaction({
-        userJwt: token,
-        walletId: 'wallet-1',
-        to: validAddress,
-      })
-    ).rejects.toThrow('expired or about to expire');
-  });
-
-  it('rejects a JWT that will expire within the buffer window', async () => {
-    // Token expires in 10 seconds, but default buffer is 30 seconds
-    const soonPayload = { ...VALID_PAYLOAD, exp: NOW_SECONDS + 10 };
-    const token = buildJwt(soonPayload);
-
-    await expect(
-      sendSponsoredEvmTransaction({
-        userJwt: token,
-        walletId: 'wallet-1',
-        to: validAddress,
-      })
-    ).rejects.toThrow('expired or about to expire');
-  });
-
-  it('respects PRIVY_JWT_EXPIRY_BUFFER_SECONDS env var', async () => {
-    // Set a very small buffer so a token expiring in 10s is accepted
-    process.env.PRIVY_JWT_EXPIRY_BUFFER_SECONDS = '5';
-    const soonPayload = { ...VALID_PAYLOAD, exp: NOW_SECONDS + 10 };
-    const token = buildJwt(soonPayload);
-
+  it('submits transaction with authorization private key context only', async () => {
     await sendSponsoredEvmTransaction({
-      userJwt: token,
       walletId: 'wallet-1',
       to: validAddress,
+      valueWei: 0n,
     });
 
-    expect(mockSendTransaction).toHaveBeenCalled();
-  });
-
-  it('falls back to default buffer when env var is invalid', async () => {
-    process.env.PRIVY_JWT_EXPIRY_BUFFER_SECONDS = 'not-a-number';
-    const soonPayload = { ...VALID_PAYLOAD, exp: NOW_SECONDS + 10 };
-    const token = buildJwt(soonPayload);
-
-    // Default buffer is 30s, token expires in 10s → should be rejected
-    await expect(
-      sendSponsoredEvmTransaction({
-        userJwt: token,
-        walletId: 'wallet-1',
-        to: validAddress,
-      })
-    ).rejects.toThrow('expired or about to expire');
-  });
-
-  it('rejects when audience does not match configured app ID', async () => {
-    process.env.PRIVY_APP_ID = 'real-app-id';
-    const token = buildJwt({ ...VALID_PAYLOAD, aud: 'wrong-app-id' });
-
-    await expect(
-      sendSponsoredEvmTransaction({
-        userJwt: token,
-        walletId: 'wallet-1',
-        to: validAddress,
-      })
-    ).rejects.toThrow('audience mismatch');
-  });
-
-  it('accepts when audience matches configured app ID', async () => {
-    process.env.PRIVY_APP_ID = 'test-app-id';
-    const token = buildJwt(VALID_PAYLOAD);
-
-    await sendSponsoredEvmTransaction({
-      userJwt: token,
-      walletId: 'wallet-1',
-      to: validAddress,
+    expect(mockSendTransaction).toHaveBeenCalledTimes(1);
+    expect(mockSendTransaction).toHaveBeenCalledWith('wallet-1', {
+      caip2: 'eip155:1',
+      sponsor: true,
+      authorization_context: {
+        authorization_private_keys: ['test-authorization-key'],
+      },
+      params: {
+        transaction: {
+          to: validAddress,
+          chain_id: 1,
+        },
+      },
     });
-
-    expect(mockSendTransaction).toHaveBeenCalled();
-  });
-
-  it('accepts array audience containing the configured app ID', async () => {
-    process.env.PRIVY_APP_ID = 'test-app-id';
-    const token = buildJwt({ ...VALID_PAYLOAD, aud: ['other', 'test-app-id'] });
-
-    await sendSponsoredEvmTransaction({
-      userJwt: token,
-      walletId: 'wallet-1',
-      to: validAddress,
-    });
-
-    expect(mockSendTransaction).toHaveBeenCalled();
   });
 
   it('fails fast when offline configuration is incomplete', async () => {
     delete process.env.PRIVY_APP_ID;
     delete process.env.NEXT_PUBLIC_PRIVY_APP_ID;
 
-    const token = buildJwt({ ...VALID_PAYLOAD, aud: 'any-audience' });
-
     await expect(
       sendSponsoredEvmTransaction({
-        userJwt: token,
         walletId: 'wallet-1',
         to: validAddress,
       })
@@ -345,59 +245,40 @@ describe('sendSponsoredEvmTransaction – JWT pre-flight checks', () => {
     );
   });
 
-  it('retries with a fallback token when Privy rejects the primary JWT at the wallet endpoint', async () => {
-    const primary = buildJwt(VALID_PAYLOAD);
-    const fallback = buildJwt({ ...VALID_PAYLOAD, sid: 'fallback-session' });
-
-    mockSendTransaction
-      .mockImplementationOnce(() =>
-        Promise.reject(
-          new Error(
-            '400 {"error":"Invalid JWT token provided","code":"invalid_data"}'
-          )
-        )
-      )
-      .mockImplementationOnce(() =>
-        Promise.resolve({ hash: '0xdef', caip2: 'eip155:1' })
-      );
-
-    const result = await sendSponsoredEvmTransaction({
-      userJwt: primary,
-      userJwtFallbacks: [fallback],
+  it('passes idempotency key when provided', async () => {
+    await sendSponsoredEvmTransaction({
       walletId: 'wallet-1',
       to: validAddress,
+      idempotencyKey: 'idem-123',
     });
 
-    expect(result.hash).toBe('0xdef');
-    expect(mockSendTransaction).toHaveBeenCalledTimes(2);
+    expect(mockSendTransaction).toHaveBeenCalledTimes(1);
+    expect(mockSendTransaction).toHaveBeenCalledWith('wallet-1', {
+      caip2: 'eip155:1',
+      sponsor: true,
+      authorization_context: {
+        authorization_private_keys: ['test-authorization-key'],
+      },
+      idempotency_key: 'idem-123',
+      params: {
+        transaction: {
+          to: validAddress,
+          chain_id: 1,
+        },
+      },
+    });
   });
 
-  it('does not use fallback tokens whose subject does not match expectedPrivyUserId', async () => {
-    const primary = buildJwt(VALID_PAYLOAD);
-    const fallbackWrongUser = buildJwt({
-      ...VALID_PAYLOAD,
-      sub: 'did:privy:someone-else',
-    });
-
+  it('propagates wallet endpoint errors', async () => {
     mockSendTransaction.mockImplementationOnce(() =>
-      Promise.reject(
-        new Error(
-          '400 {"error":"Invalid JWT token provided","code":"invalid_data"}'
-        )
-      )
+      Promise.reject(new Error('upstream failed'))
     );
 
     await expect(
       sendSponsoredEvmTransaction({
-        userJwt: primary,
-        userJwtFallbacks: [fallbackWrongUser],
-        expectedPrivyUserId: VALID_PAYLOAD.sub,
         walletId: 'wallet-1',
         to: validAddress,
       })
-    ).rejects.toThrow('Invalid JWT token provided');
-
-    // Only the primary token should be attempted; fallback is filtered out by pre-flight validation.
-    expect(mockSendTransaction).toHaveBeenCalledTimes(1);
+    ).rejects.toThrow('upstream failed');
   });
 });

--- a/packages/api/src/services/privy/evm-send-transaction.ts
+++ b/packages/api/src/services/privy/evm-send-transaction.ts
@@ -7,23 +7,13 @@ import { getPrivyOfflineConfig } from './offline-config';
 import { getPrivyNodeClient } from './privy-node';
 
 export type SendSponsoredEvmTransactionInput = {
-  userJwt: string;
-  /**
-   * Optional fallback tokens (e.g. cookie token vs freshly-refreshed token).
-   * These are tried only if the primary token is rejected by Privy's wallet endpoint.
-   */
-  userJwtFallbacks?: string[];
-  /**
-   * Optional safety check: require that the JWT subject matches the expected Privy user id.
-   * Use this when the caller already verified auth and knows the `privyId`.
-   */
-  expectedPrivyUserId?: string;
   walletId: string;
   to: Address;
   data?: Hex;
   valueWei?: bigint;
   caip2?: string;
   chainId?: number;
+  idempotencyKey?: string;
 };
 
 /**
@@ -76,34 +66,12 @@ export function safeDecodeJwtPayload(token: string): PrivyJwtPayload | null {
   }
 }
 
-function isInvalidPrivyWalletJwtError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  // Privy wallet endpoints currently surface this message for invalid/revoked JWTs.
-  // Keep the match strict to avoid retrying on unrelated failures.
-  return error.message.toLowerCase().includes('invalid jwt token provided');
-}
-
-function dedupeNonEmptyStrings(values: Array<string | undefined>): string[] {
-  const seen = new Set<string>();
-  const out: string[] = [];
-  for (const v of values) {
-    if (typeof v !== 'string') continue;
-    const trimmed = v.trim();
-    if (trimmed.length === 0) continue;
-    if (seen.has(trimmed)) continue;
-    seen.add(trimmed);
-    out.push(trimmed);
-  }
-  return out;
-}
-
 /**
  * Sends a sponsored EVM transaction on behalf of a user via Privy's server-side wallet flow.
  *
  * Gas is covered by Privy's native sponsorship (`sponsor: true`), but any ETH value
  * transfers still require the user's wallet to hold sufficient funds.
  *
- * @param userJwt - The user's Privy access token (JWT) for authorization
  * @param walletId - The Privy wallet resource ID (stored in users.privyWalletId)
  * @param to - The destination contract/address
  * @param data - Optional encoded function call data
@@ -113,131 +81,16 @@ function dedupeNonEmptyStrings(values: Array<string | undefined>): string[] {
  * @returns Transaction hash and CAIP-2 identifier
  */
 export async function sendSponsoredEvmTransaction({
-  userJwt,
-  userJwtFallbacks,
-  expectedPrivyUserId,
   walletId,
   to,
   data,
   valueWei,
   caip2 = `eip155:${CHAIN.id}`,
   chainId = CHAIN.id,
+  idempotencyKey,
 }: SendSponsoredEvmTransactionInput): Promise<{ hash: Hex; caip2: string }> {
-  const jwtCandidates = dedupeNonEmptyStrings([
-    userJwt,
-    ...(userJwtFallbacks ?? []),
-  ]);
-  if (jwtCandidates.length === 0) {
-    throw new Error('Missing Privy user JWT');
-  }
-
   const offlineConfig = getPrivyOfflineConfig();
   const appId = offlineConfig.appId;
-
-  // Pre-flight validate candidates (decode-only) so we can skip obviously-invalid tokens
-  // without paying for a wallet API call.
-  const parsedBuffer = Number(process.env.PRIVY_JWT_EXPIRY_BUFFER_SECONDS);
-  const expiryBuffer =
-    Number.isFinite(parsedBuffer) && parsedBuffer > 0 ? parsedBuffer : 30;
-
-  const invalidJwtError = new Error(
-    'Invalid Privy user JWT: token must be a valid JWT with the expected Privy claims (aud, sub, iss, iat, exp)'
-  );
-
-  const candidates: Array<{ token: string; payload: PrivyJwtPayload }> = [];
-  let firstValidationError: Error | undefined;
-  let lastValidationError: Error | undefined;
-  for (const token of jwtCandidates) {
-    const payload = safeDecodeJwtPayload(token);
-    if (!payload) {
-      // Preserve the previous error message semantics for single-token calls.
-      lastValidationError = invalidJwtError;
-      if (!firstValidationError) firstValidationError = invalidJwtError;
-      continue;
-    }
-
-    if (expectedPrivyUserId && payload.sub !== expectedPrivyUserId) {
-      const err = new Error(
-        'Privy token subject mismatch: token does not match the authenticated user'
-      );
-      lastValidationError = err;
-      if (!firstValidationError) firstValidationError = err;
-      continue;
-    }
-
-    if (!payload.exp) {
-      const err = new Error(
-        'Privy JWT is missing an expiration claim (exp). Cannot authorize wallet operations without a verifiable token lifetime.'
-      );
-      lastValidationError = err;
-      if (!firstValidationError) firstValidationError = err;
-      continue;
-    }
-
-    if (payload.exp < Date.now() / 1000 + expiryBuffer) {
-      const err = new Error(
-        `Privy JWT is expired or about to expire (exp: ${new Date(payload.exp * 1000).toISOString()}). Please refresh your session.`
-      );
-      lastValidationError = err;
-      if (!firstValidationError) firstValidationError = err;
-      continue;
-    }
-
-    if (appId) {
-      const tokenAud = payload.aud;
-      const audMatches =
-        tokenAud === appId ||
-        (Array.isArray(tokenAud) && tokenAud.includes(appId));
-      if (!audMatches) {
-        const err = new Error(
-          `Privy token audience mismatch: token audience "${tokenAud}" does not match app ID "${appId}"`
-        );
-        lastValidationError = err;
-        if (!firstValidationError) firstValidationError = err;
-        continue;
-      }
-    }
-
-    candidates.push({ token, payload });
-  }
-
-  if (candidates.length === 0) {
-    // Preserve clear, single-cause error semantics for callers/tests.
-    throw firstValidationError ?? lastValidationError ?? invalidJwtError;
-  }
-
-  // Debug: Log JWT header + claims to diagnose auth issues (no sensitive identifiers).
-  // Only log for the first candidate we will try.
-  const first = candidates[0];
-  // Satisfy `noUncheckedIndexedAccess`: even with length checks, TS keeps index access as possibly-undefined.
-  if (!first) {
-    throw new Error('Invalid Privy user JWT: no usable token candidates');
-  }
-  const jwtHeader = safeDecodeJwtHeader(first.token);
-  const nowSeconds = Math.floor(Date.now() / 1000);
-  logger.debug(
-    'Privy JWT diagnostics',
-    {
-      alg: jwtHeader?.alg,
-      typ: jwtHeader?.typ,
-      kid: jwtHeader?.kid,
-      iss: first.payload.iss,
-      aud: first.payload.aud,
-      sid: first.payload.sid,
-      iat: first.payload.iat,
-      exp: first.payload.exp,
-      tokenAgeSec: nowSeconds - first.payload.iat,
-      timeToExpirySec: first.payload.exp - nowSeconds,
-      isExpired: first.payload.exp ? first.payload.exp < nowSeconds : 'no-exp',
-      configuredAppId: appId,
-      candidatesCount: candidates.length,
-      jwtLength: first.token.length,
-      expectedPrivyUserId: expectedPrivyUserId ? 'provided' : 'not-provided',
-      caip2,
-      chainId,
-    },
-    'sendSponsoredEvmTransaction'
-  );
 
   const privy = getPrivyNodeClient();
   const authorizationPrivateKey = offlineConfig.authorizationPrivateKey;
@@ -260,98 +113,68 @@ export async function sendSponsoredEvmTransaction({
   logger.debug(
     'Submitting sponsored transaction via Privy',
     {
+      appId,
       walletId,
       to,
       chainId,
       hasData: !!data,
       hasValue: !!valueHex,
       valueWei: valueWei?.toString(),
+      hasIdempotencyKey: Boolean(idempotencyKey),
     },
     'sendSponsoredEvmTransaction'
   );
 
-  let lastError: unknown;
-  for (let i = 0; i < candidates.length; i += 1) {
-    const candidate = candidates[i];
-    if (!candidate) continue;
-    const { token } = candidate;
-    const authorizationContext: AuthorizationContext = {
-      user_jwts: [token],
-      authorization_private_keys: [authorizationPrivateKey],
-    };
+  const authorizationContext: AuthorizationContext = {
+    authorization_private_keys: [authorizationPrivateKey],
+  };
 
-    try {
-      const response = await privy
-        .wallets()
-        .ethereum()
-        .sendTransaction(walletId, {
-          caip2,
-          sponsor: true,
-          authorization_context: authorizationContext,
-          params: {
-            transaction: {
-              to,
-              chain_id: chainId,
-              ...(valueHex ? { value: valueHex } : {}),
-              ...(data ? { data } : {}),
-            },
+  try {
+    const response = await privy
+      .wallets()
+      .ethereum()
+      .sendTransaction(walletId, {
+        caip2,
+        sponsor: true,
+        authorization_context: authorizationContext,
+        ...(idempotencyKey ? { idempotency_key: idempotencyKey } : {}),
+        params: {
+          transaction: {
+            to,
+            chain_id: chainId,
+            ...(valueHex ? { value: valueHex } : {}),
+            ...(data ? { data } : {}),
           },
-        });
-
-      logger.info(
-        'Sponsored transaction submitted successfully',
-        {
-          txHash: response.hash,
-          caip2: response.caip2,
-          walletId,
-          to,
         },
-        'sendSponsoredEvmTransaction'
-      );
+      });
 
-      return { hash: response.hash as Hex, caip2: response.caip2 };
-    } catch (error) {
-      lastError = error;
-      // Only retry on the specific auth failure we expect for token rotation/revocation.
-      if (!isInvalidPrivyWalletJwtError(error)) {
-        throw error;
-      }
-      if (i < candidates.length - 1) {
-        logger.warn(
-          'Privy wallet rejected JWT, trying fallback token',
-          {
-            candidateIndex: i,
-            candidatesCount: candidates.length,
-            caip2,
-            chainId,
-            walletId,
-            sid: candidate.payload.sid,
-            tokenAgeSec: Math.floor(Date.now() / 1000 - candidate.payload.iat),
-          },
-          'sendSponsoredEvmTransaction'
-        );
-      }
-      // Continue to next candidate (if any).
-    }
+    logger.info(
+      'Sponsored transaction submitted successfully',
+      {
+        txHash: response.hash,
+        caip2: response.caip2,
+        walletId,
+        to,
+      },
+      'sendSponsoredEvmTransaction'
+    );
+
+    return { hash: response.hash as Hex, caip2: response.caip2 };
+  } catch (error) {
+    logger.error(
+      'Failed to submit offline sponsored transaction',
+      {
+        caip2,
+        chainId,
+        walletId,
+        to,
+        errorMessage: error instanceof Error ? error.message : 'unknown',
+      },
+      'sendSponsoredEvmTransaction'
+    );
+
+    throw error instanceof Error
+      ? error
+      : new Error('Failed to submit sponsored transaction via Privy');
   }
-
-  // All candidates exhausted — log a final summary with chain context so
-  // chain-specific configuration issues (e.g. missing gas sponsorship) are
-  // immediately visible in logs.
-  logger.error(
-    'All JWT candidates rejected by Privy wallet endpoint',
-    {
-      caip2,
-      chainId,
-      walletId,
-      to,
-      candidatesCount: candidates.length,
-      errorMessage: lastError instanceof Error ? lastError.message : 'unknown',
-    },
-    'sendSponsoredEvmTransaction'
-  );
-
-  throw lastError instanceof Error
-    ? lastError
-    : new Error('Failed to submit sponsored transaction via Privy');
 }


### PR DESCRIPTION
## Summary

- Switches sponsored EVM transaction submission to an offline authorization-key path only.
- Removes JWT submission branch from the transaction sender and updates all callsites.
- Adds optional idempotency key propagation for transaction submission robustness.

## Type

- [ ] Feature
- [ ] Bug fix
- [x] Refactor / cleanup (no behavior change)
- [ ] Performance
- [x] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Offline-first Privy transaction stack PR `3/6`.
- Parent PR: #1061
- Base: `feat/offline-pr2-wallet-provisioning`
- Next PR in stack: `feat/offline-pr4-flow-cleanup`

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- Updated `sendSponsoredEvmTransaction` to offline delegated signing only (`authorization_private_keys`).
- Removed JWT-based submission path from tx sender.
- Added optional `idempotencyKey` input and forwarded it to Privy request metadata.
- Updated callsites in web actions and onchain service to remove JWT tx submission usage.
- Updated unit tests for new offline-only sender behavior.
- Removed obsolete JWT buffer env comments from `.env.example`.

## Review guide

**Start here**
- `packages/api/src/services/privy/evm-send-transaction.ts`
- `packages/api/src/services/onchain-service.ts`
- `apps/web/src/app/_actions/onchain.ts`
- `apps/web/src/app/_actions/nft.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- This intentionally enforces one tx submission path to reduce branch complexity and debug surface.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Verified tx sender request payload includes only offline authorization context.
2. Ran targeted checks:
   - `bun test packages/api/src/services/privy/__tests__/evm-send-transaction.test.ts`
   - `bun run --cwd packages/api typecheck`
   - `bun run --cwd apps/web typecheck`

## Ops / Migration / Deployment

- [ ] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: Deploy stacked PRs in order; monitor tx submission success/error rates.
- Rollback: Revert this PR to restore previous sender branching behavior.

## Breaking changes

- [ ] None
- [x] Yes (describe + migration guide below)

**Migration guide**
- All server-side sponsored transaction callers must use offline auth-key flow.
- JWT-based tx submit path is removed from sender internals.

## Security / privacy

- [ ] No security impact
- [x] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- Internal service contract changed: sender no longer relies on JWT tx submission context.

### Database
- No DB changes.

### Contracts / on-chain
- No contract changes.

### Docs
- `.env.example` cleanup only.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Server-side transaction path refactor only.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
