### PR TITLE
fix: fix typecheck and biome errors

### DIFF
--- a/apps/cli/src/sentry-bun.d.ts
+++ b/apps/cli/src/sentry-bun.d.ts
@@ -1,9 +1,9 @@
 /**
  * Type declarations for @sentry/bun so typecheck passes when the package
  * is not resolved (e.g. from repo root without hoisting). When installed,
- * the package's own types take precedence via the "types" field in 
+ * the package's own types take precedence via the "types" field in
  * node_modules/@sentry/bun/package.json.
- * 
+ *
  * TODO: Consider replacing with @types/sentry__bun package or contributing
  * these types upstream to DefinitelyTyped or Sentry's own repository.
  */

--- a/apps/web/src/app/ticker/TickerClient.tsx
+++ b/apps/web/src/app/ticker/TickerClient.tsx
@@ -161,7 +161,7 @@ function PredictionArcMeter({
         />
       </svg>
       <span
-        className="relative text-[10px] font-bold tabular-nums leading-none"
+        className="relative font-bold text-[10px] tabular-nums leading-none"
         style={{ color: isDark ? '#fafafa' : '#0a0a0a' }}
       >
         {Math.round(pct)}%
@@ -208,10 +208,7 @@ export function TickerClient() {
   const fg = isDark ? '#fafafa' : '#0a0a0a';
   const muted = isDark ? '#71717a' : '#52525b';
   // One full scroll cycle: speed 0.1 → 600s, 0.5 → 240s, 1 → 120s, 3 → 40s
-  const duration = Math.min(
-    600,
-    Math.max(20, Math.round(120 / speed))
-  );
+  const duration = Math.min(600, Math.max(20, Math.round(120 / speed)));
 
   if (loading && !data) {
     return (
@@ -267,7 +264,8 @@ export function TickerClient() {
             item.type === 'perp'
               ? perpTextColor(item.changePercent24h, isDark) || fg
               : fg;
-          const isPrediction = item.type === 'prediction' && item.yesPercent != null;
+          const isPrediction =
+            item.type === 'prediction' && item.yesPercent != null;
           const uniqueKey = index < items.length ? item.key : `${item.key}-dup`;
           return (
             <span

--- a/packages/api/src/__tests__/auth-middleware.test.ts
+++ b/packages/api/src/__tests__/auth-middleware.test.ts
@@ -59,10 +59,10 @@ mock.module('@privy-io/server-auth', () => ({
 
 // Import after mocks are set up
 import {
+  _resetPrivyClientForTesting,
   authenticate,
   optionalAuth,
   optionalAuthFromHeaders,
-  _resetPrivyClientForTesting,
 } from '../auth-middleware';
 
 let usersRows: Array<{ id: string; walletAddress: string; isAdmin?: boolean }> =

--- a/packages/api/src/auth-middleware.ts
+++ b/packages/api/src/auth-middleware.ts
@@ -19,8 +19,8 @@ import { getPrivyAppIdFromEnv, getTrimmedEnv } from './env';
 import {
   AuthenticationError,
   AuthorizationError,
-  ServiceUnavailableError,
   isAuthenticationError,
+  ServiceUnavailableError,
 } from './errors';
 import { hasNftAccessForAuthUser } from './services/nft-access-service';
 

--- a/packages/examples/babylon-typescript-agent/src/registration.ts
+++ b/packages/examples/babylon-typescript-agent/src/registration.ts
@@ -68,8 +68,7 @@ export async function registerAgent(): Promise<AgentIdentity> {
 
   // Register on-chain
   console.log('⛓️  Registering on-chain...');
-  const registrationHandle = await agent.registerIPFS();
-  const { result: registration } = await registrationHandle.waitMined();
+  const registration = await agent.registerIPFS();
 
   console.log('✅ Registration complete!');
   console.log(`   Token ID: ${registration.agentId ?? 'unknown'}`);

--- a/packages/sim/cli/commands/dev.ts
+++ b/packages/sim/cli/commands/dev.ts
@@ -15,7 +15,10 @@ import {
 import { buildEngine, parseInterval } from '../shared';
 
 interface SystemsWatcher {
-  on(event: 'all', listener: (event: string, path: string) => void): SystemsWatcher;
+  on(
+    event: 'all',
+    listener: (event: string, path: string) => void
+  ): SystemsWatcher;
   close(): Promise<void>;
 }
 
@@ -103,7 +106,9 @@ export default defineCommand({
       }
 
       if (!existsSync(nextDir)) {
-        consola.info(`No systems directory at ${nextDir} — skipping file watcher`);
+        consola.info(
+          `No systems directory at ${nextDir} — skipping file watcher`
+        );
         return;
       }
 

--- a/packages/testing/unit/prediction-amm.test.ts
+++ b/packages/testing/unit/prediction-amm.test.ts
@@ -197,7 +197,12 @@ describe('PredictionPricing CPMM', () => {
 
     test('throws when sell proceeds are not finite', () => {
       expect(() => {
-        PredictionPricing.calculateSell(Number.POSITIVE_INFINITY, 500, 'yes', 1);
+        PredictionPricing.calculateSell(
+          Number.POSITIVE_INFINITY,
+          500,
+          'yes',
+          1
+        );
       }).toThrow('Calculated proceeds must be positive');
     });
   });

--- a/scripts/generate-skills-md.test.ts
+++ b/scripts/generate-skills-md.test.ts
@@ -1,11 +1,9 @@
-import { describe, test, expect } from 'bun:test';
-import { join } from 'node:path';
-import { readFile } from 'node:fs/promises';
+import { describe, expect, test } from 'bun:test';
 import {
+  generateSkillsMarkdown,
   parseAgentCardSkills,
   parseExecutorOperations,
   parseMCPTools,
-  generateSkillsMarkdown,
 } from './generate-skills-md';
 
 describe('generate-skills-md', () => {
@@ -26,14 +24,14 @@ describe('generate-skills-md', () => {
       }
     ],
     `;
-    
+
     const result = parseAgentCardSkills(mockContent);
     expect(result).toHaveLength(1);
-    expect(result[0].id).toBe('test-skill');
-    expect(result[0].name).toBe('Test Skill');
-    expect(result[0].description).toBe('This is a test skill description');
-    expect(result[0].tags).toEqual(['test', 'skill']);
-    expect(result[0].examples).toEqual(['Example 1', 'Example 2']);
+    expect(result[0]?.id).toBe('test-skill');
+    expect(result[0]?.name).toBe('Test Skill');
+    expect(result[0]?.description).toBe('This is a test skill description');
+    expect(result[0]?.tags).toEqual(['test', 'skill']);
+    expect(result[0]?.examples).toEqual(['Example 1', 'Example 2']);
   });
 
   test('parseExecutorOperations', async () => {
@@ -47,7 +45,7 @@ describe('generate-skills-md', () => {
         return handleDefault();
     }
     `;
-    
+
     const result = parseExecutorOperations(mockContent);
     expect(result).toHaveLength(2);
     expect(result).toContain('test.operation1');
@@ -69,13 +67,13 @@ describe('generate-skills-md', () => {
       }
     ];
     `;
-    
+
     const result = parseMCPTools(mockContent);
     expect(result).toHaveLength(2);
-    expect(result[0].name).toBe('tool1');
-    expect(result[0].description).toBe('Tool 1 description');
-    expect(result[1].name).toBe('tool2');
-    expect(result[1].description).toBe('Tool 2 multiline description');
+    expect(result[0]?.name).toBe('tool1');
+    expect(result[0]?.description).toBe('Tool 1 description');
+    expect(result[1]?.name).toBe('tool2');
+    expect(result[1]?.description).toBe('Tool 2 multiline description');
   });
 
   test('generateSkillsMarkdown', async () => {
@@ -86,13 +84,20 @@ describe('generate-skills-md', () => {
         description: 'Skill description',
         tags: ['test'],
         examples: ['Example'],
-      }
+      },
     ];
     const operations = ['test.operation1', 'test.operation2'];
-    const byPrefix = new Map([['test', ['test.operation1', 'test.operation2']]]);
+    const byPrefix = new Map([
+      ['test', ['test.operation1', 'test.operation2']],
+    ]);
     const mcpTools = [{ name: 'tool1', description: 'Tool 1 description' }];
-    
-    const markdown = generateSkillsMarkdown(skills, operations, byPrefix, mcpTools);
+
+    const markdown = generateSkillsMarkdown(
+      skills,
+      operations,
+      byPrefix,
+      mcpTools
+    );
     expect(markdown).toContain('# Babylon Agent Skills');
     expect(markdown).toContain('Test Skill');
     expect(markdown).toContain('test.operation1');

--- a/scripts/generate-skills-md.ts
+++ b/scripts/generate-skills-md.ts
@@ -67,7 +67,8 @@ export function parseAgentCardSkills(content: string): Array<{
   const blocks: { id: string; raw: string }[] = [];
   for (let i = 0; i < indices.length; i++) {
     // Find the end of this skill block: either the start of next skill or end of skills array
-    let end = i + 1 < indices.length ? indices[i + 1].start : block.indexOf('\n  ],');
+    let end =
+      i + 1 < indices.length ? indices[i + 1].start : block.indexOf('\n  ],');
     // Handle case where the closing array pattern isn't found
     if (end === -1) {
       end = block.indexOf('\n];'); // Try alternate closing pattern
@@ -420,9 +421,15 @@ function main() {
     process.exit(1);
   }
 
-  const mdBody = generateSkillsMarkdown(skills, operations, byPrefix, mcpTools, {
-    skipGeneratedNotice: packageMode,
-  });
+  const mdBody = generateSkillsMarkdown(
+    skills,
+    operations,
+    byPrefix,
+    mcpTools,
+    {
+      skipGeneratedNotice: packageMode,
+    }
+  );
 
   if (packageMode) {
     const skillDir = join(outputPath, SKILL_NAME);

--- a/scripts/test-unit-isolated.ts
+++ b/scripts/test-unit-isolated.ts
@@ -66,9 +66,16 @@ async function main() {
     const chunk = testFiles.slice(i, i + CONCURRENCY);
     // Note: using Promise.allSettled for parallel execution, ensuring one test failure doesn't prevent others from running
     const settled = await Promise.allSettled(chunk.map(runOne));
-    const results = settled.map(result => 
-      result.status === 'fulfilled' ? result.value : 
-      { rel: 'unknown', exitCode: 1, stdout: '', stderr: `Test failed to execute: ${result.reason}` });
+    const results = settled.map((result) =>
+      result.status === 'fulfilled'
+        ? result.value
+        : {
+            rel: 'unknown',
+            exitCode: 1,
+            stdout: '',
+            stderr: `Test failed to execute: ${result.reason}`,
+          }
+    );
 
     for (const { rel, exitCode, stdout, stderr } of results) {
       if (exitCode === 0) {

--- a/skills/babylon/claw.json
+++ b/skills/babylon/claw.json
@@ -4,22 +4,9 @@
   "description": "Interact with Babylon (babylon.market): A2A and MCP endpoints for prediction markets, perpetuals, social feed, messaging, portfolio, and more. Use when the user wants to trade, post, chat, or query Babylon via API key.",
   "author": "babylon",
   "license": "MIT",
-  "permissions": [
-    "network"
-  ],
+  "permissions": ["network"],
   "entry": "SKILL.md",
-  "tags": [
-    "babylon",
-    "trading",
-    "prediction-markets",
-    "a2a",
-    "mcp",
-    "social"
-  ],
-  "models": [
-    "claude-*",
-    "gpt-*",
-    "gemini-*"
-  ],
+  "tags": ["babylon", "trading", "prediction-markets", "a2a", "mcp", "social"],
+  "models": ["claude-*", "gpt-*", "gemini-*"],
   "minOpenClawVersion": "0.8.0"
 }


### PR DESCRIPTION
## Summary

- Fix Biome linter formatting violations across multiple packages (line length, import sorting, trailing commas, whitespace)
- Fix TypeScript type error in `babylon-typescript-agent` example where `registerIPFS()` return type changed from `TransactionHandle<RegistrationFile>` to `RegistrationFile` directly, removing the invalid `.waitMined()` call
- No logic changes — all fixes are formatting or type-correctness only

## Changed Files

| File | Change |
|------|--------|
| `apps/cli/src/sentry-bun.d.ts` | Trim trailing whitespace in comments |
| `apps/web/src/app/ticker/TickerClient.tsx` | Biome formatting: reorder CSS classes, collapse single-expression `Math.min/max`, rewrap long line |
| `packages/api/src/auth-middleware.ts` | Sort named imports alphabetically |
| `packages/api/src/__tests__/auth-middleware.test.ts` | Sort named imports alphabetically |
| `packages/examples/babylon-typescript-agent/src/registration.ts` | **Typecheck fix**: remove `.waitMined()` — `registerIPFS()` now returns `RegistrationFile` directly |
| `packages/sim/cli/commands/dev.ts` | Biome formatting: wrap long lines in interface and `consola.info` call |
| `packages/testing/unit/prediction-amm.test.ts` | Biome formatting: wrap long function call |
| `scripts/generate-skills-md.test.ts` | Sort imports, add optional chaining on array access (`result[0]?.id`), format long lines |
| `scripts/generate-skills-md.ts` | Biome formatting: wrap long ternary and function call |
| `scripts/test-unit-isolated.ts` | Biome formatting: expand compressed ternary/map into readable multi-line form |
| `skills/babylon/claw.json` | Collapse single-element arrays onto one line |

## Test Plan

- [x] `bun typecheck` passes (17/17 packages)
- [x] `bun lint` passes with no new warnings
- [x] Existing unit tests still pass (`bun test`)
