### PR TITLE
fix(observability): log silent .catch(() => {}) errors for debuggability

### DIFF
--- a/apps/web/src/app/api/users/[userId]/verify-share/route.ts
+++ b/apps/web/src/app/api/users/[userId]/verify-share/route.ts
@@ -367,7 +367,13 @@ export const POST = withErrorHandling(
               const hasFallback = index < twitterAuthAttempts.length - 1;
               if (twitterResponse.status === 401 && hasFallback) {
                 // Drain the response body to release the connection.
-                await twitterResponse.text().catch(() => {});
+                await twitterResponse.text().catch((err) => {
+                  logger.debug(
+                    'Failed to drain Twitter response body',
+                    { error: err, shareId },
+                    'POST /api/users/[userId]/verify-share'
+                  );
+                });
                 logger.warn(
                   `Twitter API auth failed, retrying with fallback token: ${shareId}`,
                   {

--- a/apps/web/src/app/api/users/signup/route.ts
+++ b/apps/web/src/app/api/users/signup/route.ts
@@ -785,8 +785,12 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
           trackServerEvent(result.user.id, 'alpha_group_assignment.success', {
             groupsAssigned: assignmentResult.groupsAssigned,
             assignments: assignmentResult.assignments.map((a) => a.npcName),
-          }).catch(() => {
-            /* ignore tracking errors */
+          }).catch((err) => {
+            logger.debug(
+              'Tracking event failed',
+              { error: err, event: 'alpha_group_assignment.success' },
+              'POST /api/users/signup'
+            );
           });
         }
         if (assignmentResult.errors.length > 0) {
@@ -806,8 +810,12 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
               groupsAssigned: assignmentResult.groupsAssigned,
               errorCount: assignmentResult.errors.length,
             }
-          ).catch(() => {
-            /* ignore tracking errors */
+          ).catch((err) => {
+            logger.debug(
+              'Tracking event failed',
+              { error: err, event: 'alpha_group_assignment.partial_failure' },
+              'POST /api/users/signup'
+            );
           });
         }
       })
@@ -821,8 +829,12 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
         // Track failures for monitoring and alerting
         trackServerEvent(result.user.id, 'alpha_group_assignment.failure', {
           error: String(error),
-        }).catch(() => {
-          /* ignore tracking errors */
+        }).catch((err) => {
+          logger.debug(
+            'Tracking event failed',
+            { error: err, event: 'alpha_group_assignment.failure' },
+            'POST /api/users/signup'
+          );
         });
       });
   }

--- a/apps/web/src/components/markets/PerpPositionsList.tsx
+++ b/apps/web/src/components/markets/PerpPositionsList.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import { calculateUnrealizedPnL, cn, formatCurrency } from '@babylon/shared';
+import {
+  calculateUnrealizedPnL,
+  cn,
+  formatCurrency,
+  logger,
+} from '@babylon/shared';
 import { AlertTriangle, Bot, TrendingDown, TrendingUp } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 import { toast } from 'sonner';
@@ -158,7 +163,13 @@ export function PerpPositionsList({
       invalidatePerpMarketsCache();
       const refreshResult = onPositionClosed?.();
       if (refreshResult instanceof Promise) {
-        void refreshResult.catch(() => {});
+        void refreshResult.catch((err) => {
+          logger.debug(
+            'Background position refresh failed',
+            { error: err },
+            'PerpPositionsList'
+          );
+        });
       }
     } catch (err) {
       toast.error('Failed to close position', {

--- a/apps/web/src/hooks/useSessionHeartbeat.ts
+++ b/apps/web/src/hooks/useSessionHeartbeat.ts
@@ -7,7 +7,7 @@
  * @module useSessionHeartbeat
  */
 
-import { generateUUID } from '@babylon/shared';
+import { generateUUID, logger } from '@babylon/shared';
 import { usePathname } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 import { useAuth } from '@/hooks/useAuth';
@@ -85,7 +85,13 @@ export function useSessionHeartbeat(): void {
         keepalive: true,
         signal: controller.signal,
       })
-        .catch(() => {})
+        .catch((err) => {
+          logger.debug(
+            'Heartbeat fetch failed',
+            { error: err },
+            'useSessionHeartbeat'
+          );
+        })
         .finally(() => {
           clearTimeout(timeoutId);
         });

--- a/packages/agents/src/autonomous/AutonomousBatchResponseService.ts
+++ b/packages/agents/src/autonomous/AutonomousBatchResponseService.ts
@@ -607,7 +607,13 @@ LEAVE EMPTY IF:
                     skipped: true,
                   },
                 })
-                .catch(() => {});
+                .catch((err) => {
+                  logger.warn(
+                    'Failed to create log for skipped response',
+                    { error: err, interactionId: interaction.id },
+                    'AutonomousBatchResponse'
+                  );
+                });
             }
 
             cleanContent = null; // Mark as skipped


### PR DESCRIPTION
## Summary

- Replace 7 silent `.catch(() => {})` handlers with structured `logger.debug`/`logger.warn` calls across 5 files for production observability
- No logic or control flow changes — errors are still caught and swallowed, just now logged
- Uses the existing `logger` from `@babylon/shared` (migrated in prior PR)

## Type

- [x] Refactor / cleanup (no behavior change)

## Context / Links

- Follow-up to logger migration PR
- Addresses silent error swallowing that makes production debugging harder

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [x] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)

**Non-goals / exclusions:**
- `optionalAuth().catch(() => null)` (~12 routes) — anonymous auth is a normal code path, null is properly checked
- Client-side `fetch().catch(() => null)` (~8 sites) — UI fallbacks handle gracefully, null checked immediately
- `getAccessToken().catch(() => null)` (~4 hooks) — checked with `if (!token)` and throws
- `response.json().catch(() => null)` — parsing fallbacks with proper null handling
- Test files — intentional resilience patterns

## Changes

- `apps/web/src/hooks/useSessionHeartbeat.ts` — added `logger` import, heartbeat fetch catch → `logger.debug`
- `apps/web/src/components/markets/PerpPositionsList.tsx` — added `logger` import, background refresh catch → `logger.debug`
- `packages/agents/src/autonomous/AutonomousBatchResponseService.ts` — skipped-response log catch → `logger.warn` (matches existing `logger.error` for non-skipped variant)
- `apps/web/src/app/api/users/[userId]/verify-share/route.ts` — Twitter response drain catch → `logger.debug`
- `apps/web/src/app/api/users/signup/route.ts` — 3 tracking event catches → `logger.debug` with event-specific names

## Review guide

**Start here**
- Any of the 5 files — each change is a 2-3 line diff replacing an empty catch body with a logger call

**Risk**
- [x] Low

**Notes for reviewers**
- Zero control flow changes — every catch still swallows the error
- 6 of 7 sites use `debug` level (filtered in production by default) — appropriate for non-critical fire-and-forget operations
- 1 site uses `warn` level (`AutonomousBatchResponseService`) — logging infrastructure failure is more operationally significant

## Test plan

**Commands run**
- [x] `bun run test`
- [x] `bun run build`
- [x] `bun run lint`
- [x] `bun run typecheck`

**Manual verification**
1. No behavioral changes to verify — catch handlers still swallow errors, just with logging added

## Ops / Migration / Deployment

- [x] No deploy impact

## Breaking changes

- [x] None

## Security / privacy

- [x] No security impact

### Option B: No visual changes

- Reason: Backend/observability-only change — replaces empty catch bodies with logger calls, no UI impact

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
