### PR TITLE
Fix cross-suite cron mock collisions in unit tests

### DIFF
--- a/packages/testing/unit/auth/siwe.test.ts
+++ b/packages/testing/unit/auth/siwe.test.ts
@@ -4,40 +4,7 @@
  * Tests for nonce generation, consumption, and SIWE message verification.
  */
 
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import * as actualRedisClientModule from '../../../api/src/redis/client';
-import * as actualSharedModule from '../../../shared/src/index';
-
-// Mock Redis before importing siwe module
-const mockRedis = {
-  setex: mock(() => Promise.resolve('OK')),
-  del: mock(() => Promise.resolve(1)),
-};
-
-let mockSnowflakeCounter = 0;
-
-const nextMockSnowflakeId = (): string => {
-  mockSnowflakeCounter += 1;
-  return `mock-snowflake-${Date.now()}-${mockSnowflakeCounter}`;
-};
-
-mock.module('../../../api/src/redis/client', () => ({
-  ...actualRedisClientModule,
-  getRedis: () => mockRedis,
-  getRedisClient: () => mockRedis,
-}));
-
-// Keep full shared export surface and override only test-specific pieces.
-mock.module('@babylon/shared', () => ({
-  ...actualSharedModule,
-  generateSnowflakeId: async () => nextMockSnowflakeId(),
-  logger: {
-    debug: () => {},
-    info: () => {},
-    warn: () => {},
-    error: () => {},
-  },
-}));
+import { describe, expect, test } from 'bun:test';
 
 // Import after mocks
 const {
@@ -50,11 +17,6 @@ const {
 } = await import('../../../api/src/auth/siwe');
 
 describe('SIWE Authentication', () => {
-  beforeEach(() => {
-    mockRedis.setex.mockClear();
-    mockRedis.del.mockClear();
-  });
-
   describe('getExpectedDomain', () => {
     test('returns localhost for development', () => {
       const originalEnv = process.env.NEXT_PUBLIC_APP_URL;
@@ -131,30 +93,25 @@ describe('SIWE Authentication', () => {
       expect(diffMinutes).toBeCloseTo(5, 0);
     });
 
-    test('stores nonce in Redis', async () => {
-      await generateNonce();
+    test('nonce can be consumed exactly once', async () => {
+      const { nonce } = await generateNonce();
 
-      expect(mockRedis.setex).toHaveBeenCalledTimes(1);
-      expect(mockRedis.setex).toHaveBeenCalledWith(
-        expect.stringMatching(/^siwe:nonce:/),
-        300,
-        '1'
-      );
+      const firstConsume = await consumeNonce(nonce);
+      const secondConsume = await consumeNonce(nonce);
+
+      expect(firstConsume).toBe(true);
+      expect(secondConsume).toBe(false);
     });
   });
 
   describe('consumeNonce', () => {
-    test('returns true when nonce exists in Redis', async () => {
-      mockRedis.del.mockImplementation(() => Promise.resolve(1));
-
-      const result = await consumeNonce('testnonce');
+    test('returns true when nonce exists', async () => {
+      const { nonce } = await generateNonce();
+      const result = await consumeNonce(nonce);
       expect(result).toBe(true);
-      expect(mockRedis.del).toHaveBeenCalledWith('siwe:nonce:testnonce');
     });
 
     test('returns false when nonce does not exist', async () => {
-      mockRedis.del.mockImplementation(() => Promise.resolve(0));
-
       const result = await consumeNonce('nonexistentnonce');
       expect(result).toBe(false);
     });
@@ -213,8 +170,6 @@ describe('SIWE Authentication', () => {
     });
 
     test('returns invalid_nonce when nonce not found', async () => {
-      mockRedis.del.mockImplementation(() => Promise.resolve(0));
-
       const message = createSiweMessage({
         address: '0x1234567890123456789012345678901234567890',
         nonce: 'invalidnonce789',
@@ -229,10 +184,9 @@ describe('SIWE Authentication', () => {
     });
 
     test('returns expired_message when message is expired', async () => {
-      mockRedis.del.mockImplementation(() => Promise.resolve(1));
-
       const { SiweMessage } = await import('siwe');
       const { privateKeyToAccount } = await import('viem/accounts');
+      const { nonce } = await generateNonce();
 
       const account = privateKeyToAccount(`0x${'1'.repeat(64)}`);
       const expiredMessage = new SiweMessage({
@@ -242,7 +196,7 @@ describe('SIWE Authentication', () => {
         uri: getAppUrl(),
         version: '1',
         chainId: 1,
-        nonce: 'validnonce123',
+        nonce,
         issuedAt: new Date(Date.now() - 10_000).toISOString(),
         expirationTime: new Date(Date.now() - 1_000).toISOString(),
       });

--- a/packages/testing/unit/auth/siwe.test.ts
+++ b/packages/testing/unit/auth/siwe.test.ts
@@ -5,6 +5,8 @@
  */
 
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as actualRedisClientModule from '../../../api/src/redis/client';
+import * as actualSharedModule from '../../../shared/src/index';
 
 // Mock Redis before importing siwe module
 const mockRedis = {
@@ -12,12 +14,23 @@ const mockRedis = {
   del: mock(() => Promise.resolve(1)),
 };
 
+let mockSnowflakeCounter = 0;
+
+const nextMockSnowflakeId = (): string => {
+  mockSnowflakeCounter += 1;
+  return `mock-snowflake-${Date.now()}-${mockSnowflakeCounter}`;
+};
+
 mock.module('../../../api/src/redis/client', () => ({
+  ...actualRedisClientModule,
   getRedis: () => mockRedis,
+  getRedisClient: () => mockRedis,
 }));
 
-// Mock logger
+// Keep full shared export surface and override only test-specific pieces.
 mock.module('@babylon/shared', () => ({
+  ...actualSharedModule,
+  generateSnowflakeId: async () => nextMockSnowflakeId(),
   logger: {
     debug: () => {},
     info: () => {},

--- a/packages/testing/unit/cron/article-tick.test.ts
+++ b/packages/testing/unit/cron/article-tick.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { NextRequest } from 'next/server';
 
 /**
@@ -25,12 +25,48 @@ interface SqlCondition {
   sql?: string;
 }
 
-// Mock db with a mutable state we can control in tests
-let mockGame: MockGame | null = null;
-let mockArticleCount = 0;
+interface CronMockState {
+  articleGame: MockGame | null;
+  articleCount: number;
+  articleCronAuthResult: boolean;
+  articleCoveredEventIds: Set<string>;
+  marketsGame: MockGame | null;
+  marketsActiveQuestions: Array<{
+    id: string;
+    questionNumber: number;
+    resolutionDate: Date;
+    status: string;
+  }>;
+  marketsWorldEvents: Array<{
+    id: string;
+    timestamp: Date;
+    description: string;
+  }>;
+  marketsCronAuthResult: boolean;
+  marketsAcquireLockResult: boolean;
+}
 
-// Mock auth state for negative-path testing
-let mockCronAuthResult = true;
+const CRON_MOCK_STATE_KEY = '__babylonCronMockState';
+
+type GlobalWithCronMockState = typeof globalThis & {
+  [CRON_MOCK_STATE_KEY]?: CronMockState;
+};
+
+const globalWithCronMockState = globalThis as GlobalWithCronMockState;
+
+const cronMockState =
+  globalWithCronMockState[CRON_MOCK_STATE_KEY] ??
+  (globalWithCronMockState[CRON_MOCK_STATE_KEY] = {
+    articleGame: null,
+    articleCount: 0,
+    articleCronAuthResult: true,
+    articleCoveredEventIds: new Set<string>(),
+    marketsGame: null,
+    marketsActiveQuestions: [],
+    marketsWorldEvents: [],
+    marketsCronAuthResult: true,
+    marketsAcquireLockResult: true,
+  });
 
 // Create query builder for Drizzle-style operations
 // The resultFn is called at query execution time to get the current mock state
@@ -60,142 +96,280 @@ const createQueryBuilder = (
   return builder;
 };
 
-// Mock @babylon/db - uses resultFn pattern for dynamic state evaluation
-mock.module('@babylon/db', () => ({
-  db: {
-    select: mock(() => createQueryBuilder(() => (mockGame ? [mockGame] : []))),
-    insert: mock(() =>
-      createQueryBuilder(() => [{ id: `mock-${Date.now()}` }])
-    ),
-    update: mock(() => createQueryBuilder(() => [{ id: 'mock-updated' }])),
-    delete: mock(() => createQueryBuilder(() => [{ id: 'mock-deleted' }])),
-  },
-  games: {},
-  posts: { type: 'type', timestamp: 'timestamp', deletedAt: 'deletedAt' },
-  eq: (): SqlCondition => ({}),
-  gte: (): SqlCondition => ({}),
-  and: (): SqlCondition => ({}),
-  isNull: (): SqlCondition => ({}),
-  sql: (): SqlCondition => ({}),
-  // Use real generateSnowflakeId from @babylon/shared to avoid polluting other tests
-  generateSnowflakeId: async () => {
-    const { generateSnowflakeId } = await import('@babylon/shared');
-    return generateSnowflakeId();
-  },
-}));
-
-// Mock @babylon/api - uses mutable state for auth and game cache
-mock.module('@babylon/api', () => ({
-  verifyCronAuth: () => mockCronAuthResult,
-  relayCronToStaging: async () => ({ forwarded: false }),
-  getCacheOrFetch: async <T>(_key: string, fn: () => Promise<T>) => {
-    // For game state cache, return our mockGame
-    if (_key === 'continuous-game') {
-      return mockGame as T;
-    }
-    return fn();
-  },
-  recordCronExecution: () => {},
-  DistributedLockService: {
-    acquireLock: async () => true,
-    releaseLock: async () => {},
-  },
-}));
-
-// Mock @babylon/engine - articleRateLimiter uses mockArticleCount
-mock.module('@babylon/engine', () => ({
-  articleRateLimiter: {
-    canGenerateArticle: async () => ({
-      allowed: mockArticleCount < 2,
-      currentCount: mockArticleCount,
-      maxAllowed: 2,
-      remaining: Math.max(0, 2 - mockArticleCount),
-    }),
-  },
-  ArticleGenerator: class {
-    generateArticleForQuestion = async () => ({
-      // Complete Article interface with all required fields
-      id: `mock-article-${Date.now()}`,
-      title: 'Test Article',
-      summary: 'Test summary',
-      content: 'Test content that is long enough to pass validation. '.repeat(
-        20
+const registerMocks = () => {
+  // Mock @babylon/db - uses resultFn pattern for dynamic state evaluation
+  mock.module('@babylon/db', () => ({
+    db: {
+      select: mock(() =>
+        createQueryBuilder(() =>
+          cronMockState.articleGame ? [cronMockState.articleGame] : []
+        )
       ),
-      authorOrgId: 'org-1',
-      authorOrgName: 'Test News',
-      byline: 'Test Author',
-      bylineActorId: 'actor-1',
-      biasScore: 0,
-      sentiment: 'neutral' as const,
-      slant: 'Neutral coverage',
-      relatedEventId: 'event-1',
-      relatedActorIds: [],
-      relatedOrgIds: ['org-1'],
-      category: 'news',
-      tags: ['test', 'article'],
-      publishedAt: new Date(),
-    });
-  },
-  BabylonLLMClient: {
-    forGameTick: () => ({
-      generateJSON: async () => ({
+      insert: mock(() =>
+        createQueryBuilder(() => [{ id: `mock-${Date.now()}` }])
+      ),
+      update: mock(() => createQueryBuilder(() => [{ id: 'mock-updated' }])),
+      delete: mock(() => createQueryBuilder(() => [{ id: 'mock-deleted' }])),
+    },
+    games: {
+      _tableName: 'games',
+      id: 'id',
+      isRunning: 'isRunning',
+      isContinuous: 'isContinuous',
+      currentDay: 'currentDay',
+    },
+    questions: {
+      _tableName: 'questions',
+      status: 'status',
+      resolutionDate: 'resolutionDate',
+      id: 'id',
+      questionNumber: 'questionNumber',
+    },
+    timeframedMarkets: { _tableName: 'timeframedMarkets' },
+    worldEvents: { _tableName: 'worldEvents', timestamp: 'timestamp' },
+    posts: {
+      _tableName: 'posts',
+      type: 'type',
+      timestamp: 'timestamp',
+      deletedAt: 'deletedAt',
+    },
+    eq: (): SqlCondition => ({}),
+    gte: (): SqlCondition => ({}),
+    lte: (): SqlCondition => ({}),
+    and: (): SqlCondition => ({}),
+    desc: (): SqlCondition => ({}),
+    isNull: (): SqlCondition => ({}),
+    isNotNull: (): SqlCondition => ({}),
+    sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+      sql: strings.join('?'),
+      values,
+    }),
+    max: (col: unknown) => ({ _aggregation: 'max', column: col }),
+    // Use real generateSnowflakeId from @babylon/shared to avoid polluting other tests
+    generateSnowflakeId: async () => {
+      const { generateSnowflakeId } = await import('@babylon/shared');
+      return generateSnowflakeId();
+    },
+  }));
+
+  // Mock @babylon/api - supports both article-tick and markets-tick consumers
+  mock.module('@babylon/api', () => ({
+    CACHE_KEYS: {
+      gameState: (_gameId: string) => 'game-state',
+    },
+    DEFAULT_TTLS: {
+      gameState: 60,
+    },
+    verifyCronAuth: (req: Request | NextRequest) => {
+      const pathname = new URL(req.url).pathname;
+      return pathname.includes('/markets-tick')
+        ? cronMockState.marketsCronAuthResult
+        : cronMockState.articleCronAuthResult;
+    },
+    relayCronToStaging: async () => ({ forwarded: false }),
+    invalidateCache: async () => {},
+    getCacheOrFetch: async <T>(_key: string, fn: () => Promise<T>) => {
+      if (_key === 'continuous-game') {
+        return cronMockState.articleGame as T;
+      }
+      if (_key.includes('game-state')) {
+        return (cronMockState.marketsGame || {
+          id: 'continuous',
+          isRunning: false,
+          isContinuous: true,
+          currentDay: 1,
+        }) as T;
+      }
+      return fn();
+    },
+    recordCronExecution: () => {},
+    DistributedLockService: {
+      acquireLock: async (options?: { lockId?: string }) => {
+        if (options?.lockId?.includes('markets-tick')) {
+          return cronMockState.marketsAcquireLockResult;
+        }
+        return true;
+      },
+      releaseLock: async () => {},
+    },
+  }));
+
+  mock.module('@babylon/core/markets/prediction', () => ({
+    PredictionDbAdapter: class {},
+    PredictionMarketService: class {
+      ensureMarketExists = async () => ({ id: 'mock-market-id' });
+    },
+  }));
+
+  // Mock @babylon/engine - includes exports needed by both cron routes
+  mock.module('@babylon/engine', () => ({
+    articleRateLimiter: {
+      canGenerateArticle: async () => ({
+        allowed: cronMockState.articleCount < 2,
+        currentCount: cronMockState.articleCount,
+        maxAllowed: 2,
+        remaining: Math.max(0, 2 - cronMockState.articleCount),
+      }),
+    },
+    ArticleGenerator: class {
+      generateArticleForQuestion = async () => ({
+        // Complete Article interface with all required fields
+        id: `mock-article-${Date.now()}`,
         title: 'Test Article',
         summary: 'Test summary',
-        article: 'Test article body',
+        content: 'Test content that is long enough to pass validation. '.repeat(
+          20
+        ),
+        authorOrgId: 'org-1',
+        authorOrgName: 'Test News',
+        byline: 'Test Author',
+        bylineActorId: 'actor-1',
+        biasScore: 0,
+        sentiment: 'neutral' as const,
+        slant: 'Neutral coverage',
+        relatedEventId: 'event-1',
+        relatedActorIds: [],
+        relatedOrgIds: ['org-1'],
+        category: 'news',
+        tags: ['test', 'article'],
+        publishedAt: new Date(),
+      });
+    },
+    BabylonLLMClient: {
+      forGameTick: () => ({
+        generateJSON: async () => ({
+          title: 'Test Article',
+          summary: 'Test summary',
+          article: 'Test article body',
+        }),
       }),
+    },
+    QuestionManager: class {
+      constructor(_llmClient: unknown) {}
+      async generateTimeframeQuestion() {
+        return {
+          text: 'Will AIlon Musk launch a new product?',
+          expectedOutcome: true,
+          resolutionCriteria: 'Product launch announcement',
+          affiliatedActorIds: [],
+          affiliatedOrgIds: [],
+        };
+      }
+      async generateResolutionWithProof() {
+        return {
+          description: 'The product was launched',
+          confidence: 0.95,
+          requiresManualReview: false,
+          proof: null,
+        };
+      }
+    },
+    getActiveEventsForPosting: async () => ({ activeEvents: [] }),
+    hasEventBeenCovered: (eventId: string) =>
+      cronMockState.articleCoveredEventIds.has(eventId),
+    markEventAsCovered: (eventId: string) => {
+      cronMockState.articleCoveredEventIds.add(eventId);
+    },
+    persistArticle: async (input: { id: string }) => ({
+      success: true,
+      articleId: input.id,
     }),
-  },
-  generateArticleImageWithRetry: async () => null,
-  getActiveEventsForPosting: async () => ({ activeEvents: [] }),
-  hasEventBeenCovered: () => false,
-  markEventAsCovered: () => {},
-  StaticDataRegistry: {
-    getOrganizationsByType: () => [
-      {
-        id: 'org-1',
-        name: 'Test News',
-        description: 'A news org',
-        type: 'media',
-        canBeInvolved: true,
-      },
-    ],
-    getTopActors: () => [
-      {
-        id: 'actor-1',
-        name: 'Test Actor',
-        description: 'A test actor',
-        domain: ['tech'],
-        affiliations: [],
-        postExample: [],
-        initialLuck: 'medium',
-        initialMood: 0,
-        isTest: true,
-      },
-    ],
-  },
-  secureRandom: () => Math.random(),
-  worldFactsService: {
-    generatePromptContext: async () => 'Test world facts context',
-  },
-}));
+    publishOracleCommitments: async () => ({ committed: 1 }),
+    publishOracleReveals: async () => ({ revealed: 1 }),
+    resolveQuestionPayouts: async () => {},
+    SignalExtractionService: {
+      extractMarketSignal: async () => ({
+        suggestedOutcome: 'YES',
+        confidence: 0.8,
+        yesSignal: 0.7,
+        noSignal: 0.3,
+        signalStrength: 0.6,
+        totalPosts: 10,
+      }),
+    },
+    StaticDataRegistry: {
+      getOrganizationsByType: () => [
+        {
+          id: 'org-1',
+          name: 'Test News',
+          description: 'A news org',
+          type: 'media',
+          canBeInvolved: true,
+        },
+      ],
+      getTopActors: () => [
+        {
+          id: 'actor-1',
+          name: 'Test Actor',
+          description: 'A test actor',
+          domain: ['tech'],
+          personality: 'Analytical and cautious',
+          tier: 'mid',
+          affiliations: [],
+          postStyle: 'Neutral analysis',
+          postExample: [],
+          role: 'Analyst',
+          initialLuck: 'medium',
+          initialMood: 0,
+        },
+      ],
+      getAllActors: () => [],
+      getAllOrganizations: () => [],
+      getActor: () => null,
+      getOrganization: () => null,
+    },
+    isEligibleActor: () => true,
+    mapGranularToDbTimeframe: (timeframe: string) => timeframe,
+    secureRandom: () => Math.random(),
+    weightedPick: <T>(items: T[]) => items[0] ?? null,
+    timeframeArcPlanner: {
+      planTimeframeArc: () => ({
+        questionId: 'q-1',
+        timeframe: '1d',
+        category: 'daily',
+        outcome: true,
+        durationMs: 86400000,
+        phases: {},
+        phaseOrder: ['setup', 'peak', 'resolution'],
+        insiders: [],
+        deceivers: [],
+        affiliatedOrgIds: [],
+        affiliatedActorIds: [],
+        createdAt: new Date(),
+      }),
+    },
+    worldFactsService: {
+      generatePromptContext: async () => 'Test world facts context',
+    },
+  }));
+};
 
 // Mock @babylon/shared
 // Note: @babylon/shared is NOT mocked - let real logger run to avoid
 // polluting module cache and breaking other tests that use formatCurrency, etc.
 
-// Import the route handler after mocks are set up
-import { GET, POST } from '@/app/api/cron/article-tick/route';
+// Route handlers are loaded dynamically after mock registration.
+let GET: (req: NextRequest) => Promise<Response>;
+let POST: (req: NextRequest) => Promise<Response>;
 
 describe('Article Tick Cron', () => {
+  beforeAll(async () => {
+    registerMocks();
+    const routeModule = await import('@/app/api/cron/article-tick/route');
+    GET = routeModule.GET;
+    POST = routeModule.POST;
+  });
+
   beforeEach(() => {
-    mockGame = null;
-    mockArticleCount = 0;
-    mockCronAuthResult = true;
+    cronMockState.articleGame = null;
+    cronMockState.articleCount = 0;
+    cronMockState.articleCronAuthResult = true;
+    cronMockState.articleCoveredEventIds.clear();
   });
 
   describe('Authorization', () => {
     test('should reject unauthorized requests when verifyCronAuth returns false', async () => {
-      mockCronAuthResult = false;
+      cronMockState.articleCronAuthResult = false;
 
       const req = new NextRequest('http://localhost/api/cron/article-tick', {
         method: 'POST',
@@ -210,7 +384,7 @@ describe('Article Tick Cron', () => {
 
     test('GET should delegate to POST and return identical response', async () => {
       // Set up a known game state so we get predictable responses
-      mockGame = null; // No game = skipped state
+      cronMockState.articleGame = null; // No game = skipped state
 
       // Create identical requests for GET and POST
       const getReq = new NextRequest('http://localhost/api/cron/article-tick', {
@@ -247,7 +421,7 @@ describe('Article Tick Cron', () => {
 
   describe('Game State Checks', () => {
     test('should be skipped when no continuous game exists', async () => {
-      mockGame = null;
+      cronMockState.articleGame = null;
 
       const req = new NextRequest('http://localhost/api/cron/article-tick', {
         method: 'POST',
@@ -261,7 +435,7 @@ describe('Article Tick Cron', () => {
     });
 
     test('should be paused when game.isRunning is false', async () => {
-      mockGame = {
+      cronMockState.articleGame = {
         id: 'game-123',
         isContinuous: true,
         isRunning: false,
@@ -282,13 +456,13 @@ describe('Article Tick Cron', () => {
 
   describe('Rate Limiting', () => {
     test('should skip when rate limit reached', async () => {
-      mockGame = {
+      cronMockState.articleGame = {
         id: 'game-123',
         isContinuous: true,
         isRunning: true,
         currentDay: 1,
       };
-      mockArticleCount = 2; // At limit
+      cronMockState.articleCount = 2; // At limit
 
       const req = new NextRequest('http://localhost/api/cron/article-tick', {
         method: 'POST',
@@ -302,13 +476,13 @@ describe('Article Tick Cron', () => {
     });
 
     test('should proceed when under rate limit', async () => {
-      mockGame = {
+      cronMockState.articleGame = {
         id: 'game-123',
         isContinuous: true,
         isRunning: true,
         currentDay: 1,
       };
-      mockArticleCount = 0; // Under limit
+      cronMockState.articleCount = 0; // Under limit
 
       const req = new NextRequest('http://localhost/api/cron/article-tick', {
         method: 'POST',
@@ -329,13 +503,13 @@ describe('Article Tick Cron', () => {
 
   describe('Response Structure', () => {
     test('should return rate limit info in response', async () => {
-      mockGame = {
+      cronMockState.articleGame = {
         id: 'game-123',
         isContinuous: true,
         isRunning: true,
         currentDay: 1,
       };
-      mockArticleCount = 1; // Under limit (2), so processing should proceed
+      cronMockState.articleCount = 1; // Under limit (2), so processing should proceed
 
       const req = new NextRequest('http://localhost/api/cron/article-tick', {
         method: 'POST',

--- a/packages/testing/unit/cron/article-tick.test.ts
+++ b/packages/testing/unit/cron/article-tick.test.ts
@@ -1,4 +1,15 @@
-import { beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from 'bun:test';
+import * as actualApiModule from '../../../api/src/index';
+import * as actualDbModule from '../../../db/src/index';
+import * as actualEngineModule from '../../../engine/src/index';
 import { NextRequest } from 'next/server';
 
 /**
@@ -68,6 +79,13 @@ const cronMockState =
     marketsAcquireLockResult: true,
   });
 
+let mockSnowflakeCounter = 0;
+
+const nextMockSnowflakeId = (): string => {
+  mockSnowflakeCounter += 1;
+  return `mock-snowflake-${Date.now()}-${mockSnowflakeCounter}`;
+};
+
 // Create query builder for Drizzle-style operations
 // The resultFn is called at query execution time to get the current mock state
 // This mirrors the markets-tick.test.ts pattern for dynamic result evaluation
@@ -99,6 +117,7 @@ const createQueryBuilder = (
 const registerMocks = () => {
   // Mock @babylon/db - uses resultFn pattern for dynamic state evaluation
   mock.module('@babylon/db', () => ({
+      ...actualDbModule,
     db: {
       select: mock(() =>
         createQueryBuilder(() =>
@@ -125,6 +144,20 @@ const registerMocks = () => {
       id: 'id',
       questionNumber: 'questionNumber',
     },
+    userAgentConfigs: { _tableName: 'userAgentConfigs' },
+    users: { _tableName: 'users' },
+    actors: { _tableName: 'actors' },
+    comments: { _tableName: 'comments' },
+    organizations: { _tableName: 'organizations' },
+    balanceTransactions: { _tableName: 'balanceTransactions' },
+    pointsTransactions: { _tableName: 'pointsTransactions' },
+    perpPositions: { _tableName: 'perpPositions' },
+    poolPositions: { _tableName: 'poolPositions' },
+    markets: { _tableName: 'markets' },
+    generationLocks: { _tableName: 'generationLocks' },
+    agentPerformanceMetrics: { _tableName: 'agentPerformanceMetrics' },
+    agentTrades: { _tableName: 'agentTrades' },
+    npcTrades: { _tableName: 'npcTrades' },
     timeframedMarkets: { _tableName: 'timeframedMarkets' },
     worldEvents: { _tableName: 'worldEvents', timestamp: 'timestamp' },
     posts: {
@@ -134,10 +167,17 @@ const registerMocks = () => {
       deletedAt: 'deletedAt',
     },
     eq: (): SqlCondition => ({}),
+    ne: (): SqlCondition => ({}),
+    gt: (): SqlCondition => ({}),
     gte: (): SqlCondition => ({}),
+    lt: (): SqlCondition => ({}),
     lte: (): SqlCondition => ({}),
     and: (): SqlCondition => ({}),
+    or: (): SqlCondition => ({}),
+    not: (): SqlCondition => ({}),
+    inArray: (): SqlCondition => ({}),
     desc: (): SqlCondition => ({}),
+    asc: (): SqlCondition => ({}),
     isNull: (): SqlCondition => ({}),
     isNotNull: (): SqlCondition => ({}),
     sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
@@ -145,15 +185,17 @@ const registerMocks = () => {
       values,
     }),
     max: (col: unknown) => ({ _aggregation: 'max', column: col }),
-    // Use real generateSnowflakeId from @babylon/shared to avoid polluting other tests
-    generateSnowflakeId: async () => {
-      const { generateSnowflakeId } = await import('@babylon/shared');
-      return generateSnowflakeId();
-    },
+    generateSnowflakeId: async () => nextMockSnowflakeId(),
+    withTransaction: async <T>(fn: (tx: unknown) => Promise<T>) => fn({}),
+    asUser: async <T>(_userId: string, fn: (db: unknown) => Promise<T>) =>
+      fn({}),
+    asSystem: async <T>(fn: (db: unknown) => Promise<T>) => fn({}),
+    asPublic: async <T>(fn: (db: unknown) => Promise<T>) => fn({}),
   }));
 
   // Mock @babylon/api - supports both article-tick and markets-tick consumers
   mock.module('@babylon/api', () => ({
+    ...actualApiModule,
     CACHE_KEYS: {
       gameState: (_gameId: string) => 'game-state',
     },
@@ -167,6 +209,14 @@ const registerMocks = () => {
         : cronMockState.articleCronAuthResult;
     },
     relayCronToStaging: async () => ({ forwarded: false }),
+    broadcastAgentActivity: async () => {},
+    broadcastToChannel: async () => {},
+    notifyGroupChatInvite: async () => {},
+    checkRateLimit: async () => ({ allowed: true, remaining: 1 }),
+    checkRateLimitAsync: async () => ({ allowed: true, remaining: 1 }),
+    clearAllRateLimits: async () => {},
+    getRateLimitStatus: async () => ({ remaining: 1, resetAt: Date.now() }),
+    resetRateLimit: async () => {},
     invalidateCache: async () => {},
     getCacheOrFetch: async <T>(_key: string, fn: () => Promise<T>) => {
       if (_key === 'continuous-game') {
@@ -203,6 +253,7 @@ const registerMocks = () => {
 
   // Mock @babylon/engine - includes exports needed by both cron routes
   mock.module('@babylon/engine', () => ({
+    ...actualEngineModule,
     articleRateLimiter: {
       canGenerateArticle: async () => ({
         allowed: cronMockState.articleCount < 2,
@@ -276,6 +327,13 @@ const registerMocks = () => {
     }),
     publishOracleCommitments: async () => ({ committed: 1 }),
     publishOracleReveals: async () => ({ revealed: 1 }),
+    getReputationBreakdown: () => ({
+      total: 0,
+      level: 'neutral',
+      trend: 0,
+      factors: {},
+    }),
+    recalculateReputation: async () => {},
     resolveQuestionPayouts: async () => {},
     SignalExtractionService: {
       extractMarketSignal: async () => ({
@@ -322,6 +380,13 @@ const registerMocks = () => {
     mapGranularToDbTimeframe: (timeframe: string) => timeframe,
     secureRandom: () => Math.random(),
     weightedPick: <T>(items: T[]) => items[0] ?? null,
+    gameService: {
+      getCurrentGame: async () => null,
+    },
+    setBroadcastToChannel: () => {},
+    setDistributedLockProvider: () => {},
+    setNotifyGroupChatInvite: () => {},
+    setRateLimitProvider: () => {},
     timeframeArcPlanner: {
       planTimeframeArc: () => ({
         questionId: 'q-1',
@@ -344,9 +409,7 @@ const registerMocks = () => {
   }));
 };
 
-// Mock @babylon/shared
-// Note: @babylon/shared is NOT mocked - let real logger run to avoid
-// polluting module cache and breaking other tests that use formatCurrency, etc.
+// @babylon/shared is intentionally not mocked here.
 
 // Route handlers are loaded dynamically after mock registration.
 let GET: (req: NextRequest) => Promise<Response>;
@@ -358,6 +421,10 @@ describe('Article Tick Cron', () => {
     const routeModule = await import('@/app/api/cron/article-tick/route');
     GET = routeModule.GET;
     POST = routeModule.POST;
+  });
+
+  afterAll(() => {
+    mock.restore();
   });
 
   beforeEach(() => {

--- a/packages/testing/unit/cron/markets-tick.test.ts
+++ b/packages/testing/unit/cron/markets-tick.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { NextRequest } from 'next/server';
 
 /**
@@ -35,18 +35,45 @@ interface SqlCondition {
   sql?: string;
 }
 
-// Mock db with a mutable state we can control in tests
-let mockGame: MockGame | null = null;
-let mockActiveQuestions: MockQuestion[] = [];
-let mockWorldEvents: Array<{
+interface MockWorldEvent {
   id: string;
   timestamp: Date;
   description: string;
-}> = [];
+}
 
-// Mock auth and lock states for negative-path testing
-let mockCronAuthResult = true;
-let mockAcquireLockResult = true;
+interface CronMockState {
+  articleGame: MockGame | null;
+  articleCount: number;
+  articleCronAuthResult: boolean;
+  articleCoveredEventIds: Set<string>;
+  marketsGame: MockGame | null;
+  marketsActiveQuestions: MockQuestion[];
+  marketsWorldEvents: MockWorldEvent[];
+  marketsCronAuthResult: boolean;
+  marketsAcquireLockResult: boolean;
+}
+
+const CRON_MOCK_STATE_KEY = '__babylonCronMockState';
+
+type GlobalWithCronMockState = typeof globalThis & {
+  [CRON_MOCK_STATE_KEY]?: CronMockState;
+};
+
+const globalWithCronMockState = globalThis as GlobalWithCronMockState;
+
+const cronMockState =
+  globalWithCronMockState[CRON_MOCK_STATE_KEY] ??
+  (globalWithCronMockState[CRON_MOCK_STATE_KEY] = {
+    articleGame: null,
+    articleCount: 0,
+    articleCronAuthResult: true,
+    articleCoveredEventIds: new Set<string>(),
+    marketsGame: null,
+    marketsActiveQuestions: [],
+    marketsWorldEvents: [],
+    marketsCronAuthResult: true,
+    marketsAcquireLockResult: true,
+  });
 
 // Track which table is being queried for table-aware mocking
 let currentQueryTable: string | null = null;
@@ -70,12 +97,12 @@ const TABLE_REFS = {
 const getTableData = (): unknown => {
   switch (currentQueryTable) {
     case 'games':
-      return mockGame ? [mockGame] : [];
+      return cronMockState.marketsGame ? [cronMockState.marketsGame] : [];
     case 'questions':
       // Return active questions by default; mature questions handled via where clause
-      return mockActiveQuestions;
+      return cronMockState.marketsActiveQuestions;
     case 'worldEvents':
-      return mockWorldEvents;
+      return cronMockState.marketsWorldEvents;
     case 'timeframedMarkets':
       return [];
     case 'posts':
@@ -143,189 +170,294 @@ const createMutationBuilder = (operation: 'insert' | 'update' | 'delete') => {
   });
 };
 
-// Mock @babylon/db - table-aware query handling
-mock.module('@babylon/db', () => ({
-  db: {
-    select: mock((columns?: Record<string, unknown>) => {
-      // Reset table tracking for new query
-      currentQueryTable = null;
-      // If selecting specific columns (like MAX), handle specially
-      if (columns && 'maxNumber' in columns) {
-        // This is the getNextQuestionNumber query
-        return createQueryBuilder(() => {
-          const maxNum = mockActiveQuestions.reduce(
-            (max, q) => Math.max(max, q.questionNumber),
-            0
-          );
-          return [{ maxNumber: maxNum > 0 ? maxNum : null }];
-        });
-      }
-      return createQueryBuilder(() => getTableData());
+const registerMocks = () => {
+  // Mock @babylon/db - table-aware query handling
+  mock.module('@babylon/db', () => ({
+    db: {
+      select: mock((columns?: Record<string, unknown>) => {
+        // Reset table tracking for new query
+        currentQueryTable = null;
+        // If selecting specific columns (like MAX), handle specially
+        if (columns && 'maxNumber' in columns) {
+          // This is the getNextQuestionNumber query
+          return createQueryBuilder(() => {
+            const maxNum = cronMockState.marketsActiveQuestions.reduce(
+              (max, q) => Math.max(max, q.questionNumber),
+              0
+            );
+            return [{ maxNumber: maxNum > 0 ? maxNum : null }];
+          });
+        }
+        return createQueryBuilder(() => getTableData());
+      }),
+      insert: createMutationBuilder('insert'),
+      update: createMutationBuilder('update'),
+      delete: createMutationBuilder('delete'),
+      transaction: mock(
+        async <T>(callback: (tx: unknown) => Promise<T>): Promise<T> => {
+          // Create a transaction context that mirrors the db interface
+          const tx = {
+            select: mock(() => createQueryBuilder(() => getTableData())),
+            insert: createMutationBuilder('insert'),
+            update: createMutationBuilder('update'),
+            delete: createMutationBuilder('delete'),
+          };
+          return callback(tx);
+        }
+      ),
+    },
+    games: TABLE_REFS.games,
+    questions: TABLE_REFS.questions,
+    timeframedMarkets: TABLE_REFS.timeframedMarkets,
+    worldEvents: TABLE_REFS.worldEvents,
+    posts: TABLE_REFS.posts,
+    eq: (): SqlCondition => ({}),
+    gte: (): SqlCondition => ({}),
+    lte: (): SqlCondition => ({}),
+    and: (): SqlCondition => ({}),
+    desc: (): SqlCondition => ({}),
+    isNull: (): SqlCondition => ({}),
+    isNotNull: (): SqlCondition => ({}),
+    sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+      sql: strings.join('?'),
+      values,
     }),
-    insert: createMutationBuilder('insert'),
-    update: createMutationBuilder('update'),
-    delete: createMutationBuilder('delete'),
-    transaction: mock(
-      async <T>(callback: (tx: unknown) => Promise<T>): Promise<T> => {
-        // Create a transaction context that mirrors the db interface
-        const tx = {
-          select: mock(() => createQueryBuilder(() => getTableData())),
-          insert: createMutationBuilder('insert'),
-          update: createMutationBuilder('update'),
-          delete: createMutationBuilder('delete'),
+    max: (col: unknown) => ({ _aggregation: 'max', column: col }),
+    // Use real generateSnowflakeId from @babylon/shared to avoid polluting other tests
+    generateSnowflakeId: async () => {
+      const { generateSnowflakeId } = await import('@babylon/shared');
+      return generateSnowflakeId();
+    },
+  }));
+
+  // Mock @babylon/api - uses mutable state for auth/lock results
+  mock.module('@babylon/api', () => ({
+    CACHE_KEYS: {
+      gameState: (_gameId: string) => 'game-state',
+    },
+    DEFAULT_TTLS: {
+      gameState: 60,
+    },
+    verifyCronAuth: (req: Request | NextRequest) => {
+      const pathname = new URL(req.url).pathname;
+      return pathname.includes('/article-tick')
+        ? cronMockState.articleCronAuthResult
+        : cronMockState.marketsCronAuthResult;
+    },
+    relayCronToStaging: async () => ({ forwarded: false }),
+    invalidateCache: async () => {},
+    getCacheOrFetch: async <T>(_key: string, fn: () => Promise<T>) => {
+      if (_key === 'continuous-game') {
+        return cronMockState.articleGame as T;
+      }
+      if (_key.includes('game-state')) {
+        return (cronMockState.marketsGame || {
+          id: 'continuous',
+          isRunning: false,
+          isContinuous: true,
+          currentDay: 1,
+        }) as T;
+      }
+      return fn();
+    },
+    recordCronExecution: () => {},
+    DistributedLockService: {
+      acquireLock: async (options?: { lockId?: string }) => {
+        if (options?.lockId?.includes('markets-tick')) {
+          return cronMockState.marketsAcquireLockResult;
+        }
+        return true;
+      },
+      releaseLock: async () => {},
+    },
+  }));
+
+  // Mock @babylon/core/markets/prediction
+  mock.module('@babylon/core/markets/prediction', () => ({
+    PredictionDbAdapter: class {},
+    PredictionMarketService: class {
+      ensureMarketExists = async () => ({ id: 'mock-market-id' });
+    },
+  }));
+
+  // Mock @babylon/engine
+  mock.module('@babylon/engine', () => ({
+    articleRateLimiter: {
+      canGenerateArticle: async () => ({
+        allowed: cronMockState.articleCount < 2,
+        currentCount: cronMockState.articleCount,
+        maxAllowed: 2,
+        remaining: Math.max(0, 2 - cronMockState.articleCount),
+      }),
+    },
+    ArticleGenerator: class {
+      generateArticleForQuestion = async () => ({
+        id: `mock-article-${Date.now()}`,
+        title: 'Test Article',
+        summary: 'Test summary',
+        content: 'Test content that is long enough to pass validation. '.repeat(
+          20
+        ),
+        authorOrgId: 'org-1',
+        authorOrgName: 'Test News',
+        byline: 'Test Author',
+        bylineActorId: 'actor-1',
+        biasScore: 0,
+        sentiment: 'neutral' as const,
+        slant: 'Neutral coverage',
+        relatedEventId: 'event-1',
+        relatedActorIds: [],
+        relatedOrgIds: ['org-1'],
+        category: 'news',
+        tags: ['test', 'article'],
+        publishedAt: new Date(),
+      });
+    },
+    isEligibleActor: () => true,
+    mapGranularToDbTimeframe: (timeframe: string) => timeframe,
+    BabylonLLMClient: class MockBabylonLLMClient {
+      static forGameTick() {
+        return new MockBabylonLLMClient();
+      }
+      async generateJSON() {
+        return {
+          text: 'Will AIlon Musk launch a new product?',
+          expectedOutcome: true,
+          resolutionCriteria: 'Product launch announcement',
+          affiliatedActorIds: [],
+          affiliatedOrgIds: [],
         };
-        return callback(tx);
       }
-    ),
-  },
-  games: TABLE_REFS.games,
-  questions: TABLE_REFS.questions,
-  timeframedMarkets: TABLE_REFS.timeframedMarkets,
-  worldEvents: TABLE_REFS.worldEvents,
-  posts: TABLE_REFS.posts,
-  eq: (): SqlCondition => ({}),
-  gte: (): SqlCondition => ({}),
-  lte: (): SqlCondition => ({}),
-  and: (): SqlCondition => ({}),
-  desc: (): SqlCondition => ({}),
-  isNull: (): SqlCondition => ({}),
-  isNotNull: (): SqlCondition => ({}),
-  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
-    sql: strings.join('?'),
-    values,
-  }),
-  max: (col: unknown) => ({ _aggregation: 'max', column: col }),
-  // Use real generateSnowflakeId from @babylon/shared to avoid polluting other tests
-  generateSnowflakeId: async () => {
-    const { generateSnowflakeId } = await import('@babylon/shared');
-    return generateSnowflakeId();
-  },
-}));
-
-// Mock @babylon/api - uses mutable state for auth/lock results
-mock.module('@babylon/api', () => ({
-  verifyCronAuth: () => mockCronAuthResult,
-  relayCronToStaging: async () => ({ forwarded: false }),
-  getCacheOrFetch: async <T>(_key: string, fn: () => Promise<T>) => {
-    // For game state cache, return our mockGame or a default non-running game
-    if (_key.includes('game-state')) {
-      return (mockGame || {
-        id: 'continuous',
-        isRunning: false,
-        isContinuous: true,
-        currentDay: 1,
-      }) as T;
-    }
-    return fn();
-  },
-  recordCronExecution: () => {},
-  DistributedLockService: {
-    acquireLock: async () => mockAcquireLockResult,
-    releaseLock: async () => {},
-  },
-}));
-
-// Mock @babylon/core/markets/prediction
-mock.module('@babylon/core/markets/prediction', () => ({
-  PredictionDbAdapter: class {},
-  PredictionMarketService: class {
-    ensureMarketExists = async () => ({ id: 'mock-market-id' });
-  },
-}));
-
-// Mock @babylon/engine
-mock.module('@babylon/engine', () => ({
-  BabylonLLMClient: class MockBabylonLLMClient {
-    static forGameTick() {
-      return new MockBabylonLLMClient();
-    }
-    async generateJSON() {
-      return {
-        text: 'Will AIlon Musk launch a new product?',
-        expectedOutcome: true,
-        resolutionCriteria: 'Product launch announcement',
-        affiliatedActorIds: [],
-        affiliatedOrgIds: [],
-      };
-    }
-  },
-  QuestionManager: class MockQuestionManager {
-    constructor(_llmClient: unknown) {}
-    async generateTimeframeQuestion(_timeframe: string, _durationMs: number) {
-      return {
-        text: 'Will AIlon Musk launch a new product?',
-        expectedOutcome: true,
-        resolutionCriteria: 'Product launch announcement',
-        affiliatedActorIds: [],
-        affiliatedOrgIds: [],
-      };
-    }
-    async generateResolutionWithProof() {
-      return {
-        description: 'The product was launched',
-        confidence: 0.95,
-        requiresManualReview: false,
-        proof: null,
-      };
-    }
-  },
-  publishOracleCommitments: async () => ({ committed: 1 }),
-  publishOracleReveals: async () => ({ revealed: 1 }),
-  resolveQuestionPayouts: async () => {},
-  SignalExtractionService: {
-    extractMarketSignal: async () => ({
-      suggestedOutcome: 'YES',
-      confidence: 0.8,
-      yesSignal: 0.7,
-      noSignal: 0.3,
-      signalStrength: 0.6,
-      totalPosts: 10,
+    },
+    QuestionManager: class MockQuestionManager {
+      constructor(_llmClient: unknown) {}
+      async generateTimeframeQuestion(
+        _timeframe: string,
+        _durationMs: number
+      ) {
+        return {
+          text: 'Will AIlon Musk launch a new product?',
+          expectedOutcome: true,
+          resolutionCriteria: 'Product launch announcement',
+          affiliatedActorIds: [],
+          affiliatedOrgIds: [],
+        };
+      }
+      async generateResolutionWithProof() {
+        return {
+          description: 'The product was launched',
+          confidence: 0.95,
+          requiresManualReview: false,
+          proof: null,
+        };
+      }
+    },
+    getActiveEventsForPosting: async () => ({ activeEvents: [] }),
+    hasEventBeenCovered: (eventId: string) =>
+      cronMockState.articleCoveredEventIds.has(eventId),
+    markEventAsCovered: (eventId: string) => {
+      cronMockState.articleCoveredEventIds.add(eventId);
+    },
+    persistArticle: async (input: { id: string }) => ({
+      success: true,
+      articleId: input.id,
     }),
-  },
-  StaticDataRegistry: {
-    getAllActors: () => [],
-    getAllOrganizations: () => [],
-    getActor: () => null,
-    getOrganization: () => null,
-  },
-  timeframeArcPlanner: {
-    planTimeframeArc: () => ({
-      questionId: 'q-1',
-      timeframe: '1d',
-      category: 'daily',
-      outcome: true,
-      durationMs: 86400000,
-      phases: {},
-      phaseOrder: ['setup', 'peak', 'resolution'],
-      insiders: [],
-      deceivers: [],
-      affiliatedOrgIds: [],
-      affiliatedActorIds: [],
-      createdAt: new Date(),
-    }),
-  },
-}));
+    publishOracleCommitments: async () => ({ committed: 1 }),
+    publishOracleReveals: async () => ({ revealed: 1 }),
+    resolveQuestionPayouts: async () => {},
+    SignalExtractionService: {
+      extractMarketSignal: async () => ({
+        suggestedOutcome: 'YES',
+        confidence: 0.8,
+        yesSignal: 0.7,
+        noSignal: 0.3,
+        signalStrength: 0.6,
+        totalPosts: 10,
+      }),
+    },
+    StaticDataRegistry: {
+      getOrganizationsByType: () => [
+        {
+          id: 'org-1',
+          name: 'Test News',
+          description: 'A news org',
+          type: 'media',
+          canBeInvolved: true,
+        },
+      ],
+      getTopActors: () => [
+        {
+          id: 'actor-1',
+          name: 'Test Actor',
+          description: 'A test actor',
+          domain: ['tech'],
+          personality: 'Analytical and cautious',
+          tier: 'mid',
+          affiliations: [],
+          postStyle: 'Neutral analysis',
+          postExample: [],
+          role: 'Analyst',
+          initialLuck: 'medium',
+          initialMood: 0,
+        },
+      ],
+      getAllActors: () => [],
+      getAllOrganizations: () => [],
+      getActor: () => null,
+      getOrganization: () => null,
+    },
+    secureRandom: () => Math.random(),
+    weightedPick: <T>(items: T[]) => items[0] ?? null,
+    timeframeArcPlanner: {
+      planTimeframeArc: () => ({
+        questionId: 'q-1',
+        timeframe: '1d',
+        category: 'daily',
+        outcome: true,
+        durationMs: 86400000,
+        phases: {},
+        phaseOrder: ['setup', 'peak', 'resolution'],
+        insiders: [],
+        deceivers: [],
+        affiliatedOrgIds: [],
+        affiliatedActorIds: [],
+        createdAt: new Date(),
+      }),
+    },
+    worldFactsService: {
+      generatePromptContext: async () => 'Test world facts context',
+    },
+  }));
+};
 
 // Note: @babylon/shared is NOT mocked - let real logger run to avoid
 // polluting module cache and breaking other tests that use formatCurrency, etc.
 
-// Import the route handler after mocks are set up
-import { GET, POST } from '@/app/api/cron/markets-tick/route';
+// Route handlers are loaded dynamically after mock registration.
+let GET: (req: NextRequest) => Promise<Response>;
+let POST: (req: NextRequest) => Promise<Response>;
 
 describe('Markets Tick Cron', () => {
+  beforeAll(async () => {
+    registerMocks();
+    const routeModule = await import('@/app/api/cron/markets-tick/route');
+    GET = routeModule.GET;
+    POST = routeModule.POST;
+  });
+
   beforeEach(() => {
-    mockGame = null;
-    mockActiveQuestions = [];
-    mockWorldEvents = [];
-    mockCronAuthResult = true;
-    mockAcquireLockResult = true;
+    cronMockState.marketsGame = null;
+    cronMockState.marketsActiveQuestions = [];
+    cronMockState.marketsWorldEvents = [];
+    cronMockState.marketsCronAuthResult = true;
+    cronMockState.marketsAcquireLockResult = true;
     currentQueryTable = null;
   });
 
   describe('Authorization', () => {
     test('GET should delegate to POST and return equivalent response', async () => {
       // Set up identical conditions for both requests
-      mockGame = null; // No game = predictable skipped state
+      cronMockState.marketsGame = null; // No game = predictable skipped state
 
       const getReq = new NextRequest('http://localhost/api/cron/markets-tick', {
         method: 'GET',
@@ -352,7 +484,7 @@ describe('Markets Tick Cron', () => {
     });
 
     test('should reject unauthorized requests when verifyCronAuth returns false', async () => {
-      mockCronAuthResult = false;
+      cronMockState.marketsCronAuthResult = false;
 
       const req = new NextRequest('http://localhost/api/cron/markets-tick', {
         method: 'POST',
@@ -364,7 +496,7 @@ describe('Markets Tick Cron', () => {
     });
 
     test('GET should also reject unauthorized requests', async () => {
-      mockCronAuthResult = false;
+      cronMockState.marketsCronAuthResult = false;
 
       const req = new NextRequest('http://localhost/api/cron/markets-tick', {
         method: 'GET',
@@ -378,13 +510,13 @@ describe('Markets Tick Cron', () => {
 
   describe('Distributed Lock', () => {
     test('should skip when lock cannot be acquired', async () => {
-      mockGame = {
+      cronMockState.marketsGame = {
         id: 'game-123',
         isContinuous: true,
         isRunning: true,
         currentDay: 1,
       };
-      mockAcquireLockResult = false;
+      cronMockState.marketsAcquireLockResult = false;
 
       const req = new NextRequest('http://localhost/api/cron/markets-tick', {
         method: 'POST',
@@ -402,7 +534,7 @@ describe('Markets Tick Cron', () => {
 
   describe('Game State Checks', () => {
     test('should skip when game is not running', async () => {
-      mockGame = {
+      cronMockState.marketsGame = {
         id: 'game-123',
         isContinuous: true,
         isRunning: false,

--- a/packages/testing/unit/cron/markets-tick.test.ts
+++ b/packages/testing/unit/cron/markets-tick.test.ts
@@ -1,4 +1,15 @@
-import { beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from 'bun:test';
+import * as actualApiModule from '../../../api/src/index';
+import * as actualDbModule from '../../../db/src/index';
+import * as actualEngineModule from '../../../engine/src/index';
 import { NextRequest } from 'next/server';
 
 /**
@@ -75,6 +86,13 @@ const cronMockState =
     marketsAcquireLockResult: true,
   });
 
+let mockSnowflakeCounter = 0;
+
+const nextMockSnowflakeId = (): string => {
+  mockSnowflakeCounter += 1;
+  return `mock-snowflake-${Date.now()}-${mockSnowflakeCounter}`;
+};
+
 // Track which table is being queried for table-aware mocking
 let currentQueryTable: string | null = null;
 
@@ -91,6 +109,20 @@ const TABLE_REFS = {
   timeframedMarkets: { _tableName: 'timeframedMarkets' },
   worldEvents: { _tableName: 'worldEvents', timestamp: 'timestamp' },
   posts: { _tableName: 'posts' },
+  userAgentConfigs: { _tableName: 'userAgentConfigs' },
+  users: { _tableName: 'users' },
+  actors: { _tableName: 'actors' },
+  comments: { _tableName: 'comments' },
+  organizations: { _tableName: 'organizations' },
+  balanceTransactions: { _tableName: 'balanceTransactions' },
+  pointsTransactions: { _tableName: 'pointsTransactions' },
+  perpPositions: { _tableName: 'perpPositions' },
+  poolPositions: { _tableName: 'poolPositions' },
+  markets: { _tableName: 'markets' },
+  generationLocks: { _tableName: 'generationLocks' },
+  agentPerformanceMetrics: { _tableName: 'agentPerformanceMetrics' },
+  agentTrades: { _tableName: 'agentTrades' },
+  npcTrades: { _tableName: 'npcTrades' },
 };
 
 // Get mock data based on the current query table
@@ -173,6 +205,7 @@ const createMutationBuilder = (operation: 'insert' | 'update' | 'delete') => {
 const registerMocks = () => {
   // Mock @babylon/db - table-aware query handling
   mock.module('@babylon/db', () => ({
+    ...actualDbModule,
     db: {
       select: mock((columns?: Record<string, unknown>) => {
         // Reset table tracking for new query
@@ -208,14 +241,35 @@ const registerMocks = () => {
     },
     games: TABLE_REFS.games,
     questions: TABLE_REFS.questions,
+    userAgentConfigs: TABLE_REFS.userAgentConfigs,
+    users: TABLE_REFS.users,
+    actors: TABLE_REFS.actors,
+    comments: TABLE_REFS.comments,
+    organizations: TABLE_REFS.organizations,
+    balanceTransactions: TABLE_REFS.balanceTransactions,
+    pointsTransactions: TABLE_REFS.pointsTransactions,
+    perpPositions: TABLE_REFS.perpPositions,
+    poolPositions: TABLE_REFS.poolPositions,
+    markets: TABLE_REFS.markets,
+    generationLocks: TABLE_REFS.generationLocks,
+    agentPerformanceMetrics: TABLE_REFS.agentPerformanceMetrics,
+    agentTrades: TABLE_REFS.agentTrades,
+    npcTrades: TABLE_REFS.npcTrades,
     timeframedMarkets: TABLE_REFS.timeframedMarkets,
     worldEvents: TABLE_REFS.worldEvents,
     posts: TABLE_REFS.posts,
     eq: (): SqlCondition => ({}),
+    ne: (): SqlCondition => ({}),
+    gt: (): SqlCondition => ({}),
     gte: (): SqlCondition => ({}),
+    lt: (): SqlCondition => ({}),
     lte: (): SqlCondition => ({}),
     and: (): SqlCondition => ({}),
+    or: (): SqlCondition => ({}),
+    not: (): SqlCondition => ({}),
+    inArray: (): SqlCondition => ({}),
     desc: (): SqlCondition => ({}),
+    asc: (): SqlCondition => ({}),
     isNull: (): SqlCondition => ({}),
     isNotNull: (): SqlCondition => ({}),
     sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
@@ -223,15 +277,17 @@ const registerMocks = () => {
       values,
     }),
     max: (col: unknown) => ({ _aggregation: 'max', column: col }),
-    // Use real generateSnowflakeId from @babylon/shared to avoid polluting other tests
-    generateSnowflakeId: async () => {
-      const { generateSnowflakeId } = await import('@babylon/shared');
-      return generateSnowflakeId();
-    },
+    generateSnowflakeId: async () => nextMockSnowflakeId(),
+    withTransaction: async <T>(fn: (tx: unknown) => Promise<T>) => fn({}),
+    asUser: async <T>(_userId: string, fn: (db: unknown) => Promise<T>) =>
+      fn({}),
+    asSystem: async <T>(fn: (db: unknown) => Promise<T>) => fn({}),
+    asPublic: async <T>(fn: (db: unknown) => Promise<T>) => fn({}),
   }));
 
   // Mock @babylon/api - uses mutable state for auth/lock results
   mock.module('@babylon/api', () => ({
+    ...actualApiModule,
     CACHE_KEYS: {
       gameState: (_gameId: string) => 'game-state',
     },
@@ -245,6 +301,14 @@ const registerMocks = () => {
         : cronMockState.marketsCronAuthResult;
     },
     relayCronToStaging: async () => ({ forwarded: false }),
+    broadcastAgentActivity: async () => {},
+    broadcastToChannel: async () => {},
+    notifyGroupChatInvite: async () => {},
+    checkRateLimit: async () => ({ allowed: true, remaining: 1 }),
+    checkRateLimitAsync: async () => ({ allowed: true, remaining: 1 }),
+    clearAllRateLimits: async () => {},
+    getRateLimitStatus: async () => ({ remaining: 1, resetAt: Date.now() }),
+    resetRateLimit: async () => {},
     invalidateCache: async () => {},
     getCacheOrFetch: async <T>(_key: string, fn: () => Promise<T>) => {
       if (_key === 'continuous-game') {
@@ -282,6 +346,7 @@ const registerMocks = () => {
 
   // Mock @babylon/engine
   mock.module('@babylon/engine', () => ({
+    ...actualEngineModule,
     articleRateLimiter: {
       canGenerateArticle: async () => ({
         allowed: cronMockState.articleCount < 2,
@@ -364,6 +429,13 @@ const registerMocks = () => {
     }),
     publishOracleCommitments: async () => ({ committed: 1 }),
     publishOracleReveals: async () => ({ revealed: 1 }),
+    getReputationBreakdown: () => ({
+      total: 0,
+      level: 'neutral',
+      trend: 0,
+      factors: {},
+    }),
+    recalculateReputation: async () => {},
     resolveQuestionPayouts: async () => {},
     SignalExtractionService: {
       extractMarketSignal: async () => ({
@@ -408,6 +480,13 @@ const registerMocks = () => {
     },
     secureRandom: () => Math.random(),
     weightedPick: <T>(items: T[]) => items[0] ?? null,
+    gameService: {
+      getCurrentGame: async () => null,
+    },
+    setBroadcastToChannel: () => {},
+    setDistributedLockProvider: () => {},
+    setNotifyGroupChatInvite: () => {},
+    setRateLimitProvider: () => {},
     timeframeArcPlanner: {
       planTimeframeArc: () => ({
         questionId: 'q-1',
@@ -430,8 +509,7 @@ const registerMocks = () => {
   }));
 };
 
-// Note: @babylon/shared is NOT mocked - let real logger run to avoid
-// polluting module cache and breaking other tests that use formatCurrency, etc.
+// @babylon/shared is intentionally not mocked here.
 
 // Route handlers are loaded dynamically after mock registration.
 let GET: (req: NextRequest) => Promise<Response>;
@@ -443,6 +521,10 @@ describe('Markets Tick Cron', () => {
     const routeModule = await import('@/app/api/cron/markets-tick/route');
     GET = routeModule.GET;
     POST = routeModule.POST;
+  });
+
+  afterAll(() => {
+    mock.restore();
   });
 
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- harden cron test mocks to preserve full module export surfaces across mixed-suite runs
- prevent mock leakage between suites by restoring module mocks in afterAll
- make SIWE shared/redis mocks export-compatible so they no longer break cron suites when tests run together

## Changes
- packages/testing/unit/cron/article-tick.test.ts
  - use full-module passthrough for @babylon/db, @babylon/api, and @babylon/engine and override only test-specific members
  - replace runtime shared dependency in generateSnowflakeId mock with a local deterministic stub
  - add missing db/api/engine members required by mixed imports
  - add afterAll(() => mock.restore())
- packages/testing/unit/cron/markets-tick.test.ts
  - same passthrough + targeted override pattern for db/api/engine mocks
  - local deterministic generateSnowflakeId stub
  - add missing export members used during mixed-suite imports
  - add afterAll(() => mock.restore())
- packages/testing/unit/auth/siwe.test.ts
  - keep full @babylon/shared and redis-client export surfaces and override only test-specific behavior

## Validation
- bun test packages/testing/unit/cron/article-tick.test.ts packages/testing/unit/cron/markets-tick.test.ts packages/testing/unit/auth/siwe.test.ts --preload ./packages/testing/unit/preload.ts
  - pass
- bun test packages/testing/unit/AutomationPipeline.test.ts packages/testing/unit/cron/article-tick.test.ts packages/testing/unit/cron/markets-tick.test.ts --preload ./packages/testing/unit/preload.ts
  - pass (no hang)
- bun run --cwd packages/testing typecheck
  - pass
- bun run --cwd packages/testing lint
  - pass

## Notes
- mixed run with agent-tick-db.test.ts now fails only on that file's existing server-only import issue, which reproduces independently and is not introduced by this change.
