### PR TITLE
feat(web): add Sentry webhook inbox ingestion

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -283,6 +283,13 @@ SENTRY_PROJECT=
 # Format: version or git commit hash
 NEXT_PUBLIC_SENTRY_RELEASE=""
 SENTRY_RELEASE=""
+
+# Sentry Service Hook webhook security (required if using /api/sentry/webhook)
+# Create a secret in Sentry Project Settings > Integrations > Internal Integrations > Webhooks
+SENTRY_WEBHOOK_SECRET=""
+
+# Max allowed webhook timestamp skew in seconds (default 300, min 30, max 3600)
+SENTRY_WEBHOOK_MAX_TIMESTAMP_SKEW_SECONDS=300
 # ============================================================================
 # Perpetuals Settlement Mode Configuration
 # ============================================================================

--- a/apps/web/src/app/api/sentry/webhook/route.ts
+++ b/apps/web/src/app/api/sentry/webhook/route.ts
@@ -1,0 +1,80 @@
+import { ingestSentryWebhook, withErrorHandling } from '@babylon/api';
+import { logger } from '@babylon/shared';
+import { NextResponse } from 'next/server';
+
+const DEFAULT_MAX_TIMESTAMP_SKEW_SECONDS = 300;
+const MIN_TIMESTAMP_SKEW_SECONDS = 30;
+const MAX_TIMESTAMP_SKEW_SECONDS = 3600;
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 30;
+
+function parseMaxTimestampSkewSeconds(): number {
+  const rawValue = process.env.SENTRY_WEBHOOK_MAX_TIMESTAMP_SKEW_SECONDS;
+  if (!rawValue) {
+    return DEFAULT_MAX_TIMESTAMP_SKEW_SECONDS;
+  }
+
+  const parsed = Number.parseInt(rawValue, 10);
+  if (!Number.isInteger(parsed)) {
+    return DEFAULT_MAX_TIMESTAMP_SKEW_SECONDS;
+  }
+
+  return Math.max(
+    MIN_TIMESTAMP_SKEW_SECONDS,
+    Math.min(MAX_TIMESTAMP_SKEW_SECONDS, parsed)
+  );
+}
+
+export const POST = withErrorHandling(async function POST(request: Request) {
+  const webhookSecret = process.env.SENTRY_WEBHOOK_SECRET?.trim();
+  if (!webhookSecret) {
+    logger.error(
+      'Sentry webhook secret is missing. Rejecting webhook ingestion.',
+      {},
+      'SentryWebhook'
+    );
+    return NextResponse.json(
+      {
+        error:
+          'Sentry webhook endpoint is not configured. Set SENTRY_WEBHOOK_SECRET.',
+        code: 'WEBHOOK_NOT_CONFIGURED',
+      },
+      { status: 503 }
+    );
+  }
+
+  const rawBody = await request.text();
+  const result = await ingestSentryWebhook({
+    rawBody,
+    secret: webhookSecret,
+    maxTimestampSkewSeconds: parseMaxTimestampSkewSeconds(),
+    headers: {
+      signature: request.headers.get('sentry-hook-signature'),
+      timestamp: request.headers.get('sentry-hook-timestamp'),
+      resource: request.headers.get('sentry-hook-resource'),
+      event: request.headers.get('sentry-hook-event'),
+      requestId: request.headers.get('x-request-id'),
+      userAgent: request.headers.get('user-agent'),
+    },
+  });
+
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: result.message, code: result.code },
+      { status: result.httpStatus }
+    );
+  }
+
+  return NextResponse.json({
+    received: true,
+    enqueued: result.enqueued,
+    inboxId: result.inboxId ?? null,
+    dedupeKey: result.dedupeKey,
+    resource: result.resource,
+    action: result.action,
+    projectSlug: result.projectSlug,
+    issueId: result.issueId,
+    eventId: result.eventId,
+  });
+});

--- a/docs/infra/sentry-observability-contract.md
+++ b/docs/infra/sentry-observability-contract.md
@@ -47,6 +47,9 @@ Unexpected server errors are captured.
   - `SENTRY_ORG`, `SENTRY_PROJECT`
   - Recommended: `SENTRY_RELEASE`, `NEXT_PUBLIC_SENTRY_RELEASE`
   - If release env vars are not set, runtime fallback uses Vercel commit SHA (`VERCEL_GIT_COMMIT_SHA` / `NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA`)
+- Webhook ingestion (optional, for autonomous incident workers):
+  - `SENTRY_WEBHOOK_SECRET` (required when enabling `/api/sentry/webhook`)
+  - Optional: `SENTRY_WEBHOOK_MAX_TIMESTAMP_SKEW_SECONDS` (default `300`)
 
 ## Known gaps / follow-up
 

--- a/packages/api/src/services/index.ts
+++ b/packages/api/src/services/index.ts
@@ -50,4 +50,5 @@ export {
   withNPCLock,
   withQuestionLock,
 } from './resource-locks';
+export * from './sentry-webhook-inbox-service';
 export * from './waitlist-service';

--- a/packages/api/src/services/sentry-webhook-inbox-service.ts
+++ b/packages/api/src/services/sentry-webhook-inbox-service.ts
@@ -1,0 +1,535 @@
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
+import {
+  db,
+  generateSnowflakeId,
+  type JsonValue,
+  sentryWebhookInboxes,
+} from '@babylon/db';
+import { logger } from '@babylon/shared';
+
+const DEFAULT_MAX_TIMESTAMP_SKEW_SECONDS = 300;
+const HMAC_SHA256_HEX_LENGTH = 64;
+const HEX_PATTERN = /^[a-f0-9]+$/i;
+
+type JsonObject = Record<string, JsonValue>;
+
+export interface SentryWebhookHeaders {
+  signature: string | null;
+  timestamp: string | null;
+  resource: string | null;
+  event: string | null;
+  requestId: string | null;
+  userAgent: string | null;
+}
+
+export interface IngestSentryWebhookInput {
+  rawBody: string;
+  headers: SentryWebhookHeaders;
+  secret: string;
+  maxTimestampSkewSeconds?: number;
+  now?: Date;
+}
+
+type IngestSentryWebhookErrorCode =
+  | 'MISSING_SIGNATURE'
+  | 'MISSING_TIMESTAMP'
+  | 'INVALID_SIGNATURE'
+  | 'INVALID_TIMESTAMP'
+  | 'STALE_TIMESTAMP'
+  | 'INVALID_JSON'
+  | 'INVALID_PAYLOAD_SHAPE';
+
+export interface IngestSentryWebhookFailure {
+  ok: false;
+  httpStatus: 400 | 401;
+  code: IngestSentryWebhookErrorCode;
+  message: string;
+}
+
+export interface IngestSentryWebhookSuccess {
+  ok: true;
+  enqueued: boolean;
+  inboxId?: string;
+  dedupeKey: string;
+  resource: string;
+  action: string | null;
+  projectSlug: string | null;
+  issueId: string | null;
+  eventId: string | null;
+}
+
+export type IngestSentryWebhookResult =
+  | IngestSentryWebhookFailure
+  | IngestSentryWebhookSuccess;
+
+function trimToNull(value: string | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeSignature(signature: string): string {
+  const trimmed = signature.trim();
+
+  if (trimmed.startsWith('sha256=')) {
+    return trimmed.slice('sha256='.length);
+  }
+
+  if (trimmed.startsWith('v0=')) {
+    return trimmed.slice('v0='.length);
+  }
+
+  return trimmed;
+}
+
+function isValidHexDigest(value: string): boolean {
+  return value.length === HMAC_SHA256_HEX_LENGTH && HEX_PATTERN.test(value);
+}
+
+function areHexDigestsEqual(leftHex: string, rightHex: string): boolean {
+  const leftBuffer = Buffer.from(leftHex, 'hex');
+  const rightBuffer = Buffer.from(rightHex, 'hex');
+
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function computeSentrySignature(
+  secret: string,
+  timestamp: string,
+  rawBody: string
+): string {
+  return createHmac('sha256', secret)
+    .update(`${timestamp}.${rawBody}`)
+    .digest('hex');
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.every((item) => isJsonValue(item));
+  }
+
+  if (typeof value === 'object') {
+    return Object.values(value).every((item) => isJsonValue(item));
+  }
+
+  return false;
+}
+
+function isJsonObject(value: JsonValue): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readPath(
+  source: JsonObject,
+  path: readonly string[]
+): JsonValue | undefined {
+  let current: JsonValue = source;
+
+  for (const segment of path) {
+    if (!isJsonObject(current)) {
+      return undefined;
+    }
+    const next: JsonValue | undefined = current[segment];
+    if (typeof next === 'undefined') {
+      return undefined;
+    }
+    current = next;
+  }
+
+  return current;
+}
+
+function toOptionalString(value: JsonValue | undefined): string | null {
+  if (typeof value === 'string') {
+    return trimToNull(value);
+  }
+
+  if (typeof value === 'number') {
+    return String(value);
+  }
+
+  return null;
+}
+
+function getFirstString(
+  source: JsonObject,
+  candidatePaths: readonly (readonly string[])[]
+): string | null {
+  for (const path of candidatePaths) {
+    const value = toOptionalString(readPath(source, path));
+    if (value) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function parseWebhookTimestamp(
+  rawTimestamp: string,
+  now: Date,
+  maxSkewSeconds: number
+): { ok: true; timestampSeconds: number } | IngestSentryWebhookFailure {
+  const timestampSeconds = Number.parseInt(rawTimestamp, 10);
+  if (!Number.isInteger(timestampSeconds) || timestampSeconds <= 0) {
+    return {
+      ok: false,
+      httpStatus: 401,
+      code: 'INVALID_TIMESTAMP',
+      message: 'Invalid sentry-hook-timestamp header.',
+    };
+  }
+
+  const nowSeconds = Math.floor(now.getTime() / 1000);
+  if (Math.abs(nowSeconds - timestampSeconds) > maxSkewSeconds) {
+    return {
+      ok: false,
+      httpStatus: 401,
+      code: 'STALE_TIMESTAMP',
+      message: 'Sentry webhook timestamp outside allowed window.',
+    };
+  }
+
+  return { ok: true, timestampSeconds };
+}
+
+function buildDedupeKey(params: {
+  resource: string;
+  action: string | null;
+  projectSlug: string | null;
+  issueId: string | null;
+  issueShortId: string | null;
+  eventId: string | null;
+  bodyHash: string;
+}): string {
+  const actionPart = params.action ?? 'unknown-action';
+  const projectPart = params.projectSlug ?? 'unknown-project';
+  const issuePart = params.issueId ?? params.issueShortId ?? 'unknown-issue';
+
+  if (params.eventId) {
+    return `sentry:${params.resource}:${actionPart}:${projectPart}:event:${params.eventId}`;
+  }
+
+  return `sentry:${params.resource}:${actionPart}:${projectPart}:issue:${issuePart}:body:${params.bodyHash}`;
+}
+
+function buildRoutingKey(params: {
+  projectSlug: string | null;
+  issueId: string | null;
+  issueShortId: string | null;
+  level: string | null;
+  action: string | null;
+}): string | null {
+  const parts: string[] = [];
+
+  if (params.projectSlug) {
+    parts.push(`project:${params.projectSlug}`);
+  }
+  if (params.issueId ?? params.issueShortId) {
+    parts.push(`issue:${params.issueId ?? params.issueShortId}`);
+  }
+  if (params.level) {
+    parts.push(`level:${params.level}`);
+  }
+  if (params.action) {
+    parts.push(`action:${params.action}`);
+  }
+
+  return parts.length > 0 ? parts.join('|') : null;
+}
+
+function toMetadata(params: {
+  bodyHash: string;
+  headers: SentryWebhookHeaders;
+  receivedAt: Date;
+}): JsonValue {
+  return {
+    headers: {
+      sentryHookTimestamp: params.headers.timestamp,
+      sentryHookResource: params.headers.resource,
+      sentryHookEvent: params.headers.event,
+      requestId: params.headers.requestId,
+      userAgent: params.headers.userAgent,
+    },
+    ingestion: {
+      bodyHash: params.bodyHash,
+      receivedAt: params.receivedAt.toISOString(),
+      signatureAlgorithm: 'hmac-sha256',
+    },
+  };
+}
+
+export async function ingestSentryWebhook(
+  input: IngestSentryWebhookInput
+): Promise<IngestSentryWebhookResult> {
+  const signatureHeader = trimToNull(input.headers.signature);
+  if (!signatureHeader) {
+    return {
+      ok: false,
+      httpStatus: 401,
+      code: 'MISSING_SIGNATURE',
+      message: 'Missing sentry-hook-signature header.',
+    };
+  }
+
+  const timestampHeader = trimToNull(input.headers.timestamp);
+  if (!timestampHeader) {
+    return {
+      ok: false,
+      httpStatus: 401,
+      code: 'MISSING_TIMESTAMP',
+      message: 'Missing sentry-hook-timestamp header.',
+    };
+  }
+
+  const now = input.now ?? new Date();
+  const maxSkewSeconds =
+    input.maxTimestampSkewSeconds ?? DEFAULT_MAX_TIMESTAMP_SKEW_SECONDS;
+  const parsedTimestamp = parseWebhookTimestamp(
+    timestampHeader,
+    now,
+    maxSkewSeconds
+  );
+  if (!parsedTimestamp.ok) {
+    return parsedTimestamp;
+  }
+
+  const providedSignature = normalizeSignature(signatureHeader);
+  if (!isValidHexDigest(providedSignature)) {
+    return {
+      ok: false,
+      httpStatus: 401,
+      code: 'INVALID_SIGNATURE',
+      message: 'Invalid sentry-hook-signature format.',
+    };
+  }
+
+  const expectedSignature = computeSentrySignature(
+    input.secret,
+    timestampHeader,
+    input.rawBody
+  );
+  if (!areHexDigestsEqual(expectedSignature, providedSignature)) {
+    return {
+      ok: false,
+      httpStatus: 401,
+      code: 'INVALID_SIGNATURE',
+      message: 'Sentry webhook signature mismatch.',
+    };
+  }
+
+  let parsedPayloadUnknown: unknown;
+  try {
+    parsedPayloadUnknown = JSON.parse(input.rawBody);
+  } catch {
+    return {
+      ok: false,
+      httpStatus: 400,
+      code: 'INVALID_JSON',
+      message: 'Webhook payload is not valid JSON.',
+    };
+  }
+
+  if (!isJsonValue(parsedPayloadUnknown)) {
+    return {
+      ok: false,
+      httpStatus: 400,
+      code: 'INVALID_PAYLOAD_SHAPE',
+      message: 'Webhook payload is not JSON-serializable.',
+    };
+  }
+
+  const payload = parsedPayloadUnknown;
+  if (!isJsonObject(payload)) {
+    return {
+      ok: false,
+      httpStatus: 400,
+      code: 'INVALID_PAYLOAD_SHAPE',
+      message: 'Webhook payload must be a JSON object.',
+    };
+  }
+
+  const action =
+    getFirstString(payload, [['action'], ['data', 'action']]) ??
+    trimToNull(input.headers.event);
+  const resource =
+    trimToNull(input.headers.resource) ??
+    getFirstString(payload, [['resource'], ['data', 'resource']]) ??
+    'issue';
+  const projectSlug = getFirstString(payload, [
+    ['data', 'project', 'slug'],
+    ['project', 'slug'],
+    ['project', 'name'],
+    ['project'],
+    ['project_slug'],
+  ]);
+  const organizationSlug = getFirstString(payload, [
+    ['data', 'organization', 'slug'],
+    ['organization', 'slug'],
+    ['organization'],
+    ['organization_slug'],
+  ]);
+  const issueId = getFirstString(payload, [
+    ['data', 'issue', 'id'],
+    ['issue', 'id'],
+    ['data', 'group', 'id'],
+    ['group', 'id'],
+    ['group_id'],
+  ]);
+  const issueShortId = getFirstString(payload, [
+    ['data', 'issue', 'shortId'],
+    ['issue', 'shortId'],
+    ['data', 'group', 'shortId'],
+    ['group', 'shortId'],
+    ['shortId'],
+  ]);
+  const issueTitle = getFirstString(payload, [
+    ['data', 'issue', 'title'],
+    ['issue', 'title'],
+    ['data', 'group', 'title'],
+    ['group', 'title'],
+    ['title'],
+  ]);
+  const issueUrl = getFirstString(payload, [
+    ['data', 'issue', 'permalink'],
+    ['data', 'issue', 'url'],
+    ['issue', 'permalink'],
+    ['issue', 'url'],
+    ['url'],
+  ]);
+  const eventId = getFirstString(payload, [
+    ['data', 'event', 'id'],
+    ['event', 'id'],
+    ['data', 'event_id'],
+    ['event_id'],
+  ]);
+  const level = getFirstString(payload, [
+    ['data', 'event', 'level'],
+    ['event', 'level'],
+    ['level'],
+  ]);
+  const culprit = getFirstString(payload, [
+    ['data', 'event', 'culprit'],
+    ['event', 'culprit'],
+    ['culprit'],
+  ]);
+
+  const bodyHash = createHash('sha256').update(input.rawBody).digest('hex');
+  const dedupeKey = buildDedupeKey({
+    resource,
+    action,
+    projectSlug,
+    issueId,
+    issueShortId,
+    eventId,
+    bodyHash,
+  });
+  const routingKey = buildRoutingKey({
+    projectSlug,
+    issueId,
+    issueShortId,
+    level,
+    action,
+  });
+  const webhookTimestamp = new Date(parsedTimestamp.timestampSeconds * 1000);
+  const inboxId = await generateSnowflakeId();
+  const insertResult = await db
+    .insert(sentryWebhookInboxes)
+    .values({
+      id: inboxId,
+      resource,
+      action,
+      organizationSlug,
+      projectSlug,
+      issueId,
+      issueShortId,
+      issueTitle,
+      issueUrl,
+      eventId,
+      level,
+      culprit,
+      dedupeKey,
+      routingKey,
+      webhookTimestamp,
+      payload,
+      metadata: toMetadata({
+        bodyHash,
+        headers: input.headers,
+        receivedAt: now,
+      }),
+      receivedAt: now,
+      nextAttemptAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoNothing({ target: sentryWebhookInboxes.dedupeKey })
+    .returning({ id: sentryWebhookInboxes.id });
+
+  const insertedId = insertResult[0]?.id;
+  if (!insertedId) {
+    logger.info(
+      'Ignored duplicate Sentry webhook event',
+      {
+        dedupeKey,
+        resource,
+        action,
+        projectSlug,
+        issueId,
+        eventId,
+      },
+      'SentryWebhookInbox'
+    );
+
+    return {
+      ok: true,
+      enqueued: false,
+      dedupeKey,
+      resource,
+      action,
+      projectSlug,
+      issueId,
+      eventId,
+    };
+  }
+
+  logger.info(
+    'Enqueued Sentry webhook event',
+    {
+      inboxId: insertedId,
+      dedupeKey,
+      resource,
+      action,
+      projectSlug,
+      issueId,
+      eventId,
+    },
+    'SentryWebhookInbox'
+  );
+
+  return {
+    ok: true,
+    enqueued: true,
+    inboxId: insertedId,
+    dedupeKey,
+    resource,
+    action,
+    projectSlug,
+    issueId,
+    eventId,
+  };
+}

--- a/packages/db/drizzle/migrations/0045_add_sentry_webhook_inbox.sql
+++ b/packages/db/drizzle/migrations/0045_add_sentry_webhook_inbox.sql
@@ -1,0 +1,72 @@
+-- Add Sentry webhook inbox table for autonomous incident worker ingestion
+-- Stores verified webhook payloads with idempotency keys and worker processing state
+
+DO $$
+BEGIN
+  CREATE TYPE "SentryWebhookInboxStatus" AS ENUM (
+    'pending',
+    'processing',
+    'processed',
+    'failed',
+    'dead'
+  );
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+
+CREATE TABLE IF NOT EXISTS "SentryWebhookInbox" (
+  "id" text PRIMARY KEY NOT NULL,
+  "provider" text NOT NULL DEFAULT 'sentry',
+  "resource" text NOT NULL,
+  "action" text,
+  "organizationSlug" text,
+  "projectSlug" text,
+  "issueId" text,
+  "issueShortId" text,
+  "issueTitle" text,
+  "issueUrl" text,
+  "eventId" text,
+  "level" text,
+  "culprit" text,
+  "dedupeKey" text NOT NULL,
+  "routingKey" text,
+  "webhookTimestamp" timestamp,
+  "status" "SentryWebhookInboxStatus" NOT NULL DEFAULT 'pending',
+  "attempts" integer NOT NULL DEFAULT 0,
+  "maxAttempts" integer NOT NULL DEFAULT 8,
+  "nextAttemptAt" timestamp NOT NULL DEFAULT now(),
+  "processingStartedAt" timestamp,
+  "processedAt" timestamp,
+  "failedAt" timestamp,
+  "lastError" text,
+  "payload" json NOT NULL,
+  "metadata" json,
+  "receivedAt" timestamp NOT NULL DEFAULT now(),
+  "updatedAt" timestamp NOT NULL,
+  CONSTRAINT "SentryWebhookInbox_dedupeKey_unique" UNIQUE("dedupeKey")
+);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "SentryWebhookInbox_status_nextAttemptAt_idx"
+  ON "SentryWebhookInbox" USING btree ("status", "nextAttemptAt");
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "SentryWebhookInbox_project_issue_status_idx"
+  ON "SentryWebhookInbox" USING btree ("projectSlug", "issueId", "status");
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "SentryWebhookInbox_eventId_idx"
+  ON "SentryWebhookInbox" USING btree ("eventId");
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "SentryWebhookInbox_routingKey_status_idx"
+  ON "SentryWebhookInbox" USING btree ("routingKey", "status");
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "SentryWebhookInbox_receivedAt_idx"
+  ON "SentryWebhookInbox" USING btree ("receivedAt");
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "SentryWebhookInbox_resource_action_idx"
+  ON "SentryWebhookInbox" USING btree ("resource", "action");

--- a/packages/db/drizzle/migrations/meta/_journal.json
+++ b/packages/db/drizzle/migrations/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1772615198560,
       "tag": "0044_add_user_agent_price_alerts",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1772718287000,
+      "tag": "0045_add_sentry_webhook_inbox",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/enums.ts
+++ b/packages/db/src/schema/enums.ts
@@ -7,6 +7,15 @@ export const realtimeOutboxStatusEnum = pgEnum('RealtimeOutboxStatus', [
   'failed',
 ]);
 
+// Sentry Webhook Inbox Status
+export const sentryWebhookInboxStatusEnum = pgEnum('SentryWebhookInboxStatus', [
+  'pending',
+  'processing',
+  'processed',
+  'failed',
+  'dead',
+]);
+
 // Onboarding Status
 export const onboardingStatusEnum = pgEnum('OnboardingStatus', [
   'PENDING_PROFILE',

--- a/packages/db/src/schema/misc.ts
+++ b/packages/db/src/schema/misc.ts
@@ -10,7 +10,10 @@ import {
   timestamp,
 } from 'drizzle-orm/pg-core';
 import type { JsonValue } from '../types';
-import { realtimeOutboxStatusEnum } from './enums';
+import {
+  realtimeOutboxStatusEnum,
+  sentryWebhookInboxStatusEnum,
+} from './enums';
 
 // Game
 export const games = pgTable(
@@ -73,6 +76,66 @@ export const realtimeOutboxes = pgTable(
       table.createdAt
     ),
     index('RealtimeOutbox_channel_status_idx').on(table.channel, table.status),
+  ]
+);
+
+// SentryWebhookInbox
+export const sentryWebhookInboxes = pgTable(
+  'SentryWebhookInbox',
+  {
+    id: text('id').primaryKey(),
+    provider: text('provider').notNull().default('sentry'),
+    resource: text('resource').notNull(),
+    action: text('action'),
+    organizationSlug: text('organizationSlug'),
+    projectSlug: text('projectSlug'),
+    issueId: text('issueId'),
+    issueShortId: text('issueShortId'),
+    issueTitle: text('issueTitle'),
+    issueUrl: text('issueUrl'),
+    eventId: text('eventId'),
+    level: text('level'),
+    culprit: text('culprit'),
+    dedupeKey: text('dedupeKey').notNull().unique(),
+    routingKey: text('routingKey'),
+    webhookTimestamp: timestamp('webhookTimestamp', { mode: 'date' }),
+    status: sentryWebhookInboxStatusEnum('status').notNull().default('pending'),
+    attempts: integer('attempts').notNull().default(0),
+    maxAttempts: integer('maxAttempts').notNull().default(8),
+    nextAttemptAt: timestamp('nextAttemptAt', { mode: 'date' })
+      .notNull()
+      .defaultNow(),
+    processingStartedAt: timestamp('processingStartedAt', { mode: 'date' }),
+    processedAt: timestamp('processedAt', { mode: 'date' }),
+    failedAt: timestamp('failedAt', { mode: 'date' }),
+    lastError: text('lastError'),
+    payload: json('payload').$type<JsonValue>().notNull(),
+    metadata: json('metadata').$type<JsonValue>(),
+    receivedAt: timestamp('receivedAt', { mode: 'date' })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updatedAt', { mode: 'date' }).notNull(),
+  },
+  (table) => [
+    index('SentryWebhookInbox_status_nextAttemptAt_idx').on(
+      table.status,
+      table.nextAttemptAt
+    ),
+    index('SentryWebhookInbox_project_issue_status_idx').on(
+      table.projectSlug,
+      table.issueId,
+      table.status
+    ),
+    index('SentryWebhookInbox_eventId_idx').on(table.eventId),
+    index('SentryWebhookInbox_routingKey_status_idx').on(
+      table.routingKey,
+      table.status
+    ),
+    index('SentryWebhookInbox_receivedAt_idx').on(table.receivedAt),
+    index('SentryWebhookInbox_resource_action_idx').on(
+      table.resource,
+      table.action
+    ),
   ]
 );
 
@@ -428,6 +491,8 @@ export type GameConfig = typeof gameConfigs.$inferSelect;
 export type NewGameConfig = typeof gameConfigs.$inferInsert;
 export type RealtimeOutbox = typeof realtimeOutboxes.$inferSelect;
 export type NewRealtimeOutbox = typeof realtimeOutboxes.$inferInsert;
+export type SentryWebhookInbox = typeof sentryWebhookInboxes.$inferSelect;
+export type NewSentryWebhookInbox = typeof sentryWebhookInboxes.$inferInsert;
 export type OAuthState = typeof oAuthStates.$inferSelect;
 export type NewOAuthState = typeof oAuthStates.$inferInsert;
 export type OracleCommitment = typeof oracleCommitments.$inferSelect;


### PR DESCRIPTION
## Summary

- Add a new `POST /api/sentry/webhook` endpoint to receive Sentry service hooks and enqueue them quickly for async worker processing.
- Add a dedicated ingestion service that validates Sentry HMAC/timestamp headers, normalizes payload metadata, and enforces idempotency via a stable dedupe key.
- Add a DB-backed inbox (`SentryWebhookInbox`) with processing fields (`status`, `attempts`, `nextAttemptAt`, `lastError`, timestamps) to support reliable worker retries.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [x] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Sentry observability contract update in this PR: `docs/infra/sentry-observability-contract.md`

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [x] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [x] Other: env + infra contract docs

## Changes

- Add route: `apps/web/src/app/api/sentry/webhook/route.ts`
  - Requires `SENTRY_WEBHOOK_SECRET`.
  - Supports configurable timestamp tolerance via `SENTRY_WEBHOOK_MAX_TIMESTAMP_SKEW_SECONDS`.
  - Returns fast JSON acknowledgements with enqueue/idempotency details.
- Add service: `packages/api/src/services/sentry-webhook-inbox-service.ts`
  - Verifies `sentry-hook-signature` and `sentry-hook-timestamp`.
  - Parses and validates payload shape.
  - Extracts routing metadata (`projectSlug`, `issueId`, `eventId`, etc.).
  - Writes durable inbox rows with `onConflictDoNothing` dedupe.
- Add DB schema + migration:
  - Enum: `SentryWebhookInboxStatus`
  - Table: `SentryWebhookInbox`
  - Indexes for worker polling and issue-level routing.
- Export service from API barrel and document new env vars.

## Review guide

**Start here**
- `packages/api/src/services/sentry-webhook-inbox-service.ts`
- `apps/web/src/app/api/sentry/webhook/route.ts`
- `packages/db/src/schema/misc.ts`
- `packages/db/drizzle/migrations/0045_add_sentry_webhook_inbox.sql`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- This change intentionally limits route responsibility to auth/validation/enqueue.
- Worker claiming/execution logic is a follow-up (next PR).
- Idempotency is guaranteed by `dedupeKey` unique constraint + conflict-safe insert.

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Configure `SENTRY_WEBHOOK_SECRET` in local/staging env.
2. Send a signed test payload to `POST /api/sentry/webhook` and verify a new `SentryWebhookInbox` row is created.
3. Replay the exact same payload and verify response is `enqueued: false` (dedupe hit).

## Ops / Migration / Deployment

- [ ] No deploy impact
- [x] Requires env var updates (listed below + `.env.example` updated)
- [x] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `SENTRY_WEBHOOK_SECRET`, `SENTRY_WEBHOOK_MAX_TIMESTAMP_SKEW_SECONDS`
- Changed: none
- Removed: none

**DB / data migration**
- Migration(s): `packages/db/drizzle/migrations/0045_add_sentry_webhook_inbox.sql`
- Backfill/seed: none required

**Rollout / rollback plan**
- Rollout: deploy + run `bun run db:migrate` + configure Sentry service hook URL/secret.
- Rollback: remove Sentry service hook + rollback code; inbox table can remain safely until cleanup migration.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- N/A

## Security / privacy

- [ ] No security impact
- [x] Needs extra review (describe)

- Public endpoint is protected by strict HMAC signature verification + timestamp skew validation.
- Payload is persisted for worker diagnostics; no secrets are logged.

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- New internal endpoint contract for Sentry service hooks: `POST /api/sentry/webhook`.

### Database
- New queue-like inbox table designed for reliable worker consumption and retries.
- Polling indexes included for `status + nextAttemptAt` and project/issue routing.

### Contracts / on-chain
- Not applicable.

### Docs
- Updated Sentry observability contract and `.env.example` for webhook env setup.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend/API + DB change only; no user-facing UI changes.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
