### PR TITLE
fix(web): restore waitlist X/Discord verification

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -427,7 +427,11 @@ DISCORD_GUILD_ID=1438561373012627456
 # Discord Invite URL (public invite link for users to join)
 # Create in Discord: Server Settings → Invites → Create Invite
 # Example: https://discord.gg/YourInviteCode
-NEXT_PUBLIC_DISCORD_INVITE_URL=https://discord.gg/4DYsFgyp
+NEXT_PUBLIC_DISCORD_INVITE_URL=https://discord.gg/FEJpGH8f3r
+
+# Optional: redirect path after completing OAuth linking flows (Twitter/Discord).
+# Defaults to `/rewards` if unset or empty.
+OAUTH_REDIRECT_PATH=/rewards
 
 # Discord Activity (Embedded App) Client ID
 # Used client-side by the Discord Embedded App SDK for Activities/mini-apps.

--- a/apps/web/src/app/agents/team/TeamPnL.tsx
+++ b/apps/web/src/app/agents/team/TeamPnL.tsx
@@ -56,8 +56,15 @@ export function TeamPnL({
 
   // Use pre-computed totals from the hook instead of re-reducing
   const totals = useMemo(() => {
-    if (!summary) return { lifetimePnL: 0, unrealizedPnL: 0, currentPnL: 0, openPositions: 0 };
-    const src = scope === 'agents_only' ? summary.agentsOnlyTotals : summary.totals;
+    if (!summary)
+      return {
+        lifetimePnL: 0,
+        unrealizedPnL: 0,
+        currentPnL: 0,
+        openPositions: 0,
+      };
+    const src =
+      scope === 'agents_only' ? summary.agentsOnlyTotals : summary.totals;
     return {
       lifetimePnL: src.lifetimePnL,
       unrealizedPnL: src.unrealizedPnL,
@@ -84,7 +91,7 @@ export function TeamPnL({
 
   if (error) {
     return (
-      <div className="p-4 text-sm text-muted-foreground">
+      <div className="p-4 text-muted-foreground text-sm">
         Failed to load team P&L: {error}
       </div>
     );
@@ -139,7 +146,7 @@ export function TeamPnL({
             <span className="font-medium">{totals.openPositions}</span>
           </div>
         </div>
-        <div className="pt-1 text-muted-foreground text-[11px]">
+        <div className="pt-1 text-[11px] text-muted-foreground">
           {currentPositive
             ? 'Team is currently profitable.'
             : 'Team is currently down.'}
@@ -163,7 +170,10 @@ export function TeamPnL({
                 type="button"
                 onClick={() => {
                   if (!onSelectMember) return;
-                  onSelectMember(m.id, m.entityType === 'owner' ? 'user' : 'agent');
+                  onSelectMember(
+                    m.id,
+                    m.entityType === 'owner' ? 'user' : 'agent'
+                  );
                 }}
                 className={cn(
                   'flex w-full items-start justify-between gap-3 rounded-md px-2 py-2 text-left transition-colors',
@@ -182,8 +192,9 @@ export function TeamPnL({
                       @{m.username}
                     </div>
                   )}
-                  <div className="mt-1 text-muted-foreground text-[11px]">
-                    {m.openPositions} open position{m.openPositions === 1 ? '' : 's'}
+                  <div className="mt-1 text-[11px] text-muted-foreground">
+                    {m.openPositions} open position
+                    {m.openPositions === 1 ? '' : 's'}
                   </div>
                 </div>
 
@@ -192,7 +203,7 @@ export function TeamPnL({
                     {m.currentPnL >= 0 ? '+' : ''}
                     {formatCompactCurrency(m.currentPnL)}
                   </div>
-                  <div className="text-muted-foreground text-[11px]">
+                  <div className="text-[11px] text-muted-foreground">
                     L: {m.lifetimePnL >= 0 ? '+' : ''}
                     {formatCompactCurrency(m.lifetimePnL)}
                     {'  '}U: {m.unrealizedPnL >= 0 ? '+' : ''}

--- a/apps/web/src/app/agents/team/TeamPortfolio.tsx
+++ b/apps/web/src/app/agents/team/TeamPortfolio.tsx
@@ -3,7 +3,10 @@
 import { cn, formatCompactCurrency } from '@babylon/shared';
 import { Loader2, Users, Wallet } from 'lucide-react';
 import { useMemo } from 'react';
-import type { TeamScope, TeamTradingSummary } from '@/hooks/useTeamTradingSummary';
+import type {
+  TeamScope,
+  TeamTradingSummary,
+} from '@/hooks/useTeamTradingSummary';
 import { ScopeToggle } from './_components/ScopeToggle';
 
 export function TeamPortfolio({
@@ -54,7 +57,7 @@ export function TeamPortfolio({
 
   if (error) {
     return (
-      <div className="p-4 text-sm text-muted-foreground">
+      <div className="p-4 text-muted-foreground text-sm">
         Failed to load team wallet: {error}
       </div>
     );
@@ -100,7 +103,10 @@ export function TeamPortfolio({
                 type="button"
                 onClick={() => {
                   if (!onSelectMember) return;
-                  onSelectMember(m.id, m.entityType === 'owner' ? 'user' : 'agent');
+                  onSelectMember(
+                    m.id,
+                    m.entityType === 'owner' ? 'user' : 'agent'
+                  );
                 }}
                 className={cn(
                   'flex w-full items-center justify-between gap-3 rounded-md px-2 py-2 text-left transition-colors',

--- a/apps/web/src/app/agents/team/page.tsx
+++ b/apps/web/src/app/agents/team/page.tsx
@@ -64,11 +64,11 @@ import { Skeleton } from '@/components/shared/Skeleton';
 import { SpotlightTutorial } from '@/components/tutorial/SpotlightTutorial';
 import { TutorialHelpButton } from '@/components/tutorial/TutorialHelpButton';
 import { useAuth } from '@/hooks/useAuth';
+import { useTeamChat } from '@/hooks/useTeamChat';
 import {
   type TeamScope,
   useTeamTradingSummary,
 } from '@/hooks/useTeamTradingSummary';
-import { useTeamChat } from '@/hooks/useTeamChat';
 import {
   TUTORIAL_PERPS_DATA,
   TUTORIAL_PERPS_ENTITY_ID,
@@ -76,8 +76,6 @@ import {
 import { useAgentsTutorial } from './_components/tutorial/useAgentsTutorial';
 import { AgentPnL } from './AgentPnL';
 import { AgentPortfolio } from './AgentPortfolio';
-import { TeamPnL } from './TeamPnL';
-import { TeamPortfolio } from './TeamPortfolio';
 import {
   BOTTOM_PANEL_COLLAPSED_HEIGHT,
   BOTTOM_PANEL_DEFAULT_HEIGHT,
@@ -100,6 +98,8 @@ import {
   RightSidebar,
   type RightSidebarTab,
 } from './RightSidebar';
+import { TeamPnL } from './TeamPnL';
+import { TeamPortfolio } from './TeamPortfolio';
 
 // Lazy load AgentLogs for performance
 const AgentLogs = dynamic(
@@ -445,7 +445,10 @@ export default function TeamChatPage() {
       if (type === 'user' && bottomPanelTab === 'logs') {
         setBottomPanelTab('activity');
       }
-      if (type === 'team' && (bottomPanelTab === 'logs' || bottomPanelTab === 'activity')) {
+      if (
+        type === 'team' &&
+        (bottomPanelTab === 'logs' || bottomPanelTab === 'activity')
+      ) {
         setBottomPanelTab('wallet');
       }
     },
@@ -460,13 +463,16 @@ export default function TeamChatPage() {
     bottomPanelEntityType === 'team' &&
     (bottomPanelTab === 'wallet' || bottomPanelTab === 'pnl');
 
-  const { summary: teamSummary, loading: teamSummaryLoading, error: teamSummaryError } =
-    useTeamTradingSummary({
-      ownerId: user?.id,
-      ownerName: user?.displayName || user?.username || 'You',
-      enabled: teamSummaryEnabled,
-      getAccessToken,
-    });
+  const {
+    summary: teamSummary,
+    loading: teamSummaryLoading,
+    error: teamSummaryError,
+  } = useTeamTradingSummary({
+    ownerId: user?.id,
+    ownerName: user?.displayName || user?.username || 'You',
+    enabled: teamSummaryEnabled,
+    getAccessToken,
+  });
 
   // Handle sidebar "Settings" - open edit modal
   const handleViewSettings = useCallback(

--- a/apps/web/src/app/api/auth/discord/callback/route.ts
+++ b/apps/web/src/app/api/auth/discord/callback/route.ts
@@ -16,8 +16,10 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 
-// Configurable redirect destination after OAuth completion
-const OAUTH_REDIRECT_PATH = process.env.OAUTH_REDIRECT_PATH ?? '/rewards';
+// Configurable redirect destination after OAuth completion.
+// Treat empty string as "unset" to avoid redirecting to `/?success=...`.
+const OAUTH_REDIRECT_PATH =
+  process.env.OAUTH_REDIRECT_PATH?.trim() || '/rewards';
 
 const DiscordCallbackQuerySchema = z.object({
   code: z.string().optional(),

--- a/apps/web/src/app/api/auth/twitter/callback/route.ts
+++ b/apps/web/src/app/api/auth/twitter/callback/route.ts
@@ -179,30 +179,12 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     },
   });
 
-  // Debug: Check all records without filters
-  const allStates = await db.oAuthState.findMany({
-    where: {
-      userId,
-    },
-    select: {
-      state: true,
-      returnPath: true,
-      expiresAt: true,
-      createdAt: true,
-    },
-    orderBy: {
-      createdAt: 'desc',
-    },
-    take: 3,
-  });
-
   if (!oauthState || !oauthState.codeVerifier) {
     logger.warn(
       'Twitter callback missing or expired PKCE state',
       {
         state,
         userId,
-        allStates,
         found: !!oauthState,
       },
       'TwitterCallback'

--- a/apps/web/src/app/api/auth/twitter/callback/route.ts
+++ b/apps/web/src/app/api/auth/twitter/callback/route.ts
@@ -64,8 +64,10 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
 
-// Configurable redirect destination after OAuth completion
-const OAUTH_REDIRECT_PATH = process.env.OAUTH_REDIRECT_PATH ?? '/rewards';
+// Configurable redirect destination after OAuth completion.
+// Treat empty string as "unset" to avoid redirecting to `/?success=...`.
+const OAUTH_REDIRECT_PATH =
+  process.env.OAUTH_REDIRECT_PATH?.trim() || '/rewards';
 
 const TwitterCallbackQuerySchema = z.object({
   code: z.string().optional(),

--- a/apps/web/src/app/api/users/[userId]/verify-discord-join/route.ts
+++ b/apps/web/src/app/api/users/[userId]/verify-discord-join/route.ts
@@ -13,6 +13,7 @@ import {
   AuthorizationError,
   authenticate,
   BusinessLogicError,
+  invalidateCache,
   PointsService,
   requireUserByIdentifier,
   successResponse,
@@ -209,6 +210,11 @@ export const POST = withErrorHandling(
       if (pointsResult.success) {
         pointsAwarded = pointsResult.pointsAwarded;
         newPointsTotal = pointsResult.newTotal;
+
+        // Ensure waitlist dashboard reflects new points immediately.
+        await invalidateCache(canonicalUserId, {
+          namespace: 'waitlist:position',
+        });
 
         logger.info(
           `Awarded ${pointsAwarded} points for Discord join`,

--- a/apps/web/src/app/api/users/[userId]/verify-twitter-follow/route.ts
+++ b/apps/web/src/app/api/users/[userId]/verify-twitter-follow/route.ts
@@ -47,6 +47,7 @@ import {
   AuthorizationError,
   authenticate,
   BusinessLogicError,
+  invalidateCache,
   PointsService,
   requireUserByIdentifier,
   successResponse,
@@ -138,6 +139,11 @@ export const POST = withErrorHandling(
     if (pointsResult.success) {
       pointsAwarded = pointsResult.pointsAwarded;
       newPointsTotal = pointsResult.newTotal;
+
+      // Ensure waitlist dashboard reflects new points immediately.
+      await invalidateCache(canonicalUserId, {
+        namespace: 'waitlist:position',
+      });
 
       logger.info(
         `Awarded ${pointsAwarded} points for Twitter follow (trusted)`,

--- a/apps/web/src/components/shared/ComingSoon.tsx
+++ b/apps/web/src/components/shared/ComingSoon.tsx
@@ -525,7 +525,7 @@ export function ComingSoon() {
     // Open Discord invite in new tab
     const discordInviteUrl =
       process.env.NEXT_PUBLIC_DISCORD_INVITE_URL ||
-      'https://discord.gg/4DYsFgyp';
+      'https://discord.gg/FEJpGH8f3r';
     window.open(discordInviteUrl, '_blank');
 
     // Show verify button

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -317,6 +317,16 @@ export function useAuth(): UseAuthReturn {
             currentUser.reputationPoints !== hydratedUser.reputationPoints ||
             currentUser.hasFarcaster !== hydratedUser.hasFarcaster ||
             currentUser.hasTwitter !== hydratedUser.hasTwitter ||
+            currentUser.hasDiscord !== hydratedUser.hasDiscord ||
+            currentUser.pointsAwardedForFarcasterFollow !==
+              hydratedUser.pointsAwardedForFarcasterFollow ||
+            currentUser.pointsAwardedForTwitterFollow !==
+              hydratedUser.pointsAwardedForTwitterFollow ||
+            currentUser.pointsAwardedForDiscordJoin !==
+              hydratedUser.pointsAwardedForDiscordJoin ||
+            currentUser.farcasterUsername !== hydratedUser.farcasterUsername ||
+            currentUser.twitterUsername !== hydratedUser.twitterUsername ||
+            currentUser.discordUsername !== hydratedUser.discordUsername ||
             currentUser.isAdmin !== hydratedUser.isAdmin ||
             currentUser.isActor !== hydratedUser.isActor ||
             currentUser.isBanned !== hydratedUser.isBanned ||

--- a/apps/web/src/hooks/useSocialVerification.ts
+++ b/apps/web/src/hooks/useSocialVerification.ts
@@ -398,7 +398,7 @@ export function useSocialVerification({
 
     const discordInviteUrl =
       process.env.NEXT_PUBLIC_DISCORD_INVITE_URL ||
-      'https://discord.gg/4DYsFgyp';
+      'https://discord.gg/FEJpGH8f3r';
     window.open(discordInviteUrl, '_blank');
     setShowVerifyDiscordJoinButton(true);
     toast.success('After joining, click the "Verify Join" button below!');

--- a/apps/web/src/hooks/useTeamTradingSummary.ts
+++ b/apps/web/src/hooks/useTeamTradingSummary.ts
@@ -35,7 +35,10 @@ export interface TeamTradingSummary {
   updatedAt: string | null;
 }
 
-function toNumber(value: string | number | undefined | null, fallback = 0): number {
+function toNumber(
+  value: string | number | undefined | null,
+  fallback = 0
+): number {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
   if (typeof value === 'string') {
     const parsed = Number(value);
@@ -53,7 +56,13 @@ function sumMemberTotals(members: TeamMemberTradingSummary[]): TeamTotals {
       currentPnL: acc.currentPnL + m.currentPnL,
       openPositions: acc.openPositions + m.openPositions,
     }),
-    { walletBalance: 0, lifetimePnL: 0, unrealizedPnL: 0, currentPnL: 0, openPositions: 0 }
+    {
+      walletBalance: 0,
+      lifetimePnL: 0,
+      unrealizedPnL: 0,
+      currentPnL: 0,
+      openPositions: 0,
+    }
   );
 }
 
@@ -115,9 +124,8 @@ export function useTeamTradingSummary({
 } {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [ownerBalance, setOwnerBalance] = useState<UserBalanceApiResponse | null>(
-    null
-  );
+  const [ownerBalance, setOwnerBalance] =
+    useState<UserBalanceApiResponse | null>(null);
   const [agents, setAgents] = useState<AgentsApiAgent[] | null>(null);
   const [positions, setPositions] = useState<PositionsApiResponse | null>(null);
   const [refreshNonce, setRefreshNonce] = useState(0);
@@ -142,9 +150,12 @@ export function useTeamTradingSummary({
           fetch(`/api/users/${encodeURIComponent(ownerId)}/balance`, {
             signal: abort.signal,
           }),
-          fetch(`/api/markets/positions/${encodeURIComponent(ownerId)}?type=all&status=open`, {
-            signal: abort.signal,
-          }),
+          fetch(
+            `/api/markets/positions/${encodeURIComponent(ownerId)}?type=all&status=open`,
+            {
+              signal: abort.signal,
+            }
+          ),
           getAccessToken(),
         ]);
 
@@ -159,14 +170,17 @@ export function useTeamTradingSummary({
         });
 
         if (!balanceRes.ok) {
-          throw new Error(`Failed to fetch owner balance (${balanceRes.status})`);
+          throw new Error(
+            `Failed to fetch owner balance (${balanceRes.status})`
+          );
         }
         if (!positionsRes.ok) {
           throw new Error(`Failed to fetch positions (${positionsRes.status})`);
         }
 
         const balanceJson = (await balanceRes.json()) as UserBalanceApiResponse;
-        const positionsJson = (await positionsRes.json()) as PositionsApiResponse;
+        const positionsJson =
+          (await positionsRes.json()) as PositionsApiResponse;
 
         const agentsRes = await agentsPromise;
         if (!agentsRes.ok) {
@@ -220,7 +234,10 @@ export function useTeamTradingSummary({
     >();
 
     const addPosition = (memberId: string, unrealized: number) => {
-      const cur = byMember.get(memberId) ?? { unrealizedPnL: 0, openPositions: 0 };
+      const cur = byMember.get(memberId) ?? {
+        unrealizedPnL: 0,
+        openPositions: 0,
+      };
       byMember.set(memberId, {
         unrealizedPnL: cur.unrealizedPnL + unrealized,
         openPositions: cur.openPositions + 1,

--- a/apps/web/src/hooks/useTeamTradingSummary.ts
+++ b/apps/web/src/hooks/useTeamTradingSummary.ts
@@ -134,6 +134,7 @@ export function useTeamTradingSummary({
     setRefreshNonce((n) => n + 1);
   }, []);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refreshNonce is an intentional trigger to force re-fetch
   useEffect(() => {
     if (!enabled || !ownerId) return;
 


### PR DESCRIPTION
## Summary

- Fix waitlist social verification UI getting stuck (Discord linked/claimed state not refreshing correctly).
- Make Twitter/Discord OAuth callbacks robust to empty `OAUTH_REDIRECT_PATH` (defaults to `/rewards`).
- Invalidate waitlist position cache after claim/verify so points update immediately.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [x] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Users reported they could not verify X follow / Discord join in the waitlist flow.

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- `useAuth` now treats social connection + reward flags as state-change triggers (fixes stale UI state after OAuth / claims).
- OAuth callbacks (`/api/auth/twitter/callback`, `/api/auth/discord/callback`) fall back to `/rewards` when `OAUTH_REDIRECT_PATH` is unset or empty.
- `/api/users/:id/verify-twitter-follow` and `/api/users/:id/verify-discord-join` invalidate `waitlist:position` cache on successful award.
- Default Discord invite fallback updated to the current invite.
- `.env.example` updated with the new Discord invite and `OAUTH_REDIRECT_PATH` documentation.

## Review guide

**Start here**
- `apps/web/src/hooks/useAuth.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- X follow is intentionally a trusted claim (no Twitter follow API verification).

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [x] `bun run typecheck` (via `bun run typecheck -- --filter=web`)
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. On waitlist host, link X, then click "Follow @PlayBabylon on X" and "Claim Reward"; verify state flips to completed and points update.
2. Link Discord, join via invite, click "Verify Join"; verify state flips to completed and points update.

## Ops / Migration / Deployment

- [ ] No deploy impact
- [x] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `DISCORD_GUILD_ID=1438561373012627456`
- Changed: `NEXT_PUBLIC_DISCORD_INVITE_URL=https://discord.gg/FEJpGH8f3r`
- Changed (optional): `OAUTH_REDIRECT_PATH=/rewards` (code defaults to `/rewards` if unset/empty)

**DB / data migration**
- Migration(s): N/A
- Backfill/seed: N/A

**Rollout / rollback plan**
- Rollout: deploy + verify waitlist social actions on `babylon.market`.
- Rollback: revert deployment or revert this PR.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: No UI redesign; behavior/state/redirect fixes only.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

**Non-goals / follow-ups**
- Add actual Twitter follow verification (intentionally avoided due to API cost).
