### PR TITLE
fix(db): register missing migrations in drizzle journal

### DIFF
--- a/packages/db/drizzle/migrations/0045_add_message_reply_to.sql
+++ b/packages/db/drizzle/migrations/0045_add_message_reply_to.sql
@@ -1,4 +1,4 @@
 -- Add reply-to-message support (Telegram/Discord-style message replies)
 -- No foreign key constraint: replied-to messages may be deleted without breaking replies.
-ALTER TABLE "Message" ADD COLUMN "replyToMessageId" TEXT;
-CREATE INDEX "Message_replyToMessageId_idx" ON "Message" ("replyToMessageId");
+ALTER TABLE "Message" ADD COLUMN IF NOT EXISTS "replyToMessageId" TEXT;
+CREATE INDEX IF NOT EXISTS "Message_replyToMessageId_idx" ON "Message" ("replyToMessageId");

--- a/packages/db/drizzle/migrations/meta/_journal.json
+++ b/packages/db/drizzle/migrations/meta/_journal.json
@@ -316,6 +316,20 @@
       "when": 1772718287000,
       "tag": "0045_add_sentry_webhook_inbox",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1773187500000,
+      "tag": "0045_add_message_reply_to",
+      "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1773187500001,
+      "tag": "0045_add_daily_topics",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Two migration files (`0045_add_message_reply_to.sql`, `0045_add_daily_topics.sql`) were on disk but never added to drizzle's `_journal.json`, so `bun db:migrate` silently skipped them
- This caused a production error on staging: `column "replyToMessageId" of relation "Message" does not exist` when sending messages in agents team chat
- Added both migrations to the journal and made the reply-to migration idempotent (`IF NOT EXISTS`) for safety

## Test plan
- [x] Ran `bun db:migrate` against staging — all migrations applied successfully
- [x] Verified `replyToMessageId` column exists on staging via psql
- [x] Verified `DailyTopic` table created on staging
- [x] Confirm sending messages in agents team chat works on staging
