### PR TITLE
fix(web): batch leaderboard follow states

### DIFF
--- a/apps/web/src/app/api/leaderboard/route.ts
+++ b/apps/web/src/app/api/leaderboard/route.ts
@@ -51,6 +51,7 @@ import {
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
+import { and, db, eq, follows, inArray } from '@babylon/db';
 import { logger } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 import { parseLeaderboardQuery } from './query';
@@ -136,6 +137,38 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     }
   }
 
+  const authUserId = authUser?.dbUserId ?? authUser?.userId;
+  const canResolveFollowingUserIds =
+    authUserId !== undefined && (!userId || userId === authUserId);
+  let followingUserIdsResolved = false;
+  let followingUserIds: string[] = [];
+
+  if (canResolveFollowingUserIds) {
+    const leaderboardUserIds = leaderboardData.users
+      .map((entry) => entry.id)
+      .filter((id) => id !== authUserId);
+
+    if (leaderboardUserIds.length > 0) {
+      const followedUsers = await db
+        .select({ followingId: follows.followingId })
+        .from(follows)
+        .where(
+          and(
+            eq(follows.followerId, authUserId),
+            inArray(follows.followingId, leaderboardUserIds)
+          )
+        );
+
+      followingUserIds = followedUsers.map((follow) => follow.followingId);
+    }
+
+    followingUserIdsResolved = true;
+  }
+
+  const isPersonalizedResponse = Boolean(
+    effectiveUserId || followingUserIdsResolved
+  );
+
   logger.info(
     'Leaderboard fetched successfully',
     {
@@ -160,11 +193,13 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       },
       leaderboardType,
       currentUser,
+      followingUserIds,
+      followingUserIdsResolved,
     },
     200,
     {
       'x-cache': cacheHit ? 'leaderboard-hit' : 'leaderboard-miss',
-      'Cache-Control': effectiveUserId
+      'Cache-Control': isPersonalizedResponse
         ? 'private, no-store'
         : `public, s-maxage=${CACHE_TTL_SECONDS}, stale-while-revalidate=${STALE_SECONDS}`,
       Vary: 'Accept-Encoding',

--- a/apps/web/src/app/leaderboard/fetchLeaderboardData.ts
+++ b/apps/web/src/app/leaderboard/fetchLeaderboardData.ts
@@ -36,6 +36,8 @@ export interface LeaderboardData {
   };
   leaderboardType: LeaderboardTab;
   currentUser: CurrentUserPosition | null;
+  followingUserIds: string[];
+  followingUserIdsResolved: boolean;
 }
 
 export class LeaderboardFetchError extends Error {
@@ -53,6 +55,7 @@ export type FetchLeaderboardOptions = {
   pageSize: number;
   selectedTab: LeaderboardTab;
   userId?: string;
+  authToken?: string | null;
   signal?: AbortSignal;
   retryDelayMs?: number;
   retries?: number;
@@ -137,6 +140,7 @@ export async function fetchLeaderboardData({
   pageSize,
   selectedTab,
   userId,
+  authToken,
   signal,
   retryDelayMs = 1000,
   retries = 2,
@@ -148,9 +152,13 @@ export async function fetchLeaderboardData({
     userId,
   });
 
+  const headers: HeadersInit | undefined = authToken
+    ? { Authorization: `Bearer ${authToken}` }
+    : undefined;
+
   for (let attempt = 0; attempt <= retries; attempt++) {
     try {
-      const response = await fetch(url, { signal });
+      const response = await fetch(url, { signal, headers });
 
       if (!response.ok) {
         throw new LeaderboardFetchError(

--- a/apps/web/src/app/leaderboard/page.tsx
+++ b/apps/web/src/app/leaderboard/page.tsx
@@ -40,7 +40,7 @@ const LeaderboardWidgetSidebar = dynamic(
 );
 
 export default function LeaderboardPage() {
-  const { authenticated, user } = useAuth();
+  const { authenticated, getAccessToken, user } = useAuth();
   const [leaderboardData, setLeaderboardData] =
     useState<LeaderboardData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -61,11 +61,13 @@ export default function LeaderboardPage() {
       setError(null);
 
       try {
+        const authToken = authenticated ? await getAccessToken() : null;
         const data = await fetchLeaderboardData({
           currentPage,
           pageSize,
           selectedTab,
           userId: authenticatedUserId,
+          authToken,
           signal: controller.signal,
         });
 
@@ -83,7 +85,7 @@ export default function LeaderboardPage() {
 
     void loadLeaderboard();
     return () => controller.abort();
-  }, [currentPage, selectedTab, authenticatedUserId]);
+  }, [currentPage, selectedTab, authenticatedUserId, authenticated, getAccessToken]);
 
   useEffect(() => {
     if (scrollToUserRef.current && !loading) {
@@ -159,6 +161,7 @@ export default function LeaderboardPage() {
   const isCurrentUserOnPage = currentUserRowId
     ? leaderboardData?.leaderboard.some((p) => p.id === currentUserRowId)
     : false;
+  const followedUserIds = new Set(leaderboardData?.followingUserIds ?? []);
 
   const tabDescriptions: Record<LeaderboardTab, string> = {
     wallet:
@@ -208,7 +211,15 @@ export default function LeaderboardPage() {
               onClick={(e) => e.stopPropagation()}
               onKeyDown={(e) => e.stopPropagation()}
             >
-              <FollowButton userId={player.id} variant="circle" />
+              <FollowButton
+                userId={player.id}
+                variant="circle"
+                initialFollowing={
+                  leaderboardData?.followingUserIdsResolved
+                    ? followedUserIds.has(player.id)
+                    : undefined
+                }
+              />
             </div>
           )}
         </div>

--- a/apps/web/src/app/leaderboard/page.tsx
+++ b/apps/web/src/app/leaderboard/page.tsx
@@ -85,7 +85,13 @@ export default function LeaderboardPage() {
 
     void loadLeaderboard();
     return () => controller.abort();
-  }, [currentPage, selectedTab, authenticatedUserId, authenticated, getAccessToken]);
+  }, [
+    currentPage,
+    selectedTab,
+    authenticatedUserId,
+    authenticated,
+    getAccessToken,
+  ]);
 
   useEffect(() => {
     if (scrollToUserRef.current && !loading) {

--- a/apps/web/src/components/interactions/FollowButton.tsx
+++ b/apps/web/src/components/interactions/FollowButton.tsx
@@ -40,7 +40,7 @@ interface FollowButtonProps {
 
 export function FollowButton({
   userId,
-  initialFollowing = false,
+  initialFollowing,
   size = 'md',
   variant = 'button',
   className,
@@ -48,13 +48,19 @@ export function FollowButton({
   onFollowerCountChange,
 }: FollowButtonProps) {
   const { authenticated, user } = useAuth();
-  const [isFollowing, setIsFollowing] = useState(initialFollowing);
+  const [isFollowing, setIsFollowing] = useState(initialFollowing ?? false);
   const [isLoading, setIsLoading] = useState(false);
-  const [isChecking, setIsChecking] = useState(true);
+  const [isChecking, setIsChecking] = useState(initialFollowing === undefined);
   const { trackFollow } = useSocialTracking();
 
   // Check follow status on mount
   useEffect(() => {
+    if (initialFollowing !== undefined) {
+      setIsFollowing(initialFollowing);
+      setIsChecking(false);
+      return;
+    }
+
     // Check if viewing own profile (userId could be username or user ID)
     const isOwnProfile =
       user &&
@@ -100,7 +106,7 @@ export function FollowButton({
     };
 
     checkFollowStatus();
-  }, [authenticated, user, userId]);
+  }, [authenticated, initialFollowing, user, userId]);
 
   const handleFollow = async () => {
     if (!authenticated || !user) {

--- a/packages/testing/unit/leaderboard-route.test.ts
+++ b/packages/testing/unit/leaderboard-route.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { NextRequest } from 'next/server';
+
+const mockAuthenticate = mock(async () => ({ userId: 'viewer-1' }));
+const mockGetCache = mock(async () => null);
+const mockSetCache = mock(async () => undefined);
+const mockGetWalletLeaderboard = mock(async () => ({
+  users: [
+    {
+      id: 'user-1',
+      username: 'alpha',
+      displayName: 'Alpha',
+      profileImageUrl: null,
+      totalPoints: 100,
+      balance: 100,
+      lifetimePnL: 0,
+      createdAt: new Date('2026-03-10T00:00:00.000Z'),
+      rank: 1,
+    },
+    {
+      id: 'user-2',
+      username: 'beta',
+      displayName: 'Beta',
+      profileImageUrl: null,
+      totalPoints: 90,
+      balance: 90,
+      lifetimePnL: 0,
+      createdAt: new Date('2026-03-10T00:00:00.000Z'),
+      rank: 2,
+    },
+  ],
+  totalCount: 2,
+  page: 1,
+  pageSize: 100,
+  totalPages: 1,
+  leaderboardType: 'wallet' as const,
+}));
+const mockGetTeamLeaderboard = mock(async () => ({
+  users: [],
+  totalCount: 0,
+  page: 1,
+  pageSize: 100,
+  totalPages: 0,
+  leaderboardType: 'team' as const,
+}));
+const mockGetUserPosition = mock(async () => null);
+
+const mockDbWhere = mock(async () => [{ followingId: 'user-2' }]);
+const mockDbFrom = mock(() => ({ where: mockDbWhere }));
+const mockDbSelect = mock(() => ({ from: mockDbFrom }));
+
+mock.module('@babylon/api', () => ({
+  authenticate: mockAuthenticate,
+  getCache: mockGetCache,
+  PointsService: {
+    getWalletLeaderboard: mockGetWalletLeaderboard,
+    getTeamLeaderboard: mockGetTeamLeaderboard,
+    getUserPosition: mockGetUserPosition,
+  },
+  setCache: mockSetCache,
+  successResponse: (
+    body: unknown,
+    status = 200,
+    headers?: Record<string, string>
+  ) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: {
+        'content-type': 'application/json',
+        ...headers,
+      },
+    }),
+  withErrorHandling:
+    (handler: (request: NextRequest) => Promise<Response>) =>
+    (request: NextRequest) =>
+      handler(request),
+}));
+
+mock.module('@babylon/db', () => ({
+  and: (...conditions: unknown[]) => ({ op: 'and', conditions }),
+  db: {
+    get select() {
+      return mockDbSelect;
+    },
+  },
+  eq: (left: unknown, right: unknown) => ({ op: 'eq', left, right }),
+  follows: {
+    followerId: 'follows.followerId',
+    followingId: 'follows.followingId',
+  },
+  inArray: (column: unknown, values: unknown[]) => ({
+    op: 'inArray',
+    column,
+    values,
+  }),
+}));
+
+mock.module('@babylon/shared', () => ({
+  LeaderboardQuerySchema: {
+    safeParse: (input: Record<string, string>) => ({
+      success: true,
+      data: {
+        page: Number(input.page ?? '1'),
+        pageSize: Number(input.pageSize ?? '100'),
+        type: input.type ?? 'wallet',
+        userId: input.userId,
+      },
+    }),
+  },
+  logger: {
+    info: mock(() => undefined),
+  },
+}));
+
+const { GET } = await import('@/app/api/leaderboard/route');
+
+function makeRequest(
+  searchParams: Record<string, string>,
+  headers?: Record<string, string>
+): NextRequest {
+  const url = new URL('http://localhost:3000/api/leaderboard');
+  for (const [key, value] of Object.entries(searchParams)) {
+    url.searchParams.set(key, value);
+  }
+
+  return new Request(url.toString(), {
+    headers,
+  }) as NextRequest;
+}
+
+describe('Leaderboard route follow state enrichment', () => {
+  beforeEach(() => {
+    mockAuthenticate.mockClear();
+    mockAuthenticate.mockResolvedValue({ userId: 'viewer-1' });
+    mockGetCache.mockClear();
+    mockSetCache.mockClear();
+    mockGetWalletLeaderboard.mockClear();
+    mockGetTeamLeaderboard.mockClear();
+    mockGetUserPosition.mockClear();
+    mockDbSelect.mockClear();
+    mockDbFrom.mockClear();
+    mockDbWhere.mockClear();
+    mockDbWhere.mockResolvedValue([{ followingId: 'user-2' }]);
+  });
+
+  test('returns batched following ids for the authenticated viewer', async () => {
+    const response = await GET(
+      makeRequest(
+        {
+          page: '1',
+          pageSize: '100',
+          type: 'wallet',
+          userId: 'viewer-1',
+        },
+        {
+          Authorization: 'Bearer test-token',
+        }
+      )
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+
+    expect(body.followingUserIdsResolved).toBe(true);
+    expect(body.followingUserIds).toEqual(['user-2']);
+    expect(mockDbSelect).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not expose follow state for a different requested user id', async () => {
+    const response = await GET(
+      makeRequest(
+        {
+          page: '1',
+          pageSize: '100',
+          type: 'wallet',
+          userId: 'someone-else',
+        },
+        {
+          Authorization: 'Bearer test-token',
+        }
+      )
+    );
+
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+
+    expect(body.followingUserIdsResolved).toBe(false);
+    expect(body.followingUserIds).toEqual([]);
+    expect(mockDbSelect).not.toHaveBeenCalled();
+  });
+});

--- a/packages/testing/unit/leaderboard-route.test.ts
+++ b/packages/testing/unit/leaderboard-route.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
 import type { NextRequest } from 'next/server';
 
-const mockAuthenticate = mock(async () => ({ userId: 'viewer-1' }));
+const mockOptionalAuth = mock(async () => ({
+  userId: 'viewer-1',
+  dbUserId: 'viewer-1',
+}));
+const mockFindUserByIdentifier = mock(async () => ({ id: 'viewer-1' }));
 const mockGetCache = mock(async () => null);
 const mockSetCache = mock(async () => undefined);
 const mockGetWalletLeaderboard = mock(async () => ({
@@ -49,8 +53,19 @@ const mockDbWhere = mock(async () => [{ followingId: 'user-2' }]);
 const mockDbFrom = mock(() => ({ where: mockDbWhere }));
 const mockDbSelect = mock(() => ({ from: mockDbFrom }));
 
+class MockApiError extends Error {
+  status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+  }
+}
+
 mock.module('@babylon/api', () => ({
-  authenticate: mockAuthenticate,
+  ApiError: MockApiError,
+  findUserByIdentifier: mockFindUserByIdentifier,
+  optionalAuth: mockOptionalAuth,
   getCache: mockGetCache,
   PointsService: {
     getWalletLeaderboard: mockGetWalletLeaderboard,
@@ -109,6 +124,7 @@ mock.module('@babylon/shared', () => ({
   },
   logger: {
     info: mock(() => undefined),
+    warn: mock(() => undefined),
   },
 }));
 
@@ -130,8 +146,13 @@ function makeRequest(
 
 describe('Leaderboard route follow state enrichment', () => {
   beforeEach(() => {
-    mockAuthenticate.mockClear();
-    mockAuthenticate.mockResolvedValue({ userId: 'viewer-1' });
+    mockOptionalAuth.mockClear();
+    mockOptionalAuth.mockResolvedValue({
+      userId: 'viewer-1',
+      dbUserId: 'viewer-1',
+    });
+    mockFindUserByIdentifier.mockClear();
+    mockFindUserByIdentifier.mockResolvedValue({ id: 'viewer-1' });
     mockGetCache.mockClear();
     mockSetCache.mockClear();
     mockGetWalletLeaderboard.mockClear();
@@ -168,6 +189,8 @@ describe('Leaderboard route follow state enrichment', () => {
   });
 
   test('does not expose follow state for a different requested user id', async () => {
+    mockFindUserByIdentifier.mockResolvedValue({ id: 'someone-else' });
+
     const response = await GET(
       makeRequest(
         {


### PR DESCRIPTION
## Summary
- Batch follow-state lookups for leaderboard rows in `/api/leaderboard` instead of letting each row button fan out its own request.
- Reuse the preloaded follow state in `FollowButton` so leaderboard rows stop issuing mount-time follow checks.
- Keep personalized leaderboard responses private and add a targeted unit test for the new enrichment path.

## Type
- [x] Bug fix
- [x] Performance
- [ ] Feature
- [ ] Refactor / cleanup (no behavior change)
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Linear: https://linear.app/eliza-labs/issue/BAB-261/bugweb-remove-per-row-follow-status-requests-on-leaderboard
- Sentry: https://eliza-uv.sentry.io/issues/7310658617/

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [x] Tests (`packages/testing`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Other: …

## Changes
- Enrich `/api/leaderboard` with batched `followingUserIds` for the authenticated viewer on the current page.
- Pass the resolved follow state through the leaderboard page fetch and hydrate row-level `FollowButton`s from it.
- Skip the mount-time follow-status fetch in `FollowButton` when the caller already knows the state.
- Add a unit test covering authenticated enrichment and the guard against exposing another user's follow graph.

## Review guide
**Start here**
- `apps/web/src/app/api/leaderboard/route.ts`
- `apps/web/src/app/leaderboard/page.tsx`
- `apps/web/src/components/interactions/FollowButton.tsx`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- Personalized follow-state enrichment is only returned when the authenticated requester matches the requested `userId` (or omits it), and those responses are forced to `private, no-store`.
- The visible UI stays the same; the change is about avoiding the per-row follow GET burst during leaderboard render.

## Test plan
**Commands run**
- [x] `bunx biome check apps/web/src/app/api/leaderboard/route.ts apps/web/src/app/leaderboard/page.tsx apps/web/src/components/interactions/FollowButton.tsx packages/testing/unit/leaderboard-route.test.ts`
- [x] `bun test packages/testing/unit/leaderboard-route.test.ts --preload ./packages/testing/unit/preload.ts`
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Open `/leaderboard` while authenticated.
2. Confirm the initial load no longer bursts `GET /api/users/:id/follow` requests for each row.
3. Confirm follow/unfollow still works from leaderboard rows after hydration.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `…`
- Changed: `…`
- Removed: `…`

**DB / data migration**
- Migration(s): `…`
- Backfill/seed: `…`

**Rollout / rollback plan**
- Rollout: normal deploy.
- Rollback: revert this PR to restore the previous per-button follow lookup path.

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- …

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- `/api/leaderboard` now returns `followingUserIds` and `followingUserIdsResolved` alongside the existing payload.

### Database
- Adds one batched `follows` lookup for personalized leaderboard responses instead of N per-row follow checks.

### Contracts / on-chain
- …

### Docs
- …

</details>

## Screenshots / recordings (UI)
### Option B: No visual changes
- Reason: This is a performance and API-load fix with no intentional visual UI delta.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
