### PR TITLE
ci(env): enforce env audit check

### DIFF
--- a/.github/workflows/env-audit.yml
+++ b/.github/workflows/env-audit.yml
@@ -1,0 +1,36 @@
+name: Env Audit
+
+on:
+  pull_request:
+  push:
+    branches: [staging, production]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CI: true
+
+jobs:
+  env-audit:
+    name: env:audit:check
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Env audit check
+        run: bun run env:audit:check
+


### PR DESCRIPTION
## Summary
- Add a lightweight CI workflow that runs `bun run env:audit:check` to prevent env var drift (runtime `process.env` usage must stay documented in `.env.example`).

## Type
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [x] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Linear: https://linear.app/eliza-labs/issue/BAB-240/env-vars-cleanup-and-consolidation-follow-up-to-bab-216
- Stacked on:
  - PR1: https://github.com/BabylonSocial/babylon/pull/1164
  - PR2: https://github.com/BabylonSocial/babylon/pull/1165
  - PR3: https://github.com/BabylonSocial/babylon/pull/1166

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)

**Areas touched**
- [x] Other: GitHub Actions (`.github/workflows`)

## Changes
- Add `.github/workflows/env-audit.yml` and run `bun run env:audit:check` on `pull_request` and on pushes to `staging`/`production`.

## Review guide
**Start here**
- `.github/workflows/env-audit.yml`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

## Test plan
Additional targeted commands:
- `bun run env:audit:check`

## Ops / Migration / Deployment
- [x] No deploy impact

## Screenshots / recordings (UI)
### Option B: No visual changes
- Reason: CI-only change

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (stacked on `chore/bab-240-env-example-cleanup`)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
