### PR TITLE
fix/on chain registration

### DIFF
--- a/packages/api/src/services/onchain-service.ts
+++ b/packages/api/src/services/onchain-service.ts
@@ -31,6 +31,7 @@ import {
 import {
   type Account,
   type Address,
+  type Chain,
   createPublicClient,
   createWalletClient,
   decodeEventLog,
@@ -40,7 +41,24 @@ import {
   type WalletClient,
 } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
-import { baseSepolia, foundry } from 'viem/chains';
+import { baseSepolia, foundry, mainnet } from 'viem/chains';
+
+/**
+ * Resolve the viem Chain object from a numeric chain ID.
+ * Used to ensure publicClient and walletClient use the correct chain configuration.
+ */
+function resolveViemChain(chainId: number): Chain {
+  switch (chainId) {
+    case 1:
+      return mainnet;
+    case 84532:
+      return baseSepolia;
+    case 31337:
+      return foundry;
+    default:
+      return baseSepolia;
+  }
+}
 import { sendSponsoredEvmTransaction } from './privy/evm-send-transaction';
 
 /**
@@ -351,7 +369,7 @@ export async function processOnchainRegistration({
 
   // Create publicClient at function scope for use throughout registration flow
   const publicClient = createPublicClient({
-    chain: isLocalNetwork ? foundry : baseSepolia,
+    chain: resolveViemChain(chainId),
     transport: http(getRpcUrl()),
   });
 
@@ -373,13 +391,17 @@ export async function processOnchainRegistration({
       contractCode && contractCode !== '0x' && contractCode.length > 2;
 
     if (!contractExists) {
-      // Contract not deployed yet - use database state
-      logger.warn(
-        'Identity registry contract not deployed yet, using database state',
+      // Contract not deployed at this address on this chain — abort registration
+      // This prevents sending transactions to a non-existent contract
+      logger.error(
+        'Identity registry contract not deployed — cannot register on-chain',
         { contractAddress: IDENTITY_REGISTRY, chainId },
         'processOnchainRegistration'
       );
-      isRegistered = dbUser.onChainRegistered && dbUser.nftTokenId !== null;
+      throw new BusinessLogicError(
+        `Identity registry contract is not deployed at ${IDENTITY_REGISTRY} on chain ${chainId}. On-chain registration is unavailable.`,
+        'CONTRACT_NOT_DEPLOYED'
+      );
     } else {
       // Contract exists - check blockchain for registration status
       isRegistered = await publicClient.readContract({
@@ -460,7 +482,7 @@ export async function processOnchainRegistration({
     deployerAccount = privateKeyToAccount(DEPLOYER_PRIVATE_KEY!);
     deployerWalletClient = createWalletClient({
       account: deployerAccount,
-      chain: isLocalNetwork ? foundry : baseSepolia,
+      chain: resolveViemChain(chainId),
       transport: http(getRpcUrl()),
     });
   }
@@ -1043,7 +1065,7 @@ export async function confirmOnchainProfileUpdate({
   const lowerWallet = walletAddress.toLowerCase();
   const chainId = Number(process.env.NEXT_PUBLIC_CHAIN_ID || 31337);
   const publicClient = createPublicClient({
-    chain: chainId === 31337 ? foundry : baseSepolia,
+    chain: resolveViemChain(chainId),
     transport: http(getRpcUrl()),
   });
 
@@ -1213,7 +1235,7 @@ export async function getOnchainRegistrationStatus(
   // On testnets/mainnet, verify against the chain
   if (!user.isAgent && userRecord.walletAddress && chainId !== 31337) {
     const publicClient = createPublicClient({
-      chain: baseSepolia,
+      chain: resolveViemChain(chainId),
       transport: http(getRpcUrl()),
     });
 

--- a/packages/api/src/services/onchain-service.ts
+++ b/packages/api/src/services/onchain-service.ts
@@ -59,6 +59,7 @@ function resolveViemChain(chainId: number): Chain {
       return baseSepolia;
   }
 }
+
 import { sendSponsoredEvmTransaction } from './privy/evm-send-transaction';
 
 /**

--- a/packages/contracts/src/deployment/addresses.ts
+++ b/packages/contracts/src/deployment/addresses.ts
@@ -10,7 +10,11 @@
  * @remarks Base mainnet support will be added when contracts are deployed.
  */
 
-import { getCurrentChainId, getCurrentRpcUrl } from '@babylon/shared';
+import {
+  getCurrentChainId,
+  getCurrentRpcUrl,
+  PUBLIC_CONFIG,
+} from '@babylon/shared';
 import type { Address } from 'viem';
 import baseSepoliaDeployment from '../../deployments/base-sepolia';
 import localDeployment from '../../deployments/local';
@@ -91,13 +95,37 @@ export function getContractAddresses(): DeployedContracts {
     };
   }
 
+  if (chainId === 1) {
+    // Ethereum Mainnet - identity & reputation contracts deployed, others not applicable
+    const ethContracts = PUBLIC_CONFIG.networks.ethereum.contracts;
+    return {
+      diamond: '0x0000000000000000000000000000000000000000' as Address,
+      babylonOracle: '0x0000000000000000000000000000000000000000' as Address,
+      predictionMarketFacet:
+        '0x0000000000000000000000000000000000000000' as Address,
+      identityRegistry: ethContracts.identityRegistry as Address,
+      reputationSystem: ethContracts.reputationSystem as Address,
+      chainId: 1,
+      network: 'ethereum',
+    };
+  }
+
   if (chainId === 8453) {
     throw new Error(
       'Base mainnet contracts are not yet deployed. Use localnet or base-sepolia.'
     );
   }
 
-  // Default to localnet for unknown chains
+  // Default to localnet for unknown chains (development only)
+  if (
+    process.env.NODE_ENV === 'production' ||
+    process.env.DEPLOYMENT_ENV === 'mainnet'
+  ) {
+    throw new Error(
+      `Unsupported chain ID ${chainId} in production. Supported: 1 (Ethereum), 84532 (Base Sepolia), 31337 (local).`
+    );
+  }
+
   return {
     diamond: localDeployment.contracts.diamond as Address,
     babylonOracle: localDeployment.contracts.babylonOracle as Address,

--- a/packages/shared/src/config/index.ts
+++ b/packages/shared/src/config/index.ts
@@ -65,12 +65,13 @@ export interface PublicConfig {
 
 export const PUBLIC_CONFIG = configData as PublicConfig;
 
-type NetworkId = 'local' | 'baseSepolia' | 'base';
+type NetworkId = 'local' | 'baseSepolia' | 'base' | 'ethereum';
 
 const CHAIN_ID_TO_NETWORK: Record<number, NetworkId> = {
   31337: 'local',
   84532: 'baseSepolia',
   8453: 'base',
+  1: 'ethereum',
 };
 
 export function getCurrentChainId(): number {
@@ -83,7 +84,7 @@ export function getCurrentChainId(): number {
   return 31337;
 }
 
-function getCurrentNetwork(): NetworkConfig {
+function getCurrentNetwork(): NetworkConfig | EthereumNetworkConfig {
   const networkId = CHAIN_ID_TO_NETWORK[getCurrentChainId()] || 'local';
   return PUBLIC_CONFIG.networks[networkId];
 }
@@ -94,15 +95,17 @@ function getCurrentNetwork(): NetworkConfig {
 
 export function getCurrentContractAddresses():
   | CoreContractAddresses
-  | LocalContractAddresses {
+  | LocalContractAddresses
+  | EthereumContractAddresses {
   return getCurrentNetwork().contracts;
 }
 
 export function areContractsDeployed(chainId: number): boolean {
   const networkId = CHAIN_ID_TO_NETWORK[chainId] || 'local';
-  const contracts = PUBLIC_CONFIG.networks[networkId].contracts;
+  const network = PUBLIC_CONFIG.networks[networkId];
   return (
-    contracts.identityRegistry !== '0x0000000000000000000000000000000000000000'
+    network.contracts.identityRegistry !==
+    '0x0000000000000000000000000000000000000000'
   );
 }
 


### PR DESCRIPTION
## Problem

All non-agent users in production are unable to complete on-chain registration. The UI shows "Registering on-chain..." followed by "Registration Failed — An unexpected error occurred". Out of 14 elizalabs.ai team accounts, only 1 (registered months ago) has `onChainRegistered = true`.

### Vercel error logs

```
[sendSponsoredEvmTransaction] [ERROR] Failed to submit offline sponsored transaction
  {"caip2":"eip155:1","chainId":1,"walletId":"...","to":"0x0B306BF915C4d645ff596e518fAf3F9669b97016",
   "errorMessage":"400 Transaction confirmation timeout - the operation may still be pending on the network"}

[processOnchainRegistration] [WARN] Identity registry contract not deployed yet, using database state
  {"contractAddress":"0x0B306BF915C4d645ff596e518fAf3F9669b97016","chainId":1}

[ERROR] WaitForTransactionReceiptTimeoutError: Timed out while waiting for transaction with hash "0xbdadc34f..." to be confirmed.
```

## Root Cause

Three compounding bugs in the chain configuration:

### 1. `getContractAddresses()` returns local Hardhat addresses for chain ID 1

Production has `NEXT_PUBLIC_CHAIN_ID=1` (Ethereum mainnet), but `getContractAddresses()` only handled chain IDs 31337, 84532, and 8453. Chain ID 1 fell through to the **default case**, which returned **local Hardhat deployment addresses** — specifically `0x0B306BF915C4d645ff596e518fAf3F9669b97016` for the identity registry, an address with no contract on Ethereum mainnet.

The real Ethereum mainnet identity registry is at `0x8004A169FB4a3325136EB29fA0ceB6D2e539a432` (defined in `public-config.json` but never wired up).

### 2. `processOnchainRegistration` hardcodes `baseSepolia` chain

The viem `publicClient` was created with `chain: baseSepolia` for all non-local environments. Combined with `NEXT_PUBLIC_RPC_URL=https://sepolia.base.org` in Vercel, this meant:

- Privy sends the sponsored transaction on **Ethereum mainnet** (chain 1)
- `waitForTransactionReceipt` polls on **Base Sepolia** (chain 84532)
- The receipt is never found → 3-minute timeout → error

### 3. No guard when contract doesn't exist

When `getCode()` returned empty (the Hardhat address has no contract on mainnet), the code logged a warning but **still proceeded** to send a transaction to the empty address, wasting gas and causing timeouts.

## Changes

### `packages/shared/src/config/index.ts`
- Added `'ethereum'` to `NetworkId` type
- Added `1: 'ethereum'` to `CHAIN_ID_TO_NETWORK` so `getCurrentRpcUrl()` correctly resolves to the Ethereum mainnet RPC from `public-config.json`

### `packages/contracts/src/deployment/addresses.ts`
- Added chain ID 1 case returning real Ethereum mainnet contract addresses (`identityRegistry: 0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`, `reputationSystem: 0x8004BAa17C55a88189AE136b182e5fdA19dE9b63`)
- Added a safety throw for unknown chain IDs in production to prevent silently falling back to local addresses

### `packages/api/src/services/onchain-service.ts`
- Added `resolveViemChain()` helper that maps chain IDs → viem chain objects (mainnet, baseSepolia, foundry)
- Replaced all 5 hardcoded `baseSepolia` references with dynamic `resolveViemChain(chainId)`
- Added guard: when `getCode()` returns empty (contract not deployed), the function now **throws a `BusinessLogicError`** instead of silently proceeding

## Required Vercel Change

`NEXT_PUBLIC_RPC_URL` is currently set to `https://sepolia.base.org` (Base Sepolia testnet) in the Vercel production environment. This must be either:
- **Removed** — the code will now resolve to `https://eth.llamarpc.com` from `public-config.json`
- **Changed** to an Ethereum mainnet RPC URL

## Follow-up

`packages/api/src/services/reputation-service.ts` also hardcodes `baseSepolia` chain and `REPUTATION_SYSTEM_BASE_SEPOLIA` address. This will need a similar fix for post-market reputation updates to work on chain 1, but it does not block the registration flow.

