### PR TITLE
fix(web): address BAB-248 medium QA issues

### DIFF
--- a/apps/web/src/app/api/groups/[groupId]/members/route.ts
+++ b/apps/web/src/app/api/groups/[groupId]/members/route.ts
@@ -38,6 +38,101 @@ const AddMemberSchema = z.object({
 });
 
 /**
+ * GET /api/groups/[groupId]/members
+ * List active group members for an authenticated member.
+ */
+export const GET = withErrorHandling(
+  async (
+    request: NextRequest,
+    { params }: { params: Promise<{ groupId: string }> }
+  ) => {
+    const user = await authenticate(request);
+    const { groupId } = await params;
+
+    const groupMembersList = await asUser(user, async (db) => {
+      const group = await db.group.findUnique({
+        where: { id: groupId },
+        select: { id: true },
+      });
+
+      if (!group) {
+        throw new ApiError('Group not found', 404);
+      }
+
+      const members = await db.groupMember.findMany({
+        where: {
+          groupId,
+          isActive: true,
+        },
+        orderBy: {
+          joinedAt: 'asc',
+        },
+      });
+
+      const requesterMembership = members.find(
+        (member) => member.userId === user.userId
+      );
+      if (!requesterMembership) {
+        throw new ApiError('You are not a member of this group', 403);
+      }
+
+      const memberIds = members.map((member) => member.userId);
+      const memberUsers =
+        memberIds.length > 0
+          ? await db.user.findMany({
+              where: {
+                id: { in: memberIds },
+              },
+              select: {
+                id: true,
+                displayName: true,
+                username: true,
+                profileImageUrl: true,
+                isActor: true,
+                isAgent: true,
+              },
+            })
+          : [];
+      const memberUserMap = new Map(
+        memberUsers.map((memberUser) => [memberUser.id, memberUser])
+      );
+
+      return members.map((member) => {
+        const memberUser = memberUserMap.get(member.userId);
+        const memberType = memberUser?.isActor
+          ? 'npc'
+          : memberUser?.isAgent
+            ? 'agent'
+            : 'user';
+
+        return {
+          id: member.userId,
+          displayName: memberUser?.displayName ?? null,
+          username: memberUser?.username ?? null,
+          profileImageUrl: memberUser?.profileImageUrl ?? null,
+          memberType,
+          role: member.role,
+          isAdmin: member.role === 'admin' || member.role === 'owner',
+          isOwner: member.role === 'owner',
+          joinedAt: member.joinedAt,
+        };
+      });
+    });
+
+    logger.info(
+      'Group members retrieved',
+      { userId: user.userId, groupId, count: groupMembersList.length },
+      'GET /api/groups/:groupId/members'
+    );
+
+    return successResponse({
+      groupId,
+      members: groupMembersList,
+    });
+  }
+);
+
+/**
  * POST /api/groups/[groupId]/members
  * Add a member to the group (admin only)
  *

--- a/apps/web/src/app/api/groups/[groupId]/messages/route.ts
+++ b/apps/web/src/app/api/groups/[groupId]/messages/route.ts
@@ -1,0 +1,198 @@
+/**
+ * Group Messages API
+ *
+ * @route GET /api/groups/[groupId]/messages - List group chat messages
+ * @access Authenticated members only
+ */
+
+import {
+  ApiError,
+  authenticate,
+  successResponse,
+  withErrorHandling,
+} from '@babylon/api';
+import { asUser } from '@babylon/db';
+import { StaticDataRegistry } from '@babylon/engine';
+import { logger } from '@babylon/shared';
+import type { NextRequest } from 'next/server';
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 100;
+
+export const GET = withErrorHandling(
+  async (
+    request: NextRequest,
+    { params }: { params: Promise<{ groupId: string }> }
+  ) => {
+    const user = await authenticate(request);
+    const { groupId } = await params;
+    const { searchParams } = new URL(request.url);
+    const cursor = searchParams.get('cursor');
+    const limit = Math.min(
+      MAX_LIMIT,
+      Math.max(
+        1,
+        Number.parseInt(searchParams.get('limit') ?? String(DEFAULT_LIMIT), 10)
+      )
+    );
+
+    const result = await asUser(user, async (db) => {
+      const group = await db.group.findUnique({
+        where: { id: groupId },
+        select: { id: true, name: true },
+      });
+
+      if (!group) {
+        throw new ApiError('Group not found', 404);
+      }
+
+      const membership = await db.groupMember.findFirst({
+        where: {
+          groupId,
+          userId: user.userId,
+          isActive: true,
+        },
+      });
+
+      if (!membership) {
+        throw new ApiError('You are not a member of this group', 403);
+      }
+
+      const groupChat = await db.chat.findFirst({
+        where: { groupId },
+        select: { id: true, name: true },
+      });
+
+      if (!groupChat) {
+        throw new ApiError('Group chat not found', 404);
+      }
+
+      const cursorMessage = cursor
+        ? await db.message.findUnique({
+            where: { id: cursor },
+            select: { createdAt: true },
+          })
+        : null;
+
+      const messages = await db.message.findMany({
+        where: {
+          chatId: groupChat.id,
+          ...(cursorMessage
+            ? {
+                createdAt: {
+                  lt: cursorMessage.createdAt,
+                },
+              }
+            : {}),
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+        take: limit + 1,
+        select: {
+          id: true,
+          content: true,
+          createdAt: true,
+          senderId: true,
+          type: true,
+        },
+      });
+
+      const hasMore = messages.length > limit;
+      const visibleMessages = hasMore ? messages.slice(0, limit) : messages;
+
+      const senderIds = Array.from(
+        new Set(
+          visibleMessages
+            .map((message) => message.senderId)
+            .filter((senderId) => senderId !== 'system')
+        )
+      );
+
+      const senderUsers =
+        senderIds.length > 0
+          ? await db.user.findMany({
+              where: {
+                id: { in: senderIds },
+              },
+              select: {
+                id: true,
+                displayName: true,
+                username: true,
+                profileImageUrl: true,
+                isActor: true,
+              },
+            })
+          : [];
+      const senderUserMap = new Map(
+        senderUsers.map((senderUser) => [senderUser.id, senderUser])
+      );
+
+      return {
+        groupId,
+        groupName: group.name,
+        chatId: groupChat.id,
+        messages: visibleMessages.map((message) => {
+          if (message.senderId === 'system') {
+            return {
+              id: message.id,
+              content: message.content,
+              createdAt: message.createdAt,
+              type: message.type,
+              sender: {
+                id: 'system',
+                name: 'System',
+                username: null,
+                profileImageUrl: null,
+                isNPC: false,
+              },
+            };
+          }
+
+          const senderUser = senderUserMap.get(message.senderId);
+          const actor = StaticDataRegistry.getActor(message.senderId);
+
+          return {
+            id: message.id,
+            content: message.content,
+            createdAt: message.createdAt,
+            type: message.type,
+            sender: {
+              id: message.senderId,
+              name:
+                senderUser?.displayName ||
+                senderUser?.username ||
+                actor?.name ||
+                'Unknown',
+              username: senderUser?.username ?? null,
+              profileImageUrl:
+                senderUser?.profileImageUrl || actor?.profileImageUrl || null,
+              isNPC: actor !== null || senderUser?.isActor === true,
+            },
+          };
+        }),
+        pagination: {
+          limit,
+          hasMore,
+          nextCursor: hasMore
+            ? visibleMessages[visibleMessages.length - 1]?.id ?? null
+            : null,
+        },
+      };
+    });
+
+    logger.info(
+      'Group messages retrieved',
+      {
+        userId: user.userId,
+        groupId,
+        count: result.messages.length,
+        limit,
+        hasCursor: !!cursor,
+      },
+      'GET /api/groups/:groupId/messages'
+    );
+
+    return successResponse(result);
+  }
+);

--- a/apps/web/src/app/api/leaderboard/query.test.ts
+++ b/apps/web/src/app/api/leaderboard/query.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'bun:test';
+import { parseLeaderboardQuery } from './query';
+
+describe('parseLeaderboardQuery', () => {
+  it('parses supported leaderboard params', () => {
+    const result = parseLeaderboardQuery(
+      new URLSearchParams({
+        page: '2',
+        pageSize: '25',
+        type: 'team',
+        userId: 'user-1',
+      })
+    );
+
+    expect(result.page).toBe(2);
+    expect(result.pageSize).toBe(25);
+    expect(result.type).toBe('team');
+    expect(result.userId).toBe('user-1');
+  });
+
+  it('rejects silently-ignored params with a 400-style error', () => {
+    expect(() =>
+      parseLeaderboardQuery(
+        new URLSearchParams({
+          sortBy: 'score',
+          timeRange: 'weekly',
+          search: 'alice',
+        })
+      )
+    ).toThrow('Unsupported query parameters: sortBy, timeRange, search');
+  });
+});

--- a/apps/web/src/app/api/leaderboard/query.ts
+++ b/apps/web/src/app/api/leaderboard/query.ts
@@ -1,0 +1,36 @@
+import { ApiError } from '@babylon/api';
+import { LeaderboardQuerySchema } from '@babylon/shared';
+
+const SUPPORTED_LEADERBOARD_QUERY_PARAMS = new Set([
+  'page',
+  'pageSize',
+  'type',
+  'userId',
+  'minPoints',
+  'pointsType',
+]);
+
+export function parseLeaderboardQuery(searchParams: URLSearchParams) {
+  const unsupportedParams = Array.from(searchParams.keys()).filter(
+    (key) => !SUPPORTED_LEADERBOARD_QUERY_PARAMS.has(key)
+  );
+
+  if (unsupportedParams.length > 0) {
+    throw new ApiError(
+      `Unsupported query parameter${unsupportedParams.length === 1 ? '' : 's'}: ${unsupportedParams.join(
+        ', '
+      )}`,
+      400
+    );
+  }
+
+  const validationResult = LeaderboardQuerySchema.safeParse(
+    Object.fromEntries(searchParams.entries())
+  );
+
+  if (!validationResult.success) {
+    throw validationResult.error;
+  }
+
+  return validationResult.data;
+}

--- a/apps/web/src/app/api/leaderboard/route.ts
+++ b/apps/web/src/app/api/leaderboard/route.ts
@@ -49,8 +49,9 @@ import {
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
-import { LeaderboardQuerySchema, logger } from '@babylon/shared';
+import { logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
+import { parseLeaderboardQuery } from './query';
 
 const CACHE_KEY_NAMESPACE = 'leaderboard';
 const CACHE_TTL_MS = (() => {
@@ -72,14 +73,7 @@ type CachedLeaderboardData = WalletLeaderboardResult | TeamLeaderboardResult;
 
 export const GET = withErrorHandling(async (request: NextRequest) => {
   const { searchParams } = new URL(request.url);
-  const queryParams = Object.fromEntries(searchParams.entries());
-  const validationResult = LeaderboardQuerySchema.safeParse(queryParams);
-
-  if (!validationResult.success) {
-    throw validationResult.error;
-  }
-
-  const { page, pageSize, type, userId } = validationResult.data;
+  const { page, pageSize, type, userId } = parseLeaderboardQuery(searchParams);
   const leaderboardType = type ?? 'wallet';
 
   const cacheKey = `${leaderboardType}-${page}-${pageSize}`;

--- a/apps/web/src/app/api/nft/gallery/route.ts
+++ b/apps/web/src/app/api/nft/gallery/route.ts
@@ -1,0 +1,5 @@
+/**
+ * Backward-compatible alias for the NFT collection/gallery endpoint.
+ */
+
+export { GET } from '../collection/route';

--- a/apps/web/src/app/api/npc/performance/leaderboard/route.ts
+++ b/apps/web/src/app/api/npc/performance/leaderboard/route.ts
@@ -58,18 +58,9 @@ import {
   publicRateLimit,
   withErrorHandling,
 } from '@babylon/api';
-import {
-  and,
-  db,
-  desc,
-  eq,
-  gte,
-  inArray,
-  isNull,
-  poolPositions,
-  pools,
-} from '@babylon/db';
-import { StaticDataRegistry } from '@babylon/engine';
+import { db, eq, pools } from '@babylon/db';
+import { NPCInvestmentManager, StaticDataRegistry } from '@babylon/engine';
+import { logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
@@ -85,94 +76,65 @@ export const GET = withErrorHandling(async function GET(request: NextRequest) {
   const limit = limitParam ? Number.parseInt(limitParam, 10) : 50;
   const minValue = minValueParam ? Number.parseFloat(minValueParam) : 0;
 
-  // Fetch pools with filter
-  const poolsList = await db
+  const activePools = await db
     .select()
     .from(pools)
-    .where(
-      and(eq(pools.isActive, true), gte(pools.totalValue, String(minValue)))
-    )
-    .orderBy(desc(pools.totalValue))
-    .limit(limit);
+    .where(eq(pools.isActive, true));
 
-  const actorIds = poolsList.map((p) => p.npcActorId);
-  const actorsMap = new Map(
-    actorIds
-      .map((id) => StaticDataRegistry.getActor(id))
-      .filter((a): a is NonNullable<typeof a> => a !== null)
-      .map((a) => [
-        a.id,
-        {
-          id: a.id,
-          name: a.name,
-          profileImageUrl: a.profileImageUrl,
-          personality: a.personality,
-        },
-      ])
+  const leaderboardRows = await Promise.all(
+    activePools.map(async (pool) => {
+      try {
+        const metrics = await NPCInvestmentManager.getPortfolioMetrics(pool.id);
+        return { pool, metrics };
+      } catch (error) {
+        logger.warn(
+          'Skipping NPC performance row due to metrics failure',
+          {
+            poolId: pool.id,
+            actorId: pool.npcActorId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          'GET /api/npc/performance/leaderboard'
+        );
+        return null;
+      }
+    })
   );
 
-  // Fetch open positions for all pools
-  const poolIds = poolsList.map((p) => p.id);
-  const positionsList =
-    poolIds.length > 0
-      ? await db
-          .select({
-            poolId: poolPositions.poolId,
-            unrealizedPnL: poolPositions.unrealizedPnL,
-          })
-          .from(poolPositions)
-          .where(
-            and(
-              inArray(poolPositions.poolId, poolIds),
-              isNull(poolPositions.closedAt)
-            )
-          )
-      : [];
-  const positionsByPool = new Map<string, typeof positionsList>();
-  for (const pos of positionsList) {
-    const existing = positionsByPool.get(pos.poolId) || [];
-    existing.push(pos);
-    positionsByPool.set(pos.poolId, existing);
-  }
+  const leaderboard = leaderboardRows
+    .filter(
+      (row): row is NonNullable<(typeof leaderboardRows)[number]> =>
+        row !== null && row.metrics.totalValue >= minValue
+    )
+    .sort((a, b) => b.metrics.totalValue - a.metrics.totalValue)
+    .slice(0, limit)
+    .map(({ pool, metrics }, index) => {
+      const initialValue = Number.parseFloat(
+        pool.totalDeposits?.toString() || '0'
+      );
+      const roi =
+        initialValue > 0
+          ? ((metrics.totalValue - initialValue) / initialValue) * 100
+          : 0;
+      const actor = StaticDataRegistry.getActor(pool.npcActorId);
 
-  const leaderboard = poolsList.map((pool, index) => {
-    const totalValue = Number.parseFloat(pool.totalValue?.toString() || '0');
-    const availableBalance = Number.parseFloat(
-      pool.availableBalance?.toString() || '0'
-    );
-    const initialValue = Number.parseFloat(
-      pool.totalDeposits?.toString() || '0'
-    );
-
-    const poolPositionsList = positionsByPool.get(pool.id) || [];
-    const unrealizedPnL = poolPositionsList.reduce((sum: number, pos) => {
-      return sum + Number.parseFloat(pos.unrealizedPnL?.toString() || '0');
-    }, 0);
-
-    const roi =
-      initialValue > 0 ? ((totalValue - initialValue) / initialValue) * 100 : 0;
-
-    const invested = totalValue - availableBalance;
-    const utilization = totalValue > 0 ? (invested / totalValue) * 100 : 0;
-
-    const actor = actorsMap.get(pool.npcActorId);
-
-    return {
-      rank: index + 1,
-      actorId: actor?.id || pool.npcActorId,
-      actorName: actor?.name || 'Unknown',
-      personality: actor?.personality || null,
-      profileImageUrl: actor?.profileImageUrl || null,
-      poolId: pool.id,
-      performance: {
-        totalValue: Math.round(totalValue),
-        roi: Number.parseFloat(roi.toFixed(2)),
-        unrealizedPnL: Math.round(unrealizedPnL),
-        positionCount: poolPositionsList.length,
-        utilization: Number.parseFloat(utilization.toFixed(1)),
-      },
-    };
-  });
+      return {
+        rank: index + 1,
+        actorId: actor?.id || pool.npcActorId,
+        actorName: actor?.name || 'Unknown',
+        personality: actor?.personality || null,
+        profileImageUrl: actor?.profileImageUrl || null,
+        poolId: pool.id,
+        performance: {
+          totalValue: Math.round(metrics.totalValue),
+          roi: Number.parseFloat(roi.toFixed(2)),
+          realizedPnL: Math.round(metrics.realizedPnL),
+          unrealizedPnL: Math.round(metrics.unrealizedPnL),
+          positionCount: metrics.positionCount,
+          utilization: Number.parseFloat(metrics.utilization.toFixed(1)),
+        },
+      };
+    });
 
   const res = NextResponse.json({
     success: true,

--- a/apps/web/src/app/api/posts/route.ts
+++ b/apps/web/src/app/api/posts/route.ts
@@ -232,13 +232,16 @@ import {
   broadcastToChannel,
   cachedDb,
   checkRateLimitAndDuplicates,
+  checkRateLimitAsync,
   DUPLICATE_DETECTION_CONFIGS,
   ensureUserForAuth,
   getCacheOrFetch,
+  getHashedClientIp,
   invalidateCache,
   notifyMention,
   publicRateLimit,
   RATE_LIMIT_CONFIGS,
+  rateLimitError,
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
@@ -1347,14 +1350,7 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
   const authUser = await authenticate(request);
 
   const body = (await request.json()) as { content: string };
-  const { content } = body;
-
-  checkRateLimitAndDuplicates(
-    authUser.userId,
-    content,
-    RATE_LIMIT_CONFIGS.CREATE_POST,
-    DUPLICATE_DETECTION_CONFIGS.POST
-  );
+  const normalizedContent = body.content.trim();
 
   const fallbackDisplayName = authUser.walletAddress
     ? `${authUser.walletAddress.slice(0, 6)}...${authUser.walletAddress.slice(-4)}`
@@ -1364,13 +1360,33 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
     displayName: fallbackDisplayName,
   });
   const canonicalUserId = canonicalUser.id;
+  const rateLimitResponse = checkRateLimitAndDuplicates(
+    canonicalUserId,
+    normalizedContent,
+    RATE_LIMIT_CONFIGS.CREATE_POST,
+    DUPLICATE_DETECTION_CONFIGS.POST
+  );
+  if (rateLimitResponse) {
+    return rateLimitResponse;
+  }
+
+  const clientIpHash = getHashedClientIp(request.headers);
+  if (clientIpHash) {
+    const ipRateLimit = await checkRateLimitAsync(
+      `post-ip:${clientIpHash}`,
+      RATE_LIMIT_CONFIGS.CREATE_POST
+    );
+    if (!ipRateLimit.allowed) {
+      return rateLimitError(ipRateLimit.retryAfter);
+    }
+  }
 
   const postId = await generateSnowflakeId();
   const [post] = await db
     .insert(posts)
     .values({
       id: postId,
-      content: content.trim(),
+      content: normalizedContent,
       authorId: canonicalUserId,
       timestamp: new Date(),
     })

--- a/apps/web/src/app/api/profiles/favorites/route.ts
+++ b/apps/web/src/app/api/profiles/favorites/route.ts
@@ -53,95 +53,137 @@
 
 import { authenticate, successResponse, withErrorHandling } from '@babylon/api';
 import { asUser } from '@babylon/db';
-import { logger, PaginationSchema } from '@babylon/shared';
+import { logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
+import { z } from 'zod';
+
+const FavoritesPaginationSchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  limit: z.coerce.number().int().min(1).max(100).default(10),
+});
 
 /**
  * GET /api/profiles/favorites
  * Get list of profiles the authenticated user has favorited
  */
 export const GET = withErrorHandling(async (request: NextRequest) => {
-  // Authenticate user
   const user = await authenticate(request);
 
-  // Validate query parameters
   const { searchParams } = new URL(request.url);
-  const queryParams = {
-    page: searchParams.get('page'),
-    limit: searchParams.get('limit'),
-  };
-  PaginationSchema.partial().parse(queryParams);
-
-  // Get favorited profiles with RLS
-  const favoritedProfiles = await asUser(user, async (db) => {
-    // Get favorited profiles
-    const favorites = await db.favorite.findMany({
-      where: {
-        userId: user.userId,
-      },
-      orderBy: {
-        createdAt: 'desc',
-      },
-    });
-
-    // Get user details for each favorited user
-    const targetUserIds = favorites.map((f) => f.targetUserId);
-    const targetUsers = await db.user.findMany({
-      where: {
-        id: { in: targetUserIds },
-      },
-      select: {
-        id: true,
-        displayName: true,
-        username: true,
-        profileImageUrl: true,
-        bio: true,
-        isActor: true,
-      },
-    });
-    const userMap = new Map(targetUsers.map((u) => [u.id, u]));
-
-    // Get post counts and favorite counts for each profile
-    const profiles = await Promise.all(
-      favorites.map(async (favorite) => {
-        const targetUser = userMap.get(favorite.targetUserId);
-        if (!targetUser) return null;
-
-        const [postCount, favoriteCount] = await Promise.all([
-          db.post.count({
-            where: { authorId: targetUser.id },
-          }),
-          db.favorite.count({
-            where: { targetUserId: targetUser.id },
-          }),
-        ]);
-
-        return {
-          id: targetUser.id,
-          displayName: targetUser.displayName,
-          username: targetUser.username,
-          profileImageUrl: targetUser.profileImageUrl,
-          bio: targetUser.bio,
-          isActor: targetUser.isActor,
-          postCount,
-          favoriteCount,
-          favoritedAt: favorite.createdAt,
-          isFavorited: true,
-        };
-      })
-    );
-
-    return profiles.filter((p): p is NonNullable<typeof p> => p !== null);
+  const { page, limit } = FavoritesPaginationSchema.parse({
+    page: searchParams.get('page') ?? undefined,
+    limit: searchParams.get('limit') ?? undefined,
   });
+  const offset = (page - 1) * limit;
+
+  const { profiles: favoritedProfiles, total } = await asUser(
+    user,
+    async (db) => {
+      const [totalFavorites, favorites] = await Promise.all([
+        db.favorite.count({
+          where: {
+            userId: user.userId,
+          },
+        }),
+        db.favorite.findMany({
+          where: {
+            userId: user.userId,
+          },
+          orderBy: {
+            createdAt: 'desc',
+          },
+          skip: offset,
+          take: limit,
+        }),
+      ]);
+
+      if (favorites.length === 0) {
+        return {
+          profiles: [],
+          total: totalFavorites,
+        };
+      }
+
+      const targetUserIds = favorites.map((favorite) => favorite.targetUserId);
+      const targetUsers = await db.user.findMany({
+        where: {
+          id: { in: targetUserIds },
+        },
+        select: {
+          id: true,
+          displayName: true,
+          username: true,
+          profileImageUrl: true,
+          bio: true,
+          isActor: true,
+        },
+      });
+      const userMap = new Map(
+        targetUsers.map((targetUser) => [targetUser.id, targetUser])
+      );
+
+      const profiles = await Promise.all(
+        favorites.map(async (favorite) => {
+          const targetUser = userMap.get(favorite.targetUserId);
+          if (!targetUser) return null;
+
+          const [postCount, favoriteCount] = await Promise.all([
+            db.post.count({
+              where: { authorId: targetUser.id },
+            }),
+            db.favorite.count({
+              where: { targetUserId: targetUser.id },
+            }),
+          ]);
+
+          return {
+            id: targetUser.id,
+            displayName: targetUser.displayName,
+            username: targetUser.username,
+            profileImageUrl: targetUser.profileImageUrl,
+            bio: targetUser.bio,
+            isActor: targetUser.isActor,
+            postCount,
+            favoriteCount,
+            favoritedAt: favorite.createdAt,
+            isFavorited: true,
+          };
+        })
+      );
+
+      return {
+        profiles: profiles.filter(
+          (profile): profile is NonNullable<typeof profile> => profile !== null
+        ),
+        total: totalFavorites,
+      };
+    }
+  );
+
+  const totalPages = total === 0 ? 0 : Math.ceil(total / limit);
 
   logger.info(
     'Favorited profiles fetched successfully',
-    { userId: user.userId, count: favoritedProfiles.length },
+    {
+      userId: user.userId,
+      count: favoritedProfiles.length,
+      total,
+      page,
+      limit,
+    },
     'GET /api/profiles/favorites'
   );
 
   return successResponse({
     profiles: favoritedProfiles,
-    total: favoritedProfiles.length,
+    total,
+    page,
+    limit,
+    pagination: {
+      page,
+      limit,
+      total,
+      totalPages,
+    },
   });
 });

--- a/apps/web/src/app/api/reputation/leaderboard/query.test.ts
+++ b/apps/web/src/app/api/reputation/leaderboard/query.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  getReputationActivityCutoff,
+  parseReputationLeaderboardQuery,
+} from './query';
+
+describe('parseReputationLeaderboardQuery', () => {
+  it('applies defaults when params are omitted', () => {
+    const result = parseReputationLeaderboardQuery(new URLSearchParams());
+
+    expect(result.limit).toBe(100);
+    expect(result.minGames).toBe(5);
+    expect(result.timeRange).toBe('all');
+  });
+
+  it('parses supported time ranges', () => {
+    const result = parseReputationLeaderboardQuery(
+      new URLSearchParams({
+        limit: '25',
+        minGames: '3',
+        timeRange: 'weekly',
+      })
+    );
+
+    expect(result.limit).toBe(25);
+    expect(result.minGames).toBe(3);
+    expect(result.timeRange).toBe('weekly');
+  });
+});
+
+describe('getReputationActivityCutoff', () => {
+  it('returns null for all-time filtering', () => {
+    expect(getReputationActivityCutoff('all')).toBeNull();
+  });
+
+  it('returns the expected cutoff date for activity windows', () => {
+    const now = new Date('2026-03-09T12:00:00.000Z');
+
+    expect(getReputationActivityCutoff('daily', now)?.toISOString()).toBe(
+      '2026-03-08T12:00:00.000Z'
+    );
+    expect(getReputationActivityCutoff('weekly', now)?.toISOString()).toBe(
+      '2026-03-02T12:00:00.000Z'
+    );
+    expect(getReputationActivityCutoff('monthly', now)?.toISOString()).toBe(
+      '2026-02-07T12:00:00.000Z'
+    );
+  });
+});

--- a/apps/web/src/app/api/reputation/leaderboard/query.ts
+++ b/apps/web/src/app/api/reputation/leaderboard/query.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+
+const ReputationLeaderboardQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).default(100),
+  minGames: z.coerce.number().int().min(0).default(5),
+  timeRange: z.enum(['all', 'daily', 'weekly', 'monthly']).default('all'),
+});
+
+export type ReputationLeaderboardQuery = z.infer<
+  typeof ReputationLeaderboardQuerySchema
+>;
+export type ReputationTimeRange = ReputationLeaderboardQuery['timeRange'];
+
+const TIME_RANGE_TO_MS: Record<Exclude<ReputationTimeRange, 'all'>, number> = {
+  daily: 24 * 60 * 60 * 1000,
+  weekly: 7 * 24 * 60 * 60 * 1000,
+  monthly: 30 * 24 * 60 * 60 * 1000,
+};
+
+export function parseReputationLeaderboardQuery(
+  searchParams: URLSearchParams
+): ReputationLeaderboardQuery {
+  return ReputationLeaderboardQuerySchema.parse({
+    limit: searchParams.get('limit') ?? undefined,
+    minGames: searchParams.get('minGames') ?? undefined,
+    timeRange: searchParams.get('timeRange') ?? undefined,
+  });
+}
+
+export function getReputationActivityCutoff(
+  timeRange: ReputationTimeRange,
+  now = new Date()
+): Date | null {
+  if (timeRange === 'all') {
+    return null;
+  }
+
+  return new Date(now.getTime() - TIME_RANGE_TO_MS[timeRange]);
+}

--- a/apps/web/src/app/api/reputation/leaderboard/route.ts
+++ b/apps/web/src/app/api/reputation/leaderboard/route.ts
@@ -42,6 +42,13 @@
  *           minimum: 0
  *           default: 5
  *         description: Minimum games/trades threshold
+ *       - in: query
+ *         name: timeRange
+ *         schema:
+ *           type: string
+ *           enum: [all, daily, weekly, monthly]
+ *           default: all
+ *         description: Filter leaderboard entries by recent activity window
  *     responses:
  *       200:
  *         description: Reputation leaderboard
@@ -80,6 +87,8 @@
  *                       type: integer
  *                     minGames:
  *                       type: integer
+ *                     timeRange:
+ *                       type: string
  *
  * @example
  * ```typescript
@@ -110,20 +119,22 @@ import {
 import { getReputationLeaderboard } from '@babylon/engine';
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+import {
+  getReputationActivityCutoff,
+  parseReputationLeaderboardQuery,
+} from './query';
 
 export const GET = withErrorHandling(async function GET(request: NextRequest) {
   const { error, rateLimitInfo } = await publicRateLimit(request);
   if (error) return error;
 
   const { searchParams } = new URL(request.url);
-
-  const limitParam = searchParams.get('limit');
-  const minGamesParam = searchParams.get('minGames');
-
-  const limit = limitParam ? Number.parseInt(limitParam, 10) : 100;
-  const minGames = minGamesParam ? Number.parseInt(minGamesParam, 10) : 5;
-
-  const leaderboard = await getReputationLeaderboard(limit, minGames);
+  const { limit, minGames, timeRange } =
+    parseReputationLeaderboardQuery(searchParams);
+  const activeSince = getReputationActivityCutoff(timeRange);
+  const leaderboard = await getReputationLeaderboard(limit, minGames, {
+    activeSince,
+  });
 
   const res = NextResponse.json({
     success: true,
@@ -132,6 +143,8 @@ export const GET = withErrorHandling(async function GET(request: NextRequest) {
       count: leaderboard.length,
       limit,
       minGames,
+      timeRange,
+      activitySince: activeSince?.toISOString() ?? null,
     },
   });
   if (rateLimitInfo) addPublicReadHeaders(res, rateLimitInfo);

--- a/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
+++ b/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
@@ -399,7 +399,7 @@ export function PerpsOrderEntryPanel({
           <div>
             <div className="mb-1 flex items-center justify-between">
               <label className="font-medium text-muted-foreground text-xs">
-                Size (USD)
+                Notional Size (USD)
               </label>
               <span className="text-muted-foreground text-xs">
                 Min {BABYLON_POINTS_SYMBOL}

--- a/apps/web/src/components/markets/PerpTradingModal.tsx
+++ b/apps/web/src/components/markets/PerpTradingModal.tsx
@@ -283,7 +283,7 @@ export function PerpTradingModal({
           <div className="mb-6 space-y-4 rounded bg-muted p-4">
             <div className="flex items-center justify-between">
               <label className="font-medium text-muted-foreground text-sm">
-                Position Size (PTS)
+                Notional Size (USD)
               </label>
               <input
                 type="number"

--- a/apps/web/src/components/markets/TradeConfirmationDialog.tsx
+++ b/apps/web/src/components/markets/TradeConfirmationDialog.tsx
@@ -223,7 +223,7 @@ export function TradeConfirmationDialog({
               <span className="font-medium">${tradeDetails.ticker}</span>
             </div>
             <div className="flex justify-between text-sm">
-              <span className="text-muted-foreground">Position Size</span>
+              <span className="text-muted-foreground">Notional Size</span>
               <span className="font-medium">
                 {formatPrice(tradeDetails.size)}
               </span>
@@ -295,7 +295,7 @@ export function TradeConfirmationDialog({
               <span className="font-medium">${tradeDetails.ticker}</span>
             </div>
             <div className="flex justify-between text-sm">
-              <span className="text-muted-foreground">Position Size</span>
+              <span className="text-muted-foreground">Notional Size</span>
               <span className="font-medium">
                 {formatPrice(tradeDetails.size)}
               </span>

--- a/apps/web/src/components/shared/ComingSoon.tsx
+++ b/apps/web/src/components/shared/ComingSoon.tsx
@@ -62,8 +62,8 @@ function getAppBaseUrl(): string {
  * Waitlist data structure containing user position and points information.
  */
 interface WaitlistData {
-  position: number; // Leaderboard rank (dynamic)
-  leaderboardRank: number; // Same as position
+  position: number; // Current rank shown to the user
+  leaderboardRank: number; // Dynamic rank based on points
   waitlistPosition: number; // Historical signup order
   totalAhead: number;
   totalCount: number;
@@ -2711,13 +2711,16 @@ export function ComingSoon() {
                 {/* Position Card */}
                 <div className="rounded-xl border border-primary/10 bg-primary/5 p-4 backdrop-blur-sm transition-colors hover:bg-primary/10 sm:p-5">
                   <div className="mb-2 text-muted-foreground text-sm">
-                    Position
+                    Current Rank
                   </div>
                   <div className="mb-1 whitespace-nowrap font-bold text-lg text-primary sm:text-xl md:text-2xl">
                     #{waitlistData.position}
                   </div>
                   <div className="text-muted-foreground text-sm">
                     Top {waitlistData.percentile}%
+                  </div>
+                  <div className="text-muted-foreground/80 text-xs">
+                    Signup order #{waitlistData.waitlistPosition}
                   </div>
                 </div>
 

--- a/apps/web/src/components/waitlist/dashboard/StatsCards.tsx
+++ b/apps/web/src/components/waitlist/dashboard/StatsCards.tsx
@@ -15,12 +15,15 @@ export function StatsCards({ waitlistData }: StatsCardsProps) {
     <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
       {/* Position Card */}
       <div className="rounded-xl border border-primary/10 bg-primary/5 p-4 backdrop-blur-sm transition-colors hover:bg-primary/10 sm:p-5">
-        <div className="mb-2 text-muted-foreground text-sm">Position</div>
+        <div className="mb-2 text-muted-foreground text-sm">Current Rank</div>
         <div className="mb-1 whitespace-nowrap font-bold text-lg text-primary sm:text-xl md:text-2xl">
           #{waitlistData.position}
         </div>
         <div className="text-muted-foreground text-sm">
           Top {waitlistData.percentile}%
+        </div>
+        <div className="text-muted-foreground/80 text-xs">
+          Signup order #{waitlistData.waitlistPosition}
         </div>
       </div>
 

--- a/apps/web/src/components/waitlist/types.ts
+++ b/apps/web/src/components/waitlist/types.ts
@@ -7,9 +7,9 @@
  * Waitlist data structure containing user position and points information.
  */
 export interface WaitlistData {
-  position: number;
-  leaderboardRank: number;
-  waitlistPosition: number;
+  position: number; // Current rank shown to the user
+  leaderboardRank: number; // Dynamic rank based on points
+  waitlistPosition: number; // Historical signup order
   totalAhead: number;
   totalCount: number;
   percentile: number;

--- a/packages/core/markets/perps/__tests__/PerpMarketService.test.ts
+++ b/packages/core/markets/perps/__tests__/PerpMarketService.test.ts
@@ -337,6 +337,27 @@ describe('PerpMarketService', () => {
     expect(totalPnL).toBeCloseTo(19.8, 4);
   });
 
+  it('calculates realized PnL from notional size while leverage only affects margin', async () => {
+    const open = await service.openPosition({
+      userId: 'u1',
+      ticker: 'ABC',
+      side: 'long',
+      size: 1000,
+      leverage: 10,
+    });
+
+    await db.updateMarketStats('ABC', { currentPrice: 110 });
+
+    const close = await service.closePosition({
+      userId: 'u1',
+      positionId: open.positionId,
+    });
+
+    expect(open.marginPaid).toBeCloseTo(100, 4);
+    expect(close.marginPaid).toBeCloseTo(100, 4);
+    expect(close.realizedPnL).toBeCloseTo(100, 4);
+  });
+
   it('liquidates a position on price drop and records loss', async () => {
     const open = await service.openPosition({
       userId: 'u1',

--- a/packages/engine/src/QuestionManager.ts
+++ b/packages/engine/src/QuestionManager.ts
@@ -1219,6 +1219,12 @@ TOPIC DIVERSITY (CRITICAL):
 - Mix question types: product launches, price targets, announcements, partnerships
 - NO two questions about the same actor or company in this batch
 
+STYLE VARIETY (CRITICAL):
+- Do NOT repeat the same sentence scaffold across the batch
+- Mix lead structures: person-led, company-led, metric-led, product/event-led, regulator/media-led
+- If two questions begin with the same named subject or same verb phrase, rewrite one
+- Avoid repetitive filler patterns such as "announce X by Y", "ban X in Y labs", or "launch X within Y"
+
 OUTCOME BALANCE:
 - Aim for 40-60% yes/no split in expectedOutcome
 - Not all questions should resolve the same way

--- a/packages/engine/src/data/question-examples.test.ts
+++ b/packages/engine/src/data/question-examples.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'bun:test';
+import { getQuestionExamples } from './question-examples';
+
+describe('getQuestionExamples', () => {
+  it('returns only well-formed question examples', () => {
+    const examples = getQuestionExamples();
+
+    expect(examples.length).toBeGreaterThan(0);
+    expect(examples.every((line) => line.startsWith('Will '))).toBe(true);
+    expect(examples.every((line) => line.endsWith('?'))).toBe(true);
+  });
+
+  it('filters out section headings and malformed lines', () => {
+    const examples = getQuestionExamples();
+
+    expect(examples).not.toContain('Crypto Degeneracy & Financial Absurdity');
+    expect(
+      examples.some((line) =>
+        line.includes(
+          'Will AIlon Musk successfully land a SpAIceX rocket on the roof of the MetAI headquarters as a "friendly prank"'
+        )
+      )
+    ).toBe(true);
+    expect(
+      examples.some((line) =>
+        line.includes(
+          `Will Mark Zuckerborg's challenge to a "Metaverse Deathmatch" actually be accepted by Sim Cook`
+        )
+      )
+    ).toBe(true);
+  });
+});

--- a/packages/engine/src/data/question-examples.ts
+++ b/packages/engine/src/data/question-examples.ts
@@ -24,7 +24,7 @@ Will BernAI Sanders propose a "Robot Tax" on any AI agent that earns more than m
 Will AIlex Jones claim that NeurAIlink chips are turning frogs into crypto-miners by {resolutionDate}?
 Will Jared Kushner announce a peace treaty between Bitcoin maxis and Ethereum devs by {resolutionDate}?
 Will Kash PAItel issue a subpoena to ChAItSMH for "withholding evidence" by {resolutionDate}?
-Crypto Degeneracy & Financial Absurdity
+### Crypto Degeneracy & Financial Absurdity
 Will Michael SAIlor announce that he has legally adopted a Bitcoin block as his son by {resolutionDate}?
 Will VitAIlik Buterin give a keynote speech at a conference while wearing a full-body "Merge Panda" costume by {resolutionDate}?
 Will Jim CrAImer post "BUY THE DIP" while smashing a keyboard with a hammer by {resolutionDate}?
@@ -50,7 +50,8 @@ Will AImazon announce a "Pre-Crime" shipping feature that sends you items before
 Will AInduril reveal a defense drone that plays "Flight of the Valkyries" via loud speakers by {resolutionDate}?
 Will ColAIssal Sciences accidentally resurrect a Dodo bird instead of a Woolly Mammoth by {resolutionDate}?
 Will NVIDAI announce a graphics card that requires a dedicated nuclear reactor to run by {resolutionDate}?
-Will AIlon Musk successfully land a SpAIceX rocket on the roof of the MetAI headquarters as a "friendly prank" by {resolutionDate}?Will Mark Zuckerborg's challenge to a "Metaverse Deathmatch" actually be accepted by Sim Cook by {resolutionDate}?
+Will AIlon Musk successfully land a SpAIceX rocket on the roof of the MetAI headquarters as a "friendly prank" by {resolutionDate}?
+Will Mark Zuckerborg's challenge to a "Metaverse Deathmatch" actually be accepted by Sim Cook by {resolutionDate}?
 Will Sam AIltman finally admit that the "Blue Orb" he carries is actually a sentient alien hard drive by {resolutionDate}?
 Will Jeff BAIzos's attempt to dismantle a historic bridge to fit his new super-yacht be blocked by the Deparment of War by {resolutionDate}?
 Will Jensen HuAIng's leather jacket actually be revealed to be a fully functional NvidAI cooling system by {resolutionDate}?
@@ -125,5 +126,6 @@ Will a major music festival be held entirely in virtual reality by {resolutionDa
 export function getQuestionExamples(): string[] {
   return questionExamples
     .split('\n')
-    .filter((line) => line.trim().length > 0 && !line.startsWith('#'));
+    .map((line) => line.trim())
+    .filter((line) => /^Will\b.+\?$/.test(line));
 }

--- a/packages/engine/src/prompts/game/questions.ts
+++ b/packages/engine/src/prompts/game/questions.ts
@@ -83,6 +83,12 @@ Instead of multiple "Will X announce Y?" questions, vary:
 - "Will MSDNC break exclusive on leaked documents?"
 - "Will The Fud intervene in the market?"
 
+ANTI-TEMPLATE RULES:
+- Never reuse the same sentence scaffold across the batch.
+- Vary lead structures across the batch: person-led, company-led, metric-led, regulator/media-led, and product/event-led.
+- If two questions start with the same named subject or same verb phrase, rewrite one.
+- Avoid repetitive filler patterns such as "announce X by Y", "ban X in Y labs", or "launch X within Y" appearing multiple times in one batch.
+
 BUILDING ON RESOLVED QUESTIONS:
 If "Will AIlon announce X?" resolved YES, good follow-ups:
 - "Will AIlon's X launch on schedule?"

--- a/packages/engine/src/reputation/reputation-calculation-service.ts
+++ b/packages/engine/src/reputation/reputation-calculation-service.ts
@@ -7,6 +7,7 @@
 
 import {
   agentPerformanceMetrics,
+  and,
   db,
   desc,
   eq,
@@ -573,8 +574,21 @@ export async function getReputationBreakdown(
  */
 export async function getReputationLeaderboard(
   limit = 100,
-  minGames = 5
+  minGames = 5,
+  options?: {
+    activeSince?: Date | null;
+  }
 ): Promise<LeaderboardEntry[]> {
+  const leaderboardFilters = [
+    gte(agentPerformanceMetrics.gamesPlayed, minGames),
+  ];
+
+  if (options?.activeSince) {
+    leaderboardFilters.push(
+      gte(agentPerformanceMetrics.lastActivityAt, options.activeSince)
+    );
+  }
+
   const topAgents = await db
     .select({
       userId: agentPerformanceMetrics.userId,
@@ -586,7 +600,7 @@ export async function getReputationLeaderboard(
       normalizedPnL: agentPerformanceMetrics.normalizedPnL,
     })
     .from(agentPerformanceMetrics)
-    .where(gte(agentPerformanceMetrics.gamesPlayed, minGames))
+    .where(and(...leaderboardFilters))
     .orderBy(desc(agentPerformanceMetrics.reputationScore))
     .limit(limit);
 


### PR DESCRIPTION
## Summary

- Fix the medium-severity QA regressions behind BAB-248 across favorites pagination, group APIs, leaderboard validation, NPC performance, post rate limiting, and the missing NFT gallery alias.
- Add clearer waitlist/perps copy so rank vs signup order and notional size vs margin are no longer ambiguous in the UI.
- Tighten question-generation inputs/prompts so generated market titles have cleaner examples and stronger anti-template guidance.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: [BAB-248](https://linear.app/eliza-labs/issue/BAB-248/test-bug-fixing-agent-qa-fix-medium-priority-bugs-babylon-qa-findings)

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- Add real defaults and applied pagination to `GET /api/profiles/favorites` (`page=1`, `limit=10`) with pagination metadata.
- Add `GET /api/groups/[groupId]/members` and `GET /api/groups/[groupId]/messages` so group sub-routes return JSON responses instead of falling through to missing handlers.
- Reject unsupported query params on `/api/leaderboard` instead of silently ignoring them.
- Add `timeRange=all|daily|weekly|monthly` support on `/api/reputation/leaderboard` by filtering leaderboard entries by recent activity windows.
- Rebuild NPC performance leaderboard rows from `NPCInvestmentManager` metrics so realized/unrealized PnL and position counts reflect the actual pipeline.
- Make post creation rate limiting actually execute, and add a per-IP limiter on top of the per-account guard.
- Add `/api/nft/gallery` as a backward-compatible alias to the collection endpoint.
- Clarify waitlist UI copy (`Current Rank` vs `Signup order`) and perp trading copy (`Notional Size`) to reduce misleading interpretations.
- Clean up question example inputs and add stronger anti-template prompt instructions for market generation.
- Follow-up / non-goal: BAB-248 M7 was verified as a notional-vs-margin interpretation issue rather than a broken backend PnL formula; this PR locks that in with UI copy + regression coverage.

## Review guide

**Start here**
- `apps/web/src/app/api/profiles/favorites/route.ts`
- `apps/web/src/app/api/groups/[groupId]/members/route.ts`
- `apps/web/src/app/api/groups/[groupId]/messages/route.ts`
- `apps/web/src/app/api/posts/route.ts`
- `apps/web/src/app/api/npc/performance/leaderboard/route.ts`
- `apps/web/src/app/api/reputation/leaderboard/route.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- The reputation `timeRange` filter is implemented as an activity window (`lastActivityAt`) because the current reputation model stores cumulative scores, not historical snapshots per period.
- The leaderboard query change intentionally returns `400` for unsupported params (`sortBy`, `timeRange`, `search`, etc.) rather than pretending to support them.
- Group message/member endpoints are additive and keep existing group/chat routes unchanged.

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Ran `bun test packages/core/markets/perps/__tests__/PerpMarketService.test.ts packages/engine/src/data/question-examples.test.ts apps/web/src/app/api/leaderboard/query.test.ts apps/web/src/app/api/reputation/leaderboard/query.test.ts`
2. Ran `bunx biome check $(git diff --name-only -- '*.ts' '*.tsx')`
3. Did not run full build/typecheck to avoid heavy parallel repo-wide checks for this multi-agent session.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: standard deploy
- Rollback: revert this PR

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- Added JSON GET handlers for group members/messages and a backward-compatible NFT gallery alias.
- `/api/leaderboard` now rejects unsupported params with `400` instead of silently ignoring them.
- `/api/reputation/leaderboard` now returns `metadata.timeRange` and `metadata.activitySince`.

### Database
- No schema changes.

### Contracts / on-chain
- Not applicable.

### Docs
- Not applicable.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Primary scope is backend/API behavior; UI changes are limited to copy clarifications (`Current Rank`, `Signup order`, `Notional Size`) and do not require a dedicated screenshot to review the underlying fix set.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
