### PR TITLE
feat(billing): stripe webhook metadata filtering

### DIFF
--- a/apps/web/src/app/api/stripe/checkout/session/route.ts
+++ b/apps/web/src/app/api/stripe/checkout/session/route.ts
@@ -159,6 +159,7 @@ export async function POST(req: NextRequest) {
     ],
     // Store purchase details in metadata for webhook processing
     metadata: {
+      app: 'babylon',
       userId,
       pointsAmount: pointsAmount.toString(),
       amountUSD: amountUSD.toString(),

--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -107,6 +107,26 @@ export async function POST(req: Request) {
     'StripeWebhook'
   );
 
+  // Filter events by app metadata — only process events belonging to this app (babylon).
+  // Events without metadata.app are allowed through for backward compatibility with
+  // resources created before this tagging was added.
+  const eventObject = event.data.object as Record<string, unknown>;
+  const appMetadata =
+    (eventObject?.metadata as Record<string, string> | undefined)?.app ??
+    (
+      (eventObject?.subscription_details as Record<string, unknown> | undefined)
+        ?.metadata as Record<string, string> | undefined
+    )?.app;
+
+  if (appMetadata && appMetadata !== 'babylon') {
+    logger.info(
+      `Ignoring Stripe event for different app: ${appMetadata}`,
+      { eventId: event.id, type: event.type, app: appMetadata },
+      'StripeWebhook'
+    );
+    return NextResponse.json({ received: true, ignored: true });
+  }
+
   // Handle events - each handler returns a result indicating success/failure
   let result: WebhookHandlerResult = { success: true };
 

--- a/apps/web/src/app/api/stripe/webhook/route.ts
+++ b/apps/web/src/app/api/stripe/webhook/route.ts
@@ -110,7 +110,7 @@ export async function POST(req: Request) {
   // Filter events by app metadata — only process events belonging to this app (babylon).
   // Events without metadata.app are allowed through for backward compatibility with
   // resources created before this tagging was added.
-  const eventObject = event.data.object as Record<string, unknown>;
+  const eventObject = event.data.object as unknown as Record<string, unknown>;
   const appMetadata =
     (eventObject?.metadata as Record<string, string> | undefined)?.app ??
     (

--- a/packages/testing/integration/stripe-webhook-handler.integration.test.ts
+++ b/packages/testing/integration/stripe-webhook-handler.integration.test.ts
@@ -40,6 +40,20 @@ async function processWebhookEvent(
     paymentIntentId: string
   ) => Promise<string | null>
 ): Promise<{ handled: boolean; action?: string; error?: string }> {
+  // App metadata filter — only process events belonging to this app (babylon).
+  // Events without metadata.app are allowed for backward compatibility.
+  const eventObject = event.data.object as Record<string, unknown>;
+  const appMetadata =
+    (eventObject?.metadata as Record<string, string> | undefined)?.app ??
+    (
+      (eventObject?.subscription_details as Record<string, unknown> | undefined)
+        ?.metadata as Record<string, string> | undefined
+    )?.app;
+
+  if (appMetadata && appMetadata !== 'babylon') {
+    return { handled: true, action: 'ignored_other_app' };
+  }
+
   switch (event.type) {
     case 'checkout.session.completed': {
       const session = event.data.object as MockCheckoutSession;
@@ -569,7 +583,7 @@ describe('Stripe Webhook Handler Integration', () => {
         object: 'event',
         type: 'customer.created',
         created: Date.now(),
-        data: { object: {} },
+        data: { object: { metadata: { app: 'babylon' } } },
       };
 
       const result = await processWebhookEvent(
@@ -579,6 +593,347 @@ describe('Stripe Webhook Handler Integration', () => {
 
       expect(result.handled).toBe(false);
       expect(result.action).toBe('unhandled_event_type');
+    });
+  });
+
+  describe('App Metadata Filtering', () => {
+    describe('Events tagged with babylon should be processed', () => {
+      it('should process checkout.session.completed with app=babylon', async () => {
+        const userId = await createDbUser();
+        const event = createCheckoutCompletedEvent(userId, 10, {
+          app: 'babylon',
+        });
+
+        const result = await processWebhookEvent(
+          event,
+          getUserIdFromPaymentIntent
+        );
+
+        expect(result.handled).toBe(true);
+        expect(result.action).toBe('points_credited');
+
+        const balance = await getUserBalance(userId);
+        expect(balance).toBe(1000);
+      });
+
+      it('should process charge.dispute.created with app=babylon', async () => {
+        const userId = await createDbUser();
+        const paymentIntentId = `pi_filter_dispute_${Date.now()}`;
+        paymentIntentToUser.set(paymentIntentId, userId);
+
+        // Give user some points first
+        await PointsService.purchasePoints(
+          userId,
+          50,
+          `cs_test_${Date.now()}`,
+          paymentIntentId,
+          'stripe'
+        );
+
+        const event = createDisputeCreatedEvent(paymentIntentId, 50, {
+          app: 'babylon',
+        });
+
+        const result = await processWebhookEvent(
+          event,
+          getUserIdFromPaymentIntent
+        );
+
+        expect(result.handled).toBe(true);
+        expect(result.action).toBe('points_deducted_dispute');
+      });
+
+      it('should process charge.dispute.closed (won) with app=babylon', async () => {
+        const userId = await createDbUser(0);
+        const paymentIntentId = `pi_filter_won_${Date.now()}`;
+        paymentIntentToUser.set(paymentIntentId, userId);
+
+        const event = createDisputeWonEvent(paymentIntentId, 25, {
+          app: 'babylon',
+        });
+
+        const result = await processWebhookEvent(
+          event,
+          getUserIdFromPaymentIntent
+        );
+
+        expect(result.handled).toBe(true);
+        expect(result.action).toBe('points_recredited_dispute_won');
+      });
+
+      it('should process charge.dispute.closed (lost) with app=babylon', async () => {
+        const userId = await createDbUser(0);
+        const paymentIntentId = `pi_filter_lost_${Date.now()}`;
+        paymentIntentToUser.set(paymentIntentId, userId);
+
+        const event = createDisputeLostEvent(paymentIntentId, 25, {
+          app: 'babylon',
+        });
+
+        const result = await processWebhookEvent(
+          event,
+          getUserIdFromPaymentIntent
+        );
+
+        expect(result.handled).toBe(true);
+        expect(result.action).toBe('dispute_lost_logged');
+      });
+
+      it('should process charge.refunded with app=babylon', async () => {
+        const userId = await createDbUser();
+        const paymentIntentId = `pi_filter_refund_${Date.now()}`;
+        paymentIntentToUser.set(paymentIntentId, userId);
+
+        await PointsService.purchasePoints(
+          userId,
+          30,
+          `cs_test_${Date.now()}`,
+          paymentIntentId,
+          'stripe'
+        );
+
+        const event = createChargeRefundedEvent(paymentIntentId, 30, 30, {
+          app: 'babylon',
+        });
+
+        const result = await processWebhookEvent(
+          event,
+          getUserIdFromPaymentIntent
+        );
+
+        expect(result.handled).toBe(true);
+        expect(result.action).toBe('points_deducted_refund');
+      });
+    });
+
+    describe('Events tagged with eliza-cloud should be ignored', () => {
+      it('should ignore checkout.session.completed with app=eliza-cloud', async () => {
+        const userId = await createDbUser();
+        const event = createCheckoutCompletedEvent(userId, 10, {
+          app: 'eliza-cloud',
+        });
+
+        const result = await processWebhookEvent(
+          event,
+          getUserIdFromPaymentIntent
+        );
+
+        expect(result.handled).toBe(true);
+        expect(result.action).toBe('ignored_other_app');
+
+        // Balance should remain 0 — event was filtered out
+        const balance = await getUserBalance(userId);
+        expect(balance).toBe(0);
+      });
+
+      it('should ignore charge.dispute.created with app=eliza-cloud', async () => {
+        const userId = await createDbUser(5000);
+        const paymentIntentId = `pi_ec_dispute_${Date.now()}`;
+        paymentIntentToUser.set(paymentIntentId, userId);
+
+        const event = createDisputeCreatedEvent(paymentIntentId, 50, {
+          app: 'eliza-cloud',
+        });
+
+        const result = await processWebhookEvent(
+          event,
+          getUserIdFromPaymentIntent
+        );
+
+        expect(result.handled).toBe(true);
+        expect(result.action).toBe('ignored_other_app');
+
+        // Balance should remain unchanged
+        const balance = await getUserBalance(userId);
+        expect(balance).toBe(5000);
+      });
+
+      it('should ignore charge.dispute.closed (won) with app=eliza-cloud', async () => {
+        const userId = await createDbUser(0);
+        const paymentIntentId = `pi_ec_won_${Date.now()}`;
+        paymentIntentToUser.set(paymentIntentId, userId);
+
+        const event = createDisputeWonEvent(paymentIntentId, 50, {
+          app: 'eliza-cloud',
+        });
+
+        const result = await processWebhookEvent(
+          event,
+          getUserIdFromPaymentIntent
+        );
+
+        expect(result.handled).toBe(true);
+        expect(result.action).toBe('ignored_other_app');
+
+        const balance = await getUserBalance(userId);
+        expect(balance).toBe(0);
+      });
+
+      it('should ignore charge.dispute.closed (lost) with app=eliza-cloud', async () => {
+        const userId = await createDbUser(0);
+        const paymentIntentId = `pi_ec_lost_${Date.now()}`;
+        paymentIntentToUser.set(paymentIntentId, userId);
+
+        const event = createDisputeLostEvent(paymentIntentId, 50, {
+          app: 'eliza-cloud',
+        });
+
+        const result = await processWebhookEvent(
+          event,
+          getUserIdFromPaymentIntent
+        );
+
+        expect(result.handled).toBe(true);
+        expect(result.action).toBe('ignored_other_app');
+      });
+
+      it('should ignore charge.refunded with app=eliza-cloud', async () => {
+        const userId = await createDbUser(5000);
+        const paymentIntentId = `pi_ec_refund_${Date.now()}`;
+        paymentIntentToUser.set(paymentIntentId, userId);
+
+        const event = createChargeRefundedEvent(paymentIntentId, 25, 50, {
+          app: 'eliza-cloud',
+        });
+
+        const result = await processWebhookEvent(
+          event,
+          getUserIdFromPaymentIntent
+        );
+
+        expect(result.handled).toBe(true);
+        expect(result.action).toBe('ignored_other_app');
+
+        // Balance should remain unchanged
+        const balance = await getUserBalance(userId);
+        expect(balance).toBe(5000);
+      });
+    });
+
+    describe('Events without app metadata (backward compatibility)', () => {
+      it('should process checkout.session.completed without app tag', async () => {
+        const userId = await createDbUser();
+        const event = createCheckoutCompletedEvent(userId, 15);
+        // Remove app metadata to simulate legacy event
+        delete (event.data.object as MockCheckoutSession).metadata.app;
+
+        const result = await processWebhookEvent(
+          event,
+          getUserIdFromPaymentIntent
+        );
+
+        expect(result.handled).toBe(true);
+        expect(result.action).toBe('points_credited');
+
+        const balance = await getUserBalance(userId);
+        expect(balance).toBe(1500);
+      });
+
+      it('should process charge.dispute.created without app tag', async () => {
+        const userId = await createDbUser();
+        const paymentIntentId = `pi_noapp_dispute_${Date.now()}`;
+        paymentIntentToUser.set(paymentIntentId, userId);
+
+        await PointsService.purchasePoints(
+          userId,
+          40,
+          `cs_test_${Date.now()}`,
+          paymentIntentId,
+          'stripe'
+        );
+
+        const event = createDisputeCreatedEvent(paymentIntentId, 40);
+        // Remove app from metadata to simulate legacy
+        delete (event.data.object as MockDispute).metadata.app;
+
+        const result = await processWebhookEvent(
+          event,
+          getUserIdFromPaymentIntent
+        );
+
+        expect(result.handled).toBe(true);
+        expect(result.action).toBe('points_deducted_dispute');
+      });
+
+      it('should process charge.refunded without app tag', async () => {
+        const userId = await createDbUser();
+        const paymentIntentId = `pi_noapp_refund_${Date.now()}`;
+        paymentIntentToUser.set(paymentIntentId, userId);
+
+        await PointsService.purchasePoints(
+          userId,
+          20,
+          `cs_test_${Date.now()}`,
+          paymentIntentId,
+          'stripe'
+        );
+
+        const event = createChargeRefundedEvent(paymentIntentId, 20, 20);
+        // Remove app from metadata to simulate legacy
+        delete (event.data.object as MockCharge).metadata.app;
+
+        const result = await processWebhookEvent(
+          event,
+          getUserIdFromPaymentIntent
+        );
+
+        expect(result.handled).toBe(true);
+        expect(result.action).toBe('points_deducted_refund');
+      });
+    });
+
+    describe('subscription_details metadata fallback', () => {
+      it('should filter by subscription_details.metadata.app when top-level is empty', async () => {
+        // Simulate an event where app metadata is in subscription_details
+        const event: MockStripeEvent = {
+          id: `evt_sub_${Date.now()}`,
+          object: 'event',
+          type: 'invoice.payment_succeeded',
+          created: Date.now(),
+          data: {
+            object: {
+              metadata: {},
+              subscription_details: {
+                metadata: { app: 'eliza-cloud' },
+              },
+            },
+          },
+        };
+
+        const result = await processWebhookEvent(
+          event,
+          getUserIdFromPaymentIntent
+        );
+
+        expect(result.handled).toBe(true);
+        expect(result.action).toBe('ignored_other_app');
+      });
+
+      it('should allow subscription_details with app=babylon', async () => {
+        const event: MockStripeEvent = {
+          id: `evt_sub_bab_${Date.now()}`,
+          object: 'event',
+          type: 'invoice.payment_succeeded',
+          created: Date.now(),
+          data: {
+            object: {
+              metadata: {},
+              subscription_details: {
+                metadata: { app: 'babylon' },
+              },
+            },
+          },
+        };
+
+        const result = await processWebhookEvent(
+          event,
+          getUserIdFromPaymentIntent
+        );
+
+        // This unhandled event type passes the filter but is unhandled
+        expect(result.handled).toBe(false);
+        expect(result.action).toBe('unhandled_event_type');
+      });
     });
   });
 });

--- a/packages/testing/unit/stripe/stripe-webhook-logic.test.ts
+++ b/packages/testing/unit/stripe/stripe-webhook-logic.test.ts
@@ -2,11 +2,19 @@
  * Unit Tests: Stripe Webhook Event Logic
  *
  * Tests for the business logic in Stripe webhook event handling.
- * These are pure logic tests that verify event type routing and
- * metadata extraction behavior.
+ * These are pure logic tests that verify event type routing,
+ * metadata extraction behavior, and app metadata filtering.
  */
 
 import { describe, expect, it } from 'bun:test';
+import {
+  createChargeRefundedEvent,
+  createCheckoutCompletedEvent,
+  createCheckoutExpiredEvent,
+  createDisputeCreatedEvent,
+  createDisputeLostEvent,
+  createDisputeWonEvent,
+} from './test-fixtures';
 
 /**
  * Simulated Stripe event types we handle
@@ -362,6 +370,357 @@ describe('Checkout Session Status Validation', () => {
   it('should not credit points when payment not paid', () => {
     expect(shouldCreditPoints('complete', 'unpaid')).toBe(false);
     expect(shouldCreditPoints('complete', 'no_payment_required')).toBe(false);
+  });
+});
+
+describe('App Metadata Filtering', () => {
+  /**
+   * Extract app metadata from a Stripe event object.
+   * Mirrors the logic in the webhook handler that checks
+   * event.data.object.metadata.app and falls back to
+   * event.data.object.subscription_details.metadata.app.
+   */
+  function extractAppMetadata(
+    eventObject: Record<string, unknown>
+  ): string | undefined {
+    return (
+      (eventObject?.metadata as Record<string, string> | undefined)?.app ??
+      (
+        (
+          eventObject?.subscription_details as
+            | Record<string, unknown>
+            | undefined
+        )?.metadata as Record<string, string> | undefined
+      )?.app
+    );
+  }
+
+  /**
+   * Determine if an event should be processed by this app.
+   * Returns true if the event belongs to 'babylon' or has no app tag (backward compat).
+   */
+  function shouldProcessForApp(
+    eventObject: Record<string, unknown>,
+    appName: string = 'babylon'
+  ): boolean {
+    const app = extractAppMetadata(eventObject);
+    // If no app metadata, allow (backward compat with pre-tagging resources)
+    if (!app) return true;
+    // Only process if it matches our app
+    return app === appName;
+  }
+
+  describe('extractAppMetadata', () => {
+    it('should extract app from top-level metadata', () => {
+      const obj = { metadata: { app: 'babylon' } };
+      expect(extractAppMetadata(obj)).toBe('babylon');
+    });
+
+    it('should extract app from subscription_details.metadata', () => {
+      const obj = {
+        metadata: {},
+        subscription_details: { metadata: { app: 'eliza-cloud' } },
+      };
+      expect(extractAppMetadata(obj)).toBe('eliza-cloud');
+    });
+
+    it('should prefer top-level metadata over subscription_details', () => {
+      const obj = {
+        metadata: { app: 'babylon' },
+        subscription_details: { metadata: { app: 'eliza-cloud' } },
+      };
+      expect(extractAppMetadata(obj)).toBe('babylon');
+    });
+
+    it('should return undefined when no app metadata exists', () => {
+      const obj = { metadata: {} };
+      expect(extractAppMetadata(obj)).toBeUndefined();
+    });
+
+    it('should return undefined when metadata is absent', () => {
+      const obj = {};
+      expect(extractAppMetadata(obj)).toBeUndefined();
+    });
+
+    it('should return undefined when metadata is null-ish', () => {
+      const obj = { metadata: null };
+      expect(
+        extractAppMetadata(obj as Record<string, unknown>)
+      ).toBeUndefined();
+    });
+  });
+
+  describe('shouldProcessForApp', () => {
+    it('should process events tagged with babylon', () => {
+      const obj = { metadata: { app: 'babylon' } };
+      expect(shouldProcessForApp(obj)).toBe(true);
+    });
+
+    it('should reject events tagged with eliza-cloud', () => {
+      const obj = { metadata: { app: 'eliza-cloud' } };
+      expect(shouldProcessForApp(obj)).toBe(false);
+    });
+
+    it('should reject events tagged with unknown app', () => {
+      const obj = { metadata: { app: 'some-other-app' } };
+      expect(shouldProcessForApp(obj)).toBe(false);
+    });
+
+    it('should allow events with no app metadata (backward compat)', () => {
+      const obj = { metadata: {} };
+      expect(shouldProcessForApp(obj)).toBe(true);
+    });
+
+    it('should allow events with no metadata at all (backward compat)', () => {
+      const obj = {};
+      expect(shouldProcessForApp(obj)).toBe(true);
+    });
+
+    it('should process when subscription_details has babylon', () => {
+      const obj = {
+        metadata: {},
+        subscription_details: { metadata: { app: 'babylon' } },
+      };
+      expect(shouldProcessForApp(obj)).toBe(true);
+    });
+
+    it('should reject when subscription_details has eliza-cloud', () => {
+      const obj = {
+        metadata: {},
+        subscription_details: { metadata: { app: 'eliza-cloud' } },
+      };
+      expect(shouldProcessForApp(obj)).toBe(false);
+    });
+  });
+
+  describe('Filtering across all webhook event types', () => {
+    describe('checkout.session.completed', () => {
+      it('should process babylon-tagged event', () => {
+        const event = createCheckoutCompletedEvent('user_1', 10, {
+          app: 'babylon',
+        });
+        expect(
+          shouldProcessForApp(
+            event.data.object as unknown as Record<string, unknown>
+          )
+        ).toBe(true);
+      });
+
+      it('should reject eliza-cloud-tagged event', () => {
+        const event = createCheckoutCompletedEvent('user_1', 10, {
+          app: 'eliza-cloud',
+        });
+        expect(
+          shouldProcessForApp(
+            event.data.object as unknown as Record<string, unknown>
+          )
+        ).toBe(false);
+      });
+
+      it('should allow event with no app tag (backward compat)', () => {
+        const event = createCheckoutCompletedEvent('user_1', 10);
+        // Remove app from metadata to simulate legacy event
+        delete (
+          event.data.object as unknown as Record<string, unknown> & {
+            metadata: Record<string, string | undefined>;
+          }
+        ).metadata.app;
+        expect(
+          shouldProcessForApp(
+            event.data.object as unknown as Record<string, unknown>
+          )
+        ).toBe(true);
+      });
+    });
+
+    describe('checkout.session.expired', () => {
+      it('should process babylon-tagged event', () => {
+        const event = createCheckoutExpiredEvent(undefined, undefined, {
+          app: 'babylon',
+        });
+        expect(
+          shouldProcessForApp(
+            event.data.object as unknown as Record<string, unknown>
+          )
+        ).toBe(true);
+      });
+
+      it('should reject eliza-cloud-tagged event', () => {
+        const event = createCheckoutExpiredEvent(undefined, undefined, {
+          app: 'eliza-cloud',
+        });
+        expect(
+          shouldProcessForApp(
+            event.data.object as unknown as Record<string, unknown>
+          )
+        ).toBe(false);
+      });
+    });
+
+    describe('checkout.session.async_payment_succeeded', () => {
+      it('should process babylon-tagged event', () => {
+        const event = createCheckoutCompletedEvent('user_1', 10, {
+          app: 'babylon',
+        });
+        event.type = 'checkout.session.async_payment_succeeded';
+        expect(
+          shouldProcessForApp(
+            event.data.object as unknown as Record<string, unknown>
+          )
+        ).toBe(true);
+      });
+
+      it('should reject eliza-cloud-tagged event', () => {
+        const event = createCheckoutCompletedEvent('user_1', 10, {
+          app: 'eliza-cloud',
+        });
+        event.type = 'checkout.session.async_payment_succeeded';
+        expect(
+          shouldProcessForApp(
+            event.data.object as unknown as Record<string, unknown>
+          )
+        ).toBe(false);
+      });
+    });
+
+    describe('checkout.session.async_payment_failed', () => {
+      it('should process babylon-tagged event', () => {
+        const event = createCheckoutCompletedEvent('user_1', 10, {
+          app: 'babylon',
+        });
+        event.type = 'checkout.session.async_payment_failed';
+        expect(
+          shouldProcessForApp(
+            event.data.object as unknown as Record<string, unknown>
+          )
+        ).toBe(true);
+      });
+
+      it('should reject eliza-cloud-tagged event', () => {
+        const event = createCheckoutCompletedEvent('user_1', 10, {
+          app: 'eliza-cloud',
+        });
+        event.type = 'checkout.session.async_payment_failed';
+        expect(
+          shouldProcessForApp(
+            event.data.object as unknown as Record<string, unknown>
+          )
+        ).toBe(false);
+      });
+    });
+
+    describe('charge.dispute.created', () => {
+      it('should process babylon-tagged event', () => {
+        const event = createDisputeCreatedEvent('pi_test', 50, {
+          app: 'babylon',
+        });
+        expect(
+          shouldProcessForApp(
+            event.data.object as unknown as Record<string, unknown>
+          )
+        ).toBe(true);
+      });
+
+      it('should reject eliza-cloud-tagged event', () => {
+        const event = createDisputeCreatedEvent('pi_test', 50, {
+          app: 'eliza-cloud',
+        });
+        expect(
+          shouldProcessForApp(
+            event.data.object as unknown as Record<string, unknown>
+          )
+        ).toBe(false);
+      });
+    });
+
+    describe('charge.dispute.closed (won)', () => {
+      it('should process babylon-tagged event', () => {
+        const event = createDisputeWonEvent('pi_test', 50, {
+          app: 'babylon',
+        });
+        expect(
+          shouldProcessForApp(
+            event.data.object as unknown as Record<string, unknown>
+          )
+        ).toBe(true);
+      });
+
+      it('should reject eliza-cloud-tagged event', () => {
+        const event = createDisputeWonEvent('pi_test', 50, {
+          app: 'eliza-cloud',
+        });
+        expect(
+          shouldProcessForApp(
+            event.data.object as unknown as Record<string, unknown>
+          )
+        ).toBe(false);
+      });
+    });
+
+    describe('charge.dispute.closed (lost)', () => {
+      it('should process babylon-tagged event', () => {
+        const event = createDisputeLostEvent('pi_test', 50, {
+          app: 'babylon',
+        });
+        expect(
+          shouldProcessForApp(
+            event.data.object as unknown as Record<string, unknown>
+          )
+        ).toBe(true);
+      });
+
+      it('should reject eliza-cloud-tagged event', () => {
+        const event = createDisputeLostEvent('pi_test', 50, {
+          app: 'eliza-cloud',
+        });
+        expect(
+          shouldProcessForApp(
+            event.data.object as unknown as Record<string, unknown>
+          )
+        ).toBe(false);
+      });
+    });
+
+    describe('charge.refunded', () => {
+      it('should process babylon-tagged event', () => {
+        const event = createChargeRefundedEvent('pi_test', 25, 50, {
+          app: 'babylon',
+        });
+        expect(
+          shouldProcessForApp(
+            event.data.object as unknown as Record<string, unknown>
+          )
+        ).toBe(true);
+      });
+
+      it('should reject eliza-cloud-tagged event', () => {
+        const event = createChargeRefundedEvent('pi_test', 25, 50, {
+          app: 'eliza-cloud',
+        });
+        expect(
+          shouldProcessForApp(
+            event.data.object as unknown as Record<string, unknown>
+          )
+        ).toBe(false);
+      });
+    });
+  });
+
+  describe('Response behavior for filtered events', () => {
+    it('should return 200 for filtered events (prevent Stripe retries)', () => {
+      // When an event is filtered, we return 200 so Stripe doesn't retry
+      const filteredResponse = {
+        status: 200,
+        body: { received: true, ignored: true },
+      };
+      expect(filteredResponse.status).toBe(200);
+      expect(filteredResponse.body.ignored).toBe(true);
+    });
+
+    it('should return 200 for processed events', () => {
+      const processedResponse = { status: 200, body: { received: true } };
+      expect(processedResponse.status).toBe(200);
+    });
   });
 });
 

--- a/packages/testing/unit/stripe/test-fixtures.ts
+++ b/packages/testing/unit/stripe/test-fixtures.ts
@@ -17,6 +17,7 @@ export interface MockCheckoutSession {
   amount_total: number;
   currency: string;
   metadata: {
+    app?: string;
     userId: string;
     pointsAmount: string;
     amountUSD: string;
@@ -81,6 +82,7 @@ export function createCheckoutCompletedEvent(
     sessionId?: string;
     paymentIntentId?: string;
     eventId?: string;
+    app?: string;
   } = {}
 ): MockStripeEvent<MockCheckoutSession> {
   const pointsAmount = Math.floor(amountUSD * 100);
@@ -103,6 +105,9 @@ export function createCheckoutCompletedEvent(
         amount_total: amountUSD * 100, // cents
         currency: 'usd',
         metadata: {
+          ...(options.app !== undefined
+            ? { app: options.app }
+            : { app: 'babylon' }),
           userId,
           pointsAmount: pointsAmount.toString(),
           amountUSD: amountUSD.toString(),
@@ -117,7 +122,8 @@ export function createCheckoutCompletedEvent(
  */
 export function createCheckoutExpiredEvent(
   sessionId?: string,
-  eventId?: string
+  eventId?: string,
+  options: { app?: string } = {}
 ): MockStripeEvent<MockCheckoutSession> {
   return {
     id: eventId ?? `evt_test_${Date.now()}`,
@@ -134,6 +140,9 @@ export function createCheckoutExpiredEvent(
         amount_total: 0,
         currency: 'usd',
         metadata: {
+          ...(options.app !== undefined
+            ? { app: options.app }
+            : { app: 'babylon' }),
           userId: '',
           pointsAmount: '',
           amountUSD: '',
@@ -153,6 +162,7 @@ export function createDisputeCreatedEvent(
     disputeId?: string;
     chargeId?: string;
     eventId?: string;
+    app?: string;
   } = {}
 ): MockStripeEvent<MockDispute> {
   const disputeId = options.disputeId ?? `dp_test_${Date.now()}`;
@@ -173,7 +183,8 @@ export function createDisputeCreatedEvent(
         status: 'needs_response',
         payment_intent: paymentIntentId,
         charge: chargeId,
-        metadata: {},
+        metadata:
+          options.app !== undefined ? { app: options.app } : { app: 'babylon' },
       },
     },
   };
@@ -189,6 +200,7 @@ export function createDisputeWonEvent(
     disputeId?: string;
     chargeId?: string;
     eventId?: string;
+    app?: string;
   } = {}
 ): MockStripeEvent<MockDispute> {
   const disputeId = options.disputeId ?? `dp_test_${Date.now()}`;
@@ -209,7 +221,8 @@ export function createDisputeWonEvent(
         status: 'won',
         payment_intent: paymentIntentId,
         charge: chargeId,
-        metadata: {},
+        metadata:
+          options.app !== undefined ? { app: options.app } : { app: 'babylon' },
       },
     },
   };
@@ -225,6 +238,7 @@ export function createDisputeLostEvent(
     disputeId?: string;
     chargeId?: string;
     eventId?: string;
+    app?: string;
   } = {}
 ): MockStripeEvent<MockDispute> {
   const event = createDisputeWonEvent(paymentIntentId, amountUSD, options);
@@ -243,6 +257,7 @@ export function createChargeRefundedEvent(
   options: {
     chargeId?: string;
     eventId?: string;
+    app?: string;
   } = {}
 ): MockStripeEvent<MockCharge> {
   const chargeId = options.chargeId ?? `ch_test_${Date.now()}`;
@@ -262,7 +277,8 @@ export function createChargeRefundedEvent(
         currency: 'usd',
         payment_intent: paymentIntentId,
         refunded: amountRefundedUSD === originalAmountUSD,
-        metadata: {},
+        metadata:
+          options.app !== undefined ? { app: options.app } : { app: 'babylon' },
       },
     },
   };


### PR DESCRIPTION
## Summary
<!-- 1–3 bullets: what changed + why (user impact / business goal). -->

- **Filter Stripe webhooks by app metadata** — We share one Stripe account between multiploe apps. All apps receive all webhook events. This PR tags every Stripe resource we create with `metadata.app = 'babylon'` and adds an early filter in the webhook handler so we only process events that belong to us (or have no tag, for backward compatibility with pre-existing resources).
- **Prevent cross-app side effects** — Without this, a checkout or refund from a seperate app could trigger points crediting/deduction in Babylon.

## Type
<!-- Helps triage + release notes. -->

- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
<!-- Link issues, Linear tickets, docs, prior PRs. -->

- All apps share a single Stripe account. Stripe delivers subscribed events to all configured webhook endpoints regardless of which app created the resource. This causes each app to process the other's events.

## Scope (keep it focused)
<!-- If you had to touch multiple areas, explain why and what you intentionally left out. -->

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

**Non-goals / follow-ups**
- The  codebases for other apps needs the same treatment (tag with `app: 'other-elizalabs-app` and filter for it). That is a separate PR in that repo.
- Backfilling `metadata.app` on existing Stripe resources (customers, sessions) created before this change. The filter allows untagged events through for backward compatibility, so this is not blocking.

## Changes
<!-- List the notable changes (what is new/removed/modified). Link key files if it helps. -->

**Part 1 — Tag Stripe resource creation (`1 line`)**
- `apps/web/src/app/api/stripe/checkout/session/route.ts` — Added `app: 'babylon'` to the `metadata` object in `stripe.checkout.sessions.create`. This is the only Stripe resource creation call in the codebase.

**Part 2 — Filter incoming webhooks (`~20 lines`)**
- `apps/web/src/app/api/stripe/webhook/route.ts` — After signature verification and before the event `switch`, added a metadata check:
  - Reads `event.data.object.metadata.app`, falling back to `event.data.object.subscription_details.metadata.app` (for events like `invoice.payment_succeeded` where metadata can be nested).
  - If `app` is present and ≠ `'babylon'`, returns `200 { received: true, ignored: true }` (so Stripe doesn't retry).
  - If `app` is absent, allows through (backward compat with pre-tagging resources).

**Part 3 — Tests (`~750 lines`)**
- `packages/testing/unit/stripe/test-fixtures.ts` — Added `app?: string` to `MockCheckoutSession.metadata`; all fixture factories now accept an `app` option and default to `'babylon'`.
- `packages/testing/unit/stripe/stripe-webhook-logic.test.ts` — Added `App Metadata Filtering` describe block: `extractAppMetadata` extraction tests, `shouldProcessForApp` logic tests, per-event-type filtering for all 7 handled webhook event types (babylon/eliza-cloud/no-tag), and response behavior assertions.
- `packages/testing/integration/stripe-webhook-handler.integration.test.ts` — Added app metadata filter to simulated `processWebhookEvent`; added `App Metadata Filtering` describe block with tests for babylon (processed), eliza-cloud (ignored with no side effects), backward compat (no tag), and `subscription_details` fallback.

## Review guide
<!-- Help reviewers go fast: where to start, what to ignore, tricky bits, key decisions. -->

**Start here**
- `apps/web/src/app/api/stripe/webhook/route.ts` — the core filter logic (~15 lines after signature verification)
- `apps/web/src/app/api/stripe/checkout/session/route.ts` — single-line metadata addition

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- The filter is intentionally permissive for events without `metadata.app` (backward compat). This means old Stripe resources still get processed. Once both apps are tagging and enough time has passed, we could tighten this to require the tag.
- The `subscription_details.metadata` fallback is defensive — we don't currently use subscriptions, but it handles Stripe's nesting for invoice events if we add them later.
- Webhook signature verification is untouched.

## Test plan
<!-- Tick what you ran. Add manual steps for anything user-facing. -->

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [x] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Unit tests: 128 pass, 0 fail (all Stripe unit test files)
2. New tests cover every handled event type × {babylon, eliza-cloud, no-tag} and the `subscription_details` fallback path

## Ops / Migration / Deployment
<!-- Anything that impacts deploys, data, cron, config, or rollouts. -->

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- None

**DB / data migration**
- None

**Rollout / rollback plan**
- Rollout: Deploy normally. Old untagged events continue to be processed (backward compat). New events are tagged and filtered.
- Rollback: Revert the commit. Untagged events still process fine; tagged events will also still process (the `app` key is just ignored metadata without the filter).

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy
<!-- Authn/authz, secrets handling, PII, prompt injection surfaces, etc. -->

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- Webhook response shape gains an optional `ignored: true` field for filtered events. No consumers depend on this.

### Database
- No changes.

### Contracts / on-chain
- No changes.

### Docs
- No changes.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend-only change — Stripe webhook handler and checkout session creation. No UI impact.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

