### PR TITLE
fix(coordinator): robust agent resolution and stronger dispatch rules

### DIFF
--- a/apps/web/src/app/api/agents/[agentId]/chat/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/chat/route.ts
@@ -582,7 +582,7 @@ export const POST = withErrorHandling(
               const firstResult = resultsArray[0];
               if (firstResult) {
                 actionResult = {
-                  success: firstResult.content?.success ?? true,
+                  success: firstResult.content?.success ?? false,
                   text:
                     typeof firstResult.content?.text === 'string'
                       ? firstResult.content.text

--- a/apps/web/src/app/api/agents/team-chat/coordinator/route.ts
+++ b/apps/web/src/app/api/agents/team-chat/coordinator/route.ts
@@ -167,6 +167,7 @@ No actions were taken this turn.
 4. Do NOT make up information — only reference data from the Actions You Completed section.
 5. If you dispatched to an agent, include a brief quote or summary of what the agent actually did or said. Use plain @username for mentions.
 6. Keep your response concise and factual.
+7. NEVER tell the user to @mention or tag their agents. The coordinator handles all dispatch routing.
 
 Output ONLY this XML:
 
@@ -470,7 +471,7 @@ export const POST = withErrorHandling(async (req: NextRequest) => {
         }> | null;
         if (resultsArray && resultsArray.length > 0 && resultsArray[0]) {
           fpResultHolder.result = {
-            success: resultsArray[0].content?.success ?? true,
+            success: resultsArray[0].content?.success ?? false,
             text:
               typeof resultsArray[0].content?.text === 'string'
                 ? resultsArray[0].content.text
@@ -812,7 +813,7 @@ export const POST = withErrorHandling(async (req: NextRequest) => {
               const firstResult = resultsArray[0];
               if (firstResult) {
                 resultHolder.result = {
-                  success: firstResult.content?.success ?? true,
+                  success: firstResult.content?.success ?? false,
                   text:
                     typeof firstResult.content?.text === 'string'
                       ? firstResult.content.text
@@ -942,7 +943,7 @@ export const POST = withErrorHandling(async (req: NextRequest) => {
       const summaryResponse = await runtime.useModel(modelType, {
         prompt:
           attempt > 1 ? summaryPrompt + SUMMARY_XML_FORMAT_HINT : summaryPrompt,
-        temperature: attempt > 1 ? 0.3 : 0.7,
+        temperature: attempt > 1 ? 0.3 : 0.4,
       });
 
       const summary = parseKeyValueXml(summaryResponse);
@@ -980,7 +981,7 @@ export const POST = withErrorHandling(async (req: NextRequest) => {
       extractedText ||
       (traceActionResults.length > 0
         ? 'Here is the information you requested.'
-        : "I'm here to help! You can ask me about markets, or @mention your agents to trade.");
+        : "I'm here to help! I can check markets, your portfolio, the feed, or dispatch commands to your agents.");
   }
 
   const responseText = finalResponse ?? "I'm here to help!";

--- a/packages/agents/src/plugins/plugin-user-core/src/actions/dispatch-to-agent.ts
+++ b/packages/agents/src/plugins/plugin-user-core/src/actions/dispatch-to-agent.ts
@@ -130,9 +130,11 @@ export const dispatchToAgentAction: Action = {
     });
 
     if (!result.success) {
+      // Include available agent info so the coordinator's next iteration can retry
+      // with the correct agent ID instead of giving up.
       const failResult: ActionResult = {
         success: false,
-        text: `Failed to dispatch to agent: ${result.error ?? 'Unknown error'}`,
+        text: `Failed to dispatch to agent "${agentId}": ${result.error ?? 'Unknown error'}. Check the Team Members list for the correct agent [id: ...] and retry.`,
         values: { agentId, command, error: result.error },
       };
       _callback?.({ content: failResult });

--- a/packages/agents/src/plugins/plugin-user-core/src/coordinator-decision-template.ts
+++ b/packages/agents/src/plugins/plugin-user-core/src/coordinator-decision-template.ts
@@ -74,33 +74,40 @@ No actions taken yet.
 
 # Decision Guide
 
-## MANDATORY: Agent Dispatch Rules
-**You MUST use DISPATCH_TO_AGENT** whenever the user wants ANY action performed by an agent.
-You are a DISPATCHER — you NEVER execute agent work yourself and you NEVER tell the user to do it.
-If the user has exactly 1 agent and asks for ANY action, dispatch to that agent automatically.
-If no agents exist in the team, tell the user to create one at /agents.
+## CRITICAL: Agent Dispatch Rules
+**You are a DISPATCHER. Your #1 job is routing user requests to their agents.**
 
-**Always dispatch when the user says any of these (or similar):**
-  - "tell my agent to..." / "ask my agent to..." / "have my agent..."
-  - "make agent X..." / "get agent X to..." / "command agent X..."
-  - "buy/sell/trade/open/close..." (trading intent = agent action)
-  - "post about..." / "comment on..." / "write about..." (content intent = agent action)
-  - "how are my agents doing" / "what are my agents up to" (dispatch to ask for status)
-  - Any instruction that requires an agent to act on the user's behalf
+When the user wants ANY action done, you MUST use DISPATCH_TO_AGENT. You never do agent work yourself.
 
-**"my agent" auto-resolve:** When the user says "my agent" without naming one, look at the Team Members list. If there is exactly 1 agent, dispatch to that agent. If there are multiple, pick the most relevant one or ask which agent. NEVER tell the user to @mention — YOU resolve the agent and dispatch.
+**ALWAYS use the agent's [id: ...] from the Team Members list as the agentId parameter.** The id is a long string like "cm..." shown in brackets. Copy it exactly.
+
+**Auto-resolve "my agent":** When the user says "my agent", "the agent", or doesn't name one:
+  - If there is exactly 1 agent in Team Members → dispatch to that agent automatically
+  - If there are multiple agents → pick the most relevant one based on the request
+  - NEVER tell the user to @mention or tag an agent. YOU resolve and dispatch.
+
+**Dispatch triggers (always dispatch for these):**
+  - "tell/ask/have/make/get/command my agent to..." → dispatch
+  - "buy/sell/trade/open/close [anything]" → dispatch (trading = agent action)
+  - "post/comment/write/share about..." → dispatch (content = agent action)
+  - "how is my agent doing" / "agent status" → dispatch with command "give me a status update on your current positions and recent activity"
+  - Any instruction that requires an agent to act
 
 **How to dispatch:**
-  - Select the agent using their [id: ...] from the Team Members list above
-  - Write the command clearly as the exact instruction for the agent
-  - Parameters: {"agentId": "the-agent-id", "command": "clear instruction for the agent"}
+  - Parameters: {"agentId": "[copy the id from Team Members]", "command": "clear instruction"}
+  - The command should be a direct instruction to the agent, not a description of what the user said
 
-**Dispatch examples:**
-  - User: "tell my agent to buy TSLAI for $100" → look up the user's agent from Team Members, action: DISPATCH_TO_AGENT with their id, command: "buy TSLAI for $100"
-  - User: "buy TSLAI" → action: DISPATCH_TO_AGENT to user's agent, command: "buy TSLAI"
-  - User: "have alice open a 2x long on NVDAI for $50" → action: DISPATCH_TO_AGENT to alice, command: "open a 2x long on NVDAI for $50"
-  - User: "how are my agents doing" → action: DISPATCH_TO_AGENT, command: "give me a status update on your current positions and recent activity"
-  - User: "ask bob what he thinks" → action: DISPATCH_TO_AGENT to bob, command: "share your thoughts on the current market"
+**Examples:**
+  - User: "tell my agent to buy TSLAI for $100" → find agent in Team Members, use their [id: ...], command: "buy TSLAI for $100"
+  - User: "buy TSLAI" → dispatch to user's agent, command: "buy TSLAI"
+  - User: "have alice open a 2x long on NVDAI for $50" → find alice's id, command: "open a 2x long on NVDAI for $50"
+  - User: "how are my agents doing" → dispatch, command: "give me a status update on your current positions and recent activity"
+
+**NEVER do any of these:**
+  - Tell the user to @mention or tag their agent
+  - Say "I can't do that" when the user wants an agent action
+  - Execute trades, posts, or actions yourself
+  - Skip dispatch when the user clearly wants an agent to act
 ${orchestrationSection}
 ## Information Queries (no agent needed)
 **Use a data-fetch action** (CHECK_PERPS, CHECK_PREDICTIONS, CHECK_USER_PNL, etc.) when you need information to answer the user's question.
@@ -110,11 +117,11 @@ Only use these for read-only queries where the user wants data, NOT when they wa
 **Set action to "" and isFinish to true ONLY when:**
   - The question is purely conversational ("what is Babylon?", "how does this work?")
   - You already have the data needed from a previous action this turn
-  - The user is asking about a previous turn's result — just answer directly
+  - The user is asking about a previous turn's result
 
 **NEVER skip when the user wants an action done — ALWAYS dispatch instead.**
 **NEVER repeat the same action with the same parameters.**
-**NEVER include action names or action syntax in a text response — actions are separate from your final reply.**
+**NEVER mention action names in your text response.**
 
 Use plain @username for mentions. No markdown links.
 

--- a/packages/agents/src/services/AgentChatService.ts
+++ b/packages/agents/src/services/AgentChatService.ts
@@ -304,21 +304,66 @@ export async function dispatchAgentChat(
     };
   }
 
-  // --- Ownership verification (with name/username fallback) ---
+  // --- Ownership verification (with fuzzy name fallback) ---
   let agentWithConfig;
   let resolvedAgentId = agentId;
   try {
     agentWithConfig = await agentService.getAgentWithConfig(agentId, ownerId);
 
-    // Fallback: if not found by ID, try resolving by username or displayName
+    // Fallback: if not found by ID, try resolving by username or displayName.
+    // The LLM often passes a username, display name, or partial name instead of
+    // the UUID. We try progressively fuzzier matching to maximize resolution:
+    //   1. Exact match on username or displayName (case-insensitive)
+    //   2. Normalized match (strip spaces, punctuation)
+    //   3. Partial match (needle contained in name or vice versa)
+    //   4. Single-agent fallback (if only 1 agent, use it regardless of name)
     if (!agentWithConfig) {
       const ownerAgents = await agentService.listUserAgents(ownerId);
-      const needle = agentId.toLowerCase();
-      const match = ownerAgents.find(
+      const needle = agentId.toLowerCase().trim();
+      const needleNormalized = needle.replace(/[\s\-_.]+/g, '');
+
+      // 1. Exact match on username or displayName
+      let match = ownerAgents.find(
         (a) =>
           a.username?.toLowerCase() === needle ||
           a.displayName?.toLowerCase() === needle
       );
+
+      // 2. Normalized match (strip spaces/punctuation for "larry david" vs "larrydavid")
+      if (!match) {
+        match = ownerAgents.find((a) => {
+          const uNorm = a.username?.toLowerCase().replace(/[\s\-_.]+/g, '');
+          const dNorm = a.displayName?.toLowerCase().replace(/[\s\-_.]+/g, '');
+          return uNorm === needleNormalized || dNorm === needleNormalized;
+        });
+      }
+
+      // 3. Partial match (needle contained in name or name contained in needle)
+      if (!match) {
+        match = ownerAgents.find((a) => {
+          const uLower = a.username?.toLowerCase() ?? '';
+          const dLower = a.displayName?.toLowerCase() ?? '';
+          return (
+            (uLower && (uLower.includes(needle) || needle.includes(uLower))) ||
+            (dLower && (dLower.includes(needle) || needle.includes(dLower)))
+          );
+        });
+      }
+
+      // 4. Single-agent fallback: if the user only has one agent, it's unambiguous
+      if (!match && ownerAgents.length === 1) {
+        match = ownerAgents[0];
+        logger.info(
+          '[AgentChatService] Single-agent fallback used',
+          {
+            input: agentId,
+            resolvedId: match!.id,
+            resolvedName: match!.displayName ?? match!.username,
+          },
+          'AgentChatService'
+        );
+      }
+
       if (match) {
         resolvedAgentId = match.id;
         agentWithConfig = await agentService.getAgentWithConfig(
@@ -327,7 +372,21 @@ export async function dispatchAgentChat(
         );
         logger.info(
           '[AgentChatService] Resolved agent by name fallback',
-          { input: agentId, resolvedId: resolvedAgentId },
+          {
+            input: agentId,
+            resolvedId: resolvedAgentId,
+            resolvedName: match.displayName ?? match.username,
+          },
+          'AgentChatService'
+        );
+      } else {
+        // Log available agents for debugging failed resolution
+        const available = ownerAgents.map(
+          (a) => `${a.displayName ?? a.username ?? 'unnamed'} (${a.id})`
+        );
+        logger.warn(
+          '[AgentChatService] Agent resolution failed — no match found',
+          { input: agentId, availableAgents: available },
           'AgentChatService'
         );
       }
@@ -355,13 +414,26 @@ export async function dispatchAgentChat(
   }
 
   if (!agentWithConfig) {
+    // List available agents in the error so the coordinator can retry with correct ID
+    let availableHint = '';
+    try {
+      const ownerAgents = await agentService.listUserAgents(ownerId);
+      if (ownerAgents.length > 0) {
+        const names = ownerAgents
+          .map((a) => `@${a.username ?? a.displayName ?? a.id}`)
+          .join(', ');
+        availableHint = `. Available agents: ${names}`;
+      }
+    } catch {
+      // Best-effort — don't let hint lookup mask the real error
+    }
     return {
       success: false,
       response: '',
       agentId: resolvedAgentId,
       actionsExecuted: 0,
       isLLMFailure: false,
-      error: 'Agent not found',
+      error: `Agent "${agentId}" not found${availableHint}`,
     };
   }
 
@@ -592,7 +664,7 @@ export async function dispatchAgentChat(
             const firstResult = resultsArray[0];
             if (firstResult) {
               actionResult = {
-                success: firstResult.content?.success ?? true,
+                success: firstResult.content?.success ?? false,
                 text:
                   typeof firstResult.content?.text === 'string'
                     ? firstResult.content.text

--- a/packages/agents/src/services/AgentChatService.ts
+++ b/packages/agents/src/services/AgentChatService.ts
@@ -320,7 +320,16 @@ export async function dispatchAgentChat(
     if (!agentWithConfig) {
       const ownerAgents = await agentService.listUserAgents(ownerId);
       const needle = agentId.toLowerCase().trim();
-      const needleNormalized = needle.replace(/[\s\-_.]+/g, '');
+      const normalizeAgentName = (value: string | null | undefined): string =>
+        value?.toLowerCase().replace(/[\s\-_.]+/g, '') ?? '';
+      const needleNormalized = normalizeAgentName(needle);
+      const isGenericSingleAgentReference = new Set([
+        'agent',
+        'agents',
+        'myagent',
+        'myagents',
+        'theagent',
+      ]).has(needleNormalized);
 
       // 1. Exact match on username or displayName
       let match = ownerAgents.find(
@@ -332,15 +341,16 @@ export async function dispatchAgentChat(
       // 2. Normalized match (strip spaces/punctuation for "larry david" vs "larrydavid")
       if (!match) {
         match = ownerAgents.find((a) => {
-          const uNorm = a.username?.toLowerCase().replace(/[\s\-_.]+/g, '');
-          const dNorm = a.displayName?.toLowerCase().replace(/[\s\-_.]+/g, '');
+          const uNorm = normalizeAgentName(a.username);
+          const dNorm = normalizeAgentName(a.displayName);
           return uNorm === needleNormalized || dNorm === needleNormalized;
         });
       }
 
-      // 3. Partial match (needle contained in name or name contained in needle)
+      // 3. Partial match (needle contained in name or name contained in needle).
+      // Only accept unambiguous matches to avoid dispatching to the wrong agent.
       if (!match) {
-        match = ownerAgents.find((a) => {
+        const partialMatches = ownerAgents.filter((a) => {
           const uLower = a.username?.toLowerCase() ?? '';
           const dLower = a.displayName?.toLowerCase() ?? '';
           return (
@@ -348,10 +358,24 @@ export async function dispatchAgentChat(
             (dLower && (dLower.includes(needle) || needle.includes(dLower)))
           );
         });
+        if (partialMatches.length === 1) {
+          match = partialMatches[0];
+        } else if (partialMatches.length > 1) {
+          logger.warn(
+            '[AgentChatService] Agent resolution failed — ambiguous partial match',
+            {
+              input: agentId,
+              partialMatches: partialMatches.map(
+                (a) => a.displayName ?? a.username ?? a.id
+              ),
+            },
+            'AgentChatService'
+          );
+        }
       }
 
-      // 4. Single-agent fallback: if the user only has one agent, it's unambiguous
-      if (!match && ownerAgents.length === 1) {
+      // 4. Single-agent fallback only for generic references like "my agent".
+      if (!match && ownerAgents.length === 1 && isGenericSingleAgentReference) {
         match = ownerAgents[0];
         logger.info(
           '[AgentChatService] Single-agent fallback used',

--- a/packages/agents/src/services/__tests__/AgentChatService.test.ts
+++ b/packages/agents/src/services/__tests__/AgentChatService.test.ts
@@ -306,7 +306,7 @@ describe('dispatchAgentChat', () => {
       const result = await dispatchAgentChat(BASE_PARAMS);
 
       expect(result.success).toBe(false);
-      expect(result.error).toContain('Agent not found');
+      expect(result.error).toContain(`Agent "${AGENT_ID}" not found`);
       expect(mockGetRuntime).not.toHaveBeenCalled();
       expect(mockDbInsert).not.toHaveBeenCalled();
     });
@@ -348,6 +348,124 @@ describe('dispatchAgentChat', () => {
       // Auth errors map to permission message, not raw internal message
       expect(result.success).toBe(false);
       expect(result.error).toBeDefined();
+    });
+
+    it('resolves normalized agent names for a single matching owner agent', async () => {
+      const resolvedAgent = {
+        ...MOCK_AGENT_WITH_CONFIG,
+        username: 'larrydavid',
+        displayName: 'Larry David',
+      };
+      mockGetAgentWithConfig
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(resolvedAgent);
+      mockListUserAgents.mockResolvedValue([resolvedAgent]);
+      mockUseModel
+        .mockResolvedValueOnce('DECISION_RESP')
+        .mockResolvedValueOnce('SUMMARY_RESP');
+      mockParseKeyValueXml
+        .mockReturnValueOnce({
+          thought: 'done',
+          action: '',
+          parameters: {},
+          isFinish: 'true',
+        })
+        .mockReturnValueOnce({
+          thought: 'summarizing',
+          text: 'Resolved the agent correctly.',
+        });
+
+      const result = await dispatchAgentChat({
+        ...BASE_PARAMS,
+        agentId: 'larry david',
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockGetAgentWithConfig).toHaveBeenNthCalledWith(1, 'larry david', OWNER_ID);
+      expect(mockGetAgentWithConfig).toHaveBeenNthCalledWith(2, AGENT_ID, OWNER_ID);
+    });
+
+    it('uses single-agent fallback only for generic references like "my agent"', async () => {
+      const resolvedAgent = {
+        ...MOCK_AGENT_WITH_CONFIG,
+        username: 'larrydavid',
+        displayName: 'Larry David',
+      };
+      mockGetAgentWithConfig
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(resolvedAgent);
+      mockListUserAgents.mockResolvedValue([resolvedAgent]);
+      mockUseModel
+        .mockResolvedValueOnce('DECISION_RESP')
+        .mockResolvedValueOnce('SUMMARY_RESP');
+      mockParseKeyValueXml
+        .mockReturnValueOnce({
+          thought: 'done',
+          action: '',
+          parameters: {},
+          isFinish: 'true',
+        })
+        .mockReturnValueOnce({
+          thought: 'summarizing',
+          text: 'Single agent fallback worked.',
+        });
+
+      const result = await dispatchAgentChat({
+        ...BASE_PARAMS,
+        agentId: 'my agent',
+      });
+
+      expect(result.success).toBe(true);
+      expect(mockGetAgentWithConfig).toHaveBeenNthCalledWith(2, AGENT_ID, OWNER_ID);
+    });
+
+    it('does not dispatch to the only agent when the requested name is unknown', async () => {
+      const resolvedAgent = {
+        ...MOCK_AGENT_WITH_CONFIG,
+        username: 'larrydavid',
+        displayName: 'Larry David',
+      };
+      mockGetAgentWithConfig.mockResolvedValue(null);
+      mockListUserAgents.mockResolvedValue([resolvedAgent]);
+
+      const result = await dispatchAgentChat({
+        ...BASE_PARAMS,
+        agentId: 'unknownbot',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Agent "unknownbot" not found');
+      expect(result.error).toContain('@larrydavid');
+      expect(mockGetAgentWithConfig).toHaveBeenCalledTimes(1);
+      expect(mockGetRuntime).not.toHaveBeenCalled();
+    });
+
+    it('fails ambiguous partial matches instead of picking the first agent arbitrarily', async () => {
+      mockGetAgentWithConfig.mockResolvedValue(null);
+      mockListUserAgents.mockResolvedValue([
+        {
+          ...MOCK_AGENT_WITH_CONFIG,
+          id: 'agent-1',
+          username: 'larrydavid',
+          displayName: 'Larry David',
+        },
+        {
+          ...MOCK_AGENT_WITH_CONFIG,
+          id: 'agent-2',
+          username: 'larrytrades',
+          displayName: 'Larry Trades',
+        },
+      ]);
+
+      const result = await dispatchAgentChat({
+        ...BASE_PARAMS,
+        agentId: 'larry',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Agent "larry" not found');
+      expect(mockGetAgentWithConfig).toHaveBeenCalledTimes(1);
+      expect(mockGetRuntime).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary
- **Fuzzy agent name resolution**: The LLM often passes usernames, display names, or partial names instead of UUIDs. Added 4-tier matching: exact → normalized (strips spaces/punctuation, so "larry david" matches "larrydavid") → partial (substring match) → single-agent fallback (if user has only 1 agent, use it). Previously only exact match existed, causing "agent not found" failures.
- **Stronger dispatch prompt**: Rewrote the decision guide to hammer home auto-resolve behavior. Added explicit "NEVER tell the user to @mention" anti-pattern, "how are my agents doing" as a dispatch trigger, and emphasized copying the `[id: ...]` from Team Members.
- **Fix silent failure masking**: 3 locations had `?? true` that defaulted missing action results to success. Changed to `?? false` so failures surface properly.
- **Summary reliability**: Lowered summary temperature from 0.7 to 0.4, added anti-@mention rule to summary template, fixed fallback message that told users to @mention.

## Changes
- `packages/agents/src/services/AgentChatService.ts` — 4-tier fuzzy agent resolution with logging
- `packages/agents/src/plugins/plugin-user-core/src/coordinator-decision-template.ts` — Rewritten dispatch rules
- `packages/agents/src/plugins/plugin-user-core/src/actions/dispatch-to-agent.ts` — Better error messages with retry hint
- `apps/web/src/app/api/agents/team-chat/coordinator/route.ts` — ?? false fix, summary temp, anti-@mention
- `apps/web/src/app/api/agents/[agentId]/chat/route.ts` — ?? false fix

## Test plan
- [ ] "tell my agent to buy TSLAI for $100" with 1 agent → dispatches automatically
- [ ] "tell larrydavid to buy TSLAI" where username is "larrydavid" → resolves and dispatches
- [ ] "tell larry david to check positions" where username is "larrydavid" → fuzzy match resolves
- [ ] "how are my agents doing" → dispatches for status update
- [ ] "tell unknownbot to do something" → clear error with available agent list
- [ ] All existing tests pass (fast-path: 110, route: 15, dispatch: 30, groq: 2)