### PR TITLE
fix(api): fail fast on unsupported onchain chain ids

### DIFF
--- a/packages/api/src/services/onchain-service.ts
+++ b/packages/api/src/services/onchain-service.ts
@@ -56,7 +56,10 @@ function resolveViemChain(chainId: number): Chain {
     case 31337:
       return foundry;
     default:
-      return baseSepolia;
+      throw new BusinessLogicError(
+        `Unsupported chain ID for on-chain registration: ${chainId}`,
+        'UNSUPPORTED_CHAIN'
+      );
   }
 }
 


### PR DESCRIPTION
## Summary

- Prevent silent fallback to Base Sepolia when `NEXT_PUBLIC_CHAIN_ID` is unsupported in on-chain registration flows.
- Make chain resolution fail fast with a clear `BusinessLogicError` (`UNSUPPORTED_CHAIN`) to avoid running registration logic against the wrong chain config.
- Keep behavior unchanged for supported chain IDs (`1`, `84532`, `31337`).

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Follow-up to merged PR #1111 (`fix/on chain registration`).
- Goal: close remaining minor safety gap in chain mapping logic.

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- Updated `resolveViemChain(chainId)` in `packages/api/src/services/onchain-service.ts`:
  - before: unknown chain IDs silently returned `baseSepolia`
  - after: unknown chain IDs throw `BusinessLogicError('UNSUPPORTED_CHAIN')`

## Review guide

**Start here**
- `packages/api/src/services/onchain-service.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- This is intentionally minimal and isolated.
- Non-goal: broader chain support expansion.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Not executed in this ephemeral worktree because local dependency installation failed (`bun install` returned `EDQUOT`).
2. Logic-only validation performed by code inspection of affected call sites.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `none`
- Changed: `none`
- Removed: `none`

**DB / data migration**
- Migration(s): `none`
- Backfill/seed: `none`

**Rollout / rollback plan**
- Rollout: normal deploy
- Rollback: revert this PR

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- n/a

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- No API shape change.

### Database
- No DB impact.

### Contracts / on-chain
- No contract change; runtime safety behavior only.

### Docs
- No docs update required.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend/service logic only, no UI impact.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
