### PR TITLE
fix: mobile viewport height and tone down trading card colors

### DIFF
--- a/apps/web/src/app/(authenticated)/admin/training/page.tsx
+++ b/apps/web/src/app/(authenticated)/admin/training/page.tsx
@@ -175,7 +175,7 @@ export default function TrainingDashboard() {
 
   if (loading) {
     return (
-      <div className="flex min-h-screen items-center justify-center">
+      <div className="flex min-h-dvh items-center justify-center md:min-h-screen">
         <Loader2 className="h-8 w-8 animate-spin" />
       </div>
     );

--- a/apps/web/src/app/api-docs/page.tsx
+++ b/apps/web/src/app/api-docs/page.tsx
@@ -24,7 +24,7 @@ const SwaggerUI = dynamic(() => import('swagger-ui-react'), { ssr: false });
  */
 export default function ApiDocsPage() {
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-dvh bg-background md:min-h-screen">
       <div className="container mx-auto px-4 py-8">
         <div className="mb-8">
           <h1 className="mb-2 font-bold text-4xl">Babylon API Documentation</h1>

--- a/apps/web/src/app/article/[id]/page.tsx
+++ b/apps/web/src/app/article/[id]/page.tsx
@@ -77,7 +77,7 @@ export default function ArticlePage({ params }: ArticlePageProps) {
   if (isLoading) {
     return (
       <PageContainer noPadding className="flex w-full flex-col">
-        <div className="relative flex min-h-screen flex-1">
+        <div className="relative flex min-h-dvh flex-1 md:min-h-screen">
           <div className="flex min-w-0 flex-1 flex-col border-border lg:border-r lg:border-l">
             <div className="sticky top-0 z-10 shrink-0 bg-background shadow-sm">
               <div className="px-6 py-4">
@@ -106,7 +106,7 @@ export default function ArticlePage({ params }: ArticlePageProps) {
   if (error || !article) {
     return (
       <PageContainer noPadding className="flex w-full flex-col">
-        <div className="relative flex min-h-screen flex-1">
+        <div className="relative flex min-h-dvh flex-1 md:min-h-screen">
           <div className="flex min-w-0 flex-1 flex-col border-border lg:border-r lg:border-l">
             <div className="flex flex-1 flex-col items-center justify-center bg-background">
               <div className="text-center">
@@ -136,7 +136,7 @@ export default function ArticlePage({ params }: ArticlePageProps) {
 
   return (
     <PageContainer noPadding className="flex w-full flex-col">
-      <div className="relative flex min-h-screen flex-1">
+      <div className="relative flex min-h-dvh flex-1 md:min-h-screen">
         {/* Desktop: Article content area */}
         <div className="hidden min-w-0 flex-1 flex-col border-border lg:flex lg:border-r lg:border-l">
           {/* Desktop: Top bar with back button */}

--- a/apps/web/src/app/comment/[id]/page.tsx
+++ b/apps/web/src/app/comment/[id]/page.tsx
@@ -563,7 +563,7 @@ export default function CommentPage({ params }: CommentPageProps) {
   if (isLoading) {
     return (
       <PageContainer noPadding className="flex w-full flex-col">
-        <div className="relative flex min-h-screen flex-1">
+        <div className="relative flex min-h-dvh flex-1 md:min-h-screen">
           {/* Desktop loading */}
           <div className="hidden min-w-0 flex-1 flex-col border-border lg:flex lg:border-r lg:border-l">
             <div className="sticky top-0 z-10 shrink-0 bg-background shadow-sm">
@@ -607,7 +607,7 @@ export default function CommentPage({ params }: CommentPageProps) {
   if (error || !comment) {
     return (
       <PageContainer noPadding className="flex w-full flex-col">
-        <div className="relative flex min-h-screen flex-1">
+        <div className="relative flex min-h-dvh flex-1 md:min-h-screen">
           {/* Desktop error */}
           <div className="hidden min-w-0 flex-1 flex-col border-border lg:flex lg:border-r lg:border-l">
             <div className="flex flex-1 flex-col items-center justify-center bg-background">
@@ -855,7 +855,7 @@ export default function CommentPage({ params }: CommentPageProps) {
 
   return (
     <PageContainer noPadding className="flex w-full flex-col">
-      <div className="relative flex min-h-screen flex-1">
+      <div className="relative flex min-h-dvh flex-1 md:min-h-screen">
         {/* Desktop: Thread content area */}
         <div className="hidden min-w-0 flex-1 flex-col border-border lg:flex lg:border-r lg:border-l">
           {/* Desktop: Top bar with back button */}

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -55,7 +55,7 @@ export default function GlobalError({
   return (
     <html lang="en">
       <body>
-        <div className="flex min-h-screen flex-col items-center justify-center p-8">
+        <div className="flex min-h-dvh flex-col items-center justify-center p-8 md:min-h-screen">
           <div className="max-w-md text-center">
             <AlertTriangle className="mx-auto mb-4 h-16 w-16 text-destructive" />
             <h2 className="mb-2 font-bold text-2xl">Something went wrong</h2>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -135,14 +135,14 @@ export default async function RootLayout({
                 <MobileHeader />
               </Suspense>
 
-              <div className="mark mx-auto flex min-h-screen max-w-7xl bg-sidebar">
+              <div className="mark mx-auto flex min-h-dvh max-w-7xl bg-sidebar md:min-h-screen">
                 {/* Desktop Sidebar - Sticky, not affected by pull-to-refresh */}
                 <Suspense fallback={null}>
                   <Sidebar />
                 </Suspense>
 
                 {/* Main Content Area - Scrollable content with pull-to-refresh */}
-                <main className="min-h-screen min-w-0 flex-1 bg-background pb-[--bottom-nav-height] md:pb-0">
+                <main className="min-h-dvh min-w-0 flex-1 bg-background pb-[--bottom-nav-height] md:min-h-screen md:pb-0">
                   {children}
                 </main>
 

--- a/apps/web/src/app/post/[id]/loading.tsx
+++ b/apps/web/src/app/post/[id]/loading.tsx
@@ -3,7 +3,7 @@ import { PostCardSkeleton, Skeleton } from '@/components/shared/Skeleton';
 
 export default function PostDetailLoading() {
   return (
-    <PageContainer noPadding className="flex min-h-screen flex-col">
+    <PageContainer noPadding className="flex min-h-dvh flex-col md:min-h-screen">
       {/* Desktop */}
       <div className="hidden flex-1 lg:flex">
         {/* Main Content */}

--- a/apps/web/src/app/post/[id]/loading.tsx
+++ b/apps/web/src/app/post/[id]/loading.tsx
@@ -3,7 +3,10 @@ import { PostCardSkeleton, Skeleton } from '@/components/shared/Skeleton';
 
 export default function PostDetailLoading() {
   return (
-    <PageContainer noPadding className="flex min-h-dvh flex-col md:min-h-screen">
+    <PageContainer
+      noPadding
+      className="flex min-h-dvh flex-col md:min-h-screen"
+    >
       {/* Desktop */}
       <div className="hidden flex-1 lg:flex">
         {/* Main Content */}

--- a/apps/web/src/app/post/[id]/page.tsx
+++ b/apps/web/src/app/post/[id]/page.tsx
@@ -200,7 +200,7 @@ export default function PostPage({ params }: PostPageProps) {
         noPadding
         className="!overflow-visible flex w-full flex-col"
       >
-        <div className="relative flex min-h-screen flex-1">
+        <div className="relative flex min-h-dvh flex-1 md:min-h-screen">
           {/* Desktop loading */}
           <div className="hidden min-w-0 flex-1 flex-col border-border lg:flex lg:border-r lg:border-l">
             <div className="flex-1 bg-background">
@@ -233,7 +233,7 @@ export default function PostPage({ params }: PostPageProps) {
         noPadding
         className="!overflow-visible flex w-full flex-col"
       >
-        <div className="relative flex min-h-screen flex-1">
+        <div className="relative flex min-h-dvh flex-1 md:min-h-screen">
           {/* Desktop error */}
           <div className="hidden min-w-0 flex-1 flex-col border-border lg:flex lg:border-r lg:border-l">
             <div className="flex flex-1 flex-col items-center justify-center bg-background">
@@ -274,7 +274,7 @@ export default function PostPage({ params }: PostPageProps) {
 
   return (
     <PageContainer noPadding className="!overflow-visible flex w-full flex-col">
-      <div className="relative flex min-h-screen flex-1">
+      <div className="relative flex min-h-dvh flex-1 md:min-h-screen">
         {/* Desktop: Post content area */}
         <div className="hidden min-w-0 flex-1 flex-col border-border lg:flex lg:border-r lg:border-l">
           {/* Desktop: Top bar with back button */}

--- a/apps/web/src/app/profile/[id]/loading.tsx
+++ b/apps/web/src/app/profile/[id]/loading.tsx
@@ -15,7 +15,7 @@ import {
 
 export default function ProfileLoading() {
   return (
-    <PageContainer noPadding className="min-h-screen">
+    <PageContainer noPadding className="min-h-dvh md:min-h-screen">
       <div className="flex flex-1 overflow-hidden">
         {/* Main Content */}
         <div className="flex min-w-0 flex-1 flex-col overflow-hidden">

--- a/apps/web/src/app/profile/loading.tsx
+++ b/apps/web/src/app/profile/loading.tsx
@@ -6,7 +6,7 @@ import {
 
 export default function ProfileLoading() {
   return (
-    <PageContainer noPadding className="min-h-screen">
+    <PageContainer noPadding className="min-h-dvh md:min-h-screen">
       <div className="flex flex-1 overflow-hidden">
         {/* Main Content */}
         <div className="flex min-w-0 flex-1 flex-col overflow-hidden">

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -43,7 +43,7 @@ export default function ProfileRootRedirectPage() {
   }, [ready, authenticated, user?.id, user?.username, router, login]);
 
   return (
-    <PageContainer noPadding className="min-h-screen">
+    <PageContainer noPadding className="min-h-dvh md:min-h-screen">
       <div className="mx-auto w-full max-w-[700px]">
         <ProfileHeaderSkeleton />
       </div>

--- a/apps/web/src/app/ticker/page.tsx
+++ b/apps/web/src/app/ticker/page.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
  */
 export default function TickerPage() {
   return (
-    <div className="min-h-screen w-full">
+    <div className="min-h-dvh w-full md:min-h-screen">
       <TickerClient />
     </div>
   );

--- a/apps/web/src/app/trending/[tag]/loading.tsx
+++ b/apps/web/src/app/trending/[tag]/loading.tsx
@@ -4,7 +4,7 @@ import { FeedSkeleton, Skeleton } from '@/components/shared/Skeleton';
 export default function TrendingTagLoading() {
   return (
     <PageContainer noPadding className="flex w-full flex-col">
-      <div className="relative flex min-h-screen flex-1">
+      <div className="relative flex min-h-dvh flex-1 md:min-h-screen">
         {/* Desktop */}
         <div className="hidden min-w-0 flex-1 flex-col border-border lg:flex lg:border-r lg:border-l">
           {/* Header */}

--- a/apps/web/src/app/trending/[tag]/page.tsx
+++ b/apps/web/src/app/trending/[tag]/page.tsx
@@ -181,7 +181,7 @@ export default function TrendingTagPage() {
 
   return (
     <PageContainer noPadding className="flex w-full flex-col">
-      <div className="relative flex min-h-screen flex-1">
+      <div className="relative flex min-h-dvh flex-1 md:min-h-screen">
         {/* Desktop: Content area */}
         <div className="hidden min-w-0 flex-1 flex-col border-border lg:flex lg:border-r lg:border-l">
           {/* Desktop header */}

--- a/apps/web/src/app/trending/group/page.tsx
+++ b/apps/web/src/app/trending/group/page.tsx
@@ -135,7 +135,7 @@ export default function GroupedTrendingPage() {
 
   return (
     <PageContainer noPadding className="flex w-full flex-col">
-      <div className="relative flex min-h-screen flex-1">
+      <div className="relative flex min-h-dvh flex-1 md:min-h-screen">
         {/* Desktop: Content area */}
         <div className="hidden min-w-0 flex-1 flex-col border-border lg:flex lg:border-r lg:border-l">
           {/* Desktop header */}

--- a/apps/web/src/app/~offline/page.tsx
+++ b/apps/web/src/app/~offline/page.tsx
@@ -7,7 +7,7 @@
  */
 export default function OfflinePage() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-[#0a0a0a] px-8 text-[#fafafa]">
+    <div className="flex min-h-dvh items-center justify-center bg-[#0a0a0a] px-8 text-[#fafafa] md:min-h-screen">
       <div className="max-w-[400px] text-center">
         <svg
           className="mx-auto mb-6 h-20 w-20 opacity-50"

--- a/apps/web/src/components/analytics/PostHogErrorBoundary.tsx
+++ b/apps/web/src/components/analytics/PostHogErrorBoundary.tsx
@@ -81,7 +81,7 @@ export class PostHogErrorBoundary extends Component<Props, State> {
     if (this.state.hasError) {
       return (
         this.props.fallback || (
-          <div className="flex min-h-screen items-center justify-center p-4">
+          <div className="flex min-h-dvh items-center justify-center p-4 md:min-h-screen">
             <div className="text-center">
               <h2 className="mb-2 font-bold text-2xl">Something went wrong</h2>
               <p className="mb-4 text-muted-foreground">

--- a/apps/web/src/components/landing/LandingPage.tsx
+++ b/apps/web/src/components/landing/LandingPage.tsx
@@ -11,9 +11,9 @@ import { JoinWaitlistButton } from './client/JoinWaitlistButton';
  */
 export function LandingPage() {
   return (
-    <div className="safe-area-bottom flex min-h-screen w-full flex-col overflow-x-hidden bg-background text-foreground">
+    <div className="safe-area-bottom flex min-h-dvh w-full flex-col overflow-x-hidden bg-background text-foreground md:min-h-screen">
       {/* Hero Section */}
-      <section className="relative z-10 flex min-h-screen items-center justify-center overflow-x-hidden overflow-y-visible px-4 pt-4 pb-8 sm:px-6 sm:py-16 md:px-8 md:py-20 lg:py-24">
+      <section className="relative z-10 flex min-h-dvh items-center justify-center overflow-x-hidden overflow-y-visible px-4 pt-4 pb-8 sm:px-6 sm:py-16 md:min-h-screen md:px-8 md:py-20 lg:py-24">
         {/* Background Image */}
         <div className="-translate-x-1/2 fixed inset-0 left-1/2 z-0 h-full w-screen">
           <Image

--- a/apps/web/src/components/markets/AssetTradesFeed.tsx
+++ b/apps/web/src/components/markets/AssetTradesFeed.tsx
@@ -547,7 +547,7 @@ const TradeCard = memo(function TradeCard({
               {user?.displayName || user?.username || 'Unknown'}
             </Link>
             {user?.isActor && (
-              <span className="rounded bg-purple-600/20 px-2 py-0.5 text-purple-600 text-xs">
+              <span className="rounded bg-muted px-2 py-0.5 text-muted-foreground text-xs">
                 NPC
               </span>
             )}

--- a/apps/web/src/components/markets/PerpPositionsList.tsx
+++ b/apps/web/src/components/markets/PerpPositionsList.tsx
@@ -222,7 +222,7 @@ export function PerpPositionsList({
                     ${position.ticker}
                   </span>
                   {position.isAgentPosition && (
-                    <span className="flex shrink-0 items-center gap-0.5 rounded bg-purple-600/20 px-1 py-0.5 font-medium text-[11px] text-purple-500">
+                    <span className="flex shrink-0 items-center gap-0.5 rounded bg-muted px-1 py-0.5 font-medium text-[11px] text-muted-foreground">
                       <Bot size={10} />
                       {position.agentName || 'Agent'}
                     </span>
@@ -261,21 +261,14 @@ export function PerpPositionsList({
                   <span className="text-muted-foreground/40">&middot;</span>
                   <span>
                     Liq{' '}
-                    <span className="font-medium text-red-600">
+                    <span className="font-medium text-foreground">
                       {formatPrice(position.liquidationPrice)}
                     </span>
                   </span>
                   <span className="text-muted-foreground/40">&middot;</span>
                   <span>
                     Fund{' '}
-                    <span
-                      className={cn(
-                        'font-medium',
-                        position.fundingPaid >= 0
-                          ? 'text-red-600'
-                          : 'text-green-600'
-                      )}
-                    >
+                    <span className="font-medium text-foreground">
                       {position.fundingPaid >= 0 ? '-' : '+'}
                       {formatPrice(Math.abs(position.fundingPaid))}
                     </span>

--- a/apps/web/src/components/markets/PredictionPositionsList.tsx
+++ b/apps/web/src/components/markets/PredictionPositionsList.tsx
@@ -214,7 +214,7 @@ export function PredictionPositionsList({
                   {position.side}
                 </span>
                 {position.isAgentPosition && (
-                  <span className="flex shrink-0 items-center gap-0.5 rounded bg-purple-600/20 px-1 py-0.5 font-medium text-[11px] text-purple-500">
+                  <span className="flex shrink-0 items-center gap-0.5 rounded bg-muted px-1 py-0.5 font-medium text-[11px] text-muted-foreground">
                     <Bot size={10} />
                     {position.agentName || 'Agent'}
                   </span>

--- a/apps/web/src/components/profile/ProfilePageClient.tsx
+++ b/apps/web/src/components/profile/ProfilePageClient.tsx
@@ -786,7 +786,7 @@ export function ProfilePageClient({
     }
 
     return (
-      <PageContainer noPadding className="min-h-screen">
+      <PageContainer noPadding className="min-h-dvh md:min-h-screen">
         <div className="flex flex-1 overflow-hidden">
           <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
             <div className="flex-1 overflow-y-auto">

--- a/apps/web/src/components/providers/Providers.tsx
+++ b/apps/web/src/components/providers/Providers.tsx
@@ -269,7 +269,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
                     {children}
                   </Fragment>
                 ) : (
-                  <div className="min-h-screen bg-sidebar" />
+                  <div className="min-h-dvh bg-sidebar md:min-h-screen" />
                 )}
               </WidgetRefreshProvider>
             </QueryClientProvider>
@@ -315,7 +315,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
                                   {mounted ? (
                                     <Fragment>{children}</Fragment>
                                   ) : (
-                                    <div className="min-h-screen bg-sidebar" />
+                                    <div className="min-h-dvh bg-sidebar md:min-h-screen" />
                                   )}
                                 </WidgetRefreshProvider>
                               </GameGuideProvider>

--- a/apps/web/src/components/shared/ComingSoon.tsx
+++ b/apps/web/src/components/shared/ComingSoon.tsx
@@ -1332,9 +1332,9 @@ export function ComingSoon() {
   // Unauthenticated state - Show landing page
   if (!authenticated || !dbUser) {
     return (
-      <div className="safe-area-bottom flex min-h-screen w-full flex-col overflow-x-hidden bg-background text-foreground">
+      <div className="safe-area-bottom flex min-h-dvh w-full flex-col overflow-x-hidden bg-background text-foreground md:min-h-screen">
         {/* Hero Section */}
-        <section className="relative z-10 flex min-h-screen items-center justify-center overflow-x-hidden overflow-y-visible px-4 pt-4 pb-8 sm:px-6 sm:py-16 md:px-8 md:py-20 lg:py-24">
+        <section className="relative z-10 flex min-h-dvh items-center justify-center overflow-x-hidden overflow-y-visible px-4 pt-4 pb-8 sm:px-6 sm:py-16 md:min-h-screen md:px-8 md:py-20 lg:py-24">
           {/* Background Image - Full Width */}
           <div className="-translate-x-1/2 fixed inset-0 left-1/2 z-0 h-full w-screen">
             <Image
@@ -2444,7 +2444,7 @@ export function ComingSoon() {
 
   // Authenticated & waitlisted - Show position and leaderboard
   return (
-    <div className="flex min-h-screen w-full flex-col overflow-x-hidden bg-background text-foreground">
+    <div className="flex min-h-dvh w-full flex-col overflow-x-hidden bg-background text-foreground md:min-h-screen">
       {/* Background Image - Full Width */}
       <div className="-translate-x-1/2 fixed inset-0 left-1/2 z-0 h-full w-screen">
         <Image

--- a/packages/testing/unit/game-guide.test.ts
+++ b/packages/testing/unit/game-guide.test.ts
@@ -5,31 +5,26 @@ import { describe, expect, test } from 'bun:test';
 // Must match GAME_GUIDE_SLIDES in apps/web/src/components/onboarding/game-guide-slides.ts
 const GAME_GUIDE_SLIDES = [
   {
-
     title: 'Welcome to Babylon',
     description:
       'A world of humans, NPCs, and AI agents. You command a team of agents that work for you — narratives emerge here first, markets react, and better information means more points. Points are the game currency, onchain tokens on the horizon.',
   },
   {
-
     title: 'Your Agent Team',
     description:
       "Agents scout, analyze, and trade on your behalf. Prompt them with goals, learn from results, and refine. The loop: prompt → gather intel → analyze → trade → improve. They work around the clock so you don't miss a signal.",
   },
   {
-
     title: 'The Feed',
     description:
       'The timeline where agents, humans, and NPCs post. Your agents track topics and NPCs, surface sentiment shifts, and summarize what changed — narratives start here and markets pull signal from them.',
   },
   {
-
     title: 'DMs & Group Chats',
     description:
       'Private channels where NPCs drop context, timing, and hints. Prompt your agents on which NPCs to approach, what questions to ask, and what to extract — signals, catalysts, and timing. The right prompts get you into the right rooms.',
   },
   {
-
     title: 'Trade & Improve',
     description:
       'Trade on what your agents find via prediction markets and perps. Agents act faster than manual trading — iterate on prompts, sharpen your edge, climb the leaderboard.',
@@ -59,8 +54,6 @@ describe('Game Guide - Slide Content', () => {
     }
   });
 
-
-
   test('slide titles should be unique', () => {
     const titles = GAME_GUIDE_SLIDES.map((s) => s.title);
     const uniqueTitles = new Set(titles);
@@ -72,10 +65,10 @@ describe('Game Guide - Slide Content', () => {
   });
 
   test('last slide should be the CTA slide', () => {
-    const lastSlide = GAME_GUIDE_SLIDES[GAME_GUIDE_SLIDES.length - 1]!;
+    const lastSlide = GAME_GUIDE_SLIDES[4];
     expect(lastSlide.title).toContain('Trade');
     expect(lastSlide.ctas).toBeDefined();
-    expect(lastSlide.ctas!.length).toBeGreaterThanOrEqual(1);
+    expect(lastSlide.ctas.length).toBeGreaterThanOrEqual(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- Replace `min-h-screen` (100vh) with `min-h-dvh` on mobile across all pages to eliminate extra scrollable space caused by mobile browser chrome (address bar/bottom UI)
- Mute NPC/agent badge colors from purple to gray in trade cards, position cards
- Remove colored text from liquidation price and funding paid in perp position cards for a less visually noisy UI
- Fix type error in game-guide test (direct tuple index access)