### PR TITLE
testing: align formatCurrency negative sign expectations

### DIFF
--- a/packages/testing/unit/shared/format.test.ts
+++ b/packages/testing/unit/shared/format.test.ts
@@ -150,9 +150,9 @@ describe('Format Utilities', () => {
     });
 
     it('should handle negative numbers correctly', () => {
-      // Sign should come before the symbol
-      expect(formatCurrency(-100)).toBe('-ƀ100.00');
-      expect(formatCurrency(-1234.56)).toBe('-ƀ1234.56');
+      // Shared formatter keeps symbol first for positive and negative values.
+      expect(formatCurrency(-100)).toBe('ƀ-100.00');
+      expect(formatCurrency(-1234.56)).toBe('ƀ-1234.56');
     });
 
     it('should handle edge cases with thousands separators', () => {
@@ -161,7 +161,7 @@ describe('Format Utilities', () => {
         'ƀ999.00'
       );
       expect(formatCurrency(-1234.56, { useThousandsSeparator: true })).toBe(
-        '-ƀ1,234.56'
+        'ƀ-1,234.56'
       );
     });
   });


### PR DESCRIPTION
## Summary
- update `packages/testing/unit/shared/format.test.ts` negative-currency expectations to match canonical formatter output (`ƀ-...`)
- keep assertion behavior consistent with existing shared currency tests and runtime formatter semantics

## Problem
`format.test.ts` expected negative values as `-ƀ...`, but the shared formatter intentionally returns `ƀ-...`. This caused deterministic unit failures in the full suite.

## Validation
- `bun test packages/testing/unit/shared/format.test.ts --preload ./packages/testing/unit/preload.ts` (pass)
- `bun test packages/testing/unit/shared/format-currency.test.ts --preload ./packages/testing/unit/preload.ts` (pass)
