### PR TITLE
testing: fix agent-tick-db unit crash from server-only import ordering

### DIFF
--- a/packages/testing/unit/cron/agent-tick-db.test.ts
+++ b/packages/testing/unit/cron/agent-tick-db.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { NextRequest } from 'next/server';
+import * as actualDbModule from '../../../db/src/index';
 
 /**
  * Mock game state type
@@ -50,6 +51,8 @@ interface SqlCondition {
 // Mock db with a mutable state we can control in tests
 let mockGame: MockGame | null = null;
 
+mock.module('server-only', () => ({}));
+
 // Create a complete mock that includes schema exports
 mock.module('@babylon/db', () => {
   const createModelMock = (overrides: Partial<MockModel> = {}): MockModel => ({
@@ -96,6 +99,7 @@ mock.module('@babylon/db', () => {
   };
 
   return {
+    ...actualDbModule,
     db: {
       game: createModelMock(),
       user: createModelMock(),
@@ -200,10 +204,18 @@ mock.module('@babylon/api/services/cron-relay-service', () => ({
   relayCronToStaging: async () => ({ forwarded: false }),
 }));
 
+mock.module('@/lib/engine/ensure-engine-services', () => ({
+  ensureEngineServices: () => {},
+}));
+
 // Import the route handler after mocks are set up
-import { POST } from '@/app/api/cron/agent-tick/route';
+const { POST } = await import('@/app/api/cron/agent-tick/route');
 
 describe('Agent Tick Cron - DB State', () => {
+  afterAll(() => {
+    mock.restore();
+  });
+
   beforeEach(() => {
     mockGame = null;
   });


### PR DESCRIPTION
## Summary
- load the `agent-tick` route via top-level dynamic import so test mocks are registered before module evaluation
- mock `server-only` and `@/lib/engine/ensure-engine-services` in the unit test to prevent server-component guards from crashing Bun unit runs
- preserve full `@babylon/db` export compatibility by spreading actual module exports and overriding only test-specific members
- add `afterAll(() => mock.restore())` to avoid cross-suite mock leakage

## Problem
`agent-tick-db.test.ts` could fail before executing any tests due to module-load order and incomplete mocked exports.

## Validation
- `bun test packages/testing/unit/cron/agent-tick-db.test.ts --preload ./packages/testing/unit/preload.ts` (pass)
- `bun test packages/testing/unit/cron/article-tick.test.ts packages/testing/unit/cron/markets-tick.test.ts packages/testing/unit/cron/agent-tick-db.test.ts --preload ./packages/testing/unit/preload.ts` (pass)
- `bun run --cwd packages/testing lint` (pass)
- `bun run --cwd packages/testing typecheck` fails only on existing baseline `onchain-service.ts` errors (addressed separately in #1134)
