### PR TITLE
fix(web): remove Website link from marketing footer

### DIFF
--- a/apps/web/src/components/shared/MarketingFooter.tsx
+++ b/apps/web/src/components/shared/MarketingFooter.tsx
@@ -159,14 +159,6 @@ export function MarketingFooter({ className }: MarketingFooterProps) {
                 >
                   GitHub
                 </a>
-                <a
-                  href={EXTERNAL_LINKS.website}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="touch-manipulation transition-colors duration-200 hover:text-primary"
-                >
-                  Website
-                </a>
               </nav>
             </div>
 

--- a/packages/testing/unit/marketing-footer-links.test.ts
+++ b/packages/testing/unit/marketing-footer-links.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const marketingFooterPath = path.resolve(
+  import.meta.dir,
+  '../../../apps/web/src/components/shared/MarketingFooter.tsx'
+);
+
+describe('MarketingFooter links', () => {
+  it('keeps main resource links and removes legacy Website link', () => {
+    const source = readFileSync(marketingFooterPath, 'utf8');
+
+    expect(source.includes('EXTERNAL_LINKS.docs')).toBe(true);
+    expect(source.includes('EXTERNAL_LINKS.blog')).toBe(true);
+    expect(source.includes('EXTERNAL_LINKS.github')).toBe(true);
+
+    expect(source.includes('EXTERNAL_LINKS.website')).toBe(false);
+    expect(
+      source.includes('>\n                  Website\n                <')
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Remove the legacy `Website` link from the desktop marketing footer resources list.
- Keep the other footer resource links unchanged (`Documentation`, `Blog`, `GitHub`).
- Add a focused unit test to prevent regressions for this footer link set.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: [BAB-231](https://linear.app/eliza-labs/issue/BAB-231/remove-website-from-the-footer)

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- Removed the `Website` anchor from `apps/web/src/components/shared/MarketingFooter.tsx`.
- Added `packages/testing/unit/marketing-footer-links.test.ts` to assert:
  - expected footer resource links still exist in source (`docs`, `blog`, `github`)
  - legacy `EXTERNAL_LINKS.website` usage is absent from `MarketingFooter`.

## Review guide

**Start here**
- `apps/web/src/components/shared/MarketingFooter.tsx`
- `packages/testing/unit/marketing-footer-links.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- Scope is intentionally minimal for BAB-231 only.
- Non-goal: removing `EXTERNAL_LINKS.website` from shared constants globally (kept untouched to avoid unrelated fallout).

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Ran formatting/lint on changed files only:
   - `bunx biome check --write apps/web/src/components/shared/MarketingFooter.tsx packages/testing/unit/marketing-footer-links.test.ts`
2. Ran targeted unit test:
   - `bun test packages/testing/unit/marketing-footer-links.test.ts --preload ./packages/testing/unit/preload.ts`
   - Result: pass (1/1)
3. Tried targeted Playwright check:
   - `cd packages/testing && bunx playwright test e2e/landing-page-blog-links.spec.ts --project=chromium --grep "desktop footer resources section" --no-deps`
   - Result: failed due existing environment/setup baseline (missing/invalid auth state / page mismatch), not tied to this diff.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: standard web deploy.
- Rollback: revert this PR.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- N/A

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- N/A

### Database
- N/A

### Contracts / on-chain
- N/A

### Docs
- N/A

</details>

## Screenshots / recordings (UI)

### Option A: Visual demo

| Feature | Before | After |
|---------|--------|-------|
| Footer resources | `Website` link visible in desktop footer | `Website` link removed from desktop footer |

*Demo script (for recording):*
1. Open landing page on desktop viewport.
2. Scroll to footer `Resources` section.
3. Confirm `Documentation`, `Blog`, `GitHub` are present and `Website` is absent.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
