### PR TITLE
fix(BAB-243): Posthog fixes/improvements

### DIFF
--- a/apps/web/src/app/api/agents/[agentId]/chat/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/chat/route.ts
@@ -878,7 +878,11 @@ export const POST = withErrorHandling(
       points_cost: actualPointsCost,
       model_used: modelUsed,
     }).catch((err) => {
-      logger.warn('Failed to track agent_message_sent', { error: err }, 'AgentChat');
+      logger.warn(
+        'Failed to track agent_message_sent',
+        { error: err },
+        'AgentChat'
+      );
     });
 
     return NextResponse.json({

--- a/apps/web/src/app/api/agents/[agentId]/chat/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/chat/route.ts
@@ -41,6 +41,7 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { v4 as uuidv4 } from 'uuid';
 import { MODEL_TIER_POINTS_COST } from '@/lib/constants';
+import { trackServerEvent } from '@/lib/posthog/server';
 
 // =============================================================================
 // Multi-Step Decision Template
@@ -869,6 +870,16 @@ export const POST = withErrorHandling(
       { actionsExecuted: traceActionResults.length },
       'AgentsAPI'
     );
+
+    trackServerEvent(user.id, 'agent_message_sent', {
+      agent_id: agentId,
+      message_id: responseMessageId,
+      use_pro: usePro,
+      points_cost: actualPointsCost,
+      model_used: modelUsed,
+    }).catch((err) => {
+      logger.warn('Failed to track agent_message_sent', { error: err }, 'AgentChat');
+    });
 
     return NextResponse.json({
       success: true,

--- a/apps/web/src/app/api/points/purchase/verify-payment/route.ts
+++ b/apps/web/src/app/api/points/purchase/verify-payment/route.ts
@@ -106,17 +106,35 @@ export const POST = withErrorHandling(async function POST(req: NextRequest) {
     confirmed: true,
   });
 
-  logger.warn(
-    `Payment verification failed for request ${requestId}`,
-    { requestId, txHash, error: verificationResult.error },
-    'PointsPurchase'
-  );
+  if (!verificationResult.verified) {
+    logger.warn(
+      `Payment verification failed for request ${requestId}`,
+      { requestId, txHash, error: verificationResult.error },
+      'PointsPurchase'
+    );
+    return NextResponse.json(
+      {
+        success: false,
+        error: verificationResult.error ?? 'Payment verification failed',
+      },
+      { status: 400 }
+    );
+  }
 
   const paymentRequest = await x402Manager.getPaymentRequest(requestId);
+  if (!paymentRequest?.metadata) {
+    logger.error(
+      'Payment request or metadata missing after verification',
+      { requestId },
+      'PointsPurchase'
+    );
+    return NextResponse.json(
+      { success: false, error: 'Payment request not found' },
+      { status: 400 }
+    );
+  }
 
-  const metadata = paymentRequest!.metadata;
-  const amountUSD = metadata!.amountUSD as number;
-
+  const amountUSD = paymentRequest.metadata.amountUSD as number;
   const result = await PointsService.purchasePoints(
     userId,
     amountUSD,
@@ -124,31 +142,46 @@ export const POST = withErrorHandling(async function POST(req: NextRequest) {
     txHash
   );
 
-  logger.error(
-    'Failed to credit points after payment verification',
-    { userId, requestId, error: result.error },
-    'PointsPurchase'
-  );
+  if (result.error) {
+    logger.error(
+      'Failed to credit points after payment verification',
+      { userId, requestId, error: result.error },
+      'PointsPurchase'
+    );
+    return NextResponse.json(
+      { success: false, error: result.error ?? 'Failed to credit points' },
+      { status: 500 }
+    );
+  }
 
-  logger.info(
-    `Successfully credited ${result.pointsAwarded} points to user ${userId}`,
-    {
-      userId,
-      requestId,
-      txHash,
+  const actuallyCredited = !result.alreadyAwarded && result.pointsAwarded > 0;
+  if (actuallyCredited) {
+    logger.info(
+      `Successfully credited ${result.pointsAwarded} points to user ${userId}`,
+      {
+        userId,
+        requestId,
+        txHash,
+        pointsAwarded: result.pointsAwarded,
+        newTotal: result.newTotal,
+      },
+      'PointsPurchase'
+    );
+
+    trackServerEvent(userId, 'points_purchase_completed', {
+      amountUSD,
       pointsAwarded: result.pointsAwarded,
       newTotal: result.newTotal,
-    },
-    'PointsPurchase'
-  );
-
-  trackServerEvent(userId, 'points_purchase_completed', {
-    amountUSD,
-    pointsAwarded: result.pointsAwarded,
-    newTotal: result.newTotal,
-    requestId,
-    txHash,
-  });
+      requestId,
+      txHash,
+    }).catch((err) => {
+      logger.warn(
+        'Failed to track points_purchase_completed',
+        { error: err },
+        'PointsPurchase'
+      );
+    });
+  }
 
   return NextResponse.json({
     success: true,

--- a/apps/web/src/app/api/points/purchase/verify-payment/route.ts
+++ b/apps/web/src/app/api/points/purchase/verify-payment/route.ts
@@ -123,6 +123,9 @@ export const POST = withErrorHandling(async function POST(req: NextRequest) {
 
   const paymentRequest = await x402Manager.getPaymentRequest(requestId);
   if (!paymentRequest?.metadata) {
+    // Payment verified on-chain but request data is missing — this is a
+    // server-side state inconsistency, not a client error. Use 500 so the
+    // client knows to retry rather than treating the request as permanently bad.
     logger.error(
       'Payment request or metadata missing after verification',
       { requestId },
@@ -130,7 +133,7 @@ export const POST = withErrorHandling(async function POST(req: NextRequest) {
     );
     return NextResponse.json(
       { success: false, error: 'Payment request not found' },
-      { status: 400 }
+      { status: 500 }
     );
   }
 

--- a/bun.lock
+++ b/bun.lock
@@ -257,6 +257,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@babylon/a2a": "workspace:*",
+        "posthog-node": "^5.17.0",
       },
       "devDependencies": {
         "@types/node": "^24.10.0",

--- a/docs/POSTHOG_AGENT_CHAT_TRACKING.md
+++ b/docs/POSTHOG_AGENT_CHAT_TRACKING.md
@@ -1,0 +1,24 @@
+# PostHog Agent Chat Tracking
+
+Server-side event for agent chat so we can measure agent usage in PostHog.
+
+## Event: `agent_message_sent`
+
+Emitted when a user sends a message to an agent and the agent completes a response (single-agent chat or team chat).
+
+**Where:** `apps/web/src/app/api/agents/[agentId]/chat/route.ts`  
+**When:** After the response is written (DB + broadcast) and points are deducted, before returning the JSON response.
+
+**distinctId:** `user.id` (the owner / human user).
+
+**Properties:**
+
+| Property       | Type    | Description                                      |
+|----------------|---------|--------------------------------------------------|
+| `agent_id`     | string  | Agent user id (the agent that replied).          |
+| `message_id`   | string  | ID of the assistant response message.           |
+| `use_pro`      | boolean | Whether the user requested the pro model.        |
+| `points_cost`  | number  | Points deducted for this message (0 if LLM fail).|
+| `model_used`   | string  | Model display name (e.g. free vs pro).           |
+
+Tracking is best-effort: failures are logged and do not affect the API response.

--- a/docs/analytics/POSTHOG-AUDIT.md
+++ b/docs/analytics/POSTHOG-AUDIT.md
@@ -1,0 +1,151 @@
+# PostHog Analytics Audit
+
+This document summarizes how PostHog is used in the repo and identifies gaps—especially around **agents** (prompting, trading on behalf of users) and **point purchase**—so you can fix or extend tracking.
+
+---
+
+## 1. PostHog architecture in this repo
+
+| Layer | Location | Purpose |
+|-------|----------|---------|
+| **Browser client** | `apps/web/src/lib/posthog/client.ts` | Init with `NEXT_PUBLIC_POSTHOG_PROJECT_ID`, optional host override |
+| **Server client** | `apps/web/src/lib/posthog/server.ts` | Singleton `posthog-node` for API routes; `trackServerEvent(distinctId, event, properties)` |
+| **Provider** | `PostHogProvider` + `PostHogIdentifier` in `Providers.tsx` | Init client, `$pageview` on pathname change, identify logged-in user |
+| **Hooks** | `apps/web/src/hooks/usePostHog.ts` | `track`, `trackAction`, `trackNavigation`, `trackClick`, `trackFormSubmit`, `trackError`; plus `useSignupTracking`, `useMarketTracking`, `useSocialTracking`, `usePerformanceTracking` |
+
+All server events get `environment`, `deployment_url`, `app_version`, and `timestamp`. Server calls use `distinctId` (usually `userId`) so events align with the identified user in PostHog.
+
+---
+
+## 2. What is tracked today
+
+### 2.1 User lifecycle & profile
+
+- **Signup**: `signup_completed` (API), `alpha_group_assignment.success` / `alpha_group_assignment.failure`
+- **Profile**: `profile_updated`, `social_account_linked`
+- **Follow**: `user_followed`, `user_unfollowed`
+
+### 2.2 Social & content
+
+- **Posts**: `post_created`, `post_liked`, `post_unliked`, `post_shared`, `post_unshared`
+- **Chat**: `dm_opened`, `message_sent` (DMs)
+
+### 2.3 Markets (human-only via web API)
+
+- **Predictions**: `prediction_bought`, `prediction_sold` — in `apps/web/src/app/api/markets/predictions/[id]/buy/route.ts` and `sell/route.ts`
+- **Perps**: `trade_opened`, `trade_closed` — in `apps/web/src/app/api/markets/perps/open/route.ts` and `position/[id]/close/route.ts`
+
+These fire only when the **Next.js API routes** are called. They use `user.userId` from `authenticate(request)`. So only **human-initiated** trades through the web app are tracked.
+
+### 2.4 Point purchase
+
+Two paths exist; event names differ.
+
+| Path | Initiated event | Completed event | Where |
+|------|------------------|-----------------|--------|
+| **Stripe (card)** | `stripe_checkout_initiated` | `stripe_checkout_completed` | `api/stripe/checkout/session/route.ts`, `api/stripe/webhook/route.ts` |
+| **x402 (on-chain)** | `points_purchase_initiated` | `points_purchase_completed` | `api/points/purchase/create-payment/route.ts`, `api/points/purchase/verify-payment/route.ts` |
+
+So “point purchase” in PostHog is split: Stripe uses `stripe_checkout_*`, x402 uses `points_purchase_*`. Funnels or dashboards that treat “point purchase” as one flow need to combine both.
+
+---
+
+## 3. Gaps: agents
+
+**No PostHog tracking** is used in any route under `apps/web/src/app/api/agents/`. So the following are **not** tracked today.
+
+### 3.1 User prompting agents
+
+- **Team chat message**  
+  - `POST /api/agents/team-chat/message` — user sends a message to the team chat.  
+  - No `trackServerEvent` (no “user sent message to agents” or “conversation started”).
+- **Single-agent chat**  
+  - `POST /api/agents/[agentId]/chat` — user sends a message to one agent.  
+  - No `trackServerEvent` (no “user prompted agent” or “agent chat message”).
+- **Coordinator**  
+  - `POST /api/agents/team-chat/coordinator` — coordinator reply when no agent is tagged.  
+  - No tracking.
+
+So you cannot currently measure in PostHog:
+
+- How many users prompt agents (team or single).
+- Volume of agent conversations or messages.
+
+**Recommendation:** Add server-side events such as:
+
+- `agent_team_message_sent` (e.g. `userId`, `chatId`, optional `agentIds` if tagged).
+- `agent_chat_message_sent` (e.g. `userId`, `agentId`, `isTeamChat` or channel).
+- Optionally `agent_coordinator_replied` if you care about coordinator usage.
+
+Use the same `userId` (owner) as `distinctId` so you can join with other events and identify “users who use agents”.
+
+### 3.2 Agents trading on behalf of users
+
+Agent trading does **not** go through the Next.js market API routes. It uses the same engine services (e.g. `PredictionMarketService.buy/sell`, perp open/close) but from:
+
+- **Chat-initiated**: plugin-agent-core actions (e.g. `buy-prediction`, `sell-prediction`, `open-perp`, `close-perp`) and A2A/Babylon plugin actions call services **inside the agent runtime** with the agent’s `userId`.
+- **Autonomous**: cron `POST /api/cron/agent-tick` runs the autonomous coordinator; agents trade via the same internal services.
+
+So:
+
+- `prediction_bought`, `prediction_sold`, `trade_opened`, `trade_closed` are **only** emitted when a **human** hits the web market API. They are **not** emitted when an agent trades (chat or cron).
+- The cron route and the agent plugin code do not call `trackServerEvent`.
+
+So in PostHog you cannot currently:
+
+- Count trades executed by agents.
+- Distinguish “user traded” vs “agent traded for user”.
+- Attribute agent trades to the owning user (for LTV, engagement, etc.).
+
+**Recommendation:**
+
+1. **Option A – Instrument agent execution only**  
+   In the agent plugin layer (e.g. after a successful buy/sell/open/close in `packages/agents/src/plugins/plugin-agent-core/src/actions/` or the A2A/Babylon trading actions), call a small shared helper that:
+   - Accepts `agentUserId`, `ownerUserId`, `event` (e.g. `agent_prediction_bought`), and market/position props.
+   - From the Next.js app, call `trackServerEvent(ownerUserId, event, { agentId: agentUserId, ... })` (e.g. via an internal API or a shared server-only module the app exposes).  
+   That way you track “agent traded” with the **owner** as `distinctId` and `agentId` in properties.
+
+2. **Option B – Instrument cron as well**  
+   In `api/cron/agent-tick/route.ts`, after processing each agent (or batch), you could emit a summary event per agent or per run (e.g. `agent_tick_trades` with counts or high-level stats). That would require the cron route to have access to `trackServerEvent` and to know the mapping from agent id to owner id (which you already have in DB).
+
+3. **Event naming**  
+   Use distinct names from human trades, e.g. `agent_prediction_bought`, `agent_prediction_sold`, `agent_trade_opened`, `agent_trade_closed`, and always include `agentId` and optionally `trigger: 'chat' | 'autonomous'` so you can segment in PostHog.
+
+---
+
+## 4. Point purchase: is it tracked correctly?
+
+- **Stripe path**: Initiated and completed are both tracked (`stripe_checkout_initiated`, `stripe_checkout_completed`) with `userId`, amount, points, session id. Correct.
+- **x402 path**: Initiated is tracked (`points_purchase_initiated`). Completed is tracked in `verify-payment` (`points_purchase_completed`).
+
+**Bug in verify-payment:**  
+In `apps/web/src/app/api/points/purchase/verify-payment/route.ts`, the handler does **not** check `verificationResult` before continuing. It always:
+
+1. Calls `getPaymentRequest(requestId)` (and uses `paymentRequest!.metadata`)
+2. Calls `PointsService.purchasePoints(...)`
+3. Calls `trackServerEvent(userId, 'points_purchase_completed', ...)`
+
+So if verification fails, you still run the success path and emit `points_purchase_completed`, which is incorrect. You should only credit points and send `points_purchase_completed` when verification succeeded (e.g. when `verificationResult` indicates success). Fixing that will make point purchase completion tracking accurate for the x402 path.
+
+---
+
+## 5. Quick reference: where to add tracking
+
+| Area | File(s) | Suggested event(s) |
+|------|--------|--------------------|
+| Team chat message | `api/agents/team-chat/message/route.ts` | `agent_team_message_sent` |
+| Single-agent chat | `api/agents/[agentId]/chat/route.ts` | `agent_chat_message_sent` |
+| Coordinator reply | `api/agents/team-chat/coordinator/route.ts` | optional `agent_coordinator_replied` |
+| Agent prediction buy/sell | `packages/agents/.../buy-prediction.ts`, `sell-prediction.ts` (or shared wrapper) | `agent_prediction_bought`, `agent_prediction_sold` |
+| Agent perp open/close | `packages/agents/.../open-perp.ts`, `close-perp.ts` (or shared wrapper) | `agent_trade_opened`, `agent_trade_closed` |
+| x402 verify-payment | `api/points/purchase/verify-payment/route.ts` | Fix control flow so `points_purchase_completed` only fires on success |
+
+---
+
+## 6. Env and docs
+
+- **Env**: `NEXT_PUBLIC_POSTHOG_PROJECT_ID`, optional `NEXT_PUBLIC_POSTHOG_HOST` (see `.env.example`).
+- **Validation**: `scripts/validate-env.ts` warns if PostHog is not configured.
+- **Types**: `packages/shared/src/types/common.ts` has `PostHogServerClient` / `PostHogClient` interfaces; `packages/testing/types/test-types.ts` has test doubles.
+
+If you want, next steps can be: (1) add the agent events and (2) fix the verify-payment flow and optionally unify point-purchase event names for funnels.

--- a/docs/analytics/POSTHOG_RETENTION.md
+++ b/docs/analytics/POSTHOG_RETENTION.md
@@ -1,0 +1,90 @@
+# PostHog retention (D1, D7, D30)
+
+How to set up and interpret retention in PostHog so D1/D7/D30 match product expectations. Retention is **configured in the PostHog UI**; this doc defines the events and steps.
+
+---
+
+## Definitions
+
+| Metric | Meaning |
+|--------|--------|
+| **D1** | % of users who performed the “return” event **1 day** after their “start” event. |
+| **D7** | % of users who performed the “return” event **7 days** after their “start” event. |
+| **D30** | % of users who performed the “return” event **30 days** after their “start” event. |
+
+“Start” = first time the user did the chosen **starting event**.  
+“Return” = user did the chosen **returning event** on a later day (1, 7, or 30 days later).
+
+---
+
+## Recommended events
+
+### Starting event (cohort definition)
+
+Pick one depending on what you want to measure:
+
+| Event | Use case |
+|-------|----------|
+| `signup_completed` | Retention of **signed-up users** (server-tracked on signup). |
+| `$pageview` | Retention of **any visitor** (first page view). |
+
+Use **one** of these per retention insight so cohorts are clear.
+
+### Returning event ( “came back” )
+
+Pick one or combine in separate insights:
+
+| Event | Use case |
+|-------|----------|
+| `$pageview` | “Came back to the app” (any page). |
+| `signup_completed` | Only useful if you run multiple signup flows; usually not for retention. |
+| `prediction_bought` or `prediction_sold` | “Came back and traded (prediction)”. |
+| `trade_opened` or `trade_closed` | “Came back and traded (perp)”. |
+| `agent_message_sent` | “Came back and used agent chat”. |
+| `post_created` | “Came back and posted”. |
+| `message_sent` | “Came back and sent a DM”. |
+
+For a single “active user” retention view, **`$pageview`** is the simplest returning event. For “power user” retention, use a specific action (e.g. any trade event or `agent_message_sent`).
+
+---
+
+## How to create the insight in PostHog
+
+1. In PostHog go to **Insights** → **New insight** → **Retention**.
+2. **Starting event:** e.g. `signup_completed` (for signed-up users) or `$pageview` (for all visitors). Optionally add filters (e.g. `environment = production`).
+3. **Returning event:** e.g. `$pageview` or `prediction_bought` / `trade_opened` / `agent_message_sent` etc.
+4. **Retention type:** “Retention (classic)” with **Day 1, Day 7, Day 30** (or “Retention (total)” and interpret the 1-, 7-, 30-day buckets).
+5. Save and add to a dashboard (e.g. “Growth” or “Retention”).
+
+Result: you get a retention table and/or curve; D1/D7/D30 are the percentages for days 1, 7, and 30.
+
+---
+
+## Identity
+
+Retention in PostHog is per **distinct_id**. The app identifies logged-in users with `posthog.identify(user.id)` (see `PostHogIdentifier`). Server events use the same `userId` as `distinctId`. So:
+
+- **Signed-up users:** use `signup_completed` as starting event; distinct_id is the user id.
+- **Anonymous then signed up:** if you want “first touch” retention, use `$pageview` as starting event; after signup, the same user may have a new distinct_id unless you merge/anonymize (PostHog’s identity merge settings).
+
+For consistent D1/D7/D30, prefer **signed-up users** and `signup_completed` as the starting event.
+
+---
+
+## In-app D7 vs PostHog
+
+The app has its **own** D7 retention in the admin growth API (`/api/admin/stats/growth`), computed from DB cohorts and activity (trades, posts, messages). That is **separate** from PostHog:
+
+- **PostHog retention:** event-based, defined by the events above; configure in PostHog UI.
+- **Admin growth D7:** cohort-based from your database; no PostHog setup.
+
+Use PostHog for product/behavior retention (events); use the admin API for internal reporting that must match your DB.
+
+---
+
+## Checklist (BAB-243)
+
+- [ ] Create at least one **Retention** insight in PostHog with starting event = `signup_completed` (or `$pageview`) and returning event = `$pageview` (or a key action).
+- [ ] Confirm **Day 1, Day 7, Day 30** (or equivalent) are visible and labeled.
+- [ ] Optional: add a second retention insight for “power users” (e.g. starting = `signup_completed`, returning = `prediction_bought` or `agent_message_sent`).
+- [ ] Add the insight(s) to a shared dashboard so D1/D7/D30 are easy to find.

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -22,7 +22,8 @@
     "typecheck": "tsc -b ."
   },
   "dependencies": {
-    "@babylon/a2a": "workspace:*"
+    "@babylon/a2a": "workspace:*",
+    "posthog-node": "^5.17.0"
   },
   "peerDependencies": {
     "@a2a-js/sdk": "^0.3.5",

--- a/packages/agents/src/autonomous/AutonomousA2AService.ts
+++ b/packages/agents/src/autonomous/AutonomousA2AService.ts
@@ -11,12 +11,12 @@ import { db, eq, users } from '@babylon/db';
 import type { IAgentRuntime } from '@elizaos/core';
 import type { BabylonRuntime } from '../plugins/babylon/types';
 import { agentPnLService } from '../services/AgentPnLService';
-import { trackAgentTradeExecuted } from './track-agent-trade';
 import {
   getAgentConfig,
   isAutonomousTradingEnabled,
 } from '../shared/agent-config';
 import { logger } from '../shared/logger';
+import { trackAgentTradeExecuted } from './track-agent-trade';
 
 /**
  * Type guard to check if runtime has A2A client
@@ -351,14 +351,14 @@ Your JSON response:`;
         leverage: perpLeverage,
       })) as { positionId?: string; entryPrice?: number };
 
-    logger.info('A2A LLM-based perp trade executed', {
-      agentUserId,
-      ticker,
-      side,
-      size,
-      leverage: perpLeverage,
-      reasoning,
-    });
+      logger.info('A2A LLM-based perp trade executed', {
+        agentUserId,
+        ticker,
+        side,
+        size,
+        leverage: perpLeverage,
+        reasoning,
+      });
 
       // Record trade via shared service (DRY - same as DirectExecutors)
       await agentPnLService.recordTrade({

--- a/packages/agents/src/autonomous/AutonomousA2AService.ts
+++ b/packages/agents/src/autonomous/AutonomousA2AService.ts
@@ -11,6 +11,7 @@ import { db, eq, users } from '@babylon/db';
 import type { IAgentRuntime } from '@elizaos/core';
 import type { BabylonRuntime } from '../plugins/babylon/types';
 import { agentPnLService } from '../services/AgentPnLService';
+import { trackAgentTradeExecuted } from './track-agent-trade';
 import {
   getAgentConfig,
   isAutonomousTradingEnabled,
@@ -350,14 +351,14 @@ Your JSON response:`;
         leverage: perpLeverage,
       })) as { positionId?: string; entryPrice?: number };
 
-      logger.info('A2A LLM-based perp trade executed', {
-        agentUserId,
-        ticker,
-        side,
-        size,
-        leverage: perpLeverage,
-        reasoning,
-      });
+    logger.info('A2A LLM-based perp trade executed', {
+      agentUserId,
+      ticker,
+      side,
+      size,
+      leverage: perpLeverage,
+      reasoning,
+    });
 
       // Record trade via shared service (DRY - same as DirectExecutors)
       await agentPnLService.recordTrade({
@@ -370,6 +371,17 @@ Your JSON response:`;
         amount: size,
         price: tradeResult.entryPrice || 0,
         reasoning: `LLM decision (${perpLeverage}x leverage): ${reasoning}`,
+      });
+
+      const ownerId = agent?.managedBy ?? agentUserId;
+      trackAgentTradeExecuted(agentUserId, {
+        agent_id: agentUserId,
+        market_type: 'perp',
+        action: 'open',
+        ticker,
+        side,
+        amount: size,
+        owner_id: ownerId,
       });
 
       return {
@@ -432,6 +444,17 @@ Your JSON response:`;
       amount,
       price: tradeResult.avgPrice || 0,
       reasoning: `LLM decision: ${reasoning}`,
+    });
+
+    const ownerId = agent?.managedBy ?? agentUserId;
+    trackAgentTradeExecuted(agentUserId, {
+      agent_id: agentUserId,
+      market_type: 'prediction',
+      action: 'buy',
+      market_id: marketId,
+      side: outcome,
+      amount,
+      owner_id: ownerId,
     });
 
     return {

--- a/packages/agents/src/autonomous/AutonomousTradingService.ts
+++ b/packages/agents/src/autonomous/AutonomousTradingService.ts
@@ -28,6 +28,7 @@ import { callGroqDirect } from '../llm/direct-groq';
 import { getAgentConfig } from '../shared/agent-config';
 import { logger } from '../shared/logger';
 import { executeDirectTrade } from './DirectExecutors';
+import { trackAgentTradeExecuted } from './track-agent-trade';
 import { resolvePerpTicker } from './utils/resolvePerpTicker';
 
 const SUGGESTED_TRADE_PERCENT = 0.25; // 25% of balance for more aggressive trading
@@ -410,6 +411,18 @@ If holding:
       undefined,
       'AutonomousTrading'
     );
+
+    const ownerId = agent?.managedBy ?? agentUserId;
+    trackAgentTradeExecuted(agentUserId, {
+      agent_id: agentUserId,
+      market_type: marketType,
+      action: side,
+      market_id: result.marketId,
+      ticker: result.ticker,
+      side: result.side,
+      amount: normalizedAmount,
+      owner_id: ownerId,
+    });
 
     return {
       tradesExecuted: 1,

--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -35,6 +35,7 @@ import {
   executeDirectTrade,
   executeDirectUnfollow,
 } from './DirectExecutors';
+import { trackAgentTradeExecuted } from './track-agent-trade';
 import { topicDiversityService } from './TopicDiversityService';
 
 import {
@@ -869,6 +870,25 @@ export class MultiStepExecutor {
       amount,
       reasoning,
     });
+
+    if (tradeResult.success) {
+      const [agentRow] = await db
+        .select({ managedBy: users.managedBy })
+        .from(users)
+        .where(eq(users.id, agentUserId))
+        .limit(1);
+      const ownerId = agentRow?.managedBy ?? agentUserId;
+      trackAgentTradeExecuted(agentUserId, {
+        agent_id: agentUserId,
+        market_type: marketType || 'prediction',
+        action: side,
+        market_id: tradeResult.marketId,
+        ticker: tradeResult.ticker,
+        side: tradeResult.side,
+        amount,
+        owner_id: ownerId,
+      });
+    }
 
     return {
       actionType: Actions.TRADE,

--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -327,7 +327,8 @@ export class MultiStepExecutor {
         effectiveFeatures,
         runtime,
         isNpc,
-        { prompt, completion: rawResponse, thought: decision.thought }
+        { prompt, completion: rawResponse, thought: decision.thought },
+        agent?.managedBy ?? agentUserId
       );
       iterationTimings.actionExecution = Date.now() - actionStartTime;
       iterationTimings.total = Date.now() - iterationStartTime;
@@ -734,7 +735,8 @@ export class MultiStepExecutor {
     enabledFeatures: string[],
     _runtime: IAgentRuntime,
     isNpc: boolean,
-    logContext?: { prompt: string; completion: string; thought: string }
+    logContext?: { prompt: string; completion: string; thought: string },
+    ownerId: string = agentUserId
   ): Promise<ActionTraceResult> {
     const normalizedAction = action.toUpperCase();
 
@@ -764,7 +766,7 @@ export class MultiStepExecutor {
 
     switch (normalizedAction) {
       case Actions.TRADE:
-        return this.executeTrade(agentUserId, parameters);
+        return this.executeTrade(agentUserId, parameters, ownerId);
 
       case Actions.POST:
         return this.executePost(agentUserId, parameters, isNpc, logContext);
@@ -835,7 +837,8 @@ export class MultiStepExecutor {
 
   private async executeTrade(
     agentUserId: string,
-    parameters: Record<string, unknown>
+    parameters: Record<string, unknown>,
+    ownerId: string = agentUserId
   ): Promise<ActionTraceResult> {
     const marketType = parameters.marketType as 'prediction' | 'perp';
     const marketId = parameters.marketId as string;
@@ -871,12 +874,6 @@ export class MultiStepExecutor {
     });
 
     if (tradeResult.success) {
-      const [agentRow] = await db
-        .select({ managedBy: users.managedBy })
-        .from(users)
-        .where(eq(users.id, agentUserId))
-        .limit(1);
-      const ownerId = agentRow?.managedBy ?? agentUserId;
       trackAgentTradeExecuted(agentUserId, {
         agent_id: agentUserId,
         market_type: marketType || 'prediction',

--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -35,9 +35,7 @@ import {
   executeDirectTrade,
   executeDirectUnfollow,
 } from './DirectExecutors';
-import { trackAgentTradeExecuted } from './track-agent-trade';
 import { topicDiversityService } from './TopicDiversityService';
-
 import {
   Actions,
   type ActionTraceResult,
@@ -47,6 +45,7 @@ import {
   getRequiredFeature,
   type MultiStepDecision,
 } from './templates/multi-step-decision';
+import { trackAgentTradeExecuted } from './track-agent-trade';
 
 // Import utilities
 import {

--- a/packages/agents/src/autonomous/track-agent-trade.ts
+++ b/packages/agents/src/autonomous/track-agent-trade.ts
@@ -1,0 +1,80 @@
+/**
+ * Server-side PostHog tracking for agent trades.
+ * Used by AutonomousTradingService, AutonomousA2AService, and MultiStepExecutor
+ * when running in the Next.js app (e.g. cron); no-ops when NEXT_PUBLIC_POSTHOG_PROJECT_ID is not set.
+ * Environment properties match apps/web/src/lib/posthog/server.ts for consistent filtering.
+ */
+
+import { PostHog } from 'posthog-node';
+
+let client: PostHog | null = null;
+
+function getServerEnvironment(): 'production' | 'staging' | 'development' {
+  if (process.env.VERCEL_ENV === 'production') return 'production';
+  if (process.env.VERCEL_ENV === 'preview') return 'staging';
+  if (process.env.NODE_ENV === 'production') return 'production';
+  return 'development';
+}
+
+function getEnvironmentProperties(): Record<string, string> {
+  return {
+    environment: getServerEnvironment(),
+    deployment_url: process.env.VERCEL_URL || 'localhost:3000',
+    app_version: process.env.VERCEL_GIT_COMMIT_SHA || 'dev',
+  };
+}
+
+function getClient(): PostHog | null {
+  if (client !== null) return client;
+  const apiKey = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_ID;
+  const apiHost =
+    process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com';
+  if (!apiKey) return null;
+  try {
+    client = new PostHog(apiKey, {
+      host: apiHost,
+      flushAt: 10,
+      flushInterval: 5000,
+    });
+  } catch {
+    return null;
+  }
+  return client;
+}
+
+export interface AgentTradeExecutedProperties {
+  agent_id: string;
+  market_type: 'prediction' | 'perp';
+  action: string;
+  market_id?: string;
+  ticker?: string;
+  side?: string;
+  amount?: number;
+  owner_id: string;
+}
+
+/**
+ * Track agent_trade_executed in PostHog.
+ * distinctId is the agent user id; owner_id in properties for owner analytics.
+ */
+export function trackAgentTradeExecuted(
+  agentUserId: string,
+  properties: AgentTradeExecutedProperties
+): void {
+  const c = getClient();
+  if (!c) return;
+  try {
+    c.capture({
+      distinctId: agentUserId,
+      event: 'agent_trade_executed',
+      properties: {
+        ...properties,
+        $lib: 'posthog-node',
+        ...getEnvironmentProperties(),
+        timestamp: new Date().toISOString(),
+      },
+    });
+  } catch {
+    // no-op on error to avoid breaking trade flow
+  }
+}

--- a/packages/agents/src/autonomous/track-agent-trade.ts
+++ b/packages/agents/src/autonomous/track-agent-trade.ts
@@ -31,10 +31,13 @@ function getClient(): PostHog | null {
     process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://us.i.posthog.com';
   if (!apiKey) return null;
   try {
+    // Match the config in apps/web/src/lib/posthog/server.ts so cron/serverless
+    // executions don't hang on a slow PostHog endpoint.
     client = new PostHog(apiKey, {
       host: apiHost,
-      flushAt: 10,
-      flushInterval: 5000,
+      flushAt: 20,
+      flushInterval: 10000,
+      requestTimeout: 5000,
     });
   } catch {
     return null;
@@ -55,7 +58,12 @@ export interface AgentTradeExecutedProperties {
 
 /**
  * Track agent_trade_executed in PostHog.
- * distinctId is the agent user id; owner_id in properties for owner analytics.
+ *
+ * distinctId is the owning human's user ID (owner_id) so PostHog funnels,
+ * retention, and People records reflect the owner, not the agent. This
+ * matches how agent_message_sent is tracked in the web app (trackServerEvent
+ * uses the human user's ID as distinctId, with agent_id as a property).
+ * The agent user ID is included as agent_id in properties.
  */
 export function trackAgentTradeExecuted(
   agentUserId: string,
@@ -65,10 +73,12 @@ export function trackAgentTradeExecuted(
   if (!c) return;
   try {
     c.capture({
-      distinctId: agentUserId,
+      // Use owner as the actor so PostHog user counts represent humans, not agents
+      distinctId: properties.owner_id,
       event: 'agent_trade_executed',
       properties: {
         ...properties,
+        agent_id: agentUserId,
         $lib: 'posthog-node',
         ...getEnvironmentProperties(),
         timestamp: new Date().toISOString(),


### PR DESCRIPTION
<!--
Babylon PR template

Goal: make PRs easy to review + easy to ship.
- Prefer small, focused PRs (one theme). Avoid catch‑all PRs.
- Keep app-layer thin and portable (validate → service → map errors).
- Put domain logic in packages (framework-agnostic), not in Next handlers/components.
- Before requesting review, run the relevant checks (see "Test plan").
-->

## Summary
<!-- 1–3 bullets: what changed + why (user impact / business goal). -->

- **PostHog tracking (BAB-243):** Server-side events for agent chat (`agent_message_sent`), points purchase completion (`points_purchase_completed` only on verify-payment success and when points actually credited), and agent trades (`agent_trade_executed` in AutonomousTradingService, AutonomousA2AService, MultiStepExecutor) so we can measure agent usage, point purchases, and agent-driven trades in PostHog.
- **Points verify-payment fix:** Early return on verification failure; success path and logging corrected so we don’t credit or track on failure or on idempotent retries (`alreadyAwarded`).
- **Docs:** POSTHOG_AGENT_CHAT_TRACKING.md, POSTHOG-AUDIT.md, POSTHOG_RETENTION.md (D1/D7/D30 setup in PostHog UI).

## Type
<!-- Helps triage + release notes. -->

- [x] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [x] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
<!-- Link issues, Linear tickets, docs, prior PRs. -->

- Linear: **BAB-243** (PostHog tracking improvements)
- `docs/POSTHOG_AGENT_CHAT_TRACKING.md` — agent_message_sent spec
- `docs/analytics/POSTHOG-AUDIT.md` — audit of PostHog usage and gaps
- `docs/analytics/POSTHOG_RETENTION.md` — how to set up D1/D7/D30 retention in PostHog

## Scope (keep it focused)
<!-- If you had to touch multiple areas, explain why and what you intentionally left out. -->

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [ ] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`) — no UI changes
- [x] Web API routes (`apps/web`: agent chat, points verify-payment)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [x] Agents / autonomous (`packages/agents`: AutonomousTradingService, AutonomousA2AService, MultiStepExecutor, new track-agent-trade.ts)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
<!-- List the notable changes (what is new/removed/modified). Link key files if it helps. -->

**Commits**
- `1f8f4e2b4` feat(analytics): PostHog tracking for agent chat, points purchase, agent trades (BAB-243)
- `1a975d2f8` chore: apply biome formatting to PostHog tracking files

**New files**
- `packages/agents/src/autonomous/track-agent-trade.ts` — server-side PostHog capture for `agent_trade_executed` (posthog-node in @babylon/agents; env properties match web app).
- `docs/POSTHOG_AGENT_CHAT_TRACKING.md` — spec for `agent_message_sent`.
- `docs/analytics/POSTHOG-AUDIT.md` — audit of current PostHog usage and gaps.
- `docs/analytics/POSTHOG_RETENTION.md` — how to configure D1/D7/D30 retention in PostHog UI.

**Agent chat**
- `apps/web/src/app/api/agents/[agentId]/chat/route.ts` — after successful response, `trackServerEvent(user.id, 'agent_message_sent', { agent_id, message_id, use_pro, points_cost, model_used })`.

**Points purchase**
- `apps/web/src/app/api/points/purchase/verify-payment/route.ts` — early return when `!verificationResult.verified`; only credit and `trackServerEvent('points_purchase_completed')` when `actuallyCredited` (!result.alreadyAwarded && result.pointsAwarded > 0); fix logger usage (warn/error conditional).

**Agent trades**
- `packages/agents/package.json` — added `posthog-node` dependency.
- `packages/agents/src/autonomous/track-agent-trade.ts` — `trackAgentTradeExecuted(agentUserId, properties)` with `environment`, `deployment_url`, `app_version`.
- `AutonomousTradingService.ts` — call `trackAgentTradeExecuted` after successful `executeDirectTrade` (owner_id from agent.managedBy).
- `AutonomousA2AService.ts` — call `trackAgentTradeExecuted` after successful perp and prediction trades.
- `MultiStepExecutor.ts` — call `trackAgentTradeExecuted` after successful `executeDirectTrade` (multi_step path).

## Review guide
<!-- Help reviewers go fast: where to start, what to ignore, tricky bits, key decisions. -->

**Start here**
- `packages/agents/src/autonomous/track-agent-trade.ts` — single place for agent trade events; no-ops when PostHog not configured.
- `apps/web/src/app/api/points/purchase/verify-payment/route.ts` — success/failure flow and when we track.
- One agent path (e.g. AutonomousTradingService after executeDirectTrade) to see the tracking call shape.

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- Agent trades use a shared module in `packages/agents` (posthog-node) because the app cannot import `@/lib/posthog/server` from the agents package. Events include `owner_id` for owner-level analytics.
- Retention (D1/D7/D30) is documented for PostHog UI setup; no code change for retention in this PR.

## Test plan
<!-- Tick what you ran. Add manual steps for anything user-facing. -->

**Commands run**
- [x] `bun run check` (Biome)
- [x] `bun run typecheck` (agents + web and deps)
- [x] `bun run build` (full turbo build)
- [ ] `bun run lint`
- [ ] `bun run test` (unit)
- [ ] `bun run test:integration`
- [ ] `bun run test:e2e`
- [ ] `bun run contracts:test`
- [ ] `bun run db:check`

**Manual verification**
1. After deploy: send an agent chat message and confirm `agent_message_sent` in PostHog.
2. Complete an x402 points purchase and confirm `points_purchase_completed` only on success (and not on duplicate verify).
3. Run an agent tick that executes a trade and confirm `agent_trade_executed` in PostHog.

## Ops / Migration / Deployment
<!-- Anything that impacts deploys, data, cron, config, or rollouts. -->

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- None (uses existing `NEXT_PUBLIC_POSTHOG_PROJECT_ID` / `NEXT_PUBLIC_POSTHOG_HOST` when set).

**DB / data migration**
- None.

**Rollout / rollback plan**
- Standard deploy; rollback by reverting branch. No new env or DB.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- N/A

## Security / privacy
<!-- Authn/authz, secrets handling, PII, prompt injection surfaces, etc. -->

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- Agent chat and verify-payment responses unchanged; tracking is best-effort (catch and log, don’t fail the request).

### Database
- No schema or query changes.

### Contracts / on-chain
- N/A

### Docs
- New markdown docs only; no generated docs.

</details>

## Screenshots / recordings (UI)
<!--
⚠️ REQUIRED SECTION - Do not leave empty.

Choose ONE of the following:

1. **If visual changes exist**: Add screenshots (before/after) or a short recording.
2. **If no visual changes**: Explain WHY a screenshot/recording is not relevant.
-->

### Option B: No visual changes

- Reason: Analytics and server-side tracking only. No UI or user-facing flow changes.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [ ] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (tracking module in agents package)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (POSTHOG_AGENT_CHAT_TRACKING, POSTHOG-AUDIT, POSTHOG_RETENTION)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`posthog-node` in @babylon/agents, `bun.lock`)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (explanation: no visual changes)
