### PR TITLE
BAB-186: Unlink X/Twitter account

### DIFF
--- a/apps/web/src/app/api/twitter/disconnect/route.ts
+++ b/apps/web/src/app/api/twitter/disconnect/route.ts
@@ -58,6 +58,7 @@ export async function POST(request: NextRequest) {
       twitterTokenExpiresAt: null,
       twitterId: null,
       twitterUsername: null,
+      twitterVerifiedAt: null,
       hasTwitter: false,
     },
   });

--- a/apps/web/src/components/profile/LinkSocialAccountsModal.tsx
+++ b/apps/web/src/components/profile/LinkSocialAccountsModal.tsx
@@ -81,31 +81,36 @@ export function LinkSocialAccountsModal({
     }
 
     setUnlinkingTwitter(true);
-    const response = await fetch('/api/twitter/disconnect', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
+    try {
+      const response = await fetch('/api/twitter/disconnect', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
 
-    const data = (await response.json().catch(() => null)) as
-      | { success?: boolean; error?: string }
-      | null;
+      const data = (await response.json().catch(() => null)) as {
+        success?: boolean;
+        error?: string;
+      } | null;
 
-    if (!response.ok || !data?.success) {
-      toast.error(data?.error || 'Failed to unlink X account');
+      if (!response.ok || !data?.success) {
+        toast.error(data?.error || 'Failed to unlink X account');
+        return;
+      }
+
+      setUser({
+        ...user,
+        hasTwitter: false,
+        twitterUsername: undefined,
+      });
+      setConfirmUnlinkTwitter(false);
+      toast.success('X account unlinked');
+    } catch {
+      toast.error('Network error. Please try again.');
+    } finally {
       setUnlinkingTwitter(false);
-      return;
     }
-
-    setUser({
-      ...user,
-      hasTwitter: false,
-      twitterUsername: undefined,
-    });
-    setConfirmUnlinkTwitter(false);
-    setUnlinkingTwitter(false);
-    toast.success('X account unlinked');
   };
 
   const handleFarcasterAuth = async () => {
@@ -219,7 +224,9 @@ export function LinkSocialAccountsModal({
                 <div className="flex items-center gap-2 rounded-lg border border-green-500/20 bg-green-500/10 p-3">
                   <Check className="h-4 w-4 text-green-500" />
                   <span className="font-medium text-sm">
-                    {user.twitterUsername ? `@${user.twitterUsername}` : 'Connected'}
+                    {user.twitterUsername
+                      ? `@${user.twitterUsername}`
+                      : 'Connected'}
                   </span>
                   <div className="ml-auto flex items-center gap-2">
                     {user.twitterUsername && (

--- a/apps/web/src/components/profile/LinkSocialAccountsModal.tsx
+++ b/apps/web/src/components/profile/LinkSocialAccountsModal.tsx
@@ -2,7 +2,7 @@
 
 import { cn, signInWithFarcaster } from '@babylon/shared';
 import { Check, ExternalLink, Shield, X as XIcon } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { getAuthToken } from '@/lib/auth';
 import { useAuthStore } from '@/stores/authStore';
@@ -45,6 +45,15 @@ export function LinkSocialAccountsModal({
 }: LinkSocialAccountsModalProps) {
   const { user, setUser } = useAuthStore();
   const [linking, setLinking] = useState<string | null>(null);
+  const [confirmUnlinkTwitter, setConfirmUnlinkTwitter] = useState(false);
+  const [unlinkingTwitter, setUnlinkingTwitter] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) return;
+    setLinking(null);
+    setConfirmUnlinkTwitter(false);
+    setUnlinkingTwitter(false);
+  }, [isOpen]);
 
   if (!isOpen) return null;
 
@@ -60,6 +69,43 @@ export function LinkSocialAccountsModal({
     sessionStorage.setItem('oauth_return_url', window.location.pathname);
 
     window.location.href = initiateUrl;
+  };
+
+  const handleTwitterDisconnect = async () => {
+    if (!user?.id) return;
+
+    const token = getAuthToken();
+    if (!token) {
+      toast.error('Please sign in again to unlink X');
+      return;
+    }
+
+    setUnlinkingTwitter(true);
+    const response = await fetch('/api/twitter/disconnect', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const data = (await response.json().catch(() => null)) as
+      | { success?: boolean; error?: string }
+      | null;
+
+    if (!response.ok || !data?.success) {
+      toast.error(data?.error || 'Failed to unlink X account');
+      setUnlinkingTwitter(false);
+      return;
+    }
+
+    setUser({
+      ...user,
+      hasTwitter: false,
+      twitterUsername: undefined,
+    });
+    setConfirmUnlinkTwitter(false);
+    setUnlinkingTwitter(false);
+    toast.success('X account unlinked');
   };
 
   const handleFarcasterAuth = async () => {
@@ -169,19 +215,64 @@ export function LinkSocialAccountsModal({
             </div>
 
             {user?.hasTwitter ? (
-              <div className="flex items-center gap-2 rounded-lg border border-green-500/20 bg-green-500/10 p-3">
-                <Check className="h-4 w-4 text-green-500" />
-                <span className="font-medium text-sm">
-                  @{user.twitterUsername}
-                </span>
-                <a
-                  href={`https://x.com/${user.twitterUsername}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="ml-auto text-primary hover:text-primary/80"
-                >
-                  <ExternalLink className="h-4 w-4" />
-                </a>
+              <div className="space-y-2">
+                <div className="flex items-center gap-2 rounded-lg border border-green-500/20 bg-green-500/10 p-3">
+                  <Check className="h-4 w-4 text-green-500" />
+                  <span className="font-medium text-sm">
+                    {user.twitterUsername ? `@${user.twitterUsername}` : 'Connected'}
+                  </span>
+                  <div className="ml-auto flex items-center gap-2">
+                    {user.twitterUsername && (
+                      <a
+                        href={`https://x.com/${user.twitterUsername}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary hover:text-primary/80"
+                        title="Open X profile"
+                      >
+                        <ExternalLink className="h-4 w-4" />
+                      </a>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => setConfirmUnlinkTwitter((v) => !v)}
+                      className="rounded px-2 py-1 font-medium text-red-600 text-xs hover:bg-red-500/10"
+                    >
+                      Unlink
+                    </button>
+                  </div>
+                </div>
+
+                {confirmUnlinkTwitter && (
+                  <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3">
+                    <p className="text-muted-foreground text-xs">
+                      This disconnects your X account from Babylon. You can
+                      reconnect a different X account afterwards.
+                    </p>
+                    <div className="mt-3 flex items-center justify-end gap-2">
+                      <button
+                        type="button"
+                        onClick={() => setConfirmUnlinkTwitter(false)}
+                        disabled={unlinkingTwitter}
+                        className="rounded px-3 py-1.5 font-medium text-xs hover:bg-muted"
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => void handleTwitterDisconnect()}
+                        disabled={unlinkingTwitter}
+                        className={cn(
+                          'rounded px-3 py-1.5 font-semibold text-xs',
+                          'bg-red-600 text-white hover:bg-red-600/90',
+                          'disabled:cursor-not-allowed disabled:opacity-50'
+                        )}
+                      >
+                        {unlinkingTwitter ? 'Unlinking...' : 'Confirm unlink'}
+                      </button>
+                    </div>
+                  </div>
+                )}
               </div>
             ) : (
               <div className="space-y-2">


### PR DESCRIPTION
## Summary

- Add an **Unlink** action for X/Twitter in the Social Accounts modal so users can disconnect a mistakenly linked account and re-link the correct one.
- Reuse existing disconnect API and make the UI/state update immediately after a successful unlink.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: BAB-186
- Linear URL: https://linear.app/eliza-labs/issue/BAB-186/feature-unlink-social-account-xtwitter

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

**Non-goals / follow-ups**
- Farcaster unlink is not implemented here (no existing equivalent endpoint/UI).

## Changes

- Add X/Twitter **Unlink** UI with confirmation inside `LinkSocialAccountsModal`.
- Call `POST /api/twitter/disconnect` and update the local auth store on success.
- Clear `twitterVerifiedAt` server-side during disconnect.

## Review guide

**Start here**
- `apps/web/src/components/profile/LinkSocialAccountsModal.tsx`
- `apps/web/src/app/api/twitter/disconnect/route.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- The disconnect API already existed; this PR primarily exposes it in the user-facing Social Accounts modal.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Go to Settings -> Profile -> Link accounts.
2. If X is connected, click **Unlink**.
3. Confirm unlink.
4. Verify the UI switches to the "Connect with X" state.
5. Click "Connect with X" to re-link (OAuth flow).

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: N/A
- Changed: N/A
- Removed: N/A

**DB / data migration**
- Migration(s): N/A
- Backfill/seed: N/A

**Rollout / rollback plan**
- Rollout: standard deploy.
- Rollback: revert this PR.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option A: Visual demo

| Feature | Before | After |
|---------|--------|-------|
| Unlink X/Twitter in Social Accounts modal | X shows as connected with no unlink action | X shows an **Unlink** action with a confirmation step; after unlink the modal returns to **Connect with X** |

*Demo script (for recording):*
1. Open Settings -> Profile -> Link accounts.
2. Show X as connected.
3. Click **Unlink** -> confirm.
4. Show the modal now offers **Connect with X** again.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
