### PR TITLE
fix(mcp): correct double /api prefix in get_post URL

### DIFF
--- a/packages/mcp/src/handlers/tool-handlers.ts
+++ b/packages/mcp/src/handlers/tool-handlers.ts
@@ -1447,7 +1447,7 @@ export async function executeGetPost(
 ): Promise<GetPostResult> {
   const apiBaseUrl = getAPIBaseUrl();
   return safeFetchRequired<GetPostResult>(
-    new URL(`${apiBaseUrl}/api/posts/${args.postId}`)
+    new URL(`${apiBaseUrl}/posts/${args.postId}`)
   );
 }
 


### PR DESCRIPTION
## Summary
- `getAPIBaseUrl()` already returns `baseUrl/api`, so `executeGetPost` was constructing `baseUrl/api/api/posts/:id` — a double `/api` prefix causing 404 for valid post IDs returned by `query_feed`
- Removed the redundant `/api` segment so the URL is `baseUrl/api/posts/:id`

## Test plan
- [ ] Call `babylon_get_post` with a post ID from `babylon_get_feed` and verify it returns post data
- [ ] Verify no regressions in other post operations (create, delete, like)

🤖 Generated with [Claude Code](https://claude.com/claude-code)