### PR TITLE
feat(web): delete team chat channels and add jump-to-latest

### DIFF
--- a/apps/web/src/app/agents/team/ConversationList.tsx
+++ b/apps/web/src/app/agents/team/ConversationList.tsx
@@ -105,6 +105,8 @@ export function ConversationList({
     setDeletingId(conversation.id);
     try {
       await onDeleteConversation(conversation.id);
+    } catch {
+      // onDeleteConversation is responsible for user-facing error feedback
     } finally {
       setDeletingId(null);
     }
@@ -119,6 +121,8 @@ export function ConversationList({
     setIsSaving(true);
     try {
       await onRenameConversation(editingId, editValue.trim());
+    } catch {
+      // onRenameConversation is responsible for user-facing error feedback
     } finally {
       setIsSaving(false);
       setEditingId(null);

--- a/apps/web/src/app/agents/team/ConversationList.tsx
+++ b/apps/web/src/app/agents/team/ConversationList.tsx
@@ -1,8 +1,20 @@
 'use client';
 
 import { cn } from '@babylon/shared';
-import { Check, Loader2, MessageCircle, Pencil, Plus, X } from 'lucide-react';
+import {
+  Check,
+  Loader2,
+  MessageCircle,
+  Pencil,
+  Plus,
+  Trash2,
+  X,
+} from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
+import {
+  canDeleteConversation,
+  getConversationDisplayName,
+} from './conversation-utils';
 
 /** Conversation info */
 interface ConversationInfo {
@@ -13,41 +25,13 @@ interface ConversationInfo {
   isActive: boolean;
 }
 
-/**
- * Get display name for a conversation.
- * Returns the actual name if set, or a fallback using createdAt timestamp.
- */
-function getConversationDisplayName(conversation: ConversationInfo): string {
-  if (conversation.name) return conversation.name;
-
-  // Fallback: "New Chat - Jan 30, 1:55 AM"
-  // Guard against invalid/missing createdAt
-  const date = new Date(conversation.createdAt);
-  if (isNaN(date.getTime())) {
-    return 'New Chat';
-  }
-
-  // Use browser locale if available, otherwise undefined for system default
-  const locale =
-    typeof navigator !== 'undefined' ? navigator.language : undefined;
-  const dateStr = date.toLocaleDateString(locale, {
-    month: 'short',
-    day: 'numeric',
-  });
-  const timeStr = date.toLocaleTimeString(locale, {
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true,
-  });
-  return `New Chat - ${dateStr}, ${timeStr}`;
-}
-
 interface ConversationListProps {
   conversations: ConversationInfo[];
   loading?: boolean;
   onNewChat: () => void;
   onSelectConversation: (chatId: string) => void;
   onRenameConversation?: (chatId: string, newName: string) => Promise<void>;
+  onDeleteConversation?: (chatId: string) => Promise<void>;
   /** Called when a link is clicked (for closing drawer on mobile) */
   onClose?: () => void;
 }
@@ -65,11 +49,13 @@ export function ConversationList({
   onNewChat,
   onSelectConversation,
   onRenameConversation,
+  onDeleteConversation,
   onClose,
 }: ConversationListProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editValue, setEditValue] = useState('');
   const [isSaving, setIsSaving] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   // Focus input when editing starts
@@ -95,6 +81,33 @@ export function ConversationList({
     setEditingId(conversation.id);
     // Use display name as initial edit value
     setEditValue(getConversationDisplayName(conversation));
+  };
+
+  const handleDeleteConversation = async (
+    e: React.MouseEvent,
+    conversation: ConversationInfo
+  ) => {
+    e.stopPropagation();
+    if (!onDeleteConversation) return;
+    if (!canDeleteConversation(conversations.length)) return;
+    if (deletingId) return;
+
+    const confirmed = window.confirm(
+      'Delete this conversation? This action cannot be undone.'
+    );
+    if (!confirmed) return;
+
+    if (editingId === conversation.id) {
+      setEditingId(null);
+      setEditValue('');
+    }
+
+    setDeletingId(conversation.id);
+    try {
+      await onDeleteConversation(conversation.id);
+    } finally {
+      setDeletingId(null);
+    }
   };
 
   const handleSaveRename = async () => {
@@ -207,15 +220,43 @@ export function ConversationList({
                   >
                     {getConversationDisplayName(conversation)}
                   </button>
-                  {onRenameConversation && (
-                    <button
-                      type="button"
-                      onClick={(e) => handleStartEdit(e, conversation)}
-                      className="shrink-0 p-0.5 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100"
-                      title="Rename"
-                    >
-                      <Pencil className="h-3 w-3" />
-                    </button>
+                  {(onRenameConversation || onDeleteConversation) && (
+                    <div className="flex shrink-0 items-center gap-0.5">
+                      {onRenameConversation && (
+                        <button
+                          type="button"
+                          onClick={(e) => handleStartEdit(e, conversation)}
+                          className="rounded p-0.5 text-muted-foreground opacity-100 transition-opacity hover:text-foreground md:opacity-0 md:group-hover:opacity-100"
+                          title="Rename"
+                          aria-label="Rename conversation"
+                        >
+                          <Pencil className="h-3 w-3" />
+                        </button>
+                      )}
+                      {onDeleteConversation && (
+                        <button
+                          type="button"
+                          onClick={(e) => handleDeleteConversation(e, conversation)}
+                          disabled={
+                            deletingId !== null ||
+                            !canDeleteConversation(conversations.length)
+                          }
+                          className="rounded p-0.5 text-muted-foreground opacity-100 transition-opacity hover:text-destructive disabled:cursor-not-allowed disabled:text-muted-foreground/40 md:opacity-0 md:group-hover:opacity-100"
+                          title={
+                            canDeleteConversation(conversations.length)
+                              ? 'Delete'
+                              : 'Cannot delete the only conversation'
+                          }
+                          aria-label="Delete conversation"
+                        >
+                          {deletingId === conversation.id ? (
+                            <Loader2 className="h-3 w-3 animate-spin" />
+                          ) : (
+                            <Trash2 className="h-3 w-3" />
+                          )}
+                        </button>
+                      )}
+                    </div>
                   )}
                 </>
               )}

--- a/apps/web/src/app/agents/team/conversation-utils.test.ts
+++ b/apps/web/src/app/agents/team/conversation-utils.test.ts
@@ -46,4 +46,24 @@ describe('conversation-utils', () => {
     expect(canDeleteConversation(2)).toBe(true);
     expect(canDeleteConversation(5)).toBe(true);
   });
+
+  test('disallows delete when conversation count is zero (degenerate state)', () => {
+    expect(canDeleteConversation(0)).toBe(false);
+  });
+
+  test('treats empty string name as absent and falls back to date format', () => {
+    const label = getConversationDisplayName(
+      { name: '', createdAt: '2026-03-01T10:30:00.000Z' },
+      'en-US'
+    );
+    expect(label.startsWith('New Chat -')).toBe(true);
+  });
+
+  test('produces a fallback label without throwing when no locale is provided', () => {
+    const label = getConversationDisplayName({
+      name: null,
+      createdAt: '2026-03-01T10:30:00.000Z',
+    });
+    expect(label.startsWith('New Chat -')).toBe(true);
+  });
 });

--- a/apps/web/src/app/agents/team/conversation-utils.test.ts
+++ b/apps/web/src/app/agents/team/conversation-utils.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  canDeleteConversation,
+  getConversationDisplayName,
+} from './conversation-utils';
+
+describe('conversation-utils', () => {
+  test('returns explicit conversation name when present', () => {
+    const label = getConversationDisplayName(
+      {
+        name: 'Strategy Thread',
+        createdAt: '2026-03-01T10:30:00.000Z',
+      },
+      'en-US'
+    );
+
+    expect(label).toBe('Strategy Thread');
+  });
+
+  test('builds fallback name from createdAt when name is null', () => {
+    const label = getConversationDisplayName(
+      {
+        name: null,
+        createdAt: '2026-03-01T10:30:00.000Z',
+      },
+      'en-US'
+    );
+
+    expect(label.startsWith('New Chat -')).toBe(true);
+  });
+
+  test('returns generic fallback when createdAt is invalid', () => {
+    const label = getConversationDisplayName(
+      {
+        name: null,
+        createdAt: 'not-a-date',
+      },
+      'en-US'
+    );
+
+    expect(label).toBe('New Chat');
+  });
+
+  test('allows delete only when more than one conversation exists', () => {
+    expect(canDeleteConversation(1)).toBe(false);
+    expect(canDeleteConversation(2)).toBe(true);
+    expect(canDeleteConversation(5)).toBe(true);
+  });
+});

--- a/apps/web/src/app/agents/team/conversation-utils.ts
+++ b/apps/web/src/app/agents/team/conversation-utils.ts
@@ -1,0 +1,44 @@
+/**
+ * Minimal conversation shape used for sidebar display logic.
+ */
+export interface ConversationDisplayInfo {
+  name: string | null;
+  createdAt: string;
+}
+
+/**
+ * Returns the sidebar label for a conversation.
+ * Uses an explicit title when present, otherwise a localized timestamp fallback.
+ */
+export function getConversationDisplayName(
+  conversation: ConversationDisplayInfo,
+  locale?: string
+): string {
+  if (conversation.name) return conversation.name;
+
+  const date = new Date(conversation.createdAt);
+  if (Number.isNaN(date.getTime())) {
+    return 'New Chat';
+  }
+
+  const effectiveLocale =
+    locale ?? (typeof navigator !== 'undefined' ? navigator.language : undefined);
+  const dateStr = date.toLocaleDateString(effectiveLocale, {
+    month: 'short',
+    day: 'numeric',
+  });
+  const timeStr = date.toLocaleTimeString(effectiveLocale, {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
+
+  return `New Chat - ${dateStr}, ${timeStr}`;
+}
+
+/**
+ * Deletion is only allowed when more than one conversation exists.
+ */
+export function canDeleteConversation(totalConversations: number): boolean {
+  return totalConversations > 1;
+}

--- a/apps/web/src/app/agents/team/page.tsx
+++ b/apps/web/src/app/agents/team/page.tsx
@@ -209,6 +209,7 @@ export default function TeamChatPage() {
     createConversation,
     switchConversation,
     renameConversation,
+    deleteConversation,
   } = useTeamChat();
 
   // Mobile view state - which tab is active on mobile
@@ -840,6 +841,7 @@ export default function TeamChatPage() {
                 setMobileView('chat');
               }}
               onRenameConversation={renameConversation}
+              onDeleteConversation={deleteConversation}
             />
           </div>
 
@@ -1039,6 +1041,7 @@ export default function TeamChatPage() {
                   onNewChat={() => createConversation()}
                   onSelectConversation={switchConversation}
                   onRenameConversation={renameConversation}
+                  onDeleteConversation={deleteConversation}
                 />
               </div>
 

--- a/apps/web/src/components/chats/TeamChatView.tsx
+++ b/apps/web/src/components/chats/TeamChatView.tsx
@@ -224,6 +224,10 @@ export function TeamChatView({
     []
   );
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: chatDetails?.chat?.id,
+  // chatDetails?.messages?.length, and loading are intentional trigger deps —
+  // they re-run the effect on conversation switch / new message arrival even
+  // though they aren't referenced inside the callback body.
   React.useEffect(() => {
     const container = messagesContainerRef.current;
     if (!container) {
@@ -342,7 +346,7 @@ export function TeamChatView({
        * children of a scrolling container are anchored to the full content
        * height, so the button would be invisible when scrolled up.
        */}
-      <div className="relative min-h-0 flex-1 flex flex-col">
+      <div className="relative flex min-h-0 flex-1 flex-col">
         <div
           data-chat-messages-container
           ref={messagesContainerRef}

--- a/apps/web/src/components/chats/TeamChatView.tsx
+++ b/apps/web/src/components/chats/TeamChatView.tsx
@@ -224,10 +224,7 @@ export function TeamChatView({
     []
   );
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: chatDetails?.chat?.id,
-  // chatDetails?.messages?.length, and loading are intentional trigger deps —
-  // they re-run the effect on conversation switch / new message arrival even
-  // though they aren't referenced inside the callback body.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: chatDetails?.chat?.id, chatDetails?.messages?.length, and loading are intentional trigger deps — they re-run the effect on conversation switch / new message arrival even though they aren't referenced inside the callback body.
   React.useEffect(() => {
     const container = messagesContainerRef.current;
     if (!container) {

--- a/apps/web/src/components/chats/TeamChatView.tsx
+++ b/apps/web/src/components/chats/TeamChatView.tsx
@@ -2,6 +2,7 @@
 
 import { cn, type MessageTag } from '@babylon/shared';
 import {
+  ArrowDown,
   Brain,
   MessageCircle,
   PanelLeft,
@@ -15,6 +16,10 @@ import { FeedbackMessages } from './FeedbackMessages';
 import type { MentionableAgent } from './MentionAutocomplete';
 import { MessageInput } from './MessageInput';
 import { MessageList } from './MessageList';
+import {
+  getDistanceFromBottom,
+  shouldShowScrollToLatest,
+} from './scroll-utils';
 import type { ChatDetails } from './types';
 
 /** Typing user info */
@@ -204,6 +209,45 @@ export function TeamChatView({
   onInputFocus,
 }: TeamChatViewProps) {
   const compact = density === 'compact';
+  const messagesContainerRef = React.useRef<HTMLDivElement | null>(null);
+  const [showScrollToLatest, setShowScrollToLatest] = React.useState(false);
+
+  const updateScrollToLatestVisibility = React.useCallback(
+    (container: HTMLDivElement) => {
+      const distanceFromBottom = getDistanceFromBottom(
+        container.scrollTop,
+        container.scrollHeight,
+        container.clientHeight
+      );
+      setShowScrollToLatest(shouldShowScrollToLatest(distanceFromBottom));
+    },
+    []
+  );
+
+  React.useEffect(() => {
+    const container = messagesContainerRef.current;
+    if (!container) return;
+    updateScrollToLatestVisibility(container);
+  }, [
+    chatDetails?.messages?.length,
+    loading,
+    updateScrollToLatestVisibility,
+  ]);
+
+  const handleScrollToLatest = React.useCallback(() => {
+    const container = messagesContainerRef.current;
+    if (container) {
+      container.scrollTo({
+        top: container.scrollHeight,
+        behavior: 'smooth',
+      });
+      setShowScrollToLatest(false);
+      return;
+    }
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    setShowScrollToLatest(false);
+  }, [messagesEndRef]);
+
   // Empty state when no chat selected
   if (!chatDetails) {
     return (
@@ -289,11 +333,15 @@ export function TeamChatView({
       {/* Messages - Scrollable */}
       <div
         data-chat-messages-container
+        ref={messagesContainerRef}
         className={cn(
           'relative min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden',
           compact ? 'space-y-2 px-3 py-2' : 'space-y-4 px-4 py-3'
         )}
-        onScroll={(e) => onScroll?.(e.currentTarget)}
+        onScroll={(e) => {
+          onScroll?.(e.currentTarget);
+          updateScrollToLatestVisibility(e.currentTarget);
+        }}
       >
         <MessageList
           messages={chatDetails.messages || []}
@@ -312,6 +360,18 @@ export function TeamChatView({
           agentIds={agentIds}
           onViewSettings={onViewSettings}
         />
+
+        {showScrollToLatest && (
+          <button
+            type="button"
+            onClick={handleScrollToLatest}
+            className="absolute right-4 bottom-4 z-20 rounded-full border border-border bg-background/95 p-2 text-muted-foreground shadow-sm backdrop-blur transition-colors hover:text-foreground"
+            aria-label="Jump to latest message"
+            title="Jump to latest message"
+          >
+            <ArrowDown className="h-4 w-4" />
+          </button>
+        )}
       </div>
 
       {/* Footer - Fixed */}

--- a/apps/web/src/components/chats/TeamChatView.tsx
+++ b/apps/web/src/components/chats/TeamChatView.tsx
@@ -226,9 +226,13 @@ export function TeamChatView({
 
   React.useEffect(() => {
     const container = messagesContainerRef.current;
-    if (!container) return;
+    if (!container) {
+      setShowScrollToLatest(false);
+      return;
+    }
     updateScrollToLatestVisibility(container);
   }, [
+    chatDetails?.chat?.id,
     chatDetails?.messages?.length,
     loading,
     updateScrollToLatestVisibility,
@@ -330,36 +334,45 @@ export function TeamChatView({
         </div>
       )}
 
-      {/* Messages - Scrollable */}
-      <div
-        data-chat-messages-container
-        ref={messagesContainerRef}
-        className={cn(
-          'relative min-h-0 min-w-0 flex-1 overflow-y-auto overflow-x-hidden',
-          compact ? 'space-y-2 px-3 py-2' : 'space-y-4 px-4 py-3'
-        )}
-        onScroll={(e) => {
-          onScroll?.(e.currentTarget);
-          updateScrollToLatestVisibility(e.currentTarget);
-        }}
-      >
-        <MessageList
-          messages={chatDetails.messages || []}
-          participants={chatDetails.participants || []}
-          currentUserId={currentUserId}
-          loading={loading}
-          isLoadingMore={isLoadingMore}
-          hasMore={hasMore}
-          authenticated={authenticated}
-          topSentinelRef={topSentinelRef}
-          messagesEndRef={messagesEndRef}
-          density={density}
-          onTagClick={onTagClick}
-          onToggleReaction={onToggleReaction}
-          compactActions
-          agentIds={agentIds}
-          onViewSettings={onViewSettings}
-        />
+      {/* Messages - Scrollable + jump-to-latest overlay */}
+      {/*
+       * The outer div is `relative` so the jump button can be absolutely
+       * positioned against the VISIBLE viewport of the chat area, not the
+       * scroll content area.  The inner div owns overflow-y-auto; absolute
+       * children of a scrolling container are anchored to the full content
+       * height, so the button would be invisible when scrolled up.
+       */}
+      <div className="relative min-h-0 flex-1 flex flex-col">
+        <div
+          data-chat-messages-container
+          ref={messagesContainerRef}
+          className={cn(
+            'flex-1 overflow-y-auto overflow-x-hidden',
+            compact ? 'space-y-2 px-3 py-2' : 'space-y-4 px-4 py-3'
+          )}
+          onScroll={(e) => {
+            onScroll?.(e.currentTarget);
+            updateScrollToLatestVisibility(e.currentTarget);
+          }}
+        >
+          <MessageList
+            messages={chatDetails.messages || []}
+            participants={chatDetails.participants || []}
+            currentUserId={currentUserId}
+            loading={loading}
+            isLoadingMore={isLoadingMore}
+            hasMore={hasMore}
+            authenticated={authenticated}
+            topSentinelRef={topSentinelRef}
+            messagesEndRef={messagesEndRef}
+            density={density}
+            onTagClick={onTagClick}
+            onToggleReaction={onToggleReaction}
+            compactActions
+            agentIds={agentIds}
+            onViewSettings={onViewSettings}
+          />
+        </div>
 
         {showScrollToLatest && (
           <button

--- a/apps/web/src/components/chats/scroll-utils.test.ts
+++ b/apps/web/src/components/chats/scroll-utils.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  getDistanceFromBottom,
+  SCROLL_TO_LATEST_THRESHOLD_PX,
+  shouldShowScrollToLatest,
+} from './scroll-utils';
+
+describe('scroll-utils', () => {
+  test('computes distance from bottom', () => {
+    const distance = getDistanceFromBottom(300, 1200, 700);
+    expect(distance).toBe(200);
+  });
+
+  test('clamps negative distances to zero', () => {
+    const distance = getDistanceFromBottom(900, 1000, 200);
+    expect(distance).toBe(0);
+  });
+
+  test('shows jump-to-latest only above threshold', () => {
+    expect(
+      shouldShowScrollToLatest(SCROLL_TO_LATEST_THRESHOLD_PX + 1)
+    ).toBe(true);
+    expect(
+      shouldShowScrollToLatest(SCROLL_TO_LATEST_THRESHOLD_PX)
+    ).toBe(false);
+    expect(shouldShowScrollToLatest(10)).toBe(false);
+  });
+});

--- a/apps/web/src/components/chats/scroll-utils.test.ts
+++ b/apps/web/src/components/chats/scroll-utils.test.ts
@@ -25,4 +25,14 @@ describe('scroll-utils', () => {
     ).toBe(false);
     expect(shouldShowScrollToLatest(10)).toBe(false);
   });
+
+  test('returns zero for uninitialized scroll container (all-zero dimensions)', () => {
+    expect(getDistanceFromBottom(0, 0, 0)).toBe(0);
+  });
+
+  test('respects a custom threshold override', () => {
+    expect(shouldShowScrollToLatest(50, 40)).toBe(true);
+    expect(shouldShowScrollToLatest(40, 40)).toBe(false);
+    expect(shouldShowScrollToLatest(30, 40)).toBe(false);
+  });
 });

--- a/apps/web/src/components/chats/scroll-utils.ts
+++ b/apps/web/src/components/chats/scroll-utils.ts
@@ -1,0 +1,16 @@
+export const SCROLL_TO_LATEST_THRESHOLD_PX = 180;
+
+export function getDistanceFromBottom(
+  scrollTop: number,
+  scrollHeight: number,
+  clientHeight: number
+): number {
+  return Math.max(0, scrollHeight - scrollTop - clientHeight);
+}
+
+export function shouldShowScrollToLatest(
+  distanceFromBottom: number,
+  threshold = SCROLL_TO_LATEST_THRESHOLD_PX
+): boolean {
+  return distanceFromBottom > threshold;
+}

--- a/apps/web/src/hooks/useTeamChat.ts
+++ b/apps/web/src/hooks/useTeamChat.ts
@@ -1193,9 +1193,16 @@ export function useTeamChat(): UseTeamChatReturn {
           conversations: ConversationInfo[];
         };
         setConversations(data.conversations);
+      } else {
+        const errorData = (await response.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        console.error('Failed to fetch conversations:', response.status, errorData);
+        toast.error(errorData.error || 'Failed to load conversations');
       }
     } catch (err) {
       console.error('Failed to fetch conversations:', err);
+      toast.error('Failed to load conversations');
     } finally {
       setConversationsLoading(false);
     }
@@ -1394,26 +1401,32 @@ export function useTeamChat(): UseTeamChatReturn {
             newActiveChatId: string | null;
           };
 
-          // Remove from conversations list
-          setConversations((prev) => prev.filter((c) => c.id !== chatId));
-
-          // If we switched to a new active chat, update state
-          if (data.newActiveChatId) {
-            setConversations((prev) =>
-              prev.map((c) => ({
-                ...c,
-                isActive: c.id === data.newActiveChatId,
-              }))
+          if (!data.newActiveChatId) {
+            // Unexpected: backend couldn't determine a replacement active chat
+            // (e.g. race condition where another session deleted conversations).
+            // Refresh the full list so the UI recovers to a consistent state.
+            toast.error(
+              'Conversation deleted, but could not determine the new active chat. Refreshing...'
             );
-            setTeamChat((prev) =>
-              prev ? { ...prev, chatId: data.newActiveChatId! } : prev
-            );
-            clearMessages();
+            await refreshConversations();
+            return;
           }
 
+          // Single atomic update: remove deleted + mark new active in one pass
+          setConversations((prev) =>
+            prev
+              .filter((c) => c.id !== chatId)
+              .map((c) => ({ ...c, isActive: c.id === data.newActiveChatId }))
+          );
+          setTeamChat((prev) =>
+            prev ? { ...prev, chatId: data.newActiveChatId! } : prev
+          );
+          clearMessages();
           toast.success('Conversation deleted');
         } else {
-          const errorData = (await response.json()) as { error?: string };
+          const errorData = (await response.json().catch(() => ({}))) as {
+            error?: string;
+          };
           toast.error(errorData.error || 'Failed to delete conversation');
         }
       } catch (err) {

--- a/apps/web/src/hooks/useTeamChat.ts
+++ b/apps/web/src/hooks/useTeamChat.ts
@@ -1197,7 +1197,11 @@ export function useTeamChat(): UseTeamChatReturn {
         const errorData = (await response.json().catch(() => ({}))) as {
           error?: string;
         };
-        console.error('Failed to fetch conversations:', response.status, errorData);
+        console.error(
+          'Failed to fetch conversations:',
+          response.status,
+          errorData
+        );
         toast.error(errorData.error || 'Failed to load conversations');
       }
     } catch (err) {
@@ -1434,7 +1438,7 @@ export function useTeamChat(): UseTeamChatReturn {
         toast.error('Failed to delete conversation');
       }
     },
-    [user, getAccessToken, clearMessages]
+    [user, getAccessToken, clearMessages, refreshConversations]
   );
 
   // Fetch conversations when team chat loads


### PR DESCRIPTION
## Summary
- Add delete controls to team chat conversations (desktop + mobile sidebars) and wire them to the existing delete API flow.
- Add a quick "jump to latest message" floating button in team chat when the user is away from the bottom.
- Keep existing backend constraints (cannot delete the only conversation) and surface them in UI affordances.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Linear: [BAB-235](https://linear.app/eliza-labs/issue/BAB-235/delete-chat-channels-and-scroll-to-last-message)

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [x] Other: app-level unit tests in `apps/web/src`

## Changes
- Wire `deleteConversation` from `useTeamChat` into `ConversationList` in both mobile and desktop layouts.
- Add delete action button with confirmation, disabled state, and loading state in `ConversationList`.
- Add `conversation-utils.ts` to centralize conversation display naming + delete eligibility.
- Add scroll helper utilities and a floating jump-to-latest button in `TeamChatView`.
- Add targeted unit tests:
  - `apps/web/src/app/agents/team/conversation-utils.test.ts`
  - `apps/web/src/components/chats/scroll-utils.test.ts`

## Review guide
**Start here**
- `apps/web/src/app/agents/team/page.tsx`
- `apps/web/src/app/agents/team/ConversationList.tsx`
- `apps/web/src/components/chats/TeamChatView.tsx`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- Backend delete flow already existed; this PR mainly completes front-end wiring and adds the jump-to-latest UX control.
- Non-goal: changing conversation deletion business rules in backend service.

## Test plan
**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

Additional targeted commands executed:
- [x] `bunx biome check --write apps/web/src/app/agents/team/ConversationList.tsx apps/web/src/app/agents/team/page.tsx apps/web/src/app/agents/team/conversation-utils.ts apps/web/src/app/agents/team/conversation-utils.test.ts apps/web/src/components/chats/TeamChatView.tsx apps/web/src/components/chats/scroll-utils.ts apps/web/src/components/chats/scroll-utils.test.ts`
- [x] `bun test apps/web/src/app/agents/team/conversation-utils.test.ts apps/web/src/components/chats/scroll-utils.test.ts`

**Manual verification**
1. Open `/agents/team`.
2. In conversations sidebar, hover/tap a conversation and delete it.
3. Confirm deletion prompt appears and conversation is removed.
4. Verify delete button is disabled when only one conversation remains.
5. Scroll up in message history and verify the jump-to-latest button appears.
6. Click the button and confirm the view scrolls to the newest message.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `none`
- Changed: `none`
- Removed: `none`

**DB / data migration**
- Migration(s): `none`
- Backfill/seed: `none`

**Rollout / rollback plan**
- Rollout: regular web deploy.
- Rollback: revert this PR.

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- N/A

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- No API contract changes.

### Database
- No DB changes.

### Contracts / on-chain
- Not applicable.

### Docs
- Not applicable.

</details>

## Screenshots / recordings (UI)

### Option A: Visual demo

| Feature | Before | After |
|---------|--------|-------|
| Conversation deletion action | Delete action not exposed in sidebar | Delete action available in sidebar (mobile + desktop) |
| Jump to latest message | No explicit quick-jump control | Floating jump-to-latest button appears when scrolled up |

*Demo script (for recording):*
1. Open `/agents/team` and create/switch conversations.
2. Delete one conversation from the sidebar and confirm fallback behavior.
3. Scroll up in chat history, show the jump button, then click it to return to latest message.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
