### PR TITLE
fix: resolve typecheck failures in onchain-service

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,7 @@
     "lint": "biome lint .",
     "lint:fix": "biome check --write .",
     "format": "biome format --write .",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "NODE_OPTIONS='--max-old-space-size=8192' tsc --noEmit",
     "clean": "rm -rf .next .turbo node_modules/.cache"
   },
   "dependencies": {

--- a/apps/web/src/components/shared/ComingSoon.tsx
+++ b/apps/web/src/components/shared/ComingSoon.tsx
@@ -28,13 +28,13 @@ import { createPortal } from 'react-dom';
 import { toast } from 'sonner';
 import { LinkSocialAccountsModal } from '@/components/profile/LinkSocialAccountsModal';
 import { Avatar } from '@/components/shared/Avatar';
-import { MarketingFooter } from '@/components/shared/MarketingFooter';
-import { PlayerStatsModal } from '@/components/shared/PlayerStatsModal';
 import {
   getPrimaryAccessLabel,
-  shouldAutoRedirectWhitelistedUser,
   type NftAccessState,
+  shouldAutoRedirectWhitelistedUser,
 } from '@/components/shared/comingSoonAccess';
+import { MarketingFooter } from '@/components/shared/MarketingFooter';
+import { PlayerStatsModal } from '@/components/shared/PlayerStatsModal';
 import { useAuth } from '@/hooks/useAuth';
 import { getAuthToken } from '@/lib/auth';
 import { EXTERNAL_LINKS } from '@/lib/constants';

--- a/apps/web/src/components/shared/comingSoonAccess.test.ts
+++ b/apps/web/src/components/shared/comingSoonAccess.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'bun:test';
 import {
   getPrimaryAccessLabel,
-  shouldAutoRedirectWhitelistedUser,
   type NftAccessState,
+  shouldAutoRedirectWhitelistedUser,
 } from './comingSoonAccess';
 
 describe('comingSoonAccess', () => {
@@ -13,9 +13,9 @@ describe('comingSoonAccess', () => {
         reason: 'whitelist',
       };
 
-      expect(
-        shouldAutoRedirectWhitelistedUser(true, 'user-1', nftAccess)
-      ).toBe(true);
+      expect(shouldAutoRedirectWhitelistedUser(true, 'user-1', nftAccess)).toBe(
+        true
+      );
     });
 
     it('returns false for non-whitelist access reasons', () => {

--- a/packages/api/src/services/onchain-service.ts
+++ b/packages/api/src/services/onchain-service.ts
@@ -25,6 +25,7 @@ import {
   identityRegistryAbi,
   logger,
   POINTS,
+  type PointsReason,
   reputationSystemAbi,
   ValidationError,
 } from '@babylon/shared';
@@ -100,7 +101,7 @@ type OnboardingServices = {
     awardPoints: (
       userId: string,
       amount: number,
-      reason: string,
+      reason: PointsReason,
       metadata?: StringRecord<JsonValue>
     ) => Promise<{
       success: boolean;
@@ -132,7 +133,7 @@ function getOnboardingServices(): OnboardingServices {
     onboardingServicesFallbackLogged = true;
   }
 
-  onboardingServicesInstance = {
+  const services: OnboardingServices = {
     notifyNewAccount,
     pointsService: {
       awardReferralSignup: PointsService.awardReferralSignup,
@@ -140,8 +141,9 @@ function getOnboardingServices(): OnboardingServices {
     },
     getOrCreateReferralCode,
   };
+  onboardingServicesInstance = services;
 
-  return onboardingServicesInstance;
+  return services;
 }
 
 // Get contract addresses based on environment


### PR DESCRIPTION
## Summary

- Fix two TypeScript errors in `onchain-service.ts`: mismatched `awardPoints` parameter type (`string` vs `PointsReason`) and a null-safety issue on the fallback return path.
- Fix `web` package typecheck consistently crashing with OOM by increasing the Node.js heap limit (matching the `build` script).

## Type

- [x] Bug fix
- [x] Infra / ops

## Context / Links

- `bun run typecheck` was failing across the monorepo due to these two independent issues.

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] API infra (`packages/api`)

## Changes

- `packages/api/src/services/onchain-service.ts`: Changed `OnboardingServices.awardPoints` parameter type from `string` to `PointsReason` to match `PointsService.awardPoints` signature. Introduced a typed local variable in `getOnboardingServices()` to avoid returning a value still typed as `| null`.
- `apps/web/package.json`: Added `NODE_OPTIONS='--max-old-space-size=8192'` to the `typecheck` script (already present on the `build` script).
- `apps/web/src/components/shared/ComingSoon.tsx`, `comingSoonAccess.test.ts`: Import sort order and formatting (Biome auto-fix).

## Review guide

**Start here**
- `packages/api/src/services/onchain-service.ts`

**Risk**
- [x] Low

**Notes for reviewers**
- The `PointsReason` type change is safe — `PointsService.awardPoints` already required this type; the `OnboardingServices` interface was simply lagging behind.
- The OOM fix mirrors the existing `build` script approach.

## Test plan

**Commands run**
- [x] `bun run typecheck`
- [x] `bun run test` (unit + integration)

**Manual verification**
1. `bun run typecheck` now passes all 16 packages (previously failed on `@babylon/api` and `web`).

## Ops / Migration / Deployment

- [x] No deploy impact

## Breaking changes

- [x] None

## Security / privacy

- [x] No security impact

### Option B: No visual changes

- Reason: Type-level fix and build config change, no UI impact.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)