### PR TITLE
fix(chat): add NPC guard for existing DM chats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ scripts/cleanup-excess-markets.ts
 
 # Continuous Claude cache (local only)
 .claude/cache/
+.claude/worktrees/
 .claude/tsc-cache/
 .claudekit/
 .env.hook-test

--- a/apps/web/src/app/api/chats/[id]/message/route.ts
+++ b/apps/web/src/app/api/chats/[id]/message/route.ts
@@ -296,15 +296,28 @@ export const POST = withErrorHandling(
           );
         }
 
-        // Check if users have blocked each other
+        // Check if the other participant is an NPC or has blocked the user
         const otherParticipant = chatParticipantsList.find(
           (p) => p.userId !== user.userId
         );
         if (otherParticipant) {
-          const [isBlocked, hasBlockedMe] = await Promise.all([
+          const [otherUser, isBlocked, hasBlockedMe] = await Promise.all([
+            db
+              .select({ isActor: users.isActor })
+              .from(users)
+              .where(eq(users.id, otherParticipant.userId))
+              .limit(1)
+              .then((rows) => rows[0] ?? null),
             hasBlocked(user.userId, otherParticipant.userId),
             hasBlocked(otherParticipant.userId, user.userId),
           ]);
+
+          if (otherUser?.isActor) {
+            throw new BusinessLogicError(
+              'Cannot send direct messages to NPC actors. Use group chats to interact with NPCs.',
+              'CANNOT_DM_ACTOR'
+            );
+          }
 
           if (isBlocked || hasBlockedMe) {
             throw new BusinessLogicError(


### PR DESCRIPTION
## Summary
- Adds NPC actor check when sending messages to **existing** DM chats. The auto-create path already blocked DMs to NPCs, but the existing-chat path only checked block status — allowing bypass via a pre-existing `dm-{userId}-{npcId}` chat record.
- Queries `users.isActor` in parallel with block checks to avoid extra round-trips.

## Test plan
- [ ] Verify `POST /api/chats/{dm-userId-npcId}/message` returns error when other participant is NPC
- [ ] Verify normal DM messaging still works
- [ ] Verify `POST /api/chats/dm` still rejects NPC targets (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)