### PR TITLE
fix(BAB-178): wallet export always exports same private key

### DIFF
--- a/apps/web/src/components/settings/SecurityTab.tsx
+++ b/apps/web/src/components/settings/SecurityTab.tsx
@@ -211,7 +211,9 @@ export function SecurityTab() {
                       {isEmbeddedWallet(wallet.walletClientType) &&
                         exportWallet && (
                           <button
-                            onClick={exportWallet}
+                            onClick={() =>
+                              exportWallet({ address: wallet.address })
+                            }
                             className="flex items-center gap-1 rounded border border-border bg-background px-3 py-1.5 font-medium text-xs hover:bg-accent"
                             title="Export wallet private key"
                           >


### PR DESCRIPTION
## Summary

Fixes BAB-178 — clicking "Export" on any embedded wallet in Settings always exported the same wallet's private key (index 0) instead of the selected one.

## Root Cause

`exportWallet()` from Privy's `usePrivy()` hook was called without specifying which wallet to export. When a user has multiple embedded wallets, it defaults to the first one.

## Fix

Pass `{ address: wallet.address }` to `exportWallet()` so each button exports the correct wallet's private key.

## Files Changed

- `apps/web/src/components/settings/SecurityTab.tsx`

## Test Plan

- [ ] User with 2+ embedded wallets can export each one individually
- [ ] Export modal shows the correct private key for the selected wallet

Made with [Cursor](https://cursor.com)