### PR TITLE
feat(web): move social connections from rewards to profile settings

### DIFF
--- a/apps/web/src/app/rewards/page.tsx
+++ b/apps/web/src/app/rewards/page.tsx
@@ -12,11 +12,9 @@ import {
   Copy,
   ExternalLink,
   Gift,
-  Link as LinkIcon,
   Share2,
   Shield,
   TrendingUp,
-  Twitter,
   UserPlus,
   Users,
   Wallet,
@@ -25,7 +23,6 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { DailyStreakCard } from '@/components/daily-login';
-import { LinkSocialAccountsModal } from '@/components/profile/LinkSocialAccountsModal';
 import { RewardsSkeleton } from '@/components/rewards/RewardsSkeleton';
 import { Avatar } from '@/components/shared/Avatar';
 import { ExternalShareButton } from '@/components/shared/ExternalShareButton';
@@ -34,6 +31,7 @@ import { Separator } from '@/components/shared/Separator';
 import { ShareEarnModal } from '@/components/shared/ShareEarnModal';
 import { useAuth } from '@/hooks/useAuth';
 import { useAuthStore } from '@/stores/authStore';
+import { buildRewardTasks, type RewardTaskDefinition } from './reward-tasks';
 
 interface ReferredUser {
   id: string;
@@ -98,7 +96,6 @@ export default function RewardsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [copiedUrl, setCopiedUrl] = useState(false);
-  const [showLinkSocialModal, setShowLinkSocialModal] = useState(false);
   const [showShareModal, setShowShareModal] = useState(false);
   const [livePortfolio, setLivePortfolio] = useState<{
     totalPoints: number;
@@ -236,85 +233,30 @@ export default function RewardsPage() {
     return total;
   };
 
-  const rewardTasks = referralData
-    ? [
-        {
-          id: 'profile',
-          title: 'Complete Profile',
-          description: (() => {
-            if (referralData.user.pointsAwardedForProfile) {
-              return 'Username, image, and bio complete! ✓';
-            }
-            const missing = [];
-            if (!referralData.user.username) missing.push('username');
-            if (!referralData.user.profileImageUrl) missing.push('image');
-            if (!referralData.user.bio || referralData.user.bio.length < 50)
-              missing.push('bio (50+ chars)');
-            return `Set ${missing.join(', ')}`;
-          })(),
-          points: POINTS.PROFILE_COMPLETION,
-          completed: referralData.user.pointsAwardedForProfile,
-          action: 'profile-settings',
-          icon: UserPlus,
-          color: 'text-purple-500',
-        },
-        {
-          id: 'twitter',
-          title: 'Link X Account',
-          description: referralData.user.twitterUsername
-            ? `@${referralData.user.twitterUsername}`
-            : 'Connect your X account',
-          points: POINTS.TWITTER_LINK,
-          completed: referralData.user.pointsAwardedForTwitter,
-          action: 'link-social',
-          icon: Twitter,
-          color: 'text-blue-400',
-        },
-        {
-          id: 'farcaster',
-          title: 'Link Farcaster',
-          description: referralData.user.farcasterUsername
-            ? `@${referralData.user.farcasterUsername}`
-            : 'Connect Farcaster account',
-          points: POINTS.FARCASTER_LINK,
-          completed: referralData.user.pointsAwardedForFarcaster,
-          action: 'link-social',
-          icon: LinkIcon,
-          color: 'text-purple-400',
-        },
-        {
-          id: 'wallet',
-          title: 'Connect Wallet',
-          description: referralData.user.walletAddress
-            ? `${referralData.user.walletAddress.slice(0, 6)}...${referralData.user.walletAddress.slice(-4)}`
-            : 'Link your wallet',
-          points: POINTS.WALLET_CONNECT,
-          completed: referralData.user.pointsAwardedForWallet,
-          action: 'wallet-connect',
-          icon: Wallet,
-          color: 'text-orange-500',
-        },
-        {
-          id: 'onchain-registration',
-          title: 'Register On-Chain',
-          description: referralData.user.onChainRegistered
-            ? 'ERC-8004 verified identity ✓'
-            : 'Get verified with ERC-8004 on Ethereum',
-          points: -POINTS.ONCHAIN_REGISTRATION,
-          completed: referralData.user.onChainRegistered,
-          action: 'register-onchain',
-          icon: Shield,
-          color: 'text-emerald-500',
-        },
-      ]
-    : [];
+  const rewardTasks = buildRewardTasks(referralData?.user ?? null);
+
+  const rewardTaskVisuals: Record<
+    RewardTaskDefinition['id'],
+    { icon: typeof UserPlus; color: string }
+  > = {
+    profile: {
+      icon: UserPlus,
+      color: 'text-purple-500',
+    },
+    wallet: {
+      icon: Wallet,
+      color: 'text-orange-500',
+    },
+    'onchain-registration': {
+      icon: Shield,
+      color: 'text-emerald-500',
+    },
+  };
 
   const [registeringOnchain, setRegisteringOnchain] = useState(false);
 
   const handleTaskClick = async (_taskId: string, action: string) => {
-    if (action === 'link-social') {
-      setShowLinkSocialModal(true);
-    } else if (action === 'profile-settings') {
+    if (action === 'profile-settings') {
       window.location.href = '/settings';
     } else if (action === 'wallet-connect') {
       if (authenticated) {
@@ -390,6 +332,16 @@ export default function RewardsPage() {
               </h1>
               <p className="text-muted-foreground">
                 Complete tasks and invite friends to earn points
+              </p>
+              <p className="mt-1 text-muted-foreground text-sm">
+                Manage X and Farcaster connections in{' '}
+                <a
+                  href="/settings?tab=profile"
+                  className="text-primary hover:underline"
+                >
+                  Profile settings
+                </a>
+                .
               </p>
             </div>
 
@@ -489,7 +441,7 @@ export default function RewardsPage() {
 
               <div className="grid gap-3">
                 {rewardTasks.map((task) => {
-                  const Icon = task.icon;
+                  const { icon: Icon, color } = rewardTaskVisuals[task.id];
                   return (
                     <button
                       key={task.id}
@@ -503,7 +455,7 @@ export default function RewardsPage() {
                           : 'cursor-pointer border-border hover:bg-muted/50 disabled:cursor-wait disabled:opacity-60'
                       }`}
                     >
-                      <div className={`shrink-0 ${task.color}`}>
+                      <div className={`shrink-0 ${color}`}>
                         <Icon className="h-6 w-6" />
                       </div>
                       <div className="min-w-0 flex-1">
@@ -722,6 +674,16 @@ export default function RewardsPage() {
               <p className="text-muted-foreground">
                 Complete tasks and invite friends to earn points
               </p>
+              <p className="mt-1 text-muted-foreground text-sm">
+                Manage X and Farcaster connections in{' '}
+                <a
+                  href="/settings?tab=profile"
+                  className="text-primary hover:underline"
+                >
+                  Profile settings
+                </a>
+                .
+              </p>
             </div>
 
             {/* Stats Row */}
@@ -820,7 +782,7 @@ export default function RewardsPage() {
 
               <div className="space-y-2">
                 {rewardTasks.map((task) => {
-                  const Icon = task.icon;
+                  const { icon: Icon, color } = rewardTaskVisuals[task.id];
                   return (
                     <button
                       key={task.id}
@@ -834,7 +796,7 @@ export default function RewardsPage() {
                           : 'cursor-pointer border-border hover:bg-muted/50 disabled:cursor-wait disabled:opacity-60'
                       }`}
                     >
-                      <div className={`shrink-0 ${task.color}`}>
+                      <div className={`shrink-0 ${color}`}>
                         <Icon className="h-5 w-5" />
                       </div>
                       <div className="min-w-0 flex-1">
@@ -1027,18 +989,6 @@ export default function RewardsPage() {
           </div>
         </div>
       )}
-
-      {/* Link Social Accounts Modal */}
-      <LinkSocialAccountsModal
-        isOpen={showLinkSocialModal}
-        onClose={() => {
-          setShowLinkSocialModal(false);
-          // Refresh data to update the UI
-          if (user?.id && authenticated) {
-            fetchReferralData();
-          }
-        }}
-      />
 
       {/* Share & Earn Modal */}
       <ShareEarnModal

--- a/apps/web/src/app/rewards/reward-tasks.ts
+++ b/apps/web/src/app/rewards/reward-tasks.ts
@@ -1,0 +1,71 @@
+import { POINTS } from '@babylon/shared';
+
+export interface RewardsTaskUserState {
+  username: string | null;
+  profileImageUrl: string | null;
+  bio: string | null;
+  pointsAwardedForProfile: boolean;
+  walletAddress: string | null;
+  pointsAwardedForWallet: boolean;
+  onChainRegistered: boolean;
+}
+
+export type RewardTaskAction =
+  | 'profile-settings'
+  | 'wallet-connect'
+  | 'register-onchain';
+
+export interface RewardTaskDefinition {
+  id: 'profile' | 'wallet' | 'onchain-registration';
+  title: string;
+  description: string;
+  points: number;
+  completed: boolean;
+  action: RewardTaskAction;
+}
+
+export function buildRewardTasks(
+  user: RewardsTaskUserState | null
+): RewardTaskDefinition[] {
+  if (!user) return [];
+
+  return [
+    {
+      id: 'profile',
+      title: 'Complete Profile',
+      description: (() => {
+        if (user.pointsAwardedForProfile) {
+          return 'Username, image, and bio complete! ✓';
+        }
+        const missing: string[] = [];
+        if (!user.username) missing.push('username');
+        if (!user.profileImageUrl) missing.push('image');
+        if (!user.bio || user.bio.length < 50) missing.push('bio (50+ chars)');
+        return `Set ${missing.join(', ')}`;
+      })(),
+      points: POINTS.PROFILE_COMPLETION,
+      completed: user.pointsAwardedForProfile,
+      action: 'profile-settings',
+    },
+    {
+      id: 'wallet',
+      title: 'Connect Wallet',
+      description: user.walletAddress
+        ? `${user.walletAddress.slice(0, 6)}...${user.walletAddress.slice(-4)}`
+        : 'Link your wallet',
+      points: POINTS.WALLET_CONNECT,
+      completed: user.pointsAwardedForWallet,
+      action: 'wallet-connect',
+    },
+    {
+      id: 'onchain-registration',
+      title: 'Register On-Chain',
+      description: user.onChainRegistered
+        ? 'ERC-8004 verified identity ✓'
+        : 'Get verified with ERC-8004 on Ethereum',
+      points: -POINTS.ONCHAIN_REGISTRATION,
+      completed: user.onChainRegistered,
+      action: 'register-onchain',
+    },
+  ];
+}

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -648,7 +648,7 @@ export default function SettingsPage() {
                       <div>
                         <div className="font-semibold text-sm">Profile</div>
                         <div className="text-muted-foreground text-xs">
-                          Update your public info and images.
+                          Update your public info, images, and social accounts.
                         </div>
                       </div>
                       <button
@@ -657,7 +657,7 @@ export default function SettingsPage() {
                         className="flex min-h-[44px] items-center gap-2 rounded-lg border border-border px-3 py-2 text-sm transition-colors hover:bg-muted/30"
                       >
                         <LinkIcon className="h-4 w-4" />
-                        Link accounts
+                        Manage social accounts
                       </button>
                     </div>
 

--- a/packages/testing/unit/rewards/reward-tasks.test.ts
+++ b/packages/testing/unit/rewards/reward-tasks.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'bun:test';
+import { POINTS } from '@babylon/shared';
+import { buildRewardTasks } from '../../../../apps/web/src/app/rewards/reward-tasks';
+
+describe('buildRewardTasks', () => {
+  it('returns no tasks when user data is missing', () => {
+    expect(buildRewardTasks(null)).toEqual([]);
+  });
+
+  it('contains only profile, wallet, and on-chain tasks', () => {
+    const tasks = buildRewardTasks({
+      username: null,
+      profileImageUrl: null,
+      bio: null,
+      pointsAwardedForProfile: false,
+      walletAddress: null,
+      pointsAwardedForWallet: false,
+      onChainRegistered: false,
+    });
+
+    expect(tasks.map((task) => task.id)).toEqual([
+      'profile',
+      'wallet',
+      'onchain-registration',
+    ]);
+    expect(tasks.some((task) => task.title.includes('X'))).toBe(false);
+    expect(tasks.some((task) => task.title.includes('Farcaster'))).toBe(false);
+  });
+
+  it('builds expected metadata for completed user profile and wallet', () => {
+    const tasks = buildRewardTasks({
+      username: 'lucas',
+      profileImageUrl: 'https://example.com/avatar.png',
+      bio: 'A'.repeat(60),
+      pointsAwardedForProfile: true,
+      walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+      pointsAwardedForWallet: true,
+      onChainRegistered: true,
+    });
+
+    expect(tasks[0]).toEqual({
+      id: 'profile',
+      title: 'Complete Profile',
+      description: 'Username, image, and bio complete! ✓',
+      points: POINTS.PROFILE_COMPLETION,
+      completed: true,
+      action: 'profile-settings',
+    });
+
+    expect(tasks[1]).toEqual({
+      id: 'wallet',
+      title: 'Connect Wallet',
+      description: '0x1234...5678',
+      points: POINTS.WALLET_CONNECT,
+      completed: true,
+      action: 'wallet-connect',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Removed social connection tasks (X/Farcaster) from the Rewards page so Rewards focuses on rewards and gameplay-related actions.
- Kept social account linking in the Profile settings flow, and clarified this location from Rewards with a direct CTA.
- Added a dedicated reward-task builder + unit tests to lock the new task set and avoid regressions.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: [BAB-215](https://linear.app/eliza-labs/issue/BAB-215/move-social-media-connection-to-profile-from-rewards)

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- Removed `Link X Account` and `Link Farcaster` from Rewards task definitions.
- Removed social-link modal mounting/trigger from Rewards.
- Introduced `apps/web/src/app/rewards/reward-tasks.ts` to centralize and constrain Rewards tasks.
- Added user-facing copy in Rewards header linking social account management to Profile settings.
- Updated Settings profile copy/button label to explicitly indicate social account management.
- Added `packages/testing/unit/rewards/reward-tasks.test.ts` to assert only profile/wallet/on-chain tasks are present.

## Review guide

**Start here**
- `apps/web/src/app/rewards/reward-tasks.ts`
- `apps/web/src/app/rewards/page.tsx`
- `packages/testing/unit/rewards/reward-tasks.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- Non-goal in this PR: changing backend OAuth callback redirect behavior.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

Manual/targeted checks executed:
1. `bunx biome check apps/web/src/app/rewards/page.tsx apps/web/src/app/rewards/reward-tasks.ts apps/web/src/app/settings/page.tsx packages/testing/unit/rewards/reward-tasks.test.ts`
2. `bun test packages/testing/unit/rewards/reward-tasks.test.ts --preload ./packages/testing/unit/preload.ts`

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `none`
- Changed: `none`
- Removed: `none`

**DB / data migration**
- Migration(s): `none`
- Backfill/seed: `none`

**Rollout / rollback plan**
- Rollout: standard deploy.
- Rollback: revert this PR.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- N/A

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- No API contract changes.

### Database
- No schema/query changes.

### Contracts / on-chain
- No contract changes.

### Docs
- No generated docs changes.

</details>

## Screenshots / recordings (UI)

### Option A: Visual demo

| Feature | Before | After |
|---------|--------|-------|
| Rewards task list | Included `Link X Account` and `Link Farcaster` cards | Social cards removed; only profile/wallet/on-chain task cards remain |
| Social account entry point | Social linking available in Rewards task flow | Rewards points users to Profile settings, where social account management is labeled explicitly |

*Demo script (for recording):*
1. Open `/rewards` and verify social tasks are no longer displayed.
2. Open `/settings?tab=profile` and verify `Manage social accounts` opens the social linking modal.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
