### PR TITLE
fix(web): move to server-first offline wallet provisioning

### DIFF
--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -837,7 +837,10 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     !!clientEmbeddedWalletAddress &&
     clientEmbeddedWalletAddress !== dbWalletLower;
   const shouldEnsureOfflineWallet =
-    !dbWalletLower || !dbUser.privyWalletId || shouldResyncWallet;
+    !dbWalletLower ||
+    !dbUser.privyWalletId ||
+    !dbUser.offlineWalletReady ||
+    shouldResyncWallet;
 
   if (shouldEnsureOfflineWallet) {
     try {

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -211,11 +211,7 @@ export function useAuth(): UseAuthReturn {
           ? `/api/users/me?ref=${encodeURIComponent(referralCode)}`
           : '/api/users/me';
 
-        const response = await apiFetch(url, {
-          headers: wallet?.address
-            ? { 'x-embedded-wallet-address': wallet.address.toLowerCase() }
-            : undefined,
-        });
+        const response = await apiFetch(url);
 
         // 401 is expected when not authenticated - exit early without error
         if (response.status === 401) {

--- a/packages/shared/src/auth/privy-config.ts
+++ b/packages/shared/src/auth/privy-config.ts
@@ -64,7 +64,7 @@ const loginMethodsAndOrder: NonNullable<
 };
 
 const embeddedWallets: NonNullable<BabylonPrivyConfig['embeddedWallets']> = {
-  ethereum: { createOnLogin: 'users-without-wallets' },
+  ethereum: { createOnLogin: 'off' },
 };
 
 const externalWallets: BabylonPrivyConfig['externalWallets'] = (() => {


### PR DESCRIPTION
## Summary
- disable Privy client auto-create wallet on login (embeddedWallets.ethereum.createOnLogin = off)
- stop sending x-embedded-wallet-address from the client on /api/users/me
- ensure /api/users/me attempts offline wallet provisioning when offlineWalletReady is false, so existing users with non-compatible wallets are rotated to an offline-ready wallet and DB is updated

## Why
We want a single server-side source of truth for wallet provisioning used by offline actions. Client-side wallet hints and login auto-creation were adding mismatch noise and architecture confusion.

## Testing
- bun test packages/api/src/services/privy/__tests__/offline-wallet-provisioning.test.ts
- bun test packages/shared/src/auth/__tests__/privy-config.test.ts
- bun run check

## Screenshots / Recordings
- N/A (backend/config change)

## Rollout notes
- monitor /api/users/me logs after deploy for offline provisioning diagnostics
- existing users with offlineWalletReady=false will be repaired on next /api/users/me fetch