### PR TITLE
feat(feed): balanced slot-pattern feed, inline trading, NPC filter, org routing fixes

### DIFF
--- a/apps/web/src/app/api/posts/route.ts
+++ b/apps/web/src/app/api/posts/route.ts
@@ -744,10 +744,31 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       commentCounts.map((c) => [c.postId, Number(c.count)])
     );
 
+    // Fetch original posts for reposts in the following feed.
+    // getPostsForFollowing does a plain SELECT with no JOIN, so originalPost
+    // must be fetched separately — otherwise reposts render as blank cards.
+    const followingRepostIds = filteredPosts
+      .filter((p) => p.originalPostId)
+      .map((p) => p.originalPostId)
+      .filter((id): id is string => id !== null);
+
+    const followingOriginalPostsMap = new Map<string, Post>();
+    if (followingRepostIds.length > 0) {
+      const originals = await db
+        .select()
+        .from(posts)
+        .where(
+          and(inArray(posts.id, followingRepostIds), isNull(posts.deletedAt))
+        );
+      originals.forEach((p) => followingOriginalPostsMap.set(p.id, p));
+    }
+
     // Format following posts synchronously using lookup maps
-    // Note: filteredPosts already includes originalPost via the include in the query above
     const formattedFollowingPosts = filteredPosts.map((post: Post) => {
-      const postsWithOriginal = post as PostWithOriginal;
+      const originalPost = post.originalPostId
+        ? (followingOriginalPostsMap.get(post.originalPostId) ?? null)
+        : null;
+      const postsWithOriginal: PostWithOriginal = { ...post, originalPost };
       const user = post.authorId ? userMap.get(post.authorId) : undefined;
 
       // Build repost metadata from originalPost if it exists (clean, no text parsing)

--- a/apps/web/src/app/feed/components/NarrativeStoryList.tsx
+++ b/apps/web/src/app/feed/components/NarrativeStoryList.tsx
@@ -3,7 +3,10 @@
 import type { NarrativeStory } from '@babylon/shared';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { applySlotPattern, flattenStories } from '@/app/feed/utils/feedAlgorithms';
+import {
+  applySlotPattern,
+  flattenStories,
+} from '@/app/feed/utils/feedAlgorithms';
 import {
   toArticleCardData,
   toPostCardData,

--- a/apps/web/src/app/feed/components/NewMarketCard.tsx
+++ b/apps/web/src/app/feed/components/NewMarketCard.tsx
@@ -2,8 +2,8 @@
 
 import { CheckCircle, ExternalLink, XCircle } from 'lucide-react';
 import Link from 'next/link';
-import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
 import type { NarrativeStory } from '@/app/feed/types/narrative';
 import { InteractionBar } from '@/components/interactions/InteractionBar';
 import { PredictionSparkline } from '@/components/markets/PredictionSparkline';

--- a/packages/testing/unit/narrative-feed-algorithms.test.ts
+++ b/packages/testing/unit/narrative-feed-algorithms.test.ts
@@ -17,9 +17,9 @@ import type { NarrativePost, NarrativeStory } from '@babylon/shared';
 
 // Import the real implementations (not copies)
 import {
+  applySlotPattern,
   BURST_LEAD,
   BURST_SIZE,
-  applySlotPattern,
   flattenStories,
   mergeChronologically,
 } from '../../../apps/web/src/app/feed/utils/feedAlgorithms';
@@ -266,7 +266,9 @@ describe('applySlotPattern', () => {
     makePost(id, { type: 'article', authorType: 'user' });
 
   /** New market FlatItem */
-  const marketItem = (key: string): ReturnType<typeof applySlotPattern>[number] => ({
+  const marketItem = (
+    key: string
+  ): ReturnType<typeof applySlotPattern>[number] => ({
     type: 'market',
     key,
     story: {
@@ -333,7 +335,12 @@ describe('applySlotPattern', () => {
       post: articlePost('art1'),
       marketId: null,
     });
-    const items = [actorItem('a1'), actorItem('a2'), articleItem(), marketItem('m1')];
+    const items = [
+      actorItem('a1'),
+      actorItem('a2'),
+      articleItem(),
+      marketItem('m1'),
+    ];
     const result = applySlotPattern(items);
     // Third slot should be news (article)
     expect(result[2]).toMatchObject({ type: 'post' });
@@ -361,8 +368,10 @@ describe('applySlotPattern', () => {
     ];
     const result = applySlotPattern(items);
     // First two actor slots should not both be from sameAuthor
-    const firstActorId = result[0]!.type === 'post' ? result[0]!.post.authorId : null;
-    const secondActorId = result[1]!.type === 'post' ? result[1]!.post.authorId : null;
+    const firstActorId =
+      result[0]!.type === 'post' ? result[0]!.post.authorId : null;
+    const secondActorId =
+      result[1]!.type === 'post' ? result[1]!.post.authorId : null;
     expect(firstActorId).not.toBe(secondActorId);
   });
 


### PR DESCRIPTION
## Summary

All the feed improvements from today's session, bundled as a reviewable PR.

### Feed balance — slot-pattern interleaving
- `applySlotPattern()` enforces `[actor, actor, news, market]` repeating ratio so the feed is balanced across content types (was showing 15 markets in a row or 3 consecutive Bloomberg posts)
- `authorType` (`'actor' | 'news' | 'user'`) added to `NarrativePost` — set server-side from `StaticDataRegistry` lookups already running per post (zero new DB queries)
- `BURST_SIZE` reduced 3→2, `BURST_LEAD` 4→3 to cut same-source clustering before slot reordering
- NPC "NEW MARKET:" org posts filtered from feed — they duplicate `NewMarketCard` and add noise

### NewMarketCard — inline trading (no navigation away)
- **BUY YES / BUY NO** solid buttons open `PredictionTradingModal` inline — same pattern as `agents/team/panels/PredictionsPanel`
- Builds `PredictionMarket` object from story data (id, shares, resolutionDate) — zero extra API calls
- Lazy-load chart via `IntersectionObserver` (150px rootMargin) — prevents 429 cascade from simultaneous chart requests
- `InteractionBar` (like/comment/share) anchored to the first NPC post's ID so the card is social-interactive

### NarrativePredictionChart — on regular post cards
- Chart displays inside a bordered `bg-muted/20` container with YES%/NO% header
- Lazy-loaded (100px rootMargin) to prevent rate-limit cascades on scroll

### Scroll pagination on Stories tab
- `NarrativeStoryList` reveals 20 items at a time via `IntersectionObserver` sentinel
- Resets when stories array reference changes (tab switch / refresh)

### Org author routing + images fixed
- `StaticDataRegistry.getOrganization()` now checked when `getActor()` returns null
- Org authors get correct image from `/images/organizations/` and route to `/orgs/{id}` instead of "user not found" on `/u/id/`

### Repost rendering
- `originalPostId` added to posts SELECT; batch-fetch original posts + authors
- `isRepost`, `isQuote`, `quoteComment`, `originalPost` shape passed through — PostCard renders repost cards with original content

## Test plan
- Stories tab: balanced mix of actor posts, news posts, and market cards
- BUY YES/NO buttons on market cards open trading modal directly
- Clicking org author routes to correct org page (not "user not found")
- Repost cards show the original post content
- Scroll reveals 20 items at a time
- Charts lazy-load on scroll (no 429s on page load)