### PR TITLE
fix(agents): stabilize commander dispatch routing and fix silent failure masking

### DIFF
--- a/apps/web/src/app/api/agents/[agentId]/chat/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/chat/route.ts
@@ -619,7 +619,7 @@ export const POST = withErrorHandling(
               : null;
         }
 
-        const success = actionResult?.success ?? true;
+        const success = actionResult?.success ?? false;
 
         traceActionResults.push({
           actionType: action,

--- a/apps/web/src/app/api/agents/team-chat/coordinator/fast-path.test.ts
+++ b/apps/web/src/app/api/agents/team-chat/coordinator/fast-path.test.ts
@@ -118,6 +118,11 @@ describe('tryFastPath', () => {
       'place',
       'submit',
       'transfer',
+      'have',
+      'get',
+      'command',
+      'instruct',
+      'order',
     ];
 
     it.each(
@@ -139,6 +144,14 @@ describe('tryFastPath', () => {
         null
       );
       expect(tryFastPath('Ask the trading bot about TSLAI')).toBe(null);
+    });
+
+    it('returns null for new dispatch verbs in agent command context', () => {
+      expect(tryFastPath('have my agent check the market')).toBe(null);
+      expect(tryFastPath('get the bot to look at prices')).toBe(null);
+      expect(tryFastPath('command the agent to analyze TSLAI')).toBe(null);
+      expect(tryFastPath('instruct agent to review my portfolio')).toBe(null);
+      expect(tryFastPath('order the bot to check predictions')).toBe(null);
     });
   });
 

--- a/apps/web/src/app/api/agents/team-chat/coordinator/fast-path.ts
+++ b/apps/web/src/app/api/agents/team-chat/coordinator/fast-path.ts
@@ -9,6 +9,10 @@
  * Verbs that indicate the user wants an agent to ACT, not just fetch info.
  * If any of these appear in the message, we must NOT fast-path — the LLM
  * decision loop is needed to handle dispatch logic.
+ *
+ * Full list: buy, sell, trade, open, close, post, comment, tell, ask,
+ * dispatch, send, create, make, write, reply, share, execute, place,
+ * submit, transfer, have, get, command, instruct, order
  */
 const AGENT_ACTION_VERBS =
   /\b(buy|sell|trade|open|close|post|comment|tell|ask|dispatch|send|create|make|write|reply|share|execute|place|submit|transfer|have|get|command|instruct|order)\b/i;

--- a/apps/web/src/app/api/agents/team-chat/coordinator/fast-path.ts
+++ b/apps/web/src/app/api/agents/team-chat/coordinator/fast-path.ts
@@ -11,7 +11,7 @@
  * decision loop is needed to handle dispatch logic.
  */
 const AGENT_ACTION_VERBS =
-  /\b(buy|sell|trade|open|close|post|comment|tell|ask|dispatch|send|create|make|write|reply|share|execute|place|submit|transfer)\b/i;
+  /\b(buy|sell|trade|open|close|post|comment|tell|ask|dispatch|send|create|make|write|reply|share|execute|place|submit|transfer|have|get|command|instruct|order)\b/i;
 
 /** Greeting patterns — canned response, 0 LLM calls */
 const GREETING_PATTERN =

--- a/apps/web/src/app/api/agents/team-chat/coordinator/route.test.ts
+++ b/apps/web/src/app/api/agents/team-chat/coordinator/route.test.ts
@@ -22,6 +22,7 @@ import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 
 const mockAuthenticateUser = mock(async () => ({ id: 'user-001' }));
 const mockBroadcastChatMessage = mock(async () => undefined);
+const mockBroadcastThinkingIndicator = mock(async () => undefined);
 const mockCheckRateLimitAsync = mock(async () => ({
   allowed: true,
   retryAfter: null,
@@ -31,6 +32,7 @@ const mockWithErrorHandling = mock((handler: Function) => handler);
 mock.module('@babylon/api', () => ({
   authenticateUser: mockAuthenticateUser,
   broadcastChatMessage: mockBroadcastChatMessage,
+  broadcastThinkingIndicator: mockBroadcastThinkingIndicator,
   checkRateLimitAsync: mockCheckRateLimitAsync,
   RATE_LIMIT_CONFIGS: { SEND_MESSAGE: 'send_message' },
   withErrorHandling: mockWithErrorHandling,
@@ -185,6 +187,8 @@ beforeEach(() => {
   mockAuthenticateUser.mockResolvedValue({ id: 'user-001' });
   mockBroadcastChatMessage.mockClear();
   mockBroadcastChatMessage.mockResolvedValue(undefined);
+  mockBroadcastThinkingIndicator.mockClear();
+  mockBroadcastThinkingIndicator.mockResolvedValue(undefined);
   mockCheckRateLimitAsync.mockClear();
   mockCheckRateLimitAsync.mockResolvedValue({
     allowed: true,
@@ -411,6 +415,80 @@ describe('Coordinator POST', () => {
       expect(body.success).toBe(true);
       expect(body.response).toBe('NVDAI is at $200.');
       expect(mockProcessActions).toHaveBeenCalledTimes(1);
+    });
+
+    it('refreshes DISPATCH_HISTORY after each consecutive dispatch iteration', async () => {
+      const dispatchHistoryProvider = mockProviders[0]!;
+
+      mockUseModel
+        .mockResolvedValueOnce('DECISION_1')
+        .mockResolvedValueOnce('DECISION_2')
+        .mockResolvedValueOnce('DECISION_3')
+        .mockResolvedValueOnce('SUMMARY');
+      mockParseKeyValueXml
+        .mockReturnValueOnce({
+          thought: 'dispatch first agent',
+          action: 'DISPATCH_TO_AGENT',
+          parameters: { agentId: 'agent-1', command: 'first task' },
+          isFinish: 'false',
+        })
+        .mockReturnValueOnce({
+          thought: 'dispatch second agent',
+          action: 'DISPATCH_TO_AGENT',
+          parameters: { agentId: 'agent-2', command: 'second task' },
+          isFinish: 'false',
+        })
+        .mockReturnValueOnce({
+          thought: 'done',
+          action: '',
+          parameters: {},
+          isFinish: 'true',
+        })
+        .mockReturnValueOnce({
+          thought: 'summarize',
+          text: 'Both dispatches completed.',
+        });
+
+      mockProcessActions.mockImplementation(
+        async (_m: unknown, _a: unknown, _s: unknown, cb: Function) => {
+          await cb([{ content: { success: true, text: 'Dispatch completed' } }]);
+        }
+      );
+
+      await POST(makeRequest('coordinate two agents'));
+
+      expect(dispatchHistoryProvider.get).toHaveBeenCalledTimes(2);
+    });
+
+    it('clears the thinking indicator when a dispatch action throws', async () => {
+      mockUseModel.mockResolvedValueOnce('DECISION_1');
+      mockParseKeyValueXml.mockReturnValueOnce({
+        thought: 'dispatch agent',
+        action: 'DISPATCH_TO_AGENT',
+        parameters: { agentId: 'agent-1', command: 'do the task' },
+        isFinish: 'false',
+      });
+      mockProcessActions.mockRejectedValueOnce(new Error('dispatch failed'));
+
+      await expect(POST(makeRequest('tell my agent to do the task'))).rejects.toThrow(
+        'dispatch failed'
+      );
+
+      expect(mockBroadcastThinkingIndicator).toHaveBeenNthCalledWith(
+        1,
+        'chat-001',
+        'coordinator-id',
+        'Agent commander',
+        true,
+        'Dispatching to agent...'
+      );
+      expect(mockBroadcastThinkingIndicator).toHaveBeenNthCalledWith(
+        2,
+        'chat-001',
+        'coordinator-id',
+        'Agent commander',
+        false
+      );
     });
   });
 

--- a/apps/web/src/app/api/agents/team-chat/coordinator/route.ts
+++ b/apps/web/src/app/api/agents/team-chat/coordinator/route.ts
@@ -710,7 +710,7 @@ export const POST = withErrorHandling(async (req: NextRequest) => {
               state.values = { ...state.values, ...result.values };
             }
           }
-          dispatchHistoryRefreshedAt = iteration;
+          dispatchHistoryRefreshedAt = lastDispatchIteration;
         }
       }
 
@@ -820,13 +820,14 @@ export const POST = withErrorHandling(async (req: NextRequest) => {
         'CoordinatorChat'
       );
 
-      // Broadcast intermediate status for dispatch actions so the user
-      // sees progress during the 4-8s agent execution window.
-      if (
+      const isDispatchAction =
         action === 'DISPATCH_TO_AGENT' ||
         action === 'DISPATCH_TO_AGENTS' ||
-        action === 'RELAY_TO_AGENT'
-      ) {
+        action === 'RELAY_TO_AGENT';
+
+      // Broadcast intermediate status for dispatch actions so the user
+      // sees progress during the 4-8s agent execution window.
+      if (isDispatchAction) {
         const dispatchLabel =
           action === 'DISPATCH_TO_AGENTS'
             ? 'Dispatching to multiple agents...'
@@ -840,171 +841,170 @@ export const POST = withErrorHandling(async (req: NextRequest) => {
         ).catch(() => {});
       }
 
-      // Parse parameters with fail-fast validation (no silent fallbacks)
-      let actionParams: Record<string, unknown> = {};
-      if (parameters) {
-        if (typeof parameters === 'string') {
-          // Fail-fast: let JSON.parse errors propagate
-          const parsed: unknown = JSON.parse(parameters);
-          // Validate the parsed result is a non-null object (not an array)
-          if (
-            typeof parsed !== 'object' ||
-            parsed === null ||
-            Array.isArray(parsed)
-          ) {
-            throw new Error(
-              `Invalid parameters: expected object, got ${Array.isArray(parsed) ? 'array' : typeof parsed}. Original: ${parameters}`
-            );
-          }
-          actionParams = parsed as Record<string, unknown>;
-        } else if (
-          typeof parameters === 'object' &&
-          parameters !== null &&
-          !Array.isArray(parameters)
-        ) {
-          actionParams = parameters as Record<string, unknown>;
-        } else if (Array.isArray(parameters)) {
-          throw new Error(
-            `Invalid parameters: expected object, got array. Original: ${JSON.stringify(parameters)}`
-          );
-        } else {
-          throw new Error(`Unexpected parameters type: ${typeof parameters}`);
-        }
-      }
-
-      // Store params and inject broadcastFn so DISPATCH_TO_AGENT can broadcast.
-      // broadcastFn is injected here (not imported inside packages/agents) to
-      // maintain architectural separation between @babylon/api and @babylon/agents.
-      //
-      // IMPORTANT: ElizaOS processActions() re-composes state internally via
-      // runtime.composeState(), which reads from stateCache and DISCARDS any
-      // custom state.data injections. To survive the re-composition, we:
-      //   1. Write actionParams + broadcastFn into the stateCache entry
-      //   2. Also set them on the local state object (for prompt composition)
-      state.data = {
-        ...state.data,
-        actionParams,
-        broadcastFn: broadcastChatMessage,
-      };
-
-      // Persist to stateCache so processActions' internal composeState preserves them
-      const stateCache = getRuntimeStateCache(runtime);
-      if (stateCache && elizaMessage.id) {
-        const cached = stateCache.get(elizaMessage.id);
-        if (cached) {
-          cached.data = {
-            ...cached.data,
-            actionParams,
-            broadcastFn: broadcastChatMessage,
-          };
-        }
-      }
-
-      // Build action content for processActions
-      const actionContent = {
-        text: `Executing action: ${action}`,
-        actions: [action],
-      };
-
-      const actionMessage: Memory = {
-        id: uuidv4() as `${string}-${string}-${string}-${string}-${string}`,
-        entityId: runtime.agentId,
-        roomId: elizaMessage.roomId,
-        createdAt: Date.now(),
-        content: actionContent,
-      };
-
-      // Concrete types for action results
-      interface ActionResultContent {
-        success?: boolean;
-        text?: string;
-        values?: Record<string, unknown>;
-        tag?: MessageTag;
-      }
-
-      interface ProcessActionsResult {
-        content?: ActionResultContent;
-      }
-
-      // Use object to allow mutation from callback
-      const resultHolder: { result: ActionResultContent | null } = {
-        result: null,
-      };
-
-      // Fail-fast: let errors from processActions propagate to caller
-      await runtime.processActions(
-        elizaMessage,
-        [actionMessage],
-        state,
-        async (results: unknown) => {
-          const resultsArray = results as ProcessActionsResult[] | null;
-          if (resultsArray && resultsArray.length > 0) {
-            const firstResult = resultsArray[0];
-            if (firstResult) {
-              resultHolder.result = {
-                success: firstResult.content?.success ?? true,
-                text:
-                  typeof firstResult.content?.text === 'string'
-                    ? firstResult.content.text
-                    : undefined,
-                values: firstResult.content?.values,
-                tag: firstResult.content?.tag,
-              };
+      try {
+        // Parse parameters with fail-fast validation (no silent fallbacks)
+        let actionParams: Record<string, unknown> = {};
+        if (parameters) {
+          if (typeof parameters === 'string') {
+            // Fail-fast: let JSON.parse errors propagate
+            const parsed: unknown = JSON.parse(parameters);
+            // Validate the parsed result is a non-null object (not an array)
+            if (
+              typeof parsed !== 'object' ||
+              parsed === null ||
+              Array.isArray(parsed)
+            ) {
+              throw new Error(
+                `Invalid parameters: expected object, got ${Array.isArray(parsed) ? 'array' : typeof parsed}. Original: ${parameters}`
+              );
             }
+            actionParams = parsed as Record<string, unknown>;
+          } else if (
+            typeof parameters === 'object' &&
+            parameters !== null &&
+            !Array.isArray(parameters)
+          ) {
+            actionParams = parameters as Record<string, unknown>;
+          } else if (Array.isArray(parameters)) {
+            throw new Error(
+              `Invalid parameters: expected object, got array. Original: ${JSON.stringify(parameters)}`
+            );
+          } else {
+            throw new Error(`Unexpected parameters type: ${typeof parameters}`);
           }
-          return [];
         }
-      );
 
-      // Use resultHolder as the single source of truth for action results
-      // The callback in processActions captures the result; no fallback to runtime internals
-      let actionResult = resultHolder.result;
+        // Store params and inject broadcastFn so DISPATCH_TO_AGENT can broadcast.
+        // broadcastFn is injected here (not imported inside packages/agents) to
+        // maintain architectural separation between @babylon/api and @babylon/agents.
+        //
+        // IMPORTANT: ElizaOS processActions() re-composes state internally via
+        // runtime.composeState(), which reads from stateCache and DISCARDS any
+        // custom state.data injections. To survive the re-composition, we:
+        //   1. Write actionParams + broadcastFn into the stateCache entry
+        //   2. Also set them on the local state object (for prompt composition)
+        state.data = {
+          ...state.data,
+          actionParams,
+          broadcastFn: broadcastChatMessage,
+        };
 
-      // Default to false if result is missing to avoid masking silent failures
-      if (!actionResult) {
-        const cached = getRuntimeStateCache(runtime)?.get(
-          `${elizaMessage.id}_action_results`
+        // Persist to stateCache so processActions' internal composeState preserves them
+        const stateCache = getRuntimeStateCache(runtime);
+        if (stateCache && elizaMessage.id) {
+          const cached = stateCache.get(elizaMessage.id);
+          if (cached) {
+            cached.data = {
+              ...cached.data,
+              actionParams,
+              broadcastFn: broadcastChatMessage,
+            };
+          }
+        }
+
+        // Build action content for processActions
+        const actionContent = {
+          text: `Executing action: ${action}`,
+          actions: [action],
+        };
+
+        const actionMessage: Memory = {
+          id: uuidv4() as `${string}-${string}-${string}-${string}-${string}`,
+          entityId: runtime.agentId,
+          roomId: elizaMessage.roomId,
+          createdAt: Date.now(),
+          content: actionContent,
+        };
+
+        // Concrete types for action results
+        interface ActionResultContent {
+          success?: boolean;
+          text?: string;
+          values?: Record<string, unknown>;
+          tag?: MessageTag;
+        }
+
+        interface ProcessActionsResult {
+          content?: ActionResultContent;
+        }
+
+        // Use object to allow mutation from callback
+        const resultHolder: { result: ActionResultContent | null } = {
+          result: null,
+        };
+
+        // Fail-fast: let errors from processActions propagate to caller
+        await runtime.processActions(
+          elizaMessage,
+          [actionMessage],
+          state,
+          async (results: unknown) => {
+            const resultsArray = results as ProcessActionsResult[] | null;
+            if (resultsArray && resultsArray.length > 0) {
+              const firstResult = resultsArray[0];
+              if (firstResult) {
+                resultHolder.result = {
+                  success: firstResult.content?.success ?? true,
+                  text:
+                    typeof firstResult.content?.text === 'string'
+                      ? firstResult.content.text
+                      : undefined,
+                  values: firstResult.content?.values,
+                  tag: firstResult.content?.tag,
+                };
+              }
+            }
+            return [];
+          }
         );
-        const actionResultsFromCache =
-          (cached?.values?.actionResults as Array<{
-            success?: boolean;
-            text?: string;
-            values?: Record<string, unknown>;
-          }>) || [];
-        actionResult =
-          actionResultsFromCache.length > 0
-            ? (actionResultsFromCache[0] ?? null)
-            : null;
-      }
-      const success = actionResult?.success ?? false;
 
-      traceActionResults.push({
-        actionType: action,
-        success,
-        text: actionResult?.text || `${action} executed`,
-        error: success ? undefined : actionResult?.text,
-        values: actionResult?.values,
-        parameters: actionParams,
-        timestamp: Date.now(),
-        durationMs: Date.now() - actionStartMs,
-        tag: actionResult?.tag,
-      });
+        // Use resultHolder as the single source of truth for action results
+        // The callback in processActions captures the result; no fallback to runtime internals
+        let actionResult = resultHolder.result;
 
-      // Track dispatch iterations so we know to refresh DISPATCH_HISTORY
-      if (
-        action === 'DISPATCH_TO_AGENT' ||
-        action === 'DISPATCH_TO_AGENTS' ||
-        action === 'RELAY_TO_AGENT'
-      ) {
-        lastDispatchIteration = iteration;
+        // Default to false if result is missing to avoid masking silent failures
+        if (!actionResult) {
+          const cached = getRuntimeStateCache(runtime)?.get(
+            `${elizaMessage.id}_action_results`
+          );
+          const actionResultsFromCache =
+            (cached?.values?.actionResults as Array<{
+              success?: boolean;
+              text?: string;
+              values?: Record<string, unknown>;
+            }>) || [];
+          actionResult =
+            actionResultsFromCache.length > 0
+              ? (actionResultsFromCache[0] ?? null)
+              : null;
+        }
+        const success = actionResult?.success ?? false;
 
-        // Clear the thinking indicator now that dispatch is complete
-        broadcastThinkingIndicator(
-          teamChatId,
-          COORDINATOR_SENDER_ID,
-          'Agent commander',
-          false
-        ).catch(() => {});
+        traceActionResults.push({
+          actionType: action,
+          success,
+          text: actionResult?.text || `${action} executed`,
+          error: success ? undefined : actionResult?.text,
+          values: actionResult?.values,
+          parameters: actionParams,
+          timestamp: Date.now(),
+          durationMs: Date.now() - actionStartMs,
+          tag: actionResult?.tag,
+        });
+
+        // Track dispatch iterations so we know to refresh DISPATCH_HISTORY
+        if (isDispatchAction) {
+          lastDispatchIteration = iteration;
+        }
+      } finally {
+        if (isDispatchAction) {
+          broadcastThinkingIndicator(
+            teamChatId,
+            COORDINATOR_SENDER_ID,
+            'Agent commander',
+            false
+          ).catch(() => {});
+        }
       }
 
       // Check if done

--- a/apps/web/src/app/api/agents/team-chat/coordinator/route.ts
+++ b/apps/web/src/app/api/agents/team-chat/coordinator/route.ts
@@ -26,6 +26,7 @@ import { agentRuntimeManager, teamChatService } from '@babylon/agents';
 import {
   authenticateUser,
   broadcastChatMessage,
+  broadcastThinkingIndicator,
   checkRateLimitAsync,
   RATE_LIMIT_CONFIGS,
   withErrorHandling,
@@ -208,21 +209,41 @@ No actions taken yet.
 
 # Decision Guide
 
-## Single-Agent Tasks
-**Use DISPATCH_TO_AGENT** when the user wants one agent to execute a trade, post, comment, or any action.
+## MANDATORY: Agent Dispatch Rules
+**You MUST use DISPATCH_TO_AGENT** whenever the user wants ANY action performed by an agent.
+You are a DISPATCHER — you NEVER execute agent work yourself and you NEVER tell the user to do it.
+If the user has exactly 1 agent and asks for ANY action, dispatch to that agent automatically.
+If no agents exist in the team, tell the user to create one at /agents.
+
+**Always dispatch when the user says any of these (or similar):**
+  - "tell my agent to..." / "ask my agent to..." / "have my agent..."
+  - "make agent X..." / "get agent X to..." / "command agent X..."
+  - "buy/sell/trade/open/close..." (trading intent = agent action)
+  - "post about..." / "comment on..." / "write about..." (content intent = agent action)
+  - Any instruction that requires an agent to act on the user's behalf
+
+**How to dispatch:**
   - Select the agent using their [id: ...] from the Team Members list above
   - Write the command clearly as the exact instruction for the agent
-  - If no agents exist in the team, skip this action and tell the user to create one at /agents
+  - Parameters: {"agentId": "the-agent-id", "command": "clear instruction for the agent"}
+
+**Dispatch examples:**
+  - User: "tell my agent to post about crypto" → action: DISPATCH_TO_AGENT, command: "post about crypto"
+  - User: "buy TSLAI" → action: DISPATCH_TO_AGENT, command: "buy TSLAI"
+  - User: "have alice open a 2x long on NVDAI for $50" → action: DISPATCH_TO_AGENT to alice, command: "open a 2x long on NVDAI for $50"
+  - User: "ask bob what he thinks" → action: DISPATCH_TO_AGENT to bob, command: "share your thoughts on the current market"
 ${orchestrationSection}
-## Information Queries
+## Information Queries (no agent needed)
 **Use a data-fetch action** (CHECK_PERPS, CHECK_PREDICTIONS, CHECK_USER_PNL, etc.) when you need information to answer the user's question.
+Only use these for read-only queries where the user wants data, NOT when they want an agent to act.
 
-## Skip Actions
-**Skip all actions (set action to "" and isFinish to true)** when:
-  - The question is conversational or you already have the data needed
+## Skip Actions (no action needed)
+**Set action to "" and isFinish to true ONLY when:**
+  - The question is purely conversational ("what is Babylon?", "how does this work?")
+  - You already have the data needed from a previous action this turn
   - The user is asking about a previous turn's result — just answer directly
-  - You have already dispatched or fetched what was needed this turn
 
+**NEVER skip when the user wants an action done — ALWAYS dispatch instead.**
 **NEVER repeat the same action with the same parameters.**
 **NEVER include action names or action syntax in a text response — actions are separate from your final reply.**
 
@@ -481,6 +502,7 @@ export const POST = withErrorHandling(async (req: NextRequest) => {
   // return identical data within a single request.
   let lastState: State | null = null;
   let lastDispatchIteration = 0;
+  let dispatchHistoryRefreshedAt = 0;
 
   // The decision template is built once based on agent count (from first composeState).
   // We defer building it until after the first state composition.
@@ -670,11 +692,11 @@ export const POST = withErrorHandling(async (req: NextRequest) => {
         state = await runtime.composeState(elizaMessage, providers, true);
       } else {
         // Subsequent iterations: reuse state, skip redundant DB queries.
-        // Only re-fetch DISPATCH_HISTORY if we dispatched last iteration,
-        // since the agent's response is now in the messages table.
+        // Re-fetch DISPATCH_HISTORY if any dispatch happened since the last
+        // refresh, since agent responses are now visible in the messages table.
         state = lastState!;
 
-        if (lastDispatchIteration === iteration - 1) {
+        if (lastDispatchIteration > dispatchHistoryRefreshedAt) {
           const dispatchProvider = runtime.providers.find(
             (p) => p.name === 'DISPATCH_HISTORY'
           );
@@ -688,6 +710,7 @@ export const POST = withErrorHandling(async (req: NextRequest) => {
               state.values = { ...state.values, ...result.values };
             }
           }
+          dispatchHistoryRefreshedAt = iteration;
         }
       }
 
@@ -744,7 +767,7 @@ export const POST = withErrorHandling(async (req: NextRequest) => {
       for (let attempt = 1; attempt <= MAX_PARSE_RETRIES; attempt++) {
         const response = await runtime.useModel(modelType, {
           prompt: attempt > 1 ? prompt + XML_FORMAT_HINT : prompt,
-          temperature: attempt > 1 ? 0.3 : 0.7,
+          temperature: attempt > 1 ? 0.3 : 0.4,
         });
 
         parsedStep = parseKeyValueXml(response);
@@ -796,6 +819,26 @@ export const POST = withErrorHandling(async (req: NextRequest) => {
         { parameters },
         'CoordinatorChat'
       );
+
+      // Broadcast intermediate status for dispatch actions so the user
+      // sees progress during the 4-8s agent execution window.
+      if (
+        action === 'DISPATCH_TO_AGENT' ||
+        action === 'DISPATCH_TO_AGENTS' ||
+        action === 'RELAY_TO_AGENT'
+      ) {
+        const dispatchLabel =
+          action === 'DISPATCH_TO_AGENTS'
+            ? 'Dispatching to multiple agents...'
+            : 'Dispatching to agent...';
+        broadcastThinkingIndicator(
+          teamChatId,
+          COORDINATOR_SENDER_ID,
+          'Agent commander',
+          true,
+          dispatchLabel
+        ).catch(() => {});
+      }
 
       // Parse parameters with fail-fast validation (no silent fallbacks)
       let actionParams: Record<string, unknown> = {};
@@ -954,6 +997,14 @@ export const POST = withErrorHandling(async (req: NextRequest) => {
         action === 'RELAY_TO_AGENT'
       ) {
         lastDispatchIteration = iteration;
+
+        // Clear the thinking indicator now that dispatch is complete
+        broadcastThinkingIndicator(
+          teamChatId,
+          COORDINATOR_SENDER_ID,
+          'Agent commander',
+          false
+        ).catch(() => {});
       }
 
       // Check if done

--- a/packages/agents/src/plugins/plugin-user-core/src/actions/dispatch-to-agent.test.ts
+++ b/packages/agents/src/plugins/plugin-user-core/src/actions/dispatch-to-agent.test.ts
@@ -23,7 +23,7 @@
  * - text falls back to agentId when agentUsername is not set
  * - text uses agentUsername when available
  * - values contains dispatchedCommand, agentResponse, actionsExecuted
- * - NEVER calls the _callback parameter
+ * - Calls _callback with the ActionResult on all paths (success, failure, missing fields)
  */
 
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
@@ -463,7 +463,7 @@ describe('DISPATCH_TO_AGENT handler()', () => {
   // ── _callback contract ──────────────────────────────────────────────────
 
   describe('_callback contract (ElizaOS protocol)', () => {
-    it('NEVER calls the _callback parameter on success', async () => {
+    it('calls _callback with success result on successful dispatch', async () => {
       mockDispatchAgentChat.mockResolvedValue({
         success: true,
         agentId: AGENT_ID,
@@ -484,10 +484,14 @@ describe('DISPATCH_TO_AGENT handler()', () => {
         callbackFn
       );
 
-      expect(callbackFn).not.toHaveBeenCalled();
+      expect(callbackFn).toHaveBeenCalledTimes(1);
+      const callArg = callbackFn.mock.calls[0]![0] as unknown as {
+        content: { success: boolean };
+      };
+      expect(callArg.content.success).toBe(true);
     });
 
-    it('NEVER calls _callback even on missing fields (error path)', async () => {
+    it('calls _callback with failure result on missing fields (error path)', async () => {
       const callbackFn = mock(async () => []);
       const state = buildState({ actionParams: undefined });
 
@@ -499,10 +503,15 @@ describe('DISPATCH_TO_AGENT handler()', () => {
         callbackFn
       );
 
-      expect(callbackFn).not.toHaveBeenCalled();
+      expect(callbackFn).toHaveBeenCalledTimes(1);
+      const callArg = callbackFn.mock.calls[0]![0] as unknown as {
+        content: { success: boolean; text: string };
+      };
+      expect(callArg.content.success).toBe(false);
+      expect(callArg.content.text).toContain('Missing');
     });
 
-    it('NEVER calls _callback when dispatch fails', async () => {
+    it('calls _callback with failure result when dispatch fails', async () => {
       mockDispatchAgentChat.mockResolvedValue({
         success: false,
         error: 'Failed',
@@ -521,7 +530,12 @@ describe('DISPATCH_TO_AGENT handler()', () => {
         callbackFn
       );
 
-      expect(callbackFn).not.toHaveBeenCalled();
+      expect(callbackFn).toHaveBeenCalledTimes(1);
+      const callArg = callbackFn.mock.calls[0]![0] as unknown as {
+        content: { success: boolean; text: string };
+      };
+      expect(callArg.content.success).toBe(false);
+      expect(callArg.content.text).toContain('Failed');
     });
   });
 

--- a/packages/agents/src/services/AgentChatService.ts
+++ b/packages/agents/src/services/AgentChatService.ts
@@ -625,7 +625,7 @@ export async function dispatchAgentChat(
         actionResult = cached.length > 0 ? (cached[0] ?? null) : null;
       }
 
-      const success = actionResult?.success ?? true;
+      const success = actionResult?.success ?? false;
 
       traceActionResults.push({
         actionType: action,


### PR DESCRIPTION
## Summary

- Fix coordinator telling users to perform actions themselves instead of dispatching to agents — rewrote decision prompt with mandatory dispatch rules and concrete examples
- Fix silent failure masking where agent action failures defaulted to `success: true`, hiding broken trades/posts from users
- Add live "Dispatching to agent..." thinking indicator so users see progress during the 4-8s agent execution window

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: ...

## Context / Links

- Pre-launch stabilization of the Commander Agent before March 20 Solana launch
- Core bug: asking the commander to "tell my agent to do X" resulted in the coordinator advising the user to do it themselves instead of dispatching
- See `COMMANDER_AUDIT.md` for full audit report with architecture analysis and player experience recommendations

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Non-goals / follow-ups:**
- Fast-path auto-dispatch for single-agent users (skips LLM entirely)
- Fast-path auto-dispatch for @named agent intent ("tell alice to buy TSLAI")
- Coordinator dry-run endpoint for rapid prompt testing
- Solana agent registration (zero implementation exists today)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [x] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: ...

## Changes

- **Modified**: `apps/web/src/app/api/agents/team-chat/coordinator/route.ts` — rewrote Decision Guide with mandatory dispatch rules + 6 examples, lowered decision temperature 0.7→0.4, fixed DISPATCH_HISTORY refresh logic, added `broadcastThinkingIndicator` for dispatch status
- **Modified**: `apps/web/src/app/api/agents/team-chat/coordinator/fast-path.ts` — added 5 missing action verbs (have/get/command/instruct/order) to prevent incorrect fast-pathing
- **Modified**: `apps/web/src/app/api/agents/[agentId]/chat/route.ts` — changed `actionResult?.success ?? true` to `?? false` to stop masking failures
- **Modified**: `packages/agents/src/services/AgentChatService.ts` — same `?? true` → `?? false` fix
- **Modified**: `packages/agents/src/plugins/plugin-user-core/src/actions/dispatch-to-agent.test.ts` — fixed 3 tests that incorrectly asserted callback is never called (it is, on all paths)

## Review guide

**Start here**
- `apps/web/src/app/api/agents/team-chat/coordinator/route.ts` — the prompt rewrite (lines 209-260) is the main change

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- The prompt changes are the highest-impact part — the coordinator's dispatch reliability depends on how well the LLM follows these directives
- The `?? false` change (Fix 3) may surface previously-hidden failures in agent actions — this is intentional. Silent success was worse.
- The `broadcastThinkingIndicator` import already exists in `@babylon/api` exports — no new dependencies
- Test fix: the old tests were asserting `_callback` is never called, but `dispatch-to-agent.ts:118,138,153` clearly calls it on every path. Tests now match reality.

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [x] `bun run test` (unit — 30/30 pass on dispatch-to-agent)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Open Agents chat (no @mentions) → send "tell my agent to post about crypto" → verify agent is dispatched (not told to do it yourself)
2. Send "buy TSLAI" → verify coordinator dispatches to trading agent
3. Send "have my agent say hello" → verify dispatch, not advice
4. Send "what's the TSLAI price" → verify fast-path to CHECK_PERPS (no dispatch)
5. Send "hello" → verify fast-path greeting response
6. Trigger a failed agent action (e.g. trade with zero balance) → verify it shows as failure, not silent success
7. During dispatch, verify "Dispatching to agent..." indicator appears

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend-only changes to coordinator routing logic, LLM prompts, and error handling. The only user-visible change is the new "Dispatching to agent..." thinking indicator, which uses the existing `broadcastThinkingIndicator` infrastructure already rendered by the frontend.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
