### PR TITLE
feat(mobile): improve chat keyboard UX and hide nav on keyboard open

### DIFF
--- a/apps/web/src/app/agents/loading.tsx
+++ b/apps/web/src/app/agents/loading.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from '@/components/shared/Skeleton';
 
 export default function AgentsLoading() {
   return (
-    <div className="flex h-[calc(100dvh-112px)] flex-col md:h-dvh">
+    <div className="flex h-[calc(100dvh-56px-var(--bottom-nav-height))] flex-col md:h-dvh">
       <div className="flex min-h-0 flex-1 overflow-hidden">
         {/* Member sidebar skeleton */}
         <div className="hidden w-64 flex-col border-border border-r p-4 lg:flex">

--- a/apps/web/src/app/agents/team/page.tsx
+++ b/apps/web/src/app/agents/team/page.tsx
@@ -627,13 +627,19 @@ export default function TeamChatPage() {
     // Only scroll when loaded data
     if (!teamChat?.chatId || loading) return;
 
-    const endMarker = messagesEndRef.current;
-    if (!endMarker) return;
-
-    // Find the scroll container
-    const container = endMarker.closest('[data-chat-messages-container]');
+    // Find the visible scroll container (mobile and desktop render separate
+    // TeamChatView instances — pick the one that's actually visible).
+    const containers = document.querySelectorAll<HTMLElement>(
+      '[data-chat-messages-container]'
+    );
+    let container: HTMLElement | null = null;
+    for (const el of containers) {
+      if (el.offsetHeight > 0) {
+        container = el;
+        break;
+      }
+    }
     if (!container) {
-      // Fallback: just scroll once
       scrollToBottom('instant');
       return;
     }
@@ -646,7 +652,7 @@ export default function TeamChatPage() {
     let isActive = true;
 
     const scrollToEnd = () => {
-      endMarker.scrollIntoView({ behavior: 'auto', block: 'end' });
+      container.scrollTop = container.scrollHeight;
     };
 
     const finish = () => {
@@ -696,7 +702,7 @@ export default function TeamChatPage() {
       observer?.disconnect();
       if (idleTimeout) clearTimeout(idleTimeout);
     };
-  }, [teamChat?.chatId, loading, messagesEndRef, scrollToBottom]);
+  }, [teamChat?.chatId, loading, scrollToBottom]);
 
   // Auth required — redirect to feed and show login
   useEffect(() => {
@@ -713,7 +719,7 @@ export default function TeamChatPage() {
   // Loading state
   if (loading) {
     return (
-      <div className="flex h-[calc(100dvh-112px)] flex-col md:h-dvh">
+      <div className="flex h-[calc(100dvh-56px-var(--bottom-nav-height))] flex-col md:h-dvh">
         <div className="flex min-h-0 flex-1 overflow-hidden">
           {/* Member sidebar skeleton */}
           <div className="hidden w-80 flex-col border-border border-r p-4 lg:flex">
@@ -759,7 +765,7 @@ export default function TeamChatPage() {
   return (
     <div
       data-command-center-container
-      className="relative mt-14 flex h-[calc(100dvh-112px)] flex-col overflow-hidden border-border md:mt-0 md:h-dvh lg:border-l"
+      className="relative mt-14 flex h-[calc(100dvh-56px-var(--bottom-nav-height))] flex-col overflow-hidden border-border md:mt-0 md:h-dvh lg:border-l"
     >
       {/* Mobile Tab Navigation - visible on small screens only */}
       <div
@@ -1002,6 +1008,9 @@ export default function TeamChatPage() {
           }}
           agentIds={agentIds}
           onViewSettings={handleViewSettings}
+          onInputFocus={() => {
+            setTimeout(() => scrollToBottom('smooth'), 150);
+          }}
         />
       </div>
 
@@ -1107,6 +1116,9 @@ export default function TeamChatPage() {
             onTagClick={handleTagClick}
             agentIds={agentIds}
             onViewSettings={handleViewSettings}
+            onInputFocus={() => {
+              setTimeout(() => scrollToBottom('smooth'), 150);
+            }}
           />
         </div>
 
@@ -1120,7 +1132,8 @@ export default function TeamChatPage() {
         )}
       </div>
 
-      {/* Bottom Panel - spans full width */}
+      {/* Bottom Panel - spans full width, hidden on mobile */}
+      <div className="hidden lg:contents">
       <BottomPanel
         isOpen={bottomPanelOpen}
         onToggle={() => setBottomPanelOpen((prev) => !prev)}
@@ -1252,6 +1265,7 @@ export default function TeamChatPage() {
           </>
         )}
       </BottomPanel>
+      </div>
 
       {/* Right Sidebar - Fixed position overlay, desktop only */}
       {rightSidebarOpen && (

--- a/apps/web/src/app/agents/team/page.tsx
+++ b/apps/web/src/app/agents/team/page.tsx
@@ -1134,137 +1134,142 @@ export default function TeamChatPage() {
 
       {/* Bottom Panel - spans full width, hidden on mobile */}
       <div className="hidden lg:contents">
-      <BottomPanel
-        isOpen={bottomPanelOpen}
-        onToggle={() => setBottomPanelOpen((prev) => !prev)}
-        activeTab={bottomPanelTab}
-        onTabChange={setBottomPanelTab}
-        selectedEntityId={bottomPanelEntityId}
-        selectedEntityType={bottomPanelEntityType}
-        onEntityChange={handleBottomPanelEntityChange}
-        userId={user?.id}
-        userName={user?.displayName || user?.username || 'You'}
-        agents={
-          teamChat?.agents.map((a) => ({
-            id: a.id,
-            name: a.displayName || a.username || 'Agent',
-          })) || []
-        }
-        height={bottomPanelHeight}
-        onHeightChange={setBottomPanelHeight}
-      >
-        {bottomPanelEntityId && bottomPanelEntityType && (
-          <>
-            {/* Activity Tab */}
-            {bottomPanelTab === 'activity' && (
-              <div className="min-h-0 flex-1 overflow-y-auto">
-                {bottomPanelEntityType === 'agent' ? (
-                  <div className="p-4">
-                    <AgentActivityFeed
-                      agentId={bottomPanelEntityId}
-                      limit={20}
-                      showAgent={false}
-                      showConnectionStatus={false}
-                      emptyMessage="No activity from this agent yet."
-                    />
-                  </div>
-                ) : (
-                  <div className="p-4">
-                    <UserActivity userId={bottomPanelEntityId} />
-                  </div>
-                )}
-              </div>
-            )}
+        <BottomPanel
+          isOpen={bottomPanelOpen}
+          onToggle={() => setBottomPanelOpen((prev) => !prev)}
+          activeTab={bottomPanelTab}
+          onTabChange={setBottomPanelTab}
+          selectedEntityId={bottomPanelEntityId}
+          selectedEntityType={bottomPanelEntityType}
+          onEntityChange={handleBottomPanelEntityChange}
+          userId={user?.id}
+          userName={user?.displayName || user?.username || 'You'}
+          agents={
+            teamChat?.agents.map((a) => ({
+              id: a.id,
+              name: a.displayName || a.username || 'Agent',
+            })) || []
+          }
+          height={bottomPanelHeight}
+          onHeightChange={setBottomPanelHeight}
+        >
+          {bottomPanelEntityId && bottomPanelEntityType && (
+            <>
+              {/* Activity Tab */}
+              {bottomPanelTab === 'activity' && (
+                <div className="min-h-0 flex-1 overflow-y-auto">
+                  {bottomPanelEntityType === 'agent' ? (
+                    <div className="p-4">
+                      <AgentActivityFeed
+                        agentId={bottomPanelEntityId}
+                        limit={20}
+                        showAgent={false}
+                        showConnectionStatus={false}
+                        emptyMessage="No activity from this agent yet."
+                      />
+                    </div>
+                  ) : (
+                    <div className="p-4">
+                      <UserActivity userId={bottomPanelEntityId} />
+                    </div>
+                  )}
+                </div>
+              )}
 
-            {/* Wallet Tab */}
-            {bottomPanelTab === 'wallet' &&
-              (() => {
-                if (bottomPanelEntityType === 'team') {
-                  return (
-                    <TeamPortfolio
-                      summary={teamSummary}
-                      loading={teamSummaryLoading}
-                      error={teamSummaryError}
-                      scope={teamScope}
-                      onScopeChange={setTeamScope}
-                      onSelectMember={handleBottomPanelEntityChange}
-                    />
+              {/* Wallet Tab */}
+              {bottomPanelTab === 'wallet' &&
+                (() => {
+                  if (bottomPanelEntityType === 'team') {
+                    return (
+                      <TeamPortfolio
+                        summary={teamSummary}
+                        loading={teamSummaryLoading}
+                        error={teamSummaryError}
+                        scope={teamScope}
+                        onScopeChange={setTeamScope}
+                        onSelectMember={handleBottomPanelEntityChange}
+                      />
+                    );
+                  }
+                  if (bottomPanelEntityType === 'user') {
+                    return (
+                      <AgentPortfolio
+                        entityType="user"
+                        userId={bottomPanelEntityId}
+                        entityName={
+                          user?.displayName || user?.username || 'You'
+                        }
+                      />
+                    );
+                  }
+                  const bottomAgent = teamChat?.agents.find(
+                    (a) => a.id === bottomPanelEntityId
                   );
-                }
-                if (bottomPanelEntityType === 'user') {
                   return (
                     <AgentPortfolio
-                      entityType="user"
-                      userId={bottomPanelEntityId}
-                      entityName={user?.displayName || user?.username || 'You'}
+                      entityType="agent"
+                      agentId={bottomPanelEntityId}
+                      entityName={
+                        bottomAgent?.displayName ||
+                        bottomAgent?.username ||
+                        'Agent'
+                      }
                     />
                   );
-                }
-                const bottomAgent = teamChat?.agents.find(
-                  (a) => a.id === bottomPanelEntityId
-                );
-                return (
-                  <AgentPortfolio
-                    entityType="agent"
-                    agentId={bottomPanelEntityId}
-                    entityName={
-                      bottomAgent?.displayName ||
-                      bottomAgent?.username ||
-                      'Agent'
-                    }
-                  />
-                );
-              })()}
+                })()}
 
-            {/* PnL Tab */}
-            {bottomPanelTab === 'pnl' &&
-              (() => {
-                if (bottomPanelEntityType === 'team') {
-                  return (
-                    <TeamPnL
-                      summary={teamSummary}
-                      loading={teamSummaryLoading}
-                      error={teamSummaryError}
-                      scope={teamScope}
-                      onScopeChange={setTeamScope}
-                      onSelectMember={handleBottomPanelEntityChange}
-                    />
+              {/* PnL Tab */}
+              {bottomPanelTab === 'pnl' &&
+                (() => {
+                  if (bottomPanelEntityType === 'team') {
+                    return (
+                      <TeamPnL
+                        summary={teamSummary}
+                        loading={teamSummaryLoading}
+                        error={teamSummaryError}
+                        scope={teamScope}
+                        onScopeChange={setTeamScope}
+                        onSelectMember={handleBottomPanelEntityChange}
+                      />
+                    );
+                  }
+                  if (bottomPanelEntityType === 'user') {
+                    return (
+                      <AgentPnL
+                        entityType={'user' as const}
+                        userId={bottomPanelEntityId}
+                        entityName={
+                          user?.displayName || user?.username || 'You'
+                        }
+                      />
+                    );
+                  }
+                  const bottomAgent = teamChat?.agents.find(
+                    (a) => a.id === bottomPanelEntityId
                   );
-                }
-                if (bottomPanelEntityType === 'user') {
                   return (
                     <AgentPnL
-                      entityType={'user' as const}
-                      userId={bottomPanelEntityId}
-                      entityName={user?.displayName || user?.username || 'You'}
+                      entityType={'agent' as const}
+                      agentId={bottomPanelEntityId}
+                      entityName={
+                        bottomAgent?.displayName ||
+                        bottomAgent?.username ||
+                        'Agent'
+                      }
                     />
                   );
-                }
-                const bottomAgent = teamChat?.agents.find(
-                  (a) => a.id === bottomPanelEntityId
-                );
-                return (
-                  <AgentPnL
-                    entityType={'agent' as const}
-                    agentId={bottomPanelEntityId}
-                    entityName={
-                      bottomAgent?.displayName ||
-                      bottomAgent?.username ||
-                      'Agent'
-                    }
-                  />
-                );
-              })()}
+                })()}
 
-            {/* Logs Tab - only for agents */}
-            {bottomPanelTab === 'logs' && bottomPanelEntityType === 'agent' && (
-              <div className="p-4">
-                <AgentLogs agentId={bottomPanelEntityId} />
-              </div>
-            )}
-          </>
-        )}
-      </BottomPanel>
+              {/* Logs Tab - only for agents */}
+              {bottomPanelTab === 'logs' &&
+                bottomPanelEntityType === 'agent' && (
+                  <div className="p-4">
+                    <AgentLogs agentId={bottomPanelEntityId} />
+                  </div>
+                )}
+            </>
+          )}
+        </BottomPanel>
       </div>
 
       {/* Right Sidebar - Fixed position overlay, desktop only */}

--- a/apps/web/src/app/chats/loading.tsx
+++ b/apps/web/src/app/chats/loading.tsx
@@ -2,7 +2,7 @@ import { ChatListSkeleton, Skeleton } from '@/components/shared/Skeleton';
 
 export default function ChatsLoading() {
   return (
-    <div className="flex h-[calc(100dvh-var(--header-height,112px))] flex-col overflow-hidden md:h-dvh">
+    <div className="flex h-[calc(100dvh-56px-var(--bottom-nav-height))] flex-col overflow-hidden md:h-dvh">
       <div className="flex min-h-0 flex-1 overflow-hidden">
         {/* Left column: Chat list */}
         <div className="flex w-full flex-col border-border bg-background xl:w-80 xl:border-r">

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -2,6 +2,7 @@
 @config "../../tailwind.config.ts";
 
 :root {
+  --bottom-nav-height: 56px;
   --background: #ffffff;
   --foreground: #0f1419;
   --card: #f7f8f8;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -142,7 +142,7 @@ export default async function RootLayout({
                 </Suspense>
 
                 {/* Main Content Area - Scrollable content with pull-to-refresh */}
-                <main className="min-h-screen min-w-0 flex-1 bg-background pb-14 md:pb-0">
+                <main className="min-h-screen min-w-0 flex-1 bg-background pb-[--bottom-nav-height] md:pb-0">
                   {children}
                 </main>
 

--- a/apps/web/src/app/markets/page.tsx
+++ b/apps/web/src/app/markets/page.tsx
@@ -79,7 +79,7 @@ export default function MarketsPage() {
   return (
     <PageContainer
       noPadding
-      className="mt-14 flex h-[calc(100dvh-112px)] min-h-0 flex-col overflow-hidden md:mt-0 md:h-dvh"
+      className="mt-14 flex h-[calc(100dvh-56px-var(--bottom-nav-height))] min-h-0 flex-col overflow-hidden md:mt-0 md:h-dvh"
     >
       <div className="flex flex-1 overflow-hidden border-border bg-background/20 lg:border-l">
         <MarketsTradingTerminal

--- a/apps/web/src/components/chats/MessageInput.tsx
+++ b/apps/web/src/components/chats/MessageInput.tsx
@@ -187,6 +187,8 @@ export interface MessageInputProps {
   placeholder?: string;
   /** Mentionable members - when provided, enables @mention autocomplete */
   mentionableMembers?: MentionableAgent[];
+  /** Called when the input is focused (e.g. to scroll chat to bottom on mobile keyboard open) */
+  onInputFocus?: () => void;
 }
 
 /**
@@ -205,6 +207,7 @@ export function MessageInput({
   disabled = false,
   placeholder,
   mentionableMembers,
+  onInputFocus,
 }: MessageInputProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -561,7 +564,10 @@ export function MessageInput({
                 onKeyDown={handleKeyDown}
                 onScroll={handleScroll}
                 onSelect={handleSelect}
-                onFocus={() => setIsFocused(true)}
+                onFocus={() => {
+                  setIsFocused(true);
+                  onInputFocus?.();
+                }}
                 onBlur={() => setIsFocused(false)}
                 aria-label="Message input, use @ to mention members"
                 placeholder={placeholderText}
@@ -588,7 +594,10 @@ export function MessageInput({
               value={value}
               onChange={handleChange}
               onKeyDown={handleKeyDown}
-              onFocus={() => setIsFocused(true)}
+              onFocus={() => {
+                setIsFocused(true);
+                onInputFocus?.();
+              }}
               onBlur={() => setIsFocused(false)}
               placeholder={placeholderText}
               disabled={sending || disabled}

--- a/apps/web/src/components/chats/TeamChatView.tsx
+++ b/apps/web/src/components/chats/TeamChatView.tsx
@@ -162,6 +162,8 @@ interface TeamChatViewProps {
   agentIds?: ReadonlySet<string>;
   /** Callback to open agent settings modal */
   onViewSettings?: (agentId: string) => void;
+  /** Called when the message input is focused (e.g. to scroll to bottom on mobile keyboard open) */
+  onInputFocus?: () => void;
 }
 
 /**
@@ -199,6 +201,7 @@ export function TeamChatView({
   onToggleReaction,
   agentIds,
   onViewSettings,
+  onInputFocus,
 }: TeamChatViewProps) {
   const compact = density === 'compact';
   // Empty state when no chat selected
@@ -312,7 +315,7 @@ export function TeamChatView({
       </div>
 
       {/* Footer - Fixed */}
-      <div className="shrink-0">
+      <div className="shrink-0 pb-safe lg:pb-0">
         {/* Thinking Indicator - shown when agents are processing complex queries */}
         {thinkingAgents.length > 0 && (
           <ThinkingIndicator
@@ -341,6 +344,7 @@ export function TeamChatView({
           density={density}
           placeholder="Message your team — @ to mention agents"
           mentionableMembers={agents}
+          onInputFocus={onInputFocus}
         />
       </div>
     </div>

--- a/apps/web/src/components/shared/BottomNav.tsx
+++ b/apps/web/src/components/shared/BottomNav.tsx
@@ -67,6 +67,30 @@ function BottomNavContent() {
     return () => clearInterval(interval);
   }, [authenticated, user]);
 
+  // Hide when virtual keyboard is open (interactiveWidget: 'resizes-content'
+  // shrinks the layout viewport, pushing the fixed nav up with the keyboard).
+  // Also sets --bottom-nav-height CSS variable so page height calcs (e.g.
+  // h-[calc(100dvh-112px)]) and main pb-[--bottom-nav-height] adjust too.
+  const [keyboardOpen, setKeyboardOpen] = useState(false);
+  useEffect(() => {
+    const vv = window.visualViewport;
+    if (!vv) return;
+
+    let fullHeight = vv.height;
+    const onResize = () => {
+      if (vv.height > fullHeight) fullHeight = vv.height;
+      const open = fullHeight - vv.height > 150;
+      setKeyboardOpen(open);
+      document.documentElement.style.setProperty(
+        '--bottom-nav-height',
+        open ? '0px' : '56px'
+      );
+    };
+
+    vv.addEventListener('resize', onResize);
+    return () => vv.removeEventListener('resize', onResize);
+  }, []);
+
   // If should be hidden, don't render anything
   if (shouldHide) {
     return null;
@@ -114,7 +138,10 @@ function BottomNavContent() {
     <nav
       id="app-bottom-nav"
       data-bottom-nav
-      className="fixed right-0 bottom-0 bottom-nav-rounded left-0 z-50 border-border border-t bg-sidebar md:hidden"
+      className={cn(
+        'fixed right-0 bottom-0 bottom-nav-rounded left-0 z-50 border-border border-t bg-sidebar md:hidden',
+        keyboardOpen && 'hidden'
+      )}
     >
       {/* Navigation Items */}
       <div className="safe-area-bottom flex h-14 items-center justify-between px-4">

--- a/apps/web/src/components/shared/BottomNav.tsx
+++ b/apps/web/src/components/shared/BottomNav.tsx
@@ -70,7 +70,7 @@ function BottomNavContent() {
   // Hide when virtual keyboard is open (interactiveWidget: 'resizes-content'
   // shrinks the layout viewport, pushing the fixed nav up with the keyboard).
   // Also sets --bottom-nav-height CSS variable so page height calcs (e.g.
-  // h-[calc(100dvh-112px)]) and main pb-[--bottom-nav-height] adjust too.
+  // h-[calc(100dvh-56px-var(--bottom-nav-height))]) and main pb-[--bottom-nav-height] adjust too.
   const [keyboardOpen, setKeyboardOpen] = useState(false);
   useEffect(() => {
     const vv = window.visualViewport;

--- a/apps/web/src/hooks/useTeamChat.ts
+++ b/apps/web/src/hooks/useTeamChat.ts
@@ -280,11 +280,24 @@ export function useTeamChat(): UseTeamChatReturn {
     markPendingReactionDelta,
   });
 
-  // Helper to find scroll container from messagesEndRef
+  // Helper to find the visible scroll container.
+  // On mobile/desktop, two TeamChatView instances share the same messagesEndRef,
+  // but only one is visible at a time. Prefer the ref's ancestor, but fall back
+  // to querying for the visible [data-chat-messages-container].
   const getScrollContainer = useCallback((): HTMLElement | null => {
-    return messagesEndRef.current?.closest(
+    const fromRef = messagesEndRef.current?.closest(
       '[class*="overflow"]'
     ) as HTMLElement | null;
+    if (fromRef && fromRef.offsetHeight > 0) return fromRef;
+
+    // Ref points to a hidden container — find the visible one
+    const containers = document.querySelectorAll<HTMLElement>(
+      '[data-chat-messages-container]'
+    );
+    for (const el of containers) {
+      if (el.offsetHeight > 0) return el;
+    }
+    return fromRef;
   }, []);
 
   // Scroll to bottom helper


### PR DESCRIPTION
## Summary
- Hide BottomPanel on mobile (keep on desktop) to maximize chat message area
- Hide bottom nav bar when virtual keyboard opens using `visualViewport` API, with `--bottom-nav-height` CSS variable so page layouts reclaim the space without leaving a white gap
- Add safe-area padding (`pb-safe`) to TeamChatView footer for notched devices
- Scroll chat to bottom on input focus (keyboard open) with 150ms delay for smooth behavior
- Fix scroll-to-bottom on initial load for mobile by finding the visible scroll container instead of relying on a shared ref that points to the hidden desktop view