### PR TITLE
fix: avoid first-call 500 when onboarding services singleton is uninitialized

### DIFF
--- a/packages/api/src/services/onchain-service.ts
+++ b/packages/api/src/services/onchain-service.ts
@@ -64,7 +64,10 @@ function resolveViemChain(chainId: number): Chain {
   }
 }
 
+import { notifyNewAccount } from './notification-service';
+import { PointsService } from './points-service';
 import { sendSponsoredEvmTransaction } from './privy/evm-send-transaction';
+import { getOrCreateReferralCode } from './referral-service';
 
 const agent0IdentityRegistryAbi = parseAbi([
   'function balanceOf(address owner) external view returns (uint256)',
@@ -109,17 +112,35 @@ type OnboardingServices = {
 };
 
 let onboardingServicesInstance: OnboardingServices | null = null;
+let onboardingServicesFallbackLogged = false;
 
 export function setOnboardingServices(services: OnboardingServices): void {
   onboardingServicesInstance = services;
 }
 
 function getOnboardingServices(): OnboardingServices {
-  if (!onboardingServicesInstance) {
-    throw new Error(
-      'OnboardingServices not initialized. Call setOnboardingServices() first.'
-    );
+  if (onboardingServicesInstance) {
+    return onboardingServicesInstance;
   }
+
+  if (!onboardingServicesFallbackLogged) {
+    logger.warn(
+      'OnboardingServices not explicitly initialized, using default service bindings',
+      undefined,
+      'OnboardingOnchain'
+    );
+    onboardingServicesFallbackLogged = true;
+  }
+
+  onboardingServicesInstance = {
+    notifyNewAccount,
+    pointsService: {
+      awardReferralSignup: PointsService.awardReferralSignup,
+      awardPoints: PointsService.awardPoints,
+    },
+    getOrCreateReferralCode,
+  };
+
   return onboardingServicesInstance;
 }
 


### PR DESCRIPTION
## Summary
- stop throwing when `OnboardingServices` singleton is not initialized in serverless runtime
- add safe default service bindings in `onchain-service` using existing implementations:
  - `PointsService`
  - `notifyNewAccount`
  - `getOrCreateReferralCode`
- preserve explicit `setOnboardingServices` override behavior

## Why
- production first onboarding call can fail with:
  - `OnboardingServices not initialized. Call setOnboardingServices() first.`
- second retry succeeds because user is already on-chain by then

## Scope
- single-file fix in `packages/api/src/services/onchain-service.ts`
- no build changes
