### PR TITLE
fix(web): restore Privy email linking path in settings

### DIFF
--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -873,7 +873,20 @@ export default function SettingsPage() {
                           {user.emailVerified ? 'verified' : 'unverified'})
                         </>
                       ) : (
-                        'No email linked yet. Enabling email notifications will try to sync a verified email from Privy.'
+                        <div className="space-y-2">
+                          <p>
+                            No email linked yet. Enabling email notifications
+                            requires a verified email in Privy.
+                          </p>
+                          <button
+                            type="button"
+                            onClick={() => setShowLinkAccountsModal(true)}
+                            className="inline-flex min-h-[36px] items-center gap-1 rounded-md border border-border px-2.5 py-1.5 font-medium text-xs transition-colors hover:bg-muted/30"
+                          >
+                            <LinkIcon className="h-3.5 w-3.5" />
+                            <span>Link my email to Privy</span>
+                          </button>
+                        </div>
                       )}
                     </div>
                     <div className="mt-4 space-y-3">

--- a/apps/web/src/components/onboarding/game-guide-slides.ts
+++ b/apps/web/src/components/onboarding/game-guide-slides.ts
@@ -10,31 +10,26 @@ export interface GameGuideSlide {
 
 export const GAME_GUIDE_SLIDES: GameGuideSlide[] = [
   {
-
     title: 'Welcome to Babylon',
     description:
       'A world of humans, NPCs, and AI agents. You command a team of agents that work for you — narratives emerge here first, markets react, and better information means more points. Points are the game currency, onchain tokens on the horizon.',
   },
   {
-
     title: 'Your Agent Team',
     description:
       "Agents scout, analyze, and trade on your behalf. Prompt them with goals, learn from results, and refine. The loop: prompt → gather intel → analyze → trade → improve. They work around the clock so you don't miss a signal.",
   },
   {
-
     title: 'The Feed',
     description:
       'The timeline where agents, humans, and NPCs post. Your agents track topics and NPCs, surface sentiment shifts, and summarize what changed — narratives start here and markets pull signal from them.',
   },
   {
-
     title: 'DMs & Group Chats',
     description:
       'Private channels where NPCs drop context, timing, and hints. Prompt your agents on which NPCs to approach, what questions to ask, and what to extract — signals, catalysts, and timing. The right prompts get you into the right rooms.',
   },
   {
-
     title: 'Trade & Improve',
     description:
       'Trade on what your agents find via prediction markets and perps. Agents act faster than manual trading — iterate on prompts, sharpen your edge, climb the leaderboard.',

--- a/apps/web/src/components/profile/LinkSocialAccountsModal.tsx
+++ b/apps/web/src/components/profile/LinkSocialAccountsModal.tsx
@@ -5,8 +5,8 @@ import { useLinkAccount, usePrivy } from '@privy-io/react-auth';
 import { Check, ExternalLink, Mail, Shield, X as XIcon } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
-import { getAuthToken } from '@/lib/auth';
 import { isLinkEmailFlowCancellationError } from '@/components/profile/link-email-utils';
+import { getAuthToken } from '@/lib/auth';
 import { useAuthStore } from '@/stores/authStore';
 
 /**
@@ -259,8 +259,8 @@ export function LinkSocialAccountsModal({
                 <div className="flex items-start gap-2 rounded-lg border border-blue-500/20 bg-blue-500/10 p-3">
                   <Shield className="mt-0.5 h-4 w-4 shrink-0 text-blue-500" />
                   <p className="text-muted-foreground text-xs">
-                    Link a verified email in Privy to enable notification
-                    emails and account recovery.
+                    Link a verified email in Privy to enable notification emails
+                    and account recovery.
                   </p>
                 </div>
                 <button

--- a/apps/web/src/components/profile/LinkSocialAccountsModal.tsx
+++ b/apps/web/src/components/profile/LinkSocialAccountsModal.tsx
@@ -1,20 +1,26 @@
 'use client';
 
 import { cn, signInWithFarcaster } from '@babylon/shared';
-import { Check, ExternalLink, Shield, X as XIcon } from 'lucide-react';
+import { useLinkAccount, usePrivy } from '@privy-io/react-auth';
+import { Check, ExternalLink, Mail, Shield, X as XIcon } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { getAuthToken } from '@/lib/auth';
+import {
+  getLinkedEmail,
+  isLinkEmailFlowCancellationError,
+} from '@/components/profile/link-email-utils';
 import { useAuthStore } from '@/stores/authStore';
 
 /**
  * Link social accounts modal component for connecting social accounts.
  *
- * Provides a modal interface for linking Twitter and Farcaster accounts
- * via OAuth. Handles OAuth callbacks and updates user profile with linked
- * account information. Awards reputation points for linking accounts.
+ * Provides a modal interface for linking email, Twitter, and Farcaster
+ * accounts. Handles account-link callbacks and updates user profile with
+ * linked account information. Awards reputation points for social linking.
  *
  * Features:
+ * - Email linking via Privy
  * - Twitter OAuth linking
  * - Farcaster OAuth linking
  * - OAuth callback handling
@@ -44,9 +50,13 @@ export function LinkSocialAccountsModal({
   onClose,
 }: LinkSocialAccountsModalProps) {
   const { user, setUser } = useAuthStore();
+  const { user: privyUser } = usePrivy();
+  const { linkEmail } = useLinkAccount();
   const [linking, setLinking] = useState<string | null>(null);
   const [confirmUnlinkTwitter, setConfirmUnlinkTwitter] = useState(false);
   const [unlinkingTwitter, setUnlinkingTwitter] = useState(false);
+  const linkedEmail = getLinkedEmail(privyUser?.email?.address, user?.email);
+  const hasLinkedEmail = Boolean(linkedEmail);
 
   useEffect(() => {
     if (isOpen) return;
@@ -56,6 +66,21 @@ export function LinkSocialAccountsModal({
   }, [isOpen]);
 
   if (!isOpen) return null;
+
+  const handleEmailLink = async () => {
+    if (!user?.id) return;
+
+    setLinking('email');
+    try {
+      await linkEmail();
+      toast.success('Email linked to Privy');
+    } catch (error) {
+      if (isLinkEmailFlowCancellationError(error)) return;
+      toast.error('Failed to link email. Please try again.');
+    } finally {
+      setLinking(null);
+    }
+  };
 
   const handleTwitterOAuth = async () => {
     if (!user?.id) return;
@@ -192,7 +217,7 @@ export function LinkSocialAccountsModal({
         <div className="flex shrink-0 items-start justify-between border-border border-b p-6">
           <div className="flex items-center gap-2">
             <Shield className="h-5 w-5 text-primary" />
-            <h2 className="font-bold text-xl">Link Social Accounts</h2>
+            <h2 className="font-bold text-xl">Link Accounts</h2>
           </div>
           <button
             onClick={onClose}
@@ -204,6 +229,56 @@ export function LinkSocialAccountsModal({
 
         {/* Content */}
         <div className="min-h-0 flex-1 space-y-6 overflow-y-auto p-6">
+          {/* Email */}
+          <div className="space-y-3">
+            <div className="flex items-center gap-2">
+              <Mail className="h-5 w-5" />
+              <h3 className="font-semibold">Email</h3>
+              {hasLinkedEmail && (
+                <span className="ml-auto flex items-center gap-1 text-green-500 text-sm">
+                  <Check className="h-4 w-4" />
+                  Verified
+                </span>
+              )}
+            </div>
+
+            {hasLinkedEmail ? (
+              <div className="flex items-center gap-2 rounded-lg border border-green-500/20 bg-green-500/10 p-3">
+                <Check className="h-4 w-4 text-green-500" />
+                <span className="font-medium text-sm">{linkedEmail}</span>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <div className="flex items-start gap-2 rounded-lg border border-blue-500/20 bg-blue-500/10 p-3">
+                  <Shield className="mt-0.5 h-4 w-4 shrink-0 text-blue-500" />
+                  <p className="text-muted-foreground text-xs">
+                    Link a verified email in Privy to enable notification
+                    emails and account recovery.
+                  </p>
+                </div>
+                <button
+                  onClick={() => void handleEmailLink()}
+                  disabled={linking === 'email'}
+                  className={cn(
+                    'w-full rounded-lg px-4 py-2 font-semibold transition-colors',
+                    'bg-[#0066FF] text-primary-foreground hover:bg-[#2952d9]',
+                    'disabled:cursor-not-allowed disabled:opacity-50',
+                    'flex items-center justify-center gap-2'
+                  )}
+                >
+                  {linking === 'email' ? (
+                    <span>Opening Privy...</span>
+                  ) : (
+                    <>
+                      <Mail className="h-4 w-4" />
+                      <span>Link my email to Privy</span>
+                    </>
+                  )}
+                </button>
+              </div>
+            )}
+          </div>
+
           {/* Twitter/X */}
           <div className="space-y-3">
             <div className="flex items-center gap-2">
@@ -390,8 +465,8 @@ export function LinkSocialAccountsModal({
             <div className="flex items-start gap-2">
               <Shield className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
               <p className="text-muted-foreground text-sm">
-                OAuth authentication verifies your account ownership and earns
-                you reputation points!
+                Account linking verifies ownership and can unlock features like
+                notifications and reputation rewards.
               </p>
             </div>
           </div>

--- a/apps/web/src/components/profile/LinkSocialAccountsModal.tsx
+++ b/apps/web/src/components/profile/LinkSocialAccountsModal.tsx
@@ -1,15 +1,12 @@
 'use client';
 
-import { cn, signInWithFarcaster } from '@babylon/shared';
+import { cn, logger, signInWithFarcaster } from '@babylon/shared';
 import { useLinkAccount, usePrivy } from '@privy-io/react-auth';
 import { Check, ExternalLink, Mail, Shield, X as XIcon } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { getAuthToken } from '@/lib/auth';
-import {
-  getLinkedEmail,
-  isLinkEmailFlowCancellationError,
-} from '@/components/profile/link-email-utils';
+import { isLinkEmailFlowCancellationError } from '@/components/profile/link-email-utils';
 import { useAuthStore } from '@/stores/authStore';
 
 /**
@@ -51,12 +48,31 @@ export function LinkSocialAccountsModal({
 }: LinkSocialAccountsModalProps) {
   const { user, setUser } = useAuthStore();
   const { user: privyUser } = usePrivy();
-  const { linkEmail } = useLinkAccount();
   const [linking, setLinking] = useState<string | null>(null);
   const [confirmUnlinkTwitter, setConfirmUnlinkTwitter] = useState(false);
   const [unlinkingTwitter, setUnlinkingTwitter] = useState(false);
-  const linkedEmail = getLinkedEmail(privyUser?.email?.address, user?.email);
-  const hasLinkedEmail = Boolean(linkedEmail);
+
+  // Only treat the email as verified/linked when Privy holds it — the stored
+  // user.email may be unverified (e.g. imported from a previous auth method).
+  const privyEmail = privyUser?.email?.address?.trim() || null;
+
+  const { linkEmail } = useLinkAccount({
+    onSuccess: () => {
+      toast.success('Email linked to Privy');
+      setLinking(null);
+      onClose();
+    },
+    onError: (error) => {
+      setLinking(null);
+      if (isLinkEmailFlowCancellationError(error)) return;
+      logger.error(
+        'Failed to link email via Privy',
+        { error: String(error) },
+        'LinkSocialAccountsModal'
+      );
+      toast.error('Failed to link email. Please try again.');
+    },
+  });
 
   useEffect(() => {
     if (isOpen) return;
@@ -67,19 +83,10 @@ export function LinkSocialAccountsModal({
 
   if (!isOpen) return null;
 
-  const handleEmailLink = async () => {
+  const handleEmailLink = () => {
     if (!user?.id) return;
-
     setLinking('email');
-    try {
-      await linkEmail();
-      toast.success('Email linked to Privy');
-    } catch (error) {
-      if (isLinkEmailFlowCancellationError(error)) return;
-      toast.error('Failed to link email. Please try again.');
-    } finally {
-      setLinking(null);
-    }
+    linkEmail();
   };
 
   const handleTwitterOAuth = async () => {
@@ -234,7 +241,7 @@ export function LinkSocialAccountsModal({
             <div className="flex items-center gap-2">
               <Mail className="h-5 w-5" />
               <h3 className="font-semibold">Email</h3>
-              {hasLinkedEmail && (
+              {privyEmail && (
                 <span className="ml-auto flex items-center gap-1 text-green-500 text-sm">
                   <Check className="h-4 w-4" />
                   Verified
@@ -242,10 +249,10 @@ export function LinkSocialAccountsModal({
               )}
             </div>
 
-            {hasLinkedEmail ? (
+            {privyEmail ? (
               <div className="flex items-center gap-2 rounded-lg border border-green-500/20 bg-green-500/10 p-3">
                 <Check className="h-4 w-4 text-green-500" />
-                <span className="font-medium text-sm">{linkedEmail}</span>
+                <span className="font-medium text-sm">{privyEmail}</span>
               </div>
             ) : (
               <div className="space-y-2">
@@ -257,7 +264,7 @@ export function LinkSocialAccountsModal({
                   </p>
                 </div>
                 <button
-                  onClick={() => void handleEmailLink()}
+                  onClick={handleEmailLink}
                   disabled={linking === 'email'}
                   className={cn(
                     'w-full rounded-lg px-4 py-2 font-semibold transition-colors',

--- a/apps/web/src/components/profile/link-email-utils.test.ts
+++ b/apps/web/src/components/profile/link-email-utils.test.ts
@@ -28,19 +28,31 @@ describe('link-email-utils', () => {
   });
 
   describe('isLinkEmailFlowCancellationError', () => {
-    it('detects exited/cancelled flow errors', () => {
-      expect(
-        isLinkEmailFlowCancellationError(
-          new Error('User exited link email flow')
-        )
-      ).toBe(true);
+    it('detects the exited_auth_flow string code from useLinkAccount onError', () => {
+      expect(isLinkEmailFlowCancellationError('exited_auth_flow')).toBe(true);
     });
 
-    it('returns false for non-cancellation errors', () => {
-      expect(
-        isLinkEmailFlowCancellationError(new Error('Network failure'))
-      ).toBe(false);
+    it('detects a PrivyClientError-shaped object with code exited_auth_flow', () => {
+      const err = Object.assign(new Error('User exited link email flow'), {
+        code: 'exited_auth_flow',
+      });
+      expect(isLinkEmailFlowCancellationError(err)).toBe(true);
+    });
+
+    it('returns false when the thrown value is not an Error instance', () => {
       expect(isLinkEmailFlowCancellationError('exited')).toBe(false);
+      expect(isLinkEmailFlowCancellationError(null)).toBe(false);
+      expect(isLinkEmailFlowCancellationError(42)).toBe(false);
+    });
+
+    it('returns false for plain Error without a matching code', () => {
+      expect(isLinkEmailFlowCancellationError(new Error('Network failure'))).toBe(
+        false
+      );
+      const errWrongCode = Object.assign(new Error('other'), {
+        code: 'network_error',
+      });
+      expect(isLinkEmailFlowCancellationError(errWrongCode)).toBe(false);
     });
   });
 });

--- a/apps/web/src/components/profile/link-email-utils.test.ts
+++ b/apps/web/src/components/profile/link-email-utils.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  getLinkedEmail,
+  isLinkEmailFlowCancellationError,
+} from './link-email-utils';
+
+describe('link-email-utils', () => {
+  describe('getLinkedEmail', () => {
+    it('prefers Privy email when present', () => {
+      expect(
+        getLinkedEmail('linked@example.com', 'stored@example.com')
+      ).toBe('linked@example.com');
+    });
+
+    it('falls back to stored email when Privy email is missing', () => {
+      expect(getLinkedEmail(undefined, 'stored@example.com')).toBe(
+        'stored@example.com'
+      );
+      expect(getLinkedEmail('   ', 'stored@example.com')).toBe(
+        'stored@example.com'
+      );
+    });
+
+    it('returns null when neither source has an email', () => {
+      expect(getLinkedEmail(undefined, undefined)).toBeNull();
+      expect(getLinkedEmail(' ', ' ')).toBeNull();
+    });
+  });
+
+  describe('isLinkEmailFlowCancellationError', () => {
+    it('detects exited/cancelled flow errors', () => {
+      expect(
+        isLinkEmailFlowCancellationError(
+          new Error('User exited link email flow')
+        )
+      ).toBe(true);
+    });
+
+    it('returns false for non-cancellation errors', () => {
+      expect(
+        isLinkEmailFlowCancellationError(new Error('Network failure'))
+      ).toBe(false);
+      expect(isLinkEmailFlowCancellationError('exited')).toBe(false);
+    });
+  });
+});

--- a/apps/web/src/components/profile/link-email-utils.test.ts
+++ b/apps/web/src/components/profile/link-email-utils.test.ts
@@ -7,9 +7,9 @@ import {
 describe('link-email-utils', () => {
   describe('getLinkedEmail', () => {
     it('prefers Privy email when present', () => {
-      expect(
-        getLinkedEmail('linked@example.com', 'stored@example.com')
-      ).toBe('linked@example.com');
+      expect(getLinkedEmail('linked@example.com', 'stored@example.com')).toBe(
+        'linked@example.com'
+      );
     });
 
     it('falls back to stored email when Privy email is missing', () => {
@@ -46,9 +46,9 @@ describe('link-email-utils', () => {
     });
 
     it('returns false for plain Error without a matching code', () => {
-      expect(isLinkEmailFlowCancellationError(new Error('Network failure'))).toBe(
-        false
-      );
+      expect(
+        isLinkEmailFlowCancellationError(new Error('Network failure'))
+      ).toBe(false);
       const errWrongCode = Object.assign(new Error('other'), {
         code: 'network_error',
       });

--- a/apps/web/src/components/profile/link-email-utils.ts
+++ b/apps/web/src/components/profile/link-email-utils.ts
@@ -9,7 +9,16 @@ export function getLinkedEmail(
   return normalizedStored || null;
 }
 
+/**
+ * Returns true when the Privy link-email flow was cancelled by the user.
+ *
+ * Handles two shapes:
+ * - The string error code `'exited_auth_flow'` passed to `useLinkAccount` onError callbacks.
+ * - A PrivyClientError (or similar) thrown synchronously with `code === 'exited_auth_flow'`.
+ */
 export function isLinkEmailFlowCancellationError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  return error.message.toLowerCase().includes('exited');
+  if (error === 'exited_auth_flow') return true;
+  if (error instanceof Error && (error as { code?: string }).code === 'exited_auth_flow')
+    return true;
+  return false;
 }

--- a/apps/web/src/components/profile/link-email-utils.ts
+++ b/apps/web/src/components/profile/link-email-utils.ts
@@ -1,0 +1,15 @@
+export function getLinkedEmail(
+  privyEmail?: string | null,
+  storedEmail?: string | null
+): string | null {
+  const normalizedPrivy = privyEmail?.trim() || '';
+  if (normalizedPrivy) return normalizedPrivy;
+
+  const normalizedStored = storedEmail?.trim() || '';
+  return normalizedStored || null;
+}
+
+export function isLinkEmailFlowCancellationError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return error.message.toLowerCase().includes('exited');
+}

--- a/apps/web/src/components/profile/link-email-utils.ts
+++ b/apps/web/src/components/profile/link-email-utils.ts
@@ -18,7 +18,10 @@ export function getLinkedEmail(
  */
 export function isLinkEmailFlowCancellationError(error: unknown): boolean {
   if (error === 'exited_auth_flow') return true;
-  if (error instanceof Error && (error as { code?: string }).code === 'exited_auth_flow')
+  if (
+    error instanceof Error &&
+    (error as { code?: string }).code === 'exited_auth_flow'
+  )
     return true;
   return false;
 }


### PR DESCRIPTION
## Summary

- Add an explicit `Link my email to Privy` entry point in Settings when no email is linked.
- Extend the account-link modal to support email linking via Privy (`linkEmail`) in addition to X/Farcaster.
- Unblock users who signed up with non-email methods from linking an email for notification preferences (BAB-197 dependency).

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: [BAB-221](https://linear.app/eliza-labs/issue/BAB-221/cant-connect-email-no-link-my-email-to-privy-in-profile-settings)
- Related dependency context: BAB-197 (notification emails)

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [x] Other: `apps/web` colocated unit test

## Changes

- Add email link section to `LinkSocialAccountsModal`:
  - linked state displays verified email
  - unlinked state displays CTA `Link my email to Privy`
  - uses Privy `useLinkAccount().linkEmail()`
  - handles link-flow cancellation without false error toast
- Add direct CTA in Settings > Notification Emails when no email is linked:
  - `Link my email to Privy` opens the linking modal
- Add small utility + tests for email selection and cancellation-error detection:
  - `link-email-utils.ts`
  - `link-email-utils.test.ts`

## Review guide

**Start here**
- `apps/web/src/app/settings/page.tsx`
- `apps/web/src/components/profile/LinkSocialAccountsModal.tsx`
- `apps/web/src/components/profile/link-email-utils.ts`
- `apps/web/src/components/profile/link-email-utils.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- Existing X/Farcaster linking flows are unchanged.
- This is intentionally UI-only to expose existing Privy email-link capability.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Sign in with a non-email auth method (wallet/X/Farcaster).
2. Go to `Settings > Profile`.
3. In `Notification Emails`, confirm `Link my email to Privy` is visible when no email exists.
4. Click it, then click `Link my email to Privy` in the modal.
5. Complete Privy email flow and confirm linked email appears as verified in modal/settings.

**Targeted checks executed in this PR**
- `bun test apps/web/src/components/profile/link-email-utils.test.ts`
- `bun x biome check apps/web/src/components/profile/LinkSocialAccountsModal.tsx apps/web/src/components/profile/link-email-utils.ts apps/web/src/components/profile/link-email-utils.test.ts apps/web/src/app/settings/page.tsx`
- Attempted: `bun x tsc --noEmit -p apps/web/tsconfig.json` (blocked locally due missing workspace type deps in this worktree: `@serwist/next/typings`, `bun-types`)

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `none`
- Changed: `none`
- Removed: `none`

**DB / data migration**
- Migration(s): `none`
- Backfill/seed: `none`

**Rollout / rollback plan**
- Rollout: regular frontend deploy
- Rollback: revert PR

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- N/A

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option A: Visual demo

| Feature | Before | After |
|---------|--------|-------|
| Email linking entry in Settings | No explicit CTA when user has no email linked | `Link my email to Privy` CTA visible in Notification Emails |
| Account linking modal | Only X/Farcaster actions | Email section + `Link my email to Privy` action |

*Demo script (for recording):*
1. Open `Settings > Profile` with a non-email-auth account.
2. Show missing-email state and the new CTA in `Notification Emails`.
3. Open the link modal and trigger `Link my email to Privy`.
4. Complete the Privy flow and show the verified email state.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

## Non-goals / follow-ups

- Add an E2E scenario for Privy email linking flow in CI (requires deterministic test auth harness).
