### PR TITLE
feat: add open positions preview widget to homepage sidebar

### DIFF
--- a/apps/web/src/app/api/agents/team-chat/coordinator/route.ts
+++ b/apps/web/src/app/api/agents/team-chat/coordinator/route.ts
@@ -68,9 +68,7 @@ export const maxDuration = 120;
  * Verified against: @elizaos/core processActions (line ~48919) and
  * composeState (line ~49200) in node_modules/@elizaos/core/dist/node/index.node.js
  */
-function getRuntimeStateCache(
-  runtime: unknown
-):
+function getRuntimeStateCache(runtime: unknown):
   | Map<
       string,
       {

--- a/apps/web/src/app/api/groups/[groupId]/messages/route.ts
+++ b/apps/web/src/app/api/groups/[groupId]/messages/route.ts
@@ -175,7 +175,7 @@ export const GET = withErrorHandling(
           limit,
           hasMore,
           nextCursor: hasMore
-            ? visibleMessages[visibleMessages.length - 1]?.id ?? null
+            ? (visibleMessages[visibleMessages.length - 1]?.id ?? null)
             : null,
         },
       };

--- a/apps/web/src/app/api/markets/positions/[userId]/route.ts
+++ b/apps/web/src/app/api/markets/positions/[userId]/route.ts
@@ -378,6 +378,7 @@ export const GET = withErrorHandling(
               resolved: market.resolved,
               resolution: market.resolution,
               status: p.status as string,
+              createdAt: p.createdAt?.toISOString() ?? null,
               // Agent position metadata
               isAgentPosition: p.isAgentPosition,
               agentId: p.agentId ?? null,

--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -167,8 +167,8 @@ import {
   type PrivyIdentitySnapshot,
   shouldSyncMissingPrivyIdentity,
 } from '@/lib/auth/privyIdentitySync';
-import { POST as updateProfilePOST } from '../[userId]/update-profile/route';
 import { getOptionalProfileStats } from '@/lib/users/profile-stats';
+import { POST as updateProfilePOST } from '../[userId]/update-profile/route';
 
 type PrivyUserWithWallets = PrivyUser &
   PrivyUserWithEmails &

--- a/apps/web/src/app/feed/FeedClient.tsx
+++ b/apps/web/src/app/feed/FeedClient.tsx
@@ -430,7 +430,7 @@ export function FeedClient() {
         </div>
 
         {/* Widget sidebar - lazy loaded, desktop only */}
-        <WidgetSidebar />
+        <WidgetSidebar showPositions />
       </div>
     </PageContainer>
   );

--- a/apps/web/src/components/feed/PositionsPreviewPanel.tsx
+++ b/apps/web/src/components/feed/PositionsPreviewPanel.tsx
@@ -90,6 +90,31 @@ export function PositionsPreviewPanel() {
   const { getPositionsPreview, setPositionsPreview } = useWidgetCacheStore();
   const { registerRefresh, unregisterRefresh } = useWidgetRefresh();
 
+  useEffect(() => {
+    setExpanded(false);
+    setModalOpen(false);
+    setSelectedPosition(null);
+
+    if (!userId) {
+      setPredictions([]);
+      setPerps([]);
+      setLoading(false);
+      return;
+    }
+
+    const cached = getPositionsPreview(userId);
+    if (cached) {
+      setPredictions(cached.predictions);
+      setPerps(cached.perps);
+      setLoading(false);
+      return;
+    }
+
+    setPredictions([]);
+    setPerps([]);
+    setLoading(true);
+  }, [userId, getPositionsPreview]);
+
   const fetchPositions = useCallback(
     async (skipCache = false) => {
       if (!userId) return;

--- a/apps/web/src/components/feed/PositionsPreviewPanel.tsx
+++ b/apps/web/src/components/feed/PositionsPreviewPanel.tsx
@@ -1,0 +1,357 @@
+'use client';
+
+import type { PerpPositionFromAPI, PredictionPosition } from '@babylon/shared';
+import { BABYLON_POINTS_SYMBOL, cn, logger } from '@babylon/shared';
+import {
+  ChevronDown,
+  ChevronUp,
+  TrendingDown,
+  TrendingUp,
+  Wallet,
+} from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
+import { PositionDetailModal } from '@/components/profile/PositionDetailModal';
+import { Skeleton } from '@/components/shared/Skeleton';
+import { useWidgetRefresh } from '@/contexts/WidgetRefreshContext';
+import { useAuth } from '@/hooks/useAuth';
+import { useWidgetCacheStore } from '@/stores/widgetCacheStore';
+
+const PREVIEW_COUNT = 3;
+
+const formatPoints = (points: number) =>
+  points.toLocaleString('en-US', { maximumFractionDigits: 0 });
+
+const formatPercent = (value: number) =>
+  `${value >= 0 ? '+' : ''}${value.toFixed(1)}%`;
+
+const formatPrice = (price: number) =>
+  `${BABYLON_POINTS_SYMBOL}${price.toFixed(2)}`;
+
+function toNumber(value: unknown, fallback = 0): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+  return fallback;
+}
+
+/** Unified position item for sorting by timestamp */
+interface PositionItem {
+  type: 'perp' | 'prediction';
+  data: PerpPositionFromAPI | PredictionPosition;
+  openedAt: string; // ISO timestamp for sorting
+}
+
+function buildSortedPositions(
+  perps: PerpPositionFromAPI[],
+  predictions: PredictionPosition[]
+): PositionItem[] {
+  const items: PositionItem[] = [
+    ...perps.map((p) => ({
+      type: 'perp' as const,
+      data: p,
+      openedAt: p.openedAt,
+    })),
+    ...predictions
+      .filter((p) => !p.resolved)
+      .map((p) => ({
+        type: 'prediction' as const,
+        data: p,
+        openedAt: p.createdAt ?? new Date(0).toISOString(),
+      })),
+  ];
+  items.sort(
+    (a, b) => new Date(b.openedAt).getTime() - new Date(a.openedAt).getTime()
+  );
+  return items;
+}
+
+export function PositionsPreviewPanel() {
+  const router = useRouter();
+  const { user } = useAuth();
+  const userId = user?.id;
+
+  const [predictions, setPredictions] = useState<PredictionPosition[]>([]);
+  const [perps, setPerps] = useState<PerpPositionFromAPI[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [expanded, setExpanded] = useState(false);
+
+  // Modal state
+  const [modalOpen, setModalOpen] = useState(false);
+  const [modalType, setModalType] = useState<'prediction' | 'perp'>(
+    'prediction'
+  );
+  const [selectedPosition, setSelectedPosition] = useState<
+    PredictionPosition | PerpPositionFromAPI | null
+  >(null);
+
+  const { getPositionsPreview, setPositionsPreview } = useWidgetCacheStore();
+  const { registerRefresh, unregisterRefresh } = useWidgetRefresh();
+
+  const fetchPositions = useCallback(
+    async (skipCache = false) => {
+      if (!userId) return;
+
+      if (!skipCache) {
+        const cached = getPositionsPreview(userId);
+        if (cached) {
+          setPredictions(cached.predictions);
+          setPerps(cached.perps);
+          setLoading(false);
+          return;
+        }
+      }
+
+      try {
+        const response = await fetch(
+          `/api/markets/positions/${encodeURIComponent(userId)}`
+        );
+        if (!response.ok) {
+          logger.error(
+            'Failed to fetch positions for preview',
+            { status: response.status },
+            'PositionsPreviewPanel'
+          );
+          setLoading(false);
+          return;
+        }
+
+        const data = await response.json();
+        const fetchedPerps: PerpPositionFromAPI[] = (
+          data?.perpetuals?.positions ?? []
+        ).map((p: Record<string, unknown>) => ({
+          id: p.id as string,
+          ticker: p.ticker as string,
+          side: p.side as 'long' | 'short',
+          entryPrice: toNumber(p.entryPrice),
+          currentPrice: toNumber(p.currentPrice),
+          size: toNumber(p.size),
+          leverage: toNumber(p.leverage),
+          unrealizedPnL: toNumber(p.unrealizedPnL),
+          unrealizedPnLPercent: toNumber(p.unrealizedPnLPercent),
+          liquidationPrice: toNumber(p.liquidationPrice),
+          fundingPaid: toNumber(p.fundingPaid),
+          openedAt: p.openedAt as string,
+        }));
+
+        const fetchedPredictions: PredictionPosition[] = (
+          data?.predictions?.positions ?? []
+        ).map((p: Record<string, unknown>) => ({
+          id: p.id as string,
+          marketId: p.marketId as string,
+          question: p.question as string,
+          side: p.side as 'YES' | 'NO',
+          shares: toNumber(p.shares),
+          avgPrice: toNumber(p.avgPrice),
+          currentPrice: toNumber(p.currentPrice),
+          currentProbability: toNumber(p.currentProbability),
+          currentValue: toNumber(p.currentValue),
+          costBasis: toNumber(p.costBasis),
+          unrealizedPnL: toNumber(p.unrealizedPnL),
+          resolved: p.resolved as boolean,
+          resolution: p.resolution as boolean | null | undefined,
+          status: p.status as string | undefined,
+          createdAt: p.createdAt as string | undefined,
+        }));
+
+        setPredictions(fetchedPredictions);
+        setPerps(fetchedPerps);
+        setPositionsPreview(userId, {
+          predictions: fetchedPredictions,
+          perps: fetchedPerps,
+        });
+      } catch (err) {
+        logger.error(
+          'Error fetching positions preview',
+          err instanceof Error ? err : { error: err },
+          'PositionsPreviewPanel'
+        );
+      } finally {
+        setLoading(false);
+      }
+    },
+    [userId, getPositionsPreview, setPositionsPreview]
+  );
+
+  useEffect(() => {
+    if (!userId) {
+      setLoading(false);
+      return;
+    }
+    fetchPositions();
+
+    const interval = setInterval(() => fetchPositions(true), 30000);
+    return () => clearInterval(interval);
+  }, [userId, fetchPositions]);
+
+  // Register with WidgetRefreshContext for pull-to-refresh
+  useEffect(() => {
+    const refresh = () => fetchPositions(true);
+    registerRefresh('positions-preview', refresh);
+    return () => unregisterRefresh('positions-preview');
+  }, [registerRefresh, unregisterRefresh, fetchPositions]);
+
+  const sortedPositions = buildSortedPositions(perps, predictions);
+
+  // Don't render if not authenticated or no positions
+  if (!userId || (!loading && sortedPositions.length === 0)) {
+    return null;
+  }
+
+  const displayPositions = expanded
+    ? sortedPositions
+    : sortedPositions.slice(0, PREVIEW_COUNT);
+  const hasMore = sortedPositions.length > PREVIEW_COUNT;
+
+  const handlePositionClick = (item: PositionItem) => {
+    setSelectedPosition(item.data);
+    setModalType(item.type);
+    setModalOpen(true);
+  };
+
+  return (
+    <div className="flex flex-col">
+      <div className="mb-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Wallet className="h-4 w-4 text-primary" />
+          <h2 className="font-bold text-foreground text-lg">Open Positions</h2>
+        </div>
+        {hasMore && (
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="flex items-center gap-1 text-muted-foreground text-xs transition-colors hover:text-foreground"
+          >
+            {expanded ? (
+              <>
+                Show less
+                <ChevronUp className="h-3 w-3" />
+              </>
+            ) : (
+              <>
+                See more
+                <ChevronDown className="h-3 w-3" />
+              </>
+            )}
+          </button>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="space-y-2">
+          <Skeleton className="h-14 w-full" />
+          <Skeleton className="h-14 w-full" />
+          <Skeleton className="h-14 w-full" />
+        </div>
+      ) : (
+        <>
+          <div className="space-y-1">
+            {displayPositions.map((item) => {
+              if (item.type === 'perp') {
+                const perp = item.data as PerpPositionFromAPI;
+                return (
+                  <button
+                    key={`perp-${perp.id}`}
+                    onClick={() => handlePositionClick(item)}
+                    className="-mx-2 w-[calc(100%+16px)] rounded-lg px-2 py-2 text-left transition-colors hover:bg-muted/30"
+                  >
+                    <div className="flex items-center gap-1.5">
+                      <span className="font-medium text-foreground text-sm">
+                        {perp.ticker}
+                      </span>
+                      <span
+                        className={cn(
+                          'text-xs',
+                          perp.side === 'long'
+                            ? 'text-green-500'
+                            : 'text-red-500'
+                        )}
+                      >
+                        {perp.side === 'long' ? 'Long' : 'Short'}
+                      </span>
+                      {perp.unrealizedPnLPercent >= 0 ? (
+                        <TrendingUp className="h-3 w-3 text-green-500" />
+                      ) : (
+                        <TrendingDown className="h-3 w-3 text-red-500" />
+                      )}
+                    </div>
+                    <div className="mt-0.5 flex items-center justify-between">
+                      <span className="text-muted-foreground text-xs">
+                        {formatPoints(perp.size)} pts @{' '}
+                        {formatPrice(perp.entryPrice)}
+                      </span>
+                      <span
+                        className={cn(
+                          'font-medium text-xs',
+                          perp.unrealizedPnL >= 0
+                            ? 'text-green-500'
+                            : 'text-red-500'
+                        )}
+                      >
+                        {formatPoints(perp.unrealizedPnL)} pts (
+                        {formatPercent(perp.unrealizedPnLPercent)})
+                      </span>
+                    </div>
+                  </button>
+                );
+              }
+
+              const pred = item.data as PredictionPosition;
+              const pnlPct =
+                pred.avgPrice > 0
+                  ? ((pred.currentPrice - pred.avgPrice) / pred.avgPrice) * 100
+                  : 0;
+              return (
+                <button
+                  key={`pred-${pred.id}`}
+                  onClick={() => handlePositionClick(item)}
+                  className="-mx-2 w-[calc(100%+16px)] rounded-lg px-2 py-2 text-left transition-colors hover:bg-muted/30"
+                >
+                  <div className="truncate font-medium text-foreground text-sm">
+                    {pred.question}
+                  </div>
+                  <div className="mt-0.5 flex items-center justify-between">
+                    <span className="text-muted-foreground text-xs">
+                      {pred.shares} shares {pred.side} @{' '}
+                      {formatPrice(pred.avgPrice)}
+                    </span>
+                    <span
+                      className={cn(
+                        'font-medium text-xs',
+                        pnlPct >= 0 ? 'text-green-500' : 'text-red-500'
+                      )}
+                    >
+                      {formatPercent(pnlPct)}
+                    </span>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+
+          <button
+            onClick={() => router.push('/markets')}
+            className="mt-3 w-full rounded-lg border border-border py-2 text-center text-muted-foreground text-sm transition-colors hover:bg-muted/30 hover:text-foreground"
+          >
+            View Positions
+          </button>
+        </>
+      )}
+
+      <PositionDetailModal
+        isOpen={modalOpen}
+        onClose={() => {
+          setModalOpen(false);
+          setSelectedPosition(null);
+        }}
+        type={modalType}
+        data={selectedPosition}
+        userId={userId}
+        onSuccess={() => {
+          void fetchPositions(true);
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/shared/WidgetSidebar.tsx
+++ b/apps/web/src/components/shared/WidgetSidebar.tsx
@@ -32,7 +32,7 @@ interface WidgetSidebarProps {
  * @returns Widget sidebar element (hidden on screens < XL)
  */
 export function WidgetSidebar({
-  showPositions = true,
+  showPositions = false,
   showLatestNews = true,
   showTrending = true,
   showMarkets = true,

--- a/apps/web/src/components/shared/WidgetSidebar.tsx
+++ b/apps/web/src/components/shared/WidgetSidebar.tsx
@@ -4,9 +4,11 @@ import { useEffect, useRef, useState } from 'react';
 import { EntitySearchAutocomplete } from '@/components/explore/EntitySearchAutocomplete';
 import { LatestNewsPanel } from '@/components/feed/LatestNewsPanel';
 import { MarketsPanel } from '@/components/feed/MarketsPanel';
+import { PositionsPreviewPanel } from '@/components/feed/PositionsPreviewPanel';
 import { TrendingPanel } from '@/components/feed/TrendingPanel';
 
 interface WidgetSidebarProps {
+  showPositions?: boolean;
   showLatestNews?: boolean;
   showTrending?: boolean;
   showMarkets?: boolean;
@@ -30,6 +32,7 @@ interface WidgetSidebarProps {
  * @returns Widget sidebar element (hidden on screens < XL)
  */
 export function WidgetSidebar({
+  showPositions = true,
   showLatestNews = true,
   showTrending = true,
   showMarkets = true,
@@ -150,6 +153,12 @@ export function WidgetSidebar({
             searchType="users"
           />
         </div>
+
+        {showPositions && (
+          <div className="flex-shrink-0">
+            <PositionsPreviewPanel />
+          </div>
+        )}
 
         {showLatestNews && (
           <div className="flex-shrink-0">

--- a/apps/web/src/stores/userPositionsStore.ts
+++ b/apps/web/src/stores/userPositionsStore.ts
@@ -125,6 +125,7 @@ interface ApiPredictionPositionPayload {
   resolved?: boolean;
   resolution?: boolean | null;
   status?: string;
+  createdAt?: string;
   // Agent position metadata
   isAgentPosition?: boolean;
   agentId?: string | null;
@@ -186,6 +187,7 @@ function normalizePredictionPosition(
     resolved: raw.resolved ?? false,
     resolution: raw.resolution ?? null,
     status: raw.status,
+    createdAt: raw.createdAt ?? undefined,
     // Agent position metadata
     isAgentPosition: raw.isAgentPosition ?? false,
     agentId: raw.agentId ?? undefined,

--- a/apps/web/src/stores/widgetCacheStore.ts
+++ b/apps/web/src/stores/widgetCacheStore.ts
@@ -101,6 +101,11 @@ interface ProfileWidgetData {
   stats: UserProfileStats | null;
 }
 
+export interface PositionsPreviewData {
+  predictions: PredictionPosition[];
+  perps: PerpPositionFromAPI[];
+}
+
 interface CacheEntry<T> {
   data: T;
   timestamp: number;
@@ -115,6 +120,7 @@ interface WidgetCacheState {
   markets: CacheEntry<MarketsWidgetData> | null;
   profileWidget: Map<string, CacheEntry<ProfileWidgetData>>; // Keyed by userId
   reputationWidget: Map<string, CacheEntry<A2AReputationResponse>>; // Keyed by userId
+  positionsPreview: Map<string, CacheEntry<PositionsPreviewData>>; // Keyed by userId
 
   // TTL in milliseconds (default: 30 seconds)
   ttl: number;
@@ -128,6 +134,7 @@ interface WidgetCacheState {
   setMarkets: (data: MarketsWidgetData) => void;
   setProfileWidget: (userId: string, data: ProfileWidgetData) => void;
   setReputationWidget: (userId: string, data: A2AReputationResponse) => void;
+  setPositionsPreview: (userId: string, data: PositionsPreviewData) => void;
 
   // Get cache entry (returns null if stale or missing)
   getBreakingNews: () => BreakingNewsItem[] | null;
@@ -138,6 +145,7 @@ interface WidgetCacheState {
   getMarkets: () => MarketsWidgetData | null;
   getProfileWidget: (userId: string) => ProfileWidgetData | null;
   getReputationWidget: (userId: string) => A2AReputationResponse | null;
+  getPositionsPreview: (userId: string) => PositionsPreviewData | null;
 
   // Check if cache is fresh
   isFresh: <T>(entry: CacheEntry<T> | null) => boolean;
@@ -151,6 +159,7 @@ interface WidgetCacheState {
   clearMarkets: () => void;
   clearProfileWidget: (userId: string) => void;
   clearReputationWidget: (userId: string) => void;
+  clearPositionsPreview: (userId: string) => void;
   clearAll: () => void;
 }
 
@@ -165,6 +174,7 @@ export const useWidgetCacheStore = create<WidgetCacheState>((set, get) => ({
   markets: null,
   profileWidget: new Map(),
   reputationWidget: new Map(),
+  positionsPreview: new Map(),
   ttl: DEFAULT_TTL,
 
   isFresh: <T>(entry: CacheEntry<T> | null) => {
@@ -245,6 +255,15 @@ export const useWidgetCacheStore = create<WidgetCacheState>((set, get) => ({
     set({ reputationWidget });
   },
 
+  setPositionsPreview: (userId: string, data: PositionsPreviewData) => {
+    const positionsPreview = new Map(get().positionsPreview);
+    positionsPreview.set(userId, {
+      data,
+      timestamp: Date.now(),
+    });
+    set({ positionsPreview });
+  },
+
   getBreakingNews: () => {
     const entry = get().breakingNews;
     return entry && get().isFresh(entry) ? entry.data : null;
@@ -287,6 +306,12 @@ export const useWidgetCacheStore = create<WidgetCacheState>((set, get) => ({
     return entry && get().isFresh(entry) ? entry.data : null;
   },
 
+  getPositionsPreview: (userId: string) => {
+    const positionsPreview = get().positionsPreview;
+    const entry = positionsPreview.get(userId);
+    return entry && get().isFresh(entry) ? entry.data : null;
+  },
+
   clearBreakingNews: () => set({ breakingNews: null }),
   clearLatestNews: () => set({ latestNews: null }),
   clearUpcomingEvents: () => set({ upcomingEvents: null }),
@@ -303,6 +328,11 @@ export const useWidgetCacheStore = create<WidgetCacheState>((set, get) => ({
     reputationWidget.delete(userId);
     set({ reputationWidget });
   },
+  clearPositionsPreview: (userId: string) => {
+    const positionsPreview = new Map(get().positionsPreview);
+    positionsPreview.delete(userId);
+    set({ positionsPreview });
+  },
   clearAll: () =>
     set({
       breakingNews: null,
@@ -313,5 +343,6 @@ export const useWidgetCacheStore = create<WidgetCacheState>((set, get) => ({
       markets: null,
       profileWidget: new Map(),
       reputationWidget: new Map(),
+      positionsPreview: new Map(),
     }),
 }));

--- a/packages/shared/src/types/profile.ts
+++ b/packages/shared/src/types/profile.ts
@@ -60,6 +60,8 @@ export interface PredictionPosition {
   resolution?: boolean | null;
   /** Position status: active, closed, resolved, cancelled */
   status?: string;
+  /** ISO timestamp of when the position was opened */
+  createdAt?: string;
   // Agent position metadata (optional)
   /** True if this position belongs to an agent */
   isAgentPosition?: boolean;


### PR DESCRIPTION
## Summary

- Add a desktop-only widget to the homepage sidebar that shows the user's 3 most recent open positions (perps + predictions), sorted by timestamp
- Positions are expandable inline ("See more"), clickable to open a detail/trade modal, and link through to the full markets/positions view
- Expose `createdAt` on prediction positions API so both position types can be sorted by recency

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: ...

## Context / Links

- BAB-251 (wallet implementation)
- Workshop note: "latest open position should be there in the preview... three... click to get into the wallet or see more and it opens down more"
- Mobile: no wallet preview, wallet is in navigation only

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [x] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: ...

**Non-goals / follow-ups**
- Deep-link to positions tab (`/markets?tab=positions`) — not yet supported
- Consolidate `userPositionsStore` singleton userId design — pre-existing issue, separate ticket
- SSE real-time position updates in the preview — can be added later

## Changes

- **`apps/web/src/components/feed/PositionsPreviewPanel.tsx`** (new) — Widget component. Fetches positions directly from API (avoids `userPositionsStore` singleton conflict). Caches via `widgetCacheStore`. Auto-refreshes every 30s. Registers with `WidgetRefreshContext`.
- **`apps/web/src/components/shared/WidgetSidebar.tsx`** — Added `showPositions` prop (default `true`), renders `PositionsPreviewPanel` after search and before news.
- **`apps/web/src/stores/widgetCacheStore.ts`** — Added `PositionsPreviewData` type and `positionsPreview` cache (Map keyed by userId, 30s TTL).
- **`apps/web/src/stores/userPositionsStore.ts`** — Added `createdAt` to `ApiPredictionPositionPayload` and normalizer pass-through.
- **`packages/shared/src/types/profile.ts`** — Added `createdAt?: string` to `PredictionPosition`.
- **`apps/web/src/app/api/markets/positions/[userId]/route.ts`** — Added `createdAt` to prediction position API response.

## Review guide

**Start here**
- `apps/web/src/components/feed/PositionsPreviewPanel.tsx` — the main new component

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- The widget fetches directly from `/api/markets/positions/{userId}` with its own local state, deliberately avoiding the global `userPositionsStore`. This prevents a known singleton conflict where navigating to another page that uses the store with a different userId wipes cached data.
- The widget returns `null` (renders nothing) when the user is not authenticated or has no open positions — no empty card clutter.
- `PositionDetailModal` was verified to be fully portable (no ProfileWidget or profile-context dependencies).

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**

### 1. Widget visibility (desktop only)
1. Open the app on a desktop browser (viewport >= 1280px)
2. Log in with a user that has open positions (perps and/or predictions)
3. Navigate to the homepage (feed)
4. Verify the **"Open Positions"** widget appears in the right sidebar, between search and "Latest News"
5. Resize the browser below 1280px — widget sidebar should disappear entirely

### 2. Position display and sorting
1. Verify up to 3 positions are shown by default
2. Verify positions are sorted newest-first (check `openedAt` for perps, `createdAt` for predictions)
3. Verify perp rows show: ticker, Long/Short badge (green/red), trending icon, size, entry price, PnL with color
4. Verify prediction rows show: question (truncated), shares count, side (YES/NO), avg price, PnL % with color

### 3. Expand/collapse
1. If the user has more than 3 positions, verify the **"See more"** button appears in the header
2. Click "See more" — all positions should appear inline, button text changes to **"Show less"**
3. Click "Show less" — collapses back to 3
4. If the user has 3 or fewer positions, verify no "See more" button is shown

### 4. Position detail modal
1. Click any position row
2. Verify the `PositionDetailModal` opens with correct data (matching the clicked position)
3. For perps: verify trade actions (close position) work and the widget refreshes after
4. For predictions: verify trade actions work and the widget refreshes after
5. Close the modal — verify it dismisses cleanly

### 5. "View Positions" link
1. Click the **"View Positions"** button at the bottom of the widget
2. Verify it navigates to `/markets`

### 6. Empty / unauthenticated states
1. Log out — verify the widget does not render at all (no empty card)
2. Log in with a user that has zero open positions — verify the widget does not render
3. Open a position, return to feed — widget should appear on next refresh cycle (up to 30s)

### 7. Caching and refresh
1. Open the feed, note positions displayed
2. Navigate away (e.g., to a profile page), then return to feed
3. Verify positions load instantly from cache (no loading skeleton flash for < 30s round-trip)
4. Wait 30s or pull-to-refresh — verify data updates
5. Open a trade via the modal, close it — verify the widget refreshes immediately via `onSuccess`

### 8. No interference with other pages
1. Open the feed (widget fetches positions for current user)
2. Navigate to `/markets` — verify the positions tab still works correctly
3. Navigate to another user's profile — verify their ProfileWidget shows their data, not yours
4. Return to feed — verify your positions still display correctly in the widget

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

The widget only fetches the current user's own positions via the existing `/api/markets/positions/{userId}` endpoint which already applies RLS. No new endpoints or auth changes.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate -> service -> map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [ ] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
