### PR TITLE
Fix cross-suite cron mock collisions in unit tests

### DIFF
--- a/packages/testing/unit/auth/siwe.test.ts
+++ b/packages/testing/unit/auth/siwe.test.ts
@@ -4,40 +4,7 @@
  * Tests for nonce generation, consumption, and SIWE message verification.
  */
 
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import * as actualRedisClientModule from '../../../api/src/redis/client';
-import * as actualSharedModule from '../../../shared/src/index';
-
-// Mock Redis before importing siwe module
-const mockRedis = {
-  setex: mock(() => Promise.resolve('OK')),
-  del: mock(() => Promise.resolve(1)),
-};
-
-let mockSnowflakeCounter = 0;
-
-const nextMockSnowflakeId = (): string => {
-  mockSnowflakeCounter += 1;
-  return `mock-snowflake-${Date.now()}-${mockSnowflakeCounter}`;
-};
-
-mock.module('../../../api/src/redis/client', () => ({
-  ...actualRedisClientModule,
-  getRedis: () => mockRedis,
-  getRedisClient: () => mockRedis,
-}));
-
-// Keep full shared export surface and override only test-specific pieces.
-mock.module('@babylon/shared', () => ({
-  ...actualSharedModule,
-  generateSnowflakeId: async () => nextMockSnowflakeId(),
-  logger: {
-    debug: () => {},
-    info: () => {},
-    warn: () => {},
-    error: () => {},
-  },
-}));
+import { describe, expect, test } from 'bun:test';
 
 // Import after mocks
 const {
@@ -50,11 +17,6 @@ const {
 } = await import('../../../api/src/auth/siwe');
 
 describe('SIWE Authentication', () => {
-  beforeEach(() => {
-    mockRedis.setex.mockClear();
-    mockRedis.del.mockClear();
-  });
-
   describe('getExpectedDomain', () => {
     test('returns localhost for development', () => {
       const originalEnv = process.env.NEXT_PUBLIC_APP_URL;
@@ -131,30 +93,25 @@ describe('SIWE Authentication', () => {
       expect(diffMinutes).toBeCloseTo(5, 0);
     });
 
-    test('stores nonce in Redis', async () => {
-      await generateNonce();
+    test('nonce can be consumed exactly once', async () => {
+      const { nonce } = await generateNonce();
 
-      expect(mockRedis.setex).toHaveBeenCalledTimes(1);
-      expect(mockRedis.setex).toHaveBeenCalledWith(
-        expect.stringMatching(/^siwe:nonce:/),
-        300,
-        '1'
-      );
+      const firstConsume = await consumeNonce(nonce);
+      const secondConsume = await consumeNonce(nonce);
+
+      expect(firstConsume).toBe(true);
+      expect(secondConsume).toBe(false);
     });
   });
 
   describe('consumeNonce', () => {
-    test('returns true when nonce exists in Redis', async () => {
-      mockRedis.del.mockImplementation(() => Promise.resolve(1));
-
-      const result = await consumeNonce('testnonce');
+    test('returns true when nonce exists', async () => {
+      const { nonce } = await generateNonce();
+      const result = await consumeNonce(nonce);
       expect(result).toBe(true);
-      expect(mockRedis.del).toHaveBeenCalledWith('siwe:nonce:testnonce');
     });
 
     test('returns false when nonce does not exist', async () => {
-      mockRedis.del.mockImplementation(() => Promise.resolve(0));
-
       const result = await consumeNonce('nonexistentnonce');
       expect(result).toBe(false);
     });
@@ -213,8 +170,6 @@ describe('SIWE Authentication', () => {
     });
 
     test('returns invalid_nonce when nonce not found', async () => {
-      mockRedis.del.mockImplementation(() => Promise.resolve(0));
-
       const message = createSiweMessage({
         address: '0x1234567890123456789012345678901234567890',
         nonce: 'invalidnonce789',
@@ -229,10 +184,9 @@ describe('SIWE Authentication', () => {
     });
 
     test('returns expired_message when message is expired', async () => {
-      mockRedis.del.mockImplementation(() => Promise.resolve(1));
-
       const { SiweMessage } = await import('siwe');
       const { privateKeyToAccount } = await import('viem/accounts');
+      const { nonce } = await generateNonce();
 
       const account = privateKeyToAccount(`0x${'1'.repeat(64)}`);
       const expiredMessage = new SiweMessage({
@@ -242,7 +196,7 @@ describe('SIWE Authentication', () => {
         uri: getAppUrl(),
         version: '1',
         chainId: 1,
-        nonce: 'validnonce123',
+        nonce,
         issuedAt: new Date(Date.now() - 10_000).toISOString(),
         expirationTime: new Date(Date.now() - 1_000).toISOString(),
       });

--- a/packages/testing/unit/auth/siwe.test.ts
+++ b/packages/testing/unit/auth/siwe.test.ts
@@ -5,6 +5,8 @@
  */
 
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import * as actualRedisClientModule from '../../../api/src/redis/client';
+import * as actualSharedModule from '../../../shared/src/index';
 
 // Mock Redis before importing siwe module
 const mockRedis = {
@@ -12,12 +14,23 @@ const mockRedis = {
   del: mock(() => Promise.resolve(1)),
 };
 
+let mockSnowflakeCounter = 0;
+
+const nextMockSnowflakeId = (): string => {
+  mockSnowflakeCounter += 1;
+  return `mock-snowflake-${Date.now()}-${mockSnowflakeCounter}`;
+};
+
 mock.module('../../../api/src/redis/client', () => ({
+  ...actualRedisClientModule,
   getRedis: () => mockRedis,
+  getRedisClient: () => mockRedis,
 }));
 
-// Mock logger
+// Keep full shared export surface and override only test-specific pieces.
 mock.module('@babylon/shared', () => ({
+  ...actualSharedModule,
+  generateSnowflakeId: async () => nextMockSnowflakeId(),
   logger: {
     debug: () => {},
     info: () => {},

--- a/packages/testing/unit/cron/article-tick.test.ts
+++ b/packages/testing/unit/cron/article-tick.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { NextRequest } from 'next/server';
 
 /**
@@ -25,12 +25,48 @@ interface SqlCondition {
   sql?: string;
 }
 
-// Mock db with a mutable state we can control in tests
-let mockGame: MockGame | null = null;
-let mockArticleCount = 0;
+interface CronMockState {
+  articleGame: MockGame | null;
+  articleCount: number;
+  articleCronAuthResult: boolean;
+  articleCoveredEventIds: Set<string>;
+  marketsGame: MockGame | null;
+  marketsActiveQuestions: Array<{
+    id: string;
+    questionNumber: number;
+    resolutionDate: Date;
+    status: string;
+  }>;
+  marketsWorldEvents: Array<{
+    id: string;
+    timestamp: Date;
+    description: string;
+  }>;
+  marketsCronAuthResult: boolean;
+  marketsAcquireLockResult: boolean;
+}
 
-// Mock auth state for negative-path testing
-let mockCronAuthResult = true;
+const CRON_MOCK_STATE_KEY = '__babylonCronMockState';
+
+type GlobalWithCronMockState = typeof globalThis & {
+  [CRON_MOCK_STATE_KEY]?: CronMockState;
+};
+
+const globalWithCronMockState = globalThis as GlobalWithCronMockState;
+
+const cronMockState =
+  globalWithCronMockState[CRON_MOCK_STATE_KEY] ??
+  (globalWithCronMockState[CRON_MOCK_STATE_KEY] = {
+    articleGame: null,
+    articleCount: 0,
+    articleCronAuthResult: true,
+    articleCoveredEventIds: new Set<string>(),
+    marketsGame: null,
+    marketsActiveQuestions: [],
+    marketsWorldEvents: [],
+    marketsCronAuthResult: true,
+    marketsAcquireLockResult: true,
+  });
 
 // Create query builder for Drizzle-style operations
 // The resultFn is called at query execution time to get the current mock state
@@ -60,142 +96,280 @@ const createQueryBuilder = (
   return builder;
 };
 
-// Mock @babylon/db - uses resultFn pattern for dynamic state evaluation
-mock.module('@babylon/db', () => ({
-  db: {
-    select: mock(() => createQueryBuilder(() => (mockGame ? [mockGame] : []))),
-    insert: mock(() =>
-      createQueryBuilder(() => [{ id: `mock-${Date.now()}` }])
-    ),
-    update: mock(() => createQueryBuilder(() => [{ id: 'mock-updated' }])),
-    delete: mock(() => createQueryBuilder(() => [{ id: 'mock-deleted' }])),
-  },
-  games: {},
-  posts: { type: 'type', timestamp: 'timestamp', deletedAt: 'deletedAt' },
-  eq: (): SqlCondition => ({}),
-  gte: (): SqlCondition => ({}),
-  and: (): SqlCondition => ({}),
-  isNull: (): SqlCondition => ({}),
-  sql: (): SqlCondition => ({}),
-  // Use real generateSnowflakeId from @babylon/shared to avoid polluting other tests
-  generateSnowflakeId: async () => {
-    const { generateSnowflakeId } = await import('@babylon/shared');
-    return generateSnowflakeId();
-  },
-}));
-
-// Mock @babylon/api - uses mutable state for auth and game cache
-mock.module('@babylon/api', () => ({
-  verifyCronAuth: () => mockCronAuthResult,
-  relayCronToStaging: async () => ({ forwarded: false }),
-  getCacheOrFetch: async <T>(_key: string, fn: () => Promise<T>) => {
-    // For game state cache, return our mockGame
-    if (_key === 'continuous-game') {
-      return mockGame as T;
-    }
-    return fn();
-  },
-  recordCronExecution: () => {},
-  DistributedLockService: {
-    acquireLock: async () => true,
-    releaseLock: async () => {},
-  },
-}));
-
-// Mock @babylon/engine - articleRateLimiter uses mockArticleCount
-mock.module('@babylon/engine', () => ({
-  articleRateLimiter: {
-    canGenerateArticle: async () => ({
-      allowed: mockArticleCount < 2,
-      currentCount: mockArticleCount,
-      maxAllowed: 2,
-      remaining: Math.max(0, 2 - mockArticleCount),
-    }),
-  },
-  ArticleGenerator: class {
-    generateArticleForQuestion = async () => ({
-      // Complete Article interface with all required fields
-      id: `mock-article-${Date.now()}`,
-      title: 'Test Article',
-      summary: 'Test summary',
-      content: 'Test content that is long enough to pass validation. '.repeat(
-        20
+const registerMocks = () => {
+  // Mock @babylon/db - uses resultFn pattern for dynamic state evaluation
+  mock.module('@babylon/db', () => ({
+    db: {
+      select: mock(() =>
+        createQueryBuilder(() =>
+          cronMockState.articleGame ? [cronMockState.articleGame] : []
+        )
       ),
-      authorOrgId: 'org-1',
-      authorOrgName: 'Test News',
-      byline: 'Test Author',
-      bylineActorId: 'actor-1',
-      biasScore: 0,
-      sentiment: 'neutral' as const,
-      slant: 'Neutral coverage',
-      relatedEventId: 'event-1',
-      relatedActorIds: [],
-      relatedOrgIds: ['org-1'],
-      category: 'news',
-      tags: ['test', 'article'],
-      publishedAt: new Date(),
-    });
-  },
-  BabylonLLMClient: {
-    forGameTick: () => ({
-      generateJSON: async () => ({
+      insert: mock(() =>
+        createQueryBuilder(() => [{ id: `mock-${Date.now()}` }])
+      ),
+      update: mock(() => createQueryBuilder(() => [{ id: 'mock-updated' }])),
+      delete: mock(() => createQueryBuilder(() => [{ id: 'mock-deleted' }])),
+    },
+    games: {
+      _tableName: 'games',
+      id: 'id',
+      isRunning: 'isRunning',
+      isContinuous: 'isContinuous',
+      currentDay: 'currentDay',
+    },
+    questions: {
+      _tableName: 'questions',
+      status: 'status',
+      resolutionDate: 'resolutionDate',
+      id: 'id',
+      questionNumber: 'questionNumber',
+    },
+    timeframedMarkets: { _tableName: 'timeframedMarkets' },
+    worldEvents: { _tableName: 'worldEvents', timestamp: 'timestamp' },
+    posts: {
+      _tableName: 'posts',
+      type: 'type',
+      timestamp: 'timestamp',
+      deletedAt: 'deletedAt',
+    },
+    eq: (): SqlCondition => ({}),
+    gte: (): SqlCondition => ({}),
+    lte: (): SqlCondition => ({}),
+    and: (): SqlCondition => ({}),
+    desc: (): SqlCondition => ({}),
+    isNull: (): SqlCondition => ({}),
+    isNotNull: (): SqlCondition => ({}),
+    sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+      sql: strings.join('?'),
+      values,
+    }),
+    max: (col: unknown) => ({ _aggregation: 'max', column: col }),
+    // Use real generateSnowflakeId from @babylon/shared to avoid polluting other tests
+    generateSnowflakeId: async () => {
+      const { generateSnowflakeId } = await import('@babylon/shared');
+      return generateSnowflakeId();
+    },
+  }));
+
+  // Mock @babylon/api - supports both article-tick and markets-tick consumers
+  mock.module('@babylon/api', () => ({
+    CACHE_KEYS: {
+      gameState: (_gameId: string) => 'game-state',
+    },
+    DEFAULT_TTLS: {
+      gameState: 60,
+    },
+    verifyCronAuth: (req: Request | NextRequest) => {
+      const pathname = new URL(req.url).pathname;
+      return pathname.includes('/markets-tick')
+        ? cronMockState.marketsCronAuthResult
+        : cronMockState.articleCronAuthResult;
+    },
+    relayCronToStaging: async () => ({ forwarded: false }),
+    invalidateCache: async () => {},
+    getCacheOrFetch: async <T>(_key: string, fn: () => Promise<T>) => {
+      if (_key === 'continuous-game') {
+        return cronMockState.articleGame as T;
+      }
+      if (_key.includes('game-state')) {
+        return (cronMockState.marketsGame || {
+          id: 'continuous',
+          isRunning: false,
+          isContinuous: true,
+          currentDay: 1,
+        }) as T;
+      }
+      return fn();
+    },
+    recordCronExecution: () => {},
+    DistributedLockService: {
+      acquireLock: async (options?: { lockId?: string }) => {
+        if (options?.lockId?.includes('markets-tick')) {
+          return cronMockState.marketsAcquireLockResult;
+        }
+        return true;
+      },
+      releaseLock: async () => {},
+    },
+  }));
+
+  mock.module('@babylon/core/markets/prediction', () => ({
+    PredictionDbAdapter: class {},
+    PredictionMarketService: class {
+      ensureMarketExists = async () => ({ id: 'mock-market-id' });
+    },
+  }));
+
+  // Mock @babylon/engine - includes exports needed by both cron routes
+  mock.module('@babylon/engine', () => ({
+    articleRateLimiter: {
+      canGenerateArticle: async () => ({
+        allowed: cronMockState.articleCount < 2,
+        currentCount: cronMockState.articleCount,
+        maxAllowed: 2,
+        remaining: Math.max(0, 2 - cronMockState.articleCount),
+      }),
+    },
+    ArticleGenerator: class {
+      generateArticleForQuestion = async () => ({
+        // Complete Article interface with all required fields
+        id: `mock-article-${Date.now()}`,
         title: 'Test Article',
         summary: 'Test summary',
-        article: 'Test article body',
+        content: 'Test content that is long enough to pass validation. '.repeat(
+          20
+        ),
+        authorOrgId: 'org-1',
+        authorOrgName: 'Test News',
+        byline: 'Test Author',
+        bylineActorId: 'actor-1',
+        biasScore: 0,
+        sentiment: 'neutral' as const,
+        slant: 'Neutral coverage',
+        relatedEventId: 'event-1',
+        relatedActorIds: [],
+        relatedOrgIds: ['org-1'],
+        category: 'news',
+        tags: ['test', 'article'],
+        publishedAt: new Date(),
+      });
+    },
+    BabylonLLMClient: {
+      forGameTick: () => ({
+        generateJSON: async () => ({
+          title: 'Test Article',
+          summary: 'Test summary',
+          article: 'Test article body',
+        }),
       }),
+    },
+    QuestionManager: class {
+      constructor(_llmClient: unknown) {}
+      async generateTimeframeQuestion() {
+        return {
+          text: 'Will AIlon Musk launch a new product?',
+          expectedOutcome: true,
+          resolutionCriteria: 'Product launch announcement',
+          affiliatedActorIds: [],
+          affiliatedOrgIds: [],
+        };
+      }
+      async generateResolutionWithProof() {
+        return {
+          description: 'The product was launched',
+          confidence: 0.95,
+          requiresManualReview: false,
+          proof: null,
+        };
+      }
+    },
+    getActiveEventsForPosting: async () => ({ activeEvents: [] }),
+    hasEventBeenCovered: (eventId: string) =>
+      cronMockState.articleCoveredEventIds.has(eventId),
+    markEventAsCovered: (eventId: string) => {
+      cronMockState.articleCoveredEventIds.add(eventId);
+    },
+    persistArticle: async (input: { id: string }) => ({
+      success: true,
+      articleId: input.id,
     }),
-  },
-  generateArticleImageWithRetry: async () => null,
-  getActiveEventsForPosting: async () => ({ activeEvents: [] }),
-  hasEventBeenCovered: () => false,
-  markEventAsCovered: () => {},
-  StaticDataRegistry: {
-    getOrganizationsByType: () => [
-      {
-        id: 'org-1',
-        name: 'Test News',
-        description: 'A news org',
-        type: 'media',
-        canBeInvolved: true,
-      },
-    ],
-    getTopActors: () => [
-      {
-        id: 'actor-1',
-        name: 'Test Actor',
-        description: 'A test actor',
-        domain: ['tech'],
-        affiliations: [],
-        postExample: [],
-        initialLuck: 'medium',
-        initialMood: 0,
-        isTest: true,
-      },
-    ],
-  },
-  secureRandom: () => Math.random(),
-  worldFactsService: {
-    generatePromptContext: async () => 'Test world facts context',
-  },
-}));
+    publishOracleCommitments: async () => ({ committed: 1 }),
+    publishOracleReveals: async () => ({ revealed: 1 }),
+    resolveQuestionPayouts: async () => {},
+    SignalExtractionService: {
+      extractMarketSignal: async () => ({
+        suggestedOutcome: 'YES',
+        confidence: 0.8,
+        yesSignal: 0.7,
+        noSignal: 0.3,
+        signalStrength: 0.6,
+        totalPosts: 10,
+      }),
+    },
+    StaticDataRegistry: {
+      getOrganizationsByType: () => [
+        {
+          id: 'org-1',
+          name: 'Test News',
+          description: 'A news org',
+          type: 'media',
+          canBeInvolved: true,
+        },
+      ],
+      getTopActors: () => [
+        {
+          id: 'actor-1',
+          name: 'Test Actor',
+          description: 'A test actor',
+          domain: ['tech'],
+          personality: 'Analytical and cautious',
+          tier: 'mid',
+          affiliations: [],
+          postStyle: 'Neutral analysis',
+          postExample: [],
+          role: 'Analyst',
+          initialLuck: 'medium',
+          initialMood: 0,
+        },
+      ],
+      getAllActors: () => [],
+      getAllOrganizations: () => [],
+      getActor: () => null,
+      getOrganization: () => null,
+    },
+    isEligibleActor: () => true,
+    mapGranularToDbTimeframe: (timeframe: string) => timeframe,
+    secureRandom: () => Math.random(),
+    weightedPick: <T>(items: T[]) => items[0] ?? null,
+    timeframeArcPlanner: {
+      planTimeframeArc: () => ({
+        questionId: 'q-1',
+        timeframe: '1d',
+        category: 'daily',
+        outcome: true,
+        durationMs: 86400000,
+        phases: {},
+        phaseOrder: ['setup', 'peak', 'resolution'],
+        insiders: [],
+        deceivers: [],
+        affiliatedOrgIds: [],
+        affiliatedActorIds: [],
+        createdAt: new Date(),
+      }),
+    },
+    worldFactsService: {
+      generatePromptContext: async () => 'Test world facts context',
+    },
+  }));
+};
 
 // Mock @babylon/shared
 // Note: @babylon/shared is NOT mocked - let real logger run to avoid
 // polluting module cache and breaking other tests that use formatCurrency, etc.
 
-// Import the route handler after mocks are set up
-import { GET, POST } from '@/app/api/cron/article-tick/route';
+// Route handlers are loaded dynamically after mock registration.
+let GET: (req: NextRequest) => Promise<Response>;
+let POST: (req: NextRequest) => Promise<Response>;
 
 describe('Article Tick Cron', () => {
+  beforeAll(async () => {
+    registerMocks();
+    const routeModule = await import('@/app/api/cron/article-tick/route');
+    GET = routeModule.GET;
+    POST = routeModule.POST;
+  });
+
   beforeEach(() => {
-    mockGame = null;
-    mockArticleCount = 0;
-    mockCronAuthResult = true;
+    cronMockState.articleGame = null;
+    cronMockState.articleCount = 0;
+    cronMockState.articleCronAuthResult = true;
+    cronMockState.articleCoveredEventIds.clear();
   });
 
   describe('Authorization', () => {
     test('should reject unauthorized requests when verifyCronAuth returns false', async () => {
-      mockCronAuthResult = false;
+      cronMockState.articleCronAuthResult = false;
 
       const req = new NextRequest('http://localhost/api/cron/article-tick', {
         method: 'POST',
@@ -210,7 +384,7 @@ describe('Article Tick Cron', () => {
 
     test('GET should delegate to POST and return identical response', async () => {
       // Set up a known game state so we get predictable responses
-      mockGame = null; // No game = skipped state
+      cronMockState.articleGame = null; // No game = skipped state
 
       // Create identical requests for GET and POST
       const getReq = new NextRequest('http://localhost/api/cron/article-tick', {
@@ -247,7 +421,7 @@ describe('Article Tick Cron', () => {
 
   describe('Game State Checks', () => {
     test('should be skipped when no continuous game exists', async () => {
-      mockGame = null;
+      cronMockState.articleGame = null;
 
       const req = new NextRequest('http://localhost/api/cron/article-tick', {
         method: 'POST',
@@ -261,7 +435,7 @@ describe('Article Tick Cron', () => {
     });
 
     test('should be paused when game.isRunning is false', async () => {
-      mockGame = {
+      cronMockState.articleGame = {
         id: 'game-123',
         isContinuous: true,
         isRunning: false,
@@ -282,13 +456,13 @@ describe('Article Tick Cron', () => {
 
   describe('Rate Limiting', () => {
     test('should skip when rate limit reached', async () => {
-      mockGame = {
+      cronMockState.articleGame = {
         id: 'game-123',
         isContinuous: true,
         isRunning: true,
         currentDay: 1,
       };
-      mockArticleCount = 2; // At limit
+      cronMockState.articleCount = 2; // At limit
 
       const req = new NextRequest('http://localhost/api/cron/article-tick', {
         method: 'POST',
@@ -302,13 +476,13 @@ describe('Article Tick Cron', () => {
     });
 
     test('should proceed when under rate limit', async () => {
-      mockGame = {
+      cronMockState.articleGame = {
         id: 'game-123',
         isContinuous: true,
         isRunning: true,
         currentDay: 1,
       };
-      mockArticleCount = 0; // Under limit
+      cronMockState.articleCount = 0; // Under limit
 
       const req = new NextRequest('http://localhost/api/cron/article-tick', {
         method: 'POST',
@@ -329,13 +503,13 @@ describe('Article Tick Cron', () => {
 
   describe('Response Structure', () => {
     test('should return rate limit info in response', async () => {
-      mockGame = {
+      cronMockState.articleGame = {
         id: 'game-123',
         isContinuous: true,
         isRunning: true,
         currentDay: 1,
       };
-      mockArticleCount = 1; // Under limit (2), so processing should proceed
+      cronMockState.articleCount = 1; // Under limit (2), so processing should proceed
 
       const req = new NextRequest('http://localhost/api/cron/article-tick', {
         method: 'POST',

--- a/packages/testing/unit/cron/article-tick.test.ts
+++ b/packages/testing/unit/cron/article-tick.test.ts
@@ -1,4 +1,15 @@
-import { beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from 'bun:test';
+import * as actualApiModule from '../../../api/src/index';
+import * as actualDbModule from '../../../db/src/index';
+import * as actualEngineModule from '../../../engine/src/index';
 import { NextRequest } from 'next/server';
 
 /**
@@ -68,6 +79,13 @@ const cronMockState =
     marketsAcquireLockResult: true,
   });
 
+let mockSnowflakeCounter = 0;
+
+const nextMockSnowflakeId = (): string => {
+  mockSnowflakeCounter += 1;
+  return `mock-snowflake-${Date.now()}-${mockSnowflakeCounter}`;
+};
+
 // Create query builder for Drizzle-style operations
 // The resultFn is called at query execution time to get the current mock state
 // This mirrors the markets-tick.test.ts pattern for dynamic result evaluation
@@ -99,6 +117,7 @@ const createQueryBuilder = (
 const registerMocks = () => {
   // Mock @babylon/db - uses resultFn pattern for dynamic state evaluation
   mock.module('@babylon/db', () => ({
+      ...actualDbModule,
     db: {
       select: mock(() =>
         createQueryBuilder(() =>
@@ -125,6 +144,20 @@ const registerMocks = () => {
       id: 'id',
       questionNumber: 'questionNumber',
     },
+    userAgentConfigs: { _tableName: 'userAgentConfigs' },
+    users: { _tableName: 'users' },
+    actors: { _tableName: 'actors' },
+    comments: { _tableName: 'comments' },
+    organizations: { _tableName: 'organizations' },
+    balanceTransactions: { _tableName: 'balanceTransactions' },
+    pointsTransactions: { _tableName: 'pointsTransactions' },
+    perpPositions: { _tableName: 'perpPositions' },
+    poolPositions: { _tableName: 'poolPositions' },
+    markets: { _tableName: 'markets' },
+    generationLocks: { _tableName: 'generationLocks' },
+    agentPerformanceMetrics: { _tableName: 'agentPerformanceMetrics' },
+    agentTrades: { _tableName: 'agentTrades' },
+    npcTrades: { _tableName: 'npcTrades' },
     timeframedMarkets: { _tableName: 'timeframedMarkets' },
     worldEvents: { _tableName: 'worldEvents', timestamp: 'timestamp' },
     posts: {
@@ -134,10 +167,17 @@ const registerMocks = () => {
       deletedAt: 'deletedAt',
     },
     eq: (): SqlCondition => ({}),
+    ne: (): SqlCondition => ({}),
+    gt: (): SqlCondition => ({}),
     gte: (): SqlCondition => ({}),
+    lt: (): SqlCondition => ({}),
     lte: (): SqlCondition => ({}),
     and: (): SqlCondition => ({}),
+    or: (): SqlCondition => ({}),
+    not: (): SqlCondition => ({}),
+    inArray: (): SqlCondition => ({}),
     desc: (): SqlCondition => ({}),
+    asc: (): SqlCondition => ({}),
     isNull: (): SqlCondition => ({}),
     isNotNull: (): SqlCondition => ({}),
     sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
@@ -145,15 +185,17 @@ const registerMocks = () => {
       values,
     }),
     max: (col: unknown) => ({ _aggregation: 'max', column: col }),
-    // Use real generateSnowflakeId from @babylon/shared to avoid polluting other tests
-    generateSnowflakeId: async () => {
-      const { generateSnowflakeId } = await import('@babylon/shared');
-      return generateSnowflakeId();
-    },
+    generateSnowflakeId: async () => nextMockSnowflakeId(),
+    withTransaction: async <T>(fn: (tx: unknown) => Promise<T>) => fn({}),
+    asUser: async <T>(_userId: string, fn: (db: unknown) => Promise<T>) =>
+      fn({}),
+    asSystem: async <T>(fn: (db: unknown) => Promise<T>) => fn({}),
+    asPublic: async <T>(fn: (db: unknown) => Promise<T>) => fn({}),
   }));
 
   // Mock @babylon/api - supports both article-tick and markets-tick consumers
   mock.module('@babylon/api', () => ({
+    ...actualApiModule,
     CACHE_KEYS: {
       gameState: (_gameId: string) => 'game-state',
     },
@@ -167,6 +209,14 @@ const registerMocks = () => {
         : cronMockState.articleCronAuthResult;
     },
     relayCronToStaging: async () => ({ forwarded: false }),
+    broadcastAgentActivity: async () => {},
+    broadcastToChannel: async () => {},
+    notifyGroupChatInvite: async () => {},
+    checkRateLimit: async () => ({ allowed: true, remaining: 1 }),
+    checkRateLimitAsync: async () => ({ allowed: true, remaining: 1 }),
+    clearAllRateLimits: async () => {},
+    getRateLimitStatus: async () => ({ remaining: 1, resetAt: Date.now() }),
+    resetRateLimit: async () => {},
     invalidateCache: async () => {},
     getCacheOrFetch: async <T>(_key: string, fn: () => Promise<T>) => {
       if (_key === 'continuous-game') {
@@ -203,6 +253,7 @@ const registerMocks = () => {
 
   // Mock @babylon/engine - includes exports needed by both cron routes
   mock.module('@babylon/engine', () => ({
+    ...actualEngineModule,
     articleRateLimiter: {
       canGenerateArticle: async () => ({
         allowed: cronMockState.articleCount < 2,
@@ -276,6 +327,13 @@ const registerMocks = () => {
     }),
     publishOracleCommitments: async () => ({ committed: 1 }),
     publishOracleReveals: async () => ({ revealed: 1 }),
+    getReputationBreakdown: () => ({
+      total: 0,
+      level: 'neutral',
+      trend: 0,
+      factors: {},
+    }),
+    recalculateReputation: async () => {},
     resolveQuestionPayouts: async () => {},
     SignalExtractionService: {
       extractMarketSignal: async () => ({
@@ -322,6 +380,13 @@ const registerMocks = () => {
     mapGranularToDbTimeframe: (timeframe: string) => timeframe,
     secureRandom: () => Math.random(),
     weightedPick: <T>(items: T[]) => items[0] ?? null,
+    gameService: {
+      getCurrentGame: async () => null,
+    },
+    setBroadcastToChannel: () => {},
+    setDistributedLockProvider: () => {},
+    setNotifyGroupChatInvite: () => {},
+    setRateLimitProvider: () => {},
     timeframeArcPlanner: {
       planTimeframeArc: () => ({
         questionId: 'q-1',
@@ -344,9 +409,7 @@ const registerMocks = () => {
   }));
 };
 
-// Mock @babylon/shared
-// Note: @babylon/shared is NOT mocked - let real logger run to avoid
-// polluting module cache and breaking other tests that use formatCurrency, etc.
+// @babylon/shared is intentionally not mocked here.
 
 // Route handlers are loaded dynamically after mock registration.
 let GET: (req: NextRequest) => Promise<Response>;
@@ -358,6 +421,10 @@ describe('Article Tick Cron', () => {
     const routeModule = await import('@/app/api/cron/article-tick/route');
     GET = routeModule.GET;
     POST = routeModule.POST;
+  });
+
+  afterAll(() => {
+    mock.restore();
   });
 
   beforeEach(() => {

--- a/packages/testing/unit/cron/article-tick.test.ts
+++ b/packages/testing/unit/cron/article-tick.test.ts
@@ -7,10 +7,8 @@ import {
   mock,
   test,
 } from 'bun:test';
-import * as actualApiModule from '../../../api/src/index';
-import * as actualDbModule from '../../../db/src/index';
-import * as actualEngineModule from '../../../engine/src/index';
 import { NextRequest } from 'next/server';
+import { cronMockState, registerCronMocks } from './cron-test-mocks';
 
 /**
  * Article Tick Cron Job Tests
@@ -19,405 +17,12 @@ import { NextRequest } from 'next/server';
  * article generation with rate limiting.
  */
 
-/**
- * Mock game state type
- */
-interface MockGame {
-  id: string;
-  isContinuous: boolean;
-  isRunning: boolean;
-  currentDay: number | null;
-}
-
-/**
- * Drizzle SQL condition result
- */
-interface SqlCondition {
-  sql?: string;
-}
-
-interface CronMockState {
-  articleGame: MockGame | null;
-  articleCount: number;
-  articleCronAuthResult: boolean;
-  articleCoveredEventIds: Set<string>;
-  marketsGame: MockGame | null;
-  marketsActiveQuestions: Array<{
-    id: string;
-    questionNumber: number;
-    resolutionDate: Date;
-    status: string;
-  }>;
-  marketsWorldEvents: Array<{
-    id: string;
-    timestamp: Date;
-    description: string;
-  }>;
-  marketsCronAuthResult: boolean;
-  marketsAcquireLockResult: boolean;
-}
-
-const CRON_MOCK_STATE_KEY = '__babylonCronMockState';
-
-type GlobalWithCronMockState = typeof globalThis & {
-  [CRON_MOCK_STATE_KEY]?: CronMockState;
-};
-
-const globalWithCronMockState = globalThis as GlobalWithCronMockState;
-
-const cronMockState =
-  globalWithCronMockState[CRON_MOCK_STATE_KEY] ??
-  (globalWithCronMockState[CRON_MOCK_STATE_KEY] = {
-    articleGame: null,
-    articleCount: 0,
-    articleCronAuthResult: true,
-    articleCoveredEventIds: new Set<string>(),
-    marketsGame: null,
-    marketsActiveQuestions: [],
-    marketsWorldEvents: [],
-    marketsCronAuthResult: true,
-    marketsAcquireLockResult: true,
-  });
-
-let mockSnowflakeCounter = 0;
-
-const nextMockSnowflakeId = (): string => {
-  mockSnowflakeCounter += 1;
-  return `mock-snowflake-${Date.now()}-${mockSnowflakeCounter}`;
-};
-
-// Create query builder for Drizzle-style operations
-// The resultFn is called at query execution time to get the current mock state
-// This mirrors the markets-tick.test.ts pattern for dynamic result evaluation
-const createQueryBuilder = (
-  resultFn: () => unknown = () => [{ id: 'mock-id' }]
-) => {
-  const builder = {
-    set: mock(() => builder),
-    where: mock(() => builder),
-    values: mock(() => builder),
-    from: mock(() => builder),
-    limit: mock(() => builder),
-    returning: mock(async () => resultFn()),
-    onConflictDoNothing: mock(() => builder),
-    then: <TResult1, TResult2 = never>(
-      onFulfilled?:
-        | ((value: unknown) => TResult1 | PromiseLike<TResult1>)
-        | null,
-      onRejected?:
-        | ((reason: unknown) => TResult2 | PromiseLike<TResult2>)
-        | null
-    ): Promise<TResult1 | TResult2> => {
-      return Promise.resolve(resultFn()).then(onFulfilled, onRejected);
-    },
-  };
-  return builder;
-};
-
-const registerMocks = () => {
-  // Mock @babylon/db - uses resultFn pattern for dynamic state evaluation
-  mock.module('@babylon/db', () => ({
-      ...actualDbModule,
-    db: {
-      select: mock(() =>
-        createQueryBuilder(() =>
-          cronMockState.articleGame ? [cronMockState.articleGame] : []
-        )
-      ),
-      insert: mock(() =>
-        createQueryBuilder(() => [{ id: `mock-${Date.now()}` }])
-      ),
-      update: mock(() => createQueryBuilder(() => [{ id: 'mock-updated' }])),
-      delete: mock(() => createQueryBuilder(() => [{ id: 'mock-deleted' }])),
-    },
-    games: {
-      _tableName: 'games',
-      id: 'id',
-      isRunning: 'isRunning',
-      isContinuous: 'isContinuous',
-      currentDay: 'currentDay',
-    },
-    questions: {
-      _tableName: 'questions',
-      status: 'status',
-      resolutionDate: 'resolutionDate',
-      id: 'id',
-      questionNumber: 'questionNumber',
-    },
-    userAgentConfigs: { _tableName: 'userAgentConfigs' },
-    users: { _tableName: 'users' },
-    actors: { _tableName: 'actors' },
-    comments: { _tableName: 'comments' },
-    organizations: { _tableName: 'organizations' },
-    balanceTransactions: { _tableName: 'balanceTransactions' },
-    pointsTransactions: { _tableName: 'pointsTransactions' },
-    perpPositions: { _tableName: 'perpPositions' },
-    poolPositions: { _tableName: 'poolPositions' },
-    markets: { _tableName: 'markets' },
-    generationLocks: { _tableName: 'generationLocks' },
-    agentPerformanceMetrics: { _tableName: 'agentPerformanceMetrics' },
-    agentTrades: { _tableName: 'agentTrades' },
-    npcTrades: { _tableName: 'npcTrades' },
-    timeframedMarkets: { _tableName: 'timeframedMarkets' },
-    worldEvents: { _tableName: 'worldEvents', timestamp: 'timestamp' },
-    posts: {
-      _tableName: 'posts',
-      type: 'type',
-      timestamp: 'timestamp',
-      deletedAt: 'deletedAt',
-    },
-    eq: (): SqlCondition => ({}),
-    ne: (): SqlCondition => ({}),
-    gt: (): SqlCondition => ({}),
-    gte: (): SqlCondition => ({}),
-    lt: (): SqlCondition => ({}),
-    lte: (): SqlCondition => ({}),
-    and: (): SqlCondition => ({}),
-    or: (): SqlCondition => ({}),
-    not: (): SqlCondition => ({}),
-    inArray: (): SqlCondition => ({}),
-    desc: (): SqlCondition => ({}),
-    asc: (): SqlCondition => ({}),
-    isNull: (): SqlCondition => ({}),
-    isNotNull: (): SqlCondition => ({}),
-    sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
-      sql: strings.join('?'),
-      values,
-    }),
-    max: (col: unknown) => ({ _aggregation: 'max', column: col }),
-    generateSnowflakeId: async () => nextMockSnowflakeId(),
-    withTransaction: async <T>(fn: (tx: unknown) => Promise<T>) => fn({}),
-    asUser: async <T>(_userId: string, fn: (db: unknown) => Promise<T>) =>
-      fn({}),
-    asSystem: async <T>(fn: (db: unknown) => Promise<T>) => fn({}),
-    asPublic: async <T>(fn: (db: unknown) => Promise<T>) => fn({}),
-  }));
-
-  // Mock @babylon/api - supports both article-tick and markets-tick consumers
-  mock.module('@babylon/api', () => ({
-    ...actualApiModule,
-    CACHE_KEYS: {
-      gameState: (_gameId: string) => 'game-state',
-    },
-    DEFAULT_TTLS: {
-      gameState: 60,
-    },
-    verifyCronAuth: (req: Request | NextRequest) => {
-      const pathname = new URL(req.url).pathname;
-      return pathname.includes('/markets-tick')
-        ? cronMockState.marketsCronAuthResult
-        : cronMockState.articleCronAuthResult;
-    },
-    relayCronToStaging: async () => ({ forwarded: false }),
-    broadcastAgentActivity: async () => {},
-    broadcastToChannel: async () => {},
-    notifyGroupChatInvite: async () => {},
-    checkRateLimit: async () => ({ allowed: true, remaining: 1 }),
-    checkRateLimitAsync: async () => ({ allowed: true, remaining: 1 }),
-    clearAllRateLimits: async () => {},
-    getRateLimitStatus: async () => ({ remaining: 1, resetAt: Date.now() }),
-    resetRateLimit: async () => {},
-    invalidateCache: async () => {},
-    getCacheOrFetch: async <T>(_key: string, fn: () => Promise<T>) => {
-      if (_key === 'continuous-game') {
-        return cronMockState.articleGame as T;
-      }
-      if (_key.includes('game-state')) {
-        return (cronMockState.marketsGame || {
-          id: 'continuous',
-          isRunning: false,
-          isContinuous: true,
-          currentDay: 1,
-        }) as T;
-      }
-      return fn();
-    },
-    recordCronExecution: () => {},
-    DistributedLockService: {
-      acquireLock: async (options?: { lockId?: string }) => {
-        if (options?.lockId?.includes('markets-tick')) {
-          return cronMockState.marketsAcquireLockResult;
-        }
-        return true;
-      },
-      releaseLock: async () => {},
-    },
-  }));
-
-  mock.module('@babylon/core/markets/prediction', () => ({
-    PredictionDbAdapter: class {},
-    PredictionMarketService: class {
-      ensureMarketExists = async () => ({ id: 'mock-market-id' });
-    },
-  }));
-
-  // Mock @babylon/engine - includes exports needed by both cron routes
-  mock.module('@babylon/engine', () => ({
-    ...actualEngineModule,
-    articleRateLimiter: {
-      canGenerateArticle: async () => ({
-        allowed: cronMockState.articleCount < 2,
-        currentCount: cronMockState.articleCount,
-        maxAllowed: 2,
-        remaining: Math.max(0, 2 - cronMockState.articleCount),
-      }),
-    },
-    ArticleGenerator: class {
-      generateArticleForQuestion = async () => ({
-        // Complete Article interface with all required fields
-        id: `mock-article-${Date.now()}`,
-        title: 'Test Article',
-        summary: 'Test summary',
-        content: 'Test content that is long enough to pass validation. '.repeat(
-          20
-        ),
-        authorOrgId: 'org-1',
-        authorOrgName: 'Test News',
-        byline: 'Test Author',
-        bylineActorId: 'actor-1',
-        biasScore: 0,
-        sentiment: 'neutral' as const,
-        slant: 'Neutral coverage',
-        relatedEventId: 'event-1',
-        relatedActorIds: [],
-        relatedOrgIds: ['org-1'],
-        category: 'news',
-        tags: ['test', 'article'],
-        publishedAt: new Date(),
-      });
-    },
-    BabylonLLMClient: {
-      forGameTick: () => ({
-        generateJSON: async () => ({
-          title: 'Test Article',
-          summary: 'Test summary',
-          article: 'Test article body',
-        }),
-      }),
-    },
-    QuestionManager: class {
-      constructor(_llmClient: unknown) {}
-      async generateTimeframeQuestion() {
-        return {
-          text: 'Will AIlon Musk launch a new product?',
-          expectedOutcome: true,
-          resolutionCriteria: 'Product launch announcement',
-          affiliatedActorIds: [],
-          affiliatedOrgIds: [],
-        };
-      }
-      async generateResolutionWithProof() {
-        return {
-          description: 'The product was launched',
-          confidence: 0.95,
-          requiresManualReview: false,
-          proof: null,
-        };
-      }
-    },
-    getActiveEventsForPosting: async () => ({ activeEvents: [] }),
-    hasEventBeenCovered: (eventId: string) =>
-      cronMockState.articleCoveredEventIds.has(eventId),
-    markEventAsCovered: (eventId: string) => {
-      cronMockState.articleCoveredEventIds.add(eventId);
-    },
-    persistArticle: async (input: { id: string }) => ({
-      success: true,
-      articleId: input.id,
-    }),
-    publishOracleCommitments: async () => ({ committed: 1 }),
-    publishOracleReveals: async () => ({ revealed: 1 }),
-    getReputationBreakdown: () => ({
-      total: 0,
-      level: 'neutral',
-      trend: 0,
-      factors: {},
-    }),
-    recalculateReputation: async () => {},
-    resolveQuestionPayouts: async () => {},
-    SignalExtractionService: {
-      extractMarketSignal: async () => ({
-        suggestedOutcome: 'YES',
-        confidence: 0.8,
-        yesSignal: 0.7,
-        noSignal: 0.3,
-        signalStrength: 0.6,
-        totalPosts: 10,
-      }),
-    },
-    StaticDataRegistry: {
-      getOrganizationsByType: () => [
-        {
-          id: 'org-1',
-          name: 'Test News',
-          description: 'A news org',
-          type: 'media',
-          canBeInvolved: true,
-        },
-      ],
-      getTopActors: () => [
-        {
-          id: 'actor-1',
-          name: 'Test Actor',
-          description: 'A test actor',
-          domain: ['tech'],
-          personality: 'Analytical and cautious',
-          tier: 'mid',
-          affiliations: [],
-          postStyle: 'Neutral analysis',
-          postExample: [],
-          role: 'Analyst',
-          initialLuck: 'medium',
-          initialMood: 0,
-        },
-      ],
-      getAllActors: () => [],
-      getAllOrganizations: () => [],
-      getActor: () => null,
-      getOrganization: () => null,
-    },
-    isEligibleActor: () => true,
-    mapGranularToDbTimeframe: (timeframe: string) => timeframe,
-    secureRandom: () => Math.random(),
-    weightedPick: <T>(items: T[]) => items[0] ?? null,
-    gameService: {
-      getCurrentGame: async () => null,
-    },
-    setBroadcastToChannel: () => {},
-    setDistributedLockProvider: () => {},
-    setNotifyGroupChatInvite: () => {},
-    setRateLimitProvider: () => {},
-    timeframeArcPlanner: {
-      planTimeframeArc: () => ({
-        questionId: 'q-1',
-        timeframe: '1d',
-        category: 'daily',
-        outcome: true,
-        durationMs: 86400000,
-        phases: {},
-        phaseOrder: ['setup', 'peak', 'resolution'],
-        insiders: [],
-        deceivers: [],
-        affiliatedOrgIds: [],
-        affiliatedActorIds: [],
-        createdAt: new Date(),
-      }),
-    },
-    worldFactsService: {
-      generatePromptContext: async () => 'Test world facts context',
-    },
-  }));
-};
-
-// @babylon/shared is intentionally not mocked here.
-
-// Route handlers are loaded dynamically after mock registration.
 let GET: (req: NextRequest) => Promise<Response>;
 let POST: (req: NextRequest) => Promise<Response>;
 
 describe('Article Tick Cron', () => {
   beforeAll(async () => {
-    registerMocks();
+    registerCronMocks();
     const routeModule = await import('@/app/api/cron/article-tick/route');
     GET = routeModule.GET;
     POST = routeModule.POST;
@@ -450,28 +55,21 @@ describe('Article Tick Cron', () => {
     });
 
     test('GET should delegate to POST and return identical response', async () => {
-      // Set up a known game state so we get predictable responses
-      cronMockState.articleGame = null; // No game = skipped state
+      cronMockState.articleGame = null;
 
-      // Create identical requests for GET and POST
       const getReq = new NextRequest('http://localhost/api/cron/article-tick', {
         method: 'GET',
       });
       const postReq = new NextRequest(
         'http://localhost/api/cron/article-tick',
-        {
-          method: 'POST',
-        }
+        { method: 'POST' }
       );
 
-      // Call both handlers
       const getRes = await GET(getReq);
       const postRes = await POST(postReq);
 
-      // Both should return the same status
       expect(getRes.status).toBe(postRes.status);
 
-      // Both should return the same response body
       const getBody = await getRes.json();
       const postBody = await postRes.json();
 
@@ -479,7 +77,6 @@ describe('Article Tick Cron', () => {
       expect(getBody.skipped).toBe(postBody.skipped);
       expect(getBody.reason).toBe(postBody.reason);
 
-      // Verify the expected behavior (skipped because no game)
       expect(getBody.success).toBe(true);
       expect(getBody.skipped).toBe(true);
       expect(getBody.reason).toBe('No continuous game found');
@@ -529,7 +126,7 @@ describe('Article Tick Cron', () => {
         isRunning: true,
         currentDay: 1,
       };
-      cronMockState.articleCount = 2; // At limit
+      cronMockState.articleCount = 2;
 
       const req = new NextRequest('http://localhost/api/cron/article-tick', {
         method: 'POST',
@@ -549,7 +146,7 @@ describe('Article Tick Cron', () => {
         isRunning: true,
         currentDay: 1,
       };
-      cronMockState.articleCount = 0; // Under limit
+      cronMockState.articleCount = 0;
 
       const req = new NextRequest('http://localhost/api/cron/article-tick', {
         method: 'POST',
@@ -557,13 +154,10 @@ describe('Article Tick Cron', () => {
       const res = await POST(req);
       const data = await res.json();
 
-      // Positive assertions: handler succeeded and actually processed
       expect(res.status).toBe(200);
       expect(res.ok).toBe(true);
       expect(data.success).toBe(true);
       expect(data.skipped).toBe(false);
-
-      // Should not be skipped due to rate limit
       expect(data.reason).not.toBe('Rate limit reached');
     });
   });
@@ -576,7 +170,7 @@ describe('Article Tick Cron', () => {
         isRunning: true,
         currentDay: 1,
       };
-      cronMockState.articleCount = 1; // Under limit (2), so processing should proceed
+      cronMockState.articleCount = 1;
 
       const req = new NextRequest('http://localhost/api/cron/article-tick', {
         method: 'POST',
@@ -584,12 +178,10 @@ describe('Article Tick Cron', () => {
       const res = await POST(req);
       const data = await res.json();
 
-      // Verify handler succeeded and was not skipped
       expect(res.status).toBe(200);
       expect(data.success).toBe(true);
-      expect(data.skipped).toBe(false); // Explicit assertion - test fails if skipped
+      expect(data.skipped).toBe(false);
 
-      // Rate limit info should always be included when not skipped
       expect(data.rateLimit).toBeDefined();
       expect(data.rateLimit.currentCount).toBe(1);
       expect(data.rateLimit.maxAllowed).toBe(2);

--- a/packages/testing/unit/cron/cron-test-mocks.ts
+++ b/packages/testing/unit/cron/cron-test-mocks.ts
@@ -1,0 +1,505 @@
+/**
+ * Shared mock infrastructure for cron test suites.
+ *
+ * Both article-tick and markets-tick route handlers import from @babylon/db,
+ * @babylon/api, @babylon/engine, and @babylon/core. When Bun runs multiple
+ * test files in the same process, `mock.module()` calls from one suite can
+ * pollute the module registry for another. This module centralises mock
+ * registration so both suites share identical, non-leaking mocks.
+ */
+
+import { mock } from 'bun:test';
+import { NextRequest } from 'next/server';
+
+// Pre-import rate-limiting and format utilities from @babylon/api BEFORE
+// mock.module replaces the module. These are re-exported in the mock so
+// downstream tests that import them from @babylon/api still get the real
+// implementations.
+import * as rateLimiting from '../../../api/src/rate-limiting';
+import {
+  isValidSnowflakeId,
+  parseSnowflakeId,
+  SnowflakeGenerator,
+} from '../../../shared/src/utils/snowflake';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MockGame {
+  id: string;
+  isContinuous: boolean;
+  isRunning: boolean;
+  currentDay: number | null;
+}
+
+export interface MockQuestion {
+  id: string;
+  questionNumber: number;
+  resolutionDate: Date;
+  status: string;
+}
+
+export interface MockWorldEvent {
+  id: string;
+  timestamp: Date;
+  description: string;
+}
+
+interface SqlCondition {
+  sql?: string;
+}
+
+export interface CronMockState {
+  articleGame: MockGame | null;
+  articleCount: number;
+  articleCronAuthResult: boolean;
+  articleCoveredEventIds: Set<string>;
+  marketsGame: MockGame | null;
+  marketsActiveQuestions: MockQuestion[];
+  marketsWorldEvents: MockWorldEvent[];
+  marketsCronAuthResult: boolean;
+  marketsAcquireLockResult: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Shared global state (survives across suites in the same Bun process)
+// ---------------------------------------------------------------------------
+
+const CRON_MOCK_STATE_KEY = '__babylonCronMockState';
+
+type GlobalWithCronMockState = typeof globalThis & {
+  [CRON_MOCK_STATE_KEY]?: CronMockState;
+};
+
+const g = globalThis as GlobalWithCronMockState;
+
+export const cronMockState: CronMockState =
+  g[CRON_MOCK_STATE_KEY] ??
+  (g[CRON_MOCK_STATE_KEY] = {
+    articleGame: null,
+    articleCount: 0,
+    articleCronAuthResult: true,
+    articleCoveredEventIds: new Set<string>(),
+    marketsGame: null,
+    marketsActiveQuestions: [],
+    marketsWorldEvents: [],
+    marketsCronAuthResult: true,
+    marketsAcquireLockResult: true,
+  });
+
+// ---------------------------------------------------------------------------
+// Deterministic snowflake stub (returns valid BigInt-parseable numeric strings)
+// ---------------------------------------------------------------------------
+
+let snowflakeSeq = 0;
+
+const SNOWFLAKE_EPOCH = 1_704_067_200_000n; // Jan 1, 2024 UTC — must match @babylon/shared
+
+export function nextMockSnowflakeId(): string {
+  snowflakeSeq += 1;
+  const ts = BigInt(Date.now()) - SNOWFLAKE_EPOCH;
+  return String((ts << 22n) | BigInt(snowflakeSeq & 0x3fffff));
+}
+
+// ---------------------------------------------------------------------------
+// Table tracking (used by markets-tick's table-aware query builder)
+// ---------------------------------------------------------------------------
+
+export let currentQueryTable: string | null = null;
+
+export function resetQueryTable() {
+  currentQueryTable = null;
+}
+
+// ---------------------------------------------------------------------------
+// Table reference stubs
+// ---------------------------------------------------------------------------
+
+const TABLE_REFS: Record<string, Record<string, string>> = {
+  games: {
+    _tableName: 'games',
+    id: 'id',
+    isRunning: 'isRunning',
+    isContinuous: 'isContinuous',
+    currentDay: 'currentDay',
+  },
+  questions: {
+    _tableName: 'questions',
+    status: 'status',
+    resolutionDate: 'resolutionDate',
+    id: 'id',
+    questionNumber: 'questionNumber',
+  },
+  userAgentConfigs: { _tableName: 'userAgentConfigs' },
+  users: { _tableName: 'users' },
+  actors: { _tableName: 'actors' },
+  comments: { _tableName: 'comments' },
+  organizations: { _tableName: 'organizations' },
+  balanceTransactions: { _tableName: 'balanceTransactions' },
+  pointsTransactions: { _tableName: 'pointsTransactions' },
+  perpPositions: { _tableName: 'perpPositions' },
+  poolPositions: { _tableName: 'poolPositions' },
+  markets: { _tableName: 'markets' },
+  generationLocks: { _tableName: 'generationLocks' },
+  agentPerformanceMetrics: { _tableName: 'agentPerformanceMetrics' },
+  agentTrades: { _tableName: 'agentTrades' },
+  npcTrades: { _tableName: 'npcTrades' },
+  timeframedMarkets: { _tableName: 'timeframedMarkets' },
+  worldEvents: { _tableName: 'worldEvents', timestamp: 'timestamp' },
+  posts: {
+    _tableName: 'posts',
+    type: 'type',
+    timestamp: 'timestamp',
+    deletedAt: 'deletedAt',
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Query builder helpers
+// ---------------------------------------------------------------------------
+
+function getTableData(): unknown {
+  switch (currentQueryTable) {
+    case 'games':
+      return cronMockState.marketsGame ? [cronMockState.marketsGame] : [];
+    case 'questions':
+      return cronMockState.marketsActiveQuestions;
+    case 'worldEvents':
+      return cronMockState.marketsWorldEvents;
+    case 'timeframedMarkets':
+    case 'posts':
+      return [];
+    default:
+      return [];
+  }
+}
+
+export function createQueryBuilder(
+  resultFn: () => unknown = () => [{ id: 'mock-id' }],
+  operation: 'select' | 'insert' | 'update' | 'delete' = 'select'
+) {
+  const builder: Record<string, unknown> = {
+    set: mock(() => builder),
+    where: mock(() => builder),
+    values: mock(() => builder),
+    from: mock((table: { _tableName?: string }) => {
+      if (table?._tableName) currentQueryTable = table._tableName;
+      return builder;
+    }),
+    leftJoin: mock(() => builder),
+    innerJoin: mock(() => builder),
+    rightJoin: mock(() => builder),
+    fullJoin: mock(() => builder),
+    limit: mock(() => builder),
+    orderBy: mock(() => builder),
+    returning: mock(async () => {
+      if (operation === 'insert') return [{ id: `mock-${Date.now()}` }];
+      if (operation === 'update') return [{ id: 'mock-updated' }];
+      if (operation === 'delete') return [{ id: 'mock-deleted' }];
+      return resultFn();
+    }),
+    onConflictDoNothing: mock(() => builder),
+    then: <TResult1, TResult2 = never>(
+      onFulfilled?:
+        | ((value: unknown) => TResult1 | PromiseLike<TResult1>)
+        | null,
+      onRejected?:
+        | ((reason: unknown) => TResult2 | PromiseLike<TResult2>)
+        | null
+    ): Promise<TResult1 | TResult2> => {
+      return Promise.resolve(resultFn()).then(onFulfilled, onRejected);
+    },
+  };
+  return builder;
+}
+
+function createMutationBuilder(operation: 'insert' | 'update' | 'delete') {
+  return mock((table: { _tableName?: string }) => {
+    if (table?._tableName) currentQueryTable = table._tableName;
+    return createQueryBuilder(
+      () => [{ id: `mock-${operation}-id` }],
+      operation
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// SQL operator stubs
+// ---------------------------------------------------------------------------
+
+const sqlOps = {
+  eq: (): SqlCondition => ({}),
+  ne: (): SqlCondition => ({}),
+  gt: (): SqlCondition => ({}),
+  gte: (): SqlCondition => ({}),
+  lt: (): SqlCondition => ({}),
+  lte: (): SqlCondition => ({}),
+  and: (): SqlCondition => ({}),
+  or: (): SqlCondition => ({}),
+  not: (): SqlCondition => ({}),
+  inArray: (): SqlCondition => ({}),
+  desc: (): SqlCondition => ({}),
+  asc: (): SqlCondition => ({}),
+  isNull: (): SqlCondition => ({}),
+  isNotNull: (): SqlCondition => ({}),
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    sql: strings.join('?'),
+    values,
+  }),
+  max: (col: unknown) => ({ _aggregation: 'max', column: col }),
+};
+
+// ---------------------------------------------------------------------------
+// registerCronMocks — call once in beforeAll
+// ---------------------------------------------------------------------------
+
+export function registerCronMocks() {
+  // --- @babylon/db ---
+  mock.module('@babylon/db', () => ({
+    ...TABLE_REFS,
+    ...sqlOps,
+    db: {
+      select: mock((columns?: Record<string, unknown>) => {
+        currentQueryTable = null;
+        if (columns && 'maxNumber' in columns) {
+          return createQueryBuilder(() => {
+            const maxNum = cronMockState.marketsActiveQuestions.reduce(
+              (max, q) => Math.max(max, q.questionNumber),
+              0
+            );
+            return [{ maxNumber: maxNum > 0 ? maxNum : null }];
+          });
+        }
+        return createQueryBuilder(() => {
+          if (currentQueryTable) return getTableData();
+          return cronMockState.articleGame ? [cronMockState.articleGame] : [];
+        });
+      }),
+      insert: createMutationBuilder('insert'),
+      update: createMutationBuilder('update'),
+      delete: createMutationBuilder('delete'),
+      transaction: mock(
+        async <T>(callback: (tx: unknown) => Promise<T>): Promise<T> => {
+          const tx = {
+            select: mock(() => createQueryBuilder(() => getTableData())),
+            insert: createMutationBuilder('insert'),
+            update: createMutationBuilder('update'),
+            delete: createMutationBuilder('delete'),
+          };
+          return callback(tx);
+        }
+      ),
+    },
+    generateSnowflakeId: async () => nextMockSnowflakeId(),
+    isValidSnowflakeId,
+    parseSnowflakeId,
+    SnowflakeGenerator,
+    withTransaction: async <T>(fn: (tx: unknown) => Promise<T>) => fn({}),
+    asUser: async <T>(_userId: string, fn: (db: unknown) => Promise<T>) =>
+      fn({}),
+    asSystem: async <T>(fn: (db: unknown) => Promise<T>) => fn({}),
+    asPublic: async <T>(fn: (db: unknown) => Promise<T>) => fn({}),
+  }));
+
+  // --- @babylon/api ---
+  mock.module('@babylon/api', () => ({
+    // Re-export real rate-limiting so downstream tests get real implementations
+    ...rateLimiting,
+    CACHE_KEYS: { gameState: (_gameId: string) => 'game-state' },
+    DEFAULT_TTLS: { gameState: 60 },
+    verifyCronAuth: (req: Request | NextRequest) => {
+      const pathname = new URL(req.url).pathname;
+      return pathname.includes('/markets-tick')
+        ? cronMockState.marketsCronAuthResult
+        : cronMockState.articleCronAuthResult;
+    },
+    relayCronToStaging: async () => ({ forwarded: false }),
+    broadcastAgentActivity: async () => {},
+    broadcastToChannel: async () => {},
+    notifyGroupChatInvite: async () => {},
+    invalidateCache: async () => {},
+    getCacheOrFetch: async <T>(_key: string, fn: () => Promise<T>) => {
+      if (_key === 'continuous-game') return cronMockState.articleGame as T;
+      if (_key.includes('game-state')) {
+        return (cronMockState.marketsGame || {
+          id: 'continuous',
+          isRunning: false,
+          isContinuous: true,
+          currentDay: 1,
+        }) as T;
+      }
+      return fn();
+    },
+    recordCronExecution: () => {},
+    DistributedLockService: {
+      acquireLock: async (options?: { lockId?: string }) => {
+        if (options?.lockId?.includes('markets-tick'))
+          return cronMockState.marketsAcquireLockResult;
+        return true;
+      },
+      releaseLock: async () => {},
+    },
+  }));
+
+  // --- @babylon/core/markets/prediction ---
+  mock.module('@babylon/core/markets/prediction', () => ({
+    PredictionDbAdapter: class {},
+    PredictionMarketService: class {
+      ensureMarketExists = async () => ({ id: 'mock-market-id' });
+    },
+  }));
+
+  // --- @babylon/engine ---
+  mock.module('@babylon/engine', () => ({
+    articleRateLimiter: {
+      canGenerateArticle: async () => ({
+        allowed: cronMockState.articleCount < 2,
+        currentCount: cronMockState.articleCount,
+        maxAllowed: 2,
+        remaining: Math.max(0, 2 - cronMockState.articleCount),
+      }),
+    },
+    ArticleGenerator: class {
+      generateArticleForQuestion = async () => ({
+        id: `mock-article-${Date.now()}`,
+        title: 'Test Article',
+        summary: 'Test summary',
+        content: 'Test content that is long enough to pass validation. '.repeat(
+          20
+        ),
+        authorOrgId: 'org-1',
+        authorOrgName: 'Test News',
+        byline: 'Test Author',
+        bylineActorId: 'actor-1',
+        biasScore: 0,
+        sentiment: 'neutral' as const,
+        slant: 'Neutral coverage',
+        relatedEventId: 'event-1',
+        relatedActorIds: [],
+        relatedOrgIds: ['org-1'],
+        category: 'news',
+        tags: ['test', 'article'],
+        publishedAt: new Date(),
+      });
+    },
+    BabylonLLMClient: {
+      forGameTick: () => ({
+        generateJSON: async () => ({
+          title: 'Test Article',
+          summary: 'Test summary',
+          article: 'Test article body',
+        }),
+      }),
+    },
+    QuestionManager: class {
+      constructor(_llmClient: unknown) {}
+      async generateTimeframeQuestion() {
+        return {
+          text: 'Will AIlon Musk launch a new product?',
+          expectedOutcome: true,
+          resolutionCriteria: 'Product launch announcement',
+          affiliatedActorIds: [],
+          affiliatedOrgIds: [],
+        };
+      }
+      async generateResolutionWithProof() {
+        return {
+          description: 'The product was launched',
+          confidence: 0.95,
+          requiresManualReview: false,
+          proof: null,
+        };
+      }
+    },
+    getActiveEventsForPosting: async () => ({ activeEvents: [] }),
+    hasEventBeenCovered: (eventId: string) =>
+      cronMockState.articleCoveredEventIds.has(eventId),
+    markEventAsCovered: (eventId: string) => {
+      cronMockState.articleCoveredEventIds.add(eventId);
+    },
+    persistArticle: async (input: { id: string }) => ({
+      success: true,
+      articleId: input.id,
+    }),
+    publishOracleCommitments: async () => ({ committed: 1 }),
+    publishOracleReveals: async () => ({ revealed: 1 }),
+    getReputationBreakdown: () => ({
+      total: 0,
+      level: 'neutral',
+      trend: 0,
+      factors: {},
+    }),
+    recalculateReputation: async () => {},
+    resolveQuestionPayouts: async () => {},
+    SignalExtractionService: {
+      extractMarketSignal: async () => ({
+        suggestedOutcome: 'YES',
+        confidence: 0.8,
+        yesSignal: 0.7,
+        noSignal: 0.3,
+        signalStrength: 0.6,
+        totalPosts: 10,
+      }),
+    },
+    StaticDataRegistry: {
+      getOrganizationsByType: () => [
+        {
+          id: 'org-1',
+          name: 'Test News',
+          description: 'A news org',
+          type: 'media',
+          canBeInvolved: true,
+        },
+      ],
+      getTopActors: () => [
+        {
+          id: 'actor-1',
+          name: 'Test Actor',
+          description: 'A test actor',
+          domain: ['tech'],
+          personality: 'Analytical and cautious',
+          tier: 'mid',
+          affiliations: [],
+          postStyle: 'Neutral analysis',
+          postExample: [],
+          role: 'Analyst',
+          initialLuck: 'medium',
+          initialMood: 0,
+        },
+      ],
+      getAllActors: () => [],
+      getAllOrganizations: () => [],
+      getActor: () => null,
+      getOrganization: () => null,
+    },
+    isEligibleActor: () => true,
+    mapGranularToDbTimeframe: (timeframe: string) => timeframe,
+    secureRandom: () => Math.random(),
+    weightedPick: <T>(items: T[]) => items[0] ?? null,
+    gameService: { getCurrentGame: async () => null },
+    setBroadcastToChannel: () => {},
+    setDistributedLockProvider: () => {},
+    setNotifyGroupChatInvite: () => {},
+    setRateLimitProvider: () => {},
+    timeframeArcPlanner: {
+      planTimeframeArc: () => ({
+        questionId: 'q-1',
+        timeframe: '1d',
+        category: 'daily',
+        outcome: true,
+        durationMs: 86400000,
+        phases: {},
+        phaseOrder: ['setup', 'peak', 'resolution'],
+        insiders: [],
+        deceivers: [],
+        affiliatedOrgIds: [],
+        affiliatedActorIds: [],
+        createdAt: new Date(),
+      }),
+    },
+    worldFactsService: {
+      generatePromptContext: async () => 'Test world facts context',
+    },
+  }));
+}

--- a/packages/testing/unit/cron/markets-tick.test.ts
+++ b/packages/testing/unit/cron/markets-tick.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { NextRequest } from 'next/server';
 
 /**
@@ -35,18 +35,45 @@ interface SqlCondition {
   sql?: string;
 }
 
-// Mock db with a mutable state we can control in tests
-let mockGame: MockGame | null = null;
-let mockActiveQuestions: MockQuestion[] = [];
-let mockWorldEvents: Array<{
+interface MockWorldEvent {
   id: string;
   timestamp: Date;
   description: string;
-}> = [];
+}
 
-// Mock auth and lock states for negative-path testing
-let mockCronAuthResult = true;
-let mockAcquireLockResult = true;
+interface CronMockState {
+  articleGame: MockGame | null;
+  articleCount: number;
+  articleCronAuthResult: boolean;
+  articleCoveredEventIds: Set<string>;
+  marketsGame: MockGame | null;
+  marketsActiveQuestions: MockQuestion[];
+  marketsWorldEvents: MockWorldEvent[];
+  marketsCronAuthResult: boolean;
+  marketsAcquireLockResult: boolean;
+}
+
+const CRON_MOCK_STATE_KEY = '__babylonCronMockState';
+
+type GlobalWithCronMockState = typeof globalThis & {
+  [CRON_MOCK_STATE_KEY]?: CronMockState;
+};
+
+const globalWithCronMockState = globalThis as GlobalWithCronMockState;
+
+const cronMockState =
+  globalWithCronMockState[CRON_MOCK_STATE_KEY] ??
+  (globalWithCronMockState[CRON_MOCK_STATE_KEY] = {
+    articleGame: null,
+    articleCount: 0,
+    articleCronAuthResult: true,
+    articleCoveredEventIds: new Set<string>(),
+    marketsGame: null,
+    marketsActiveQuestions: [],
+    marketsWorldEvents: [],
+    marketsCronAuthResult: true,
+    marketsAcquireLockResult: true,
+  });
 
 // Track which table is being queried for table-aware mocking
 let currentQueryTable: string | null = null;
@@ -70,12 +97,12 @@ const TABLE_REFS = {
 const getTableData = (): unknown => {
   switch (currentQueryTable) {
     case 'games':
-      return mockGame ? [mockGame] : [];
+      return cronMockState.marketsGame ? [cronMockState.marketsGame] : [];
     case 'questions':
       // Return active questions by default; mature questions handled via where clause
-      return mockActiveQuestions;
+      return cronMockState.marketsActiveQuestions;
     case 'worldEvents':
-      return mockWorldEvents;
+      return cronMockState.marketsWorldEvents;
     case 'timeframedMarkets':
       return [];
     case 'posts':
@@ -143,189 +170,294 @@ const createMutationBuilder = (operation: 'insert' | 'update' | 'delete') => {
   });
 };
 
-// Mock @babylon/db - table-aware query handling
-mock.module('@babylon/db', () => ({
-  db: {
-    select: mock((columns?: Record<string, unknown>) => {
-      // Reset table tracking for new query
-      currentQueryTable = null;
-      // If selecting specific columns (like MAX), handle specially
-      if (columns && 'maxNumber' in columns) {
-        // This is the getNextQuestionNumber query
-        return createQueryBuilder(() => {
-          const maxNum = mockActiveQuestions.reduce(
-            (max, q) => Math.max(max, q.questionNumber),
-            0
-          );
-          return [{ maxNumber: maxNum > 0 ? maxNum : null }];
-        });
-      }
-      return createQueryBuilder(() => getTableData());
+const registerMocks = () => {
+  // Mock @babylon/db - table-aware query handling
+  mock.module('@babylon/db', () => ({
+    db: {
+      select: mock((columns?: Record<string, unknown>) => {
+        // Reset table tracking for new query
+        currentQueryTable = null;
+        // If selecting specific columns (like MAX), handle specially
+        if (columns && 'maxNumber' in columns) {
+          // This is the getNextQuestionNumber query
+          return createQueryBuilder(() => {
+            const maxNum = cronMockState.marketsActiveQuestions.reduce(
+              (max, q) => Math.max(max, q.questionNumber),
+              0
+            );
+            return [{ maxNumber: maxNum > 0 ? maxNum : null }];
+          });
+        }
+        return createQueryBuilder(() => getTableData());
+      }),
+      insert: createMutationBuilder('insert'),
+      update: createMutationBuilder('update'),
+      delete: createMutationBuilder('delete'),
+      transaction: mock(
+        async <T>(callback: (tx: unknown) => Promise<T>): Promise<T> => {
+          // Create a transaction context that mirrors the db interface
+          const tx = {
+            select: mock(() => createQueryBuilder(() => getTableData())),
+            insert: createMutationBuilder('insert'),
+            update: createMutationBuilder('update'),
+            delete: createMutationBuilder('delete'),
+          };
+          return callback(tx);
+        }
+      ),
+    },
+    games: TABLE_REFS.games,
+    questions: TABLE_REFS.questions,
+    timeframedMarkets: TABLE_REFS.timeframedMarkets,
+    worldEvents: TABLE_REFS.worldEvents,
+    posts: TABLE_REFS.posts,
+    eq: (): SqlCondition => ({}),
+    gte: (): SqlCondition => ({}),
+    lte: (): SqlCondition => ({}),
+    and: (): SqlCondition => ({}),
+    desc: (): SqlCondition => ({}),
+    isNull: (): SqlCondition => ({}),
+    isNotNull: (): SqlCondition => ({}),
+    sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+      sql: strings.join('?'),
+      values,
     }),
-    insert: createMutationBuilder('insert'),
-    update: createMutationBuilder('update'),
-    delete: createMutationBuilder('delete'),
-    transaction: mock(
-      async <T>(callback: (tx: unknown) => Promise<T>): Promise<T> => {
-        // Create a transaction context that mirrors the db interface
-        const tx = {
-          select: mock(() => createQueryBuilder(() => getTableData())),
-          insert: createMutationBuilder('insert'),
-          update: createMutationBuilder('update'),
-          delete: createMutationBuilder('delete'),
+    max: (col: unknown) => ({ _aggregation: 'max', column: col }),
+    // Use real generateSnowflakeId from @babylon/shared to avoid polluting other tests
+    generateSnowflakeId: async () => {
+      const { generateSnowflakeId } = await import('@babylon/shared');
+      return generateSnowflakeId();
+    },
+  }));
+
+  // Mock @babylon/api - uses mutable state for auth/lock results
+  mock.module('@babylon/api', () => ({
+    CACHE_KEYS: {
+      gameState: (_gameId: string) => 'game-state',
+    },
+    DEFAULT_TTLS: {
+      gameState: 60,
+    },
+    verifyCronAuth: (req: Request | NextRequest) => {
+      const pathname = new URL(req.url).pathname;
+      return pathname.includes('/article-tick')
+        ? cronMockState.articleCronAuthResult
+        : cronMockState.marketsCronAuthResult;
+    },
+    relayCronToStaging: async () => ({ forwarded: false }),
+    invalidateCache: async () => {},
+    getCacheOrFetch: async <T>(_key: string, fn: () => Promise<T>) => {
+      if (_key === 'continuous-game') {
+        return cronMockState.articleGame as T;
+      }
+      if (_key.includes('game-state')) {
+        return (cronMockState.marketsGame || {
+          id: 'continuous',
+          isRunning: false,
+          isContinuous: true,
+          currentDay: 1,
+        }) as T;
+      }
+      return fn();
+    },
+    recordCronExecution: () => {},
+    DistributedLockService: {
+      acquireLock: async (options?: { lockId?: string }) => {
+        if (options?.lockId?.includes('markets-tick')) {
+          return cronMockState.marketsAcquireLockResult;
+        }
+        return true;
+      },
+      releaseLock: async () => {},
+    },
+  }));
+
+  // Mock @babylon/core/markets/prediction
+  mock.module('@babylon/core/markets/prediction', () => ({
+    PredictionDbAdapter: class {},
+    PredictionMarketService: class {
+      ensureMarketExists = async () => ({ id: 'mock-market-id' });
+    },
+  }));
+
+  // Mock @babylon/engine
+  mock.module('@babylon/engine', () => ({
+    articleRateLimiter: {
+      canGenerateArticle: async () => ({
+        allowed: cronMockState.articleCount < 2,
+        currentCount: cronMockState.articleCount,
+        maxAllowed: 2,
+        remaining: Math.max(0, 2 - cronMockState.articleCount),
+      }),
+    },
+    ArticleGenerator: class {
+      generateArticleForQuestion = async () => ({
+        id: `mock-article-${Date.now()}`,
+        title: 'Test Article',
+        summary: 'Test summary',
+        content: 'Test content that is long enough to pass validation. '.repeat(
+          20
+        ),
+        authorOrgId: 'org-1',
+        authorOrgName: 'Test News',
+        byline: 'Test Author',
+        bylineActorId: 'actor-1',
+        biasScore: 0,
+        sentiment: 'neutral' as const,
+        slant: 'Neutral coverage',
+        relatedEventId: 'event-1',
+        relatedActorIds: [],
+        relatedOrgIds: ['org-1'],
+        category: 'news',
+        tags: ['test', 'article'],
+        publishedAt: new Date(),
+      });
+    },
+    isEligibleActor: () => true,
+    mapGranularToDbTimeframe: (timeframe: string) => timeframe,
+    BabylonLLMClient: class MockBabylonLLMClient {
+      static forGameTick() {
+        return new MockBabylonLLMClient();
+      }
+      async generateJSON() {
+        return {
+          text: 'Will AIlon Musk launch a new product?',
+          expectedOutcome: true,
+          resolutionCriteria: 'Product launch announcement',
+          affiliatedActorIds: [],
+          affiliatedOrgIds: [],
         };
-        return callback(tx);
       }
-    ),
-  },
-  games: TABLE_REFS.games,
-  questions: TABLE_REFS.questions,
-  timeframedMarkets: TABLE_REFS.timeframedMarkets,
-  worldEvents: TABLE_REFS.worldEvents,
-  posts: TABLE_REFS.posts,
-  eq: (): SqlCondition => ({}),
-  gte: (): SqlCondition => ({}),
-  lte: (): SqlCondition => ({}),
-  and: (): SqlCondition => ({}),
-  desc: (): SqlCondition => ({}),
-  isNull: (): SqlCondition => ({}),
-  isNotNull: (): SqlCondition => ({}),
-  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
-    sql: strings.join('?'),
-    values,
-  }),
-  max: (col: unknown) => ({ _aggregation: 'max', column: col }),
-  // Use real generateSnowflakeId from @babylon/shared to avoid polluting other tests
-  generateSnowflakeId: async () => {
-    const { generateSnowflakeId } = await import('@babylon/shared');
-    return generateSnowflakeId();
-  },
-}));
-
-// Mock @babylon/api - uses mutable state for auth/lock results
-mock.module('@babylon/api', () => ({
-  verifyCronAuth: () => mockCronAuthResult,
-  relayCronToStaging: async () => ({ forwarded: false }),
-  getCacheOrFetch: async <T>(_key: string, fn: () => Promise<T>) => {
-    // For game state cache, return our mockGame or a default non-running game
-    if (_key.includes('game-state')) {
-      return (mockGame || {
-        id: 'continuous',
-        isRunning: false,
-        isContinuous: true,
-        currentDay: 1,
-      }) as T;
-    }
-    return fn();
-  },
-  recordCronExecution: () => {},
-  DistributedLockService: {
-    acquireLock: async () => mockAcquireLockResult,
-    releaseLock: async () => {},
-  },
-}));
-
-// Mock @babylon/core/markets/prediction
-mock.module('@babylon/core/markets/prediction', () => ({
-  PredictionDbAdapter: class {},
-  PredictionMarketService: class {
-    ensureMarketExists = async () => ({ id: 'mock-market-id' });
-  },
-}));
-
-// Mock @babylon/engine
-mock.module('@babylon/engine', () => ({
-  BabylonLLMClient: class MockBabylonLLMClient {
-    static forGameTick() {
-      return new MockBabylonLLMClient();
-    }
-    async generateJSON() {
-      return {
-        text: 'Will AIlon Musk launch a new product?',
-        expectedOutcome: true,
-        resolutionCriteria: 'Product launch announcement',
-        affiliatedActorIds: [],
-        affiliatedOrgIds: [],
-      };
-    }
-  },
-  QuestionManager: class MockQuestionManager {
-    constructor(_llmClient: unknown) {}
-    async generateTimeframeQuestion(_timeframe: string, _durationMs: number) {
-      return {
-        text: 'Will AIlon Musk launch a new product?',
-        expectedOutcome: true,
-        resolutionCriteria: 'Product launch announcement',
-        affiliatedActorIds: [],
-        affiliatedOrgIds: [],
-      };
-    }
-    async generateResolutionWithProof() {
-      return {
-        description: 'The product was launched',
-        confidence: 0.95,
-        requiresManualReview: false,
-        proof: null,
-      };
-    }
-  },
-  publishOracleCommitments: async () => ({ committed: 1 }),
-  publishOracleReveals: async () => ({ revealed: 1 }),
-  resolveQuestionPayouts: async () => {},
-  SignalExtractionService: {
-    extractMarketSignal: async () => ({
-      suggestedOutcome: 'YES',
-      confidence: 0.8,
-      yesSignal: 0.7,
-      noSignal: 0.3,
-      signalStrength: 0.6,
-      totalPosts: 10,
+    },
+    QuestionManager: class MockQuestionManager {
+      constructor(_llmClient: unknown) {}
+      async generateTimeframeQuestion(
+        _timeframe: string,
+        _durationMs: number
+      ) {
+        return {
+          text: 'Will AIlon Musk launch a new product?',
+          expectedOutcome: true,
+          resolutionCriteria: 'Product launch announcement',
+          affiliatedActorIds: [],
+          affiliatedOrgIds: [],
+        };
+      }
+      async generateResolutionWithProof() {
+        return {
+          description: 'The product was launched',
+          confidence: 0.95,
+          requiresManualReview: false,
+          proof: null,
+        };
+      }
+    },
+    getActiveEventsForPosting: async () => ({ activeEvents: [] }),
+    hasEventBeenCovered: (eventId: string) =>
+      cronMockState.articleCoveredEventIds.has(eventId),
+    markEventAsCovered: (eventId: string) => {
+      cronMockState.articleCoveredEventIds.add(eventId);
+    },
+    persistArticle: async (input: { id: string }) => ({
+      success: true,
+      articleId: input.id,
     }),
-  },
-  StaticDataRegistry: {
-    getAllActors: () => [],
-    getAllOrganizations: () => [],
-    getActor: () => null,
-    getOrganization: () => null,
-  },
-  timeframeArcPlanner: {
-    planTimeframeArc: () => ({
-      questionId: 'q-1',
-      timeframe: '1d',
-      category: 'daily',
-      outcome: true,
-      durationMs: 86400000,
-      phases: {},
-      phaseOrder: ['setup', 'peak', 'resolution'],
-      insiders: [],
-      deceivers: [],
-      affiliatedOrgIds: [],
-      affiliatedActorIds: [],
-      createdAt: new Date(),
-    }),
-  },
-}));
+    publishOracleCommitments: async () => ({ committed: 1 }),
+    publishOracleReveals: async () => ({ revealed: 1 }),
+    resolveQuestionPayouts: async () => {},
+    SignalExtractionService: {
+      extractMarketSignal: async () => ({
+        suggestedOutcome: 'YES',
+        confidence: 0.8,
+        yesSignal: 0.7,
+        noSignal: 0.3,
+        signalStrength: 0.6,
+        totalPosts: 10,
+      }),
+    },
+    StaticDataRegistry: {
+      getOrganizationsByType: () => [
+        {
+          id: 'org-1',
+          name: 'Test News',
+          description: 'A news org',
+          type: 'media',
+          canBeInvolved: true,
+        },
+      ],
+      getTopActors: () => [
+        {
+          id: 'actor-1',
+          name: 'Test Actor',
+          description: 'A test actor',
+          domain: ['tech'],
+          personality: 'Analytical and cautious',
+          tier: 'mid',
+          affiliations: [],
+          postStyle: 'Neutral analysis',
+          postExample: [],
+          role: 'Analyst',
+          initialLuck: 'medium',
+          initialMood: 0,
+        },
+      ],
+      getAllActors: () => [],
+      getAllOrganizations: () => [],
+      getActor: () => null,
+      getOrganization: () => null,
+    },
+    secureRandom: () => Math.random(),
+    weightedPick: <T>(items: T[]) => items[0] ?? null,
+    timeframeArcPlanner: {
+      planTimeframeArc: () => ({
+        questionId: 'q-1',
+        timeframe: '1d',
+        category: 'daily',
+        outcome: true,
+        durationMs: 86400000,
+        phases: {},
+        phaseOrder: ['setup', 'peak', 'resolution'],
+        insiders: [],
+        deceivers: [],
+        affiliatedOrgIds: [],
+        affiliatedActorIds: [],
+        createdAt: new Date(),
+      }),
+    },
+    worldFactsService: {
+      generatePromptContext: async () => 'Test world facts context',
+    },
+  }));
+};
 
 // Note: @babylon/shared is NOT mocked - let real logger run to avoid
 // polluting module cache and breaking other tests that use formatCurrency, etc.
 
-// Import the route handler after mocks are set up
-import { GET, POST } from '@/app/api/cron/markets-tick/route';
+// Route handlers are loaded dynamically after mock registration.
+let GET: (req: NextRequest) => Promise<Response>;
+let POST: (req: NextRequest) => Promise<Response>;
 
 describe('Markets Tick Cron', () => {
+  beforeAll(async () => {
+    registerMocks();
+    const routeModule = await import('@/app/api/cron/markets-tick/route');
+    GET = routeModule.GET;
+    POST = routeModule.POST;
+  });
+
   beforeEach(() => {
-    mockGame = null;
-    mockActiveQuestions = [];
-    mockWorldEvents = [];
-    mockCronAuthResult = true;
-    mockAcquireLockResult = true;
+    cronMockState.marketsGame = null;
+    cronMockState.marketsActiveQuestions = [];
+    cronMockState.marketsWorldEvents = [];
+    cronMockState.marketsCronAuthResult = true;
+    cronMockState.marketsAcquireLockResult = true;
     currentQueryTable = null;
   });
 
   describe('Authorization', () => {
     test('GET should delegate to POST and return equivalent response', async () => {
       // Set up identical conditions for both requests
-      mockGame = null; // No game = predictable skipped state
+      cronMockState.marketsGame = null; // No game = predictable skipped state
 
       const getReq = new NextRequest('http://localhost/api/cron/markets-tick', {
         method: 'GET',
@@ -352,7 +484,7 @@ describe('Markets Tick Cron', () => {
     });
 
     test('should reject unauthorized requests when verifyCronAuth returns false', async () => {
-      mockCronAuthResult = false;
+      cronMockState.marketsCronAuthResult = false;
 
       const req = new NextRequest('http://localhost/api/cron/markets-tick', {
         method: 'POST',
@@ -364,7 +496,7 @@ describe('Markets Tick Cron', () => {
     });
 
     test('GET should also reject unauthorized requests', async () => {
-      mockCronAuthResult = false;
+      cronMockState.marketsCronAuthResult = false;
 
       const req = new NextRequest('http://localhost/api/cron/markets-tick', {
         method: 'GET',
@@ -378,13 +510,13 @@ describe('Markets Tick Cron', () => {
 
   describe('Distributed Lock', () => {
     test('should skip when lock cannot be acquired', async () => {
-      mockGame = {
+      cronMockState.marketsGame = {
         id: 'game-123',
         isContinuous: true,
         isRunning: true,
         currentDay: 1,
       };
-      mockAcquireLockResult = false;
+      cronMockState.marketsAcquireLockResult = false;
 
       const req = new NextRequest('http://localhost/api/cron/markets-tick', {
         method: 'POST',
@@ -402,7 +534,7 @@ describe('Markets Tick Cron', () => {
 
   describe('Game State Checks', () => {
     test('should skip when game is not running', async () => {
-      mockGame = {
+      cronMockState.marketsGame = {
         id: 'game-123',
         isContinuous: true,
         isRunning: false,

--- a/packages/testing/unit/cron/markets-tick.test.ts
+++ b/packages/testing/unit/cron/markets-tick.test.ts
@@ -1,4 +1,15 @@
-import { beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from 'bun:test';
+import * as actualApiModule from '../../../api/src/index';
+import * as actualDbModule from '../../../db/src/index';
+import * as actualEngineModule from '../../../engine/src/index';
 import { NextRequest } from 'next/server';
 
 /**
@@ -75,6 +86,13 @@ const cronMockState =
     marketsAcquireLockResult: true,
   });
 
+let mockSnowflakeCounter = 0;
+
+const nextMockSnowflakeId = (): string => {
+  mockSnowflakeCounter += 1;
+  return `mock-snowflake-${Date.now()}-${mockSnowflakeCounter}`;
+};
+
 // Track which table is being queried for table-aware mocking
 let currentQueryTable: string | null = null;
 
@@ -91,6 +109,20 @@ const TABLE_REFS = {
   timeframedMarkets: { _tableName: 'timeframedMarkets' },
   worldEvents: { _tableName: 'worldEvents', timestamp: 'timestamp' },
   posts: { _tableName: 'posts' },
+  userAgentConfigs: { _tableName: 'userAgentConfigs' },
+  users: { _tableName: 'users' },
+  actors: { _tableName: 'actors' },
+  comments: { _tableName: 'comments' },
+  organizations: { _tableName: 'organizations' },
+  balanceTransactions: { _tableName: 'balanceTransactions' },
+  pointsTransactions: { _tableName: 'pointsTransactions' },
+  perpPositions: { _tableName: 'perpPositions' },
+  poolPositions: { _tableName: 'poolPositions' },
+  markets: { _tableName: 'markets' },
+  generationLocks: { _tableName: 'generationLocks' },
+  agentPerformanceMetrics: { _tableName: 'agentPerformanceMetrics' },
+  agentTrades: { _tableName: 'agentTrades' },
+  npcTrades: { _tableName: 'npcTrades' },
 };
 
 // Get mock data based on the current query table
@@ -173,6 +205,7 @@ const createMutationBuilder = (operation: 'insert' | 'update' | 'delete') => {
 const registerMocks = () => {
   // Mock @babylon/db - table-aware query handling
   mock.module('@babylon/db', () => ({
+    ...actualDbModule,
     db: {
       select: mock((columns?: Record<string, unknown>) => {
         // Reset table tracking for new query
@@ -208,14 +241,35 @@ const registerMocks = () => {
     },
     games: TABLE_REFS.games,
     questions: TABLE_REFS.questions,
+    userAgentConfigs: TABLE_REFS.userAgentConfigs,
+    users: TABLE_REFS.users,
+    actors: TABLE_REFS.actors,
+    comments: TABLE_REFS.comments,
+    organizations: TABLE_REFS.organizations,
+    balanceTransactions: TABLE_REFS.balanceTransactions,
+    pointsTransactions: TABLE_REFS.pointsTransactions,
+    perpPositions: TABLE_REFS.perpPositions,
+    poolPositions: TABLE_REFS.poolPositions,
+    markets: TABLE_REFS.markets,
+    generationLocks: TABLE_REFS.generationLocks,
+    agentPerformanceMetrics: TABLE_REFS.agentPerformanceMetrics,
+    agentTrades: TABLE_REFS.agentTrades,
+    npcTrades: TABLE_REFS.npcTrades,
     timeframedMarkets: TABLE_REFS.timeframedMarkets,
     worldEvents: TABLE_REFS.worldEvents,
     posts: TABLE_REFS.posts,
     eq: (): SqlCondition => ({}),
+    ne: (): SqlCondition => ({}),
+    gt: (): SqlCondition => ({}),
     gte: (): SqlCondition => ({}),
+    lt: (): SqlCondition => ({}),
     lte: (): SqlCondition => ({}),
     and: (): SqlCondition => ({}),
+    or: (): SqlCondition => ({}),
+    not: (): SqlCondition => ({}),
+    inArray: (): SqlCondition => ({}),
     desc: (): SqlCondition => ({}),
+    asc: (): SqlCondition => ({}),
     isNull: (): SqlCondition => ({}),
     isNotNull: (): SqlCondition => ({}),
     sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
@@ -223,15 +277,17 @@ const registerMocks = () => {
       values,
     }),
     max: (col: unknown) => ({ _aggregation: 'max', column: col }),
-    // Use real generateSnowflakeId from @babylon/shared to avoid polluting other tests
-    generateSnowflakeId: async () => {
-      const { generateSnowflakeId } = await import('@babylon/shared');
-      return generateSnowflakeId();
-    },
+    generateSnowflakeId: async () => nextMockSnowflakeId(),
+    withTransaction: async <T>(fn: (tx: unknown) => Promise<T>) => fn({}),
+    asUser: async <T>(_userId: string, fn: (db: unknown) => Promise<T>) =>
+      fn({}),
+    asSystem: async <T>(fn: (db: unknown) => Promise<T>) => fn({}),
+    asPublic: async <T>(fn: (db: unknown) => Promise<T>) => fn({}),
   }));
 
   // Mock @babylon/api - uses mutable state for auth/lock results
   mock.module('@babylon/api', () => ({
+    ...actualApiModule,
     CACHE_KEYS: {
       gameState: (_gameId: string) => 'game-state',
     },
@@ -245,6 +301,14 @@ const registerMocks = () => {
         : cronMockState.marketsCronAuthResult;
     },
     relayCronToStaging: async () => ({ forwarded: false }),
+    broadcastAgentActivity: async () => {},
+    broadcastToChannel: async () => {},
+    notifyGroupChatInvite: async () => {},
+    checkRateLimit: async () => ({ allowed: true, remaining: 1 }),
+    checkRateLimitAsync: async () => ({ allowed: true, remaining: 1 }),
+    clearAllRateLimits: async () => {},
+    getRateLimitStatus: async () => ({ remaining: 1, resetAt: Date.now() }),
+    resetRateLimit: async () => {},
     invalidateCache: async () => {},
     getCacheOrFetch: async <T>(_key: string, fn: () => Promise<T>) => {
       if (_key === 'continuous-game') {
@@ -282,6 +346,7 @@ const registerMocks = () => {
 
   // Mock @babylon/engine
   mock.module('@babylon/engine', () => ({
+    ...actualEngineModule,
     articleRateLimiter: {
       canGenerateArticle: async () => ({
         allowed: cronMockState.articleCount < 2,
@@ -364,6 +429,13 @@ const registerMocks = () => {
     }),
     publishOracleCommitments: async () => ({ committed: 1 }),
     publishOracleReveals: async () => ({ revealed: 1 }),
+    getReputationBreakdown: () => ({
+      total: 0,
+      level: 'neutral',
+      trend: 0,
+      factors: {},
+    }),
+    recalculateReputation: async () => {},
     resolveQuestionPayouts: async () => {},
     SignalExtractionService: {
       extractMarketSignal: async () => ({
@@ -408,6 +480,13 @@ const registerMocks = () => {
     },
     secureRandom: () => Math.random(),
     weightedPick: <T>(items: T[]) => items[0] ?? null,
+    gameService: {
+      getCurrentGame: async () => null,
+    },
+    setBroadcastToChannel: () => {},
+    setDistributedLockProvider: () => {},
+    setNotifyGroupChatInvite: () => {},
+    setRateLimitProvider: () => {},
     timeframeArcPlanner: {
       planTimeframeArc: () => ({
         questionId: 'q-1',
@@ -430,8 +509,7 @@ const registerMocks = () => {
   }));
 };
 
-// Note: @babylon/shared is NOT mocked - let real logger run to avoid
-// polluting module cache and breaking other tests that use formatCurrency, etc.
+// @babylon/shared is intentionally not mocked here.
 
 // Route handlers are loaded dynamically after mock registration.
 let GET: (req: NextRequest) => Promise<Response>;
@@ -443,6 +521,10 @@ describe('Markets Tick Cron', () => {
     const routeModule = await import('@/app/api/cron/markets-tick/route');
     GET = routeModule.GET;
     POST = routeModule.POST;
+  });
+
+  afterAll(() => {
+    mock.restore();
   });
 
   beforeEach(() => {

--- a/packages/testing/unit/cron/markets-tick.test.ts
+++ b/packages/testing/unit/cron/markets-tick.test.ts
@@ -7,10 +7,12 @@ import {
   mock,
   test,
 } from 'bun:test';
-import * as actualApiModule from '../../../api/src/index';
-import * as actualDbModule from '../../../db/src/index';
-import * as actualEngineModule from '../../../engine/src/index';
 import { NextRequest } from 'next/server';
+import {
+  cronMockState,
+  registerCronMocks,
+  resetQueryTable,
+} from './cron-test-mocks';
 
 /**
  * Markets Tick Cron Job Tests
@@ -19,505 +21,12 @@ import { NextRequest } from 'next/server';
  * lifecycle of prediction markets.
  */
 
-/**
- * Mock game state type
- */
-interface MockGame {
-  id: string;
-  isContinuous: boolean;
-  isRunning: boolean;
-  currentDay: number | null;
-}
-
-/**
- * Mock question type for markets
- */
-interface MockQuestion {
-  id: string;
-  questionNumber: number;
-  resolutionDate: Date;
-  status: string;
-}
-
-/**
- * Drizzle SQL condition result
- */
-interface SqlCondition {
-  sql?: string;
-}
-
-interface MockWorldEvent {
-  id: string;
-  timestamp: Date;
-  description: string;
-}
-
-interface CronMockState {
-  articleGame: MockGame | null;
-  articleCount: number;
-  articleCronAuthResult: boolean;
-  articleCoveredEventIds: Set<string>;
-  marketsGame: MockGame | null;
-  marketsActiveQuestions: MockQuestion[];
-  marketsWorldEvents: MockWorldEvent[];
-  marketsCronAuthResult: boolean;
-  marketsAcquireLockResult: boolean;
-}
-
-const CRON_MOCK_STATE_KEY = '__babylonCronMockState';
-
-type GlobalWithCronMockState = typeof globalThis & {
-  [CRON_MOCK_STATE_KEY]?: CronMockState;
-};
-
-const globalWithCronMockState = globalThis as GlobalWithCronMockState;
-
-const cronMockState =
-  globalWithCronMockState[CRON_MOCK_STATE_KEY] ??
-  (globalWithCronMockState[CRON_MOCK_STATE_KEY] = {
-    articleGame: null,
-    articleCount: 0,
-    articleCronAuthResult: true,
-    articleCoveredEventIds: new Set<string>(),
-    marketsGame: null,
-    marketsActiveQuestions: [],
-    marketsWorldEvents: [],
-    marketsCronAuthResult: true,
-    marketsAcquireLockResult: true,
-  });
-
-let mockSnowflakeCounter = 0;
-
-const nextMockSnowflakeId = (): string => {
-  mockSnowflakeCounter += 1;
-  return `mock-snowflake-${Date.now()}-${mockSnowflakeCounter}`;
-};
-
-// Track which table is being queried for table-aware mocking
-let currentQueryTable: string | null = null;
-
-// Table reference symbols for detection
-const TABLE_REFS = {
-  games: { _tableName: 'games' },
-  questions: {
-    _tableName: 'questions',
-    status: 'status',
-    resolutionDate: 'resolutionDate',
-    id: 'id',
-    questionNumber: 'questionNumber',
-  },
-  timeframedMarkets: { _tableName: 'timeframedMarkets' },
-  worldEvents: { _tableName: 'worldEvents', timestamp: 'timestamp' },
-  posts: { _tableName: 'posts' },
-  userAgentConfigs: { _tableName: 'userAgentConfigs' },
-  users: { _tableName: 'users' },
-  actors: { _tableName: 'actors' },
-  comments: { _tableName: 'comments' },
-  organizations: { _tableName: 'organizations' },
-  balanceTransactions: { _tableName: 'balanceTransactions' },
-  pointsTransactions: { _tableName: 'pointsTransactions' },
-  perpPositions: { _tableName: 'perpPositions' },
-  poolPositions: { _tableName: 'poolPositions' },
-  markets: { _tableName: 'markets' },
-  generationLocks: { _tableName: 'generationLocks' },
-  agentPerformanceMetrics: { _tableName: 'agentPerformanceMetrics' },
-  agentTrades: { _tableName: 'agentTrades' },
-  npcTrades: { _tableName: 'npcTrades' },
-};
-
-// Get mock data based on the current query table
-const getTableData = (): unknown => {
-  switch (currentQueryTable) {
-    case 'games':
-      return cronMockState.marketsGame ? [cronMockState.marketsGame] : [];
-    case 'questions':
-      // Return active questions by default; mature questions handled via where clause
-      return cronMockState.marketsActiveQuestions;
-    case 'worldEvents':
-      return cronMockState.marketsWorldEvents;
-    case 'timeframedMarkets':
-      return [];
-    case 'posts':
-      return [];
-    default:
-      return [];
-  }
-};
-
-// Create query builder for Drizzle-style operations
-// The resultFn is called at query execution time to get the current mock state
-const createQueryBuilder = (
-  resultFn: () => unknown,
-  operation: 'select' | 'insert' | 'update' | 'delete' = 'select'
-) => {
-  const builder = {
-    set: mock(() => builder),
-    where: mock(() => builder),
-    values: mock(() => builder),
-    from: mock((table: { _tableName?: string }) => {
-      // Track which table is being queried
-      if (table && table._tableName) {
-        currentQueryTable = table._tableName;
-      }
-      return builder;
-    }),
-    leftJoin: mock(() => builder),
-    innerJoin: mock(() => builder),
-    rightJoin: mock(() => builder),
-    fullJoin: mock(() => builder),
-    limit: mock(() => builder),
-    orderBy: mock(() => builder),
-    returning: mock(async () => {
-      if (operation === 'insert') return [{ id: `mock-${Date.now()}` }];
-      if (operation === 'update') return [{ id: 'mock-updated' }];
-      if (operation === 'delete') return [{ id: 'mock-deleted' }];
-      return resultFn();
-    }),
-    onConflictDoNothing: mock(() => builder),
-    then: <TResult1, TResult2 = never>(
-      onFulfilled?:
-        | ((value: unknown) => TResult1 | PromiseLike<TResult1>)
-        | null,
-      onRejected?:
-        | ((reason: unknown) => TResult2 | PromiseLike<TResult2>)
-        | null
-    ): Promise<TResult1 | TResult2> => {
-      const result = resultFn();
-      return Promise.resolve(result).then(onFulfilled, onRejected);
-    },
-  };
-  return builder;
-};
-
-// Create table-aware insert/update/delete builders
-const createMutationBuilder = (operation: 'insert' | 'update' | 'delete') => {
-  return mock((table: { _tableName?: string }) => {
-    if (table && table._tableName) {
-      currentQueryTable = table._tableName;
-    }
-    return createQueryBuilder(
-      () => [{ id: `mock-${operation}-id` }],
-      operation
-    );
-  });
-};
-
-const registerMocks = () => {
-  // Mock @babylon/db - table-aware query handling
-  mock.module('@babylon/db', () => ({
-    ...actualDbModule,
-    db: {
-      select: mock((columns?: Record<string, unknown>) => {
-        // Reset table tracking for new query
-        currentQueryTable = null;
-        // If selecting specific columns (like MAX), handle specially
-        if (columns && 'maxNumber' in columns) {
-          // This is the getNextQuestionNumber query
-          return createQueryBuilder(() => {
-            const maxNum = cronMockState.marketsActiveQuestions.reduce(
-              (max, q) => Math.max(max, q.questionNumber),
-              0
-            );
-            return [{ maxNumber: maxNum > 0 ? maxNum : null }];
-          });
-        }
-        return createQueryBuilder(() => getTableData());
-      }),
-      insert: createMutationBuilder('insert'),
-      update: createMutationBuilder('update'),
-      delete: createMutationBuilder('delete'),
-      transaction: mock(
-        async <T>(callback: (tx: unknown) => Promise<T>): Promise<T> => {
-          // Create a transaction context that mirrors the db interface
-          const tx = {
-            select: mock(() => createQueryBuilder(() => getTableData())),
-            insert: createMutationBuilder('insert'),
-            update: createMutationBuilder('update'),
-            delete: createMutationBuilder('delete'),
-          };
-          return callback(tx);
-        }
-      ),
-    },
-    games: TABLE_REFS.games,
-    questions: TABLE_REFS.questions,
-    userAgentConfigs: TABLE_REFS.userAgentConfigs,
-    users: TABLE_REFS.users,
-    actors: TABLE_REFS.actors,
-    comments: TABLE_REFS.comments,
-    organizations: TABLE_REFS.organizations,
-    balanceTransactions: TABLE_REFS.balanceTransactions,
-    pointsTransactions: TABLE_REFS.pointsTransactions,
-    perpPositions: TABLE_REFS.perpPositions,
-    poolPositions: TABLE_REFS.poolPositions,
-    markets: TABLE_REFS.markets,
-    generationLocks: TABLE_REFS.generationLocks,
-    agentPerformanceMetrics: TABLE_REFS.agentPerformanceMetrics,
-    agentTrades: TABLE_REFS.agentTrades,
-    npcTrades: TABLE_REFS.npcTrades,
-    timeframedMarkets: TABLE_REFS.timeframedMarkets,
-    worldEvents: TABLE_REFS.worldEvents,
-    posts: TABLE_REFS.posts,
-    eq: (): SqlCondition => ({}),
-    ne: (): SqlCondition => ({}),
-    gt: (): SqlCondition => ({}),
-    gte: (): SqlCondition => ({}),
-    lt: (): SqlCondition => ({}),
-    lte: (): SqlCondition => ({}),
-    and: (): SqlCondition => ({}),
-    or: (): SqlCondition => ({}),
-    not: (): SqlCondition => ({}),
-    inArray: (): SqlCondition => ({}),
-    desc: (): SqlCondition => ({}),
-    asc: (): SqlCondition => ({}),
-    isNull: (): SqlCondition => ({}),
-    isNotNull: (): SqlCondition => ({}),
-    sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
-      sql: strings.join('?'),
-      values,
-    }),
-    max: (col: unknown) => ({ _aggregation: 'max', column: col }),
-    generateSnowflakeId: async () => nextMockSnowflakeId(),
-    withTransaction: async <T>(fn: (tx: unknown) => Promise<T>) => fn({}),
-    asUser: async <T>(_userId: string, fn: (db: unknown) => Promise<T>) =>
-      fn({}),
-    asSystem: async <T>(fn: (db: unknown) => Promise<T>) => fn({}),
-    asPublic: async <T>(fn: (db: unknown) => Promise<T>) => fn({}),
-  }));
-
-  // Mock @babylon/api - uses mutable state for auth/lock results
-  mock.module('@babylon/api', () => ({
-    ...actualApiModule,
-    CACHE_KEYS: {
-      gameState: (_gameId: string) => 'game-state',
-    },
-    DEFAULT_TTLS: {
-      gameState: 60,
-    },
-    verifyCronAuth: (req: Request | NextRequest) => {
-      const pathname = new URL(req.url).pathname;
-      return pathname.includes('/article-tick')
-        ? cronMockState.articleCronAuthResult
-        : cronMockState.marketsCronAuthResult;
-    },
-    relayCronToStaging: async () => ({ forwarded: false }),
-    broadcastAgentActivity: async () => {},
-    broadcastToChannel: async () => {},
-    notifyGroupChatInvite: async () => {},
-    checkRateLimit: async () => ({ allowed: true, remaining: 1 }),
-    checkRateLimitAsync: async () => ({ allowed: true, remaining: 1 }),
-    clearAllRateLimits: async () => {},
-    getRateLimitStatus: async () => ({ remaining: 1, resetAt: Date.now() }),
-    resetRateLimit: async () => {},
-    invalidateCache: async () => {},
-    getCacheOrFetch: async <T>(_key: string, fn: () => Promise<T>) => {
-      if (_key === 'continuous-game') {
-        return cronMockState.articleGame as T;
-      }
-      if (_key.includes('game-state')) {
-        return (cronMockState.marketsGame || {
-          id: 'continuous',
-          isRunning: false,
-          isContinuous: true,
-          currentDay: 1,
-        }) as T;
-      }
-      return fn();
-    },
-    recordCronExecution: () => {},
-    DistributedLockService: {
-      acquireLock: async (options?: { lockId?: string }) => {
-        if (options?.lockId?.includes('markets-tick')) {
-          return cronMockState.marketsAcquireLockResult;
-        }
-        return true;
-      },
-      releaseLock: async () => {},
-    },
-  }));
-
-  // Mock @babylon/core/markets/prediction
-  mock.module('@babylon/core/markets/prediction', () => ({
-    PredictionDbAdapter: class {},
-    PredictionMarketService: class {
-      ensureMarketExists = async () => ({ id: 'mock-market-id' });
-    },
-  }));
-
-  // Mock @babylon/engine
-  mock.module('@babylon/engine', () => ({
-    ...actualEngineModule,
-    articleRateLimiter: {
-      canGenerateArticle: async () => ({
-        allowed: cronMockState.articleCount < 2,
-        currentCount: cronMockState.articleCount,
-        maxAllowed: 2,
-        remaining: Math.max(0, 2 - cronMockState.articleCount),
-      }),
-    },
-    ArticleGenerator: class {
-      generateArticleForQuestion = async () => ({
-        id: `mock-article-${Date.now()}`,
-        title: 'Test Article',
-        summary: 'Test summary',
-        content: 'Test content that is long enough to pass validation. '.repeat(
-          20
-        ),
-        authorOrgId: 'org-1',
-        authorOrgName: 'Test News',
-        byline: 'Test Author',
-        bylineActorId: 'actor-1',
-        biasScore: 0,
-        sentiment: 'neutral' as const,
-        slant: 'Neutral coverage',
-        relatedEventId: 'event-1',
-        relatedActorIds: [],
-        relatedOrgIds: ['org-1'],
-        category: 'news',
-        tags: ['test', 'article'],
-        publishedAt: new Date(),
-      });
-    },
-    isEligibleActor: () => true,
-    mapGranularToDbTimeframe: (timeframe: string) => timeframe,
-    BabylonLLMClient: class MockBabylonLLMClient {
-      static forGameTick() {
-        return new MockBabylonLLMClient();
-      }
-      async generateJSON() {
-        return {
-          text: 'Will AIlon Musk launch a new product?',
-          expectedOutcome: true,
-          resolutionCriteria: 'Product launch announcement',
-          affiliatedActorIds: [],
-          affiliatedOrgIds: [],
-        };
-      }
-    },
-    QuestionManager: class MockQuestionManager {
-      constructor(_llmClient: unknown) {}
-      async generateTimeframeQuestion(
-        _timeframe: string,
-        _durationMs: number
-      ) {
-        return {
-          text: 'Will AIlon Musk launch a new product?',
-          expectedOutcome: true,
-          resolutionCriteria: 'Product launch announcement',
-          affiliatedActorIds: [],
-          affiliatedOrgIds: [],
-        };
-      }
-      async generateResolutionWithProof() {
-        return {
-          description: 'The product was launched',
-          confidence: 0.95,
-          requiresManualReview: false,
-          proof: null,
-        };
-      }
-    },
-    getActiveEventsForPosting: async () => ({ activeEvents: [] }),
-    hasEventBeenCovered: (eventId: string) =>
-      cronMockState.articleCoveredEventIds.has(eventId),
-    markEventAsCovered: (eventId: string) => {
-      cronMockState.articleCoveredEventIds.add(eventId);
-    },
-    persistArticle: async (input: { id: string }) => ({
-      success: true,
-      articleId: input.id,
-    }),
-    publishOracleCommitments: async () => ({ committed: 1 }),
-    publishOracleReveals: async () => ({ revealed: 1 }),
-    getReputationBreakdown: () => ({
-      total: 0,
-      level: 'neutral',
-      trend: 0,
-      factors: {},
-    }),
-    recalculateReputation: async () => {},
-    resolveQuestionPayouts: async () => {},
-    SignalExtractionService: {
-      extractMarketSignal: async () => ({
-        suggestedOutcome: 'YES',
-        confidence: 0.8,
-        yesSignal: 0.7,
-        noSignal: 0.3,
-        signalStrength: 0.6,
-        totalPosts: 10,
-      }),
-    },
-    StaticDataRegistry: {
-      getOrganizationsByType: () => [
-        {
-          id: 'org-1',
-          name: 'Test News',
-          description: 'A news org',
-          type: 'media',
-          canBeInvolved: true,
-        },
-      ],
-      getTopActors: () => [
-        {
-          id: 'actor-1',
-          name: 'Test Actor',
-          description: 'A test actor',
-          domain: ['tech'],
-          personality: 'Analytical and cautious',
-          tier: 'mid',
-          affiliations: [],
-          postStyle: 'Neutral analysis',
-          postExample: [],
-          role: 'Analyst',
-          initialLuck: 'medium',
-          initialMood: 0,
-        },
-      ],
-      getAllActors: () => [],
-      getAllOrganizations: () => [],
-      getActor: () => null,
-      getOrganization: () => null,
-    },
-    secureRandom: () => Math.random(),
-    weightedPick: <T>(items: T[]) => items[0] ?? null,
-    gameService: {
-      getCurrentGame: async () => null,
-    },
-    setBroadcastToChannel: () => {},
-    setDistributedLockProvider: () => {},
-    setNotifyGroupChatInvite: () => {},
-    setRateLimitProvider: () => {},
-    timeframeArcPlanner: {
-      planTimeframeArc: () => ({
-        questionId: 'q-1',
-        timeframe: '1d',
-        category: 'daily',
-        outcome: true,
-        durationMs: 86400000,
-        phases: {},
-        phaseOrder: ['setup', 'peak', 'resolution'],
-        insiders: [],
-        deceivers: [],
-        affiliatedOrgIds: [],
-        affiliatedActorIds: [],
-        createdAt: new Date(),
-      }),
-    },
-    worldFactsService: {
-      generatePromptContext: async () => 'Test world facts context',
-    },
-  }));
-};
-
-// @babylon/shared is intentionally not mocked here.
-
-// Route handlers are loaded dynamically after mock registration.
 let GET: (req: NextRequest) => Promise<Response>;
 let POST: (req: NextRequest) => Promise<Response>;
 
 describe('Markets Tick Cron', () => {
   beforeAll(async () => {
-    registerMocks();
+    registerCronMocks();
     const routeModule = await import('@/app/api/cron/markets-tick/route');
     GET = routeModule.GET;
     POST = routeModule.POST;
@@ -533,34 +42,29 @@ describe('Markets Tick Cron', () => {
     cronMockState.marketsWorldEvents = [];
     cronMockState.marketsCronAuthResult = true;
     cronMockState.marketsAcquireLockResult = true;
-    currentQueryTable = null;
+    resetQueryTable();
   });
 
   describe('Authorization', () => {
     test('GET should delegate to POST and return equivalent response', async () => {
-      // Set up identical conditions for both requests
-      cronMockState.marketsGame = null; // No game = predictable skipped state
+      cronMockState.marketsGame = null;
 
       const getReq = new NextRequest('http://localhost/api/cron/markets-tick', {
         method: 'GET',
       });
       const postReq = new NextRequest(
         'http://localhost/api/cron/markets-tick',
-        {
-          method: 'POST',
-        }
+        { method: 'POST' }
       );
 
       const getRes = await GET(getReq);
       const postRes = await POST(postReq);
 
-      // GET should delegate to POST, so responses should match
       expect(getRes.status).toBe(postRes.status);
 
       const getData = await getRes.json();
       const postData = await postRes.json();
 
-      // Key response properties should be equivalent
       expect(getData.success).toBe(postData.success);
       expect(getData.skipped).toBe(postData.skipped);
     });
@@ -573,7 +77,6 @@ describe('Markets Tick Cron', () => {
       });
       const res = await POST(req);
 
-      // Should return 401 Unauthorized
       expect(res.status).toBe(401);
     });
 
@@ -585,7 +88,6 @@ describe('Markets Tick Cron', () => {
       });
       const res = await GET(req);
 
-      // GET delegates to POST, so should also return 401
       expect(res.status).toBe(401);
     });
   });
@@ -606,7 +108,6 @@ describe('Markets Tick Cron', () => {
       const res = await POST(req);
       const data = await res.json();
 
-      // Should indicate lock failure/skip (route returns "Previous tick still running")
       expect(res.status).toBe(200);
       expect(data.success).toBe(true);
       expect(data.skipped).toBe(true);
@@ -633,21 +134,11 @@ describe('Markets Tick Cron', () => {
       expect(data.skipped).toBe(true);
       expect(data.reason).toBe('Game not running');
     });
-
-    // Additional integration tests (game running, market creation, resolution)
-    // are in packages/testing/integration/markets-tick.integration.test.ts
-    // These require real database access and are run separately.
   });
 });
 
 describe('Market Timeframe Configuration', () => {
   test('should have correct market distribution (10 total)', () => {
-    // Expected: 1x 3-day, 1x 2-day, 1x 1-day, 1x 12-hour, 1x 6-hour, 1x 1-hour, 2x 30-minute, 2x 15-minute
-    //
-    // IMPORTANT: These values are a deliberate contract-style duplication of the production
-    // MARKET_TIMEFRAMES config in markets-tick/route.ts. Do NOT import production internals here.
-    // If the production config changes, this test must be updated to match. This ensures the
-    // test acts as a contract verification rather than a tautology.
     const expectedMarkets = {
       '3d': 1,
       '2d': 1,
@@ -672,31 +163,25 @@ describe('Market Timeframe Configuration', () => {
 // =============================================================================
 
 describe('inferGranularTimeframe', () => {
-  // Define MARKET_STRUCTURE durations locally (contract-style test)
   const DURATIONS = {
-    '15m': 15 * 60 * 1000, // 900,000 ms
-    '30m': 30 * 60 * 1000, // 1,800,000 ms
-    '1h': 60 * 60 * 1000, // 3,600,000 ms
-    '6h': 6 * 60 * 60 * 1000, // 21,600,000 ms
-    '12h': 12 * 60 * 60 * 1000, // 43,200,000 ms
-    '1d': 24 * 60 * 60 * 1000, // 86,400,000 ms
-    '2d': 2 * 24 * 60 * 60 * 1000, // 172,800,000 ms
-    '3d': 3 * 24 * 60 * 60 * 1000, // 259,200,000 ms
+    '15m': 15 * 60 * 1000,
+    '30m': 30 * 60 * 1000,
+    '1h': 60 * 60 * 1000,
+    '6h': 6 * 60 * 60 * 1000,
+    '12h': 12 * 60 * 60 * 1000,
+    '1d': 24 * 60 * 60 * 1000,
+    '2d': 2 * 24 * 60 * 60 * 1000,
+    '3d': 3 * 24 * 60 * 60 * 1000,
   };
 
-  // Replicate inferGranularTimeframe logic for testing
   function inferGranularTimeframe(durationMs: number): string {
     const sortedEntries = Object.entries(DURATIONS).sort((a, b) => a[1] - b[1]);
 
-    // 10% tolerance matching
     for (const [key, expectedDuration] of sortedEntries) {
       const tolerance = expectedDuration * 0.1;
-      if (Math.abs(durationMs - expectedDuration) <= tolerance) {
-        return key;
-      }
+      if (Math.abs(durationMs - expectedDuration) <= tolerance) return key;
     }
 
-    // Fallback to closest
     let closestKey = '1h';
     let closestDiff = Infinity;
     for (const [key, expectedDuration] of sortedEntries) {
@@ -713,31 +198,24 @@ describe('inferGranularTimeframe', () => {
     test('should match 15m duration exactly', () => {
       expect(inferGranularTimeframe(DURATIONS['15m'])).toBe('15m');
     });
-
     test('should match 30m duration exactly', () => {
       expect(inferGranularTimeframe(DURATIONS['30m'])).toBe('30m');
     });
-
     test('should match 1h duration exactly', () => {
       expect(inferGranularTimeframe(DURATIONS['1h'])).toBe('1h');
     });
-
     test('should match 6h duration exactly', () => {
       expect(inferGranularTimeframe(DURATIONS['6h'])).toBe('6h');
     });
-
     test('should match 12h duration exactly', () => {
       expect(inferGranularTimeframe(DURATIONS['12h'])).toBe('12h');
     });
-
     test('should match 1d duration exactly', () => {
       expect(inferGranularTimeframe(DURATIONS['1d'])).toBe('1d');
     });
-
     test('should match 2d duration exactly', () => {
       expect(inferGranularTimeframe(DURATIONS['2d'])).toBe('2d');
     });
-
     test('should match 3d duration exactly', () => {
       expect(inferGranularTimeframe(DURATIONS['3d'])).toBe('3d');
     });
@@ -745,57 +223,37 @@ describe('inferGranularTimeframe', () => {
 
   describe('10% tolerance boundary tests', () => {
     test('should match 15m at +10% tolerance boundary', () => {
-      const duration = DURATIONS['15m'] * 1.1; // 990,000 ms
-      expect(inferGranularTimeframe(duration)).toBe('15m');
+      expect(inferGranularTimeframe(DURATIONS['15m'] * 1.1)).toBe('15m');
     });
-
     test('should match 15m at -10% tolerance boundary', () => {
-      const duration = DURATIONS['15m'] * 0.9; // 810,000 ms
-      expect(inferGranularTimeframe(duration)).toBe('15m');
+      expect(inferGranularTimeframe(DURATIONS['15m'] * 0.9)).toBe('15m');
     });
-
     test('should match 1h at +10% tolerance boundary', () => {
-      const duration = DURATIONS['1h'] * 1.1; // 3,960,000 ms
-      expect(inferGranularTimeframe(duration)).toBe('1h');
+      expect(inferGranularTimeframe(DURATIONS['1h'] * 1.1)).toBe('1h');
     });
-
     test('should match 1h at -10% tolerance boundary', () => {
-      const duration = DURATIONS['1h'] * 0.9; // 3,240,000 ms
-      expect(inferGranularTimeframe(duration)).toBe('1h');
+      expect(inferGranularTimeframe(DURATIONS['1h'] * 0.9)).toBe('1h');
     });
 
     test('should fall back to closest when outside all tolerances', () => {
-      // Duration exactly between 15m and 30m (outside both tolerances)
-      const midpoint = (DURATIONS['15m'] + DURATIONS['30m']) / 2; // 1,350,000 ms
-      // Should fall back to closest, which is 15m (450k away) vs 30m (450k away)
-      // Since they're equidistant, it will match 15m first in sorted order
-      const result = inferGranularTimeframe(midpoint);
-      expect(['15m', '30m']).toContain(result);
+      const midpoint = (DURATIONS['15m'] + DURATIONS['30m']) / 2;
+      expect(['15m', '30m']).toContain(inferGranularTimeframe(midpoint));
     });
 
     test('should handle very short durations (below 15m)', () => {
-      const shortDuration = 5 * 60 * 1000; // 5 minutes
-      // Should fall back to closest, which is 15m
-      expect(inferGranularTimeframe(shortDuration)).toBe('15m');
+      expect(inferGranularTimeframe(5 * 60 * 1000)).toBe('15m');
     });
-
     test('should handle very long durations (above 3d)', () => {
-      const longDuration = 5 * 24 * 60 * 60 * 1000; // 5 days
-      // Should fall back to closest, which is 3d
-      expect(inferGranularTimeframe(longDuration)).toBe('3d');
+      expect(inferGranularTimeframe(5 * 24 * 60 * 60 * 1000)).toBe('3d');
     });
   });
 
   describe('edge cases', () => {
     test('should handle zero duration', () => {
-      // Should fall back to closest, which is 15m (smallest)
       expect(inferGranularTimeframe(0)).toBe('15m');
     });
-
     test('should handle negative duration gracefully', () => {
-      // Should fall back to closest
-      const result = inferGranularTimeframe(-1000);
-      expect(result).toBeDefined();
+      expect(inferGranularTimeframe(-1000)).toBeDefined();
     });
   });
 });
@@ -809,46 +267,21 @@ describe('Sub-Market Batch Creation Logic', () => {
   const MAX_SUB_MARKETS_PER_TICK = 5;
 
   test('should create up to MAX_SUB_MARKETS_PER_TICK when many needed', () => {
-    const activeSubMarkets = 0;
-    const subMarketsNeeded = MAX_SUB_MARKETS - activeSubMarkets; // 10
-    const createCount = Math.min(subMarketsNeeded, MAX_SUB_MARKETS_PER_TICK);
-
-    expect(createCount).toBe(5);
+    expect(Math.min(MAX_SUB_MARKETS - 0, MAX_SUB_MARKETS_PER_TICK)).toBe(5);
   });
-
   test('should create exact amount when fewer than limit needed', () => {
-    const activeSubMarkets = 7;
-    const subMarketsNeeded = MAX_SUB_MARKETS - activeSubMarkets; // 3
-    const createCount = Math.min(subMarketsNeeded, MAX_SUB_MARKETS_PER_TICK);
-
-    expect(createCount).toBe(3);
+    expect(Math.min(MAX_SUB_MARKETS - 7, MAX_SUB_MARKETS_PER_TICK)).toBe(3);
   });
-
   test('should create zero when at maximum', () => {
-    const activeSubMarkets = 10;
-    const subMarketsNeeded = MAX_SUB_MARKETS - activeSubMarkets; // 0
-    const createCount = Math.min(subMarketsNeeded, MAX_SUB_MARKETS_PER_TICK);
-
-    expect(createCount).toBe(0);
+    expect(Math.min(MAX_SUB_MARKETS - 10, MAX_SUB_MARKETS_PER_TICK)).toBe(0);
   });
-
   test('should create one when one needed', () => {
-    const activeSubMarkets = 9;
-    const subMarketsNeeded = MAX_SUB_MARKETS - activeSubMarkets; // 1
-    const createCount = Math.min(subMarketsNeeded, MAX_SUB_MARKETS_PER_TICK);
-
-    expect(createCount).toBe(1);
+    expect(Math.min(MAX_SUB_MARKETS - 9, MAX_SUB_MARKETS_PER_TICK)).toBe(1);
   });
-
   test('should handle over-capacity gracefully', () => {
-    const activeSubMarkets = 12; // More than max (shouldn't happen but testing edge case)
-    const subMarketsNeeded = MAX_SUB_MARKETS - activeSubMarkets; // -2
-    const createCount = Math.max(
-      0,
-      Math.min(subMarketsNeeded, MAX_SUB_MARKETS_PER_TICK)
-    );
-
-    expect(createCount).toBe(0);
+    expect(
+      Math.max(0, Math.min(MAX_SUB_MARKETS - 12, MAX_SUB_MARKETS_PER_TICK))
+    ).toBe(0);
   });
 });
 
@@ -863,7 +296,6 @@ describe('Market Idempotency Check Logic', () => {
     startTime: Date;
     endTime: Date;
   }
-
   const DURATIONS = {
     '15m': 15 * 60 * 1000,
     '30m': 30 * 60 * 1000,
@@ -871,12 +303,10 @@ describe('Market Idempotency Check Logic', () => {
   };
 
   function inferGranularTimeframe(durationMs: number): string {
-    const sortedEntries = Object.entries(DURATIONS).sort((a, b) => a[1] - b[1]);
-    for (const [key, expectedDuration] of sortedEntries) {
-      const tolerance = expectedDuration * 0.1;
-      if (Math.abs(durationMs - expectedDuration) <= tolerance) {
-        return key;
-      }
+    for (const [key, expected] of Object.entries(DURATIONS).sort(
+      (a, b) => a[1] - b[1]
+    )) {
+      if (Math.abs(durationMs - expected) <= expected * 0.1) return key;
     }
     return '1h';
   }
@@ -915,7 +345,6 @@ describe('Market Idempotency Check Logic', () => {
         endTime: new Date(now + DURATIONS['30m']),
       },
     ];
-
     expect(countMarketsForTimeframe(markets, '15m')).toBe(2);
     expect(countMarketsForTimeframe(markets, '30m')).toBe(1);
     expect(countMarketsForTimeframe(markets, '1h')).toBe(0);
@@ -926,36 +355,25 @@ describe('Market Idempotency Check Logic', () => {
     const markets: MockMarket[] = [
       {
         id: '1',
-        granularTimeframe: null, // Legacy market
+        granularTimeframe: null,
         startTime: new Date(now),
         endTime: new Date(now + DURATIONS['15m']),
       },
       {
         id: '2',
-        granularTimeframe: '15m', // New market
+        granularTimeframe: '15m',
         startTime: new Date(now),
         endTime: new Date(now + DURATIONS['15m']),
       },
     ];
-
-    // Both should be counted as 15m
     expect(countMarketsForTimeframe(markets, '15m')).toBe(2);
   });
 
   test('should prevent creation when at target count', () => {
-    const targetCount = 2;
-    const currentCount = 2;
-
-    const shouldCreate = currentCount < targetCount;
-    expect(shouldCreate).toBe(false);
+    expect(2 < 2).toBe(false);
   });
-
   test('should allow creation when below target count', () => {
-    const targetCount = 2;
-    const currentCount = 1;
-
-    const shouldCreate = currentCount < targetCount;
-    expect(shouldCreate).toBe(true);
+    expect(1 < 2).toBe(true);
   });
 });
 
@@ -964,7 +382,6 @@ describe('Market Idempotency Check Logic', () => {
 // =============================================================================
 
 describe('Granular to DB Timeframe Mapping', () => {
-  // Contract-style test - these mappings should match production
   const EXPECTED_MAPPINGS: Record<string, string> = {
     '15m': 'flash',
     '30m': 'flash',
@@ -980,17 +397,14 @@ describe('Granular to DB Timeframe Mapping', () => {
     expect(EXPECTED_MAPPINGS['15m']).toBe('flash');
     expect(EXPECTED_MAPPINGS['30m']).toBe('flash');
   });
-
   test('should map intraday timeframes correctly', () => {
     expect(EXPECTED_MAPPINGS['1h']).toBe('intraday');
     expect(EXPECTED_MAPPINGS['6h']).toBe('intraday');
   });
-
   test('should map daily timeframes correctly', () => {
     expect(EXPECTED_MAPPINGS['12h']).toBe('daily');
     expect(EXPECTED_MAPPINGS['1d']).toBe('daily');
   });
-
   test('should map weekly timeframes correctly', () => {
     expect(EXPECTED_MAPPINGS['2d']).toBe('weekly');
     expect(EXPECTED_MAPPINGS['3d']).toBe('weekly');
@@ -999,26 +413,18 @@ describe('Granular to DB Timeframe Mapping', () => {
   test('should have all 8 granular timeframes mapped', () => {
     const keys = Object.keys(EXPECTED_MAPPINGS);
     expect(keys.length).toBe(8);
-    expect(keys).toContain('15m');
-    expect(keys).toContain('30m');
-    expect(keys).toContain('1h');
-    expect(keys).toContain('6h');
-    expect(keys).toContain('12h');
-    expect(keys).toContain('1d');
-    expect(keys).toContain('2d');
-    expect(keys).toContain('3d');
+    for (const k of ['15m', '30m', '1h', '6h', '12h', '1d', '2d', '3d'])
+      expect(keys).toContain(k);
   });
 
   test('should aggregate to correct DB timeframe counts', () => {
     const dbCounts: Record<string, number> = {};
-    for (const dbTimeframe of Object.values(EXPECTED_MAPPINGS)) {
-      dbCounts[dbTimeframe] = (dbCounts[dbTimeframe] || 0) + 1;
-    }
-
-    expect(dbCounts['flash']).toBe(2); // 15m + 30m
-    expect(dbCounts['intraday']).toBe(2); // 1h + 6h
-    expect(dbCounts['daily']).toBe(2); // 12h + 1d
-    expect(dbCounts['weekly']).toBe(2); // 2d + 3d
+    for (const v of Object.values(EXPECTED_MAPPINGS))
+      dbCounts[v] = (dbCounts[v] || 0) + 1;
+    expect(dbCounts['flash']).toBe(2);
+    expect(dbCounts['intraday']).toBe(2);
+    expect(dbCounts['daily']).toBe(2);
+    expect(dbCounts['weekly']).toBe(2);
   });
 });
 
@@ -1027,45 +433,32 @@ describe('Granular to DB Timeframe Mapping', () => {
 // =============================================================================
 
 describe('toStringArray Type Guard', () => {
-  // Replicate the toStringArray helper for testing
-  function isStringArray(value: unknown): value is string[] {
-    return (
-      Array.isArray(value) && value.every((item) => typeof item === 'string')
-    );
-  }
-
   function toStringArray(value: unknown): string[] {
-    if (isStringArray(value)) return value;
-    if (value === null || value === undefined) return [];
+    if (Array.isArray(value) && value.every((item) => typeof item === 'string'))
+      return value;
     return [];
   }
 
   test('should return array for valid string array', () => {
     expect(toStringArray(['a', 'b', 'c'])).toEqual(['a', 'b', 'c']);
   });
-
   test('should return empty array for null', () => {
     expect(toStringArray(null)).toEqual([]);
   });
-
   test('should return empty array for undefined', () => {
     expect(toStringArray(undefined)).toEqual([]);
   });
-
   test('should return empty array for non-array types', () => {
     expect(toStringArray('string')).toEqual([]);
     expect(toStringArray(123)).toEqual([]);
     expect(toStringArray({ key: 'value' })).toEqual([]);
   });
-
   test('should return empty array for mixed arrays', () => {
     expect(toStringArray(['a', 1, 'b'])).toEqual([]);
   });
-
   test('should return empty array for empty array', () => {
     expect(toStringArray([])).toEqual([]);
   });
-
   test('should handle nested arrays as invalid', () => {
     expect(toStringArray([['a', 'b'], ['c']])).toEqual([]);
   });
@@ -1076,53 +469,31 @@ describe('toStringArray Type Guard', () => {
 // =============================================================================
 
 describe('inferSubMarketTimeframe (Fixed Version)', () => {
-  // Replicate the FIXED inferSubMarketTimeframe logic
-  // Now only returns supported keys: '15m', '30m', '1h'
   function inferSubMarketTimeframe(durationMs: number): '15m' | '30m' | '1h' {
     const minutes = durationMs / (60 * 1000);
     if (minutes <= 22.5) return '15m';
     if (minutes <= 45) return '30m';
-    return '1h'; // All durations > 45min map to 1h (closest supported key)
+    return '1h';
   }
 
   test('should return 15m for durations up to 22.5 minutes', () => {
-    expect(inferSubMarketTimeframe(15 * 60 * 1000)).toBe('15m'); // 15 min
-    expect(inferSubMarketTimeframe(20 * 60 * 1000)).toBe('15m'); // 20 min
-    expect(inferSubMarketTimeframe(22.5 * 60 * 1000)).toBe('15m'); // 22.5 min
+    expect(inferSubMarketTimeframe(15 * 60 * 1000)).toBe('15m');
+    expect(inferSubMarketTimeframe(20 * 60 * 1000)).toBe('15m');
+    expect(inferSubMarketTimeframe(22.5 * 60 * 1000)).toBe('15m');
   });
-
   test('should return 30m for durations from 22.5 to 45 minutes', () => {
-    expect(inferSubMarketTimeframe(23 * 60 * 1000)).toBe('30m'); // 23 min
-    expect(inferSubMarketTimeframe(30 * 60 * 1000)).toBe('30m'); // 30 min
-    expect(inferSubMarketTimeframe(45 * 60 * 1000)).toBe('30m'); // 45 min
+    expect(inferSubMarketTimeframe(23 * 60 * 1000)).toBe('30m');
+    expect(inferSubMarketTimeframe(30 * 60 * 1000)).toBe('30m');
+    expect(inferSubMarketTimeframe(45 * 60 * 1000)).toBe('30m');
   });
-
   test('should return 1h for all durations over 45 minutes', () => {
-    expect(inferSubMarketTimeframe(46 * 60 * 1000)).toBe('1h'); // 46 min
-    expect(inferSubMarketTimeframe(60 * 60 * 1000)).toBe('1h'); // 60 min
-    expect(inferSubMarketTimeframe(90 * 60 * 1000)).toBe('1h'); // 90 min
-    expect(inferSubMarketTimeframe(120 * 60 * 1000)).toBe('1h'); // 120 min
-    expect(inferSubMarketTimeframe(180 * 60 * 1000)).toBe('1h'); // 180 min (3 hours)
+    for (const m of [46, 60, 90, 120, 180])
+      expect(inferSubMarketTimeframe(m * 60 * 1000)).toBe('1h');
   });
-
   test('should only return keys supported by GRANULAR_TO_DB_TIMEFRAME', () => {
-    // This is the critical fix - no more '2h' or '3h' which would cause throws
-    const supportedKeys = ['15m', '30m', '1h'];
-
-    // Test a range of durations
-    const testDurations = [
-      15 * 60 * 1000, // 15 min
-      30 * 60 * 1000, // 30 min
-      60 * 60 * 1000, // 1 hour
-      90 * 60 * 1000, // 1.5 hours
-      120 * 60 * 1000, // 2 hours
-      180 * 60 * 1000, // 3 hours
-    ];
-
-    for (const duration of testDurations) {
-      const result = inferSubMarketTimeframe(duration);
-      expect(supportedKeys).toContain(result);
-    }
+    const supported = ['15m', '30m', '1h'];
+    for (const d of [15, 30, 60, 90, 120, 180])
+      expect(supported).toContain(inferSubMarketTimeframe(d * 60 * 1000));
   });
 });
 
@@ -1135,50 +506,24 @@ describe('Transactional Sub-Market Creation Logic', () => {
   const MAX_SUB_MARKETS_PER_TICK = 5;
 
   test('should abort creation when count reaches MAX_SUB_MARKETS inside transaction', () => {
-    // Simulate scenario where count was 8 outside tx, but 10 inside tx
-    const outsideCount = 8;
-    const insideCount = 10;
-
-    // Outside transaction check suggests we need to create
-    const outsideNeeded = MAX_SUB_MARKETS - outsideCount;
-    expect(outsideNeeded).toBe(2);
-
-    // But inside transaction, we discover we're at max
-    const shouldCreate = insideCount < MAX_SUB_MARKETS;
-    expect(shouldCreate).toBe(false);
+    expect(MAX_SUB_MARKETS - 8).toBe(2);
+    expect(10 < MAX_SUB_MARKETS).toBe(false);
   });
-
   test('should respect MAX_SUB_MARKETS_PER_TICK even when many needed', () => {
-    const activeSubMarkets = 0;
-    const subMarketsNeeded = MAX_SUB_MARKETS - activeSubMarkets; // 10
-    const createCount = Math.min(subMarketsNeeded, MAX_SUB_MARKETS_PER_TICK);
-
-    expect(createCount).toBe(5);
+    expect(Math.min(MAX_SUB_MARKETS - 0, MAX_SUB_MARKETS_PER_TICK)).toBe(5);
   });
-
   test('should handle concurrent tick scenario with SKIP LOCKED', () => {
-    // Simulate SKIP LOCKED behavior:
-    // If another transaction has locked the rows, we should get empty results
-    const lockedByOtherTransaction = true;
-    const parentMarketsReturned = lockedByOtherTransaction ? [] : [{ id: '1' }];
-
-    // When SKIP LOCKED returns empty, we create 0 sub-markets
+    const parentMarketsReturned = true ? [] : [{ id: '1' }];
     expect(parentMarketsReturned.length).toBe(0);
   });
-
   test('should track gapFillingSkippedDueToMax metric correctly', () => {
-    // When activeSubMarketCount >= MAX_SUB_MARKETS, we should set the flag
-    const testCases = [
+    for (const { activeCount, expected } of [
       { activeCount: 10, expected: true },
       { activeCount: 11, expected: true },
       { activeCount: 9, expected: false },
       { activeCount: 0, expected: false },
-    ];
-
-    for (const { activeCount, expected } of testCases) {
-      const gapFillingSkippedDueToMax = activeCount >= MAX_SUB_MARKETS;
-      expect(gapFillingSkippedDueToMax).toBe(expected);
-    }
+    ])
+      expect(activeCount >= MAX_SUB_MARKETS).toBe(expected);
   });
 });
 
@@ -1188,17 +533,79 @@ describe('Transactional Sub-Market Creation Logic', () => {
 
 describe('Cache Invalidation Logic', () => {
   test('should invalidate cache when sub-markets are created', () => {
-    // Simulate: subMarketsCreated > 0 -> invalidate cache
-    const subMarketsCreated = 3;
-    const shouldInvalidate = subMarketsCreated > 0;
-    expect(shouldInvalidate).toBe(true);
+    expect(3 > 0).toBe(true);
   });
-
   test('should not invalidate cache when no sub-markets created', () => {
-    // Simulate: subMarketsCreated === 0 -> skip cache invalidation
-    const subMarketsCreated = 0;
-    const shouldInvalidate = subMarketsCreated > 0;
-    expect(shouldInvalidate).toBe(false);
+    expect(0 > 0).toBe(false);
+  });
+});
+
+// =============================================================================
+// Sub-Market Duration Constraint Tests
+// =============================================================================
+
+describe('Sub-Market Duration Constraints', () => {
+  const SUB_MARKET_MIN_DURATION_MS = 15 * 60 * 1000;
+  const SUB_MARKET_MAX_DURATION_MS = 3 * 60 * 60 * 1000;
+  const SUB_MARKET_RESOLUTION_BUFFER_MS = 5 * 60 * 1000;
+
+  function getMaxSubMarketDuration(
+    parentEndTime: Date,
+    now: number = Date.now()
+  ): number | null {
+    const remainingTimeMs =
+      parentEndTime.getTime() - now - SUB_MARKET_RESOLUTION_BUFFER_MS;
+    if (remainingTimeMs < SUB_MARKET_MIN_DURATION_MS) return null;
+    return Math.min(remainingTimeMs, SUB_MARKET_MAX_DURATION_MS);
+  }
+
+  test('should return null when parent has less than minimum duration remaining', () => {
+    const now = Date.now();
+    expect(
+      getMaxSubMarketDuration(new Date(now + 10 * 60 * 1000), now)
+    ).toBeNull();
+  });
+  test('should return minimum when parent ends exactly at minimum + buffer', () => {
+    const now = Date.now();
+    expect(getMaxSubMarketDuration(new Date(now + 20 * 60 * 1000), now)).toBe(
+      15 * 60 * 1000
+    );
+  });
+  test('should return constrained duration when parent has limited time', () => {
+    const now = Date.now();
+    expect(getMaxSubMarketDuration(new Date(now + 30 * 60 * 1000), now)).toBe(
+      25 * 60 * 1000
+    );
+  });
+  test('should cap at maximum duration when parent has plenty of time', () => {
+    const now = Date.now();
+    expect(
+      getMaxSubMarketDuration(new Date(now + 24 * 60 * 60 * 1000), now)
+    ).toBe(SUB_MARKET_MAX_DURATION_MS);
+  });
+  test('should handle parent ending very soon (less than buffer)', () => {
+    const now = Date.now();
+    expect(
+      getMaxSubMarketDuration(new Date(now + 3 * 60 * 1000), now)
+    ).toBeNull();
+  });
+  test('should handle parent already ended', () => {
+    const now = Date.now();
+    expect(
+      getMaxSubMarketDuration(new Date(now - 5 * 60 * 1000), now)
+    ).toBeNull();
+  });
+  test('should correctly calculate for 1-hour parent markets', () => {
+    const now = Date.now();
+    expect(getMaxSubMarketDuration(new Date(now + 60 * 60 * 1000), now)).toBe(
+      55 * 60 * 1000
+    );
+  });
+  test('should correctly calculate for parent with exactly 3 hours remaining', () => {
+    const now = Date.now();
+    expect(
+      getMaxSubMarketDuration(new Date(now + 3 * 60 * 60 * 1000), now)
+    ).toBe((3 * 60 - 5) * 60 * 1000);
   });
 });
 
@@ -1206,110 +613,7 @@ describe('Cache Invalidation Logic', () => {
 // Media Selection Relevance Scoring Tests
 // =============================================================================
 
-// =============================================================================
-// Sub-Market Duration Constraint Tests
-// =============================================================================
-
-describe('Sub-Market Duration Constraints', () => {
-  const SUB_MARKET_MIN_DURATION_MS = 15 * 60 * 1000; // 15 minutes
-  const SUB_MARKET_MAX_DURATION_MS = 3 * 60 * 60 * 1000; // 3 hours
-  const SUB_MARKET_RESOLUTION_BUFFER_MS = 5 * 60 * 1000; // 5 minutes
-
-  // Replicate the getMaxSubMarketDuration helper for testing
-  function getMaxSubMarketDuration(
-    parentEndTime: Date,
-    now: number = Date.now()
-  ): number | null {
-    const remainingTimeMs =
-      parentEndTime.getTime() - now - SUB_MARKET_RESOLUTION_BUFFER_MS;
-
-    if (remainingTimeMs < SUB_MARKET_MIN_DURATION_MS) {
-      return null;
-    }
-
-    return Math.min(remainingTimeMs, SUB_MARKET_MAX_DURATION_MS);
-  }
-
-  test('should return null when parent has less than minimum duration remaining', () => {
-    const now = Date.now();
-    // Parent ends in 10 minutes (less than 15 min minimum + 5 min buffer)
-    const parentEndTime = new Date(now + 10 * 60 * 1000);
-
-    expect(getMaxSubMarketDuration(parentEndTime, now)).toBeNull();
-  });
-
-  test('should return minimum when parent ends exactly at minimum + buffer', () => {
-    const now = Date.now();
-    // Parent ends in exactly 20 minutes (15 min min + 5 min buffer)
-    // This is the edge case - should return null because remaining = 15 which is not > 15
-    const parentEndTime = new Date(now + 20 * 60 * 1000);
-
-    // After subtracting buffer: 20 - 5 = 15 minutes
-    // 15 minutes is exactly minimum, so this should work
-    const result = getMaxSubMarketDuration(parentEndTime, now);
-    expect(result).toBe(15 * 60 * 1000); // Should return exactly minimum
-  });
-
-  test('should return constrained duration when parent has limited time', () => {
-    const now = Date.now();
-    // Parent ends in 30 minutes
-    const parentEndTime = new Date(now + 30 * 60 * 1000);
-
-    // After buffer: 30 - 5 = 25 minutes max duration
-    const result = getMaxSubMarketDuration(parentEndTime, now);
-    expect(result).toBe(25 * 60 * 1000);
-  });
-
-  test('should cap at maximum duration when parent has plenty of time', () => {
-    const now = Date.now();
-    // Parent ends in 24 hours
-    const parentEndTime = new Date(now + 24 * 60 * 60 * 1000);
-
-    // Should cap at MAX_DURATION (3 hours)
-    const result = getMaxSubMarketDuration(parentEndTime, now);
-    expect(result).toBe(SUB_MARKET_MAX_DURATION_MS);
-  });
-
-  test('should handle parent ending very soon (less than buffer)', () => {
-    const now = Date.now();
-    // Parent ends in 3 minutes (less than 5 min buffer)
-    const parentEndTime = new Date(now + 3 * 60 * 1000);
-
-    expect(getMaxSubMarketDuration(parentEndTime, now)).toBeNull();
-  });
-
-  test('should handle parent already ended', () => {
-    const now = Date.now();
-    // Parent ended 5 minutes ago
-    const parentEndTime = new Date(now - 5 * 60 * 1000);
-
-    expect(getMaxSubMarketDuration(parentEndTime, now)).toBeNull();
-  });
-
-  test('should correctly calculate for 1-hour parent markets', () => {
-    const now = Date.now();
-    // Parent is a 1-hour market, currently at the start
-    const parentEndTime = new Date(now + 60 * 60 * 1000);
-
-    // After buffer: 60 - 5 = 55 minutes max
-    const result = getMaxSubMarketDuration(parentEndTime, now);
-    expect(result).toBe(55 * 60 * 1000);
-  });
-
-  test('should correctly calculate for parent with exactly 3 hours remaining', () => {
-    const now = Date.now();
-    // Parent ends in 3 hours
-    const parentEndTime = new Date(now + 3 * 60 * 60 * 1000);
-
-    // After buffer: 3h - 5m = 175 minutes, but capped at 3 hours (180 min)
-    // Actually: 175 min < 180 min, so should return 175 minutes
-    const result = getMaxSubMarketDuration(parentEndTime, now);
-    expect(result).toBe((3 * 60 - 5) * 60 * 1000); // 175 minutes
-  });
-});
-
 describe('Media Selection Relevance Scoring', () => {
-  // Base scoring weights from the implementation
   const BASE_WEIGHT = 1.0;
   const DIRECT_AFFILIATION_BONUS = 2.0;
   const INDIRECT_AFFILIATION_BONUS = 1.5;
@@ -1317,47 +621,35 @@ describe('Media Selection Relevance Scoring', () => {
   const MAX_RANDOM_VARIANCE = 1.0;
 
   test('should give all orgs at least base weight', () => {
-    // Every media org starts with BASE_WEIGHT = 1.0
-    const baseScore = BASE_WEIGHT;
-    expect(baseScore).toBe(1.0);
+    expect(BASE_WEIGHT).toBe(1.0);
   });
-
   test('should add bonus for direct actor affiliation', () => {
-    // If org has actors affiliated with market's actors
-    const scoreWithBonus = BASE_WEIGHT + DIRECT_AFFILIATION_BONUS;
-    expect(scoreWithBonus).toBe(3.0);
+    expect(BASE_WEIGHT + DIRECT_AFFILIATION_BONUS).toBe(3.0);
   });
-
   test('should add smaller bonus for indirect affiliation', () => {
-    // If org has actors that share affiliations with market orgs
-    const scoreWithBonus = BASE_WEIGHT + INDIRECT_AFFILIATION_BONUS;
-    expect(scoreWithBonus).toBe(2.5);
+    expect(BASE_WEIGHT + INDIRECT_AFFILIATION_BONUS).toBe(2.5);
   });
-
   test('should add bonus for category match', () => {
-    // If org's actors cover the market category domain
-    const scoreWithBonus = BASE_WEIGHT + CATEGORY_MATCH_BONUS;
-    expect(scoreWithBonus).toBe(1.5);
+    expect(BASE_WEIGHT + CATEGORY_MATCH_BONUS).toBe(1.5);
   });
-
   test('should include random variance to prevent determinism', () => {
-    // Random variance between 0 and MAX_RANDOM_VARIANCE
-    const minPossibleScore = BASE_WEIGHT + 0;
-    const maxPossibleScore =
+    expect(BASE_WEIGHT).toBe(1.0);
+    expect(
       BASE_WEIGHT +
-      DIRECT_AFFILIATION_BONUS +
-      INDIRECT_AFFILIATION_BONUS +
-      CATEGORY_MATCH_BONUS +
-      MAX_RANDOM_VARIANCE;
-
-    expect(minPossibleScore).toBe(1.0);
-    expect(maxPossibleScore).toBe(6.0);
+        DIRECT_AFFILIATION_BONUS +
+        INDIRECT_AFFILIATION_BONUS +
+        CATEGORY_MATCH_BONUS +
+        MAX_RANDOM_VARIANCE
+    ).toBe(6.0);
   });
 });
 
+// =============================================================================
+// parseMarketCategory Type Narrowing Tests
+// =============================================================================
+
 describe('parseMarketCategory Type Narrowing', () => {
-  // Valid market categories from the implementation
-  const VALID_MARKET_CATEGORIES = [
+  const VALID = [
     'tech',
     'politics',
     'entertainment',
@@ -1366,74 +658,34 @@ describe('parseMarketCategory Type Narrowing', () => {
     'business',
     'general',
   ] as const;
-
-  type MarketCategory = (typeof VALID_MARKET_CATEGORIES)[number];
-
-  // Replicate the parseMarketCategory logic for testing
-  function isMarketCategory(value: unknown): value is MarketCategory {
-    return (
-      typeof value === 'string' &&
-      VALID_MARKET_CATEGORIES.includes(value as MarketCategory)
-    );
-  }
+  type MarketCategory = (typeof VALID)[number];
 
   function parseMarketCategory(
-    value: string | null | undefined,
-    _context?: string
+    value: string | null | undefined
   ): MarketCategory {
-    if (isMarketCategory(value)) {
-      return value;
-    }
-    // Treat null, undefined, and empty string as missing data - no warning needed
-    if (value === null || value === undefined || value === '') {
-      return 'general';
-    }
-    // Only warn for invalid non-empty strings (likely a bug or data corruption)
-    // In tests, we just return 'general' without the warning side effect
+    if (typeof value === 'string' && VALID.includes(value as MarketCategory))
+      return value as MarketCategory;
     return 'general';
   }
 
   test('should return valid category unchanged', () => {
-    expect(parseMarketCategory('tech')).toBe('tech');
-    expect(parseMarketCategory('politics')).toBe('politics');
-    expect(parseMarketCategory('sports')).toBe('sports');
-    expect(parseMarketCategory('science')).toBe('science');
-    expect(parseMarketCategory('business')).toBe('business');
-    expect(parseMarketCategory('entertainment')).toBe('entertainment');
-    expect(parseMarketCategory('general')).toBe('general');
+    for (const c of VALID) expect(parseMarketCategory(c)).toBe(c);
   });
-
   test('should return general for null without warning', () => {
-    const result = parseMarketCategory(null);
-    expect(result).toBe('general');
+    expect(parseMarketCategory(null)).toBe('general');
   });
-
   test('should return general for undefined without warning', () => {
-    const result = parseMarketCategory(undefined);
-    expect(result).toBe('general');
+    expect(parseMarketCategory(undefined)).toBe('general');
   });
-
   test('should return general for empty string without warning', () => {
-    // Empty string should be treated as missing data, not as an invalid category
-    const result = parseMarketCategory('');
-    expect(result).toBe('general');
+    expect(parseMarketCategory('')).toBe('general');
   });
-
   test('should return general for invalid non-empty string (with warning in production)', () => {
-    // Invalid strings like typos should trigger a warning in production
-    const result = parseMarketCategory('invalid-category');
-    expect(result).toBe('general');
-
-    const result2 = parseMarketCategory('TECH'); // Case sensitive
-    expect(result2).toBe('general');
-
-    const result3 = parseMarketCategory('technology'); // Not in valid list
-    expect(result3).toBe('general');
+    expect(parseMarketCategory('invalid-category')).toBe('general');
+    expect(parseMarketCategory('TECH')).toBe('general');
+    expect(parseMarketCategory('technology')).toBe('general');
   });
-
   test('should handle whitespace-only strings as invalid (not empty)', () => {
-    // Whitespace strings are non-empty invalid strings
-    const result = parseMarketCategory('   ');
-    expect(result).toBe('general');
+    expect(parseMarketCategory('   ')).toBe('general');
   });
 });


### PR DESCRIPTION
## Summary

Supersedes #1125 — takes the same direction but fixes mock leakage issues that caused 13 new test failures in the original approach.

- Extract shared cron mock infrastructure into `cron-test-mocks.ts` (eliminates ~400 lines of duplication)
- Remove `...actualModule` spreads that imported real module trees (caused `@privy-io/node` failures and mock pollution)
- Snowflake mock returns valid BigInt-parseable IDs using the correct epoch
- Re-export real rate-limiting and snowflake utilities through mocks so downstream tests get real implementations
- Remove unnecessary Redis/shared mocks from SIWE tests (module has in-memory fallback)

## Test Results

| Metric | Staging (before) | This PR |
|--------|-----------------|---------|
| Full unit suite | **Hangs, SIGKILL after 66s** | **1,906 pass, 4 fail (all pre-existing), 4.8s** |
| article-tick alone | Hangs | 7/7 pass |
| markets-tick alone | 74/74 pass | 74/74 pass |
| All 3 cron+siwe together | Hangs | 94/94 pass |
| Mixed with AutomationPipeline | Hangs | 102/102 pass |

Pre-existing failures (same on staging): 1 Agent Card streaming flag, 2 formatCurrency locale tests.

## Changes

- `packages/testing/unit/cron/cron-test-mocks.ts` — **new** shared mock helper
- `packages/testing/unit/cron/article-tick.test.ts` — rewritten to use shared mocks (599 → 180 lines)
- `packages/testing/unit/cron/markets-tick.test.ts` — rewritten to use shared mocks (1440 → 400 lines)
- `packages/testing/unit/auth/siwe.test.ts` — removed Redis/shared mocks, uses in-memory nonce store

## Test plan

- [x] `bun test` all three cron+siwe files together — 94/94 pass
- [x] Mixed run with AutomationPipeline — 102/102 pass
- [x] Full `bun run test:unit` — 1,906 pass, 0 new failures
- [x] Snowflake tests pass in mixed-suite runs (no BigInt parse errors)
- [x] Rate-limiting tests pass in mixed-suite runs (no mock leakage)

Closes #1125