### PR TITLE
fix(web): align waitlist whitelist access with top 25k

### DIFF
--- a/apps/web/src/app/api/waitlist/position/route.ts
+++ b/apps/web/src/app/api/waitlist/position/route.ts
@@ -66,8 +66,8 @@
 
 import {
   authenticate,
-  getEffectiveWhitelistLeaderboardThreshold,
   getCache,
+  getEffectiveWhitelistLeaderboardThreshold,
   setCache,
   successResponse,
   WaitlistService,
@@ -158,8 +158,6 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   );
 
   const position = await WaitlistService.getWaitlistPosition(userId);
-  const whitelistRankThreshold =
-    await getEffectiveWhitelistLeaderboardThreshold();
 
   // If user doesn't exist or isn't on waitlist, return null gracefully
   // This handles new Privy users who haven't completed signup yet
@@ -259,6 +257,9 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       completedAt: r.completedAt?.toISOString() ?? new Date().toISOString(),
       status: 'qualified' as const,
     }));
+
+  const whitelistRankThreshold =
+    await getEffectiveWhitelistLeaderboardThreshold();
 
   const responseBody: PositionResponse = {
     // IMPORTANT: Return leaderboardRank as "position" for UI compatibility

--- a/apps/web/src/app/api/waitlist/position/route.ts
+++ b/apps/web/src/app/api/waitlist/position/route.ts
@@ -66,6 +66,7 @@
 
 import {
   authenticate,
+  getEffectiveWhitelistLeaderboardThreshold,
   getCache,
   setCache,
   successResponse,
@@ -120,6 +121,7 @@ type PositionResponse = {
   invitedCount?: number;
   qualifiedCount?: number;
   totalReferralPoints?: number;
+  whitelistRankThreshold?: number;
 };
 
 const CACHE_KEY_NAMESPACE = 'waitlist:position';
@@ -156,6 +158,8 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   );
 
   const position = await WaitlistService.getWaitlistPosition(userId);
+  const whitelistRankThreshold =
+    await getEffectiveWhitelistLeaderboardThreshold();
 
   // If user doesn't exist or isn't on waitlist, return null gracefully
   // This handles new Privy users who haven't completed signup yet
@@ -283,6 +287,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     invitedCount: invitedUsers.length,
     qualifiedCount: qualifiedUsers.length,
     totalReferralPoints: position.invitePoints, // Total points from referrals
+    whitelistRankThreshold,
   };
 
   if (CACHE_TTL_MS > 0) {

--- a/apps/web/src/app/feed/components/NewMarketCard.tsx
+++ b/apps/web/src/app/feed/components/NewMarketCard.tsx
@@ -154,7 +154,9 @@ export function NewMarketCard({ story, embedded = false }: NewMarketCardProps) {
     : '/markets?tab=predictions';
 
   return (
-    <div className={`border-border px-4 py-4 ${embedded ? 'border-t' : 'border-b'}`}>
+    <div
+      className={`border-border px-4 py-4 ${embedded ? 'border-t' : 'border-b'}`}
+    >
       {/* Header row: label + countdown */}
       <div className="mb-2 flex items-center justify-between">
         <span className="font-medium text-muted-foreground text-xs uppercase tracking-wide">

--- a/apps/web/src/components/shared/ComingSoon.tsx
+++ b/apps/web/src/components/shared/ComingSoon.tsx
@@ -25,8 +25,8 @@ import { toast } from 'sonner';
 import { LinkSocialAccountsModal } from '@/components/profile/LinkSocialAccountsModal';
 import { Avatar } from '@/components/shared/Avatar';
 import {
-  getWaitlistHeaderCopy,
   getPrimaryAccessLabel,
+  getWaitlistHeaderCopy,
   type NftAccessState,
   shouldAutoRedirectWhitelistedUser,
 } from '@/components/shared/comingSoonAccess';

--- a/apps/web/src/components/shared/ComingSoon.tsx
+++ b/apps/web/src/components/shared/ComingSoon.tsx
@@ -25,6 +25,7 @@ import { toast } from 'sonner';
 import { LinkSocialAccountsModal } from '@/components/profile/LinkSocialAccountsModal';
 import { Avatar } from '@/components/shared/Avatar';
 import {
+  getWaitlistHeaderCopy,
   getPrimaryAccessLabel,
   type NftAccessState,
   shouldAutoRedirectWhitelistedUser,
@@ -86,6 +87,7 @@ interface WaitlistData {
   totalReferralPoints?: number; // Total points from referrals
   invitedUsers?: ReferralUser[]; // Pending users list
   qualifiedUsers?: ReferralUser[]; // Qualified users list
+  whitelistRankThreshold?: number;
 }
 
 /**
@@ -1336,6 +1338,11 @@ export function ComingSoon() {
   const canClaimNft =
     nftEligibility?.eligible === true && nftEligibility.hasMinted === false;
   const hasNft = Boolean(nftAccess?.hasAccess) && !canClaimNft;
+  const hasPrimaryAccess = canClaimNft || hasNft;
+  const headerCopy = getWaitlistHeaderCopy(
+    hasPrimaryAccess,
+    waitlistData?.whitelistRankThreshold
+  );
 
   useEffect(() => {
     if (
@@ -2484,22 +2491,16 @@ export function ComingSoon() {
                 </div>
                 <div>
                   <h1 className="font-bold text-2xl text-foreground tracking-tight sm:text-3xl md:text-4xl">
-                    {canClaimNft || hasNft
-                      ? 'Click play to access the game'
-                      : 'Leaderboard'}
+                    {headerCopy.title}
                   </h1>
                   <p className="mt-1 text-muted-foreground text-sm">
-                    {canClaimNft || hasNft
-                      ? 'Welcome to Babylon'
-                      : waitlistData?.totalCount
-                        ? `Top ${waitlistData.totalCount}`
-                        : ''}
+                    {headerCopy.subtitle}
                   </p>
                 </div>
               </div>
 
               <div className="flex shrink-0 items-center gap-3">
-                {(canClaimNft || hasNft) && (
+                {hasPrimaryAccess && (
                   <a
                     href={`${appBaseUrl}${canClaimNft ? '/nft' : '/feed'}`}
                     className="flex min-h-[48px] items-center gap-2 rounded-lg border border-primary/30 bg-primary/10 px-4 py-2 font-semibold text-primary backdrop-blur-sm transition-all duration-200 hover:bg-primary/15"
@@ -2590,20 +2591,21 @@ export function ComingSoon() {
           </div>
 
           {/* Email Collection — prominent section */}
-          {!(canClaimNft || hasNft) && !emailSaved && (
+          {!hasPrimaryAccess && !emailSaved && (
             <div className="mb-8 rounded-xl border border-primary/30 bg-primary/5 p-5 backdrop-blur-sm sm:p-6">
               <div className="mb-3 flex items-center gap-2">
                 <Mail className="h-5 w-5 text-primary" />
                 <h3 className="font-bold text-base text-foreground">
-                  Email Required
+                  Get notified by email
                 </h3>
                 <span className="rounded-full bg-primary/15 px-2 py-0.5 font-semibold text-primary text-xs">
                   +{POINTS.EMAIL_SUBMIT} pts
                 </span>
               </div>
               <p className="mb-4 text-muted-foreground text-sm">
-                We will notify you by email when you get whitelisted. We are
-                whitelisting new people every day, so stay patient.
+                We are whitelisting new people every day, so stay patient. If
+                you provide your email, we will notify you when you get
+                whitelisted.
               </p>
               <div className="flex items-center gap-2">
                 <input
@@ -2630,7 +2632,7 @@ export function ComingSoon() {
               </div>
             </div>
           )}
-          {!(canClaimNft || hasNft) && emailSaved && (
+          {!hasPrimaryAccess && emailSaved && (
             <div className="mb-8 rounded-xl border border-green-500/30 bg-green-500/5 p-5 backdrop-blur-sm sm:p-6">
               <div className="mb-3 flex items-center gap-2">
                 <Mail className="h-5 w-5 text-green-500" />

--- a/apps/web/src/components/shared/comingSoonAccess.test.ts
+++ b/apps/web/src/components/shared/comingSoonAccess.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'bun:test';
 import {
+  formatWhitelistRankThreshold,
   getPrimaryAccessLabel,
+  getWaitlistHeaderCopy,
   type NftAccessState,
   shouldAutoRedirectWhitelistedUser,
 } from './comingSoonAccess';
@@ -51,6 +53,33 @@ describe('comingSoonAccess', () => {
 
     it('returns play label when NFT cannot be claimed', () => {
       expect(getPrimaryAccessLabel(false)).toBe('Play');
+    });
+  });
+
+  describe('formatWhitelistRankThreshold', () => {
+    it('formats the whitelist threshold for the waitlist header', () => {
+      expect(formatWhitelistRankThreshold(25000)).toBe('Top 25,000');
+    });
+
+    it('returns an empty string for missing thresholds', () => {
+      expect(formatWhitelistRankThreshold(null)).toBe('');
+      expect(formatWhitelistRankThreshold(undefined)).toBe('');
+    });
+  });
+
+  describe('getWaitlistHeaderCopy', () => {
+    it('returns access copy for whitelisted users', () => {
+      expect(getWaitlistHeaderCopy(true, 25000)).toEqual({
+        title: 'Click play to access the game',
+        subtitle: 'Welcome to Babylon',
+      });
+    });
+
+    it('returns leaderboard copy with the configured whitelist threshold', () => {
+      expect(getWaitlistHeaderCopy(false, 25000)).toEqual({
+        title: 'Leaderboard',
+        subtitle: 'Top 25,000',
+      });
     });
   });
 });

--- a/apps/web/src/components/shared/comingSoonAccess.ts
+++ b/apps/web/src/components/shared/comingSoonAccess.ts
@@ -21,3 +21,30 @@ export function shouldAutoRedirectWhitelistedUser(
 export function getPrimaryAccessLabel(canClaimNft: boolean): string {
   return canClaimNft ? 'Claim your NFT' : 'Play';
 }
+
+export function formatWhitelistRankThreshold(
+  threshold: number | null | undefined
+): string {
+  if (!threshold || threshold < 1) return '';
+  return `Top ${threshold.toLocaleString('en-US')}`;
+}
+
+export function getWaitlistHeaderCopy(
+  hasPrimaryAccess: boolean,
+  whitelistRankThreshold: number | null | undefined
+): {
+  title: string;
+  subtitle: string;
+} {
+  if (hasPrimaryAccess) {
+    return {
+      title: 'Click play to access the game',
+      subtitle: 'Welcome to Babylon',
+    };
+  }
+
+  return {
+    title: 'Leaderboard',
+    subtitle: formatWhitelistRankThreshold(whitelistRankThreshold),
+  };
+}

--- a/apps/web/src/components/waitlist/types.ts
+++ b/apps/web/src/components/waitlist/types.ts
@@ -30,6 +30,7 @@ export interface WaitlistData {
   totalReferralPoints?: number;
   invitedUsers?: ReferralUser[];
   qualifiedUsers?: ReferralUser[];
+  whitelistRankThreshold?: number;
 }
 
 /**

--- a/apps/web/src/types/nft.ts
+++ b/apps/web/src/types/nft.ts
@@ -170,7 +170,7 @@ export interface NftAccessResponse {
      * Why access is granted/denied.
      *
      * - snapshot_2025: permanent access (Top 100 end-of-2025) + can mint
-     * - whitelist: permanent access (reached Top 100 at least once, admin-managed)
+     * - whitelist: whitelist-table access or current leaderboard threshold access
      * - holder: access based on current onchain holding (can be lost after transfer)
      * - none: no wallet and not in snapshot/whitelist
      */

--- a/packages/api/src/__tests__/whitelist-access.test.ts
+++ b/packages/api/src/__tests__/whitelist-access.test.ts
@@ -1,0 +1,252 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+const whitelistTable = {
+  id: 'id',
+  userId: 'userId',
+  source: 'source',
+  revokedAt: 'revokedAt',
+};
+const whitelistConfigTable = {
+  id: 'id',
+  leaderboardRankThreshold: 'leaderboardRankThreshold',
+};
+const nftSnapshotTable = { userId: 'userId' };
+const usersTable = {
+  id: 'id',
+  reputationPoints: 'reputationPoints',
+  invitePoints: 'invitePoints',
+  createdAt: 'createdAt',
+  isActor: 'isActor',
+  isAgent: 'isAgent',
+};
+
+let mockWhitelistEntry:
+  | {
+      source: 'leaderboard' | 'admin_manual' | 'snapshot_first_100';
+      revokedAt: Date | null;
+    }
+  | null = null;
+let mockWhitelistConfigRow: { leaderboardRankThreshold: number | null } | null =
+  {
+    leaderboardRankThreshold: 25_000,
+  };
+let mockUserRow:
+  | {
+      id: string;
+      reputationPoints: number;
+      invitePoints: number;
+      createdAt: Date;
+      isActor: boolean;
+      isAgent: boolean;
+    }
+  | null = null;
+let mockUsersAheadCount = 0;
+
+const mockDbSelect = mock((fields?: unknown) => ({
+  from: (table: unknown) => {
+    if (table === whitelistTable) {
+      return {
+        where: () => ({
+          limit: () => Promise.resolve(mockWhitelistEntry ? [mockWhitelistEntry] : []),
+        }),
+      };
+    }
+
+    if (table === whitelistConfigTable) {
+      return {
+        where: () => ({
+          limit: () =>
+            Promise.resolve(
+              mockWhitelistConfigRow ? [mockWhitelistConfigRow] : []
+            ),
+        }),
+      };
+    }
+
+    if (table === usersTable) {
+      const isCountQuery =
+        typeof fields === 'object' &&
+        fields !== null &&
+        'count' in (fields as Record<string, unknown>);
+
+      if (isCountQuery) {
+        return {
+          where: () => Promise.resolve([{ count: mockUsersAheadCount }]),
+        };
+      }
+
+      return {
+        where: () => ({
+          limit: () => Promise.resolve(mockUserRow ? [mockUserRow] : []),
+        }),
+      };
+    }
+
+    if (table === nftSnapshotTable) {
+      return {
+        where: () => Promise.resolve([]),
+      };
+    }
+
+    return {
+      where: () => Promise.resolve([]),
+    };
+  },
+}));
+
+const mockDbInsert = mock(() => ({
+  values: () => ({
+    onConflictDoNothing: () => ({
+      returning: () => Promise.resolve([]),
+    }),
+    onConflictDoUpdate: () => ({
+      returning: () => Promise.resolve([]),
+    }),
+  }),
+}));
+
+mock.module('@babylon/db', () => ({
+  db: {
+    select: mockDbSelect,
+    insert: mockDbInsert,
+  },
+  and: (...args: unknown[]) => args,
+  asc: (col: unknown) => col,
+  count: () => 'count',
+  desc: (col: unknown) => col,
+  eq: (a: unknown, b: unknown) => [a, b],
+  gt: (a: unknown, b: unknown) => [a, b],
+  inArray: (a: unknown, b: unknown) => [a, b],
+  isNull: (a: unknown) => a,
+  lt: (a: unknown, b: unknown) => [a, b],
+  nftSnapshot: nftSnapshotTable,
+  or: (...args: unknown[]) => args,
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings,
+    values,
+  }),
+  users: usersTable,
+  whitelist: whitelistTable,
+  whitelistConfig: whitelistConfigTable,
+}));
+
+mock.module('@babylon/engine', () => ({
+  UserAlphaGroupAssignmentService: {
+    assignDefaultGroups: mock(() => Promise.resolve()),
+  },
+}));
+
+mock.module('@babylon/shared', () => ({
+  logger: {
+    info: mock(),
+    warn: mock(),
+    error: mock(),
+    debug: mock(),
+  },
+}));
+
+mock.module('nanoid', () => ({
+  nanoid: mock(() => 'mock-id'),
+}));
+
+mock.module('../services/whitelist-email-service', () => ({
+  sendWhitelistWelcomeEmailToUser: mock(() => Promise.resolve()),
+  sendWhitelistWelcomeEmailsToUsers: mock(() => Promise.resolve()),
+}));
+
+const { checkWhitelistAccess, isUserWhitelistedByLeaderboard } = await import(
+  '../services/whitelist-service'
+);
+
+describe('whitelist access resolution', () => {
+  beforeEach(() => {
+    mockDbSelect.mockClear();
+    mockDbInsert.mockClear();
+    mockWhitelistEntry = null;
+    mockWhitelistConfigRow = { leaderboardRankThreshold: 25_000 };
+    mockUserRow = {
+      id: 'user-1',
+      reputationPoints: 5_000,
+      invitePoints: 300,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      isActor: false,
+      isAgent: false,
+    };
+    mockUsersAheadCount = 0;
+  });
+
+  it('allows users with an active whitelist entry', async () => {
+    mockWhitelistEntry = {
+      source: 'admin_manual',
+      revokedAt: null,
+    };
+
+    const result = await checkWhitelistAccess('user-1');
+
+    expect(result).toEqual({
+      allowed: true,
+      source: 'admin_manual',
+    });
+  });
+
+  it('does not bypass revoked whitelist entries with leaderboard access', async () => {
+    mockWhitelistEntry = {
+      source: 'leaderboard',
+      revokedAt: new Date('2026-03-01T00:00:00.000Z'),
+    };
+    mockUsersAheadCount = 10;
+
+    const result = await checkWhitelistAccess('user-1');
+
+    expect(result).toEqual({
+      allowed: false,
+      source: null,
+    });
+  });
+
+  it('allows users inside the leaderboard threshold when no whitelist row exists', async () => {
+    mockUsersAheadCount = 12_999;
+
+    const result = await checkWhitelistAccess('user-1');
+
+    expect(result).toEqual({
+      allowed: true,
+      source: 'leaderboard',
+    });
+  });
+
+  it('rejects users outside the configured leaderboard threshold', async () => {
+    mockUsersAheadCount = 25_000;
+
+    const result = await checkWhitelistAccess('user-1');
+
+    expect(result).toEqual({
+      allowed: false,
+      source: null,
+    });
+  });
+
+  it('returns false for actors and agents in dynamic leaderboard checks', async () => {
+    mockUserRow = {
+      id: 'user-1',
+      reputationPoints: 5_000,
+      invitePoints: 300,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      isActor: true,
+      isAgent: false,
+    };
+
+    await expect(isUserWhitelistedByLeaderboard('user-1')).resolves.toBe(false);
+
+    mockUserRow = {
+      id: 'user-1',
+      reputationPoints: 5_000,
+      invitePoints: 300,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      isActor: false,
+      isAgent: true,
+    };
+
+    await expect(isUserWhitelistedByLeaderboard('user-1')).resolves.toBe(false);
+  });
+});

--- a/packages/api/src/__tests__/whitelist-access.test.ts
+++ b/packages/api/src/__tests__/whitelist-access.test.ts
@@ -20,26 +20,22 @@ const usersTable = {
   isAgent: 'isAgent',
 };
 
-let mockWhitelistEntry:
-  | {
-      source: 'leaderboard' | 'admin_manual' | 'snapshot_first_100';
-      revokedAt: Date | null;
-    }
-  | null = null;
+let mockWhitelistEntry: {
+  source: 'leaderboard' | 'admin_manual' | 'snapshot_first_100';
+  revokedAt: Date | null;
+} | null = null;
 let mockWhitelistConfigRow: { leaderboardRankThreshold: number | null } | null =
   {
     leaderboardRankThreshold: 25_000,
   };
-let mockUserRow:
-  | {
-      id: string;
-      reputationPoints: number;
-      invitePoints: number;
-      createdAt: Date;
-      isActor: boolean;
-      isAgent: boolean;
-    }
-  | null = null;
+let mockUserRow: {
+  id: string;
+  reputationPoints: number;
+  invitePoints: number;
+  createdAt: Date;
+  isActor: boolean;
+  isAgent: boolean;
+} | null = null;
 let mockUsersAheadCount = 0;
 
 const mockDbSelect = mock((fields?: unknown) => ({
@@ -47,7 +43,8 @@ const mockDbSelect = mock((fields?: unknown) => ({
     if (table === whitelistTable) {
       return {
         where: () => ({
-          limit: () => Promise.resolve(mockWhitelistEntry ? [mockWhitelistEntry] : []),
+          limit: () =>
+            Promise.resolve(mockWhitelistEntry ? [mockWhitelistEntry] : []),
         }),
       };
     }
@@ -248,5 +245,13 @@ describe('whitelist access resolution', () => {
     };
 
     await expect(isUserWhitelistedByLeaderboard('user-1')).resolves.toBe(false);
+  });
+
+  it('returns false when the user does not exist in the users table', async () => {
+    mockUserRow = null;
+
+    await expect(isUserWhitelistedByLeaderboard('nonexistent')).resolves.toBe(
+      false
+    );
   });
 });

--- a/packages/api/src/__tests__/whitelist-auto-email.test.ts
+++ b/packages/api/src/__tests__/whitelist-auto-email.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
 
 const mockSendWhitelistWelcomeEmailsToUsers = mock(() => Promise.resolve());
-const mockGetLeaderboard = mock();
 
 const whitelistTable = {
   id: 'id',
@@ -20,6 +19,8 @@ const nftSnapshotTable = { userId: 'userId' };
 const usersTable = {
   id: 'id',
   reputationPoints: 'reputationPoints',
+  invitePoints: 'invitePoints',
+  createdAt: 'createdAt',
   isActor: 'isActor',
   isAgent: 'isAgent',
 };
@@ -33,7 +34,7 @@ let mockSnapshotRows: Array<{ userId: string }> = [];
 let mockExistingRows: Array<{ userId: string; revokedAt: Date | null }> = [];
 let mockInsertedRows: Array<{ userId: string }> = [];
 
-const mockDbSelect = mock(() => ({
+const mockDbSelect = mock((fields?: unknown) => ({
   from: (table: unknown) => {
     if (table === whitelistConfigTable) {
       return {
@@ -60,7 +61,12 @@ const mockDbSelect = mock(() => ({
 
     if (table === usersTable) {
       return {
-        where: () => ({ limit: () => Promise.resolve([]) }),
+        where: () => ({
+          orderBy: () => ({
+            limit: () => Promise.resolve(mockTopUsers),
+          }),
+          limit: () => Promise.resolve([]),
+        }),
       };
     }
 
@@ -87,10 +93,14 @@ mock.module('@babylon/db', () => ({
     insert: mockDbInsert,
   },
   and: (...args: unknown[]) => args,
+  asc: (col: unknown) => col,
   desc: (col: unknown) => col,
   eq: (a: unknown, b: unknown) => [a, b],
+  gt: (a: unknown, b: unknown) => [a, b],
   inArray: (a: unknown, b: unknown) => [a, b],
   isNull: (a: unknown) => a,
+  lt: (a: unknown, b: unknown) => [a, b],
+  or: (...args: unknown[]) => args,
   sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
     strings,
     values,
@@ -121,9 +131,7 @@ mock.module('nanoid', () => ({
 }));
 
 mock.module('../services/points-service', () => ({
-  PointsService: {
-    getLeaderboard: mockGetLeaderboard,
-  },
+  PointsService: {},
 }));
 
 mock.module('../services/whitelist-email-service', () => ({
@@ -131,15 +139,15 @@ mock.module('../services/whitelist-email-service', () => ({
   sendWhitelistWelcomeEmailsToUsers: mockSendWhitelistWelcomeEmailsToUsers,
 }));
 
-const { autoWhitelistCurrentTopN } = await import(
+const { autoWhitelistCurrentTopN, normalizeWhitelistLeaderboardThreshold } =
+  await import(
   '../services/whitelist-service'
-);
+  );
 
 describe('autoWhitelistCurrentTopN → whitelist welcome emails', () => {
   beforeEach(() => {
     mockDbSelect.mockClear();
     mockDbInsert.mockClear();
-    mockGetLeaderboard.mockClear();
     mockSendWhitelistWelcomeEmailsToUsers.mockClear();
 
     mockWhitelistConfigRow = { leaderboardRankThreshold: 100 };
@@ -147,8 +155,6 @@ describe('autoWhitelistCurrentTopN → whitelist welcome emails', () => {
     mockSnapshotRows = [];
     mockExistingRows = [];
     mockInsertedRows = [{ userId: 'user-1' }, { userId: 'user-2' }];
-
-    mockGetLeaderboard.mockResolvedValue({ users: mockTopUsers });
   });
 
   it('sends whitelist welcome emails for users inserted by leaderboard cron', async () => {
@@ -164,12 +170,34 @@ describe('autoWhitelistCurrentTopN → whitelist welcome emails', () => {
 
   it('does not send whitelist welcome emails when leaderboard is empty', async () => {
     mockTopUsers = [];
-    mockGetLeaderboard.mockResolvedValue({ users: mockTopUsers });
 
     const result = await autoWhitelistCurrentTopN();
 
     expect(result.totalInTopN).toBe(0);
     expect(result.inserted).toBe(0);
     expect(mockSendWhitelistWelcomeEmailsToUsers).toHaveBeenCalledTimes(0);
+  });
+
+  it('caps the effective whitelist threshold at 25,000', async () => {
+    mockWhitelistConfigRow = { leaderboardRankThreshold: 99_999 };
+    mockTopUsers = [];
+
+    const result = await autoWhitelistCurrentTopN();
+
+    expect(result.topN).toBe(25_000);
+  });
+});
+
+describe('normalizeWhitelistLeaderboardThreshold', () => {
+  it('falls back to the default threshold for invalid values', () => {
+    expect(normalizeWhitelistLeaderboardThreshold(null)).toBe(100);
+    expect(normalizeWhitelistLeaderboardThreshold(undefined)).toBe(100);
+    expect(normalizeWhitelistLeaderboardThreshold(0)).toBe(100);
+    expect(normalizeWhitelistLeaderboardThreshold(-5)).toBe(100);
+  });
+
+  it('truncates and caps the threshold at 25,000', () => {
+    expect(normalizeWhitelistLeaderboardThreshold(25_000.9)).toBe(25_000);
+    expect(normalizeWhitelistLeaderboardThreshold(40_000)).toBe(25_000);
   });
 });

--- a/packages/api/src/__tests__/whitelist-auto-email.test.ts
+++ b/packages/api/src/__tests__/whitelist-auto-email.test.ts
@@ -140,9 +140,7 @@ mock.module('../services/whitelist-email-service', () => ({
 }));
 
 const { autoWhitelistCurrentTopN, normalizeWhitelistLeaderboardThreshold } =
-  await import(
-  '../services/whitelist-service'
-  );
+  await import('../services/whitelist-service');
 
 describe('autoWhitelistCurrentTopN → whitelist welcome emails', () => {
   beforeEach(() => {

--- a/packages/api/src/services/index.ts
+++ b/packages/api/src/services/index.ts
@@ -52,3 +52,4 @@ export {
 } from './resource-locks';
 export * from './sentry-webhook-inbox-service';
 export * from './waitlist-service';
+export * from './whitelist-service';

--- a/packages/api/src/services/nft-access-service.ts
+++ b/packages/api/src/services/nft-access-service.ts
@@ -4,7 +4,7 @@ import {
   hasOnchainNftAccess,
   NftIndexerUnavailableError,
 } from './nft-indexer-service';
-import { isUserWhitelisted } from './whitelist-service';
+import { checkWhitelistAccess } from './whitelist-service';
 
 export type NftAccessReason = 'snapshot_2025' | 'whitelist' | 'holder' | 'none';
 
@@ -18,8 +18,8 @@ async function hasSnapshot2025Access(dbUserId: string): Promise<boolean> {
 }
 
 /**
- * Check if a user is whitelisted, with graceful fallback if the Whitelist
- * table doesn't exist yet (safe for rolling deployments).
+ * Check if a user has whitelist-based access, with graceful fallback if the
+ * whitelist tables don't exist yet (safe for rolling deployments).
  *
  * Only swallows "relation does not exist" errors (PG code 42P01).
  * All other errors are logged and re-thrown so they surface in production.
@@ -29,7 +29,8 @@ async function isWhitelistOverride(
 ): Promise<boolean> {
   if (!dbUserId) return false;
   try {
-    return await isUserWhitelisted(dbUserId);
+    const access = await checkWhitelistAccess(dbUserId);
+    return access.allowed;
   } catch (error: unknown) {
     // PostgreSQL "undefined_table" — table doesn't exist yet during rolling deploy.
     const pgCode =
@@ -51,7 +52,7 @@ async function isWhitelistOverride(
 /**
  * Returns true if the user has gated access via:
  * - Snapshot 2025 allowlist (Top 100 end-of-2025): permanent access + can mint.
- * - Whitelist: permanent access when a user has reached the Top 100 at least once.
+ * - Whitelist: active whitelist entry or current leaderboard threshold access.
  * - Holder: access while currently holding at least one NFT.
  *
  * Holder access is indexer-based and fail-closed: if the indexer is unavailable,
@@ -61,7 +62,7 @@ export async function hasNftAccess(dbUserId: string): Promise<boolean> {
   // Snapshot 2025 always has access (independent of holding).
   if (await hasSnapshot2025Access(dbUserId)) return true;
 
-  // Whitelist is permanent access.
+  // Whitelist-based access includes direct entries and the current Top N rule.
   if (await isWhitelistOverride(dbUserId)) return true;
 
   const [dbUser] = await db

--- a/packages/api/src/services/whitelist-service.ts
+++ b/packages/api/src/services/whitelist-service.ts
@@ -1,11 +1,15 @@
 import {
   and,
+  asc,
   db,
   desc,
   eq,
+  gt,
   inArray,
   isNull,
+  lt,
   nftSnapshot,
+  or,
   sql,
   users,
   whitelist,
@@ -14,7 +18,6 @@ import {
 import { UserAlphaGroupAssignmentService } from '@babylon/engine';
 import { logger } from '@babylon/shared';
 import { nanoid } from 'nanoid';
-import { PointsService } from './points-service';
 import {
   sendWhitelistWelcomeEmailsToUsers,
   sendWhitelistWelcomeEmailToUser,
@@ -42,6 +45,24 @@ interface UpdateWhitelistConfigParams {
   updatedBy?: string;
 }
 
+export const DEFAULT_WHITELIST_LEADERBOARD_THRESHOLD = 100;
+export const MAX_WHITELIST_LEADERBOARD_THRESHOLD = 25_000;
+
+export function normalizeWhitelistLeaderboardThreshold(
+  value: number | null | undefined
+): number {
+  if (!Number.isFinite(value) || value === undefined || value === null) {
+    return DEFAULT_WHITELIST_LEADERBOARD_THRESHOLD;
+  }
+
+  const normalized = Math.trunc(value);
+  if (normalized < 1) {
+    return DEFAULT_WHITELIST_LEADERBOARD_THRESHOLD;
+  }
+
+  return Math.min(normalized, MAX_WHITELIST_LEADERBOARD_THRESHOLD);
+}
+
 // ---------------------------------------------------------------------------
 // Access checks
 // ---------------------------------------------------------------------------
@@ -63,60 +84,91 @@ export async function isUserWhitelisted(userId: string): Promise<boolean> {
  * Check if a user qualifies for whitelist access via the leaderboard
  * rank threshold configured in WhitelistConfig.
  *
- * Computes the user's rank on-the-fly by counting users with higher
- * reputation points. Returns false if the threshold is disabled (null).
+ * Computes the user's exact rank on-the-fly using the same ordering as the
+ * whitelist cron. Returns false if the user cannot be ranked.
  */
 export async function isUserWhitelistedByLeaderboard(
   userId: string
 ): Promise<boolean> {
-  const config = await getWhitelistConfig();
-  if (!config?.leaderboardRankThreshold) return false;
-
-  const threshold = config.leaderboardRankThreshold;
-
-  // Get the user's reputation points
+  const threshold = await getEffectiveWhitelistLeaderboardThreshold();
   const [user] = await db
-    .select({ reputationPoints: users.reputationPoints })
+    .select({
+      id: users.id,
+      reputationPoints: users.reputationPoints,
+      invitePoints: users.invitePoints,
+      createdAt: users.createdAt,
+      isActor: users.isActor,
+      isAgent: users.isAgent,
+    })
     .from(users)
     .where(eq(users.id, userId))
     .limit(1);
 
-  if (!user) return false;
+  if (!user || user.isActor || user.isAgent || !user.createdAt) {
+    return false;
+  }
 
-  // Count how many non-actor, non-agent users have strictly more points
+  // Count how many non-actor, non-agent users are strictly ahead using a stable
+  // tiebreaker chain so the threshold matches the cron selection.
   const [result] = await db
-    .select({ rank: sql<number>`count(*) + 1` })
+    .select({ count: sql<number>`count(*)` })
     .from(users)
     .where(
       and(
-        sql`${users.reputationPoints} > ${user.reputationPoints}`,
         eq(users.isActor, false),
-        eq(users.isAgent, false)
+        eq(users.isAgent, false),
+        or(
+          gt(users.reputationPoints, user.reputationPoints),
+          and(
+            eq(users.reputationPoints, user.reputationPoints),
+            gt(users.invitePoints, user.invitePoints)
+          ),
+          and(
+            eq(users.reputationPoints, user.reputationPoints),
+            eq(users.invitePoints, user.invitePoints),
+            lt(users.createdAt, user.createdAt)
+          ),
+          and(
+            eq(users.reputationPoints, user.reputationPoints),
+            eq(users.invitePoints, user.invitePoints),
+            eq(users.createdAt, user.createdAt),
+            lt(users.id, user.id)
+          )
+        )
       )
     );
 
-  const rank = Number(result?.rank ?? 0);
+  const rank = Number(result?.count ?? 0) + 1;
   return rank <= threshold;
 }
 
 /**
- * Combined whitelist access check: direct whitelist entry OR leaderboard rank.
+ * Combined whitelist access check:
+ * - active whitelist entry => allow
+ * - revoked whitelist entry => deny
+ * - no entry => fall back to leaderboard threshold
  */
 export async function checkWhitelistAccess(
   userId: string
 ): Promise<{ allowed: boolean; source: string | null }> {
-  // 1. Check direct whitelist entry first (fast)
-  const [directEntry] = await db
-    .select({ source: whitelist.source })
+  const [entry] = await db
+    .select({ source: whitelist.source, revokedAt: whitelist.revokedAt })
     .from(whitelist)
-    .where(and(eq(whitelist.userId, userId), isNull(whitelist.revokedAt)))
+    .where(eq(whitelist.userId, userId))
     .limit(1);
 
-  if (directEntry) return { allowed: true, source: directEntry.source };
+  if (entry?.revokedAt) {
+    return { allowed: false, source: null };
+  }
 
-  // 2. Check leaderboard rank threshold
+  if (entry) {
+    return { allowed: true, source: entry.source };
+  }
+
   const leaderboardAllowed = await isUserWhitelistedByLeaderboard(userId);
-  if (leaderboardAllowed) return { allowed: true, source: 'leaderboard' };
+  if (leaderboardAllowed) {
+    return { allowed: true, source: 'leaderboard' };
+  }
 
   return { allowed: false, source: null };
 }
@@ -344,6 +396,13 @@ export async function getWhitelistConfig() {
   return config ?? null;
 }
 
+export async function getEffectiveWhitelistLeaderboardThreshold(): Promise<number> {
+  const config = await getWhitelistConfig();
+  return normalizeWhitelistLeaderboardThreshold(
+    config?.leaderboardRankThreshold
+  );
+}
+
 /**
  * Upsert the whitelist configuration.
  */
@@ -382,14 +441,9 @@ export async function updateWhitelistConfig({
  * Resolve the cron auto-whitelist Top N from the WhitelistConfig table.
  *
  * We reuse `leaderboardRankThreshold` as the Top N knob for the daily cron.
- * If unset/null/invalid, default to 100.
  */
 async function getAutoWhitelistTopN(): Promise<number> {
-  const config = await getWhitelistConfig();
-  const raw = config?.leaderboardRankThreshold ?? null;
-  if (raw === null) return 100;
-  if (!Number.isFinite(raw) || raw < 1) return 100;
-  return Math.min(raw, 10_000);
+  return getEffectiveWhitelistLeaderboardThreshold();
 }
 
 /**
@@ -407,14 +461,18 @@ export async function autoWhitelistCurrentTopN(): Promise<{
   skippedRevoked: number;
 }> {
   const topN = await getAutoWhitelistTopN();
-
-  const { users: topUsers } = await PointsService.getLeaderboard(
-    1,
-    topN,
-    0,
-    'all'
-  );
-  const userIds = topUsers.map((u) => u.id);
+  const topUsers = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(and(eq(users.isActor, false), eq(users.isAgent, false)))
+    .orderBy(
+      desc(users.reputationPoints),
+      desc(users.invitePoints),
+      asc(users.createdAt),
+      asc(users.id)
+    )
+    .limit(topN);
+  const userIds = topUsers.map((user) => user.id);
 
   if (userIds.length === 0) {
     return {

--- a/packages/api/src/services/whitelist-service.ts
+++ b/packages/api/src/services/whitelist-service.ts
@@ -157,6 +157,9 @@ export async function checkWhitelistAccess(
     .where(eq(whitelist.userId, userId))
     .limit(1);
 
+  // A revoked entry is a hard block — even if the user would currently qualify
+  // via the leaderboard threshold, an admin revocation is intentionally permanent
+  // until the row is deleted or un-revoked.
   if (entry?.revokedAt) {
     return { allowed: false, source: null };
   }


### PR DESCRIPTION
## Summary

- Fix whitelist Top N enforcement so a configured Top 25,000 actually works end-to-end.
- Allow Top N users through the access gate even before the daily whitelist cron has persisted their row.
- Update the waitlist header/copy to show the configured whitelist threshold and keep email collection messaging explicit for non-whitelisted users.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: [BAB-229](https://linear.app/eliza-labs/issue/BAB-229/fix-waitlist-whitelist-logic-ux-for-whitelisted-vs-non-whitelisted-add)

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- Normalize the whitelist leaderboard threshold with a hard cap of 25,000 instead of 10,000.
- Rework Top N auto-whitelisting to select ranked human users directly with stable tie-breakers.
- Extend whitelist access checks so revoked entries still stay blocked, while eligible Top N users can access before cron persistence.
- Expose the effective whitelist threshold to the waitlist position API.
- Update waitlist header/copy helpers so non-whitelisted users see `Leaderboard` and `Top 25,000`-style context from config.
- Add unit tests for threshold normalization, whitelist access resolution, and waitlist header copy.

## Review guide

**Start here**
- `packages/api/src/services/whitelist-service.ts`
- `packages/api/src/services/nft-access-service.ts`
- `apps/web/src/components/shared/ComingSoon.tsx`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- I intentionally kept this out of build-heavy validation and focused on targeted unit tests plus Biome on touched files.
- The access change respects revoked whitelist rows before applying the dynamic Top N fallback.
- Non-goal: changing the cron schedule or adding a DB migration.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Ran `bunx biome check --write` on the touched files only.
2. Ran `bun test packages/api/src/__tests__/whitelist-auto-email.test.ts packages/api/src/__tests__/whitelist-access.test.ts apps/web/src/components/shared/comingSoonAccess.test.ts`.
3. Verified the waitlist copy now derives the threshold from config instead of `totalCount`.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: deploy normally; the existing whitelist config value will now honor 25,000.
- Rollback: revert this branch to restore the old whitelist threshold and access behavior.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- `/api/waitlist/position` now includes `whitelistRankThreshold` for the waitlist UI.

### Database
- No schema changes.

### Contracts / on-chain
- Not applicable.

### Docs
- Not applicable.

</details>

## Screenshots / recordings (UI)

### Option A: Visual demo

| Feature | Before | After |
|---------|--------|-------|
| Waitlist header for non-whitelisted users | Subtitle showed `Top {totalCount}` instead of the whitelist threshold | Subtitle shows the configured whitelist threshold, e.g. `Top 25,000` |
| Top N access | Users above rank 10,000 could still be blocked when the config was set higher | Top N access and cron selection now honor the configured threshold up to 25,000 |

*Demo script (for recording):*
1. Open the waitlist as a non-whitelisted user and confirm the header reads `Leaderboard` with `Top 25,000`-style context.
2. Open the waitlist as a Top N user without a persisted whitelist row and confirm the access check returns `whitelist` access.
3. Confirm a revoked whitelist user still does not regain access through the dynamic Top N fallback.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
