### PR TITLE
fix(feed): exclude reposts from narrative feed — blank content cards

### DIFF
--- a/apps/web/src/app/api/feed/narrative/route.ts
+++ b/apps/web/src/app/api/feed/narrative/route.ts
@@ -34,6 +34,7 @@ import {
   inArray,
   isNotNull,
   isNull,
+  ne,
   lt,
   lte,
   markets,
@@ -170,7 +171,10 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
             gte(posts.timestamp, cutoff),
             lte(posts.timestamp, now),
             isNull(posts.commentOnPostId),
-            isNull(posts.parentCommentId)
+            isNull(posts.parentCommentId),
+            // Reposts have content: "" — exclude them so the feed doesn't
+            // surface hundreds of blank cards from NPC repost activity.
+            ne(posts.type, 'repost')
           )
         )
         .orderBy(desc(posts.timestamp))

--- a/apps/web/src/app/api/feed/narrative/route.ts
+++ b/apps/web/src/app/api/feed/narrative/route.ts
@@ -285,7 +285,9 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
           })
           .from(posts)
           .where(inArray(posts.id, repostOriginalIds));
-        const originalAuthorIds = [...new Set(originalRows.map((r) => r.authorId))];
+        const originalAuthorIds = [
+          ...new Set(originalRows.map((r) => r.authorId)),
+        ];
         const originalAuthorUsers =
           originalAuthorIds.length > 0
             ? await db
@@ -298,7 +300,9 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
                 .from(users)
                 .where(inArray(users.id, originalAuthorIds))
             : [];
-        const originalUserMap = new Map(originalAuthorUsers.map((u) => [u.id, u]));
+        const originalUserMap = new Map(
+          originalAuthorUsers.map((u) => [u.id, u])
+        );
         for (const r of originalRows) {
           const u = originalUserMap.get(r.authorId);
           originalPostMap.set(r.id, {
@@ -386,11 +390,13 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
         const isRepost = post.type === 'repost';
         const isQuote = isRepost && post.content !== '';
         const originalPostData = post.originalPostId
-          ? originalPostMap.get(post.originalPostId) ?? null
+          ? (originalPostMap.get(post.originalPostId) ?? null)
           : null;
         let originalPost: NarrativePost['originalPost'] = null;
         if (originalPostData) {
-          const origActor = StaticDataRegistry.getActor(originalPostData.authorId);
+          const origActor = StaticDataRegistry.getActor(
+            originalPostData.authorId
+          );
           const origAuthorName =
             origActor?.name ??
             originalPostData.displayName ??
@@ -401,9 +407,12 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
             content: originalPostData.content,
             authorId: originalPostData.authorId,
             authorName: origAuthorName,
-            authorUsername: origActor?.username ?? originalPostData.username ?? null,
+            authorUsername:
+              origActor?.username ?? originalPostData.username ?? null,
             authorProfileImageUrl:
-              origActor?.profileImageUrl ?? originalPostData.profileImageUrl ?? null,
+              origActor?.profileImageUrl ??
+              originalPostData.profileImageUrl ??
+              null,
             timestamp: toISOStringStrict(
               originalPostData.timestamp,
               'timestamp',
@@ -547,6 +556,35 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
           posts: [post],
           hasUserPosition: false,
         });
+      }
+
+      // Resolve marketId for question-backed stories so the frontend can render
+      // a live probability chart (PredictionSparkline) on each post card.
+      // Same text-based join used for new market cards; this fetches only
+      // existing stories (not new markets which already have marketId set).
+      const storyQuestionNumbers = stories
+        .filter((s) => !s.isNewMarket && s.questionNumber !== null)
+        .map((s) => s.questionNumber as number);
+      if (storyQuestionNumbers.length > 0) {
+        const marketRows = await db
+          .select({
+            questionNumber: questions.questionNumber,
+            marketId: markets.id,
+          })
+          .from(questions)
+          .innerJoin(
+            markets,
+            sql`lower(trim(${markets.question})) = lower(trim(${questions.text}))`
+          )
+          .where(inArray(questions.questionNumber, storyQuestionNumbers));
+        const questionToMarket = new Map(
+          marketRows.map((r) => [r.questionNumber, r.marketId])
+        );
+        for (const story of stories) {
+          if (!story.isNewMarket && story.questionNumber !== null) {
+            story.marketId = questionToMarket.get(story.questionNumber) ?? null;
+          }
+        }
       }
 
       // Sort all stories — question stories AND standalone posts — by score DESC.

--- a/apps/web/src/app/api/feed/narrative/route.ts
+++ b/apps/web/src/app/api/feed/narrative/route.ts
@@ -34,7 +34,6 @@ import {
   inArray,
   isNotNull,
   isNull,
-  ne,
   lt,
   lte,
   markets,
@@ -163,6 +162,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
           category: posts.category,
           imageUrl: posts.imageUrl,
           relatedQuestion: posts.relatedQuestion,
+          originalPostId: posts.originalPostId,
         })
         .from(posts)
         .where(
@@ -171,10 +171,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
             gte(posts.timestamp, cutoff),
             lte(posts.timestamp, now),
             isNull(posts.commentOnPostId),
-            isNull(posts.parentCommentId),
-            // Reposts have content: "" — exclude them so the feed doesn't
-            // surface hundreds of blank cards from NPC repost activity.
-            ne(posts.type, 'repost')
+            isNull(posts.parentCommentId)
           )
         )
         .orderBy(desc(posts.timestamp))
@@ -256,6 +253,66 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
         .where(inArray(users.id, authorIds));
       const userMap = new Map(authorUsers.map((u) => [u.id, u]));
 
+      // Fetch original posts for reposts so their content can be displayed
+      // the same way as the main feed. Simple reposts have content: ""; quote
+      // posts put the quote text in content and the original in originalPostId.
+      const repostOriginalIds = [
+        ...new Set(
+          recentPosts
+            .filter((p) => p.originalPostId)
+            .map((p) => p.originalPostId as string)
+        ),
+      ];
+      const originalPostMap = new Map<
+        string,
+        {
+          id: string;
+          content: string;
+          authorId: string;
+          timestamp: Date;
+          profileImageUrl: string | null;
+          username: string | null;
+          displayName: string | null;
+        }
+      >();
+      if (repostOriginalIds.length > 0) {
+        const originalRows = await db
+          .select({
+            id: posts.id,
+            content: posts.content,
+            authorId: posts.authorId,
+            timestamp: posts.timestamp,
+          })
+          .from(posts)
+          .where(inArray(posts.id, repostOriginalIds));
+        const originalAuthorIds = [...new Set(originalRows.map((r) => r.authorId))];
+        const originalAuthorUsers =
+          originalAuthorIds.length > 0
+            ? await db
+                .select({
+                  id: users.id,
+                  username: users.username,
+                  displayName: users.displayName,
+                  profileImageUrl: users.profileImageUrl,
+                })
+                .from(users)
+                .where(inArray(users.id, originalAuthorIds))
+            : [];
+        const originalUserMap = new Map(originalAuthorUsers.map((u) => [u.id, u]));
+        for (const r of originalRows) {
+          const u = originalUserMap.get(r.authorId);
+          originalPostMap.set(r.id, {
+            id: r.id,
+            content: r.content,
+            authorId: r.authorId,
+            timestamp: r.timestamp,
+            profileImageUrl: u?.profileImageUrl ?? null,
+            username: u?.username ?? null,
+            displayName: u?.displayName ?? null,
+          });
+        }
+      }
+
       // Resolve question metadata (title, status, arcState) via posts.relatedQuestion → questions.questionNumber
       // LEFT JOIN arcStates to get narrative state in one round-trip.
       const questionNumbers = [
@@ -324,6 +381,37 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
           authorProfileImageUrl = authorUser.profileImageUrl;
         }
 
+        // Build repost metadata the same way the main feed does so PostCard
+        // can render repost cards with the original post's content.
+        const isRepost = post.type === 'repost';
+        const isQuote = isRepost && post.content !== '';
+        const originalPostData = post.originalPostId
+          ? originalPostMap.get(post.originalPostId) ?? null
+          : null;
+        let originalPost: NarrativePost['originalPost'] = null;
+        if (originalPostData) {
+          const origActor = StaticDataRegistry.getActor(originalPostData.authorId);
+          const origAuthorName =
+            origActor?.name ??
+            originalPostData.displayName ??
+            originalPostData.username ??
+            originalPostData.authorId;
+          originalPost = {
+            id: originalPostData.id,
+            content: originalPostData.content,
+            authorId: originalPostData.authorId,
+            authorName: origAuthorName,
+            authorUsername: origActor?.username ?? originalPostData.username ?? null,
+            authorProfileImageUrl:
+              origActor?.profileImageUrl ?? originalPostData.profileImageUrl ?? null,
+            timestamp: toISOStringStrict(
+              originalPostData.timestamp,
+              'timestamp',
+              originalPostData.id
+            ),
+          };
+        }
+
         const narrativePost: NarrativePost = {
           id: post.id,
           content: post.content,
@@ -343,6 +431,11 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
           isLiked: false,
           isShared: false,
           relatedQuestion: post.relatedQuestion ?? null,
+          isRepost,
+          isQuote,
+          quoteComment: isQuote ? post.content : null,
+          originalPostId: post.originalPostId ?? null,
+          originalPost,
         };
 
         const storyKey =

--- a/apps/web/src/app/feed/components/NarrativePredictionChart.tsx
+++ b/apps/web/src/app/feed/components/NarrativePredictionChart.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { PredictionSparkline } from '@/components/markets/PredictionSparkline';
+import { usePredictionHistory } from '@/hooks/usePredictionHistory';
+
+interface NarrativePredictionChartProps {
+  marketId: string;
+}
+
+/**
+ * Compact prediction probability chart for inline use on feed post cards.
+ *
+ * Fetches price history for the given marketId and renders a sparkline
+ * showing the YES/NO probability trend. Silently renders nothing if
+ * history is unavailable (loading, error, or empty).
+ */
+export function NarrativePredictionChart({
+  marketId,
+}: NarrativePredictionChartProps) {
+  const { history, loading } = usePredictionHistory(marketId, { limit: 40 });
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [chartWidth, setChartWidth] = useState(280);
+
+  // Measure container width so the sparkline fills the available space
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const ro = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) setChartWidth(Math.floor(entry.contentRect.width));
+    });
+    ro.observe(containerRef.current);
+    return () => ro.disconnect();
+  }, []);
+
+  if (loading || history.length === 0) return null;
+
+  const latest = history[history.length - 1];
+  const yesPercent = Math.round((latest?.yesPrice ?? 0.5) * 100);
+  const noPercent = 100 - yesPercent;
+
+  return (
+    <div className="mx-4 mb-3 rounded-lg border border-border bg-muted/30 px-3 py-2">
+      <div className="mb-1.5 flex items-center justify-between text-xs">
+        <span className="font-medium text-green-500">{yesPercent}% YES</span>
+        <span className="text-muted-foreground text-[10px]">probability</span>
+        <span className="font-medium text-red-500">{noPercent}% NO</span>
+      </div>
+      <div ref={containerRef} className="w-full overflow-hidden">
+        <PredictionSparkline data={history} width={chartWidth} height={40} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/feed/components/NarrativeStoryList.tsx
+++ b/apps/web/src/app/feed/components/NarrativeStoryList.tsx
@@ -29,12 +29,15 @@ export function NarrativeStoryList({ stories }: NarrativeStoryListProps) {
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
   const sentinelRef = useRef<HTMLDivElement>(null);
 
-  // Reset visible count when the underlying data changes (tab switch / refresh).
-  // Depend on `stories` (the prop) rather than `allItems` (the memo result)
-  // because the effect body doesn't reference allItems — Biome would flag it.
-  useEffect(() => {
+  // Reset visible count when stories changes (tab switch / refresh).
+  // Using a ref comparison during render is the React-idiomatic way to
+  // reset derived state without a useEffect, since the effect body wouldn't
+  // reference the dependency and Biome would flag it as unnecessary.
+  const prevStoriesRef = useRef(stories);
+  if (prevStoriesRef.current !== stories) {
+    prevStoriesRef.current = stories;
     setVisibleCount(PAGE_SIZE);
-  }, [stories]);
+  }
 
   const loadMore = useCallback(() => {
     setVisibleCount((n) => Math.min(n + PAGE_SIZE, allItems.length));

--- a/apps/web/src/app/feed/components/NarrativeStoryList.tsx
+++ b/apps/web/src/app/feed/components/NarrativeStoryList.tsx
@@ -2,7 +2,7 @@
 
 import type { NarrativeStory } from '@babylon/shared';
 import { useRouter } from 'next/navigation';
-import { useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { flattenStories } from '@/app/feed/utils/feedAlgorithms';
 import {
   toArticleCardData,
@@ -10,7 +10,10 @@ import {
 } from '@/app/feed/utils/postMappers';
 import { ArticleCard } from '@/components/articles/ArticleCard';
 import { PostCard } from '@/components/posts/PostCard';
+import { NarrativePredictionChart } from './NarrativePredictionChart';
 import { NewMarketCard } from './NewMarketCard';
+
+const PAGE_SIZE = 20;
 
 interface NarrativeStoryListProps {
   stories: NarrativeStory[];
@@ -19,18 +22,51 @@ interface NarrativeStoryListProps {
 export function NarrativeStoryList({ stories }: NarrativeStoryListProps) {
   const router = useRouter();
 
-  const items = useMemo(() => flattenStories(stories), [stories]);
+  const allItems = useMemo(() => flattenStories(stories), [stories]);
 
-  if (items.length === 0) return null;
+  // Reveal items progressively as the user scrolls — identical behaviour to
+  // the infinite-scroll feed on other tabs.
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  // Reset visible count when the underlying data changes (tab switch / refresh)
+  useEffect(() => {
+    setVisibleCount(PAGE_SIZE);
+  }, [allItems]);
+
+  const loadMore = useCallback(() => {
+    setVisibleCount((n) => Math.min(n + PAGE_SIZE, allItems.length));
+  }, [allItems.length]);
+
+  // Watch the sentinel div at the bottom of the visible list. When it enters
+  // the viewport, reveal the next page of items.
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) loadMore();
+      },
+      { rootMargin: '200px' }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [loadMore]);
+
+  const visibleItems = allItems.slice(0, visibleCount);
+  const hasMore = visibleCount < allItems.length;
+
+  if (visibleItems.length === 0) return null;
 
   return (
     <div className="w-full">
-      {items.map((item) => {
+      {visibleItems.map((item) => {
         if (item.type === 'market') {
           return <NewMarketCard key={item.key} story={item.story} />;
         }
 
-        const { post } = item;
+        const { post, marketId } = item;
         return (
           <div key={item.key} className="border-border border-b">
             {post.type === 'article' ? (
@@ -40,20 +76,30 @@ export function NarrativeStoryList({ stories }: NarrativeStoryListProps) {
                 onClick={() => router.push(`/article/${post.id}`)}
               />
             ) : (
-              <PostCard
-                post={toPostCardData(post)}
-                density="default"
-                showCommentInputBar={false}
-                onCommentClick={() => router.push(`/post/${post.id}`)}
-              />
+              <>
+                <PostCard
+                  post={toPostCardData(post)}
+                  density="default"
+                  showCommentInputBar={false}
+                  onCommentClick={() => router.push(`/post/${post.id}`)}
+                />
+                {marketId && (
+                  <NarrativePredictionChart marketId={marketId} />
+                )}
+              </>
             )}
           </div>
         );
       })}
 
-      <div className="py-4 text-center text-muted-foreground text-xs">
-        You&apos;re all caught up.
-      </div>
+      {/* Sentinel element — triggers next page load when scrolled into view */}
+      <div ref={sentinelRef} className="h-1" />
+
+      {!hasMore && (
+        <div className="py-4 text-center text-muted-foreground text-xs">
+          You&apos;re all caught up.
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/app/feed/components/NarrativeStoryList.tsx
+++ b/apps/web/src/app/feed/components/NarrativeStoryList.tsx
@@ -29,10 +29,12 @@ export function NarrativeStoryList({ stories }: NarrativeStoryListProps) {
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
   const sentinelRef = useRef<HTMLDivElement>(null);
 
-  // Reset visible count when the underlying data changes (tab switch / refresh)
+  // Reset visible count when the underlying data changes (tab switch / refresh).
+  // Depend on `stories` (the prop) rather than `allItems` (the memo result)
+  // because the effect body doesn't reference allItems — Biome would flag it.
   useEffect(() => {
     setVisibleCount(PAGE_SIZE);
-  }, [allItems]);
+  }, [stories]);
 
   const loadMore = useCallback(() => {
     setVisibleCount((n) => Math.min(n + PAGE_SIZE, allItems.length));
@@ -83,9 +85,7 @@ export function NarrativeStoryList({ stories }: NarrativeStoryListProps) {
                   showCommentInputBar={false}
                   onCommentClick={() => router.push(`/post/${post.id}`)}
                 />
-                {marketId && (
-                  <NarrativePredictionChart marketId={marketId} />
-                )}
+                {marketId && <NarrativePredictionChart marketId={marketId} />}
               </>
             )}
           </div>

--- a/apps/web/src/app/feed/utils/feedAlgorithms.ts
+++ b/apps/web/src/app/feed/utils/feedAlgorithms.ts
@@ -11,7 +11,7 @@ import type { NewMarketEntry } from '@/app/api/feed/new-markets/route';
 // ─── flattenStories ───────────────────────────────────────────────────────────
 
 export type FlatItem =
-  | { type: 'post'; post: NarrativePost; key: string }
+  | { type: 'post'; post: NarrativePost; key: string; marketId: string | null }
   | { type: 'market'; story: NarrativeStory; key: string };
 
 /**
@@ -81,6 +81,7 @@ export function flattenStories(stories: NarrativeStory[]): FlatItem[] {
           type: 'post',
           post,
           key: `${q.story.storyKey}:${post.id}`,
+          marketId: q.story.marketId ?? null,
         });
         took++;
       }

--- a/apps/web/src/app/feed/utils/postMappers.ts
+++ b/apps/web/src/app/feed/utils/postMappers.ts
@@ -25,6 +25,12 @@ export function toPostCardData(post: NarrativePost) {
     shareCount: post.shareCount,
     isLiked: post.isLiked,
     isShared: post.isShared,
+    // Repost fields — passed through so PostCard renders the original content
+    isRepost: post.isRepost ?? false,
+    isQuote: post.isQuote ?? false,
+    quoteComment: post.quoteComment ?? null,
+    originalPostId: post.originalPostId ?? null,
+    originalPost: post.originalPost ?? null,
   };
 }
 

--- a/packages/shared/src/types/feed.ts
+++ b/packages/shared/src/types/feed.ts
@@ -52,6 +52,20 @@ export interface NarrativePost {
   isLiked: boolean;
   isShared: boolean;
   relatedQuestion: number | null;
+  // Repost fields — mirrors the shape PostCard expects
+  isRepost?: boolean;
+  isQuote?: boolean;
+  quoteComment?: string | null;
+  originalPostId?: string | null;
+  originalPost?: {
+    id: string;
+    content: string;
+    authorId: string;
+    authorName: string;
+    authorUsername: string | null;
+    authorProfileImageUrl: string | null;
+    timestamp: string;
+  } | null;
 }
 
 /**


### PR DESCRIPTION
## Bug

The narrative feed was returning hundreds of repost posts with `content: ""` (empty string). Reposts don't store their own content — the content lives on the original post. When the Stories feed flattened these into individual cards, users saw a feed full of blank post cards.

**Root cause:** The `/api/feed/narrative` posts query filtered comments (`isNull(posts.commentOnPostId)`) and replies (`isNull(posts.parentCommentId)`) but not reposts (`type = 'repost'`).

Confirmed via live API check — the `__general__` bucket had 483 posts, nearly all reposts with `content: ""`.

## Fix

Add `ne(posts.type, 'repost')` to the WHERE clause alongside the existing comment/reply filters.

```typescript
ne(posts.type, 'repost')  // reposts have content: "" — blank cards
```

This applies to both the general bucket standalone posts AND question-linked story posts.