### PR TITLE
feat(ui): polish chats, rewards, and group modals for mobile

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -369,15 +369,6 @@ button:disabled {
   box-shadow: inset 5px 5px 5px rgba(0, 0, 0, 0.1), inset -5px -5px 5px rgba(255, 255, 255, 0.05);
 }
 
-.chat-button {
-  box-shadow: inset 3px 3px 3px rgba(0, 0, 0, 0.1), inset -3px -3px 3px rgba(255, 255, 255, 0.05);
-  transition: all 0.3s ease;
-}
-
-.chat-button:hover:not(:disabled) {
-  box-shadow: none;
-}
-
 .message-input {
   box-shadow: none;
 }
@@ -398,10 +389,6 @@ button:disabled {
 /* Dark mode adjustments for chat styles */
 .dark .chat-card {
   box-shadow: inset 5px 5px 5px rgba(0, 0, 0, 0.3), inset -5px -5px 5px rgba(255, 255, 255, 0.02);
-}
-
-.dark .chat-button {
-  box-shadow: inset 3px 3px 3px rgba(0, 0, 0, 0.3), inset -3px -3px 3px rgba(255, 255, 255, 0.02);
 }
 
 .dark .message-input {

--- a/apps/web/src/app/rewards/page.tsx
+++ b/apps/web/src/app/rewards/page.tsx
@@ -664,20 +664,7 @@ export default function RewardsPage() {
             </div>
 
             {/* Stats Row */}
-            <div className="grid grid-cols-3 gap-2 sm:gap-3">
-              {/* Total Earned */}
-              <div className="rounded-lg border border-border p-3">
-                <div className="mb-1 flex items-center gap-1">
-                  <Award className="h-4 w-4 text-yellow-500" />
-                  <h2 className="font-medium text-muted-foreground text-xs">
-                    Earned
-                  </h2>
-                </div>
-                <div className="font-bold text-2xl text-yellow-500">
-                  {calculateTotalEarned().toLocaleString()}
-                </div>
-              </div>
-
+            <div className="space-y-2 sm:grid sm:grid-cols-3 sm:gap-3 sm:space-y-0">
               {/* Total Points */}
               <div className="rounded-lg border border-border p-3">
                 <div className="mb-1 flex items-center gap-1">
@@ -693,55 +680,70 @@ export default function RewardsPage() {
                 </div>
               </div>
 
-              {/* Total Referrals */}
-              <div className="rounded-lg border border-border p-3">
-                <div className="mb-1 flex items-center gap-1">
-                  <Users className="h-4 w-4 text-primary" />
-                  <h2 className="font-medium text-muted-foreground text-xs">
-                    Referrals
-                  </h2>
+              <div className="grid grid-cols-2 gap-2 sm:contents">
+                {/* Total Earned */}
+                <div className="rounded-lg border border-border p-3">
+                  <div className="mb-1 flex items-center gap-1">
+                    <Award className="h-4 w-4 text-yellow-500" />
+                    <h2 className="font-medium text-muted-foreground text-xs">
+                      Earned
+                    </h2>
+                  </div>
+                  <div className="font-bold text-2xl text-yellow-500">
+                    {calculateTotalEarned().toLocaleString()}
+                  </div>
                 </div>
-                <div className="font-bold text-2xl text-foreground">
-                  {referralData.stats.totalReferrals}
+
+                {/* Total Referrals */}
+                <div className="rounded-lg border border-border p-3">
+                  <div className="mb-1 flex items-center gap-1">
+                    <Users className="h-4 w-4 text-primary" />
+                    <h2 className="font-medium text-muted-foreground text-xs">
+                      Referrals
+                    </h2>
+                  </div>
+                  <div className="font-bold text-2xl text-foreground">
+                    {referralData.stats.totalReferrals}
+                  </div>
+                  {referralData.stats.weeklyReferralCount !== undefined &&
+                    referralData.stats.weeklyLimit !== undefined && (
+                      <div className="mt-1.5 border-border border-t pt-1.5">
+                        <div className="mb-0.5 flex items-center justify-between text-xs">
+                          <span className="text-muted-foreground">Week</span>
+                          <span
+                            className={`font-semibold ${
+                              referralData.stats.weeklyReferralCount >=
+                              referralData.stats.weeklyLimit
+                                ? 'text-red-500'
+                                : referralData.stats.weeklyReferralCount >=
+                                    referralData.stats.weeklyLimit * 0.8
+                                  ? 'text-yellow-500'
+                                  : 'text-foreground'
+                            }`}
+                          >
+                            {referralData.stats.weeklyReferralCount}/
+                            {referralData.stats.weeklyLimit}
+                          </span>
+                        </div>
+                        <div className="h-1 w-full rounded-full bg-background">
+                          <div
+                            className={`h-1 rounded-full transition-all ${
+                              referralData.stats.weeklyReferralCount >=
+                              referralData.stats.weeklyLimit
+                                ? 'bg-red-500'
+                                : referralData.stats.weeklyReferralCount >=
+                                    referralData.stats.weeklyLimit * 0.8
+                                  ? 'bg-yellow-500'
+                                  : 'bg-primary'
+                            }`}
+                            style={{
+                              width: `${Math.min(100, (referralData.stats.weeklyReferralCount / referralData.stats.weeklyLimit) * 100)}%`,
+                            }}
+                          />
+                        </div>
+                      </div>
+                    )}
                 </div>
-                {referralData.stats.weeklyReferralCount !== undefined &&
-                  referralData.stats.weeklyLimit !== undefined && (
-                    <div className="mt-1.5 border-border border-t pt-1.5">
-                      <div className="mb-0.5 flex items-center justify-between text-xs">
-                        <span className="text-muted-foreground">Week</span>
-                        <span
-                          className={`font-semibold ${
-                            referralData.stats.weeklyReferralCount >=
-                            referralData.stats.weeklyLimit
-                              ? 'text-red-500'
-                              : referralData.stats.weeklyReferralCount >=
-                                  referralData.stats.weeklyLimit * 0.8
-                                ? 'text-yellow-500'
-                                : 'text-foreground'
-                          }`}
-                        >
-                          {referralData.stats.weeklyReferralCount}/
-                          {referralData.stats.weeklyLimit}
-                        </span>
-                      </div>
-                      <div className="h-1 w-full rounded-full bg-background">
-                        <div
-                          className={`h-1 rounded-full transition-all ${
-                            referralData.stats.weeklyReferralCount >=
-                            referralData.stats.weeklyLimit
-                              ? 'bg-red-500'
-                              : referralData.stats.weeklyReferralCount >=
-                                  referralData.stats.weeklyLimit * 0.8
-                                ? 'bg-yellow-500'
-                                : 'bg-primary'
-                          }`}
-                          style={{
-                            width: `${Math.min(100, (referralData.stats.weeklyReferralCount / referralData.stats.weeklyLimit) * 100)}%`,
-                          }}
-                        />
-                      </div>
-                    </div>
-                  )}
               </div>
             </div>
 
@@ -824,8 +826,6 @@ export default function RewardsPage() {
                 </button>
               </div>
             </div>
-
-            <Separator />
 
             {/* Referral Link */}
             <div className="rounded-lg border border-border p-4">

--- a/apps/web/src/components/chats/ChatHeader.tsx
+++ b/apps/web/src/components/chats/ChatHeader.tsx
@@ -20,7 +20,7 @@ export function ChatHeader({
 }: ChatHeaderProps) {
   return (
     <div className="px-4 py-3">
-      <div className="mb-4 flex items-center justify-between">
+      <div className="mb-2 flex items-center justify-between">
         <div className="flex items-center gap-2">
           <h2 className="font-bold text-foreground text-xl">Messages</h2>
           {isConnected ? (
@@ -52,7 +52,7 @@ export function ChatHeader({
       </div>
 
       {/* Filter Tabs */}
-      <div className="mb-4 flex items-center border-border border-b">
+      <div className="flex items-center border-border border-b">
         <button
           onClick={() => onFilterChange('all')}
           aria-label="Show all conversations"

--- a/apps/web/src/components/chats/ChatListItem.tsx
+++ b/apps/web/src/components/chats/ChatListItem.tsx
@@ -37,7 +37,7 @@ export function ChatListItem({
     >
       <div className="flex items-center gap-3">
         {chat.isGroup ? (
-          <div className="chat-button flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-sidebar-accent/50">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-sidebar-accent/50">
             <Users className="h-5 w-5 text-primary" />
           </div>
         ) : (

--- a/apps/web/src/components/chats/ChatViewHeader.tsx
+++ b/apps/web/src/components/chats/ChatViewHeader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArrowLeft, Loader2, Settings, Users } from 'lucide-react';
+import { ArrowLeft, Loader2, Settings } from 'lucide-react';
 import Link from 'next/link';
 import { Avatar } from '@/components/shared/Avatar';
 import { Button } from '@/components/ui/button';
@@ -23,24 +23,20 @@ export function ChatViewHeader({
   onManageGroup,
 }: ChatViewHeaderProps) {
   return (
-    <div className="overflow-hidden bg-background px-4 py-4">
+    <div className="overflow-hidden bg-background px-4 py-2 md:py-4">
       <div className="flex min-w-0 items-center gap-3">
         {showBackButton && (
           <button
             onClick={onBack}
-            className="flex items-center gap-2 rounded-md px-3 py-1.5 font-medium text-foreground text-sm transition-colors hover:bg-sidebar-accent/50 lg:hidden"
+            className="rounded-md p-1.5 text-foreground transition-colors hover:bg-sidebar-accent/50 lg:hidden"
+            aria-label="Back"
           >
-            <ArrowLeft className="h-4 w-4" />
-            Back
+            <ArrowLeft className="h-5 w-5" />
           </button>
         )}
 
-        {/* Avatar */}
-        {chatDetails.chat.isGroup ? (
-          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-sidebar-accent/50">
-            <Users className="h-5 w-5 text-primary" />
-          </div>
-        ) : chatDetails.chat.otherUser ? (
+        {/* Avatar (DM only) */}
+        {chatDetails.chat.isGroup ? null : chatDetails.chat.otherUser ? (
           <Link
             href={getProfilePath(chatDetails.chat.otherUser)}
             className="transition-opacity hover:opacity-80"
@@ -59,24 +55,27 @@ export function ChatViewHeader({
 
         {/* Chat name and status */}
         <div className="min-w-0 flex-1">
-          <div className="flex min-w-0 items-center gap-2">
-            {chatDetails.chat.isGroup ? (
-              <h3 className="truncate font-bold text-foreground text-lg">
-                {chatDetails.chat.name || 'Chat'}
-              </h3>
-            ) : chatDetails.chat.otherUser ? (
-              <Link
-                href={getProfilePath(chatDetails.chat.otherUser)}
-                className="truncate font-bold text-foreground text-lg transition-colors hover:text-primary"
-              >
-                {chatDetails.chat.otherUser.displayName || 'Chat'}
-              </Link>
-            ) : (
-              <h3 className="truncate font-bold text-foreground text-lg">
-                Chat
-              </h3>
-            )}
+          {chatDetails.chat.isGroup ? (
+            <h3 className="truncate font-bold text-foreground text-lg">
+              {chatDetails.chat.name || 'Chat'}
+            </h3>
+          ) : chatDetails.chat.otherUser ? (
+            <Link
+              href={getProfilePath(chatDetails.chat.otherUser)}
+              className="truncate font-bold text-foreground text-lg transition-colors hover:text-primary"
+            >
+              {chatDetails.chat.otherUser.displayName || 'Chat'}
+            </Link>
+          ) : (
+            <h3 className="truncate font-bold text-foreground text-lg">Chat</h3>
+          )}
 
+          <div className="-mt-0.5 flex items-center gap-2 md:mt-0">
+            {chatDetails.chat.isGroup && (
+              <span className="text-muted-foreground text-xs">
+                {chatDetails.participants.length} participants
+              </span>
+            )}
             {/* SSE status */}
             {sseConnected ? (
               <span
@@ -96,12 +95,6 @@ export function ChatViewHeader({
               </span>
             )}
           </div>
-
-          {chatDetails.chat.isGroup && (
-            <p className="text-muted-foreground text-xs">
-              {chatDetails.participants.length} participants
-            </p>
-          )}
         </div>
 
         {/* Group actions */}

--- a/apps/web/src/components/chats/MessageList.tsx
+++ b/apps/web/src/components/chats/MessageList.tsx
@@ -101,11 +101,32 @@ export function MessageList({
   if (loading) {
     return (
       <>
-        <div className="flex h-full items-center justify-center">
-          <div className="w-full max-w-md space-y-3">
-            <Skeleton className="h-16 w-full" />
-            <Skeleton className="h-16 w-full" />
-            <Skeleton className="h-16 w-full" />
+        <div className="flex flex-1 flex-col justify-end p-4">
+          <div className="space-y-4">
+            {/* Other user message skeleton */}
+            <div className="flex items-start gap-3">
+              <Skeleton className="h-10 w-10 shrink-0 rounded-full" />
+              <div className="space-y-1">
+                <Skeleton className="h-3 w-24" />
+                <Skeleton className="h-14 w-48 rounded-2xl rounded-tl-sm" />
+              </div>
+            </div>
+            {/* Current user message skeleton */}
+            <div className="flex justify-end">
+              <Skeleton className="h-10 w-40 rounded-2xl rounded-tr-sm" />
+            </div>
+            {/* Other user message skeleton */}
+            <div className="flex items-start gap-3">
+              <Skeleton className="h-10 w-10 shrink-0 rounded-full" />
+              <div className="space-y-1">
+                <Skeleton className="h-3 w-20" />
+                <Skeleton className="h-20 w-64 rounded-2xl rounded-tl-sm" />
+              </div>
+            </div>
+            {/* Current user message skeleton */}
+            <div className="flex justify-end">
+              <Skeleton className="h-10 w-56 rounded-2xl rounded-tr-sm" />
+            </div>
           </div>
         </div>
         <div ref={messagesEndRef} />

--- a/apps/web/src/components/groups/CreateGroupModal.tsx
+++ b/apps/web/src/components/groups/CreateGroupModal.tsx
@@ -266,12 +266,19 @@ export function CreateGroupModal({
           <div className="space-y-4">
             {/* Group Name (Optional) */}
             <div>
-              <label className="mb-2 block font-medium text-sm">
-                Group Name{' '}
-                <span className="font-normal text-muted-foreground text-xs">
-                  (Optional)
-                </span>
-              </label>
+              <div className="mb-2 flex items-baseline justify-between">
+                <label className="font-medium text-sm">
+                  Group Name{' '}
+                  <span className="font-normal text-muted-foreground text-xs">
+                    (Optional)
+                  </span>
+                </label>
+                {groupName && (
+                  <span className="text-muted-foreground text-xs">
+                    {groupName.length}/100
+                  </span>
+                )}
+              </div>
               <input
                 id="groupName"
                 type="text"
@@ -282,11 +289,6 @@ export function CreateGroupModal({
                 className="w-full rounded-lg border border-border bg-sidebar px-4 py-3 transition-colors focus:border-primary focus:outline-none"
                 disabled={creating}
               />
-              {groupName && (
-                <p className="mt-1 text-muted-foreground text-xs">
-                  {groupName.length}/100 characters
-                </p>
-              )}
             </div>
 
             {/* Selected Members */}

--- a/apps/web/src/components/groups/GroupManagementModal.tsx
+++ b/apps/web/src/components/groups/GroupManagementModal.tsx
@@ -7,7 +7,6 @@ import {
   Loader2,
   LogOut,
   Search,
-  Settings,
   Shield,
   Trash2,
   UserMinus,
@@ -578,13 +577,16 @@ export function GroupManagementModal({
           onClick={(e) => e.stopPropagation()}
         >
           {/* Header */}
-          <div className="flex shrink-0 items-start justify-between border-border border-b p-6">
-            <div className="flex items-center gap-2">
-              <Settings className="h-5 w-5 text-primary" />
-              <h2 className="font-bold text-xl">
+          <div className="flex shrink-0 items-start justify-between border-border border-b px-6 py-4">
+            <div className="min-w-0 flex-1">
+              <h2 className="truncate font-bold text-xl">
                 {groupDetails?.name || 'Group Settings'}
               </h2>
-              {groupDetails && <GroupTypeBadge type={groupDetails.type} />}
+              {groupDetails && (
+                <div className="mt-1">
+                  <GroupTypeBadge type={groupDetails.type} />
+                </div>
+              )}
             </div>
             <button
               onClick={handleClose}
@@ -596,7 +598,7 @@ export function GroupManagementModal({
           </div>
 
           {/* Content */}
-          <div className="min-h-0 flex-1 overflow-y-auto p-6">
+          <div className="min-h-0 flex-1 overflow-y-auto px-6 pt-4 pb-6">
             {error && (
               <div className="mb-4 rounded-lg border border-red-500/20 bg-red-500/10 p-3">
                 <p className="text-red-500 text-sm">{error}</p>
@@ -719,9 +721,7 @@ export function GroupManagementModal({
                         className="mt-2 w-full rounded-lg border border-border bg-background px-3 py-2 text-sm transition-colors focus:border-primary focus:outline-none"
                       />
                     ) : (
-                      <p className="mt-2 truncate text-sm">
-                        {groupDetails.name}
-                      </p>
+                      <p className="truncate text-sm">{groupDetails.name}</p>
                     )}
                   </div>
                 )}


### PR DESCRIPTION
## Summary

- **Chat back button**: Simplified to icon-only (removed "Back" text), larger arrow
- **Chat header**: Removed group icon, reduced height on mobile, moved SSE Live badge to participants row for more title space, tightened gap between title and subtitle
- **Chat sidebar**: Removed inner shadow from group icons, reduced whitespace before search/filter tabs
- **Message loading skeleton**: Updated to match real chat bubble layout (avatars, sender names, alternating left/right bubbles)
- **Rewards page**: Top 3 stats stack vertically on mobile (Total Points first), Earned & Referrals side-by-side, removed separator between Earn Points and Referral Link sections
- **Group settings modal**: Type badge on separate row below name, name truncates with ellipsis, removed gear icon, reduced padding and spacing
- **Create group modal**: Character count inline with Group Name label (right-aligned), no layout shift on input