### PR TITLE
[6/6] Privy Offline: Add signer/policy bootstrap CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "ruler:apply": "ruler apply",
     "ruler:apply:dry": "ruler apply --dry-run --verbose",
     "ruler:revert": "ruler revert",
-    "audit:offline-wallet-readiness": "bun run scripts/audit-offline-wallet-readiness.ts"
+    "audit:offline-wallet-readiness": "bun run scripts/audit-offline-wallet-readiness.ts",
+    "privy:setup:offline-controls": "bun run scripts/setup-privy-offline-controls.ts"
   },
   "dependencies": {
     "@a2a-js/sdk": "^0.3.5",

--- a/scripts/setup-privy-offline-controls.ts
+++ b/scripts/setup-privy-offline-controls.ts
@@ -1,0 +1,186 @@
+import { generateP256KeyPair, PrivyClient } from '@privy-io/node';
+
+type PolicyOwnerMode = 'signer' | 'none';
+
+type CliOptions = {
+  appId: string;
+  appSecret: string;
+  namePrefix: string;
+  policyOwner: PolicyOwnerMode;
+  json: boolean;
+};
+
+function printUsage(): void {
+  console.log(`
+Setup Privy offline controls (authorization key + signer + policy)
+
+Usage:
+  bun run scripts/setup-privy-offline-controls.ts [options]
+
+Options:
+  --app-id <value>          Privy app ID (fallback: PRIVY_APP_ID or NEXT_PUBLIC_PRIVY_APP_ID)
+  --app-secret <value>      Privy app secret (fallback: PRIVY_APP_SECRET)
+  --name-prefix <value>     Prefix for created resource names (default: babylon-offline)
+  --policy-owner <mode>     "none" or "signer" (default: none)
+  --json                    Output machine-readable JSON only
+  -h, --help                Show this help
+
+What this creates:
+  1. A new P-256 authorization key pair (private key returned once)
+  2. A signer (Privy key quorum with threshold 1)
+  3. An Ethereum policy:
+     - DENY exportPrivateKey
+     - ALLOW all other methods
+
+Output:
+  - PRIVY_AUTHORIZATION_PRIVATE_KEY
+  - PRIVY_OFFLINE_SIGNER_ID
+  - PRIVY_OFFLINE_POLICY_ID
+`);
+}
+
+function readEnv(name: string): string | undefined {
+  const value = process.env[name];
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readRequiredValue(
+  args: string[],
+  name: '--app-id' | '--app-secret' | '--name-prefix' | '--policy-owner'
+): string | undefined {
+  const index = args.findIndex((arg) => arg === name);
+  if (index === -1) return undefined;
+  const value = args[index + 1];
+  if (!value) {
+    throw new Error(`Missing value after ${name}`);
+  }
+  return value.trim();
+}
+
+function hasFlag(args: string[], flag: '-h' | '--help' | '--json'): boolean {
+  return args.includes(flag);
+}
+
+function getPolicyOwnerMode(raw: string | undefined): PolicyOwnerMode {
+  if (!raw) return 'none';
+  if (raw === 'none' || raw === 'signer') return raw;
+  throw new Error(
+    `Invalid --policy-owner value "${raw}". Expected "none" or "signer".`
+  );
+}
+
+function parseOptions(): CliOptions {
+  const args = process.argv.slice(2);
+  if (hasFlag(args, '-h') || hasFlag(args, '--help')) {
+    printUsage();
+    process.exit(0);
+  }
+
+  const appId =
+    readRequiredValue(args, '--app-id') ??
+    readEnv('PRIVY_APP_ID') ??
+    readEnv('NEXT_PUBLIC_PRIVY_APP_ID');
+  const appSecret =
+    readRequiredValue(args, '--app-secret') ?? readEnv('PRIVY_APP_SECRET');
+  const namePrefix =
+    readRequiredValue(args, '--name-prefix') ?? 'babylon-offline';
+  const policyOwner = getPolicyOwnerMode(
+    readRequiredValue(args, '--policy-owner')
+  );
+  const json = hasFlag(args, '--json');
+
+  const missing: string[] = [];
+  if (!appId) missing.push('app ID (--app-id or PRIVY_APP_ID)');
+  if (!appSecret) {
+    missing.push('app secret (--app-secret or PRIVY_APP_SECRET)');
+  }
+
+  if (missing.length > 0) {
+    throw new Error(`Missing required inputs: ${missing.join(', ')}`);
+  }
+
+  return {
+    appId: appId!,
+    appSecret: appSecret!,
+    namePrefix,
+    policyOwner,
+    json,
+  };
+}
+
+function timestampTag(): string {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+async function main() {
+  const options = parseOptions();
+  const privy = new PrivyClient({
+    appId: options.appId,
+    appSecret: options.appSecret,
+  });
+
+  const keyPair = await generateP256KeyPair();
+
+  const signer = await privy.keyQuorums().create({
+    display_name: `${options.namePrefix}-signer-${timestampTag()}`,
+    authorization_threshold: 1,
+    public_keys: [keyPair.publicKey],
+  });
+
+  const policy = await privy.policies().create({
+    version: '1.0',
+    name: `${options.namePrefix}-policy-${timestampTag()}`,
+    chain_type: 'ethereum',
+    ...(options.policyOwner === 'signer' ? { owner_id: signer.id } : {}),
+    rules: [
+      {
+        name: 'Deny private key exports',
+        method: 'exportPrivateKey',
+        conditions: [],
+        action: 'DENY',
+      },
+      {
+        name: 'Allow all other actions',
+        method: '*',
+        conditions: [],
+        action: 'ALLOW',
+      },
+    ],
+  });
+
+  const result = {
+    appId: options.appId,
+    signerId: signer.id,
+    policyId: policy.id,
+    authorizationPrivateKey: keyPair.privateKey,
+  };
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  console.log('Privy offline controls created successfully.\n');
+  console.log('Copy these env vars:\n');
+  console.log(`PRIVY_APP_ID=${result.appId}`);
+  console.log(
+    `PRIVY_AUTHORIZATION_PRIVATE_KEY='${result.authorizationPrivateKey}'`
+  );
+  console.log(`PRIVY_OFFLINE_SIGNER_ID=${result.signerId}`);
+  console.log(`PRIVY_OFFLINE_POLICY_ID=${result.policyId}`);
+  console.log('\nNotes:');
+  console.log(
+    '- The private key is shown once; store it in secret manager immediately.'
+  );
+  console.log(
+    "- Policy created: DENY 'exportPrivateKey', ALLOW '*' for all other methods."
+  );
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Failed to setup Privy offline controls: ${message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds a CLI bootstrap script to create Privy offline controls for an app.
- Script generates an authorization keypair, creates signer (key quorum), creates an Ethereum policy, and prints env vars to set.
- Adds root command alias for operational use.

## Type

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [x] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [x] Other: developer tooling

## Context / Links

- Offline-first Privy transaction stack PR `6/6`.
- Parent PR: #1064
- Base: `feat/offline-pr5-ops-and-tests`

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [x] Other: root scripts / ops tooling

## Changes

- Added `scripts/setup-privy-offline-controls.ts`:
  - accepts `--app-id`, `--app-secret`, optional naming/ownership flags,
  - generates P-256 authorization keypair,
  - creates key quorum signer,
  - creates Ethereum policy (`DENY exportPrivateKey`, `ALLOW *`),
  - outputs:
    - `PRIVY_AUTHORIZATION_PRIVATE_KEY`
    - `PRIVY_OFFLINE_SIGNER_ID`
    - `PRIVY_OFFLINE_POLICY_ID`
- Added root command `privy:setup:offline-controls` in `package.json`.

## Review guide

**Start here**
- `scripts/setup-privy-offline-controls.ts`
- `package.json`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- Tooling-only PR; no runtime app path changes.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Verified CLI help and command wiring:
   - `bun run privy:setup:offline-controls --help`
2. Verified formatting/checks for touched files.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None` (script outputs values for existing env vars)
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: Use script to provision signer/policy per environment.
- Rollback: Revert this PR; provisioning artifacts in Privy can be managed from dashboard/API if needed.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- N/A

## Security / privacy

- [ ] No security impact
- [x] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- No service API changes.

### Database
- No DB changes.

### Contracts / on-chain
- No contract changes.

### Docs
- No docs changes.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Operational CLI tooling only.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
