### PR TITLE
fix(web): align team unrealized P&L with open positions only

### DIFF
--- a/apps/web/src/hooks/__tests__/useTeamTradingSummary.test.ts
+++ b/apps/web/src/hooks/__tests__/useTeamTradingSummary.test.ts
@@ -1,15 +1,26 @@
 import { describe, expect, it } from 'bun:test';
 import { buildTeamTradingSummary } from '../useTeamTradingSummary';
 
+const BASE_INPUT = {
+  ownerId: 'owner-1',
+  ownerName: 'Owner',
+  ownerBalance: { balance: '1000', lifetimePnL: '0' },
+  agents: [
+    {
+      id: 'agent-1',
+      name: 'agent',
+      username: 'agent',
+      virtualBalance: 500,
+      lifetimePnL: 0,
+    },
+  ],
+} as const;
+
 describe('buildTeamTradingSummary', () => {
-  it('excludes closed prediction positions from team unrealized PnL and open count', () => {
+  it('excludes closed prediction positions (resolved: true) from unrealized PnL and open count', () => {
     const summary = buildTeamTradingSummary({
-      ownerId: 'owner-1',
-      ownerName: 'Owner',
-      ownerBalance: {
-        balance: '1000',
-        lifetimePnL: '0',
-      },
+      ...BASE_INPUT,
+      ownerBalance: { balance: '1000', lifetimePnL: '0' },
       agents: [
         {
           id: 'agent-1',
@@ -46,14 +57,10 @@ describe('buildTeamTradingSummary', () => {
     expect(summary.totals.openPositions).toBe(0);
   });
 
-  it('includes active prediction positions in team unrealized PnL and open count', () => {
+  it('includes active prediction positions in unrealized PnL and open count', () => {
     const summary = buildTeamTradingSummary({
-      ownerId: 'owner-1',
-      ownerName: 'Owner',
-      ownerBalance: {
-        balance: '1000',
-        lifetimePnL: '10',
-      },
+      ...BASE_INPUT,
+      ownerBalance: { balance: '1000', lifetimePnL: '10' },
       agents: [
         {
           id: 'agent-1',
@@ -88,5 +95,171 @@ describe('buildTeamTradingSummary', () => {
 
     expect(summary.totals.unrealizedPnL).toBe(50);
     expect(summary.totals.openPositions).toBe(1);
+  });
+
+  it('excludes prediction positions with non-active status even when resolved is false', () => {
+    const summary = buildTeamTradingSummary({
+      ...BASE_INPUT,
+      positions: {
+        perpetuals: { positions: [] },
+        predictions: {
+          positions: [
+            {
+              isAgentPosition: true,
+              agentId: 'agent-1',
+              unrealizedPnL: 100,
+              resolved: false,
+              status: 'closed',
+            },
+            {
+              isAgentPosition: true,
+              agentId: 'agent-1',
+              unrealizedPnL: 75,
+              resolved: false,
+              status: 'settled',
+            },
+          ],
+        },
+      },
+    });
+
+    const agentRow = summary.members.find((m) => m.id === 'agent-1');
+    expect(agentRow?.unrealizedPnL).toBe(0);
+    expect(agentRow?.openPositions).toBe(0);
+    expect(summary.totals.unrealizedPnL).toBe(0);
+    expect(summary.totals.openPositions).toBe(0);
+  });
+
+  it('excludes prediction positions with missing status (conservative default)', () => {
+    const summary = buildTeamTradingSummary({
+      ...BASE_INPUT,
+      positions: {
+        perpetuals: { positions: [] },
+        predictions: {
+          positions: [
+            {
+              isAgentPosition: true,
+              agentId: 'agent-1',
+              unrealizedPnL: 200,
+              resolved: false,
+            },
+          ],
+        },
+      },
+    });
+
+    const agentRow = summary.members.find((m) => m.id === 'agent-1');
+    expect(agentRow?.unrealizedPnL).toBe(0);
+    expect(agentRow?.openPositions).toBe(0);
+    expect(summary.totals.unrealizedPnL).toBe(0);
+    expect(summary.totals.openPositions).toBe(0);
+  });
+
+  it('accrues active prediction positions that belong to the owner (isAgentPosition: false)', () => {
+    const summary = buildTeamTradingSummary({
+      ...BASE_INPUT,
+      positions: {
+        perpetuals: { positions: [] },
+        predictions: {
+          positions: [
+            {
+              isAgentPosition: false,
+              unrealizedPnL: 30,
+              resolved: false,
+              status: 'active',
+            },
+          ],
+        },
+      },
+    });
+
+    const ownerRow = summary.members.find((m) => m.id === 'owner-1');
+    expect(ownerRow?.unrealizedPnL).toBe(30);
+    expect(ownerRow?.openPositions).toBe(1);
+    expect(summary.totals.unrealizedPnL).toBe(30);
+    expect(summary.totals.openPositions).toBe(1);
+  });
+
+  it('accumulates perpetual and prediction positions together for the same member', () => {
+    const summary = buildTeamTradingSummary({
+      ...BASE_INPUT,
+      positions: {
+        perpetuals: {
+          positions: [
+            {
+              isAgentPosition: true,
+              agentId: 'agent-1',
+              unrealizedPnL: 40,
+            },
+          ],
+        },
+        predictions: {
+          positions: [
+            {
+              isAgentPosition: true,
+              agentId: 'agent-1',
+              unrealizedPnL: 60,
+              resolved: false,
+              status: 'active',
+            },
+            {
+              isAgentPosition: true,
+              agentId: 'agent-1',
+              unrealizedPnL: 999,
+              resolved: true,
+              status: 'resolved',
+            },
+          ],
+        },
+      },
+    });
+
+    const agentRow = summary.members.find((m) => m.id === 'agent-1');
+    expect(agentRow?.unrealizedPnL).toBe(100);
+    expect(agentRow?.openPositions).toBe(2);
+    expect(summary.totals.unrealizedPnL).toBe(100);
+    expect(summary.totals.openPositions).toBe(2);
+  });
+
+  it('keeps agentsOnlyTotals separate from owner totals', () => {
+    const summary = buildTeamTradingSummary({
+      ...BASE_INPUT,
+      ownerBalance: { balance: '1000', lifetimePnL: '5' },
+      agents: [
+        {
+          id: 'agent-1',
+          name: 'agent',
+          username: 'agent',
+          virtualBalance: 200,
+          lifetimePnL: 10,
+        },
+      ],
+      positions: {
+        perpetuals: { positions: [] },
+        predictions: {
+          positions: [
+            {
+              isAgentPosition: false,
+              unrealizedPnL: 15,
+              resolved: false,
+              status: 'active',
+            },
+            {
+              isAgentPosition: true,
+              agentId: 'agent-1',
+              unrealizedPnL: 25,
+              resolved: false,
+              status: 'active',
+            },
+          ],
+        },
+      },
+    });
+
+    expect(summary.totals.unrealizedPnL).toBe(40);
+    expect(summary.totals.openPositions).toBe(2);
+
+    expect(summary.agentsOnlyTotals.unrealizedPnL).toBe(25);
+    expect(summary.agentsOnlyTotals.openPositions).toBe(1);
   });
 });

--- a/apps/web/src/hooks/__tests__/useTeamTradingSummary.test.ts
+++ b/apps/web/src/hooks/__tests__/useTeamTradingSummary.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'bun:test';
+import { buildTeamTradingSummary } from '../useTeamTradingSummary';
+
+describe('buildTeamTradingSummary', () => {
+  it('excludes closed prediction positions from team unrealized PnL and open count', () => {
+    const summary = buildTeamTradingSummary({
+      ownerId: 'owner-1',
+      ownerName: 'Owner',
+      ownerBalance: {
+        balance: '1000',
+        lifetimePnL: '0',
+      },
+      agents: [
+        {
+          id: 'agent-1',
+          name: 'mnd',
+          username: 'mnd',
+          virtualBalance: 500,
+          lifetimePnL: '-105.10',
+        },
+      ],
+      positions: {
+        perpetuals: { positions: [] },
+        predictions: {
+          positions: [
+            {
+              isAgentPosition: true,
+              agentId: 'agent-1',
+              unrealizedPnL: 539.39,
+              resolved: true,
+              status: 'resolved',
+            },
+          ],
+        },
+        timestamp: '2026-02-28T00:00:00.000Z',
+      },
+    });
+
+    const agentRow = summary.members.find((m) => m.id === 'agent-1');
+    expect(agentRow).toBeDefined();
+    expect(agentRow?.unrealizedPnL).toBe(0);
+    expect(agentRow?.openPositions).toBe(0);
+    expect(agentRow?.currentPnL).toBe(-105.1);
+
+    expect(summary.totals.unrealizedPnL).toBe(0);
+    expect(summary.totals.openPositions).toBe(0);
+  });
+
+  it('includes active prediction positions in team unrealized PnL and open count', () => {
+    const summary = buildTeamTradingSummary({
+      ownerId: 'owner-1',
+      ownerName: 'Owner',
+      ownerBalance: {
+        balance: '1000',
+        lifetimePnL: '10',
+      },
+      agents: [
+        {
+          id: 'agent-1',
+          name: 'agent',
+          username: 'agent',
+          virtualBalance: 500,
+          lifetimePnL: 20,
+        },
+      ],
+      positions: {
+        perpetuals: { positions: [] },
+        predictions: {
+          positions: [
+            {
+              isAgentPosition: true,
+              agentId: 'agent-1',
+              unrealizedPnL: 50,
+              resolved: false,
+              status: 'active',
+            },
+          ],
+        },
+        timestamp: '2026-02-28T00:00:00.000Z',
+      },
+    });
+
+    const agentRow = summary.members.find((m) => m.id === 'agent-1');
+    expect(agentRow).toBeDefined();
+    expect(agentRow?.unrealizedPnL).toBe(50);
+    expect(agentRow?.openPositions).toBe(1);
+    expect(agentRow?.currentPnL).toBe(70);
+
+    expect(summary.totals.unrealizedPnL).toBe(50);
+    expect(summary.totals.openPositions).toBe(1);
+  });
+});

--- a/apps/web/src/hooks/useTeamTradingSummary.ts
+++ b/apps/web/src/hooks/useTeamTradingSummary.ts
@@ -111,9 +111,7 @@ function isAbortError(e: unknown): boolean {
 function isOpenPredictionPosition(
   position: PositionWithUnrealizedPnL
 ): boolean {
-  if (position.resolved) return false;
-  if (position.status && position.status !== 'active') return false;
-  return true;
+  return position.resolved === false && position.status === 'active';
 }
 
 export function buildTeamTradingSummary({

--- a/apps/web/src/hooks/useTeamTradingSummary.ts
+++ b/apps/web/src/hooks/useTeamTradingSummary.ts
@@ -88,6 +88,8 @@ type PositionWithUnrealizedPnL = {
   unrealizedPnL: number;
   isAgentPosition?: boolean;
   agentId?: string | null;
+  resolved?: boolean;
+  status?: string;
 };
 
 interface PositionsApiResponse {
@@ -104,6 +106,117 @@ function isAbortError(e: unknown): boolean {
   if (e instanceof DOMException && e.name === 'AbortError') return true;
   if (e instanceof Error && e.name === 'AbortError') return true;
   return false;
+}
+
+function isOpenPredictionPosition(
+  position: PositionWithUnrealizedPnL
+): boolean {
+  if (position.resolved) return false;
+  if (position.status && position.status !== 'active') return false;
+  return true;
+}
+
+export function buildTeamTradingSummary({
+  ownerId,
+  ownerName,
+  ownerBalance,
+  positions,
+  agents,
+}: {
+  ownerId: string;
+  ownerName: string;
+  ownerBalance: {
+    balance: string | number;
+    lifetimePnL: string | number;
+  };
+  positions: PositionsApiResponse;
+  agents: Array<{
+    id: string;
+    username?: string | null;
+    name?: string | null;
+    virtualBalance?: number;
+    lifetimePnL?: string | number;
+  }>;
+}): TeamTradingSummary {
+  const byMember = new Map<
+    string,
+    { unrealizedPnL: number; openPositions: number }
+  >();
+
+  const addPosition = (memberId: string, unrealized: number) => {
+    const cur = byMember.get(memberId) ?? {
+      unrealizedPnL: 0,
+      openPositions: 0,
+    };
+    byMember.set(memberId, {
+      unrealizedPnL: cur.unrealizedPnL + unrealized,
+      openPositions: cur.openPositions + 1,
+    });
+  };
+
+  const perpPositions = positions.perpetuals?.positions ?? [];
+  for (const p of perpPositions) {
+    const memberId = p.isAgentPosition ? (p.agentId ?? ownerId) : ownerId;
+    addPosition(memberId, toNumber(p.unrealizedPnL));
+  }
+
+  const predictionPositions = positions.predictions?.positions ?? [];
+  for (const p of predictionPositions) {
+    if (!isOpenPredictionPosition(p)) continue;
+    const memberId = p.isAgentPosition ? (p.agentId ?? ownerId) : ownerId;
+    addPosition(memberId, toNumber(p.unrealizedPnL));
+  }
+
+  const ownerWallet = toNumber(ownerBalance.balance);
+  const ownerLifetime = toNumber(ownerBalance.lifetimePnL);
+  const ownerUnrealized = byMember.get(ownerId)?.unrealizedPnL ?? 0;
+  const ownerOpenPositions = byMember.get(ownerId)?.openPositions ?? 0;
+
+  const ownerRow: TeamMemberTradingSummary = {
+    entityType: 'owner',
+    id: ownerId,
+    name: ownerName,
+    username: null,
+    walletBalance: ownerWallet,
+    lifetimePnL: ownerLifetime,
+    unrealizedPnL: ownerUnrealized,
+    currentPnL: ownerLifetime + ownerUnrealized,
+    openPositions: ownerOpenPositions,
+  };
+
+  const agentRows: TeamMemberTradingSummary[] = agents.map((a) => {
+    const id = a.id;
+    const unrealized = byMember.get(id)?.unrealizedPnL ?? 0;
+    const openPositions = byMember.get(id)?.openPositions ?? 0;
+    const walletBalance = toNumber(a.virtualBalance);
+    const lifetimePnL = toNumber(a.lifetimePnL);
+    const name = a.name ?? 'Agent';
+
+    return {
+      entityType: 'agent',
+      id,
+      name,
+      username: a.username ?? null,
+      walletBalance,
+      lifetimePnL,
+      unrealizedPnL: unrealized,
+      currentPnL: lifetimePnL + unrealized,
+      openPositions,
+    };
+  });
+
+  const members = [ownerRow, ...agentRows];
+  const totals = sumMemberTotals(members);
+  const agentsOnlyTotals = sumMemberTotals(agentRows);
+
+  return {
+    ownerId,
+    ownerName,
+    members,
+    totals,
+    agentsOnlyTotals,
+    updatedAt: positions.timestamp ?? null,
+  };
 }
 
 export function useTeamTradingSummary({
@@ -227,86 +340,13 @@ export function useTeamTradingSummary({
   const summary = useMemo<TeamTradingSummary | null>(() => {
     if (!ownerId) return null;
     if (!ownerBalance || !positions || !agents) return null;
-
-    // Aggregate unrealized PnL and counts per member (ownerId for owner).
-    const byMember = new Map<
-      string,
-      { unrealizedPnL: number; openPositions: number }
-    >();
-
-    const addPosition = (memberId: string, unrealized: number) => {
-      const cur = byMember.get(memberId) ?? {
-        unrealizedPnL: 0,
-        openPositions: 0,
-      };
-      byMember.set(memberId, {
-        unrealizedPnL: cur.unrealizedPnL + unrealized,
-        openPositions: cur.openPositions + 1,
-      });
-    };
-
-    const perpPositions = positions.perpetuals?.positions ?? [];
-    for (const p of perpPositions) {
-      const memberId = p.isAgentPosition ? (p.agentId ?? ownerId) : ownerId;
-      addPosition(memberId, toNumber(p.unrealizedPnL));
-    }
-
-    const predictionPositions = positions.predictions?.positions ?? [];
-    for (const p of predictionPositions) {
-      const memberId = p.isAgentPosition ? (p.agentId ?? ownerId) : ownerId;
-      addPosition(memberId, toNumber(p.unrealizedPnL));
-    }
-
-    const ownerWallet = toNumber(ownerBalance.balance);
-    const ownerLifetime = toNumber(ownerBalance.lifetimePnL);
-    const ownerUnrealized = byMember.get(ownerId)?.unrealizedPnL ?? 0;
-    const ownerOpenPositions = byMember.get(ownerId)?.openPositions ?? 0;
-
-    const ownerRow: TeamMemberTradingSummary = {
-      entityType: 'owner',
-      id: ownerId,
-      name: ownerName,
-      username: null,
-      walletBalance: ownerWallet,
-      lifetimePnL: ownerLifetime,
-      unrealizedPnL: ownerUnrealized,
-      currentPnL: ownerLifetime + ownerUnrealized,
-      openPositions: ownerOpenPositions,
-    };
-
-    const agentRows: TeamMemberTradingSummary[] = agents.map((a) => {
-      const id = a.id;
-      const unrealized = byMember.get(id)?.unrealizedPnL ?? 0;
-      const openPositions = byMember.get(id)?.openPositions ?? 0;
-      const walletBalance = toNumber(a.virtualBalance);
-      const lifetimePnL = toNumber(a.lifetimePnL);
-      const name = a.name ?? 'Agent';
-
-      return {
-        entityType: 'agent',
-        id,
-        name,
-        username: a.username ?? null,
-        walletBalance,
-        lifetimePnL,
-        unrealizedPnL: unrealized,
-        currentPnL: lifetimePnL + unrealized,
-        openPositions,
-      };
-    });
-
-    const members = [ownerRow, ...agentRows];
-    const totals = sumMemberTotals(members);
-    const agentsOnlyTotals = sumMemberTotals(agentRows);
-
-    return {
+    return buildTeamTradingSummary({
       ownerId,
       ownerName,
-      members,
-      totals,
-      agentsOnlyTotals,
-      updatedAt: positions.timestamp ?? null,
-    };
+      ownerBalance,
+      positions,
+      agents,
+    });
   }, [ownerId, ownerName, ownerBalance, positions, agents]);
 
   return { summary, loading, error, refresh };


### PR DESCRIPTION
## Summary

- Fix team P&L aggregation to exclude closed/resolved prediction positions from unrealized P&L and open-position counts.
- Keep team panel behavior aligned with agent panel behavior (agent panel already shows only open positions by default).
- Add focused unit tests to lock this regression.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: [BAB-222](https://linear.app/eliza-labs/issue/BAB-222/agent-pnl-mismatch-team-view-shows-unrealized-pnl-but-agent-has-no)

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [x] Other: `apps/web` hook tests

## Changes

- Added `buildTeamTradingSummary` pure helper in `useTeamTradingSummary` for deterministic aggregation + testability.
- Updated team summary aggregation to skip prediction positions that are not open (`resolved === true` or `status !== 'active'`).
- Added unit tests for:
  - closed prediction positions are excluded from unrealized/open counts,
  - active prediction positions are included.

## Review guide

**Start here**
- `apps/web/src/hooks/useTeamTradingSummary.ts`
- `apps/web/src/hooks/__tests__/useTeamTradingSummary.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- This intentionally leaves API-route semantics unchanged and hardens the team aggregation logic directly where the mismatch happens.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

Additional targeted checks run:
- [x] `bunx biome check apps/web/src/hooks/useTeamTradingSummary.ts apps/web/src/hooks/__tests__/useTeamTradingSummary.test.ts`
- [x] `bun test apps/web/src/hooks/__tests__/useTeamTradingSummary.test.ts`

**Manual verification**
1. Open `Agents -> Team -> P&L` for an account where an agent has only closed prediction positions.
2. Verify team `Unrealized P&L` and `Open Positions` do not include those closed positions.
3. Open the same agent panel and confirm values are consistent with team breakdown.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `none`
- Changed: `none`
- Removed: `none`

**DB / data migration**
- Migration(s): `none`
- Backfill/seed: `none`

**Rollout / rollback plan**
- Rollout: standard deploy.
- Rollback: revert this PR.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- N/A

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- No API contract changes.

### Database
- No DB changes.

### Contracts / on-chain
- N/A.

### Docs
- N/A.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Logic-only fix in team P&L aggregation; no layout/style or interaction surface changed.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
