### PR TITLE
[7/7] Privy Offline: Remove user JWT dependency and harden provisioning

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -529,6 +529,9 @@ GAME_TICK_BUDGET_MS=180000
 # ============================================
 # Enable debug logging
 DEBUG=false
+# Expose structured on-chain error details in server action responses.
+# Keep disabled in production unless you explicitly need temporary diagnostics.
+EXPOSE_ONCHAIN_ERROR_DETAILS=false
 
 # ============================================
 # Linear Integration (Optional)

--- a/apps/web/src/app/_actions/nft.ts
+++ b/apps/web/src/app/_actions/nft.ts
@@ -1,7 +1,10 @@
 'use server';
 
 import {
+  extractPrivyApiDiagnostics,
   getAuthedUserContextFromPrivyTokenBundle,
+  type PrivyApiDiagnostics,
+  redactJwtLikeTokens,
   sendSponsoredEvmTransaction,
 } from '@babylon/api';
 import {
@@ -21,30 +24,9 @@ type MintStep =
   | 'send_transaction'
   | 'confirm';
 
-type MintDebugDetails = {
-  errorName?: string;
-  errorMessage?: string;
-  status?: number;
-  providerCode?: string;
-  providerRequestId?: string;
-  providerMessage?: string;
-};
-
-function redactJwtLikeTokens(text: string): string {
-  // Redact JWT-like strings (base64url.base64url.base64url).
-  // This avoids accidentally logging auth tokens if they show up in an error message/stack.
-  const jwtLike =
-    /(?<![A-Za-z0-9_-])([A-Za-z0-9_-]{10,})\.([A-Za-z0-9_-]{10,})\.([A-Za-z0-9_-]{10,})(?![A-Za-z0-9_-])/g;
-  return text.replace(jwtLike, '[REDACTED_JWT]');
-}
-
 function errorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
   return typeof error === 'string' ? error : 'Unknown error';
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
 }
 
 function exposeOnchainErrorDetails(): boolean {
@@ -53,65 +35,12 @@ function exposeOnchainErrorDetails(): boolean {
   return ['1', 'true', 'yes', 'on'].includes(raw.toLowerCase());
 }
 
-function pickHeaderValue(
-  headers: unknown,
-  headerName: string
-): string | undefined {
-  if (!headers) return undefined;
-
-  if (typeof Headers !== 'undefined' && headers instanceof Headers) {
-    return headers.get(headerName) ?? undefined;
-  }
-
-  if (isRecord(headers)) {
-    const direct = headers[headerName];
-    if (typeof direct === 'string' && direct.length > 0) return direct;
-    const lower = headers[headerName.toLowerCase()];
-    if (typeof lower === 'string' && lower.length > 0) return lower;
-  }
-
-  return undefined;
-}
-
-function toDebugDetails(error: unknown): MintDebugDetails | undefined {
+function toDebugDetails(error: unknown): PrivyApiDiagnostics | undefined {
   if (!exposeOnchainErrorDetails()) return undefined;
 
-  const debug: MintDebugDetails = {};
-
-  if (error instanceof Error) {
-    debug.errorName = error.name;
-    debug.errorMessage = redactJwtLikeTokens(error.message);
-  } else if (typeof error === 'string') {
-    debug.errorMessage = redactJwtLikeTokens(error);
-  }
-
-  if (isRecord(error)) {
-    const status = error.status;
-    if (typeof status === 'number' && Number.isFinite(status)) {
-      debug.status = status;
-    }
-
-    const providerRequestId =
-      pickHeaderValue(error.headers, 'x-request-id') ??
-      pickHeaderValue(error.headers, 'x-privy-request-id');
-    if (providerRequestId) {
-      debug.providerRequestId = providerRequestId;
-    }
-
-    const providerError = error.error;
-    if (isRecord(providerError)) {
-      const providerCode = providerError.code;
-      if (typeof providerCode === 'string' && providerCode.length > 0) {
-        debug.providerCode = providerCode;
-      }
-
-      const providerMessage = providerError.message;
-      if (typeof providerMessage === 'string' && providerMessage.length > 0) {
-        debug.providerMessage = redactJwtLikeTokens(providerMessage);
-      }
-    }
-  }
-
+  const debug = extractPrivyApiDiagnostics(error, {
+    redactJwtLike: true,
+  });
   return Object.keys(debug).length > 0 ? debug : undefined;
 }
 
@@ -176,7 +105,7 @@ export type MintNftActionResult =
       error: string;
       step: MintStep;
       errorId: string;
-      debug?: MintDebugDetails;
+      debug?: PrivyApiDiagnostics;
     };
 
 /**

--- a/apps/web/src/app/_actions/nft.ts
+++ b/apps/web/src/app/_actions/nft.ts
@@ -21,6 +21,15 @@ type MintStep =
   | 'send_transaction'
   | 'confirm';
 
+type MintDebugDetails = {
+  errorName?: string;
+  errorMessage?: string;
+  status?: number;
+  providerCode?: string;
+  providerRequestId?: string;
+  providerMessage?: string;
+};
+
 function redactJwtLikeTokens(text: string): string {
   // Redact JWT-like strings (base64url.base64url.base64url).
   // This avoids accidentally logging auth tokens if they show up in an error message/stack.
@@ -32,6 +41,78 @@ function redactJwtLikeTokens(text: string): string {
 function errorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
   return typeof error === 'string' ? error : 'Unknown error';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function exposeOnchainErrorDetails(): boolean {
+  const raw = process.env.EXPOSE_ONCHAIN_ERROR_DETAILS;
+  if (!raw) return false;
+  return ['1', 'true', 'yes', 'on'].includes(raw.toLowerCase());
+}
+
+function pickHeaderValue(
+  headers: unknown,
+  headerName: string
+): string | undefined {
+  if (!headers) return undefined;
+
+  if (typeof Headers !== 'undefined' && headers instanceof Headers) {
+    return headers.get(headerName) ?? undefined;
+  }
+
+  if (isRecord(headers)) {
+    const direct = headers[headerName];
+    if (typeof direct === 'string' && direct.length > 0) return direct;
+    const lower = headers[headerName.toLowerCase()];
+    if (typeof lower === 'string' && lower.length > 0) return lower;
+  }
+
+  return undefined;
+}
+
+function toDebugDetails(error: unknown): MintDebugDetails | undefined {
+  if (!exposeOnchainErrorDetails()) return undefined;
+
+  const debug: MintDebugDetails = {};
+
+  if (error instanceof Error) {
+    debug.errorName = error.name;
+    debug.errorMessage = redactJwtLikeTokens(error.message);
+  } else if (typeof error === 'string') {
+    debug.errorMessage = redactJwtLikeTokens(error);
+  }
+
+  if (isRecord(error)) {
+    const status = error.status;
+    if (typeof status === 'number' && Number.isFinite(status)) {
+      debug.status = status;
+    }
+
+    const providerRequestId =
+      pickHeaderValue(error.headers, 'x-request-id') ??
+      pickHeaderValue(error.headers, 'x-privy-request-id');
+    if (providerRequestId) {
+      debug.providerRequestId = providerRequestId;
+    }
+
+    const providerError = error.error;
+    if (isRecord(providerError)) {
+      const providerCode = providerError.code;
+      if (typeof providerCode === 'string' && providerCode.length > 0) {
+        debug.providerCode = providerCode;
+      }
+
+      const providerMessage = providerError.message;
+      if (typeof providerMessage === 'string' && providerMessage.length > 0) {
+        debug.providerMessage = redactJwtLikeTokens(providerMessage);
+      }
+    }
+  }
+
+  return Object.keys(debug).length > 0 ? debug : undefined;
 }
 
 function toSafeLogError(error: unknown): {
@@ -90,7 +171,13 @@ function toUserSafeMintError(step: MintStep, error: unknown): string {
 export type MintNftActionResult =
   | ({ status: 'confirmed'; txHash: Hex } & ConfirmResult)
   | { status: 'pending'; txHash: Hex; message: string }
-  | { status: 'error'; error: string; step: MintStep; errorId: string };
+  | {
+      status: 'error';
+      error: string;
+      step: MintStep;
+      errorId: string;
+      debug?: MintDebugDetails;
+    };
 
 /**
  * Exponential backoff sleep with jitter for polling.
@@ -141,6 +228,7 @@ export async function mintNftAction(input?: {
       error: toUserSafeMintError(step, e),
       step,
       errorId,
+      debug: toDebugDetails(e),
     };
   }
 
@@ -164,6 +252,7 @@ export async function mintNftAction(input?: {
       error: toUserSafeMintError(step, e),
       step,
       errorId,
+      debug: toDebugDetails(e),
     };
   }
 
@@ -184,6 +273,7 @@ export async function mintNftAction(input?: {
       error: toUserSafeMintError(step, e),
       step,
       errorId,
+      debug: toDebugDetails(e),
     };
   }
 
@@ -219,6 +309,7 @@ export async function mintNftAction(input?: {
       error: toUserSafeMintError(step, e),
       step,
       errorId,
+      debug: toDebugDetails(e),
     };
   }
 
@@ -254,6 +345,7 @@ export async function mintNftAction(input?: {
         error: toUserSafeMintError(step, error),
         step,
         errorId,
+        debug: toDebugDetails(error),
       };
     }
   }

--- a/apps/web/src/app/_actions/onchain.ts
+++ b/apps/web/src/app/_actions/onchain.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import {
-  getAuthedUserContextFromPrivyToken,
+  getAuthedUserContextFromPrivyTokenBundle,
   sendSponsoredEvmTransaction,
 } from '@babylon/api';
 import { getContractAddresses } from '@babylon/contracts';
@@ -63,8 +63,7 @@ export async function buySharesOnchainAction(input: {
   userJwt?: string;
 }): Promise<{ txHash: Hex }> {
   const bundle = await requirePrivyTokenBundle(input.userJwt);
-  const privyToken = bundle.primary;
-  const ctx = await getAuthedUserContextFromPrivyToken(privyToken);
+  const ctx = await getAuthedUserContextFromPrivyTokenBundle(bundle);
 
   const marketIdBytes32 = marketIdToBytes32(input.marketId);
   const outcomeIndex = input.outcome === 'YES' ? 1 : 0;
@@ -95,8 +94,7 @@ export async function sellSharesOnchainAction(input: {
   userJwt?: string;
 }): Promise<{ txHash: Hex }> {
   const bundle = await requirePrivyTokenBundle(input.userJwt);
-  const privyToken = bundle.primary;
-  const ctx = await getAuthedUserContextFromPrivyToken(privyToken);
+  const ctx = await getAuthedUserContextFromPrivyTokenBundle(bundle);
 
   const marketIdBytes32 = marketIdToBytes32(input.marketId);
   const outcomeIndex = input.outcome === 'YES' ? 1 : 0;
@@ -126,8 +124,7 @@ export async function sendSponsoredEthTransferAction(input: {
   userJwt?: string;
 }): Promise<{ txHash: Hex }> {
   const bundle = await requirePrivyTokenBundle(input.userJwt);
-  const privyToken = bundle.primary;
-  const ctx = await getAuthedUserContextFromPrivyToken(privyToken);
+  const ctx = await getAuthedUserContextFromPrivyTokenBundle(bundle);
 
   if (!isAddress(input.to)) {
     throw new Error('Invalid recipient address');
@@ -151,8 +148,7 @@ export async function updateAgentProfileOnchainAction(input: {
   userJwt?: string;
 }): Promise<{ txHash: Hex }> {
   const bundle = await requirePrivyTokenBundle(input.userJwt);
-  const privyToken = bundle.primary;
-  const ctx = await getAuthedUserContextFromPrivyToken(privyToken);
+  const ctx = await getAuthedUserContextFromPrivyTokenBundle(bundle);
 
   const registryAddress = getIdentityRegistryAddress();
   if (!registryAddress) {

--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -143,7 +143,6 @@
 
 import {
   authenticate,
-  BusinessLogicError,
   ConflictError,
   cachedDb,
   ensureOfflineWalletReady,
@@ -381,12 +380,6 @@ async function updateReferrerForIncompleteUser(
 
 export const GET = withErrorHandling(async (request: NextRequest) => {
   const authUser = await authenticate(request);
-  const cookieToken = request.cookies.get('privy-token')?.value;
-  const authHeader = request.headers.get('authorization');
-  const headerToken = authHeader?.startsWith('Bearer ')
-    ? authHeader.substring(7)
-    : undefined;
-  const userJwt = cookieToken ?? headerToken ?? null;
   const privyId = authUser.privyId ?? authUser.userId;
   const canonicalUserId = authUser.dbUserId ?? authUser.userId;
   const clientEmbeddedWalletAddressRaw = request.headers.get(
@@ -830,14 +823,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     shouldResyncWallet;
 
   if (shouldEnsureOfflineWallet) {
-    if (!userJwt) {
-      throw new BusinessLogicError(
-        'Authentication required. Missing Privy access token for offline wallet provisioning.',
-        'AUTH_REQUIRED'
-      );
-    }
-
-    const offlineWallet = await ensureOfflineWalletReady({ privyId, userJwt });
+    const offlineWallet = await ensureOfflineWalletReady({ privyId });
     const resolvedAddress = offlineWallet.walletAddress.toLowerCase();
 
     if (

--- a/apps/web/src/app/api/users/onboarding/onchain/route.ts
+++ b/apps/web/src/app/api/users/onboarding/onchain/route.ts
@@ -67,27 +67,11 @@ interface OnchainRequestBody {
 }
 
 export const POST = withErrorHandling(async (request: NextRequest) => {
-  const cookieToken = request.cookies.get('privy-token')?.value;
-  const authHeader = request.headers.get('authorization');
-  const headerToken = authHeader?.startsWith('Bearer ')
-    ? authHeader.substring(7)
-    : undefined;
-  // Prefer the HttpOnly `privy-token` cookie when present. With Privy cookies enabled,
-  // this cookie contains the user's access token (JWT) and is the most reliable source.
-  // Fall back to the Authorization header for external clients/agents.
-  const userJwt = cookieToken ?? headerToken ?? null;
-
   const authUser = await authenticate(request);
+  const privyId = authUser.privyId ?? authUser.userId;
   const body = (await request.json()) as
     | OnchainRequestBody
     | Record<string, JsonValue>;
-
-  if (!userJwt) {
-    throw new BusinessLogicError(
-      'Authentication required. Missing Privy access token.',
-      'AUTH_REQUIRED'
-    );
-  }
 
   const referralCode =
     typeof (body as OnchainRequestBody).referralCode === 'string'
@@ -131,8 +115,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
   }
 
   const offlineWallet = await ensureOfflineWalletReady({
-    privyId: dbUser.privyId ?? authUser.privyId ?? authUser.userId,
-    userJwt,
+    privyId: dbUser.privyId ?? privyId,
   });
   const walletAddress = offlineWallet.walletAddress.toLowerCase();
 

--- a/apps/web/src/app/api/users/signup/route.ts
+++ b/apps/web/src/app/api/users/signup/route.ts
@@ -89,7 +89,6 @@
 import type { JsonValue } from '@babylon/api';
 import {
   authenticate,
-  BusinessLogicError,
   ConflictError,
   ensureOfflineWalletReady,
   getHashedClientIp,
@@ -155,19 +154,7 @@ const SignupSchema = OnboardingProfileSchema.extend({
 
 export const POST = withErrorHandling(async (request: NextRequest) => {
   const authUser = await authenticate(request);
-  const cookieToken = request.cookies.get('privy-token')?.value;
-  const authHeader = request.headers.get('authorization');
-  const headerToken = authHeader?.startsWith('Bearer ')
-    ? authHeader.substring(7)
-    : undefined;
-  const userJwt = cookieToken ?? headerToken ?? null;
-
-  if (!userJwt) {
-    throw new BusinessLogicError(
-      'Authentication required. Missing Privy access token.',
-      'AUTH_REQUIRED'
-    );
-  }
+  const privyId = authUser.privyId ?? authUser.userId;
 
   const body = (await request.json()) as
     | SignupRequestBody
@@ -184,7 +171,6 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
   const referralCode = rawReferralCode?.trim() || null;
 
   const canonicalUserId = authUser.dbUserId ?? authUser.userId;
-  const privyId = authUser.privyId ?? authUser.userId;
   // Embedded-wallet-only: persist the embedded wallet (EOA) as the user's onchain identity.
   let walletAddress = authUser.walletAddress?.toLowerCase() ?? null;
   let privyWalletId: string | null = null;
@@ -223,7 +209,9 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
   const importedTwitter = parsedProfile.importedFrom === 'twitter';
   const importedFarcaster = parsedProfile.importedFrom === 'farcaster';
 
-  const offlineWallet = await ensureOfflineWalletReady({ privyId, userJwt });
+  const offlineWallet = await ensureOfflineWalletReady({
+    privyId,
+  });
   privyWalletId = offlineWallet.privyWalletId;
   walletAddress = offlineWallet.walletAddress;
 

--- a/apps/web/src/hooks/useNftMint.ts
+++ b/apps/web/src/hooks/useNftMint.ts
@@ -175,6 +175,7 @@ export function useNftMint(): UseNftMintResult {
           step: result.step,
           errorId: result.errorId,
           message: result.error,
+          debug: result.debug,
         });
         handleError(result.error, result.errorId);
         return;

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -228,13 +228,13 @@ export {
   getAuthedUserContextFromPrivyToken,
   getAuthedUserContextFromPrivyTokenBundle,
 } from './services/privy/authed-user';
-export { sendSponsoredEvmTransaction } from './services/privy/evm-send-transaction';
-export { ensureOfflineWalletReady } from './services/privy/offline-wallet-provisioning';
 export {
   extractPrivyApiDiagnostics,
-  redactJwtLikeTokens,
   type PrivyApiDiagnostics,
+  redactJwtLikeTokens,
 } from './services/privy/error-diagnostics';
+export { sendSponsoredEvmTransaction } from './services/privy/evm-send-transaction';
+export { ensureOfflineWalletReady } from './services/privy/offline-wallet-provisioning';
 // Privy (embedded wallet server-side helpers)
 export {
   type PrivyUserWalletsLite,

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -230,6 +230,11 @@ export {
 } from './services/privy/authed-user';
 export { sendSponsoredEvmTransaction } from './services/privy/evm-send-transaction';
 export { ensureOfflineWalletReady } from './services/privy/offline-wallet-provisioning';
+export {
+  extractPrivyApiDiagnostics,
+  redactJwtLikeTokens,
+  type PrivyApiDiagnostics,
+} from './services/privy/error-diagnostics';
 // Privy (embedded wallet server-side helpers)
 export {
   type PrivyUserWalletsLite,

--- a/packages/api/src/services/privy/__tests__/error-diagnostics.test.ts
+++ b/packages/api/src/services/privy/__tests__/error-diagnostics.test.ts
@@ -4,8 +4,7 @@ import {
   redactJwtLikeTokens,
 } from '../error-diagnostics';
 
-const JWT_LIKE =
-  'aaaaaaaaaaaa.bbbbbbbbbbbb.cccccccccccc';
+const JWT_LIKE = 'aaaaaaaaaaaa.bbbbbbbbbbbb.cccccccccccc';
 
 describe('redactJwtLikeTokens', () => {
   it('redacts JWT-like tokens in text', () => {

--- a/packages/api/src/services/privy/__tests__/error-diagnostics.test.ts
+++ b/packages/api/src/services/privy/__tests__/error-diagnostics.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  extractPrivyApiDiagnostics,
+  redactJwtLikeTokens,
+} from '../error-diagnostics';
+
+const JWT_LIKE =
+  'aaaaaaaaaaaa.bbbbbbbbbbbb.cccccccccccc';
+
+describe('redactJwtLikeTokens', () => {
+  it('redacts JWT-like tokens in text', () => {
+    const input = `failed with token ${JWT_LIKE}`;
+    const output = redactJwtLikeTokens(input);
+
+    expect(output).toContain('[REDACTED_JWT]');
+    expect(output).not.toContain(JWT_LIKE);
+  });
+});
+
+describe('extractPrivyApiDiagnostics', () => {
+  it('extracts provider diagnostics from error-shaped input', () => {
+    const error = new Error('request failed') as Error & {
+      status: number;
+      headers: Record<string, string>;
+      error: {
+        code: string;
+        message: string;
+      };
+    };
+    error.status = 400;
+    error.headers = { 'x-request-id': 'req_123' };
+    error.error = {
+      code: 'invalid_data',
+      message: 'Invalid JWT token provided',
+    };
+
+    const diagnostics = extractPrivyApiDiagnostics(error);
+
+    expect(diagnostics.errorName).toBe('Error');
+    expect(diagnostics.errorMessage).toBe('request failed');
+    expect(diagnostics.status).toBe(400);
+    expect(diagnostics.providerRequestId).toBe('req_123');
+    expect(diagnostics.providerCode).toBe('invalid_data');
+    expect(diagnostics.providerMessage).toBe('Invalid JWT token provided');
+  });
+
+  it('redacts JWT-like strings when requested', () => {
+    const error = new Error(`request failed: ${JWT_LIKE}`) as Error & {
+      error: {
+        message: string;
+      };
+    };
+    error.error = { message: `provider said: ${JWT_LIKE}` };
+
+    const diagnostics = extractPrivyApiDiagnostics(error, {
+      redactJwtLike: true,
+    });
+
+    expect(diagnostics.errorMessage).toContain('[REDACTED_JWT]');
+    expect(diagnostics.errorMessage).not.toContain(JWT_LIKE);
+    expect(diagnostics.providerMessage).toContain('[REDACTED_JWT]');
+    expect(diagnostics.providerMessage).not.toContain(JWT_LIKE);
+  });
+});

--- a/packages/api/src/services/privy/__tests__/offline-wallet-provisioning.test.ts
+++ b/packages/api/src/services/privy/__tests__/offline-wallet-provisioning.test.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it, mock } from 'bun:test';
 const mockGetUser = mock();
 const mockCreateWallets = mock();
 const mockWalletGet = mock();
-const mockWalletUpdate = mock();
 
 mock.module('@babylon/shared', () => ({
   logger: {
@@ -25,7 +24,6 @@ mock.module('../privy-node', () => ({
   getPrivyNodeClient: () => ({
     wallets: () => ({
       get: mockWalletGet,
-      update: mockWalletUpdate,
     }),
   }),
 }));
@@ -46,7 +44,6 @@ describe('ensureOfflineWalletReady', () => {
     mockGetUser.mockReset();
     mockCreateWallets.mockReset();
     mockWalletGet.mockReset();
-    mockWalletUpdate.mockReset();
 
     process.env.PRIVY_APP_ID = 'test-app-id';
     process.env.PRIVY_APP_SECRET = 'test-secret';
@@ -72,7 +69,6 @@ describe('ensureOfflineWalletReady', () => {
 
     const result = await ensureOfflineWalletReady({
       privyId: 'did:privy:user-1',
-      userJwt: 'jwt-token',
     });
 
     expect(result.offlineWalletReady).toBe(true);
@@ -80,7 +76,6 @@ describe('ensureOfflineWalletReady', () => {
     expect(result.updatedSigner).toBe(false);
     expect(result.privyWalletId).toBe('wallet-1');
     expect(mockCreateWallets).not.toHaveBeenCalled();
-    expect(mockWalletUpdate).not.toHaveBeenCalled();
   });
 
   it('creates wallet when embedded wallet is missing', async () => {
@@ -92,8 +87,15 @@ describe('ensureOfflineWalletReady', () => {
       })
       .mockResolvedValueOnce({
         id: 'did:privy:user-2',
-        wallet: EMBEDDED_WALLET,
-        linkedAccounts: [],
+        wallet: null,
+        linkedAccounts: [
+          {
+            ...EMBEDDED_WALLET,
+            id: 'wallet-2',
+            address: EMBEDDED_WALLET.address,
+            type: 'wallet',
+          },
+        ],
       });
     mockWalletGet.mockResolvedValue({
       additional_signers: [
@@ -106,63 +108,81 @@ describe('ensureOfflineWalletReady', () => {
 
     const result = await ensureOfflineWalletReady({
       privyId: 'did:privy:user-2',
-      userJwt: 'jwt-token',
     });
 
     expect(result.createdWallet).toBe(true);
     expect(result.updatedSigner).toBe(false);
+    expect(result.privyWalletId).toBe('wallet-2');
     expect(mockCreateWallets).toHaveBeenCalledTimes(1);
   });
 
-  it('updates wallet signers when signer policy is missing', async () => {
-    mockGetUser.mockResolvedValue({
-      id: 'did:privy:user-3',
-      wallet: EMBEDDED_WALLET,
-      linkedAccounts: [],
-    });
-    mockWalletGet
+  it('rotates wallet when existing embedded wallet is not offline-ready', async () => {
+    mockGetUser
       .mockResolvedValueOnce({
-        additional_signers: [],
+        id: 'did:privy:user-3',
+        wallet: { ...EMBEDDED_WALLET, id: 'wallet-old' },
+        linkedAccounts: [],
       })
       .mockResolvedValueOnce({
-        additional_signers: [
+        id: 'did:privy:user-3',
+        wallet: { ...EMBEDDED_WALLET, id: 'wallet-old' },
+        linkedAccounts: [
           {
-            signer_id: 'offline-signer-id',
-            override_policy_ids: ['offline-policy-id'],
+            ...EMBEDDED_WALLET,
+            id: 'wallet-new',
+            address: '0x0000000000000000000000000000000000000002',
+            type: 'wallet',
           },
         ],
       });
+    mockWalletGet.mockImplementation(async (walletId: string) => {
+      if (walletId === 'wallet-old') return { additional_signers: [] };
+      if (walletId === 'wallet-new') {
+        return {
+          additional_signers: [
+            {
+              signer_id: 'offline-signer-id',
+              override_policy_ids: ['offline-policy-id'],
+            },
+          ],
+        };
+      }
+      return { additional_signers: [] };
+    });
 
     const result = await ensureOfflineWalletReady({
       privyId: 'did:privy:user-3',
-      userJwt: 'jwt-token',
     });
 
-    expect(result.createdWallet).toBe(false);
-    expect(result.updatedSigner).toBe(true);
-    expect(mockWalletUpdate).toHaveBeenCalledTimes(1);
-    expect(mockWalletUpdate).toHaveBeenCalledWith('wallet-1', {
-      additional_signers: [
-        {
-          signer_id: 'offline-signer-id',
-          override_policy_ids: ['offline-policy-id'],
-        },
-      ],
-      authorization_context: {
-        user_jwts: ['jwt-token'],
-        authorization_private_keys: ['test-authorization-key'],
-      },
-    });
+    expect(result.createdWallet).toBe(true);
+    expect(result.updatedSigner).toBe(false);
+    expect(result.privyWalletId).toBe('wallet-new');
+    expect(result.walletAddress).toBe(
+      '0x0000000000000000000000000000000000000002'
+    );
+    expect(mockCreateWallets).toHaveBeenCalledTimes(1);
   });
 
-  it('rejects when user JWT is missing', async () => {
+  it('fails when no offline-ready wallet can be resolved after creation', async () => {
+    mockGetUser
+      .mockResolvedValueOnce({
+        id: 'did:privy:user-4',
+        wallet: { ...EMBEDDED_WALLET, id: 'wallet-old' },
+        linkedAccounts: [],
+      })
+      .mockResolvedValueOnce({
+        id: 'did:privy:user-4',
+        wallet: { ...EMBEDDED_WALLET, id: 'wallet-old' },
+        linkedAccounts: [],
+      });
+    mockWalletGet.mockResolvedValue({ additional_signers: [] });
+
     await expect(
       ensureOfflineWalletReady({
         privyId: 'did:privy:user-4',
-        userJwt: '',
       })
     ).rejects.toThrow(
-      'Cannot provision offline wallet readiness without an authenticated Privy JWT'
+      'Offline wallet provisioning failed: signer/policy not attached on newly created wallet'
     );
   });
 });

--- a/packages/api/src/services/privy/error-diagnostics.ts
+++ b/packages/api/src/services/privy/error-diagnostics.ts
@@ -1,0 +1,88 @@
+export type PrivyApiDiagnostics = {
+  errorName?: string;
+  errorMessage?: string;
+  status?: number;
+  providerCode?: string;
+  providerRequestId?: string;
+  providerMessage?: string;
+};
+
+type ExtractPrivyApiDiagnosticsOptions = {
+  redactJwtLike?: boolean;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function pickHeaderValue(
+  headers: unknown,
+  headerName: string
+): string | undefined {
+  if (!headers) return undefined;
+
+  if (typeof Headers !== 'undefined' && headers instanceof Headers) {
+    return headers.get(headerName) ?? undefined;
+  }
+
+  if (isRecord(headers)) {
+    const direct = headers[headerName];
+    if (typeof direct === 'string' && direct.length > 0) return direct;
+    const lower = headers[headerName.toLowerCase()];
+    if (typeof lower === 'string' && lower.length > 0) return lower;
+  }
+
+  return undefined;
+}
+
+export function redactJwtLikeTokens(text: string): string {
+  // Redact JWT-like strings (base64url.base64url.base64url).
+  const jwtLike =
+    /(?<![A-Za-z0-9_-])([A-Za-z0-9_-]{10,})\.([A-Za-z0-9_-]{10,})\.([A-Za-z0-9_-]{10,})(?![A-Za-z0-9_-])/g;
+  return text.replace(jwtLike, '[REDACTED_JWT]');
+}
+
+export function extractPrivyApiDiagnostics(
+  error: unknown,
+  options: ExtractPrivyApiDiagnosticsOptions = {}
+): PrivyApiDiagnostics {
+  const diagnostics: PrivyApiDiagnostics = {};
+  const maybeRedact = (value: string): string =>
+    options.redactJwtLike ? redactJwtLikeTokens(value) : value;
+
+  if (error instanceof Error) {
+    diagnostics.errorName = error.name;
+    diagnostics.errorMessage = maybeRedact(error.message);
+  } else if (typeof error === 'string') {
+    diagnostics.errorMessage = maybeRedact(error);
+  }
+
+  if (!isRecord(error)) return diagnostics;
+
+  const status = error.status;
+  if (typeof status === 'number' && Number.isFinite(status)) {
+    diagnostics.status = status;
+  }
+
+  const providerRequestId =
+    pickHeaderValue(error.headers, 'x-request-id') ??
+    pickHeaderValue(error.headers, 'x-privy-request-id');
+  if (providerRequestId) {
+    diagnostics.providerRequestId = providerRequestId;
+  }
+
+  const providerError = error.error;
+  if (isRecord(providerError)) {
+    const providerCode = providerError.code;
+    if (typeof providerCode === 'string' && providerCode.length > 0) {
+      diagnostics.providerCode = providerCode;
+    }
+
+    const providerMessage = providerError.message;
+    if (typeof providerMessage === 'string' && providerMessage.length > 0) {
+      diagnostics.providerMessage = maybeRedact(providerMessage);
+    }
+  }
+
+  return diagnostics;
+}

--- a/packages/api/src/services/privy/evm-send-transaction.ts
+++ b/packages/api/src/services/privy/evm-send-transaction.ts
@@ -16,6 +16,79 @@ export type SendSponsoredEvmTransactionInput = {
   idempotencyKey?: string;
 };
 
+type PrivyApiDiagnostics = {
+  errorName?: string;
+  errorMessage?: string;
+  status?: number;
+  providerCode?: string;
+  providerRequestId?: string;
+  providerMessage?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function pickHeaderValue(
+  headers: unknown,
+  headerName: string
+): string | undefined {
+  if (!headers) return undefined;
+
+  if (typeof Headers !== 'undefined' && headers instanceof Headers) {
+    return headers.get(headerName) ?? undefined;
+  }
+
+  if (isRecord(headers)) {
+    const direct = headers[headerName];
+    if (typeof direct === 'string' && direct.length > 0) return direct;
+    const lower = headers[headerName.toLowerCase()];
+    if (typeof lower === 'string' && lower.length > 0) return lower;
+  }
+
+  return undefined;
+}
+
+function extractPrivyApiDiagnostics(error: unknown): PrivyApiDiagnostics {
+  const diagnostics: PrivyApiDiagnostics = {};
+
+  if (error instanceof Error) {
+    diagnostics.errorName = error.name;
+    diagnostics.errorMessage = error.message;
+  } else if (typeof error === 'string') {
+    diagnostics.errorMessage = error;
+  }
+
+  if (!isRecord(error)) return diagnostics;
+
+  const status = error.status;
+  if (typeof status === 'number' && Number.isFinite(status)) {
+    diagnostics.status = status;
+  }
+
+  const providerRequestId =
+    pickHeaderValue(error.headers, 'x-request-id') ??
+    pickHeaderValue(error.headers, 'x-privy-request-id');
+  if (providerRequestId) {
+    diagnostics.providerRequestId = providerRequestId;
+  }
+
+  const providerError = error.error;
+  if (isRecord(providerError)) {
+    const providerCode = providerError.code;
+    if (typeof providerCode === 'string' && providerCode.length > 0) {
+      diagnostics.providerCode = providerCode;
+    }
+
+    const providerMessage = providerError.message;
+    if (typeof providerMessage === 'string' && providerMessage.length > 0) {
+      diagnostics.providerMessage = providerMessage;
+    }
+  }
+
+  return diagnostics;
+}
+
 /**
  * Runtime schema for a Privy JWT payload.
  * See: https://docs.privy.io/guide/server/authorization/verification
@@ -161,6 +234,8 @@ export async function sendSponsoredEvmTransaction({
 
     return { hash: response.hash as Hex, caip2: response.caip2 };
   } catch (error) {
+    const diagnostics = extractPrivyApiDiagnostics(error);
+
     logger.error(
       'Failed to submit offline sponsored transaction',
       {
@@ -168,7 +243,7 @@ export async function sendSponsoredEvmTransaction({
         chainId,
         walletId,
         to,
-        errorMessage: error instanceof Error ? error.message : 'unknown',
+        ...diagnostics,
       },
       'sendSponsoredEvmTransaction'
     );

--- a/packages/api/src/services/privy/evm-send-transaction.ts
+++ b/packages/api/src/services/privy/evm-send-transaction.ts
@@ -3,6 +3,7 @@ import type { AuthorizationContext } from '@privy-io/node';
 import { decodeJwt, decodeProtectedHeader } from 'jose';
 import type { Address, Hex } from 'viem';
 import { z } from 'zod';
+import { extractPrivyApiDiagnostics } from './error-diagnostics';
 import { getPrivyOfflineConfig } from './offline-config';
 import { getPrivyNodeClient } from './privy-node';
 
@@ -15,79 +16,6 @@ export type SendSponsoredEvmTransactionInput = {
   chainId?: number;
   idempotencyKey?: string;
 };
-
-type PrivyApiDiagnostics = {
-  errorName?: string;
-  errorMessage?: string;
-  status?: number;
-  providerCode?: string;
-  providerRequestId?: string;
-  providerMessage?: string;
-};
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-function pickHeaderValue(
-  headers: unknown,
-  headerName: string
-): string | undefined {
-  if (!headers) return undefined;
-
-  if (typeof Headers !== 'undefined' && headers instanceof Headers) {
-    return headers.get(headerName) ?? undefined;
-  }
-
-  if (isRecord(headers)) {
-    const direct = headers[headerName];
-    if (typeof direct === 'string' && direct.length > 0) return direct;
-    const lower = headers[headerName.toLowerCase()];
-    if (typeof lower === 'string' && lower.length > 0) return lower;
-  }
-
-  return undefined;
-}
-
-function extractPrivyApiDiagnostics(error: unknown): PrivyApiDiagnostics {
-  const diagnostics: PrivyApiDiagnostics = {};
-
-  if (error instanceof Error) {
-    diagnostics.errorName = error.name;
-    diagnostics.errorMessage = error.message;
-  } else if (typeof error === 'string') {
-    diagnostics.errorMessage = error;
-  }
-
-  if (!isRecord(error)) return diagnostics;
-
-  const status = error.status;
-  if (typeof status === 'number' && Number.isFinite(status)) {
-    diagnostics.status = status;
-  }
-
-  const providerRequestId =
-    pickHeaderValue(error.headers, 'x-request-id') ??
-    pickHeaderValue(error.headers, 'x-privy-request-id');
-  if (providerRequestId) {
-    diagnostics.providerRequestId = providerRequestId;
-  }
-
-  const providerError = error.error;
-  if (isRecord(providerError)) {
-    const providerCode = providerError.code;
-    if (typeof providerCode === 'string' && providerCode.length > 0) {
-      diagnostics.providerCode = providerCode;
-    }
-
-    const providerMessage = providerError.message;
-    if (typeof providerMessage === 'string' && providerMessage.length > 0) {
-      diagnostics.providerMessage = providerMessage;
-    }
-  }
-
-  return diagnostics;
-}
 
 /**
  * Runtime schema for a Privy JWT payload.

--- a/packages/api/src/services/privy/offline-wallet-provisioning.ts
+++ b/packages/api/src/services/privy/offline-wallet-provisioning.ts
@@ -87,7 +87,8 @@ export async function ensureOfflineWalletReady({
     privyId
   )) as PrivyUserWithWallets;
   const initialWallets = listEmbeddedEvmWallets(initialPrivyUser);
-  let embedded = initialWallets[0] ?? null;
+  let embedded: (typeof initialWallets)[number] | null =
+    initialWallets[0] ?? null;
 
   for (const candidate of initialWallets) {
     const wallet = await privyNode.wallets().get(candidate.walletId);

--- a/packages/api/src/services/privy/offline-wallet-provisioning.ts
+++ b/packages/api/src/services/privy/offline-wallet-provisioning.ts
@@ -4,8 +4,8 @@ import { getPrivyClient } from '../../auth-middleware';
 import { getPrivyOfflineConfig } from './offline-config';
 import { getPrivyNodeClient } from './privy-node';
 import {
+  listEmbeddedEvmWallets,
   type PrivyUserWalletsLite,
-  pickEmbeddedEvmWallet,
 } from './user-wallets';
 
 type PrivyUserWithWallets = PrivyUser & PrivyUserWalletsLite;
@@ -19,7 +19,6 @@ type WalletWithSigners = {
 
 export type EnsureOfflineWalletReadyInput = {
   privyId: string;
-  userJwt: string;
 };
 
 export type EnsureOfflineWalletReadyResult = {
@@ -42,46 +41,88 @@ function hasOfflineSignerPolicy(
   return (signer.override_policy_ids ?? []).includes(policyId);
 }
 
-function buildUpdatedSigners(
-  wallet: WalletWithSigners,
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function findReadyWalletWithRetry(
+  walletIds: string[],
+  privyNode: ReturnType<typeof getPrivyNodeClient>,
   signerId: string,
   policyId: string
-): WalletSigner[] {
-  const withoutTarget = wallet.additional_signers.filter(
-    (s) => s.signer_id !== signerId
-  );
-  return [
-    ...withoutTarget,
-    {
-      signer_id: signerId,
-      override_policy_ids: [policyId],
-    },
-  ];
+): Promise<string | null> {
+  if (walletIds.length === 0) return null;
+
+  const isTest = process.env.NODE_ENV === 'test';
+  const maxAttempts = isTest ? 1 : 8;
+  const delayMs = isTest ? 0 : 250;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    for (const walletId of walletIds) {
+      const wallet = await privyNode.wallets().get(walletId);
+      if (hasOfflineSignerPolicy(wallet, signerId, policyId)) {
+        return walletId;
+      }
+    }
+
+    if (attempt < maxAttempts - 1 && delayMs > 0) {
+      await sleep(delayMs);
+    }
+  }
+
+  return null;
 }
 
 export async function ensureOfflineWalletReady({
   privyId,
-  userJwt,
 }: EnsureOfflineWalletReadyInput): Promise<EnsureOfflineWalletReadyResult> {
   const privyNode = getPrivyNodeClient();
   const privyServer = getPrivyClient();
   const offlineConfig = getPrivyOfflineConfig();
 
-  if (!userJwt || userJwt.trim().length === 0) {
-    throw new Error(
-      'Cannot provision offline wallet readiness without an authenticated Privy JWT'
-    );
-  }
-
   let createdWallet = false;
-  let updatedSigner = false;
+  const updatedSigner = false;
 
   const initialPrivyUser = (await privyServer.getUser(
     privyId
   )) as PrivyUserWithWallets;
-  let embedded = pickEmbeddedEvmWallet(initialPrivyUser);
+  const initialWallets = listEmbeddedEvmWallets(initialPrivyUser);
+  let embedded = initialWallets[0] ?? null;
 
-  if (!embedded) {
+  for (const candidate of initialWallets) {
+    const wallet = await privyNode.wallets().get(candidate.walletId);
+    const isReady = hasOfflineSignerPolicy(
+      wallet,
+      offlineConfig.offlineSignerId,
+      offlineConfig.offlinePolicyId
+    );
+
+    if (!isReady) continue;
+
+    logger.info(
+      'Offline wallet is ready for delegated transactions',
+      {
+        privyId,
+        walletId: candidate.walletId,
+        walletAddress: candidate.address.toLowerCase(),
+        createdWallet: false,
+        updatedSigner: false,
+      },
+      'ensureOfflineWalletReady'
+    );
+
+    return {
+      privyWalletId: candidate.walletId,
+      walletAddress: candidate.address.toLowerCase(),
+      offlineWalletReady: true,
+      createdWallet: false,
+      updatedSigner: false,
+    };
+  }
+
+  // No embedded wallet or incompatible embedded wallet:
+  // create a fresh wallet with signer+policy attached instead of mutating existing wallet.
+  {
     createdWallet = true;
     await privyServer.createWallets({
       userId: privyId,
@@ -102,49 +143,43 @@ export async function ensureOfflineWalletReady({
     const refreshedPrivyUser = (await privyServer.getUser(
       privyId
     )) as PrivyUserWithWallets;
-    embedded = pickEmbeddedEvmWallet(refreshedPrivyUser);
+    const refreshedWallets = listEmbeddedEvmWallets(refreshedPrivyUser);
+    const initialWalletIds = new Set(initialWallets.map((w) => w.walletId));
+    const newWalletCandidates = refreshedWallets.filter(
+      (wallet) => !initialWalletIds.has(wallet.walletId)
+    );
+
+    const candidateWallets =
+      newWalletCandidates.length > 0 ? newWalletCandidates : refreshedWallets;
+
+    const readyWalletId = await findReadyWalletWithRetry(
+      candidateWallets.map((wallet) => wallet.walletId),
+      privyNode,
+      offlineConfig.offlineSignerId,
+      offlineConfig.offlinePolicyId
+    );
+    if (readyWalletId) {
+      embedded =
+        candidateWallets.find((wallet) => wallet.walletId === readyWalletId) ??
+        null;
+    }
   }
 
   if (!embedded) {
     throw new Error(
-      'Failed to resolve embedded wallet after provisioning step'
+      'Failed to resolve offline-ready embedded wallet after provisioning step'
     );
   }
 
-  let wallet = await privyNode.wallets().get(embedded.walletId);
-  const signerReady = hasOfflineSignerPolicy(
-    wallet,
+  const createdWalletState = await privyNode.wallets().get(embedded.walletId);
+  const readyAfterCreate = hasOfflineSignerPolicy(
+    createdWalletState,
     offlineConfig.offlineSignerId,
     offlineConfig.offlinePolicyId
   );
-
-  if (!signerReady) {
-    updatedSigner = true;
-    const additionalSigners = buildUpdatedSigners(
-      wallet,
-      offlineConfig.offlineSignerId,
-      offlineConfig.offlinePolicyId
-    );
-
-    await privyNode.wallets().update(embedded.walletId, {
-      additional_signers: additionalSigners,
-      authorization_context: {
-        user_jwts: [userJwt],
-        authorization_private_keys: [offlineConfig.authorizationPrivateKey],
-      },
-    });
-
-    wallet = await privyNode.wallets().get(embedded.walletId);
-  }
-
-  const readyAfterUpdate = hasOfflineSignerPolicy(
-    wallet,
-    offlineConfig.offlineSignerId,
-    offlineConfig.offlinePolicyId
-  );
-  if (!readyAfterUpdate) {
+  if (!readyAfterCreate) {
     throw new Error(
-      'Offline wallet provisioning failed: signer/policy not attached after update'
+      'Offline wallet provisioning failed: signer/policy not attached on newly created wallet'
     );
   }
 

--- a/packages/api/src/services/privy/user-wallets.ts
+++ b/packages/api/src/services/privy/user-wallets.ts
@@ -43,6 +43,13 @@ function isPrivyEmbeddedWallet(wallet: PrivyWalletLite): boolean {
 export function pickEmbeddedEvmWallet(
   user: PrivyUserWalletsLite
 ): { walletId: string; address: Address } | null {
+  const wallets = listEmbeddedEvmWallets(user);
+  return wallets.length > 0 ? wallets[0]! : null;
+}
+
+export function listEmbeddedEvmWallets(
+  user: PrivyUserWalletsLite
+): Array<{ walletId: string; address: Address }> {
   const candidates: Array<{
     wallet: PrivyWalletLite;
     source: 'primary' | 'linked';
@@ -56,6 +63,9 @@ export function pickEmbeddedEvmWallet(
     if (acc?.type === 'wallet')
       candidates.push({ wallet: acc, source: 'linked' });
   }
+
+  const wallets: Array<{ walletId: string; address: Address }> = [];
+  const seen = new Set<string>();
 
   for (const { wallet, source } of candidates) {
     if (!wallet?.id || typeof wallet.id !== 'string') continue;
@@ -71,11 +81,13 @@ export function pickEmbeddedEvmWallet(
       }
     }
     if (!isPrivyEmbeddedWallet(wallet)) continue;
-    return {
+    if (seen.has(wallet.id)) continue;
+    seen.add(wallet.id);
+    wallets.push({
       walletId: wallet.id,
       address: wallet.address.toLowerCase() as Address,
-    };
+    });
   }
 
-  return null;
+  return wallets;
 }


### PR DESCRIPTION
## Summary

- Enforces an offline-only Privy transaction model across onboarding and server-side onchain actions by removing runtime dependence on `userJwt` for wallet readiness.
- Hardens offline wallet provisioning: if no compatible embedded wallet exists, provision a new wallet with signer+policy and verify readiness with retry polling.
- Improves operability/debuggability with structured onchain error diagnostics (opt-in via env var) and dedicated setup/audit scripts.

## Type

- [x] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [x] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Follow-up implementation for the Privy offline-first rollout and staging hardening.
- Prior merged branch work: PR #1065.

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [x] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [x] Other: operational scripts (`scripts/*`)

## Changes

- Added/used offline wallet readiness model in user onboarding/profile flows:
  - `apps/web/src/app/api/users/me/route.ts`
  - `apps/web/src/app/api/users/signup/route.ts`
  - `apps/web/src/app/api/users/onboarding/onchain/route.ts`
- Removed direct `userJwt` dependency from offline provisioning path.
- Updated offline provisioning service to:
  - inspect all embedded wallets,
  - prefer already-ready wallets,
  - provision a fresh wallet when needed,
  - verify signer/policy attachment with short retries.
- Added wallet discovery helper (`listEmbeddedEvmWallets`) and updated tests.
- Improved sponsored tx diagnostics logging (`packages/api/src/services/privy/evm-send-transaction.ts`).
- Added optional action-level debug payload for mint errors, gated by `EXPOSE_ONCHAIN_ERROR_DETAILS`.
- Added ops scripts:
  - `scripts/setup-privy-offline-controls.ts`
  - `scripts/audit-offline-wallet-readiness.ts`
- Added DB support for readiness state:
  - migration `0040_add_offline_wallet_ready.sql`
  - user schema fields for readiness metadata.

## Review guide

**Start here**
- `packages/api/src/services/privy/offline-wallet-provisioning.ts`
- `apps/web/src/app/api/users/me/route.ts`
- `packages/api/src/services/privy/evm-send-transaction.ts`
- `scripts/setup-privy-offline-controls.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- The key behavioral change is strict offline-only provisioning: no wallet mutation path requiring `userJwt`.
- For users with incompatible existing wallets, provisioning now creates a fresh compatible wallet and updates app state to use it.
- Mint action debug payload remains disabled unless explicitly enabled via env var.

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

Additional command run:
- `bun test packages/api/src/services/privy/__tests__/offline-wallet-provisioning.test.ts`

**Manual verification**
1. Run `scripts/setup-privy-offline-controls.ts` with Privy app credentials and set returned env vars.
2. Start web staging profile locally, re-authenticate user, call `/api/users/me` and verify `offlineWalletReady=true` when provisioning succeeds.
3. Trigger `/api/users/onboarding/onchain` and NFT mint flow; confirm no popup-based signing flow is required.
4. Use `scripts/audit-offline-wallet-readiness.ts` to inspect readiness distribution.

## Ops / Migration / Deployment

- [ ] No deploy impact
- [x] Requires env var updates (listed below + `.env.example` updated)
- [x] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `EXPOSE_ONCHAIN_ERROR_DETAILS`
- Added/required for offline flow: `PRIVY_OFFLINE_SIGNER_ID`, `PRIVY_OFFLINE_POLICY_ID`, `PRIVY_AUTHORIZATION_PRIVATE_KEY`
- Added/used script-side: `PRIVY_APP_ID`, `PRIVY_APP_SECRET`
- Removed: none

**DB / data migration**
- Migration(s): `packages/db/drizzle/migrations/0040_add_offline_wallet_ready.sql`
- Backfill/seed: optional readiness backfill by hitting authenticated `/api/users/me` or running readiness audit + targeted user re-auth

**Rollout / rollback plan**
- Rollout: deploy migration + env vars, then deploy app; run readiness audit script and monitor mint/onchain logs.
- Rollback: revert to previous app version and disable offline-only env settings if needed.

## Breaking changes

- [ ] None
- [x] Yes (describe + migration guide below)

**Migration guide**
- Server-side onchain flow is now expected to run with configured Privy offline signer/policy controls.
- Apply DB migration and configure offline env vars before enabling the flow in staging/production.

## Security / privacy

- [ ] No security impact
- [x] Needs extra review (describe)

- Moves more onchain capability into delegated/offline execution paths; ensure signer policy scope is tightly constrained.
- Debug details are explicitly gated via env var and should remain disabled in production by default.

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- No public API contract break, but internal auth/provisioning path no longer relies on forwarding `userJwt` for wallet update operations.

### Database
- Adds offline wallet readiness fields for user state tracking and observability.

### Contracts / on-chain
- No smart contract changes in this PR.

### Docs
- No vendor/docs-site generated docs changes included.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend/API + server-action behavior changes only; no direct UI visual modifications.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
