### PR TITLE
feat: add show/hide closed positions toggle to agent P&L and predictions panel

### DIFF
--- a/apps/web/src/app/agents/team/AgentPnL.tsx
+++ b/apps/web/src/app/agents/team/AgentPnL.tsx
@@ -9,6 +9,7 @@ import {
 import { ChevronDown, Loader2, TrendingDown, TrendingUp } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
+import { Switch } from '@/components/ui/switch';
 import { useAuth } from '@/hooks/useAuth';
 import { useCollapsibleHeight } from '@/hooks/useCollapsibleHeight';
 import { useUserPositions } from '@/hooks/useUserPositions';
@@ -50,6 +51,24 @@ type AgentPnLProps =
       entityName: string;
       agentId?: never;
     };
+
+/** Returns true if a prediction position is still open (not resolved/closed) */
+function isOpenPrediction(p: { resolved?: boolean; status?: string }): boolean {
+  if (p.resolved) return false;
+  if (p.status && p.status !== 'active') return false;
+  return true;
+}
+
+/** Returns a label + color variant for a closed prediction position */
+function getResolutionLabel(p: {
+  resolution?: boolean | null;
+  status?: string;
+}): { text: string; variant: 'green' | 'red' | 'muted' } {
+  if (p.status === 'cancelled') return { text: 'Cancelled', variant: 'muted' };
+  if (p.resolution === true) return { text: 'Won', variant: 'green' };
+  if (p.resolution === false) return { text: 'Lost', variant: 'red' };
+  return { text: 'Closed', variant: 'muted' };
+}
 
 /** Collapsible section with smooth height animation */
 function CollapsibleSection({
@@ -125,6 +144,7 @@ function UserPnL({
   const [expandedSections, setExpandedSections] = useState<
     Set<'predictions' | 'perps'>
   >(new Set(['predictions', 'perps']));
+  const [showClosed, setShowClosed] = useState(false);
 
   // Portfolio breakdown (same calculation as profile page)
   const [portfolio, setPortfolio] = useState<PortfolioSnapshot | null>(null);
@@ -138,11 +158,16 @@ function UserPnL({
 
   const loading = portfolioLoading || perpsLoading || predictionsLoading;
 
-  // Filter to only user's personal active positions (exclude agent positions and non-active)
+  // Filter to only user's personal positions (exclude agent positions)
   const perps = (perpsData ?? []).filter((p) => !p.isAgentPosition);
-  const predictions = (predictionsData ?? []).filter(
-    (p) => !p.isAgentPosition && (!p.status || p.status === 'active')
+  const userPredictions = (predictionsData ?? []).filter(
+    (p) => !p.isAgentPosition
   );
+  const openPredictions = userPredictions.filter(isOpenPrediction);
+  const closedPredictions = userPredictions.filter((p) => !isOpenPrediction(p));
+  const predictions = showClosed
+    ? [...openPredictions, ...closedPredictions]
+    : openPredictions;
 
   // Fetch portfolio breakdown (same endpoint as profile page)
   useEffect(() => {
@@ -294,11 +319,25 @@ function UserPnL({
 
       {/* Open Positions */}
       <div className="flex flex-col rounded-lg border border-border bg-card/50 p-3 lg:min-h-0 lg:flex-1 lg:overflow-hidden">
-        <div className="mb-2 shrink-0 font-medium text-sm">Open Positions</div>
+        <div className="mb-2 flex shrink-0 items-center justify-between">
+          <span className="font-medium text-sm">
+            {showClosed ? 'All Positions' : 'Open Positions'}
+          </span>
+          {closedPredictions.length > 0 && (
+            <label className="flex items-center gap-1.5 text-muted-foreground text-xs">
+              <span>Show closed</span>
+              <Switch
+                checked={showClosed}
+                onCheckedChange={setShowClosed}
+                className="scale-75"
+              />
+            </label>
+          )}
+        </div>
 
         {predictions.length === 0 && perps.length === 0 ? (
           <div className="flex items-center justify-center py-4 text-muted-foreground text-xs">
-            No open positions
+            {showClosed ? 'No positions' : 'No open positions'}
           </div>
         ) : (
           <div className="space-y-2 lg:min-h-0 lg:flex-1 lg:overflow-y-auto">
@@ -311,48 +350,75 @@ function UserPnL({
                 onToggle={() => toggleSection('predictions')}
               >
                 <div className="space-y-1">
-                  {predictions.map((pos) => (
-                    <button
-                      type="button"
-                      key={pos.id}
-                      onClick={() =>
-                        router.push(`/markets/predictions/${pos.marketId}`)
-                      }
-                      className="flex w-full items-center justify-between rounded bg-muted/30 px-2 py-1.5 text-left text-xs transition-colors hover:bg-muted/50"
-                    >
-                      <div className="min-w-0 flex-1">
-                        <div className="truncate font-medium">
-                          {pos.question || `Market ${pos.marketId}`}
+                  {predictions.map((pos) => {
+                    const closed = !isOpenPrediction(pos);
+                    return (
+                      <button
+                        type="button"
+                        key={pos.id}
+                        onClick={() =>
+                          router.push(`/markets/predictions/${pos.marketId}`)
+                        }
+                        className={cn(
+                          'flex w-full items-center justify-between rounded bg-muted/30 px-2 py-1.5 text-left text-xs transition-colors hover:bg-muted/50',
+                          closed && 'opacity-60'
+                        )}
+                      >
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-1.5 truncate font-medium">
+                            <span className="truncate">
+                              {pos.question || `Market ${pos.marketId}`}
+                            </span>
+                            {closed && (
+                              <span
+                                className={cn(
+                                  'shrink-0 rounded-full px-1.5 py-0.5 font-medium text-[10px] leading-none',
+                                  {
+                                    'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400':
+                                      getResolutionLabel(pos).variant ===
+                                      'green',
+                                    'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400':
+                                      getResolutionLabel(pos).variant === 'red',
+                                    'bg-muted text-muted-foreground':
+                                      getResolutionLabel(pos).variant ===
+                                      'muted',
+                                  }
+                                )}
+                              >
+                                {getResolutionLabel(pos).text}
+                              </span>
+                            )}
+                          </div>
+                          <div className="flex items-center gap-2 text-muted-foreground">
+                            <span
+                              className={cn(
+                                'font-medium',
+                                pos.side === 'YES'
+                                  ? 'text-green-600'
+                                  : 'text-red-600'
+                              )}
+                            >
+                              {pos.side}
+                            </span>
+                            <span>{Number(pos.shares).toFixed(2)} shares</span>
+                          </div>
                         </div>
-                        <div className="flex items-center gap-2 text-muted-foreground">
+                        {pos.unrealizedPnL !== undefined && (
                           <span
                             className={cn(
-                              'font-medium',
-                              pos.side === 'YES'
+                              'ml-2 shrink-0 font-medium',
+                              Number(pos.unrealizedPnL) >= 0
                                 ? 'text-green-600'
                                 : 'text-red-600'
                             )}
                           >
-                            {pos.side}
+                            {Number(pos.unrealizedPnL) >= 0 ? '+' : ''}
+                            {formatCompactCurrency(Number(pos.unrealizedPnL))}
                           </span>
-                          <span>{Number(pos.shares).toFixed(2)} shares</span>
-                        </div>
-                      </div>
-                      {pos.unrealizedPnL !== undefined && (
-                        <span
-                          className={cn(
-                            'ml-2 shrink-0 font-medium',
-                            Number(pos.unrealizedPnL) >= 0
-                              ? 'text-green-600'
-                              : 'text-red-600'
-                          )}
-                        >
-                          {Number(pos.unrealizedPnL) >= 0 ? '+' : ''}
-                          {formatCompactCurrency(Number(pos.unrealizedPnL))}
-                        </span>
-                      )}
-                    </button>
-                  ))}
+                        )}
+                      </button>
+                    );
+                  })}
                 </div>
               </CollapsibleSection>
             )}
@@ -436,6 +502,7 @@ function AgentPnLView({
   const [expandedSections, setExpandedSections] = useState<
     Set<'predictions' | 'perps'>
   >(new Set(['predictions', 'perps']));
+  const [showClosed, setShowClosed] = useState(false);
 
   // Portfolio breakdown (same calculation as profile page)
   const [portfolio, setPortfolio] = useState<PortfolioSnapshot | null>(null);
@@ -455,10 +522,12 @@ function AgentPnLView({
     loading: positionsLoading,
   } = useUserPositions(agentId);
 
-  // Filter to only active prediction positions (matches check-pnl action)
-  const predictions = allPredictions.filter(
-    (p) => !p.status || p.status === 'active'
-  );
+  // Split prediction positions into open vs closed
+  const openPredictions = allPredictions.filter(isOpenPrediction);
+  const closedPredictions = allPredictions.filter((p) => !isOpenPrediction(p));
+  const predictions = showClosed
+    ? [...openPredictions, ...closedPredictions]
+    : openPredictions;
 
   // Fetch portfolio breakdown (same endpoint as profile page)
   useEffect(() => {
@@ -654,7 +723,21 @@ function AgentPnLView({
 
       {/* Open Positions */}
       <div className="flex flex-col rounded-lg border border-border bg-card/50 p-3 lg:min-h-0 lg:flex-1 lg:overflow-hidden">
-        <div className="mb-2 shrink-0 font-medium text-sm">Open Positions</div>
+        <div className="mb-2 flex shrink-0 items-center justify-between">
+          <span className="font-medium text-sm">
+            {showClosed ? 'All Positions' : 'Open Positions'}
+          </span>
+          {closedPredictions.length > 0 && (
+            <label className="flex items-center gap-1.5 text-muted-foreground text-xs">
+              <span>Show closed</span>
+              <Switch
+                checked={showClosed}
+                onCheckedChange={setShowClosed}
+                className="scale-75"
+              />
+            </label>
+          )}
+        </div>
 
         {positionsLoading ? (
           <div className="flex items-center justify-center py-4">
@@ -662,7 +745,7 @@ function AgentPnLView({
           </div>
         ) : predictions.length === 0 && perps.length === 0 ? (
           <div className="flex items-center justify-center py-4 text-muted-foreground text-xs">
-            No open positions
+            {showClosed ? 'No positions' : 'No open positions'}
           </div>
         ) : (
           <div className="space-y-2 lg:min-h-0 lg:flex-1 lg:overflow-y-auto">
@@ -675,48 +758,75 @@ function AgentPnLView({
                 onToggle={() => toggleSection('predictions')}
               >
                 <div className="space-y-1">
-                  {predictions.map((pos) => (
-                    <button
-                      type="button"
-                      key={pos.id}
-                      onClick={() =>
-                        router.push(`/markets/predictions/${pos.marketId}`)
-                      }
-                      className="flex w-full items-center justify-between rounded bg-muted/30 px-2 py-1.5 text-left text-xs transition-colors hover:bg-muted/50"
-                    >
-                      <div className="min-w-0 flex-1">
-                        <div className="truncate font-medium">
-                          {pos.question || `Market ${pos.marketId}`}
+                  {predictions.map((pos) => {
+                    const closed = !isOpenPrediction(pos);
+                    return (
+                      <button
+                        type="button"
+                        key={pos.id}
+                        onClick={() =>
+                          router.push(`/markets/predictions/${pos.marketId}`)
+                        }
+                        className={cn(
+                          'flex w-full items-center justify-between rounded bg-muted/30 px-2 py-1.5 text-left text-xs transition-colors hover:bg-muted/50',
+                          closed && 'opacity-60'
+                        )}
+                      >
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center gap-1.5 truncate font-medium">
+                            <span className="truncate">
+                              {pos.question || `Market ${pos.marketId}`}
+                            </span>
+                            {closed && (
+                              <span
+                                className={cn(
+                                  'shrink-0 rounded-full px-1.5 py-0.5 font-medium text-[10px] leading-none',
+                                  {
+                                    'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400':
+                                      getResolutionLabel(pos).variant ===
+                                      'green',
+                                    'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400':
+                                      getResolutionLabel(pos).variant === 'red',
+                                    'bg-muted text-muted-foreground':
+                                      getResolutionLabel(pos).variant ===
+                                      'muted',
+                                  }
+                                )}
+                              >
+                                {getResolutionLabel(pos).text}
+                              </span>
+                            )}
+                          </div>
+                          <div className="flex items-center gap-2 text-muted-foreground">
+                            <span
+                              className={cn(
+                                'font-medium',
+                                pos.side === 'YES'
+                                  ? 'text-green-600'
+                                  : 'text-red-600'
+                              )}
+                            >
+                              {pos.side}
+                            </span>
+                            <span>{Number(pos.shares).toFixed(2)} shares</span>
+                          </div>
                         </div>
-                        <div className="flex items-center gap-2 text-muted-foreground">
+                        {pos.unrealizedPnL !== undefined && (
                           <span
                             className={cn(
-                              'font-medium',
-                              pos.side === 'YES'
+                              'ml-2 shrink-0 font-medium',
+                              Number(pos.unrealizedPnL) >= 0
                                 ? 'text-green-600'
                                 : 'text-red-600'
                             )}
                           >
-                            {pos.side}
+                            {Number(pos.unrealizedPnL) >= 0 ? '+' : ''}
+                            {formatCompactCurrency(Number(pos.unrealizedPnL))}
                           </span>
-                          <span>{Number(pos.shares).toFixed(2)} shares</span>
-                        </div>
-                      </div>
-                      {pos.unrealizedPnL !== undefined && (
-                        <span
-                          className={cn(
-                            'ml-2 shrink-0 font-medium',
-                            Number(pos.unrealizedPnL) >= 0
-                              ? 'text-green-600'
-                              : 'text-red-600'
-                          )}
-                        >
-                          {Number(pos.unrealizedPnL) >= 0 ? '+' : ''}
-                          {formatCompactCurrency(Number(pos.unrealizedPnL))}
-                        </span>
-                      )}
-                    </button>
-                  ))}
+                        )}
+                      </button>
+                    );
+                  })}
                 </div>
               </CollapsibleSection>
             )}

--- a/apps/web/src/app/agents/team/AgentPnL.tsx
+++ b/apps/web/src/app/agents/team/AgentPnL.tsx
@@ -352,6 +352,7 @@ function UserPnL({
                 <div className="space-y-1">
                   {predictions.map((pos) => {
                     const closed = !isOpenPrediction(pos);
+                    const resolution = closed ? getResolutionLabel(pos) : null;
                     return (
                       <button
                         type="button"
@@ -375,17 +376,15 @@ function UserPnL({
                                   'shrink-0 rounded-full px-1.5 py-0.5 font-medium text-[10px] leading-none',
                                   {
                                     'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400':
-                                      getResolutionLabel(pos).variant ===
-                                      'green',
+                                      resolution?.variant === 'green',
                                     'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400':
-                                      getResolutionLabel(pos).variant === 'red',
+                                      resolution?.variant === 'red',
                                     'bg-muted text-muted-foreground':
-                                      getResolutionLabel(pos).variant ===
-                                      'muted',
+                                      resolution?.variant === 'muted',
                                   }
                                 )}
                               >
-                                {getResolutionLabel(pos).text}
+                                {resolution?.text}
                               </span>
                             )}
                           </div>
@@ -760,6 +759,7 @@ function AgentPnLView({
                 <div className="space-y-1">
                   {predictions.map((pos) => {
                     const closed = !isOpenPrediction(pos);
+                    const resolution = closed ? getResolutionLabel(pos) : null;
                     return (
                       <button
                         type="button"
@@ -783,17 +783,15 @@ function AgentPnLView({
                                   'shrink-0 rounded-full px-1.5 py-0.5 font-medium text-[10px] leading-none',
                                   {
                                     'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400':
-                                      getResolutionLabel(pos).variant ===
-                                      'green',
+                                      resolution?.variant === 'green',
                                     'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400':
-                                      getResolutionLabel(pos).variant === 'red',
+                                      resolution?.variant === 'red',
                                     'bg-muted text-muted-foreground':
-                                      getResolutionLabel(pos).variant ===
-                                      'muted',
+                                      resolution?.variant === 'muted',
                                   }
                                 )}
                               >
-                                {getResolutionLabel(pos).text}
+                                {resolution?.text}
                               </span>
                             )}
                           </div>

--- a/apps/web/src/app/agents/team/panels/PredictionsPanel.tsx
+++ b/apps/web/src/app/agents/team/panels/PredictionsPanel.tsx
@@ -6,6 +6,7 @@ import { CheckCircle, Clock, XCircle } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { PredictionProbabilityChart } from '@/components/markets/PredictionProbabilityChart';
 import { PredictionTradingModal } from '@/components/markets/PredictionTradingModal';
+import { Switch } from '@/components/ui/switch';
 import { usePredictionHistory } from '@/hooks/usePredictionHistory';
 import type { MarketTimeRange, PredictionMarket } from '@/types/markets';
 import { PanelViewMoreLink } from './PanelViewMoreLink';
@@ -45,6 +46,7 @@ interface TradingState {
 export function PredictionsPanel({ data }: PredictionsPanelProps) {
   const [tradingState, setTradingState] = useState<TradingState | null>(null);
   const [timeRange, setTimeRange] = useState<MarketTimeRange>('1D');
+  const [showClosed, setShowClosed] = useState(false);
 
   // Fetch history for single prediction view
   const marketId = data.prediction ? String(data.prediction.id) : null;
@@ -208,9 +210,9 @@ export function PredictionsPanel({ data }: PredictionsPanelProps) {
   }
 
   // Handle list view
-  const { predictions, status } = data;
+  const { predictions: allPredictions, status } = data;
 
-  if (!predictions || predictions.length === 0) {
+  if (!allPredictions || allPredictions.length === 0) {
     return (
       <div className="flex h-full items-center justify-center p-4">
         <p className="text-muted-foreground text-sm">
@@ -220,92 +222,130 @@ export function PredictionsPanel({ data }: PredictionsPanelProps) {
     );
   }
 
+  const openPredictions = allPredictions.filter((p) => !p.resolved);
+  const closedPredictions = allPredictions.filter((p) => p.resolved);
+  const predictions = showClosed
+    ? [...openPredictions, ...closedPredictions]
+    : openPredictions;
+
   return (
     <div className="space-y-3 p-4">
       <div className="flex items-center justify-between">
-        <h3 className="font-semibold text-sm">Prediction Markets</h3>
-        {status && (
-          <span className="rounded-full bg-muted px-2 py-0.5 text-muted-foreground text-xs capitalize">
-            {status}
-          </span>
-        )}
+        <h3 className="font-semibold text-sm">
+          {showClosed ? 'All Predictions' : 'Prediction Markets'}
+        </h3>
+        <div className="flex items-center gap-2">
+          {status && (
+            <span className="rounded-full bg-muted px-2 py-0.5 text-muted-foreground text-xs capitalize">
+              {status}
+            </span>
+          )}
+          {closedPredictions.length > 0 && (
+            <label className="flex items-center gap-1.5 text-muted-foreground text-xs">
+              <span>Show closed</span>
+              <Switch
+                checked={showClosed}
+                onCheckedChange={setShowClosed}
+                className="scale-75"
+              />
+            </label>
+          )}
+        </div>
       </div>
-      <div className="space-y-2">
-        {predictions.map((prediction) => {
-          const predictionMarket = toPredictionMarket(prediction);
-          // Normalize percentages to ensure they sum to 100%
-          const yesRaw = Number(prediction.yesPercent) || 0;
-          const yesClamped = Math.max(0, Math.min(100, yesRaw));
-          const noClamped = 100 - yesClamped;
-          return (
-            <div
-              key={prediction.id}
-              className="rounded-lg border border-border bg-card p-3"
-            >
-              <p className="line-clamp-2 font-medium text-sm">
-                {prediction.question}
-              </p>
-              <div className="mt-2 flex items-center gap-2">
-                {/* YES/NO bars */}
-                <div className="flex flex-1 overflow-hidden rounded-full bg-muted">
-                  <div
-                    className="h-2 bg-green-500"
-                    style={{ width: `${yesClamped}%` }}
-                  />
-                  <div
-                    className="h-2 bg-red-500"
-                    style={{ width: `${noClamped}%` }}
-                  />
-                </div>
-              </div>
-              <div className="mt-1.5 flex items-center justify-between text-xs">
-                <span className="text-green-500">
-                  {Math.round(yesClamped)}% YES
-                </span>
-                <span className="text-red-500">
-                  {Math.round(noClamped)}% NO
-                </span>
-              </div>
-              <div className="mt-2 flex items-center justify-between text-muted-foreground text-xs">
-                {prediction.resolved ? (
-                  <span
-                    className={cn(
-                      'font-medium',
-                      prediction.resolution === 'YES'
-                        ? 'text-green-500'
+      {predictions.length === 0 ? (
+        <div className="flex items-center justify-center py-4 text-muted-foreground text-xs">
+          No open predictions
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {predictions.map((prediction) => {
+            const predictionMarket = toPredictionMarket(prediction);
+            // Normalize percentages to ensure they sum to 100%
+            const yesRaw = Number(prediction.yesPercent) || 0;
+            const yesClamped = Math.max(0, Math.min(100, yesRaw));
+            const noClamped = 100 - yesClamped;
+            return (
+              <div
+                key={prediction.id}
+                className={cn(
+                  'rounded-lg border border-border bg-card p-3',
+                  prediction.resolved && 'opacity-60'
+                )}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <p className="line-clamp-2 font-medium text-sm">
+                    {prediction.question}
+                  </p>
+                  {prediction.resolved && (
+                    <span
+                      className={cn(
+                        'shrink-0 rounded-full px-1.5 py-0.5 font-medium text-[10px] leading-none',
+                        prediction.resolution === 'YES'
+                          ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+                          : prediction.resolution === 'NO'
+                            ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+                            : 'bg-muted text-muted-foreground'
+                      )}
+                    >
+                      {prediction.resolution === 'YES'
+                        ? 'Yes'
                         : prediction.resolution === 'NO'
-                          ? 'text-red-500'
-                          : ''
+                          ? 'No'
+                          : 'Cancelled'}
+                    </span>
+                  )}
+                </div>
+                <div className="mt-2 flex items-center gap-2">
+                  {/* YES/NO bars */}
+                  <div className="flex flex-1 overflow-hidden rounded-full bg-muted">
+                    <div
+                      className="h-2 bg-green-500"
+                      style={{ width: `${yesClamped}%` }}
+                    />
+                    <div
+                      className="h-2 bg-red-500"
+                      style={{ width: `${noClamped}%` }}
+                    />
+                  </div>
+                </div>
+                <div className="mt-1.5 flex items-center justify-between text-xs">
+                  <span className="text-green-500">
+                    {Math.round(yesClamped)}% YES
+                  </span>
+                  <span className="text-red-500">
+                    {Math.round(noClamped)}% NO
+                  </span>
+                </div>
+                {!prediction.resolved && (
+                  <div className="mt-2 flex items-center justify-between text-muted-foreground text-xs">
+                    {prediction.daysUntil !== null ? (
+                      <span>
+                        {prediction.daysUntil > 0
+                          ? `${prediction.daysUntil}d left`
+                          : 'Ending soon'}
+                      </span>
+                    ) : (
+                      <span>End: {prediction.endDate}</span>
                     )}
+                  </div>
+                )}
+                {/* Quick Trade Button - only show for unresolved markets */}
+                {!prediction.resolved && (
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setTradingState({ market: predictionMarket, side: 'YES' })
+                    }
+                    className="mt-2 w-full rounded bg-primary/10 py-1.5 font-medium text-primary text-xs transition-colors hover:bg-primary/20"
                   >
-                    Resolved: {prediction.resolution}
-                  </span>
-                ) : prediction.daysUntil !== null ? (
-                  <span>
-                    {prediction.daysUntil > 0
-                      ? `${prediction.daysUntil}d left`
-                      : 'Ending soon'}
-                  </span>
-                ) : (
-                  <span>End: {prediction.endDate}</span>
+                    Trade
+                  </button>
                 )}
               </div>
-              {/* Quick Trade Button - only show for unresolved markets */}
-              {!prediction.resolved && (
-                <button
-                  type="button"
-                  onClick={() =>
-                    setTradingState({ market: predictionMarket, side: 'YES' })
-                  }
-                  className="mt-2 w-full rounded bg-primary/10 py-1.5 font-medium text-primary text-xs transition-colors hover:bg-primary/20"
-                >
-                  Trade
-                </button>
-              )}
-            </div>
-          );
-        })}
-      </div>
+            );
+          })}
+        </div>
+      )}
 
       {/* View All Predictions Link */}
       <PanelViewMoreLink href="/markets">View all markets</PanelViewMoreLink>


### PR DESCRIPTION
## Summary
- Resolved prediction positions no longer clutter the "Open Positions" view in the Agent P&L panel — the filter now checks both `resolved` and `status` fields
- Adds a "Show closed" toggle switch that reveals closed positions with muted styling (`opacity-60`) and Won/Lost/Cancelled resolution badges
- Applied to both `AgentPnL` (UserPnL + AgentPnLView) and `PredictionsPanel` list view