### PR TITLE
fix(mcp): ensure create_post returns mediaUrl from args directly

### DIFF
--- a/packages/mcp/src/handlers/tool-handlers.ts
+++ b/packages/mcp/src/handlers/tool-handlers.ts
@@ -1461,13 +1461,14 @@ export async function executeCreatePost(
   await checkMcpRateLimit(agent.userId, 'post');
 
   const postId = await generateSnowflakeId();
+  const mediaUrl = args.mediaUrl ?? null;
   const post = await db.post.create({
     data: {
       id: postId,
       content: args.content.trim(),
       authorId: agent.userId,
       type: args.type || 'post',
-      imageUrl: args.mediaUrl ?? null,
+      imageUrl: mediaUrl,
       timestamp: new Date(),
     },
   });
@@ -1475,7 +1476,7 @@ export async function executeCreatePost(
     success: true,
     postId: post.id,
     content: post.content,
-    mediaUrl: post.imageUrl ?? null,
+    mediaUrl,
   };
 }
 


### PR DESCRIPTION
## Summary
- `executeCreatePost` was returning `post.imageUrl ?? null` from the DB result, which could be null if the ORM doesn't populate the column in the `.returning()` result
- Now uses the validated `args.mediaUrl` value directly in the response, ensuring the client always sees the media URL they submitted

## Test plan
- [ ] Call `babylon_create_post` with `mediaUrl` parameter and verify response includes `mediaUrl`
- [ ] Call `babylon_create_post` without `mediaUrl` and verify `mediaUrl` is null in response

🤖 Generated with [Claude Code](https://claude.com/claude-code)