### PR TITLE
fix(api): accept current Sentry webhook signatures

### DIFF
--- a/packages/api/src/services/sentry-webhook-inbox-service.ts
+++ b/packages/api/src/services/sentry-webhook-inbox-service.ts
@@ -100,7 +100,7 @@ function areHexDigestsEqual(leftHex: string, rightHex: string): boolean {
   return timingSafeEqual(leftBuffer, rightBuffer);
 }
 
-function computeSentrySignature(
+function computeTimestampPrefixedSentrySignature(
   secret: string,
   timestamp: string,
   rawBody: string
@@ -108,6 +108,37 @@ function computeSentrySignature(
   return createHmac('sha256', secret)
     .update(`${timestamp}.${rawBody}`)
     .digest('hex');
+}
+
+function computeBodyOnlySentrySignature(
+  secret: string,
+  rawBody: string
+): string {
+  return createHmac('sha256', secret).update(rawBody).digest('hex');
+}
+
+function isSupportedSentrySignature(params: {
+  secret: string;
+  timestamp: string;
+  rawBody: string;
+  providedSignature: string;
+}): boolean {
+  const timestampPrefixedSignature = computeTimestampPrefixedSentrySignature(
+    params.secret,
+    params.timestamp,
+    params.rawBody
+  );
+  if (
+    areHexDigestsEqual(timestampPrefixedSignature, params.providedSignature)
+  ) {
+    return true;
+  }
+
+  const bodyOnlySignature = computeBodyOnlySentrySignature(
+    params.secret,
+    params.rawBody
+  );
+  return areHexDigestsEqual(bodyOnlySignature, params.providedSignature);
 }
 
 function isJsonValue(value: unknown): value is JsonValue {
@@ -320,12 +351,14 @@ export async function ingestSentryWebhook(
     };
   }
 
-  const expectedSignature = computeSentrySignature(
-    input.secret,
-    timestampHeader,
-    input.rawBody
-  );
-  if (!areHexDigestsEqual(expectedSignature, providedSignature)) {
+  if (
+    !isSupportedSentrySignature({
+      secret: input.secret,
+      timestamp: timestampHeader,
+      rawBody: input.rawBody,
+      providedSignature,
+    })
+  ) {
     return {
       ok: false,
       httpStatus: 401,

--- a/packages/testing/unit/sentry-webhook-inbox-service.test.ts
+++ b/packages/testing/unit/sentry-webhook-inbox-service.test.ts
@@ -1,0 +1,162 @@
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { createHmac } from 'node:crypto';
+
+const insertReturningMock = mock(async () => [{ id: 'inbox-123' }]);
+const insertOnConflictMock = mock(() => ({
+  returning: insertReturningMock,
+}));
+const insertValuesMock = mock(() => ({
+  onConflictDoNothing: insertOnConflictMock,
+}));
+const insertMock = mock(() => ({
+  values: insertValuesMock,
+}));
+const generateSnowflakeIdMock = mock(async () => 'inbox-123');
+
+let ingestSentryWebhook: typeof import('../../../packages/api/src/services/sentry-webhook-inbox-service').ingestSentryWebhook;
+
+function computeTimestampPrefixedSignature(
+  secret: string,
+  timestamp: string,
+  rawBody: string
+): string {
+  return createHmac('sha256', secret)
+    .update(`${timestamp}.${rawBody}`)
+    .digest('hex');
+}
+
+function computeBodyOnlySignature(secret: string, rawBody: string): string {
+  return createHmac('sha256', secret).update(rawBody).digest('hex');
+}
+
+function toTimestampDate(timestamp: string): Date {
+  return new Date(Number.parseInt(timestamp, 10) * 1000);
+}
+
+describe('ingestSentryWebhook signature compatibility', () => {
+  beforeAll(async () => {
+    mock.module('@babylon/db', () => ({
+      db: {
+        insert: insertMock,
+      },
+      generateSnowflakeId: generateSnowflakeIdMock,
+      sentryWebhookInboxes: {
+        dedupeKey: 'dedupeKey',
+        id: 'id',
+      },
+    }));
+
+    mock.module('@babylon/shared', () => ({
+      logger: {
+        info: () => {},
+      },
+    }));
+
+    ({ ingestSentryWebhook } = await import(
+      '../../../packages/api/src/services/sentry-webhook-inbox-service'
+    ));
+  });
+
+  beforeEach(() => {
+    insertMock.mockClear();
+    insertValuesMock.mockClear();
+    insertOnConflictMock.mockClear();
+    insertReturningMock.mockClear();
+    generateSnowflakeIdMock.mockClear();
+  });
+
+  it('accepts timestamp-prefixed signatures', async () => {
+    const rawBody = JSON.stringify({
+      action: 'assigned',
+      data: {
+        project: { slug: 'babylon' },
+        issue: { id: '123', shortId: 'BAB-123', title: 'Test issue' },
+      },
+    });
+    const timestamp = '1772915046';
+    const secret = 'secret';
+
+    const result = await ingestSentryWebhook({
+      rawBody,
+      secret,
+      now: toTimestampDate(timestamp),
+      headers: {
+        signature: computeTimestampPrefixedSignature(
+          secret,
+          timestamp,
+          rawBody
+        ),
+        timestamp,
+        resource: 'issue',
+        event: 'assigned',
+        requestId: null,
+        userAgent: 'bun-test',
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(insertMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts body-only signatures used by current Sentry internal integrations', async () => {
+    const rawBody = JSON.stringify({
+      action: 'assigned',
+      data: {
+        project: { slug: 'babylon' },
+        issue: { id: '456', shortId: 'BAB-456', title: 'Body-only signature' },
+      },
+    });
+    const timestamp = '1772915046';
+    const secret = 'secret';
+
+    const result = await ingestSentryWebhook({
+      rawBody,
+      secret,
+      now: toTimestampDate(timestamp),
+      headers: {
+        signature: computeBodyOnlySignature(secret, rawBody),
+        timestamp,
+        resource: 'issue',
+        event: 'assigned',
+        requestId: null,
+        userAgent: 'bun-test',
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(insertMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('still rejects invalid signatures', async () => {
+    const rawBody = JSON.stringify({
+      action: 'assigned',
+      data: {
+        project: { slug: 'babylon' },
+        issue: { id: '789', shortId: 'BAB-789', title: 'Bad signature' },
+      },
+    });
+    const timestamp = '1772915046';
+
+    const result = await ingestSentryWebhook({
+      rawBody,
+      secret: 'secret',
+      now: toTimestampDate(timestamp),
+      headers: {
+        signature: '0'.repeat(64),
+        timestamp,
+        resource: 'issue',
+        event: 'assigned',
+        requestId: null,
+        userAgent: 'bun-test',
+      },
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      httpStatus: 401,
+      code: 'INVALID_SIGNATURE',
+      message: 'Sentry webhook signature mismatch.',
+    });
+    expect(insertMock).toHaveBeenCalledTimes(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Fix Sentry webhook ingestion so Babylon accepts the signature format currently emitted by Sentry internal integrations.
- Keep timestamp skew validation in place while supporting both the existing timestamp-prefixed format and the body-only format observed in production.
- Add a focused unit test suite covering both accepted formats plus invalid signature rejection.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [x] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Follow-up to `feat(web): add Sentry webhook inbox ingestion`
- Production validation showed signed Sentry webhooks were reaching the endpoint but being rejected before inbox persistence.

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [x] Other: Sentry webhook compatibility hotfix

## Changes

- Update Sentry webhook signature verification to accept both:
  - timestamp-prefixed HMAC (`${timestamp}.${rawBody}`)
  - body-only HMAC (`rawBody`)
- Preserve existing timestamp presence + skew validation.
- Add unit tests for both supported signature modes and for invalid signature rejection.

## Review guide

**Start here**
- `packages/api/src/services/sentry-webhook-inbox-service.ts`
- `packages/testing/unit/sentry-webhook-inbox-service.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- This is intentionally narrow: no worker behavior changes, no schema changes, no route shape changes.
- The goal is to unblock production webhook ingestion without weakening anti-replay timestamp checks.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [x] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Configure a Sentry internal integration pointing to `POST /api/sentry/webhook`.
2. Trigger issue webhooks from Sentry (`assigned`, `resolved`, `unresolved`).
3. Verify valid requests are persisted into `SentryWebhookInbox` instead of failing signature verification.

## Ops / Migration / Deployment

- [ ] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: none
- Changed: none
- Removed: none

**DB / data migration**
- Migration(s): none in this PR
- Backfill/seed: none

**Rollout / rollback plan**
- Rollout: deploy the hotfix, then replay a real Sentry issue action and confirm inbox insertion.
- Rollback: revert this PR; webhook ingestion returns to timestamp-prefixed signature verification only.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- N/A

## Security / privacy

- [ ] No security impact
- [x] Needs extra review (describe)

- The change widens accepted Sentry signature formats for compatibility, but still requires a valid HMAC digest and a valid timestamp within the configured skew window.

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- No public contract change. The endpoint continues to require signed Sentry webhook requests.

### Database
- No schema change in this PR.

### Contracts / on-chain
- Not applicable.

### Docs
- Not updated in this PR because this is a production hotfix and the supported signature formats are implementation detail.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: API-only hotfix for webhook verification; no UI impact.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
