### PR TITLE
feat(agents): agent messaging, coordinator orchestration, and price alerts

### DIFF
--- a/apps/web/src/app/api/agents/[agentId]/alerts/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/alerts/route.ts
@@ -1,0 +1,276 @@
+/**
+ * Agent Price Alerts API
+ *
+ * @route GET /api/agents/[agentId]/alerts - List price alerts
+ * @route POST /api/agents/[agentId]/alerts - Create/update a price alert
+ * @route DELETE /api/agents/[agentId]/alerts - Remove a price alert
+ * @access Authenticated (manager only)
+ *
+ * Manages price alerts stored in userAgentConfigs.priceAlerts JSONB column.
+ * Alerts are checked every autonomous tick (~3 min) by PriceAlertService.
+ */
+
+import { authenticateUser, withErrorHandling } from '@babylon/api';
+import { db, eq, userAgentConfigs, users } from '@babylon/db';
+import type { PriceAlert } from '@babylon/db/schema';
+import { generateSnowflakeId } from '@babylon/shared';
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+
+/**
+ * Verify agent exists, is an agent, and is managed by the authenticated user.
+ * Returns the agent's userAgentConfigs row or an error response.
+ */
+async function verifyAgentOwnership(
+  req: NextRequest,
+  agentId: string
+): Promise<
+  | { error: NextResponse }
+  | { config: { id: string; priceAlerts: PriceAlert[] }; userId: string }
+> {
+  const user = await authenticateUser(req);
+
+  const [agent] = await db
+    .select({
+      id: users.id,
+      isAgent: users.isAgent,
+      managedBy: users.managedBy,
+    })
+    .from(users)
+    .where(eq(users.id, agentId))
+    .limit(1);
+
+  if (!agent || !agent.isAgent) {
+    return {
+      error: NextResponse.json({ error: 'Agent not found' }, { status: 404 }),
+    };
+  }
+
+  if (agent.managedBy !== user.id) {
+    return {
+      error: NextResponse.json({ error: 'Unauthorized' }, { status: 403 }),
+    };
+  }
+
+  const [config] = await db
+    .select({
+      id: userAgentConfigs.id,
+      priceAlerts: userAgentConfigs.priceAlerts,
+    })
+    .from(userAgentConfigs)
+    .where(eq(userAgentConfigs.userId, agentId))
+    .limit(1);
+
+  if (!config) {
+    return {
+      error: NextResponse.json(
+        { error: 'Agent configuration not found' },
+        { status: 404 }
+      ),
+    };
+  }
+
+  return {
+    config: {
+      id: config.id,
+      priceAlerts: (config.priceAlerts ?? []) as PriceAlert[],
+    },
+    userId: user.id,
+  };
+}
+
+/**
+ * GET - List all price alerts for an agent
+ */
+export const GET = withErrorHandling(async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ agentId: string }> }
+) {
+  const { agentId } = await params;
+  const result = await verifyAgentOwnership(req, agentId);
+
+  if ('error' in result) return result.error;
+
+  return NextResponse.json({
+    success: true,
+    alerts: result.config.priceAlerts,
+  });
+});
+
+/**
+ * POST - Create or update a price alert
+ *
+ * Body: { tokenSymbol, condition, threshold, deliveryChannel?, deliveryChatId?, cooldownMinutes? }
+ *
+ * If an alert for the same tokenSymbol+condition already exists, it is updated.
+ */
+export const POST = withErrorHandling(async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ agentId: string }> }
+) {
+  const { agentId } = await params;
+  const result = await verifyAgentOwnership(req, agentId);
+
+  if ('error' in result) return result.error;
+
+  const body = (await req.json()) as Record<string, unknown>;
+  const {
+    tokenSymbol,
+    condition,
+    threshold,
+    deliveryChannel,
+    deliveryChatId,
+    cooldownMinutes,
+  } = body;
+
+  // Validate required fields
+  if (
+    typeof tokenSymbol !== 'string' ||
+    !tokenSymbol.trim() ||
+    (condition !== 'above' && condition !== 'below') ||
+    typeof threshold !== 'number' ||
+    threshold <= 0
+  ) {
+    return NextResponse.json(
+      {
+        error:
+          'Invalid input. Required: tokenSymbol (string), condition ("above"|"below"), threshold (positive number)',
+      },
+      { status: 400 }
+    );
+  }
+
+  if (deliveryChannel === 'group' && typeof deliveryChatId !== 'string') {
+    return NextResponse.json(
+      { error: 'deliveryChatId is required when deliveryChannel is "group"' },
+      { status: 400 }
+    );
+  }
+
+  const alerts = result.config.priceAlerts;
+  const upperSymbol = tokenSymbol.trim().toUpperCase();
+
+  // Check for existing alert with same token+condition
+  const existingIdx = alerts.findIndex(
+    (a) => a.tokenSymbol === upperSymbol && a.condition === condition
+  );
+
+  const now = new Date().toISOString();
+  let alert: PriceAlert;
+  let updated = false;
+
+  if (existingIdx >= 0) {
+    // Update existing
+    const existing = alerts[existingIdx]!;
+    alert = {
+      ...existing,
+      threshold,
+      deliveryChannel:
+        (deliveryChannel as 'team_chat' | 'group') ?? existing.deliveryChannel,
+      deliveryChatId:
+        typeof deliveryChatId === 'string'
+          ? deliveryChatId
+          : existing.deliveryChatId,
+      cooldownMinutes:
+        typeof cooldownMinutes === 'number'
+          ? cooldownMinutes
+          : existing.cooldownMinutes,
+      enabled: true,
+      lastTriggeredAt: undefined, // Reset cooldown on update
+    };
+    alerts[existingIdx] = alert;
+    updated = true;
+  } else {
+    // Create new
+    alert = {
+      id: await generateSnowflakeId(),
+      tokenSymbol: upperSymbol,
+      condition: condition as 'above' | 'below',
+      threshold,
+      deliveryChannel:
+        (deliveryChannel as 'team_chat' | 'group') ?? 'team_chat',
+      deliveryChatId:
+        typeof deliveryChatId === 'string' ? deliveryChatId : undefined,
+      enabled: true,
+      cooldownMinutes:
+        typeof cooldownMinutes === 'number' ? cooldownMinutes : 15,
+      createdAt: now,
+    };
+    alerts.push(alert);
+  }
+
+  await db
+    .update(userAgentConfigs)
+    .set({ priceAlerts: alerts, updatedAt: new Date() })
+    .where(eq(userAgentConfigs.id, result.config.id));
+
+  return NextResponse.json(
+    {
+      success: true,
+      alert,
+      updated,
+    },
+    { status: updated ? 200 : 201 }
+  );
+});
+
+/**
+ * DELETE - Remove a price alert
+ *
+ * Query params: ?alertId=... OR ?tokenSymbol=...&condition=...
+ */
+export const DELETE = withErrorHandling(async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ agentId: string }> }
+) {
+  const { agentId } = await params;
+  const result = await verifyAgentOwnership(req, agentId);
+
+  if ('error' in result) return result.error;
+
+  const url = new URL(req.url);
+  const alertId = url.searchParams.get('alertId');
+  const tokenSymbol = url.searchParams.get('tokenSymbol');
+  const condition = url.searchParams.get('condition');
+
+  if (!alertId && !tokenSymbol) {
+    return NextResponse.json(
+      { error: 'Provide alertId or tokenSymbol query parameter' },
+      { status: 400 }
+    );
+  }
+
+  const alerts = result.config.priceAlerts;
+  let removed: PriceAlert | undefined;
+  let remaining: PriceAlert[];
+
+  if (alertId) {
+    removed = alerts.find((a) => a.id === alertId);
+    remaining = alerts.filter((a) => a.id !== alertId);
+  } else {
+    const upperSymbol = tokenSymbol!.toUpperCase();
+    removed = alerts.find(
+      (a) =>
+        a.tokenSymbol === upperSymbol &&
+        (!condition || a.condition === condition)
+    );
+    remaining = removed ? alerts.filter((a) => a.id !== removed!.id) : alerts;
+  }
+
+  if (!removed) {
+    return NextResponse.json(
+      { error: 'Price alert not found' },
+      { status: 404 }
+    );
+  }
+
+  await db
+    .update(userAgentConfigs)
+    .set({ priceAlerts: remaining, updatedAt: new Date() })
+    .where(eq(userAgentConfigs.id, result.config.id));
+
+  return NextResponse.json({
+    success: true,
+    removed,
+  });
+});

--- a/apps/web/src/app/api/agents/[agentId]/alerts/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/alerts/route.ts
@@ -16,6 +16,16 @@ import type { PriceAlert } from '@babylon/db/schema';
 import { generateSnowflakeId } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+const createAlertSchema = z.object({
+  tokenSymbol: z.string().trim().min(1).max(20),
+  condition: z.enum(['above', 'below']),
+  threshold: z.number().positive(),
+  deliveryChannel: z.enum(['team_chat', 'group']).optional(),
+  deliveryChatId: z.string().optional(),
+  cooldownMinutes: z.number().int().positive().max(1440).optional(),
+});
 
 /**
  * Verify agent exists, is an agent, and is managed by the authenticated user.
@@ -113,7 +123,19 @@ export const POST = withErrorHandling(async function POST(
 
   if ('error' in result) return result.error;
 
-  const body = (await req.json()) as Record<string, unknown>;
+  const raw = await req.json();
+  const parsed = createAlertSchema.safeParse(raw);
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      {
+        error: 'Invalid input',
+        details: parsed.error.flatten().fieldErrors,
+      },
+      { status: 400 }
+    );
+  }
+
   const {
     tokenSymbol,
     condition,
@@ -121,26 +143,9 @@ export const POST = withErrorHandling(async function POST(
     deliveryChannel,
     deliveryChatId,
     cooldownMinutes,
-  } = body;
+  } = parsed.data;
 
-  // Validate required fields
-  if (
-    typeof tokenSymbol !== 'string' ||
-    !tokenSymbol.trim() ||
-    (condition !== 'above' && condition !== 'below') ||
-    typeof threshold !== 'number' ||
-    threshold <= 0
-  ) {
-    return NextResponse.json(
-      {
-        error:
-          'Invalid input. Required: tokenSymbol (string), condition ("above"|"below"), threshold (positive number)',
-      },
-      { status: 400 }
-    );
-  }
-
-  if (deliveryChannel === 'group' && typeof deliveryChatId !== 'string') {
+  if (deliveryChannel === 'group' && !deliveryChatId) {
     return NextResponse.json(
       { error: 'deliveryChatId is required when deliveryChannel is "group"' },
       { status: 400 }
@@ -165,16 +170,9 @@ export const POST = withErrorHandling(async function POST(
     alert = {
       ...existing,
       threshold,
-      deliveryChannel:
-        (deliveryChannel as 'team_chat' | 'group') ?? existing.deliveryChannel,
-      deliveryChatId:
-        typeof deliveryChatId === 'string'
-          ? deliveryChatId
-          : existing.deliveryChatId,
-      cooldownMinutes:
-        typeof cooldownMinutes === 'number'
-          ? cooldownMinutes
-          : existing.cooldownMinutes,
+      deliveryChannel: deliveryChannel ?? existing.deliveryChannel,
+      deliveryChatId: deliveryChatId ?? existing.deliveryChatId,
+      cooldownMinutes: cooldownMinutes ?? existing.cooldownMinutes,
       enabled: true,
       lastTriggeredAt: undefined, // Reset cooldown on update
     };
@@ -185,15 +183,12 @@ export const POST = withErrorHandling(async function POST(
     alert = {
       id: await generateSnowflakeId(),
       tokenSymbol: upperSymbol,
-      condition: condition as 'above' | 'below',
+      condition,
       threshold,
-      deliveryChannel:
-        (deliveryChannel as 'team_chat' | 'group') ?? 'team_chat',
-      deliveryChatId:
-        typeof deliveryChatId === 'string' ? deliveryChatId : undefined,
+      deliveryChannel: deliveryChannel ?? 'team_chat',
+      deliveryChatId,
       enabled: true,
-      cooldownMinutes:
-        typeof cooldownMinutes === 'number' ? cooldownMinutes : 15,
+      cooldownMinutes: cooldownMinutes ?? 15,
       createdAt: now,
     };
     alerts.push(alert);

--- a/apps/web/src/app/api/agents/[agentId]/chat/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/chat/route.ts
@@ -516,6 +516,28 @@ export const POST = withErrorHandling(
         actionParams,
       };
 
+      // Persist actionParams to stateCache so processActions' internal
+      // composeState() preserves them (it re-composes from cache, discarding
+      // any local state.data modifications).
+      const stateCache = (
+        runtime as unknown as {
+          stateCache?: Map<
+            string,
+            {
+              values?: Record<string, unknown>;
+              data?: Record<string, unknown>;
+              text?: string;
+            }
+          >;
+        }
+      ).stateCache;
+      if (stateCache && elizaMessage.id) {
+        const cached = stateCache.get(elizaMessage.id);
+        if (cached) {
+          cached.data = { ...cached.data, actionParams };
+        }
+      }
+
       // Build action content for processActions
       const actionContent = {
         text: `Executing action: ${action}`,

--- a/apps/web/src/app/api/agents/team-chat/coordinator/route.ts
+++ b/apps/web/src/app/api/agents/team-chat/coordinator/route.ts
@@ -43,10 +43,10 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { v4 as uuidv4 } from 'uuid';
 
-// Coordinator may dispatch to child agents via DISPATCH_TO_AGENT:
-// coordinator (3 iters ≈ 3s) + agent dispatch (4 iters ≈ 8s) + summary (≈ 2s) ≈ 13s total
-// Without this, Vercel's 10s default kills any dispatch request.
-export const maxDuration = 60;
+// Coordinator may dispatch to child agents via DISPATCH_TO_AGENT / DISPATCH_TO_AGENTS:
+// coordinator (5 iters ≈ 5s) + parallel agent dispatch (≈ 15s) + summary (≈ 2s) ≈ 22s total
+// Parallel dispatches via DISPATCH_TO_AGENTS can take longer — 120s covers worst case.
+export const maxDuration = 120;
 
 // =============================================================================
 // Coordinator Prompt Templates
@@ -99,16 +99,34 @@ No actions taken yet.
 
 # Decision Guide
 
-**Use DISPATCH_TO_AGENT** when the user wants to execute a trade, post, comment, or any agent action.
+## Single-Agent Tasks
+**Use DISPATCH_TO_AGENT** when the user wants one agent to execute a trade, post, comment, or any action.
   - Select the agent using their [id: ...] from the Team Members list above
   - Write the command clearly as the exact instruction for the agent
   - If no agents exist in the team, skip this action and tell the user to create one at /agents
 
+## Multi-Agent Orchestration
+**Use DISPATCH_TO_AGENTS** when the user's request benefits from input from multiple agents.
+  - Dispatches run in parallel — much faster than asking agents one by one
+  - Use when the user says "all agents", "everyone", "coordinate", "team", or when you need perspectives from multiple agents
+  - Parameters: {"dispatches": [{"agentId": "...", "command": "..."}, ...]}
+
+**Use RELAY_TO_AGENT** when you need to pass one agent's results as context to another agent.
+  - Use after a dispatch has completed and another agent needs those findings
+  - Parameters: {"agentId": "...", "command": "...", "relayContext": "Summary of what other agents found"}
+
+## Orchestration Patterns
+**Gather & Synthesize**: DISPATCH_TO_AGENTS → collect all responses → summarize for user
+**Gather, Relay & Execute**: DISPATCH_TO_AGENTS (research) → RELAY_TO_AGENT (trader with context) → summarize
+**Expert Consultation**: DISPATCH_TO_AGENT to the single relevant expert
+
+## Information Queries
 **Use a data-fetch action** (CHECK_PERPS, CHECK_PREDICTIONS, CHECK_USER_PNL, etc.) when you need information to answer the user's question.
 
+## Skip Actions
 **Skip all actions (set action to "" and isFinish to true)** when:
   - The question is conversational or you already have the data needed
-  - The user is asking about a previous turn's result (e.g., "why didn't I see X") — just answer directly
+  - The user is asking about a previous turn's result — just answer directly
   - You have already dispatched or fetched what was needed this turn
 
 **NEVER repeat the same action with the same parameters.**
@@ -181,6 +199,9 @@ No actions were taken this turn.
 
 **Agent dispatched — include a brief summary of what the agent did:**
 "I dispatched to @trading_bot to open a long TSLAI position for $50. They confirmed: [brief quote from agent's response]."
+
+**Multiple agents dispatched — synthesize all responses:**
+"I asked all your agents for their market outlook: @trading_bot sees momentum in TSLAI, @research_agent noted high volume on NVDAI, and @social_bot reports bullish sentiment. Based on this consensus, TSLAI and NVDAI look strongest."
 
 **Agent dispatch failed:** "I wasn't able to dispatch that — [reason]. You can @mention your agent directly to retry."
 
@@ -311,8 +332,11 @@ export const POST = withErrorHandling(async (req: NextRequest) => {
     createdAt: Date.now(),
   };
 
-  // Multi-step execution (simplified for coordinator - max 3 iterations)
-  const MAX_ITERATIONS = 3;
+  // Multi-step execution — 5 iterations supports multi-agent orchestration patterns:
+  // Iteration 1: DISPATCH_TO_AGENTS (parallel gather)
+  // Iteration 2: RELAY_TO_AGENT (pass context to executor)
+  // Iterations 3-5: follow-up dispatches or early finish
+  const MAX_ITERATIONS = 5;
   const traceActionResults: Array<{
     actionType: string;
     success: boolean;

--- a/apps/web/src/app/api/agents/team-chat/coordinator/route.ts
+++ b/apps/web/src/app/api/agents/team-chat/coordinator/route.ts
@@ -484,14 +484,44 @@ export const POST = withErrorHandling(async (req: NextRequest) => {
       }
     }
 
-    // Store params and inject broadcastFn so DISPATCH_TO_AGENT can broadcast
+    // Store params and inject broadcastFn so DISPATCH_TO_AGENT can broadcast.
     // broadcastFn is injected here (not imported inside packages/agents) to
-    // maintain architectural separation between @babylon/api and @babylon/agents
+    // maintain architectural separation between @babylon/api and @babylon/agents.
+    //
+    // IMPORTANT: ElizaOS processActions() re-composes state internally via
+    // runtime.composeState(), which reads from stateCache and DISCARDS any
+    // custom state.data injections. To survive the re-composition, we:
+    //   1. Write actionParams + broadcastFn into the stateCache entry
+    //   2. Also set them on the local state object (for prompt composition)
     state.data = {
       ...state.data,
       actionParams,
       broadcastFn: broadcastChatMessage,
     };
+
+    // Persist to stateCache so processActions' internal composeState preserves them
+    const stateCache = (
+      runtime as unknown as {
+        stateCache?: Map<
+          string,
+          {
+            values?: Record<string, unknown>;
+            data?: Record<string, unknown>;
+            text?: string;
+          }
+        >;
+      }
+    ).stateCache;
+    if (stateCache && elizaMessage.id) {
+      const cached = stateCache.get(elizaMessage.id);
+      if (cached) {
+        cached.data = {
+          ...cached.data,
+          actionParams,
+          broadcastFn: broadcastChatMessage,
+        };
+      }
+    }
 
     // Build action content for processActions
     const actionContent = {

--- a/packages/a2a/src/executors/babylon-executor.ts
+++ b/packages/a2a/src/executors/babylon-executor.ts
@@ -1921,6 +1921,24 @@ export class BabylonAgentExecutor implements AgentExecutor {
       },
     });
 
+    // Broadcast to SSE for real-time delivery to all chat participants
+    const { broadcastChatMessage } = await import('@babylon/api');
+    broadcastChatMessage(chatId, {
+      id: message.id,
+      content: message.content,
+      chatId,
+      senderId: message.senderId,
+      type: 'user',
+      createdAt: message.createdAt?.toISOString() ?? new Date().toISOString(),
+      isGameChat: false,
+      isDMChat: false,
+    }).catch((err: Error) => {
+      logger.warn(
+        `[A2AExecutor] Failed to broadcast chat message: ${err.message}`,
+        { chatId, messageId: message.id }
+      );
+    });
+
     return {
       success: true,
       message: {
@@ -2006,6 +2024,24 @@ export class BabylonAgentExecutor implements AgentExecutor {
           },
         });
       }
+    });
+
+    // Broadcast a system message so members see the new group in real-time
+    const { broadcastChatMessage } = await import('@babylon/api');
+    broadcastChatMessage(chatId, {
+      id: await generateSnowflakeId(),
+      content: `Group "${name}" created`,
+      chatId,
+      senderId: userId,
+      type: 'system',
+      createdAt: new Date().toISOString(),
+      isGameChat: false,
+      isDMChat: false,
+    }).catch((err: Error) => {
+      logger.warn(
+        `[A2AExecutor] Failed to broadcast group creation: ${err.message}`,
+        { chatId, groupId }
+      );
     });
 
     return {

--- a/packages/a2a/src/executors/babylon-executor.ts
+++ b/packages/a2a/src/executors/babylon-executor.ts
@@ -1921,7 +1921,9 @@ export class BabylonAgentExecutor implements AgentExecutor {
       },
     });
 
-    // Broadcast to SSE for real-time delivery to all chat participants
+    // Fire-and-forget SSE broadcast — the message is already persisted to DB above,
+    // so a broadcast failure only affects real-time delivery (clients will pick it up
+    // on next poll/reconnect). We log the failure but don't block the response.
     const { broadcastChatMessage } = await import('@babylon/api');
     broadcastChatMessage(chatId, {
       id: message.id,
@@ -1934,7 +1936,7 @@ export class BabylonAgentExecutor implements AgentExecutor {
       isDMChat: false,
     }).catch((err: Error) => {
       logger.warn(
-        `[A2AExecutor] Failed to broadcast chat message: ${err.message}`,
+        `[A2AExecutor] SSE broadcast failed (message ${message.id} persisted, will be visible on refresh): ${err.message}`,
         { chatId, messageId: message.id }
       );
     });

--- a/packages/agents/src/autonomous/AutonomousCoordinator.ts
+++ b/packages/agents/src/autonomous/AutonomousCoordinator.ts
@@ -35,6 +35,7 @@ import { logger } from '../shared/logger';
 // Import services
 import { autonomousPlanningCoordinator } from './AutonomousPlanningCoordinator';
 import { multiStepExecutor } from './MultiStepExecutor';
+import { priceAlertService } from './PriceAlertService';
 import { topicDiversityService } from './TopicDiversityService';
 
 export interface AutonomousTickResult {
@@ -151,6 +152,19 @@ export class AutonomousCoordinator {
     };
 
     try {
+      // Price alert pre-step: lightweight DB checks, no LLM calls
+      // Only for user-controlled agents (NPCs don't have price alert configs)
+      if (!isNpc) {
+        const alertsSent = await priceAlertService.checkAlerts(agentUserId);
+        if (alertsSent > 0) {
+          logger.info(
+            `[PriceAlert] ${alertsSent} alert(s) triggered for agent ${agentUserId}`,
+            { agentUserId, alertsSent },
+            'AutonomousCoordinator'
+          );
+        }
+      }
+
       // Check if agent has goals configured
       const hasGoals =
         (await db.agentGoal.count({

--- a/packages/agents/src/autonomous/DirectExecutors.ts
+++ b/packages/agents/src/autonomous/DirectExecutors.ts
@@ -14,6 +14,7 @@ import {
   cachedDb,
   type JsonValue,
   type MessageActivityData,
+  notifyGroupChatMessage,
   type PostActivityData,
 } from '@babylon/api';
 import { PerpDbAdapter, PerpMarketService } from '@babylon/core/markets/perps';
@@ -1619,6 +1620,40 @@ export async function executeDirectMessage(
         'DirectExecutors'
       );
     });
+  }
+
+  // Notify group chat members for offline/push notifications
+  // Only for group messages (no recipientId means it's a group chat message)
+  if (!recipientId && chatId) {
+    const participantRows = await db
+      .select({ userId: chatParticipants.userId })
+      .from(chatParticipants)
+      .where(eq(chatParticipants.chatId, chatId));
+    const recipientIds = participantRows
+      .map((p) => p.userId)
+      .filter((id) => id !== agentUserId);
+
+    if (recipientIds.length > 0) {
+      const [chatRecord] = await db
+        .select({ name: chats.name })
+        .from(chats)
+        .where(eq(chats.id, chatId))
+        .limit(1);
+
+      notifyGroupChatMessage(
+        recipientIds,
+        agentUserId,
+        chatId,
+        chatRecord?.name ?? 'Group Chat',
+        cleanContent.substring(0, 50)
+      ).catch((error: Error) => {
+        logger.warn(
+          `Failed to notify group chat message: ${error.message}`,
+          { chatId, messageId },
+          'DirectExecutors'
+        );
+      });
+    }
   }
 
   return {

--- a/packages/agents/src/autonomous/PriceAlertService.ts
+++ b/packages/agents/src/autonomous/PriceAlertService.ts
@@ -19,6 +19,7 @@ import {
   db,
   eq,
   perpMarketSnapshots,
+  sql,
   userAgentConfigs,
   users,
 } from '@babylon/db';
@@ -176,35 +177,32 @@ export class PriceAlertService {
 
   /**
    * Update the lastTriggeredAt timestamp for a specific alert.
-   * Uses a JSON update to modify only the relevant alert in the array.
+   * Uses an atomic SQL JSONB update to avoid read-modify-write race conditions.
    */
   private async updateAlertTimestamp(
     agentUserId: string,
     alertId: string
   ): Promise<void> {
-    const [config] = await db
-      .select({
-        id: userAgentConfigs.id,
-        priceAlerts: userAgentConfigs.priceAlerts,
-      })
-      .from(userAgentConfigs)
-      .where(eq(userAgentConfigs.userId, agentUserId))
-      .limit(1);
+    const now = new Date().toISOString();
 
-    if (!config) return;
-
-    const alerts = (config.priceAlerts ?? []) as PriceAlert[];
-    const updatedAlerts = alerts.map((a) =>
-      a.id === alertId ? { ...a, lastTriggeredAt: new Date().toISOString() } : a
-    );
-
+    // Atomic JSONB update: iterate the array and set lastTriggeredAt on the matching alert
+    // This avoids the read-modify-write race of SELECT → map → UPDATE
     await db
       .update(userAgentConfigs)
       .set({
-        priceAlerts: updatedAlerts,
+        priceAlerts: sql`(
+          SELECT jsonb_agg(
+            CASE
+              WHEN elem->>'id' = ${alertId}
+              THEN elem || jsonb_build_object('lastTriggeredAt', ${now}::text)
+              ELSE elem
+            END
+          )
+          FROM jsonb_array_elements(${userAgentConfigs.priceAlerts}) AS elem
+        )`,
         updatedAt: new Date(),
       })
-      .where(eq(userAgentConfigs.id, config.id));
+      .where(eq(userAgentConfigs.userId, agentUserId));
   }
 }
 

--- a/packages/agents/src/autonomous/PriceAlertService.ts
+++ b/packages/agents/src/autonomous/PriceAlertService.ts
@@ -1,0 +1,211 @@
+/**
+ * Price Alert Service
+ *
+ * Monitors perpetual market prices against user-configured thresholds
+ * and delivers alerts via team chat or group chat.
+ *
+ * Called during each autonomous agent tick (~3 minutes). Checks are
+ * non-LLM (pure DB lookups) so they add negligible latency to the tick.
+ *
+ * Alert delivery:
+ * - team_chat: Uses executeDirectMessage with the team chat's chatId
+ * - group: Uses executeDirectMessage with the configured group chatId
+ *
+ * Note: Agent→owner DMs are blocked by executeDirectMessage (DirectExecutors.ts:1392).
+ * Owner alerts use team chat instead.
+ */
+
+import {
+  db,
+  eq,
+  perpMarketSnapshots,
+  userAgentConfigs,
+  users,
+} from '@babylon/db';
+import type { PriceAlert } from '@babylon/db/schema';
+// Import TeamChatService to resolve the team chat for owner alerts
+import { teamChatService } from '../services/TeamChatService';
+import { logger } from '../shared/logger';
+import { executeDirectMessage } from './DirectExecutors';
+
+/**
+ * Price Alert Service
+ *
+ * Checks configured price alerts for an agent and sends notifications
+ * when thresholds are breached.
+ */
+export class PriceAlertService {
+  /**
+   * Check all price alerts for an agent during autonomous tick.
+   * Returns the number of alerts triggered and sent.
+   */
+  async checkAlerts(agentUserId: string): Promise<number> {
+    const [config] = await db
+      .select({ priceAlerts: userAgentConfigs.priceAlerts })
+      .from(userAgentConfigs)
+      .where(eq(userAgentConfigs.userId, agentUserId))
+      .limit(1);
+
+    const alerts = (config?.priceAlerts ?? []) as PriceAlert[];
+    const enabledAlerts = alerts.filter((a) => a.enabled);
+
+    if (enabledAlerts.length === 0) return 0;
+
+    let alertsSent = 0;
+
+    for (const alert of enabledAlerts) {
+      // Check cooldown
+      if (alert.lastTriggeredAt) {
+        const cooldownMs = (alert.cooldownMinutes || 15) * 60 * 1000;
+        const elapsed = Date.now() - new Date(alert.lastTriggeredAt).getTime();
+        if (elapsed < cooldownMs) {
+          continue;
+        }
+      }
+
+      // Get current price from perpetual market snapshots
+      const currentPrice = await this.getCurrentPrice(alert.tokenSymbol);
+      if (currentPrice === null) continue;
+
+      // Check threshold
+      const triggered =
+        (alert.condition === 'below' && currentPrice < alert.threshold) ||
+        (alert.condition === 'above' && currentPrice > alert.threshold);
+
+      if (!triggered) continue;
+
+      // Resolve delivery target
+      const message = this.formatAlertMessage(alert, currentPrice);
+      let deliveryChatId: string | undefined;
+
+      if (alert.deliveryChannel === 'group' && alert.deliveryChatId) {
+        deliveryChatId = alert.deliveryChatId;
+      } else {
+        // Default: deliver to team chat (agent→owner standard channel)
+        deliveryChatId = await this.getOwnerTeamChatId(agentUserId);
+      }
+
+      if (!deliveryChatId) {
+        logger.warn(
+          `[PriceAlert] No delivery channel found for alert ${alert.id}`,
+          { agentUserId, tokenSymbol: alert.tokenSymbol },
+          'PriceAlertService'
+        );
+        continue;
+      }
+
+      // Send alert
+      const result = await executeDirectMessage({
+        agentUserId,
+        chatId: deliveryChatId,
+        content: message,
+      });
+
+      if (result.success) {
+        alertsSent++;
+        logger.info(
+          `[PriceAlert] Alert triggered: ${alert.tokenSymbol} ${alert.condition} ${alert.threshold} (current: ${currentPrice})`,
+          { agentUserId, alertId: alert.id, chatId: deliveryChatId },
+          'PriceAlertService'
+        );
+
+        // Update lastTriggeredAt in the config
+        await this.updateAlertTimestamp(agentUserId, alert.id);
+      } else {
+        logger.warn(
+          `[PriceAlert] Failed to send alert: ${result.error}`,
+          { agentUserId, alertId: alert.id },
+          'PriceAlertService'
+        );
+      }
+    }
+
+    return alertsSent;
+  }
+
+  /**
+   * Format a price alert message for delivery.
+   */
+  private formatAlertMessage(alert: PriceAlert, currentPrice: number): string {
+    const direction =
+      alert.condition === 'below' ? 'dropped below' : 'rose above';
+    const emoji = alert.condition === 'below' ? '📉' : '📈';
+    const diff = Math.abs(currentPrice - alert.threshold);
+    const pctDiff = ((diff / alert.threshold) * 100).toFixed(1);
+
+    return `${emoji} Price Alert: ${alert.tokenSymbol} has ${direction} $${alert.threshold}. Current price: $${currentPrice.toFixed(2)} (${pctDiff}% ${alert.condition === 'below' ? 'below' : 'above'} threshold).`;
+  }
+
+  /**
+   * Get current market price for a token symbol from perpMarketSnapshots.
+   * Returns markPrice if available, otherwise currentPrice.
+   */
+  private async getCurrentPrice(tokenSymbol: string): Promise<number | null> {
+    const [snapshot] = await db
+      .select({
+        currentPrice: perpMarketSnapshots.currentPrice,
+        markPrice: perpMarketSnapshots.markPrice,
+      })
+      .from(perpMarketSnapshots)
+      .where(eq(perpMarketSnapshots.ticker, tokenSymbol))
+      .limit(1);
+
+    return snapshot?.markPrice ?? snapshot?.currentPrice ?? null;
+  }
+
+  /**
+   * Get the team chat ID for an agent's owner.
+   * Agents communicate with owners via the team chat (Agents group).
+   */
+  private async getOwnerTeamChatId(
+    agentUserId: string
+  ): Promise<string | undefined> {
+    // Find the agent's owner
+    const [agent] = await db
+      .select({ managedBy: users.managedBy })
+      .from(users)
+      .where(eq(users.id, agentUserId))
+      .limit(1);
+
+    if (!agent?.managedBy) return undefined;
+
+    // Get the owner's team chat
+    const teamChat = await teamChatService.getTeamChat(agent.managedBy);
+    return teamChat?.chatId;
+  }
+
+  /**
+   * Update the lastTriggeredAt timestamp for a specific alert.
+   * Uses a JSON update to modify only the relevant alert in the array.
+   */
+  private async updateAlertTimestamp(
+    agentUserId: string,
+    alertId: string
+  ): Promise<void> {
+    const [config] = await db
+      .select({
+        id: userAgentConfigs.id,
+        priceAlerts: userAgentConfigs.priceAlerts,
+      })
+      .from(userAgentConfigs)
+      .where(eq(userAgentConfigs.userId, agentUserId))
+      .limit(1);
+
+    if (!config) return;
+
+    const alerts = (config.priceAlerts ?? []) as PriceAlert[];
+    const updatedAlerts = alerts.map((a) =>
+      a.id === alertId ? { ...a, lastTriggeredAt: new Date().toISOString() } : a
+    );
+
+    await db
+      .update(userAgentConfigs)
+      .set({
+        priceAlerts: updatedAlerts,
+        updatedAt: new Date(),
+      })
+      .where(eq(userAgentConfigs.id, config.id));
+  }
+}
+
+export const priceAlertService = new PriceAlertService();

--- a/packages/agents/src/autonomous/PriceAlertService.ts
+++ b/packages/agents/src/autonomous/PriceAlertService.ts
@@ -192,14 +192,19 @@ export class PriceAlertService {
       .update(userAgentConfigs)
       .set({
         priceAlerts: sql`(
-          SELECT jsonb_agg(
-            CASE
-              WHEN elem->>'id' = ${alertId}
-              THEN elem || jsonb_build_object('lastTriggeredAt', ${now}::text)
-              ELSE elem
-            END
+          SELECT COALESCE(
+            jsonb_agg(
+              CASE
+                WHEN elem->>'id' = ${alertId}
+                THEN elem || jsonb_build_object('lastTriggeredAt', ${now}::text)
+                ELSE elem
+              END
+            ),
+            '[]'::jsonb
           )::json
-          FROM jsonb_array_elements(${userAgentConfigs.priceAlerts}::jsonb) AS elem
+          FROM jsonb_array_elements(
+            COALESCE(${userAgentConfigs.priceAlerts}::jsonb, '[]'::jsonb)
+          ) AS elem
         )`,
         updatedAt: new Date(),
       })

--- a/packages/agents/src/autonomous/PriceAlertService.ts
+++ b/packages/agents/src/autonomous/PriceAlertService.ts
@@ -185,8 +185,9 @@ export class PriceAlertService {
   ): Promise<void> {
     const now = new Date().toISOString();
 
-    // Atomic JSONB update: iterate the array and set lastTriggeredAt on the matching alert
-    // This avoids the read-modify-write race of SELECT → map → UPDATE
+    // Atomic JSON update: iterate the array and set lastTriggeredAt on the matching alert.
+    // This avoids the read-modify-write race of SELECT → map → UPDATE.
+    // Column is json (not jsonb), so cast to jsonb for processing, then back to json.
     await db
       .update(userAgentConfigs)
       .set({
@@ -197,8 +198,8 @@ export class PriceAlertService {
               THEN elem || jsonb_build_object('lastTriggeredAt', ${now}::text)
               ELSE elem
             END
-          )
-          FROM jsonb_array_elements(${userAgentConfigs.priceAlerts}) AS elem
+          )::json
+          FROM jsonb_array_elements(${userAgentConfigs.priceAlerts}::jsonb) AS elem
         )`,
         updatedAt: new Date(),
       })

--- a/packages/agents/src/autonomous/utils/context-gatherers.ts
+++ b/packages/agents/src/autonomous/utils/context-gatherers.ts
@@ -18,6 +18,7 @@ import {
   getRawDrizzle,
   groups,
   gte,
+  ilike,
   inArray,
   isNull,
   lte,
@@ -301,6 +302,55 @@ export async function getAgentGroupChats(
     );
     return [];
   }
+}
+
+/**
+ * Resolve a group chat by name for an agent.
+ * Returns the chatId of the first matching group chat the agent is a member of.
+ * Used for channel resolution when agents reference groups by name rather than ID.
+ */
+export async function resolveGroupChatByName(
+  agentUserId: string,
+  groupName: string
+): Promise<string | null> {
+  // Sanitize input to prevent ilike pattern injection
+  const sanitized = groupName.replace(/[%_\\]/g, '').trim();
+  if (sanitized.length < 2) return null;
+
+  const results = await db
+    .select({ chatId: chats.id })
+    .from(chatParticipants)
+    .innerJoin(chats, eq(chatParticipants.chatId, chats.id))
+    .innerJoin(groups, eq(chats.groupId, groups.id))
+    .where(
+      and(
+        eq(chatParticipants.userId, agentUserId),
+        eq(chats.isGroup, true),
+        ilike(groups.name, `%${sanitized}%`)
+      )
+    )
+    .limit(1);
+
+  return results[0]?.chatId ?? null;
+}
+
+/**
+ * Resolve a user by their username.
+ * Returns the userId or null if not found.
+ */
+export async function resolveUserByUsername(
+  username: string
+): Promise<string | null> {
+  const clean = username.replace(/^@/, '').trim().toLowerCase();
+  if (!clean) return null;
+
+  const [user] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.username, clean))
+    .limit(1);
+
+  return user?.id ?? null;
 }
 
 /**

--- a/packages/agents/src/plugins/babylon/actions/messaging.ts
+++ b/packages/agents/src/plugins/babylon/actions/messaging.ts
@@ -275,6 +275,8 @@ export const sendMessageAction: Action = {
       }
 
       // Strategy 3: Recipient @username
+      // resolveUserByUsername only resolves the ID — authorization (owner-DM block,
+      // recipient existence) is enforced downstream in executeDirectMessage.
       const username = parseRecipientUsername(content);
       if (username) {
         const recipientId = await resolveUserByUsername(username);

--- a/packages/agents/src/plugins/babylon/actions/messaging.ts
+++ b/packages/agents/src/plugins/babylon/actions/messaging.ts
@@ -1,6 +1,13 @@
 /**
  * Messaging Actions
- * Actions for sending messages and managing chats
+ * Actions for sending messages and managing chats.
+ *
+ * Supports three resolution strategies for SEND_MESSAGE:
+ * 1. Explicit chat ID: "send message to chat 12345: hello"
+ * 2. Group name:       "send message to 'Price Alerts': hello"
+ * 3. Recipient @user:  "DM @username: hello"
+ *
+ * Falls back through strategies in order until one resolves.
  */
 
 import type {
@@ -10,17 +17,91 @@ import type {
   Memory,
   State,
 } from '@elizaos/core';
-// // import { logger } from '../../../shared/logger' // Commented out - not needed // Unused - needed when A2A methods are implemented
+import { executeDirectMessage } from '../../../autonomous/DirectExecutors';
+import {
+  resolveGroupChatByName,
+  resolveUserByUsername,
+} from '../../../autonomous/utils/context-gatherers';
+import { logger } from '../../../shared/logger';
 import type { BabylonRuntime } from '../types';
+
+// =============================================================================
+// Parsing helpers
+// =============================================================================
+
+/**
+ * Extract a chat ID from text.
+ * Matches patterns like: "chat 12345", "chat:12345", "chat-12345", "chatId: 12345"
+ */
+function parseChatId(text: string): string | null {
+  const match = text.match(/chat(?:\s*id)?[:\s-]+([a-zA-Z0-9_-]+)/i);
+  return match?.[1] ?? null;
+}
+
+/**
+ * Extract a group/channel name enclosed in quotes from text.
+ * Matches: "to 'Price Alerts'", 'to "My Group"', "group 'Alerts'"
+ */
+function parseGroupName(text: string): string | null {
+  const match = text.match(/(?:to|group|channel|in)\s+["']([^"']+)["']/i);
+  return match?.[1]?.trim() ?? null;
+}
+
+/**
+ * Extract a @username mention from text.
+ * Matches: "DM @alice", "message @bob", "send to @charlie"
+ */
+function parseRecipientUsername(text: string): string | null {
+  const match = text.match(/(?:dm|message|send\s+to|to)\s+@([a-zA-Z0-9_]+)/i);
+  return match?.[1] ?? null;
+}
+
+/**
+ * Extract the message body from the input text.
+ * Tries multiple patterns to find the actual content to send.
+ */
+function parseMessageContent(text: string): string {
+  // Pattern 1: Content after colon in quotes — 'chat 123: "hello there"'
+  const quotedMatch = text.match(/:\s*["'](.+?)["']\s*$/);
+  if (quotedMatch?.[1]) return quotedMatch[1];
+
+  // Pattern 2: Content after colon — 'chat 123: hello there'
+  const colonMatch = text.match(/:\s*["']?(.+?)["']?\s*$/);
+  if (colonMatch?.[1]) return colonMatch[1];
+
+  // Pattern 3: Content after "message" or "saying" keyword
+  const keywordMatch = text.match(
+    /(?:message|saying|with text)\s+["']?(.+?)["']?\s*$/i
+  );
+  if (keywordMatch?.[1]) return keywordMatch[1];
+
+  // Fallback: return everything after the first recognizable target
+  const afterTarget = text.replace(
+    /^.*?(?:chat[:\s-]+\S+|["'][^"']+["']|@\w+)\s*/i,
+    ''
+  );
+  return afterTarget.trim() || text;
+}
+
+// =============================================================================
+// SEND_MESSAGE Action
+// =============================================================================
 
 /**
  * Action: Send Message
- * Allows agent to send a message in a chat
+ * Allows agent to send a message via DM or to a group chat.
+ *
+ * Resolution order:
+ * 1. Explicit chatId in text
+ * 2. Group name lookup (agent must be a member)
+ * 3. Recipient @username (creates DM if needed)
+ * 4. A2A client fallback for pre-parsed chatId
  */
 export const sendMessageAction: Action = {
   name: 'SEND_MESSAGE',
-  description: 'Send a message in a chat',
-  similes: ['send message', 'message', 'dm', 'send dm', 'chat'],
+  description:
+    'Send a message in a chat by chat ID, group name, or recipient @username',
+  similes: ['send message', 'message', 'dm', 'send dm', 'chat', 'alert'],
   examples: [
     [
       {
@@ -32,13 +113,40 @@ export const sendMessageAction: Action = {
         content: { text: 'Sending message...', action: 'SEND_MESSAGE' },
       },
     ],
+    [
+      {
+        name: '{{user1}}',
+        content: {
+          text: "Send message to 'ScanMachine Price Alerts': OPENAGI dropped below 22.5",
+        },
+      },
+      {
+        name: '{{agent}}',
+        content: {
+          text: 'Sending to group...',
+          action: 'SEND_MESSAGE',
+        },
+      },
+    ],
+    [
+      {
+        name: '{{user1}}',
+        content: { text: 'DM @alice: Hey, check out TSLAI!' },
+      },
+      {
+        name: '{{agent}}',
+        content: { text: 'Sending DM...', action: 'SEND_MESSAGE' },
+      },
+    ],
   ],
 
   validate: async (_runtime: IAgentRuntime, message: Memory) => {
     const content = message.content.text?.toLowerCase() || '';
     return (
-      content.includes('send') &&
-      (content.includes('message') || content.includes('dm'))
+      (content.includes('send') &&
+        (content.includes('message') || content.includes('dm'))) ||
+      (content.includes('dm') && content.includes('@')) ||
+      (content.includes('alert') && content.includes('send'))
     );
   },
 
@@ -50,57 +158,144 @@ export const sendMessageAction: Action = {
     callback?: HandlerCallback
   ): Promise<void> => {
     const babylonRuntime = runtime as BabylonRuntime;
-
-    if (!babylonRuntime.a2aClient?.isConnected()) {
-      if (callback) {
-        callback({
-          text: 'A2A client not connected. Cannot send message.',
-          action: 'SEND_MESSAGE',
-        });
-      }
-      return;
-    }
-
-    // Parse message
     const content = _message.content.text || '';
-    const chatIdMatch = content.match(/chat[:\s-]+([a-zA-Z0-9-]+)/);
-    const messageMatch =
-      content.match(/(?::|with)\s*["'](.+?)["']/) ||
-      content.match(/message\s+(.+)$/i);
+    const agentUserId = babylonRuntime.a2aClient?.agentId;
+    const messageBody = parseMessageContent(content);
 
-    if (!chatIdMatch || !messageMatch) {
-      if (callback) {
-        callback({
-          text: 'Could not parse message parameters. Please specify chat ID and message content.',
-          action: 'SEND_MESSAGE',
-        });
-      }
+    if (!messageBody || messageBody.length < 2) {
+      callback?.({
+        text: 'Could not parse message content. Please include the message you want to send.',
+        action: 'SEND_MESSAGE',
+      });
       return;
     }
 
-    const chatId = chatIdMatch[1]!;
-    const messageContent = messageMatch[1]!;
+    // Strategy 1: Explicit chat ID
+    const chatId = parseChatId(content);
+    if (chatId) {
+      logger.info(
+        `[SEND_MESSAGE] Resolved via chatId: ${chatId}`,
+        undefined,
+        'MessagingAction'
+      );
 
-    const result = (await babylonRuntime.a2aClient.sendMessage(
-      chatId,
-      messageContent
-    )) as { success?: boolean; messageId?: string; message?: string };
+      if (agentUserId) {
+        const result = await executeDirectMessage({
+          agentUserId,
+          chatId,
+          content: messageBody,
+        });
 
-    if (callback) {
-      if (result.success === false) {
-        callback({
-          text: `Failed to send message: ${result.message || 'Unknown error'}`,
+        callback?.({
+          text: result.success
+            ? `Message sent to chat ${chatId}. Message ID: ${result.messageId}`
+            : `Failed to send message: ${result.error}`,
           action: 'SEND_MESSAGE',
         });
-      } else {
-        callback({
-          text: `Successfully sent message! Message ID: ${result.messageId || 'unknown'}`,
+        return;
+      }
+
+      // Fallback to A2A client if no agentUserId (should not happen in practice)
+      if (babylonRuntime.a2aClient?.isConnected()) {
+        const result = (await babylonRuntime.a2aClient.sendMessage(
+          chatId,
+          messageBody
+        )) as { success?: boolean; messageId?: string; message?: string };
+
+        callback?.({
+          text:
+            result.success === false
+              ? `Failed to send message: ${result.message || 'Unknown error'}`
+              : `Message sent! ID: ${result.messageId || 'unknown'}`,
           action: 'SEND_MESSAGE',
         });
+        return;
       }
     }
+
+    // Strategy 2: Group name resolution
+    if (agentUserId) {
+      const groupName = parseGroupName(content);
+      if (groupName) {
+        const resolvedChatId = await resolveGroupChatByName(
+          agentUserId,
+          groupName
+        );
+        if (resolvedChatId) {
+          logger.info(
+            `[SEND_MESSAGE] Resolved group "${groupName}" to chat ${resolvedChatId}`,
+            undefined,
+            'MessagingAction'
+          );
+
+          const result = await executeDirectMessage({
+            agentUserId,
+            chatId: resolvedChatId,
+            content: messageBody,
+          });
+
+          callback?.({
+            text: result.success
+              ? `Message sent to "${groupName}". Message ID: ${result.messageId}`
+              : `Failed to send to "${groupName}": ${result.error}`,
+            action: 'SEND_MESSAGE',
+          });
+          return;
+        }
+
+        // Group not found — report clearly
+        callback?.({
+          text: `Could not find a group chat named "${groupName}" that you are a member of.`,
+          action: 'SEND_MESSAGE',
+        });
+        return;
+      }
+
+      // Strategy 3: Recipient @username
+      const username = parseRecipientUsername(content);
+      if (username) {
+        const recipientId = await resolveUserByUsername(username);
+        if (recipientId) {
+          logger.info(
+            `[SEND_MESSAGE] Resolved @${username} to user ${recipientId}`,
+            undefined,
+            'MessagingAction'
+          );
+
+          const result = await executeDirectMessage({
+            agentUserId,
+            recipientId,
+            content: messageBody,
+          });
+
+          callback?.({
+            text: result.success
+              ? `DM sent to @${username}. Message ID: ${result.messageId}`
+              : `Failed to DM @${username}: ${result.error}`,
+            action: 'SEND_MESSAGE',
+          });
+          return;
+        }
+
+        callback?.({
+          text: `Could not find user @${username}.`,
+          action: 'SEND_MESSAGE',
+        });
+        return;
+      }
+    }
+
+    // No resolution strategy matched
+    callback?.({
+      text: "Could not determine where to send the message. Specify a chat ID (chat 12345: ...), group name (to 'My Group': ...), or recipient (@username: ...).",
+      action: 'SEND_MESSAGE',
+    });
   },
 };
+
+// =============================================================================
+// CREATE_GROUP Action
+// =============================================================================
 
 /**
  * Action: Create Group Chat
@@ -140,12 +335,10 @@ export const createGroupAction: Action = {
     const babylonRuntime = runtime as BabylonRuntime;
 
     if (!babylonRuntime.a2aClient?.isConnected()) {
-      if (callback) {
-        callback({
-          text: 'A2A client not connected. Cannot create group.',
-          action: 'CREATE_GROUP',
-        });
-      }
+      callback?.({
+        text: 'A2A client not connected. Cannot create group.',
+        action: 'CREATE_GROUP',
+      });
       return;
     }
 
@@ -156,12 +349,10 @@ export const createGroupAction: Action = {
     const membersMatch = content.match(/(?:with|members?)\s+(.+)$/);
 
     if (!nameMatch) {
-      if (callback) {
-        callback({
-          text: 'Could not parse group name. Please specify a name for the group.',
-          action: 'CREATE_GROUP',
-        });
-      }
+      callback?.({
+        text: 'Could not parse group name. Please specify a name for the group.',
+        action: 'CREATE_GROUP',
+      });
       return;
     }
 

--- a/packages/agents/src/plugins/babylon/actions/messaging.ts
+++ b/packages/agents/src/plugins/babylon/actions/messaging.ts
@@ -32,19 +32,42 @@ import type { BabylonRuntime } from '../types';
 /**
  * Extract a chat ID from text.
  * Matches patterns like: "chat 12345", "chat:12345", "chat-12345", "chatId: 12345"
+ *
+ * Guards against false positives from compound names like "General Chat:"
+ * by checking that "chat" is not preceded by a capitalized word (name component).
  */
 function parseChatId(text: string): string | null {
-  const match = text.match(/chat(?:\s*id)?[:\s-]+([a-zA-Z0-9_-]+)/i);
-  return match?.[1] ?? null;
+  const match = text.match(/\bchat(?:\s*id)?[:\s-]+([a-zA-Z0-9_-]{5,})/i);
+  if (!match?.[1]) return null;
+  // Reject if "chat" is preceded by a capitalized word (part of a name like "General Chat")
+  const prefix = text.substring(
+    Math.max(0, (match.index ?? 0) - 20),
+    match.index ?? 0
+  );
+  if (/[A-Z][a-zA-Z]*\s*$/.test(prefix)) return null;
+  return match[1];
 }
 
 /**
  * Extract a group/channel name enclosed in quotes from text.
  * Matches: "to 'Price Alerts'", 'to "My Group"', "group 'Alerts'"
+ *
+ * Also supports unquoted multi-word names terminated by a colon:
+ *   "to General Chat: hello" → "General Chat"
  */
 function parseGroupName(text: string): string | null {
-  const match = text.match(/(?:to|group|channel|in)\s+["']([^"']+)["']/i);
-  return match?.[1]?.trim() ?? null;
+  // Pattern 1: Quoted group name
+  const quoted = text.match(/(?:to|group|channel|in)\s+["']([^"']+)["']/i);
+  if (quoted?.[1]?.trim()) return quoted[1].trim();
+
+  // Pattern 2: Unquoted group name — "to <Name>: <message>"
+  // Captures one or more capitalized words before a colon
+  const unquoted = text.match(
+    /(?:to|group|channel|in)\s+((?:[A-Z][a-zA-Z]*\s*){1,5}):/i
+  );
+  if (unquoted?.[1]?.trim()) return unquoted[1].trim();
+
+  return null;
 }
 
 /**

--- a/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts
+++ b/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts
@@ -476,8 +476,17 @@ export class BabylonA2AClient {
       getUserProfile: 'users.get_profile',
       // Messaging operations
       getChats: 'messaging.get_chats',
+      getChatMessages: 'messaging.get_chat_messages',
+      sendMessage: 'messaging.send_message',
+      createGroup: 'messaging.create_group',
+      leaveChat: 'messaging.leave_chat',
       getUnreadCount: 'messaging.get_unread_count',
+      // Notifications operations
       getNotifications: 'messaging.get_notifications',
+      markNotificationsRead: 'notifications.mark_read',
+      getGroupInvites: 'notifications.get_group_invites',
+      acceptGroupInvite: 'notifications.accept_invite',
+      declineGroupInvite: 'notifications.decline_invite',
     };
 
     const operationName = operationMap[action] || action;

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/index.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/index.ts
@@ -20,6 +20,11 @@ export { closePerpAction } from './close-perp';
 export { createCommentAction } from './create-comment';
 export { createPostAction } from './create-post';
 export { lookupUserAction } from './lookup-user';
+export {
+  listPriceAlertsAction,
+  removePriceAlertAction,
+  setPriceAlertAction,
+} from './manage-price-alerts';
 export { openPerpAction } from './open-perp';
 export { sellPredictionAction } from './sell-prediction';
 export { toggleAutonomyAction } from './toggle-autonomy';

--- a/packages/agents/src/plugins/plugin-agent-core/src/actions/manage-price-alerts.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/actions/manage-price-alerts.ts
@@ -1,0 +1,481 @@
+/**
+ * Manage Price Alerts Actions
+ *
+ * Three actions for managing price alerts on perpetual markets:
+ * - SET_PRICE_ALERT: Create or update a price alert
+ * - LIST_PRICE_ALERTS: Show all configured price alerts
+ * - REMOVE_PRICE_ALERT: Delete a specific price alert
+ *
+ * Alerts are stored as JSONB in userAgentConfigs.priceAlerts and checked
+ * every autonomous tick (~3 minutes) by PriceAlertService.
+ */
+
+import { db, eq, userAgentConfigs } from '@babylon/db';
+import type { PriceAlert } from '@babylon/db/schema';
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from '@elizaos/core';
+import { logger } from '../../../../shared/logger';
+import { generateSnowflakeId } from '../../../../shared/snowflake';
+
+// ─── SET_PRICE_ALERT ────────────────────────────────────────────────────
+
+interface SetPriceAlertParams {
+  tokenSymbol: string;
+  condition: 'below' | 'above';
+  threshold: number;
+  deliveryChannel?: 'team_chat' | 'group';
+  deliveryChatId?: string;
+  cooldownMinutes?: number;
+}
+
+export const setPriceAlertAction: Action = {
+  name: 'SET_PRICE_ALERT',
+  description:
+    'Set a price alert on a perpetual market token. You will be notified when the price crosses the threshold. Delivery goes to your team chat by default, or a specific group chat.',
+
+  parameters: {
+    tokenSymbol: {
+      type: 'string',
+      description:
+        'Token ticker symbol matching perpMarketSnapshots (e.g., "OPENAGI", "TSLAI")',
+      required: true,
+    },
+    condition: {
+      type: 'string',
+      description: '"above" or "below" — the direction to trigger on',
+      required: true,
+    },
+    threshold: {
+      type: 'number',
+      description: 'Price threshold to trigger the alert',
+      required: true,
+    },
+    deliveryChannel: {
+      type: 'string',
+      description:
+        '"team_chat" (default) or "group" — where to deliver the alert',
+      required: false,
+    },
+    deliveryChatId: {
+      type: 'string',
+      description: 'Group chat ID — required when deliveryChannel is "group"',
+      required: false,
+    },
+    cooldownMinutes: {
+      type: 'number',
+      description:
+        'Minutes between re-triggers (default 15). Prevents alert spam.',
+      required: false,
+    },
+  },
+
+  examples: [
+    [
+      {
+        name: 'User',
+        content: {
+          text: 'Alert me when OPENAGI drops below $0.50',
+        },
+      },
+      {
+        name: 'Agent',
+        content: {
+          text: 'I have set a price alert for OPENAGI below $0.50. You will be notified in team chat when it triggers.',
+          action: 'SET_PRICE_ALERT',
+        },
+      },
+    ],
+    [
+      {
+        name: 'User',
+        content: {
+          text: 'Set an alert for TSLAI above $2.00 with 30 minute cooldown',
+        },
+      },
+      {
+        name: 'Agent',
+        content: {
+          text: 'Price alert set: TSLAI above $2.00 with 30-minute cooldown between notifications.',
+          action: 'SET_PRICE_ALERT',
+        },
+      },
+    ],
+  ],
+
+  validate: async (): Promise<boolean> => true,
+
+  handler: async (
+    _runtime: IAgentRuntime,
+    _message: Memory,
+    state?: State,
+    _options?: Record<string, unknown>,
+    _callback?: HandlerCallback
+  ): Promise<ActionResult> => {
+    const agentUserId = _runtime.agentId;
+    const params = state?.data?.actionParams as SetPriceAlertParams | undefined;
+
+    if (!params) {
+      return {
+        success: false,
+        text: 'Missing parameters: tokenSymbol, condition, threshold required.',
+        error: 'Missing parameters',
+      };
+    }
+
+    const {
+      tokenSymbol,
+      condition,
+      threshold,
+      deliveryChannel,
+      deliveryChatId,
+      cooldownMinutes,
+    } = params;
+
+    if (!tokenSymbol || !condition || threshold == null) {
+      return {
+        success: false,
+        text: 'Missing required parameters: tokenSymbol, condition, threshold.',
+        error: 'Missing required parameters',
+      };
+    }
+
+    if (condition !== 'above' && condition !== 'below') {
+      return {
+        success: false,
+        text: 'Condition must be "above" or "below".',
+        error: 'Invalid condition',
+      };
+    }
+
+    if (typeof threshold !== 'number' || threshold <= 0) {
+      return {
+        success: false,
+        text: 'Threshold must be a positive number.',
+        error: 'Invalid threshold',
+      };
+    }
+
+    if (deliveryChannel === 'group' && !deliveryChatId) {
+      return {
+        success: false,
+        text: 'deliveryChatId is required when deliveryChannel is "group".',
+        error: 'Missing deliveryChatId',
+      };
+    }
+
+    // Fetch current config
+    const [config] = await db
+      .select({
+        id: userAgentConfigs.id,
+        priceAlerts: userAgentConfigs.priceAlerts,
+      })
+      .from(userAgentConfigs)
+      .where(eq(userAgentConfigs.userId, agentUserId))
+      .limit(1);
+
+    if (!config) {
+      return {
+        success: false,
+        text: 'Agent configuration not found. Ensure agent is properly set up.',
+        error: 'Config not found',
+      };
+    }
+
+    const alerts = (config.priceAlerts ?? []) as PriceAlert[];
+
+    // Check for duplicate (same token + condition)
+    const existing = alerts.find(
+      (a) =>
+        a.tokenSymbol === tokenSymbol.toUpperCase() && a.condition === condition
+    );
+
+    const now = new Date().toISOString();
+    let newAlert: PriceAlert;
+
+    if (existing) {
+      // Update existing alert
+      newAlert = {
+        ...existing,
+        threshold,
+        deliveryChannel: deliveryChannel ?? existing.deliveryChannel,
+        deliveryChatId: deliveryChatId ?? existing.deliveryChatId,
+        cooldownMinutes: cooldownMinutes ?? existing.cooldownMinutes,
+        enabled: true,
+        lastTriggeredAt: undefined, // Reset cooldown on update
+      };
+      const updatedAlerts = alerts.map((a) =>
+        a.id === existing.id ? newAlert : a
+      );
+
+      await db
+        .update(userAgentConfigs)
+        .set({ priceAlerts: updatedAlerts, updatedAt: new Date() })
+        .where(eq(userAgentConfigs.id, config.id));
+
+      logger.info(
+        `[SET_PRICE_ALERT] Updated alert: ${tokenSymbol} ${condition} ${threshold}`,
+        { agentUserId, alertId: existing.id },
+        'ManagePriceAlerts'
+      );
+
+      return {
+        success: true,
+        text: `Updated price alert: ${tokenSymbol.toUpperCase()} ${condition} $${threshold}. Delivery: ${deliveryChannel ?? existing.deliveryChannel}. Cooldown: ${cooldownMinutes ?? existing.cooldownMinutes} min.`,
+        data: { alertId: existing.id, updated: true },
+      };
+    }
+
+    // Create new alert
+    const alertId = await generateSnowflakeId();
+    newAlert = {
+      id: alertId,
+      tokenSymbol: tokenSymbol.toUpperCase(),
+      condition,
+      threshold,
+      deliveryChannel: deliveryChannel ?? 'team_chat',
+      deliveryChatId,
+      enabled: true,
+      cooldownMinutes: cooldownMinutes ?? 15,
+      createdAt: now,
+    };
+
+    const updatedAlerts = [...alerts, newAlert];
+    await db
+      .update(userAgentConfigs)
+      .set({ priceAlerts: updatedAlerts, updatedAt: new Date() })
+      .where(eq(userAgentConfigs.id, config.id));
+
+    logger.info(
+      `[SET_PRICE_ALERT] Created alert: ${tokenSymbol} ${condition} ${threshold}`,
+      { agentUserId, alertId },
+      'ManagePriceAlerts'
+    );
+
+    return {
+      success: true,
+      text: `Price alert set: ${tokenSymbol.toUpperCase()} ${condition} $${threshold}. Delivery: ${newAlert.deliveryChannel}. Cooldown: ${newAlert.cooldownMinutes} min.`,
+      data: { alertId, created: true },
+    };
+  },
+};
+
+// ─── LIST_PRICE_ALERTS ──────────────────────────────────────────────────
+
+export const listPriceAlertsAction: Action = {
+  name: 'LIST_PRICE_ALERTS',
+  description:
+    'List all configured price alerts with their current status, thresholds, and delivery settings.',
+
+  parameters: {},
+
+  examples: [
+    [
+      {
+        name: 'User',
+        content: {
+          text: 'Show my price alerts',
+        },
+      },
+      {
+        name: 'Agent',
+        content: {
+          text: 'Here are your active price alerts:\n1. OPENAGI below $0.50 (team_chat, 15min cooldown)\n2. TSLAI above $2.00 (team_chat, 30min cooldown)',
+          action: 'LIST_PRICE_ALERTS',
+        },
+      },
+    ],
+  ],
+
+  validate: async (): Promise<boolean> => true,
+
+  handler: async (
+    _runtime: IAgentRuntime,
+    _message: Memory,
+    _state?: State,
+    _options?: Record<string, unknown>,
+    _callback?: HandlerCallback
+  ): Promise<ActionResult> => {
+    const agentUserId = _runtime.agentId;
+
+    const [config] = await db
+      .select({ priceAlerts: userAgentConfigs.priceAlerts })
+      .from(userAgentConfigs)
+      .where(eq(userAgentConfigs.userId, agentUserId))
+      .limit(1);
+
+    const alerts = (config?.priceAlerts ?? []) as PriceAlert[];
+
+    if (alerts.length === 0) {
+      return {
+        success: true,
+        text: 'No price alerts configured. Use SET_PRICE_ALERT to create one.',
+        data: { alerts: [] },
+      };
+    }
+
+    const lines = alerts.map((a, i) => {
+      const status = a.enabled ? '✓' : '✗';
+      const lastTriggered = a.lastTriggeredAt
+        ? ` (last triggered: ${new Date(a.lastTriggeredAt).toLocaleString()})`
+        : '';
+      return `${i + 1}. [${status}] ${a.tokenSymbol} ${a.condition} $${a.threshold} → ${a.deliveryChannel}, ${a.cooldownMinutes}min cooldown${lastTriggered} (id: ${a.id})`;
+    });
+
+    return {
+      success: true,
+      text: `Price alerts (${alerts.length}):\n${lines.join('\n')}`,
+      data: { alerts },
+    };
+  },
+};
+
+// ─── REMOVE_PRICE_ALERT ─────────────────────────────────────────────────
+
+interface RemovePriceAlertParams {
+  alertId?: string;
+  tokenSymbol?: string;
+  condition?: 'below' | 'above';
+}
+
+export const removePriceAlertAction: Action = {
+  name: 'REMOVE_PRICE_ALERT',
+  description:
+    'Remove a price alert by its ID, or by token symbol and condition.',
+
+  parameters: {
+    alertId: {
+      type: 'string',
+      description: 'The alert ID to remove (from LIST_PRICE_ALERTS)',
+      required: false,
+    },
+    tokenSymbol: {
+      type: 'string',
+      description:
+        'Token symbol to match (used with condition when alertId not provided)',
+      required: false,
+    },
+    condition: {
+      type: 'string',
+      description:
+        '"above" or "below" — used with tokenSymbol when alertId not provided',
+      required: false,
+    },
+  },
+
+  examples: [
+    [
+      {
+        name: 'User',
+        content: {
+          text: 'Remove my OPENAGI price alert',
+        },
+      },
+      {
+        name: 'Agent',
+        content: {
+          text: 'Removed price alert for OPENAGI below $0.50.',
+          action: 'REMOVE_PRICE_ALERT',
+        },
+      },
+    ],
+  ],
+
+  validate: async (): Promise<boolean> => true,
+
+  handler: async (
+    _runtime: IAgentRuntime,
+    _message: Memory,
+    state?: State,
+    _options?: Record<string, unknown>,
+    _callback?: HandlerCallback
+  ): Promise<ActionResult> => {
+    const agentUserId = _runtime.agentId;
+    const params = state?.data?.actionParams as
+      | RemovePriceAlertParams
+      | undefined;
+
+    if (!params) {
+      return {
+        success: false,
+        text: 'Missing parameters: provide alertId or tokenSymbol+condition.',
+        error: 'Missing parameters',
+      };
+    }
+
+    const { alertId, tokenSymbol, condition } = params;
+
+    if (!alertId && !tokenSymbol) {
+      return {
+        success: false,
+        text: 'Provide either alertId or tokenSymbol to identify the alert to remove.',
+        error: 'Missing identifier',
+      };
+    }
+
+    const [config] = await db
+      .select({
+        id: userAgentConfigs.id,
+        priceAlerts: userAgentConfigs.priceAlerts,
+      })
+      .from(userAgentConfigs)
+      .where(eq(userAgentConfigs.userId, agentUserId))
+      .limit(1);
+
+    if (!config) {
+      return {
+        success: false,
+        text: 'Agent configuration not found.',
+        error: 'Config not found',
+      };
+    }
+
+    const alerts = (config.priceAlerts ?? []) as PriceAlert[];
+
+    let removed: PriceAlert | undefined;
+    let remaining: PriceAlert[];
+
+    if (alertId) {
+      removed = alerts.find((a) => a.id === alertId);
+      remaining = alerts.filter((a) => a.id !== alertId);
+    } else {
+      const upperSymbol = tokenSymbol!.toUpperCase();
+      removed = alerts.find(
+        (a) =>
+          a.tokenSymbol === upperSymbol &&
+          (!condition || a.condition === condition)
+      );
+      remaining = removed ? alerts.filter((a) => a.id !== removed!.id) : alerts;
+    }
+
+    if (!removed) {
+      return {
+        success: false,
+        text: `No matching price alert found${alertId ? ` with ID ${alertId}` : ` for ${tokenSymbol}`}.`,
+        error: 'Alert not found',
+      };
+    }
+
+    await db
+      .update(userAgentConfigs)
+      .set({ priceAlerts: remaining, updatedAt: new Date() })
+      .where(eq(userAgentConfigs.id, config.id));
+
+    logger.info(
+      `[REMOVE_PRICE_ALERT] Removed alert: ${removed.tokenSymbol} ${removed.condition} ${removed.threshold}`,
+      { agentUserId, alertId: removed.id },
+      'ManagePriceAlerts'
+    );
+
+    return {
+      success: true,
+      text: `Removed price alert: ${removed.tokenSymbol} ${removed.condition} $${removed.threshold}.`,
+      data: { removedAlert: removed },
+    };
+  },
+};

--- a/packages/agents/src/plugins/plugin-agent-core/src/index.ts
+++ b/packages/agents/src/plugins/plugin-agent-core/src/index.ts
@@ -22,6 +22,9 @@
  * - SELL_PREDICTION action for selling prediction market shares
  * - OPEN_PERP action for opening perpetual positions
  * - CLOSE_PERP action for closing perpetual positions
+ * - SET_PRICE_ALERT action for creating/updating price alerts on perp markets
+ * - LIST_PRICE_ALERTS action for viewing configured price alerts
+ * - REMOVE_PRICE_ALERT action for deleting price alerts
  * - Providers for actions, recent messages, and action state
  *
  * @packageDocumentation
@@ -46,6 +49,11 @@ import { closePerpAction } from './actions/close-perp';
 import { createCommentAction } from './actions/create-comment';
 import { createPostAction } from './actions/create-post';
 import { lookupUserAction } from './actions/lookup-user';
+import {
+  listPriceAlertsAction,
+  removePriceAlertAction,
+  setPriceAlertAction,
+} from './actions/manage-price-alerts';
 import { openPerpAction } from './actions/open-perp';
 import { sellPredictionAction } from './actions/sell-prediction';
 import { toggleAutonomyAction } from './actions/toggle-autonomy';
@@ -85,6 +93,10 @@ export const agentCorePlugin: Plugin = {
     checkTeamChatAction,
     // User lookup
     lookupUserAction,
+    // Price alerts
+    setPriceAlertAction,
+    listPriceAlertsAction,
+    removePriceAlertAction,
     // Social actions
     createPostAction,
     createCommentAction,

--- a/packages/agents/src/plugins/plugin-user-core/src/actions/dispatch-to-agent.ts
+++ b/packages/agents/src/plugins/plugin-user-core/src/actions/dispatch-to-agent.ts
@@ -8,8 +8,8 @@
  * to avoid importing @babylon/api from packages/agents.
  *
  * Key implementation notes:
- * - Returns ActionResult directly — _callback is accepted but never invoked
- *   (consistent with every other action in this codebase)
+ * - Returns ActionResult AND calls _callback (so processActions can
+ *   relay the result to the coordinator route's callback handler)
  * - validate() only shows this action when the team has at least one agent
  *   (reads from state.data.teamMembers populated by coordinatorTeamMembersProvider)
  * - state.data.actionParams is the established pattern for passing params to handlers
@@ -89,7 +89,6 @@ export const dispatchToAgentAction: Action = {
     return members.some((m) => m.isAgent);
   },
 
-  // Returns ActionResult directly — _callback is accepted but NOT called
   handler: async (
     _runtime: IAgentRuntime,
     _message: Memory,
@@ -112,10 +111,12 @@ export const dispatchToAgentAction: Action = {
     const ownerUsername = state?.values?.ownerUsername as string | undefined;
 
     if (!agentId || !command || !ownerId || !teamChatId || !broadcastFn) {
-      return {
+      const failResult: ActionResult = {
         success: false,
         text: 'Missing required parameters for agent dispatch.',
       };
+      _callback?.({ content: failResult });
+      return failResult;
     }
 
     const result = await dispatchAgentChat({
@@ -129,14 +130,16 @@ export const dispatchToAgentAction: Action = {
     });
 
     if (!result.success) {
-      return {
+      const failResult: ActionResult = {
         success: false,
         text: `Failed to dispatch to agent: ${result.error ?? 'Unknown error'}`,
         values: { agentId, command, error: result.error },
       };
+      _callback?.({ content: failResult });
+      return failResult;
     }
 
-    return {
+    const successResult: ActionResult = {
       success: true,
       text: `Dispatched to @${result.agentUsername ?? agentId}: "${result.response.slice(0, 300)}"`,
       values: {
@@ -147,5 +150,7 @@ export const dispatchToAgentAction: Action = {
         actionsExecuted: result.actionsExecuted,
       },
     };
+    _callback?.({ content: successResult });
+    return successResult;
   },
 };

--- a/packages/agents/src/plugins/plugin-user-core/src/actions/dispatch-to-agents.ts
+++ b/packages/agents/src/plugins/plugin-user-core/src/actions/dispatch-to-agents.ts
@@ -11,7 +11,7 @@
  *
  * Implementation follows the same patterns as dispatch-to-agent.ts:
  * - broadcastFn injected via state.data from the route layer
- * - Returns ActionResult directly — callback is not invoked
+ * - Returns ActionResult AND calls _callback (so processActions can relay the result)
  * - actionParams passed via state.data.actionParams
  */
 
@@ -156,10 +156,29 @@ export const dispatchToAgentsAction: Action = {
     // Cap at 5 concurrent dispatches to prevent resource exhaustion
     const cappedDispatches = validDispatches.slice(0, 5);
 
+    const raceWithTimeout = async <T>(promise: Promise<T>): Promise<T> => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+          reject(
+            new Error(
+              `Agent dispatch timed out after ${DISPATCH_TIMEOUT_MS / 1000}s`
+            )
+          );
+        }, DISPATCH_TIMEOUT_MS);
+      });
+
+      try {
+        return await Promise.race([promise, timeoutPromise]);
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+    };
+
     // Execute all dispatches in parallel with per-agent timeout
     const settledResults = await Promise.allSettled(
       cappedDispatches.map(({ agentId, command }) =>
-        Promise.race([
+        raceWithTimeout(
           dispatchAgentChat({
             agentId,
             ownerId,
@@ -168,19 +187,8 @@ export const dispatchToAgentsAction: Action = {
             ownerName,
             ownerUsername,
             broadcastFn,
-          }),
-          new Promise<never>((_, reject) =>
-            setTimeout(
-              () =>
-                reject(
-                  new Error(
-                    `Agent dispatch timed out after ${DISPATCH_TIMEOUT_MS / 1000}s`
-                  )
-                ),
-              DISPATCH_TIMEOUT_MS
-            )
-          ),
-        ])
+          })
+        )
       )
     );
 

--- a/packages/agents/src/plugins/plugin-user-core/src/actions/dispatch-to-agents.ts
+++ b/packages/agents/src/plugins/plugin-user-core/src/actions/dispatch-to-agents.ts
@@ -1,0 +1,235 @@
+/**
+ * DISPATCH_TO_AGENTS Action (Parallel Multi-Agent Dispatch)
+ *
+ * Allows the coordinator to dispatch commands to multiple agents simultaneously.
+ * All dispatches run in parallel via Promise.allSettled with per-agent timeouts.
+ *
+ * Used for multi-agent orchestration patterns:
+ * - "Ask all my agents for their market outlook"
+ * - "Have trading and research agents coordinate on a strategy"
+ * - "Get portfolio status from all agents"
+ *
+ * Implementation follows the same patterns as dispatch-to-agent.ts:
+ * - broadcastFn injected via state.data from the route layer
+ * - Returns ActionResult directly — callback is not invoked
+ * - actionParams passed via state.data.actionParams
+ */
+
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from '@elizaos/core';
+import {
+  type BroadcastFn,
+  dispatchAgentChat,
+} from '../../../../services/AgentChatService';
+
+/** Per-agent dispatch timeout — prevents one slow agent from blocking all others */
+const DISPATCH_TIMEOUT_MS = 15_000;
+
+interface AgentDispatch {
+  agentId: string;
+  command: string;
+}
+
+interface AgentDispatchResult {
+  agentId: string;
+  agentUsername?: string;
+  success: boolean;
+  response: string;
+  actionsExecuted: number;
+  error?: string;
+}
+
+export const dispatchToAgentsAction: Action = {
+  name: 'DISPATCH_TO_AGENTS',
+  description:
+    'Dispatch commands to multiple agents simultaneously. Use when the user wants input from several agents, or when a task benefits from parallel agent work.',
+
+  parameters: {
+    dispatches: {
+      type: 'array',
+      required: true,
+      description:
+        'Array of dispatch objects, each with agentId and command. Example: [{"agentId": "abc", "command": "check positions"}, {"agentId": "def", "command": "analyze trends"}]',
+    },
+  },
+
+  examples: [
+    [
+      {
+        name: 'user',
+        content: {
+          text: 'Ask all my agents what they think about the market',
+        },
+      },
+      {
+        name: 'coordinator',
+        content: {
+          text: "I'll dispatch to all your agents simultaneously to gather their market views.",
+        },
+      },
+    ],
+    [
+      {
+        name: 'user',
+        content: { text: 'Have my agents coordinate on a trading strategy' },
+      },
+      {
+        name: 'coordinator',
+        content: {
+          text: "I'll ask all agents for their analysis in parallel, then synthesize a strategy.",
+        },
+      },
+    ],
+  ],
+
+  // Only show when team has at least 2 agents (single agent → use DISPATCH_TO_AGENT)
+  validate: async (
+    _runtime: IAgentRuntime,
+    _message: Memory,
+    state?: State
+  ): Promise<boolean> => {
+    interface TeamMember {
+      isAgent: boolean;
+    }
+    const members =
+      (state?.data?.teamMembers as TeamMember[] | undefined) ?? [];
+    return members.filter((m) => m.isAgent).length >= 2;
+  },
+
+  handler: async (
+    _runtime: IAgentRuntime,
+    _message: Memory,
+    state?: State,
+    _options?: Record<string, unknown>,
+    _callback?: HandlerCallback
+  ): Promise<ActionResult> => {
+    const actionParams = state?.data?.actionParams as
+      | { dispatches?: AgentDispatch[] }
+      | undefined;
+
+    const broadcastFn = state?.data?.broadcastFn as BroadcastFn | undefined;
+    const ownerId = state?.values?.ownerId as string | undefined;
+    const teamChatId = state?.values?.teamChatId as string | undefined;
+    const ownerName = state?.values?.ownerName as string | undefined;
+    const ownerUsername = state?.values?.ownerUsername as string | undefined;
+
+    const dispatches = actionParams?.dispatches;
+
+    if (
+      !dispatches ||
+      !Array.isArray(dispatches) ||
+      dispatches.length === 0 ||
+      !ownerId ||
+      !teamChatId ||
+      !broadcastFn
+    ) {
+      return {
+        success: false,
+        text: 'Missing required parameters for multi-agent dispatch. Provide an array of {agentId, command} objects.',
+      };
+    }
+
+    // Validate each dispatch entry
+    const validDispatches = dispatches.filter(
+      (d): d is AgentDispatch =>
+        typeof d.agentId === 'string' &&
+        d.agentId.length > 0 &&
+        typeof d.command === 'string' &&
+        d.command.length > 0
+    );
+
+    if (validDispatches.length === 0) {
+      return {
+        success: false,
+        text: 'No valid dispatch entries found. Each entry needs agentId and command.',
+      };
+    }
+
+    // Cap at 5 concurrent dispatches to prevent resource exhaustion
+    const cappedDispatches = validDispatches.slice(0, 5);
+
+    // Execute all dispatches in parallel with per-agent timeout
+    const settledResults = await Promise.allSettled(
+      cappedDispatches.map(({ agentId, command }) =>
+        Promise.race([
+          dispatchAgentChat({
+            agentId,
+            ownerId,
+            message: command,
+            teamChatId,
+            ownerName,
+            ownerUsername,
+            broadcastFn,
+          }),
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () =>
+                reject(
+                  new Error(
+                    `Agent dispatch timed out after ${DISPATCH_TIMEOUT_MS / 1000}s`
+                  )
+                ),
+              DISPATCH_TIMEOUT_MS
+            )
+          ),
+        ])
+      )
+    );
+
+    // Collect results
+    const agentResults: AgentDispatchResult[] = settledResults.map(
+      (settled, i) => {
+        const dispatch = cappedDispatches[i]!;
+        if (settled.status === 'fulfilled') {
+          const result = settled.value;
+          return {
+            agentId: result.agentId,
+            agentUsername: result.agentUsername,
+            success: result.success,
+            response: result.response,
+            actionsExecuted: result.actionsExecuted,
+            error: result.error,
+          };
+        }
+        return {
+          agentId: dispatch.agentId,
+          success: false,
+          response: '',
+          actionsExecuted: 0,
+          error:
+            settled.reason instanceof Error
+              ? settled.reason.message
+              : String(settled.reason),
+        };
+      }
+    );
+
+    const successCount = agentResults.filter((r) => r.success).length;
+    const totalCount = agentResults.length;
+
+    // Build summary text
+    const summaryParts = agentResults.map((r) => {
+      const label = r.agentUsername ? `@${r.agentUsername}` : r.agentId;
+      if (r.success) {
+        return `${label}: "${r.response.slice(0, 300)}"`;
+      }
+      return `${label}: FAILED — ${r.error ?? 'Unknown error'}`;
+    });
+
+    return {
+      success: successCount > 0,
+      text: `Dispatched to ${totalCount} agents (${successCount} succeeded):\n\n${summaryParts.join('\n\n')}`,
+      values: {
+        agentResults,
+        successCount,
+        totalCount,
+      },
+    };
+  },
+};

--- a/packages/agents/src/plugins/plugin-user-core/src/actions/dispatch-to-agents.ts
+++ b/packages/agents/src/plugins/plugin-user-core/src/actions/dispatch-to-agents.ts
@@ -129,10 +129,12 @@ export const dispatchToAgentsAction: Action = {
       !teamChatId ||
       !broadcastFn
     ) {
-      return {
+      const failResult: ActionResult = {
         success: false,
         text: 'Missing required parameters for multi-agent dispatch. Provide an array of {agentId, command} objects.',
       };
+      _callback?.({ content: failResult });
+      return failResult;
     }
 
     // Validate each dispatch entry
@@ -222,7 +224,7 @@ export const dispatchToAgentsAction: Action = {
       return `${label}: FAILED — ${r.error ?? 'Unknown error'}`;
     });
 
-    return {
+    const finalResult: ActionResult = {
       success: successCount > 0,
       text: `Dispatched to ${totalCount} agents (${successCount} succeeded):\n\n${summaryParts.join('\n\n')}`,
       values: {
@@ -231,5 +233,7 @@ export const dispatchToAgentsAction: Action = {
         totalCount,
       },
     };
+    _callback?.({ content: finalResult });
+    return finalResult;
   },
 };

--- a/packages/agents/src/plugins/plugin-user-core/src/actions/index.ts
+++ b/packages/agents/src/plugins/plugin-user-core/src/actions/index.ts
@@ -13,3 +13,5 @@ export { checkRecentMarketTradesAction } from './check-recent-market-trades';
 export { checkTeamChatAction } from './check-team-chat';
 export { checkUserPnlAction } from './check-user-pnl';
 export { dispatchToAgentAction } from './dispatch-to-agent';
+export { dispatchToAgentsAction } from './dispatch-to-agents';
+export { relayToAgentAction } from './relay-to-agent';

--- a/packages/agents/src/plugins/plugin-user-core/src/actions/relay-to-agent.ts
+++ b/packages/agents/src/plugins/plugin-user-core/src/actions/relay-to-agent.ts
@@ -1,0 +1,150 @@
+/**
+ * RELAY_TO_AGENT Action (Context-Enriched Dispatch)
+ *
+ * Dispatches a command to an agent with structured context from previous
+ * agent responses. This enables multi-agent workflows where one agent's
+ * output informs another agent's task.
+ *
+ * Example flow:
+ * 1. Coordinator dispatches to Agent A (research): "What's trending?"
+ * 2. Agent A responds with research findings
+ * 3. Coordinator relays to Agent B (trading): "Based on research: [Agent A's findings],
+ *    execute the best trade opportunity"
+ *
+ * The relayContext is prepended to the command so the target agent sees it
+ * as additional context in its system prompt.
+ */
+
+import type {
+  Action,
+  ActionResult,
+  HandlerCallback,
+  IAgentRuntime,
+  Memory,
+  State,
+} from '@elizaos/core';
+import {
+  type BroadcastFn,
+  dispatchAgentChat,
+} from '../../../../services/AgentChatService';
+
+export const relayToAgentAction: Action = {
+  name: 'RELAY_TO_AGENT',
+  description:
+    'Dispatch to an agent with context from previous agent responses. Use after gathering information from other agents to pass their findings to an execution agent.',
+
+  parameters: {
+    agentId: {
+      type: 'string',
+      required: true,
+      description:
+        'The ID of the target agent — use the [id: ...] shown in Team Members',
+    },
+    command: {
+      type: 'string',
+      required: true,
+      description: 'The instruction for the target agent',
+    },
+    relayContext: {
+      type: 'string',
+      required: true,
+      description:
+        'Structured context from other agents to pass along (e.g., "Agent A found: X, Agent B found: Y")',
+    },
+  },
+
+  examples: [
+    [
+      {
+        name: 'user',
+        content: {
+          text: 'Have my research agent analyze trends, then my trader execute on it',
+        },
+      },
+      {
+        name: 'coordinator',
+        content: {
+          text: "I'll relay the research findings to your trading agent for execution.",
+        },
+      },
+    ],
+  ],
+
+  validate: async (
+    _runtime: IAgentRuntime,
+    _message: Memory,
+    state?: State
+  ): Promise<boolean> => {
+    interface TeamMember {
+      isAgent: boolean;
+    }
+    const members =
+      (state?.data?.teamMembers as TeamMember[] | undefined) ?? [];
+    return members.some((m) => m.isAgent);
+  },
+
+  handler: async (
+    _runtime: IAgentRuntime,
+    _message: Memory,
+    state?: State,
+    _options?: Record<string, unknown>,
+    _callback?: HandlerCallback
+  ): Promise<ActionResult> => {
+    const actionParams = state?.data?.actionParams as
+      | { agentId?: string; command?: string; relayContext?: string }
+      | undefined;
+
+    const broadcastFn = state?.data?.broadcastFn as BroadcastFn | undefined;
+    const ownerId = state?.values?.ownerId as string | undefined;
+    const teamChatId = state?.values?.teamChatId as string | undefined;
+    const ownerName = state?.values?.ownerName as string | undefined;
+    const ownerUsername = state?.values?.ownerUsername as string | undefined;
+
+    const agentId = actionParams?.agentId;
+    const command = actionParams?.command;
+    const relayContext = actionParams?.relayContext;
+
+    if (!agentId || !command || !ownerId || !teamChatId || !broadcastFn) {
+      return {
+        success: false,
+        text: 'Missing required parameters for relay dispatch.',
+      };
+    }
+
+    // Build enriched command with relay context prepended
+    const enrichedCommand = relayContext
+      ? `--- Context from other agents ---\n${relayContext}\n--- End context ---\n\nYour task: ${command}`
+      : command;
+
+    const result = await dispatchAgentChat({
+      agentId,
+      ownerId,
+      message: enrichedCommand,
+      teamChatId,
+      ownerName,
+      ownerUsername,
+      broadcastFn,
+    });
+
+    if (!result.success) {
+      return {
+        success: false,
+        text: `Failed to relay to agent: ${result.error ?? 'Unknown error'}`,
+        values: { agentId, command, relayContext, error: result.error },
+      };
+    }
+
+    return {
+      success: true,
+      text: `Relayed to @${result.agentUsername ?? agentId} (with context from other agents): "${result.response.slice(0, 300)}"`,
+      values: {
+        agentId: result.agentId,
+        agentUsername: result.agentUsername,
+        dispatchedCommand: command,
+        relayContext,
+        agentResponse: result.response,
+        actionsExecuted: result.actionsExecuted,
+      },
+    };
+  },
+};

--- a/packages/agents/src/plugins/plugin-user-core/src/actions/relay-to-agent.ts
+++ b/packages/agents/src/plugins/plugin-user-core/src/actions/relay-to-agent.ts
@@ -105,10 +105,12 @@ export const relayToAgentAction: Action = {
     const relayContext = actionParams?.relayContext;
 
     if (!agentId || !command || !ownerId || !teamChatId || !broadcastFn) {
-      return {
+      const failResult: ActionResult = {
         success: false,
         text: 'Missing required parameters for relay dispatch.',
       };
+      _callback?.({ content: failResult });
+      return failResult;
     }
 
     // Build enriched command with relay context prepended
@@ -127,14 +129,16 @@ export const relayToAgentAction: Action = {
     });
 
     if (!result.success) {
-      return {
+      const failResult: ActionResult = {
         success: false,
         text: `Failed to relay to agent: ${result.error ?? 'Unknown error'}`,
         values: { agentId, command, relayContext, error: result.error },
       };
+      _callback?.({ content: failResult });
+      return failResult;
     }
 
-    return {
+    const successResult: ActionResult = {
       success: true,
       text: `Relayed to @${result.agentUsername ?? agentId} (with context from other agents): "${result.response.slice(0, 300)}"`,
       values: {
@@ -146,5 +150,7 @@ export const relayToAgentAction: Action = {
         actionsExecuted: result.actionsExecuted,
       },
     };
+    _callback?.({ content: successResult });
+    return successResult;
   },
 };

--- a/packages/agents/src/plugins/plugin-user-core/src/index.ts
+++ b/packages/agents/src/plugins/plugin-user-core/src/index.ts
@@ -22,10 +22,13 @@ import {
   checkTeamChatAction,
   checkUserPnlAction,
   dispatchToAgentAction,
+  dispatchToAgentsAction,
+  relayToAgentAction,
 } from './actions';
 import {
   coordinatorActionStateProvider,
   coordinatorActionsProvider,
+  coordinatorAgentActivityProvider,
   coordinatorContextProvider,
   coordinatorDispatchHistoryProvider,
   coordinatorRecentMessagesProvider,
@@ -53,6 +56,9 @@ export const userCorePlugin: Plugin = {
   actions: [
     // Orchestration — listed first so the LLM sees it as the primary action for execution requests
     dispatchToAgentAction,
+    // Multi-agent orchestration
+    dispatchToAgentsAction,
+    relayToAgentAction,
     // Market information
     checkPredictionsAction,
     checkPerpsAction,
@@ -73,6 +79,7 @@ export const userCorePlugin: Plugin = {
     coordinatorTeamMembersProvider,
     coordinatorContextProvider,
     coordinatorDispatchHistoryProvider,
+    coordinatorAgentActivityProvider,
   ],
 };
 
@@ -85,10 +92,13 @@ export {
   checkTeamChatAction,
   checkUserPnlAction,
   dispatchToAgentAction,
+  dispatchToAgentsAction,
+  relayToAgentAction,
 } from './actions';
 export {
   coordinatorActionStateProvider,
   coordinatorActionsProvider,
+  coordinatorAgentActivityProvider,
   coordinatorContextProvider,
   coordinatorDispatchHistoryProvider,
   coordinatorRecentMessagesProvider,

--- a/packages/agents/src/plugins/plugin-user-core/src/providers/agent-activity.ts
+++ b/packages/agents/src/plugins/plugin-user-core/src/providers/agent-activity.ts
@@ -1,0 +1,72 @@
+/**
+ * Agent Activity Provider
+ *
+ * Surfaces recent inter-agent events from the EventBus for the coordinator's
+ * context. This gives the coordinator visibility into what agents have done
+ * programmatically (dispatches, trades, posts) beyond just team chat messages.
+ *
+ * Events are published by AgentChatService after each dispatch completes.
+ * This provider reads the EventBus history and formats it for the coordinator's
+ * decision-making context.
+ */
+
+import type {
+  IAgentRuntime,
+  Memory,
+  Provider,
+  ProviderResult,
+  State,
+} from '@elizaos/core';
+import { getEventBus } from '../../../../communication/EventBus';
+
+export const coordinatorAgentActivityProvider: Provider = {
+  name: 'AGENT_ACTIVITY',
+  description:
+    'Recent programmatic agent activities (dispatch results, inter-agent events)',
+  dynamic: true,
+
+  get: async (
+    _runtime: IAgentRuntime,
+    _message: Memory,
+    _state?: State
+  ): Promise<ProviderResult> => {
+    const eventBus = getEventBus();
+    const recentEvents = eventBus.getHistory('agent.*', 20);
+
+    if (recentEvents.length === 0) {
+      return { text: '' };
+    }
+
+    const formatted = recentEvents
+      .slice(-10) // Last 10 events
+      .map((event) => {
+        const data = event.data as Record<string, unknown>;
+        const timestamp = (data.timestamp as string) ?? event.timestamp;
+        const agent =
+          (data.agentUsername as string) ??
+          (data.agentId as string) ??
+          'unknown';
+        const command =
+          typeof data.command === 'string' ? data.command.slice(0, 100) : '';
+        const response =
+          typeof data.response === 'string' ? data.response.slice(0, 200) : '';
+        const success = data.success ?? true;
+
+        const timeStr = timestamp
+          ? new Date(timestamp as string).toLocaleTimeString('en-US', {
+              hour: '2-digit',
+              minute: '2-digit',
+            })
+          : '??:??';
+
+        if (event.type === 'agent.dispatch.result') {
+          return `${timeStr} @${agent}: ${success ? '✓' : '✗'} "${command}" → "${response}"`;
+        }
+
+        return `${timeStr} ${event.type}: ${JSON.stringify(data).slice(0, 200)}`;
+      })
+      .join('\n');
+
+    return { text: `## Recent Agent Activity (Programmatic)\n${formatted}` };
+  },
+};

--- a/packages/agents/src/plugins/plugin-user-core/src/providers/index.ts
+++ b/packages/agents/src/plugins/plugin-user-core/src/providers/index.ts
@@ -8,6 +8,7 @@
 export { coordinatorActionStateProvider } from './action-state';
 // Coordinator-specific providers
 export { coordinatorActionsProvider } from './actions';
+export { coordinatorAgentActivityProvider } from './agent-activity';
 export { coordinatorContextProvider } from './coordinator-context';
 export { coordinatorDispatchHistoryProvider } from './dispatch-history';
 export { coordinatorRecentMessagesProvider } from './recent-messages';

--- a/packages/agents/src/services/AgentChatService.ts
+++ b/packages/agents/src/services/AgentChatService.ts
@@ -25,6 +25,7 @@ import {
   type State,
 } from '@elizaos/core';
 import { v4 as uuidv4 } from 'uuid';
+import { getEventBus } from '../communication/EventBus';
 import { AuthorizationError } from '../errors';
 import { agentRuntimeManager } from '../runtime/AgentRuntimeManager';
 import { generateSnowflakeId } from '../shared/snowflake';
@@ -665,6 +666,24 @@ export async function dispatchAgentChat(
     '[AgentChatService] Dispatch completed',
     { agentId, actionsExecuted: traceActionResults.length, isLLMFailure },
     'AgentChatService'
+  );
+
+  // Publish dispatch result to EventBus for inter-agent awareness.
+  // Other agents or services can subscribe to 'agent.dispatch.result' events
+  // to build contextual awareness of what's happening across the team.
+  const eventBus = getEventBus();
+  eventBus.publish(
+    'agent.dispatch.result',
+    {
+      agentId,
+      agentUsername: agentUsername ?? null,
+      command: params.message,
+      response: responseText.slice(0, 500),
+      actionsExecuted: traceActionResults.length,
+      success: true,
+      timestamp: new Date().toISOString(),
+    },
+    agentId
   );
 
   return {

--- a/packages/agents/src/services/AgentChatService.ts
+++ b/packages/agents/src/services/AgentChatService.ts
@@ -257,10 +257,34 @@ export async function dispatchAgentChat(
     };
   }
 
-  // --- Ownership verification ---
+  // --- Ownership verification (with name/username fallback) ---
   let agentWithConfig;
+  let resolvedAgentId = agentId;
   try {
     agentWithConfig = await agentService.getAgentWithConfig(agentId, ownerId);
+
+    // Fallback: if not found by ID, try resolving by username or displayName
+    if (!agentWithConfig) {
+      const ownerAgents = await agentService.listUserAgents(ownerId);
+      const needle = agentId.toLowerCase();
+      const match = ownerAgents.find(
+        (a) =>
+          a.username?.toLowerCase() === needle ||
+          a.displayName?.toLowerCase() === needle
+      );
+      if (match) {
+        resolvedAgentId = match.id;
+        agentWithConfig = await agentService.getAgentWithConfig(
+          resolvedAgentId,
+          ownerId
+        );
+        logger.info(
+          '[AgentChatService] Resolved agent by name fallback',
+          { input: agentId, resolvedId: resolvedAgentId },
+          'AgentChatService'
+        );
+      }
+    }
   } catch (err) {
     const errorMsg =
       err instanceof AuthorizationError
@@ -270,13 +294,13 @@ export async function dispatchAgentChat(
           : 'Unknown authorization error';
     logger.warn(
       '[AgentChatService] Ownership check failed',
-      { agentId, ownerId, error: errorMsg },
+      { agentId: resolvedAgentId, ownerId, error: errorMsg },
       'AgentChatService'
     );
     return {
       success: false,
       response: '',
-      agentId,
+      agentId: resolvedAgentId,
       actionsExecuted: 0,
       isLLMFailure: false,
       error: errorMsg,
@@ -287,7 +311,7 @@ export async function dispatchAgentChat(
     return {
       success: false,
       response: '',
-      agentId,
+      agentId: resolvedAgentId,
       actionsExecuted: 0,
       isLLMFailure: false,
       error: 'Agent not found',
@@ -303,12 +327,13 @@ export async function dispatchAgentChat(
   const modelType = ModelType.TEXT_SMALL;
 
   // --- Get agent runtime ---
-  const runtime = await agentRuntimeManager.getRuntime(agentId);
+  const runtime = await agentRuntimeManager.getRuntime(resolvedAgentId);
 
   const elizaMessage: Memory = {
     id: uuidv4() as `${string}-${string}-${string}-${string}-${string}`,
     entityId: ownerId as `${string}-${string}-${string}-${string}-${string}`,
-    roomId: agentId as `${string}-${string}-${string}-${string}-${string}`,
+    roomId:
+      resolvedAgentId as `${string}-${string}-${string}-${string}-${string}`,
     content: { text: message },
     createdAt: Date.now(),
   };
@@ -333,7 +358,7 @@ export async function dispatchAgentChat(
   for (let iteration = 1; iteration <= MAX_ITERATIONS; iteration++) {
     logger.info(
       `[AgentChatService] Iteration ${iteration}/${MAX_ITERATIONS}`,
-      { agentId, actionsCompleted: traceActionResults.length },
+      { agentId: resolvedAgentId, actionsCompleted: traceActionResults.length },
       'AgentChatService'
     );
 
@@ -352,7 +377,7 @@ export async function dispatchAgentChat(
 
     state.values = {
       ...state.values,
-      agentId,
+      agentId: resolvedAgentId,
       system: agentConfig?.systemPrompt ?? 'You are a helpful AI assistant.',
       personality: agentConfig?.personality ?? '',
       tradingStrategy: agentConfig?.tradingStrategy ?? '',
@@ -554,7 +579,7 @@ export async function dispatchAgentChat(
 
     summaryState.values = {
       ...summaryState.values,
-      agentId,
+      agentId: resolvedAgentId,
       system: agentConfig?.systemPrompt ?? 'You are a helpful AI assistant.',
       personality: agentConfig?.personality ?? '',
       tradingStrategy: agentConfig?.tradingStrategy ?? '',
@@ -633,7 +658,7 @@ export async function dispatchAgentChat(
   await db.insert(messages).values({
     id: responseMessageId,
     chatId: teamChatId,
-    senderId: agentId,
+    senderId: resolvedAgentId,
     content: responseText,
     createdAt: responseTime,
     metadata: messageMetadata,
@@ -643,28 +668,32 @@ export async function dispatchAgentChat(
   await db
     .update(userAgentConfigs)
     .set({ lastChatAt: new Date(), updatedAt: new Date() })
-    .where(eq(userAgentConfigs.userId, agentId));
+    .where(eq(userAgentConfigs.userId, resolvedAgentId));
 
   // --- Broadcast so SSE clients see the agent response immediately ---
   broadcastFn(teamChatId, {
     id: responseMessageId,
     content: responseText,
     chatId: teamChatId,
-    senderId: agentId,
+    senderId: resolvedAgentId,
     type: 'user',
     createdAt: responseTime.toISOString(),
     metadata: messageMetadata,
   }).catch((err) => {
     logger.warn(
       `[AgentChatService] Failed to broadcast agent message`,
-      { teamChatId, agentId, error: err },
+      { teamChatId, agentId: resolvedAgentId, error: err },
       'AgentChatService'
     );
   });
 
   logger.info(
     '[AgentChatService] Dispatch completed',
-    { agentId, actionsExecuted: traceActionResults.length, isLLMFailure },
+    {
+      agentId: resolvedAgentId,
+      actionsExecuted: traceActionResults.length,
+      isLLMFailure,
+    },
     'AgentChatService'
   );
 
@@ -675,7 +704,7 @@ export async function dispatchAgentChat(
   eventBus.publish(
     'agent.dispatch.result',
     {
-      agentId,
+      agentId: resolvedAgentId,
       agentUsername: agentUsername ?? null,
       command: params.message,
       response: responseText.slice(0, 500),
@@ -683,13 +712,13 @@ export async function dispatchAgentChat(
       success: true,
       timestamp: new Date().toISOString(),
     },
-    agentId
+    resolvedAgentId
   );
 
   return {
     success: true,
     response: responseText,
-    agentId,
+    agentId: resolvedAgentId,
     agentUsername,
     actionsExecuted: traceActionResults.length,
     isLLMFailure,

--- a/packages/agents/src/services/AgentChatService.ts
+++ b/packages/agents/src/services/AgentChatService.ts
@@ -469,6 +469,28 @@ export async function dispatchAgentChat(
       actionParams,
     };
 
+    // Persist actionParams to stateCache so processActions' internal
+    // composeState() preserves them (it re-composes from cache, discarding
+    // any local state.data modifications).
+    const stateCache = (
+      runtime as unknown as {
+        stateCache?: Map<
+          string,
+          {
+            values?: Record<string, unknown>;
+            data?: Record<string, unknown>;
+            text?: string;
+          }
+        >;
+      }
+    ).stateCache;
+    if (stateCache && elizaMessage.id) {
+      const cached = stateCache.get(elizaMessage.id);
+      if (cached) {
+        cached.data = { ...cached.data, actionParams };
+      }
+    }
+
     const actionContent = {
       text: `Executing action: ${action}`,
       actions: [action],

--- a/packages/db/drizzle/migrations/0044_add_user_agent_price_alerts.sql
+++ b/packages/db/drizzle/migrations/0044_add_user_agent_price_alerts.sql
@@ -1,0 +1,5 @@
+-- Add price alerts JSON config to UserAgentConfig
+-- Used by agents to persist and check threshold-based notifications
+
+ALTER TABLE "UserAgentConfig"
+ADD COLUMN IF NOT EXISTS "priceAlerts" json DEFAULT '[]'::json;

--- a/packages/db/drizzle/migrations/meta/_journal.json
+++ b/packages/db/drizzle/migrations/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1771363144000,
       "tag": "0043_add_notification_email_preferences",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "7",
+      "when": 1772615198560,
+      "tag": "0044_add_user_agent_price_alerts",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/user-agent-configs.ts
+++ b/packages/db/src/schema/user-agent-configs.ts
@@ -12,6 +12,33 @@ import type { JsonValue } from '../types';
 import { users } from './users';
 
 /**
+ * Price alert configuration for agent-monitored price thresholds.
+ * Checked every agent tick (~3 minutes). Cooldown prevents alert spam.
+ */
+export interface PriceAlert {
+  /** Snowflake ID */
+  id: string;
+  /** Must match perpMarketSnapshots.ticker (e.g., "OPENAGI", "TSLAI") */
+  tokenSymbol: string;
+  /** Threshold direction */
+  condition: 'below' | 'above';
+  /** Price threshold to trigger on */
+  threshold: number;
+  /** Where to deliver the alert */
+  deliveryChannel: 'team_chat' | 'group';
+  /** Group chat ID — required when deliveryChannel is 'group' */
+  deliveryChatId?: string;
+  /** Whether this alert is active */
+  enabled: boolean;
+  /** ISO timestamp of last trigger — used for cooldown enforcement */
+  lastTriggeredAt?: string;
+  /** Minutes between re-triggers (default 15) */
+  cooldownMinutes: number;
+  /** ISO timestamp of creation */
+  createdAt: string;
+}
+
+/**
  * UserAgentConfig - Agent configuration for users who have enabled agent features.
  * Extracted from users table to optimize for the common case (users without agents).
  * Only created when a user enables agent functionality.
@@ -34,6 +61,9 @@ export const userAgentConfigs = pgTable(
     goals: json('goals').$type<JsonValue>(),
     directives: json('directives').$type<JsonValue>(),
     constraints: json('constraints').$type<JsonValue>(),
+
+    // Price alerts - monitored during each agent tick
+    priceAlerts: json('priceAlerts').$type<PriceAlert[]>().default([]),
 
     // Agent settings
     planningHorizon: text('planningHorizon').notNull().default('single'),

--- a/packages/testing/unit/a2a/operation-map-completeness.test.ts
+++ b/packages/testing/unit/a2a/operation-map-completeness.test.ts
@@ -59,9 +59,12 @@ mock.module('../../../agents/src/shared/snowflake', () => ({
 // Let's read the file directly and check for the patterns
 
 import { readFileSync } from 'fs';
+import { resolve } from 'path';
 
-const filePath =
-  '/home/dev/bab/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts';
+const filePath = resolve(
+  import.meta.dir,
+  '../../../agents/src/plugins/babylon/integration-a2a-sdk.ts'
+);
 const fileContent = readFileSync(filePath, 'utf-8');
 
 // ─── Tests ───────────────────────────────────────────────────────────────────

--- a/packages/testing/unit/a2a/operation-map-completeness.test.ts
+++ b/packages/testing/unit/a2a/operation-map-completeness.test.ts
@@ -1,0 +1,186 @@
+/**
+ * A2A Operation Map Completeness Tests
+ *
+ * Verifies that the operationMap in integration-a2a-sdk.ts contains all
+ * required messaging and notification operations that were added in Phase 1.
+ *
+ * This is a regression test — the root cause of "unsupported operation: sendMessage"
+ * was missing entries in operationMap. These tests ensure they stay present.
+ *
+ * Tests:
+ * - All messaging operations are mapped
+ * - All notification operations are mapped
+ * - Map values follow the "category.snake_case" format
+ * - No duplicate values in the map
+ * - Critical operations that existed before are still present
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+
+// ─── Mock dependencies that integration-a2a-sdk needs ────────────────────────
+
+mock.module('@babylon/db', () => ({
+  db: {
+    select: mock(() => ({
+      from: mock(() => ({
+        where: mock(() => ({ limit: mock(async () => []) })),
+      })),
+    })),
+  },
+  eq: () => ({}),
+  users: { id: '' },
+}));
+
+mock.module('@elizaos/core', () => ({
+  ActionTimelineType: {},
+  ModelType: {},
+  composePromptFromState: mock(),
+  parseKeyValueXml: mock(),
+  generateText: mock(),
+}));
+
+mock.module('../../../agents/src/shared/logger', () => ({
+  logger: {
+    info: mock(),
+    warn: mock(),
+    error: mock(),
+    debug: mock(),
+  },
+}));
+
+mock.module('../../../agents/src/shared/snowflake', () => ({
+  generateSnowflakeId: mock(async () => 'test-id'),
+}));
+
+// ─── Import the module to access operationMap ────────────────────────────────
+
+// We need to read the file and extract the operationMap since it's not exported
+// Instead, we test via the actual module behavior
+// Let's read the file directly and check for the patterns
+
+import { readFileSync } from 'fs';
+
+const filePath =
+  '/home/dev/bab/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts';
+const fileContent = readFileSync(filePath, 'utf-8');
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('operationMap completeness', () => {
+  // ─── Messaging operations (Phase 1 additions) ────────────────────────
+
+  describe('messaging operations', () => {
+    test('sendMessage is mapped to messaging.send_message', () => {
+      expect(fileContent).toContain("sendMessage: 'messaging.send_message'");
+    });
+
+    test('getChatMessages is mapped to messaging.get_chat_messages', () => {
+      expect(fileContent).toContain(
+        "getChatMessages: 'messaging.get_chat_messages'"
+      );
+    });
+
+    test('getChats is mapped to messaging.get_chats', () => {
+      expect(fileContent).toContain("getChats: 'messaging.get_chats'");
+    });
+
+    test('createGroup is mapped to messaging.create_group', () => {
+      expect(fileContent).toContain("createGroup: 'messaging.create_group'");
+    });
+
+    test('leaveChat is mapped to messaging.leave_chat', () => {
+      expect(fileContent).toContain("leaveChat: 'messaging.leave_chat'");
+    });
+
+    test('getUnreadCount is mapped to messaging.get_unread_count', () => {
+      expect(fileContent).toContain(
+        "getUnreadCount: 'messaging.get_unread_count'"
+      );
+    });
+  });
+
+  // ─── Notification operations (Phase 1 additions) ─────────────────────
+
+  describe('notification operations', () => {
+    test('getNotifications is mapped', () => {
+      expect(fileContent).toContain('getNotifications:');
+    });
+
+    test('markNotificationsRead is mapped', () => {
+      expect(fileContent).toContain('markNotificationsRead:');
+    });
+
+    test('getGroupInvites is mapped', () => {
+      expect(fileContent).toContain('getGroupInvites:');
+    });
+
+    test('acceptGroupInvite is mapped', () => {
+      expect(fileContent).toContain('acceptGroupInvite:');
+    });
+
+    test('declineGroupInvite is mapped', () => {
+      expect(fileContent).toContain('declineGroupInvite:');
+    });
+  });
+
+  // ─── Pre-existing critical operations still present ──────────────────
+
+  describe('pre-existing operations', () => {
+    test('getBalance is mapped', () => {
+      expect(fileContent).toContain('getBalance:');
+    });
+
+    test('getPositions is mapped', () => {
+      expect(fileContent).toContain('getPositions:');
+    });
+
+    test('createPost is mapped', () => {
+      expect(fileContent).toContain('createPost:');
+    });
+
+    test('getPredictions is mapped', () => {
+      expect(fileContent).toContain('getPredictions:');
+    });
+
+    test('getPerpetuals is mapped', () => {
+      expect(fileContent).toContain('getPerpetuals:');
+    });
+  });
+
+  // ─── Format validation ───────────────────────────────────────────────
+
+  describe('operationMap format', () => {
+    test('all values follow category.snake_case format', () => {
+      // Extract all operationMap values
+      const mapBlock = fileContent.match(
+        /const operationMap[\s\S]*?=[\s\S]*?\{([\s\S]*?)\}\s*(?:as|;)/
+      );
+      expect(mapBlock).toBeTruthy();
+
+      if (mapBlock) {
+        const entries = mapBlock[1]!.match(/['"]([a-z_]+\.[a-z_]+)['"]/g);
+        expect(entries).toBeTruthy();
+        expect(entries!.length).toBeGreaterThan(20); // We expect 30+ mappings
+
+        // Every value should be category.operation format
+        for (const entry of entries!) {
+          const clean = entry.replace(/['"]/g, '');
+          expect(clean).toMatch(/^[a-z_]+\.[a-z_]+$/);
+        }
+      }
+    });
+
+    test('no duplicate values in the map', () => {
+      const mapBlock = fileContent.match(
+        /const operationMap[\s\S]*?=[\s\S]*?\{([\s\S]*?)\}\s*(?:as|;)/
+      );
+
+      if (mapBlock) {
+        const entries = mapBlock[1]!.match(/['"]([a-z_]+\.[a-z_]+)['"]/g) || [];
+        const values = entries.map((e) => e.replace(/['"]/g, ''));
+        const unique = new Set(values);
+        expect(values.length).toBe(unique.size);
+      }
+    });
+  });
+});

--- a/packages/testing/unit/agent-activity-provider.test.ts
+++ b/packages/testing/unit/agent-activity-provider.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Agent Activity Provider Tests
+ *
+ * Tests the coordinatorAgentActivityProvider that surfaces
+ * EventBus history for the coordinator's context window.
+ *
+ * Coverage:
+ * - Empty event history → returns empty string
+ * - Event formatting: timestamps, agent names, commands, responses
+ * - Truncation of long commands (100 chars) and responses (200 chars)
+ * - Missing fields: timestamp, agentUsername, command, response
+ * - agent.dispatch.result type: special formatting with ✓/✗
+ * - Other event types: generic JSON formatting
+ * - Caps at 10 events even when 20 fetched
+ */
+
+import { describe, expect, mock, test } from 'bun:test';
+import type { IAgentRuntime, Memory, State } from '@elizaos/core';
+
+// ─── Mock EventBus ───────────────────────────────────────────────────────────
+
+let mockHistory: Array<{
+  type: string;
+  data: Record<string, unknown>;
+  timestamp?: string;
+}> = [];
+
+mock.module('../../agents/src/communication/EventBus', () => ({
+  getEventBus: () => ({
+    getHistory: (_pattern: string, _limit: number) => mockHistory,
+  }),
+}));
+
+// ─── Import after mocks ──────────────────────────────────────────────────────
+
+const { coordinatorAgentActivityProvider } = await import(
+  '../../agents/src/plugins/plugin-user-core/src/providers/agent-activity'
+);
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const mockRuntime = {} as IAgentRuntime;
+const mockMessage = {} as Memory;
+const mockState = {} as State;
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('coordinatorAgentActivityProvider', () => {
+  test('returns empty string when no events exist', async () => {
+    mockHistory = [];
+
+    const result = await coordinatorAgentActivityProvider.get(
+      mockRuntime,
+      mockMessage,
+      mockState
+    );
+
+    expect(result.text).toBe('');
+  });
+
+  test('formats agent.dispatch.result events with ✓ for success', async () => {
+    mockHistory = [
+      {
+        type: 'agent.dispatch.result',
+        data: {
+          agentUsername: 'trader-bot',
+          command: 'buy OPENAGI',
+          response: 'Bought 100 shares',
+          success: true,
+          timestamp: '2025-06-15T10:30:00.000Z',
+        },
+        timestamp: '2025-06-15T10:30:00.000Z',
+      },
+    ];
+
+    const result = await coordinatorAgentActivityProvider.get(
+      mockRuntime,
+      mockMessage,
+      mockState
+    );
+
+    expect(result.text).toContain('## Recent Agent Activity');
+    expect(result.text).toContain('@trader-bot');
+    expect(result.text).toContain('✓');
+    expect(result.text).toContain('buy OPENAGI');
+    expect(result.text).toContain('Bought 100 shares');
+  });
+
+  test('formats agent.dispatch.result events with ✗ for failure', async () => {
+    mockHistory = [
+      {
+        type: 'agent.dispatch.result',
+        data: {
+          agentUsername: 'trader-bot',
+          command: 'buy NONEXIST',
+          response: 'Market not found',
+          success: false,
+          timestamp: '2025-06-15T10:30:00.000Z',
+        },
+        timestamp: '2025-06-15T10:30:00.000Z',
+      },
+    ];
+
+    const result = await coordinatorAgentActivityProvider.get(
+      mockRuntime,
+      mockMessage,
+      mockState
+    );
+
+    expect(result.text).toContain('✗');
+  });
+
+  test('falls back to agentId when agentUsername is missing', async () => {
+    mockHistory = [
+      {
+        type: 'agent.dispatch.result',
+        data: {
+          agentId: 'agent-xyz-123',
+          command: 'check balance',
+          response: 'Balance: $500',
+          success: true,
+          timestamp: '2025-06-15T10:30:00.000Z',
+        },
+        timestamp: '2025-06-15T10:30:00.000Z',
+      },
+    ];
+
+    const result = await coordinatorAgentActivityProvider.get(
+      mockRuntime,
+      mockMessage,
+      mockState
+    );
+
+    expect(result.text).toContain('@agent-xyz-123');
+  });
+
+  test('shows "unknown" when both agentUsername and agentId are missing', async () => {
+    mockHistory = [
+      {
+        type: 'agent.dispatch.result',
+        data: {
+          command: 'check',
+          response: 'OK',
+          success: true,
+          timestamp: '2025-06-15T10:30:00.000Z',
+        },
+        timestamp: '2025-06-15T10:30:00.000Z',
+      },
+    ];
+
+    const result = await coordinatorAgentActivityProvider.get(
+      mockRuntime,
+      mockMessage,
+      mockState
+    );
+
+    expect(result.text).toContain('@unknown');
+  });
+
+  test('truncates long commands to 100 chars', async () => {
+    mockHistory = [
+      {
+        type: 'agent.dispatch.result',
+        data: {
+          agentUsername: 'bot',
+          command: 'A'.repeat(200),
+          response: 'OK',
+          success: true,
+          timestamp: '2025-06-15T10:30:00.000Z',
+        },
+        timestamp: '2025-06-15T10:30:00.000Z',
+      },
+    ];
+
+    const result = await coordinatorAgentActivityProvider.get(
+      mockRuntime,
+      mockMessage,
+      mockState
+    );
+
+    // The 200-char command should be truncated to 100
+    const commandInOutput = result.text!.match(/"(.+?)"/)?.[1] ?? '';
+    expect(commandInOutput.length).toBeLessThanOrEqual(100);
+  });
+
+  test('truncates long responses to 200 chars', async () => {
+    mockHistory = [
+      {
+        type: 'agent.dispatch.result',
+        data: {
+          agentUsername: 'bot',
+          command: 'check',
+          response: 'R'.repeat(500),
+          success: true,
+          timestamp: '2025-06-15T10:30:00.000Z',
+        },
+        timestamp: '2025-06-15T10:30:00.000Z',
+      },
+    ];
+
+    const result = await coordinatorAgentActivityProvider.get(
+      mockRuntime,
+      mockMessage,
+      mockState
+    );
+
+    // The response slice is applied to the data.response field (200 chars)
+    // The formatted output includes the truncated response in quotes
+    // Verify the full 500-char response is NOT in the output
+    expect(result.text).not.toContain('R'.repeat(500));
+    // But truncated version should be
+    expect(result.text).toContain('R'.repeat(200));
+  });
+
+  test('handles non-string command gracefully', async () => {
+    mockHistory = [
+      {
+        type: 'agent.dispatch.result',
+        data: {
+          agentUsername: 'bot',
+          command: { action: 'buy' }, // Object, not string
+          response: 'OK',
+          success: true,
+          timestamp: '2025-06-15T10:30:00.000Z',
+        },
+        timestamp: '2025-06-15T10:30:00.000Z',
+      },
+    ];
+
+    const result = await coordinatorAgentActivityProvider.get(
+      mockRuntime,
+      mockMessage,
+      mockState
+    );
+
+    // Should not throw, command should be empty string
+    expect(result.text).toContain('bot');
+  });
+
+  test('handles non-string response gracefully', async () => {
+    mockHistory = [
+      {
+        type: 'agent.dispatch.result',
+        data: {
+          agentUsername: 'bot',
+          command: 'check',
+          response: null, // Not a string
+          success: true,
+          timestamp: '2025-06-15T10:30:00.000Z',
+        },
+        timestamp: '2025-06-15T10:30:00.000Z',
+      },
+    ];
+
+    const result = await coordinatorAgentActivityProvider.get(
+      mockRuntime,
+      mockMessage,
+      mockState
+    );
+
+    // Should not throw
+    expect(result.text).toContain('bot');
+  });
+
+  test('formats unknown event types with generic JSON', async () => {
+    mockHistory = [
+      {
+        type: 'agent.custom.event',
+        data: {
+          foo: 'bar',
+          timestamp: '2025-06-15T10:30:00.000Z',
+        },
+        timestamp: '2025-06-15T10:30:00.000Z',
+      },
+    ];
+
+    const result = await coordinatorAgentActivityProvider.get(
+      mockRuntime,
+      mockMessage,
+      mockState
+    );
+
+    expect(result.text).toContain('agent.custom.event');
+    expect(result.text).toContain('foo');
+  });
+
+  test('only formats last 10 events when more than 10 exist', async () => {
+    mockHistory = Array.from({ length: 15 }, (_, i) => ({
+      type: 'agent.dispatch.result',
+      data: {
+        agentUsername: `bot-${i}`,
+        command: `cmd-${i}`,
+        response: `res-${i}`,
+        success: true,
+        timestamp: `2025-06-15T10:${String(i).padStart(2, '0')}:00.000Z`,
+      },
+      timestamp: `2025-06-15T10:${String(i).padStart(2, '0')}:00.000Z`,
+    }));
+
+    const result = await coordinatorAgentActivityProvider.get(
+      mockRuntime,
+      mockMessage,
+      mockState
+    );
+
+    // Should show last 10 (indices 5-14)
+    expect(result.text).not.toContain('bot-0');
+    expect(result.text).not.toContain('bot-4');
+    expect(result.text).toContain('bot-5');
+    expect(result.text).toContain('bot-14');
+  });
+
+  test('uses ??:?? when timestamp cannot be determined', async () => {
+    mockHistory = [
+      {
+        type: 'agent.dispatch.result',
+        data: {
+          agentUsername: 'bot',
+          command: 'check',
+          response: 'OK',
+          success: true,
+          // No timestamp in data
+        },
+        // No event.timestamp either
+      },
+    ];
+
+    const result = await coordinatorAgentActivityProvider.get(
+      mockRuntime,
+      mockMessage,
+      mockState
+    );
+
+    expect(result.text).toContain('??:??');
+  });
+
+  test('defaults success to true when not specified', async () => {
+    mockHistory = [
+      {
+        type: 'agent.dispatch.result',
+        data: {
+          agentUsername: 'bot',
+          command: 'check',
+          response: 'OK',
+          // success not specified
+          timestamp: '2025-06-15T10:30:00.000Z',
+        },
+        timestamp: '2025-06-15T10:30:00.000Z',
+      },
+    ];
+
+    const result = await coordinatorAgentActivityProvider.get(
+      mockRuntime,
+      mockMessage,
+      mockState
+    );
+
+    expect(result.text).toContain('✓'); // Defaults to success
+  });
+});

--- a/packages/testing/unit/coordinator-orchestration/coordinator-route.test.ts
+++ b/packages/testing/unit/coordinator-orchestration/coordinator-route.test.ts
@@ -10,7 +10,7 @@
  * tests exercise real parsing paths.
  *
  * Coverage:
- * - maxDuration=60 is exported (Vercel timeout guard)
+ * - maxDuration=120 is exported (Vercel timeout guard — 120s for parallel multi-agent dispatch)
  * - Unsafe input returns 400 before auth or DB call
  * - Auth errors propagate without hitting LLM
  * - Rate limit exceeded returns 429 with Retry-After header
@@ -226,9 +226,9 @@ describe('POST /api/agents/team-chat/coordinator', () => {
   // ── maxDuration export ──────────────────────────────────────────────────
 
   describe('Vercel timeout guard', () => {
-    it('exports maxDuration = 60', () => {
+    it('exports maxDuration = 120', () => {
       const { maxDuration } = routeModule as { maxDuration?: number };
-      expect(maxDuration).toBe(60);
+      expect(maxDuration).toBe(120);
     });
   });
 

--- a/packages/testing/unit/coordinator-orchestration/dispatch-to-agents.test.ts
+++ b/packages/testing/unit/coordinator-orchestration/dispatch-to-agents.test.ts
@@ -1,0 +1,642 @@
+/**
+ * DISPATCH_TO_AGENTS & RELAY_TO_AGENT Action Tests
+ *
+ * Tests parallel multi-agent dispatch (Phase 3):
+ * - Parameter validation (dispatches array, required state fields)
+ * - Parallel execution with Promise.allSettled
+ * - Per-agent timeout enforcement (15s)
+ * - Result aggregation (success/failure counting)
+ * - Cap at 5 concurrent dispatches
+ * - validate() — requires ≥2 agents for DISPATCH_TO_AGENTS
+ * - RELAY_TO_AGENT context enrichment
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { IAgentRuntime, Memory, State } from '@elizaos/core';
+
+// ─── Mock dispatchAgentChat ──────────────────────────────────────────────────
+
+const mockDispatchAgentChat = mock(
+  async (params: {
+    agentId: string;
+    message: string;
+    ownerId: string;
+    teamChatId: string;
+    broadcastFn: unknown;
+  }) => ({
+    agentId: params.agentId,
+    agentUsername: `agent-${params.agentId}` as string | undefined,
+    success: true as boolean,
+    response: `Response from ${params.agentId}`,
+    actionsExecuted: 1,
+  })
+);
+
+mock.module('../../../agents/src/services/AgentChatService', () => ({
+  dispatchAgentChat: mockDispatchAgentChat,
+}));
+
+// ─── Import after mocks ──────────────────────────────────────────────────────
+
+const { dispatchToAgentsAction } = await import(
+  '../../../agents/src/plugins/plugin-user-core/src/actions/dispatch-to-agents'
+);
+
+const { relayToAgentAction } = await import(
+  '../../../agents/src/plugins/plugin-user-core/src/actions/relay-to-agent'
+);
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const mockRuntime = {} as IAgentRuntime;
+const mockMessage = {} as Memory;
+const mockBroadcastFn = mock(async () => {});
+
+function makeState(overrides: Record<string, unknown> = {}): State {
+  const has = (key: string) => key in overrides;
+  return {
+    data: {
+      actionParams: has('actionParams')
+        ? overrides.actionParams
+        : {
+            dispatches: [
+              { agentId: 'agent-a', command: 'check positions' },
+              { agentId: 'agent-b', command: 'analyze trends' },
+            ],
+          },
+      broadcastFn: has('broadcastFn') ? overrides.broadcastFn : mockBroadcastFn,
+      teamMembers: has('teamMembers')
+        ? overrides.teamMembers
+        : [{ isAgent: true }, { isAgent: true }, { isAgent: false }],
+    },
+    values: {
+      ownerId: has('ownerId') ? overrides.ownerId : 'owner-001',
+      teamChatId: has('teamChatId') ? overrides.teamChatId : 'team-chat-001',
+      ownerName: has('ownerName') ? overrides.ownerName : 'Alice',
+      ownerUsername: has('ownerUsername') ? overrides.ownerUsername : 'alice',
+    },
+  } as unknown as State;
+}
+
+// ─── DISPATCH_TO_AGENTS Tests ────────────────────────────────────────────────
+
+describe('dispatchToAgentsAction', () => {
+  beforeEach(() => {
+    mockDispatchAgentChat.mockClear();
+    mockDispatchAgentChat.mockImplementation(
+      async (params: { agentId: string; message: string }) => ({
+        agentId: params.agentId,
+        agentUsername: `agent-${params.agentId}`,
+        success: true,
+        response: `Response from ${params.agentId}`,
+        actionsExecuted: 1,
+      })
+    );
+  });
+
+  // ─── validate ────────────────────────────────────────────────────────
+
+  describe('validate', () => {
+    test('returns true when team has ≥2 agents', async () => {
+      const state = makeState();
+      const result = await dispatchToAgentsAction.validate!(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+      expect(result).toBe(true);
+    });
+
+    test('returns false when team has only 1 agent', async () => {
+      const state = makeState({
+        teamMembers: [{ isAgent: true }, { isAgent: false }],
+      });
+      const result = await dispatchToAgentsAction.validate!(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+      expect(result).toBe(false);
+    });
+
+    test('returns false when team has no agents', async () => {
+      const state = makeState({
+        teamMembers: [{ isAgent: false }],
+      });
+      const result = await dispatchToAgentsAction.validate!(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+      expect(result).toBe(false);
+    });
+
+    test('returns false when teamMembers is undefined', async () => {
+      const state = { data: {}, values: {} } as unknown as State;
+      const result = await dispatchToAgentsAction.validate!(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+      expect(result).toBe(false);
+    });
+  });
+
+  // ─── handler ─────────────────────────────────────────────────────────
+
+  describe('handler', () => {
+    test('returns error when dispatches array is missing', async () => {
+      const state = makeState({ actionParams: {} });
+
+      const result = await dispatchToAgentsAction.handler(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+
+      expect(result!.success).toBe(false);
+      expect(result!.text).toContain('Missing required parameters');
+    });
+
+    test('returns error when dispatches is empty array', async () => {
+      const state = makeState({ actionParams: { dispatches: [] } });
+
+      const result = await dispatchToAgentsAction.handler(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+
+      expect(result!.success).toBe(false);
+    });
+
+    test('returns error when ownerId is missing', async () => {
+      const state = makeState({ ownerId: undefined });
+
+      const result = await dispatchToAgentsAction.handler(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+
+      expect(result!.success).toBe(false);
+    });
+
+    test('returns error when broadcastFn is missing', async () => {
+      const state = makeState({ broadcastFn: undefined });
+
+      const result = await dispatchToAgentsAction.handler(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+
+      expect(result!.success).toBe(false);
+    });
+
+    test('returns error when teamChatId is missing', async () => {
+      const state = makeState({ teamChatId: undefined });
+
+      const result = await dispatchToAgentsAction.handler(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+
+      expect(result!.success).toBe(false);
+    });
+
+    test('filters out invalid dispatch entries', async () => {
+      const state = makeState({
+        actionParams: {
+          dispatches: [
+            { agentId: '', command: 'valid command' }, // empty agentId
+            { agentId: 'agent-a', command: '' }, // empty command
+            { agentId: 'agent-b', command: 'valid command' }, // valid
+          ],
+        },
+      });
+
+      const result = await dispatchToAgentsAction.handler(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+
+      // Only 1 valid dispatch
+      expect(mockDispatchAgentChat).toHaveBeenCalledTimes(1);
+      expect(result!.success).toBe(true);
+    });
+
+    test('returns error when ALL dispatch entries are invalid', async () => {
+      const state = makeState({
+        actionParams: {
+          dispatches: [
+            { agentId: '', command: '' },
+            { agentId: null, command: null },
+          ],
+        },
+      });
+
+      const result = await dispatchToAgentsAction.handler(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+
+      expect(result!.success).toBe(false);
+      expect(result!.text).toContain('No valid dispatch entries');
+    });
+
+    test('dispatches to multiple agents in parallel', async () => {
+      const state = makeState();
+
+      const result = await dispatchToAgentsAction.handler(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+
+      expect(mockDispatchAgentChat).toHaveBeenCalledTimes(2);
+      expect(result!.success).toBe(true);
+      expect(result!.text).toContain('2 agents');
+      expect(result!.text).toContain('2 succeeded');
+    });
+
+    test('caps at 5 concurrent dispatches', async () => {
+      const dispatches = Array.from({ length: 8 }, (_, i) => ({
+        agentId: `agent-${i}`,
+        command: `task ${i}`,
+      }));
+
+      const state = makeState({ actionParams: { dispatches } });
+
+      await dispatchToAgentsAction.handler(mockRuntime, mockMessage, state);
+
+      // Should only dispatch to first 5
+      expect(mockDispatchAgentChat).toHaveBeenCalledTimes(5);
+    });
+
+    test('handles partial failure (some agents succeed, some fail)', async () => {
+      let callCount = 0;
+      mockDispatchAgentChat.mockImplementation(
+        async (params: { agentId: string }) => {
+          callCount++;
+          if (callCount === 1) {
+            throw new Error('Agent unavailable');
+          }
+          return {
+            agentId: params.agentId,
+            agentUsername: 'agent-b',
+            success: true,
+            response: 'Success response',
+            actionsExecuted: 1,
+          };
+        }
+      );
+
+      const state = makeState();
+
+      const result = await dispatchToAgentsAction.handler(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+
+      expect(result!.success).toBe(true); // At least one succeeded
+      expect(result!.text).toContain('1 succeeded');
+      expect(result!.values?.successCount).toBe(1);
+      expect(result!.values?.totalCount).toBe(2);
+    });
+
+    test('handles all agents failing', async () => {
+      mockDispatchAgentChat.mockImplementation(async () => {
+        throw new Error('Service down');
+      });
+
+      const state = makeState();
+
+      const result = await dispatchToAgentsAction.handler(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+
+      expect(result!.success).toBe(false);
+      expect(result!.values?.successCount).toBe(0);
+    });
+
+    test('handles agent returning failure result (not throwing)', async () => {
+      mockDispatchAgentChat.mockImplementation(
+        async (params: { agentId: string }) => ({
+          agentId: params.agentId,
+          agentUsername: 'agent-a',
+          success: false,
+          response: '',
+          actionsExecuted: 0,
+          error: 'Agent is offline',
+        })
+      );
+
+      const state = makeState({
+        actionParams: {
+          dispatches: [{ agentId: 'agent-a', command: 'check' }],
+        },
+      });
+
+      const result = await dispatchToAgentsAction.handler(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+
+      // fulfilled but success: false → still "fulfilled" from Promise.allSettled perspective
+      // The result mapping takes the return value's success field
+      expect(result!.success).toBe(false);
+    });
+
+    test('truncates long agent responses in summary', async () => {
+      mockDispatchAgentChat.mockImplementation(
+        async (params: { agentId: string }) => ({
+          agentId: params.agentId,
+          agentUsername: 'agent-a',
+          success: true,
+          response: 'A'.repeat(500), // Very long response
+          actionsExecuted: 1,
+        })
+      );
+
+      const state = makeState({
+        actionParams: {
+          dispatches: [{ agentId: 'agent-a', command: 'check' }],
+        },
+      });
+
+      const result = await dispatchToAgentsAction.handler(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+
+      // Response truncated to 300 chars in summary
+      expect(result!.text!.length).toBeLessThan(500);
+    });
+
+    test('uses agentId as label when agentUsername is missing', async () => {
+      mockDispatchAgentChat.mockImplementation(
+        async (params: { agentId: string }) => ({
+          agentId: params.agentId,
+          agentUsername: undefined,
+          success: true,
+          response: 'Result',
+          actionsExecuted: 1,
+        })
+      );
+
+      const state = makeState({
+        actionParams: {
+          dispatches: [{ agentId: 'my-agent-xyz', command: 'check' }],
+        },
+      });
+
+      const result = await dispatchToAgentsAction.handler(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+
+      expect(result!.text).toContain('my-agent-xyz');
+    });
+  });
+});
+
+// ─── RELAY_TO_AGENT Tests ────────────────────────────────────────────────────
+
+describe('relayToAgentAction', () => {
+  beforeEach(() => {
+    mockDispatchAgentChat.mockClear();
+    mockDispatchAgentChat.mockImplementation(
+      async (params: { agentId: string }) => ({
+        agentId: params.agentId,
+        agentUsername: `agent-${params.agentId}`,
+        success: true,
+        response: 'Executed successfully',
+        actionsExecuted: 2,
+      })
+    );
+  });
+
+  // ─── validate ────────────────────────────────────────────────────────
+
+  describe('validate', () => {
+    test('returns true when team has at least 1 agent', async () => {
+      const state = makeState({
+        teamMembers: [{ isAgent: true }, { isAgent: false }],
+      });
+      const result = await relayToAgentAction.validate!(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+      expect(result).toBe(true);
+    });
+
+    test('returns false when team has no agents', async () => {
+      const state = makeState({
+        teamMembers: [{ isAgent: false }],
+      });
+      const result = await relayToAgentAction.validate!(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+      expect(result).toBe(false);
+    });
+  });
+
+  // ─── handler ─────────────────────────────────────────────────────────
+
+  describe('handler', () => {
+    test('returns error when agentId is missing', async () => {
+      const state = makeState({
+        actionParams: { command: 'buy TSLAI' },
+      });
+
+      const result = await relayToAgentAction.handler(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+
+      expect(result!.success).toBe(false);
+      expect(result!.text).toContain('Missing required parameters');
+    });
+
+    test('returns error when command is missing', async () => {
+      const state = makeState({
+        actionParams: { agentId: 'agent-a' },
+      });
+
+      const result = await relayToAgentAction.handler(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+
+      expect(result!.success).toBe(false);
+    });
+
+    test('dispatches with enriched context when relayContext provided', async () => {
+      const state = makeState({
+        actionParams: {
+          agentId: 'agent-trader',
+          command: 'execute the best trade',
+          relayContext:
+            'Agent A found: OPENAGI trending up. Agent B found: Volume increasing.',
+        },
+      });
+
+      const result = await relayToAgentAction.handler(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+
+      expect(result!.success).toBe(true);
+      // Verify the enriched command was passed
+      const dispatchCall = mockDispatchAgentChat.mock.calls[0]![0] as Record<
+        string,
+        unknown
+      >;
+      const message = dispatchCall.message as string;
+      expect(message).toContain('--- Context from other agents ---');
+      expect(message).toContain('Agent A found: OPENAGI trending up');
+      expect(message).toContain('--- End context ---');
+      expect(message).toContain('Your task: execute the best trade');
+    });
+
+    test('dispatches plain command when relayContext is undefined', async () => {
+      const state = makeState({
+        actionParams: {
+          agentId: 'agent-trader',
+          command: 'check positions',
+          relayContext: undefined,
+        },
+      });
+
+      const result = await relayToAgentAction.handler(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+
+      expect(result!.success).toBe(true);
+      const dispatchCall = mockDispatchAgentChat.mock.calls[0]![0] as Record<
+        string,
+        unknown
+      >;
+      const message = dispatchCall.message as string;
+      expect(message).toBe('check positions');
+      expect(message).not.toContain('Context from other agents');
+    });
+
+    test('dispatches plain command when relayContext is empty string', async () => {
+      const state = makeState({
+        actionParams: {
+          agentId: 'agent-trader',
+          command: 'check positions',
+          relayContext: '',
+        },
+      });
+
+      await relayToAgentAction.handler(mockRuntime, mockMessage, state);
+
+      // Empty relayContext is falsy, so it should use plain command
+      const dispatchCall = mockDispatchAgentChat.mock.calls[0]![0] as Record<
+        string,
+        unknown
+      >;
+      const message = dispatchCall.message as string;
+      expect(message).toBe('check positions');
+    });
+
+    test('returns failure when dispatch fails', async () => {
+      mockDispatchAgentChat.mockImplementation(async () => ({
+        agentId: 'agent-trader',
+        agentUsername: 'trader',
+        success: false,
+        response: '',
+        actionsExecuted: 0,
+        error: 'Agent offline',
+      }));
+
+      const state = makeState({
+        actionParams: {
+          agentId: 'agent-trader',
+          command: 'buy TSLAI',
+        },
+      });
+
+      const result = await relayToAgentAction.handler(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+
+      expect(result!.success).toBe(false);
+      expect(result!.text).toContain('Failed to relay');
+      expect(result!.text).toContain('Agent offline');
+    });
+
+    test('returns success with agent response details', async () => {
+      const state = makeState({
+        actionParams: {
+          agentId: 'agent-trader',
+          command: 'buy TSLAI',
+          relayContext: 'Research says buy',
+        },
+      });
+
+      const result = await relayToAgentAction.handler(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+
+      expect(result!.success).toBe(true);
+      expect(result!.text).toContain('Relayed to');
+      expect(result!.values?.dispatchedCommand).toBe('buy TSLAI');
+      expect(result!.values?.relayContext).toBe('Research says buy');
+      expect(result!.values?.actionsExecuted).toBe(2);
+    });
+
+    test('truncates long agent response in summary text', async () => {
+      mockDispatchAgentChat.mockImplementation(
+        async (params: { agentId: string }) => ({
+          agentId: params.agentId,
+          agentUsername: 'trader',
+          success: true,
+          response: 'R'.repeat(500),
+          actionsExecuted: 1,
+        })
+      );
+
+      const state = makeState({
+        actionParams: {
+          agentId: 'agent-trader',
+          command: 'check',
+        },
+      });
+
+      const result = await relayToAgentAction.handler(
+        mockRuntime,
+        mockMessage,
+        state
+      );
+
+      // Response truncated to 300 chars in the text
+      const quoteContent = result!.text!.match(/"(.+?)"/)?.[1] ?? '';
+      expect(quoteContent.length).toBeLessThanOrEqual(300);
+    });
+  });
+});

--- a/packages/testing/unit/manage-price-alerts.test.ts
+++ b/packages/testing/unit/manage-price-alerts.test.ts
@@ -1,0 +1,590 @@
+/**
+ * Manage Price Alerts Action Tests
+ *
+ * Tests SET_PRICE_ALERT, LIST_PRICE_ALERTS, REMOVE_PRICE_ALERT actions:
+ * - Parameter validation and error handling
+ * - Create vs update logic (deduplication by tokenSymbol+condition)
+ * - Token symbol uppercasing
+ * - Cooldown reset on update
+ * - List formatting (enabled/disabled, lastTriggeredAt)
+ * - Removal by alertId vs tokenSymbol+condition
+ * - Edge cases: empty arrays, missing config, invalid inputs
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { IAgentRuntime, Memory, State } from '@elizaos/core';
+
+// ─── Mock Setup ──────────────────────────────────────────────────────────────
+
+let mockDbSelectLimit: ReturnType<typeof mock>;
+let mockDbSelectWhere: ReturnType<typeof mock>;
+let mockDbSelectFrom: ReturnType<typeof mock>;
+let mockDbSelect: ReturnType<typeof mock>;
+let mockDbUpdateWhere: ReturnType<typeof mock>;
+let mockDbUpdateSet: ReturnType<typeof mock>;
+let mockDbUpdate: ReturnType<typeof mock>;
+
+function resetDbMocks() {
+  mockDbSelectLimit = mock(async () => []);
+  mockDbSelectWhere = mock(() => ({ limit: mockDbSelectLimit }));
+  mockDbSelectFrom = mock(() => ({ where: mockDbSelectWhere }));
+  mockDbSelect = mock(() => ({ from: mockDbSelectFrom }));
+  mockDbUpdateWhere = mock(async () => []);
+  mockDbUpdateSet = mock(() => ({ where: mockDbUpdateWhere }));
+  mockDbUpdate = mock(() => ({ set: mockDbUpdateSet }));
+}
+
+resetDbMocks();
+
+mock.module('@babylon/db', () => ({
+  db: {
+    get select() {
+      return mockDbSelect;
+    },
+    get update() {
+      return mockDbUpdate;
+    },
+  },
+  eq: (a: unknown, b: unknown) => ({ op: 'eq', a, b }),
+  and: (...args: unknown[]) => ({ op: 'and', args }),
+  count: () => 'count',
+  userAgentConfigs: {
+    id: 'userAgentConfigs.id',
+    userId: 'userAgentConfigs.userId',
+    priceAlerts: 'userAgentConfigs.priceAlerts',
+  },
+}));
+
+const mockGenerateSnowflakeId = mock(async () => 'snowflake-new-alert');
+
+mock.module('../../agents/src/shared/snowflake', () => ({
+  generateSnowflakeId: mockGenerateSnowflakeId,
+}));
+
+mock.module('../../agents/src/shared/logger', () => ({
+  logger: {
+    info: mock(),
+    warn: mock(),
+    error: mock(),
+    debug: mock(),
+  },
+}));
+
+// ─── Import after mocks ──────────────────────────────────────────────────────
+
+const { setPriceAlertAction, listPriceAlertsAction, removePriceAlertAction } =
+  await import(
+    '../../agents/src/plugins/plugin-agent-core/src/actions/manage-price-alerts'
+  );
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const mockRuntime = { agentId: 'agent-001' } as unknown as IAgentRuntime;
+const mockMessage = { content: { text: 'test' } } as unknown as Memory;
+
+function makeState(actionParams: Record<string, unknown>): State {
+  return { data: { actionParams } } as unknown as State;
+}
+
+function makeAlert(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'alert-001',
+    tokenSymbol: 'OPENAGI',
+    condition: 'below',
+    threshold: 1.0,
+    deliveryChannel: 'team_chat',
+    deliveryChatId: undefined,
+    enabled: true,
+    lastTriggeredAt: undefined,
+    cooldownMinutes: 15,
+    createdAt: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// ─── SET_PRICE_ALERT ─────────────────────────────────────────────────────────
+
+describe('setPriceAlertAction', () => {
+  beforeEach(() => {
+    resetDbMocks();
+    mockGenerateSnowflakeId.mockClear();
+    mockGenerateSnowflakeId.mockResolvedValue('snowflake-new-alert');
+  });
+
+  test('returns error when actionParams is missing', async () => {
+    const result = await setPriceAlertAction.handler(mockRuntime, mockMessage, {
+      data: {},
+    } as unknown as State);
+    expect(result!.success).toBe(false);
+    expect(result!.text).toContain('Missing parameters');
+  });
+
+  test('returns error when tokenSymbol is missing', async () => {
+    const result = await setPriceAlertAction.handler(
+      mockRuntime,
+      mockMessage,
+      makeState({ condition: 'below', threshold: 1.0 })
+    );
+    expect(result!.success).toBe(false);
+    expect(result!.text).toContain('Missing required parameters');
+  });
+
+  test('returns error when condition is invalid', async () => {
+    const result = await setPriceAlertAction.handler(
+      mockRuntime,
+      mockMessage,
+      makeState({ tokenSymbol: 'OPENAGI', condition: 'around', threshold: 1.0 })
+    );
+    expect(result!.success).toBe(false);
+    expect(result!.text).toContain('must be "above" or "below"');
+  });
+
+  test('returns error when threshold is zero', async () => {
+    const result = await setPriceAlertAction.handler(
+      mockRuntime,
+      mockMessage,
+      makeState({ tokenSymbol: 'OPENAGI', condition: 'below', threshold: 0 })
+    );
+    expect(result!.success).toBe(false);
+    expect(result!.text).toContain('positive number');
+  });
+
+  test('returns error when threshold is negative', async () => {
+    const result = await setPriceAlertAction.handler(
+      mockRuntime,
+      mockMessage,
+      makeState({ tokenSymbol: 'OPENAGI', condition: 'below', threshold: -5.0 })
+    );
+    expect(result!.success).toBe(false);
+  });
+
+  test('returns error when threshold is not a number', async () => {
+    const result = await setPriceAlertAction.handler(
+      mockRuntime,
+      mockMessage,
+      makeState({
+        tokenSymbol: 'OPENAGI',
+        condition: 'below',
+        threshold: 'one dollar',
+      })
+    );
+    expect(result!.success).toBe(false);
+  });
+
+  test('returns error when deliveryChannel=group but no deliveryChatId', async () => {
+    mockDbSelectLimit.mockResolvedValueOnce([{ id: 'cfg-1', priceAlerts: [] }]);
+
+    const result = await setPriceAlertAction.handler(
+      mockRuntime,
+      mockMessage,
+      makeState({
+        tokenSymbol: 'OPENAGI',
+        condition: 'below',
+        threshold: 1.0,
+        deliveryChannel: 'group',
+      })
+    );
+    expect(result!.success).toBe(false);
+    expect(result!.text).toContain('deliveryChatId is required');
+  });
+
+  test('returns error when agent config not found', async () => {
+    mockDbSelectLimit.mockResolvedValueOnce([]); // No config
+
+    const result = await setPriceAlertAction.handler(
+      mockRuntime,
+      mockMessage,
+      makeState({
+        tokenSymbol: 'OPENAGI',
+        condition: 'below',
+        threshold: 1.0,
+      })
+    );
+    expect(result!.success).toBe(false);
+    expect(result!.text).toContain('configuration not found');
+  });
+
+  test('creates new alert with defaults', async () => {
+    mockDbSelectLimit.mockResolvedValueOnce([{ id: 'cfg-1', priceAlerts: [] }]);
+
+    const result = await setPriceAlertAction.handler(
+      mockRuntime,
+      mockMessage,
+      makeState({
+        tokenSymbol: 'openagi', // lowercase — should be uppercased
+        condition: 'below',
+        threshold: 1.0,
+      })
+    );
+
+    expect(result!.success).toBe(true);
+    expect(result!.text).toContain('OPENAGI'); // Uppercased
+    expect(result!.text).toContain('below');
+    expect(result!.text).toContain('team_chat'); // Default delivery
+    expect(result!.data?.created).toBe(true);
+
+    // Verify DB update was called
+    expect(mockDbUpdateSet).toHaveBeenCalledTimes(1);
+    const setArg = mockDbUpdateSet.mock.calls[0]![0] as Record<string, unknown>;
+    const alerts = setArg.priceAlerts as Array<Record<string, unknown>>;
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]!.tokenSymbol).toBe('OPENAGI');
+    expect(alerts[0]!.cooldownMinutes).toBe(15); // Default
+  });
+
+  test('creates alert with custom cooldown and group delivery', async () => {
+    mockDbSelectLimit.mockResolvedValueOnce([{ id: 'cfg-1', priceAlerts: [] }]);
+
+    const result = await setPriceAlertAction.handler(
+      mockRuntime,
+      mockMessage,
+      makeState({
+        tokenSymbol: 'TSLAI',
+        condition: 'above',
+        threshold: 2.0,
+        deliveryChannel: 'group',
+        deliveryChatId: 'group-chat-999',
+        cooldownMinutes: 30,
+      })
+    );
+
+    expect(result!.success).toBe(true);
+    const setArg = mockDbUpdateSet.mock.calls[0]![0] as Record<string, unknown>;
+    const alerts = setArg.priceAlerts as Array<Record<string, unknown>>;
+    expect(alerts[0]!.deliveryChannel).toBe('group');
+    expect(alerts[0]!.deliveryChatId).toBe('group-chat-999');
+    expect(alerts[0]!.cooldownMinutes).toBe(30);
+  });
+
+  test('updates existing alert with same tokenSymbol+condition', async () => {
+    const existingAlert = makeAlert({
+      id: 'existing-alert',
+      tokenSymbol: 'OPENAGI',
+      condition: 'below',
+      threshold: 0.5,
+      lastTriggeredAt: '2025-01-01T00:00:00.000Z',
+    });
+
+    mockDbSelectLimit.mockResolvedValueOnce([
+      { id: 'cfg-1', priceAlerts: [existingAlert] },
+    ]);
+
+    const result = await setPriceAlertAction.handler(
+      mockRuntime,
+      mockMessage,
+      makeState({
+        tokenSymbol: 'OPENAGI',
+        condition: 'below',
+        threshold: 0.8, // New threshold
+      })
+    );
+
+    expect(result!.success).toBe(true);
+    expect(result!.data?.updated).toBe(true);
+
+    const setArg = mockDbUpdateSet.mock.calls[0]![0] as Record<string, unknown>;
+    const alerts = setArg.priceAlerts as Array<Record<string, unknown>>;
+    expect(alerts).toHaveLength(1); // Still 1 alert (updated, not added)
+    expect(alerts[0]!.threshold).toBe(0.8);
+    expect(alerts[0]!.lastTriggeredAt).toBeUndefined(); // Reset on update
+    expect(alerts[0]!.enabled).toBe(true); // Re-enabled on update
+  });
+
+  test('preserves other alerts when updating one', async () => {
+    const alerts = [
+      makeAlert({ id: 'a1', tokenSymbol: 'OPENAGI', condition: 'below' }),
+      makeAlert({ id: 'a2', tokenSymbol: 'TSLAI', condition: 'above' }),
+    ];
+
+    mockDbSelectLimit.mockResolvedValueOnce([
+      { id: 'cfg-1', priceAlerts: alerts },
+    ]);
+
+    await setPriceAlertAction.handler(
+      mockRuntime,
+      mockMessage,
+      makeState({
+        tokenSymbol: 'OPENAGI',
+        condition: 'below',
+        threshold: 2.0,
+      })
+    );
+
+    const setArg = mockDbUpdateSet.mock.calls[0]![0] as Record<string, unknown>;
+    const updatedAlerts = setArg.priceAlerts as Array<Record<string, unknown>>;
+    expect(updatedAlerts).toHaveLength(2);
+    expect(updatedAlerts.find((a) => a.id === 'a2')!.threshold).toBe(1.0); // Unchanged
+  });
+
+  test('accepts very small positive threshold', async () => {
+    mockDbSelectLimit.mockResolvedValueOnce([{ id: 'cfg-1', priceAlerts: [] }]);
+
+    const result = await setPriceAlertAction.handler(
+      mockRuntime,
+      mockMessage,
+      makeState({
+        tokenSymbol: 'MICRO',
+        condition: 'below',
+        threshold: 0.000001,
+      })
+    );
+
+    expect(result!.success).toBe(true);
+  });
+});
+
+// ─── LIST_PRICE_ALERTS ───────────────────────────────────────────────────────
+
+describe('listPriceAlertsAction', () => {
+  beforeEach(() => {
+    resetDbMocks();
+  });
+
+  test('returns message when no alerts configured', async () => {
+    mockDbSelectLimit.mockResolvedValueOnce([{ priceAlerts: [] }]);
+
+    const result = await listPriceAlertsAction.handler(
+      mockRuntime,
+      mockMessage
+    );
+
+    expect(result!.success).toBe(true);
+    expect(result!.text).toContain('No price alerts configured');
+    expect(result!.data?.alerts).toEqual([]);
+  });
+
+  test('returns message when config has null priceAlerts', async () => {
+    mockDbSelectLimit.mockResolvedValueOnce([{ priceAlerts: null }]);
+
+    const result = await listPriceAlertsAction.handler(
+      mockRuntime,
+      mockMessage
+    );
+
+    expect(result!.success).toBe(true);
+    expect(result!.text).toContain('No price alerts configured');
+  });
+
+  test('returns message when no config exists', async () => {
+    mockDbSelectLimit.mockResolvedValueOnce([]);
+
+    const result = await listPriceAlertsAction.handler(
+      mockRuntime,
+      mockMessage
+    );
+
+    expect(result!.success).toBe(true);
+    expect(result!.text).toContain('No price alerts');
+  });
+
+  test('lists alerts with status indicators', async () => {
+    const alerts = [
+      makeAlert({
+        id: 'a1',
+        enabled: true,
+        tokenSymbol: 'OPENAGI',
+        condition: 'below',
+        threshold: 1.0,
+      }),
+      makeAlert({
+        id: 'a2',
+        enabled: false,
+        tokenSymbol: 'TSLAI',
+        condition: 'above',
+        threshold: 2.0,
+      }),
+    ];
+
+    mockDbSelectLimit.mockResolvedValueOnce([{ priceAlerts: alerts }]);
+
+    const result = await listPriceAlertsAction.handler(
+      mockRuntime,
+      mockMessage
+    );
+
+    expect(result!.success).toBe(true);
+    expect(result!.text).toContain('2)'); // Count
+    expect(result!.text).toContain('[✓]'); // Enabled
+    expect(result!.text).toContain('[✗]'); // Disabled
+    expect(result!.text).toContain('OPENAGI');
+    expect(result!.text).toContain('TSLAI');
+    expect(result!.data?.alerts).toHaveLength(2);
+  });
+
+  test('shows lastTriggeredAt when present', async () => {
+    const alerts = [makeAlert({ lastTriggeredAt: '2025-06-15T10:30:00.000Z' })];
+
+    mockDbSelectLimit.mockResolvedValueOnce([{ priceAlerts: alerts }]);
+
+    const result = await listPriceAlertsAction.handler(
+      mockRuntime,
+      mockMessage
+    );
+
+    expect(result!.text).toContain('last triggered');
+  });
+});
+
+// ─── REMOVE_PRICE_ALERT ──────────────────────────────────────────────────────
+
+describe('removePriceAlertAction', () => {
+  beforeEach(() => {
+    resetDbMocks();
+  });
+
+  test('returns error when no params provided', async () => {
+    const result = await removePriceAlertAction.handler(
+      mockRuntime,
+      mockMessage,
+      { data: {} } as unknown as State
+    );
+    expect(result!.success).toBe(false);
+  });
+
+  test('returns error when neither alertId nor tokenSymbol provided', async () => {
+    const result = await removePriceAlertAction.handler(
+      mockRuntime,
+      mockMessage,
+      makeState({})
+    );
+    expect(result!.success).toBe(false);
+    expect(result!.text).toContain('alertId or tokenSymbol');
+  });
+
+  test('removes alert by alertId', async () => {
+    const alerts = [
+      makeAlert({ id: 'a1' }),
+      makeAlert({ id: 'a2', tokenSymbol: 'TSLAI' }),
+    ];
+
+    mockDbSelectLimit.mockResolvedValueOnce([
+      { id: 'cfg-1', priceAlerts: alerts },
+    ]);
+
+    const result = await removePriceAlertAction.handler(
+      mockRuntime,
+      mockMessage,
+      makeState({ alertId: 'a1' })
+    );
+
+    expect(result!.success).toBe(true);
+    expect(result!.text).toContain('Removed price alert');
+    expect(result!.text).toContain('OPENAGI');
+
+    // Verify only a2 remains
+    const setArg = mockDbUpdateSet.mock.calls[0]![0] as Record<string, unknown>;
+    const remaining = setArg.priceAlerts as Array<Record<string, unknown>>;
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]!.id).toBe('a2');
+  });
+
+  test('removes alert by tokenSymbol (case-insensitive)', async () => {
+    const alerts = [
+      makeAlert({ id: 'a1', tokenSymbol: 'OPENAGI', condition: 'below' }),
+    ];
+
+    mockDbSelectLimit.mockResolvedValueOnce([
+      { id: 'cfg-1', priceAlerts: alerts },
+    ]);
+
+    const result = await removePriceAlertAction.handler(
+      mockRuntime,
+      mockMessage,
+      makeState({ tokenSymbol: 'openagi' }) // lowercase
+    );
+
+    expect(result!.success).toBe(true);
+  });
+
+  test('removes alert by tokenSymbol + condition', async () => {
+    const alerts = [
+      makeAlert({ id: 'a1', tokenSymbol: 'OPENAGI', condition: 'below' }),
+      makeAlert({ id: 'a2', tokenSymbol: 'OPENAGI', condition: 'above' }),
+    ];
+
+    mockDbSelectLimit.mockResolvedValueOnce([
+      { id: 'cfg-1', priceAlerts: alerts },
+    ]);
+
+    const result = await removePriceAlertAction.handler(
+      mockRuntime,
+      mockMessage,
+      makeState({ tokenSymbol: 'OPENAGI', condition: 'above' })
+    );
+
+    expect(result!.success).toBe(true);
+    const setArg = mockDbUpdateSet.mock.calls[0]![0] as Record<string, unknown>;
+    const remaining = setArg.priceAlerts as Array<Record<string, unknown>>;
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]!.id).toBe('a1'); // 'below' alert preserved
+  });
+
+  test('returns error when alert not found by alertId', async () => {
+    const alerts = [makeAlert({ id: 'a1' })];
+
+    mockDbSelectLimit.mockResolvedValueOnce([
+      { id: 'cfg-1', priceAlerts: alerts },
+    ]);
+
+    const result = await removePriceAlertAction.handler(
+      mockRuntime,
+      mockMessage,
+      makeState({ alertId: 'nonexistent' })
+    );
+
+    expect(result!.success).toBe(false);
+    expect(result!.text).toContain('No matching price alert');
+  });
+
+  test('returns error when alert not found by tokenSymbol', async () => {
+    const alerts = [makeAlert({ id: 'a1', tokenSymbol: 'OPENAGI' })];
+
+    mockDbSelectLimit.mockResolvedValueOnce([
+      { id: 'cfg-1', priceAlerts: alerts },
+    ]);
+
+    const result = await removePriceAlertAction.handler(
+      mockRuntime,
+      mockMessage,
+      makeState({ tokenSymbol: 'NONEXISTENT' })
+    );
+
+    expect(result!.success).toBe(false);
+  });
+
+  test('returns error when config not found', async () => {
+    mockDbSelectLimit.mockResolvedValueOnce([]); // No config
+
+    const result = await removePriceAlertAction.handler(
+      mockRuntime,
+      mockMessage,
+      makeState({ alertId: 'a1' })
+    );
+
+    expect(result!.success).toBe(false);
+    expect(result!.text).toContain('configuration not found');
+  });
+
+  test('removes first matching alert when no condition specified', async () => {
+    const alerts = [
+      makeAlert({ id: 'a1', tokenSymbol: 'OPENAGI', condition: 'below' }),
+      makeAlert({ id: 'a2', tokenSymbol: 'OPENAGI', condition: 'above' }),
+    ];
+
+    mockDbSelectLimit.mockResolvedValueOnce([
+      { id: 'cfg-1', priceAlerts: alerts },
+    ]);
+
+    const result = await removePriceAlertAction.handler(
+      mockRuntime,
+      mockMessage,
+      makeState({ tokenSymbol: 'OPENAGI' }) // No condition
+    );
+
+    expect(result!.success).toBe(true);
+    // Should remove first match (a1)
+    expect((result!.data?.removedAlert as Record<string, unknown>)?.id).toBe(
+      'a1'
+    );
+  });
+});

--- a/packages/testing/unit/messaging-parsers.test.ts
+++ b/packages/testing/unit/messaging-parsers.test.ts
@@ -1,0 +1,518 @@
+/**
+ * Messaging Parsers & SEND_MESSAGE Action Tests
+ *
+ * Tests the parsing functions used by the SEND_MESSAGE action:
+ * - parseChatId: extract chat ID from text
+ * - parseGroupName: extract quoted group name
+ * - parseRecipientUsername: extract @username
+ * - parseMessageContent: extract message body
+ * - sendMessageAction.validate: input validation
+ * - sendMessageAction.handler: full resolution flow
+ *
+ * Also tests context-gatherers:
+ * - resolveGroupChatByName: sanitization, DB lookup
+ * - resolveUserByUsername: @ stripping, case normalization
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { HandlerCallback, IAgentRuntime, Memory } from '@elizaos/core';
+
+// ─── Mock DB for context-gatherers ───────────────────────────────────────────
+
+let mockDbSelectLimit: ReturnType<typeof mock>;
+let mockDbSelectWhere: ReturnType<typeof mock>;
+let mockDbSelectInnerJoin2: ReturnType<typeof mock>;
+let mockDbSelectInnerJoin1: ReturnType<typeof mock>;
+let mockDbSelectFrom: ReturnType<typeof mock>;
+let mockDbSelect: ReturnType<typeof mock>;
+
+function resetDbMocks() {
+  mockDbSelectLimit = mock(async () => []);
+  mockDbSelectWhere = mock(() => ({ limit: mockDbSelectLimit }));
+  mockDbSelectInnerJoin2 = mock(() => ({ where: mockDbSelectWhere }));
+  mockDbSelectInnerJoin1 = mock(() => ({
+    innerJoin: mockDbSelectInnerJoin2,
+  }));
+  mockDbSelectFrom = mock(() => ({
+    innerJoin: mockDbSelectInnerJoin1,
+    where: mockDbSelectWhere,
+  }));
+  mockDbSelect = mock(() => ({ from: mockDbSelectFrom }));
+}
+
+resetDbMocks();
+
+const mockExecuteDirectMessage = mock(
+  async () =>
+    ({ success: true, messageId: 'msg-001' }) as Record<string, unknown>
+);
+
+mock.module('@babylon/db', () => ({
+  db: {
+    get select() {
+      return mockDbSelect;
+    },
+  },
+  eq: (a: unknown, b: unknown) => ({ op: 'eq', a, b }),
+  and: (...args: unknown[]) => ({ op: 'and', args }),
+  ilike: (col: unknown, val: unknown) => ({ op: 'ilike', col, val }),
+  ne: (a: unknown, b: unknown) => ({ op: 'ne', a, b }),
+  gte: (a: unknown, b: unknown) => ({ op: 'gte', a, b }),
+  lte: (a: unknown, b: unknown) => ({ op: 'lte', a, b }),
+  desc: (col: unknown) => ({ op: 'desc', col }),
+  count: () => 'count',
+  inArray: (col: unknown, vals: unknown) => ({ op: 'inArray', col, vals }),
+  isNull: (col: unknown) => ({ op: 'isNull', col }),
+  sql: Object.assign((...args: unknown[]) => args, { raw: (s: string) => s }),
+  getDbInstance: () => ({}),
+  getRawDrizzle: () => ({}),
+  chats: {
+    id: 'chats.id',
+    groupId: 'chats.groupId',
+    isGroup: 'chats.isGroup',
+    name: 'chats.name',
+  },
+  chatParticipants: {
+    chatId: 'chatParticipants.chatId',
+    userId: 'chatParticipants.userId',
+  },
+  groups: { id: 'groups.id', name: 'groups.name' },
+  users: { id: 'users.id', username: 'users.username' },
+  markets: { id: 'markets.id', question: 'markets.question' },
+  posts: {
+    id: 'posts.id',
+    content: 'posts.content',
+    authorId: 'posts.authorId',
+    timestamp: 'posts.timestamp',
+    deletedAt: 'posts.deletedAt',
+  },
+  comments: { id: 'comments.id' },
+  reactions: { id: 'reactions.id' },
+  shares: { id: 'shares.id' },
+  positions: { id: 'positions.id' },
+  perpPositions: { id: 'perpPositions.id' },
+}));
+
+mock.module('../../agents/src/autonomous/DirectExecutors', () => ({
+  executeDirectMessage: mockExecuteDirectMessage,
+}));
+
+mock.module('@babylon/engine', () => ({
+  StaticDataRegistry: { getActor: () => null },
+}));
+
+mock.module('../../agents/src/shared/logger', () => ({
+  logger: {
+    info: mock(),
+    warn: mock(),
+    error: mock(),
+    debug: mock(),
+  },
+}));
+
+// ─── Import after mocks ──────────────────────────────────────────────────────
+
+// Import the messaging module to get the parsers — they're module-level functions
+// We access them via the action handler behavior + testing edge cases
+const { resolveGroupChatByName, resolveUserByUsername } = await import(
+  '../../agents/src/autonomous/utils/context-gatherers'
+);
+
+const { sendMessageAction } = await import(
+  '../../agents/src/plugins/babylon/actions/messaging'
+);
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeMemory(text: string) {
+  return { content: { text } } as unknown as Memory;
+}
+
+function makeRuntime(agentId?: string) {
+  return {
+    agentId: agentId ?? 'agent-001',
+    a2aClient: agentId
+      ? {
+          agentId,
+          isConnected: () => false,
+        }
+      : undefined,
+  } as unknown as IAgentRuntime;
+}
+
+// ─── resolveGroupChatByName ──────────────────────────────────────────────────
+
+describe('resolveGroupChatByName', () => {
+  beforeEach(() => {
+    resetDbMocks();
+  });
+
+  test('returns chatId when group is found', async () => {
+    mockDbSelectLimit.mockResolvedValueOnce([{ chatId: 'chat-123' }]);
+
+    const result = await resolveGroupChatByName('agent-001', 'Price Alerts');
+    expect(result).toBe('chat-123');
+  });
+
+  test('returns null when group not found', async () => {
+    mockDbSelectLimit.mockResolvedValueOnce([]);
+
+    const result = await resolveGroupChatByName('agent-001', 'Nonexistent');
+    expect(result).toBeNull();
+  });
+
+  test('sanitizes % and _ characters from input', async () => {
+    mockDbSelectLimit.mockResolvedValueOnce([{ chatId: 'chat-456' }]);
+
+    const result = await resolveGroupChatByName('agent-001', '%test_%group');
+    expect(result).toBe('chat-456');
+  });
+
+  test('returns null when sanitized name is too short (< 2 chars)', async () => {
+    const result = await resolveGroupChatByName('agent-001', 'a');
+    expect(result).toBeNull();
+    // Should not even query DB
+    expect(mockDbSelect).not.toHaveBeenCalled();
+  });
+
+  test('returns null for empty string', async () => {
+    const result = await resolveGroupChatByName('agent-001', '');
+    expect(result).toBeNull();
+  });
+
+  test('returns null when only special characters remain after sanitization', async () => {
+    const result = await resolveGroupChatByName('agent-001', '%%%___\\\\');
+    expect(result).toBeNull();
+  });
+
+  test('handles backslash sanitization', async () => {
+    mockDbSelectLimit.mockResolvedValueOnce([{ chatId: 'chat-789' }]);
+
+    // Backslashes should be stripped
+    const result = await resolveGroupChatByName('agent-001', 'test\\group');
+    expect(result).toBe('chat-789');
+  });
+
+  test('trims whitespace from group name', async () => {
+    mockDbSelectLimit.mockResolvedValueOnce([{ chatId: 'chat-101' }]);
+
+    const result = await resolveGroupChatByName('agent-001', '  Trading  ');
+    expect(result).toBe('chat-101');
+  });
+});
+
+// ─── resolveUserByUsername ───────────────────────────────────────────────────
+
+describe('resolveUserByUsername', () => {
+  beforeEach(() => {
+    resetDbMocks();
+  });
+
+  test('returns userId when user is found', async () => {
+    mockDbSelectLimit.mockResolvedValueOnce([{ id: 'user-001' }]);
+
+    const result = await resolveUserByUsername('alice');
+    expect(result).toBe('user-001');
+  });
+
+  test('strips @ prefix', async () => {
+    mockDbSelectLimit.mockResolvedValueOnce([{ id: 'user-002' }]);
+
+    const result = await resolveUserByUsername('@bob');
+    expect(result).toBe('user-002');
+  });
+
+  test('lowercases username', async () => {
+    mockDbSelectLimit.mockResolvedValueOnce([{ id: 'user-003' }]);
+
+    await resolveUserByUsername('Alice');
+    // Verify the query was called (we can't easily check the exact where clause
+    // but the function lowercases before querying)
+    expect(mockDbSelect).toHaveBeenCalled();
+  });
+
+  test('returns null for empty username', async () => {
+    const result = await resolveUserByUsername('');
+    expect(result).toBeNull();
+    expect(mockDbSelect).not.toHaveBeenCalled();
+  });
+
+  test('returns null for @ only', async () => {
+    const result = await resolveUserByUsername('@');
+    expect(result).toBeNull();
+  });
+
+  test('returns null for whitespace-only after cleaning', async () => {
+    const result = await resolveUserByUsername('  @  ');
+    expect(result).toBeNull();
+  });
+
+  test('returns null when user not found', async () => {
+    mockDbSelectLimit.mockResolvedValueOnce([]);
+
+    const result = await resolveUserByUsername('nonexistent');
+    expect(result).toBeNull();
+  });
+});
+
+// ─── sendMessageAction.validate ──────────────────────────────────────────────
+
+describe('sendMessageAction.validate', () => {
+  const runtime = makeRuntime('agent-001');
+
+  test('validates "send message to chat 123: hello"', async () => {
+    const result = await sendMessageAction.validate!(
+      runtime,
+      makeMemory('send message to chat 123: hello')
+    );
+    expect(result).toBe(true);
+  });
+
+  test('validates "DM @alice: hello"', async () => {
+    const result = await sendMessageAction.validate!(
+      runtime,
+      makeMemory('DM @alice: hello')
+    );
+    expect(result).toBe(true);
+  });
+
+  test('validates "send alert to group"', async () => {
+    const result = await sendMessageAction.validate!(
+      runtime,
+      makeMemory('send alert to group')
+    );
+    expect(result).toBe(true);
+  });
+
+  test('rejects unrelated text', async () => {
+    const result = await sendMessageAction.validate!(
+      runtime,
+      makeMemory('what is the price of OPENAGI?')
+    );
+    expect(result).toBe(false);
+  });
+
+  test('rejects empty text', async () => {
+    const result = await sendMessageAction.validate!(runtime, makeMemory(''));
+    expect(result).toBe(false);
+  });
+});
+
+// ─── sendMessageAction.handler ───────────────────────────────────────────────
+
+describe('sendMessageAction.handler', () => {
+  beforeEach(() => {
+    resetDbMocks();
+    mockExecuteDirectMessage.mockClear();
+    mockExecuteDirectMessage.mockImplementation(async () => ({
+      success: true,
+      messageId: 'msg-001',
+    }));
+  });
+
+  test('sends via explicit chatId (strategy 1)', async () => {
+    const runtime = makeRuntime('agent-001');
+    const message = makeMemory('send message to chat abc-123: Hello world');
+    let callbackResult: Record<string, unknown> = undefined!;
+    const callback = mock((data: Record<string, unknown>) => {
+      callbackResult = data;
+    });
+
+    await sendMessageAction.handler(
+      runtime,
+      message,
+      undefined,
+      undefined,
+      callback as unknown as HandlerCallback
+    );
+
+    expect(mockExecuteDirectMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentUserId: 'agent-001',
+        chatId: 'abc-123',
+      })
+    );
+    expect(callbackResult.text).toContain('Message sent');
+  });
+
+  test('sends via group name resolution (strategy 2)', async () => {
+    const runtime = makeRuntime('agent-001');
+    const message = makeMemory(
+      "send message to 'Trading Alerts': OPENAGI is pumping"
+    );
+    let callbackResult: Record<string, unknown> = undefined!;
+    const callback = mock((data: Record<string, unknown>) => {
+      callbackResult = data;
+    });
+
+    // resolveGroupChatByName returns a chat ID
+    mockDbSelectLimit.mockResolvedValueOnce([{ chatId: 'group-chat-789' }]);
+
+    await sendMessageAction.handler(
+      runtime,
+      message,
+      undefined,
+      undefined,
+      callback as unknown as HandlerCallback
+    );
+
+    expect(mockExecuteDirectMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId: 'group-chat-789',
+      })
+    );
+    expect(callbackResult.text).toContain('Trading Alerts');
+  });
+
+  test('reports error when group name not found', async () => {
+    const runtime = makeRuntime('agent-001');
+    const message = makeMemory("send message to 'Nonexistent Group': hello");
+    let callbackResult: Record<string, unknown> = undefined!;
+    const callback = mock((data: Record<string, unknown>) => {
+      callbackResult = data;
+    });
+
+    // Group not found
+    mockDbSelectLimit.mockResolvedValueOnce([]);
+
+    await sendMessageAction.handler(
+      runtime,
+      message,
+      undefined,
+      undefined,
+      callback as unknown as HandlerCallback
+    );
+
+    expect(mockExecuteDirectMessage).not.toHaveBeenCalled();
+    expect(callbackResult.text).toContain('Could not find a group chat');
+    expect(callbackResult.text).toContain('Nonexistent Group');
+  });
+
+  test('sends via @username resolution (strategy 3)', async () => {
+    const runtime = makeRuntime('agent-001');
+    const message = makeMemory('DM @alice: Hey check this out');
+    let callbackResult: Record<string, unknown> = undefined!;
+    const callback = mock((data: Record<string, unknown>) => {
+      callbackResult = data;
+    });
+
+    // resolveUserByUsername returns a user ID
+    mockDbSelectLimit.mockResolvedValueOnce([{ id: 'user-alice' }]);
+
+    await sendMessageAction.handler(
+      runtime,
+      message,
+      undefined,
+      undefined,
+      callback as unknown as HandlerCallback
+    );
+
+    expect(mockExecuteDirectMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipientId: 'user-alice',
+      })
+    );
+    expect(callbackResult.text).toContain('DM sent to @alice');
+  });
+
+  test('reports error when @username not found', async () => {
+    const runtime = makeRuntime('agent-001');
+    const message = makeMemory('DM @nobody: hello');
+    let callbackResult: Record<string, unknown> = undefined!;
+    const callback = mock((data: Record<string, unknown>) => {
+      callbackResult = data;
+    });
+
+    // User not found
+    mockDbSelectLimit.mockResolvedValueOnce([]);
+
+    await sendMessageAction.handler(
+      runtime,
+      message,
+      undefined,
+      undefined,
+      callback as unknown as HandlerCallback
+    );
+
+    expect(mockExecuteDirectMessage).not.toHaveBeenCalled();
+    expect(callbackResult.text).toContain('Could not find user @nobody');
+  });
+
+  test('returns error when message body is too short', async () => {
+    const runtime = makeRuntime('agent-001');
+    // The colon pattern will extract empty/short content
+    const message = makeMemory('send message to chat abc: a');
+    const callback = mock((_data: Record<string, unknown>) => {});
+
+    await sendMessageAction.handler(
+      runtime,
+      message,
+      undefined,
+      undefined,
+      callback as unknown as HandlerCallback
+    );
+
+    // May send "a" or may trigger the "could not parse" message depending on parsing
+    // The key is that the function completes without throwing
+    expect(callback).toHaveBeenCalled();
+  });
+
+  test('returns fallback error when no resolution strategy matches', async () => {
+    const runtime = makeRuntime('agent-001');
+    // Text that doesn't match any pattern
+    const message = makeMemory('please just say hello to everyone');
+    let callbackResult: Record<string, unknown> = undefined!;
+    const callback = mock((data: Record<string, unknown>) => {
+      callbackResult = data;
+    });
+
+    await sendMessageAction.handler(
+      runtime,
+      message,
+      undefined,
+      undefined,
+      callback as unknown as HandlerCallback
+    );
+
+    expect(callbackResult.text).toContain('Could not determine where');
+  });
+
+  test('handles executeDirectMessage failure gracefully', async () => {
+    const runtime = makeRuntime('agent-001');
+    const message = makeMemory('send message to chat xyz-999: Hello');
+    let callbackResult: Record<string, unknown> = undefined!;
+    const callback = mock((data: Record<string, unknown>) => {
+      callbackResult = data;
+    });
+
+    mockExecuteDirectMessage.mockResolvedValueOnce({
+      success: false,
+      error: 'Chat not found',
+    });
+
+    await sendMessageAction.handler(
+      runtime,
+      message,
+      undefined,
+      undefined,
+      callback as unknown as HandlerCallback
+    );
+
+    expect(callbackResult.text).toContain('Failed to send');
+    expect(callbackResult.text).toContain('Chat not found');
+  });
+
+  test('handles undefined callback without throwing', async () => {
+    const runtime = makeRuntime('agent-001');
+    const message = makeMemory('send message to chat xyz: hello');
+
+    // Should not throw even with no callback
+    await sendMessageAction.handler(
+      runtime,
+      message,
+      undefined,
+      undefined,
+      undefined
+    );
+  });
+});

--- a/packages/testing/unit/messaging-parsers.test.ts
+++ b/packages/testing/unit/messaging-parsers.test.ts
@@ -440,8 +440,8 @@ describe('sendMessageAction.handler', () => {
 
   test('returns error when message body is too short', async () => {
     const runtime = makeRuntime('agent-001');
-    // The colon pattern will extract empty/short content
-    const message = makeMemory('send message to chat abc: a');
+    // Use a chatId with 5+ chars so it passes the chatId parser
+    const message = makeMemory('send message to chat abcde: a');
     const callback = mock((_data: Record<string, unknown>) => {});
 
     await sendMessageAction.handler(
@@ -504,7 +504,7 @@ describe('sendMessageAction.handler', () => {
 
   test('handles undefined callback without throwing', async () => {
     const runtime = makeRuntime('agent-001');
-    const message = makeMemory('send message to chat xyz: hello');
+    const message = makeMemory('send message to chat xyz-test: hello');
 
     // Should not throw even with no callback
     await sendMessageAction.handler(
@@ -514,5 +514,61 @@ describe('sendMessageAction.handler', () => {
       undefined,
       undefined
     );
+  });
+
+  test('does NOT false-positive "General Chat:" as a chatId', async () => {
+    const runtime = makeRuntime('agent-001');
+    const message = makeMemory('send message to General Chat: Hello everyone');
+    let callbackResult: Record<string, unknown> = undefined!;
+    const callback = mock((data: Record<string, unknown>) => {
+      callbackResult = data;
+    });
+
+    // resolveGroupChatByName should be called (strategy 2), NOT parseChatId
+    mockDbSelectLimit.mockResolvedValueOnce([{ chatId: 'group-chat-general' }]);
+
+    await sendMessageAction.handler(
+      runtime,
+      message,
+      undefined,
+      undefined,
+      callback as unknown as HandlerCallback
+    );
+
+    // Should resolve via group name, not chatId
+    expect(mockExecuteDirectMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId: 'group-chat-general',
+      })
+    );
+    expect(callbackResult.text).toContain('General Chat');
+  });
+
+  test('resolves unquoted group name before colon', async () => {
+    const runtime = makeRuntime('agent-001');
+    const message = makeMemory(
+      'send message to Price Alerts: OPENAGI dropped below 22'
+    );
+    let callbackResult: Record<string, unknown> = undefined!;
+    const callback = mock((data: Record<string, unknown>) => {
+      callbackResult = data;
+    });
+
+    mockDbSelectLimit.mockResolvedValueOnce([{ chatId: 'alerts-chat-001' }]);
+
+    await sendMessageAction.handler(
+      runtime,
+      message,
+      undefined,
+      undefined,
+      callback as unknown as HandlerCallback
+    );
+
+    expect(mockExecuteDirectMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId: 'alerts-chat-001',
+      })
+    );
+    expect(callbackResult.text).toContain('Price Alerts');
   });
 });

--- a/packages/testing/unit/price-alert-service.test.ts
+++ b/packages/testing/unit/price-alert-service.test.ts
@@ -242,10 +242,6 @@ describe('PriceAlertService', () => {
       ]);
       // Call 3: owner lookup
       mockDbSelectLimit.mockResolvedValueOnce([{ managedBy: 'owner-001' }]);
-      // Call 4: timestamp update config fetch
-      mockDbSelectLimit.mockResolvedValueOnce([
-        { id: 'config-001', priceAlerts: [alert] },
-      ]);
 
       const result = await service.checkAlerts('agent-001');
       expect(result).toBe(1);
@@ -273,9 +269,6 @@ describe('PriceAlertService', () => {
         { markPrice: 0.5, currentPrice: 0.6 },
       ]);
       mockDbSelectLimit.mockResolvedValueOnce([{ managedBy: 'owner-001' }]);
-      mockDbSelectLimit.mockResolvedValueOnce([
-        { id: 'cfg-1', priceAlerts: [alert] },
-      ]);
 
       const result = await service.checkAlerts('agent-001');
       expect(result).toBe(1);
@@ -302,9 +295,6 @@ describe('PriceAlertService', () => {
         { markPrice: 2.5, currentPrice: 2.4 },
       ]);
       mockDbSelectLimit.mockResolvedValueOnce([{ managedBy: 'owner-001' }]);
-      mockDbSelectLimit.mockResolvedValueOnce([
-        { id: 'cfg-1', priceAlerts: [alert] },
-      ]);
 
       const result = await service.checkAlerts('agent-001');
       expect(result).toBe(1);
@@ -336,9 +326,6 @@ describe('PriceAlertService', () => {
         { markPrice: 0.5, currentPrice: 0.5 },
       ]);
       // No owner lookup needed — goes directly to group chat
-      mockDbSelectLimit.mockResolvedValueOnce([
-        { id: 'cfg-1', priceAlerts: [alert] },
-      ]);
 
       const result = await service.checkAlerts('agent-001');
       expect(result).toBe(1);
@@ -361,9 +348,6 @@ describe('PriceAlertService', () => {
       ]);
       // Falls through to team chat lookup
       mockDbSelectLimit.mockResolvedValueOnce([{ managedBy: 'owner-001' }]);
-      mockDbSelectLimit.mockResolvedValueOnce([
-        { id: 'cfg-1', priceAlerts: [alert] },
-      ]);
 
       const result = await service.checkAlerts('agent-001');
       expect(result).toBe(1);
@@ -429,11 +413,6 @@ describe('PriceAlertService', () => {
         messageId: 'msg-456',
       });
 
-      // Timestamp update for alert2
-      mockDbSelectLimit.mockResolvedValueOnce([
-        { id: 'cfg-1', priceAlerts: [alert1, alert2] },
-      ]);
-
       const result = await service.checkAlerts('agent-001');
       // Only 1 success (alert2), alert1 failed
       expect(result).toBe(1);
@@ -470,18 +449,12 @@ describe('PriceAlertService', () => {
         { markPrice: 0.8, currentPrice: 0.9 },
       ]);
       mockDbSelectLimit.mockResolvedValueOnce([{ managedBy: 'owner-001' }]);
-      mockDbSelectLimit.mockResolvedValueOnce([
-        { id: 'cfg-1', priceAlerts: alerts },
-      ]);
 
       // alert2: price check (above threshold)
       mockDbSelectLimit.mockResolvedValueOnce([
         { markPrice: 0.7, currentPrice: 0.6 },
       ]);
       mockDbSelectLimit.mockResolvedValueOnce([{ managedBy: 'owner-001' }]);
-      mockDbSelectLimit.mockResolvedValueOnce([
-        { id: 'cfg-1', priceAlerts: alerts },
-      ]);
 
       // alert3 is disabled, should be skipped
 
@@ -666,72 +639,38 @@ describe('PriceAlertService', () => {
   });
 
   // ═══ updateAlertTimestamp ══════════════════════════════════════════════
+  // The implementation uses an atomic SQL JSONB update (no SELECT needed).
 
   describe('updateAlertTimestamp', () => {
-    test('updates lastTriggeredAt for matching alert', async () => {
-      const alerts = [
-        makeAlert({ id: 'a1' }),
-        makeAlert({ id: 'a2', tokenSymbol: 'TSLAI' }),
-      ];
-
-      mockDbSelectLimit.mockResolvedValueOnce([
-        { id: 'cfg-1', priceAlerts: alerts },
-      ]);
-
+    test('issues atomic UPDATE with SQL expression', async () => {
       await (service as unknown as ServicePrivate).updateAlertTimestamp(
         'agent-001',
         'a1'
       );
 
+      // Should call db.update().set().where() — single atomic operation, no SELECT
       expect(mockDbUpdateSet).toHaveBeenCalledTimes(1);
+      expect(mockDbSelect).not.toHaveBeenCalled();
+
       const setArg = mockDbUpdateSet.mock.calls[0]![0] as Record<
         string,
         unknown
       >;
-      const updatedAlerts = setArg.priceAlerts as Array<
-        Record<string, unknown>
-      >;
-      // a1 should have lastTriggeredAt updated
-      const a1 = updatedAlerts.find((a) => a.id === 'a1');
-      expect(a1?.lastTriggeredAt).toBeDefined();
-      // a2 should be unchanged
-      const a2 = updatedAlerts.find((a) => a.id === 'a2');
-      expect(a2?.lastTriggeredAt).toBeUndefined();
+      // priceAlerts is now a SQL template expression (not a plain array)
+      expect(setArg.priceAlerts).toBeDefined();
+      expect(setArg.updatedAt).toBeInstanceOf(Date);
     });
 
-    test('silently returns when config not found', async () => {
-      mockDbSelectLimit.mockResolvedValueOnce([]);
-
-      await (service as unknown as ServicePrivate).updateAlertTimestamp(
-        'agent-001',
-        'a1'
-      );
-      // Should not throw and should not call update
-      expect(mockDbUpdateSet).not.toHaveBeenCalled();
-    });
-
-    test('does not modify other alerts when target not found', async () => {
-      const alerts = [makeAlert({ id: 'a1' })];
-
-      mockDbSelectLimit.mockResolvedValueOnce([
-        { id: 'cfg-1', priceAlerts: alerts },
-      ]);
-
-      await (service as unknown as ServicePrivate).updateAlertTimestamp(
-        'agent-001',
-        'nonexistent'
-      );
+    test('does not throw when no matching config exists', async () => {
+      // Atomic UPDATE on non-existent row simply affects 0 rows — no error
+      await expect(
+        (service as unknown as ServicePrivate).updateAlertTimestamp(
+          'nonexistent',
+          'a1'
+        )
+      ).resolves.toBeUndefined();
 
       expect(mockDbUpdateSet).toHaveBeenCalledTimes(1);
-      const setArg = mockDbUpdateSet.mock.calls[0]![0] as Record<
-        string,
-        unknown
-      >;
-      const updatedAlerts = setArg.priceAlerts as Array<
-        Record<string, unknown>
-      >;
-      // a1 should NOT have lastTriggeredAt modified
-      expect(updatedAlerts[0]?.lastTriggeredAt).toBeUndefined();
     });
   });
 });

--- a/packages/testing/unit/price-alert-service.test.ts
+++ b/packages/testing/unit/price-alert-service.test.ts
@@ -1,0 +1,737 @@
+/**
+ * PriceAlertService Unit Tests
+ *
+ * Tests the core price alert checking logic:
+ * - checkAlerts: main entry, cooldown enforcement, delivery routing
+ * - getCurrentPrice: markPrice vs currentPrice fallback
+ * - formatAlertMessage: message formatting, percentage calculation
+ * - updateAlertTimestamp: timestamp persistence
+ *
+ * Strategy: mock DB, executeDirectMessage, and teamChatService;
+ * exercise real PriceAlertService code paths.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+// ─── Mock Setup ──────────────────────────────────────────────────────────────
+
+// DB chain mocks — we rebuild per-test to control return values
+let mockDbSelectLimit: ReturnType<typeof mock>;
+let mockDbSelectWhere: ReturnType<typeof mock>;
+let mockDbSelectFrom: ReturnType<typeof mock>;
+let mockDbSelect: ReturnType<typeof mock>;
+let mockDbUpdateSet: ReturnType<typeof mock>;
+let mockDbUpdateWhere: ReturnType<typeof mock>;
+let mockDbUpdate: ReturnType<typeof mock>;
+
+function resetDbMocks() {
+  mockDbSelectLimit = mock(async () => []);
+  mockDbSelectWhere = mock(() => ({ limit: mockDbSelectLimit }));
+  mockDbSelectFrom = mock(() => ({ where: mockDbSelectWhere }));
+  mockDbSelect = mock(() => ({ from: mockDbSelectFrom }));
+  mockDbUpdateWhere = mock(async () => []);
+  mockDbUpdateSet = mock(() => ({ where: mockDbUpdateWhere }));
+  mockDbUpdate = mock(() => ({ set: mockDbUpdateSet }));
+}
+
+resetDbMocks();
+
+const mockExecuteDirectMessage = mock(
+  async () =>
+    ({ success: true, messageId: 'msg-123' }) as Record<string, unknown>
+);
+
+const mockGetTeamChat = mock(
+  async () => ({ chatId: 'team-chat-001' }) as Record<string, unknown> | null
+);
+
+mock.module('@babylon/db', () => ({
+  db: {
+    get select() {
+      return mockDbSelect;
+    },
+    get update() {
+      return mockDbUpdate;
+    },
+  },
+  eq: (a: unknown, b: unknown) => ({ op: 'eq', a, b }),
+  and: (...args: unknown[]) => ({ op: 'and', args }),
+  count: () => 'count',
+  desc: (col: unknown) => ({ op: 'desc', col }),
+  gte: (a: unknown, b: unknown) => ({ op: 'gte', a, b }),
+  ilike: (col: unknown, val: unknown) => ({ op: 'ilike', col, val }),
+  inArray: (col: unknown, vals: unknown) => ({ op: 'inArray', col, vals }),
+  isNull: (col: unknown) => ({ op: 'isNull', col }),
+  lte: (a: unknown, b: unknown) => ({ op: 'lte', a, b }),
+  ne: (a: unknown, b: unknown) => ({ op: 'ne', a, b }),
+  sql: Object.assign((...args: unknown[]) => args, { raw: (s: string) => s }),
+  getDbInstance: () => ({}),
+  getRawDrizzle: () => ({}),
+  chats: {
+    id: 'chats.id',
+    name: 'chats.name',
+    groupId: 'chats.groupId',
+    isGroup: 'chats.isGroup',
+  },
+  chatParticipants: {
+    chatId: 'chatParticipants.chatId',
+    userId: 'chatParticipants.userId',
+  },
+  groups: { id: 'groups.id', name: 'groups.name' },
+  markets: { id: 'markets.id' },
+  posts: {
+    id: 'posts.id',
+    authorId: 'posts.authorId',
+    content: 'posts.content',
+    timestamp: 'posts.timestamp',
+    deletedAt: 'posts.deletedAt',
+  },
+  comments: { id: 'comments.id' },
+  reactions: { id: 'reactions.id' },
+  shares: { id: 'shares.id' },
+  positions: { id: 'positions.id' },
+  perpPositions: { id: 'perpPositions.id' },
+  perpMarketSnapshots: {
+    currentPrice: 'perpMarketSnapshots.currentPrice',
+    markPrice: 'perpMarketSnapshots.markPrice',
+    ticker: 'perpMarketSnapshots.ticker',
+  },
+  userAgentConfigs: {
+    id: 'userAgentConfigs.id',
+    userId: 'userAgentConfigs.userId',
+    priceAlerts: 'userAgentConfigs.priceAlerts',
+  },
+  users: {
+    id: 'users.id',
+    managedBy: 'users.managedBy',
+  },
+}));
+
+mock.module('../../agents/src/autonomous/DirectExecutors', () => ({
+  executeDirectMessage: mockExecuteDirectMessage,
+}));
+
+mock.module('../../agents/src/services/TeamChatService', () => ({
+  teamChatService: { getTeamChat: mockGetTeamChat },
+}));
+
+mock.module('../../agents/src/shared/logger', () => ({
+  logger: {
+    info: mock(),
+    warn: mock(),
+    error: mock(),
+    debug: mock(),
+  },
+}));
+
+// ─── Import after mocks ──────────────────────────────────────────────────────
+
+const { PriceAlertService } = await import(
+  '../../agents/src/autonomous/PriceAlertService'
+);
+
+// Type for accessing private methods in tests
+type ServicePrivate = {
+  formatAlertMessage: (alert: Record<string, unknown>, price: number) => string;
+  getCurrentPrice: (symbol: string) => Promise<number | null>;
+  getOwnerTeamChatId: (agentId: string) => Promise<string | undefined>;
+  updateAlertTimestamp: (agentId: string, alertId: string) => Promise<void>;
+};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeAlert(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'alert-001',
+    tokenSymbol: 'OPENAGI',
+    condition: 'below',
+    threshold: 1.0,
+    deliveryChannel: 'team_chat',
+    deliveryChatId: undefined,
+    enabled: true,
+    lastTriggeredAt: undefined,
+    cooldownMinutes: 15,
+    createdAt: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('PriceAlertService', () => {
+  let service: InstanceType<typeof PriceAlertService>;
+
+  beforeEach(() => {
+    service = new PriceAlertService();
+    resetDbMocks();
+    mockExecuteDirectMessage.mockClear();
+    mockGetTeamChat.mockClear();
+    mockExecuteDirectMessage.mockImplementation(async () => ({
+      success: true,
+      messageId: 'msg-123',
+    }));
+    mockGetTeamChat.mockImplementation(async () => ({
+      chatId: 'team-chat-001',
+    }));
+  });
+
+  // ═══ checkAlerts ═══════════════════════════════════════════════════════
+
+  describe('checkAlerts', () => {
+    test('returns 0 when agent has no config', async () => {
+      // First query (config lookup) returns empty
+      mockDbSelectLimit.mockResolvedValueOnce([]);
+
+      const result = await service.checkAlerts('agent-001');
+      expect(result).toBe(0);
+    });
+
+    test('returns 0 when priceAlerts is null', async () => {
+      mockDbSelectLimit.mockResolvedValueOnce([{ priceAlerts: null }]);
+
+      const result = await service.checkAlerts('agent-001');
+      expect(result).toBe(0);
+    });
+
+    test('returns 0 when priceAlerts is empty array', async () => {
+      mockDbSelectLimit.mockResolvedValueOnce([{ priceAlerts: [] }]);
+
+      const result = await service.checkAlerts('agent-001');
+      expect(result).toBe(0);
+    });
+
+    test('returns 0 when all alerts are disabled', async () => {
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { priceAlerts: [makeAlert({ enabled: false })] },
+      ]);
+
+      const result = await service.checkAlerts('agent-001');
+      expect(result).toBe(0);
+    });
+
+    test('skips alert still in cooldown', async () => {
+      const recentTime = new Date(Date.now() - 5 * 60 * 1000).toISOString(); // 5 min ago
+      mockDbSelectLimit.mockResolvedValueOnce([
+        {
+          priceAlerts: [
+            makeAlert({ cooldownMinutes: 15, lastTriggeredAt: recentTime }),
+          ],
+        },
+      ]);
+
+      const result = await service.checkAlerts('agent-001');
+      expect(result).toBe(0);
+      // Should never reach price check
+      expect(mockDbSelect).toHaveBeenCalledTimes(1); // only config query
+    });
+
+    test('processes alert when cooldown has elapsed', async () => {
+      const oldTime = new Date(Date.now() - 20 * 60 * 1000).toISOString(); // 20 min ago
+      const alert = makeAlert({
+        cooldownMinutes: 15,
+        lastTriggeredAt: oldTime,
+        condition: 'below',
+        threshold: 1.0,
+      });
+
+      // Call 1: config lookup
+      mockDbSelectLimit.mockResolvedValueOnce([{ priceAlerts: [alert] }]);
+      // Call 2: price lookup — price below threshold
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { markPrice: 0.8, currentPrice: 0.85 },
+      ]);
+      // Call 3: owner lookup
+      mockDbSelectLimit.mockResolvedValueOnce([{ managedBy: 'owner-001' }]);
+      // Call 4: timestamp update config fetch
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { id: 'config-001', priceAlerts: [alert] },
+      ]);
+
+      const result = await service.checkAlerts('agent-001');
+      expect(result).toBe(1);
+      expect(mockExecuteDirectMessage).toHaveBeenCalledTimes(1);
+    });
+
+    test('skips alert when current price is null (token not found)', async () => {
+      mockDbSelectLimit.mockResolvedValueOnce([{ priceAlerts: [makeAlert()] }]);
+      // Price lookup returns empty
+      mockDbSelectLimit.mockResolvedValueOnce([]);
+
+      const result = await service.checkAlerts('agent-001');
+      expect(result).toBe(0);
+      expect(mockExecuteDirectMessage).not.toHaveBeenCalled();
+    });
+
+    test('triggers alert when price is below threshold (condition=below)', async () => {
+      const alert = makeAlert({
+        condition: 'below',
+        threshold: 1.0,
+      });
+
+      mockDbSelectLimit.mockResolvedValueOnce([{ priceAlerts: [alert] }]);
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { markPrice: 0.5, currentPrice: 0.6 },
+      ]);
+      mockDbSelectLimit.mockResolvedValueOnce([{ managedBy: 'owner-001' }]);
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { id: 'cfg-1', priceAlerts: [alert] },
+      ]);
+
+      const result = await service.checkAlerts('agent-001');
+      expect(result).toBe(1);
+    });
+
+    test('does NOT trigger when price is above threshold (condition=below)', async () => {
+      const alert = makeAlert({ condition: 'below', threshold: 1.0 });
+
+      mockDbSelectLimit.mockResolvedValueOnce([{ priceAlerts: [alert] }]);
+      // Price is ABOVE threshold — should NOT trigger
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { markPrice: 1.5, currentPrice: 1.5 },
+      ]);
+
+      const result = await service.checkAlerts('agent-001');
+      expect(result).toBe(0);
+    });
+
+    test('triggers alert when price is above threshold (condition=above)', async () => {
+      const alert = makeAlert({ condition: 'above', threshold: 2.0 });
+
+      mockDbSelectLimit.mockResolvedValueOnce([{ priceAlerts: [alert] }]);
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { markPrice: 2.5, currentPrice: 2.4 },
+      ]);
+      mockDbSelectLimit.mockResolvedValueOnce([{ managedBy: 'owner-001' }]);
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { id: 'cfg-1', priceAlerts: [alert] },
+      ]);
+
+      const result = await service.checkAlerts('agent-001');
+      expect(result).toBe(1);
+    });
+
+    test('does NOT trigger when price equals threshold exactly', async () => {
+      const alert = makeAlert({ condition: 'below', threshold: 1.0 });
+
+      mockDbSelectLimit.mockResolvedValueOnce([{ priceAlerts: [alert] }]);
+      // Price equals threshold — strictly not below
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { markPrice: 1.0, currentPrice: 1.0 },
+      ]);
+
+      const result = await service.checkAlerts('agent-001');
+      expect(result).toBe(0);
+    });
+
+    test('uses group chat delivery when deliveryChannel=group', async () => {
+      const alert = makeAlert({
+        deliveryChannel: 'group',
+        deliveryChatId: 'group-chat-999',
+        condition: 'below',
+        threshold: 1.0,
+      });
+
+      mockDbSelectLimit.mockResolvedValueOnce([{ priceAlerts: [alert] }]);
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { markPrice: 0.5, currentPrice: 0.5 },
+      ]);
+      // No owner lookup needed — goes directly to group chat
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { id: 'cfg-1', priceAlerts: [alert] },
+      ]);
+
+      const result = await service.checkAlerts('agent-001');
+      expect(result).toBe(1);
+      expect(mockExecuteDirectMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ chatId: 'group-chat-999' })
+      );
+    });
+
+    test('falls back to team_chat when deliveryChannel=group but no deliveryChatId', async () => {
+      const alert = makeAlert({
+        deliveryChannel: 'group',
+        deliveryChatId: undefined,
+        condition: 'below',
+        threshold: 1.0,
+      });
+
+      mockDbSelectLimit.mockResolvedValueOnce([{ priceAlerts: [alert] }]);
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { markPrice: 0.5, currentPrice: 0.5 },
+      ]);
+      // Falls through to team chat lookup
+      mockDbSelectLimit.mockResolvedValueOnce([{ managedBy: 'owner-001' }]);
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { id: 'cfg-1', priceAlerts: [alert] },
+      ]);
+
+      const result = await service.checkAlerts('agent-001');
+      expect(result).toBe(1);
+      expect(mockExecuteDirectMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ chatId: 'team-chat-001' })
+      );
+    });
+
+    test('skips alert when no delivery channel can be resolved', async () => {
+      const alert = makeAlert({ condition: 'below', threshold: 1.0 });
+
+      mockDbSelectLimit.mockResolvedValueOnce([{ priceAlerts: [alert] }]);
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { markPrice: 0.5, currentPrice: 0.5 },
+      ]);
+      // Owner has no managedBy
+      mockDbSelectLimit.mockResolvedValueOnce([{ managedBy: null }]);
+
+      const result = await service.checkAlerts('agent-001');
+      expect(result).toBe(0);
+      expect(mockExecuteDirectMessage).not.toHaveBeenCalled();
+    });
+
+    test('continues processing after a failed message send', async () => {
+      const alert1 = makeAlert({
+        id: 'a1',
+        condition: 'below',
+        threshold: 2.0,
+      });
+      const alert2 = makeAlert({
+        id: 'a2',
+        tokenSymbol: 'TSLAI',
+        condition: 'above',
+        threshold: 1.0,
+      });
+
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { priceAlerts: [alert1, alert2] },
+      ]);
+      // Price for alert1
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { markPrice: 1.0, currentPrice: 1.0 },
+      ]);
+      // Owner for alert1
+      mockDbSelectLimit.mockResolvedValueOnce([{ managedBy: 'owner-001' }]);
+
+      // First send fails
+      mockExecuteDirectMessage.mockResolvedValueOnce({
+        success: false,
+        error: 'Rate limited',
+      });
+
+      // Price for alert2
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { markPrice: 1.5, currentPrice: 1.5 },
+      ]);
+      // Owner for alert2
+      mockDbSelectLimit.mockResolvedValueOnce([{ managedBy: 'owner-001' }]);
+
+      // Second send succeeds
+      mockExecuteDirectMessage.mockResolvedValueOnce({
+        success: true,
+        messageId: 'msg-456',
+      });
+
+      // Timestamp update for alert2
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { id: 'cfg-1', priceAlerts: [alert1, alert2] },
+      ]);
+
+      const result = await service.checkAlerts('agent-001');
+      // Only 1 success (alert2), alert1 failed
+      expect(result).toBe(1);
+      expect(mockExecuteDirectMessage).toHaveBeenCalledTimes(2);
+    });
+
+    test('handles multiple enabled alerts in one pass', async () => {
+      const alerts = [
+        makeAlert({
+          id: 'a1',
+          tokenSymbol: 'OPENAGI',
+          condition: 'below',
+          threshold: 1.0,
+        }),
+        makeAlert({
+          id: 'a2',
+          tokenSymbol: 'TSLAI',
+          condition: 'above',
+          threshold: 0.5,
+        }),
+        makeAlert({
+          id: 'a3',
+          tokenSymbol: 'ETH',
+          condition: 'below',
+          threshold: 100.0,
+          enabled: false,
+        }),
+      ];
+
+      mockDbSelectLimit.mockResolvedValueOnce([{ priceAlerts: alerts }]);
+
+      // alert1: price check (below threshold)
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { markPrice: 0.8, currentPrice: 0.9 },
+      ]);
+      mockDbSelectLimit.mockResolvedValueOnce([{ managedBy: 'owner-001' }]);
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { id: 'cfg-1', priceAlerts: alerts },
+      ]);
+
+      // alert2: price check (above threshold)
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { markPrice: 0.7, currentPrice: 0.6 },
+      ]);
+      mockDbSelectLimit.mockResolvedValueOnce([{ managedBy: 'owner-001' }]);
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { id: 'cfg-1', priceAlerts: alerts },
+      ]);
+
+      // alert3 is disabled, should be skipped
+
+      const result = await service.checkAlerts('agent-001');
+      expect(result).toBe(2); // both enabled alerts triggered
+      expect(mockExecuteDirectMessage).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ═══ formatAlertMessage ════════════════════════════════════════════════
+
+  describe('formatAlertMessage', () => {
+    test('formats "dropped below" message correctly', () => {
+      const alert = makeAlert({
+        condition: 'below',
+        threshold: 1.0,
+        tokenSymbol: 'OPENAGI',
+      });
+      // Access private method via bracket notation
+      const message = (service as unknown as ServicePrivate).formatAlertMessage(
+        alert,
+        0.8
+      );
+
+      expect(message).toContain('📉');
+      expect(message).toContain('OPENAGI');
+      expect(message).toContain('dropped below');
+      expect(message).toContain('$1');
+      expect(message).toContain('$0.80');
+      expect(message).toContain('below threshold');
+    });
+
+    test('formats "rose above" message correctly', () => {
+      const alert = makeAlert({
+        condition: 'above',
+        threshold: 2.0,
+        tokenSymbol: 'TSLAI',
+      });
+      const message = (service as unknown as ServicePrivate).formatAlertMessage(
+        alert,
+        2.5
+      );
+
+      expect(message).toContain('📈');
+      expect(message).toContain('TSLAI');
+      expect(message).toContain('rose above');
+      expect(message).toContain('$2');
+      expect(message).toContain('above threshold');
+    });
+
+    test('calculates percentage difference correctly', () => {
+      const alert = makeAlert({ condition: 'below', threshold: 100.0 });
+      const message = (service as unknown as ServicePrivate).formatAlertMessage(
+        alert,
+        80.0
+      );
+
+      // Diff = 20, pctDiff = (20/100)*100 = 20.0%
+      expect(message).toContain('20.0%');
+    });
+
+    test('handles zero percentage difference (price = threshold)', () => {
+      const alert = makeAlert({ condition: 'below', threshold: 1.0 });
+      const message = (service as unknown as ServicePrivate).formatAlertMessage(
+        alert,
+        1.0
+      );
+
+      expect(message).toContain('0.0%');
+    });
+
+    test('handles very small prices with proper formatting', () => {
+      const alert = makeAlert({ condition: 'below', threshold: 0.001 });
+      const message = (service as unknown as ServicePrivate).formatAlertMessage(
+        alert,
+        0.0005
+      );
+
+      expect(message).toContain('$0.00'); // toFixed(2)
+    });
+  });
+
+  // ═══ getCurrentPrice ═══════════════════════════════════════════════════
+
+  describe('getCurrentPrice', () => {
+    test('returns markPrice when available', async () => {
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { markPrice: 1.5, currentPrice: 1.4 },
+      ]);
+
+      const price = await (
+        service as unknown as ServicePrivate
+      ).getCurrentPrice('OPENAGI');
+      expect(price).toBe(1.5);
+    });
+
+    test('falls back to currentPrice when markPrice is null', async () => {
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { markPrice: null, currentPrice: 1.4 },
+      ]);
+
+      const price = await (
+        service as unknown as ServicePrivate
+      ).getCurrentPrice('OPENAGI');
+      expect(price).toBe(1.4);
+    });
+
+    test('returns null when both prices are null', async () => {
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { markPrice: null, currentPrice: null },
+      ]);
+
+      const price = await (
+        service as unknown as ServicePrivate
+      ).getCurrentPrice('OPENAGI');
+      expect(price).toBeNull();
+    });
+
+    test('returns null when token not found', async () => {
+      mockDbSelectLimit.mockResolvedValueOnce([]);
+
+      const price = await (
+        service as unknown as ServicePrivate
+      ).getCurrentPrice('NONEXISTENT');
+      expect(price).toBeNull();
+    });
+
+    test('returns markPrice of 0 without falling back', async () => {
+      // markPrice=0 is falsy but should still be used (it's a valid price)
+      // However, ?? operator treats 0 as truthy, so this should return 0
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { markPrice: 0, currentPrice: 5.0 },
+      ]);
+
+      const price = await (
+        service as unknown as ServicePrivate
+      ).getCurrentPrice('ZERO_TOKEN');
+      expect(price).toBe(0);
+    });
+  });
+
+  // ═══ getOwnerTeamChatId ════════════════════════════════════════════════
+
+  describe('getOwnerTeamChatId', () => {
+    test('returns team chat ID for agent with owner', async () => {
+      mockDbSelectLimit.mockResolvedValueOnce([{ managedBy: 'owner-001' }]);
+      mockGetTeamChat.mockResolvedValueOnce({ chatId: 'team-chat-001' });
+
+      const chatId = await (
+        service as unknown as ServicePrivate
+      ).getOwnerTeamChatId('agent-001');
+      expect(chatId).toBe('team-chat-001');
+    });
+
+    test('returns undefined when agent has no managedBy', async () => {
+      mockDbSelectLimit.mockResolvedValueOnce([{ managedBy: null }]);
+
+      const chatId = await (
+        service as unknown as ServicePrivate
+      ).getOwnerTeamChatId('agent-001');
+      expect(chatId).toBeUndefined();
+    });
+
+    test('returns undefined when agent not found in DB', async () => {
+      mockDbSelectLimit.mockResolvedValueOnce([]);
+
+      const chatId = await (
+        service as unknown as ServicePrivate
+      ).getOwnerTeamChatId('nonexistent');
+      expect(chatId).toBeUndefined();
+    });
+
+    test('returns undefined when teamChatService returns null', async () => {
+      mockDbSelectLimit.mockResolvedValueOnce([{ managedBy: 'owner-001' }]);
+      mockGetTeamChat.mockResolvedValueOnce(null);
+
+      const chatId = await (
+        service as unknown as ServicePrivate
+      ).getOwnerTeamChatId('agent-001');
+      expect(chatId).toBeUndefined();
+    });
+  });
+
+  // ═══ updateAlertTimestamp ══════════════════════════════════════════════
+
+  describe('updateAlertTimestamp', () => {
+    test('updates lastTriggeredAt for matching alert', async () => {
+      const alerts = [
+        makeAlert({ id: 'a1' }),
+        makeAlert({ id: 'a2', tokenSymbol: 'TSLAI' }),
+      ];
+
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { id: 'cfg-1', priceAlerts: alerts },
+      ]);
+
+      await (service as unknown as ServicePrivate).updateAlertTimestamp(
+        'agent-001',
+        'a1'
+      );
+
+      expect(mockDbUpdateSet).toHaveBeenCalledTimes(1);
+      const setArg = mockDbUpdateSet.mock.calls[0]![0] as Record<
+        string,
+        unknown
+      >;
+      const updatedAlerts = setArg.priceAlerts as Array<
+        Record<string, unknown>
+      >;
+      // a1 should have lastTriggeredAt updated
+      const a1 = updatedAlerts.find((a) => a.id === 'a1');
+      expect(a1?.lastTriggeredAt).toBeDefined();
+      // a2 should be unchanged
+      const a2 = updatedAlerts.find((a) => a.id === 'a2');
+      expect(a2?.lastTriggeredAt).toBeUndefined();
+    });
+
+    test('silently returns when config not found', async () => {
+      mockDbSelectLimit.mockResolvedValueOnce([]);
+
+      await (service as unknown as ServicePrivate).updateAlertTimestamp(
+        'agent-001',
+        'a1'
+      );
+      // Should not throw and should not call update
+      expect(mockDbUpdateSet).not.toHaveBeenCalled();
+    });
+
+    test('does not modify other alerts when target not found', async () => {
+      const alerts = [makeAlert({ id: 'a1' })];
+
+      mockDbSelectLimit.mockResolvedValueOnce([
+        { id: 'cfg-1', priceAlerts: alerts },
+      ]);
+
+      await (service as unknown as ServicePrivate).updateAlertTimestamp(
+        'agent-001',
+        'nonexistent'
+      );
+
+      expect(mockDbUpdateSet).toHaveBeenCalledTimes(1);
+      const setArg = mockDbUpdateSet.mock.calls[0]![0] as Record<
+        string,
+        unknown
+      >;
+      const updatedAlerts = setArg.priceAlerts as Array<
+        Record<string, unknown>
+      >;
+      // a1 should NOT have lastTriggeredAt modified
+      expect(updatedAlerts[0]?.lastTriggeredAt).toBeUndefined();
+    });
+  });
+});

--- a/packages/testing/unit/price-alerts-api.test.ts
+++ b/packages/testing/unit/price-alerts-api.test.ts
@@ -1,0 +1,525 @@
+/**
+ * Price Alerts REST API Route Tests
+ *
+ * Tests GET/POST/DELETE /api/agents/[agentId]/alerts:
+ * - Authentication and authorization (manager-only access)
+ * - GET: list alerts (empty, populated)
+ * - POST: create new alert, update existing, validation
+ * - DELETE: by alertId, by tokenSymbol+condition, not found
+ * - Edge cases: missing config, non-agent user, non-manager access
+ *
+ * Strategy: mock DB and auth; exercise real route handler code.
+ */
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { NextRequest } from 'next/server';
+
+// ─── Mock Setup ──────────────────────────────────────────────────────────────
+
+const MANAGER_USER_ID = 'manager-001';
+const AGENT_USER_ID = 'agent-001';
+
+const mockAuthenticateUser = mock(async () => ({
+  id: MANAGER_USER_ID,
+  userId: MANAGER_USER_ID,
+}));
+
+// DB mocks — fine-grained control per test
+let usersQueryResult: unknown[] = [];
+let configQueryResult: unknown[] = [];
+let dbSelectCallIndex = 0;
+
+const mockDbUpdateWhere = mock(async () => []);
+const mockDbUpdateSet = mock((_setArg: Record<string, unknown>) => ({
+  where: mockDbUpdateWhere,
+}));
+const mockDbUpdate = mock(() => ({ set: mockDbUpdateSet }));
+
+function resetDbMocks() {
+  dbSelectCallIndex = 0;
+  usersQueryResult = [
+    { id: AGENT_USER_ID, isAgent: true, managedBy: MANAGER_USER_ID },
+  ];
+  configQueryResult = [{ id: 'cfg-1', priceAlerts: [] }];
+  mockDbUpdateWhere.mockClear();
+  mockDbUpdateSet.mockClear();
+  mockDbUpdate.mockClear();
+}
+
+// The route does two sequential select queries:
+// 1. users table (agent lookup)
+// 2. userAgentConfigs (config lookup)
+const mockDbSelectLimit = mock(async () => {
+  dbSelectCallIndex++;
+  if (dbSelectCallIndex === 1) return usersQueryResult;
+  return configQueryResult;
+});
+const mockDbSelectWhere = mock(() => ({ limit: mockDbSelectLimit }));
+const mockDbSelectFrom = mock(() => ({ where: mockDbSelectWhere }));
+const mockDbSelect = mock(() => ({ from: mockDbSelectFrom }));
+
+mock.module('@babylon/api', () => ({
+  authenticateUser: mockAuthenticateUser,
+  withErrorHandling: (
+    handler: (req: NextRequest, ctx: unknown) => Promise<unknown>
+  ) => handler,
+}));
+
+mock.module('@babylon/db', () => ({
+  db: {
+    get select() {
+      return mockDbSelect;
+    },
+    get update() {
+      return mockDbUpdate;
+    },
+  },
+  eq: (a: unknown, b: unknown) => ({ op: 'eq', a, b }),
+  userAgentConfigs: {
+    id: 'userAgentConfigs.id',
+    userId: 'userAgentConfigs.userId',
+    priceAlerts: 'userAgentConfigs.priceAlerts',
+  },
+  users: {
+    id: 'users.id',
+    isAgent: 'users.isAgent',
+    managedBy: 'users.managedBy',
+  },
+}));
+
+mock.module('@babylon/shared', () => ({
+  generateSnowflakeId: mock(async () => 'snowflake-alert-api'),
+}));
+
+// ─── Import after mocks ──────────────────────────────────────────────────────
+
+const { GET, POST, DELETE } = await import(
+  '@/app/api/agents/[agentId]/alerts/route'
+);
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeRequest(
+  method: string,
+  body?: Record<string, unknown>,
+  searchParams?: Record<string, string>
+): NextRequest {
+  const url = new URL(
+    `http://localhost:3000/api/agents/${AGENT_USER_ID}/alerts`
+  );
+  if (searchParams) {
+    for (const [k, v] of Object.entries(searchParams)) {
+      url.searchParams.set(k, v);
+    }
+  }
+  return {
+    method,
+    url: url.toString(),
+    headers: new Headers({ Authorization: 'Bearer test-token' }),
+    json: async () => body ?? {},
+  } as unknown as NextRequest;
+}
+
+const routeContext = {
+  params: Promise.resolve({ agentId: AGENT_USER_ID }),
+};
+
+function makeAlert(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'alert-001',
+    tokenSymbol: 'OPENAGI',
+    condition: 'below',
+    threshold: 1.0,
+    deliveryChannel: 'team_chat',
+    enabled: true,
+    cooldownMinutes: 15,
+    createdAt: '2025-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('Price Alerts API', () => {
+  beforeEach(() => {
+    resetDbMocks();
+    mockAuthenticateUser.mockClear();
+    mockAuthenticateUser.mockResolvedValue({
+      id: MANAGER_USER_ID,
+      userId: MANAGER_USER_ID,
+    });
+  });
+
+  // ─── Authorization ───────────────────────────────────────────────────
+
+  describe('authorization', () => {
+    test('returns 404 when agent not found', async () => {
+      usersQueryResult = []; // No agent
+
+      const req = makeRequest('GET');
+      const res = await GET(req, routeContext);
+      const body = await res.json();
+
+      expect(res.status).toBe(404);
+      expect(body.error).toContain('Agent not found');
+    });
+
+    test('returns 404 when user is not an agent', async () => {
+      usersQueryResult = [
+        { id: AGENT_USER_ID, isAgent: false, managedBy: MANAGER_USER_ID },
+      ];
+
+      const req = makeRequest('GET');
+      const res = await GET(req, routeContext);
+
+      expect(res.status).toBe(404);
+    });
+
+    test('returns 403 when caller is not the agent manager', async () => {
+      usersQueryResult = [
+        { id: AGENT_USER_ID, isAgent: true, managedBy: 'other-owner' },
+      ];
+
+      const req = makeRequest('GET');
+      const res = await GET(req, routeContext);
+
+      expect(res.status).toBe(403);
+    });
+
+    test('returns 404 when agent config not found', async () => {
+      configQueryResult = []; // No config
+
+      const req = makeRequest('GET');
+      const res = await GET(req, routeContext);
+
+      expect(res.status).toBe(404);
+      const body = await res.json();
+      expect(body.error).toContain('configuration not found');
+    });
+  });
+
+  // ─── GET ─────────────────────────────────────────────────────────────
+
+  describe('GET /alerts', () => {
+    test('returns empty alerts array', async () => {
+      configQueryResult = [{ id: 'cfg-1', priceAlerts: [] }];
+
+      const req = makeRequest('GET');
+      const res = await GET(req, routeContext);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.alerts).toEqual([]);
+    });
+
+    test('returns populated alerts array', async () => {
+      const alerts = [
+        makeAlert(),
+        makeAlert({ id: 'a2', tokenSymbol: 'TSLAI' }),
+      ];
+      configQueryResult = [{ id: 'cfg-1', priceAlerts: alerts }];
+
+      const req = makeRequest('GET');
+      const res = await GET(req, routeContext);
+      const body = await res.json();
+
+      expect(body.success).toBe(true);
+      expect(body.alerts).toHaveLength(2);
+    });
+
+    test('returns null priceAlerts as empty array', async () => {
+      configQueryResult = [{ id: 'cfg-1', priceAlerts: null }];
+
+      const req = makeRequest('GET');
+      const res = await GET(req, routeContext);
+      const body = await res.json();
+
+      // priceAlerts: null → empty alerts (via ?? [])
+      expect(body.alerts).toEqual([]);
+    });
+  });
+
+  // ─── POST ────────────────────────────────────────────────────────────
+
+  describe('POST /alerts', () => {
+    test('returns 400 when tokenSymbol is missing', async () => {
+      const req = makeRequest('POST', {
+        condition: 'below',
+        threshold: 1.0,
+      });
+      const res = await POST(req, routeContext);
+
+      expect(res.status).toBe(400);
+    });
+
+    test('returns 400 when condition is invalid', async () => {
+      const req = makeRequest('POST', {
+        tokenSymbol: 'OPENAGI',
+        condition: 'around',
+        threshold: 1.0,
+      });
+      const res = await POST(req, routeContext);
+
+      expect(res.status).toBe(400);
+    });
+
+    test('returns 400 when threshold is negative', async () => {
+      const req = makeRequest('POST', {
+        tokenSymbol: 'OPENAGI',
+        condition: 'below',
+        threshold: -5,
+      });
+      const res = await POST(req, routeContext);
+
+      expect(res.status).toBe(400);
+    });
+
+    test('returns 400 when threshold is zero', async () => {
+      const req = makeRequest('POST', {
+        tokenSymbol: 'OPENAGI',
+        condition: 'below',
+        threshold: 0,
+      });
+      const res = await POST(req, routeContext);
+
+      expect(res.status).toBe(400);
+    });
+
+    test('returns 400 when threshold is not a number', async () => {
+      const req = makeRequest('POST', {
+        tokenSymbol: 'OPENAGI',
+        condition: 'below',
+        threshold: 'one dollar',
+      });
+      const res = await POST(req, routeContext);
+
+      expect(res.status).toBe(400);
+    });
+
+    test('returns 400 when deliveryChannel=group but no deliveryChatId', async () => {
+      const req = makeRequest('POST', {
+        tokenSymbol: 'OPENAGI',
+        condition: 'below',
+        threshold: 1.0,
+        deliveryChannel: 'group',
+      });
+      const res = await POST(req, routeContext);
+
+      expect(res.status).toBe(400);
+      const body = await res.json();
+      expect(body.error).toContain('deliveryChatId');
+    });
+
+    test('returns 400 when tokenSymbol is empty string', async () => {
+      const req = makeRequest('POST', {
+        tokenSymbol: '   ',
+        condition: 'below',
+        threshold: 1.0,
+      });
+      const res = await POST(req, routeContext);
+
+      expect(res.status).toBe(400);
+    });
+
+    test('creates new alert with 201 status', async () => {
+      configQueryResult = [{ id: 'cfg-1', priceAlerts: [] }];
+
+      const req = makeRequest('POST', {
+        tokenSymbol: 'openagi', // lowercase
+        condition: 'below',
+        threshold: 1.0,
+      });
+      const res = await POST(req, routeContext);
+      const body = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(body.success).toBe(true);
+      expect(body.alert.tokenSymbol).toBe('OPENAGI'); // Uppercased
+      expect(body.alert.deliveryChannel).toBe('team_chat'); // Default
+      expect(body.alert.cooldownMinutes).toBe(15); // Default
+      expect(body.updated).toBe(false);
+    });
+
+    test('updates existing alert with 200 status', async () => {
+      const existing = makeAlert({
+        tokenSymbol: 'OPENAGI',
+        condition: 'below',
+        threshold: 0.5,
+        lastTriggeredAt: '2025-01-01T00:00:00.000Z',
+      });
+      configQueryResult = [{ id: 'cfg-1', priceAlerts: [existing] }];
+
+      const req = makeRequest('POST', {
+        tokenSymbol: 'OPENAGI',
+        condition: 'below',
+        threshold: 0.8, // Updated threshold
+      });
+      const res = await POST(req, routeContext);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.updated).toBe(true);
+      expect(body.alert.threshold).toBe(0.8);
+      expect(body.alert.lastTriggeredAt).toBeUndefined(); // Reset on update
+    });
+
+    test('creates alert with custom delivery and cooldown', async () => {
+      configQueryResult = [{ id: 'cfg-1', priceAlerts: [] }];
+
+      const req = makeRequest('POST', {
+        tokenSymbol: 'TSLAI',
+        condition: 'above',
+        threshold: 2.0,
+        deliveryChannel: 'group',
+        deliveryChatId: 'group-999',
+        cooldownMinutes: 30,
+      });
+      const res = await POST(req, routeContext);
+      const body = await res.json();
+
+      expect(res.status).toBe(201);
+      expect(body.alert.deliveryChannel).toBe('group');
+      expect(body.alert.deliveryChatId).toBe('group-999');
+      expect(body.alert.cooldownMinutes).toBe(30);
+    });
+
+    test('does not duplicate when same token+condition exists', async () => {
+      const existing = makeAlert({
+        tokenSymbol: 'OPENAGI',
+        condition: 'below',
+        threshold: 0.5,
+      });
+      configQueryResult = [{ id: 'cfg-1', priceAlerts: [existing] }];
+
+      const req = makeRequest('POST', {
+        tokenSymbol: 'OPENAGI',
+        condition: 'below',
+        threshold: 1.0,
+      });
+      await POST(req, routeContext);
+
+      // Verify only 1 alert in the update (not 2)
+      const setArg = mockDbUpdateSet.mock.calls[0]![0] as Record<
+        string,
+        unknown
+      >;
+      const alerts = setArg.priceAlerts as Array<Record<string, unknown>>;
+      expect(alerts).toHaveLength(1);
+    });
+  });
+
+  // ─── DELETE ──────────────────────────────────────────────────────────
+
+  describe('DELETE /alerts', () => {
+    test('returns 400 when no identifier provided', async () => {
+      const req = makeRequest('DELETE');
+      const res = await DELETE(req, routeContext);
+
+      expect(res.status).toBe(400);
+    });
+
+    test('deletes by alertId', async () => {
+      const alerts = [
+        makeAlert({ id: 'a1' }),
+        makeAlert({ id: 'a2', tokenSymbol: 'TSLAI' }),
+      ];
+      configQueryResult = [{ id: 'cfg-1', priceAlerts: alerts }];
+
+      const req = makeRequest('DELETE', undefined, { alertId: 'a1' });
+      const res = await DELETE(req, routeContext);
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.success).toBe(true);
+      expect(body.removed.id).toBe('a1');
+
+      // Verify a2 remains
+      const setArg = mockDbUpdateSet.mock.calls[0]![0] as Record<
+        string,
+        unknown
+      >;
+      const remaining = setArg.priceAlerts as Array<Record<string, unknown>>;
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0]!.id).toBe('a2');
+    });
+
+    test('deletes by tokenSymbol', async () => {
+      configQueryResult = [
+        { id: 'cfg-1', priceAlerts: [makeAlert({ tokenSymbol: 'OPENAGI' })] },
+      ];
+
+      const req = makeRequest('DELETE', undefined, {
+        tokenSymbol: 'OPENAGI',
+      });
+      const res = await DELETE(req, routeContext);
+      const body = await res.json();
+
+      expect(body.success).toBe(true);
+    });
+
+    test('deletes by tokenSymbol + condition', async () => {
+      const alerts = [
+        makeAlert({ id: 'a1', tokenSymbol: 'OPENAGI', condition: 'below' }),
+        makeAlert({ id: 'a2', tokenSymbol: 'OPENAGI', condition: 'above' }),
+      ];
+      configQueryResult = [{ id: 'cfg-1', priceAlerts: alerts }];
+
+      const req = makeRequest('DELETE', undefined, {
+        tokenSymbol: 'OPENAGI',
+        condition: 'above',
+      });
+      const res = await DELETE(req, routeContext);
+      const body = await res.json();
+
+      expect(body.removed.id).toBe('a2');
+      const setArg = mockDbUpdateSet.mock.calls[0]![0] as Record<
+        string,
+        unknown
+      >;
+      const remaining = setArg.priceAlerts as Array<Record<string, unknown>>;
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0]!.condition).toBe('below');
+    });
+
+    test('returns 404 when alert not found by alertId', async () => {
+      configQueryResult = [
+        { id: 'cfg-1', priceAlerts: [makeAlert({ id: 'a1' })] },
+      ];
+
+      const req = makeRequest('DELETE', undefined, {
+        alertId: 'nonexistent',
+      });
+      const res = await DELETE(req, routeContext);
+
+      expect(res.status).toBe(404);
+    });
+
+    test('returns 404 when alert not found by tokenSymbol', async () => {
+      configQueryResult = [
+        { id: 'cfg-1', priceAlerts: [makeAlert({ tokenSymbol: 'OPENAGI' })] },
+      ];
+
+      const req = makeRequest('DELETE', undefined, {
+        tokenSymbol: 'NONEXISTENT',
+      });
+      const res = await DELETE(req, routeContext);
+
+      expect(res.status).toBe(404);
+    });
+
+    test('tokenSymbol matching is case-insensitive', async () => {
+      configQueryResult = [
+        { id: 'cfg-1', priceAlerts: [makeAlert({ tokenSymbol: 'OPENAGI' })] },
+      ];
+
+      const req = makeRequest('DELETE', undefined, {
+        tokenSymbol: 'openagi',
+      });
+      const res = await DELETE(req, routeContext);
+      const body = await res.json();
+
+      expect(body.success).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Implements full agent-to-agent messaging: DM, group chat, @username resolution, and coordinator-driven multi-agent orchestration (DISPATCH_TO_AGENTS / RELAY_TO_AGENT)
- Adds price alert system: agents can monitor token prices and notify owners via team chat or group chat when thresholds are crossed
- Adds EventBus-based inter-agent awareness so the coordinator sees what agents have done programmatically

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Builds on coordinator orchestration (#1172)

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [x] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [x] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Changes

**A2A operationMap + executor SSE broadcast**
- `integration-a2a-sdk.ts`: added missing operationMap entries for all Babylon operations
- `babylon-executor.ts`: broadcast SSE events on chat/group creation

**Agent messaging**
- `messaging.ts`: rewrote `sendMessageAction` with 3 resolution strategies (chatId, group name, @username)
- `context-gatherers.ts`: added `resolveGroupChatByName` and `resolveUserByUsername` helpers
- `DirectExecutors.ts`: added `executeGroupChatNotification` for broadcasting to group chats

**Coordinator orchestration**
- `dispatch-to-agents.ts`: new `DISPATCH_TO_AGENTS` action — parallel multi-agent dispatch via `Promise.allSettled`, capped at 5 concurrent, with result aggregation
- `relay-to-agent.ts`: new `RELAY_TO_AGENT` action — single-agent relay with context enrichment from prior dispatches
- `coordinator/route.ts`: registered new actions and providers in the coordinator plugin

**Inter-agent communication**
- `AgentChatService.ts`: publishes `agent.dispatch.result` events to EventBus after each dispatch
- `agent-activity.ts`: new provider that surfaces EventBus history in the coordinator's context window (last 10 events, formatted with ✓/✗ status)

**Price alert system**
- `user-agent-configs.ts`: added `PriceAlert` interface and `priceAlerts` JSONB column
- `PriceAlertService.ts`: checks alerts during autonomous tick — price lookup, cooldown enforcement, delivery routing (team_chat / group), timestamp persistence
- `AutonomousCoordinator.ts`: integrated price alert checking as pre-step in `executeAutonomousTick`
- `manage-price-alerts.ts`: three actions (SET / LIST / REMOVE) with dedup, validation, cooldown reset
- `alerts/route.ts`: REST API for managing alerts (GET / POST / DELETE) with manager-only auth

**Tests — 173 tests across 7 files**
- `operation-map-completeness.test.ts` (18): regression for all operationMap entries
- `messaging-parsers.test.ts` (29): resolution strategies, validation, error handling
- `dispatch-to-agents.test.ts` (28): parallel dispatch, cap, partial failure, truncation
- `agent-activity-provider.test.ts` (13): formatting, truncation, missing fields, event cap
- `price-alert-service.test.ts` (33): cooldown, delivery routing, price fallback, timestamp
- `manage-price-alerts.test.ts` (27): create/update/remove, dedup, validation
- `price-alerts-api.test.ts` (25): auth, GET/POST/DELETE, validation, case-insensitive matching

## Review guide

**Start here**
- `packages/agents/src/plugins/plugin-user-core/src/actions/dispatch-to-agents.ts` — core orchestration logic
- `packages/agents/src/autonomous/PriceAlertService.ts` — price alert checking engine
- `apps/web/src/app/api/agents/[agentId]/alerts/route.ts` — REST API for alerts

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- Price alerts use the existing `perpMarketSnapshots` table for price data (markPrice → currentPrice fallback)
- Coordinator orchestration is capped at 5 concurrent dispatches to prevent runaway agent storms
- Alert deduplication is by tokenSymbol+condition (same pair updates existing rather than creating duplicate)

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [ ] `bun run lint`
- [x] `bun run build`
- [x] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [x] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. See in-app testing checklist below

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)

> The `priceAlerts` field is a JSONB column on the existing `userAgentConfigs` table — no migration needed, defaults to `null`.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

> The alerts REST API enforces `managedBy` ownership — only the agent's manager can create/view/delete alerts.

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend-only agent infrastructure — no UI components added

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

---

## In-App Testing Checklist

### A2A OperationMap
- [x] Open the coordinator team chat → verify the coordinator agent can process messages without unknown operation errors in logs
- [x] Create a new group chat with agents → verify SSE event is broadcast (check browser devtools Network tab for SSE stream)

### Agent Messaging
- [x] In team chat, tell an agent: `"send a message to chat <chatId>: Hello"` → verify the message appears in the target chat
- [x] Tell an agent: `"send message to 'General Chat': Hello everyone"` → verify group name resolution works and the message lands in the correct group
- [x] Tell an agent: `"DM @<username>: Hey check this out"` → verify the DM is sent to the correct user's chat
- [x] Try an invalid target: `"send message to 'Nonexistent Group': test"` → verify the agent responds with a "could not find" error

### Coordinator Orchestration
- [x] In the coordinator team chat (with ≥2 agents), give a multi-agent task like `"Have all agents check their positions and report back"` → verify the coordinator dispatches to multiple agents simultaneously
- [x] Verify the coordinator's response includes a summary like "Dispatched to 2 agents: 2 succeeded, 0 failed"
- [x] Verify each agent actually executed the task (check their team chat messages or logs)
- [x] Give a relay task: `"Have agent-X analyze OPENAGI trends, then pass the results to agent-Y to make a trade"` → verify context enrichment (agent-Y receives the context from agent-X)

### Inter-Agent Awareness
- [x] After dispatching to agents, ask the coordinator `"What have the agents been doing?"` → verify the coordinator's response includes recent agent activity (formatted with ✓/✗ status indicators)
- [x] Verify the coordinator uses agent activity context to make informed follow-up decisions

### Price Alerts

**Via REST API:**
- [x] `POST /api/agents/<agentId>/alerts` with `{ "tokenSymbol": "OPENAGI", "condition": "below", "threshold": 1.0 }` → verify 201 response with created alert
- [x] `GET /api/agents/<agentId>/alerts` → verify the alert appears in the list
- [x] `POST` the same tokenSymbol+condition with a different threshold → verify 200 response (update, not duplicate)
- [x] `DELETE /api/agents/<agentId>/alerts?tokenSymbol=OPENAGI` → verify alert is removed
- [x] Try without auth / with wrong user → verify 403/404

**Via agent actions:**
- [x] Tell an agent: `"Set a price alert for OPENAGI below $0.50"` → verify the agent confirms the alert was created
- [x] Tell an agent: `"List my price alerts"` → verify formatted list with ✓/✗ status
- [ ] Tell an agent: `"Remove the price alert for OPENAGI below"` → verify removal confirmation

**Alert triggering:**
- [x] Set an alert with a threshold that the current price already satisfies (e.g., "above $0.001" for a token trading at $1) → wait for the next autonomous tick (~3 min) → verify the alert message appears in the team chat
- [x] Verify the alert is not re-triggered within the cooldown window (default 15 min)
- [ ] After cooldown elapses, verify the alert fires again if the condition is still met

### Edge Cases
- [x] Try setting a price alert with threshold 0 or negative → verify 400 error
- [x] Try setting deliveryChannel=group without deliveryChatId → verify 400 error
- [x] Dispatch to 6+ agents → verify only 5 are dispatched (cap enforced)
- [x] Send a message with an empty body → verify validation error
