### PR TITLE
feat: polish mobile feed cards and sidebar

### DIFF
--- a/apps/web/src/components/moderation/ModerationMenu.tsx
+++ b/apps/web/src/components/moderation/ModerationMenu.tsx
@@ -211,7 +211,7 @@ export function ModerationMenu({
           }
           setShowMenu(!showMenu);
         }}
-        className="rounded-lg p-2 transition-colors hover:bg-muted"
+        className="rounded-lg px-2 py-0 transition-colors hover:bg-muted sm:p-2"
         aria-label="More options"
       >
         <MoreHorizontal className="h-5 w-5 text-muted-foreground" />

--- a/apps/web/src/components/posts/PostCard.tsx
+++ b/apps/web/src/components/posts/PostCard.tsx
@@ -1,25 +1,25 @@
-"use client";
+'use client';
 
-import type { PostInteraction } from "@babylon/shared";
-import { cn, getProfileUrl } from "@babylon/shared";
-import { Repeat2 } from "lucide-react";
-import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { type KeyboardEvent, type MouseEvent, memo } from "react";
-import { InteractionBar } from "@/components/interactions";
-import { ModerationMenu } from "@/components/moderation/ModerationMenu";
+import type { PostInteraction } from '@babylon/shared';
+import { cn, getProfileUrl } from '@babylon/shared';
+import { Repeat2 } from 'lucide-react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { type KeyboardEvent, type MouseEvent, memo } from 'react';
+import { InteractionBar } from '@/components/interactions';
+import { ModerationMenu } from '@/components/moderation/ModerationMenu';
 import {
   CommentPreview,
   type CommentPreviewData,
-} from "@/components/posts/CommentPreview";
-import { Avatar } from "@/components/shared/Avatar";
-import { TaggedText } from "@/components/shared/TaggedText";
+} from '@/components/posts/CommentPreview';
+import { Avatar } from '@/components/shared/Avatar';
+import { TaggedText } from '@/components/shared/TaggedText';
 import {
   isNpcIdentifier,
   VerifiedBadge,
-} from "@/components/shared/VerifiedBadge";
-import { useFontSize } from "@/contexts/FontSizeContext";
-import { useAuth } from "@/hooks/useAuth";
+} from '@/components/shared/VerifiedBadge';
+import { useFontSize } from '@/contexts/FontSizeContext';
+import { useAuth } from '@/hooks/useAuth';
 
 /**
  * Post card component for displaying feed posts.
@@ -89,7 +89,7 @@ export interface PostCardProps {
     commentPreviews?: CommentPreviewData[];
   };
   className?: string;
-  density?: "default" | "compact";
+  density?: 'default' | 'compact';
   onCommentClick?: () => void;
   showInteractions?: boolean;
   showCommentPreviews?: boolean;
@@ -100,7 +100,7 @@ export interface PostCardProps {
 export const PostCard = memo(function PostCard({
   post,
   className,
-  density = "default",
+  density = 'default',
   onCommentClick,
   showInteractions = true,
   showCommentPreviews = true,
@@ -110,7 +110,7 @@ export const PostCard = memo(function PostCard({
   const router = useRouter();
   const { fontSize } = useFontSize();
   const { user } = useAuth();
-  const compact = density === "compact";
+  const compact = density === 'compact';
   const densityScale = compact ? 0.9 : 1;
 
   const postDate = new Date(post.timestamp);
@@ -121,18 +121,18 @@ export const PostCard = memo(function PostCard({
 
   let timeAgo: string;
   if (diffMinutes < 1) {
-    timeAgo = "Just now";
+    timeAgo = 'Just now';
   } else if (diffMinutes < 60) {
     timeAgo = `${diffMinutes}m ago`;
   } else if (diffHours < 24) {
     timeAgo = `${diffHours}h ago`;
   } else {
     // Show date for posts older than 24 hours
-    timeAgo = postDate.toLocaleDateString("en-US", {
-      month: "short",
-      day: "numeric",
+    timeAgo = postDate.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
       year:
-        postDate.getFullYear() !== now.getFullYear() ? "numeric" : undefined,
+        postDate.getFullYear() !== now.getFullYear() ? 'numeric' : undefined,
     });
   }
 
@@ -177,8 +177,8 @@ export const PostCard = memo(function PostCard({
   const quotedPostId = post.originalPost
     ? post.originalPostId
     : post.isRepost && post.isQuote
-    ? post.id
-    : null;
+      ? post.id
+      : null;
 
   // Internal click handler that navigates to the correct post
   // For simple reposts, navigate to the original post
@@ -205,7 +205,7 @@ export const PostCard = memo(function PostCard({
   };
 
   const handleQuotedPostKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== "Enter" && event.key !== " ") {
+    if (event.key !== 'Enter' && event.key !== ' ') {
       return;
     }
 
@@ -224,9 +224,9 @@ export const PostCard = memo(function PostCard({
     return (
       <article
         className={cn(
-          compact ? "px-3 py-2" : "px-4 py-3",
-          "w-full overflow-hidden",
-          "border-border border-b",
+          compact ? 'px-3 py-2' : 'px-4 py-3',
+          'w-full overflow-hidden',
+          'border-border border-b',
           className
         )}
       >
@@ -240,11 +240,11 @@ export const PostCard = memo(function PostCard({
   return (
     <article
       className={cn(
-        compact ? "px-3 py-3" : "px-4 py-4",
+        compact ? 'px-3 py-3' : 'px-4 py-4',
         !isDetail &&
-          "cursor-pointer transition-all duration-200 hover:bg-muted/30",
-        "w-full overflow-hidden",
-        !isDetail && "border-border border-b",
+          'cursor-pointer transition-all duration-200 hover:bg-muted/30',
+        'w-full overflow-hidden',
+        !isDetail && 'border-border border-b',
         className
       )}
       style={{
@@ -257,7 +257,7 @@ export const PostCard = memo(function PostCard({
         <div className="mb-1 flex items-center gap-2 pl-12 text-muted-foreground text-xs">
           <Repeat2 size={14} className="text-green-600" />
           <span>
-            Reposted by{" "}
+            Reposted by{' '}
             {user?.id === post.authorId ? (
               <span className="font-semibold text-foreground">you</span>
             ) : (
@@ -285,7 +285,7 @@ export const PostCard = memo(function PostCard({
             <Avatar
               id={displayAuthorId}
               name={displayAuthorName}
-              type={post.type === "article" ? "business" : "actor"}
+              type={post.type === 'article' ? 'business' : 'actor'}
               size="md"
               src={displayAuthorProfileImageUrl || undefined}
               scaleFactor={fontSize}
@@ -302,12 +302,12 @@ export const PostCard = memo(function PostCard({
         {/* Right column: All content */}
         <div className="min-w-0 flex-1">
           {/* Header: Name/Handle on left, Timestamp and Menu on right */}
-          <div className="flex items-start sm:items-center justify-between gap-3 sm:pt-0.5 leading-none">
+          <div className="flex items-start justify-between gap-3 leading-none sm:items-center sm:pt-0.5">
             {/* Name and Handle inline */}
             <div className="flex min-w-0 flex-1 items-center gap-1.5">
               <Link
                 href={getProfileUrl(displayAuthorId, null)}
-                className="truncate font-semibold text-[15px] leading-tight text-foreground hover:underline"
+                className="truncate font-semibold text-[15px] text-foreground leading-tight hover:underline"
                 onClick={(e) => e.stopPropagation()}
               >
                 {displayAuthorName}
@@ -315,16 +315,16 @@ export const PostCard = memo(function PostCard({
               {showVerifiedBadge && <VerifiedBadge size="sm" />}
               <Link
                 href={getProfileUrl(displayAuthorId, null)}
-                className="truncate text-[15px] leading-tight text-muted-foreground hover:underline"
+                className="truncate text-[15px] text-muted-foreground leading-tight hover:underline"
                 onClick={(e) => e.stopPropagation()}
               >
                 @{displayAuthorUsername || displayAuthorId}
               </Link>
             </div>
             {/* Timestamp and Menu - Right aligned */}
-            <div className="flex items-start sm:items-center gap-2">
+            <div className="flex items-start gap-2 sm:items-center">
               <time
-                className="text-[15px] leading-tight text-muted-foreground"
+                className="text-[15px] text-muted-foreground leading-tight"
                 title={postDate.toLocaleString()}
               >
                 {timeAgo}
@@ -347,13 +347,13 @@ export const PostCard = memo(function PostCard({
           </div>
 
           {/* Post Content */}
-          {post.type === "article" ? (
+          {post.type === 'article' ? (
             // Article card - Show title, summary, and "Read more" button
             <div className="mb-3 w-full">
               {/* Article title with Read More Button */}
               <div className="mb-3 flex items-start justify-between gap-4">
                 <h2 className="flex-1 font-bold text-foreground text-lg leading-tight sm:text-xl">
-                  {post.articleTitle || "Untitled Article"}
+                  {post.articleTitle || 'Untitled Article'}
                 </h2>
                 {!isDetail && (
                   <button
@@ -382,10 +382,10 @@ export const PostCard = memo(function PostCard({
                 <TaggedText
                   text={post.originalPost.content}
                   onTagClick={(tag) => {
-                    if (tag.startsWith("@")) {
+                    if (tag.startsWith('@')) {
                       const username = tag.slice(1);
-                      router.push(getProfileUrl("", username));
-                    } else if (tag.startsWith("$")) {
+                      router.push(getProfileUrl('', username));
+                    } else if (tag.startsWith('$')) {
                       const symbol = tag.slice(1);
                       router.push(
                         `/markets?search=${encodeURIComponent(symbol)}`
@@ -408,10 +408,10 @@ export const PostCard = memo(function PostCard({
                   <TaggedText
                     text={post.quoteComment}
                     onTagClick={(tag) => {
-                      if (tag.startsWith("@")) {
+                      if (tag.startsWith('@')) {
                         const username = tag.slice(1);
-                        router.push(getProfileUrl("", username));
-                      } else if (tag.startsWith("$")) {
+                        router.push(getProfileUrl('', username));
+                      } else if (tag.startsWith('$')) {
                         const symbol = tag.slice(1);
                         router.push(
                           `/markets?search=${encodeURIComponent(symbol)}`
@@ -425,15 +425,15 @@ export const PostCard = memo(function PostCard({
               {/* Embedded original post */}
               <div
                 className={cn(
-                  "rounded-xl border border-border p-4",
-                  "overflow-hidden transition-colors",
+                  'rounded-xl border border-border p-4',
+                  'overflow-hidden transition-colors',
                   quotedPostId
-                    ? "cursor-pointer hover:bg-muted/50"
-                    : "cursor-default"
+                    ? 'cursor-pointer hover:bg-muted/50'
+                    : 'cursor-default'
                 )}
-                role={quotedPostId ? "link" : undefined}
+                role={quotedPostId ? 'link' : undefined}
                 tabIndex={quotedPostId ? 0 : undefined}
-                aria-label={quotedPostId ? "View quoted post" : undefined}
+                aria-label={quotedPostId ? 'View quoted post' : undefined}
                 onClick={handleQuotedPostClick}
                 onKeyDown={handleQuotedPostKeyDown}
               >
@@ -485,10 +485,10 @@ export const PostCard = memo(function PostCard({
                       <TaggedText
                         text={post.originalPost.content}
                         onTagClick={(tag) => {
-                          if (tag.startsWith("@")) {
+                          if (tag.startsWith('@')) {
                             const username = tag.slice(1);
-                            router.push(getProfileUrl("", username));
-                          } else if (tag.startsWith("$")) {
+                            router.push(getProfileUrl('', username));
+                          } else if (tag.startsWith('$')) {
                             const symbol = tag.slice(1);
                             router.push(
                               `/markets?search=${encodeURIComponent(symbol)}`
@@ -509,13 +509,13 @@ export const PostCard = memo(function PostCard({
             // Regular post - Show content as normal
             <div className="post-content mb-3 w-full whitespace-pre-wrap break-words text-[15px] text-foreground leading-normal">
               <TaggedText
-                text={post.content || ""}
+                text={post.content || ''}
                 onTagClick={(tag) => {
-                  if (tag.startsWith("@")) {
+                  if (tag.startsWith('@')) {
                     // Handle @mentions - route to profile
                     const username = tag.slice(1);
-                    router.push(getProfileUrl("", username));
-                  } else if (tag.startsWith("$")) {
+                    router.push(getProfileUrl('', username));
+                  } else if (tag.startsWith('$')) {
                     // Handle $cashtags - route to markets
                     const symbol = tag.slice(1);
                     router.push(

--- a/apps/web/src/components/posts/PostCard.tsx
+++ b/apps/web/src/components/posts/PostCard.tsx
@@ -1,25 +1,25 @@
-'use client';
+"use client";
 
-import type { PostInteraction } from '@babylon/shared';
-import { cn, getProfileUrl } from '@babylon/shared';
-import { Repeat2 } from 'lucide-react';
-import Link from 'next/link';
-import { useRouter } from 'next/navigation';
-import { type KeyboardEvent, type MouseEvent, memo } from 'react';
-import { InteractionBar } from '@/components/interactions';
-import { ModerationMenu } from '@/components/moderation/ModerationMenu';
+import type { PostInteraction } from "@babylon/shared";
+import { cn, getProfileUrl } from "@babylon/shared";
+import { Repeat2 } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { type KeyboardEvent, type MouseEvent, memo } from "react";
+import { InteractionBar } from "@/components/interactions";
+import { ModerationMenu } from "@/components/moderation/ModerationMenu";
 import {
   CommentPreview,
   type CommentPreviewData,
-} from '@/components/posts/CommentPreview';
-import { Avatar } from '@/components/shared/Avatar';
-import { TaggedText } from '@/components/shared/TaggedText';
+} from "@/components/posts/CommentPreview";
+import { Avatar } from "@/components/shared/Avatar";
+import { TaggedText } from "@/components/shared/TaggedText";
 import {
   isNpcIdentifier,
   VerifiedBadge,
-} from '@/components/shared/VerifiedBadge';
-import { useFontSize } from '@/contexts/FontSizeContext';
-import { useAuth } from '@/hooks/useAuth';
+} from "@/components/shared/VerifiedBadge";
+import { useFontSize } from "@/contexts/FontSizeContext";
+import { useAuth } from "@/hooks/useAuth";
 
 /**
  * Post card component for displaying feed posts.
@@ -89,7 +89,7 @@ export interface PostCardProps {
     commentPreviews?: CommentPreviewData[];
   };
   className?: string;
-  density?: 'default' | 'compact';
+  density?: "default" | "compact";
   onCommentClick?: () => void;
   showInteractions?: boolean;
   showCommentPreviews?: boolean;
@@ -100,7 +100,7 @@ export interface PostCardProps {
 export const PostCard = memo(function PostCard({
   post,
   className,
-  density = 'default',
+  density = "default",
   onCommentClick,
   showInteractions = true,
   showCommentPreviews = true,
@@ -110,7 +110,7 @@ export const PostCard = memo(function PostCard({
   const router = useRouter();
   const { fontSize } = useFontSize();
   const { user } = useAuth();
-  const compact = density === 'compact';
+  const compact = density === "compact";
   const densityScale = compact ? 0.9 : 1;
 
   const postDate = new Date(post.timestamp);
@@ -121,18 +121,18 @@ export const PostCard = memo(function PostCard({
 
   let timeAgo: string;
   if (diffMinutes < 1) {
-    timeAgo = 'Just now';
+    timeAgo = "Just now";
   } else if (diffMinutes < 60) {
     timeAgo = `${diffMinutes}m ago`;
   } else if (diffHours < 24) {
     timeAgo = `${diffHours}h ago`;
   } else {
     // Show date for posts older than 24 hours
-    timeAgo = postDate.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
+    timeAgo = postDate.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
       year:
-        postDate.getFullYear() !== now.getFullYear() ? 'numeric' : undefined,
+        postDate.getFullYear() !== now.getFullYear() ? "numeric" : undefined,
     });
   }
 
@@ -177,8 +177,8 @@ export const PostCard = memo(function PostCard({
   const quotedPostId = post.originalPost
     ? post.originalPostId
     : post.isRepost && post.isQuote
-      ? post.id
-      : null;
+    ? post.id
+    : null;
 
   // Internal click handler that navigates to the correct post
   // For simple reposts, navigate to the original post
@@ -205,7 +205,7 @@ export const PostCard = memo(function PostCard({
   };
 
   const handleQuotedPostKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== 'Enter' && event.key !== ' ') {
+    if (event.key !== "Enter" && event.key !== " ") {
       return;
     }
 
@@ -224,9 +224,9 @@ export const PostCard = memo(function PostCard({
     return (
       <article
         className={cn(
-          compact ? 'px-3 py-2' : 'px-4 py-3',
-          'w-full overflow-hidden',
-          'border-border border-b',
+          compact ? "px-3 py-2" : "px-4 py-3",
+          "w-full overflow-hidden",
+          "border-border border-b",
           className
         )}
       >
@@ -240,11 +240,11 @@ export const PostCard = memo(function PostCard({
   return (
     <article
       className={cn(
-        compact ? 'px-3 py-3' : 'px-4 py-4',
+        compact ? "px-3 py-3" : "px-4 py-4",
         !isDetail &&
-          'cursor-pointer transition-all duration-200 hover:bg-muted/30',
-        'w-full overflow-hidden',
-        !isDetail && 'border-border border-b',
+          "cursor-pointer transition-all duration-200 hover:bg-muted/30",
+        "w-full overflow-hidden",
+        !isDetail && "border-border border-b",
         className
       )}
       style={{
@@ -257,7 +257,7 @@ export const PostCard = memo(function PostCard({
         <div className="mb-1 flex items-center gap-2 pl-12 text-muted-foreground text-xs">
           <Repeat2 size={14} className="text-green-600" />
           <span>
-            Reposted by{' '}
+            Reposted by{" "}
             {user?.id === post.authorId ? (
               <span className="font-semibold text-foreground">you</span>
             ) : (
@@ -274,7 +274,7 @@ export const PostCard = memo(function PostCard({
       )}
 
       {/* Two-column layout: Avatar | Content */}
-      <div className="flex gap-3">
+      <div className="flex items-start gap-3">
         {/* Left column: Avatar + Connecting Line */}
         <div className="flex flex-col items-center">
           <Link
@@ -285,7 +285,7 @@ export const PostCard = memo(function PostCard({
             <Avatar
               id={displayAuthorId}
               name={displayAuthorName}
-              type={post.type === 'article' ? 'business' : 'actor'}
+              type={post.type === "article" ? "business" : "actor"}
               size="md"
               src={displayAuthorProfileImageUrl || undefined}
               scaleFactor={fontSize}
@@ -302,12 +302,12 @@ export const PostCard = memo(function PostCard({
         {/* Right column: All content */}
         <div className="min-w-0 flex-1">
           {/* Header: Name/Handle on left, Timestamp and Menu on right */}
-          <div className="mb-2 flex items-center justify-between gap-3">
+          <div className="flex items-start sm:items-center justify-between gap-3 sm:pt-0.5 leading-none">
             {/* Name and Handle inline */}
             <div className="flex min-w-0 flex-1 items-center gap-1.5">
               <Link
                 href={getProfileUrl(displayAuthorId, null)}
-                className="truncate font-semibold text-[15px] text-foreground hover:underline"
+                className="truncate font-semibold text-[15px] leading-tight text-foreground hover:underline"
                 onClick={(e) => e.stopPropagation()}
               >
                 {displayAuthorName}
@@ -315,16 +315,16 @@ export const PostCard = memo(function PostCard({
               {showVerifiedBadge && <VerifiedBadge size="sm" />}
               <Link
                 href={getProfileUrl(displayAuthorId, null)}
-                className="truncate text-[15px] text-muted-foreground hover:underline"
+                className="truncate text-[15px] leading-tight text-muted-foreground hover:underline"
                 onClick={(e) => e.stopPropagation()}
               >
                 @{displayAuthorUsername || displayAuthorId}
               </Link>
             </div>
             {/* Timestamp and Menu - Right aligned */}
-            <div className="flex shrink-0 items-center gap-2">
+            <div className="flex items-start sm:items-center gap-2">
               <time
-                className="text-[15px] text-muted-foreground"
+                className="text-[15px] leading-tight text-muted-foreground"
                 title={postDate.toLocaleString()}
               >
                 {timeAgo}
@@ -347,13 +347,13 @@ export const PostCard = memo(function PostCard({
           </div>
 
           {/* Post Content */}
-          {post.type === 'article' ? (
+          {post.type === "article" ? (
             // Article card - Show title, summary, and "Read more" button
             <div className="mb-3 w-full">
               {/* Article title with Read More Button */}
               <div className="mb-3 flex items-start justify-between gap-4">
                 <h2 className="flex-1 font-bold text-foreground text-lg leading-tight sm:text-xl">
-                  {post.articleTitle || 'Untitled Article'}
+                  {post.articleTitle || "Untitled Article"}
                 </h2>
                 {!isDetail && (
                   <button
@@ -382,10 +382,10 @@ export const PostCard = memo(function PostCard({
                 <TaggedText
                   text={post.originalPost.content}
                   onTagClick={(tag) => {
-                    if (tag.startsWith('@')) {
+                    if (tag.startsWith("@")) {
                       const username = tag.slice(1);
-                      router.push(getProfileUrl('', username));
-                    } else if (tag.startsWith('$')) {
+                      router.push(getProfileUrl("", username));
+                    } else if (tag.startsWith("$")) {
                       const symbol = tag.slice(1);
                       router.push(
                         `/markets?search=${encodeURIComponent(symbol)}`
@@ -408,10 +408,10 @@ export const PostCard = memo(function PostCard({
                   <TaggedText
                     text={post.quoteComment}
                     onTagClick={(tag) => {
-                      if (tag.startsWith('@')) {
+                      if (tag.startsWith("@")) {
                         const username = tag.slice(1);
-                        router.push(getProfileUrl('', username));
-                      } else if (tag.startsWith('$')) {
+                        router.push(getProfileUrl("", username));
+                      } else if (tag.startsWith("$")) {
                         const symbol = tag.slice(1);
                         router.push(
                           `/markets?search=${encodeURIComponent(symbol)}`
@@ -425,15 +425,15 @@ export const PostCard = memo(function PostCard({
               {/* Embedded original post */}
               <div
                 className={cn(
-                  'rounded-xl border border-border p-4',
-                  'overflow-hidden transition-colors',
+                  "rounded-xl border border-border p-4",
+                  "overflow-hidden transition-colors",
                   quotedPostId
-                    ? 'cursor-pointer hover:bg-muted/50'
-                    : 'cursor-default'
+                    ? "cursor-pointer hover:bg-muted/50"
+                    : "cursor-default"
                 )}
-                role={quotedPostId ? 'link' : undefined}
+                role={quotedPostId ? "link" : undefined}
                 tabIndex={quotedPostId ? 0 : undefined}
-                aria-label={quotedPostId ? 'View quoted post' : undefined}
+                aria-label={quotedPostId ? "View quoted post" : undefined}
                 onClick={handleQuotedPostClick}
                 onKeyDown={handleQuotedPostKeyDown}
               >
@@ -485,10 +485,10 @@ export const PostCard = memo(function PostCard({
                       <TaggedText
                         text={post.originalPost.content}
                         onTagClick={(tag) => {
-                          if (tag.startsWith('@')) {
+                          if (tag.startsWith("@")) {
                             const username = tag.slice(1);
-                            router.push(getProfileUrl('', username));
-                          } else if (tag.startsWith('$')) {
+                            router.push(getProfileUrl("", username));
+                          } else if (tag.startsWith("$")) {
                             const symbol = tag.slice(1);
                             router.push(
                               `/markets?search=${encodeURIComponent(symbol)}`
@@ -509,13 +509,13 @@ export const PostCard = memo(function PostCard({
             // Regular post - Show content as normal
             <div className="post-content mb-3 w-full whitespace-pre-wrap break-words text-[15px] text-foreground leading-normal">
               <TaggedText
-                text={post.content || ''}
+                text={post.content || ""}
                 onTagClick={(tag) => {
-                  if (tag.startsWith('@')) {
+                  if (tag.startsWith("@")) {
                     // Handle @mentions - route to profile
                     const username = tag.slice(1);
-                    router.push(getProfileUrl('', username));
-                  } else if (tag.startsWith('$')) {
+                    router.push(getProfileUrl("", username));
+                  } else if (tag.startsWith("$")) {
                     // Handle $cashtags - route to markets
                     const symbol = tag.slice(1);
                     router.push(

--- a/apps/web/src/components/shared/MobileHeader.tsx
+++ b/apps/web/src/components/shared/MobileHeader.tsx
@@ -1,16 +1,16 @@
-"use client";
+'use client';
 
-import { cn, getDisplayReferralUrl, getReferralUrl } from "@babylon/shared";
-import { Check, Copy, Gift, LogOut, Trophy, User, X } from "lucide-react";
-import Image from "next/image";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
-import { GameFeedbackModal } from "@/components/feedback/GameFeedbackModal";
-import { Avatar } from "@/components/shared/Avatar";
-import { useAuth } from "@/hooks/useAuth";
-import { getAuthToken } from "@/lib/auth";
-import { useAuthStore } from "@/stores/authStore";
+import { cn, getDisplayReferralUrl, getReferralUrl } from '@babylon/shared';
+import { Check, Copy, Gift, LogOut, Trophy, User, X } from 'lucide-react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { GameFeedbackModal } from '@/components/feedback/GameFeedbackModal';
+import { Avatar } from '@/components/shared/Avatar';
+import { useAuth } from '@/hooks/useAuth';
+import { getAuthToken } from '@/lib/auth';
+import { useAuthStore } from '@/stores/authStore';
 
 /**
  * Mobile header content component for mobile devices.
@@ -31,13 +31,12 @@ function MobileHeaderContent() {
     total: number;
   } | null>(null);
   const [copiedReferral, setCopiedReferral] = useState(false);
-  const [unreadNotifications, setUnreadNotifications] = useState(0);
   const [showFeedbackModal, setShowFeedbackModal] = useState(false);
   const pathname = usePathname();
 
   // Hide mobile header when WAITLIST_MODE is enabled on home page
-  const isWaitlistMode = process.env.NEXT_PUBLIC_WAITLIST_MODE === "true";
-  const isHomePage = pathname === "/";
+  const isWaitlistMode = process.env.NEXT_PUBLIC_WAITLIST_MODE === 'true';
+  const isHomePage = pathname === '/';
   const shouldHide = isWaitlistMode && isHomePage;
 
   // All hooks must be called before any conditional returns
@@ -55,7 +54,7 @@ function MobileHeaderContent() {
           signal: controller.signal,
         }
       ).catch((error: Error) => {
-        if (error.name === "AbortError") return null;
+        if (error.name === 'AbortError') return null;
         throw error;
       });
 
@@ -98,7 +97,7 @@ function MobileHeaderContent() {
       }
 
       const headers: HeadersInit = {
-        "Content-Type": "application/json",
+        'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`,
       };
 
@@ -145,42 +144,6 @@ function MobileHeaderContent() {
     return () => clearInterval(interval);
   }, [authenticated, user?.id, user?.reputationPoints, setUser, user]);
 
-  // Poll for unread notifications
-  useEffect(() => {
-    if (!authenticated || !user) {
-      setUnreadNotifications(0);
-      return;
-    }
-
-    const fetchUnreadCount = async () => {
-      const token = getAuthToken();
-
-      if (!token) {
-        return;
-      }
-
-      const response = await fetch(
-        "/api/notifications?unreadOnly=true&limit=1",
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      );
-
-      if (response.ok) {
-        const data = await response.json();
-        setUnreadNotifications(data.unreadCount || 0);
-      }
-    };
-
-    fetchUnreadCount();
-
-    // Refresh every 1 minute
-    const interval = setInterval(fetchUnreadCount, 60000); // 60 seconds = 1 minute
-    return () => clearInterval(interval);
-  }, [authenticated, user]);
-
   const copyReferralCode = async () => {
     if (!user?.referralCode) return;
 
@@ -197,22 +160,22 @@ function MobileHeaderContent() {
 
   const menuItems = [
     {
-      name: "Profile",
-      href: "/profile",
+      name: 'Profile',
+      href: '/profile',
       icon: User,
-      active: pathname === "/profile",
+      active: pathname === '/profile',
     },
     {
-      name: "Leaderboards",
-      href: "/leaderboard",
+      name: 'Leaderboards',
+      href: '/leaderboard',
       icon: Trophy,
-      active: pathname === "/leaderboard",
+      active: pathname === '/leaderboard',
     },
     {
-      name: "Rewards",
-      href: "/rewards",
+      name: 'Rewards',
+      href: '/rewards',
       icon: Gift,
-      active: pathname === "/rewards",
+      active: pathname === '/rewards',
     },
   ];
 
@@ -220,9 +183,9 @@ function MobileHeaderContent() {
     <>
       <header
         className={cn(
-          "md:hidden",
-          "fixed top-0 right-0 left-0 z-40",
-          "bg-sidebar/95"
+          'md:hidden',
+          'fixed top-0 right-0 left-0 z-40',
+          'bg-sidebar/95'
         )}
       >
         <div className="flex h-14 items-center justify-between px-4">
@@ -236,7 +199,7 @@ function MobileHeaderContent() {
               >
                 <Avatar
                   id={user.id}
-                  name={user.displayName || user.email || "User"}
+                  name={user.displayName || user.email || 'User'}
                   type="user"
                   size="sm"
                   src={user.profileImageUrl || undefined}
@@ -299,7 +262,7 @@ function MobileHeaderContent() {
               <div className="flex min-w-0 flex-1 items-center gap-3">
                 <Avatar
                   id={user?.id}
-                  name={user?.displayName || user?.email || "User"}
+                  name={user?.displayName || user?.email || 'User'}
                   type="user"
                   size="md"
                   src={user?.profileImageUrl || undefined}
@@ -308,7 +271,7 @@ function MobileHeaderContent() {
                 />
                 <div className="min-w-0 flex-1">
                   <div className="truncate font-bold text-foreground text-sm">
-                    {user?.displayName || user?.email || "User"}
+                    {user?.displayName || user?.email || 'User'}
                   </div>
                   <div className="truncate text-muted-foreground text-xs">
                     @{user?.username || `user${user?.id.slice(0, 8)}`}
@@ -322,7 +285,7 @@ function MobileHeaderContent() {
                 }}
                 className="shrink-0 p-2 transition-colors hover:bg-muted"
               >
-                <X size={20} style={{ color: "#0066FF" }} />
+                <X size={20} style={{ color: '#0066FF' }} />
               </button>
             </Link>
 
@@ -348,26 +311,19 @@ function MobileHeaderContent() {
             <nav className="min-h-0 flex-1 overflow-y-auto pt-2.5">
               {menuItems.map((item) => {
                 const Icon = item.icon;
-                const hasNotifications =
-                  item.name === "Notifications" && unreadNotifications > 0;
                 return (
                   <Link
                     key={item.name}
                     href={item.href}
                     onClick={() => setShowSideMenu(false)}
                     className={cn(
-                      "relative flex items-center gap-4 px-4 py-2.5 transition-colors",
+                      'relative flex items-center gap-4 px-4 py-2.5 transition-colors',
                       item.active
-                        ? "bg-[#0066FF] font-bold text-primary-foreground"
-                        : "font-semibold text-sidebar-foreground hover:bg-sidebar-accent"
+                        ? 'bg-[#0066FF] font-bold text-primary-foreground'
+                        : 'font-semibold text-sidebar-foreground hover:bg-sidebar-accent'
                     )}
                   >
-                    <div className="relative">
-                      <Icon className="h-5 w-5" />
-                      {hasNotifications && (
-                        <span className="-top-1 -right-1 absolute h-2 w-2 rounded-full bg-blue-500 ring-2 ring-sidebar" />
-                      )}
-                    </div>
+                    <Icon className="h-5 w-5" />
                     <span className="text-base">{item.name}</span>
                   </Link>
                 );
@@ -396,7 +352,7 @@ function MobileHeaderContent() {
                     </>
                   ) : (
                     <>
-                      <Copy className="h-5 w-5" style={{ color: "#0066FF" }} />
+                      <Copy className="h-5 w-5" style={{ color: '#0066FF' }} />
                       <div className="min-w-0 flex-1">
                         <div className="text-base text-foreground">
                           Copy Referral Link

--- a/apps/web/src/components/shared/MobileHeader.tsx
+++ b/apps/web/src/components/shared/MobileHeader.tsx
@@ -1,27 +1,16 @@
-'use client';
+"use client";
 
-import { cn, getDisplayReferralUrl, getReferralUrl } from '@babylon/shared';
-import {
-  Bell,
-  Check,
-  Copy,
-  Gift,
-  Home,
-  LogOut,
-  MessageCircle,
-  TrendingUp,
-  Trophy,
-  X,
-} from 'lucide-react';
-import Image from 'next/image';
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
-import { useEffect, useState } from 'react';
-import { GameFeedbackModal } from '@/components/feedback/GameFeedbackModal';
-import { Avatar } from '@/components/shared/Avatar';
-import { useAuth } from '@/hooks/useAuth';
-import { getAuthToken } from '@/lib/auth';
-import { useAuthStore } from '@/stores/authStore';
+import { cn, getDisplayReferralUrl, getReferralUrl } from "@babylon/shared";
+import { Check, Copy, Gift, LogOut, Trophy, User, X } from "lucide-react";
+import Image from "next/image";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+import { GameFeedbackModal } from "@/components/feedback/GameFeedbackModal";
+import { Avatar } from "@/components/shared/Avatar";
+import { useAuth } from "@/hooks/useAuth";
+import { getAuthToken } from "@/lib/auth";
+import { useAuthStore } from "@/stores/authStore";
 
 /**
  * Mobile header content component for mobile devices.
@@ -47,8 +36,8 @@ function MobileHeaderContent() {
   const pathname = usePathname();
 
   // Hide mobile header when WAITLIST_MODE is enabled on home page
-  const isWaitlistMode = process.env.NEXT_PUBLIC_WAITLIST_MODE === 'true';
-  const isHomePage = pathname === '/';
+  const isWaitlistMode = process.env.NEXT_PUBLIC_WAITLIST_MODE === "true";
+  const isHomePage = pathname === "/";
   const shouldHide = isWaitlistMode && isHomePage;
 
   // All hooks must be called before any conditional returns
@@ -66,7 +55,7 @@ function MobileHeaderContent() {
           signal: controller.signal,
         }
       ).catch((error: Error) => {
-        if (error.name === 'AbortError') return null;
+        if (error.name === "AbortError") return null;
         throw error;
       });
 
@@ -109,7 +98,7 @@ function MobileHeaderContent() {
       }
 
       const headers: HeadersInit = {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
         Authorization: `Bearer ${token}`,
       };
 
@@ -171,7 +160,7 @@ function MobileHeaderContent() {
       }
 
       const response = await fetch(
-        '/api/notifications?unreadOnly=true&limit=1',
+        "/api/notifications?unreadOnly=true&limit=1",
         {
           headers: {
             Authorization: `Bearer ${token}`,
@@ -208,40 +197,22 @@ function MobileHeaderContent() {
 
   const menuItems = [
     {
-      name: 'Feed',
-      href: '/feed',
-      icon: Home,
-      active: pathname === '/feed' || pathname === '/',
+      name: "Profile",
+      href: "/profile",
+      icon: User,
+      active: pathname === "/profile",
     },
     {
-      name: 'Terminal',
-      href: '/markets',
-      icon: TrendingUp,
-      active: pathname === '/markets',
-    },
-    {
-      name: 'Chats',
-      href: '/chats',
-      icon: MessageCircle,
-      active: pathname === '/chats',
-    },
-    {
-      name: 'Leaderboards',
-      href: '/leaderboard',
+      name: "Leaderboards",
+      href: "/leaderboard",
       icon: Trophy,
-      active: pathname === '/leaderboard',
+      active: pathname === "/leaderboard",
     },
     {
-      name: 'Rewards',
-      href: '/rewards',
+      name: "Rewards",
+      href: "/rewards",
       icon: Gift,
-      active: pathname === '/rewards',
-    },
-    {
-      name: 'Notifications',
-      href: '/notifications',
-      icon: Bell,
-      active: pathname === '/notifications',
+      active: pathname === "/rewards",
     },
   ];
 
@@ -249,9 +220,9 @@ function MobileHeaderContent() {
     <>
       <header
         className={cn(
-          'md:hidden',
-          'fixed top-0 right-0 left-0 z-40',
-          'bg-sidebar/95'
+          "md:hidden",
+          "fixed top-0 right-0 left-0 z-40",
+          "bg-sidebar/95"
         )}
       >
         <div className="flex h-14 items-center justify-between px-4">
@@ -265,7 +236,7 @@ function MobileHeaderContent() {
               >
                 <Avatar
                   id={user.id}
-                  name={user.displayName || user.email || 'User'}
+                  name={user.displayName || user.email || "User"}
                   type="user"
                   size="sm"
                   src={user.profileImageUrl || undefined}
@@ -328,7 +299,7 @@ function MobileHeaderContent() {
               <div className="flex min-w-0 flex-1 items-center gap-3">
                 <Avatar
                   id={user?.id}
-                  name={user?.displayName || user?.email || 'User'}
+                  name={user?.displayName || user?.email || "User"}
                   type="user"
                   size="md"
                   src={user?.profileImageUrl || undefined}
@@ -337,7 +308,7 @@ function MobileHeaderContent() {
                 />
                 <div className="min-w-0 flex-1">
                   <div className="truncate font-bold text-foreground text-sm">
-                    {user?.displayName || user?.email || 'User'}
+                    {user?.displayName || user?.email || "User"}
                   </div>
                   <div className="truncate text-muted-foreground text-xs">
                     @{user?.username || `user${user?.id.slice(0, 8)}`}
@@ -351,56 +322,44 @@ function MobileHeaderContent() {
                 }}
                 className="shrink-0 p-2 transition-colors hover:bg-muted"
               >
-                <X size={20} style={{ color: '#0066FF' }} />
+                <X size={20} style={{ color: "#0066FF" }} />
               </button>
             </Link>
 
             {/* Points Display */}
-            <div className="shrink-0 bg-muted/30 px-4 py-4">
-              <div className="flex items-start gap-3">
-                <div
-                  className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full"
-                  style={{ backgroundColor: '#0066FF' }}
-                >
-                  <Trophy className="h-5 w-5 text-foreground" />
+            <div className="shrink-0 border-border border-b px-4 py-3">
+              <div className="flex items-center justify-between">
+                <div className="text-muted-foreground text-xs">Reputation</div>
+                <div className="font-bold text-foreground text-sm">
+                  {(user?.reputationPoints || 0).toLocaleString()}
                 </div>
-                <div className="flex-1">
-                  <div className="flex items-center justify-between">
-                    <div className="font-semibold text-muted-foreground text-xs uppercase tracking-wide">
-                      Reputation
-                    </div>
-                    <div className="font-bold text-base text-foreground">
-                      {(user?.reputationPoints || 0).toLocaleString()}
-                    </div>
-                  </div>
-                  <div className="mt-2 flex items-center justify-between">
-                    <div className="text-muted-foreground text-xs">
-                      Trading Balance
-                    </div>
-                    <div className="font-semibold text-foreground text-sm">
-                      {(pointsData?.available || 0).toLocaleString()}
-                    </div>
-                  </div>
+              </div>
+              <div className="mt-1.5 flex items-center justify-between">
+                <div className="text-muted-foreground text-xs">
+                  Trading Balance
+                </div>
+                <div className="font-bold text-foreground text-sm">
+                  {(pointsData?.available || 0).toLocaleString()}
                 </div>
               </div>
             </div>
 
             {/* Menu Items - Scrollable */}
-            <nav className="min-h-0 flex-1 overflow-y-auto">
+            <nav className="min-h-0 flex-1 overflow-y-auto pt-2.5">
               {menuItems.map((item) => {
                 const Icon = item.icon;
                 const hasNotifications =
-                  item.name === 'Notifications' && unreadNotifications > 0;
+                  item.name === "Notifications" && unreadNotifications > 0;
                 return (
                   <Link
                     key={item.name}
                     href={item.href}
                     onClick={() => setShowSideMenu(false)}
                     className={cn(
-                      'relative flex items-center gap-4 px-4 py-3 transition-colors',
+                      "relative flex items-center gap-4 px-4 py-2.5 transition-colors",
                       item.active
-                        ? 'bg-[#0066FF] font-bold text-primary-foreground'
-                        : 'font-semibold text-sidebar-foreground hover:bg-sidebar-accent'
+                        ? "bg-[#0066FF] font-bold text-primary-foreground"
+                        : "font-semibold text-sidebar-foreground hover:bg-sidebar-accent"
                     )}
                   >
                     <div className="relative">
@@ -416,7 +375,7 @@ function MobileHeaderContent() {
             </nav>
 
             {/* Bottom Section - Referral & Logout */}
-            <div className="shrink-0 border-border border-t bg-sidebar pb-20">
+            <div className="shrink-0 border-border border-t bg-sidebar pb-16">
               {/* Referral Code Button */}
               {user?.referralCode && (
                 <button
@@ -426,13 +385,18 @@ function MobileHeaderContent() {
                   {copiedReferral ? (
                     <>
                       <Check className="h-5 w-5 text-green-500" />
-                      <span className="text-base text-green-500">
-                        Referral Link Copied!
-                      </span>
+                      <div className="min-w-0 flex-1">
+                        <div className="text-base text-green-500">
+                          Referral Link Copied!
+                        </div>
+                        <div className="truncate font-mono text-muted-foreground text-xs">
+                          {getDisplayReferralUrl(user.referralCode)}
+                        </div>
+                      </div>
                     </>
                   ) : (
                     <>
-                      <Copy className="h-5 w-5" style={{ color: '#0066FF' }} />
+                      <Copy className="h-5 w-5" style={{ color: "#0066FF" }} />
                       <div className="min-w-0 flex-1">
                         <div className="text-base text-foreground">
                           Copy Referral Link


### PR DESCRIPTION
## Summary
- **Feed post cards**: Top-align header with avatar, remove header-to-content gap, tighten line-heights, compact moderation menu on mobile
- **Mobile sidebar**: Remove redundant nav items (Feed, Terminal, Chats, Notifications — already in bottom bar), add Profile tab, clean up reputation/balance section (remove icon), fix referral button height jump on copy, adjust spacing