### PR TITLE
[5/6] Privy Offline: Add provisioning tests and readiness audit ops

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,8 @@
     "ruler:init": "ruler init",
     "ruler:apply": "ruler apply",
     "ruler:apply:dry": "ruler apply --dry-run --verbose",
-    "ruler:revert": "ruler revert"
+    "ruler:revert": "ruler revert",
+    "audit:offline-wallet-readiness": "bun run scripts/audit-offline-wallet-readiness.ts"
   },
   "dependencies": {
     "@a2a-js/sdk": "^0.3.5",

--- a/packages/api/src/services/privy/__tests__/offline-wallet-provisioning.test.ts
+++ b/packages/api/src/services/privy/__tests__/offline-wallet-provisioning.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+const mockGetUser = mock();
+const mockCreateWallets = mock();
+const mockWalletGet = mock();
+const mockWalletUpdate = mock();
+
+mock.module('@babylon/shared', () => ({
+  logger: {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  },
+}));
+
+mock.module('../../../auth-middleware', () => ({
+  getPrivyClient: () => ({
+    getUser: mockGetUser,
+    createWallets: mockCreateWallets,
+  }),
+}));
+
+mock.module('../privy-node', () => ({
+  getPrivyNodeClient: () => ({
+    wallets: () => ({
+      get: mockWalletGet,
+      update: mockWalletUpdate,
+    }),
+  }),
+}));
+
+const { ensureOfflineWalletReady } = await import(
+  '../offline-wallet-provisioning'
+);
+
+const EMBEDDED_WALLET = {
+  id: 'wallet-1',
+  address: '0x0000000000000000000000000000000000000001',
+  chain_type: 'ethereum',
+  wallet_client: 'privy',
+};
+
+describe('ensureOfflineWalletReady', () => {
+  beforeEach(() => {
+    mockGetUser.mockReset();
+    mockCreateWallets.mockReset();
+    mockWalletGet.mockReset();
+    mockWalletUpdate.mockReset();
+
+    process.env.PRIVY_APP_ID = 'test-app-id';
+    process.env.PRIVY_APP_SECRET = 'test-secret';
+    process.env.PRIVY_AUTHORIZATION_PRIVATE_KEY = 'test-authorization-key';
+    process.env.PRIVY_OFFLINE_SIGNER_ID = 'offline-signer-id';
+    process.env.PRIVY_OFFLINE_POLICY_ID = 'offline-policy-id';
+  });
+
+  it('returns ready state when wallet already has signer policy attached', async () => {
+    mockGetUser.mockResolvedValue({
+      id: 'did:privy:user-1',
+      wallet: EMBEDDED_WALLET,
+      linkedAccounts: [],
+    });
+    mockWalletGet.mockResolvedValue({
+      additional_signers: [
+        {
+          signer_id: 'offline-signer-id',
+          override_policy_ids: ['offline-policy-id'],
+        },
+      ],
+    });
+
+    const result = await ensureOfflineWalletReady({
+      privyId: 'did:privy:user-1',
+      userJwt: 'jwt-token',
+    });
+
+    expect(result.offlineWalletReady).toBe(true);
+    expect(result.createdWallet).toBe(false);
+    expect(result.updatedSigner).toBe(false);
+    expect(result.privyWalletId).toBe('wallet-1');
+    expect(mockCreateWallets).not.toHaveBeenCalled();
+    expect(mockWalletUpdate).not.toHaveBeenCalled();
+  });
+
+  it('creates wallet when embedded wallet is missing', async () => {
+    mockGetUser
+      .mockResolvedValueOnce({
+        id: 'did:privy:user-2',
+        wallet: null,
+        linkedAccounts: [],
+      })
+      .mockResolvedValueOnce({
+        id: 'did:privy:user-2',
+        wallet: EMBEDDED_WALLET,
+        linkedAccounts: [],
+      });
+    mockWalletGet.mockResolvedValue({
+      additional_signers: [
+        {
+          signer_id: 'offline-signer-id',
+          override_policy_ids: ['offline-policy-id'],
+        },
+      ],
+    });
+
+    const result = await ensureOfflineWalletReady({
+      privyId: 'did:privy:user-2',
+      userJwt: 'jwt-token',
+    });
+
+    expect(result.createdWallet).toBe(true);
+    expect(result.updatedSigner).toBe(false);
+    expect(mockCreateWallets).toHaveBeenCalledTimes(1);
+  });
+
+  it('updates wallet signers when signer policy is missing', async () => {
+    mockGetUser.mockResolvedValue({
+      id: 'did:privy:user-3',
+      wallet: EMBEDDED_WALLET,
+      linkedAccounts: [],
+    });
+    mockWalletGet
+      .mockResolvedValueOnce({
+        additional_signers: [],
+      })
+      .mockResolvedValueOnce({
+        additional_signers: [
+          {
+            signer_id: 'offline-signer-id',
+            override_policy_ids: ['offline-policy-id'],
+          },
+        ],
+      });
+
+    const result = await ensureOfflineWalletReady({
+      privyId: 'did:privy:user-3',
+      userJwt: 'jwt-token',
+    });
+
+    expect(result.createdWallet).toBe(false);
+    expect(result.updatedSigner).toBe(true);
+    expect(mockWalletUpdate).toHaveBeenCalledTimes(1);
+    expect(mockWalletUpdate).toHaveBeenCalledWith('wallet-1', {
+      additional_signers: [
+        {
+          signer_id: 'offline-signer-id',
+          override_policy_ids: ['offline-policy-id'],
+        },
+      ],
+      authorization_context: {
+        user_jwts: ['jwt-token'],
+        authorization_private_keys: ['test-authorization-key'],
+      },
+    });
+  });
+
+  it('rejects when user JWT is missing', async () => {
+    await expect(
+      ensureOfflineWalletReady({
+        privyId: 'did:privy:user-4',
+        userJwt: '',
+      })
+    ).rejects.toThrow(
+      'Cannot provision offline wallet readiness without an authenticated Privy JWT'
+    );
+  });
+});

--- a/scripts/audit-offline-wallet-readiness.ts
+++ b/scripts/audit-offline-wallet-readiness.ts
@@ -1,0 +1,76 @@
+import { and, count, db, desc, eq, isNotNull, users } from '@babylon/db';
+
+function parseLimitArg(): number {
+  const raw = process.argv[2]?.trim();
+  if (!raw) return 100;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 100;
+  return Math.min(parsed, 1000);
+}
+
+async function main() {
+  const limit = parseLimitArg();
+
+  const [{ totalUsers = 0 }] = await db
+    .select({ totalUsers: count() })
+    .from(users)
+    .where(isNotNull(users.privyId));
+
+  const [{ readyUsers = 0 }] = await db
+    .select({ readyUsers: count() })
+    .from(users)
+    .where(and(isNotNull(users.privyId), eq(users.offlineWalletReady, true)));
+
+  const pending = await db
+    .select({
+      id: users.id,
+      privyId: users.privyId,
+      privyWalletId: users.privyWalletId,
+      walletAddress: users.walletAddress,
+      offlineWalletReady: users.offlineWalletReady,
+      offlineWalletReadyAt: users.offlineWalletReadyAt,
+      createdAt: users.createdAt,
+      updatedAt: users.updatedAt,
+    })
+    .from(users)
+    .where(and(isNotNull(users.privyId), eq(users.offlineWalletReady, false)))
+    .orderBy(desc(users.createdAt))
+    .limit(limit);
+
+  const pendingCount = Math.max(totalUsers - readyUsers, 0);
+  const readinessPct =
+    totalUsers > 0 ? ((readyUsers / totalUsers) * 100).toFixed(2) : '0.00';
+
+  console.log('Offline wallet readiness audit');
+  console.log(`- Total users with privyId: ${totalUsers}`);
+  console.log(`- Ready users: ${readyUsers}`);
+  console.log(`- Pending users: ${pendingCount}`);
+  console.log(`- Readiness: ${readinessPct}%`);
+  console.log(`- Showing up to ${limit} pending users`);
+
+  if (pending.length === 0) {
+    console.log('\nNo pending users found.');
+    return;
+  }
+
+  console.log('\nPending users:');
+  for (const user of pending) {
+    console.log(
+      [
+        `id=${user.id}`,
+        `privyId=${user.privyId}`,
+        `walletId=${user.privyWalletId ?? 'null'}`,
+        `walletAddress=${user.walletAddress ?? 'null'}`,
+        `offlineWalletReady=${String(user.offlineWalletReady)}`,
+        `offlineWalletReadyAt=${user.offlineWalletReadyAt?.toISOString() ?? 'null'}`,
+        `createdAt=${user.createdAt.toISOString()}`,
+        `updatedAt=${user.updatedAt.toISOString()}`,
+      ].join(' | ')
+    );
+  }
+}
+
+main().catch((error) => {
+  console.error('Audit failed:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds unit tests for offline wallet provisioning service behavior.
- Adds an operational audit script to inspect offline-wallet readiness coverage.
- Exposes the audit script as a root package command.

## Type

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [x] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [x] Other: test improvements

## Context / Links

- Offline-first Privy transaction stack PR `5/6`.
- Parent PR: #1063
- Base: `feat/offline-pr4-flow-cleanup`
- Next PR in stack: `feat/offline-pr6-privy-bootstrap-script`

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [x] Other: root scripts

## Changes

- Added `offline-wallet-provisioning` unit tests covering:
  - already-ready wallet,
  - missing wallet creation,
  - signer attachment update,
  - missing JWT failure path.
- Added `scripts/audit-offline-wallet-readiness.ts` to report readiness totals + pending users.
- Added root script alias: `audit:offline-wallet-readiness`.

## Review guide

**Start here**
- `packages/api/src/services/privy/__tests__/offline-wallet-provisioning.test.ts`
- `scripts/audit-offline-wallet-readiness.ts`
- `package.json`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- No runtime behavior changes; this is test + ops observability support.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Ran new test file:
   - `bun test packages/api/src/services/privy/__tests__/offline-wallet-provisioning.test.ts`
2. Verified script invocation shape:
   - `bun run audit:offline-wallet-readiness`

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: Merge with stack; use audit script operationally as needed.
- Rollback: Revert this PR.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- N/A

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- No API contract changes.

### Database
- Read-only operational query script only.

### Contracts / on-chain
- No contract changes.

### Docs
- No docs changes.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Tests and operational script only.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
