### PR TITLE
fix: serialize Date in team leaderboard position query

### DIFF
--- a/packages/api/src/services/points-service.ts
+++ b/packages/api/src/services/points-service.ts
@@ -1910,8 +1910,8 @@ export class PointsService {
             OR (
               (u."totalPoints"::numeric + COALESCE(a."agentPoints", 0)) = ${teamTotal}
               AND (
-                u."createdAt" < ${effectiveUser.createdAt}
-                OR (u."createdAt" = ${effectiveUser.createdAt} AND u."id" < ${effectiveUserId})
+                u."createdAt" < ${effectiveUser.createdAt.toISOString()}
+                OR (u."createdAt" = ${effectiveUser.createdAt.toISOString()} AND u."id" < ${effectiveUserId})
               )
             )
           )


### PR DESCRIPTION
## Summary

- Fix team leaderboard returning "An unexpected error occurred" by converting `Date` object to ISO string before passing to raw SQL query in `getUserPosition`
- The `postgres-js` driver cannot serialize raw JavaScript `Date` objects as query parameters in `db.execute(sql\`...\`)`, causing a `TypeError` (`ERR_INVALID_ARG_TYPE`)
- Only affects the team leaderboard path; wallet leaderboard uses Drizzle's query builder which handles Date serialization internally

## Type

- [x] Bug fix

## Context / Links

- Error: `TypeError: The "string" argument must be of type string or an instance of Buffer or ArrayBuffer. Received an instance of Date`
- Triggered by `GET /api/leaderboard?type=team&page=1&pageSize=100&userId=...`

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] API infra (`packages/api`)

## Changes

- `packages/api/src/services/points-service.ts`: Changed `${effectiveUser.createdAt}` to `${effectiveUser.createdAt.toISOString()}` in the team position ranking query (2 occurrences)

## Review guide

**Start here**
- `packages/api/src/services/points-service.ts` — lines ~1913-1914

**Risk**
- [x] Low

**Notes for reviewers**
- One-line fix (two substitutions). The wallet leaderboard path already works because it uses the Drizzle query builder, which serializes Dates automatically. The team path uses raw `db.execute(sql\`...\`)` which passes params directly to postgres-js, and postgres-js does not accept `Date` instances.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`

**Manual verification**
1. Hit `GET /api/leaderboard?type=team&page=1&pageSize=100&userId=<any-valid-user-id>` on staging
2. Confirm a valid JSON response with leaderboard data and `currentUser` rank instead of `{"error":"An unexpected error occurred"}`

## Ops / Migration / Deployment

- [x] No deploy impact

## Breaking changes

- [x] None

## Security / privacy

- [x] No security impact

### Option B: No visual changes

- Reason: Backend-only bug fix in a raw SQL query parameter, no UI changes

## Checklist (author)
- [ ] Self-review done (diff + critical paths)
- [ ] Base branch is correct (`staging` by default)
- [ ] Handlers remain thin and portable (validate -> service -> map errors)
- [ ] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [ ] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
