### PR TITLE
a2a: disable streaming in generated agent cards

### DIFF
--- a/packages/a2a/src/sdk/agent-card-generator.ts
+++ b/packages/a2a/src/sdk/agent-card-generator.ts
@@ -105,7 +105,7 @@ function createAgentCardObject(
     documentationUrl: `${BASE_URL}/docs`,
 
     capabilities: {
-      streaming: true,
+      streaming: false,
       pushNotifications: false,
       stateTransitionHistory: true,
     },


### PR DESCRIPTION
## Summary
- set generated A2A agent card capability `streaming` to `false` in `generateAgentCardSync`/shared card builder
- align generated per-agent cards with Babylon's declared protocol capability expectations

## Problem
The generated agent card advertised `streaming: true`, but Babylon card behavior/tests require streaming to be disabled. This produced deterministic unit failures and capability mismatch.

## Validation
- `bun test packages/testing/unit/a2a/agent-card-generator.test.ts --preload ./packages/testing/unit/preload.ts` (pass)
- `bun test packages/testing/unit/a2a/babylon-agent-card.test.ts --preload ./packages/testing/unit/preload.ts` (pass)
