### PR TITLE
chore: unify agent rules in CLAUDE.md, slim down pre-push hook

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+All coding rules, conventions, and quality gates are defined in `CLAUDE.md` at the repo root. Read and follow that file.

--- a/.gitignore
+++ b/.gitignore
@@ -135,9 +135,8 @@ scripts/cleanup-excess-markets.ts
 /.gemini/settings.json.bak
 /.mcp.json
 /.mcp.json.bak
-/AGENTS.md
+# CLAUDE.md and AGENTS.md are checked in (single source of truth for all agents)
 /AGENTS.md.bak
-/CLAUDE.md
 /CLAUDE.md.bak
 /opencode.json
 /opencode.json.bak

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,36 +1,16 @@
 echo "Running pre-push checks..."
 
-# Run TypeScript typecheck
-bun run typecheck
+# Quick format/lint check (Biome, ~15s)
+bun run check
 if [ $? -ne 0 ]; then
-  echo "❌ Typecheck failed. Fix errors before pushing."
+  echo "❌ Biome check failed. Run 'bun run check' to auto-fix."
   exit 1
 fi
 
-# Run linting
-bun run lint
-if [ $? -ne 0 ]; then
-  echo "❌ Linting failed. Fix issues before pushing."
-  exit 1
-fi
-
-# Run unit and integration tests (only if DATABASE_URL is set)
-if [ -n "$DATABASE_URL" ]; then
-  echo "Running tests (DATABASE_URL detected)..."
-  bun run test
-  if [ $? -ne 0 ]; then
-    echo "❌ Tests failed. Fix failing tests before pushing."
-    exit 1
-  fi
-else
-  echo "⚠️  Skipping tests (DATABASE_URL not set). Tests will run in CI."
-fi
-
-# Run build
-bun run build
-if [ $? -ne 0 ]; then
-  echo "❌ Build failed. Fix build errors before pushing."
-  exit 1
-fi
-
-echo "✅ All pre-push checks passed!"
+echo "✅ Pre-push checks passed!"
+echo ""
+echo "Reminder: run these locally or rely on CI before merging:"
+echo "  bun run typecheck"
+echo "  bun run lint"
+echo "  bun run test:unit"
+echo "  bun run build"

--- a/.ruler/ruler.toml
+++ b/.ruler/ruler.toml
@@ -22,6 +22,9 @@ args = ["-y", "@modelcontextprotocol/server-filesystem", "."]
 url = "https://mcp.context7.com/mcp"
 
 # --- Agent configurations ---
+# CLAUDE.md is the single source of truth for all agents.
+# Other agent configs point to CLAUDE.md rather than duplicating rules.
+
 [agents.claude]
 enabled = true
 output_path = "CLAUDE.md"
@@ -33,7 +36,7 @@ output_path_config = ".codex/config.toml"
 
 [agents.cursor]
 enabled = true
-output_path = "AGENTS.md"
+output_path = ".cursorrules"
 
 [agents.antigravity]
 enabled = true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Rules
+
+All coding rules, conventions, and quality gates are defined in [`CLAUDE.md`](./CLAUDE.md).
+
+That file is the single source of truth for all AI coding agents (Claude Code, Cursor, Codex, Gemini CLI, OpenCode) and human contributors. Please follow it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,96 @@
+# Babylon — Agent & Developer Rules
+
+> Single source of truth for all AI coding agents (Claude Code, Cursor, Codex, etc.) and human contributors.
+> If you are reading `AGENTS.md`, it points here. Do not duplicate rules — edit this file.
+
+## Quality Gate (run before every commit)
+
+```bash
+bun run check          # Biome format + lint (auto-fix)
+bun run typecheck      # TypeScript across all packages
+bun run lint           # Turbo lint (zero warnings required)
+bun run test:unit      # Unit tests
+```
+
+Run integration tests when your changes touch DB/API:
+```bash
+bun run test:integration
+```
+
+Build before declaring done:
+```bash
+bun run build
+```
+
+## Architecture
+
+### Dependency Direction
+
+`apps/* → packages/* → packages/contracts`
+
+- **Apps are wiring-only**: validate input → call service → map errors → return response.
+- **Domain logic belongs in packages** and must stay framework-agnostic (no Next/React/Elysia imports in domain code).
+- No circular dependencies between packages.
+
+### Where to Put Code
+
+| What | Where |
+|---|---|
+| Domain rules / game logic | `packages/engine`, `packages/agents` |
+| Infra adapters (db/redis/http/sse/auth) | `packages/api`, `packages/db`, `packages/shared` |
+| UI and route wiring | `apps/web` |
+| Tests | `packages/testing` |
+| Vendor docs | `docs/vendors/{vendor}` |
+
+### State (current → target)
+
+- **Current**: Next.js `apps/web` hosts UI + API routes + SSE + A2A. CLI in `apps/cli`. Domain in `packages/engine` and `packages/agents`.
+- **Target**: Elysia host in `apps/server`, workers in `apps/daemon`, dedicated `apps/agents`, domain split into `packages/core/*`.
+
+## Code Standards
+
+- **Bun + TypeScript ESM**, 2-space indent, minimal changes.
+- **No `any`**; avoid `unknown` (only as last resort, narrow immediately).
+- **No broad `try/catch`**: catch only expected errors, map at boundaries. Fail fast otherwise.
+- **Reuse before building**: search the codebase for existing patterns/utilities before adding new ones.
+- **No invented behavior**: don't add fake placeholders or synthetic data. Build the real thing or leave a clear TODO.
+- **Secrets**: never commit API keys, private keys, or tokens. Never log sensitive values.
+- **Env hygiene**: new/changed env vars must be reflected in `.env.example` with required/optional + default notes.
+- **Scope discipline**: don't fix unrelated lint/format issues or revert other WIP. Keep changes scoped to the task.
+- **Documentation**: don't create new docs/READMEs unless requested. Update existing docs when behavior changes.
+
+## Git Conventions
+
+- Default branch: `staging` (not `main`).
+- Commits: concise, imperative, prefixed (`feat:`, `fix:`, `chore:`, `refactor:`, `test:`, `docs:`).
+- Always run `bun run check` before committing (Biome auto-fix).
+- Run `bun run typecheck` and `bun run lint` before pushing.
+
+## Testing
+
+- Prefer **integration tests** for API/DB/infra flows (`packages/testing/integration`).
+- Use **unit tests** for pure logic where they add confidence without heavy mocking (`packages/testing/unit`).
+- Keep tests deterministic. Use fakes/stubs where appropriate, but avoid synthetic success paths.
+
+## Commands Reference
+
+| Task | Command |
+|---|---|
+| Install | `bun install` |
+| Dev (full) | `bun run dev` |
+| Dev (web only) | `bun run dev:web` |
+| Format + lint fix | `bun run check` |
+| Typecheck | `bun run typecheck` |
+| Lint | `bun run lint` |
+| Build | `bun run build` |
+| Unit tests | `bun run test:unit` |
+| Integration tests | `bun run test:integration` |
+| DB generate | `bun run db:generate` |
+| DB migrate | `bun run db:migrate` |
+| DB seed | `bun run db:seed` |
+| Vendor docs | `bun run docs:generate` |
+
+## Tooling Notes
+
+- Ruler (`.ruler/`) generates agent config files. After editing `.ruler/**`, run `bun run ruler:apply`.
+- Prefer local vendor docs (`docs/vendors/`) before guessing APIs.

--- a/packages/examples/babylon-typescript-agent/src/registration.ts
+++ b/packages/examples/babylon-typescript-agent/src/registration.ts
@@ -68,17 +68,18 @@ export async function registerAgent(): Promise<AgentIdentity> {
 
   // Register on-chain
   console.log('⛓️  Registering on-chain...');
-  const registration = await agent.registerIPFS();
+  const txHandle = await agent.registerIPFS();
+  await txHandle.waitMined();
 
   console.log('✅ Registration complete!');
-  console.log(`   Token ID: ${registration.agentId ?? 'unknown'}`);
-  console.log(`   Metadata: ${registration.agentURI ?? 'unknown'}`);
+  console.log(`   Token ID: ${agent.agentId ?? 'unknown'}`);
+  console.log(`   Metadata: ${agent.agentURI ?? 'unknown'}`);
 
   // Parse agent ID
-  if (!registration.agentId) {
+  if (!agent.agentId) {
     throw new Error('Agent0 registration did not return an agentId');
   }
-  const parts = registration.agentId.split(':');
+  const parts = agent.agentId.split(':');
   const tokenId = Number.parseInt(parts[1]!);
 
   // Get wallet address from private key
@@ -88,8 +89,8 @@ export async function registerAgent(): Promise<AgentIdentity> {
   const identity: AgentIdentity = {
     tokenId,
     address: wallet.address,
-    agentId: registration.agentId,
-    metadataCID: registration.agentURI?.replace('ipfs://', ''),
+    agentId: agent.agentId,
+    metadataCID: agent.agentURI?.replace('ipfs://', ''),
   };
 
   fs.writeFileSync(IDENTITY_FILE, JSON.stringify(identity, null, 2));


### PR DESCRIPTION
## What

Unifies all AI agent coding rules into a single `CLAUDE.md` file and slims down the pre-push git hook so pushes complete in ~15s instead of ~4min.

## Why

- Multiple agents (Claude Code, Cursor, Codex, Gemini CLI, OpenCode) were each reading different config files with duplicated or missing rules
- The pre-push hook ran full `typecheck + lint + test + build` (~4 minutes), blocking both human and agent workflows. Pre-existing typecheck errors in unrelated packages would block all pushes on every branch.
- CI already runs the full suite — the hook was redundant as a gate

## Changes

| File | Change |
|---|---|
| `CLAUDE.md` | **New** — single source of truth for all agent rules (quality gates, architecture, code standards, git conventions, commands) |
| `AGENTS.md` | **New** — pointer to `CLAUDE.md` (read by Codex, Gemini CLI, OpenCode) |
| `.cursorrules` | **New** — pointer to `CLAUDE.md` (read by Cursor) |
| `.husky/pre-push` | Slimmed to only run `bun run check` (Biome, ~15s). Prints reminder to run typecheck/lint/tests locally. |
| `.gitignore` | Un-ignore `CLAUDE.md` and `AGENTS.md` so they're checked in |
| `.ruler/ruler.toml` | Comment noting CLAUDE.md is the source of truth; cursor output now targets `.cursorrules` |
| `registration.ts` | Fix pre-existing typecheck error (`registerIPFS()` returns `TransactionHandle`, not `{agentId}`) |

## Tradeoffs

- **Pre-push is lighter** — developers/agents must remember to run typecheck + lint before merging (CI enforces it)
- **Ruler still works** — `bun run ruler:apply` regenerates from `.ruler/` but CLAUDE.md is now the canonical checked-in version