### PR TITLE
fix: prevent first-call onchain onboarding nftTokenId conflict

### DIFF
--- a/packages/api/src/services/onchain-service.ts
+++ b/packages/api/src/services/onchain-service.ts
@@ -72,6 +72,10 @@ const agent0IdentityRegistryAbi = parseAbi([
   'event Registered(uint256 indexed agentId, string tokenURI, address indexed owner)',
 ]);
 
+const erc721OwnershipAbi = parseAbi([
+  'function ownerOf(uint256 tokenId) external view returns (address)',
+]);
+
 /**
  * OnboardingServices interface for dependency injection
  *
@@ -831,6 +835,73 @@ export async function processOnchainRegistration({
       { userId: dbUser.id },
       'OnboardingOnchain'
     );
+  }
+
+  if (tokenId > 0) {
+    const [conflictingUser] = await db
+      .select({
+        id: users.id,
+        walletAddress: users.walletAddress,
+        onChainRegistered: users.onChainRegistered,
+        agent0TokenId: users.agent0TokenId,
+      })
+      .from(users)
+      .where(
+        and(eq(users.nftTokenId, tokenId), sql`${users.id} <> ${dbUser.id}`)
+      )
+      .limit(1);
+
+    if (conflictingUser) {
+      const onchainOwner = (
+        await publicClient.readContract({
+          address: IDENTITY_REGISTRY,
+          abi: erc721OwnershipAbi,
+          functionName: 'ownerOf',
+          args: [BigInt(tokenId)],
+        })
+      ).toLowerCase();
+      const expectedOwner = registrationAddress.toLowerCase();
+
+      if (onchainOwner !== expectedOwner) {
+        throw new BusinessLogicError(
+          'On-chain token ownership mismatch during registration sync',
+          'TOKEN_OWNERSHIP_MISMATCH',
+          {
+            tokenId,
+            expectedOwner,
+            onchainOwner,
+            conflictingUserId: conflictingUser.id,
+            conflictingWalletAddress: conflictingUser.walletAddress,
+          }
+        );
+      }
+
+      await db
+        .update(users)
+        .set({
+          nftTokenId: null,
+          ...(usesAgent0MainnetRegistry &&
+          conflictingUser.agent0TokenId === tokenId
+            ? { agent0TokenId: null }
+            : {}),
+          onChainRegistered: false,
+          updatedAt: new Date(),
+        })
+        .where(eq(users.id, conflictingUser.id));
+
+      logger.warn(
+        'Cleared stale nftTokenId assignment before syncing registration',
+        {
+          tokenId,
+          currentUserId: dbUser.id,
+          currentWalletAddress: registrationAddress,
+          conflictingUserId: conflictingUser.id,
+          conflictingWalletAddress: conflictingUser.walletAddress,
+          conflictingWasRegistered: conflictingUser.onChainRegistered,
+        },
+        'OnboardingOnchain'
+      );
+    }
   }
 
   await db

--- a/packages/testing/unit/AutomationPipeline.test.ts
+++ b/packages/testing/unit/AutomationPipeline.test.ts
@@ -5,8 +5,8 @@
  */
 
 import { beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
-import * as actualDbModule from '../../db/src/index';
 import * as actualFsPromises from 'node:fs/promises';
+import * as actualDbModule from '../../db/src/index';
 
 // Tests use mocked db module
 const describeTests = describe;


### PR DESCRIPTION
## Summary
- prevent first onboarding call from failing with 500 when a freshly minted tokenId is still linked to another user row
- verify on-chain owner for conflicting tokenId before clearing stale DB assignment
- keep update idempotent so retry is no longer required for new users

## Notes
- includes biome formatting changes from pre-commit
- excludes reconciliation/backfill script work (kept for separate PR)