### PR TITLE
fix(feed): market cards interleaved not clustered, countdown shows minutes

### DIFF
--- a/apps/web/src/app/feed/components/MixedFeedList.tsx
+++ b/apps/web/src/app/feed/components/MixedFeedList.tsx
@@ -5,14 +5,13 @@ import { useRouter } from 'next/navigation';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { NewMarketEntry } from '@/app/api/feed/new-markets/route';
 import type { NarrativeStory } from '@/app/feed/types/narrative';
+import { mergeChronologically } from '@/app/feed/utils/feedAlgorithms';
 import { ArticleCard } from '@/components/articles/ArticleCard';
 import type { PostCardProps } from '@/components/posts/PostCard';
 import { PostCard } from '@/components/posts/PostCard';
 import { InviteFriendsBanner } from '@/components/shared/InviteFriendsBanner';
 import { useAuthStore } from '@/stores/authStore';
 import { NewMarketCard } from './NewMarketCard';
-
-import { mergeChronologically } from '@/app/feed/utils/feedAlgorithms';
 
 function marketToNarrativeStory(m: NewMarketEntry): NarrativeStory {
   return {

--- a/apps/web/src/app/feed/components/NarrativeStoryList.tsx
+++ b/apps/web/src/app/feed/components/NarrativeStoryList.tsx
@@ -4,7 +4,10 @@ import type { NarrativeStory } from '@babylon/shared';
 import { useRouter } from 'next/navigation';
 import { useMemo } from 'react';
 import { flattenStories } from '@/app/feed/utils/feedAlgorithms';
-import { toArticleCardData, toPostCardData } from '@/app/feed/utils/postMappers';
+import {
+  toArticleCardData,
+  toPostCardData,
+} from '@/app/feed/utils/postMappers';
 import { ArticleCard } from '@/components/articles/ArticleCard';
 import { PostCard } from '@/components/posts/PostCard';
 import { NewMarketCard } from './NewMarketCard';

--- a/apps/web/src/app/feed/components/NewMarketCard.tsx
+++ b/apps/web/src/app/feed/components/NewMarketCard.tsx
@@ -14,7 +14,9 @@ function formatCountdown(isoDate: string): string {
   if (isNaN(parsed.getTime())) return '';
   const ms = parsed.getTime() - Date.now();
   if (ms <= 0) return 'Closing soon';
-  const hours = Math.floor(ms / (1000 * 60 * 60));
+  const totalMinutes = Math.floor(ms / (1000 * 60));
+  if (totalMinutes < 60) return `${totalMinutes}m left`;
+  const hours = Math.floor(totalMinutes / 60);
   if (hours < 24) return `${hours}h left`;
   const days = Math.floor(hours / 24);
   return `${days}d left`;

--- a/apps/web/src/app/feed/utils/feedAlgorithms.ts
+++ b/apps/web/src/app/feed/utils/feedAlgorithms.ts
@@ -5,8 +5,7 @@
  * unit tests can import the real implementation rather than maintaining copies.
  */
 
-import type { FeedPost } from '@babylon/shared';
-import type { NarrativePost, NarrativeStory } from '@babylon/shared';
+import type { FeedPost, NarrativePost, NarrativeStory } from '@babylon/shared';
 import type { NewMarketEntry } from '@/app/api/feed/new-markets/route';
 
 // ─── flattenStories ───────────────────────────────────────────────────────────
@@ -29,38 +28,50 @@ export const BURST_LEAD = 4;
 /**
  * Flatten scored stories into an interleaved burst list.
  *
- * Stories arrive sorted by score DESC (from the API). Each story contributes
- * BURST_SIZE consecutive posts per rotation pass. The highest-scored story
- * (index 0) gets BURST_LEAD posts on its first pass for extra prominence.
- * New market cards (no posts) emit a single card at their scored position.
+ * Market cards (isNewMarket) are separated from post-stories and injected
+ * one-per-rotation so they appear throughout the feed rather than clustering
+ * at the top. Without separation, market cards score near 1.0 (brand-new
+ * recency) and beat all posts, causing every market to appear before any post.
+ *
+ * Layout produced (3 stories, 2 markets):
+ *   [A×BURST_LEAD] [B×BURST_SIZE] [C×BURST_SIZE] [Market1]
+ *   [A×BURST_SIZE] [B×BURST_SIZE] [C×BURST_SIZE] [Market2]
+ *   [A remaining…]
  */
 export function flattenStories(stories: NarrativeStory[]): FlatItem[] {
   const items: FlatItem[] = [];
-  const queues = stories.map((s) => ({
+
+  // Separate market cards from post-stories so market cards can be
+  // injected at controlled intervals rather than all before the first post.
+  const pendingMarkets = stories.filter((s) => s.isNewMarket);
+  const postStories = stories.filter((s) => !s.isNewMarket);
+
+  if (postStories.length === 0) {
+    // No posts at all — just emit the market cards in score order
+    for (const m of pendingMarkets) {
+      items.push({ type: 'market', story: m, key: m.storyKey });
+    }
+    return items;
+  }
+
+  const queues = postStories.map((s) => ({
     story: s,
     posts: [...s.posts],
-    marketEmitted: false,
     firstAppearance: true,
   }));
 
+  let marketIdx = 0;
   let anyLeft = true;
+
   while (anyLeft) {
     anyLeft = false;
-    for (const [queueIndex, q] of queues.entries()) {
-      if (q.story.isNewMarket) {
-        if (!q.marketEmitted) {
-          q.marketEmitted = true;
-          items.push({ type: 'market', story: q.story, key: q.story.storyKey });
-          anyLeft = true;
-        }
-        continue;
-      }
 
+    for (const q of queues) {
       if (q.posts.length === 0) continue;
 
-      // Top story (index 0) gets extra posts on first appearance for prominence
+      // Top post-story gets extra posts on first appearance for prominence
       const burst =
-        q.firstAppearance && queueIndex === 0 ? BURST_LEAD : BURST_SIZE;
+        q.firstAppearance && queues.indexOf(q) === 0 ? BURST_LEAD : BURST_SIZE;
       q.firstAppearance = false;
 
       let took = 0;
@@ -75,6 +86,20 @@ export function flattenStories(stories: NarrativeStory[]): FlatItem[] {
       }
       anyLeft = true;
     }
+
+    // After each complete rotation of all post-stories, inject one market card.
+    // This spaces market cards evenly through the stream instead of clustering
+    // them all before the first post.
+    if (marketIdx < pendingMarkets.length) {
+      const m = pendingMarkets[marketIdx++]!;
+      items.push({ type: 'market', story: m, key: m.storyKey });
+    }
+  }
+
+  // Append any market cards that didn't fit within the post rotations
+  while (marketIdx < pendingMarkets.length) {
+    const m = pendingMarkets[marketIdx++]!;
+    items.push({ type: 'market', story: m, key: m.storyKey });
   }
 
   return items;

--- a/packages/testing/unit/narrative-feed-algorithms.test.ts
+++ b/packages/testing/unit/narrative-feed-algorithms.test.ts
@@ -90,7 +90,7 @@ describe('flattenStories', () => {
     });
   });
 
-  it('gives top story BURST_LEAD posts on first pass', () => {
+  it('gives top story BURST_LEAD posts before rotating', () => {
     const storyA = makeStory('A', 10);
     const storyB = makeStory('B', 10);
     const items = flattenStories([storyA, storyB]);
@@ -119,13 +119,17 @@ describe('flattenStories', () => {
     expect(items.filter((i) => i.key.startsWith('C:')).length).toBe(6);
   });
 
-  it('emits a new market card once at its scored position', () => {
+  it('injects market card after post rotation, not before', () => {
     const market = makeStory('market:1', 0, {
       isNewMarket: true,
       storyKey: 'market:1',
     });
     const posts = makeStory('posts', 4);
+    // market has score ~1.0 (new), but should appear AFTER the first post burst
     const items = flattenStories([market, posts]);
+
+    // First item must be a post (market card deferred to after first rotation)
+    expect(items[0]!.type).toBe('post');
 
     const marketItems = items.filter((i) => i.type === 'market');
     expect(marketItems.length).toBe(1);
@@ -207,9 +211,9 @@ describe('mergeChronologically', () => {
       [post(t(30)), post(t(10))],
       [market(t(20))]
     );
-    expect(result[0]!.type).toBe('post');   // 10min
+    expect(result[0]!.type).toBe('post'); // 10min
     expect(result[1]!.type).toBe('market'); // 20min
-    expect(result[2]!.type).toBe('post');   // 30min
+    expect(result[2]!.type).toBe('post'); // 30min
   });
 
   it('places market card at correct chronological position between posts', () => {
@@ -217,9 +221,9 @@ describe('mergeChronologically', () => {
       [post(t(5)), post(t(35))],
       [market(t(20))]
     );
-    expect(result[0]!.type).toBe('post');   // 5min
+    expect(result[0]!.type).toBe('post'); // 5min
     expect(result[1]!.type).toBe('market'); // 20min
-    expect(result[2]!.type).toBe('post');   // 35min
+    expect(result[2]!.type).toBe('post'); // 35min
   });
 
   it('handles multiple market cards', () => {
@@ -228,7 +232,7 @@ describe('mergeChronologically', () => {
     const result = mergeChronologically([post(t(15))], [m1, m2]);
 
     expect(result[0]!.type).toBe('market'); // 5min
-    expect(result[1]!.type).toBe('post');   // 15min
+    expect(result[1]!.type).toBe('post'); // 15min
     expect(result[2]!.type).toBe('market'); // 30min
   });
 


### PR DESCRIPTION
## Bug Fixes (post-merge follow-up to #1181)

### 1. Market cards clustering at top of Stories tab

All New Market cards were appearing before any posts because markets score ~1.0 (brand-new recency at 6h half-life = 1.0), sorting them to queue positions 0–N in `flattenStories`. The burst loop then emitted all of them in the first pass before a single post appeared.

**Fix**: Separate `isNewMarket` entries from post-stories before the burst loop. Market cards are injected one-per-rotation — after each complete pass through all post-stories, one market card is appended. This distributes them evenly through the stream.

Layout produced (3 stories, 2 markets):
```
[A×BURST_LEAD] [B×BURST_SIZE] [C×BURST_SIZE] → Market 1
[A×BURST_SIZE] [B×BURST_SIZE] [C×BURST_SIZE] → Market 2
[A remaining…]
```

### 2. Countdown showing "0h left" instead of minutes

`formatCountdown` computed `Math.floor(ms / 3_600_000)` first, which rounds anything under 60 minutes down to 0, then returned `"0h left"`.

**Fix**: Compute `totalMinutes` first:
- `< 60 min` → `"45m left"`
- `< 24h` → `"3h left"`
- `≥ 24h` → `"2d left"`