### PR TITLE
feat: improve agent settings access and team chat UX on mobile

### DIFF
--- a/apps/web/src/app/agents/create/components/AgentSetupModal.tsx
+++ b/apps/web/src/app/agents/create/components/AgentSetupModal.tsx
@@ -494,12 +494,19 @@ export function AgentSetupModal({
 
         {/* Footer - fixed */}
         <div className="shrink-0 border-border border-t px-4 py-3 sm:px-6 sm:py-4">
-          <div className="flex justify-end">
+          <div className="flex gap-3">
+            <span
+              className="pointer-events-none flex-1 rounded-lg border border-transparent px-4 py-2.5 font-medium text-transparent sm:py-3"
+              aria-hidden="true"
+            >
+              Back
+            </span>
             <button
               onClick={handleContinue}
               disabled={isContinueDisabled}
               className={cn(
-                'flex w-1/2 items-center justify-center rounded-lg bg-[#0066FF] px-4 py-2.5 font-medium text-primary-foreground transition-colors hover:bg-[#2952d9] sm:py-3',
+                'flex flex-1 items-center justify-center gap-2 rounded-lg px-4 py-2.5 font-medium transition-all sm:py-3',
+                'bg-[#0066FF] text-primary-foreground hover:bg-[#2952d9]',
                 'disabled:cursor-not-allowed disabled:opacity-50'
               )}
             >

--- a/apps/web/src/app/agents/team/MemberList.tsx
+++ b/apps/web/src/app/agents/team/MemberList.tsx
@@ -134,9 +134,7 @@ export function MemberList({
                           className={cn(
                             'flex h-7 w-7 flex-shrink-0 items-center justify-center rounded transition-colors',
                             'text-muted-foreground hover:bg-muted hover:text-foreground',
-                            // Mobile: always visible. Desktop: hidden until hover/focus/open.
-                            'opacity-100 lg:opacity-0 lg:group-hover:opacity-100 lg:focus:opacity-100',
-                            'data-[state=open]:opacity-100 lg:data-[state=open]:opacity-100'
+                            'focus:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100 lg:opacity-0'
                           )}
                           aria-label={`More options for ${agentName}`}
                         >

--- a/apps/web/src/app/agents/team/MemberList.tsx
+++ b/apps/web/src/app/agents/team/MemberList.tsx
@@ -134,7 +134,9 @@ export function MemberList({
                           className={cn(
                             'flex h-7 w-7 flex-shrink-0 items-center justify-center rounded transition-colors',
                             'text-muted-foreground hover:bg-muted hover:text-foreground',
-                            'focus:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100 lg:opacity-0'
+                            // Mobile: always visible. Desktop: hidden until hover/focus/open.
+                            'opacity-100 lg:opacity-0 lg:group-hover:opacity-100 lg:focus:opacity-100',
+                            'data-[state=open]:opacity-100 lg:data-[state=open]:opacity-100'
                           )}
                           aria-label={`More options for ${agentName}`}
                         >

--- a/apps/web/src/app/agents/team/MemberList.tsx
+++ b/apps/web/src/app/agents/team/MemberList.tsx
@@ -134,7 +134,7 @@ export function MemberList({
                           className={cn(
                             'flex h-7 w-7 flex-shrink-0 items-center justify-center rounded transition-colors',
                             'text-muted-foreground hover:bg-muted hover:text-foreground',
-                            'opacity-0 focus:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100'
+                            'focus:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100 lg:opacity-0'
                           )}
                           aria-label={`More options for ${agentName}`}
                         >

--- a/apps/web/src/app/agents/team/page.tsx
+++ b/apps/web/src/app/agents/team/page.tsx
@@ -474,6 +474,12 @@ export default function TeamChatPage() {
     getAccessToken,
   });
 
+  // Agent IDs set for settings icon on latest agent messages
+  const agentIds = useMemo(
+    () => new Set(teamChat?.agents.map((a) => a.id) ?? []),
+    [teamChat?.agents]
+  );
+
   // Handle sidebar "Settings" - open edit modal
   const handleViewSettings = useCallback(
     async (agentId: string) => {
@@ -850,7 +856,6 @@ export default function TeamChatPage() {
             onStopAgent={stopAgent}
             onViewSettings={(agentId) => {
               handleViewSettings(agentId);
-              setMobileView('panel');
             }}
           />
         </div>
@@ -995,6 +1000,8 @@ export default function TeamChatPage() {
             handleTagClick(tag, messageId);
             setMobileView('panel');
           }}
+          agentIds={agentIds}
+          onViewSettings={handleViewSettings}
         />
       </div>
 
@@ -1098,6 +1105,8 @@ export default function TeamChatPage() {
             rightSidebarOpen={rightSidebarOpen}
             onToggleRightSidebar={toggleRightSidebar}
             onTagClick={handleTagClick}
+            agentIds={agentIds}
+            onViewSettings={handleViewSettings}
           />
         </div>
 

--- a/apps/web/src/components/agents/AgentEditModal.tsx
+++ b/apps/web/src/components/agents/AgentEditModal.tsx
@@ -622,7 +622,12 @@ export function AgentEditModal({
     <div className="flex gap-3">
       {currentStep === Step.Profile && (
         <>
-          <div className="flex-1" />
+          <span
+            className="pointer-events-none flex-1 rounded-lg border border-transparent px-4 py-2.5 font-medium text-transparent sm:py-3"
+            aria-hidden="true"
+          >
+            Back
+          </span>
           <button
             onClick={() => setCurrentStep(Step.Prompts)}
             className={cn(

--- a/apps/web/src/components/chats/MessageBubble.tsx
+++ b/apps/web/src/components/chats/MessageBubble.tsx
@@ -172,7 +172,7 @@ export function MessageBubble({
             <button
               type="button"
               onClick={() => onViewSettings(message.senderId)}
-              className="text-muted-foreground transition-colors hover:text-foreground"
+              className="text-muted-foreground transition-colors hover:text-foreground lg:hidden"
               aria-label="Agent settings"
             >
               <Settings className="h-3.5 w-3.5" />

--- a/apps/web/src/components/chats/MessageBubble.tsx
+++ b/apps/web/src/components/chats/MessageBubble.tsx
@@ -6,7 +6,7 @@ import {
   cn,
   type MessageTag,
 } from '@babylon/shared';
-import { ChevronRight, Plus } from 'lucide-react';
+import { ChevronRight, Plus, Settings } from 'lucide-react';
 import Link from 'next/link';
 import { Response } from '@/components/chat/Response';
 import { Avatar } from '@/components/shared/Avatar';
@@ -54,6 +54,10 @@ interface MessageBubbleProps {
     emoji: string,
     currentlyReactedByMe: boolean
   ) => void;
+  /** Compact action row: merge reactions + tags into one row, hide on own messages */
+  compactActions?: boolean;
+  /** Callback to open settings for this agent (mobile only, latest message only) */
+  onViewSettings?: (agentId: string) => void;
 }
 
 export function MessageBubble({
@@ -65,6 +69,8 @@ export function MessageBubble({
   density = 'default',
   onTagClick,
   onToggleReaction,
+  compactActions = false,
+  onViewSettings,
 }: MessageBubbleProps) {
   const msgDate = new Date(message.createdAt);
   const senderName = sender?.displayName || 'Unknown';
@@ -162,6 +168,16 @@ export function MessageBubble({
               minute: '2-digit',
             })}
           </span>
+          {onViewSettings && (
+            <button
+              type="button"
+              onClick={() => onViewSettings(message.senderId)}
+              className="text-muted-foreground transition-colors hover:text-foreground"
+              aria-label="Agent settings"
+            >
+              <Settings className="h-3.5 w-3.5" />
+            </button>
+          )}
         </div>
         <div
           className={cn(
@@ -202,88 +218,170 @@ export function MessageBubble({
           )}
         </div>
 
-        {/* Reactions */}
-        {!isThinking && (message.reactions?.length || onToggleReaction) && (
-          <div className="mt-2 flex flex-wrap items-center gap-2">
-            {(message.reactions ?? []).map((r) => (
-              <button
-                key={r.emoji}
-                type="button"
-                onClick={() =>
-                  onToggleReaction?.(message.id, r.emoji, r.reactedByMe)
-                }
-                disabled={!onToggleReaction}
-                className={cn(
-                  'inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs transition-colors',
-                  onToggleReaction ? 'hover:bg-muted' : 'cursor-default',
-                  r.reactedByMe
-                    ? 'border-primary/30 bg-primary/10 text-primary'
-                    : 'border-border bg-background text-foreground'
-                )}
-                aria-label={`React ${r.emoji}`}
-              >
-                <span aria-hidden="true">{r.emoji}</span>
-                <span className="font-medium tabular-nums">{r.count}</span>
-              </button>
-            ))}
-
-            {onToggleReaction && (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <button
-                    type="button"
-                    className="inline-flex items-center gap-1 rounded-full border border-border bg-background px-2 py-1 text-muted-foreground text-xs transition-colors hover:bg-muted hover:text-foreground"
-                    aria-label="Add reaction"
-                  >
-                    <Plus className="h-3.5 w-3.5" />
-                    <span>React</span>
-                  </button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align={isCurrentUser ? 'end' : 'start'}>
-                  {ALLOWED_REACTION_EMOJIS.map((emoji) => {
-                    const existing = (message.reactions ?? []).find(
-                      (r) => r.emoji === emoji
-                    );
-                    const reacted = existing?.reactedByMe ?? false;
-                    return (
-                      <DropdownMenuItem
-                        key={emoji}
-                        onClick={() =>
-                          onToggleReaction(message.id, emoji, reacted)
-                        }
-                      >
-                        <span className="mr-2" aria-hidden="true">
-                          {emoji}
-                        </span>
-                        <span>{reacted ? 'Remove' : 'React'}</span>
-                      </DropdownMenuItem>
-                    );
-                  })}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
-          </div>
-        )}
-
-        {/* Action Tags - Pill-style chips (outside message bubble) */}
-        {!isThinking &&
-          message.metadata?.tags &&
-          message.metadata.tags.length > 0 && (
-            <div className="mt-2 flex flex-wrap gap-2">
-              {message.metadata.tags.map((tag, i) => (
+        {/* Reactions + Action Tags */}
+        {compactActions ? (
+          /* Compact: single row, tighter gap, hidden on own messages */
+          !isThinking &&
+          !isCurrentUser &&
+          (message.reactions?.length ||
+            onToggleReaction ||
+            (message.metadata?.tags && message.metadata.tags.length > 0)) && (
+            <div className="mt-2 flex flex-wrap items-center gap-0.5">
+              {(message.reactions ?? []).map((r) => (
+                <button
+                  key={r.emoji}
+                  type="button"
+                  onClick={() =>
+                    onToggleReaction?.(message.id, r.emoji, r.reactedByMe)
+                  }
+                  disabled={!onToggleReaction}
+                  className={cn(
+                    'inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs transition-colors',
+                    onToggleReaction ? 'hover:bg-muted' : 'cursor-default',
+                    r.reactedByMe
+                      ? 'border-primary/30 bg-primary/10 text-primary'
+                      : 'border-border bg-background text-foreground'
+                  )}
+                  aria-label={`React ${r.emoji}`}
+                >
+                  <span aria-hidden="true">{r.emoji}</span>
+                  <span className="font-medium tabular-nums">{r.count}</span>
+                </button>
+              ))}
+              {onToggleReaction && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      type="button"
+                      className="inline-flex items-center gap-1 rounded-full border border-border bg-background px-2 py-1 text-muted-foreground text-xs transition-colors hover:bg-muted hover:text-foreground"
+                      aria-label="Add reaction"
+                    >
+                      <Plus className="h-3.5 w-3.5" />
+                      <span>React</span>
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align={isCurrentUser ? 'end' : 'start'}>
+                    {ALLOWED_REACTION_EMOJIS.map((emoji) => {
+                      const existing = (message.reactions ?? []).find(
+                        (r) => r.emoji === emoji
+                      );
+                      const reacted = existing?.reactedByMe ?? false;
+                      return (
+                        <DropdownMenuItem
+                          key={emoji}
+                          onClick={() =>
+                            onToggleReaction(message.id, emoji, reacted)
+                          }
+                        >
+                          <span className="mr-2" aria-hidden="true">
+                            {emoji}
+                          </span>
+                          <span>{reacted ? 'Remove' : 'React'}</span>
+                        </DropdownMenuItem>
+                      );
+                    })}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
+              {message.metadata?.tags?.map((tag, i) => (
                 <button
                   key={`${tag.type}-${tag.entityId ?? i}`}
                   type="button"
                   onClick={() => onTagClick?.(tag, message.id)}
                   data-tag-entity={tag.entityId}
-                  className="group flex items-center gap-1.5 rounded-full border border-primary/20 bg-primary/5 py-1 pr-2 pl-3 font-medium text-primary text-xs transition-all hover:border-primary/40 hover:bg-primary/10"
+                  className="group flex items-center gap-1 rounded-full border border-primary/20 bg-primary/5 px-1.5 py-1 font-medium text-primary text-xs transition-all hover:border-primary/40 hover:bg-primary/10 sm:gap-1.5 sm:pr-2 sm:pl-3"
                 >
                   <span>{tag.label}</span>
                   <ChevronRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" />
                 </button>
               ))}
             </div>
-          )}
+          )
+        ) : (
+          /* Default: separate rows */
+          <>
+            {!isThinking && (message.reactions?.length || onToggleReaction) && (
+              <div className="mt-2 flex flex-wrap items-center gap-2">
+                {(message.reactions ?? []).map((r) => (
+                  <button
+                    key={r.emoji}
+                    type="button"
+                    onClick={() =>
+                      onToggleReaction?.(message.id, r.emoji, r.reactedByMe)
+                    }
+                    disabled={!onToggleReaction}
+                    className={cn(
+                      'inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs transition-colors',
+                      onToggleReaction ? 'hover:bg-muted' : 'cursor-default',
+                      r.reactedByMe
+                        ? 'border-primary/30 bg-primary/10 text-primary'
+                        : 'border-border bg-background text-foreground'
+                    )}
+                    aria-label={`React ${r.emoji}`}
+                  >
+                    <span aria-hidden="true">{r.emoji}</span>
+                    <span className="font-medium tabular-nums">{r.count}</span>
+                  </button>
+                ))}
+                {onToggleReaction && (
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button
+                        type="button"
+                        className="inline-flex items-center gap-1 rounded-full border border-border bg-background px-2 py-1 text-muted-foreground text-xs transition-colors hover:bg-muted hover:text-foreground"
+                        aria-label="Add reaction"
+                      >
+                        <Plus className="h-3.5 w-3.5" />
+                        <span>React</span>
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent
+                      align={isCurrentUser ? 'end' : 'start'}
+                    >
+                      {ALLOWED_REACTION_EMOJIS.map((emoji) => {
+                        const existing = (message.reactions ?? []).find(
+                          (r) => r.emoji === emoji
+                        );
+                        const reacted = existing?.reactedByMe ?? false;
+                        return (
+                          <DropdownMenuItem
+                            key={emoji}
+                            onClick={() =>
+                              onToggleReaction(message.id, emoji, reacted)
+                            }
+                          >
+                            <span className="mr-2" aria-hidden="true">
+                              {emoji}
+                            </span>
+                            <span>{reacted ? 'Remove' : 'React'}</span>
+                          </DropdownMenuItem>
+                        );
+                      })}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                )}
+              </div>
+            )}
+            {!isThinking &&
+              message.metadata?.tags &&
+              message.metadata.tags.length > 0 && (
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {message.metadata.tags.map((tag, i) => (
+                    <button
+                      key={`${tag.type}-${tag.entityId ?? i}`}
+                      type="button"
+                      onClick={() => onTagClick?.(tag, message.id)}
+                      data-tag-entity={tag.entityId}
+                      className="group flex items-center gap-1.5 rounded-full border border-primary/20 bg-primary/5 py-1 pr-2 pl-3 font-medium text-primary text-xs transition-all hover:border-primary/40 hover:bg-primary/10"
+                    >
+                      <span>{tag.label}</span>
+                      <ChevronRight className="h-3.5 w-3.5 transition-transform group-hover:translate-x-0.5" />
+                    </button>
+                  ))}
+                </div>
+              )}
+          </>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/components/chats/MessageBubble.tsx
+++ b/apps/web/src/components/chats/MessageBubble.tsx
@@ -235,7 +235,7 @@ export function MessageBubble({
             <button
               type="button"
               onClick={() => onViewSettings(message.senderId)}
-              className="text-muted-foreground transition-colors hover:text-foreground lg:hidden"
+              className="text-muted-foreground transition-colors hover:text-foreground"
               aria-label="Agent settings"
             >
               <Settings className="h-3.5 w-3.5" />

--- a/apps/web/src/components/chats/MessageBubble.tsx
+++ b/apps/web/src/components/chats/MessageBubble.tsx
@@ -54,7 +54,7 @@ interface MessageBubbleProps {
     emoji: string,
     currentlyReactedByMe: boolean
   ) => void;
-  /** Compact action row: merge reactions + tags into one row, hide on own messages */
+  /** Compact action row: merge reactions + tags into one row; hides "add reaction" control on own messages */
   compactActions?: boolean;
   /** Callback to open settings for this agent (mobile only, latest message only) */
   onViewSettings?: (agentId: string) => void;
@@ -77,6 +77,69 @@ export function MessageBubble({
   const compact = density === 'compact';
   // Coordinator (Agent Commander) should not link to a profile page
   const isCoordinator = sender?.id === COORDINATOR_SENDER_ID;
+
+  // --- Derived values for reactions + tags rendering ---
+  const reactions = message.reactions ?? [];
+  const hasReactions = reactions.length > 0;
+  const tags = message.metadata?.tags ?? [];
+  const hasTags = tags.length > 0;
+  // In compact mode, hide "add reaction" control on own messages (counts still visible)
+  const showReactControl =
+    !!onToggleReaction && !(compactActions && isCurrentUser);
+
+  // Shared reaction count pills (used in both compact / default layouts)
+  const reactionPills = reactions.map((r) => (
+    <button
+      key={r.emoji}
+      type="button"
+      onClick={() => onToggleReaction?.(message.id, r.emoji, r.reactedByMe)}
+      disabled={!onToggleReaction}
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs transition-colors',
+        onToggleReaction ? 'hover:bg-muted' : 'cursor-default',
+        r.reactedByMe
+          ? 'border-primary/30 bg-primary/10 text-primary'
+          : 'border-border bg-background text-foreground'
+      )}
+      aria-label={`React ${r.emoji}`}
+    >
+      <span aria-hidden="true">{r.emoji}</span>
+      <span className="font-medium tabular-nums">{r.count}</span>
+    </button>
+  ));
+
+  // Shared "Add reaction" dropdown (hidden on own messages in compact mode)
+  const reactDropdown = showReactControl && (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex items-center gap-1 rounded-full border border-border bg-background px-2 py-1 text-muted-foreground text-xs transition-colors hover:bg-muted hover:text-foreground"
+          aria-label="Add reaction"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          <span>React</span>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align={isCurrentUser ? 'end' : 'start'}>
+        {ALLOWED_REACTION_EMOJIS.map((emoji) => {
+          const existing = reactions.find((r) => r.emoji === emoji);
+          const reacted = existing?.reactedByMe ?? false;
+          return (
+            <DropdownMenuItem
+              key={emoji}
+              onClick={() => onToggleReaction?.(message.id, emoji, reacted)}
+            >
+              <span className="mr-2" aria-hidden="true">
+                {emoji}
+              </span>
+              <span>{reacted ? 'Remove' : 'React'}</span>
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
 
   return (
     <div
@@ -219,71 +282,14 @@ export function MessageBubble({
         </div>
 
         {/* Reactions + Action Tags */}
-        {compactActions ? (
-          /* Compact: single row, tighter gap, hidden on own messages */
-          !isThinking &&
-          !isCurrentUser &&
-          (message.reactions?.length ||
-            onToggleReaction ||
-            (message.metadata?.tags && message.metadata.tags.length > 0)) && (
+        {!isThinking &&
+          (hasReactions || showReactControl || hasTags) &&
+          (compactActions ? (
+            /* Compact: single row, tighter gap */
             <div className="mt-2 flex flex-wrap items-center gap-0.5">
-              {(message.reactions ?? []).map((r) => (
-                <button
-                  key={r.emoji}
-                  type="button"
-                  onClick={() =>
-                    onToggleReaction?.(message.id, r.emoji, r.reactedByMe)
-                  }
-                  disabled={!onToggleReaction}
-                  className={cn(
-                    'inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs transition-colors',
-                    onToggleReaction ? 'hover:bg-muted' : 'cursor-default',
-                    r.reactedByMe
-                      ? 'border-primary/30 bg-primary/10 text-primary'
-                      : 'border-border bg-background text-foreground'
-                  )}
-                  aria-label={`React ${r.emoji}`}
-                >
-                  <span aria-hidden="true">{r.emoji}</span>
-                  <span className="font-medium tabular-nums">{r.count}</span>
-                </button>
-              ))}
-              {onToggleReaction && (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <button
-                      type="button"
-                      className="inline-flex items-center gap-1 rounded-full border border-border bg-background px-2 py-1 text-muted-foreground text-xs transition-colors hover:bg-muted hover:text-foreground"
-                      aria-label="Add reaction"
-                    >
-                      <Plus className="h-3.5 w-3.5" />
-                      <span>React</span>
-                    </button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align={isCurrentUser ? 'end' : 'start'}>
-                    {ALLOWED_REACTION_EMOJIS.map((emoji) => {
-                      const existing = (message.reactions ?? []).find(
-                        (r) => r.emoji === emoji
-                      );
-                      const reacted = existing?.reactedByMe ?? false;
-                      return (
-                        <DropdownMenuItem
-                          key={emoji}
-                          onClick={() =>
-                            onToggleReaction(message.id, emoji, reacted)
-                          }
-                        >
-                          <span className="mr-2" aria-hidden="true">
-                            {emoji}
-                          </span>
-                          <span>{reacted ? 'Remove' : 'React'}</span>
-                        </DropdownMenuItem>
-                      );
-                    })}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              )}
-              {message.metadata?.tags?.map((tag, i) => (
+              {reactionPills}
+              {reactDropdown}
+              {tags.map((tag, i) => (
                 <button
                   key={`${tag.type}-${tag.entityId ?? i}`}
                   type="button"
@@ -296,77 +302,18 @@ export function MessageBubble({
                 </button>
               ))}
             </div>
-          )
-        ) : (
-          /* Default: separate rows */
-          <>
-            {!isThinking && (message.reactions?.length || onToggleReaction) && (
-              <div className="mt-2 flex flex-wrap items-center gap-2">
-                {(message.reactions ?? []).map((r) => (
-                  <button
-                    key={r.emoji}
-                    type="button"
-                    onClick={() =>
-                      onToggleReaction?.(message.id, r.emoji, r.reactedByMe)
-                    }
-                    disabled={!onToggleReaction}
-                    className={cn(
-                      'inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs transition-colors',
-                      onToggleReaction ? 'hover:bg-muted' : 'cursor-default',
-                      r.reactedByMe
-                        ? 'border-primary/30 bg-primary/10 text-primary'
-                        : 'border-border bg-background text-foreground'
-                    )}
-                    aria-label={`React ${r.emoji}`}
-                  >
-                    <span aria-hidden="true">{r.emoji}</span>
-                    <span className="font-medium tabular-nums">{r.count}</span>
-                  </button>
-                ))}
-                {onToggleReaction && (
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <button
-                        type="button"
-                        className="inline-flex items-center gap-1 rounded-full border border-border bg-background px-2 py-1 text-muted-foreground text-xs transition-colors hover:bg-muted hover:text-foreground"
-                        aria-label="Add reaction"
-                      >
-                        <Plus className="h-3.5 w-3.5" />
-                        <span>React</span>
-                      </button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent
-                      align={isCurrentUser ? 'end' : 'start'}
-                    >
-                      {ALLOWED_REACTION_EMOJIS.map((emoji) => {
-                        const existing = (message.reactions ?? []).find(
-                          (r) => r.emoji === emoji
-                        );
-                        const reacted = existing?.reactedByMe ?? false;
-                        return (
-                          <DropdownMenuItem
-                            key={emoji}
-                            onClick={() =>
-                              onToggleReaction(message.id, emoji, reacted)
-                            }
-                          >
-                            <span className="mr-2" aria-hidden="true">
-                              {emoji}
-                            </span>
-                            <span>{reacted ? 'Remove' : 'React'}</span>
-                          </DropdownMenuItem>
-                        );
-                      })}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                )}
-              </div>
-            )}
-            {!isThinking &&
-              message.metadata?.tags &&
-              message.metadata.tags.length > 0 && (
+          ) : (
+            /* Default: separate rows for reactions and tags */
+            <>
+              {(hasReactions || showReactControl) && (
+                <div className="mt-2 flex flex-wrap items-center gap-2">
+                  {reactionPills}
+                  {reactDropdown}
+                </div>
+              )}
+              {hasTags && (
                 <div className="mt-2 flex flex-wrap gap-2">
-                  {message.metadata.tags.map((tag, i) => (
+                  {tags.map((tag, i) => (
                     <button
                       key={`${tag.type}-${tag.entityId ?? i}`}
                       type="button"
@@ -380,8 +327,8 @@ export function MessageBubble({
                   ))}
                 </div>
               )}
-          </>
-        )}
+            </>
+          ))}
       </div>
     </div>
   );

--- a/apps/web/src/components/chats/MessageList.tsx
+++ b/apps/web/src/components/chats/MessageList.tsx
@@ -52,6 +52,12 @@ interface MessageListProps {
     emoji: string,
     currentlyReactedByMe: boolean
   ) => void;
+  /** Compact action row: merge reactions + tags into one row, hide on own messages */
+  compactActions?: boolean;
+  /** Set of agent user IDs — used to show settings icon on latest agent message */
+  agentIds?: ReadonlySet<string>;
+  /** Callback to open agent settings modal */
+  onViewSettings?: (agentId: string) => void;
 }
 
 export function MessageList({
@@ -67,6 +73,9 @@ export function MessageList({
   density = 'default',
   onTagClick,
   onToggleReaction,
+  compactActions = false,
+  agentIds,
+  onViewSettings,
 }: MessageListProps) {
   // Extract usernames from participants for @mention formatting
   // Only usernames that exist in the chat will be formatted as mentions
@@ -75,6 +84,19 @@ export function MessageList({
       .map((p) => p.username)
       .filter((username): username is string => !!username);
   }, [participants]);
+
+  // Compute latest message ID per agent (for settings icon placement)
+  const latestAgentMessageIds = useMemo(() => {
+    if (!agentIds?.size || !onViewSettings) return new Set<string>();
+    const latest = new Map<string, string>();
+    // Messages are in chronological order; last one per agent wins
+    for (const msg of messages) {
+      if (agentIds.has(msg.senderId)) {
+        latest.set(msg.senderId, msg.id);
+      }
+    }
+    return new Set(latest.values());
+  }, [messages, agentIds, onViewSettings]);
 
   if (loading) {
     return (
@@ -142,6 +164,7 @@ export function MessageList({
                 density={density}
                 onTagClick={onTagClick}
                 onToggleReaction={authenticated ? onToggleReaction : undefined}
+                compactActions={compactActions}
               />
             );
           }
@@ -152,6 +175,10 @@ export function MessageList({
             const isCurrentUser = currentUserId
               ? msg.senderId === currentUserId
               : false;
+            const showSettings =
+              onViewSettings && latestAgentMessageIds.has(msg.id)
+                ? onViewSettings
+                : undefined;
 
             return (
               <MessageBubble
@@ -164,6 +191,8 @@ export function MessageList({
                 density={density}
                 onTagClick={onTagClick}
                 onToggleReaction={authenticated ? onToggleReaction : undefined}
+                compactActions={compactActions}
+                onViewSettings={showSettings}
               />
             );
           }

--- a/apps/web/src/components/chats/TeamChatView.tsx
+++ b/apps/web/src/components/chats/TeamChatView.tsx
@@ -158,6 +158,10 @@ interface TeamChatViewProps {
     emoji: string,
     currentlyReactedByMe: boolean
   ) => void;
+  /** Set of agent user IDs — for settings icon on latest agent message */
+  agentIds?: ReadonlySet<string>;
+  /** Callback to open agent settings modal */
+  onViewSettings?: (agentId: string) => void;
 }
 
 /**
@@ -193,6 +197,8 @@ export function TeamChatView({
   onToggleRightSidebar,
   onTagClick,
   onToggleReaction,
+  agentIds,
+  onViewSettings,
 }: TeamChatViewProps) {
   const compact = density === 'compact';
   // Empty state when no chat selected
@@ -299,6 +305,9 @@ export function TeamChatView({
           density={density}
           onTagClick={onTagClick}
           onToggleReaction={onToggleReaction}
+          compactActions
+          agentIds={agentIds}
+          onViewSettings={onViewSettings}
         />
       </div>
 


### PR DESCRIPTION
## Summary
- Make agent settings button visible on mobile (was hidden behind hover-only opacity)
- Fix settings click navigating away from modal on mobile
- Match Continue button dimensions across all setup/edit modal steps
- Combine reactions and action tags into single compact row in team chat
- Hide reaction row on user's own messages in team chat
- Add settings gear icon on latest agent messages in chat