### PR TITLE
feat(feed): shared narrative types + article image support in story cards

### DIFF
--- a/apps/web/src/app/api/feed/narrative/route.ts
+++ b/apps/web/src/app/api/feed/narrative/route.ts
@@ -20,7 +20,6 @@ import {
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
-import type { ArcStateType } from '@babylon/db';
 import {
   and,
   arcStates,
@@ -41,6 +40,11 @@ import {
   users,
 } from '@babylon/db';
 import { StaticDataRegistry } from '@babylon/engine';
+import type {
+  ArcStateType,
+  NarrativePost,
+  NarrativeStory,
+} from '@babylon/shared';
 import { logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 import {
@@ -54,38 +58,6 @@ const MAX_CANDIDATE_POSTS = 500;
 const FORTY_EIGHT_HOURS_MS = 48 * 60 * 60 * 1000;
 
 const GENERAL_STORY_KEY = '__general__';
-
-interface NarrativePost {
-  id: string;
-  content: string;
-  fullContent: string | null;
-  articleTitle: string | null;
-  category: string | null;
-  imageUrl: string | null;
-  type: string | null;
-  timestamp: string;
-  authorId: string;
-  authorName: string;
-  authorUsername: string | null;
-  authorProfileImageUrl: string | null;
-  likeCount: number;
-  commentCount: number;
-  shareCount: number;
-  isLiked: boolean;
-  isShared: boolean;
-  relatedQuestion: number | null;
-}
-
-interface NarrativeStory {
-  storyKey: string;
-  storyTitle: string;
-  questionNumber: number | null;
-  arcState: ArcStateType | null;
-  storyScore: number;
-  postCount: number;
-  posts: NarrativePost[];
-  hasUserPosition: boolean;
-}
 
 interface NarrativeFeedResponse {
   success: true;

--- a/apps/web/src/app/feed/components/NarrativeStoryCard.tsx
+++ b/apps/web/src/app/feed/components/NarrativeStoryCard.tsx
@@ -1,11 +1,15 @@
 'use client';
 
-import type { ArcStateType } from '@babylon/db';
+import type {
+  ArcStateType,
+  NarrativePost,
+  NarrativeStory,
+} from '@babylon/shared';
 import { cn } from '@babylon/shared';
 import { BookOpen, ChevronDown, ChevronUp, TrendingUp } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useMemo, useState } from 'react';
-import type { NarrativePost, NarrativeStory } from '@/app/feed/types/narrative';
+import { ArticleCard } from '@/components/articles/ArticleCard';
 import { PostCard } from '@/components/posts/PostCard';
 
 // Arc state display config: label + Tailwind classes
@@ -93,6 +97,23 @@ function toPostCardData(post: NarrativePost) {
   };
 }
 
+function toArticleCardData(post: NarrativePost) {
+  return {
+    id: post.id,
+    type: post.type ?? undefined,
+    content: post.content,
+    fullContent: post.fullContent,
+    articleTitle: post.articleTitle,
+    category: post.category,
+    imageUrl: post.imageUrl,
+    authorId: post.authorId,
+    authorName: post.authorName,
+    authorUsername: post.authorUsername,
+    authorProfileImageUrl: post.authorProfileImageUrl,
+    timestamp: post.timestamp,
+  };
+}
+
 interface NarrativeStoryCardProps {
   story: NarrativeStory;
 }
@@ -148,17 +169,26 @@ export function NarrativeStoryCard({ story }: NarrativeStoryCardProps) {
         </div>
       </div>
 
-      {/* Posts */}
+      {/* Posts — article type uses ArticleCard (renders imageUrl); others use PostCard */}
       <div className="divide-y divide-border">
-        {visiblePosts.map((post) => (
-          <PostCard
-            key={post.id}
-            post={toPostCardData(post)}
-            density="compact"
-            showCommentInputBar={false}
-            onCommentClick={() => router.push(`/post/${post.id}`)}
-          />
-        ))}
+        {visiblePosts.map((post) =>
+          post.type === 'article' ? (
+            <ArticleCard
+              key={post.id}
+              post={toArticleCardData(post)}
+              density="compact"
+              onClick={() => router.push(`/article/${post.id}`)}
+            />
+          ) : (
+            <PostCard
+              key={post.id}
+              post={toPostCardData(post)}
+              density="compact"
+              showCommentInputBar={false}
+              onCommentClick={() => router.push(`/post/${post.id}`)}
+            />
+          )
+        )}
       </div>
 
       {/* Expand / collapse toggle */}

--- a/apps/web/src/app/feed/components/NarrativeStoryList.tsx
+++ b/apps/web/src/app/feed/components/NarrativeStoryList.tsx
@@ -1,4 +1,4 @@
-import type { NarrativeStory } from '@/app/feed/types/narrative';
+import type { NarrativeStory } from '@babylon/shared';
 import { NarrativeStoryCard } from './NarrativeStoryCard';
 
 interface NarrativeStoryListProps {

--- a/apps/web/src/app/feed/hooks/useNarrativeFeed.ts
+++ b/apps/web/src/app/feed/hooks/useNarrativeFeed.ts
@@ -1,6 +1,6 @@
+import type { NarrativeStory } from '@babylon/shared';
 import { logger } from '@babylon/shared';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { NarrativeStory } from '@babylon/shared';
 
 interface UseNarrativeFeedOptions {
   enabled?: boolean;

--- a/apps/web/src/app/feed/hooks/useNarrativeFeed.ts
+++ b/apps/web/src/app/feed/hooks/useNarrativeFeed.ts
@@ -1,6 +1,6 @@
 import { logger } from '@babylon/shared';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { NarrativeStory } from '@/app/feed/types/narrative';
+import type { NarrativeStory } from '@babylon/shared';
 
 interface UseNarrativeFeedOptions {
   enabled?: boolean;

--- a/apps/web/src/app/feed/types/narrative.ts
+++ b/apps/web/src/app/feed/types/narrative.ts
@@ -1,33 +1,5 @@
-import type { ArcStateType } from '@babylon/db';
-
-export interface NarrativePost {
-  id: string;
-  content: string;
-  fullContent: string | null;
-  articleTitle: string | null;
-  category: string | null;
-  imageUrl: string | null;
-  type: string | null;
-  timestamp: string;
-  authorId: string;
-  authorName: string;
-  authorUsername: string | null;
-  authorProfileImageUrl: string | null;
-  likeCount: number;
-  commentCount: number;
-  shareCount: number;
-  isLiked: boolean;
-  isShared: boolean;
-  relatedQuestion: number | null;
-}
-
-export interface NarrativeStory {
-  storyKey: string;
-  storyTitle: string;
-  questionNumber: number | null;
-  arcState: ArcStateType | null;
-  storyScore: number;
-  postCount: number;
-  posts: NarrativePost[];
-  hasUserPosition: boolean;
-}
+/**
+ * Re-export narrative feed types from the canonical source in @babylon/shared.
+ * Import directly from @babylon/shared for new code.
+ */
+export type { ArcStateType, NarrativePost, NarrativeStory } from '@babylon/shared';

--- a/apps/web/src/app/feed/types/narrative.ts
+++ b/apps/web/src/app/feed/types/narrative.ts
@@ -2,4 +2,8 @@
  * Re-export narrative feed types from the canonical source in @babylon/shared.
  * Import directly from @babylon/shared for new code.
  */
-export type { ArcStateType, NarrativePost, NarrativeStory } from '@babylon/shared';
+export type {
+  ArcStateType,
+  NarrativePost,
+  NarrativeStory,
+} from '@babylon/shared';

--- a/packages/shared/src/types/feed.ts
+++ b/packages/shared/src/types/feed.ts
@@ -1,0 +1,71 @@
+/**
+ * Narrative Feed Types
+ *
+ * Single source of truth for narrative feed API response shapes.
+ * Consumed by both the API route (apps/web/src/app/api/feed/narrative/route.ts)
+ * and frontend feed components.
+ *
+ * ArcStateType mirrors the union defined in @babylon/db/src/schema/narrative.ts.
+ * The db schema definition is the canonical one; keep this copy in sync with it.
+ */
+
+/**
+ * Arc state for a prediction market question.
+ * Covers all market durations (long-term, weekly, daily, intraday, flash).
+ */
+export type ArcStateType =
+  | 'setup'
+  | 'tension'
+  | 'escalation'
+  | 'crisis'
+  | 'revelation'
+  | 'resolution'
+  | 'resolving'
+  | 'active'
+  | 'climax'
+  | 'live'
+  | 'morning'
+  | 'midday'
+  | 'afternoon'
+  | 'evening';
+
+/**
+ * A single post within a narrative story group.
+ * Matches the shape returned by GET /api/feed/narrative.
+ */
+export interface NarrativePost {
+  id: string;
+  content: string;
+  fullContent: string | null;
+  articleTitle: string | null;
+  category: string | null;
+  imageUrl: string | null;
+  type: string | null;
+  timestamp: string;
+  authorId: string;
+  authorName: string;
+  authorUsername: string | null;
+  authorProfileImageUrl: string | null;
+  likeCount: number;
+  commentCount: number;
+  shareCount: number;
+  isLiked: boolean;
+  isShared: boolean;
+  relatedQuestion: number | null;
+}
+
+/**
+ * A narrative story — posts grouped by prediction market question,
+ * scored by the narrative engine (engagement × arc state × resolution proximity).
+ * Matches the shape returned by GET /api/feed/narrative.
+ */
+export interface NarrativeStory {
+  storyKey: string;
+  storyTitle: string;
+  questionNumber: number | null;
+  arcState: ArcStateType | null;
+  storyScore: number;
+  postCount: number;
+  posts: NarrativePost[];
+  hasUserPosition: boolean;
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -23,6 +23,8 @@ export {
   isNetworkError,
   isValidationError,
 } from './errors';
+// Narrative feed types (NarrativePost, NarrativeStory, ArcStateType)
+export * from './feed';
 // Group types (tiers, alpha levels)
 export * from './groups';
 // Social interaction types
@@ -39,5 +41,3 @@ export * from './payments';
 export * from './profile';
 // Profile types (user/actor profiles)
 export * from './profiles';
-// Narrative feed types (NarrativePost, NarrativeStory, ArcStateType)
-export * from './feed';

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -39,3 +39,5 @@ export * from './payments';
 export * from './profile';
 // Profile types (user/actor profiles)
 export * from './profiles';
+// Narrative feed types (NarrativePost, NarrativeStory, ArcStateType)
+export * from './feed';

--- a/packages/testing/unit/narrative-arc-state-sync.test.ts
+++ b/packages/testing/unit/narrative-arc-state-sync.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Compile-time guard: ArcStateType in @babylon/shared must stay in sync
+ * with the canonical definition in @babylon/db.
+ *
+ * If these two types diverge (a state added/removed in the DB schema but
+ * not updated in shared), this file will fail to compile and surface the
+ * drift immediately — before any runtime behavior breaks.
+ *
+ * The test itself is trivial; the value is in the type-level assertions.
+ */
+import { describe, expect, it } from 'bun:test';
+import type { ArcStateType as DbArcStateType } from '@babylon/db';
+import type { ArcStateType as SharedArcStateType } from '@babylon/shared';
+
+// If SharedArcStateType and DbArcStateType diverge, one or both of these
+// assignments will produce a TS error at compile time.
+type _SharedExtendsDb = SharedArcStateType extends DbArcStateType
+  ? true
+  : false;
+type _DbExtendsShared = DbArcStateType extends SharedArcStateType
+  ? true
+  : false;
+
+const _sharedExtendsDb: _SharedExtendsDb = true;
+const _dbExtendsShared: _DbExtendsShared = true;
+
+describe('ArcStateType sync: @babylon/shared ↔ @babylon/db', () => {
+  it('shared ArcStateType is identical to db ArcStateType (compile-time check)', () => {
+    // The real assertion is the TypeScript above. This runtime check just
+    // ensures the test file runs and reports a pass in the test suite.
+    expect(_sharedExtendsDb).toBe(true);
+    expect(_dbExtendsShared).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up polish to #1175 addressing two items called out in the review.

### 1. Move types to `@babylon/shared`

`NarrativePost`, `NarrativeStory`, and `ArcStateType` were duplicated between `route.ts` (private interfaces) and `apps/web/src/app/feed/types/narrative.ts` (local copy). Neither was the authoritative source.

- Add `packages/shared/src/types/feed.ts` — canonical definitions, exported via `@babylon/shared`
- Update `route.ts` to import from `@babylon/shared` instead of re-defining locally
- Update `apps/web/src/app/feed/types/narrative.ts` to a thin re-export shim
- Update `useNarrativeFeed`, `NarrativeStoryList` to import directly from `@babylon/shared`
- `ArcStateType` is defined as a standalone string union (mirrors `@babylon/db/src/schema/narrative.ts`; comment in file points to the db definition as canonical)

### 2. Article image thumbnails in story cards

`NarrativeStoryCard` was routing all posts through `PostCard`, which doesn't render `imageUrl`. `ArticleCard` already handles `imageUrl` via `next/image` — it just wasn't being used for article posts.

- Branch on `post.type === 'article'`: render `ArticleCard` (with `imageUrl`, `fullContent`, `articleTitle`) and navigate to `/article/:id`
- All other posts continue using `PostCard` → `/post/:id`
- Adds `toArticleCardData()` helper alongside the existing `toPostCardData()`

## Test plan

- [ ] Article posts in Stories tab show cover image thumbnails
- [ ] Clicking an article in a story card navigates to `/article/:id` (not `/post/:id`)
- [ ] Regular posts still render as `PostCard` with correct navigation
- [ ] `import type { NarrativeStory } from '@babylon/shared'` resolves correctly in consuming files
- [ ] `tsc --noEmit` passes across the monorepo

Made with [Cursor](https://cursor.com)