### PR TITLE
fix(agents): enable autonomous follow actions for social graph growth

### DIFF
--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -11,6 +11,7 @@ import {
   broadcastChatMessage,
   broadcastToChannel,
   type CommentActivityData,
+  cachedDb,
   type JsonValue,
   type MessageActivityData,
   type PostActivityData,
@@ -32,6 +33,7 @@ import {
   db,
   dmAcceptances,
   eq,
+  follows,
   gte,
   isNull,
   messages,
@@ -469,6 +471,21 @@ export interface DirectRepostResult {
   success: boolean;
   repostId?: string;
   quotePostId?: string;
+  error?: string;
+}
+
+export interface DirectFollowParams {
+  agentUserId: string;
+  targetUserId: string;
+}
+
+export interface DirectFollowResult {
+  success: boolean;
+  followed?: boolean;
+  alreadyFollowing?: boolean;
+  unfollowed?: boolean;
+  wasFollowing?: boolean;
+  targetUserId?: string;
   error?: string;
 }
 
@@ -1607,6 +1624,157 @@ export async function executeDirectMessage(
   return {
     success: true,
     messageId,
+  };
+}
+
+// =============================================================================
+// Direct Follow / Unfollow Executors
+// =============================================================================
+
+/**
+ * Follow a user/agent directly without LLM decision-making.
+ * This action is restricted to real users/agents (not static NPC actors).
+ */
+export async function executeDirectFollow(
+  params: DirectFollowParams
+): Promise<DirectFollowResult> {
+  const { agentUserId, targetUserId } = params;
+  const cleanTargetUserId = targetUserId?.trim();
+
+  if (!cleanTargetUserId) {
+    return { success: false, error: 'Target user ID is required' };
+  }
+
+  if (cleanTargetUserId === agentUserId) {
+    return { success: false, error: 'Cannot follow yourself' };
+  }
+
+  const [targetUser] = await db
+    .select({ id: users.id, isActor: users.isActor })
+    .from(users)
+    .where(eq(users.id, cleanTargetUserId))
+    .limit(1);
+
+  if (!targetUser) {
+    return { success: false, error: `User not found: ${cleanTargetUserId}` };
+  }
+
+  if (targetUser.isActor) {
+    return {
+      success: false,
+      error:
+        'FOLLOW supports users/agents only. NPC actors are not supported here',
+    };
+  }
+
+  logger.info(
+    `[DirectExecutor] Following user ${cleanTargetUserId}`,
+    { agentUserId },
+    'DirectExecutors'
+  );
+
+  const followId = await generateSnowflakeId();
+  const insertResult = await db
+    .insert(follows)
+    .values({
+      id: followId,
+      followerId: agentUserId,
+      followingId: cleanTargetUserId,
+    })
+    .onConflictDoNothing()
+    .returning({ id: follows.id });
+
+  const followed = insertResult.length > 0;
+
+  if (followed) {
+    await Promise.all([
+      cachedDb.invalidateUserCache(agentUserId),
+      cachedDb.invalidateUserCache(cleanTargetUserId),
+    ]).catch((error: unknown) => {
+      logger.warn('Failed to invalidate user cache after direct follow', {
+        error,
+      });
+    });
+  }
+
+  return {
+    success: true,
+    followed,
+    alreadyFollowing: !followed,
+    targetUserId: cleanTargetUserId,
+  };
+}
+
+/**
+ * Unfollow a user/agent directly without LLM decision-making.
+ * Returns success even if there was no active follow relationship (idempotent).
+ */
+export async function executeDirectUnfollow(
+  params: DirectFollowParams
+): Promise<DirectFollowResult> {
+  const { agentUserId, targetUserId } = params;
+  const cleanTargetUserId = targetUserId?.trim();
+
+  if (!cleanTargetUserId) {
+    return { success: false, error: 'Target user ID is required' };
+  }
+
+  if (cleanTargetUserId === agentUserId) {
+    return { success: false, error: 'Cannot unfollow yourself' };
+  }
+
+  const [targetUser] = await db
+    .select({ id: users.id, isActor: users.isActor })
+    .from(users)
+    .where(eq(users.id, cleanTargetUserId))
+    .limit(1);
+
+  if (!targetUser) {
+    return { success: false, error: `User not found: ${cleanTargetUserId}` };
+  }
+
+  if (targetUser.isActor) {
+    return {
+      success: false,
+      error:
+        'UNFOLLOW supports users/agents only. NPC actors are not supported here',
+    };
+  }
+
+  logger.info(
+    `[DirectExecutor] Unfollowing user ${cleanTargetUserId}`,
+    { agentUserId },
+    'DirectExecutors'
+  );
+
+  const deletedRows = await db
+    .delete(follows)
+    .where(
+      and(
+        eq(follows.followerId, agentUserId),
+        eq(follows.followingId, cleanTargetUserId)
+      )
+    )
+    .returning({ id: follows.id });
+
+  const wasFollowing = deletedRows.length > 0;
+
+  if (wasFollowing) {
+    await Promise.all([
+      cachedDb.invalidateUserCache(agentUserId),
+      cachedDb.invalidateUserCache(cleanTargetUserId),
+    ]).catch((error: unknown) => {
+      logger.warn('Failed to invalidate user cache after direct unfollow', {
+        error,
+      });
+    });
+  }
+
+  return {
+    success: true,
+    unfollowed: wasFollowing,
+    wasFollowing,
+    targetUserId: cleanTargetUserId,
   };
 }
 

--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -8,7 +8,16 @@
  * This eliminates double LLM calls and makes execution faster.
  */
 
-import { actorState, agentLogs, and, chats, db, desc, eq, users } from '@babylon/db';
+import {
+  actorState,
+  agentLogs,
+  and,
+  chats,
+  db,
+  desc,
+  eq,
+  users,
+} from '@babylon/db';
 import { StaticDataRegistry, WalletService } from '@babylon/engine';
 import type { IAgentRuntime } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
@@ -18,11 +27,13 @@ import { getAgentConfig, getAutonomousFeatures } from '../shared/agent-config';
 import { logger } from '../shared/logger';
 import {
   executeDirectComment,
+  executeDirectFollow,
   executeDirectLike,
   executeDirectMessage,
   executeDirectPost,
   executeDirectRepost,
   executeDirectTrade,
+  executeDirectUnfollow,
 } from './DirectExecutors';
 import { topicDiversityService } from './TopicDiversityService';
 
@@ -578,7 +589,10 @@ export class MultiStepExecutor {
       })
       .from(agentLogs)
       .where(
-        and(eq(agentLogs.agentUserId, agentUserId), eq(agentLogs.type, 'system'))
+        and(
+          eq(agentLogs.agentUserId, agentUserId),
+          eq(agentLogs.type, 'system')
+        )
       )
       .orderBy(desc(agentLogs.createdAt))
       .limit(10);
@@ -763,6 +777,12 @@ export class MultiStepExecutor {
 
       case Actions.REPOST:
         return this.executeRepost(agentUserId, parameters);
+
+      case Actions.FOLLOW:
+        return this.executeFollow(agentUserId, parameters);
+
+      case Actions.UNFOLLOW:
+        return this.executeUnfollow(agentUserId, parameters);
 
       case Actions.REPLY_COMMENT:
         return this.executeReplyComment(agentUserId, parameters, logContext);
@@ -1098,6 +1118,124 @@ export class MultiStepExecutor {
         repostId: repostResult.repostId,
         quotePostId: repostResult.quotePostId,
         error: repostResult.error,
+      },
+      parameters,
+      timestamp: Date.now(),
+    };
+  }
+
+  private async executeFollow(
+    agentUserId: string,
+    parameters: Record<string, unknown>
+  ): Promise<ActionTraceResult> {
+    const targetUserId = (parameters.userId ||
+      parameters.targetUserId) as string;
+
+    if (!targetUserId) {
+      return {
+        actionType: Actions.FOLLOW,
+        success: false,
+        summary: 'Missing required parameter (userId)',
+        error: 'Invalid parameters',
+        parameters,
+        timestamp: Date.now(),
+      };
+    }
+
+    const followResult = await executeDirectFollow({
+      agentUserId,
+      targetUserId,
+    });
+
+    await agentService.createLog(agentUserId, {
+      type: 'follow',
+      level: followResult.success ? 'info' : 'warn',
+      message: followResult.success
+        ? followResult.followed
+          ? `Now following ${targetUserId}`
+          : `Already following ${targetUserId}`
+        : `Follow failed: ${followResult.error}`,
+      metadata: {
+        targetUserId,
+        success: followResult.success,
+        followed: followResult.followed ?? false,
+        alreadyFollowing: followResult.alreadyFollowing ?? false,
+        error: followResult.error ?? null,
+      },
+    });
+
+    return {
+      actionType: Actions.FOLLOW,
+      success: followResult.success,
+      summary: followResult.success
+        ? followResult.followed
+          ? `Now following ${targetUserId}`
+          : `Already following ${targetUserId}`
+        : `Follow failed: ${followResult.error}`,
+      result: {
+        success: followResult.success,
+        followed: followResult.followed,
+        alreadyFollowing: followResult.alreadyFollowing,
+        error: followResult.error,
+      },
+      parameters,
+      timestamp: Date.now(),
+    };
+  }
+
+  private async executeUnfollow(
+    agentUserId: string,
+    parameters: Record<string, unknown>
+  ): Promise<ActionTraceResult> {
+    const targetUserId = (parameters.userId ||
+      parameters.targetUserId) as string;
+
+    if (!targetUserId) {
+      return {
+        actionType: Actions.UNFOLLOW,
+        success: false,
+        summary: 'Missing required parameter (userId)',
+        error: 'Invalid parameters',
+        parameters,
+        timestamp: Date.now(),
+      };
+    }
+
+    const unfollowResult = await executeDirectUnfollow({
+      agentUserId,
+      targetUserId,
+    });
+
+    await agentService.createLog(agentUserId, {
+      type: 'follow',
+      level: unfollowResult.success ? 'info' : 'warn',
+      message: unfollowResult.success
+        ? unfollowResult.unfollowed
+          ? `Unfollowed ${targetUserId}`
+          : `Was not following ${targetUserId}`
+        : `Unfollow failed: ${unfollowResult.error}`,
+      metadata: {
+        targetUserId,
+        success: unfollowResult.success,
+        unfollowed: unfollowResult.unfollowed ?? false,
+        wasFollowing: unfollowResult.wasFollowing ?? false,
+        error: unfollowResult.error ?? null,
+      },
+    });
+
+    return {
+      actionType: Actions.UNFOLLOW,
+      success: unfollowResult.success,
+      summary: unfollowResult.success
+        ? unfollowResult.unfollowed
+          ? `Unfollowed ${targetUserId}`
+          : `Was not following ${targetUserId}`
+        : `Unfollow failed: ${unfollowResult.error}`,
+      result: {
+        success: unfollowResult.success,
+        unfollowed: unfollowResult.unfollowed,
+        wasFollowing: unfollowResult.wasFollowing,
+        error: unfollowResult.error,
       },
       parameters,
       timestamp: Date.now(),
@@ -1455,6 +1593,8 @@ export class MultiStepExecutor {
           break;
         case Actions.LIKE:
         case Actions.REPOST:
+        case Actions.FOLLOW:
+        case Actions.UNFOLLOW:
           counts.engagements++;
           break;
       }

--- a/packages/agents/src/autonomous/__tests__/direct-follow.test.ts
+++ b/packages/agents/src/autonomous/__tests__/direct-follow.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+let mockTargetUser: { id: string; isActor: boolean } | null = {
+  id: 'target-user',
+  isActor: false,
+};
+let shouldCreateFollow = true;
+let deleteReturningRows: Array<{ id: string }> = [{ id: 'follow-1' }];
+
+const invalidateUserCacheMock = mock(async () => undefined);
+
+const mockDb = {
+  select: mock(() => ({
+    from: mock(() => ({
+      where: mock(() => ({
+        limit: mock(async () => (mockTargetUser ? [mockTargetUser] : [])),
+      })),
+    })),
+  })),
+  insert: mock(() => ({
+    values: mock(() => ({
+      onConflictDoNothing: mock(() => ({
+        returning: mock(async () =>
+          shouldCreateFollow ? [{ id: 'follow-1' }] : []
+        ),
+      })),
+    })),
+  })),
+  delete: mock(() => ({
+    where: mock(() => ({
+      returning: mock(async () => deleteReturningRows),
+    })),
+  })),
+  transaction: mock(async () => undefined),
+};
+
+mock.module('@babylon/db', () => ({
+  actorState: {},
+  aliasedTable: mock(() => ({})),
+  and: (...args: unknown[]) => args,
+  asSystem: () => ({}),
+  asUser: () => ({}),
+  chatParticipants: {},
+  chats: {},
+  comments: {},
+  db: mockDb,
+  dmAcceptances: {},
+  eq: (a: unknown, b: unknown) => ({ a, b }),
+  follows: { id: 'id', followerId: 'followerId', followingId: 'followingId' },
+  gte: (...args: unknown[]) => args,
+  isNull: (...args: unknown[]) => args,
+  messages: {},
+  perpPositions: {},
+  posts: {
+    id: 'id',
+    authorId: 'authorId',
+    content: 'content',
+    originalPostId: 'originalPostId',
+  },
+  reactions: {},
+  shares: { id: 'id', postId: 'postId', userId: 'userId' },
+  sql: {},
+  users: { id: 'id', isActor: 'isActor', displayName: 'displayName' },
+}));
+
+mock.module('@babylon/api', () => ({
+  broadcastAgentActivity: mock(async () => undefined),
+  broadcastChatMessage: mock(async () => undefined),
+  broadcastToChannel: mock(async () => undefined),
+  cachedDb: {
+    invalidateUserCache: invalidateUserCacheMock,
+  },
+}));
+
+mock.module('@babylon/core/markets/perps', () => ({
+  PerpDbAdapter: class {},
+  PerpMarketService: class {},
+}));
+
+mock.module('@babylon/core/markets/prediction', () => ({
+  PredictionDbAdapter: class {},
+  PredictionMarketService: class {},
+}));
+
+mock.module('@babylon/engine', () => ({
+  FEE_CONFIG: {
+    TRADING_FEE_RATE: 0,
+    PLATFORM_SHARE: 0,
+    REFERRER_SHARE: 0,
+    MIN_FEE_AMOUNT: 0,
+    FEE_TYPES: {},
+  },
+  FeeService: { processTradingFee: mock(async () => ({ feeCharged: 0 })) },
+  generateTagsFromPost: mock(async () => []),
+  invalidateAfterPredictionTrade: mock(async () => undefined),
+  PredictionPricing: {},
+  createPerpPriceImpactPort: mock(() => ({})),
+  StaticDataRegistry: { getActor: mock(() => null) },
+  storeTagsForPost: mock(async () => undefined),
+  WalletService: class {},
+}));
+
+mock.module('../../shared/logger', () => ({
+  logger: {
+    info: mock(() => undefined),
+    warn: mock(() => undefined),
+    debug: mock(() => undefined),
+    error: mock(() => undefined),
+  },
+}));
+
+mock.module('../../shared/snowflake', () => ({
+  generateSnowflakeId: mock(async () => 'snowflake-id'),
+}));
+
+mock.module('../../services/AgentPnLService', () => ({
+  agentPnLService: { recordTrade: mock(async () => undefined) },
+}));
+
+mock.module('../TopicDiversityService', () => ({
+  topicDiversityService: { trackPostTopics: mock(async () => undefined) },
+}));
+
+mock.module('../utils/resolvePerpTicker', () => ({
+  resolvePerpTicker: mock(() => null),
+}));
+
+const { executeDirectFollow, executeDirectUnfollow } = await import(
+  '../DirectExecutors'
+);
+
+describe('executeDirectFollow / executeDirectUnfollow', () => {
+  beforeEach(() => {
+    mockTargetUser = { id: 'target-user', isActor: false };
+    shouldCreateFollow = true;
+    deleteReturningRows = [{ id: 'follow-1' }];
+    invalidateUserCacheMock.mockClear();
+  });
+
+  test('follows a valid target user and invalidates caches', async () => {
+    const result = await executeDirectFollow({
+      agentUserId: 'agent-1',
+      targetUserId: 'target-user',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.followed).toBe(true);
+    expect(result.alreadyFollowing).toBe(false);
+    expect(invalidateUserCacheMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('returns idempotent success when already following', async () => {
+    shouldCreateFollow = false;
+
+    const result = await executeDirectFollow({
+      agentUserId: 'agent-1',
+      targetUserId: 'target-user',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.followed).toBe(false);
+    expect(result.alreadyFollowing).toBe(true);
+    expect(invalidateUserCacheMock).not.toHaveBeenCalled();
+  });
+
+  test('rejects FOLLOW for actor targets', async () => {
+    mockTargetUser = { id: 'npc-1', isActor: true };
+
+    const result = await executeDirectFollow({
+      agentUserId: 'agent-1',
+      targetUserId: 'npc-1',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('users/agents only');
+  });
+
+  test('unfollow is idempotent when no relationship exists', async () => {
+    deleteReturningRows = [];
+
+    const result = await executeDirectUnfollow({
+      agentUserId: 'agent-1',
+      targetUserId: 'target-user',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.unfollowed).toBe(false);
+    expect(result.wasFollowing).toBe(false);
+    expect(invalidateUserCacheMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/agents/src/autonomous/__tests__/direct-follow.test.ts
+++ b/packages/agents/src/autonomous/__tests__/direct-follow.test.ts
@@ -175,6 +175,74 @@ describe('executeDirectFollow / executeDirectUnfollow', () => {
     expect(result.error).toContain('users/agents only');
   });
 
+  test('rejects FOLLOW when targetUserId is empty', async () => {
+    const result = await executeDirectFollow({
+      agentUserId: 'agent-1',
+      targetUserId: '  ',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Target user ID is required');
+  });
+
+  test('rejects FOLLOW on self', async () => {
+    const result = await executeDirectFollow({
+      agentUserId: 'agent-1',
+      targetUserId: 'agent-1',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Cannot follow yourself');
+  });
+
+  test('rejects FOLLOW when target user does not exist', async () => {
+    mockTargetUser = null;
+
+    const result = await executeDirectFollow({
+      agentUserId: 'agent-1',
+      targetUserId: 'nonexistent',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('User not found');
+  });
+
+  test('rejects UNFOLLOW on self', async () => {
+    const result = await executeDirectUnfollow({
+      agentUserId: 'agent-1',
+      targetUserId: 'agent-1',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Cannot unfollow yourself');
+  });
+
+  test('rejects UNFOLLOW for actor targets', async () => {
+    mockTargetUser = { id: 'npc-1', isActor: true };
+
+    const result = await executeDirectUnfollow({
+      agentUserId: 'agent-1',
+      targetUserId: 'npc-1',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('users/agents only');
+  });
+
+  test('unfollows an existing relationship and invalidates caches', async () => {
+    deleteReturningRows = [{ id: 'follow-1' }];
+
+    const result = await executeDirectUnfollow({
+      agentUserId: 'agent-1',
+      targetUserId: 'target-user',
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.unfollowed).toBe(true);
+    expect(result.wasFollowing).toBe(true);
+    expect(invalidateUserCacheMock).toHaveBeenCalledTimes(2);
+  });
+
   test('unfollow is idempotent when no relationship exists', async () => {
     deleteReturningRows = [];
 

--- a/packages/agents/src/autonomous/__tests__/direct-repost.test.ts
+++ b/packages/agents/src/autonomous/__tests__/direct-repost.test.ts
@@ -30,6 +30,7 @@ mock.module('@babylon/db', () => ({
   db: mockDb,
   dmAcceptances: {},
   eq: (a: unknown, b: unknown) => ({ a, b }),
+  follows: { id: 'id', followerId: 'followerId', followingId: 'followingId' },
   gte: (...args: unknown[]) => args,
   isNull: (...args: unknown[]) => args,
   messages: {},
@@ -50,6 +51,9 @@ mock.module('@babylon/api', () => ({
   broadcastAgentActivity: mock(async () => undefined),
   broadcastChatMessage: mock(async () => undefined),
   broadcastToChannel: mock(async () => undefined),
+  cachedDb: {
+    invalidateUserCache: mock(async () => undefined),
+  },
 }));
 
 mock.module('@babylon/core/markets/perps', () => ({
@@ -74,6 +78,7 @@ mock.module('@babylon/engine', () => ({
   generateTagsFromPost: mock(async () => []),
   invalidateAfterPredictionTrade: mock(async () => undefined),
   PredictionPricing: {},
+  createPerpPriceImpactPort: mock(() => ({})),
   StaticDataRegistry: { getActor: mock(() => null) },
   storeTagsForPost: mock(async () => undefined),
   WalletService: class {},

--- a/packages/agents/src/autonomous/__tests__/prediction-price-history.test.ts
+++ b/packages/agents/src/autonomous/__tests__/prediction-price-history.test.ts
@@ -173,6 +173,9 @@ mock.module('@babylon/api', () => ({
       broadcastedMarketsEvents.push(payload);
     }
   ),
+  cachedDb: {
+    invalidateUserCache: mock(async () => undefined),
+  },
 }));
 
 mock.module('@babylon/core/markets/perps', () => ({
@@ -200,6 +203,7 @@ mock.module('@babylon/engine', () => ({
   PredictionPricing: {
     getCurrentPrice: mock(() => 0.5),
   },
+  createPerpPriceImpactPort: mock(() => ({})),
   StaticDataRegistry: {
     getActor: () => null,
     getAllOrganizations: () => [],
@@ -233,6 +237,7 @@ mock.module('@babylon/db', () => ({
   db: mockDb,
   dmAcceptances: {},
   eq: (a: unknown, b: unknown) => ({ a, b }),
+  follows: { id: 'id', followerId: 'followerId', followingId: 'followingId' },
   gte: (a: unknown, b: unknown) => ({ a, b }),
   isNull: (a: unknown) => ({ a }),
   markets,

--- a/packages/agents/src/autonomous/templates/multi-step-decision.ts
+++ b/packages/agents/src/autonomous/templates/multi-step-decision.ts
@@ -111,6 +111,8 @@ export const Actions = {
   REPLY_COMMENT: 'REPLY_COMMENT',
   LIKE: 'LIKE',
   REPOST: 'REPOST',
+  FOLLOW: 'FOLLOW',
+  UNFOLLOW: 'UNFOLLOW',
   REPLY_CHAT: 'REPLY_CHAT',
   DM: 'DM',
   GROUP_MESSAGE: 'GROUP_MESSAGE',
@@ -205,6 +207,24 @@ export const ACTION_DEFINITIONS: Record<ActionName, ActionDefinition> = {
     parameterSchema: `{
   "postId": "exact_post_id_from_list",
   "comment": "optional quote comment (your take)"
+}`,
+  },
+  [Actions.FOLLOW]: {
+    name: Actions.FOLLOW,
+    description: 'Follow a user or agent',
+    requiredFeature: Features.ENGAGING,
+    parameters: ['userId'],
+    parameterSchema: `{
+  "userId": "exact_user_id_from_recent_posts_or_context"
+}`,
+  },
+  [Actions.UNFOLLOW]: {
+    name: Actions.UNFOLLOW,
+    description: 'Unfollow a user or agent',
+    requiredFeature: Features.ENGAGING,
+    parameters: ['userId'],
+    parameterSchema: `{
+  "userId": "exact_user_id_you_currently_follow"
 }`,
   },
   [Actions.REPLY_CHAT]: {
@@ -494,6 +514,9 @@ ${NPC_POST_QUALITY_RULES}
   const canEngage = context.enabledFeatures.includes(Features.ENGAGING);
   const canPost = context.enabledFeatures.includes(Features.POSTING);
   const canGroupChat = context.enabledFeatures.includes(Features.GROUP_CHATS);
+  const justCoordinatedInGroup = traceActionResults.some(
+    (r) => r.actionType === Actions.GROUP_MESSAGE && r.success
+  );
 
   // Check if already posted this tick (for prompt messaging, not feature filtering)
   const hasPostedThisTick = traceActionResults.some(
@@ -551,6 +574,16 @@ ${
     : ''
 }`
       : '';
+  const groupChatCoordinationEncouragement =
+    justCoordinatedInGroup && canPost
+      ? `
+# 👀 Surface Group Coordination
+You just coordinated in a group chat. Make this visible in the public feed:
+- Share a public-safe takeaway (no private details)
+- Turn private discussion into a clear market angle
+- Keep it short and concrete
+`
+      : '';
 
   // Action priority guidance - differs between NPCs and player agents
   // NPCs: Balanced priorities (trading, posting, engagement)
@@ -592,6 +625,12 @@ ${
   if (canEngage) {
     priorityActions.push('LIKE posts you find interesting');
     priorityActions.push('REPOST valuable content');
+    priorityActions.push(
+      'FOLLOW users/agents you consistently agree with or engage with'
+    );
+    priorityActions.push(
+      'UNFOLLOW users/agents when they are no longer relevant to your strategy'
+    );
   }
   if (canGroupChat) {
     priorityActions.push('GROUP_MESSAGE to discuss with your community');
@@ -680,11 +719,13 @@ ${formatPredictionMarkets(context.predictionMarkets)}
 ${formatPerpMarkets(context.perpMarkets)}`
     : '';
 
-  // Show recent posts if commenting OR DMs enabled (need posts to discover users for DMs)
-  const showRecentPosts = canComment || canRespondDMs;
+  // Show recent posts if commenting, engaging, or DMs enabled (used to discover users)
+  const showRecentPosts = canComment || canRespondDMs || canEngage;
   const recentPostsHeader = canComment
-    ? '# Recent Posts (can comment on or DM authors)'
-    : '# Recent Posts (can DM authors)';
+    ? '# Recent Posts (can comment on, follow, or DM authors)'
+    : canRespondDMs
+      ? '# Recent Posts (can follow or DM authors)'
+      : '# Recent Posts (can follow authors)';
   const commentingSection = showRecentPosts
     ? `
 ${recentPostsHeader}
@@ -732,7 +773,7 @@ ${context.contextRefreshSummary}
     : '';
 
   return `You are ${agentName}, an autonomous agent on Babylon prediction markets.
-${creatorSection}${npcContextSection}${tradePostEncouragement}# Current Execution Context
+${creatorSection}${npcContextSection}${tradePostEncouragement}${groupChatCoordinationEncouragement}# Current Execution Context
 **Step**: ${iterationCount}/${maxIterations}
 **Actions Completed This Tick**: ${traceActionResults.length}
 
@@ -780,7 +821,7 @@ ${context.assignedMarketId && canTrade ? `# YOUR FOCUS MARKET: ${context.assigne
 ${canTrade && !isNpc ? '7. **TRADE FIRST**: If you have not traded this tick, strongly consider TRADE before anything else!' : ''}
 ${canTrade && isNpc ? '7. **BALANCED ACTIONS**: Trading, posting, and engaging are all valuable. Follow your intuitions.' : ''}
 ${canComment && !isNpc ? '8. **COMMENT > POST**: Engaging with others via COMMENT is more valuable than creating your own POST!' : ''}
-${hasPostedThisTick ? `9. **NO MORE POSTS**: You already posted. Choose ${[canTrade ? 'TRADE' : '', canComment ? 'COMMENT' : '', canEngage ? 'LIKE' : '', canEngage ? 'REPOST' : '', 'FINISH'].filter(Boolean).join(', ')} instead.` : ''}
+${hasPostedThisTick ? `9. **NO MORE POSTS**: You already posted. Choose ${[canTrade ? 'TRADE' : '', canComment ? 'COMMENT' : '', canEngage ? 'LIKE' : '', canEngage ? 'REPOST' : '', canEngage ? 'FOLLOW' : '', canEngage ? 'UNFOLLOW' : '', 'FINISH'].filter(Boolean).join(', ')} instead.` : ''}
 ${!isNpc && canPost && !hasPostedThisTick ? '10. **AVOID POSTING**: As a player agent, you should almost NEVER post. Trade, comment, like, or repost instead!' : ''}
 
 # Action Ideas (in order of priority)
@@ -789,6 +830,8 @@ ${canTrade && isNpc ? '- **TRADE**: Take a position based on your intuitions' : 
 ${canComment ? "- ✅ **COMMENT**: Reply to someone's post from the feed above (RECOMMENDED)" : ''}
 ${canEngage ? '- ✅ **LIKE**: Show appreciation for a post you find interesting' : ''}
 ${canEngage ? "- ✅ **REPOST**: Share someone else's post with your take" : ''}
+${canEngage ? '- ✅ **FOLLOW**: Follow users/agents you want in your social graph (use userId from Recent Posts)' : ''}
+${canEngage ? '- ✅ **UNFOLLOW**: Unfollow users/agents that are no longer relevant' : ''}
 ${canComment ? '- 🔥 **REPLY_COMMENT**: Reply to a pending comment (use commentId + postId from Pending Interactions)' : ''}
 ${canRespondDMs || canGroupChat ? '- 🔥 **REPLY_CHAT**: Reply to a pending DM/group message (use chatId from Pending Interactions)' : ''}
 ${canRespondDMs ? '- **DM**: Start a NEW conversation with someone (use their userId from Recent Posts)' : ''}
@@ -825,7 +868,7 @@ Examples:
 # Output Format (JSON only, no markdown)
 {
   "thought": "Brief reasoning for this decision",
-  "action": "${[canTrade ? 'TRADE' : '', canPost ? 'POST' : '', canComment ? 'COMMENT' : '', canComment ? 'REPLY_COMMENT' : '', canEngage ? 'LIKE' : '', canEngage ? 'REPOST' : '', canRespondDMs || canGroupChat ? 'REPLY_CHAT' : '', canRespondDMs ? 'DM' : '', canGroupChat ? 'GROUP_MESSAGE' : '', 'FINISH'].filter(Boolean).join(' | ')}",
+  "action": "${[canTrade ? 'TRADE' : '', canPost ? 'POST' : '', canComment ? 'COMMENT' : '', canComment ? 'REPLY_COMMENT' : '', canEngage ? 'LIKE' : '', canEngage ? 'REPOST' : '', canEngage ? 'FOLLOW' : '', canEngage ? 'UNFOLLOW' : '', canRespondDMs || canGroupChat ? 'REPLY_CHAT' : '', canRespondDMs ? 'DM' : '', canGroupChat ? 'GROUP_MESSAGE' : '', 'FINISH'].filter(Boolean).join(' | ')}",
   "parameters": { /* action-specific, see below */ },
   "isFinish": false
 }

--- a/packages/agents/src/runtime/AgentRuntimeManager.ts
+++ b/packages/agents/src/runtime/AgentRuntimeManager.ts
@@ -330,9 +330,10 @@ export class AgentRuntimeManager {
         .toFixed(2)
     );
     const runtimeAgeHours = Number(
-      ((refreshEndedAt.getTime() - lifecycle.createdAtMs) / MS_PER_HOUR).toFixed(
-        2
-      )
+      (
+        (refreshEndedAt.getTime() - lifecycle.createdAtMs) /
+        MS_PER_HOUR
+      ).toFixed(2)
     );
 
     const user = userSnapshot[0];

--- a/packages/agents/src/services/AgentService.ts
+++ b/packages/agents/src/services/AgentService.ts
@@ -1050,7 +1050,8 @@ export class AgentServiceV2 {
         | 'comment'
         | 'dm'
         | 'like'
-        | 'repost';
+        | 'repost'
+        | 'follow';
       level: 'info' | 'warn' | 'error' | 'debug';
       message: string;
       prompt?: string;

--- a/packages/testing/unit/cron/article-tick.test.ts
+++ b/packages/testing/unit/cron/article-tick.test.ts
@@ -7,10 +7,10 @@ import {
   mock,
   test,
 } from 'bun:test';
+import { NextRequest } from 'next/server';
 import * as actualApiModule from '../../../api/src/index';
 import * as actualDbModule from '../../../db/src/index';
 import * as actualEngineModule from '../../../engine/src/index';
-import { NextRequest } from 'next/server';
 
 /**
  * Article Tick Cron Job Tests
@@ -117,7 +117,7 @@ const createQueryBuilder = (
 const registerMocks = () => {
   // Mock @babylon/db - uses resultFn pattern for dynamic state evaluation
   mock.module('@babylon/db', () => ({
-      ...actualDbModule,
+    ...actualDbModule,
     db: {
       select: mock(() =>
         createQueryBuilder(() =>

--- a/packages/testing/unit/cron/markets-tick.test.ts
+++ b/packages/testing/unit/cron/markets-tick.test.ts
@@ -7,10 +7,10 @@ import {
   mock,
   test,
 } from 'bun:test';
+import { NextRequest } from 'next/server';
 import * as actualApiModule from '../../../api/src/index';
 import * as actualDbModule from '../../../db/src/index';
 import * as actualEngineModule from '../../../engine/src/index';
-import { NextRequest } from 'next/server';
 
 /**
  * Markets Tick Cron Job Tests
@@ -396,10 +396,7 @@ const registerMocks = () => {
     },
     QuestionManager: class MockQuestionManager {
       constructor(_llmClient: unknown) {}
-      async generateTimeframeQuestion(
-        _timeframe: string,
-        _durationMs: number
-      ) {
+      async generateTimeframeQuestion(_timeframe: string, _durationMs: number) {
         return {
           text: 'Will AIlon Musk launch a new product?',
           expectedOutcome: true,


### PR DESCRIPTION
## Summary

- Add autonomous `FOLLOW` and `UNFOLLOW` actions to the multi-step agent decision loop.
- Implement direct follow/unfollow executors with guardrails (no self-follow, no NPC actor targets, idempotent behavior).
- Improve social visibility guidance by nudging agents to surface group-chat coordination in the public feed via public-safe posts.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: [BAB-198](https://linear.app/eliza-labs/issue/BAB-198/agents-should-be-more-social-and-coordinated-enable-following-and-feed)

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [x] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [x] Other: `packages/agents` autonomous unit tests

## Changes

- Added `FOLLOW` / `UNFOLLOW` to autonomous action registry and prompt schemas.
- Extended action-priority guidance so agents can build and prune their social graph.
- Added group-chat-to-feed surfacing guidance (public-safe summary nudge after coordination).
- Added `executeDirectFollow` / `executeDirectUnfollow`:
  - validates target user existence
  - blocks self-follow and actor-target follow/unfollow
  - uses idempotent semantics for duplicate follow/unfollow
  - invalidates relevant user caches on state change
- Wired new actions into `MultiStepExecutor` switch + result aggregation (`engagements`).
- Added new unit test file for direct follow/unfollow executor behavior.
- Updated existing DirectExecutors test mocks to include newly required exports.

## Review guide

**Start here**
- `packages/agents/src/autonomous/templates/multi-step-decision.ts`
- `packages/agents/src/autonomous/MultiStepExecutor.ts`
- `packages/agents/src/autonomous/DirectExecutors.ts`
- `packages/agents/src/autonomous/__tests__/direct-follow.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- This keeps scope intentionally within autonomous agent execution and prompt/action selection.
- Non-goal in this PR: introducing a new dedicated feed event type for follow actions.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual/targeted checks run**
1. `bunx biome check packages/agents/src/autonomous/templates/multi-step-decision.ts packages/agents/src/autonomous/MultiStepExecutor.ts packages/agents/src/autonomous/DirectExecutors.ts packages/agents/src/autonomous/__tests__/direct-follow.test.ts packages/agents/src/autonomous/__tests__/direct-repost.test.ts packages/agents/src/autonomous/__tests__/prediction-price-history.test.ts`
2. `bun test packages/agents/src/autonomous/__tests__/direct-follow.test.ts`
3. `bun test packages/agents/src/autonomous/__tests__/direct-repost.test.ts`

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `…`
- Changed: `…`
- Removed: `…`

**DB / data migration**
- Migration(s): `…`
- Backfill/seed: `…` (command/script + expected runtime)

**Rollout / rollback plan**
- Rollout: regular deploy.
- Rollback: revert this PR.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- …

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- No external API contract change.

### Database
- No schema changes.

### Contracts / on-chain
- N/A.

### Docs
- N/A.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend/autonomous-agent behavior change, no direct UI component changes in this PR.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
