### PR TITLE
fix(api): ignore non-target events when parsing registration receipt

### DIFF
--- a/packages/api/src/services/onchain-service.ts
+++ b/packages/api/src/services/onchain-service.ts
@@ -747,20 +747,25 @@ export async function processOnchainRegistration({
     if (log.topics.length === 0) {
       return false;
     }
-    const decodedLog = decodeEventLog({
-      abi: usesAgent0MainnetRegistry
-        ? agent0IdentityRegistryAbi
-        : identityRegistryAbi,
-      data: log.data,
-      topics: log.topics,
-      strict: false,
-    });
-    logger.info(
-      'Decoded log event',
-      { eventName: decodedLog.eventName },
-      'processOnchainRegistration'
-    );
-    return decodedLog.eventName === targetRegistrationEvent;
+    try {
+      const decodedLog = decodeEventLog({
+        abi: usesAgent0MainnetRegistry
+          ? agent0IdentityRegistryAbi
+          : identityRegistryAbi,
+        data: log.data,
+        topics: log.topics,
+        strict: false,
+      });
+      logger.info(
+        'Decoded log event',
+        { eventName: decodedLog.eventName },
+        'processOnchainRegistration'
+      );
+      return decodedLog.eventName === targetRegistrationEvent;
+    } catch {
+      // Ignore logs for events not present in the selected ABI (e.g. ERC-721 Transfer).
+      return false;
+    }
   });
 
   if (!agentRegisteredLog) {


### PR DESCRIPTION
## Summary

- Fix production failure in `/api/users/onboarding/onchain` after successful tx submission on mainnet.
- Ignore non-target contract events while scanning receipt logs for registration event.
- Prevent `AbiEventSignatureNotFoundError` when receipt includes ERC-721 `Transfer` or other non-selected ABI events.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [x] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Follow-up to #1117.
- Production error: `AbiEventSignatureNotFoundError` on signature `0xddf252ad...` (ERC-721 Transfer) during registration receipt parsing.

## Changes

- `packages/api/src/services/onchain-service.ts`
  - Wrap `decodeEventLog(...)` in receipt scan with `try/catch`.
  - Return `false` for logs that cannot be decoded with the selected ABI.
  - Continue scanning until `Registered` / `AgentRegistered` is found.

## Risk

- [x] Low
- [ ] Medium
- [ ] High

## Test plan

- [x] `bun run typecheck`
- [x] `bun run check`

Manual:
1. Trigger `/api/users/onboarding/onchain` on prod-like mainnet config.
2. Confirm tx is sent and receipt parsing no longer crashes on `Transfer` event.
3. Confirm registration returns success and DB is updated.

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: backend/API-only fix.
