### PR TITLE
fix(api): harden QA auth and compatibility routes

### DIFF
--- a/apps/web/src/app/api/agents/route.test.ts
+++ b/apps/web/src/app/api/agents/route.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { NextRequest } from 'next/server';
+
+const mockAuthenticateUser = mock();
+const mockListUserAgents = mock();
+const mockGetPerformance = mock();
+const mockGetAgentConfig = mock();
+const mockLoggerWarn = mock();
+const mockLoggerInfo = mock();
+
+mock.module('@babylon/agents', () => ({
+  agentService: {
+    listUserAgents: mockListUserAgents,
+    getPerformance: mockGetPerformance,
+  },
+  getAgentConfig: mockGetAgentConfig,
+  isAutonomousTradingEnabled: (
+    config: { autonomousTrading?: boolean } | null
+  ) => config?.autonomousTrading ?? false,
+}));
+
+mock.module('@babylon/api', () => ({
+  authenticateUser: mockAuthenticateUser,
+  withErrorHandling: (handler: (request: NextRequest) => Promise<unknown>) =>
+    handler,
+}));
+
+mock.module('@babylon/shared', () => ({
+  logger: {
+    warn: mockLoggerWarn,
+    info: mockLoggerInfo,
+  },
+}));
+
+const { GET } = await import('./route');
+
+describe('GET /api/agents', () => {
+  beforeEach(() => {
+    mockAuthenticateUser.mockReset();
+    mockListUserAgents.mockReset();
+    mockGetPerformance.mockReset();
+    mockGetAgentConfig.mockReset();
+    mockLoggerWarn.mockReset();
+    mockLoggerInfo.mockReset();
+  });
+
+  it('returns a successful response even if per-agent stats fail', async () => {
+    mockAuthenticateUser.mockResolvedValue({ id: 'user-1' });
+    mockListUserAgents.mockResolvedValue([
+      {
+        id: 'agent-1',
+        username: 'agent-one',
+        displayName: 'Agent One',
+        bio: 'bio',
+        profileImageUrl: null,
+        virtualBalance: '42.00',
+        lifetimePnL: '5.50',
+        walletAddress: null,
+        onChainRegistered: false,
+        agent0TokenId: null,
+        createdAt: new Date('2026-03-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-03-02T00:00:00.000Z'),
+      },
+    ]);
+    mockGetPerformance.mockRejectedValue(new Error('broken trade row'));
+    mockGetAgentConfig.mockResolvedValue(null);
+
+    const response = (await GET({
+      url: 'https://example.com/api/agents',
+    } as NextRequest)) as Response;
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.agents).toHaveLength(1);
+    expect(body.agents[0]).toMatchObject({
+      id: 'agent-1',
+      totalTrades: 0,
+      profitableTrades: 0,
+      winRate: 0,
+      autonomousTrading: false,
+    });
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/app/api/agents/route.ts
+++ b/apps/web/src/app/api/agents/route.ts
@@ -263,11 +263,55 @@ export const GET = withErrorHandling(async function GET(req: NextRequest) {
 
   const agentsWithStats = await Promise.all(
     agents.map(async (agent) => {
-      const [performance, config] = await Promise.all([
+      const defaultPerformance = {
+        totalTrades: 0,
+        profitableTrades: 0,
+        winRate: 0,
+      };
+
+      const [performanceResult, configResult] = await Promise.allSettled([
         agentService.getPerformance(agent.id),
         getAgentConfig(agent.id),
       ]);
+
+      const performance =
+        performanceResult.status === 'fulfilled'
+          ? performanceResult.value
+          : defaultPerformance;
+      const config =
+        configResult.status === 'fulfilled' ? configResult.value : null;
       const tradingEnabled = isAutonomousTradingEnabled(config);
+
+      if (performanceResult.status === 'rejected') {
+        logger.warn(
+          'Failed to load agent performance for list endpoint; using defaults',
+          {
+            agentId: agent.id,
+            managerUserId: user.id,
+            error:
+              performanceResult.reason instanceof Error
+                ? performanceResult.reason.message
+                : String(performanceResult.reason),
+          },
+          'GET /api/agents'
+        );
+      }
+
+      if (configResult.status === 'rejected') {
+        logger.warn(
+          'Failed to load agent config for list endpoint; using defaults',
+          {
+            agentId: agent.id,
+            managerUserId: user.id,
+            error:
+              configResult.reason instanceof Error
+                ? configResult.reason.message
+                : String(configResult.reason),
+          },
+          'GET /api/agents'
+        );
+      }
+
       return {
         id: agent.id,
         username: agent.username,

--- a/apps/web/src/app/api/chats/[id]/message/route.ts
+++ b/apps/web/src/app/api/chats/[id]/message/route.ts
@@ -126,6 +126,7 @@ import {
 } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 import { trackServerEvent } from '@/lib/posthog/server';
+import { getOtherDmParticipantId } from '../../_lib/dm-chat-id';
 
 /**
  * POST /api/chats/[id]/message
@@ -182,25 +183,12 @@ export const POST = withErrorHandling(
 
     // If chat doesn't exist and it's a DM format, create it automatically
     if (!chat && chatId.startsWith('dm-')) {
-      // Extract user IDs from DM chat ID format: dm-{id1}-{id2}
-      const dmPrefix = 'dm-';
-      const idsString = chatId.substring(dmPrefix.length);
-      const participantIds = idsString.split('-');
+      const otherUserId = getOtherDmParticipantId(chatId, user.userId);
 
-      // Verify the current user is one of the participants
-      if (!participantIds.includes(user.userId)) {
+      if (!otherUserId) {
         throw new BusinessLogicError(
           'Invalid DM chat participants',
           'INVALID_DM_PARTICIPANTS'
-        );
-      }
-
-      // Get the other participant ID
-      const otherUserId = participantIds.find((id) => id !== user.userId);
-      if (!otherUserId) {
-        throw new BusinessLogicError(
-          'Invalid DM chat format',
-          'INVALID_DM_FORMAT'
         );
       }
 

--- a/apps/web/src/app/api/chats/[id]/messages/route.ts
+++ b/apps/web/src/app/api/chats/[id]/messages/route.ts
@@ -1,0 +1,1 @@
+export { POST } from '../message/route';

--- a/apps/web/src/app/api/chats/[id]/participants/route.ts
+++ b/apps/web/src/app/api/chats/[id]/participants/route.ts
@@ -136,6 +136,38 @@ import { asSystem, asUser } from '@babylon/db';
 import { generateSnowflakeId, logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 
+async function loadChatWithParticipants(
+  user: Awaited<ReturnType<typeof authenticate>>,
+  chatId: string
+) {
+  return asUser(user, async (db) => {
+    const [chat, participants] = await Promise.all([
+      db.chat.findUnique({
+        where: { id: chatId },
+      }),
+      db.chatParticipant.findMany({
+        where: { chatId },
+        select: {
+          id: true,
+          chatId: true,
+          userId: true,
+          joinedAt: true,
+          isActive: true,
+        },
+      }),
+    ]);
+
+    if (!chat) {
+      throw new NotFoundError('Chat', chatId);
+    }
+
+    return {
+      ...chat,
+      participants,
+    };
+  });
+}
+
 /**
  * POST /api/chats/[id]/participants
  * Add users to a group chat
@@ -166,56 +198,31 @@ export const POST = withErrorHandling(
     }
 
     // Check if chat exists and user is a participant
-    const chat = await asUser(user, async (db) => {
-      const chat = await db.chat.findUnique({
-        where: { id: chatId },
-        include: {
-          participants: true,
-        },
-      });
+    const chat = await loadChatWithParticipants(user, chatId);
 
-      if (!chat) {
-        throw new NotFoundError('Chat', chatId);
-      }
+    const isParticipant = (chat.participants || []).some(
+      (p) => p.userId === user.userId
+    );
 
-      type ChatWithParticipants = typeof chat & {
-        participants?: Array<{
-          id: string;
-          chatId: string;
-          userId: string;
-          joinedAt: Date;
-          isActive: boolean;
-        }>;
-      };
-      const chatWithParticipants = chat as ChatWithParticipants;
-
-      // Check if user is a participant
-      const isParticipant = (chatWithParticipants.participants || []).some(
-        (p) => p.userId === user.userId
+    if (!isParticipant) {
+      throw new BusinessLogicError(
+        'You must be a participant to invite others',
+        'NOT_PARTICIPANT'
       );
+    }
 
-      if (!isParticipant) {
-        throw new BusinessLogicError(
-          'You must be a participant to invite others',
-          'NOT_PARTICIPANT'
-        );
-      }
-
-      // If it's a DM, convert to group chat
-      if (!chat.isGroup) {
-        // Update chat to be a group chat
+    if (!chat.isGroup) {
+      await asUser(user, async (db) => {
         await db.chat.update({
           where: { id: chatId },
           data: {
             isGroup: true,
-            name: 'Group Chat', // Default name, can be updated later
+            name: 'Group Chat',
             updatedAt: new Date(),
           },
         });
-      }
-
-      return chat;
-    });
+      });
+    }
 
     // Verify NFT ownership for NFT-gated chats
     if (chat.nftGated && chat.requiredNftContractAddress) {
@@ -285,15 +292,9 @@ export const POST = withErrorHandling(
       }
 
       // Filter out users already in the chat
-      type ChatWithParticipants = typeof chat & {
-        participants?: Array<{
-          userId: string;
-        }>;
-      };
-      const chatWithParticipants = chat as ChatWithParticipants;
-      const existingParticipantIds = (
-        chatWithParticipants.participants || []
-      ).map((p) => p.userId);
+      const existingParticipantIds = (chat.participants || []).map(
+        (p) => p.userId
+      );
       const newUsers = usersToAdd.filter(
         (u) => !existingParticipantIds.includes(u.id)
       );
@@ -401,42 +402,21 @@ export const GET = withErrorHandling(
     await requireNftChatAccess(user, chatId);
 
     // Get chat participants
+    const chat = await loadChatWithParticipants(user, chatId);
+    const isParticipant = (chat.participants || []).some(
+      (p) => p.userId === user.userId
+    );
+
+    if (!isParticipant) {
+      throw new BusinessLogicError(
+        'You must be a participant to view participants',
+        'NOT_PARTICIPANT'
+      );
+    }
+
+    const userIds = (chat.participants || []).map((p) => p.userId);
     const participants = await asUser(user, async (db) => {
-      const chat = await db.chat.findUnique({
-        where: { id: chatId },
-        include: {
-          participants: true,
-        },
-      });
-
-      if (!chat) {
-        throw new NotFoundError('Chat', chatId);
-      }
-
-      type ChatWithParticipants = typeof chat & {
-        participants?: Array<{
-          userId: string;
-        }>;
-      };
-      const chatWithParticipants = chat as ChatWithParticipants;
-
-      // Check if user is a participant
-      const isParticipant = (chatWithParticipants.participants || []).some(
-        (p) => p.userId === user.userId
-      );
-
-      if (!isParticipant) {
-        throw new BusinessLogicError(
-          'You must be a participant to view participants',
-          'NOT_PARTICIPANT'
-        );
-      }
-
-      // Get user details for all participants
-      const userIds = (chatWithParticipants.participants || []).map(
-        (p) => p.userId
-      );
-      const users = await db.user.findMany({
+      return db.user.findMany({
         where: {
           id: { in: userIds },
         },
@@ -447,8 +427,6 @@ export const GET = withErrorHandling(
           profileImageUrl: true,
         },
       });
-
-      return users;
     });
 
     logger.info(

--- a/apps/web/src/app/api/chats/_lib/dm-chat-id.ts
+++ b/apps/web/src/app/api/chats/_lib/dm-chat-id.ts
@@ -1,0 +1,26 @@
+export function getOtherDmParticipantId(
+  chatId: string,
+  currentUserId: string
+): string | null {
+  if (!chatId.startsWith('dm-')) {
+    return null;
+  }
+
+  const prefix = `dm-${currentUserId}-`;
+  if (chatId.startsWith(prefix)) {
+    const otherUserId = chatId.slice(prefix.length);
+    return otherUserId && otherUserId !== currentUserId ? otherUserId : null;
+  }
+
+  const suffix = `-${currentUserId}`;
+  if (chatId.endsWith(suffix)) {
+    const otherUserId = chatId.slice('dm-'.length, -suffix.length);
+    return otherUserId && otherUserId !== currentUserId ? otherUserId : null;
+  }
+
+  return null;
+}
+
+export function isUserInDmChatId(chatId: string, userId: string): boolean {
+  return getOtherDmParticipantId(chatId, userId) !== null;
+}

--- a/apps/web/src/app/api/chats/unread-count/__tests__/route.test.ts
+++ b/apps/web/src/app/api/chats/unread-count/__tests__/route.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+const mockAuthenticate = mock();
+const mockAsUser = mock();
+
+mock.module('@babylon/api', () => ({
+  authenticate: mockAuthenticate,
+  successResponse: (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), { status }),
+  withErrorHandling: (handler: (...args: unknown[]) => unknown) => handler,
+}));
+
+mock.module('@babylon/db', () => ({
+  asUser: mockAsUser,
+}));
+
+import { GET } from '../route';
+
+describe('GET /api/chats/unread-count', () => {
+  beforeEach(() => {
+    mockAuthenticate.mockReset();
+    mockAsUser.mockReset();
+  });
+
+  it('returns separate pending request and unread message counts', async () => {
+    mockAuthenticate.mockResolvedValue({ userId: 'user-1' });
+    mockAsUser.mockImplementation(
+      async (
+        user: { userId: string },
+        callback: (db: {
+          dmAcceptance: { count: (input: unknown) => Promise<number> };
+          notification: { count: (input: unknown) => Promise<number> };
+        }) => Promise<unknown>
+      ) =>
+        callback({
+          dmAcceptance: {
+            count: async () => 2,
+          },
+          notification: {
+            count: async () => 3,
+          },
+        })
+    );
+
+    const response = (await GET({} as never)) as Response;
+    const body = await response.json();
+
+    expect(body).toEqual({
+      pendingDMs: 5,
+      pendingDMRequests: 2,
+      unreadMessages: 3,
+      hasNewMessages: true,
+    });
+  });
+});

--- a/apps/web/src/app/api/chats/unread-count/route.ts
+++ b/apps/web/src/app/api/chats/unread-count/route.ts
@@ -27,10 +27,16 @@
  *               properties:
  *                 pendingDMs:
  *                   type: integer
+ *                   description: Combined DM/chat badge count for backwards compatibility
+ *                 pendingDMRequests:
+ *                   type: integer
  *                   description: Number of pending DM requests
+ *                 unreadMessages:
+ *                   type: integer
+ *                   description: Number of unread chat notifications
  *                 hasNewMessages:
  *                   type: boolean
- *                   description: Whether there are new messages in last 24h
+ *                   description: Whether there are unread chat notifications
  *       401:
  *         description: Unauthorized
  *
@@ -55,52 +61,37 @@ import type { NextRequest } from 'next/server';
  * Get counts of pending DMs and unread messages
  *
  * Returns:
- * - pendingDMs: Number of DM requests from anons awaiting acceptance
- * - hasNewMessages: Boolean indicating if there are any new messages
+ * - pendingDMs: Combined chat badge count (legacy field)
+ * - pendingDMRequests: Number of DM requests from anons awaiting acceptance
+ * - unreadMessages: Number of unread chat notifications
+ * - hasNewMessages: Boolean indicating if there are any unread chat notifications
  */
 export const GET = withErrorHandling(async (request: NextRequest) => {
   const user = await authenticate(request);
 
   const counts = await asUser(user, async (db) => {
-    let pendingDMCount = 0;
-    pendingDMCount = await db.dmAcceptance.count({
+    const pendingDMCount = await db.dmAcceptance.count({
       where: {
         userId: user.userId,
         status: 'pending',
       },
     });
 
-    const chatsWithParticipation = await db.chatParticipant.findMany({
+    const unreadMessageCount = await db.notification.count({
       where: {
         userId: user.userId,
-      },
-      select: {
-        chatId: true,
+        read: false,
+        chatId: {
+          not: null,
+        },
       },
     });
 
-    const chatIds = chatsWithParticipation.map((cp) => cp.chatId);
-
-    let recentMessageCount = 0;
-    if (chatIds.length > 0) {
-      recentMessageCount = await db.message.count({
-        where: {
-          chatId: {
-            in: chatIds,
-          },
-          senderId: {
-            not: user.userId,
-          },
-          createdAt: {
-            gte: new Date(Date.now() - 24 * 60 * 60 * 1000),
-          },
-        },
-      });
-    }
-
     return {
-      pendingDMs: pendingDMCount,
-      hasNewMessages: recentMessageCount > 0,
+      pendingDMs: pendingDMCount + unreadMessageCount,
+      pendingDMRequests: pendingDMCount,
+      unreadMessages: unreadMessageCount,
+      hasNewMessages: unreadMessageCount > 0,
     };
   });
 

--- a/apps/web/src/app/api/follow/route.ts
+++ b/apps/web/src/app/api/follow/route.ts
@@ -1,0 +1,46 @@
+import { BusinessLogicError, withErrorHandling } from '@babylon/api';
+import type { NextRequest } from 'next/server';
+import {
+  DELETE as deleteFollow,
+  GET as getFollow,
+  POST as postFollow,
+} from '../users/[userId]/follow/route';
+
+async function resolveUserId(request: NextRequest): Promise<string> {
+  const { searchParams } = new URL(request.url);
+  const queryUserId = searchParams.get('userId')?.trim();
+
+  if (queryUserId) {
+    return queryUserId;
+  }
+
+  const body = await request.json().catch(() => null);
+  const bodyUserId = typeof body?.userId === 'string' ? body.userId.trim() : '';
+
+  if (bodyUserId) {
+    return bodyUserId;
+  }
+
+  throw new BusinessLogicError('userId is required', 'USER_ID_REQUIRED');
+}
+
+function toContext(userId: string) {
+  return {
+    params: Promise.resolve({ userId }),
+  };
+}
+
+export const POST = withErrorHandling(async (request: NextRequest) => {
+  const userId = await resolveUserId(request);
+  return postFollow(request, toContext(userId));
+});
+
+export const DELETE = withErrorHandling(async (request: NextRequest) => {
+  const userId = await resolveUserId(request);
+  return deleteFollow(request, toContext(userId));
+});
+
+export const GET = withErrorHandling(async (request: NextRequest) => {
+  const userId = await resolveUserId(request);
+  return getFollow(request, toContext(userId));
+});

--- a/apps/web/src/app/api/game/state/route.ts
+++ b/apps/web/src/app/api/game/state/route.ts
@@ -1,0 +1,1 @@
+export { GET } from '../control/route';

--- a/apps/web/src/app/api/leaderboard/__tests__/route.test.ts
+++ b/apps/web/src/app/api/leaderboard/__tests__/route.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+const mockGetCache = mock();
+const mockOptionalAuth = mock();
+const mockGetWalletLeaderboard = mock();
+const mockGetTeamLeaderboard = mock();
+const mockGetUserPosition = mock();
+const mockSetCache = mock();
+const mockLoggerInfo = mock();
+
+mock.module('@babylon/api', () => ({
+  getCache: mockGetCache,
+  optionalAuth: mockOptionalAuth,
+  PointsService: {
+    getWalletLeaderboard: mockGetWalletLeaderboard,
+    getTeamLeaderboard: mockGetTeamLeaderboard,
+    getUserPosition: mockGetUserPosition,
+  },
+  setCache: mockSetCache,
+  successResponse: (
+    body: unknown,
+    status = 200,
+    headers?: Record<string, string>
+  ) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers,
+    }),
+  withErrorHandling: (handler: (...args: unknown[]) => unknown) => handler,
+}));
+
+mock.module('@babylon/shared', () => ({
+  LeaderboardQuerySchema: {
+    safeParse: (input: Record<string, string>) => ({
+      success: true,
+      data: {
+        page: Number(input.page ?? 1) || 1,
+        pageSize: Number(input.pageSize ?? 100) || 100,
+        type: input.type === 'team' ? 'team' : 'wallet',
+        userId: input.userId,
+      },
+    }),
+  },
+  logger: {
+    info: mockLoggerInfo,
+  },
+}));
+
+import { GET } from '../route';
+
+const leaderboardData = {
+  users: [
+    {
+      id: 'user-1',
+      username: 'alice',
+      displayName: 'Alice',
+      profileImageUrl: null,
+      totalPoints: 123,
+      balance: 456,
+      lifetimePnL: 7,
+      createdAt: new Date('2026-03-01T00:00:00.000Z'),
+      rank: 1,
+      isAgent: false,
+      onChainRegistered: false,
+      nftTokenId: null,
+    },
+  ],
+  totalCount: 1,
+  page: 1,
+  pageSize: 100,
+  totalPages: 1,
+};
+
+function createRequest(url: string): {
+  url: string;
+} {
+  return { url };
+}
+
+describe('GET /api/leaderboard', () => {
+  beforeEach(() => {
+    mockGetCache.mockReset();
+    mockOptionalAuth.mockReset();
+    mockGetWalletLeaderboard.mockReset();
+    mockGetTeamLeaderboard.mockReset();
+    mockGetUserPosition.mockReset();
+    mockSetCache.mockReset();
+    mockLoggerInfo.mockReset();
+
+    mockGetCache.mockResolvedValue(leaderboardData);
+    mockGetWalletLeaderboard.mockResolvedValue(leaderboardData);
+    mockGetTeamLeaderboard.mockResolvedValue(leaderboardData);
+    mockGetUserPosition.mockResolvedValue({
+      rank: 3,
+      page: 1,
+      entry: leaderboardData.users[0],
+    });
+  });
+
+  it('populates currentUser from auth when userId query param is absent', async () => {
+    mockOptionalAuth.mockResolvedValue({
+      userId: 'privy-user',
+      dbUserId: 'db-user-1',
+      isAgent: false,
+    });
+
+    const response = (await GET(
+      createRequest('https://example.com/api/leaderboard')
+    )) as Response;
+    const body = await response.json();
+
+    expect(mockGetUserPosition).toHaveBeenCalledWith(
+      'db-user-1',
+      'wallet',
+      100
+    );
+    expect(body.currentUser.rank).toBe(3);
+    expect(body.currentUser.page).toBe(1);
+    expect(body.currentUser.entry).toMatchObject({
+      id: 'user-1',
+      username: 'alice',
+      rank: 1,
+    });
+    expect(response.headers.get('Cache-Control')).toBe('private, no-store');
+  });
+
+  it('keeps public cache headers when the request is anonymous', async () => {
+    mockOptionalAuth.mockResolvedValue(null);
+
+    const response = (await GET(
+      createRequest('https://example.com/api/leaderboard?type=team')
+    )) as Response;
+    const body = await response.json();
+
+    expect(mockGetUserPosition).not.toHaveBeenCalled();
+    expect(body.currentUser).toBeNull();
+    expect(response.headers.get('Cache-Control')).toContain(
+      'public, s-maxage='
+    );
+  });
+});

--- a/apps/web/src/app/api/leaderboard/__tests__/route.test.ts
+++ b/apps/web/src/app/api/leaderboard/__tests__/route.test.ts
@@ -1,14 +1,17 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
 
 const mockGetCache = mock();
+const mockFindUserByIdentifier = mock();
 const mockOptionalAuth = mock();
 const mockGetWalletLeaderboard = mock();
 const mockGetTeamLeaderboard = mock();
 const mockGetUserPosition = mock();
 const mockSetCache = mock();
 const mockLoggerInfo = mock();
+const mockLoggerWarn = mock();
 
 mock.module('@babylon/api', () => ({
+  findUserByIdentifier: mockFindUserByIdentifier,
   getCache: mockGetCache,
   optionalAuth: mockOptionalAuth,
   PointsService: {
@@ -43,6 +46,7 @@ mock.module('@babylon/shared', () => ({
   },
   logger: {
     info: mockLoggerInfo,
+    warn: mockLoggerWarn,
   },
 }));
 
@@ -80,14 +84,17 @@ function createRequest(url: string): {
 describe('GET /api/leaderboard', () => {
   beforeEach(() => {
     mockGetCache.mockReset();
+    mockFindUserByIdentifier.mockReset();
     mockOptionalAuth.mockReset();
     mockGetWalletLeaderboard.mockReset();
     mockGetTeamLeaderboard.mockReset();
     mockGetUserPosition.mockReset();
     mockSetCache.mockReset();
     mockLoggerInfo.mockReset();
+    mockLoggerWarn.mockReset();
 
     mockGetCache.mockResolvedValue(leaderboardData);
+    mockFindUserByIdentifier.mockResolvedValue(null);
     mockGetWalletLeaderboard.mockResolvedValue(leaderboardData);
     mockGetTeamLeaderboard.mockResolvedValue(leaderboardData);
     mockGetUserPosition.mockResolvedValue({
@@ -137,5 +144,39 @@ describe('GET /api/leaderboard', () => {
     expect(response.headers.get('Cache-Control')).toContain(
       'public, s-maxage='
     );
+  });
+
+  it('resolves query userId through identifier lookup before computing currentUser', async () => {
+    mockOptionalAuth.mockResolvedValue(null);
+    mockFindUserByIdentifier.mockResolvedValue({ id: 'db-user-2' });
+
+    await GET(
+      createRequest(
+        'https://example.com/api/leaderboard?type=team&userId=alice'
+      )
+    );
+
+    expect(mockFindUserByIdentifier).toHaveBeenCalledWith('alice', {
+      id: true,
+    });
+    expect(mockGetUserPosition).toHaveBeenCalledWith('db-user-2', 'team', 100);
+  });
+
+  it('returns currentUser=null instead of failing when position lookup throws', async () => {
+    mockOptionalAuth.mockResolvedValue({
+      userId: 'privy-user',
+      isAgent: false,
+    });
+    mockGetUserPosition.mockRejectedValueOnce(
+      new Error('broken leaderboard sql')
+    );
+
+    const response = (await GET(
+      createRequest('https://example.com/api/leaderboard?type=team')
+    )) as Response;
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.currentUser).toBeNull();
   });
 });

--- a/apps/web/src/app/api/leaderboard/route.ts
+++ b/apps/web/src/app/api/leaderboard/route.ts
@@ -44,6 +44,7 @@
 
 import {
   getCache,
+  optionalAuth,
   PointsService,
   setCache,
   successResponse,
@@ -71,6 +72,7 @@ type TeamLeaderboardResult = Awaited<
 type CachedLeaderboardData = WalletLeaderboardResult | TeamLeaderboardResult;
 
 export const GET = withErrorHandling(async (request: NextRequest) => {
+  const authUser = await optionalAuth(request);
   const { searchParams } = new URL(request.url);
   const queryParams = Object.fromEntries(searchParams.entries());
   const validationResult = LeaderboardQuerySchema.safeParse(queryParams);
@@ -81,6 +83,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
 
   const { page, pageSize, type, userId } = validationResult.data;
   const leaderboardType = type ?? 'wallet';
+  const effectiveUserId = userId ?? authUser?.dbUserId ?? authUser?.userId;
 
   const cacheKey = `${leaderboardType}-${page}-${pageSize}`;
 
@@ -112,9 +115,9 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
 
   let currentUser: Awaited<ReturnType<typeof PointsService.getUserPosition>> =
     null;
-  if (userId) {
+  if (effectiveUserId) {
     currentUser = await PointsService.getUserPosition(
-      userId,
+      effectiveUserId,
       leaderboardType,
       pageSize
     );
@@ -128,7 +131,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       leaderboardType,
       totalCount: leaderboardData.totalCount,
       cacheHit,
-      hasUserId: !!userId,
+      hasUserId: !!effectiveUserId,
     },
     'GET /api/leaderboard'
   );
@@ -148,7 +151,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     200,
     {
       'x-cache': cacheHit ? 'leaderboard-hit' : 'leaderboard-miss',
-      'Cache-Control': userId
+      'Cache-Control': effectiveUserId
         ? 'private, no-store'
         : `public, s-maxage=${CACHE_TTL_SECONDS}, stale-while-revalidate=${STALE_SECONDS}`,
       Vary: 'Accept-Encoding',

--- a/apps/web/src/app/api/leaderboard/route.ts
+++ b/apps/web/src/app/api/leaderboard/route.ts
@@ -43,6 +43,7 @@
  */
 
 import {
+  findUserByIdentifier,
   getCache,
   optionalAuth,
   PointsService,
@@ -83,7 +84,12 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
 
   const { page, pageSize, type, userId } = validationResult.data;
   const leaderboardType = type ?? 'wallet';
-  const effectiveUserId = userId ?? authUser?.dbUserId ?? authUser?.userId;
+  let effectiveUserId = authUser?.dbUserId ?? authUser?.userId;
+
+  if (userId) {
+    const resolvedUser = await findUserByIdentifier(userId, { id: true });
+    effectiveUserId = resolvedUser?.id ?? userId;
+  }
 
   const cacheKey = `${leaderboardType}-${page}-${pageSize}`;
 
@@ -116,11 +122,24 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   let currentUser: Awaited<ReturnType<typeof PointsService.getUserPosition>> =
     null;
   if (effectiveUserId) {
-    currentUser = await PointsService.getUserPosition(
-      effectiveUserId,
-      leaderboardType,
-      pageSize
-    );
+    try {
+      currentUser = await PointsService.getUserPosition(
+        effectiveUserId,
+        leaderboardType,
+        pageSize
+      );
+    } catch (error) {
+      logger.warn(
+        'Failed to compute leaderboard currentUser; returning null',
+        {
+          effectiveUserId,
+          leaderboardType,
+          pageSize,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        'GET /api/leaderboard'
+      );
+    }
   }
 
   logger.info(

--- a/apps/web/src/app/api/posts/[id]/reply/route.test.ts
+++ b/apps/web/src/app/api/posts/[id]/reply/route.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { NextRequest } from 'next/server';
+
+const mockAuthenticate = mock();
+const mockEnsureEngineServices = mock();
+const mockCreateCommentPOST = mock();
+const mockParsePostId = mock();
+
+mock.module('@babylon/api', () => ({
+  authenticate: mockAuthenticate,
+  BusinessLogicError: class BusinessLogicError extends Error {},
+  ensureUserForAuth: mock(),
+  successResponse: (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), { status }),
+  withErrorHandling: (
+    handler: (
+      request: NextRequest,
+      context: { params: Promise<{ id: string }> }
+    ) => Promise<unknown>
+  ) => handler,
+}));
+
+mock.module('@babylon/db', () => ({
+  comments: {},
+  db: {},
+  eq: mock(),
+  posts: {},
+  users: {},
+}));
+
+mock.module('@babylon/engine', () => ({
+  FollowingMechanics: {},
+  GroupChatService: {},
+  MessageQualityChecker: {},
+  parsePostId: mockParsePostId,
+  ReplyRateLimiter: {},
+}));
+
+mock.module('@babylon/shared', () => ({
+  generateSnowflakeId: mock(),
+  logger: {
+    info: mock(),
+    warn: mock(),
+  },
+  PostIdParamSchema: {
+    parse: (value: { id: string }) => value,
+  },
+  ReplyToPostSchema: {
+    parse: (value: { content: string }) => value,
+  },
+}));
+
+mock.module('@/lib/engine/ensure-engine-services', () => ({
+  ensureEngineServices: mockEnsureEngineServices,
+}));
+
+mock.module('../comments/route', () => ({
+  POST: mockCreateCommentPOST,
+}));
+
+const { POST } = await import('./route');
+
+describe('POST /api/posts/[id]/reply', () => {
+  beforeEach(() => {
+    mockAuthenticate.mockReset();
+    mockEnsureEngineServices.mockReset();
+    mockCreateCommentPOST.mockReset();
+    mockParsePostId.mockReset();
+  });
+
+  it('delegates to the generic comments handler for standard post IDs', async () => {
+    mockAuthenticate.mockResolvedValue({ userId: 'user-1' });
+    mockParsePostId.mockReturnValue({
+      success: false,
+      metadata: {},
+    });
+    mockCreateCommentPOST.mockResolvedValue(
+      new Response(JSON.stringify({ delegated: true }), { status: 201 })
+    );
+
+    const request = {
+      url: 'https://example.com/api/posts/post-123/reply',
+      method: 'POST',
+    } as NextRequest;
+    const context = {
+      params: Promise.resolve({ id: 'post-123' }),
+    };
+
+    const response = (await POST(request, context)) as Response;
+    const body = await response.json();
+
+    expect(mockEnsureEngineServices).toHaveBeenCalledTimes(1);
+    expect(mockCreateCommentPOST).toHaveBeenCalledWith(request, context);
+    expect(response.status).toBe(201);
+    expect(body).toEqual({ delegated: true });
+  });
+});

--- a/apps/web/src/app/api/posts/[id]/reply/route.ts
+++ b/apps/web/src/app/api/posts/[id]/reply/route.ts
@@ -120,6 +120,7 @@ import {
 } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 import { ensureEngineServices } from '@/lib/engine/ensure-engine-services';
+import { POST as createCommentPOST } from '../comments/route';
 
 /**
  * POST /api/posts/[id]/reply
@@ -137,20 +138,19 @@ export const POST = withErrorHandling(
     const user = await authenticate(request);
     const { id: postId } = PostIdParamSchema.parse(await context.params);
 
-    // 2. Parse and validate request body
-    const body = await request.json();
-    const { content, marketId, sentiment } = ReplyToPostSchema.parse(body);
-
     // 3. Extract NPC/author ID from post ID
     const parseResult = parsePostId(postId);
 
-    // Require valid format for replies (unlike likes, which can use defaults)
+    // Fall back to the generic comments endpoint for standard post IDs.
+    // `/reply` is used as a compatibility endpoint by some clients, while the
+    // canonical app flow uses `/comments` for normal posts.
     if (!parseResult.success) {
-      throw new BusinessLogicError(
-        'Invalid post ID format',
-        'INVALID_POST_ID_FORMAT'
-      );
+      return createCommentPOST(request, context);
     }
+
+    // 2. Parse and validate request body
+    const body = await request.json();
+    const { content, marketId, sentiment } = ReplyToPostSchema.parse(body);
 
     const { gameId, authorId: npcId, timestamp } = parseResult.metadata;
 

--- a/apps/web/src/app/api/posts/[id]/route.ts
+++ b/apps/web/src/app/api/posts/[id]/route.ts
@@ -89,6 +89,7 @@ import {
 import { gameService, StaticDataRegistry } from '@babylon/engine';
 import { logger, PostIdParamSchema } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
+import { POST as likePost } from './like/route';
 
 /**
  * GET /api/posts/[id]
@@ -751,6 +752,9 @@ export const GET = withErrorHandling(
     );
   }
 );
+
+// Backwards-compatible alias for clients that POST to the post resource to like it.
+export const POST = likePost;
 
 /**
  * DELETE /api/posts/[id]

--- a/apps/web/src/app/api/realtime/token/route.ts
+++ b/apps/web/src/app/api/realtime/token/route.ts
@@ -9,6 +9,7 @@ import { logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { z } from 'zod';
+import { isUserInDmChatId } from '../../chats/_lib/dm-chat-id';
 
 const BodySchema = z.object({
   channels: z.array(z.string()).optional(),
@@ -26,26 +27,6 @@ const PUBLIC_CHANNELS: RealtimeChannel[] = [
 ];
 
 const dedupe = <T>(items: T[]) => Array.from(new Set(items));
-/**
- * Validates a DM chat ID format and checks if user is a participant.
- *
- * @security DM chat IDs follow the format dm-{userId1}-{userId2} where IDs are sorted.
- * This validation ensures:
- * 1. The format is correct (dm- prefix, exactly 2 user IDs)
- * 2. The requesting user is one of the participants
- *
- * Note: This is a format check only. For additional security, the actual
- * chat authorization is verified against the database in the main flow.
- */
-const isDmChatId = (id: string, userId: string): boolean => {
-  if (!id.startsWith('dm-')) return false;
-  const parts = id.substring('dm-'.length).split('-').filter(Boolean);
-  // Require exactly 2 user IDs
-  if (parts.length !== 2) return false;
-  // User must be one of the participants
-  return parts.includes(userId);
-};
-
 export const POST = withErrorHandling(async function POST(
   request: NextRequest
 ) {
@@ -100,7 +81,7 @@ export const POST = withErrorHandling(async function POST(
 
   // Allow deterministic DM channels even if the chat row/participants are not yet created.
   for (const chId of derivedChatIds) {
-    if (isDmChatId(chId, user.userId)) {
+    if (isUserInDmChatId(chId, user.userId)) {
       allowedChatIds.add(chId);
     }
   }

--- a/apps/web/src/app/api/social/follow/route.ts
+++ b/apps/web/src/app/api/social/follow/route.ts
@@ -1,0 +1,1 @@
+export { DELETE, GET, POST } from '../../follow/route';

--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -143,6 +143,7 @@
 
 import {
   authenticate,
+  authenticateWithDbUser,
   ConflictError,
   cachedDb,
   ensureOfflineWalletReady,
@@ -167,6 +168,7 @@ import {
   type PrivyIdentitySnapshot,
   shouldSyncMissingPrivyIdentity,
 } from '@/lib/auth/privyIdentitySync';
+import { POST as updateProfilePOST } from '../[userId]/update-profile/route';
 
 type PrivyUserWithWallets = PrivyUser &
   PrivyUserWithEmails &
@@ -1146,3 +1148,17 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     user: responseUser,
   });
 });
+
+const updateCurrentUserProfile = withErrorHandling(
+  async (request: NextRequest) => {
+    const authUser = await authenticateWithDbUser(request);
+
+    return updateProfilePOST(request, {
+      params: Promise.resolve({ userId: authUser.dbUserId }),
+    });
+  }
+);
+
+export const POST = updateCurrentUserProfile;
+export const PUT = updateCurrentUserProfile;
+export const PATCH = updateCurrentUserProfile;

--- a/apps/web/src/app/api/users/search/route.ts
+++ b/apps/web/src/app/api/users/search/route.ts
@@ -145,7 +145,8 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     return res;
   }
 
-  const searchTerm = query.trim().toLowerCase();
+  const rawSearchTerm = query.trim();
+  const searchTerm = rawSearchTerm.toLowerCase();
 
   // Get blocked/muted users to exclude from search
   const [blockedIds, mutedIds, blockedByIds] = await Promise.all([
@@ -159,60 +160,123 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   // Search for users (excluding the current user, NPCs, and blocked/muted users)
   // Optionally include AI agents if includeAgents=true
   const users = await asUser(user, async (db) => {
-    return await db.user.findMany({
+    const baseFilters = [
+      {
+        id: {
+          not: user.userId,
+        },
+      },
+      ...(excludedUserIds.length > 0
+        ? [{ id: { notIn: excludedUserIds } }]
+        : []),
+      {
+        isActor: false,
+      },
+      ...(includeAgents ? [] : [{ isAgent: false }]),
+      {
+        isBanned: false,
+      },
+    ];
+
+    const select = {
+      id: true,
+      displayName: true,
+      username: true,
+      profileImageUrl: true,
+      bio: true,
+      ...(includeAgents && { isAgent: true }),
+    };
+
+    const exactMatches = await db.user.findMany({
       where: {
         AND: [
+          ...baseFilters,
           {
-            OR: [
-              {
-                username: {
-                  contains: searchTerm,
-                  mode: 'insensitive',
-                },
-              },
-              {
-                displayName: {
-                  contains: searchTerm,
-                  mode: 'insensitive',
-                },
-              },
-            ],
-          },
-          {
-            id: {
-              not: user.userId, // Exclude current user
-            },
-          },
-          // Conditionally exclude blocked/muted users only if the array is not empty
-          ...(excludedUserIds.length > 0
-            ? [{ id: { notIn: excludedUserIds } }]
-            : []),
-          {
-            isActor: false, // Always exclude NPCs (use /api/agents/search for those)
-          },
-          // Exclude agents unless includeAgents is true
-          ...(includeAgents ? [] : [{ isAgent: false }]),
-          {
-            isBanned: false, // Exclude banned users
+            username: searchTerm,
           },
         ],
       },
-      select: {
-        id: true,
-        displayName: true,
-        username: true,
-        profileImageUrl: true,
-        bio: true,
-        // Include isAgent when agents are included to distinguish them from humans
-        ...(includeAgents && { isAgent: true }),
-      },
-      take: 20, // Limit results
-      orderBy: [
-        {
-          username: 'asc',
-        },
-      ],
+      select,
+      take: 5,
     });
+
+    const seenIds = new Set(exactMatches.map((entry) => entry.id));
+    const remainingAfterExact = 20 - exactMatches.length;
+
+    const prefixMatches =
+      remainingAfterExact > 0
+        ? await db.user.findMany({
+            where: {
+              AND: [
+                ...baseFilters,
+                ...(seenIds.size > 0 ? [{ id: { notIn: [...seenIds] } }] : []),
+                {
+                  OR: [
+                    {
+                      username: {
+                        startsWith: searchTerm,
+                      },
+                    },
+                    {
+                      displayName: {
+                        startsWith: rawSearchTerm,
+                        mode: 'insensitive',
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+            select,
+            take: remainingAfterExact,
+            orderBy: [
+              {
+                username: 'asc',
+              },
+            ],
+          })
+        : [];
+
+    prefixMatches.forEach((entry) => seenIds.add(entry.id));
+    const remainingAfterPrefix =
+      20 - exactMatches.length - prefixMatches.length;
+
+    const fallbackMatches =
+      remainingAfterPrefix > 0
+        ? await db.user.findMany({
+            where: {
+              AND: [
+                ...baseFilters,
+                ...(seenIds.size > 0 ? [{ id: { notIn: [...seenIds] } }] : []),
+                {
+                  OR: [
+                    {
+                      username: {
+                        contains: searchTerm,
+                        mode: 'insensitive',
+                      },
+                    },
+                    {
+                      displayName: {
+                        contains: rawSearchTerm,
+                        mode: 'insensitive',
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+            select,
+            take: remainingAfterPrefix,
+            orderBy: [
+              {
+                username: 'asc',
+              },
+            ],
+          })
+        : [];
+
+    return [...exactMatches, ...prefixMatches, ...fallbackMatches];
   });
 
   logger.info(

--- a/apps/web/src/hooks/useUnreadMessages.ts
+++ b/apps/web/src/hooks/useUnreadMessages.ts
@@ -8,6 +8,8 @@ import { useAuth } from '@/hooks/useAuth';
 interface UnreadCounts {
   /** Number of pending DM requests from anonymous users */
   pendingDMs: number;
+  /** Number of unread chat message notifications */
+  unreadMessages: number;
   /** Whether there are new messages in existing chats */
   hasNewMessages: boolean;
 }
@@ -25,8 +27,9 @@ interface UnreadCounts {
  *
  * @returns An object containing:
  * - `pendingDMs`: Number of pending DM requests
+ * - `unreadMessages`: Number of unread chat notifications
  * - `hasNewMessages`: Whether there are new messages in existing chats
- * - `totalUnread`: Combined unread count (pendingDMs + 1 if hasNewMessages)
+ * - `totalUnread`: Combined unread count (pending DM requests + unread chat notifications)
  * - `isLoading`: Whether counts are currently being fetched
  *
  * @example
@@ -45,6 +48,7 @@ export function useUnreadMessages() {
   const { getAccessToken } = usePrivy();
   const [counts, setCounts] = useState<UnreadCounts>({
     pendingDMs: 0,
+    unreadMessages: 0,
     hasNewMessages: false,
   });
   const [isLoading, setIsLoading] = useState(false);
@@ -52,7 +56,7 @@ export function useUnreadMessages() {
   useEffect(() => {
     // Only poll if user is authenticated
     if (!authenticated) {
-      setCounts({ pendingDMs: 0, hasNewMessages: false });
+      setCounts({ pendingDMs: 0, unreadMessages: 0, hasNewMessages: false });
       return;
     }
 
@@ -73,8 +77,21 @@ export function useUnreadMessages() {
       }
 
       const data = await response.json();
+      const pendingDMRequests =
+        typeof data.pendingDMRequests === 'number'
+          ? data.pendingDMRequests
+          : typeof data.pendingDMs === 'number'
+            ? data.pendingDMs
+            : 0;
+      const unreadMessages =
+        typeof data.unreadMessages === 'number'
+          ? data.unreadMessages
+          : data.hasNewMessages
+            ? 1
+            : 0;
       setCounts({
-        pendingDMs: data.pendingDMs || 0,
+        pendingDMs: pendingDMRequests,
+        unreadMessages,
         hasNewMessages: data.hasNewMessages || false,
       });
       setIsLoading(false);
@@ -92,7 +109,7 @@ export function useUnreadMessages() {
 
   return {
     ...counts,
-    totalUnread: counts.pendingDMs + (counts.hasNewMessages ? 1 : 0),
+    totalUnread: counts.pendingDMs + counts.unreadMessages,
     isLoading,
   };
 }

--- a/packages/api/src/__tests__/auth-middleware.test.ts
+++ b/packages/api/src/__tests__/auth-middleware.test.ts
@@ -176,6 +176,24 @@ describe('authenticate middleware', () => {
     }
   });
 
+  it('normalizes malformed token verification failures to AuthenticationError', async () => {
+    mockVerifyAgentSession.mockReturnValueOnce(null);
+    mockVerifyAuthToken.mockRejectedValueOnce(new Error('jwt malformed'));
+
+    const request = createRequest('garbage-token', '/api/users/me');
+
+    try {
+      await authenticate(request);
+      expect.unreachable('Should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toBe(
+        'Invalid authentication token. Please sign in again.'
+      );
+      expect((error as { code: string }).code).toBe('AUTH_FAILED');
+    }
+  });
+
   it('enforces NFT gating when enabled for non-allowlisted API paths', async () => {
     process.env.NFT_GATING_ENABLED = 'true';
 

--- a/packages/api/src/auth-middleware.ts
+++ b/packages/api/src/auth-middleware.ts
@@ -247,8 +247,19 @@ export async function authenticate(
     }
   }
 
-  // If we get here, all tokens failed verification
-  throw lastError ?? new AuthenticationError('Token verification failed');
+  // If we get here, all tokens failed verification.
+  // Always normalize verification failures to AuthenticationError so malformed
+  // or garbage JWTs produce a clean 401 instead of bubbling a provider error as 500.
+  if (lastError instanceof AuthenticationError) {
+    throw lastError;
+  }
+
+  throw new AuthenticationError(
+    'Invalid authentication token. Please sign in again.',
+    {
+      reason: lastError instanceof Error ? lastError.message : 'unknown',
+    }
+  );
 }
 
 /**

--- a/packages/testing/unit/dm-validation.test.ts
+++ b/packages/testing/unit/dm-validation.test.ts
@@ -5,6 +5,10 @@
  */
 
 import { describe, expect, test } from 'bun:test';
+import {
+  getOtherDmParticipantId,
+  isUserInDmChatId,
+} from '../../../apps/web/src/app/api/chats/_lib/dm-chat-id';
 
 describe('DM Chat ID Generation', () => {
   function generateDMChatId(userId1: string, userId2: string): string {
@@ -42,6 +46,40 @@ describe('DM Chat ID Generation', () => {
 
     const chatId = generateDMChatId(did1, did2);
     expect(chatId.length).toBeGreaterThan(3);
+  });
+});
+
+describe('DM Chat ID Parsing', () => {
+  test('extracts the other participant when current user appears first', () => {
+    const currentUserId = '123456789012345678';
+    const actorId = 'kash-patrol';
+
+    expect(
+      getOtherDmParticipantId(`dm-${currentUserId}-${actorId}`, currentUserId)
+    ).toBe(actorId);
+  });
+
+  test('extracts the other participant when current user appears last', () => {
+    const currentUserId = '123456789012345678';
+    const actorId = 'kash-patrol';
+
+    expect(
+      getOtherDmParticipantId(`dm-${actorId}-${currentUserId}`, currentUserId)
+    ).toBe(actorId);
+  });
+
+  test('handles hyphenated identifiers without splitting them incorrectly', () => {
+    const currentUserId = '550e8400-e29b-41d4-a716-446655440000';
+    const otherUserId = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+    const chatId = `dm-${currentUserId}-${otherUserId}`;
+
+    expect(getOtherDmParticipantId(chatId, currentUserId)).toBe(otherUserId);
+    expect(isUserInDmChatId(chatId, currentUserId)).toBe(true);
+  });
+
+  test('rejects DM chat IDs that do not include the current user', () => {
+    expect(isUserInDmChatId('dm-user-a-user-b', 'user-c')).toBe(false);
+    expect(getOtherDmParticipantId('dm-user-a-user-b', 'user-c')).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

- Normalize malformed auth token failures to return clean `401` responses instead of bubbling provider errors as `500`s.
- Harden the remaining QA edge cases around agent listing, leaderboard current-user lookup, chat participant loading, DM parsing, and post replies.
- Add compatibility routes/aliases for QA-discovered API path mismatches and improve the unread chat badge logic.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: [BAB-247](https://linear.app/eliza-labs/issue/BAB-247/test-bug-fixing-agent-qa-fix-critical-and-high-priority-bugs-babylon)
- This PR now covers the codebase-side fixes for the QA report items that map cleanly to the current repo.
- Remaining ambiguity: `POST /api/markets/predictions` does not exist in this branch (only `GET` is implemented), so that report item still needs production revalidation if it is reproducing outside this repo state.

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

Non-goals / follow-ups:
- If QA still sees `POST /api/markets/predictions` fail in production, that needs a separate prod-vs-repo reconciliation because this repo does not currently expose that method.

## Changes

- Normalize final Privy verification failures in `authenticate()` so malformed or garbage JWTs always return `401`.
- Use optional auth plus identifier resolution in `/api/leaderboard` so `currentUser` is populated from auth and bad `userId` lookups no longer take down the endpoint.
- Replace the unread badge approximation with unread chat-notification counts, while keeping backwards-compatible response fields.
- Harden `/api/agents` so one broken agent config/performance lookup no longer fails the entire list response.
- Make `/api/posts/[id]/reply` fall back to the generic comments flow for standard post IDs.
- Replace fragile DM chat-id parsing with a shared helper that safely handles hyphenated identifiers and reuse it in realtime channel authorization.
- Refactor `/api/chats/[id]/participants` to query participants explicitly instead of relying on relation includes.
- Improve `/api/users/search` by prioritizing exact/prefix matches before broad substring fallback.
- Add compatibility routes for `/api/game/state`, `/api/follow`, `/api/social/follow`, and `/api/chats/[id]/messages`.
- Add compatibility aliases so `POST /api/posts/[id]` maps to like behavior and `POST|PUT|PATCH /api/users/me` maps to the profile update handler.

## Review guide

**Start here**
- `packages/api/src/auth-middleware.ts`
- `apps/web/src/app/api/agents/route.ts`
- `apps/web/src/app/api/leaderboard/route.ts`
- `apps/web/src/app/api/chats/[id]/participants/route.ts`
- `apps/web/src/app/api/posts/[id]/reply/route.ts`
- `apps/web/src/app/api/chats/_lib/dm-chat-id.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- Compatibility routes intentionally delegate to existing handlers instead of duplicating business logic.
- The unread badge now uses unread notifications with `chatId` because the current schema does not track per-chat read cursors.
- The search change is query-shape optimization, not a DB migration.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

Targeted commands run:
- `bunx biome check packages/api/src/auth-middleware.ts packages/api/src/__tests__/auth-middleware.test.ts apps/web/src/app/api/leaderboard/route.ts apps/web/src/app/api/leaderboard/__tests__/route.test.ts apps/web/src/app/api/chats/unread-count/route.ts apps/web/src/app/api/chats/unread-count/__tests__/route.test.ts apps/web/src/hooks/useUnreadMessages.ts apps/web/src/app/api/game/state/route.ts apps/web/src/app/api/chats/[id]/messages/route.ts apps/web/src/app/api/follow/route.ts apps/web/src/app/api/social/follow/route.ts apps/web/src/app/api/users/me/route.ts apps/web/src/app/api/posts/[id]/route.ts apps/web/src/app/api/agents/route.ts apps/web/src/app/api/agents/route.test.ts apps/web/src/app/api/chats/[id]/participants/route.ts apps/web/src/app/api/users/search/route.ts apps/web/src/app/api/posts/[id]/reply/route.ts apps/web/src/app/api/posts/[id]/reply/route.test.ts apps/web/src/app/api/chats/_lib/dm-chat-id.ts apps/web/src/app/api/chats/[id]/message/route.ts apps/web/src/app/api/realtime/token/route.ts packages/testing/unit/dm-validation.test.ts`
- `bun test packages/api/src/__tests__/auth-middleware.test.ts`
- `bun test apps/web/src/app/api/chats/unread-count/__tests__/route.test.ts`
- `bun test apps/web/src/app/api/agents/route.test.ts`
- `bun test apps/web/src/app/api/leaderboard/__tests__/route.test.ts`
- `bun test apps/web/src/app/api/posts/[id]/reply/route.test.ts`
- `bun test packages/testing/unit/dm-validation.test.ts`

**Manual verification**
1. Send a malformed bearer token to an authenticated endpoint and confirm the response is `401` instead of `500`.
2. Load `/api/leaderboard` while authenticated without `userId` and confirm `currentUser` is populated.
3. Verify the alias routes delegate to the existing handlers (`/api/game/state`, `/api/follow`, `/api/social/follow`, `/api/chats/[id]/messages`).
4. Verify `/api/posts/[id]/reply` works for normal post IDs by creating a regular comment through the compatibility path.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: normal deploy
- Rollback: revert this PR

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- `/api/chats/unread-count` now returns `pendingDMRequests` and `unreadMessages` in addition to the legacy `pendingDMs` field.
- `/api/users/me` now accepts `POST`, `PUT`, and `PATCH` as compatibility aliases to the profile update handler.
- DM chat-id parsing now correctly handles hyphenated identifiers.

### Database
- No schema change. Search optimization is query-shape only. Unread counts are derived from existing unread notifications with a `chatId`.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend/API-only change, no direct UI changes.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
