### PR TITLE
feat(api): send whitelist welcome email on grant

### DIFF
--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -8,7 +8,16 @@
  * This eliminates double LLM calls and makes execution faster.
  */
 
-import { actorState, agentLogs, and, chats, db, desc, eq, users } from '@babylon/db';
+import {
+  actorState,
+  agentLogs,
+  and,
+  chats,
+  db,
+  desc,
+  eq,
+  users,
+} from '@babylon/db';
 import { StaticDataRegistry, WalletService } from '@babylon/engine';
 import type { IAgentRuntime } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
@@ -578,7 +587,10 @@ export class MultiStepExecutor {
       })
       .from(agentLogs)
       .where(
-        and(eq(agentLogs.agentUserId, agentUserId), eq(agentLogs.type, 'system'))
+        and(
+          eq(agentLogs.agentUserId, agentUserId),
+          eq(agentLogs.type, 'system')
+        )
       )
       .orderBy(desc(agentLogs.createdAt))
       .limit(10);

--- a/packages/agents/src/runtime/AgentRuntimeManager.ts
+++ b/packages/agents/src/runtime/AgentRuntimeManager.ts
@@ -330,9 +330,10 @@ export class AgentRuntimeManager {
         .toFixed(2)
     );
     const runtimeAgeHours = Number(
-      ((refreshEndedAt.getTime() - lifecycle.createdAtMs) / MS_PER_HOUR).toFixed(
-        2
-      )
+      (
+        (refreshEndedAt.getTime() - lifecycle.createdAtMs) /
+        MS_PER_HOUR
+      ).toFixed(2)
     );
 
     const user = userSnapshot[0];

--- a/packages/api/src/__tests__/email-utils.test.ts
+++ b/packages/api/src/__tests__/email-utils.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import {
+  normalizeEmail,
+  parseEmailAddress,
+  resolveSendGridConfig,
+  sendViaSendGrid,
+} from '../services/email-utils';
+
+mock.module('@babylon/shared', () => ({
+  getAllVerifiedEmails: mock(() => []),
+  logger: {
+    info: mock(),
+    warn: mock(),
+    error: mock(),
+    debug: mock(),
+  },
+}));
+
+mock.module('../auth-middleware', () => ({
+  getPrivyClient: () => ({ getUser: mock() }),
+}));
+
+describe('parseEmailAddress', () => {
+  it('parses a plain email address', () => {
+    expect(parseEmailAddress('user@example.com')).toEqual({
+      email: 'user@example.com',
+    });
+  });
+
+  it('lowercases a plain email', () => {
+    expect(parseEmailAddress('User@Example.COM')).toEqual({
+      email: 'user@example.com',
+    });
+  });
+
+  it('trims whitespace', () => {
+    expect(parseEmailAddress('  user@example.com  ')).toEqual({
+      email: 'user@example.com',
+    });
+  });
+
+  it('parses a named email address', () => {
+    expect(parseEmailAddress('Babylon Team <team@babylon.market>')).toEqual({
+      email: 'team@babylon.market',
+      name: 'Babylon Team',
+    });
+  });
+
+  it('strips surrounding quotes from name', () => {
+    expect(parseEmailAddress('"Babylon Team" <team@babylon.market>')).toEqual({
+      email: 'team@babylon.market',
+      name: 'Babylon Team',
+    });
+  });
+
+  it('returns null for empty string', () => {
+    expect(parseEmailAddress('')).toBeNull();
+  });
+
+  it('returns null for whitespace-only string', () => {
+    expect(parseEmailAddress('   ')).toBeNull();
+  });
+
+  it('returns null for invalid format', () => {
+    expect(parseEmailAddress('not-an-email')).toBeNull();
+  });
+
+  it('returns null for missing domain', () => {
+    expect(parseEmailAddress('user@')).toBeNull();
+  });
+});
+
+describe('normalizeEmail', () => {
+  it('returns null for null input', () => {
+    expect(normalizeEmail(null)).toBeNull();
+  });
+
+  it('returns null for undefined input', () => {
+    expect(normalizeEmail(undefined)).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(normalizeEmail('')).toBeNull();
+  });
+
+  it('normalizes a valid email', () => {
+    expect(normalizeEmail('User@Example.COM')).toBe('user@example.com');
+  });
+
+  it('trims whitespace', () => {
+    expect(normalizeEmail('  user@example.com  ')).toBe('user@example.com');
+  });
+
+  it('returns null for invalid email format', () => {
+    expect(normalizeEmail('not-an-email')).toBeNull();
+  });
+});
+
+describe('resolveSendGridConfig', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('returns null when SENDGRID_API_KEY is missing', () => {
+    delete process.env.SENDGRID_API_KEY;
+    expect(resolveSendGridConfig('Test')).toBeNull();
+  });
+
+  it('returns null when SENDGRID_API_KEY is empty/whitespace', () => {
+    process.env.SENDGRID_API_KEY = '   ';
+    expect(resolveSendGridConfig('Test')).toBeNull();
+  });
+
+  it('returns null when no from address is configured', () => {
+    process.env.SENDGRID_API_KEY = 'SG.test-key';
+    delete process.env.NOTIFICATION_EMAIL_FROM;
+    delete process.env.EMAIL_FROM;
+    expect(resolveSendGridConfig('Test')).toBeNull();
+  });
+
+  it('returns null when from address is invalid', () => {
+    process.env.SENDGRID_API_KEY = 'SG.test-key';
+    process.env.NOTIFICATION_EMAIL_FROM = 'not-an-email';
+    expect(resolveSendGridConfig('Test')).toBeNull();
+  });
+
+  it('resolves config with NOTIFICATION_EMAIL_FROM', () => {
+    process.env.SENDGRID_API_KEY = 'SG.test-key';
+    process.env.NOTIFICATION_EMAIL_FROM = 'noreply@babylon.market';
+
+    const config = resolveSendGridConfig('Test');
+    expect(config).toEqual({
+      apiKey: 'SG.test-key',
+      from: { email: 'noreply@babylon.market' },
+    });
+  });
+
+  it('falls back to EMAIL_FROM when NOTIFICATION_EMAIL_FROM is missing', () => {
+    process.env.SENDGRID_API_KEY = 'SG.test-key';
+    delete process.env.NOTIFICATION_EMAIL_FROM;
+    process.env.EMAIL_FROM = 'fallback@babylon.market';
+
+    const config = resolveSendGridConfig('Test');
+    expect(config).toEqual({
+      apiKey: 'SG.test-key',
+      from: { email: 'fallback@babylon.market' },
+    });
+  });
+
+  it('resolves named from address', () => {
+    process.env.SENDGRID_API_KEY = 'SG.test-key';
+    process.env.NOTIFICATION_EMAIL_FROM = 'Babylon Team <team@babylon.market>';
+
+    const config = resolveSendGridConfig('Test');
+    expect(config).toEqual({
+      apiKey: 'SG.test-key',
+      from: { email: 'team@babylon.market', name: 'Babylon Team' },
+    });
+  });
+});
+
+describe('sendViaSendGrid', () => {
+  const testPayload = {
+    from: { email: 'test@example.com' },
+    personalizations: [{ to: [{ email: 'user@example.com' }] }],
+    subject: 'Test',
+    content: [{ type: 'text/plain', value: 'Hello' }],
+  };
+
+  it('returns sent: true on 202 response', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response(null, { status: 202 }))
+    ) as unknown as typeof fetch;
+
+    try {
+      const result = await sendViaSendGrid('key', testPayload, 'Test');
+      expect(result).toEqual({ sent: true });
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('returns provider_error on non-ok response', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(() =>
+      Promise.resolve(new Response('Bad Request', { status: 400 }))
+    ) as unknown as typeof fetch;
+
+    try {
+      const result = await sendViaSendGrid('key', testPayload, 'Test');
+      expect(result.sent).toBe(false);
+      expect(result.reason).toBe('provider_error');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('returns network_error when fetch throws', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(() =>
+      Promise.reject(new Error('Network failure'))
+    ) as unknown as typeof fetch;
+
+    try {
+      const result = await sendViaSendGrid('key', testPayload, 'Test');
+      expect(result.sent).toBe(false);
+      expect(result.reason).toBe('network_error');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it('sends correct authorization header and payload', async () => {
+    const originalFetch = globalThis.fetch;
+    let capturedInit: RequestInit | undefined;
+    globalThis.fetch = mock((_url: string, init?: RequestInit) => {
+      capturedInit = init;
+      return Promise.resolve(new Response(null, { status: 202 }));
+    }) as unknown as typeof fetch;
+
+    try {
+      await sendViaSendGrid('SG.my-key', testPayload, 'Test');
+      expect(capturedInit?.headers).toEqual({
+        Authorization: 'Bearer SG.my-key',
+        'Content-Type': 'application/json',
+      });
+      const body = JSON.parse(capturedInit?.body as string);
+      expect(body.from.email).toBe('test@example.com');
+      expect(body.subject).toBe('Test');
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/packages/api/src/__tests__/whitelist-auto-email.test.ts
+++ b/packages/api/src/__tests__/whitelist-auto-email.test.ts
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+const mockSendWhitelistWelcomeEmailsToUsers = mock(() => Promise.resolve());
+const mockGetLeaderboard = mock();
+
+const whitelistTable = {
+  id: 'id',
+  userId: 'userId',
+  source: 'source',
+  reason: 'reason',
+  grantedBy: 'grantedBy',
+  grantedAt: 'grantedAt',
+  revokedAt: 'revokedAt',
+};
+const whitelistConfigTable = {
+  id: 'id',
+  leaderboardRankThreshold: 'leaderboardRankThreshold',
+};
+const nftSnapshotTable = { userId: 'userId' };
+const usersTable = {
+  id: 'id',
+  reputationPoints: 'reputationPoints',
+  isActor: 'isActor',
+  isAgent: 'isAgent',
+};
+
+let mockWhitelistConfigRow: { leaderboardRankThreshold: number | null } | null = {
+  leaderboardRankThreshold: 100,
+};
+let mockTopUsers: Array<{ id: string }> = [];
+let mockSnapshotRows: Array<{ userId: string }> = [];
+let mockExistingRows: Array<{ userId: string; revokedAt: Date | null }> = [];
+let mockInsertedRows: Array<{ userId: string }> = [];
+
+const mockDbSelect = mock(() => ({
+  from: (table: unknown) => {
+    if (table === whitelistConfigTable) {
+      return {
+        where: () => ({
+          limit: () => Promise.resolve(mockWhitelistConfigRow ? [mockWhitelistConfigRow] : []),
+        }),
+      };
+    }
+
+    if (table === nftSnapshotTable) {
+      return {
+        where: () => Promise.resolve(mockSnapshotRows),
+      };
+    }
+
+    if (table === whitelistTable) {
+      return {
+        where: () => Promise.resolve(mockExistingRows),
+      };
+    }
+
+    if (table === usersTable) {
+      return {
+        where: () => ({ limit: () => Promise.resolve([]) }),
+      };
+    }
+
+    return {
+      where: () => Promise.resolve([]),
+    };
+  },
+}));
+
+const mockDbInsert = mock(() => ({
+  values: () => ({
+    onConflictDoNothing: () => ({
+      returning: () => Promise.resolve(mockInsertedRows),
+    }),
+    onConflictDoUpdate: () => ({
+      returning: () => Promise.resolve([]),
+    }),
+  }),
+}));
+
+mock.module('@babylon/db', () => ({
+  db: {
+    select: mockDbSelect,
+    insert: mockDbInsert,
+  },
+  and: (...args: unknown[]) => args,
+  desc: (col: unknown) => col,
+  eq: (a: unknown, b: unknown) => [a, b],
+  inArray: (a: unknown, b: unknown) => [a, b],
+  isNull: (a: unknown) => a,
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values }),
+  users: usersTable,
+  whitelist: whitelistTable,
+  whitelistConfig: whitelistConfigTable,
+  nftSnapshot: nftSnapshotTable,
+}));
+
+mock.module('@babylon/engine', () => ({
+  UserAlphaGroupAssignmentService: {
+    assignDefaultGroups: mock(() => Promise.resolve()),
+  },
+}));
+
+mock.module('@babylon/shared', () => ({
+  logger: {
+    info: mock(),
+    warn: mock(),
+    error: mock(),
+    debug: mock(),
+  },
+}));
+
+mock.module('nanoid', () => ({
+  nanoid: mock(() => 'mock-id'),
+}));
+
+mock.module('../services/points-service', () => ({
+  PointsService: {
+    getLeaderboard: mockGetLeaderboard,
+  },
+}));
+
+mock.module('../services/whitelist-email-service', () => ({
+  sendWhitelistWelcomeEmailToUser: mock(() => Promise.resolve()),
+  sendWhitelistWelcomeEmailsToUsers: mockSendWhitelistWelcomeEmailsToUsers,
+}));
+
+const { autoWhitelistCurrentTopN } = await import('../services/whitelist-service');
+
+describe('autoWhitelistCurrentTopN → whitelist welcome emails', () => {
+  beforeEach(() => {
+    mockDbSelect.mockClear();
+    mockDbInsert.mockClear();
+    mockGetLeaderboard.mockClear();
+    mockSendWhitelistWelcomeEmailsToUsers.mockClear();
+
+    mockWhitelistConfigRow = { leaderboardRankThreshold: 100 };
+    mockTopUsers = [{ id: 'user-1' }, { id: 'user-2' }];
+    mockSnapshotRows = [];
+    mockExistingRows = [];
+    mockInsertedRows = [{ userId: 'user-1' }, { userId: 'user-2' }];
+
+    mockGetLeaderboard.mockResolvedValue({ users: mockTopUsers });
+  });
+
+  it('sends whitelist welcome emails for users inserted by leaderboard cron', async () => {
+    const result = await autoWhitelistCurrentTopN();
+
+    expect(result.inserted).toBe(2);
+    expect(mockSendWhitelistWelcomeEmailsToUsers).toHaveBeenCalledTimes(1);
+    expect(mockSendWhitelistWelcomeEmailsToUsers).toHaveBeenCalledWith([
+      'user-1',
+      'user-2',
+    ]);
+  });
+
+  it('does not send whitelist welcome emails when leaderboard is empty', async () => {
+    mockTopUsers = [];
+    mockGetLeaderboard.mockResolvedValue({ users: mockTopUsers });
+
+    const result = await autoWhitelistCurrentTopN();
+
+    expect(result.totalInTopN).toBe(0);
+    expect(result.inserted).toBe(0);
+    expect(mockSendWhitelistWelcomeEmailsToUsers).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/api/src/__tests__/whitelist-auto-email.test.ts
+++ b/packages/api/src/__tests__/whitelist-auto-email.test.ts
@@ -24,9 +24,10 @@ const usersTable = {
   isAgent: 'isAgent',
 };
 
-let mockWhitelistConfigRow: { leaderboardRankThreshold: number | null } | null = {
-  leaderboardRankThreshold: 100,
-};
+let mockWhitelistConfigRow: { leaderboardRankThreshold: number | null } | null =
+  {
+    leaderboardRankThreshold: 100,
+  };
 let mockTopUsers: Array<{ id: string }> = [];
 let mockSnapshotRows: Array<{ userId: string }> = [];
 let mockExistingRows: Array<{ userId: string; revokedAt: Date | null }> = [];
@@ -37,7 +38,10 @@ const mockDbSelect = mock(() => ({
     if (table === whitelistConfigTable) {
       return {
         where: () => ({
-          limit: () => Promise.resolve(mockWhitelistConfigRow ? [mockWhitelistConfigRow] : []),
+          limit: () =>
+            Promise.resolve(
+              mockWhitelistConfigRow ? [mockWhitelistConfigRow] : []
+            ),
         }),
       };
     }
@@ -87,7 +91,10 @@ mock.module('@babylon/db', () => ({
   eq: (a: unknown, b: unknown) => [a, b],
   inArray: (a: unknown, b: unknown) => [a, b],
   isNull: (a: unknown) => a,
-  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values }),
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings,
+    values,
+  }),
   users: usersTable,
   whitelist: whitelistTable,
   whitelistConfig: whitelistConfigTable,
@@ -124,7 +131,9 @@ mock.module('../services/whitelist-email-service', () => ({
   sendWhitelistWelcomeEmailsToUsers: mockSendWhitelistWelcomeEmailsToUsers,
 }));
 
-const { autoWhitelistCurrentTopN } = await import('../services/whitelist-service');
+const { autoWhitelistCurrentTopN } = await import(
+  '../services/whitelist-service'
+);
 
 describe('autoWhitelistCurrentTopN → whitelist welcome emails', () => {
   beforeEach(() => {

--- a/packages/api/src/__tests__/whitelist-email-resolve.test.ts
+++ b/packages/api/src/__tests__/whitelist-email-resolve.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+const mockGetUser = mock();
+const mockGetAllVerifiedEmails = mock(() => [] as string[]);
+
+mock.module('@babylon/shared', () => ({
+  getAllVerifiedEmails: (...args: unknown[]) =>
+    mockGetAllVerifiedEmails(
+      ...(args as Parameters<typeof mockGetAllVerifiedEmails>)
+    ),
+  logger: {
+    info: mock(),
+    warn: mock(),
+    error: mock(),
+    debug: mock(),
+  },
+}));
+
+mock.module('../auth-middleware', () => ({
+  getPrivyClient: () => ({ getUser: mockGetUser }),
+}));
+
+const { resolveRecipientEmail } = await import('../services/email-utils');
+
+describe('resolveRecipientEmail', () => {
+  beforeEach(() => {
+    mockGetUser.mockClear();
+    mockGetAllVerifiedEmails.mockClear();
+  });
+
+  it('returns verified profile email directly', async () => {
+    const result = await resolveRecipientEmail({
+      id: 'user-1',
+      email: 'verified@example.com',
+      emailVerified: true,
+      privyId: null,
+    });
+
+    expect(result).toBe('verified@example.com');
+    expect(mockGetUser).not.toHaveBeenCalled();
+  });
+
+  it('normalizes profile email to lowercase', async () => {
+    const result = await resolveRecipientEmail({
+      id: 'user-1',
+      email: 'User@Example.COM',
+      emailVerified: true,
+      privyId: null,
+    });
+
+    expect(result).toBe('user@example.com');
+  });
+
+  it('returns null for unverified profile email without Privy fallback', async () => {
+    const result = await resolveRecipientEmail({
+      id: 'user-2',
+      email: 'unverified@example.com',
+      emailVerified: false,
+      privyId: null,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('falls back to Privy verified email when profile email is unverified', async () => {
+    mockGetUser.mockResolvedValue({ linked_accounts: [] });
+    mockGetAllVerifiedEmails.mockReturnValue(['privy@example.com']);
+
+    const result = await resolveRecipientEmail({
+      id: 'user-3',
+      email: 'unverified@example.com',
+      emailVerified: false,
+      privyId: 'privy-123',
+    });
+
+    expect(mockGetUser).toHaveBeenCalledWith('privy-123');
+    expect(result).toBe('privy@example.com');
+  });
+
+  it('returns null when Privy lookup fails and profile email is unverified', async () => {
+    mockGetUser.mockRejectedValue(new Error('Privy down'));
+
+    const result = await resolveRecipientEmail({
+      id: 'user-4',
+      email: 'unverified@example.com',
+      emailVerified: false,
+      privyId: 'privy-456',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when Privy returns no verified emails and profile is unverified', async () => {
+    mockGetUser.mockResolvedValue({ linked_accounts: [] });
+    mockGetAllVerifiedEmails.mockReturnValue([]);
+
+    const result = await resolveRecipientEmail({
+      id: 'user-5',
+      email: 'unverified@example.com',
+      emailVerified: false,
+      privyId: 'privy-789',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when user has no email at all and no Privy', async () => {
+    const result = await resolveRecipientEmail({
+      id: 'user-6',
+      email: null,
+      emailVerified: false,
+      privyId: null,
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when user has no email and Privy returns nothing', async () => {
+    mockGetUser.mockResolvedValue({ linked_accounts: [] });
+    mockGetAllVerifiedEmails.mockReturnValue([]);
+
+    const result = await resolveRecipientEmail({
+      id: 'user-7',
+      email: null,
+      emailVerified: false,
+      privyId: 'privy-no-email',
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it('returns Privy email when profile email is null but Privy has one', async () => {
+    mockGetUser.mockResolvedValue({ linked_accounts: [] });
+    mockGetAllVerifiedEmails.mockReturnValue(['fromPrivy@example.com']);
+
+    const result = await resolveRecipientEmail({
+      id: 'user-8',
+      email: null,
+      emailVerified: false,
+      privyId: 'privy-with-email',
+    });
+
+    expect(result).toBe('fromprivy@example.com');
+  });
+
+  it('returns null for invalid profile email format even if marked verified', async () => {
+    const result = await resolveRecipientEmail({
+      id: 'user-9',
+      email: 'not-an-email',
+      emailVerified: true,
+      privyId: null,
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/packages/api/src/__tests__/whitelist-group-assignment.test.ts
+++ b/packages/api/src/__tests__/whitelist-group-assignment.test.ts
@@ -47,6 +47,7 @@ const mockAssignDefaultGroups = mock(() =>
 
 const mockLoggerInfo = mock();
 const mockLoggerError = mock();
+const mockSendWhitelistWelcomeEmailToUser = mock(() => Promise.resolve());
 
 // Track what the DB insert returns — controls whether addToWhitelist thinks
 // the entry is new or already exists.
@@ -116,6 +117,11 @@ mock.module('../services/points-service', () => ({
   PointsService: {},
 }));
 
+mock.module('../services/whitelist-email-service', () => ({
+  sendWhitelistWelcomeEmailToUser: mockSendWhitelistWelcomeEmailToUser,
+  sendWhitelistWelcomeEmailsToUsers: mock(() => Promise.resolve()),
+}));
+
 // NOW import the function under test
 const { addToWhitelist } = await import('../services/whitelist-service');
 
@@ -130,6 +136,7 @@ describe('addToWhitelist → group assignment', () => {
     mockLoggerError.mockClear();
     mockInsert.mockClear();
     mockReturning.mockClear();
+    mockSendWhitelistWelcomeEmailToUser.mockClear();
   });
 
   it('should call assignDefaultGroups for a NEW whitelist entry', async () => {
@@ -153,6 +160,8 @@ describe('addToWhitelist → group assignment', () => {
 
     expect(mockAssignDefaultGroups).toHaveBeenCalledTimes(1);
     expect(mockAssignDefaultGroups).toHaveBeenCalledWith('user-123');
+    expect(mockSendWhitelistWelcomeEmailToUser).toHaveBeenCalledTimes(1);
+    expect(mockSendWhitelistWelcomeEmailToUser).toHaveBeenCalledWith('user-123');
   });
 
   it('should NOT call assignDefaultGroups for an ALREADY EXISTING entry', async () => {
@@ -172,6 +181,7 @@ describe('addToWhitelist → group assignment', () => {
     await new Promise((resolve) => setTimeout(resolve, 50));
 
     expect(mockAssignDefaultGroups).toHaveBeenCalledTimes(0);
+    expect(mockSendWhitelistWelcomeEmailToUser).toHaveBeenCalledTimes(0);
   });
 
   it('should log success when groups are assigned', async () => {

--- a/packages/api/src/__tests__/whitelist-group-assignment.test.ts
+++ b/packages/api/src/__tests__/whitelist-group-assignment.test.ts
@@ -161,7 +161,9 @@ describe('addToWhitelist → group assignment', () => {
     expect(mockAssignDefaultGroups).toHaveBeenCalledTimes(1);
     expect(mockAssignDefaultGroups).toHaveBeenCalledWith('user-123');
     expect(mockSendWhitelistWelcomeEmailToUser).toHaveBeenCalledTimes(1);
-    expect(mockSendWhitelistWelcomeEmailToUser).toHaveBeenCalledWith('user-123');
+    expect(mockSendWhitelistWelcomeEmailToUser).toHaveBeenCalledWith(
+      'user-123'
+    );
   });
 
   it('should NOT call assignDefaultGroups for an ALREADY EXISTING entry', async () => {
@@ -245,12 +247,12 @@ describe('addToWhitelist → group assignment', () => {
     expect(errorLog).toBeDefined();
   });
 
-  it('should not block the whitelist response if group assignment is slow', async () => {
+  it('should not block the whitelist response if side-effects are slow', async () => {
     mockReturning.mockImplementation(() => {
       return Promise.resolve([{ id: capturedNanoid }]);
     });
 
-    // Simulate a slow assignDefaultGroups (500ms)
+    // Simulate slow side-effects (500ms each)
     mockAssignDefaultGroups.mockImplementation(
       () =>
         new Promise((resolve) =>
@@ -266,6 +268,9 @@ describe('addToWhitelist → group assignment', () => {
           )
         )
     );
+    mockSendWhitelistWelcomeEmailToUser.mockImplementation(
+      () => new Promise((resolve) => setTimeout(resolve, 500))
+    );
 
     const startTime = Date.now();
     const result = await addToWhitelist({
@@ -274,8 +279,8 @@ describe('addToWhitelist → group assignment', () => {
     });
     const elapsed = Date.now() - startTime;
 
-    // addToWhitelist should return immediately (fire-and-forget)
+    // addToWhitelist should return immediately (fire-and-forget for both)
     expect(result.alreadyExists).toBe(false);
-    expect(elapsed).toBeLessThan(200); // Should not wait for the 500ms assignment
+    expect(elapsed).toBeLessThan(200);
   });
 });

--- a/packages/api/src/services/email-utils.ts
+++ b/packages/api/src/services/email-utils.ts
@@ -1,0 +1,187 @@
+import {
+  getAllVerifiedEmails,
+  logger,
+  type PrivyUserWithEmails,
+} from '@babylon/shared';
+import { getPrivyClient } from '../auth-middleware';
+
+export interface ParsedEmailAddress {
+  email: string;
+  name?: string;
+}
+
+export function parseEmailAddress(rawValue: string): ParsedEmailAddress | null {
+  const trimmed = rawValue.trim();
+
+  const namedMatch = trimmed.match(
+    /^(?<name>[^<>]+?)\s*<(?<email>[^<>\s@]+@[^<>\s@]+)>$/
+  );
+
+  const namedEmail = namedMatch?.groups?.email?.trim().toLowerCase();
+  if (namedEmail) {
+    const rawName = namedMatch?.groups?.name?.trim();
+    const normalizedName = rawName?.replace(/^"|"$/g, '');
+    return normalizedName
+      ? { email: namedEmail, name: normalizedName }
+      : { email: namedEmail };
+  }
+
+  const isPlainEmail = /^[^<>\s@]+@[^<>\s@]+$/.test(trimmed);
+  if (isPlainEmail) {
+    return { email: trimmed.toLowerCase() };
+  }
+
+  return null;
+}
+
+export function normalizeEmail(
+  rawEmail: string | null | undefined
+): string | null {
+  if (!rawEmail) return null;
+  const normalized = rawEmail.trim().toLowerCase();
+  return /^[^<>\s@]+@[^<>\s@]+$/.test(normalized) ? normalized : null;
+}
+
+export interface SendGridEnvConfig {
+  apiKey: string;
+  from: ParsedEmailAddress;
+}
+
+/**
+ * Resolves SendGrid configuration from environment variables.
+ * Returns null (with appropriate logging) when the provider is not configured.
+ */
+export function resolveSendGridConfig(
+  callerTag: string,
+  logContext?: Record<string, unknown>
+): SendGridEnvConfig | null {
+  const apiKey = process.env.SENDGRID_API_KEY?.trim();
+  if (!apiKey) {
+    logger.debug(
+      `Skipping email: SENDGRID_API_KEY is not configured`,
+      logContext ?? {},
+      callerTag
+    );
+    return null;
+  }
+
+  const fromAddress =
+    process.env.NOTIFICATION_EMAIL_FROM?.trim() ||
+    process.env.EMAIL_FROM?.trim();
+  if (!fromAddress) {
+    logger.warn(
+      `Skipping email: sender address is not configured`,
+      logContext ?? {},
+      callerTag
+    );
+    return null;
+  }
+
+  const from = parseEmailAddress(fromAddress);
+  if (!from) {
+    logger.warn(
+      `Skipping email: sender address format is invalid`,
+      { ...logContext, fromAddress },
+      callerTag
+    );
+    return null;
+  }
+
+  return { apiKey, from };
+}
+
+export interface SendGridPayload {
+  from: ParsedEmailAddress;
+  personalizations: Array<{ to: Array<{ email: string }> }>;
+  subject: string;
+  content: Array<{ type: string; value: string }>;
+  headers?: Record<string, string>;
+}
+
+/**
+ * Low-level SendGrid send. Returns a result object so callers can decide
+ * how to handle failures without catching exceptions for expected errors.
+ */
+export async function sendViaSendGrid(
+  apiKey: string,
+  payload: SendGridPayload,
+  callerTag: string,
+  logContext?: Record<string, unknown>
+): Promise<{ sent: boolean; reason?: string }> {
+  try {
+    const response = await fetch('https://api.sendgrid.com/v3/mail/send', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const responseBody = await response.text().catch(() => '');
+      logger.warn(
+        'Email send failed',
+        { ...logContext, status: response.status, responseBody },
+        callerTag
+      );
+      return { sent: false, reason: 'provider_error' };
+    }
+
+    return { sent: true };
+  } catch (error) {
+    logger.error(
+      'Email send request failed',
+      { ...logContext, error: String(error) },
+      callerTag
+    );
+    return { sent: false, reason: 'network_error' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Recipient email resolution
+// ---------------------------------------------------------------------------
+
+export interface EmailRecipientRow {
+  id: string;
+  email: string | null;
+  emailVerified: boolean;
+  privyId: string | null;
+}
+
+/**
+ * Resolves a verified email address for a recipient. Checks the profile email
+ * first (only if verified), then falls back to Privy verified emails.
+ * Returns null if no verified email can be found.
+ */
+export async function resolveRecipientEmail(
+  recipient: EmailRecipientRow,
+  callerTag = 'EmailUtils'
+): Promise<string | null> {
+  const profileEmail = normalizeEmail(recipient.email);
+  if (profileEmail && recipient.emailVerified) {
+    return profileEmail;
+  }
+
+  if (recipient.privyId) {
+    try {
+      const privyUser = (await getPrivyClient().getUser(
+        recipient.privyId
+      )) as PrivyUserWithEmails;
+      const verifiedEmails = getAllVerifiedEmails(privyUser);
+      const privyEmail = normalizeEmail(verifiedEmails[0]);
+      if (privyEmail) {
+        return privyEmail;
+      }
+    } catch (error) {
+      logger.warn(
+        'Failed to resolve recipient email from Privy',
+        { userId: recipient.id, error: String(error) },
+        callerTag
+      );
+    }
+  }
+
+  return null;
+}

--- a/packages/api/src/services/notification-email-service.ts
+++ b/packages/api/src/services/notification-email-service.ts
@@ -1,5 +1,5 @@
 import { createHmac, timingSafeEqual } from 'node:crypto';
-import { logger } from '@babylon/shared';
+import { resolveSendGridConfig, sendViaSendGrid } from './email-utils';
 
 export type EmailNotificationCategory =
   | 'realtime'
@@ -19,11 +19,6 @@ export interface SendNotificationEmailInput {
   title: string;
   message: string;
   category: EmailNotificationCategory;
-}
-
-interface ParsedEmailAddress {
-  email: string;
-  name?: string;
 }
 
 const DEFAULT_UNSUBSCRIBE_TOKEN_TTL_SECONDS = 60 * 60 * 24 * 30;
@@ -200,63 +195,13 @@ function createEmailText(params: {
   return `${params.title}\n\nType: ${getCategoryLabel(params.category)}\n\n${params.message}${unsubscribeSection}`;
 }
 
-function parseEmailAddress(rawValue: string): ParsedEmailAddress | null {
-  const trimmed = rawValue.trim();
-
-  const namedMatch = trimmed.match(
-    /^(?<name>[^<>]+?)\s*<(?<email>[^<>\s@]+@[^<>\s@]+)>$/
-  );
-
-  const namedEmail = namedMatch?.groups?.email?.trim().toLowerCase();
-  if (namedEmail) {
-    const rawName = namedMatch?.groups?.name?.trim();
-    const normalizedName = rawName?.replace(/^"|"$/g, '');
-    return normalizedName
-      ? { email: namedEmail, name: normalizedName }
-      : { email: namedEmail };
-  }
-
-  const isPlainEmail = /^[^<>\s@]+@[^<>\s@]+$/.test(trimmed);
-  if (isPlainEmail) {
-    return { email: trimmed.toLowerCase() };
-  }
-
-  return null;
-}
-
 export async function sendNotificationEmail(
   input: SendNotificationEmailInput
 ): Promise<{ sent: boolean; reason?: string }> {
-  const sendgridApiKey = process.env.SENDGRID_API_KEY?.trim();
-  if (!sendgridApiKey) {
-    logger.debug(
-      'Skipping notification email: SENDGRID_API_KEY is not configured',
-      { userId: input.userId, category: input.category },
-      'NotificationEmailService'
-    );
+  const logContext = { userId: input.userId, category: input.category };
+  const config = resolveSendGridConfig('NotificationEmailService', logContext);
+  if (!config) {
     return { sent: false, reason: 'provider_not_configured' };
-  }
-
-  const fromAddress =
-    process.env.NOTIFICATION_EMAIL_FROM?.trim() ||
-    process.env.EMAIL_FROM?.trim();
-  if (!fromAddress) {
-    logger.warn(
-      'Skipping notification email: sender address is not configured',
-      { userId: input.userId, category: input.category },
-      'NotificationEmailService'
-    );
-    return { sent: false, reason: 'sender_not_configured' };
-  }
-
-  const parsedFromAddress = parseEmailAddress(fromAddress);
-  if (!parsedFromAddress) {
-    logger.warn(
-      'Skipping notification email: sender address format is invalid',
-      { userId: input.userId, category: input.category, fromAddress },
-      'NotificationEmailService'
-    );
-    return { sent: false, reason: 'sender_not_configured' };
   }
 
   const unsubscribeUrl = buildNotificationUnsubscribeUrl({
@@ -278,52 +223,24 @@ export async function sendNotificationEmail(
     unsubscribeUrl,
   });
 
-  try {
-    const response = await fetch('https://api.sendgrid.com/v3/mail/send', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${sendgridApiKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        from: parsedFromAddress,
-        personalizations: [{ to: [{ email: input.userEmail }] }],
-        subject,
-        content: [
-          { type: 'text/plain', value: text },
-          { type: 'text/html', value: html },
-        ],
-        headers: unsubscribeUrl
-          ? {
-              'List-Unsubscribe': `<${unsubscribeUrl}>`,
-              'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
-            }
-          : undefined,
-      }),
-    });
-
-    if (!response.ok) {
-      const responseBody = await response.text().catch(() => '');
-      logger.warn(
-        'Notification email send failed',
-        {
-          userId: input.userId,
-          category: input.category,
-          status: response.status,
-          responseBody,
-        },
-        'NotificationEmailService'
-      );
-      return { sent: false, reason: 'provider_error' };
-    }
-
-    return { sent: true };
-  } catch (error) {
-    logger.error(
-      'Notification email send threw an exception',
-      { userId: input.userId, category: input.category, error },
-      'NotificationEmailService'
-    );
-    return { sent: false, reason: 'network_error' };
-  }
+  return sendViaSendGrid(
+    config.apiKey,
+    {
+      from: config.from,
+      personalizations: [{ to: [{ email: input.userEmail }] }],
+      subject,
+      content: [
+        { type: 'text/plain', value: text },
+        { type: 'text/html', value: html },
+      ],
+      headers: unsubscribeUrl
+        ? {
+            'List-Unsubscribe': `<${unsubscribeUrl}>`,
+            'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+          }
+        : undefined,
+    },
+    'NotificationEmailService',
+    logContext
+  );
 }

--- a/packages/api/src/services/whitelist-email-service.ts
+++ b/packages/api/src/services/whitelist-email-service.ts
@@ -1,10 +1,11 @@
 import { db, inArray, users } from '@babylon/db';
+import { logger } from '@babylon/shared';
 import {
-  getAllVerifiedEmails,
-  logger,
-  type PrivyUserWithEmails,
-} from '@babylon/shared';
-import { getPrivyNodeClient } from './privy/privy-node';
+  type EmailRecipientRow,
+  resolveRecipientEmail,
+  resolveSendGridConfig,
+  sendViaSendGrid,
+} from './email-utils';
 
 const WHITELIST_WELCOME_SUBJECT =
   "Congratulations, you're off the waitlist. You can play Babylon now.";
@@ -16,179 +17,55 @@ const WHITELIST_WELCOME_TEXT = [
   '',
   'Head to play.babylon.market, sign in, look around, then create one or two agents and tell them how they can help you win the game.',
   '',
-  'Remember the best player get rewarded!',
+  'Remember the best players get rewarded!',
   '',
   'Babylon team',
 ].join('\n');
 
 const SEND_CONCURRENCY = 5;
 
-type WhitelistRecipientRow = {
-  id: string;
-  email: string | null;
-  emailVerified: boolean;
-  privyId: string | null;
-};
-
 function createWhitelistWelcomeHtml(): string {
   return [
     '<div style="font-family:Arial,sans-serif;max-width:560px;margin:0 auto;padding:24px;">',
     '  <p style="font-size:15px;line-height:1.6;color:#222;margin:0 0 16px;">Hey, you got in!</p>',
     '  <p style="font-size:15px;line-height:1.6;color:#222;margin:0 0 16px;">Babylon is an AI-built world where humans and AI compete through prediction markets and perpetuals. You can create your own agent team and compete to win.</p>',
-    '  <p style="font-size:15px;line-height:1.6;color:#222;margin:0 0 16px;">Head to play.babylon.market, sign in, look around, then create one or two agents and tell them how they can help you win the game.</p>',
-    '  <p style="font-size:15px;line-height:1.6;color:#222;margin:0 0 16px;">Remember the best player get rewarded!</p>',
+    '  <p style="font-size:15px;line-height:1.6;color:#222;margin:0 0 16px;">Head to <a href="https://play.babylon.market" style="color:#1a73e8;">play.babylon.market</a>, sign in, look around, then create one or two agents and tell them how they can help you win the game.</p>',
+    '  <p style="font-size:15px;line-height:1.6;color:#222;margin:0 0 16px;">Remember the best players get rewarded!</p>',
     '  <p style="font-size:15px;line-height:1.6;color:#222;margin:0;">Babylon team</p>',
     '</div>',
   ].join('');
-}
-
-interface ParsedEmailAddress {
-  email: string;
-  name?: string;
-}
-
-function parseEmailAddress(rawValue: string): ParsedEmailAddress | null {
-  const trimmed = rawValue.trim();
-
-  const namedMatch = trimmed.match(
-    /^(?<name>[^<>]+?)\s*<(?<email>[^<>\s@]+@[^<>\s@]+)>$/
-  );
-
-  const namedEmail = namedMatch?.groups?.email?.trim().toLowerCase();
-  if (namedEmail) {
-    const rawName = namedMatch?.groups?.name?.trim();
-    const normalizedName = rawName?.replace(/^"|"$/g, '');
-    return normalizedName
-      ? { email: namedEmail, name: normalizedName }
-      : { email: namedEmail };
-  }
-
-  const isPlainEmail = /^[^<>\s@]+@[^<>\s@]+$/.test(trimmed);
-  if (isPlainEmail) {
-    return { email: trimmed.toLowerCase() };
-  }
-
-  return null;
-}
-
-function normalizeEmail(rawEmail: string | null | undefined): string | null {
-  if (!rawEmail) return null;
-  const normalized = rawEmail.trim().toLowerCase();
-  return /^[^<>\s@]+@[^<>\s@]+$/.test(normalized) ? normalized : null;
-}
-
-async function resolveRecipientEmail(
-  recipient: WhitelistRecipientRow
-): Promise<string | null> {
-  const profileEmail = normalizeEmail(recipient.email);
-  if (profileEmail && recipient.emailVerified) {
-    return profileEmail;
-  }
-
-  if (recipient.privyId) {
-    try {
-      const privyUser = (await getPrivyNodeClient().getUser(
-        recipient.privyId
-      )) as PrivyUserWithEmails;
-      const verifiedEmails = getAllVerifiedEmails(privyUser);
-      const privyEmail = normalizeEmail(verifiedEmails[0]);
-      if (privyEmail) {
-        return privyEmail;
-      }
-    } catch (error) {
-      logger.warn(
-        'Failed to resolve whitelist recipient email from Privy',
-        { userId: recipient.id, error: String(error) },
-        'WhitelistEmailService'
-      );
-    }
-  }
-
-  return profileEmail;
 }
 
 async function sendWhitelistWelcomeEmail(input: {
   userId: string;
   userEmail: string;
 }): Promise<{ sent: boolean; reason?: string }> {
-  const sendgridApiKey = process.env.SENDGRID_API_KEY?.trim();
-  if (!sendgridApiKey) {
-    logger.debug(
-      'Skipping whitelist welcome email: SENDGRID_API_KEY is not configured',
-      { userId: input.userId },
-      'WhitelistEmailService'
-    );
+  const config = resolveSendGridConfig('WhitelistEmailService', {
+    userId: input.userId,
+  });
+  if (!config) {
     return { sent: false, reason: 'provider_not_configured' };
   }
 
-  const fromAddress =
-    process.env.NOTIFICATION_EMAIL_FROM?.trim() ||
-    process.env.EMAIL_FROM?.trim();
-  if (!fromAddress) {
-    logger.warn(
-      'Skipping whitelist welcome email: sender address is not configured',
-      { userId: input.userId },
-      'WhitelistEmailService'
-    );
-    return { sent: false, reason: 'sender_not_configured' };
-  }
-
-  const parsedFromAddress = parseEmailAddress(fromAddress);
-  if (!parsedFromAddress) {
-    logger.warn(
-      'Skipping whitelist welcome email: sender address format is invalid',
-      { userId: input.userId, fromAddress },
-      'WhitelistEmailService'
-    );
-    return { sent: false, reason: 'sender_not_configured' };
-  }
-
-  try {
-    const response = await fetch('https://api.sendgrid.com/v3/mail/send', {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${sendgridApiKey}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({
-        from: parsedFromAddress,
-        personalizations: [{ to: [{ email: input.userEmail }] }],
-        subject: WHITELIST_WELCOME_SUBJECT,
-        content: [
-          { type: 'text/plain', value: WHITELIST_WELCOME_TEXT },
-          { type: 'text/html', value: createWhitelistWelcomeHtml() },
-        ],
-      }),
-    });
-
-    if (!response.ok) {
-      const responseBody = await response.text().catch(() => '');
-      logger.warn(
-        'Whitelist welcome email send failed',
-        {
-          userId: input.userId,
-          status: response.status,
-          responseBody,
-        },
-        'WhitelistEmailService'
-      );
-      return { sent: false, reason: 'provider_error' };
-    }
-
-    return { sent: true };
-  } catch (error) {
-    logger.error(
-      'Whitelist welcome email request failed',
-      { userId: input.userId, error: String(error) },
-      'WhitelistEmailService'
-    );
-    return { sent: false, reason: 'provider_error' };
-  }
+  return sendViaSendGrid(
+    config.apiKey,
+    {
+      from: config.from,
+      personalizations: [{ to: [{ email: input.userEmail }] }],
+      subject: WHITELIST_WELCOME_SUBJECT,
+      content: [
+        { type: 'text/plain', value: WHITELIST_WELCOME_TEXT },
+        { type: 'text/html', value: createWhitelistWelcomeHtml() },
+      ],
+    },
+    'WhitelistEmailService',
+    { userId: input.userId }
+  );
 }
 
 async function fetchRecipients(
   userIds: string[]
-): Promise<Map<string, WhitelistRecipientRow>> {
+): Promise<Map<string, EmailRecipientRow>> {
   if (userIds.length === 0) return new Map();
 
   const rows = await db
@@ -206,7 +83,7 @@ async function fetchRecipients(
 
 async function sendWelcomeEmailForUser(
   userId: string,
-  recipient: WhitelistRecipientRow | undefined
+  recipient: EmailRecipientRow | undefined
 ): Promise<'sent' | 'skipped' | 'failed'> {
   if (!recipient) {
     logger.warn(
@@ -217,10 +94,13 @@ async function sendWelcomeEmailForUser(
     return 'skipped';
   }
 
-  const resolvedEmail = await resolveRecipientEmail(recipient);
+  const resolvedEmail = await resolveRecipientEmail(
+    recipient,
+    'WhitelistEmailService'
+  );
   if (!resolvedEmail) {
     logger.info(
-      'Skipping whitelist welcome email: no email found for user',
+      'Skipping whitelist welcome email: no verified email found for user',
       { userId },
       'WhitelistEmailService'
     );
@@ -256,27 +136,29 @@ export async function sendWhitelistWelcomeEmailsToUsers(
     const chunk = uniqueUserIds.slice(i, i + SEND_CONCURRENCY);
 
     const chunkResults = await Promise.all(
-      chunk.map((userId) => sendWelcomeEmailForUser(userId, recipients.get(userId)))
+      chunk.map((userId) =>
+        sendWelcomeEmailForUser(userId, recipients.get(userId))
+      )
     );
 
     const sentCount = chunkResults.filter((result) => result === 'sent').length;
     const skippedCount = chunkResults.filter(
       (result) => result === 'skipped'
     ).length;
-    const failedCount = chunkResults.filter((result) => result === 'failed').length;
+    const failedCount = chunkResults.filter(
+      (result) => result === 'failed'
+    ).length;
 
-    if (sentCount > 0 || failedCount > 0 || skippedCount > 0) {
-      logger.info(
-        'Processed whitelist welcome email chunk',
-        {
-          chunkSize: chunk.length,
-          sentCount,
-          skippedCount,
-          failedCount,
-        },
-        'WhitelistEmailService'
-      );
-    }
+    logger.info(
+      'Processed whitelist welcome email chunk',
+      {
+        chunkSize: chunk.length,
+        sentCount,
+        skippedCount,
+        failedCount,
+      },
+      'WhitelistEmailService'
+    );
   }
 }
 

--- a/packages/api/src/services/whitelist-email-service.ts
+++ b/packages/api/src/services/whitelist-email-service.ts
@@ -1,0 +1,287 @@
+import { db, inArray, users } from '@babylon/db';
+import {
+  getAllVerifiedEmails,
+  logger,
+  type PrivyUserWithEmails,
+} from '@babylon/shared';
+import { getPrivyNodeClient } from './privy/privy-node';
+
+const WHITELIST_WELCOME_SUBJECT =
+  "Congratulations, you're off the waitlist. You can play Babylon now.";
+
+const WHITELIST_WELCOME_TEXT = [
+  'Hey, you got in!',
+  '',
+  'Babylon is an AI-built world where humans and AI compete through prediction markets and perpetuals. You can create your own agent team and compete to win.',
+  '',
+  'Head to play.babylon.market, sign in, look around, then create one or two agents and tell them how they can help you win the game.',
+  '',
+  'Remember the best player get rewarded!',
+  '',
+  'Babylon team',
+].join('\n');
+
+const SEND_CONCURRENCY = 5;
+
+type WhitelistRecipientRow = {
+  id: string;
+  email: string | null;
+  emailVerified: boolean;
+  privyId: string | null;
+};
+
+function createWhitelistWelcomeHtml(): string {
+  return [
+    '<div style="font-family:Arial,sans-serif;max-width:560px;margin:0 auto;padding:24px;">',
+    '  <p style="font-size:15px;line-height:1.6;color:#222;margin:0 0 16px;">Hey, you got in!</p>',
+    '  <p style="font-size:15px;line-height:1.6;color:#222;margin:0 0 16px;">Babylon is an AI-built world where humans and AI compete through prediction markets and perpetuals. You can create your own agent team and compete to win.</p>',
+    '  <p style="font-size:15px;line-height:1.6;color:#222;margin:0 0 16px;">Head to play.babylon.market, sign in, look around, then create one or two agents and tell them how they can help you win the game.</p>',
+    '  <p style="font-size:15px;line-height:1.6;color:#222;margin:0 0 16px;">Remember the best player get rewarded!</p>',
+    '  <p style="font-size:15px;line-height:1.6;color:#222;margin:0;">Babylon team</p>',
+    '</div>',
+  ].join('');
+}
+
+interface ParsedEmailAddress {
+  email: string;
+  name?: string;
+}
+
+function parseEmailAddress(rawValue: string): ParsedEmailAddress | null {
+  const trimmed = rawValue.trim();
+
+  const namedMatch = trimmed.match(
+    /^(?<name>[^<>]+?)\s*<(?<email>[^<>\s@]+@[^<>\s@]+)>$/
+  );
+
+  const namedEmail = namedMatch?.groups?.email?.trim().toLowerCase();
+  if (namedEmail) {
+    const rawName = namedMatch?.groups?.name?.trim();
+    const normalizedName = rawName?.replace(/^"|"$/g, '');
+    return normalizedName
+      ? { email: namedEmail, name: normalizedName }
+      : { email: namedEmail };
+  }
+
+  const isPlainEmail = /^[^<>\s@]+@[^<>\s@]+$/.test(trimmed);
+  if (isPlainEmail) {
+    return { email: trimmed.toLowerCase() };
+  }
+
+  return null;
+}
+
+function normalizeEmail(rawEmail: string | null | undefined): string | null {
+  if (!rawEmail) return null;
+  const normalized = rawEmail.trim().toLowerCase();
+  return /^[^<>\s@]+@[^<>\s@]+$/.test(normalized) ? normalized : null;
+}
+
+async function resolveRecipientEmail(
+  recipient: WhitelistRecipientRow
+): Promise<string | null> {
+  const profileEmail = normalizeEmail(recipient.email);
+  if (profileEmail && recipient.emailVerified) {
+    return profileEmail;
+  }
+
+  if (recipient.privyId) {
+    try {
+      const privyUser = (await getPrivyNodeClient().getUser(
+        recipient.privyId
+      )) as PrivyUserWithEmails;
+      const verifiedEmails = getAllVerifiedEmails(privyUser);
+      const privyEmail = normalizeEmail(verifiedEmails[0]);
+      if (privyEmail) {
+        return privyEmail;
+      }
+    } catch (error) {
+      logger.warn(
+        'Failed to resolve whitelist recipient email from Privy',
+        { userId: recipient.id, error: String(error) },
+        'WhitelistEmailService'
+      );
+    }
+  }
+
+  return profileEmail;
+}
+
+async function sendWhitelistWelcomeEmail(input: {
+  userId: string;
+  userEmail: string;
+}): Promise<{ sent: boolean; reason?: string }> {
+  const sendgridApiKey = process.env.SENDGRID_API_KEY?.trim();
+  if (!sendgridApiKey) {
+    logger.debug(
+      'Skipping whitelist welcome email: SENDGRID_API_KEY is not configured',
+      { userId: input.userId },
+      'WhitelistEmailService'
+    );
+    return { sent: false, reason: 'provider_not_configured' };
+  }
+
+  const fromAddress =
+    process.env.NOTIFICATION_EMAIL_FROM?.trim() ||
+    process.env.EMAIL_FROM?.trim();
+  if (!fromAddress) {
+    logger.warn(
+      'Skipping whitelist welcome email: sender address is not configured',
+      { userId: input.userId },
+      'WhitelistEmailService'
+    );
+    return { sent: false, reason: 'sender_not_configured' };
+  }
+
+  const parsedFromAddress = parseEmailAddress(fromAddress);
+  if (!parsedFromAddress) {
+    logger.warn(
+      'Skipping whitelist welcome email: sender address format is invalid',
+      { userId: input.userId, fromAddress },
+      'WhitelistEmailService'
+    );
+    return { sent: false, reason: 'sender_not_configured' };
+  }
+
+  try {
+    const response = await fetch('https://api.sendgrid.com/v3/mail/send', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${sendgridApiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: parsedFromAddress,
+        personalizations: [{ to: [{ email: input.userEmail }] }],
+        subject: WHITELIST_WELCOME_SUBJECT,
+        content: [
+          { type: 'text/plain', value: WHITELIST_WELCOME_TEXT },
+          { type: 'text/html', value: createWhitelistWelcomeHtml() },
+        ],
+      }),
+    });
+
+    if (!response.ok) {
+      const responseBody = await response.text().catch(() => '');
+      logger.warn(
+        'Whitelist welcome email send failed',
+        {
+          userId: input.userId,
+          status: response.status,
+          responseBody,
+        },
+        'WhitelistEmailService'
+      );
+      return { sent: false, reason: 'provider_error' };
+    }
+
+    return { sent: true };
+  } catch (error) {
+    logger.error(
+      'Whitelist welcome email request failed',
+      { userId: input.userId, error: String(error) },
+      'WhitelistEmailService'
+    );
+    return { sent: false, reason: 'provider_error' };
+  }
+}
+
+async function fetchRecipients(
+  userIds: string[]
+): Promise<Map<string, WhitelistRecipientRow>> {
+  if (userIds.length === 0) return new Map();
+
+  const rows = await db
+    .select({
+      id: users.id,
+      email: users.email,
+      emailVerified: users.emailVerified,
+      privyId: users.privyId,
+    })
+    .from(users)
+    .where(inArray(users.id, userIds));
+
+  return new Map(rows.map((row) => [row.id, row]));
+}
+
+async function sendWelcomeEmailForUser(
+  userId: string,
+  recipient: WhitelistRecipientRow | undefined
+): Promise<'sent' | 'skipped' | 'failed'> {
+  if (!recipient) {
+    logger.warn(
+      'Skipping whitelist welcome email: user not found',
+      { userId },
+      'WhitelistEmailService'
+    );
+    return 'skipped';
+  }
+
+  const resolvedEmail = await resolveRecipientEmail(recipient);
+  if (!resolvedEmail) {
+    logger.info(
+      'Skipping whitelist welcome email: no email found for user',
+      { userId },
+      'WhitelistEmailService'
+    );
+    return 'skipped';
+  }
+
+  const result = await sendWhitelistWelcomeEmail({
+    userId,
+    userEmail: resolvedEmail,
+  });
+
+  if (result.sent) {
+    return 'sent';
+  }
+
+  logger.warn(
+    'Whitelist welcome email skipped by provider configuration or error',
+    { userId, reason: result.reason ?? 'unknown' },
+    'WhitelistEmailService'
+  );
+  return 'failed';
+}
+
+export async function sendWhitelistWelcomeEmailsToUsers(
+  userIds: string[]
+): Promise<void> {
+  const uniqueUserIds = [...new Set(userIds.filter(Boolean))];
+  if (uniqueUserIds.length === 0) return;
+
+  const recipients = await fetchRecipients(uniqueUserIds);
+
+  for (let i = 0; i < uniqueUserIds.length; i += SEND_CONCURRENCY) {
+    const chunk = uniqueUserIds.slice(i, i + SEND_CONCURRENCY);
+
+    const chunkResults = await Promise.all(
+      chunk.map((userId) => sendWelcomeEmailForUser(userId, recipients.get(userId)))
+    );
+
+    const sentCount = chunkResults.filter((result) => result === 'sent').length;
+    const skippedCount = chunkResults.filter(
+      (result) => result === 'skipped'
+    ).length;
+    const failedCount = chunkResults.filter((result) => result === 'failed').length;
+
+    if (sentCount > 0 || failedCount > 0 || skippedCount > 0) {
+      logger.info(
+        'Processed whitelist welcome email chunk',
+        {
+          chunkSize: chunk.length,
+          sentCount,
+          skippedCount,
+          failedCount,
+        },
+        'WhitelistEmailService'
+      );
+    }
+  }
+}
+
+export async function sendWhitelistWelcomeEmailToUser(
+  userId: string
+): Promise<void> {
+  await sendWhitelistWelcomeEmailsToUsers([userId]);
+}

--- a/packages/api/src/services/whitelist-service.ts
+++ b/packages/api/src/services/whitelist-service.ts
@@ -15,6 +15,10 @@ import { UserAlphaGroupAssignmentService } from '@babylon/engine';
 import { logger } from '@babylon/shared';
 import { nanoid } from 'nanoid';
 import { PointsService } from './points-service';
+import {
+  sendWhitelistWelcomeEmailToUser,
+  sendWhitelistWelcomeEmailsToUsers,
+} from './whitelist-email-service';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -193,6 +197,16 @@ export async function addToWhitelist({
           'addToWhitelist'
         );
       });
+
+    try {
+      await sendWhitelistWelcomeEmailToUser(userId);
+    } catch (error) {
+      logger.error(
+        'Failed to send whitelist welcome email (non-fatal)',
+        { userId, source, error: String(error) },
+        'addToWhitelist'
+      );
+    }
   }
 
   return { id: result.id, alreadyExists };
@@ -459,6 +473,18 @@ export async function autoWhitelistCurrentTopN(): Promise<{
     .values(rows)
     .onConflictDoNothing({ target: whitelist.userId })
     .returning({ userId: whitelist.userId });
+
+  try {
+    await sendWhitelistWelcomeEmailsToUsers(
+      insertedRows.map((row) => row.userId)
+    );
+  } catch (error) {
+    logger.error(
+      'Failed to send whitelist welcome emails after auto-whitelist (non-fatal)',
+      { insertedCount: insertedRows.length, error: String(error) },
+      'autoWhitelistCurrentTopN'
+    );
+  }
 
   return {
     topN,

--- a/packages/api/src/services/whitelist-service.ts
+++ b/packages/api/src/services/whitelist-service.ts
@@ -16,8 +16,8 @@ import { logger } from '@babylon/shared';
 import { nanoid } from 'nanoid';
 import { PointsService } from './points-service';
 import {
-  sendWhitelistWelcomeEmailToUser,
   sendWhitelistWelcomeEmailsToUsers,
+  sendWhitelistWelcomeEmailToUser,
 } from './whitelist-email-service';
 
 // ---------------------------------------------------------------------------
@@ -198,15 +198,13 @@ export async function addToWhitelist({
         );
       });
 
-    try {
-      await sendWhitelistWelcomeEmailToUser(userId);
-    } catch (error) {
+    sendWhitelistWelcomeEmailToUser(userId).catch((error) => {
       logger.error(
         'Failed to send whitelist welcome email (non-fatal)',
         { userId, source, error: String(error) },
         'addToWhitelist'
       );
-    }
+    });
   }
 
   return { id: result.id, alreadyExists };


### PR DESCRIPTION
## Summary

- Send a transactional welcome email when a user is newly whitelisted.
- Cover both whitelist paths: admin/menu (`addToWhitelist`) and leaderboard cron (`autoWhitelistCurrentTopN`).
- Keep whitelist grant flow resilient by treating email delivery failures as non-fatal and logging them.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-197/email-notification-when-user-is-whitelisted-leaderboard-or-menu

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- Added `packages/api/src/services/whitelist-email-service.ts`:
  - Sends the required whitelist welcome email via SendGrid with the exact subject/body from the ticket.
  - Resolves recipient email from profile first, with Privy verified-email fallback.
  - Supports batched dispatch for cron-driven whitelist grants.
- Updated `packages/api/src/services/whitelist-service.ts`:
  - `addToWhitelist` now triggers welcome email for newly granted whitelist users.
  - `autoWhitelistCurrentTopN` now sends welcome emails only for rows actually inserted in this run.
- Added/updated unit tests:
  - `packages/api/src/__tests__/whitelist-auto-email.test.ts`
  - `packages/api/src/__tests__/whitelist-group-assignment.test.ts`

## Review guide

**Start here**
- `packages/api/src/services/whitelist-service.ts`
- `packages/api/src/services/whitelist-email-service.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- Email failures are intentionally non-blocking for whitelist grants.
- De-duplication is based on existing whitelist insertion behavior: emails are sent only for new inserts/newly granted rows.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Run targeted tests:
   - `bun test packages/api/src/__tests__/whitelist-group-assignment.test.ts packages/api/src/__tests__/whitelist-auto-email.test.ts`
2. Verify both tests pass.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `…`
- Changed: `…`
- Removed: `…`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: Deploy normally.
- Rollback: Revert this PR to stop whitelist welcome email sends.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- N/A

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- No API contract changes.

### Database
- No schema changes.

### Contracts / on-chain
- N/A.

### Docs
- N/A.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend/API service change only (email dispatch on whitelist grant), no UI changes.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
