### PR TITLE
fix: skip elizaOS runtime migrations, manage tables via Drizzle

### DIFF
--- a/packages/agents/src/runtime/AgentRuntimeManager.ts
+++ b/packages/agents/src/runtime/AgentRuntimeManager.ts
@@ -669,7 +669,11 @@ export class AgentRuntimeManager {
 
     // Initialize runtime to signal services that runtime is ready
     // This prevents 30s timeout errors in services waiting for runtime initialization
-    await runtime.initialize();
+    // Skip ElizaOS plugin-sql migrations — Babylon manages its own schema via Drizzle.
+    // ElizaOS tables are included in packages/db/src/schema/eliza.ts and migrated with
+    // `bun run db:generate && bun run db:migrate`. The framework's runtime migrator is
+    // not designed for serverless and adds ~2 min cold-start overhead per agent.
+    await runtime.initialize({ skipMigrations: true });
 
     // Wrap Babylon plugin BEFORE registering (so wrapped version is used)
     // This ensures all actions and provider accesses are logged when executed
@@ -953,7 +957,8 @@ export class AgentRuntimeManager {
 
     // Initialize runtime to signal services that runtime is ready
     // This prevents 30s timeout errors in services waiting for runtime initialization
-    await runtime.initialize();
+    // Skip migrations — see comment in createNPCAgentRuntime for rationale.
+    await runtime.initialize({ skipMigrations: true });
 
     // Wrap and enhance with Babylon plugin
     // Use userId for USER_CONTROLLED agents (User table lookup), agentId for NPCs
@@ -1177,7 +1182,8 @@ export class AgentRuntimeManager {
 
     // Initialize runtime to signal services that runtime is ready
     // This prevents 30s timeout errors in services waiting for runtime initialization
-    await runtime.initialize();
+    // Skip migrations — see comment in createNPCAgentRuntime for rationale.
+    await runtime.initialize({ skipMigrations: true });
 
     // Store trajectory logger reference
     runtime.trajectoryLogger = trajectoryLogger;

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@babylon/shared": "workspace:*",
+    "@elizaos/plugin-sql": "^1.6.4",
     "drizzle-orm": "^0.44.7",
     "postgres": "^3.4.7"
   },

--- a/packages/db/src/schema/eliza.ts
+++ b/packages/db/src/schema/eliza.ts
@@ -1,0 +1,34 @@
+/**
+ * ElizaOS schema re-exports.
+ *
+ * Re-exports @elizaos/plugin-sql schema tables so Drizzle Kit can manage
+ * their DDL through `bun run db:generate && bun run db:migrate` instead of
+ * the framework's runtime migrator (which adds ~2 min cold-start per agent
+ * and is not designed for serverless deployments).
+ *
+ * Pattern borrowed from eliza-cloud-v2/db/schemas/eliza.ts.
+ */
+import plugin from '@elizaos/plugin-sql/node';
+
+const pluginSchema = (plugin as unknown as { schema: Record<string, unknown> })
+  .schema;
+
+export const elizaAgentTable = pluginSchema.agentTable;
+export const elizaRoomTable = pluginSchema.roomTable;
+export const elizaParticipantTable = pluginSchema.participantTable;
+export const elizaMemoryTable = pluginSchema.memoryTable;
+export const elizaEmbeddingTable = pluginSchema.embeddingTable;
+export const elizaEntityTable = pluginSchema.entityTable;
+export const elizaRelationshipTable = pluginSchema.relationshipTable;
+export const elizaComponentTable = pluginSchema.componentTable;
+export const elizaTaskTable = pluginSchema.taskTable;
+export const elizaLogTable = pluginSchema.logTable;
+export const elizaCacheTable = pluginSchema.cacheTable;
+export const elizaWorldTable = pluginSchema.worldTable;
+export const elizaMessageTable = pluginSchema.messageTable;
+export const elizaMessageServerTable = pluginSchema.messageServerTable;
+export const elizaChannelTable = pluginSchema.channelTable;
+export const elizaChannelParticipantsTable =
+  pluginSchema.channelParticipantsTable;
+export const elizaMessageServerAgentsTable =
+  pluginSchema.messageServerAgentsTable;

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -6,6 +6,8 @@ export * from './actor-state';
 export * from './actors';
 export * from './admin';
 export * from './agents';
+// ElizaOS framework tables (managed here instead of runtime migrations)
+export * from './eliza';
 // Enums
 export * from './enums';
 export * from './markets';


### PR DESCRIPTION
## Problem

elizaOS `plugin-sql` runtime migrator (`RuntimeMigrator`) runs on **every** `runtime.initialize()` call. It:

1. Creates a `migrations` schema with `_migrations`, `_journal`, `_snapshots` tables
2. Introspects the entire DB, diffs against plugin schemas, and applies DDL changes
3. Takes **~2 minutes per agent** on cold start

This is called **3 times** in `AgentRuntimeManager` (NPC agents, user-controlled agents, coordinator), and once per unique agent runtime creation. In a serverless environment this is a non-starter — it was never designed for it.

Meanwhile, Babylon already manages its own schema via Drizzle Kit (`bun run db:generate && bun run db:migrate`) and stubs out the elizaOS DB adapter entirely (`createAdapterStubs`).

## Solution

**1. Skip runtime migrations** — pass `{ skipMigrations: true }` to all 3 `runtime.initialize()` call sites (same approach used by [eliza-cloud-v2](https://github.com/elizaOS/eliza-cloud-v2)).

**2. Own the elizaOS tables via Drizzle** — re-export `@elizaos/plugin-sql` schema tables in `packages/db/src/schema/eliza.ts` so they are included in Babylon's Drizzle Kit migrations. This means `bun run db:generate` will pick up any elizaOS table changes and `bun run db:migrate` will apply them in a controlled way.

## Changes

- `packages/agents/src/runtime/AgentRuntimeManager.ts` — `{ skipMigrations: true }` on all 3 `runtime.initialize()` calls
- `packages/db/src/schema/eliza.ts` — new file re-exporting plugin-sql schema tables (prefixed with `eliza*` to avoid name collisions)
- `packages/db/src/schema/index.ts` — exports the new eliza schema
- `packages/db/package.json` — adds `@elizaos/plugin-sql` as explicit dependency

## Migration path

After merging, run `bun run db:generate` to capture the elizaOS tables in a Drizzle migration, then `bun run db:migrate` to apply. Existing databases that already have these tables (created by the runtime migrator) will be a no-op.