### PR TITLE
fix(feed): use PredictionProbabilityChart + seed for market cards — fixes black chart

### DIFF
--- a/apps/web/src/app/feed/components/NarrativePredictionChart.tsx
+++ b/apps/web/src/app/feed/components/NarrativePredictionChart.tsx
@@ -1,27 +1,33 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { PredictionSparkline } from '@/components/markets/PredictionSparkline';
+import { PredictionProbabilityChart } from '@/components/markets/PredictionProbabilityChart';
 import { usePredictionHistory } from '@/hooks/usePredictionHistory';
+import type { MarketTimeRange } from '@/types/markets';
 
 interface NarrativePredictionChartProps {
   marketId: string;
+  /** Live share counts used to seed the chart for markets with no API history yet */
+  yesShares?: number;
+  noShares?: number;
 }
 
 /**
- * Compact probability chart attached below a regular feed post card when the
- * post is related to a prediction market.
+ * Compact prediction probability chart for inline use on feed post cards.
  *
- * Defers the history fetch via IntersectionObserver so concurrent requests
- * don't saturate the rate limiter when 20 cards are visible at once.
+ * Uses the same PredictionProbabilityChart as the markets terminal for visual
+ * consistency. Defers history fetch via IntersectionObserver (100px rootMargin)
+ * to prevent 429 cascades when many cards are visible at once. Passes seed
+ * data from live share counts so markets with no API history still render.
  */
 export function NarrativePredictionChart({
   marketId,
+  yesShares = 500,
+  noShares = 500,
 }: NarrativePredictionChartProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
   const [inView, setInView] = useState(false);
-  const [chartWidth, setChartWidth] = useState(300);
+  const [timeRange, setTimeRange] = useState<MarketTimeRange>('1H');
 
   useEffect(() => {
     const el = wrapperRef.current;
@@ -39,49 +45,30 @@ export function NarrativePredictionChart({
     return () => io.disconnect();
   }, []);
 
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el || !inView) return;
-    const ro = new ResizeObserver((entries) => {
-      const w = entries[0]?.contentRect.width;
-      if (w) setChartWidth(Math.floor(w));
-    });
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, [inView]);
-
   const { history } = usePredictionHistory(inView ? marketId : '', {
-    limit: 40,
+    limit: 200,
+    range: timeRange,
+    seed: { yesShares, noShares },
   });
 
-  if (!inView || history.length === 0) {
-    // 1px sentinel keeps scroll position stable; no visible placeholder on posts
+  if (!inView) {
+    // 1px sentinel preserves scroll position; no visible placeholder on posts
     return <div ref={wrapperRef} className="h-px" />;
   }
-
-  const latest = history[history.length - 1];
-  const yesPercent = Math.round((latest?.yesPrice ?? 0.5) * 100);
-  const noPercent = 100 - yesPercent;
 
   return (
     <div
       ref={wrapperRef}
       className="mx-4 mb-3 overflow-hidden rounded-md border border-border bg-muted/20"
     >
-      {/* Probability header */}
-      <div className="flex items-center justify-between border-border border-b px-3 py-1.5">
-        <span className="font-semibold text-green-500 text-xs">
-          {yesPercent}% YES
-        </span>
-        <span className="text-[10px] text-muted-foreground">probability</span>
-        <span className="font-semibold text-red-500 text-xs">
-          {noPercent}% NO
-        </span>
-      </div>
-      {/* Sparkline */}
-      <div ref={containerRef} className="w-full">
-        <PredictionSparkline data={history} width={chartWidth} height={56} />
-      </div>
+      <PredictionProbabilityChart
+        data={history}
+        marketId={marketId}
+        timeRange={timeRange}
+        onTimeRangeChange={setTimeRange}
+        showHeader={true}
+        height="fixed"
+      />
     </div>
   );
 }

--- a/apps/web/src/app/feed/components/NewMarketCard.tsx
+++ b/apps/web/src/app/feed/components/NewMarketCard.tsx
@@ -6,10 +6,10 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import type { NarrativeStory } from '@/app/feed/types/narrative';
 import { InteractionBar } from '@/components/interactions/InteractionBar';
-import { PredictionSparkline } from '@/components/markets/PredictionSparkline';
+import { PredictionProbabilityChart } from '@/components/markets/PredictionProbabilityChart';
 import { PredictionTradingModal } from '@/components/markets/PredictionTradingModal';
 import { usePredictionHistory } from '@/hooks/usePredictionHistory';
-import type { PredictionMarket } from '@/types/markets';
+import type { MarketTimeRange, PredictionMarket } from '@/types/markets';
 
 interface NewMarketCardProps {
   story: NarrativeStory;
@@ -41,14 +41,26 @@ function computePercentages(
 }
 
 /**
- * Lazy-loading probability chart for market cards in the feed.
- * Only fetches price history once scrolled into view to avoid 429 cascades.
+ * Prediction probability chart for market cards in the feed.
+ *
+ * Uses the same PredictionProbabilityChart as the markets terminal so the
+ * visual language is consistent. Lazy-loads history via IntersectionObserver
+ * to prevent 429 cascades, and passes seed data from the market's live share
+ * counts so brand-new markets (no API history yet) show a flat line at the
+ * current probability instead of a black placeholder.
  */
-function MarketChart({ marketId }: { marketId: string }) {
+function MarketChart({
+  marketId,
+  yesShares,
+  noShares,
+}: {
+  marketId: string;
+  yesShares: number;
+  noShares: number;
+}) {
   const wrapperRef = useRef<HTMLDivElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
   const [inView, setInView] = useState(false);
-  const [chartWidth, setChartWidth] = useState(300);
+  const [timeRange, setTimeRange] = useState<MarketTimeRange>('1H');
 
   useEffect(() => {
     const el = wrapperRef.current;
@@ -66,30 +78,27 @@ function MarketChart({ marketId }: { marketId: string }) {
     return () => io.disconnect();
   }, []);
 
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el || !inView) return;
-    const ro = new ResizeObserver((entries) => {
-      const w = entries[0]?.contentRect.width;
-      if (w) setChartWidth(Math.floor(w));
-    });
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, [inView]);
-
   const { history } = usePredictionHistory(inView ? marketId : '', {
-    limit: 60,
+    limit: 200,
+    range: timeRange,
+    // Seed ensures brand-new markets (no API history) show a flat probability
+    // line rather than a black placeholder — same pattern as the terminal.
+    seed: { yesShares, noShares },
   });
 
   return (
     <div ref={wrapperRef} className="w-full">
-      {inView && history.length > 0 ? (
-        <div ref={containerRef} className="w-full">
-          <PredictionSparkline data={history} width={chartWidth} height={72} />
-        </div>
+      {inView ? (
+        <PredictionProbabilityChart
+          data={history}
+          marketId={marketId}
+          timeRange={timeRange}
+          onTimeRangeChange={setTimeRange}
+          showHeader={false}
+          height="fixed"
+        />
       ) : (
-        // Placeholder maintains layout height while loading
-        <div className="h-[72px] w-full animate-pulse rounded bg-muted/40" />
+        <div className="h-[160px] w-full animate-pulse rounded bg-muted/40" />
       )}
     </div>
   );
@@ -154,7 +163,11 @@ export function NewMarketCard({ story }: NewMarketCardProps) {
       {/* Probability chart — only rendered when marketId is available */}
       {story.marketId && (
         <div className="mb-3 overflow-hidden rounded-md border border-border bg-muted/20">
-          <MarketChart marketId={story.marketId} />
+          <MarketChart
+            marketId={story.marketId}
+            yesShares={story.yesShares ?? 0}
+            noShares={story.noShares ?? 0}
+          />
         </div>
       )}
 


### PR DESCRIPTION
## Problem

Market cards on the Stories and Latest feeds showed a solid black area instead of a chart. Two root causes:

1. **No seed fallback** — new markets return `400` from `/api/markets/predictions/{id}/history` (no trades yet), so `history.length === 0` and the placeholder rendered indefinitely.
2. **Wrong chart component** — `PredictionSparkline` is the micro 120×32px sparkline. The markets terminal uses `PredictionProbabilityChart` (full TradingView Lightweight Charts with YES/NO area series).

## Fix

### `NewMarketCard.tsx`
- Replace `PredictionSparkline` → `PredictionProbabilityChart` (`showHeader=false`, `height="fixed"`)
- Add `seed: { yesShares, noShares }` to `usePredictionHistory` — brand-new markets now render a flat line at the current probability instead of a black box
- Props threaded from `story.yesShares` / `story.noShares` (already present on `NarrativeStory`)
- Placeholder height updated to 160px to match the chart's fixed height

### `NarrativePredictionChart.tsx` (post card inline charts)
- Same swap to `PredictionProbabilityChart` with `showHeader=true` (self-contained with its own YES%/NO% header)
- Add optional `yesShares`/`noShares` props with sensible 50/50 defaults as seed

## Pattern alignment

Matches the terminal exactly:
```ts
// MarketsTradingTerminal.tsx
const { history } = usePredictionHistory(selected?.id ?? null, {
  limit: 1000,
  seed: { yesShares, noShares, liquidity },
});

<PredictionProbabilityChart
  data={predictionHistory}
  marketId={...}
  timeRange={predictionTimeRange}
  onTimeRangeChange={setPredictionTimeRange}
  showHeader={false}
  height="fill"
/>
```

## Also in this branch
- `fix(feed): fetch original posts for reposts in following feed` — blank repost cards in Following tab
- Biome formatting fixes