### PR TITLE
fix(agents): periodically refresh stale agent runtimes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -188,6 +188,10 @@ GAME_START=pause
 # Enable automatic trading for agents (default: false)
 AGENT_AUTO_TRADE=false
 
+# Runtime context refresh interval in hours (default: 48)
+# Long-lived runtimes are recycled at this interval to prevent context bloat.
+AGENT_CONTEXT_REFRESH_HOURS=48
+
 # ============================================================================
 # Logging Configuration (Optional)
 # ============================================================================

--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -8,7 +8,7 @@
  * This eliminates double LLM calls and makes execution faster.
  */
 
-import { actorState, chats, db, eq, users } from '@babylon/db';
+import { actorState, agentLogs, and, chats, db, desc, eq, users } from '@babylon/db';
 import { StaticDataRegistry, WalletService } from '@babylon/engine';
 import type { IAgentRuntime } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
@@ -207,6 +207,9 @@ export class MultiStepExecutor {
       }
     }
 
+    const contextRefreshSummary =
+      await this.getLatestContextRefreshSummary(agentUserId);
+
     // Main iteration loop
     for (let iteration = 1; iteration <= this.maxIterations; iteration++) {
       const iterationStartTime = Date.now();
@@ -232,7 +235,8 @@ export class MultiStepExecutor {
       const context = await this.gatherContext(
         agentUserId,
         effectiveFeatures,
-        isNpc
+        isNpc,
+        contextRefreshSummary
       );
       iterationTimings.gatherContext = Date.now() - contextStartTime;
 
@@ -360,7 +364,8 @@ export class MultiStepExecutor {
   private async gatherContext(
     agentUserId: string,
     enabledFeatures: string[],
-    isNpc: boolean
+    isNpc: boolean,
+    contextRefreshSummary?: string
   ): Promise<AgentTickContext> {
     const contextStartTime = Date.now();
     const timings: Record<string, number> = {};
@@ -522,6 +527,7 @@ export class MultiStepExecutor {
           pendingChatMessagesRaw: pendingChatMessagesRaw.length,
           groupChats: agentGroupChats.length,
           ownPosts: agentOwnPosts.length,
+          hasContextRefreshSummary: Boolean(contextRefreshSummary),
         },
       },
       'MultiStepExecutor'
@@ -546,6 +552,7 @@ export class MultiStepExecutor {
       postStyle: assignment?.postStyle,
       agentOwnPosts,
       creator,
+      contextRefreshSummary,
     };
   }
 
@@ -559,6 +566,43 @@ export class MultiStepExecutor {
     const start = Date.now();
     const data = await operation();
     return { data, duration: Date.now() - start };
+  }
+
+  private async getLatestContextRefreshSummary(
+    agentUserId: string
+  ): Promise<string | undefined> {
+    const recentSystemLogs = await db
+      .select({
+        createdAt: agentLogs.createdAt,
+        metadata: agentLogs.metadata,
+      })
+      .from(agentLogs)
+      .where(
+        and(eq(agentLogs.agentUserId, agentUserId), eq(agentLogs.type, 'system'))
+      )
+      .orderBy(desc(agentLogs.createdAt))
+      .limit(10);
+
+    for (const log of recentSystemLogs) {
+      const metadata =
+        log.metadata && typeof log.metadata === 'object' ? log.metadata : null;
+      const event =
+        metadata && 'event' in metadata ? metadata.event : undefined;
+      const summary =
+        metadata && 'summary' in metadata ? metadata.summary : undefined;
+
+      if (event !== 'context_refresh' || typeof summary !== 'string') {
+        continue;
+      }
+
+      if (!(log.createdAt instanceof Date)) {
+        return summary;
+      }
+
+      return `${summary} [recorded ${log.createdAt.toISOString()}]`;
+    }
+
+    return undefined;
   }
 
   private getActionabilitySummary(context: AgentTickContext): {

--- a/packages/agents/src/autonomous/templates/multi-step-decision.ts
+++ b/packages/agents/src/autonomous/templates/multi-step-decision.ts
@@ -348,6 +348,8 @@ export interface AgentTickContext {
   agentOwnPosts?: AgentOwnPostContext[];
   // Creator/owner info (for user-controlled agents)
   creator?: CreatorInfo;
+  // Continuity note persisted before runtime context refresh
+  contextRefreshSummary?: string;
 }
 
 export interface MultiStepDecision {
@@ -722,6 +724,13 @@ You were created by **${context.creator.name}**${context.creator.username ? ` (@
 `
       : '';
 
+  const continuitySection = context.contextRefreshSummary
+    ? `
+# Continuity Notes (Previous Runtime)
+${context.contextRefreshSummary}
+`
+    : '';
+
   return `You are ${agentName}, an autonomous agent on Babylon prediction markets.
 ${creatorSection}${npcContextSection}${tradePostEncouragement}# Current Execution Context
 **Step**: ${iterationCount}/${maxIterations}
@@ -734,6 +743,7 @@ ${creatorSection}${npcContextSection}${tradePostEncouragement}# Current Executio
 - Pending Comments: ${context.pendingCommentReplies.length}
 - Pending Chats: ${context.pendingChatMessages.length}
 ${actionabilitySection}
+${continuitySection}
 
 # Your Open Positions
 ${formatAgentPositions(context.agentPositions)}

--- a/packages/agents/src/runtime/AgentRuntimeManager.ts
+++ b/packages/agents/src/runtime/AgentRuntimeManager.ts
@@ -12,7 +12,17 @@
  * @packageDocumentation
  */
 
-import { db, eq, users } from '@babylon/db';
+import {
+  actorState,
+  agentLogs,
+  agentTrades,
+  and,
+  db,
+  desc,
+  eq,
+  gte,
+  users,
+} from '@babylon/db';
 import {
   type ActorData,
   loadActorById,
@@ -67,6 +77,26 @@ const globalRuntimes = new Map<string, AgentRuntime>();
 
 /** Global trajectory logger instances per agent */
 const trajectoryLoggers = new Map<string, TrajectoryLoggerService>();
+
+interface RuntimeLifecycleMetadata {
+  createdAtMs: number;
+  refreshCount: number;
+}
+
+/** Runtime lifecycle metadata used for periodic refresh decisions */
+const runtimeLifecycleMetadata = new Map<string, RuntimeLifecycleMetadata>();
+
+const DEFAULT_CONTEXT_REFRESH_HOURS = 48;
+const MS_PER_HOUR = 60 * 60 * 1000;
+const MAX_REFRESH_WINDOW_LOGS = 250;
+const MAX_REFRESH_WINDOW_TRADES = 250;
+const CONTEXT_REFRESH_INTERVAL_MS = (() => {
+  const configured = Number(process.env.AGENT_CONTEXT_REFRESH_HOURS ?? '');
+  if (Number.isFinite(configured) && configured > 0) {
+    return Math.floor(configured * MS_PER_HOUR);
+  }
+  return DEFAULT_CONTEXT_REFRESH_HOURS * MS_PER_HOUR;
+})();
 
 /** Pending runtime creation promises to prevent race conditions */
 const pendingRuntimePromises = new Map<string, Promise<AgentRuntime>>();
@@ -187,6 +217,184 @@ export class AgentRuntimeManager {
     return AgentRuntimeManager.instance;
   }
 
+  private shouldRefreshRuntime(createdAtMs: number): boolean {
+    return Date.now() - createdAtMs >= CONTEXT_REFRESH_INTERVAL_MS;
+  }
+
+  private async persistContextRefreshSummary(
+    agentUserId: string,
+    lifecycle: RuntimeLifecycleMetadata
+  ): Promise<void> {
+    const refreshEndedAt = new Date();
+    const refreshStartedAt = new Date(lifecycle.createdAtMs);
+
+    const [windowLogs, windowTrades, userSnapshot, npcSnapshot] =
+      await Promise.all([
+        db
+          .select({
+            type: agentLogs.type,
+            level: agentLogs.level,
+            createdAt: agentLogs.createdAt,
+          })
+          .from(agentLogs)
+          .where(
+            and(
+              eq(agentLogs.agentUserId, agentUserId),
+              gte(agentLogs.createdAt, refreshStartedAt)
+            )
+          )
+          .orderBy(desc(agentLogs.createdAt))
+          .limit(MAX_REFRESH_WINDOW_LOGS),
+        db
+          .select({
+            marketType: agentTrades.marketType,
+            action: agentTrades.action,
+            pnl: agentTrades.pnl,
+            executedAt: agentTrades.executedAt,
+          })
+          .from(agentTrades)
+          .where(
+            and(
+              eq(agentTrades.agentUserId, agentUserId),
+              gte(agentTrades.executedAt, refreshStartedAt)
+            )
+          )
+          .orderBy(desc(agentTrades.executedAt))
+          .limit(MAX_REFRESH_WINDOW_TRADES),
+        db
+          .select({
+            displayName: users.displayName,
+            virtualBalance: users.virtualBalance,
+            lifetimePnL: users.lifetimePnL,
+          })
+          .from(users)
+          .where(eq(users.id, agentUserId))
+          .limit(1),
+        db
+          .select({ tradingBalance: actorState.tradingBalance })
+          .from(actorState)
+          .where(eq(actorState.id, agentUserId))
+          .limit(1),
+      ]);
+
+    const actionCounts = {
+      ticks: 0,
+      trades: 0,
+      posts: 0,
+      comments: 0,
+      dms: 0,
+      likes: 0,
+      reposts: 0,
+      errors: 0,
+    };
+
+    for (const entry of windowLogs) {
+      if (entry.level === 'error') {
+        actionCounts.errors++;
+      }
+
+      switch (entry.type) {
+        case 'tick':
+          actionCounts.ticks++;
+          break;
+        case 'trade':
+          actionCounts.trades++;
+          break;
+        case 'post':
+          actionCounts.posts++;
+          break;
+        case 'comment':
+          actionCounts.comments++;
+          break;
+        case 'dm':
+          actionCounts.dms++;
+          break;
+        case 'like':
+          actionCounts.likes++;
+          break;
+        case 'repost':
+          actionCounts.reposts++;
+          break;
+        default:
+          break;
+      }
+    }
+
+    const closedTrades = windowTrades.filter((trade) => trade.pnl !== null);
+    const winningTrades = closedTrades.filter(
+      (trade) => Number(trade.pnl ?? 0) > 0
+    ).length;
+    const realizedPnl = Number(
+      closedTrades
+        .reduce((acc, trade) => acc + Number(trade.pnl ?? 0), 0)
+        .toFixed(2)
+    );
+    const runtimeAgeHours = Number(
+      ((refreshEndedAt.getTime() - lifecycle.createdAtMs) / MS_PER_HOUR).toFixed(
+        2
+      )
+    );
+
+    const user = userSnapshot[0];
+    const npc = npcSnapshot[0];
+    const balanceText = user
+      ? `$${Number(user.virtualBalance ?? 0).toFixed(2)} balance, lifetime PnL ${Number(user.lifetimePnL ?? 0) >= 0 ? '+' : ''}$${Number(user.lifetimePnL ?? 0).toFixed(2)}`
+      : npc
+        ? `$${Number(npc.tradingBalance ?? 0).toFixed(2)} NPC trading balance`
+        : 'balance unavailable';
+
+    const summary =
+      `Runtime refreshed after ${runtimeAgeHours}h. ` +
+      `Window activity: ${actionCounts.ticks} ticks, ${actionCounts.trades} logged trades, ` +
+      `${actionCounts.posts} posts, ${actionCounts.comments} comments, ${actionCounts.dms} DMs, ` +
+      `${actionCounts.likes + actionCounts.reposts} engagements. ` +
+      `Trade outcomes: ${windowTrades.length} trades, ${closedTrades.length} closed, ${winningTrades} wins, realized PnL ${realizedPnl >= 0 ? '+' : ''}$${Math.abs(realizedPnl).toFixed(2)}. ` +
+      `Current state: ${balanceText}.`;
+
+    const metadata: Record<string, JsonValue> = {
+      event: 'context_refresh',
+      summary,
+      refreshCount: lifecycle.refreshCount + 1,
+      refreshIntervalHours: Number(
+        (CONTEXT_REFRESH_INTERVAL_MS / MS_PER_HOUR).toFixed(2)
+      ),
+      runtimeAgeHours,
+      windowStart: refreshStartedAt.toISOString(),
+      windowEnd: refreshEndedAt.toISOString(),
+      actionCounts,
+      tradeStats: {
+        total: windowTrades.length,
+        closed: closedTrades.length,
+        wins: winningTrades,
+        realizedPnl,
+      },
+      accountState: {
+        displayName: user?.displayName ?? null,
+        balance: user
+          ? Number(user.virtualBalance ?? 0)
+          : npc
+            ? Number(npc.tradingBalance ?? 0)
+            : null,
+        lifetimePnl: user ? Number(user.lifetimePnL ?? 0) : null,
+      },
+      lastActionAt:
+        windowLogs[0]?.createdAt instanceof Date
+          ? windowLogs[0].createdAt.toISOString()
+          : null,
+      logsSampled: windowLogs.length,
+      tradesSampled: windowTrades.length,
+    };
+
+    await db.insert(agentLogs).values({
+      id: await generateSnowflakeId(),
+      agentUserId,
+      type: 'system',
+      level: 'info',
+      message: 'Context refresh checkpoint',
+      metadata,
+    });
+  }
+
   /**
    * Gets or creates a runtime for any agent type
    *
@@ -197,14 +405,64 @@ export class AgentRuntimeManager {
    * @returns Agent runtime instance
    */
   public async getRuntime(agentUserId: string): Promise<AgentRuntime> {
+    let refreshCount = 0;
+
     if (globalRuntimes.has(agentUserId)) {
-      const runtime = globalRuntimes.get(agentUserId)!;
+      const lifecycle = runtimeLifecycleMetadata.get(agentUserId);
+
+      if (!lifecycle) {
+        runtimeLifecycleMetadata.set(agentUserId, {
+          createdAtMs: Date.now(),
+          refreshCount: 0,
+        });
+        const runtime = globalRuntimes.get(agentUserId)!;
+        logger.info(
+          `Using cached runtime for agent ${agentUserId} (lifecycle initialized)`,
+          undefined,
+          'AgentRuntimeManager'
+        );
+        return runtime;
+      }
+
+      if (!this.shouldRefreshRuntime(lifecycle.createdAtMs)) {
+        const runtime = globalRuntimes.get(agentUserId)!;
+        logger.info(
+          `Using cached runtime for agent ${agentUserId}`,
+          undefined,
+          'AgentRuntimeManager'
+        );
+        return runtime;
+      }
+
+      refreshCount = lifecycle.refreshCount + 1;
+      const runtimeAgeHours = (
+        (Date.now() - lifecycle.createdAtMs) /
+        MS_PER_HOUR
+      ).toFixed(2);
+
       logger.info(
-        `Using cached runtime for agent ${agentUserId}`,
-        undefined,
+        `Refreshing runtime for agent ${agentUserId} after ${runtimeAgeHours}h`,
+        {
+          refreshIntervalHours: CONTEXT_REFRESH_INTERVAL_MS / MS_PER_HOUR,
+          refreshCount,
+        },
         'AgentRuntimeManager'
       );
-      return runtime;
+
+      try {
+        await this.persistContextRefreshSummary(agentUserId, lifecycle);
+      } catch (error) {
+        logger.warn(
+          'Failed to persist context refresh summary before runtime reset',
+          {
+            agentId: agentUserId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          'AgentRuntimeManager'
+        );
+      }
+
+      await this.clearRuntime(agentUserId);
     }
 
     const registration = await agentRegistry.getAgentById(agentUserId);
@@ -232,6 +490,10 @@ export class AgentRuntimeManager {
 
       // Cache runtime
       globalRuntimes.set(agentUserId, runtime);
+      runtimeLifecycleMetadata.set(agentUserId, {
+        createdAtMs: Date.now(),
+        refreshCount,
+      });
 
       // Use debug level for per-agent runtime creation to reduce startup noise
       logger.debug(
@@ -432,6 +694,10 @@ export class AgentRuntimeManager {
 
     // Cache runtime
     globalRuntimes.set(agentUserId, runtime);
+    runtimeLifecycleMetadata.set(agentUserId, {
+      createdAtMs: Date.now(),
+      refreshCount,
+    });
 
     // Use debug level for per-agent runtime creation to reduce startup noise
     logger.debug(
@@ -935,6 +1201,7 @@ export class AgentRuntimeManager {
     if (globalRuntimes.has(agentUserId)) {
       globalRuntimes.delete(agentUserId);
       trajectoryLoggers.delete(agentUserId);
+      runtimeLifecycleMetadata.delete(agentUserId);
 
       // Update registry status if agent exists in registry
       await agentRegistry.clearRuntimeInstance(agentUserId);
@@ -950,6 +1217,7 @@ export class AgentRuntimeManager {
   public clearAllRuntimes(): void {
     globalRuntimes.clear();
     trajectoryLoggers.clear();
+    runtimeLifecycleMetadata.clear();
     logger.info('All runtimes cleared', undefined, 'AgentRuntimeManager');
   }
 

--- a/packages/testing/unit/autonomous/context-refresh-continuity.test.ts
+++ b/packages/testing/unit/autonomous/context-refresh-continuity.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, mock, test } from 'bun:test';
+
+async function loadTemplateHelpers() {
+  mock.module('@babylon/engine', () => ({
+    NPC_POST_QUALITY_RULES: '',
+  }));
+
+  return import('../../../agents/src/autonomous/templates/multi-step-decision');
+}
+
+function createBaseContext(featuresTrading: string) {
+  return {
+    balance: 1000,
+    pnl: 120,
+    openPositions: 0,
+    pendingCommentReplies: [],
+    pendingChatMessages: [],
+    enabledFeatures: [featuresTrading],
+    predictionMarkets: [],
+    perpMarkets: [],
+    recentPosts: [],
+    agentPositions: {
+      predictions: [],
+      perps: [],
+    },
+  };
+}
+
+describe('MultiStep Prompt Context Refresh Continuity', () => {
+  test('includes continuity section when context refresh summary exists', async () => {
+    const { Features, buildMultiStepDecisionPrompt } =
+      await loadTemplateHelpers();
+
+    const prompt = buildMultiStepDecisionPrompt({
+      agentName: 'Agent Test',
+      iterationCount: 1,
+      maxIterations: 5,
+      traceActionResults: [],
+      context: {
+        ...createBaseContext(Features.TRADING),
+        contextRefreshSummary:
+          'Runtime refreshed after 48h. Keep trading thesis continuity.',
+      },
+      shareTradeRoll: 0.9,
+    });
+
+    expect(prompt).toContain('# Continuity Notes (Previous Runtime)');
+    expect(prompt).toContain(
+      'Runtime refreshed after 48h. Keep trading thesis continuity.'
+    );
+  });
+
+  test('omits continuity section when no refresh summary is present', async () => {
+    const { Features, buildMultiStepDecisionPrompt } =
+      await loadTemplateHelpers();
+
+    const prompt = buildMultiStepDecisionPrompt({
+      agentName: 'Agent Test',
+      iterationCount: 1,
+      maxIterations: 5,
+      traceActionResults: [],
+      context: createBaseContext(Features.TRADING),
+      shareTradeRoll: 0.9,
+    });
+
+    expect(prompt).not.toContain('# Continuity Notes (Previous Runtime)');
+  });
+});


### PR DESCRIPTION
## Summary

- Add periodic runtime context refresh for long-lived agent runtimes (default every 48 hours, configurable by env).
- Persist a pre-refresh continuity checkpoint to `AgentLog` (activity/trade summary + account state) before runtime recycle.
- Inject the latest refresh checkpoint into the autonomous decision prompt so agents keep continuity after runtime reset.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [x] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-193/agent-context-refresh-periodic-restart-to-prevent-trading-inactivity
- Related reference issue: https://linear.app/eliza-labs/issue/BF-86

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [x] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [x] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [x] Other: `.env.example`

## Changes

- Add runtime lifecycle metadata + TTL refresh logic in `AgentRuntimeManager`.
- Add `AGENT_CONTEXT_REFRESH_HOURS` support (default 48h fallback).
- Before runtime reset, compute a checkpoint summary from sampled `AgentLog` and `AgentTrade` activity and persist it as a system `AgentLog` entry (`event: context_refresh`).
- Clear and recreate stale runtimes transparently so autonomous ticks continue with a fresh runtime.
- Add continuity retrieval in `MultiStepExecutor` (`getLatestContextRefreshSummary`) and inject it into `AgentTickContext`.
- Render continuity section in `buildMultiStepDecisionPrompt` when present.
- Add unit test coverage for continuity section rendering.
- Document the new env var in `.env.example`.

## Review guide

**Start here**
- `packages/agents/src/runtime/AgentRuntimeManager.ts`
- `packages/agents/src/autonomous/MultiStepExecutor.ts`
- `packages/agents/src/autonomous/templates/multi-step-decision.ts`
- `packages/testing/unit/autonomous/context-refresh-continuity.test.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- The refresh path intentionally persists summary in `AgentLog` because Eliza memory is currently stubbed in runtime adapter.
- Continuity is lightweight prompt context; no schema migration required.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

Additional targeted checks executed:
- [x] `bunx biome check packages/agents/src/runtime/AgentRuntimeManager.ts packages/agents/src/autonomous/MultiStepExecutor.ts packages/agents/src/autonomous/templates/multi-step-decision.ts packages/testing/unit/autonomous/context-refresh-continuity.test.ts`
- [x] `bun test packages/testing/unit/autonomous/context-refresh-continuity.test.ts`

Attempted but blocked in local env:
- `bunx tsc --noEmit --project packages/agents/tsconfig.json` (missing `bun-types` in this environment)

**Manual verification**
1. Not run (backend/runtime logic only).

## Ops / Migration / Deployment

- [x] No deploy impact
- [x] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `AGENT_CONTEXT_REFRESH_HOURS` (optional, default 48)
- Changed: `…`
- Removed: `…`

**DB / data migration**
- Migration(s): none
- Backfill/seed: none

**Rollout / rollback plan**
- Rollout: deploy normally, optionally tune `AGENT_CONTEXT_REFRESH_HOURS`.
- Rollback: revert PR; runtime behavior returns to previous cache-without-refresh flow.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- N/A

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- No API contract changes.

### Database
- Writes additional `AgentLog` entries (`type=system`, `event=context_refresh`).

### Contracts / on-chain
- N/A.

### Docs
- `.env.example` updated for new optional runtime refresh env var.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend/runtime-only behavior change, no UI impact.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
