### PR TITLE
fix(coordinator): respect caller temperature and strengthen dispatch rules

### DIFF
--- a/apps/web/src/app/api/agents/team-chat/coordinator/route.test.ts
+++ b/apps/web/src/app/api/agents/team-chat/coordinator/route.test.ts
@@ -451,7 +451,9 @@ describe('Coordinator POST', () => {
 
       mockProcessActions.mockImplementation(
         async (_m: unknown, _a: unknown, _s: unknown, cb: Function) => {
-          await cb([{ content: { success: true, text: 'Dispatch completed' } }]);
+          await cb([
+            { content: { success: true, text: 'Dispatch completed' } },
+          ]);
         }
       );
 
@@ -470,9 +472,9 @@ describe('Coordinator POST', () => {
       });
       mockProcessActions.mockRejectedValueOnce(new Error('dispatch failed'));
 
-      await expect(POST(makeRequest('tell my agent to do the task'))).rejects.toThrow(
-        'dispatch failed'
-      );
+      await expect(
+        POST(makeRequest('tell my agent to do the task'))
+      ).rejects.toThrow('dispatch failed');
 
       expect(mockBroadcastThinkingIndicator).toHaveBeenNthCalledWith(
         1,

--- a/packages/agents/src/plugins/__tests__/groq.test.ts
+++ b/packages/agents/src/plugins/__tests__/groq.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { IAgentRuntime } from '@elizaos/core';
+
+const mockLanguageModel = mock((model: string) => `language-model:${model}`);
+const mockCreateGroq = mock(() => ({
+  languageModel: mockLanguageModel,
+}));
+const mockGenerateText = mock(async () => ({ text: 'mocked response' }));
+const mockGenerateObject = mock(async () => ({ object: { ok: true } }));
+const mockLogPrompt = mock(async () => undefined);
+
+mock.module('@ai-sdk/groq', () => ({
+  createGroq: mockCreateGroq,
+}));
+
+mock.module('ai', () => ({
+  generateObject: mockGenerateObject,
+  generateText: mockGenerateText,
+}));
+
+mock.module('@babylon/shared', () => ({
+  GROQ_MODELS: {
+    FREE: { modelId: 'groq-small-model' },
+    PRO: { modelId: 'groq-large-model' },
+  },
+}));
+
+mock.module('@elizaos/core', () => ({
+  ModelType: {
+    OBJECT_LARGE: 'object_large',
+    OBJECT_SMALL: 'object_small',
+    TEXT_LARGE: 'text_large',
+    TEXT_SMALL: 'text_small',
+    TEXT_TOKENIZER_DECODE: 'text_tokenizer_decode',
+    TEXT_TOKENIZER_ENCODE: 'text_tokenizer_encode',
+  },
+}));
+
+mock.module('js-tiktoken', () => ({
+  encodingForModel: mock(() => ({
+    decode: mock(() => ''),
+    encode: mock(() => []),
+  })),
+}));
+
+mock.module('../../shared/logger', () => ({
+  logger: {
+    debug: mock(),
+    error: mock(),
+    info: mock(),
+    warn: mock(),
+  },
+}));
+
+mock.module('../../utils/prompt-logger', () => ({
+  isPromptLoggingEnabled: () => false,
+  logPrompt: mockLogPrompt,
+}));
+
+const { ModelType } = await import('@elizaos/core');
+const { groqPlugin } = await import('../groq');
+
+const runtime = {
+  character: { system: 'System prompt' },
+  fetch: undefined,
+  getSetting: (key: string) => {
+    if (key === 'GROQ_API_KEY') return 'test-groq-key';
+    if (key === 'GROQ_BASE_URL') return 'https://groq.example';
+    return undefined;
+  },
+} as unknown as IAgentRuntime;
+
+describe('groqPlugin TEXT_SMALL', () => {
+  beforeEach(() => {
+    mockCreateGroq.mockClear();
+    mockLanguageModel.mockClear();
+    mockGenerateText.mockClear();
+    mockGenerateObject.mockClear();
+    mockLogPrompt.mockClear();
+  });
+
+  it('passes caller-provided generation params through to Groq', async () => {
+    const response = await groqPlugin.models[ModelType.TEXT_SMALL]?.(runtime, {
+      frequencyPenalty: 0.2,
+      maxTokens: 321,
+      presencePenalty: 0.1,
+      prompt: 'tell my agent to buy TSLAI',
+      stopSequences: ['</response>'],
+      temperature: 0.4,
+    });
+
+    expect(response).toBe('mocked response');
+    expect(mockCreateGroq).toHaveBeenCalledWith({
+      apiKey: 'test-groq-key',
+      baseURL: 'https://groq.example',
+      fetch: undefined,
+    });
+    expect(mockLanguageModel).toHaveBeenCalledWith('groq-small-model');
+    expect(mockGenerateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        frequencyPenalty: 0.2,
+        maxOutputTokens: 321,
+        model: 'language-model:groq-small-model',
+        presencePenalty: 0.1,
+        prompt: 'tell my agent to buy TSLAI',
+        stopSequences: ['</response>'],
+        system: 'System prompt',
+        temperature: 0.4,
+      })
+    );
+  });
+
+  it('keeps the previous defaults when caller params are omitted', async () => {
+    await groqPlugin.models[ModelType.TEXT_SMALL]?.(runtime, {
+      prompt: 'default params',
+    });
+
+    expect(mockGenerateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        frequencyPenalty: 0.7,
+        maxOutputTokens: 8000,
+        presencePenalty: 0.7,
+        prompt: 'default params',
+        stopSequences: [],
+        temperature: 0.7,
+      })
+    );
+  });
+});

--- a/packages/agents/src/plugins/groq.ts
+++ b/packages/agents/src/plugins/groq.ts
@@ -216,12 +216,15 @@ export const groqPlugin: Plugin = {
     },
     [ModelType.TEXT_SMALL]: async (
       runtime,
-      { prompt, stopSequences = [] }: GenerateTextParams
+      {
+        prompt,
+        stopSequences = [],
+        temperature = 0.7,
+        frequencyPenalty = 0.7,
+        presencePenalty = 0.7,
+        maxTokens = 8000,
+      }: GenerateTextParams
     ) => {
-      const temperature = 0.7;
-      const frequency_penalty = 0.7;
-      const presence_penalty = 0.7;
-      const max_response_length = 8000;
       const baseURL = getBaseURL(runtime);
       const groq = createGroq({
         apiKey: getStringSetting(runtime, 'GROQ_API_KEY') ?? '',
@@ -245,9 +248,9 @@ export const groqPlugin: Plugin = {
         prompt,
         system: runtime.character.system ?? undefined,
         temperature,
-        maxTokens: max_response_length,
-        frequencyPenalty: frequency_penalty,
-        presencePenalty: presence_penalty,
+        maxTokens,
+        frequencyPenalty,
+        presencePenalty,
         stopSequences,
         trajectoryLogger,
         trajectoryId,

--- a/packages/agents/src/plugins/plugin-user-core/src/coordinator-decision-template.ts
+++ b/packages/agents/src/plugins/plugin-user-core/src/coordinator-decision-template.ts
@@ -85,7 +85,10 @@ If no agents exist in the team, tell the user to create one at /agents.
   - "make agent X..." / "get agent X to..." / "command agent X..."
   - "buy/sell/trade/open/close..." (trading intent = agent action)
   - "post about..." / "comment on..." / "write about..." (content intent = agent action)
+  - "how are my agents doing" / "what are my agents up to" (dispatch to ask for status)
   - Any instruction that requires an agent to act on the user's behalf
+
+**"my agent" auto-resolve:** When the user says "my agent" without naming one, look at the Team Members list. If there is exactly 1 agent, dispatch to that agent. If there are multiple, pick the most relevant one or ask which agent. NEVER tell the user to @mention — YOU resolve the agent and dispatch.
 
 **How to dispatch:**
   - Select the agent using their [id: ...] from the Team Members list above
@@ -93,9 +96,10 @@ If no agents exist in the team, tell the user to create one at /agents.
   - Parameters: {"agentId": "the-agent-id", "command": "clear instruction for the agent"}
 
 **Dispatch examples:**
-  - User: "tell my agent to post about crypto" → action: DISPATCH_TO_AGENT, command: "post about crypto"
-  - User: "buy TSLAI" → action: DISPATCH_TO_AGENT, command: "buy TSLAI"
+  - User: "tell my agent to buy TSLAI for $100" → look up the user's agent from Team Members, action: DISPATCH_TO_AGENT with their id, command: "buy TSLAI for $100"
+  - User: "buy TSLAI" → action: DISPATCH_TO_AGENT to user's agent, command: "buy TSLAI"
   - User: "have alice open a 2x long on NVDAI for $50" → action: DISPATCH_TO_AGENT to alice, command: "open a 2x long on NVDAI for $50"
+  - User: "how are my agents doing" → action: DISPATCH_TO_AGENT, command: "give me a status update on your current positions and recent activity"
   - User: "ask bob what he thinks" → action: DISPATCH_TO_AGENT to bob, command: "share your thoughts on the current market"
 ${orchestrationSection}
 ## Information Queries (no agent needed)

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -199,10 +199,10 @@ export {
 // NPC Portfolio Metrics (shared calculation utilities)
 export {
   buildFallbackMetricsByPool,
-  getEffectiveLeverage,
-  getPositionExposure,
   type FallbackPerpRow,
   type FallbackPositionRow,
+  getEffectiveLeverage,
+  getPositionExposure,
   type PoolMetrics,
 } from './npc/portfolio-metrics';
 export {

--- a/packages/engine/src/npc/index.ts
+++ b/packages/engine/src/npc/index.ts
@@ -18,10 +18,10 @@ export {
 
 export {
   buildFallbackMetricsByPool,
-  getEffectiveLeverage,
-  getPositionExposure,
   type FallbackPerpRow,
   type FallbackPositionRow,
+  getEffectiveLeverage,
+  getPositionExposure,
   type PoolMetrics,
 } from './portfolio-metrics';
 

--- a/scripts/coordinator-playground.ts
+++ b/scripts/coordinator-playground.ts
@@ -35,8 +35,8 @@
  */
 
 import { createGroq } from '@ai-sdk/groq';
-import { buildCoordinatorDecisionTemplate } from '@babylon/agents/plugins/plugin-user-core/src/coordinator-decision-template';
 import { userCorePlugin } from '@babylon/agents/plugins/plugin-user-core/src';
+import { buildCoordinatorDecisionTemplate } from '@babylon/agents/plugins/plugin-user-core/src/coordinator-decision-template';
 import { formatActionsWithParams } from '@babylon/agents/plugins/plugin-user-core/src/providers/actions';
 import { COORDINATOR_CONTEXT_TEXT } from '@babylon/agents/plugins/plugin-user-core/src/providers/coordinator-context';
 import { parseKeyValueXml } from '@elizaos/core';


### PR DESCRIPTION
## Summary
- **TEXT_SMALL temperature bug**: The Groq plugin's `TEXT_SMALL` handler hardcoded `temperature=0.7`, silently ignoring the coordinator's `temperature: 0.4`. This caused flaky instruction-following — e.g. the coordinator refusing to dispatch for "tell my agent to buy TSLAI for $100" and instead telling the user to @mention their agent.
- **Decision template improvements**: Added explicit "my agent" auto-resolve rule (look up team members, never tell user to @mention), added "how are my agents doing" as a dispatch trigger, and updated examples to show agent resolution from the team list.

## Changes
- `packages/agents/src/plugins/groq.ts` — `TEXT_SMALL` handler now accepts `temperature`, `frequencyPenalty`, `presencePenalty`, `maxTokens` from caller params (with same defaults as before)
- `packages/agents/src/plugins/plugin-user-core/src/coordinator-decision-template.ts` — Strengthened dispatch rules with auto-resolve and anti-@mention guidance

## Test plan
- [ ] Send "tell my agent to buy TSLAI for $100" in team chat → should dispatch to the user's agent, not tell them to @mention
- [ ] Send "how are my agents doing" → should dispatch to agent for status update
- [ ] Send "buy TSLAI" → should auto-resolve to user's single agent and dispatch
- [ ] Verify coordinator still handles greetings, data queries, and multi-agent scenarios correctly