### PR TITLE
feat(ui): mobile redesign — tighten spacing, redesign components, improve navigation

### DIFF
--- a/apps/web/src/app/agents/team/page.tsx
+++ b/apps/web/src/app/agents/team/page.tsx
@@ -759,7 +759,7 @@ export default function TeamChatPage() {
   return (
     <div
       data-command-center-container
-      className="relative flex h-[calc(100dvh-112px)] flex-col overflow-hidden border-border md:h-dvh lg:border-l"
+      className="relative mt-14 flex h-[calc(100dvh-112px)] flex-col overflow-hidden border-border md:mt-0 md:h-dvh lg:border-l"
     >
       {/* Mobile Tab Navigation - visible on small screens only */}
       <div

--- a/apps/web/src/app/comment/[id]/page.tsx
+++ b/apps/web/src/app/comment/[id]/page.tsx
@@ -143,28 +143,26 @@ function OriginalPostCard({ post }: { post: PostData }) {
         {/* Content */}
         <div className="min-w-0 flex-1">
           {/* Header */}
-          <div className="mb-1 flex items-center justify-between gap-2">
-            <div className="flex min-w-0 flex-1 items-center gap-2">
+          <div className="flex items-start justify-between gap-3 leading-none sm:items-center sm:pt-0.5">
+            <div className="flex min-w-0 flex-1 items-center gap-1.5">
               <Link
                 href={getProfileUrl(post.authorId, null)}
-                className="truncate font-semibold text-sm hover:underline"
+                className="truncate font-semibold text-[15px] text-foreground leading-tight hover:underline"
                 onClick={(e) => e.stopPropagation()}
               >
                 {post.authorName}
               </Link>
-              {showVerifiedBadge && (
-                <VerifiedBadge size="sm" className="-ml-1" />
-              )}
+              {showVerifiedBadge && <VerifiedBadge size="sm" />}
               <Link
                 href={getProfileUrl(post.authorId, null)}
-                className="truncate text-muted-foreground text-xs hover:underline"
+                className="truncate text-[15px] text-muted-foreground leading-tight hover:underline"
                 onClick={(e) => e.stopPropagation()}
               >
                 @{post.authorUsername || post.authorName}
               </Link>
             </div>
-            <div className="flex shrink-0 items-center gap-2">
-              <span className="text-muted-foreground text-xs">
+            <div className="flex items-start gap-2 sm:items-center">
+              <span className="text-[15px] text-muted-foreground leading-tight">
                 {formatTimeAgo(post.createdAt)}
               </span>
               {/* Moderation menu for other users' posts */}
@@ -262,28 +260,26 @@ function ParentCommentCard({
         {/* Content */}
         <div className="min-w-0 flex-1">
           {/* Header */}
-          <div className="mb-1 flex items-center justify-between gap-2">
-            <div className="flex min-w-0 flex-1 items-center gap-2">
+          <div className="flex items-start justify-between gap-3 leading-none sm:items-center sm:pt-0.5">
+            <div className="flex min-w-0 flex-1 items-center gap-1.5">
               <Link
                 href={getProfileUrl(parent.authorId, parent.authorUsername)}
-                className="truncate font-semibold text-sm hover:underline"
+                className="truncate font-semibold text-[15px] text-foreground leading-tight hover:underline"
                 onClick={(e) => e.stopPropagation()}
               >
                 {parent.authorName}
               </Link>
-              {showVerifiedBadge && (
-                <VerifiedBadge size="sm" className="-ml-1" />
-              )}
+              {showVerifiedBadge && <VerifiedBadge size="sm" />}
               <Link
                 href={getProfileUrl(parent.authorId, parent.authorUsername)}
-                className="truncate text-muted-foreground text-xs hover:underline"
+                className="truncate text-[15px] text-muted-foreground leading-tight hover:underline"
                 onClick={(e) => e.stopPropagation()}
               >
                 @{parent.authorUsername || parent.authorName}
               </Link>
             </div>
-            <div className="flex shrink-0 items-center gap-2">
-              <span className="text-muted-foreground text-xs">
+            <div className="flex items-start gap-2 sm:items-center">
+              <span className="text-[15px] text-muted-foreground leading-tight">
                 {formatTimeAgo(parent.createdAt)}
               </span>
               {/* Moderation menu for other users' comments */}
@@ -362,28 +358,26 @@ function ReplyCard({
         {/* Content */}
         <div className="min-w-0 flex-1">
           {/* Header */}
-          <div className="mb-1 flex items-center justify-between gap-2">
-            <div className="flex min-w-0 flex-1 items-center gap-2">
+          <div className="flex items-start justify-between gap-3 leading-none sm:items-center sm:pt-0.5">
+            <div className="flex min-w-0 flex-1 items-center gap-1.5">
               <Link
                 href={getProfileUrl(reply.authorId, reply.authorUsername)}
-                className="truncate font-semibold text-sm hover:underline"
+                className="truncate font-semibold text-[15px] text-foreground leading-tight hover:underline"
                 onClick={(e) => e.stopPropagation()}
               >
                 {reply.authorName}
               </Link>
-              {showVerifiedBadge && (
-                <VerifiedBadge size="sm" className="-ml-1" />
-              )}
+              {showVerifiedBadge && <VerifiedBadge size="sm" />}
               <Link
                 href={getProfileUrl(reply.authorId, reply.authorUsername)}
-                className="truncate text-muted-foreground text-xs hover:underline"
+                className="truncate text-[15px] text-muted-foreground leading-tight hover:underline"
                 onClick={(e) => e.stopPropagation()}
               >
                 @{reply.authorUsername || reply.authorName}
               </Link>
             </div>
-            <div className="flex shrink-0 items-center gap-2">
-              <span className="text-muted-foreground text-xs">
+            <div className="flex items-start gap-2 sm:items-center">
+              <span className="text-[15px] text-muted-foreground leading-tight">
                 {formatTimeAgo(reply.createdAt)}
               </span>
               {/* Moderation menu for other users' comments */}
@@ -582,7 +576,7 @@ export default function CommentPage({ params }: CommentPageProps) {
             </div>
             <div className="flex-1 bg-background">
               <div className="w-full lg:mx-auto lg:max-w-[700px]">
-                <div className="space-y-4 px-4 py-6">
+                <div className="space-y-4 sm:px-4 sm:py-6">
                   <Skeleton className="h-8 w-3/4" />
                   <Skeleton className="h-32 w-full" />
                   <Skeleton className="h-20 w-full" />
@@ -599,7 +593,7 @@ export default function CommentPage({ params }: CommentPageProps) {
                 <Skeleton className="h-6 w-20" />
               </div>
             </div>
-            <div className="space-y-4 px-4 py-6">
+            <div className="space-y-4 sm:px-4 sm:py-6">
               <Skeleton className="h-8 w-3/4" />
               <Skeleton className="h-32 w-full" />
               <Skeleton className="h-20 w-full" />
@@ -705,26 +699,24 @@ export default function CommentPage({ params }: CommentPageProps) {
           {/* Content */}
           <div className="min-w-0 flex-1">
             {/* Author info */}
-            <div className="mb-2 flex items-center justify-between gap-2">
-              <div className="flex min-w-0 flex-1 items-center gap-2">
+            <div className="flex items-start justify-between gap-3 leading-none sm:items-center sm:pt-0.5">
+              <div className="flex min-w-0 flex-1 items-center gap-1.5">
                 <Link
                   href={getProfileUrl(comment.authorId, comment.authorUsername)}
-                  className="font-semibold hover:underline"
+                  className="truncate font-semibold text-[15px] text-foreground leading-tight hover:underline"
                 >
                   {comment.authorName}
                 </Link>
-                {showVerifiedBadge && (
-                  <VerifiedBadge size="sm" className="-ml-1" />
-                )}
+                {showVerifiedBadge && <VerifiedBadge size="sm" />}
                 <Link
                   href={getProfileUrl(comment.authorId, comment.authorUsername)}
-                  className="text-muted-foreground text-sm hover:underline"
+                  className="truncate text-[15px] text-muted-foreground leading-tight hover:underline"
                 >
                   @{comment.authorUsername || comment.authorName}
                 </Link>
               </div>
-              <div className="flex shrink-0 items-center gap-2">
-                <span className="text-muted-foreground text-xs">
+              <div className="flex items-start gap-2 sm:items-center">
+                <span className="text-[15px] text-muted-foreground leading-tight">
                   {formatTimeAgo(comment.createdAt)}
                 </span>
                 {/* Moderation menu for other users' comments */}

--- a/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
+++ b/apps/web/src/app/markets/_components/terminal/MarketsTradingTerminal.tsx
@@ -263,6 +263,12 @@ function formatYesPct(raw: number): string {
   return `${rounded.toFixed(clamped >= 10 ? 0 : 1)}%`;
 }
 
+function formatCompactNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return Math.round(n).toLocaleString();
+}
+
 function formatDate(dateStr: string | undefined | null): string {
   if (!dateStr) return '';
   const date = new Date(dateStr);
@@ -321,6 +327,7 @@ function PredictionMarketHeader({
   timeRange,
   onTimeRangeChange,
   onDetailsClick,
+  onFullscreen,
   variant = 'default',
 }: {
   predictionState: PredictionMarketTerminalState | null;
@@ -328,6 +335,7 @@ function PredictionMarketHeader({
   timeRange: MarketTimeRange;
   onTimeRangeChange: (range: MarketTimeRange) => void;
   onDetailsClick: () => void;
+  onFullscreen?: () => void;
   variant?: 'default' | 'compact';
 }) {
   const isCompact = variant === 'compact';
@@ -400,10 +408,23 @@ function PredictionMarketHeader({
             </button>
           )}
         </div>
-        <TimeRangeSelector
-          timeRange={timeRange}
-          onTimeRangeChange={onTimeRangeChange}
-        />
+        <div className="flex items-center gap-2">
+          <TimeRangeSelector
+            timeRange={timeRange}
+            onTimeRangeChange={onTimeRangeChange}
+          />
+          {onFullscreen && (
+            <button
+              type="button"
+              onClick={onFullscreen}
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded border border-white/10 bg-background/30 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground"
+              aria-label="Open chart fullscreen"
+              title="Fullscreen"
+            >
+              <Maximize2 size={14} />
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );
@@ -414,11 +435,13 @@ function PerpMarketHeader({
   selectedPerp,
   timeRange,
   onTimeRangeChange,
+  onFullscreen,
   variant = 'default',
 }: {
   selectedPerp: PerpMarket;
   timeRange: MarketTimeRange;
   onTimeRangeChange: (range: MarketTimeRange) => void;
+  onFullscreen?: () => void;
   variant?: 'default' | 'compact';
 }) {
   const isCompact = variant === 'compact';
@@ -434,10 +457,23 @@ function PerpMarketHeader({
           {selectedPerp.name}
         </div>
       </div>
-      <TimeRangeSelector
-        timeRange={timeRange}
-        onTimeRangeChange={onTimeRangeChange}
-      />
+      <div className="flex items-center gap-2">
+        <TimeRangeSelector
+          timeRange={timeRange}
+          onTimeRangeChange={onTimeRangeChange}
+        />
+        {onFullscreen && (
+          <button
+            type="button"
+            onClick={onFullscreen}
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded border border-white/10 bg-background/30 text-muted-foreground transition-colors hover:bg-muted/20 hover:text-foreground"
+            aria-label="Open chart fullscreen"
+            title="Fullscreen"
+          >
+            <Maximize2 size={14} />
+          </button>
+        )}
+      </div>
     </div>
   );
 }
@@ -833,7 +869,7 @@ export function MarketsTradingTerminal({
       title: m.ticker,
       subtitle: m.name,
       valuePrimary: `${BABYLON_POINTS_SYMBOL}${m.currentPrice.toFixed(2)}`,
-      valueSecondary: `Vol ${Math.round(m.volume24h).toLocaleString()}`,
+      valueSecondary: `Vol ${formatCompactNumber(m.volume24h)}`,
       change24hPct: m.changePercent24h,
       sortVolume: m.volume24h ?? 0,
       sortOpenInterest: m.openInterest ?? 0,
@@ -856,7 +892,7 @@ export function MarketsTradingTerminal({
           m.status !== 'active'
             ? m.status.toUpperCase()
             : vol > 0
-              ? `Vol ${Math.round(vol).toLocaleString()}`
+              ? `Vol ${formatCompactNumber(vol)}`
               : undefined,
         change24hPct: null,
         sortVolume: vol,
@@ -1589,7 +1625,7 @@ export function MarketsTradingTerminal({
         <div className="absolute right-0 bottom-0 left-0 h-px bg-white/5" />
       </div>
 
-      <div className="min-h-0 flex-1 overflow-auto">
+      <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
         {(perpLoading || predictionLoading) && rows.length === 0 ? (
           <div className="divide-y divide-white/5">
             {Array.from({ length: 5 }).map((_, i) => (
@@ -1611,10 +1647,16 @@ export function MarketsTradingTerminal({
             Failed to load markets.
           </div>
         ) : (
-          <table className="w-full text-left text-xs">
+          <table className="w-full table-fixed text-left text-xs">
+            <colgroup>
+              <col className="w-10" />
+              <col />
+              <col className="w-24" />
+              <col className="w-16" />
+            </colgroup>
             <thead className="sr-only">
               <tr className="border-white/5 border-b">
-                <th className="w-10 px-3 py-2">Favorite</th>
+                <th className="px-3 py-2">Favorite</th>
                 <th className="px-2 py-2">Market</th>
                 <th className="px-2 py-2 text-right">Value</th>
                 <th className="px-3 py-2 text-right">24h</th>
@@ -1664,17 +1706,17 @@ export function MarketsTradingTerminal({
                         </div>
                       </div>
                     </td>
-                    <td className="whitespace-nowrap px-2 py-2 text-right">
-                      <div className="font-mono font-semibold text-foreground text-xs tabular-nums">
+                    <td className="overflow-hidden px-2 py-2 text-right">
+                      <div className="truncate text-right font-mono font-semibold text-foreground text-xs tabular-nums">
                         {row.valuePrimary}
                       </div>
                       {row.valueSecondary && (
-                        <div className="font-mono font-semibold text-[11px] text-foreground/80 tabular-nums">
+                        <div className="truncate text-right font-mono font-semibold text-[11px] text-foreground/80 tabular-nums">
                           {row.valueSecondary}
                         </div>
                       )}
                     </td>
-                    <td className="whitespace-nowrap px-3 py-2 text-right">
+                    <td className="whitespace-nowrap py-2 pr-4 pl-2 text-right">
                       {row.kind === 'perp' && change != null ? (
                         <div
                           className={cn(
@@ -2545,6 +2587,7 @@ export function MarketsTradingTerminal({
                     timeRange={predictionTimeRange}
                     onTimeRangeChange={setPredictionTimeRange}
                     onDetailsClick={() => setPredictionDetailsOpen(true)}
+                    onFullscreen={() => setIsMobileChartFullscreen(true)}
                     variant="compact"
                   />
                 ) : selectedPerp ? (
@@ -2552,6 +2595,7 @@ export function MarketsTradingTerminal({
                     selectedPerp={selectedPerp}
                     timeRange={perpTimeRange}
                     onTimeRangeChange={setPerpTimeRange}
+                    onFullscreen={() => setIsMobileChartFullscreen(true)}
                     variant="compact"
                   />
                 ) : null}
@@ -2593,23 +2637,6 @@ export function MarketsTradingTerminal({
                   <div className="flex min-h-0 flex-1 items-center justify-center text-muted-foreground">
                     Select a market
                   </div>
-                )}
-
-                {selected && (
-                  <button
-                    type="button"
-                    onClick={() => setIsMobileChartFullscreen(true)}
-                    className={cn(
-                      'absolute right-3 bottom-3 z-20 inline-flex h-10 w-10 items-center justify-center rounded-full',
-                      'border border-white/10 bg-background/70 text-muted-foreground shadow-sm backdrop-blur-md',
-                      'transition-colors hover:bg-muted/40 hover:text-foreground',
-                      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30'
-                    )}
-                    aria-label="Open chart fullscreen"
-                    title="Fullscreen chart"
-                  >
-                    <Maximize2 size={18} />
-                  </button>
                 )}
               </div>
             </div>

--- a/apps/web/src/app/markets/_components/terminal/TerminalSocialFeed.tsx
+++ b/apps/web/src/app/markets/_components/terminal/TerminalSocialFeed.tsx
@@ -192,26 +192,46 @@ export function TerminalSocialFeed({ perpTicker }: TerminalSocialFeedProps) {
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      {tagMode && (
+      {tag && (
         <div className="shrink-0 px-2 pt-3">
           <div
             className={cn(
               'flex items-center justify-between rounded-md border border-white/5 bg-background/40 px-3 py-2 text-muted-foreground text-xs'
             )}
           >
-            <span className="min-w-0 truncate">
-              Showing posts for{' '}
-              <span className="font-semibold text-foreground">
-                {tagInfo?.displayName ?? perpTicker}
-              </span>
-            </span>
-            <button
-              type="button"
-              onClick={() => setTagNotFound(true)}
-              className="shrink-0 rounded px-2 py-1 font-semibold text-foreground/80 hover:bg-muted/20 hover:text-foreground"
-            >
-              Show all
-            </button>
+            {tagMode ? (
+              <>
+                <span className="min-w-0 truncate">
+                  Showing posts for{' '}
+                  <span className="font-semibold text-foreground">
+                    {tagInfo?.displayName ?? perpTicker}
+                  </span>
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setTagNotFound(true)}
+                  className="shrink-0 rounded px-2 py-1 font-semibold text-foreground/80 hover:bg-muted/20 hover:text-foreground"
+                >
+                  Show all
+                </button>
+              </>
+            ) : (
+              <>
+                <span className="min-w-0 truncate">Showing all posts</span>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setTagNotFound(false);
+                    setTagPosts([]);
+                    setTagOffset(0);
+                    setTagHasMore(true);
+                  }}
+                  className="shrink-0 rounded px-2 py-1 font-semibold text-foreground/80 hover:bg-muted/20 hover:text-foreground"
+                >
+                  {perpTicker ?? 'Filtered'}
+                </button>
+              </>
+            )}
           </div>
         </div>
       )}

--- a/apps/web/src/app/markets/page.tsx
+++ b/apps/web/src/app/markets/page.tsx
@@ -79,7 +79,7 @@ export default function MarketsPage() {
   return (
     <PageContainer
       noPadding
-      className="flex h-[calc(100dvh-112px)] min-h-0 flex-col overflow-hidden md:h-dvh"
+      className="mt-14 flex h-[calc(100dvh-112px)] min-h-0 flex-col overflow-hidden md:mt-0 md:h-dvh"
     >
       <div className="flex flex-1 overflow-hidden border-border bg-background/20 lg:border-l">
         <MarketsTradingTerminal

--- a/apps/web/src/app/nft/page.tsx
+++ b/apps/web/src/app/nft/page.tsx
@@ -163,7 +163,7 @@ export default function NftGalleryPage() {
       : 'Waiting for network confirmation...';
 
   return (
-    <PageContainer noPadding className="flex h-full flex-col">
+    <PageContainer noPadding className="flex h-full flex-col pt-14 md:pt-0">
       {/* Header */}
       <div className="border-border border-b bg-card px-4 py-5">
         <div className="mx-auto max-w-5xl">
@@ -173,7 +173,7 @@ export default function NftGalleryPage() {
                 ProtoMonkeys
               </h1>
               <p className="text-muted-foreground text-sm">
-                Exclusive NFTs for top 100 players on leaderboard
+                Exclusive NFTs for top 100 players
               </p>
             </div>
 
@@ -183,7 +183,7 @@ export default function NftGalleryPage() {
                 disabled={isMinting || isCheckingEligibility}
                 className="rounded-full bg-[#0066FF] px-5 py-2.5 font-semibold text-sm text-white shadow-md transition-all hover:scale-105 hover:bg-[#2952d9] hover:shadow-lg disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:scale-100"
               >
-                {isCheckingEligibility ? 'Checking...' : 'Claim My NFT'}
+                {isCheckingEligibility ? 'Checking...' : 'Claim'}
               </button>
             )}
 
@@ -244,7 +244,8 @@ export default function NftGalleryPage() {
                   : 'text-muted-foreground hover:bg-muted hover:text-foreground'
               }`}
             >
-              All NFTs
+              <span className="sm:hidden">All</span>
+              <span className="hidden sm:inline">All NFTs</span>
             </button>
             {authenticated && (
               <button
@@ -255,7 +256,12 @@ export default function NftGalleryPage() {
                     : 'text-muted-foreground hover:bg-muted hover:text-foreground'
                 }`}
               >
-                My NFT{myNftCount > 0 && ` (${myNftCount})`}
+                <span className="sm:hidden">
+                  Mine{myNftCount > 0 && ` (${myNftCount})`}
+                </span>
+                <span className="hidden sm:inline">
+                  My NFT{myNftCount > 0 && ` (${myNftCount})`}
+                </span>
               </button>
             )}
           </div>

--- a/apps/web/src/app/notifications/page.tsx
+++ b/apps/web/src/app/notifications/page.tsx
@@ -408,7 +408,7 @@ export default function NotificationsPage() {
                 <div className="space-y-0">
                   {/* Group Invites Section */}
                   {groupInvites.length > 0 && (
-                    <div className="space-y-3 px-4 py-4 lg:px-6">
+                    <div className="space-y-3 sm:px-4 sm:py-4 lg:px-6">
                       <h3 className="font-semibold text-muted-foreground text-sm">
                         Pending Group Invites
                       </h3>
@@ -452,10 +452,10 @@ export default function NotificationsPage() {
                         !notification.read && 'bg-primary/5'
                       )}
                     >
-                      <div className="flex items-start gap-3">
+                      <div className="flex items-center gap-3">
                         {/* Unread Indicator */}
                         {!notification.read && (
-                          <div className="mt-2 h-2 w-2 shrink-0 rounded-full bg-primary" />
+                          <div className="h-2 w-2 shrink-0 rounded-full bg-primary" />
                         )}
 
                         {/* Actor Avatar */}
@@ -491,12 +491,11 @@ export default function NotificationsPage() {
                                 </p>
                               ) : (
                                 <p className="text-foreground leading-relaxed">
-                                  <span className="font-semibold">
+                                  <span className="block font-semibold md:inline">
                                     {notification.actor?.displayName ||
                                       'Someone'}
                                   </span>{' '}
                                   <span className="text-muted-foreground">
-                                    {getNotificationIcon(notification.type)}{' '}
                                     {notification.message
                                       .replace(
                                         notification.actor?.displayName || '',

--- a/apps/web/src/app/post/[id]/page.tsx
+++ b/apps/web/src/app/post/[id]/page.tsx
@@ -205,7 +205,7 @@ export default function PostPage({ params }: PostPageProps) {
           <div className="hidden min-w-0 flex-1 flex-col border-border lg:flex lg:border-r lg:border-l">
             <div className="flex-1 bg-background">
               <div className="w-full lg:mx-auto lg:max-w-[700px]">
-                <div className="space-y-4 px-4 py-6">
+                <div className="space-y-4 sm:px-4 sm:py-6">
                   <Skeleton className="h-8 w-3/4" />
                   <Skeleton className="h-64 w-full" />
                   <Skeleton className="h-32 w-full" />
@@ -216,7 +216,7 @@ export default function PostPage({ params }: PostPageProps) {
           <WidgetSidebar showLatestNews={false} showMarkets={false} />
           {/* Mobile loading */}
           <div className="flex flex-1 flex-col lg:hidden">
-            <div className="space-y-4 px-4 py-6">
+            <div className="space-y-4 sm:px-4 sm:py-6">
               <Skeleton className="h-8 w-3/4" />
               <Skeleton className="h-64 w-full" />
               <Skeleton className="h-32 w-full" />

--- a/apps/web/src/app/settings/moderation/page.tsx
+++ b/apps/web/src/app/settings/moderation/page.tsx
@@ -121,7 +121,7 @@ export default function ModerationSettingsPage() {
 
   if (!authenticated) {
     return (
-      <PageContainer>
+      <PageContainer className="pt-14 md:pt-0">
         <div className="py-12 text-center">
           <p className="text-muted-foreground">
             Please log in to view moderation settings.
@@ -132,7 +132,7 @@ export default function ModerationSettingsPage() {
   }
 
   return (
-    <PageContainer>
+    <PageContainer className="pt-14 md:pt-0">
       <div className="mx-auto max-w-4xl">
         {/* Header */}
         <div className="mb-6">

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -509,7 +509,7 @@ export default function SettingsPage() {
 
   if (!ready) {
     return (
-      <PageContainer noPadding className="flex w-full flex-col">
+      <PageContainer noPadding className="flex w-full flex-col pt-14 md:pt-0">
         <div className="flex min-w-0 flex-1 flex-col border-border lg:border-r lg:border-l">
           {/* Header skeleton */}
           <div className="sticky top-0 z-10 flex-shrink-0 bg-background/95 backdrop-blur-sm">
@@ -548,7 +548,7 @@ export default function SettingsPage() {
 
   if (!authenticated) {
     return (
-      <PageContainer noPadding className="flex w-full flex-col">
+      <PageContainer noPadding className="flex w-full flex-col pt-14 md:pt-0">
         <div className="flex min-w-0 flex-1 flex-col border-border lg:border-r lg:border-l">
           <div className="sticky top-0 z-10 flex-shrink-0 bg-background/95 backdrop-blur-sm">
             <div className="mx-auto w-full max-w-4xl px-4 py-3 md:px-6">
@@ -567,7 +567,7 @@ export default function SettingsPage() {
   }
 
   return (
-    <PageContainer noPadding className="flex w-full flex-col">
+    <PageContainer noPadding className="flex w-full flex-col pt-14 md:pt-0">
       <div className="flex min-w-0 flex-1 flex-col border-border lg:border-r lg:border-l">
         {/* Sticky Header + Tab Navigation */}
         <div className="sticky top-0 z-10 flex-shrink-0 bg-background/95 backdrop-blur-sm">
@@ -598,11 +598,11 @@ export default function SettingsPage() {
           </div>
         </div>
 
-        <div className="mx-auto w-full max-w-4xl px-4 pb-24 md:px-6">
+        <div className="mx-auto w-full max-w-4xl px-4 pb-8 md:px-6 md:pb-24">
           {/* Tab Content */}
           <div className="pt-6">
             {activeTab === 'profile' && (
-              <div className="rounded-lg border border-border p-5">
+              <div>
                 <div className="space-y-5">
                   <div className="space-y-3">
                     <div className="flex items-center justify-between gap-3">

--- a/apps/web/src/app/trending/[tag]/page.tsx
+++ b/apps/web/src/app/trending/[tag]/page.tsx
@@ -128,7 +128,7 @@ export default function TrendingTagPage() {
   const feedContent = (
     <>
       {loading ? (
-        <div className="space-y-4 px-4 py-6">
+        <div className="space-y-4 sm:px-4 sm:py-6">
           <Skeleton className="h-24 w-full" />
           <Skeleton className="h-24 w-full" />
           <Skeleton className="h-24 w-full" />

--- a/apps/web/src/app/trending/group/page.tsx
+++ b/apps/web/src/app/trending/group/page.tsx
@@ -100,7 +100,7 @@ export default function GroupedTrendingPage() {
   const feedContent = (
     <>
       {loading ? (
-        <div className="space-y-4 px-4 py-6">
+        <div className="space-y-4 sm:px-4 sm:py-6">
           <Skeleton className="h-24 w-full" />
           <Skeleton className="h-24 w-full" />
           <Skeleton className="h-24 w-full" />

--- a/apps/web/src/components/articles/ArticleCard.tsx
+++ b/apps/web/src/components/articles/ArticleCard.tsx
@@ -105,14 +105,14 @@ export const ArticleCard = memo(function ArticleCard({
           {/* Author row: Name · @handle · Category | timeAgo right-aligned */}
           <div
             className={cn(
-              'flex items-center justify-between gap-1.5 leading-tight',
-              compact ? 'mb-1 text-[15px] md:text-[13px]' : 'mb-2 text-[15px]'
+              'flex items-start justify-between gap-3 leading-none sm:items-center sm:pt-0.5',
+              compact ? 'mb-1' : ''
             )}
           >
-            <div className="flex min-w-0 items-center gap-1.5">
+            <div className="flex min-w-0 flex-1 items-center gap-1.5">
               <Link
                 href={`/profile/${post.authorId}`}
-                className="truncate font-semibold text-foreground hover:underline"
+                className="truncate font-semibold text-[15px] text-foreground leading-tight hover:underline"
                 onClick={(e) => e.stopPropagation()}
               >
                 {post.authorName}
@@ -120,7 +120,7 @@ export const ArticleCard = memo(function ArticleCard({
               {post.authorUsername && (
                 <Link
                   href={`/profile/${post.authorId}`}
-                  className="truncate text-muted-foreground hover:underline"
+                  className="truncate text-[15px] text-muted-foreground leading-tight hover:underline"
                   onClick={(e) => e.stopPropagation()}
                 >
                   @{post.authorUsername}
@@ -136,10 +136,7 @@ export const ArticleCard = memo(function ArticleCard({
               )}
             </div>
             <time
-              className={cn(
-                'shrink-0 text-muted-foreground',
-                compact ? 'text-[15px] md:text-[13px]' : 'text-[15px]'
-              )}
+              className="text-[15px] text-muted-foreground leading-tight"
               title={publishedDate.toLocaleString()}
             >
               {timeAgo}

--- a/apps/web/src/components/feedback/GameFeedbackModal.tsx
+++ b/apps/web/src/components/feedback/GameFeedbackModal.tsx
@@ -447,9 +447,7 @@ export function GameFeedbackModal({ isOpen, onClose }: GameFeedbackModalProps) {
             <button
               type="button"
               onClick={handleSubmit}
-              disabled={
-                isSubmitting || (retryAfter !== null && retryAfter > 0)
-              }
+              disabled={isSubmitting || (retryAfter !== null && retryAfter > 0)}
               className={cn(
                 'flex w-full items-center justify-center gap-2 rounded-lg px-4 py-3 font-semibold transition-colors',
                 'bg-[#1c9cf0] text-primary-foreground hover:bg-[#1c9cf0]/90',

--- a/apps/web/src/components/feedback/GameFeedbackModal.tsx
+++ b/apps/web/src/components/feedback/GameFeedbackModal.tsx
@@ -373,9 +373,6 @@ export function GameFeedbackModal({ isOpen, onClose }: GameFeedbackModalProps) {
         <div className="flex shrink-0 items-start justify-between border-border border-b p-4 md:p-6">
           <div>
             <h2 className="font-bold text-foreground text-xl">Game Feedback</h2>
-            <p className="mt-1 text-muted-foreground text-sm">
-              Help us improve the game
-            </p>
           </div>
           <button
             type="button"
@@ -447,49 +444,35 @@ export function GameFeedbackModal({ isOpen, onClose }: GameFeedbackModalProps) {
         {/* Action Buttons - Fixed footer */}
         {feedbackType && (
           <div className="shrink-0 border-border border-t bg-background p-4 md:p-6">
-            <div className="flex items-center gap-3">
-              <button
-                type="button"
-                onClick={handleSubmit}
-                disabled={
-                  isSubmitting || (retryAfter !== null && retryAfter > 0)
-                }
-                className={cn(
-                  'flex flex-1 items-center justify-center gap-2 rounded-lg px-4 py-3 font-semibold transition-colors',
-                  'bg-[#1c9cf0] text-primary-foreground hover:bg-[#1c9cf0]/90',
-                  'disabled:cursor-not-allowed disabled:opacity-50'
-                )}
-              >
-                {isSubmitting ? (
-                  <>
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                    <span>Submitting...</span>
-                  </>
-                ) : retryAfter !== null && retryAfter > 0 ? (
-                  <>
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                    <span>Rate limited. Retry in {retryAfter}s</span>
-                  </>
-                ) : (
-                  <>
-                    <Send className="h-4 w-4" />
-                    <span>Submit Feedback</span>
-                  </>
-                )}
-              </button>
-              <button
-                type="button"
-                onClick={handleClose}
-                disabled={isSubmitting}
-                className={cn(
-                  'rounded-lg px-4 py-3 font-semibold transition-colors',
-                  'bg-muted text-foreground hover:bg-muted/70',
-                  'disabled:cursor-not-allowed disabled:opacity-50'
-                )}
-              >
-                Cancel
-              </button>
-            </div>
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={
+                isSubmitting || (retryAfter !== null && retryAfter > 0)
+              }
+              className={cn(
+                'flex w-full items-center justify-center gap-2 rounded-lg px-4 py-3 font-semibold transition-colors',
+                'bg-[#1c9cf0] text-primary-foreground hover:bg-[#1c9cf0]/90',
+                'disabled:cursor-not-allowed disabled:opacity-50'
+              )}
+            >
+              {isSubmitting ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <span>Submitting...</span>
+                </>
+              ) : retryAfter !== null && retryAfter > 0 ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  <span>Rate limited. Retry in {retryAfter}s</span>
+                </>
+              ) : (
+                <>
+                  <Send className="h-4 w-4" />
+                  <span>Submit Feedback</span>
+                </>
+              )}
+            </button>
           </div>
         )}
       </div>

--- a/apps/web/src/components/groups/CreateGroupModal.tsx
+++ b/apps/web/src/components/groups/CreateGroupModal.tsx
@@ -562,22 +562,15 @@ export function CreateGroupModal({
             </div>
           )}
 
-          {/* Action Buttons */}
-          <div className="mt-6 flex gap-3">
-            <button
-              onClick={handleClose}
-              className="flex-1 rounded-lg border border-border bg-sidebar px-4 py-3 transition-colors hover:bg-accent"
-              disabled={creating}
-            >
-              Cancel
-            </button>
+          {/* Action Button */}
+          <div className="mt-6">
             <button
               onClick={handleCreateGroup}
               disabled={
                 creating || (selectedMembers.length === 0 && !groupName.trim())
               }
               className={cn(
-                'flex-1 rounded-lg px-4 py-3 font-medium transition-colors',
+                'w-full rounded-lg px-4 py-3 font-medium transition-colors',
                 'bg-primary text-primary-foreground hover:bg-primary/90',
                 'disabled:cursor-not-allowed disabled:opacity-50'
               )}

--- a/apps/web/src/components/interactions/CommentCard.tsx
+++ b/apps/web/src/components/interactions/CommentCard.tsx
@@ -166,7 +166,7 @@ export function CommentCard({
           <Avatar
             id={comment.userId}
             name={comment.userName}
-            size="sm"
+            size="md"
             src={comment.userAvatar || undefined}
             imageUrl={comment.userAvatar || undefined}
           />
@@ -175,29 +175,26 @@ export function CommentCard({
         {/* Content */}
         <div className="min-w-0 flex-1">
           {/* Header: Username/handle on left, timestamp and actions on right */}
-          <div className="mb-2 flex items-center justify-between gap-2">
-            <div className="flex min-w-0 flex-1 items-center gap-2">
+          <div className="flex items-start justify-between gap-3 leading-none sm:items-center sm:pt-0.5">
+            <div className="flex min-w-0 flex-1 items-center gap-1.5">
               <Link
                 href={getProfileUrl(comment.userId, comment.userUsername)}
-                className="truncate font-semibold text-sm hover:underline"
+                className="truncate font-semibold text-[15px] text-foreground leading-tight hover:underline"
                 onClick={(e) => e.stopPropagation()}
               >
                 {comment.userName}
               </Link>
-              {showVerifiedBadge && (
-                <VerifiedBadge size="sm" className="-ml-1" />
-              )}
+              {showVerifiedBadge && <VerifiedBadge size="sm" />}
               <Link
                 href={getProfileUrl(comment.userId, comment.userUsername)}
-                className="truncate text-muted-foreground text-xs hover:underline"
+                className="truncate text-[15px] text-muted-foreground leading-tight hover:underline"
                 onClick={(e) => e.stopPropagation()}
               >
                 @{comment.userUsername || comment.userName}
               </Link>
             </div>
-            <div className="flex shrink-0 items-center gap-2">
-              {/* Timestamp - Right aligned */}
-              <span className="text-muted-foreground text-xs">
+            <div className="flex items-start gap-2 sm:items-center">
+              <span className="text-[15px] text-muted-foreground leading-tight">
                 {formatTimeAgo(new Date(comment.createdAt).toISOString())}
               </span>
 

--- a/apps/web/src/components/interactions/RepostButton.tsx
+++ b/apps/web/src/components/interactions/RepostButton.tsx
@@ -44,9 +44,9 @@ const sizeClasses = {
 };
 
 const iconSizes = {
-  sm: 18,
-  md: 20,
-  lg: 22,
+  sm: 20,
+  md: 22,
+  lg: 24,
 };
 
 const skeletonSizes = {
@@ -210,10 +210,10 @@ export function RepostButton({
             }}
           />
 
-          {/* Modal - Mobile */}
-          <div className="fixed inset-x-4 top-20 bottom-auto z-[110] flex max-h-[85vh] flex-col overflow-hidden rounded-2xl border border-border bg-sidebar shadow-2xl md:hidden">
-            {/* Header */}
-            <div className="flex items-center justify-between border-border border-b px-6 py-4">
+          {/* Modal - Mobile (Full Screen) */}
+          <div className="fixed inset-0 z-[110] flex flex-col bg-sidebar md:hidden">
+            {/* Header - Fixed */}
+            <div className="shrink-0 flex items-center justify-between border-border border-b px-6 py-4">
               <div className="flex items-center gap-3">
                 <button
                   type="button"
@@ -251,19 +251,23 @@ export function RepostButton({
               </button>
             </div>
 
-            {/* Content - Scrollable */}
-            <div className="flex-1 overflow-y-auto px-6 py-4">
-              {/* Quote Comment Textarea */}
+            {/* Content - Whole area scrolls */}
+            <div className="min-h-0 flex-1 overflow-y-auto px-6 pb-4">
+              {/* Quote Comment Textarea - auto-grows, never scrolls internally */}
               <textarea
                 value={quoteComment}
-                onChange={(e) => setQuoteComment(e.target.value)}
+                onChange={(e) => {
+                  setQuoteComment(e.target.value);
+                  e.target.style.height = 'auto';
+                  e.target.style.height = `${e.target.scrollHeight}px`;
+                }}
                 placeholder="Add your thoughts (optional)"
                 maxLength={500}
                 rows={3}
                 aria-label="Quote comment"
                 aria-describedby="char-count-mobile"
                 className={cn(
-                  'mb-1 w-full rounded-xl p-3',
+                  'mb-1 w-full overflow-hidden rounded-xl py-3 pr-3',
                   'border-0 bg-transparent',
                   'text-foreground placeholder:text-muted-foreground',
                   'resize-none focus:outline-none',
@@ -273,21 +277,21 @@ export function RepostButton({
               />
 
               {/* Character Count */}
-              {quoteComment.length > 0 && (
-                <div className="mb-3 flex justify-end">
-                  <span
-                    id="char-count-mobile"
-                    className={cn(
-                      'text-xs',
-                      quoteComment.length > 450
+              <div className="mb-3 flex justify-end">
+                <span
+                  id="char-count-mobile"
+                  className={cn(
+                    'text-xs',
+                    quoteComment.length === 0
+                      ? 'invisible'
+                      : quoteComment.length > 450
                         ? 'text-red-400'
                         : 'text-muted-foreground'
-                    )}
-                  >
-                    {quoteComment.length}/500
-                  </span>
-                </div>
-              )}
+                  )}
+                >
+                  {quoteComment.length || 0}/500
+                </span>
+              </div>
 
               {/* Original Post Preview */}
               {postData && (
@@ -382,7 +386,7 @@ export function RepostButton({
               </div>
 
               {/* Content - Scrollable */}
-              <div className="flex-1 overflow-y-auto px-6 py-6">
+              <div className="flex-1 overflow-y-auto px-6 pb-6">
                 {/* Quote Comment Textarea */}
                 <textarea
                   value={quoteComment}
@@ -393,7 +397,7 @@ export function RepostButton({
                   aria-label="Quote comment"
                   aria-describedby="char-count-desktop"
                   className={cn(
-                    'mb-1 w-full rounded-xl p-4',
+                    'mb-1 w-full rounded-xl py-4 pr-4',
                     'border-0 bg-transparent',
                     'text-base text-foreground placeholder:text-muted-foreground',
                     'resize-none focus:outline-none',
@@ -403,21 +407,21 @@ export function RepostButton({
                 />
 
                 {/* Character Count */}
-                {quoteComment.length > 0 && (
-                  <div className="mb-4 flex justify-end">
-                    <span
-                      id="char-count-desktop"
-                      className={cn(
-                        'text-sm',
-                        quoteComment.length > 450
+                <div className="mb-4 flex justify-end">
+                  <span
+                    id="char-count-desktop"
+                    className={cn(
+                      'text-sm',
+                      quoteComment.length === 0
+                        ? 'invisible'
+                        : quoteComment.length > 450
                           ? 'text-red-400'
                           : 'text-muted-foreground'
-                      )}
-                    >
-                      {quoteComment.length}/500
-                    </span>
-                  </div>
-                )}
+                    )}
+                  >
+                    {quoteComment.length || 0}/500
+                  </span>
+                </div>
 
                 {/* Original Post Preview */}
                 {postData && (

--- a/apps/web/src/components/interactions/RepostButton.tsx
+++ b/apps/web/src/components/interactions/RepostButton.tsx
@@ -213,7 +213,7 @@ export function RepostButton({
           {/* Modal - Mobile (Full Screen) */}
           <div className="fixed inset-0 z-[110] flex flex-col bg-sidebar md:hidden">
             {/* Header - Fixed */}
-            <div className="shrink-0 flex items-center justify-between border-border border-b px-6 py-4">
+            <div className="flex shrink-0 items-center justify-between border-border border-b px-6 py-4">
               <div className="flex items-center gap-3">
                 <button
                   type="button"

--- a/apps/web/src/components/moderation/ModerationMenu.tsx
+++ b/apps/web/src/components/moderation/ModerationMenu.tsx
@@ -1,31 +1,3 @@
-/**
- * Moderation menu component for user moderation actions.
- *
- * Provides a dropdown menu with options to follow, mute, block, and report users.
- * Opens corresponding modals for each action. Hides report option for NPCs
- * (can only block/mute NPCs). Includes overlay to close menu on outside click.
- *
- * Features:
- * - Follow/unfollow user option
- * - Mute user option
- * - Block user option
- * - Report user option (hidden for NPCs)
- * - Modal integration
- * - Overlay click to close
- *
- * @param props - ModerationMenu component props
- * @returns Moderation menu element
- *
- * @example
- * ```tsx
- * <ModerationMenu
- *   targetUserId="user-123"
- *   targetUsername="alice"
- *   isNPC={false}
- *   onActionComplete={() => refreshFeed()}
- * />
- * ```
- */
 'use client';
 
 import {
@@ -37,7 +9,7 @@ import {
   UserPlus,
   VolumeX,
 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
@@ -48,17 +20,30 @@ import { BlockUserModal } from './BlockUserModal';
 import { MuteUserModal } from './MuteUserModal';
 import { ReportModal } from './ReportModal';
 
-// Menu dimensions - keep in sync with CSS classes (w-56 = 14rem = 224px)
-const MENU_HEIGHT = 200;
-const MENU_WIDTH = 224;
+const MENU_HEIGHT = 280;
+const MENU_WIDTH = 256;
+const MOBILE_BREAKPOINT = 640;
+
+function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const check = () => setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, []);
+
+  return isMobile;
+}
 
 interface ModerationMenuProps {
   targetUserId: string;
   targetUsername?: string;
   targetDisplayName?: string;
   targetProfileImageUrl?: string;
-  postId?: string; // Optional: if reporting a specific post
-  isNPC?: boolean; // True if target is an NPC/actor (can block/mute but not report)
+  postId?: string;
+  isNPC?: boolean;
   onActionComplete?: () => void;
 }
 
@@ -73,23 +58,54 @@ export function ModerationMenu({
 }: ModerationMenuProps) {
   const { authenticated, user } = useAuth();
   const { trackFollow } = useSocialTracking();
+  const isMobile = useIsMobile();
   const [showMenu, setShowMenu] = useState(false);
+  const [isClosing, setIsClosing] = useState(false);
   const [showBlockModal, setShowBlockModal] = useState(false);
   const [showMuteModal, setShowMuteModal] = useState(false);
   const [showReportModal, setShowReportModal] = useState(false);
   const [isFollowing, setIsFollowing] = useState(false);
   const [isFollowLoading, setIsFollowLoading] = useState(false);
   const [isCheckingFollow, setIsCheckingFollow] = useState(true);
+  const [mounted, setMounted] = useState(false);
 
-  // Use custom hook for menu positioning
-  const { buttonRef, menuPosition, updatePosition, mounted } = useMenuPosition(
-    showMenu,
-    { menuHeight: MENU_HEIGHT, menuWidth: MENU_WIDTH }
+  const { buttonRef, menuPosition, updatePosition } = useMenuPosition(
+    showMenu && !isMobile,
+    { menuHeight: MENU_HEIGHT, menuWidth: MENU_WIDTH, padding: 2 }
   );
+
+  // Touch handling for swipe-to-dismiss
+  const sheetRef = useRef<HTMLDivElement>(null);
+  const dragStartY = useRef(0);
+  const dragCurrentY = useRef(0);
+  const isDragging = useRef(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const displayName = targetDisplayName || targetUsername || 'User';
 
-  // Check follow status when menu opens (with AbortController to prevent race conditions)
+  const closeMenu = useCallback(() => {
+    setIsClosing(true);
+    setTimeout(() => {
+      setShowMenu(false);
+      setIsClosing(false);
+    }, 200);
+  }, []);
+
+  // Lock body scroll when mobile sheet is open
+  useEffect(() => {
+    if (showMenu && isMobile) {
+      document.body.style.overflow = 'hidden';
+      return () => {
+        document.body.style.overflow = '';
+      };
+    }
+    return undefined;
+  }, [showMenu, isMobile]);
+
+  // Check follow status when menu opens
   useEffect(() => {
     if (!showMenu || !authenticated || !user) {
       setIsCheckingFollow(false);
@@ -122,7 +138,6 @@ export function ModerationMenu({
           setIsFollowing(false);
         }
       } catch (error) {
-        // Ignore abort errors, only handle network errors
         if (error instanceof Error && error.name !== 'AbortError') {
           setIsFollowing(false);
         }
@@ -156,7 +171,6 @@ export function ModerationMenu({
     const newFollowingState = !isFollowing;
     const method = newFollowingState ? 'POST' : 'DELETE';
 
-    // Optimistic update
     setIsFollowing(newFollowingState);
 
     try {
@@ -175,9 +189,8 @@ export function ModerationMenu({
             ? `Following ${displayName}`
             : `Unfollowed ${displayName}`
         );
-        setShowMenu(false);
+        closeMenu();
       } else {
-        // Revert optimistic update
         setIsFollowing(!newFollowingState);
         const errorData = await response.json();
         const errorMessage =
@@ -187,7 +200,6 @@ export function ModerationMenu({
         toast.error(errorMessage);
       }
     } catch {
-      // Revert optimistic update
       setIsFollowing(!newFollowingState);
       toast.error('Network error. Please try again.');
     }
@@ -197,116 +209,229 @@ export function ModerationMenu({
 
   const handleAction = () => {
     setShowMenu(false);
+    setIsClosing(false);
     onActionComplete?.();
   };
 
+  const handleTouchStart = (e: React.TouchEvent) => {
+    const touch = e.touches[0];
+    if (!touch) return;
+    dragStartY.current = touch.clientY;
+    isDragging.current = false;
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    const touch = e.touches[0];
+    if (!touch) return;
+    const currentY = touch.clientY;
+    const diff = currentY - dragStartY.current;
+    dragCurrentY.current = diff;
+
+    // Only allow dragging down
+    if (diff > 0) {
+      isDragging.current = true;
+      if (sheetRef.current) {
+        sheetRef.current.style.transform = `translateY(${diff}px)`;
+      }
+    }
+  };
+
+  const handleTouchEnd = () => {
+    if (isDragging.current && dragCurrentY.current > 80) {
+      closeMenu();
+    }
+    // Reset position
+    if (sheetRef.current) {
+      sheetRef.current.style.transform = '';
+    }
+    isDragging.current = false;
+    dragCurrentY.current = 0;
+  };
+
+  // Menu items definition
+  const menuItems = [
+    ...(authenticated
+      ? [
+          {
+            key: 'follow',
+            icon:
+              isFollowLoading || isCheckingFollow ? (
+                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+              ) : isFollowing ? (
+                <UserMinus className="h-5 w-5 text-muted-foreground" />
+              ) : (
+                <UserPlus className="h-5 w-5 text-muted-foreground" />
+              ),
+            label: isCheckingFollow
+              ? 'Loading...'
+              : isFollowing
+                ? `Unfollow ${displayName}`
+                : `Follow ${displayName}`,
+            onClick: handleFollow,
+            disabled: isFollowLoading || isCheckingFollow,
+            variant: 'default' as const,
+          },
+        ]
+      : []),
+    {
+      key: 'mute',
+      icon: <VolumeX className="h-5 w-5 text-muted-foreground" />,
+      label: `Mute ${displayName}`,
+      onClick: () => {
+        setShowMenu(false);
+        setIsClosing(false);
+        setShowMuteModal(true);
+      },
+      variant: 'default' as const,
+    },
+    {
+      key: 'block',
+      icon: <Ban className="h-5 w-5 text-orange-500" />,
+      label: `Block ${displayName}`,
+      onClick: () => {
+        setShowMenu(false);
+        setIsClosing(false);
+        setShowBlockModal(true);
+      },
+      variant: 'warning' as const,
+    },
+    ...(!isNPC
+      ? [
+          {
+            key: 'report',
+            icon: <Flag className="h-5 w-5 text-red-500" />,
+            label: postId ? 'Report post' : 'Report user',
+            onClick: () => {
+              setShowMenu(false);
+              setIsClosing(false);
+              setShowReportModal(true);
+            },
+            variant: 'danger' as const,
+          },
+        ]
+      : []),
+  ];
+
+  const renderMenuContent = () => (
+    <>
+      {menuItems.map((item) => (
+        <div key={item.key}>
+          <button
+            onClick={item.onClick}
+            disabled={item.disabled}
+            className="flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors hover:bg-muted/60 active:bg-muted disabled:opacity-50"
+          >
+            {item.icon}
+            <span
+              className={`font-medium text-[15px] ${
+                item.variant === 'warning'
+                  ? 'text-orange-500'
+                  : item.variant === 'danger'
+                    ? 'text-red-500'
+                    : 'text-foreground'
+              }`}
+            >
+              {item.label}
+            </span>
+          </button>
+        </div>
+      ))}
+    </>
+  );
+
   return (
     <div className="relative">
-      {/* Menu Button */}
+      {/* Trigger Button */}
       <button
         ref={buttonRef}
         onClick={() => {
           if (!showMenu) {
             updatePosition();
           }
-          setShowMenu(!showMenu);
+          if (showMenu) {
+            closeMenu();
+          } else {
+            setShowMenu(true);
+          }
         }}
-        className="rounded-lg px-2 py-0 transition-colors hover:bg-muted sm:p-2"
+        className="-mt-1.5 rounded-full p-1.5 transition-colors hover:bg-muted active:bg-muted/80 sm:mt-0"
         aria-label="More options"
       >
-        <MoreHorizontal className="h-5 w-5 text-muted-foreground" />
+        <MoreHorizontal className="h-[18px] w-[18px] text-muted-foreground" />
       </button>
 
-      {/* Dropdown Menu - rendered via portal to avoid overflow clipping */}
-      {/* Only render portal on client side (mounted check for SSR compatibility) */}
+      {/* Menu Portal */}
       {showMenu &&
         mounted &&
         createPortal(
-          <>
-            {/* Overlay to close menu */}
-            <div
-              className="fixed inset-0 z-40"
-              onClick={() => setShowMenu(false)}
-            />
+          isMobile ? (
+            /* ── Mobile Bottom Sheet ── */
+            <>
+              {/* Backdrop */}
+              <div
+                className={`fixed inset-0 z-40 bg-black/40 backdrop-blur-[2px] transition-opacity duration-200 ${
+                  isClosing ? 'opacity-0' : 'opacity-100'
+                }`}
+                onClick={closeMenu}
+              />
 
-            {/* Menu */}
-            <div
-              className="fixed z-50 w-56 rounded-lg border border-border bg-card shadow-lg"
-              style={{
-                top: menuPosition.openUpward ? 'auto' : menuPosition.top,
-                bottom: menuPosition.openUpward
-                  ? menuPosition.windowHeight - menuPosition.top
-                  : 'auto',
-                left: menuPosition.left,
-              }}
-            >
-              <div className="py-1">
-                {/* Follow/Unfollow option */}
-                {authenticated && (
+              {/* Sheet */}
+              <div
+                ref={sheetRef}
+                className={`fixed inset-x-0 bottom-0 z-50 bg-card pb-safe transition-transform duration-200 ease-out ${
+                  isClosing ? 'translate-y-full' : 'translate-y-0'
+                }`}
+                style={{ borderRadius: '16px 16px 0 0' }}
+                onTouchStart={handleTouchStart}
+                onTouchMove={handleTouchMove}
+                onTouchEnd={handleTouchEnd}
+              >
+                {/* Drag Handle */}
+                <div className="flex justify-center py-2.5">
+                  <div className="h-1 w-9 rounded-full bg-muted-foreground/25" />
+                </div>
+
+                {/* Actions */}
+                <div className="px-1 pb-1">{renderMenuContent()}</div>
+
+                {/* Cancel Button */}
+                <div className="px-4 pt-2 pb-4">
                   <button
-                    onClick={handleFollow}
-                    disabled={isFollowLoading || isCheckingFollow}
-                    className="flex w-full items-center gap-3 px-4 py-2 text-left text-sm transition-colors hover:bg-muted disabled:opacity-50"
+                    onClick={closeMenu}
+                    className="w-full rounded-xl bg-muted py-3 text-center font-semibold text-[15px] text-foreground transition-colors active:bg-muted/80"
                   >
-                    {isFollowLoading || isCheckingFollow ? (
-                      <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-                    ) : isFollowing ? (
-                      <UserMinus className="h-4 w-4 text-muted-foreground" />
-                    ) : (
-                      <UserPlus className="h-4 w-4 text-muted-foreground" />
-                    )}
-                    <span>
-                      {isCheckingFollow
-                        ? 'Loading...'
-                        : isFollowing
-                          ? `Unfollow ${displayName}`
-                          : `Follow ${displayName}`}
-                    </span>
+                    Cancel
                   </button>
-                )}
-
-                <button
-                  onClick={() => {
-                    setShowMenu(false);
-                    setShowMuteModal(true);
-                  }}
-                  className="flex w-full items-center gap-3 px-4 py-2 text-left text-sm transition-colors hover:bg-muted"
-                >
-                  <VolumeX className="h-4 w-4 text-muted-foreground" />
-                  <span>Mute {displayName}</span>
-                </button>
-
-                <button
-                  onClick={() => {
-                    setShowMenu(false);
-                    setShowBlockModal(true);
-                  }}
-                  className="flex w-full items-center gap-3 px-4 py-2 text-left text-orange-600 text-sm transition-colors hover:bg-muted"
-                >
-                  <Ban className="h-4 w-4" />
-                  <span>Block {displayName}</span>
-                </button>
-
-                {/* Only show report option for real users, not NPCs */}
-                {!isNPC && (
-                  <>
-                    <div className="my-1 border-border border-t" />
-
-                    <button
-                      onClick={() => {
-                        setShowMenu(false);
-                        setShowReportModal(true);
-                      }}
-                      className="flex w-full items-center gap-3 px-4 py-2 text-left text-red-600 text-sm transition-colors hover:bg-muted"
-                    >
-                      <Flag className="h-4 w-4" />
-                      <span>Report {postId ? 'post' : 'user'}</span>
-                    </button>
-                  </>
-                )}
+                </div>
               </div>
-            </div>
-          </>,
+            </>
+          ) : (
+            /* ── Desktop Dropdown ── */
+            <>
+              {/* Overlay to close */}
+              <div className="fixed inset-0 z-40" onClick={closeMenu} />
+
+              {/* Dropdown */}
+              <div
+                className={`fixed z-50 w-64 overflow-hidden border border-border bg-card shadow-xl transition-all duration-150 ${
+                  isClosing ? 'scale-95 opacity-0' : 'scale-100 opacity-100'
+                }`}
+                style={{
+                  borderRadius: '12px',
+                  top: menuPosition.openUpward ? 'auto' : menuPosition.top,
+                  bottom: menuPosition.openUpward
+                    ? menuPosition.windowHeight - menuPosition.top
+                    : 'auto',
+                  left: menuPosition.left,
+                  transformOrigin: menuPosition.openUpward
+                    ? 'bottom right'
+                    : 'top right',
+                }}
+              >
+                <div>{renderMenuContent()}</div>
+              </div>
+            </>
+          ),
           document.body
         )}
 
@@ -329,7 +454,6 @@ export function ModerationMenu({
         onSuccess={handleAction}
       />
 
-      {/* Only show report modal for real users, not NPCs */}
       {!isNPC && (
         <ReportModal
           isOpen={showReportModal}

--- a/apps/web/src/components/nft/NftPromoBanner.tsx
+++ b/apps/web/src/components/nft/NftPromoBanner.tsx
@@ -8,7 +8,13 @@ export function NftPromoBanner() {
   const pathname = usePathname();
 
   // Hide banner on pages where it doesn't belong
-  const hiddenPaths = ['/nft', '/markets', '/chats', '/agents/team', '/settings'];
+  const hiddenPaths = [
+    '/nft',
+    '/markets',
+    '/chats',
+    '/agents/team',
+    '/settings',
+  ];
   if (hiddenPaths.some((p) => pathname?.startsWith(p))) return null;
 
   return (

--- a/apps/web/src/components/nft/NftPromoBanner.tsx
+++ b/apps/web/src/components/nft/NftPromoBanner.tsx
@@ -1,7 +1,16 @@
+'use client';
+
 import Image from 'next/image';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 
 export function NftPromoBanner() {
+  const pathname = usePathname();
+
+  // Hide banner on pages where it doesn't belong
+  const hiddenPaths = ['/nft', '/markets', '/chats', '/agents/team', '/settings'];
+  if (hiddenPaths.some((p) => pathname?.startsWith(p))) return null;
+
   return (
     <div className="mt-14 border-primary/30 border-b bg-primary md:mt-0">
       <div className="mx-auto flex max-w-7xl items-center justify-between gap-4 px-4 py-2.5">
@@ -16,7 +25,7 @@ export function NftPromoBanner() {
           <span className="font-bold text-base">ProtoMonkeys</span>
           <span className="hidden text-primary-foreground/80 sm:inline">
             {' '}
-            — Exclusive NFTs for top 100 players on leaderboard
+            — Exclusive NFTs for top 100 players
           </span>
         </div>
         <div className="flex shrink-0 items-center">

--- a/apps/web/src/components/posts/CommentPreview.tsx
+++ b/apps/web/src/components/posts/CommentPreview.tsx
@@ -155,31 +155,31 @@ const CommentPreviewItem = memo(function CommentPreviewItem({
       {/* Right column: Content */}
       <div className="min-w-0 flex-1">
         {/* Header: Name + Username + Time */}
-        <div className="flex items-start justify-between gap-2">
-          <div className="flex min-w-0 items-center gap-1">
+        <div className="flex items-start justify-between gap-3 leading-none sm:items-center sm:pt-0.5">
+          <div className="flex min-w-0 flex-1 items-center gap-1.5">
             <Link
               href={getProfileUrl(comment.userId, comment.userUsername)}
-              className="truncate font-semibold text-[15px] text-foreground hover:underline"
+              className="truncate font-semibold text-[15px] text-foreground leading-tight hover:underline"
               onClick={(e) => e.stopPropagation()}
             >
               {comment.userName}
             </Link>
             {isNPC && <VerifiedBadge size="sm" />}
             {comment.userUsername && (
-              <span className="truncate text-[15px] text-muted-foreground">
+              <span className="truncate text-[15px] text-muted-foreground leading-tight">
                 @{comment.userUsername}
               </span>
             )}
           </div>
           {timeAgo && (
-            <span className="shrink-0 text-muted-foreground text-xs">
+            <span className="text-[15px] text-muted-foreground leading-tight">
               {timeAgo}
             </span>
           )}
         </div>
 
         {/* Comment content */}
-        <p className="mt-0.5 text-foreground text-sm leading-relaxed">
+        <p className="text-foreground text-sm leading-relaxed">
           {comment.content}
         </p>
 

--- a/apps/web/src/components/profile/ProfilePageClient.tsx
+++ b/apps/web/src/components/profile/ProfilePageClient.tsx
@@ -1107,7 +1107,7 @@ export function ProfilePageClient({
                 </div>
               </div>
 
-              <div className="space-y-2 px-4 py-4">
+              <div className="sm:px-4 sm:py-4">
                 {tab === 'trades' ? (
                   <TradesFeed userId={actorInfo.id} />
                 ) : tab === 'replies' ? (
@@ -1146,7 +1146,7 @@ export function ProfilePageClient({
                     }
                   />
                 ) : (
-                  <div className="space-y-3">
+                  <div>
                     {filteredPosts.map((item, i) => {
                       const postData = {
                         id: item.post.id,

--- a/apps/web/src/components/profile/ProfileReplyCard.tsx
+++ b/apps/web/src/components/profile/ProfileReplyCard.tsx
@@ -228,31 +228,31 @@ export function ProfileReplyCard({
           {/* Parent Content */}
           <div className="min-w-0 flex-1">
             {/* Header */}
-            <div className="flex items-start justify-between gap-2">
-              <div className="flex min-w-0 items-center gap-1">
+            <div className="flex items-start justify-between gap-3 leading-none sm:items-center sm:pt-0.5">
+              <div className="flex min-w-0 flex-1 items-center gap-1.5">
                 <Link
                   href={getProfileUrl(parentAuthorId, parentAuthorUsername)}
-                  className="truncate font-semibold text-[15px] text-foreground hover:underline"
+                  className="truncate font-semibold text-[15px] text-foreground leading-tight hover:underline"
                   onClick={(e) => e.stopPropagation()}
                 >
                   {parentAuthorName}
                 </Link>
                 {parentAuthorIsNPC && <VerifiedBadge size="sm" />}
                 {parentAuthorUsername && (
-                  <span className="truncate text-[15px] text-muted-foreground">
+                  <span className="truncate text-[15px] text-muted-foreground leading-tight">
                     @{parentAuthorUsername}
                   </span>
                 )}
               </div>
               {parentTimestamp && (
-                <span className="shrink-0 text-muted-foreground text-xs">
+                <span className="text-[15px] text-muted-foreground leading-tight">
                   {formatTimeAgo(parentTimestamp)}
                 </span>
               )}
             </div>
 
             {/* Parent Content - truncated */}
-            <p className="mt-0.5 line-clamp-3 text-foreground text-sm leading-relaxed">
+            <p className="line-clamp-3 text-foreground text-sm leading-relaxed">
               <TaggedText text={parentContent} onTagClick={handleTagClick} />
             </p>
 
@@ -303,29 +303,29 @@ export function ProfileReplyCard({
         {/* Reply Content */}
         <div className="min-w-0 flex-1">
           {/* Header */}
-          <div className="flex items-start justify-between gap-2">
-            <div className="flex min-w-0 items-center gap-1">
+          <div className="flex items-start justify-between gap-3 leading-none sm:items-center sm:pt-0.5">
+            <div className="flex min-w-0 flex-1 items-center gap-1.5">
               <Link
                 href={getProfileUrl(authorId, authorUsername)}
-                className="truncate font-semibold text-[15px] text-foreground hover:underline"
+                className="truncate font-semibold text-[15px] text-foreground leading-tight hover:underline"
                 onClick={(e) => e.stopPropagation()}
               >
                 {authorName}
               </Link>
               {replyAuthorIsNPC && <VerifiedBadge size="sm" />}
               {authorUsername && (
-                <span className="truncate text-[15px] text-muted-foreground">
+                <span className="truncate text-[15px] text-muted-foreground leading-tight">
                   @{authorUsername}
                 </span>
               )}
             </div>
-            <span className="shrink-0 text-muted-foreground text-xs">
+            <span className="text-[15px] text-muted-foreground leading-tight">
               {formatTimeAgo(reply.createdAt)}
             </span>
           </div>
 
           {/* Reply Content */}
-          <p className="mt-0.5 whitespace-pre-wrap break-words text-foreground text-sm leading-relaxed">
+          <p className="whitespace-pre-wrap break-words text-foreground text-sm leading-relaxed">
             <TaggedText text={reply.content} onTagClick={handleTagClick} />
           </p>
 

--- a/apps/web/src/components/shared/MobileHeader.tsx
+++ b/apps/web/src/components/shared/MobileHeader.tsx
@@ -1,16 +1,16 @@
-'use client';
+"use client";
 
-import { cn, getDisplayReferralUrl, getReferralUrl } from '@babylon/shared';
-import { Check, Copy, Gift, LogOut, Trophy, User, X } from 'lucide-react';
-import Image from 'next/image';
-import Link from 'next/link';
-import { usePathname } from 'next/navigation';
-import { useEffect, useState } from 'react';
-import { GameFeedbackModal } from '@/components/feedback/GameFeedbackModal';
-import { Avatar } from '@/components/shared/Avatar';
-import { useAuth } from '@/hooks/useAuth';
-import { getAuthToken } from '@/lib/auth';
-import { useAuthStore } from '@/stores/authStore';
+import { cn, getDisplayReferralUrl, getReferralUrl } from "@babylon/shared";
+import { Check, Copy, Gift, LogOut, Settings, Trophy, User, X } from "lucide-react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
+import { GameFeedbackModal } from "@/components/feedback/GameFeedbackModal";
+import { Avatar } from "@/components/shared/Avatar";
+import { BabylonIcon } from "@/components/shared/icons/BabylonIcon";
+import { useAuth } from "@/hooks/useAuth";
+import { getAuthToken } from "@/lib/auth";
+import { useAuthStore } from "@/stores/authStore";
 
 /**
  * Mobile header content component for mobile devices.
@@ -35,8 +35,8 @@ function MobileHeaderContent() {
   const pathname = usePathname();
 
   // Hide mobile header when WAITLIST_MODE is enabled on home page
-  const isWaitlistMode = process.env.NEXT_PUBLIC_WAITLIST_MODE === 'true';
-  const isHomePage = pathname === '/';
+  const isWaitlistMode = process.env.NEXT_PUBLIC_WAITLIST_MODE === "true";
+  const isHomePage = pathname === "/";
   const shouldHide = isWaitlistMode && isHomePage;
 
   // All hooks must be called before any conditional returns
@@ -54,7 +54,7 @@ function MobileHeaderContent() {
           signal: controller.signal,
         }
       ).catch((error: Error) => {
-        if (error.name === 'AbortError') return null;
+        if (error.name === "AbortError") return null;
         throw error;
       });
 
@@ -97,7 +97,7 @@ function MobileHeaderContent() {
       }
 
       const headers: HeadersInit = {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
         Authorization: `Bearer ${token}`,
       };
 
@@ -160,22 +160,28 @@ function MobileHeaderContent() {
 
   const menuItems = [
     {
-      name: 'Profile',
-      href: '/profile',
+      name: "Profile",
+      href: "/profile",
       icon: User,
-      active: pathname === '/profile',
+      active: pathname === "/profile",
     },
     {
-      name: 'Leaderboards',
-      href: '/leaderboard',
+      name: "Leaderboards",
+      href: "/leaderboard",
       icon: Trophy,
-      active: pathname === '/leaderboard',
+      active: pathname === "/leaderboard",
     },
     {
-      name: 'Rewards',
-      href: '/rewards',
+      name: "Rewards",
+      href: "/rewards",
       icon: Gift,
-      active: pathname === '/rewards',
+      active: pathname === "/rewards",
+    },
+    {
+      name: "Settings",
+      href: "/settings",
+      icon: Settings,
+      active: pathname?.startsWith("/settings"),
     },
   ];
 
@@ -183,9 +189,9 @@ function MobileHeaderContent() {
     <>
       <header
         className={cn(
-          'md:hidden',
-          'fixed top-0 right-0 left-0 z-40',
-          'bg-sidebar/95'
+          "md:hidden",
+          "fixed top-0 right-0 left-0 z-40",
+          "bg-sidebar/95"
         )}
       >
         <div className="flex h-14 items-center justify-between px-4">
@@ -199,7 +205,7 @@ function MobileHeaderContent() {
               >
                 <Avatar
                   id={user.id}
-                  name={user.displayName || user.email || 'User'}
+                  name={user.displayName || user.email || "User"}
                   type="user"
                   size="sm"
                   src={user.profileImageUrl || undefined}
@@ -217,13 +223,7 @@ function MobileHeaderContent() {
               href="/feed"
               className="transition-transform duration-300 hover:scale-105"
             >
-              <Image
-                src="/assets/logos/logo.svg"
-                alt="Babylon Logo"
-                width={28}
-                height={28}
-                className="h-7 w-7"
-              />
+              <BabylonIcon className="h-7 w-7 text-primary" />
             </Link>
           </div>
 
@@ -247,7 +247,7 @@ function MobileHeaderContent() {
         <>
           {/* Backdrop */}
           <div
-            className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm md:hidden"
+            className="fixed inset-0 z-50 bg-neutral-300/70 backdrop-blur-[3px] dark:bg-neutral-900/70 md:hidden"
             onClick={() => setShowSideMenu(false)}
           />
 
@@ -262,7 +262,7 @@ function MobileHeaderContent() {
               <div className="flex min-w-0 flex-1 items-center gap-3">
                 <Avatar
                   id={user?.id}
-                  name={user?.displayName || user?.email || 'User'}
+                  name={user?.displayName || user?.email || "User"}
                   type="user"
                   size="md"
                   src={user?.profileImageUrl || undefined}
@@ -271,7 +271,7 @@ function MobileHeaderContent() {
                 />
                 <div className="min-w-0 flex-1">
                   <div className="truncate font-bold text-foreground text-sm">
-                    {user?.displayName || user?.email || 'User'}
+                    {user?.displayName || user?.email || "User"}
                   </div>
                   <div className="truncate text-muted-foreground text-xs">
                     @{user?.username || `user${user?.id.slice(0, 8)}`}
@@ -285,7 +285,7 @@ function MobileHeaderContent() {
                 }}
                 className="shrink-0 p-2 transition-colors hover:bg-muted"
               >
-                <X size={20} style={{ color: '#0066FF' }} />
+                <X size={20} style={{ color: "#0066FF" }} />
               </button>
             </Link>
 
@@ -317,10 +317,10 @@ function MobileHeaderContent() {
                     href={item.href}
                     onClick={() => setShowSideMenu(false)}
                     className={cn(
-                      'relative flex items-center gap-4 px-4 py-2.5 transition-colors',
+                      "relative flex items-center gap-4 px-4 py-2.5 transition-colors",
                       item.active
-                        ? 'bg-[#0066FF] font-bold text-primary-foreground'
-                        : 'font-semibold text-sidebar-foreground hover:bg-sidebar-accent'
+                        ? "bg-[#0066FF] font-bold text-primary-foreground"
+                        : "font-semibold text-sidebar-foreground hover:bg-sidebar-accent"
                     )}
                   >
                     <Icon className="h-5 w-5" />
@@ -352,7 +352,7 @@ function MobileHeaderContent() {
                     </>
                   ) : (
                     <>
-                      <Copy className="h-5 w-5" style={{ color: '#0066FF' }} />
+                      <Copy className="h-5 w-5" style={{ color: "#0066FF" }} />
                       <div className="min-w-0 flex-1">
                         <div className="text-base text-foreground">
                           Copy Referral Link

--- a/apps/web/src/components/shared/MobileHeader.tsx
+++ b/apps/web/src/components/shared/MobileHeader.tsx
@@ -1,16 +1,25 @@
-"use client";
+'use client';
 
-import { cn, getDisplayReferralUrl, getReferralUrl } from "@babylon/shared";
-import { Check, Copy, Gift, LogOut, Settings, Trophy, User, X } from "lucide-react";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { useEffect, useState } from "react";
-import { GameFeedbackModal } from "@/components/feedback/GameFeedbackModal";
-import { Avatar } from "@/components/shared/Avatar";
-import { BabylonIcon } from "@/components/shared/icons/BabylonIcon";
-import { useAuth } from "@/hooks/useAuth";
-import { getAuthToken } from "@/lib/auth";
-import { useAuthStore } from "@/stores/authStore";
+import { cn, getDisplayReferralUrl, getReferralUrl } from '@babylon/shared';
+import {
+  Check,
+  Copy,
+  Gift,
+  LogOut,
+  Settings,
+  Trophy,
+  User,
+  X,
+} from 'lucide-react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { GameFeedbackModal } from '@/components/feedback/GameFeedbackModal';
+import { Avatar } from '@/components/shared/Avatar';
+import { BabylonIcon } from '@/components/shared/icons/BabylonIcon';
+import { useAuth } from '@/hooks/useAuth';
+import { getAuthToken } from '@/lib/auth';
+import { useAuthStore } from '@/stores/authStore';
 
 /**
  * Mobile header content component for mobile devices.
@@ -35,8 +44,8 @@ function MobileHeaderContent() {
   const pathname = usePathname();
 
   // Hide mobile header when WAITLIST_MODE is enabled on home page
-  const isWaitlistMode = process.env.NEXT_PUBLIC_WAITLIST_MODE === "true";
-  const isHomePage = pathname === "/";
+  const isWaitlistMode = process.env.NEXT_PUBLIC_WAITLIST_MODE === 'true';
+  const isHomePage = pathname === '/';
   const shouldHide = isWaitlistMode && isHomePage;
 
   // All hooks must be called before any conditional returns
@@ -54,7 +63,7 @@ function MobileHeaderContent() {
           signal: controller.signal,
         }
       ).catch((error: Error) => {
-        if (error.name === "AbortError") return null;
+        if (error.name === 'AbortError') return null;
         throw error;
       });
 
@@ -97,7 +106,7 @@ function MobileHeaderContent() {
       }
 
       const headers: HeadersInit = {
-        "Content-Type": "application/json",
+        'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`,
       };
 
@@ -160,28 +169,28 @@ function MobileHeaderContent() {
 
   const menuItems = [
     {
-      name: "Profile",
-      href: "/profile",
+      name: 'Profile',
+      href: '/profile',
       icon: User,
-      active: pathname === "/profile",
+      active: pathname === '/profile',
     },
     {
-      name: "Leaderboards",
-      href: "/leaderboard",
+      name: 'Leaderboards',
+      href: '/leaderboard',
       icon: Trophy,
-      active: pathname === "/leaderboard",
+      active: pathname === '/leaderboard',
     },
     {
-      name: "Rewards",
-      href: "/rewards",
+      name: 'Rewards',
+      href: '/rewards',
       icon: Gift,
-      active: pathname === "/rewards",
+      active: pathname === '/rewards',
     },
     {
-      name: "Settings",
-      href: "/settings",
+      name: 'Settings',
+      href: '/settings',
       icon: Settings,
-      active: pathname?.startsWith("/settings"),
+      active: pathname?.startsWith('/settings'),
     },
   ];
 
@@ -189,9 +198,9 @@ function MobileHeaderContent() {
     <>
       <header
         className={cn(
-          "md:hidden",
-          "fixed top-0 right-0 left-0 z-40",
-          "bg-sidebar/95"
+          'md:hidden',
+          'fixed top-0 right-0 left-0 z-40',
+          'bg-sidebar/95'
         )}
       >
         <div className="flex h-14 items-center justify-between px-4">
@@ -205,7 +214,7 @@ function MobileHeaderContent() {
               >
                 <Avatar
                   id={user.id}
-                  name={user.displayName || user.email || "User"}
+                  name={user.displayName || user.email || 'User'}
                   type="user"
                   size="sm"
                   src={user.profileImageUrl || undefined}
@@ -247,7 +256,7 @@ function MobileHeaderContent() {
         <>
           {/* Backdrop */}
           <div
-            className="fixed inset-0 z-50 bg-neutral-300/70 backdrop-blur-[3px] dark:bg-neutral-900/70 md:hidden"
+            className="fixed inset-0 z-50 bg-neutral-300/70 backdrop-blur-[3px] md:hidden dark:bg-neutral-900/70"
             onClick={() => setShowSideMenu(false)}
           />
 
@@ -262,7 +271,7 @@ function MobileHeaderContent() {
               <div className="flex min-w-0 flex-1 items-center gap-3">
                 <Avatar
                   id={user?.id}
-                  name={user?.displayName || user?.email || "User"}
+                  name={user?.displayName || user?.email || 'User'}
                   type="user"
                   size="md"
                   src={user?.profileImageUrl || undefined}
@@ -271,7 +280,7 @@ function MobileHeaderContent() {
                 />
                 <div className="min-w-0 flex-1">
                   <div className="truncate font-bold text-foreground text-sm">
-                    {user?.displayName || user?.email || "User"}
+                    {user?.displayName || user?.email || 'User'}
                   </div>
                   <div className="truncate text-muted-foreground text-xs">
                     @{user?.username || `user${user?.id.slice(0, 8)}`}
@@ -285,7 +294,7 @@ function MobileHeaderContent() {
                 }}
                 className="shrink-0 p-2 transition-colors hover:bg-muted"
               >
-                <X size={20} style={{ color: "#0066FF" }} />
+                <X size={20} style={{ color: '#0066FF' }} />
               </button>
             </Link>
 
@@ -317,10 +326,10 @@ function MobileHeaderContent() {
                     href={item.href}
                     onClick={() => setShowSideMenu(false)}
                     className={cn(
-                      "relative flex items-center gap-4 px-4 py-2.5 transition-colors",
+                      'relative flex items-center gap-4 px-4 py-2.5 transition-colors',
                       item.active
-                        ? "bg-[#0066FF] font-bold text-primary-foreground"
-                        : "font-semibold text-sidebar-foreground hover:bg-sidebar-accent"
+                        ? 'bg-[#0066FF] font-bold text-primary-foreground'
+                        : 'font-semibold text-sidebar-foreground hover:bg-sidebar-accent'
                     )}
                   >
                     <Icon className="h-5 w-5" />
@@ -352,7 +361,7 @@ function MobileHeaderContent() {
                     </>
                   ) : (
                     <>
-                      <Copy className="h-5 w-5" style={{ color: "#0066FF" }} />
+                      <Copy className="h-5 w-5" style={{ color: '#0066FF' }} />
                       <div className="min-w-0 flex-1">
                         <div className="text-base text-foreground">
                           Copy Referral Link

--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -8,7 +8,16 @@
  * This eliminates double LLM calls and makes execution faster.
  */
 
-import { actorState, agentLogs, and, chats, db, desc, eq, users } from '@babylon/db';
+import {
+  actorState,
+  agentLogs,
+  and,
+  chats,
+  db,
+  desc,
+  eq,
+  users,
+} from '@babylon/db';
 import { StaticDataRegistry, WalletService } from '@babylon/engine';
 import type { IAgentRuntime } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
@@ -578,7 +587,10 @@ export class MultiStepExecutor {
       })
       .from(agentLogs)
       .where(
-        and(eq(agentLogs.agentUserId, agentUserId), eq(agentLogs.type, 'system'))
+        and(
+          eq(agentLogs.agentUserId, agentUserId),
+          eq(agentLogs.type, 'system')
+        )
       )
       .orderBy(desc(agentLogs.createdAt))
       .limit(10);

--- a/packages/agents/src/runtime/AgentRuntimeManager.ts
+++ b/packages/agents/src/runtime/AgentRuntimeManager.ts
@@ -330,9 +330,10 @@ export class AgentRuntimeManager {
         .toFixed(2)
     );
     const runtimeAgeHours = Number(
-      ((refreshEndedAt.getTime() - lifecycle.createdAtMs) / MS_PER_HOUR).toFixed(
-        2
-      )
+      (
+        (refreshEndedAt.getTime() - lifecycle.createdAtMs) /
+        MS_PER_HOUR
+      ).toFixed(2)
     );
 
     const user = userSnapshot[0];

--- a/packages/api/src/services/notification-service.ts
+++ b/packages/api/src/services/notification-service.ts
@@ -496,7 +496,7 @@ export async function notifyMention(
  */
 export async function notifyNewAccount(userId: string): Promise<void> {
   const message =
-    '🎉 Welcome to Babylon! Edit your profile details to earn free points and unlock rewards.';
+    'Welcome to Babylon! Edit your profile details to earn free points and unlock rewards.';
 
   await createNotification({
     userId,
@@ -513,7 +513,7 @@ export async function notifyProfileComplete(
   userId: string,
   pointsAwarded: number
 ): Promise<void> {
-  const message = `🎊 Congratulations! You've completed your profile and earned ${pointsAwarded} points!`;
+  const message = `Congratulations! You've completed your profile and earned ${pointsAwarded} points!`;
 
   await createNotification({
     userId,


### PR DESCRIPTION
## Summary

Comprehensive mobile UI redesign pass across the app — tightening spacing, redesigning interactive components for mobile-first UX, and improving navigation accessibility.

### Repost Modal
- Full-screen modal on mobile instead of floating card
- Auto-growing textarea (overflow-hidden + JS resize) so all content is visible without internal scroll
- Removed left padding from textarea to align with quoted content on both mobile and desktop
- Fixed character counter layout shift by always rendering with `invisible` class when empty
- Removed excess top padding from content area (keep bottom only)
- Bumped repost icon sizes +2px across all variants (sm→20, md→22, lg→24) for visual consistency with other interaction icons

### Markets Terminal
- Fixed horizontal scroll on mobile market list by switching to `table-fixed` layout with explicit `<colgroup>` column widths
- Added `overflow-x-hidden` to scroll container
- Right-aligned price and volume values in the market table
- Added `formatCompactNumber()` for volume display (e.g. 1.2M, 345K) instead of truncated full numbers
- Moved mobile fullscreen chart button from floating overlay to inline next to the TimeRangeSelector (matching desktop behavior)
- Adjusted right padding on last table column

### Moderation Menu
- Redesigned as a bottom sheet on mobile with swipe-to-dismiss, slide-up/down animation, and drag handle
- Redesigned as a rounded dropdown on desktop with scale/opacity transitions
- Extracted shared menu items into data-driven `renderMenuContent()` for consistency
- Added body scroll lock when mobile sheet is open

### Card Headers (Standardized)
- Unified header layout across all card components: `items-start` on mobile, `items-center` on desktop
- Consistent text size (`text-[15px]`) and `leading-tight` for name, handle, and timestamp
- Consistent gap values (`gap-1.5` for name group, `gap-3` between left/right sections)
- Removed negative margin from VerifiedBadge
- Applied to: CommentCard, CommentPreview, ProfileReplyCard, ArticleCard, and all card variants in comment/[id] page

### NFT Promo Banner
- Converted to client component to conditionally hide based on pathname
- Hidden on `/nft`, `/markets`, `/chats`, `/agents/team`, `/settings`
- Added `mt-14`/`pt-14` with `md:mt-0`/`md:pt-0` to affected pages to offset the fixed mobile header after banner removal
- Shortened banner description (removed "on leaderboard")

### NFT Page
- Shortened tab labels on mobile: "All NFTs" → "All", "My NFT" → "Mine"
- Shortened claim button text: "Claim My NFT" → "Claim"

### Mobile Sidebar
- Replaced `logo.svg` Image with `BabylonIcon` component for consistency
- Added Settings link (gear icon) after Rewards — previously settings was not accessible from mobile sidebar
- Changed backdrop to `bg-neutral-300/70 backdrop-blur-[3px] dark:bg-neutral-900/70` for better theme-appropriate styling

### Modals
- Feedback modal: removed Cancel button (full-width Submit), removed "Help us improve the game" subtitle
- Create group modal: removed Cancel button (full-width Create)

### Social Feed
- Added toggle in TerminalSocialFeed to switch back to filtered view after clicking "Show all"

### Notifications
- Removed inline emoji from notification text on client side
- Removed baked-in emoji from backend messages (welcome, profile complete) in `notification-service.ts`
- Made notification actor name `block md:inline` for two-line layout on mobile (name on first line)
- Centered notification content vertically with avatar (`items-center` instead of `items-start`)
- Removed `mt-2` from unread indicator dot

### Mobile Spacing
- Removed horizontal padding on mobile for profile, notifications, trending, post, and comment pages
- Settings page: reduced bottom padding on mobile (`pb-8` vs `pb-24` on desktop)
- Settings page: removed outer border and padding from profile tab content
- Settings/moderation page: added top padding offset for mobile header