### PR TITLE
feat(observability): standardize Sentry capture for API wrappers and server actions

### DIFF
--- a/apps/web/instrumentation.ts
+++ b/apps/web/instrumentation.ts
@@ -26,10 +26,19 @@ export async function register() {
     const {
       setPointsService,
       setNotificationService,
+      setDefaultErrorCapture,
       PointsService,
       createNotification,
       logDevCredentials,
     } = await import('@babylon/api');
+    const { createSentryApiRouteCapture } = await import(
+      './src/lib/sentry/api-route-capture'
+    );
+
+    // Route-level captureError options still override this default.
+    setDefaultErrorCapture(
+      sentryDisabled ? undefined : createSentryApiRouteCapture()
+    );
 
     // Log development credentials at startup (only in dev mode)
     // This makes it easy for developers to authenticate with admin APIs

--- a/apps/web/src/app/_actions/nft.ts
+++ b/apps/web/src/app/_actions/nft.ts
@@ -15,6 +15,7 @@ import {
 } from '@babylon/api/services/nft-mint-service';
 import { logger, ValidationError } from '@babylon/shared';
 import type { Address, Hex } from 'viem';
+import { wrapServerActionWithSentry } from '@/lib/sentry/server-actions';
 
 import { requirePrivyTokenBundle } from './utils';
 
@@ -135,7 +136,7 @@ function backoffSleep(
  *
  * @returns MintNftActionResult with either 'confirmed' (includes NFT data) or 'pending' status
  */
-export async function mintNftAction(input?: {
+async function mintNftActionImpl(input?: {
   userJwt?: string;
 }): Promise<MintNftActionResult> {
   // Step 1: Auth
@@ -330,3 +331,8 @@ export async function mintNftAction(input?: {
       'Your NFT should appear shortly. You can track the transaction on a block explorer.',
   };
 }
+
+export const mintNftAction = wrapServerActionWithSentry(
+  'mintNftAction',
+  mintNftActionImpl
+);

--- a/apps/web/src/app/_actions/onchain.ts
+++ b/apps/web/src/app/_actions/onchain.ts
@@ -20,6 +20,7 @@ import {
   pad,
 } from 'viem';
 import type { AgentProfileMetadata } from '@/hooks/useUpdateAgentProfileTx';
+import { wrapServerActionWithSentry } from '@/lib/sentry/server-actions';
 
 import { requirePrivyTokenBundle } from './utils';
 
@@ -56,7 +57,7 @@ const PREDICTION_MARKET_ABI = [
   },
 ] as const;
 
-export async function buySharesOnchainAction(input: {
+async function buySharesOnchainActionImpl(input: {
   marketId: string;
   outcome: 'YES' | 'NO';
   numShares: number;
@@ -87,7 +88,12 @@ export async function buySharesOnchainAction(input: {
   return { txHash: hash };
 }
 
-export async function sellSharesOnchainAction(input: {
+export const buySharesOnchainAction = wrapServerActionWithSentry(
+  'buySharesOnchainAction',
+  buySharesOnchainActionImpl
+);
+
+async function sellSharesOnchainActionImpl(input: {
   marketId: string;
   outcome: 'YES' | 'NO';
   numShares: number;
@@ -118,7 +124,12 @@ export async function sellSharesOnchainAction(input: {
   return { txHash: hash };
 }
 
-export async function sendSponsoredEthTransferAction(input: {
+export const sellSharesOnchainAction = wrapServerActionWithSentry(
+  'sellSharesOnchainAction',
+  sellSharesOnchainActionImpl
+);
+
+async function sendSponsoredEthTransferActionImpl(input: {
   to: string;
   amountWei: string;
   userJwt?: string;
@@ -142,7 +153,12 @@ export async function sendSponsoredEthTransferAction(input: {
   return { txHash: hash };
 }
 
-export async function updateAgentProfileOnchainAction(input: {
+export const sendSponsoredEthTransferAction = wrapServerActionWithSentry(
+  'sendSponsoredEthTransferAction',
+  sendSponsoredEthTransferActionImpl
+);
+
+async function updateAgentProfileOnchainActionImpl(input: {
   metadata: AgentProfileMetadata;
   endpoint?: string;
   userJwt?: string;
@@ -184,3 +200,8 @@ export async function updateAgentProfileOnchainAction(input: {
 
   return { txHash: hash };
 }
+
+export const updateAgentProfileOnchainAction = wrapServerActionWithSentry(
+  'updateAgentProfileOnchainAction',
+  updateAgentProfileOnchainActionImpl
+);

--- a/apps/web/src/app/agents/team/panels/PanelErrorBoundary.tsx
+++ b/apps/web/src/app/agents/team/panels/PanelErrorBoundary.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import * as Sentry from '@sentry/nextjs';
 import { AlertTriangle } from 'lucide-react';
 import { Component, type ReactNode } from 'react';
 
@@ -28,7 +29,18 @@ export class PanelErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
-    console.error('Panel rendering error:', error, errorInfo);
+    Sentry.withScope((scope) => {
+      scope.setTag('errorBoundary', 'panel');
+      scope.setTag('surface', 'agent-team-panel');
+      scope.setContext('panelErrorBoundary', {
+        componentStack: errorInfo.componentStack,
+      });
+      Sentry.captureException(error);
+    });
+
+    if (process.env.NODE_ENV !== 'production') {
+      console.error('Panel rendering error:', error, errorInfo);
+    }
   }
 
   render(): ReactNode {

--- a/apps/web/src/app/agents/team/panels/PanelErrorBoundary.tsx
+++ b/apps/web/src/app/agents/team/panels/PanelErrorBoundary.tsx
@@ -38,9 +38,9 @@ export class PanelErrorBoundary extends Component<Props, State> {
       Sentry.captureException(error);
     });
 
-    if (process.env.NODE_ENV !== 'production') {
-      console.error('Panel rendering error:', error, errorInfo);
-    }
+    console.error('[PanelErrorBoundary] Panel rendering error:', error.message, {
+      componentStack: errorInfo.componentStack,
+    });
   }
 
   render(): ReactNode {

--- a/apps/web/src/app/agents/team/panels/PanelErrorBoundary.tsx
+++ b/apps/web/src/app/agents/team/panels/PanelErrorBoundary.tsx
@@ -38,9 +38,13 @@ export class PanelErrorBoundary extends Component<Props, State> {
       Sentry.captureException(error);
     });
 
-    console.error('[PanelErrorBoundary] Panel rendering error:', error.message, {
-      componentStack: errorInfo.componentStack,
-    });
+    console.error(
+      '[PanelErrorBoundary] Panel rendering error:',
+      error.message,
+      {
+        componentStack: errorInfo.componentStack,
+      }
+    );
   }
 
   render(): ReactNode {

--- a/apps/web/src/lib/sentry/api-route-capture.ts
+++ b/apps/web/src/lib/sentry/api-route-capture.ts
@@ -1,0 +1,93 @@
+import type { ErrorHandlerOptions, JsonValue } from '@babylon/api';
+import * as Sentry from '@sentry/nextjs';
+
+type ErrorCaptureContext = Parameters<
+  NonNullable<ErrorHandlerOptions['captureError']>
+>[1];
+
+function toRecord(
+  value: JsonValue | undefined
+): Record<string, JsonValue> | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, JsonValue>;
+}
+
+function toString(value: JsonValue | undefined): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function getHeaderValue(
+  headers: Record<string, JsonValue> | undefined,
+  key: string
+): string | undefined {
+  if (!headers) {
+    return undefined;
+  }
+
+  const targetKey = key.toLowerCase();
+  for (const [headerKey, value] of Object.entries(headers)) {
+    if (headerKey.toLowerCase() === targetKey && typeof value === 'string') {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function getEndpointFromUrl(url: string | undefined): string | undefined {
+  if (!url) {
+    return undefined;
+  }
+
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Creates the default Sentry capture callback used by @babylon/api's withErrorHandling wrapper.
+ */
+export function createSentryApiRouteCapture(): NonNullable<
+  ErrorHandlerOptions['captureError']
+> {
+  return (error: Error, context: ErrorCaptureContext): void => {
+    const request = toRecord(context.request);
+    const headers = toRecord(request?.headers);
+    const requestUrl = toString(request?.url);
+    const requestMethod = toString(request?.method);
+    const requestId = getHeaderValue(headers, 'x-request-id');
+    const endpoint = getEndpointFromUrl(requestUrl);
+    const user = toRecord(context.user);
+    const userId = toString(user?.id);
+
+    Sentry.withScope((scope) => {
+      scope.setTag('runtime', 'nodejs');
+      scope.setTag('surface', 'api-route');
+
+      if (requestMethod) {
+        scope.setTag('method', requestMethod);
+      }
+      if (endpoint) {
+        scope.setTag('endpoint', endpoint);
+      }
+      if (requestId) {
+        scope.setTag('requestId', requestId);
+      }
+      if (userId) {
+        scope.setUser({ id: userId });
+      }
+
+      scope.setContext('apiRoute', {
+        method: requestMethod,
+        endpoint,
+        requestId,
+      });
+      scope.setContext('apiErrorContext', context);
+
+      Sentry.captureException(error);
+    });
+  };
+}

--- a/apps/web/src/lib/sentry/api-route-capture.ts
+++ b/apps/web/src/lib/sentry/api-route-capture.ts
@@ -43,7 +43,7 @@ function getEndpointFromUrl(url: string | undefined): string | undefined {
   try {
     return new URL(url).pathname;
   } catch {
-    return url;
+    return url.split('?')[0];
   }
 }
 

--- a/apps/web/src/lib/sentry/server-actions.ts
+++ b/apps/web/src/lib/sentry/server-actions.ts
@@ -1,0 +1,96 @@
+import * as Sentry from '@sentry/nextjs';
+
+const SENSITIVE_KEY_PATTERN =
+  /(token|secret|password|authorization|cookie|jwt|api[-_]?key|signature)/i;
+
+function sanitizeValue(value: unknown, depth = 0): unknown {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (depth >= 2) {
+    if (Array.isArray(value)) {
+      return `[array:${value.length}]`;
+    }
+    if (typeof value === 'object') {
+      return '[object]';
+    }
+  }
+
+  if (typeof value === 'string') {
+    return `[string:${value.length}]`;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  if (typeof value === 'function' || typeof value === 'symbol') {
+    return `[${typeof value}]`;
+  }
+
+  if (Array.isArray(value)) {
+    return value.slice(0, 5).map((entry) => sanitizeValue(entry, depth + 1));
+  }
+
+  const objectValue = value as Record<string, unknown>;
+  const entries = Object.entries(objectValue).slice(0, 10);
+  const out: Record<string, unknown> = {};
+
+  for (const [key, entryValue] of entries) {
+    if (SENSITIVE_KEY_PATTERN.test(key)) {
+      out[key] = '[REDACTED]';
+      continue;
+    }
+    out[key] = sanitizeValue(entryValue, depth + 1);
+  }
+
+  return out;
+}
+
+function sanitizeActionArgs(args: unknown[]): Record<string, unknown> {
+  return {
+    argCount: args.length,
+    args: sanitizeValue(args),
+  };
+}
+
+/**
+ * Wrap a server action with Sentry performance + exception instrumentation.
+ * Argument metadata is sanitized to avoid leaking secrets/PII.
+ */
+export function wrapServerActionWithSentry<T extends unknown[], R>(
+  actionName: string,
+  action: (...args: T) => Promise<R>
+): (...args: T) => Promise<R> {
+  return async (...args: T): Promise<R> => {
+    return Sentry.startSpan(
+      {
+        op: 'server.action',
+        name: `server-action.${actionName}`,
+        attributes: {
+          'babylon.surface': 'server-action',
+          'babylon.action': actionName,
+        },
+      },
+      async () => {
+        try {
+          return await action(...args);
+        } catch (error) {
+          Sentry.withScope((scope) => {
+            scope.setTag('runtime', 'nodejs');
+            scope.setTag('surface', 'server-action');
+            scope.setTag('action', actionName);
+            scope.setContext('serverAction', sanitizeActionArgs(args));
+            Sentry.captureException(error);
+          });
+          throw error;
+        }
+      }
+    );
+  };
+}

--- a/apps/web/src/lib/sentry/server-actions.ts
+++ b/apps/web/src/lib/sentry/server-actions.ts
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/nextjs';
 
 const SENSITIVE_KEY_PATTERN =
-  /(token|secret|password|authorization|cookie|jwt|api[-_]?key|signature)/i;
+  /(token|secret|password|authorization|cookie|jwt|api[-_]?key|signature|session|credential|wallet|private[-_]?key)/i;
 
 function sanitizeValue(value: unknown, depth = 0): unknown {
   if (value === null || value === undefined) {

--- a/apps/web/src/lib/sentry/server-actions.ts
+++ b/apps/web/src/lib/sentry/server-actions.ts
@@ -62,6 +62,11 @@ function sanitizeActionArgs(args: unknown[]): Record<string, unknown> {
 /**
  * Wrap a server action with Sentry performance + exception instrumentation.
  * Argument metadata is sanitized to avoid leaking secrets/PII.
+ *
+ * On error: enriches the active Sentry scope with action context, then rethrows.
+ * The actual exception capture is delegated to Next.js's onRequestError hook
+ * (instrumentation.ts: `export const onRequestError = Sentry.captureRequestError`)
+ * to avoid double-counting the same error event.
  */
 export function wrapServerActionWithSentry<T extends unknown[], R>(
   actionName: string,
@@ -81,13 +86,10 @@ export function wrapServerActionWithSentry<T extends unknown[], R>(
         try {
           return await action(...args);
         } catch (error) {
-          Sentry.withScope((scope) => {
-            scope.setTag('runtime', 'nodejs');
-            scope.setTag('surface', 'server-action');
-            scope.setTag('action', actionName);
-            scope.setContext('serverAction', sanitizeActionArgs(args));
-            Sentry.captureException(error);
-          });
+          Sentry.setTag('runtime', 'nodejs');
+          Sentry.setTag('surface', 'server-action');
+          Sentry.setTag('action', actionName);
+          Sentry.setContext('serverAction', sanitizeActionArgs(args));
           throw error;
         }
       }

--- a/docs/infra/sentry-observability-contract.md
+++ b/docs/infra/sentry-observability-contract.md
@@ -1,0 +1,40 @@
+# Sentry Observability Contract
+
+This document defines Babylon's baseline Sentry contract for web/API/server-action surfaces.
+
+## Scope covered
+
+- Next.js API routes that use `withErrorHandling` from `@babylon/api`
+- Next.js server actions wrapped with `wrapServerActionWithSentry`
+- App error boundaries, including `PanelErrorBoundary`
+
+## Tagging contract
+
+All captured events should include:
+
+- `runtime`: runtime origin (`nodejs`, etc.)
+- `surface`: logical surface (`api-route`, `server-action`, `agent-team-panel`)
+- Surface-specific tag:
+  - API routes: `endpoint`, `method`, optional `requestId`
+  - Server actions: `action`
+
+## Context contract
+
+- API route captures include sanitized request/user context from `errorHandler`.
+- Server action captures include sanitized argument metadata only (shape/size-oriented).
+- Sensitive keys are redacted (`token`, `secret`, `password`, `authorization`, `cookie`, `jwt`, `api-key`, `signature`).
+
+## Capture policy
+
+By default, `errorHandler` does **not** capture expected client-path errors:
+
+- auth failures
+- Zod validation errors
+- operational 4xx Babylon errors
+
+Unexpected server errors are captured.
+
+## Known gaps / follow-up
+
+- Some API endpoints do not use `withErrorHandling` yet and need dedicated migration.
+- CLI and indexer runtime instrumentation should be tracked as follow-up slices.

--- a/packages/api/src/error-handler.ts
+++ b/packages/api/src/error-handler.ts
@@ -80,6 +80,35 @@ export interface ErrorHandlerOptions {
   captureError?: (error: Error, context: Record<string, JsonValue>) => void;
 }
 
+let defaultErrorCapture: ErrorHandlerOptions['captureError'];
+
+/**
+ * Sets a global default error capture callback used by withErrorHandling.
+ * Route-level options.captureError still takes precedence when provided.
+ */
+export function setDefaultErrorCapture(
+  captureError?: ErrorHandlerOptions['captureError']
+): void {
+  defaultErrorCapture = captureError;
+}
+
+function resolveErrorHandlerOptions(
+  options?: ErrorHandlerOptions
+): ErrorHandlerOptions | undefined {
+  if (options?.captureError) {
+    return options;
+  }
+
+  if (!defaultErrorCapture) {
+    return options;
+  }
+
+  return {
+    ...options,
+    captureError: defaultErrorCapture,
+  };
+}
+
 /**
  * Main error handler that processes all errors and returns appropriate responses
  */
@@ -458,7 +487,7 @@ export function withErrorHandling<TContext extends RouteContext = RouteContext>(
       const response = await handler(req, context!);
       return response;
     } catch (error) {
-      return errorHandler(error, req, options);
+      return errorHandler(error, req, resolveErrorHandlerOptions(options));
     }
   };
 }
@@ -488,7 +517,7 @@ export function asyncHandler<TContext extends RouteContext = RouteContext>(
       }
       return result;
     } catch (error) {
-      return errorHandler(error, req);
+      return errorHandler(error, req, resolveErrorHandlerOptions());
     }
   };
 }

--- a/packages/api/src/error-handler.ts
+++ b/packages/api/src/error-handler.ts
@@ -349,7 +349,9 @@ export function errorHandler(
     try {
       options.captureError(error, context);
     } catch (captureErr) {
-      logger.warn('Error capture callback threw', { error: String(captureErr) });
+      logger.warn('Error capture callback threw', {
+        error: String(captureErr),
+      });
     }
   }
 

--- a/packages/api/src/error-handler.ts
+++ b/packages/api/src/error-handler.ts
@@ -61,6 +61,29 @@ function serializeErrorCause(cause: unknown): Record<string, JsonValue> | null {
   return { message: String(cause) };
 }
 
+const SENSITIVE_CONTEXT_KEY_PATTERN =
+  /(token|secret|password|authorization|cookie|jwt|api[-_]?key|signature|session|credential|wallet)/i;
+
+/**
+ * Shallow-sanitizes a BabylonError context object before sending to Sentry.
+ * Redacts values whose key matches sensitive patterns; preserves safe primitives.
+ */
+function sanitizeErrorContext(
+  ctx: Record<string, JsonValue>
+): Record<string, JsonValue> {
+  const out: Record<string, JsonValue> = {};
+  for (const [key, value] of Object.entries(ctx)) {
+    if (SENSITIVE_CONTEXT_KEY_PATTERN.test(key)) {
+      out[key] = '[REDACTED]';
+    } else if (typeof value === 'string' && value.length > 200) {
+      out[key] = `[string:${value.length}]`;
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
 /**
  * Options for error tracking and logging
  */
@@ -199,8 +222,43 @@ export function errorHandler(
     );
   }
 
+  const userId = request.headers.get('x-user-id') || null;
+
   // Handle legacy/simple API errors used by many routes
   if (error instanceof ApiError) {
+    if (error.statusCode >= 500) {
+      logger.error('ApiError (5xx)', {
+        error: error.message,
+        code: error.code,
+        statusCode: error.statusCode,
+        ...errorContext,
+      });
+
+      if (options?.captureError) {
+        try {
+          options.captureError(error, {
+            request: {
+              url: new URL(request.url).pathname,
+              method: request.method,
+              headers: sanitizeHeaders(request.headers),
+            },
+            ...(userId ? { user: { id: userId } } : {}),
+          });
+        } catch (captureErr) {
+          logger.warn('Error capture callback threw for ApiError', {
+            error: String(captureErr),
+          });
+        }
+      }
+    } else {
+      logger.warn('ApiError (4xx)', {
+        error: error.message,
+        code: error.code,
+        statusCode: error.statusCode,
+        ...errorContext,
+      });
+    }
+
     const errorData: Record<string, JsonValue> = { error: error.message };
 
     if (process.env.NODE_ENV === 'development') {
@@ -243,7 +301,6 @@ export function errorHandler(
 
   // Track error with analytics (async, don't await to avoid slowing down response)
   // Skip tracking authentication errors, validation errors, and 4xx client errors as they're expected behavior
-  const userId = request.headers.get('x-user-id') || null;
   const isClientError =
     error instanceof BabylonError &&
     error.statusCode >= 400 &&
@@ -261,23 +318,21 @@ export function errorHandler(
   }
 
   // Capture error in error tracking (only for server errors, not client errors like validation)
-  // Skip capturing validation errors, authentication errors, and known operational errors
+  // ZodError and AuthenticationError are excluded via early returns above.
+  // BabylonError operational 4xx (e.g. ValidationError, BadRequestError) are excluded here.
   const shouldCaptureInErrorTracking =
     options?.captureError &&
     error instanceof Error &&
-    !(error instanceof ZodError) &&
     !(
       error instanceof BabylonError &&
       error.isOperational &&
       error.statusCode < 500
-    ) &&
-    !isAuthenticationError(error) &&
-    error.name !== 'ValidationError';
+    );
 
   if (shouldCaptureInErrorTracking && options.captureError) {
     const context: Record<string, JsonValue> = {
       request: {
-        url: request.url,
+        url: new URL(request.url).pathname,
         method: request.method,
         headers: sanitizeHeaders(request.headers),
       },
@@ -286,9 +341,16 @@ export function errorHandler(
       context.user = { id: userId };
     }
     if (error instanceof BabylonError && error.context) {
-      context.error = { context: error.context, code: error.code };
+      context.error = {
+        context: sanitizeErrorContext(error.context),
+        code: error.code,
+      };
     }
-    options.captureError(error, context);
+    try {
+      options.captureError(error, context);
+    } catch (captureErr) {
+      logger.warn('Error capture callback threw', { error: String(captureErr) });
+    }
   }
 
   // Handle Babylon errors (our custom errors)
@@ -499,7 +561,8 @@ export function withErrorHandling<TContext extends RouteContext = RouteContext>(
 export function asyncHandler<TContext extends RouteContext = RouteContext>(
   setup?: () => Promise<void>,
   handler?: (req: NextRequest, context?: TContext) => Promise<NextResponse>,
-  teardown?: () => Promise<void>
+  teardown?: () => Promise<void>,
+  options?: ErrorHandlerOptions
 ): (req: NextRequest, context?: TContext) => Promise<NextResponse> {
   return async (req: NextRequest, context?: TContext) => {
     try {
@@ -517,7 +580,7 @@ export function asyncHandler<TContext extends RouteContext = RouteContext>(
       }
       return result;
     } catch (error) {
-      return errorHandler(error, req, resolveErrorHandlerOptions());
+      return errorHandler(error, req, resolveErrorHandlerOptions(options));
     }
   };
 }

--- a/packages/api/src/error-handler.ts
+++ b/packages/api/src/error-handler.ts
@@ -62,7 +62,7 @@ function serializeErrorCause(cause: unknown): Record<string, JsonValue> | null {
 }
 
 const SENSITIVE_CONTEXT_KEY_PATTERN =
-  /(token|secret|password|authorization|cookie|jwt|api[-_]?key|signature|session|credential|wallet)/i;
+  /(token|secret|password|authorization|cookie|jwt|api[-_]?key|signature|session|credential|wallet|private[-_]?key)/i;
 
 /**
  * Shallow-sanitizes a BabylonError context object before sending to Sentry.

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -109,6 +109,7 @@ export {
   errorHandler,
   errorResponse,
   type RouteContext,
+  setDefaultErrorCapture,
   successResponse,
   withErrorHandling,
 } from './error-handler';

--- a/packages/testing/unit/shared/error-handler-sentry.test.ts
+++ b/packages/testing/unit/shared/error-handler-sentry.test.ts
@@ -15,10 +15,7 @@ let BadRequestError: new (message: string) => Error;
 let ValidationError: new (message: string) => Error;
 let setDefaultErrorCapture: (captureError?: ErrorCapture) => void;
 let withErrorHandling: <TContext = unknown>(
-  handler: (
-    req: Request,
-    context?: TContext
-  ) => Promise<Response> | Response,
+  handler: (req: Request, context?: TContext) => Promise<Response> | Response,
   options?: {
     captureError?: ErrorCapture;
   }
@@ -53,7 +50,9 @@ describe('withErrorHandling + default Sentry capture', () => {
       ZodError: class ZodError extends Error {
         issues: Array<{ code: string; message: string; path: string[] }>;
 
-        constructor(issues: Array<{ code: string; message: string; path: string[] }> = []) {
+        constructor(
+          issues: Array<{ code: string; message: string; path: string[] }> = []
+        ) {
           super('ZodError');
           this.name = 'ZodError';
           this.issues = issues;
@@ -94,7 +93,9 @@ describe('withErrorHandling + default Sentry capture', () => {
   });
 
   it('captures unexpected errors through the global capture callback', async () => {
-    const captureError = mock((_error: Error, _context: Record<string, unknown>) => {});
+    const captureError = mock(
+      (_error: Error, _context: Record<string, unknown>) => {}
+    );
     setDefaultErrorCapture(captureError);
 
     const handler = withErrorHandling(async () => {
@@ -107,8 +108,12 @@ describe('withErrorHandling + default Sentry capture', () => {
   });
 
   it('keeps route-level captureError precedence over the global callback', async () => {
-    const globalCapture = mock((_error: Error, _context: Record<string, unknown>) => {});
-    const routeCapture = mock((_error: Error, _context: Record<string, unknown>) => {});
+    const globalCapture = mock(
+      (_error: Error, _context: Record<string, unknown>) => {}
+    );
+    const routeCapture = mock(
+      (_error: Error, _context: Record<string, unknown>) => {}
+    );
     setDefaultErrorCapture(globalCapture);
 
     const handler = withErrorHandling(
@@ -125,7 +130,9 @@ describe('withErrorHandling + default Sentry capture', () => {
   });
 
   it('does not capture expected validation errors', async () => {
-    const captureError = mock((_error: Error, _context: Record<string, unknown>) => {});
+    const captureError = mock(
+      (_error: Error, _context: Record<string, unknown>) => {}
+    );
     setDefaultErrorCapture(captureError);
 
     const handler = withErrorHandling(async () => {
@@ -138,7 +145,9 @@ describe('withErrorHandling + default Sentry capture', () => {
   });
 
   it('does not capture authentication errors', async () => {
-    const captureError = mock((_error: Error, _context: Record<string, unknown>) => {});
+    const captureError = mock(
+      (_error: Error, _context: Record<string, unknown>) => {}
+    );
     setDefaultErrorCapture(captureError);
 
     const handler = withErrorHandling(async () => {
@@ -151,7 +160,9 @@ describe('withErrorHandling + default Sentry capture', () => {
   });
 
   it('does not capture expected 4xx operational errors', async () => {
-    const captureError = mock((_error: Error, _context: Record<string, unknown>) => {});
+    const captureError = mock(
+      (_error: Error, _context: Record<string, unknown>) => {}
+    );
     setDefaultErrorCapture(captureError);
 
     const handler = withErrorHandling(async () => {

--- a/packages/testing/unit/shared/error-handler-sentry.test.ts
+++ b/packages/testing/unit/shared/error-handler-sentry.test.ts
@@ -1,0 +1,165 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  mock,
+} from 'bun:test';
+
+type ErrorCapture = (error: Error, context: Record<string, unknown>) => void;
+
+let AuthenticationError: new (message?: string) => Error;
+let BadRequestError: new (message: string) => Error;
+let ValidationError: new (message: string) => Error;
+let setDefaultErrorCapture: (captureError?: ErrorCapture) => void;
+let withErrorHandling: <TContext = unknown>(
+  handler: (
+    req: Request,
+    context?: TContext
+  ) => Promise<Response> | Response,
+  options?: {
+    captureError?: ErrorCapture;
+  }
+) => (req: Request, context?: TContext) => Promise<Response>;
+
+function createRequest(): Request {
+  return new Request('http://localhost/api/test', {
+    method: 'POST',
+    headers: {
+      'x-user-id': 'user-123',
+      'x-request-id': 'req-123',
+    },
+  });
+}
+
+describe('withErrorHandling + default Sentry capture', () => {
+  beforeAll(async () => {
+    mock.module('@babylon/db', () => ({
+      DatabaseError: class DatabaseError extends Error {
+        code?: string;
+      },
+    }));
+
+    mock.module('@babylon/shared', () => ({
+      logger: {
+        error: () => {},
+        warn: () => {},
+      },
+    }));
+
+    mock.module('zod', () => ({
+      ZodError: class ZodError extends Error {
+        issues: Array<{ code: string; message: string; path: string[] }>;
+
+        constructor(issues: Array<{ code: string; message: string; path: string[] }> = []) {
+          super('ZodError');
+          this.name = 'ZodError';
+          this.issues = issues;
+        }
+      },
+    }));
+
+    mock.module('next/server', () => ({
+      NextResponse: class NextResponse extends Response {
+        static json(body: unknown, init?: ResponseInit): Response {
+          const headers = new Headers(init?.headers);
+          if (!headers.has('content-type')) {
+            headers.set('content-type', 'application/json');
+          }
+
+          return new Response(JSON.stringify(body), {
+            ...init,
+            headers,
+          });
+        }
+      },
+    }));
+
+    ({ AuthenticationError, BadRequestError, ValidationError } = await import(
+      '../../../api/src/errors'
+    ));
+    ({ setDefaultErrorCapture, withErrorHandling } = await import(
+      '../../../api/src/error-handler'
+    ));
+  });
+
+  afterEach(() => {
+    setDefaultErrorCapture(undefined);
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  it('captures unexpected errors through the global capture callback', async () => {
+    const captureError = mock((_error: Error, _context: Record<string, unknown>) => {});
+    setDefaultErrorCapture(captureError);
+
+    const handler = withErrorHandling(async () => {
+      throw new Error('boom');
+    });
+
+    const response = await handler(createRequest());
+    expect(response.status).toBe(500);
+    expect(captureError).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps route-level captureError precedence over the global callback', async () => {
+    const globalCapture = mock((_error: Error, _context: Record<string, unknown>) => {});
+    const routeCapture = mock((_error: Error, _context: Record<string, unknown>) => {});
+    setDefaultErrorCapture(globalCapture);
+
+    const handler = withErrorHandling(
+      async () => {
+        throw new Error('route override');
+      },
+      { captureError: routeCapture }
+    );
+
+    const response = await handler(createRequest());
+    expect(response.status).toBe(500);
+    expect(routeCapture).toHaveBeenCalledTimes(1);
+    expect(globalCapture).toHaveBeenCalledTimes(0);
+  });
+
+  it('does not capture expected validation errors', async () => {
+    const captureError = mock((_error: Error, _context: Record<string, unknown>) => {});
+    setDefaultErrorCapture(captureError);
+
+    const handler = withErrorHandling(async () => {
+      throw new ValidationError('Validation failed');
+    });
+
+    const response = await handler(createRequest());
+    expect(response.status).toBe(422);
+    expect(captureError).toHaveBeenCalledTimes(0);
+  });
+
+  it('does not capture authentication errors', async () => {
+    const captureError = mock((_error: Error, _context: Record<string, unknown>) => {});
+    setDefaultErrorCapture(captureError);
+
+    const handler = withErrorHandling(async () => {
+      throw new AuthenticationError('Authentication required');
+    });
+
+    const response = await handler(createRequest());
+    expect(response.status).toBe(401);
+    expect(captureError).toHaveBeenCalledTimes(0);
+  });
+
+  it('does not capture expected 4xx operational errors', async () => {
+    const captureError = mock((_error: Error, _context: Record<string, unknown>) => {});
+    setDefaultErrorCapture(captureError);
+
+    const handler = withErrorHandling(async () => {
+      throw new BadRequestError('Invalid request');
+    });
+
+    const response = await handler(createRequest());
+    expect(response.status).toBe(400);
+    expect(captureError).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/testing/unit/web/server-actions-sentry-wrapper.test.ts
+++ b/packages/testing/unit/web/server-actions-sentry-wrapper.test.ts
@@ -1,4 +1,12 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+} from 'bun:test';
 
 const startSpanMock = mock(
   async (

--- a/packages/testing/unit/web/server-actions-sentry-wrapper.test.ts
+++ b/packages/testing/unit/web/server-actions-sentry-wrapper.test.ts
@@ -1,0 +1,95 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+
+const startSpanMock = mock(
+  async (
+    _spanConfig: Record<string, unknown>,
+    callback: () => Promise<unknown>
+  ) => callback()
+);
+const captureExceptionMock = mock((_error: unknown) => {});
+const setTagMock = mock((_key: string, _value: string) => {});
+const setContextMock = mock(
+  (_key: string, _value: Record<string, unknown>) => {}
+);
+const withScopeMock = mock((callback: (scope: unknown) => void) => {
+  callback({
+    setTag: setTagMock,
+    setContext: setContextMock,
+  });
+});
+
+let wrapServerActionWithSentry: <T extends unknown[], R>(
+  actionName: string,
+  action: (...args: T) => Promise<R>
+) => (...args: T) => Promise<R>;
+
+describe('wrapServerActionWithSentry', () => {
+  beforeAll(async () => {
+    mock.module('@sentry/nextjs', () => ({
+      startSpan: startSpanMock,
+      withScope: withScopeMock,
+      captureException: captureExceptionMock,
+    }));
+
+    ({ wrapServerActionWithSentry } = await import(
+      '../../../../apps/web/src/lib/sentry/server-actions'
+    ));
+  });
+
+  beforeEach(() => {
+    startSpanMock.mockClear();
+    captureExceptionMock.mockClear();
+    withScopeMock.mockClear();
+    setTagMock.mockClear();
+    setContextMock.mockClear();
+  });
+
+  afterAll(() => {
+    mock.restore();
+  });
+
+  it('returns action result and creates a span on success', async () => {
+    const action = mock(async (input: { value: number }) => input.value * 2);
+    const wrapped = wrapServerActionWithSentry('doubleValue', action);
+
+    const result = await wrapped({ value: 21 });
+
+    expect(result).toBe(42);
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(startSpanMock).toHaveBeenCalledTimes(1);
+
+    const firstSpanCall = startSpanMock.mock.calls[0];
+    expect(firstSpanCall?.[0]).toMatchObject({
+      op: 'server.action',
+      name: 'server-action.doubleValue',
+    });
+    expect(captureExceptionMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('captures, tags, and rethrows errors with sanitized args', async () => {
+    const actionError = new Error('action failed');
+    const action = mock(async () => {
+      throw actionError;
+    });
+    const wrapped = wrapServerActionWithSentry('failingAction', action);
+
+    await expect(
+      wrapped({ token: 'secret-token', amount: 10 }, 'hello')
+    ).rejects.toThrow('action failed');
+
+    expect(startSpanMock).toHaveBeenCalledTimes(1);
+    expect(withScopeMock).toHaveBeenCalledTimes(1);
+    expect(captureExceptionMock).toHaveBeenCalledWith(actionError);
+    expect(setTagMock).toHaveBeenCalledWith('surface', 'server-action');
+    expect(setTagMock).toHaveBeenCalledWith('action', 'failingAction');
+
+    const serverActionContextCall = setContextMock.mock.calls.find(
+      (call) => call[0] === 'serverAction'
+    );
+    expect(serverActionContextCall).toBeDefined();
+    expect(serverActionContextCall?.[1]).toEqual({
+      argCount: 2,
+      args: [{ token: '[REDACTED]', amount: 10 }, '[string:5]'],
+    });
+  });
+});

--- a/packages/testing/unit/web/server-actions-sentry-wrapper.test.ts
+++ b/packages/testing/unit/web/server-actions-sentry-wrapper.test.ts
@@ -6,17 +6,10 @@ const startSpanMock = mock(
     callback: () => Promise<unknown>
   ) => callback()
 );
-const captureExceptionMock = mock((_error: unknown) => {});
 const setTagMock = mock((_key: string, _value: string) => {});
 const setContextMock = mock(
   (_key: string, _value: Record<string, unknown>) => {}
 );
-const withScopeMock = mock((callback: (scope: unknown) => void) => {
-  callback({
-    setTag: setTagMock,
-    setContext: setContextMock,
-  });
-});
 
 let wrapServerActionWithSentry: <T extends unknown[], R>(
   actionName: string,
@@ -27,8 +20,8 @@ describe('wrapServerActionWithSentry', () => {
   beforeAll(async () => {
     mock.module('@sentry/nextjs', () => ({
       startSpan: startSpanMock,
-      withScope: withScopeMock,
-      captureException: captureExceptionMock,
+      setTag: setTagMock,
+      setContext: setContextMock,
     }));
 
     ({ wrapServerActionWithSentry } = await import(
@@ -38,8 +31,6 @@ describe('wrapServerActionWithSentry', () => {
 
   beforeEach(() => {
     startSpanMock.mockClear();
-    captureExceptionMock.mockClear();
-    withScopeMock.mockClear();
     setTagMock.mockClear();
     setContextMock.mockClear();
   });
@@ -63,10 +54,10 @@ describe('wrapServerActionWithSentry', () => {
       op: 'server.action',
       name: 'server-action.doubleValue',
     });
-    expect(captureExceptionMock).toHaveBeenCalledTimes(0);
+    expect(setTagMock).toHaveBeenCalledTimes(0);
   });
 
-  it('captures, tags, and rethrows errors with sanitized args', async () => {
+  it('enriches scope with action context, rethrows, and does not double-capture', async () => {
     const actionError = new Error('action failed');
     const action = mock(async () => {
       throw actionError;
@@ -78,10 +69,10 @@ describe('wrapServerActionWithSentry', () => {
     ).rejects.toThrow('action failed');
 
     expect(startSpanMock).toHaveBeenCalledTimes(1);
-    expect(withScopeMock).toHaveBeenCalledTimes(1);
-    expect(captureExceptionMock).toHaveBeenCalledWith(actionError);
+
     expect(setTagMock).toHaveBeenCalledWith('surface', 'server-action');
     expect(setTagMock).toHaveBeenCalledWith('action', 'failingAction');
+    expect(setTagMock).toHaveBeenCalledWith('runtime', 'nodejs');
 
     const serverActionContextCall = setContextMock.mock.calls.find(
       (call) => call[0] === 'serverAction'


### PR DESCRIPTION
## Summary

- Wire a default Sentry capture callback into `@babylon/api` so all API routes already using `withErrorHandling` report unexpected server errors without per-route boilerplate.
- Add a reusable `wrapServerActionWithSentry` helper and adopt it in active web server actions (`onchain` + `nft`) with sanitized argument metadata.
- Instrument `PanelErrorBoundary` with Sentry capture and document the current observability contract and known follow-ups.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [x] Infra / ops
- [x] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: [BAB-233](https://linear.app/eliza-labs/issue/BAB-233/featobservability-enforce-end-to-end-sentry-integration-across-babylon)

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [x] Other: infra docs (`docs/infra`)

## Changes

- Added `setDefaultErrorCapture` in `packages/api/src/error-handler.ts` and applied it in `withErrorHandling`/`asyncHandler` so default capture is centralized.
- Exported `setDefaultErrorCapture` from `@babylon/api`.
- Added `apps/web/src/lib/sentry/api-route-capture.ts` and wired it in `apps/web/instrumentation.ts` to register default API capture for web runtime.
- Added `apps/web/src/lib/sentry/server-actions.ts` with Sentry span + exception capture and argument sanitization/redaction.
- Wrapped server actions:
  - `mintNftAction`
  - `buySharesOnchainAction`
  - `sellSharesOnchainAction`
  - `sendSponsoredEthTransferAction`
  - `updateAgentProfileOnchainAction`
- Updated `PanelErrorBoundary` to send captured exceptions to Sentry (keeps `console.error` in non-production only).
- Added observability contract doc: `docs/infra/sentry-observability-contract.md`.
- Added unit tests:
  - `packages/testing/unit/shared/error-handler-sentry.test.ts`
  - `packages/testing/unit/web/server-actions-sentry-wrapper.test.ts`

## Review guide

**Start here**
- `packages/api/src/error-handler.ts`
- `apps/web/instrumentation.ts`
- `apps/web/src/lib/sentry/server-actions.ts`
- `apps/web/src/app/_actions/{onchain.ts,nft.ts}`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- Existing capture filters (auth/validation/expected 4xx) are preserved in `errorHandler`.
- Route-level `captureError` still has precedence over the new default capture.
- This PR intentionally does not migrate all non-`withErrorHandling` API routes yet.

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

Executed in practice:
- `bun x biome check --write apps/web/instrumentation.ts apps/web/src/app/_actions/nft.ts apps/web/src/app/_actions/onchain.ts apps/web/src/app/agents/team/panels/PanelErrorBoundary.tsx apps/web/src/lib/sentry/api-route-capture.ts apps/web/src/lib/sentry/server-actions.ts packages/api/src/error-handler.ts packages/api/src/index.ts docs/infra/sentry-observability-contract.md packages/testing/unit/shared/error-handler-sentry.test.ts packages/testing/unit/web/server-actions-sentry-wrapper.test.ts`
- `bun test packages/testing/unit/shared/error-handler-sentry.test.ts packages/testing/unit/web/server-actions-sentry-wrapper.test.ts --preload ./packages/testing/unit/preload.ts`

Could not run full typecheck in this environment because `tsc` is unavailable (`command not found`).

**Manual verification**
1. Confirm `withErrorHandling` routes now use default Sentry capture via instrumentation wiring.
2. Confirm wrapped server actions still return/rethrow as before while adding Sentry span/capture.
3. Confirm panel rendering exceptions are captured by Sentry scope.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: deploy normally; verify Sentry events on API/server-action error paths.
- Rollback: revert this PR.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- N/A

## Security / privacy

- [ ] No security impact
- [x] Needs extra review (describe)

- Added explicit sanitization/redaction for server action argument metadata before Sentry capture.
- API capture context relies on existing header sanitization in `errorHandler`.

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- No external API contract changes.

### Database
- No DB schema/query changes.

### Contracts / on-chain
- No contract changes.

### Docs
- Added `docs/infra/sentry-observability-contract.md` (observability conventions + follow-up scope).

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Observability/instrumentation changes only; no intended user-facing UI/UX change.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

## Follow-ups (out of scope for this PR)

- Migrate remaining non-`withErrorHandling` API routes to standardized wrapper/capture path.
- Add dedicated Sentry initialization for CLI runtime.
- Implement indexer-side Sentry instrumentation in the indexer repository.
