### PR TITLE
fix(auth): migrate legacy babylon-auth persisted state

### DIFF
--- a/apps/web/src/stores/authStore.ts
+++ b/apps/web/src/stores/authStore.ts
@@ -97,34 +97,89 @@ interface AuthState {
   clearAuth: () => void;
 }
 
+type PersistedAuthState = Pick<
+  AuthState,
+  | 'user'
+  | 'wallet'
+  | 'loadedUserId'
+  | 'isLoadingProfile'
+  | 'needsOnboarding'
+  | 'needsOnchain'
+>;
+
+function createInitialAuthState(): PersistedAuthState {
+  return {
+    user: null,
+    wallet: null,
+    loadedUserId: null,
+    isLoadingProfile: false,
+    needsOnboarding: false,
+    needsOnchain: false,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isPersistedUser(value: unknown): value is User {
+  return (
+    isRecord(value) &&
+    typeof value.id === 'string' &&
+    typeof value.displayName === 'string'
+  );
+}
+
+function isPersistedWallet(value: unknown): value is Wallet {
+  return (
+    isRecord(value) &&
+    typeof value.address === 'string' &&
+    typeof value.chainId === 'string'
+  );
+}
+
+export function migrateAuthStoreState(
+  persistedState: unknown,
+  version: number
+): PersistedAuthState {
+  const initialState = createInitialAuthState();
+
+  if (version > 1 || !isRecord(persistedState)) {
+    return initialState;
+  }
+
+  return {
+    user: isPersistedUser(persistedState.user) ? persistedState.user : null,
+    wallet: isPersistedWallet(persistedState.wallet)
+      ? persistedState.wallet
+      : null,
+    loadedUserId:
+      typeof persistedState.loadedUserId === 'string'
+        ? persistedState.loadedUserId
+        : null,
+    // Loading state is ephemeral and should not survive a page refresh.
+    isLoadingProfile: false,
+    needsOnboarding: persistedState.needsOnboarding === true,
+    needsOnchain: persistedState.needsOnchain === true,
+  };
+}
+
 export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({
-      user: null,
-      wallet: null,
-      loadedUserId: null,
-      isLoadingProfile: false,
-      needsOnboarding: false,
-      needsOnchain: false,
+      ...createInitialAuthState(),
       setUser: (user) => set({ user }),
       setWallet: (wallet) => set({ wallet }),
       setLoadedUserId: (userId) => set({ loadedUserId: userId }),
       setIsLoadingProfile: (loading) => set({ isLoadingProfile: loading }),
       setNeedsOnboarding: (needsOnboarding) => set({ needsOnboarding }),
       setNeedsOnchain: (needsOnchain) => set({ needsOnchain }),
-      clearAuth: () =>
-        set({
-          user: null,
-          wallet: null,
-          loadedUserId: null,
-          isLoadingProfile: false,
-          needsOnboarding: false,
-          needsOnchain: false,
-        }),
+      clearAuth: () => set(createInitialAuthState()),
     }),
     {
       name: 'babylon-auth',
       version: 2, // Increment this to invalidate old cached data
+      migrate: migrateAuthStoreState,
     }
   )
 );

--- a/apps/web/src/stores/authStore.ts
+++ b/apps/web/src/stores/authStore.ts
@@ -107,6 +107,8 @@ type PersistedAuthState = Pick<
   | 'needsOnchain'
 >;
 
+const CURRENT_AUTH_STORE_VERSION = 2;
+
 function createInitialAuthState(): PersistedAuthState {
   return {
     user: null,
@@ -144,7 +146,13 @@ export function migrateAuthStoreState(
 ): PersistedAuthState {
   const initialState = createInitialAuthState();
 
-  if (version > 1 || !isRecord(persistedState)) {
+  if (!isRecord(persistedState)) {
+    return initialState;
+  }
+
+  // Migrate only legacy payloads written before the current v2 schema.
+  // Unknown future versions should fall back to the initial state instead.
+  if (version !== 0 && version !== 1) {
     return initialState;
   }
 
@@ -178,7 +186,9 @@ export const useAuthStore = create<AuthState>()(
     }),
     {
       name: 'babylon-auth',
-      version: 2, // Increment this to invalidate old cached data
+      // Bumping this triggers migrateAuthStoreState. Update the accepted
+      // legacy versions above when the persisted schema changes again.
+      version: CURRENT_AUTH_STORE_VERSION,
       migrate: migrateAuthStoreState,
     }
   )

--- a/changelogs/BAB-260--auth-store-migration.md
+++ b/changelogs/BAB-260--auth-store-migration.md
@@ -1,0 +1,8 @@
+**PR:** https://github.com/BabylonSocial/babylon/pull/1237
+**Linear:** [BAB-260](https://linear.app/eliza-labs/issue/BAB-260)
+
+### Auth Store Migration for Legacy Sessions
+- Stop the recurring client-side hydration error caused by older persisted `babylon-auth` payloads.
+- Preserve safe auth session data for returning users instead of dropping the whole store on version mismatch.
+- Reset transient loading state during migration so refreshed sessions do not keep stale in-flight UI flags.
+- Add focused unit coverage for legacy, malformed, and unsupported persisted auth payloads.

--- a/packages/testing/unit/auth-store-migration.test.ts
+++ b/packages/testing/unit/auth-store-migration.test.ts
@@ -35,37 +35,6 @@ beforeEach(() => {
 });
 
 describe('migrateAuthStoreState', () => {
-  test('migrates version 0 auth payloads with the same legacy fallback path', () => {
-    const migrated = migrateAuthStoreState(
-      {
-        user: {
-          id: 'did:privy:test-user',
-          displayName: 'Test User',
-        },
-        wallet: {
-          address: '0x123',
-          chainId: 'eip155:8453',
-        },
-      },
-      0
-    );
-
-    expect(migrated).toEqual({
-      user: {
-        id: 'did:privy:test-user',
-        displayName: 'Test User',
-      },
-      wallet: {
-        address: '0x123',
-        chainId: 'eip155:8453',
-      },
-      loadedUserId: null,
-      isLoadingProfile: false,
-      needsOnboarding: false,
-      needsOnchain: false,
-    });
-  });
-
   test('migrates persisted auth data from legacy versions without keeping loading state', () => {
     const migrated = migrateAuthStoreState(
       {

--- a/packages/testing/unit/auth-store-migration.test.ts
+++ b/packages/testing/unit/auth-store-migration.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+const storage = new Map<string, string>();
+
+const storageMock = {
+  getItem(key: string) {
+    return storage.get(key) ?? null;
+  },
+  setItem(key: string, value: string) {
+    storage.set(key, value);
+  },
+  removeItem(key: string) {
+    storage.delete(key);
+  },
+  clear() {
+    storage.clear();
+  },
+  key(index: number) {
+    return Array.from(storage.keys())[index] ?? null;
+  },
+  get length() {
+    return storage.size;
+  },
+};
+
+Object.defineProperty(globalThis, 'localStorage', {
+  value: storageMock,
+  configurable: true,
+});
+
+const { migrateAuthStoreState } = await import('@/stores/authStore');
+
+beforeEach(() => {
+  storage.clear();
+});
+
+describe('migrateAuthStoreState', () => {
+  test('migrates persisted auth data from legacy versions without keeping loading state', () => {
+    const migrated = migrateAuthStoreState(
+      {
+        user: {
+          id: 'did:privy:test-user',
+          displayName: 'Test User',
+          username: 'test-user',
+        },
+        wallet: {
+          address: '0x123',
+          chainId: 'eip155:8453',
+        },
+        loadedUserId: 'did:privy:test-user',
+        isLoadingProfile: true,
+        needsOnboarding: true,
+        needsOnchain: true,
+      },
+      1
+    );
+
+    expect(migrated).toEqual({
+      user: {
+        id: 'did:privy:test-user',
+        displayName: 'Test User',
+        username: 'test-user',
+      },
+      wallet: {
+        address: '0x123',
+        chainId: 'eip155:8453',
+      },
+      loadedUserId: 'did:privy:test-user',
+      isLoadingProfile: false,
+      needsOnboarding: true,
+      needsOnchain: true,
+    });
+  });
+
+  test('falls back to the default state for malformed persisted payloads', () => {
+    expect(migrateAuthStoreState('invalid', 1)).toEqual({
+      user: null,
+      wallet: null,
+      loadedUserId: null,
+      isLoadingProfile: false,
+      needsOnboarding: false,
+      needsOnchain: false,
+    });
+  });
+
+  test('drops unsupported future-version payloads instead of hydrating unknown state', () => {
+    const migrated = migrateAuthStoreState(
+      {
+        user: {
+          id: 'did:privy:test-user',
+          displayName: 'Test User',
+        },
+        needsOnboarding: true,
+      },
+      3
+    );
+
+    expect(migrated).toEqual({
+      user: null,
+      wallet: null,
+      loadedUserId: null,
+      isLoadingProfile: false,
+      needsOnboarding: false,
+      needsOnchain: false,
+    });
+  });
+});

--- a/packages/testing/unit/auth-store-migration.test.ts
+++ b/packages/testing/unit/auth-store-migration.test.ts
@@ -83,6 +83,70 @@ describe('migrateAuthStoreState', () => {
     });
   });
 
+  test('migrates version 0 payloads (no version ever set)', () => {
+    const migrated = migrateAuthStoreState(
+      {
+        user: {
+          id: 'did:privy:test-user',
+          displayName: 'Test User',
+        },
+        wallet: {
+          address: '0xabc',
+          chainId: 'eip155:1',
+        },
+        needsOnboarding: true,
+      },
+      0
+    );
+
+    expect(migrated).toEqual({
+      user: {
+        id: 'did:privy:test-user',
+        displayName: 'Test User',
+      },
+      wallet: {
+        address: '0xabc',
+        chainId: 'eip155:1',
+      },
+      loadedUserId: null,
+      isLoadingProfile: false,
+      needsOnboarding: true,
+      needsOnchain: false,
+    });
+  });
+
+  test('returns null for user missing required displayName', () => {
+    const migrated = migrateAuthStoreState(
+      {
+        user: { id: 'did:privy:test-user' },
+        wallet: { address: '0x123', chainId: 'eip155:8453' },
+      },
+      1
+    );
+
+    expect(migrated.user).toBeNull();
+    expect(migrated.wallet).toEqual({
+      address: '0x123',
+      chainId: 'eip155:8453',
+    });
+  });
+
+  test('returns null for wallet missing required chainId', () => {
+    const migrated = migrateAuthStoreState(
+      {
+        user: { id: 'did:privy:test-user', displayName: 'Test' },
+        wallet: { address: '0x123' },
+      },
+      1
+    );
+
+    expect(migrated.user).toEqual({
+      id: 'did:privy:test-user',
+      displayName: 'Test',
+    });
+    expect(migrated.wallet).toBeNull();
+  });
+
   test('drops unsupported future-version payloads instead of hydrating unknown state', () => {
     const migrated = migrateAuthStoreState(
       {

--- a/packages/testing/unit/auth-store-migration.test.ts
+++ b/packages/testing/unit/auth-store-migration.test.ts
@@ -35,6 +35,37 @@ beforeEach(() => {
 });
 
 describe('migrateAuthStoreState', () => {
+  test('migrates version 0 auth payloads with the same legacy fallback path', () => {
+    const migrated = migrateAuthStoreState(
+      {
+        user: {
+          id: 'did:privy:test-user',
+          displayName: 'Test User',
+        },
+        wallet: {
+          address: '0x123',
+          chainId: 'eip155:8453',
+        },
+      },
+      0
+    );
+
+    expect(migrated).toEqual({
+      user: {
+        id: 'did:privy:test-user',
+        displayName: 'Test User',
+      },
+      wallet: {
+        address: '0x123',
+        chainId: 'eip155:8453',
+      },
+      loadedUserId: null,
+      isLoadingProfile: false,
+      needsOnboarding: false,
+      needsOnchain: false,
+    });
+  });
+
   test('migrates persisted auth data from legacy versions without keeping loading state', () => {
     const migrated = migrateAuthStoreState(
       {
@@ -115,7 +146,7 @@ describe('migrateAuthStoreState', () => {
     });
   });
 
-  test('returns null for user missing required displayName', () => {
+  test('drops partial user objects that do not satisfy the persisted user guard', () => {
     const migrated = migrateAuthStoreState(
       {
         user: { id: 'did:privy:test-user' },
@@ -131,7 +162,7 @@ describe('migrateAuthStoreState', () => {
     });
   });
 
-  test('returns null for wallet missing required chainId', () => {
+  test('drops partial wallet objects that do not satisfy the persisted wallet guard', () => {
     const migrated = migrateAuthStoreState(
       {
         user: { id: 'did:privy:test-user', displayName: 'Test' },


### PR DESCRIPTION
## Summary

- Add a Zustand `migrate` handler for `babylon-auth` so legacy persisted auth payloads no longer trigger the version-mismatch hydration error.
- Preserve safe auth data during migration while resetting transient loading state on refresh.
- Add focused unit coverage for legacy, malformed, and unsupported persisted payloads.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-260/bugauth-handle-persisted-store-version-mismatch-for-babylon-auth
- Sentry: https://eliza-uv.sentry.io/issues/7308913249/

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- Reuse a shared initial auth state so `clearAuth` and persisted hydration fall back to the same defaults.
- Migrate legacy `babylon-auth` payloads instead of dropping them when the persisted version is older than the current store version.
- Reset `isLoadingProfile` during migration so transient loading state is never carried across page reloads.
- Add a unit test that covers legacy migration, malformed payload fallback, and unsupported future-version invalidation.

## Review guide

**Start here**
- `apps/web/src/stores/authStore.ts`
- `packages/testing/unit/auth-store-migration.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- Non-goal: this PR does not change the current persisted key or broaden the persisted auth surface.
- The migration only preserves fields already used by the current auth store and deliberately resets ephemeral loading state.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Run `bunx biome check --write apps/web/src/stores/authStore.ts packages/testing/unit/auth-store-migration.test.ts`.
2. Run `bun test packages/testing/unit/auth-store-migration.test.ts packages/testing/unit/logout.test.ts --preload ./packages/testing/unit/preload.ts`.
3. Run `bunx tsc -p apps/web/tsconfig.typecheck.json --noEmit` and note the existing unrelated workspace failure: `apps/web/src/components/ui/context-menu.tsx` cannot resolve `@radix-ui/react-context-menu` in this environment.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: deploy normally.
- Rollback: revert this PR to restore the previous hydration behavior.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Client-side persisted auth store migration only; no UI or visual behavior changes.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
