### PR TITLE
feat: edit group chat name

### DIFF
--- a/apps/web/src/components/groups/GroupManagementModal.tsx
+++ b/apps/web/src/components/groups/GroupManagementModal.tsx
@@ -29,7 +29,9 @@ interface Member {
   username: string | null;
   profileImageUrl: string | null;
   memberType: 'user' | 'agent' | 'npc';
+  role: 'owner' | 'admin' | 'member';
   isAdmin: boolean;
+  isOwner: boolean;
   joinedAt: Date | string;
 }
 
@@ -42,8 +44,9 @@ interface GroupDetails {
   description: string | null;
   type: 'user' | 'npc' | 'agent' | 'team';
   members: Member[];
+  userRole: 'owner' | 'admin' | 'member';
   isAdmin: boolean;
-  isCreator: boolean;
+  isOwner: boolean;
   createdById: string;
 }
 
@@ -96,6 +99,10 @@ export function GroupManagementModal({
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  // Group info state
+  const [isEditingGroupName, setIsEditingGroupName] = useState(false);
+  const [groupNameDraft, setGroupNameDraft] = useState('');
+
   // Add member state
   const [showAddMember, setShowAddMember] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
@@ -114,6 +121,8 @@ export function GroupManagementModal({
     if (!isOpen || !groupId) {
       setGroupDetails(null);
       setError(null);
+      setIsEditingGroupName(false);
+      setGroupNameDraft('');
       setShowAddMember(false);
       setSearchQuery('');
       setSearchResults([]);
@@ -138,11 +147,69 @@ export function GroupManagementModal({
 
       const data = await response.json();
       setGroupDetails(data.group);
+      setGroupNameDraft(data.group?.name || '');
+      setIsEditingGroupName(false);
       setLoading(false);
     };
 
     loadGroupDetails();
   }, [isOpen, groupId, getAccessToken]);
+
+  const handleUpdateGroupName = async () => {
+    if (!groupId) return;
+
+    const nextName = groupNameDraft.trim();
+    if (!nextName) {
+      setError('Group name is required');
+      return;
+    }
+    if (nextName.length > 100) {
+      setError('Group name must be 100 characters or less');
+      return;
+    }
+
+    setActionLoading('group-name');
+    setError(null);
+
+    try {
+      const token = await getAccessToken();
+      const response = await fetch(`/api/groups/${groupId}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ name: nextName }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json();
+        setError(data.error || 'Failed to update group name');
+        return;
+      }
+
+      // Reload group details so member/admin flags stay consistent.
+      const detailsResponse = await fetch(`/api/groups/${groupId}`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      if (detailsResponse.ok) {
+        const data = await detailsResponse.json();
+        setGroupDetails(data.group);
+        setGroupNameDraft(data.group?.name || nextName);
+      }
+
+      toast.success('Group name updated');
+      setIsEditingGroupName(false);
+      onGroupUpdated?.();
+    } catch (err) {
+      console.error('Failed to update group name:', err);
+      setError('Network error. Please try again.');
+    } finally {
+      setActionLoading(null);
+    }
+  };
 
   // Search for users (including user-created agents)
   useEffect(() => {
@@ -510,7 +577,7 @@ export function GroupManagementModal({
                 {/* Action Buttons */}
                 <div className="flex justify-end gap-2">
                   {/* Leave Group (everyone can do this) */}
-                  {!groupDetails.isCreator && (
+                  {!groupDetails.isOwner && (
                     <button
                       onClick={() => setConfirmAction({ type: 'leave' })}
                       disabled={!!actionLoading}
@@ -521,8 +588,8 @@ export function GroupManagementModal({
                     </button>
                   )}
 
-                  {/* Delete Group (admins only, not for NPC groups) */}
-                  {groupDetails.isAdmin && !isNpcGroup && (
+                  {/* Delete Group (owner only, not for NPC groups) */}
+                  {groupDetails.isOwner && !isNpcGroup && (
                     <button
                       onClick={() => setConfirmAction({ type: 'delete' })}
                       disabled={!!actionLoading}
@@ -541,6 +608,74 @@ export function GroupManagementModal({
                       This is an NPC-controlled group. Member management is
                       handled by the tiered invitation system.
                     </p>
+                  </div>
+                )}
+
+                {/* Group Name */}
+                {!isNpcGroup && (
+                  <div className="rounded-lg border border-border bg-sidebar p-3">
+                    <div className="flex items-center justify-between gap-3">
+                      <label className="block font-semibold text-sm">
+                        Group name
+                      </label>
+                      {groupDetails.isAdmin && (
+                        <div className="flex items-center gap-2">
+                          {isEditingGroupName ? (
+                            <>
+                              <button
+                                onClick={handleUpdateGroupName}
+                                disabled={
+                                  !!actionLoading ||
+                                  actionLoading === 'group-name'
+                                }
+                                className="rounded-lg bg-primary px-3 py-1.5 font-medium text-primary-foreground text-sm transition-colors hover:bg-primary/90 disabled:opacity-50"
+                              >
+                                {actionLoading === 'group-name' ? (
+                                  <Loader2 className="inline h-4 w-4 animate-spin" />
+                                ) : (
+                                  'Save'
+                                )}
+                              </button>
+                              <button
+                                onClick={() => {
+                                  setError(null);
+                                  setGroupNameDraft(groupDetails.name);
+                                  setIsEditingGroupName(false);
+                                }}
+                                disabled={!!actionLoading}
+                                className="rounded-lg border border-border bg-background px-3 py-1.5 font-medium text-sm transition-colors hover:bg-accent disabled:opacity-50"
+                              >
+                                Cancel
+                              </button>
+                            </>
+                          ) : (
+                            <button
+                              onClick={() => {
+                                setError(null);
+                                setGroupNameDraft(groupDetails.name);
+                                setIsEditingGroupName(true);
+                              }}
+                              disabled={!!actionLoading}
+                              className="rounded-lg border border-border bg-background px-3 py-1.5 font-medium text-sm transition-colors hover:bg-accent disabled:opacity-50"
+                            >
+                              Edit
+                            </button>
+                          )}
+                        </div>
+                      )}
+                    </div>
+
+                    {isEditingGroupName ? (
+                      <input
+                        type="text"
+                        value={groupNameDraft}
+                        onChange={(e) => setGroupNameDraft(e.target.value)}
+                        maxLength={100}
+                        className="mt-2 w-full rounded-lg border border-border bg-background px-3 py-2 text-sm transition-colors focus:border-primary focus:outline-none"
+                      />
+                    ) : (
+                      <p className="mt-2 truncate text-sm">{groupDetails.name}</p>
+                    )}
                   </div>
                 )}
 
@@ -640,7 +775,7 @@ export function GroupManagementModal({
                   {/* Members List */}
                   <div className="space-y-2">
                     {groupDetails.members.map((member) => {
-                      const isCreator = member.id === groupDetails.createdById;
+                      const isOwner = member.isOwner;
                       return (
                         <div
                           key={member.id}
@@ -662,7 +797,7 @@ export function GroupManagementModal({
                                   member.username ||
                                   'Unknown'}
                               </span>
-                              {isCreator && (
+                              {isOwner && (
                                 <Crown className="h-3.5 w-3.5 shrink-0 text-yellow-500" />
                               )}
                               {member.isAdmin && (
@@ -678,7 +813,7 @@ export function GroupManagementModal({
 
                           {/* Actions (only for admins, not for creator, not for NPC groups) */}
                           {groupDetails.isAdmin &&
-                            !isCreator &&
+                            !isOwner &&
                             !isNpcGroup && (
                               <div className="flex items-center gap-1">
                                 {!member.isAdmin ? (

--- a/apps/web/src/components/groups/GroupManagementModal.tsx
+++ b/apps/web/src/components/groups/GroupManagementModal.tsx
@@ -22,6 +22,11 @@ import { GroupTypeBadge } from './MemberTypeBadge';
 
 /**
  * Member structure for group management modal.
+ *
+ * Role model: `role` is the canonical field.
+ * - `isAdmin` is derived: `role === 'admin' || role === 'owner'`
+ * - `isOwner` is derived: `role === 'owner'`
+ * Invariant: `isOwner === true` implies `isAdmin === true`.
  */
 interface Member {
   id: string;
@@ -37,6 +42,9 @@ interface Member {
 
 /**
  * Group details structure for group management modal.
+ *
+ * `userRole`, `isAdmin`, and `isOwner` reflect the current user's role.
+ * See {@link Member} for the role model invariants.
  */
 interface GroupDetails {
   id: string;
@@ -47,7 +55,6 @@ interface GroupDetails {
   userRole: 'owner' | 'admin' | 'member';
   isAdmin: boolean;
   isOwner: boolean;
-  createdById: string;
 }
 
 /**
@@ -103,6 +110,14 @@ export function GroupManagementModal({
   const [isEditingGroupName, setIsEditingGroupName] = useState(false);
   const [groupNameDraft, setGroupNameDraft] = useState('');
 
+  const secondaryBtnClass =
+    'rounded-lg border border-border bg-background px-3 py-1.5 font-medium text-sm transition-colors hover:bg-accent disabled:opacity-50';
+
+  const resetGroupNameEdit = () => {
+    setError(null);
+    if (groupDetails) setGroupNameDraft(groupDetails.name);
+  };
+
   // Add member state
   const [showAddMember, setShowAddMember] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
@@ -132,24 +147,29 @@ export function GroupManagementModal({
     const loadGroupDetails = async () => {
       setLoading(true);
       setError(null);
-      const token = await getAccessToken();
-      const response = await fetch(`/api/groups/${groupId}`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
+      try {
+        const token = await getAccessToken();
+        const response = await fetch(`/api/groups/${groupId}`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
 
-      if (!response.ok) {
-        setError('Failed to load group details');
+        if (!response.ok) {
+          setError('Failed to load group details');
+          return;
+        }
+
+        const data = await response.json();
+        setGroupDetails(data.group);
+        setGroupNameDraft(data.group?.name || '');
+        setIsEditingGroupName(false);
+      } catch (err) {
+        console.error('Failed to load group details:', err);
+        setError('Failed to load group details. Please try again.');
+      } finally {
         setLoading(false);
-        return;
       }
-
-      const data = await response.json();
-      setGroupDetails(data.group);
-      setGroupNameDraft(data.group?.name || '');
-      setIsEditingGroupName(false);
-      setLoading(false);
     };
 
     loadGroupDetails();
@@ -183,21 +203,33 @@ export function GroupManagementModal({
       });
 
       if (!response.ok) {
-        const data = await response.json();
+        const data = await response.json().catch(() => ({}));
         setError(data.error || 'Failed to update group name');
         return;
       }
 
       // Reload group details so member/admin flags stay consistent.
-      const detailsResponse = await fetch(`/api/groups/${groupId}`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
-      if (detailsResponse.ok) {
-        const data = await detailsResponse.json();
-        setGroupDetails(data.group);
-        setGroupNameDraft(data.group?.name || nextName);
+      try {
+        const detailsResponse = await fetch(`/api/groups/${groupId}`, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+        if (detailsResponse.ok) {
+          const data = await detailsResponse.json();
+          setGroupDetails(data.group);
+          setGroupNameDraft(data.group?.name || nextName);
+        } else {
+          // PATCH succeeded; optimistically update UI with the new name
+          setGroupDetails((prev) =>
+            prev ? { ...prev, name: nextName } : prev
+          );
+          setGroupNameDraft(nextName);
+        }
+      } catch {
+        // Reload failed but PATCH succeeded; apply optimistic update
+        setGroupDetails((prev) => (prev ? { ...prev, name: nextName } : prev));
+        setGroupNameDraft(nextName);
       }
 
       toast.success('Group name updated');
@@ -615,7 +647,10 @@ export function GroupManagementModal({
                 {!isNpcGroup && (
                   <div className="rounded-lg border border-border bg-sidebar p-3">
                     <div className="flex items-center justify-between gap-3">
-                      <label className="block font-semibold text-sm">
+                      <label
+                        htmlFor="group-name-input"
+                        className="block font-semibold text-sm"
+                      >
                         Group name
                       </label>
                       {groupDetails.isAdmin && (
@@ -624,10 +659,7 @@ export function GroupManagementModal({
                             <>
                               <button
                                 onClick={handleUpdateGroupName}
-                                disabled={
-                                  !!actionLoading ||
-                                  actionLoading === 'group-name'
-                                }
+                                disabled={!!actionLoading}
                                 className="rounded-lg bg-primary px-3 py-1.5 font-medium text-primary-foreground text-sm transition-colors hover:bg-primary/90 disabled:opacity-50"
                               >
                                 {actionLoading === 'group-name' ? (
@@ -638,12 +670,11 @@ export function GroupManagementModal({
                               </button>
                               <button
                                 onClick={() => {
-                                  setError(null);
-                                  setGroupNameDraft(groupDetails.name);
+                                  resetGroupNameEdit();
                                   setIsEditingGroupName(false);
                                 }}
                                 disabled={!!actionLoading}
-                                className="rounded-lg border border-border bg-background px-3 py-1.5 font-medium text-sm transition-colors hover:bg-accent disabled:opacity-50"
+                                className={secondaryBtnClass}
                               >
                                 Cancel
                               </button>
@@ -651,12 +682,11 @@ export function GroupManagementModal({
                           ) : (
                             <button
                               onClick={() => {
-                                setError(null);
-                                setGroupNameDraft(groupDetails.name);
+                                resetGroupNameEdit();
                                 setIsEditingGroupName(true);
                               }}
                               disabled={!!actionLoading}
-                              className="rounded-lg border border-border bg-background px-3 py-1.5 font-medium text-sm transition-colors hover:bg-accent disabled:opacity-50"
+                              className={secondaryBtnClass}
                             >
                               Edit
                             </button>
@@ -667,14 +697,28 @@ export function GroupManagementModal({
 
                     {isEditingGroupName ? (
                       <input
+                        id="group-name-input"
                         type="text"
                         value={groupNameDraft}
                         onChange={(e) => setGroupNameDraft(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            e.preventDefault();
+                            handleUpdateGroupName();
+                          }
+                          if (e.key === 'Escape') {
+                            resetGroupNameEdit();
+                            setIsEditingGroupName(false);
+                          }
+                        }}
+                        autoFocus
                         maxLength={100}
                         className="mt-2 w-full rounded-lg border border-border bg-background px-3 py-2 text-sm transition-colors focus:border-primary focus:outline-none"
                       />
                     ) : (
-                      <p className="mt-2 truncate text-sm">{groupDetails.name}</p>
+                      <p className="mt-2 truncate text-sm">
+                        {groupDetails.name}
+                      </p>
                     )}
                   </div>
                 )}
@@ -812,51 +856,13 @@ export function GroupManagementModal({
                           </div>
 
                           {/* Actions (only for admins, not for creator, not for NPC groups) */}
-                          {groupDetails.isAdmin &&
-                            !isOwner &&
-                            !isNpcGroup && (
-                              <div className="flex items-center gap-1">
-                                {!member.isAdmin ? (
-                                  <button
-                                    onClick={() =>
-                                      setConfirmAction({
-                                        type: 'promote',
-                                        userId: member.id,
-                                        userName:
-                                          member.displayName ||
-                                          member.username ||
-                                          'this user',
-                                      })
-                                    }
-                                    disabled={!!actionLoading}
-                                    className="rounded-md p-2 transition-colors hover:bg-background disabled:opacity-50"
-                                    title="Make Admin"
-                                  >
-                                    <Shield className="h-4 w-4 text-primary" />
-                                  </button>
-                                ) : (
-                                  <button
-                                    onClick={() =>
-                                      setConfirmAction({
-                                        type: 'demote',
-                                        userId: member.id,
-                                        userName:
-                                          member.displayName ||
-                                          member.username ||
-                                          'this user',
-                                      })
-                                    }
-                                    disabled={!!actionLoading}
-                                    className="rounded-md p-2 transition-colors hover:bg-background disabled:opacity-50"
-                                    title="Remove Admin"
-                                  >
-                                    <Shield className="h-4 w-4 text-muted-foreground" />
-                                  </button>
-                                )}
+                          {groupDetails.isAdmin && !isOwner && !isNpcGroup && (
+                            <div className="flex items-center gap-1">
+                              {!member.isAdmin ? (
                                 <button
                                   onClick={() =>
                                     setConfirmAction({
-                                      type: 'remove',
+                                      type: 'promote',
                                       userId: member.id,
                                       userName:
                                         member.displayName ||
@@ -866,12 +872,48 @@ export function GroupManagementModal({
                                   }
                                   disabled={!!actionLoading}
                                   className="rounded-md p-2 transition-colors hover:bg-background disabled:opacity-50"
-                                  title="Remove Member"
+                                  title="Make Admin"
                                 >
-                                  <UserMinus className="h-4 w-4 text-red-500" />
+                                  <Shield className="h-4 w-4 text-primary" />
                                 </button>
-                              </div>
-                            )}
+                              ) : (
+                                <button
+                                  onClick={() =>
+                                    setConfirmAction({
+                                      type: 'demote',
+                                      userId: member.id,
+                                      userName:
+                                        member.displayName ||
+                                        member.username ||
+                                        'this user',
+                                    })
+                                  }
+                                  disabled={!!actionLoading}
+                                  className="rounded-md p-2 transition-colors hover:bg-background disabled:opacity-50"
+                                  title="Remove Admin"
+                                >
+                                  <Shield className="h-4 w-4 text-muted-foreground" />
+                                </button>
+                              )}
+                              <button
+                                onClick={() =>
+                                  setConfirmAction({
+                                    type: 'remove',
+                                    userId: member.id,
+                                    userName:
+                                      member.displayName ||
+                                      member.username ||
+                                      'this user',
+                                  })
+                                }
+                                disabled={!!actionLoading}
+                                className="rounded-md p-2 transition-colors hover:bg-background disabled:opacity-50"
+                                title="Remove Member"
+                              >
+                                <UserMinus className="h-4 w-4 text-red-500" />
+                              </button>
+                            </div>
+                          )}
                         </div>
                       );
                     })}


### PR DESCRIPTION
## Summary
- Adds a group-name rename UI in Group Settings for group chats.
- Uses existing `PATCH /api/groups/:groupId` (which also syncs `Chat.name`) so the new name persists and is visible to all members.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Linear: BAB-187

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

**Non-goals / follow-ups**
- Renaming ad-hoc group chats not backed by `Group` (i.e. chats with no `Chat.groupId`).

## Changes
- UI: add an editable "Group name" section (Edit/Save/Cancel) in Group Settings modal.
- UI: align permissions copy/visibility with API semantics (delete is owner-only; leave is non-owner).

## Review guide
**Start here**
- `apps/web/src/components/groups/GroupManagementModal.tsx`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- Only affects group chats that have a backing `Group` (`Chat.groupId` set). Settings button already relies on `/api/chats/:id/group`.

## Test plan
**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Go to `/chats`.
2. Open a group chat.
3. Click the settings icon.
4. In "Group name", click Edit, change the name, click Save.
5. Verify the new name shows in the chat header and chat list after refresh.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)
### Option A: Visual demo

| Feature | Before | After |
|---------|--------|-------|
| Rename group chat name | No rename control in Group Settings | Group Settings shows "Group name" with Edit/Save/Cancel |

*Demo script (for recording):*
1. Go to `/chats` and open a group chat.
2. Click settings.
3. Rename the group and save.
4. Show the updated name in header + chat list.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] Screenshots/recordings section filled (visual demo OR explanation why N/A)
