### PR TITLE
feat: message reactions in chats (BAB-185)

### DIFF
--- a/apps/web/src/app/agents/team/page.tsx
+++ b/apps/web/src/app/agents/team/page.tsx
@@ -188,6 +188,7 @@ export default function TeamChatPage() {
     messagesEndRef,
     topSentinelRef,
     sendMessage,
+    toggleReaction,
     handleScroll,
     scrollToBottom,
     refresh: refreshTeamChat,
@@ -934,6 +935,7 @@ export default function TeamChatPage() {
           messagesEndRef={messagesEndRef}
           onMessageChange={handleInputChange}
           onSendMessage={sendMessage}
+          onToggleReaction={toggleReaction}
           agents={[
             ...(user
               ? [
@@ -1034,6 +1036,7 @@ export default function TeamChatPage() {
             messagesEndRef={messagesEndRef}
             onMessageChange={handleInputChange}
             onSendMessage={sendMessage}
+            onToggleReaction={toggleReaction}
             agents={[
               // Include current user so they can mention themselves
               ...(user

--- a/apps/web/src/app/api/chats/[id]/messages/[messageId]/reactions/route.ts
+++ b/apps/web/src/app/api/chats/[id]/messages/[messageId]/reactions/route.ts
@@ -27,20 +27,11 @@ import {
   messages,
 } from '@babylon/db';
 import {
+  ALLOWED_REACTION_EMOJI_SET,
   ChatMessageReactionCreateSchema,
   generateSnowflakeId,
 } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
-
-const ALLOWED_REACTION_EMOJIS = new Set([
-  '👍',
-  '❤️',
-  '😂',
-  '🔥',
-  '😮',
-  '😢',
-  '🙏',
-]);
 
 async function requireChatAccess(
   user: Awaited<ReturnType<typeof authenticate>>,
@@ -131,7 +122,7 @@ export const POST = withErrorHandling(
     const body = await request.json();
     const { emoji } = ChatMessageReactionCreateSchema.parse(body);
 
-    if (!ALLOWED_REACTION_EMOJIS.has(emoji)) {
+    if (!ALLOWED_REACTION_EMOJI_SET.has(emoji)) {
       throw new BusinessLogicError(
         'Unsupported reaction emoji',
         'UNSUPPORTED_REACTION_EMOJI'
@@ -193,7 +184,7 @@ export const DELETE = withErrorHandling(
     if (!emoji) {
       throw new BusinessLogicError('emoji is required', 'EMOJI_REQUIRED');
     }
-    if (!ALLOWED_REACTION_EMOJIS.has(emoji)) {
+    if (!ALLOWED_REACTION_EMOJI_SET.has(emoji)) {
       throw new BusinessLogicError(
         'Unsupported reaction emoji',
         'UNSUPPORTED_REACTION_EMOJI'

--- a/apps/web/src/app/api/chats/[id]/messages/[messageId]/reactions/route.ts
+++ b/apps/web/src/app/api/chats/[id]/messages/[messageId]/reactions/route.ts
@@ -10,7 +10,10 @@ import {
   authenticate,
   BusinessLogicError,
   broadcastChatMessageReaction,
+  checkRateLimitAsync,
   NotFoundError,
+  RATE_LIMIT_CONFIGS,
+  rateLimitError,
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
@@ -117,6 +120,14 @@ export const POST = withErrorHandling(
     context: { params: Promise<{ id: string; messageId: string }> }
   ) => {
     const user = await authenticate(request);
+
+    // Rate-limit reaction toggles (30 per minute per user)
+    const rl = await checkRateLimitAsync(
+      user.userId,
+      RATE_LIMIT_CONFIGS.REACTION_TOGGLE
+    );
+    if (!rl.allowed) return rateLimitError(rl.retryAfter);
+
     const { id: chatId, messageId } = await context.params;
 
     const body = await request.json();
@@ -177,6 +188,14 @@ export const DELETE = withErrorHandling(
     context: { params: Promise<{ id: string; messageId: string }> }
   ) => {
     const user = await authenticate(request);
+
+    // Rate-limit reaction toggles (30 per minute per user)
+    const rl = await checkRateLimitAsync(
+      user.userId,
+      RATE_LIMIT_CONFIGS.REACTION_TOGGLE
+    );
+    if (!rl.allowed) return rateLimitError(rl.retryAfter);
+
     const { id: chatId, messageId } = await context.params;
 
     const { searchParams } = new URL(request.url);

--- a/apps/web/src/app/api/chats/[id]/messages/[messageId]/reactions/route.ts
+++ b/apps/web/src/app/api/chats/[id]/messages/[messageId]/reactions/route.ts
@@ -1,0 +1,239 @@
+/**
+ * Chat Message Reactions API
+ *
+ * @route POST /api/chats/[id]/messages/[messageId]/reactions
+ * @route DELETE /api/chats/[id]/messages/[messageId]/reactions?emoji=...
+ */
+
+import {
+  AuthorizationError,
+  authenticate,
+  BusinessLogicError,
+  broadcastChatMessageReaction,
+  NotFoundError,
+  successResponse,
+  withErrorHandling,
+} from '@babylon/api';
+import { requireNftChatAccess } from '@babylon/api/services/nft-chat-gating-service';
+import {
+  and,
+  asSystem,
+  asUser,
+  chatParticipants,
+  chats,
+  count,
+  eq,
+  messageReactions,
+  messages,
+} from '@babylon/db';
+import {
+  ChatMessageReactionCreateSchema,
+  generateSnowflakeId,
+} from '@babylon/shared';
+import type { NextRequest } from 'next/server';
+
+const ALLOWED_REACTION_EMOJIS = new Set([
+  '👍',
+  '❤️',
+  '😂',
+  '🔥',
+  '😮',
+  '😢',
+  '🙏',
+]);
+
+async function requireChatAccess(
+  user: Awaited<ReturnType<typeof authenticate>>,
+  chatId: string
+) {
+  const [chat] = await asSystem(async (db) => {
+    return await db.select().from(chats).where(eq(chats.id, chatId)).limit(1);
+  }, 'get-chat-for-reaction');
+  if (!chat) throw new NotFoundError('Chat', chatId);
+
+  const [isMember] = await asUser(user, async (db) => {
+    return await db
+      .select()
+      .from(chatParticipants)
+      .where(
+        and(
+          eq(chatParticipants.chatId, chatId),
+          eq(chatParticipants.userId, user.userId)
+        )
+      )
+      .limit(1);
+  });
+  if (!isMember) {
+    throw new AuthorizationError(
+      'You do not have access to this chat',
+      'chat',
+      'read'
+    );
+  }
+
+  await requireNftChatAccess(user, chatId);
+}
+
+async function requireMessageInChat(chatId: string, messageId: string) {
+  const [msg] = await asSystem(async (db) => {
+    return await db
+      .select({ id: messages.id })
+      .from(messages)
+      .where(and(eq(messages.id, messageId), eq(messages.chatId, chatId)))
+      .limit(1);
+  }, 'get-message-for-reaction');
+  if (!msg) throw new NotFoundError('Message', messageId);
+}
+
+async function getReactionSummary(messageId: string, currentUserId: string) {
+  const [countsByEmoji, myEmojis] = await Promise.all([
+    asSystem(async (db) => {
+      return await db
+        .select({
+          emoji: messageReactions.emoji,
+          count: count(),
+        })
+        .from(messageReactions)
+        .where(eq(messageReactions.messageId, messageId))
+        .groupBy(messageReactions.emoji);
+    }, 'get-message-reaction-counts'),
+    asSystem(async (db) => {
+      return await db
+        .select({ emoji: messageReactions.emoji })
+        .from(messageReactions)
+        .where(
+          and(
+            eq(messageReactions.messageId, messageId),
+            eq(messageReactions.userId, currentUserId)
+          )
+        );
+    }, 'get-message-reaction-mine'),
+  ]);
+
+  const myEmojiSet = new Set(myEmojis.map((r) => r.emoji));
+  return countsByEmoji
+    .map((r) => ({
+      emoji: r.emoji,
+      count: Number(r.count ?? 0),
+      reactedByMe: myEmojiSet.has(r.emoji),
+    }))
+    .filter((r) => r.count > 0);
+}
+
+export const POST = withErrorHandling(
+  async (
+    request: NextRequest,
+    context: { params: Promise<{ id: string; messageId: string }> }
+  ) => {
+    const user = await authenticate(request);
+    const { id: chatId, messageId } = await context.params;
+
+    const body = await request.json();
+    const { emoji } = ChatMessageReactionCreateSchema.parse(body);
+
+    if (!ALLOWED_REACTION_EMOJIS.has(emoji)) {
+      throw new BusinessLogicError(
+        'Unsupported reaction emoji',
+        'UNSUPPORTED_REACTION_EMOJI'
+      );
+    }
+
+    await requireChatAccess(user, chatId);
+    await requireMessageInChat(chatId, messageId);
+
+    const [existing] = await asSystem(async (db) => {
+      return await db
+        .select({ id: messageReactions.id })
+        .from(messageReactions)
+        .where(
+          and(
+            eq(messageReactions.messageId, messageId),
+            eq(messageReactions.userId, user.userId),
+            eq(messageReactions.emoji, emoji)
+          )
+        )
+        .limit(1);
+    }, 'check-existing-message-reaction');
+
+    if (!existing) {
+      await asUser(user, async (db) => {
+        await db.insert(messageReactions).values({
+          id: await generateSnowflakeId(),
+          chatId,
+          messageId,
+          userId: user.userId,
+          emoji,
+        });
+      });
+
+      await broadcastChatMessageReaction(chatId, {
+        messageId,
+        chatId,
+        emoji,
+        userId: user.userId,
+        action: 'added',
+      });
+    }
+
+    const reactions = await getReactionSummary(messageId, user.userId);
+    return successResponse({ messageId, reactions });
+  }
+);
+
+export const DELETE = withErrorHandling(
+  async (
+    request: NextRequest,
+    context: { params: Promise<{ id: string; messageId: string }> }
+  ) => {
+    const user = await authenticate(request);
+    const { id: chatId, messageId } = await context.params;
+
+    const { searchParams } = new URL(request.url);
+    const emoji = searchParams.get('emoji');
+    if (!emoji) {
+      throw new BusinessLogicError('emoji is required', 'EMOJI_REQUIRED');
+    }
+    if (!ALLOWED_REACTION_EMOJIS.has(emoji)) {
+      throw new BusinessLogicError(
+        'Unsupported reaction emoji',
+        'UNSUPPORTED_REACTION_EMOJI'
+      );
+    }
+
+    await requireChatAccess(user, chatId);
+    await requireMessageInChat(chatId, messageId);
+
+    const [existing] = await asSystem(async (db) => {
+      return await db
+        .select({ id: messageReactions.id })
+        .from(messageReactions)
+        .where(
+          and(
+            eq(messageReactions.messageId, messageId),
+            eq(messageReactions.userId, user.userId),
+            eq(messageReactions.emoji, emoji)
+          )
+        )
+        .limit(1);
+    }, 'check-existing-message-reaction-delete');
+
+    if (existing) {
+      await asUser(user, async (db) => {
+        await db
+          .delete(messageReactions)
+          .where(eq(messageReactions.id, existing.id));
+      });
+
+      await broadcastChatMessageReaction(chatId, {
+        messageId,
+        chatId,
+        emoji,
+        userId: user.userId,
+        action: 'removed',
+      });
+    }
+
+    const reactions = await getReactionSummary(messageId, user.userId);
+    return successResponse({ messageId, reactions });
+  }
+);

--- a/apps/web/src/app/api/chats/[id]/route.ts
+++ b/apps/web/src/app/api/chats/[id]/route.ts
@@ -65,10 +65,12 @@ import {
   asUser,
   chatParticipants,
   chats,
+  count,
   desc,
   eq,
   inArray,
   lt,
+  messageReactions,
   messages,
   users,
 } from '@babylon/db';
@@ -353,6 +355,55 @@ export const GET = withErrorHandling(
     // Reverse to get chronological order (oldest first)
     const messagesInOrder = [...messagesList].reverse();
 
+    // Message reactions summary (counts + reactedByMe)
+    const messageIds = messagesInOrder.map((m) => m.id);
+    const reactionsByMessageId = new Map<
+      string,
+      { emoji: string; count: number; reactedByMe: boolean }[]
+    >();
+    if (messageIds.length > 0) {
+      const [counts, mine] = await Promise.all([
+        asSystem(async (db) => {
+          return await db
+            .select({
+              messageId: messageReactions.messageId,
+              emoji: messageReactions.emoji,
+              count: count(),
+            })
+            .from(messageReactions)
+            .where(inArray(messageReactions.messageId, messageIds))
+            .groupBy(messageReactions.messageId, messageReactions.emoji);
+        }, 'get-message-reaction-counts'),
+        authUser
+          ? asSystem(async (db) => {
+              return await db
+                .select({
+                  messageId: messageReactions.messageId,
+                  emoji: messageReactions.emoji,
+                })
+                .from(messageReactions)
+                .where(
+                  and(
+                    inArray(messageReactions.messageId, messageIds),
+                    eq(messageReactions.userId, authUser!.userId)
+                  )
+                );
+            }, 'get-message-reactions-mine')
+          : Promise.resolve([]),
+      ]);
+
+      const mineSet = new Set(mine.map((r) => `${r.messageId}:${r.emoji}`));
+      for (const row of counts) {
+        const arr = reactionsByMessageId.get(row.messageId) ?? [];
+        arr.push({
+          emoji: row.emoji,
+          count: Number(row.count ?? 0),
+          reactedByMe: mineSet.has(`${row.messageId}:${row.emoji}`),
+        });
+        reactionsByMessageId.set(row.messageId, arr);
+      }
+    }
+
     // Get the cursor for the next page (oldest message ID in this batch)
     const nextCursor = hasMore
       ? fullChat.messages[effectiveLimit - 1]?.id
@@ -413,6 +464,7 @@ export const GET = withErrorHandling(
         type: msg.type,
         createdAt: msg.createdAt,
         metadata: msg.metadata,
+        reactions: reactionsByMessageId.get(msg.id) ?? [],
       })),
       participants: participantsInfo,
       pagination: {

--- a/apps/web/src/app/chats/page.tsx
+++ b/apps/web/src/app/chats/page.tsx
@@ -105,6 +105,7 @@ export default function ChatsPage() {
 
     // Actions
     sendMessage,
+    toggleReaction,
   } = useChatPage();
 
   // Detect if the current chat is with the user's own agent
@@ -218,6 +219,7 @@ export default function ChatsPage() {
                 topSentinelRef={topSentinelRef}
                 messagesEndRef={messagesEndRef}
                 onBack={() => setSelectedChatId(null)}
+                onToggleReaction={toggleReaction}
                 onManageGroup={handleManageGroup}
                 onLeaveChat={() => setLeaveConfirmOpen(true)}
                 onMessageChange={setMessageInput}

--- a/apps/web/src/app/markets/_components/terminal/TerminalAgentsChat.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalAgentsChat.tsx
@@ -23,6 +23,7 @@ export function TerminalAgentsChat() {
     messagesEndRef,
     topSentinelRef,
     sendMessage,
+    toggleReaction,
     handleScroll,
   } = useTeamChat();
 
@@ -61,6 +62,7 @@ export function TerminalAgentsChat() {
         messagesEndRef={messagesEndRef}
         onMessageChange={handleInputChange}
         onSendMessage={sendMessage}
+        onToggleReaction={toggleReaction}
         agents={[
           ...(user
             ? [

--- a/apps/web/src/components/chats/ChatView.tsx
+++ b/apps/web/src/components/chats/ChatView.tsx
@@ -33,6 +33,11 @@ interface ChatViewProps {
   onLeaveChat: () => void;
   onMessageChange: (value: string) => void;
   onSendMessage: () => void;
+  onToggleReaction?: (
+    messageId: string,
+    emoji: string,
+    currentlyReactedByMe: boolean
+  ) => void;
 }
 
 export function ChatView({
@@ -57,6 +62,7 @@ export function ChatView({
   onLeaveChat,
   onMessageChange,
   onSendMessage,
+  onToggleReaction,
 }: ChatViewProps) {
   // Convert chat participants to mentionable members format
   const mentionableMembers: MentionableAgent[] = useMemo(() => {
@@ -129,6 +135,7 @@ export function ChatView({
             authenticated={authenticated}
             topSentinelRef={topSentinelRef}
             messagesEndRef={messagesEndRef}
+            onToggleReaction={onToggleReaction}
           />
         </div>
       </div>

--- a/apps/web/src/components/chats/MessageBubble.tsx
+++ b/apps/web/src/components/chats/MessageBubble.tsx
@@ -1,12 +1,20 @@
 'use client';
 
 import { COORDINATOR_SENDER_ID, cn, type MessageTag } from '@babylon/shared';
-import { ChevronRight } from 'lucide-react';
+import { ChevronRight, Plus } from 'lucide-react';
 import Link from 'next/link';
 import { Response } from '@/components/chat/Response';
 import { Avatar } from '@/components/shared/Avatar';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import type { ChatParticipant, Message } from './types';
 import { getProfilePath } from './types';
+
+const COMMON_REACTIONS = ['👍', '❤️', '😂', '🔥', '😮', '😢', '🙏'] as const;
 
 /**
  * Extracts the displayable content from a message, stripping `<think>...</think>` reasoning blocks.
@@ -37,6 +45,12 @@ interface MessageBubbleProps {
   density?: 'default' | 'compact';
   /** Callback when a tag is clicked - opens sidebar with tag data */
   onTagClick?: (tag: MessageTag, messageId: string) => void;
+  /** Toggle a reaction emoji on this message (current user). */
+  onToggleReaction?: (
+    messageId: string,
+    emoji: string,
+    currentlyReactedByMe: boolean
+  ) => void;
 }
 
 export function MessageBubble({
@@ -47,6 +61,7 @@ export function MessageBubble({
   isThinking,
   density = 'default',
   onTagClick,
+  onToggleReaction,
 }: MessageBubbleProps) {
   const msgDate = new Date(message.createdAt);
   const senderName = sender?.displayName || 'Unknown';
@@ -183,6 +198,69 @@ export function MessageBubble({
             </Response>
           )}
         </div>
+
+        {/* Reactions */}
+        {!isThinking && (message.reactions?.length || onToggleReaction) && (
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            {(message.reactions ?? []).map((r) => (
+              <button
+                key={r.emoji}
+                type="button"
+                onClick={() =>
+                  onToggleReaction?.(message.id, r.emoji, r.reactedByMe)
+                }
+                disabled={!onToggleReaction}
+                className={cn(
+                  'inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs transition-colors',
+                  onToggleReaction ? 'hover:bg-muted' : 'cursor-default',
+                  r.reactedByMe
+                    ? 'border-primary/30 bg-primary/10 text-primary'
+                    : 'border-border bg-background text-foreground'
+                )}
+                aria-label={`React ${r.emoji}`}
+              >
+                <span aria-hidden="true">{r.emoji}</span>
+                <span className="font-medium tabular-nums">{r.count}</span>
+              </button>
+            ))}
+
+            {onToggleReaction && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    type="button"
+                    className="inline-flex items-center gap-1 rounded-full border border-border bg-background px-2 py-1 text-muted-foreground text-xs transition-colors hover:bg-muted hover:text-foreground"
+                    aria-label="Add reaction"
+                  >
+                    <Plus className="h-3.5 w-3.5" />
+                    <span>React</span>
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align={isCurrentUser ? 'end' : 'start'}>
+                  {COMMON_REACTIONS.map((emoji) => {
+                    const existing = (message.reactions ?? []).find(
+                      (r) => r.emoji === emoji
+                    );
+                    const reacted = existing?.reactedByMe ?? false;
+                    return (
+                      <DropdownMenuItem
+                        key={emoji}
+                        onClick={() =>
+                          onToggleReaction(message.id, emoji, reacted)
+                        }
+                      >
+                        <span className="mr-2" aria-hidden="true">
+                          {emoji}
+                        </span>
+                        <span>{reacted ? 'Remove' : 'React'}</span>
+                      </DropdownMenuItem>
+                    );
+                  })}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+          </div>
+        )}
 
         {/* Action Tags - Pill-style chips (outside message bubble) */}
         {!isThinking &&

--- a/apps/web/src/components/chats/MessageBubble.tsx
+++ b/apps/web/src/components/chats/MessageBubble.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import { COORDINATOR_SENDER_ID, cn, type MessageTag } from '@babylon/shared';
+import {
+  ALLOWED_REACTION_EMOJIS,
+  COORDINATOR_SENDER_ID,
+  cn,
+  type MessageTag,
+} from '@babylon/shared';
 import { ChevronRight, Plus } from 'lucide-react';
 import Link from 'next/link';
 import { Response } from '@/components/chat/Response';
@@ -13,8 +18,6 @@ import {
 } from '@/components/ui/dropdown-menu';
 import type { ChatParticipant, Message } from './types';
 import { getProfilePath } from './types';
-
-const COMMON_REACTIONS = ['👍', '❤️', '😂', '🔥', '😮', '😢', '🙏'] as const;
 
 /**
  * Extracts the displayable content from a message, stripping `<think>...</think>` reasoning blocks.
@@ -237,7 +240,7 @@ export function MessageBubble({
                   </button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align={isCurrentUser ? 'end' : 'start'}>
-                  {COMMON_REACTIONS.map((emoji) => {
+                  {ALLOWED_REACTION_EMOJIS.map((emoji) => {
                     const existing = (message.reactions ?? []).find(
                       (r) => r.emoji === emoji
                     );

--- a/apps/web/src/components/chats/MessageList.tsx
+++ b/apps/web/src/components/chats/MessageList.tsx
@@ -46,6 +46,12 @@ interface MessageListProps {
   density?: 'default' | 'compact';
   /** Callback when a message tag is clicked */
   onTagClick?: (tag: MessageTag, messageId: string) => void;
+  /** Toggle a reaction emoji on a message (current user) */
+  onToggleReaction?: (
+    messageId: string,
+    emoji: string,
+    currentlyReactedByMe: boolean
+  ) => void;
 }
 
 export function MessageList({
@@ -60,6 +66,7 @@ export function MessageList({
   messagesEndRef,
   density = 'default',
   onTagClick,
+  onToggleReaction,
 }: MessageListProps) {
   // Extract usernames from participants for @mention formatting
   // Only usernames that exist in the chat will be formatted as mentions
@@ -134,6 +141,7 @@ export function MessageList({
                 isThinking={msg.isThinking}
                 density={density}
                 onTagClick={onTagClick}
+                onToggleReaction={authenticated ? onToggleReaction : undefined}
               />
             );
           }
@@ -155,6 +163,7 @@ export function MessageList({
                 isThinking={msg.isThinking}
                 density={density}
                 onTagClick={onTagClick}
+                onToggleReaction={authenticated ? onToggleReaction : undefined}
               />
             );
           }

--- a/apps/web/src/components/chats/TeamChatView.tsx
+++ b/apps/web/src/components/chats/TeamChatView.tsx
@@ -152,6 +152,12 @@ interface TeamChatViewProps {
   onToggleRightSidebar?: () => void;
   /** Callback when a message tag is clicked */
   onTagClick?: (tag: MessageTag, messageId: string) => void;
+  /** Toggle a reaction emoji on a message (current user). */
+  onToggleReaction?: (
+    messageId: string,
+    emoji: string,
+    currentlyReactedByMe: boolean
+  ) => void;
 }
 
 /**
@@ -186,6 +192,7 @@ export function TeamChatView({
   rightSidebarOpen = false,
   onToggleRightSidebar,
   onTagClick,
+  onToggleReaction,
 }: TeamChatViewProps) {
   const compact = density === 'compact';
   // Empty state when no chat selected
@@ -291,6 +298,7 @@ export function TeamChatView({
           messagesEndRef={messagesEndRef}
           density={density}
           onTagClick={onTagClick}
+          onToggleReaction={onToggleReaction}
         />
       </div>
 

--- a/apps/web/src/components/chats/hooks/useChatPage.ts
+++ b/apps/web/src/components/chats/hooks/useChatPage.ts
@@ -5,13 +5,9 @@ import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { useChatMessages } from '@/hooks/useChatMessages';
+import { useToggleReaction } from '@/hooks/useToggleReaction';
 import { useAuthStore } from '@/stores/authStore';
-import type {
-  Chat,
-  ChatDetails,
-  ChatFilter,
-  MessageReactionSummary,
-} from '../types';
+import type { Chat, ChatDetails, ChatFilter } from '../types';
 
 export function useChatPage() {
   const router = useRouter();
@@ -90,91 +86,12 @@ export function useChatPage() {
     markPendingReactionDelta,
   } = useChatMessages(selectedChatId);
 
-  const applyMyReactionDelta = useCallback(
-    (
-      existing: MessageReactionSummary[] | undefined,
-      emoji: string,
-      action: 'added' | 'removed'
-    ): MessageReactionSummary[] => {
-      const map = new Map<string, MessageReactionSummary>();
-      for (const r of existing ?? []) map.set(r.emoji, { ...r });
-
-      const prev = map.get(emoji);
-      const prevCount = prev?.count ?? 0;
-      const nextCount =
-        action === 'added' ? prevCount + 1 : Math.max(0, prevCount - 1);
-
-      if (nextCount <= 0) {
-        map.delete(emoji);
-      } else {
-        map.set(emoji, {
-          emoji,
-          count: nextCount,
-          reactedByMe: action === 'added',
-        });
-      }
-
-      const out = [...map.values()];
-      out.sort((a, b) => b.count - a.count);
-      return out;
-    },
-    []
-  );
-
-  const toggleReaction = useCallback(
-    async (messageId: string, emoji: string, currentlyReactedByMe: boolean) => {
-      if (!selectedChatId || !user) return;
-
-      const token = await getAccessToken();
-      if (!token) return;
-
-      const existing = realtimeMessages.find((m) => m.id === messageId);
-      const prevReactions = existing?.reactions;
-
-      const action: 'added' | 'removed' = currentlyReactedByMe
-        ? 'removed'
-        : 'added';
-
-      markPendingReactionDelta({ messageId, emoji, action });
-      updateMessage(messageId, {
-        reactions: applyMyReactionDelta(prevReactions, emoji, action),
-      });
-
-      const url = currentlyReactedByMe
-        ? `/api/chats/${selectedChatId}/messages/${messageId}/reactions?emoji=${encodeURIComponent(
-            emoji
-          )}`
-        : `/api/chats/${selectedChatId}/messages/${messageId}/reactions`;
-
-      const response = await fetch(url, {
-        method: currentlyReactedByMe ? 'DELETE' : 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
-        body: currentlyReactedByMe ? undefined : JSON.stringify({ emoji }),
-      });
-
-      if (!response.ok) {
-        updateMessage(messageId, { reactions: prevReactions });
-        return;
-      }
-
-      const data = await response.json();
-      if (Array.isArray(data.reactions)) {
-        updateMessage(messageId, { reactions: data.reactions });
-      }
-    },
-    [
-      selectedChatId,
-      user,
-      getAccessToken,
-      realtimeMessages,
-      updateMessage,
-      markPendingReactionDelta,
-      applyMyReactionDelta,
-    ]
-  );
+  const toggleReaction = useToggleReaction({
+    chatId: selectedChatId,
+    messages: realtimeMessages,
+    updateMessage,
+    markPendingReactionDelta,
+  });
 
   // Load chats
   const loadChats = useCallback(async () => {

--- a/apps/web/src/components/chats/hooks/useChatPage.ts
+++ b/apps/web/src/components/chats/hooks/useChatPage.ts
@@ -6,7 +6,12 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { useChatMessages } from '@/hooks/useChatMessages';
 import { useAuthStore } from '@/stores/authStore';
-import type { Chat, ChatDetails, ChatFilter } from '../types';
+import type {
+  Chat,
+  ChatDetails,
+  ChatFilter,
+  MessageReactionSummary,
+} from '../types';
 
 export function useChatPage() {
   const router = useRouter();
@@ -81,7 +86,95 @@ export function useChatPage() {
     hasMore,
     loadMore,
     addMessage,
+    updateMessage,
+    markPendingReactionDelta,
   } = useChatMessages(selectedChatId);
+
+  const applyMyReactionDelta = useCallback(
+    (
+      existing: MessageReactionSummary[] | undefined,
+      emoji: string,
+      action: 'added' | 'removed'
+    ): MessageReactionSummary[] => {
+      const map = new Map<string, MessageReactionSummary>();
+      for (const r of existing ?? []) map.set(r.emoji, { ...r });
+
+      const prev = map.get(emoji);
+      const prevCount = prev?.count ?? 0;
+      const nextCount =
+        action === 'added' ? prevCount + 1 : Math.max(0, prevCount - 1);
+
+      if (nextCount <= 0) {
+        map.delete(emoji);
+      } else {
+        map.set(emoji, {
+          emoji,
+          count: nextCount,
+          reactedByMe: action === 'added',
+        });
+      }
+
+      const out = [...map.values()];
+      out.sort((a, b) => b.count - a.count);
+      return out;
+    },
+    []
+  );
+
+  const toggleReaction = useCallback(
+    async (messageId: string, emoji: string, currentlyReactedByMe: boolean) => {
+      if (!selectedChatId || !user) return;
+
+      const token = await getAccessToken();
+      if (!token) return;
+
+      const existing = realtimeMessages.find((m) => m.id === messageId);
+      const prevReactions = existing?.reactions;
+
+      const action: 'added' | 'removed' = currentlyReactedByMe
+        ? 'removed'
+        : 'added';
+
+      markPendingReactionDelta({ messageId, emoji, action });
+      updateMessage(messageId, {
+        reactions: applyMyReactionDelta(prevReactions, emoji, action),
+      });
+
+      const url = currentlyReactedByMe
+        ? `/api/chats/${selectedChatId}/messages/${messageId}/reactions?emoji=${encodeURIComponent(
+            emoji
+          )}`
+        : `/api/chats/${selectedChatId}/messages/${messageId}/reactions`;
+
+      const response = await fetch(url, {
+        method: currentlyReactedByMe ? 'DELETE' : 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: currentlyReactedByMe ? undefined : JSON.stringify({ emoji }),
+      });
+
+      if (!response.ok) {
+        updateMessage(messageId, { reactions: prevReactions });
+        return;
+      }
+
+      const data = await response.json();
+      if (Array.isArray(data.reactions)) {
+        updateMessage(messageId, { reactions: data.reactions });
+      }
+    },
+    [
+      selectedChatId,
+      user,
+      getAccessToken,
+      realtimeMessages,
+      updateMessage,
+      markPendingReactionDelta,
+      applyMyReactionDelta,
+    ]
+  );
 
   // Load chats
   const loadChats = useCallback(async () => {
@@ -758,6 +851,7 @@ export function useChatPage() {
 
     // Actions
     sendMessage,
+    toggleReaction,
     loadChats,
   };
 }

--- a/apps/web/src/components/chats/types.ts
+++ b/apps/web/src/components/chats/types.ts
@@ -48,6 +48,14 @@ export interface Message {
   isThinking?: boolean;
   /** Metadata containing action tags for sidebar display */
   metadata?: MessageMetadata | null;
+  /** Aggregated emoji reactions summary (counts + whether current user reacted). */
+  reactions?: MessageReactionSummary[];
+}
+
+export interface MessageReactionSummary {
+  emoji: string;
+  count: number;
+  reactedByMe: boolean;
 }
 
 export interface ChatParticipant {

--- a/apps/web/src/hooks/__tests__/useToggleReaction.test.ts
+++ b/apps/web/src/hooks/__tests__/useToggleReaction.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for applyReactionDelta – the pure function behind
+ * optimistic reaction updates (used by useToggleReaction and useChatMessages).
+ *
+ * Run with:
+ *   bun test apps/web/src/hooks/__tests__/useToggleReaction.test.ts
+ */
+
+import { describe, expect, it } from 'bun:test';
+import type { MessageReactionSummary } from '@/components/chats/types';
+import { applyReactionDelta } from '../useToggleReaction';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function summary(
+  emoji: string,
+  count: number,
+  reactedByMe: boolean
+): MessageReactionSummary {
+  return { emoji, count, reactedByMe };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('applyReactionDelta', () => {
+  // ---- Adding reactions ----
+
+  describe('adding a reaction', () => {
+    it('adds a new emoji to an empty reactions array', () => {
+      const result = applyReactionDelta([], '👍', 'added', true);
+      expect(result).toEqual([summary('👍', 1, true)]);
+    });
+
+    it('adds a new emoji to undefined reactions', () => {
+      const result = applyReactionDelta(undefined, '❤️', 'added', true);
+      expect(result).toEqual([summary('❤️', 1, true)]);
+    });
+
+    it('increments count when emoji already exists', () => {
+      const existing = [summary('👍', 2, false)];
+      const result = applyReactionDelta(existing, '👍', 'added', false);
+      expect(result).toEqual([summary('👍', 3, false)]);
+    });
+
+    it('increments count and sets reactedByMe when isMine', () => {
+      const existing = [summary('👍', 2, false)];
+      const result = applyReactionDelta(existing, '👍', 'added', true);
+      expect(result).toEqual([summary('👍', 3, true)]);
+    });
+
+    it('adds a different emoji alongside existing ones', () => {
+      const existing = [summary('👍', 3, true)];
+      const result = applyReactionDelta(existing, '🔥', 'added', true);
+      // Sorted by count descending: 👍(3) then 🔥(1)
+      expect(result).toEqual([summary('👍', 3, true), summary('🔥', 1, true)]);
+    });
+
+    it('preserves reactedByMe for existing emojis from other users', () => {
+      const existing = [summary('👍', 2, true)];
+      const result = applyReactionDelta(existing, '👍', 'added', false);
+      // isMine=false, so reactedByMe is preserved from prev (true)
+      expect(result).toEqual([summary('👍', 3, true)]);
+    });
+  });
+
+  // ---- Removing reactions ----
+
+  describe('removing a reaction', () => {
+    it('decrements the count', () => {
+      const existing = [summary('👍', 3, true)];
+      const result = applyReactionDelta(existing, '👍', 'removed', true);
+      expect(result).toEqual([summary('👍', 2, false)]);
+    });
+
+    it('removes the emoji entirely when count reaches zero', () => {
+      const existing = [summary('👍', 1, true)];
+      const result = applyReactionDelta(existing, '👍', 'removed', true);
+      expect(result).toEqual([]);
+    });
+
+    it('does not produce negative counts', () => {
+      const result = applyReactionDelta([], '👍', 'removed', true);
+      expect(result).toEqual([]);
+    });
+
+    it('does not produce negative counts for undefined', () => {
+      const result = applyReactionDelta(undefined, '❤️', 'removed', true);
+      expect(result).toEqual([]);
+    });
+
+    it('clears reactedByMe when isMine removes', () => {
+      const existing = [summary('❤️', 2, true)];
+      const result = applyReactionDelta(existing, '❤️', 'removed', true);
+      expect(result).toEqual([summary('❤️', 1, false)]);
+    });
+
+    it('preserves reactedByMe when someone else removes', () => {
+      const existing = [summary('❤️', 3, true)];
+      const result = applyReactionDelta(existing, '❤️', 'removed', false);
+      expect(result).toEqual([summary('❤️', 2, true)]);
+    });
+  });
+
+  // ---- Sorting ----
+
+  describe('sorting', () => {
+    it('sorts results by count descending', () => {
+      const existing = [
+        summary('😂', 1, false),
+        summary('👍', 5, true),
+        summary('🔥', 3, false),
+      ];
+      const result = applyReactionDelta(existing, '😂', 'added', false);
+      expect(result.map((r) => r.emoji)).toEqual(['👍', '🔥', '😂']);
+      expect(result.map((r) => r.count)).toEqual([5, 3, 2]);
+    });
+
+    it('re-sorts after a removal changes relative order', () => {
+      const existing = [summary('👍', 3, false), summary('🔥', 3, true)];
+      // Removing one 👍 puts it below 🔥
+      const result = applyReactionDelta(existing, '👍', 'removed', false);
+      expect(result.map((r) => r.emoji)).toEqual(['🔥', '👍']);
+      expect(result.map((r) => r.count)).toEqual([3, 2]);
+    });
+  });
+
+  // ---- Immutability ----
+
+  describe('immutability', () => {
+    it('does not mutate the input array', () => {
+      const existing = [summary('👍', 2, false)];
+      const copy = [...existing.map((r) => ({ ...r }))];
+      applyReactionDelta(existing, '👍', 'added', true);
+      expect(existing).toEqual(copy);
+    });
+  });
+});

--- a/apps/web/src/hooks/useChatMessages.ts
+++ b/apps/web/src/hooks/useChatMessages.ts
@@ -1,8 +1,13 @@
 import { logger, type MessageMetadata } from '@babylon/shared';
 import { usePrivy } from '@privy-io/react-auth';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { type MessageType, MessageTypeEnum } from '@/components/chats/types';
+import {
+  type MessageReactionSummary,
+  type MessageType,
+  MessageTypeEnum,
+} from '@/components/chats/types';
 import { CHAT_PAGE_SIZE } from '@/lib/constants';
+import { useAuthStore } from '@/stores/authStore';
 import { useSSEChannel } from './useSSE';
 
 /**
@@ -22,6 +27,8 @@ export interface ChatMessage {
   isThinking?: boolean;
   /** Metadata containing action tags for sidebar display */
   metadata?: MessageMetadata | null;
+  /** Aggregated emoji reactions summary (counts + whether current user reacted). */
+  reactions?: MessageReactionSummary[];
 }
 
 /** Raw message from API (createdAt may be string or Date) */
@@ -32,6 +39,7 @@ interface RawApiMessage {
   type?: MessageType;
   createdAt: string | Date;
   metadata?: MessageMetadata | null;
+  reactions?: MessageReactionSummary[];
 }
 
 /** Format raw API message to ChatMessage */
@@ -47,6 +55,7 @@ function formatMessage(msg: RawApiMessage, chatId: string): ChatMessage {
         ? msg.createdAt
         : msg.createdAt.toISOString(),
     metadata: msg.metadata,
+    reactions: msg.reactions,
   };
 }
 
@@ -137,6 +146,49 @@ function replaceOptimisticMessage(
   return [...messages, confirmed];
 }
 
+function reactionsEqual(
+  a: MessageReactionSummary[] | undefined,
+  b: MessageReactionSummary[] | undefined
+): boolean {
+  if (!a?.length && !b?.length) return true;
+  if (!a || !b) return false;
+  if (a.length !== b.length) return false;
+  const key = (r: MessageReactionSummary) =>
+    `${r.emoji}:${r.count}:${r.reactedByMe ? 1 : 0}`;
+  const as = [...a].map(key).sort().join('|');
+  const bs = [...b].map(key).sort().join('|');
+  return as === bs;
+}
+
+function applyReactionDelta(
+  existing: MessageReactionSummary[] | undefined,
+  emoji: string,
+  action: 'added' | 'removed',
+  isMine: boolean
+): MessageReactionSummary[] {
+  const map = new Map<string, MessageReactionSummary>();
+  for (const r of existing ?? []) map.set(r.emoji, { ...r });
+
+  const prev = map.get(emoji);
+  const prevCount = prev?.count ?? 0;
+  const nextCount =
+    action === 'added' ? prevCount + 1 : Math.max(0, prevCount - 1);
+
+  if (nextCount <= 0) {
+    map.delete(emoji);
+  } else {
+    map.set(emoji, {
+      emoji,
+      count: nextCount,
+      reactedByMe: isMine ? action === 'added' : (prev?.reactedByMe ?? false),
+    });
+  }
+
+  const out = [...map.values()];
+  out.sort((a, b) => b.count - a.count);
+  return out;
+}
+
 /** Polling interval - less aggressive since SSE is primary */
 const POLLING_INTERVAL_MS = 15000;
 
@@ -180,6 +232,7 @@ const POLLING_INTERVAL_MS = 15000;
  */
 export function useChatMessages(chatId: string | null) {
   const { getAccessToken } = usePrivy();
+  const { user } = useAuthStore();
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
@@ -187,6 +240,21 @@ export function useChatMessages(chatId: string | null) {
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const previousChatIdRef = useRef<string | null>(null);
   const hasLoadedRef = useRef<Set<string>>(new Set());
+  const pendingReactionDeltasRef = useRef<Set<string>>(new Set());
+
+  const markPendingReactionDelta = useCallback(
+    (delta: {
+      messageId: string;
+      emoji: string;
+      action: 'added' | 'removed';
+    }) => {
+      const key = `${delta.messageId}:${delta.emoji}:${delta.action}`;
+      pendingReactionDeltasRef.current.add(key);
+      // Safety: auto-expire in case the SSE event never arrives.
+      setTimeout(() => pendingReactionDeltasRef.current.delete(key), 5000);
+    },
+    []
+  );
 
   // Load existing messages from API (initial load)
   const loadMessages = useCallback(
@@ -297,42 +365,83 @@ export function useChatMessages(chatId: string | null) {
   // Handle SSE updates for this chat
   const handleChatUpdate = useCallback(
     (data: Record<string, unknown>) => {
-      if (data.type !== 'new_message' || !data.message) return;
+      if (data.type === 'new_message' && data.message) {
+        const m = data.message as Record<string, unknown>;
+        // Type guard for required fields
+        if (
+          typeof m.id !== 'string' ||
+          typeof m.content !== 'string' ||
+          typeof m.chatId !== 'string' ||
+          typeof m.senderId !== 'string' ||
+          typeof m.createdAt !== 'string' ||
+          m.chatId !== chatId
+        ) {
+          return;
+        }
 
-      const m = data.message as Record<string, unknown>;
-      // Type guard for required fields
-      if (
-        typeof m.id !== 'string' ||
-        typeof m.content !== 'string' ||
-        typeof m.chatId !== 'string' ||
-        typeof m.senderId !== 'string' ||
-        typeof m.createdAt !== 'string' ||
-        m.chatId !== chatId
-      ) {
+        const newMessage: ChatMessage = {
+          id: m.id,
+          content: m.content,
+          chatId: m.chatId,
+          senderId: m.senderId,
+          type:
+            m.type === MessageTypeEnum.USER ||
+            m.type === MessageTypeEnum.SYSTEM ||
+            m.type === MessageTypeEnum.COORDINATOR
+              ? (m.type as MessageType)
+              : undefined,
+          createdAt: m.createdAt,
+          isGameChat:
+            typeof m.isGameChat === 'boolean' ? m.isGameChat : undefined,
+          metadata: m.metadata as MessageMetadata | null | undefined,
+          reactions: Array.isArray(m.reactions)
+            ? (m.reactions as MessageReactionSummary[])
+            : undefined,
+        };
+
+        setIsLoading(false);
+        setMessages((prev) => replaceOptimisticMessage(prev, newMessage));
         return;
       }
 
-      const newMessage: ChatMessage = {
-        id: m.id,
-        content: m.content,
-        chatId: m.chatId,
-        senderId: m.senderId,
-        type:
-          m.type === MessageTypeEnum.USER ||
-          m.type === MessageTypeEnum.SYSTEM ||
-          m.type === MessageTypeEnum.COORDINATOR
-            ? (m.type as MessageType)
-            : undefined,
-        createdAt: m.createdAt,
-        isGameChat:
-          typeof m.isGameChat === 'boolean' ? m.isGameChat : undefined,
-        metadata: m.metadata as MessageMetadata | null | undefined,
-      };
+      if (data.type === 'message_reaction' && data.reaction) {
+        const r = data.reaction as Record<string, unknown>;
+        if (
+          typeof r.messageId !== 'string' ||
+          typeof r.chatId !== 'string' ||
+          typeof r.emoji !== 'string' ||
+          typeof r.userId !== 'string' ||
+          typeof r.action !== 'string' ||
+          r.chatId !== chatId ||
+          (r.action !== 'added' && r.action !== 'removed')
+        ) {
+          return;
+        }
 
-      setIsLoading(false);
-      setMessages((prev) => replaceOptimisticMessage(prev, newMessage));
+        const isMine = !!user?.id && r.userId === user.id;
+        const emoji = r.emoji;
+        const action = r.action as 'added' | 'removed';
+
+        if (isMine) {
+          const key = `${r.messageId}:${emoji}:${action}`;
+          if (pendingReactionDeltasRef.current.has(key)) {
+            pendingReactionDeltasRef.current.delete(key);
+            return;
+          }
+        }
+
+        setMessages((prev) => {
+          const idx = prev.findIndex((m) => m.id === r.messageId);
+          if (idx < 0) return prev;
+          const msg = prev[idx];
+          const next = applyReactionDelta(msg.reactions, emoji, action, isMine);
+          return prev.map((m, i) =>
+            i === idx ? { ...m, reactions: next } : m
+          );
+        });
+      }
     },
-    [chatId]
+    [chatId, user?.id]
   );
 
   // Subscribe to chat channel
@@ -400,7 +509,28 @@ export function useChatMessages(chatId: string | null) {
             let changed = false;
 
             for (const msg of formatted) {
-              if (existingIds.has(msg.id)) continue;
+              if (existingIds.has(msg.id)) {
+                const existingIdx = updated.findIndex((m) => m.id === msg.id);
+                if (existingIdx < 0) continue;
+                const existing = updated[existingIdx];
+
+                // Merge in reactions/metadata updates from the API snapshot.
+                if (!reactionsEqual(existing.reactions, msg.reactions)) {
+                  updated[existingIdx] = {
+                    ...existing,
+                    reactions: msg.reactions,
+                  };
+                  changed = true;
+                }
+                if (msg.metadata && !existing.metadata) {
+                  updated[existingIdx] = {
+                    ...updated[existingIdx],
+                    metadata: msg.metadata,
+                  };
+                  changed = true;
+                }
+                continue;
+              }
 
               const pending = updated.find((m) => isMatchingOptimistic(m, msg));
               if (pending) {
@@ -494,5 +624,6 @@ export function useChatMessages(chatId: string | null) {
     clearMessages,
     reloadMessages,
     isConnected,
+    markPendingReactionDelta,
   };
 }

--- a/apps/web/src/hooks/useChatMessages.ts
+++ b/apps/web/src/hooks/useChatMessages.ts
@@ -9,6 +9,7 @@ import {
 import { CHAT_PAGE_SIZE } from '@/lib/constants';
 import { useAuthStore } from '@/stores/authStore';
 import { useSSEChannel } from './useSSE';
+import { applyReactionDelta } from './useToggleReaction';
 
 /**
  * Represents a chat message in the system.
@@ -158,35 +159,6 @@ function reactionsEqual(
   const as = [...a].map(key).sort().join('|');
   const bs = [...b].map(key).sort().join('|');
   return as === bs;
-}
-
-function applyReactionDelta(
-  existing: MessageReactionSummary[] | undefined,
-  emoji: string,
-  action: 'added' | 'removed',
-  isMine: boolean
-): MessageReactionSummary[] {
-  const map = new Map<string, MessageReactionSummary>();
-  for (const r of existing ?? []) map.set(r.emoji, { ...r });
-
-  const prev = map.get(emoji);
-  const prevCount = prev?.count ?? 0;
-  const nextCount =
-    action === 'added' ? prevCount + 1 : Math.max(0, prevCount - 1);
-
-  if (nextCount <= 0) {
-    map.delete(emoji);
-  } else {
-    map.set(emoji, {
-      emoji,
-      count: nextCount,
-      reactedByMe: isMine ? action === 'added' : (prev?.reactedByMe ?? false),
-    });
-  }
-
-  const out = [...map.values()];
-  out.sort((a, b) => b.count - a.count);
-  return out;
 }
 
 /** Polling interval - less aggressive since SSE is primary */
@@ -433,7 +405,7 @@ export function useChatMessages(chatId: string | null) {
         setMessages((prev) => {
           const idx = prev.findIndex((m) => m.id === r.messageId);
           if (idx < 0) return prev;
-          const msg = prev[idx];
+          const msg = prev[idx]!;
           const next = applyReactionDelta(msg.reactions, emoji, action, isMine);
           return prev.map((m, i) =>
             i === idx ? { ...m, reactions: next } : m
@@ -512,7 +484,7 @@ export function useChatMessages(chatId: string | null) {
               if (existingIds.has(msg.id)) {
                 const existingIdx = updated.findIndex((m) => m.id === msg.id);
                 if (existingIdx < 0) continue;
-                const existing = updated[existingIdx];
+                const existing = updated[existingIdx]!;
 
                 // Merge in reactions/metadata updates from the API snapshot.
                 if (!reactionsEqual(existing.reactions, msg.reactions)) {
@@ -524,7 +496,7 @@ export function useChatMessages(chatId: string | null) {
                 }
                 if (msg.metadata && !existing.metadata) {
                   updated[existingIdx] = {
-                    ...updated[existingIdx],
+                    ...updated[existingIdx]!,
                     metadata: msg.metadata,
                   };
                   changed = true;

--- a/apps/web/src/hooks/useTeamChat.ts
+++ b/apps/web/src/hooks/useTeamChat.ts
@@ -20,17 +20,14 @@ import {
   useState,
 } from 'react';
 import { toast } from 'sonner';
-import type {
-  ChatDetails,
-  ChatParticipant,
-  MessageReactionSummary,
-} from '@/components/chats/types';
+import type { ChatDetails, ChatParticipant } from '@/components/chats/types';
 import { MessageTypeEnum } from '@/components/chats/types';
 import {
   OptimisticMessageIdPrefix,
   useChatMessages,
 } from '@/hooks/useChatMessages';
 import { useSSEChannel } from '@/hooks/useSSE';
+import { useToggleReaction } from '@/hooks/useToggleReaction';
 import { useAuthStore } from '@/stores/authStore';
 
 // Constants for scroll behavior
@@ -203,6 +200,11 @@ interface UseTeamChatReturn {
 
   // Actions
   sendMessage: () => Promise<void>;
+  toggleReaction: (
+    messageId: string,
+    emoji: string,
+    currentlyReactedByMe: boolean
+  ) => Promise<void>;
   refresh: () => Promise<void>;
   handleScroll: (container: HTMLDivElement) => void;
   scrollToBottom: (behavior?: 'instant' | 'smooth') => void;
@@ -271,92 +273,12 @@ export function useTeamChat(): UseTeamChatReturn {
     markPendingReactionDelta,
   } = useChatMessages(teamChat?.chatId ?? null);
 
-  const applyMyReactionDelta = useCallback(
-    (
-      existing: MessageReactionSummary[] | undefined,
-      emoji: string,
-      action: 'added' | 'removed'
-    ): MessageReactionSummary[] => {
-      const map = new Map<string, MessageReactionSummary>();
-      for (const r of existing ?? []) map.set(r.emoji, { ...r });
-
-      const prev = map.get(emoji);
-      const prevCount = prev?.count ?? 0;
-      const nextCount =
-        action === 'added' ? prevCount + 1 : Math.max(0, prevCount - 1);
-
-      if (nextCount <= 0) {
-        map.delete(emoji);
-      } else {
-        map.set(emoji, {
-          emoji,
-          count: nextCount,
-          reactedByMe: action === 'added',
-        });
-      }
-
-      const out = [...map.values()];
-      out.sort((a, b) => b.count - a.count);
-      return out;
-    },
-    []
-  );
-
-  const toggleReaction = useCallback(
-    async (messageId: string, emoji: string, currentlyReactedByMe: boolean) => {
-      if (!teamChat?.chatId || !user) return;
-
-      const token = await getAccessToken();
-      if (!token) return;
-
-      const existing = realtimeMessages.find((m) => m.id === messageId);
-      const prevReactions = existing?.reactions;
-
-      const action: 'added' | 'removed' = currentlyReactedByMe
-        ? 'removed'
-        : 'added';
-      markPendingReactionDelta({ messageId, emoji, action });
-      updateMessage(messageId, {
-        reactions: applyMyReactionDelta(prevReactions, emoji, action),
-      });
-
-      const url = currentlyReactedByMe
-        ? `/api/chats/${teamChat.chatId}/messages/${messageId}/reactions?emoji=${encodeURIComponent(
-            emoji
-          )}`
-        : `/api/chats/${teamChat.chatId}/messages/${messageId}/reactions`;
-
-      const response = await fetch(url, {
-        method: currentlyReactedByMe ? 'DELETE' : 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
-        body: currentlyReactedByMe ? undefined : JSON.stringify({ emoji }),
-      });
-
-      if (!response.ok) {
-        updateMessage(messageId, { reactions: prevReactions });
-        toast.error('Failed to update reaction');
-        return;
-      }
-
-      const data = await response.json();
-      if (Array.isArray(data.reactions)) {
-        updateMessage(messageId, { reactions: data.reactions });
-      }
-    },
-    [
-      teamChat?.chatId,
-      teamChat,
-      user,
-      getAccessToken,
-      realtimeMessages,
-      updateMessage,
-      markPendingReactionDelta,
-      applyMyReactionDelta,
-    ]
-  );
+  const toggleReaction = useToggleReaction({
+    chatId: teamChat?.chatId ?? null,
+    messages: realtimeMessages,
+    updateMessage,
+    markPendingReactionDelta,
+  });
 
   // Helper to find scroll container from messagesEndRef
   const getScrollContainer = useCallback((): HTMLElement | null => {

--- a/apps/web/src/hooks/useTeamChat.ts
+++ b/apps/web/src/hooks/useTeamChat.ts
@@ -20,7 +20,11 @@ import {
   useState,
 } from 'react';
 import { toast } from 'sonner';
-import type { ChatDetails, ChatParticipant } from '@/components/chats/types';
+import type {
+  ChatDetails,
+  ChatParticipant,
+  MessageReactionSummary,
+} from '@/components/chats/types';
 import { MessageTypeEnum } from '@/components/chats/types';
 import {
   OptimisticMessageIdPrefix,
@@ -264,7 +268,95 @@ export function useTeamChat(): UseTeamChatReturn {
     updateMessage,
     removeMessage,
     clearMessages,
+    markPendingReactionDelta,
   } = useChatMessages(teamChat?.chatId ?? null);
+
+  const applyMyReactionDelta = useCallback(
+    (
+      existing: MessageReactionSummary[] | undefined,
+      emoji: string,
+      action: 'added' | 'removed'
+    ): MessageReactionSummary[] => {
+      const map = new Map<string, MessageReactionSummary>();
+      for (const r of existing ?? []) map.set(r.emoji, { ...r });
+
+      const prev = map.get(emoji);
+      const prevCount = prev?.count ?? 0;
+      const nextCount =
+        action === 'added' ? prevCount + 1 : Math.max(0, prevCount - 1);
+
+      if (nextCount <= 0) {
+        map.delete(emoji);
+      } else {
+        map.set(emoji, {
+          emoji,
+          count: nextCount,
+          reactedByMe: action === 'added',
+        });
+      }
+
+      const out = [...map.values()];
+      out.sort((a, b) => b.count - a.count);
+      return out;
+    },
+    []
+  );
+
+  const toggleReaction = useCallback(
+    async (messageId: string, emoji: string, currentlyReactedByMe: boolean) => {
+      if (!teamChat?.chatId || !user) return;
+
+      const token = await getAccessToken();
+      if (!token) return;
+
+      const existing = realtimeMessages.find((m) => m.id === messageId);
+      const prevReactions = existing?.reactions;
+
+      const action: 'added' | 'removed' = currentlyReactedByMe
+        ? 'removed'
+        : 'added';
+      markPendingReactionDelta({ messageId, emoji, action });
+      updateMessage(messageId, {
+        reactions: applyMyReactionDelta(prevReactions, emoji, action),
+      });
+
+      const url = currentlyReactedByMe
+        ? `/api/chats/${teamChat.chatId}/messages/${messageId}/reactions?emoji=${encodeURIComponent(
+            emoji
+          )}`
+        : `/api/chats/${teamChat.chatId}/messages/${messageId}/reactions`;
+
+      const response = await fetch(url, {
+        method: currentlyReactedByMe ? 'DELETE' : 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: currentlyReactedByMe ? undefined : JSON.stringify({ emoji }),
+      });
+
+      if (!response.ok) {
+        updateMessage(messageId, { reactions: prevReactions });
+        toast.error('Failed to update reaction');
+        return;
+      }
+
+      const data = await response.json();
+      if (Array.isArray(data.reactions)) {
+        updateMessage(messageId, { reactions: data.reactions });
+      }
+    },
+    [
+      teamChat?.chatId,
+      teamChat,
+      user,
+      getAccessToken,
+      realtimeMessages,
+      updateMessage,
+      markPendingReactionDelta,
+      applyMyReactionDelta,
+    ]
+  );
 
   // Helper to find scroll container from messagesEndRef
   const getScrollContainer = useCallback((): HTMLElement | null => {
@@ -1425,6 +1517,7 @@ export function useTeamChat(): UseTeamChatReturn {
     tagAgentInInput,
     // Actions
     sendMessage,
+    toggleReaction,
     refresh: fetchTeamChat,
     handleScroll,
     scrollToBottom,

--- a/apps/web/src/hooks/useToggleReaction.ts
+++ b/apps/web/src/hooks/useToggleReaction.ts
@@ -1,0 +1,129 @@
+/**
+ * useToggleReaction Hook
+ *
+ * Shared hook for toggling emoji reactions on chat messages.
+ * Used by both useChatPage (DMs / group chats) and useTeamChat (team chat).
+ *
+ * Provides optimistic UI updates, SSE echo suppression, and automatic rollback on failure.
+ */
+
+import { usePrivy } from '@privy-io/react-auth';
+import { useCallback } from 'react';
+import { toast } from 'sonner';
+import type { MessageReactionSummary } from '@/components/chats/types';
+import { useAuthStore } from '@/stores/authStore';
+import type { ChatMessage } from './useChatMessages';
+
+/**
+ * Compute the next reactions array after a local user toggles an emoji.
+ * Exported so SSE handlers in useChatMessages can reuse the same logic.
+ */
+export function applyReactionDelta(
+  existing: MessageReactionSummary[] | undefined,
+  emoji: string,
+  action: 'added' | 'removed',
+  isMine: boolean
+): MessageReactionSummary[] {
+  const map = new Map<string, MessageReactionSummary>();
+  for (const r of existing ?? []) map.set(r.emoji, { ...r });
+
+  const prev = map.get(emoji);
+  const prevCount = prev?.count ?? 0;
+  const nextCount =
+    action === 'added' ? prevCount + 1 : Math.max(0, prevCount - 1);
+
+  if (nextCount <= 0) {
+    map.delete(emoji);
+  } else {
+    map.set(emoji, {
+      emoji,
+      count: nextCount,
+      reactedByMe: isMine ? action === 'added' : (prev?.reactedByMe ?? false),
+    });
+  }
+
+  const out = [...map.values()];
+  out.sort((a, b) => b.count - a.count);
+  return out;
+}
+
+interface UseToggleReactionOptions {
+  chatId: string | null;
+  messages: ChatMessage[];
+  updateMessage: (id: string, updates: Partial<ChatMessage>) => void;
+  markPendingReactionDelta: (delta: {
+    messageId: string;
+    emoji: string;
+    action: 'added' | 'removed';
+  }) => void;
+}
+
+/**
+ * Returns a stable `toggleReaction(messageId, emoji, currentlyReactedByMe)` callback.
+ */
+export function useToggleReaction({
+  chatId,
+  messages,
+  updateMessage,
+  markPendingReactionDelta,
+}: UseToggleReactionOptions) {
+  const { user } = useAuthStore();
+  const { getAccessToken } = usePrivy();
+
+  const toggleReaction = useCallback(
+    async (messageId: string, emoji: string, currentlyReactedByMe: boolean) => {
+      if (!chatId || !user) return;
+
+      const token = await getAccessToken();
+      if (!token) return;
+
+      const existing = messages.find((m) => m.id === messageId);
+      const prevReactions = existing?.reactions;
+
+      const action: 'added' | 'removed' = currentlyReactedByMe
+        ? 'removed'
+        : 'added';
+
+      // Optimistic update + SSE echo suppression
+      markPendingReactionDelta({ messageId, emoji, action });
+      updateMessage(messageId, {
+        reactions: applyReactionDelta(prevReactions, emoji, action, true),
+      });
+
+      const url = currentlyReactedByMe
+        ? `/api/chats/${chatId}/messages/${messageId}/reactions?emoji=${encodeURIComponent(emoji)}`
+        : `/api/chats/${chatId}/messages/${messageId}/reactions`;
+
+      const response = await fetch(url, {
+        method: currentlyReactedByMe ? 'DELETE' : 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: currentlyReactedByMe ? undefined : JSON.stringify({ emoji }),
+      });
+
+      if (!response.ok) {
+        // Rollback optimistic update
+        updateMessage(messageId, { reactions: prevReactions });
+        toast.error('Failed to update reaction');
+        return;
+      }
+
+      const data = await response.json();
+      if (Array.isArray(data.reactions)) {
+        updateMessage(messageId, { reactions: data.reactions });
+      }
+    },
+    [
+      chatId,
+      user,
+      getAccessToken,
+      messages,
+      updateMessage,
+      markPendingReactionDelta,
+    ]
+  );
+
+  return toggleReaction;
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -245,6 +245,7 @@ export {
   type AgentActivityEvent,
   broadcastAgentActivity,
   broadcastChatMessage,
+  broadcastChatMessageReaction,
   broadcastChatTitleUpdate,
   broadcastThinkingIndicator,
   broadcastToChannel,

--- a/packages/api/src/rate-limiting/user-rate-limiter.ts
+++ b/packages/api/src/rate-limiting/user-rate-limiter.ts
@@ -61,6 +61,11 @@ export const RATE_LIMIT_CONFIGS = {
     windowMs: 60000,
     actionType: 'send_message',
   }, // 20 messages per minute
+  REACTION_TOGGLE: {
+    maxRequests: 30,
+    windowMs: 60000,
+    actionType: 'reaction_toggle',
+  }, // 30 reaction toggles per minute
   TYPING_INDICATOR: {
     maxRequests: 60,
     windowMs: 60000,

--- a/packages/api/src/sse/event-broadcaster.ts
+++ b/packages/api/src/sse/event-broadcaster.ts
@@ -100,6 +100,25 @@ export async function broadcastChatMessage(
   });
 }
 
+/**
+ * Broadcast a chat message reaction delta to a specific chat room.
+ */
+export async function broadcastChatMessageReaction(
+  chatId: string,
+  reaction: {
+    messageId: string;
+    chatId: string;
+    emoji: string;
+    userId: string;
+    action: 'added' | 'removed';
+  }
+): Promise<void> {
+  await broadcastToChannel(`chat:${chatId}`, {
+    type: 'message_reaction',
+    reaction: reaction as unknown as JsonValue,
+  });
+}
+
 // ============================================================================
 // Agent Activity Broadcasting
 // ============================================================================

--- a/packages/db/drizzle/migrations/0041_add_message_reactions.sql
+++ b/packages/db/drizzle/migrations/0041_add_message_reactions.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS "MessageReaction" (
+	"id" text PRIMARY KEY NOT NULL,
+	"chatId" text NOT NULL,
+	"messageId" text NOT NULL,
+	"userId" text NOT NULL,
+	"emoji" text NOT NULL,
+	"createdAt" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "MessageReaction_messageId_userId_emoji_key" UNIQUE("messageId","userId","emoji")
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "MessageReaction_messageId_idx" ON "MessageReaction" USING btree ("messageId");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "MessageReaction_chatId_idx" ON "MessageReaction" USING btree ("chatId");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "MessageReaction_userId_idx" ON "MessageReaction" USING btree ("userId");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "MessageReaction_chatId_messageId_idx" ON "MessageReaction" USING btree ("chatId","messageId");
+

--- a/packages/db/drizzle/migrations/0042_add_message_reaction_fk.sql
+++ b/packages/db/drizzle/migrations/0042_add_message_reaction_fk.sql
@@ -1,0 +1,13 @@
+-- Add foreign key constraints to MessageReaction table
+-- messageId cascades on delete so reactions are cleaned up when a message is removed
+-- chatId cascades on delete for consistency
+-- userId cascades on delete if the user account is removed
+
+ALTER TABLE "MessageReaction" ADD CONSTRAINT "MessageReaction_messageId_Message_id_fk"
+  FOREIGN KEY ("messageId") REFERENCES "public"."Message"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "MessageReaction" ADD CONSTRAINT "MessageReaction_chatId_Chat_id_fk"
+  FOREIGN KEY ("chatId") REFERENCES "public"."Chat"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "MessageReaction" ADD CONSTRAINT "MessageReaction_userId_User_id_fk"
+  FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE cascade ON UPDATE no action;

--- a/packages/db/drizzle/migrations/meta/_journal.json
+++ b/packages/db/drizzle/migrations/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1770912000000,
       "tag": "0040_add_offline_wallet_ready",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1770990012019,
+      "tag": "0041_add_message_reactions",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/drizzle/migrations/meta/_journal.json
+++ b/packages/db/drizzle/migrations/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1770990012019,
       "tag": "0041_add_message_reactions",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1771077600000,
+      "tag": "0042_add_message_reaction_fk",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/messaging.ts
+++ b/packages/db/src/schema/messaging.ts
@@ -126,6 +126,33 @@ export const messages = pgTable(
   ]
 );
 
+// MessageReaction - emoji reactions on chat messages
+export const messageReactions = pgTable(
+  'MessageReaction',
+  {
+    id: text('id').primaryKey(),
+    chatId: text('chatId').notNull(),
+    messageId: text('messageId').notNull(),
+    userId: text('userId').notNull(),
+    emoji: text('emoji').notNull(),
+    createdAt: timestamp('createdAt', { mode: 'date' }).notNull().defaultNow(),
+  },
+  (table) => [
+    unique('MessageReaction_messageId_userId_emoji_key').on(
+      table.messageId,
+      table.userId,
+      table.emoji
+    ),
+    index('MessageReaction_messageId_idx').on(table.messageId),
+    index('MessageReaction_chatId_idx').on(table.chatId),
+    index('MessageReaction_userId_idx').on(table.userId),
+    index('MessageReaction_chatId_messageId_idx').on(
+      table.chatId,
+      table.messageId
+    ),
+  ]
+);
+
 // DMAcceptance
 export const dmAcceptances = pgTable(
   'DMAcceptance',
@@ -355,6 +382,7 @@ export const groupInvites = pgTable(
 export const chatsRelations = relations(chats, ({ one, many }) => ({
   ChatParticipant: many(chatParticipants),
   Message: many(messages),
+  MessageReaction: many(messageReactions),
   group: one(groups, {
     fields: [chats.groupId],
     references: [groups.id],
@@ -371,12 +399,27 @@ export const chatParticipantsRelations = relations(
   })
 );
 
-export const messagesRelations = relations(messages, ({ one }) => ({
+export const messagesRelations = relations(messages, ({ one, many }) => ({
   chat: one(chats, {
     fields: [messages.chatId],
     references: [chats.id],
   }),
+  MessageReaction: many(messageReactions),
 }));
+
+export const messageReactionsRelations = relations(
+  messageReactions,
+  ({ one }) => ({
+    chat: one(chats, {
+      fields: [messageReactions.chatId],
+      references: [chats.id],
+    }),
+    message: one(messages, {
+      fields: [messageReactions.messageId],
+      references: [messages.id],
+    }),
+  })
+);
 
 export const groupsRelations = relations(groups, ({ many }) => ({
   chats: many(chats),
@@ -408,6 +451,8 @@ export type ChatParticipant = typeof chatParticipants.$inferSelect;
 export type NewChatParticipant = typeof chatParticipants.$inferInsert;
 export type Message = typeof messages.$inferSelect;
 export type NewMessage = typeof messages.$inferInsert;
+export type MessageReaction = typeof messageReactions.$inferSelect;
+export type NewMessageReaction = typeof messageReactions.$inferInsert;
 export type DMAcceptance = typeof dmAcceptances.$inferSelect;
 export type NewDMAcceptance = typeof dmAcceptances.$inferInsert;
 export type Notification = typeof notifications.$inferSelect;

--- a/packages/examples/babylon-typescript-agent/src/registration.ts
+++ b/packages/examples/babylon-typescript-agent/src/registration.ts
@@ -69,7 +69,6 @@ export async function registerAgent(): Promise<AgentIdentity> {
   // Register on-chain
   console.log('⛓️  Registering on-chain...');
   const tx = await agent.registerIPFS();
-  // @ts-expect-error -- agent0-sdk generic (TransactionHandle<RegistrationFile>) collapses under bundler resolution; runtime type is correct
   const { result: registration } = await tx.waitMined();
 
   console.log('✅ Registration complete!');

--- a/packages/shared/src/validation/schemas/chat.ts
+++ b/packages/shared/src/validation/schemas/chat.ts
@@ -23,6 +23,25 @@ export const ChatMessageCreateSchema = z.object({
 });
 
 /**
+ * Canonical list of supported reaction emojis.
+ * Used by both the API (server-side validation) and the UI (picker).
+ */
+export const ALLOWED_REACTION_EMOJIS = [
+  '👍',
+  '❤️',
+  '😂',
+  '🔥',
+  '😮',
+  '😢',
+  '🙏',
+] as const;
+
+/** Set for O(1) membership checks on the server. */
+export const ALLOWED_REACTION_EMOJI_SET = new Set<string>(
+  ALLOWED_REACTION_EMOJIS
+);
+
+/**
  * Chat message reaction emoji schema
  */
 export const ChatMessageReactionEmojiSchema = createTrimmedStringSchema(1, 16);

--- a/packages/shared/src/validation/schemas/chat.ts
+++ b/packages/shared/src/validation/schemas/chat.ts
@@ -23,6 +23,18 @@ export const ChatMessageCreateSchema = z.object({
 });
 
 /**
+ * Chat message reaction emoji schema
+ */
+export const ChatMessageReactionEmojiSchema = createTrimmedStringSchema(1, 16);
+
+/**
+ * Chat message reaction submission schema
+ */
+export const ChatMessageReactionCreateSchema = z.object({
+  emoji: ChatMessageReactionEmojiSchema,
+});
+
+/**
  * Chat creation schema
  */
 export const ChatCreateSchema = z

--- a/packages/testing/unit/chat-message-reactions.test.ts
+++ b/packages/testing/unit/chat-message-reactions.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Chat Message Reactions – Unit Tests
+ *
+ * Covers:
+ *   - ALLOWED_REACTION_EMOJIS constant integrity
+ *   - ChatMessageReactionCreateSchema validation
+ *   - applyReactionDelta pure function (optimistic UI updates)
+ */
+
+import { describe, expect, it } from 'bun:test';
+import {
+  ALLOWED_REACTION_EMOJI_SET,
+  ALLOWED_REACTION_EMOJIS,
+  ChatMessageReactionCreateSchema,
+} from '@babylon/shared';
+
+// ---------------------------------------------------------------------------
+// ALLOWED_REACTION_EMOJIS
+// ---------------------------------------------------------------------------
+
+describe('ALLOWED_REACTION_EMOJIS', () => {
+  it('contains exactly seven emojis', () => {
+    expect(ALLOWED_REACTION_EMOJIS).toHaveLength(7);
+  });
+
+  it('includes the expected emoji set', () => {
+    const expected = ['👍', '❤️', '😂', '🔥', '😮', '😢', '🙏'] as const;
+    expect([...ALLOWED_REACTION_EMOJIS]).toEqual([...expected]);
+  });
+
+  it('has a matching Set for O(1) lookups', () => {
+    for (const emoji of ALLOWED_REACTION_EMOJIS) {
+      expect(ALLOWED_REACTION_EMOJI_SET.has(emoji)).toBe(true);
+    }
+    expect(ALLOWED_REACTION_EMOJI_SET.size).toBe(
+      ALLOWED_REACTION_EMOJIS.length
+    );
+  });
+
+  it('rejects emojis not in the set', () => {
+    expect(ALLOWED_REACTION_EMOJI_SET.has('💀')).toBe(false);
+    expect(ALLOWED_REACTION_EMOJI_SET.has('🤡')).toBe(false);
+    expect(ALLOWED_REACTION_EMOJI_SET.has('')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ChatMessageReactionCreateSchema
+// ---------------------------------------------------------------------------
+
+describe('ChatMessageReactionCreateSchema', () => {
+  it('accepts a valid emoji string', () => {
+    const result = ChatMessageReactionCreateSchema.parse({ emoji: '👍' });
+    expect(result.emoji).toBe('👍');
+  });
+
+  it('trims whitespace around emoji', () => {
+    const result = ChatMessageReactionCreateSchema.parse({ emoji: '  ❤️  ' });
+    expect(result.emoji).toBe('❤️');
+  });
+
+  it('rejects missing emoji field', () => {
+    expect(() => ChatMessageReactionCreateSchema.parse({})).toThrow();
+  });
+
+  it('rejects empty string', () => {
+    expect(() =>
+      ChatMessageReactionCreateSchema.parse({ emoji: '' })
+    ).toThrow();
+  });
+
+  it('rejects string over 16 characters', () => {
+    expect(() =>
+      ChatMessageReactionCreateSchema.parse({ emoji: 'x'.repeat(17) })
+    ).toThrow();
+  });
+
+  it('accepts strings up to 16 characters', () => {
+    const longEmoji = '🏴󠁧󠁢󠁳󠁣󠁴󠁿'; // flag sequences can be long
+    // As long as it's <= 16 code points/chars it should pass the schema
+    if (longEmoji.length <= 16) {
+      expect(() =>
+        ChatMessageReactionCreateSchema.parse({ emoji: longEmoji })
+      ).not.toThrow();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds emoji reactions to chat messages (DMs, group chats, and team chat) with real-time updates.
- Provides a quick reaction picker and displays reaction counts per message.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: BAB-185

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [x] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [x] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- DB: add `MessageReaction` table + migration `0041_add_message_reactions.sql`.
- API: add `POST/DELETE /api/chats/:chatId/messages/:messageId/reactions`.
- API: include `reactions` summary on messages returned by `GET /api/chats/:chatId`.
- Realtime: broadcast and handle SSE event `message_reaction`.
- UI: show reaction pills under each message + quick picker.

## Review guide

**Start here**
- `apps/web/src/app/api/chats/[id]/messages/[messageId]/reactions/route.ts`
- `apps/web/src/app/api/chats/[id]/route.ts`
- `apps/web/src/hooks/useChatMessages.ts`
- `apps/web/src/components/chats/MessageBubble.tsx`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- Emoji reactions are intentionally limited to a small “common” set for MVP.
- Client applies optimistic updates and suppresses the matching SSE echo for the same user to avoid double-counting.

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Open any chat.
2. Add a reaction via the quick picker.
3. Toggle the same reaction off.
4. Verify reaction counts update in real-time in a second tab.

## Ops / Migration / Deployment

- [ ] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [x] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: N/A
- Changed: N/A
- Removed: N/A

**DB / data migration**
- Migration(s): `0041_add_message_reactions.sql`
- Backfill/seed: N/A

**Rollout / rollback plan**
- Rollout: deploy web + run migration before/with deploy.
- Rollback: revert deployment; reaction UI will disappear, data remains in `MessageReaction`.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- New endpoint: `POST/DELETE /api/chats/:chatId/messages/:messageId/reactions`.
- New SSE event: `message_reaction` on `chat:${chatId}`.

### Database
- New table: `MessageReaction` with unique constraint `(messageId, userId, emoji)` and supporting indexes.

</details>

## Screenshots / recordings (UI)

### Option A: Visual demo

| Feature | Before | After |
|---------|--------|-------|
| Message reactions | N/A | N/A |

*Demo script (for recording):*
1. Open a chat.
2. Click “React” on a message and pick an emoji.
3. Open the same chat in another tab and verify the reaction appears.
4. Toggle the reaction off.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [ ] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
