### PR TITLE
fix(agents): require real offline-ready Privy wallets

### DIFF
--- a/changelogs/agent-offline-wallet-ready-remediation.md
+++ b/changelogs/agent-offline-wallet-ready-remediation.md
@@ -1,0 +1,8 @@
+**PR:** https://github.com/BabylonSocial/babylon/pull/1251
+**Linear:** N/A
+
+### Agent Offline-Ready Wallet Remediation
+- Remove the agent wallet fallback path that could persist fake custody state without a usable signing backend.
+- Enforce canonical Privy-backed wallet state for agents with `privyId`, `privyWalletId`, `walletAddress`, and `offlineWalletReady`.
+- Add audit and remediation scripts to classify agent wallet state and repair corrupted records safely.
+- Remediate all current staging and production agent records to the offline-ready Privy wallet model.

--- a/packages/agents/src/__tests__/agent-wallet-service.test.ts
+++ b/packages/agents/src/__tests__/agent-wallet-service.test.ts
@@ -208,7 +208,7 @@ describe('AgentWalletService', () => {
     ];
 
     await expect(service.createAgentEmbeddedWallet('agent-4')).rejects.toThrow(
-      'Agent wallet state is inconsistent; manual remediation required'
+      /agent-4.*inconsistent|inconsistent.*agent-4/i
     );
 
     expect(mockProvisionAgentPrivyWallet).not.toHaveBeenCalled();
@@ -285,5 +285,37 @@ describe('AgentWalletService', () => {
     ).rejects.toThrow('Agent wallet is not offline-ready');
 
     expect(mockSignPrivyEvmTransaction).not.toHaveBeenCalled();
+  });
+
+  const readyAgent = {
+    id: 'agent-val',
+    isAgent: true,
+    privyId: 'did:privy:agent-val',
+    privyWalletId: 'wallet-val',
+    walletAddress: '0x000000000000000000000000000000000000000a',
+    offlineWalletReady: true,
+  };
+
+  it.each([
+    ['empty string', '', undefined],
+    ['whitespace only', '   ', undefined],
+    ['"0"', '0', undefined],
+    ['"0x0"', '0x0', undefined],
+    ['decimal integer', '1000000000000000000', 1000000000000000000n],
+    ['hex value "0x1"', '0x1', 1n],
+    ['hex ETH value', '0xde0b6b3a7640000', 1000000000000000000n],
+  ])('passes valueWei correctly for value %s', async (_label, value, expectedValueWei) => {
+    selectedRows = [readyAgent];
+    mockSignPrivyEvmTransaction.mockResolvedValue('0xsigned');
+
+    await service.signTransaction('agent-val', {
+      to: '0x000000000000000000000000000000000000000a',
+      value,
+      data: '0x',
+    });
+
+    expect(mockSignPrivyEvmTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({ valueWei: expectedValueWei })
+    );
   });
 });

--- a/packages/agents/src/__tests__/agent-wallet-service.test.ts
+++ b/packages/agents/src/__tests__/agent-wallet-service.test.ts
@@ -1,119 +1,260 @@
-/**
- * Unit Tests for Agent Wallet Service
- * Verifies Privy integration and on-chain registration with mocked dependencies
- */
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
 
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import { ethers } from 'ethers';
+const mockProvisionAgentPrivyWallet = mock();
+const mockSignPrivyEvmTransaction = mock();
 
-// Mock database
+let selectedRows: unknown[] = [];
+let lastUpdateData: Record<string, unknown> | null = null;
+let lastInsertedLog: Record<string, unknown> | null = null;
+
 const mockDb = {
   select: mock(() => ({
     from: mock(() => ({
-      where: mock(async () => [
-        {
-          id: 'test-agent-id',
-          walletAddress: '0x1234567890123456789012345678901234567890',
-          privyId: 'did:privy:test-wallet',
-        },
-      ]),
+      where: mock(() => ({
+        limit: mock(async () => selectedRows),
+      })),
     })),
   })),
   update: mock(() => ({
-    set: mock(() => ({
-      where: mock(async () => []),
-    })),
+    set: mock((data: Record<string, unknown>) => {
+      lastUpdateData = data;
+      return {
+        where: mock(async () => []),
+      };
+    }),
+  })),
+  insert: mock(() => ({
+    values: mock(async (data: Record<string, unknown>) => {
+      lastInsertedLog = data;
+      return [];
+    }),
   })),
 };
 
-// Mock the db module
-mock.module('@babylon/db', () => ({
-  db: mockDb,
-  users: { id: 'id' },
-  eq: (a: unknown, b: unknown) => ({ a, b }),
+mock.module('@babylon/api', () => ({
+  provisionAgentPrivyWallet: mockProvisionAgentPrivyWallet,
+  signPrivyEvmTransaction: mockSignPrivyEvmTransaction,
 }));
 
-// Mock ethers wallet
-const mockWallet = ethers.Wallet.createRandom();
+mock.module('@babylon/db', () => ({
+  agentLogs: { id: 'id' },
+  db: mockDb,
+  eq: (field: unknown, value: unknown) => ({ field, value }),
+  users: {
+    id: 'id',
+    isAgent: 'isAgent',
+    walletAddress: 'walletAddress',
+    privyId: 'privyId',
+    privyWalletId: 'privyWalletId',
+    offlineWalletReady: 'offlineWalletReady',
+  },
+}));
 
-describe('Agent Wallet Service', () => {
+mock.module('../agent0/sdk-instance', () => ({
+  getAgent0SDK: () => ({
+    createAgent: () => {
+      throw new Error('not expected in these tests');
+    },
+    getAgent: async () => null,
+  }),
+}));
+
+mock.module('../shared/agent-config', () => ({
+  getAgentConfig: async () => null,
+  isAutonomousTradingEnabled: () => false,
+}));
+
+mock.module('../shared/logger', () => ({
+  logger: {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  },
+}));
+
+const { AgentWalletService } = await import('../identity/AgentWalletService');
+
+describe('AgentWalletService', () => {
+  let service: InstanceType<typeof AgentWalletService>;
+
   beforeEach(() => {
+    service = new AgentWalletService();
+    selectedRows = [];
+    lastUpdateData = null;
+    lastInsertedLog = null;
+    mockProvisionAgentPrivyWallet.mockReset();
+    mockSignPrivyEvmTransaction.mockReset();
     mockDb.select.mockClear();
+    mockDb.update.mockClear();
+    mockDb.insert.mockClear();
   });
 
-  test('generates valid Ethereum addresses', () => {
-    const address = mockWallet.address;
-
-    expect(address).toBeTruthy();
-    expect(address).toMatch(/^0x[a-fA-F0-9]{40}$/);
-    expect(address.length).toBe(42);
-  });
-
-  test('wallet addresses have correct format', () => {
-    const addresses = [
-      '0x1234567890123456789012345678901234567890',
-      '0xabcdef0123456789ABCDEF0123456789abcdef01',
-      mockWallet.address,
+  it('returns the persisted wallet when the agent is already ready', async () => {
+    selectedRows = [
+      {
+        id: 'agent-1',
+        isAgent: true,
+        walletAddress: '0x0000000000000000000000000000000000000001',
+        privyId: 'did:privy:agent-1',
+        privyWalletId: 'wallet-1',
+        offlineWalletReady: true,
+      },
     ];
 
-    for (const address of addresses) {
-      expect(address).toMatch(/^0x[a-fA-F0-9]{40}$/);
-      expect(address.length).toBe(42);
-    }
+    const result = await service.createAgentEmbeddedWallet('agent-1');
+
+    expect(result).toEqual({
+      walletAddress: '0x0000000000000000000000000000000000000001',
+      privyUserId: 'did:privy:agent-1',
+      privyWalletId: 'wallet-1',
+    });
+    expect(mockProvisionAgentPrivyWallet).not.toHaveBeenCalled();
+    expect(mockDb.update).not.toHaveBeenCalled();
   });
 
-  test('can create wallet from random seed', () => {
-    const wallet1 = ethers.Wallet.createRandom();
-    const wallet2 = ethers.Wallet.createRandom();
+  it('provisions and persists a new offline-ready wallet from scratch', async () => {
+    selectedRows = [
+      {
+        id: 'agent-2',
+        isAgent: true,
+        walletAddress: null,
+        privyId: null,
+        privyWalletId: null,
+        offlineWalletReady: false,
+      },
+    ];
+    mockProvisionAgentPrivyWallet.mockResolvedValue({
+      privyId: 'did:privy:agent-2',
+      privyWalletId: 'wallet-2',
+      walletAddress: '0x0000000000000000000000000000000000000002',
+      offlineWalletReady: true,
+      createdPrivyUser: true,
+      createdWallet: false,
+      updatedSigner: false,
+    });
 
-    expect(wallet1.address).not.toBe(wallet2.address);
-    expect(wallet1.privateKey).not.toBe(wallet2.privateKey);
+    const result = await service.createAgentEmbeddedWallet('agent-2');
+
+    expect(mockProvisionAgentPrivyWallet).toHaveBeenCalledWith({
+      agentUserId: 'agent-2',
+      existingPrivyId: null,
+    });
+    expect(lastUpdateData).toMatchObject({
+      walletAddress: '0x0000000000000000000000000000000000000002',
+      privyId: 'did:privy:agent-2',
+      privyWalletId: 'wallet-2',
+      offlineWalletReady: true,
+      offlineWalletReadyAt: expect.any(Date),
+      updatedAt: expect.any(Date),
+    });
+    expect(lastInsertedLog).toMatchObject({
+      agentUserId: 'agent-2',
+      type: 'system',
+      level: 'info',
+      message:
+        'Agent wallet provisioned: 0x0000000000000000000000000000000000000002',
+    });
+    expect(result).toEqual({
+      walletAddress: '0x0000000000000000000000000000000000000002',
+      privyUserId: 'did:privy:agent-2',
+      privyWalletId: 'wallet-2',
+    });
   });
 
-  test('wallet private key has correct format', () => {
-    expect(mockWallet.privateKey).toMatch(/^0x[a-fA-F0-9]{64}$/);
+  it('reuses an existing Privy user when only wallet readiness is missing', async () => {
+    selectedRows = [
+      {
+        id: 'agent-3',
+        isAgent: true,
+        walletAddress: null,
+        privyId: 'did:privy:agent-3',
+        privyWalletId: null,
+        offlineWalletReady: false,
+      },
+    ];
+    mockProvisionAgentPrivyWallet.mockResolvedValue({
+      privyId: 'did:privy:agent-3',
+      privyWalletId: 'wallet-3',
+      walletAddress: '0x0000000000000000000000000000000000000003',
+      offlineWalletReady: true,
+      createdPrivyUser: false,
+      createdWallet: true,
+      updatedSigner: false,
+    });
+
+    await service.createAgentEmbeddedWallet('agent-3');
+
+    expect(mockProvisionAgentPrivyWallet).toHaveBeenCalledWith({
+      agentUserId: 'agent-3',
+      existingPrivyId: 'did:privy:agent-3',
+    });
   });
 
-  test('can sign messages with wallet', async () => {
-    const message = 'Test message for signing';
-    const signature = await mockWallet.signMessage(message);
+  it('rejects inconsistent partial wallet state instead of masking it', async () => {
+    selectedRows = [
+      {
+        id: 'agent-4',
+        isAgent: true,
+        walletAddress: '0x0000000000000000000000000000000000000004',
+        privyId: null,
+        privyWalletId: null,
+        offlineWalletReady: false,
+      },
+    ];
 
-    expect(signature).toBeTruthy();
-    expect(signature).toMatch(/^0x[a-fA-F0-9]+$/);
-
-    // Verify signature
-    const recoveredAddress = ethers.verifyMessage(message, signature);
-    expect(recoveredAddress).toBe(mockWallet.address);
-  });
-
-  test('database mock returns expected agent data', async () => {
-    const result = await mockDb
-      .select()
-      .from({ id: 'id' })
-      .where({ a: 'id', b: 'test-agent-id' });
-
-    expect(result).toHaveLength(1);
-    expect(result[0]?.walletAddress).toBe(
-      '0x1234567890123456789012345678901234567890'
+    await expect(service.createAgentEmbeddedWallet('agent-4')).rejects.toThrow(
+      'Agent wallet state is inconsistent; manual remediation required'
     );
+
+    expect(mockProvisionAgentPrivyWallet).not.toHaveBeenCalled();
+    expect(mockDb.update).not.toHaveBeenCalled();
   });
 
-  test('verifyOnChainIdentity returns boolean', () => {
-    // Without actual chain, verification returns false
-    const isVerified = false;
-    expect(typeof isVerified).toBe('boolean');
+  it('signs transactions with the persisted Privy wallet id', async () => {
+    selectedRows = [
+      {
+        id: 'agent-5',
+        isAgent: true,
+        privyWalletId: 'wallet-5',
+        offlineWalletReady: true,
+      },
+    ];
+    mockSignPrivyEvmTransaction.mockResolvedValue('0xsigned');
+
+    const result = await service.signTransaction('agent-5', {
+      to: '0x0000000000000000000000000000000000000005',
+      value: '42',
+      data: '0xdeadbeef',
+    });
+
+    expect(result).toBe('0xsigned');
+    expect(mockSignPrivyEvmTransaction).toHaveBeenCalledWith({
+      walletId: 'wallet-5',
+      to: '0x0000000000000000000000000000000000000005',
+      data: '0xdeadbeef',
+      valueWei: 42n,
+    });
   });
 
-  test('setupAgentIdentity result structure', () => {
-    const result = {
-      walletAddress: mockWallet.address,
-      onChainRegistered: false,
-      privyUserId: 'did:privy:test-123',
-      privyWalletId: 'wallet-123',
-    };
+  it('blocks signing when the wallet is not offline-ready', async () => {
+    selectedRows = [
+      {
+        id: 'agent-6',
+        isAgent: true,
+        privyWalletId: null,
+        offlineWalletReady: false,
+      },
+    ];
 
-    expect(result.walletAddress).toMatch(/^0x[a-fA-F0-9]{40}$/);
-    expect(typeof result.onChainRegistered).toBe('boolean');
-    expect(result.privyUserId).toBeTruthy();
+    await expect(
+      service.signTransaction('agent-6', {
+        to: '0x0000000000000000000000000000000000000006',
+        value: '0',
+        data: '0x',
+      })
+    ).rejects.toThrow('Agent wallet is not offline-ready');
+
+    expect(mockSignPrivyEvmTransaction).not.toHaveBeenCalled();
   });
 });

--- a/packages/agents/src/__tests__/agent-wallet-service.test.ts
+++ b/packages/agents/src/__tests__/agent-wallet-service.test.ts
@@ -301,6 +301,8 @@ describe('AgentWalletService', () => {
     ['whitespace only', '   ', undefined],
     ['"0"', '0', undefined],
     ['"0x0"', '0x0', undefined],
+    ['bare hex prefix "0x"', '0x', undefined],
+    ['malformed hex "0xgg"', '0xgg', undefined],
     ['decimal integer', '1000000000000000000', 1000000000000000000n],
     ['hex value "0x1"', '0x1', 1n],
     ['hex ETH value', '0xde0b6b3a7640000', 1000000000000000000n],

--- a/packages/agents/src/__tests__/agent-wallet-service.test.ts
+++ b/packages/agents/src/__tests__/agent-wallet-service.test.ts
@@ -73,6 +73,10 @@ mock.module('../shared/logger', () => ({
   },
 }));
 
+mock.module('uuid', () => ({
+  v4: () => 'test-uuid',
+}));
+
 const { AgentWalletService } = await import('../identity/AgentWalletService');
 
 describe('AgentWalletService', () => {
@@ -216,7 +220,9 @@ describe('AgentWalletService', () => {
       {
         id: 'agent-5',
         isAgent: true,
+        privyId: 'did:privy:agent-5',
         privyWalletId: 'wallet-5',
+        walletAddress: '0x0000000000000000000000000000000000000005',
         offlineWalletReady: true,
       },
     ];
@@ -250,6 +256,29 @@ describe('AgentWalletService', () => {
     await expect(
       service.signTransaction('agent-6', {
         to: '0x0000000000000000000000000000000000000006',
+        value: '0',
+        data: '0x',
+      })
+    ).rejects.toThrow('Agent wallet is not offline-ready');
+
+    expect(mockSignPrivyEvmTransaction).not.toHaveBeenCalled();
+  });
+
+  it('blocks signing when the persisted wallet state is partial', async () => {
+    selectedRows = [
+      {
+        id: 'agent-7',
+        isAgent: true,
+        privyId: null,
+        privyWalletId: 'wallet-7',
+        walletAddress: null,
+        offlineWalletReady: true,
+      },
+    ];
+
+    await expect(
+      service.signTransaction('agent-7', {
+        to: '0x0000000000000000000000000000000000000007',
         value: '0',
         data: '0x',
       })

--- a/packages/agents/src/__tests__/agent-wallet-state.test.ts
+++ b/packages/agents/src/__tests__/agent-wallet-state.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'bun:test';
+import { assessAgentWalletState } from '../identity/agent-wallet-state';
+
+describe('assessAgentWalletState', () => {
+  it('classifies a fully ready wallet state as ready', () => {
+    const result = assessAgentWalletState({
+      privyId: 'did:privy:agent-1',
+      privyWalletId: 'wallet-1',
+      walletAddress: '0x0000000000000000000000000000000000000001',
+      offlineWalletReady: true,
+    });
+
+    expect(result.classification).toBe('ready');
+    expect(result.remediationAction).toBe('none');
+    expect(result.isReady).toBe(true);
+  });
+
+  it('classifies an empty state as requiring a new Privy user', () => {
+    const result = assessAgentWalletState({
+      privyId: null,
+      privyWalletId: null,
+      walletAddress: null,
+      offlineWalletReady: false,
+    });
+
+    expect(result.classification).toBe('empty');
+    expect(result.remediationAction).toBe('provision_with_new_privy_user');
+  });
+
+  it('reuses a real Privy user id when wallet readiness is missing', () => {
+    const result = assessAgentWalletState({
+      privyId: 'did:privy:agent-2',
+      privyWalletId: null,
+      walletAddress: null,
+      offlineWalletReady: false,
+    });
+
+    expect(result.classification).toBe('recover_with_existing_privy_user');
+    expect(result.remediationAction).toBe('provision_with_existing_privy_user');
+  });
+
+  it('forces recreation when legacy synthetic ids are present', () => {
+    const result = assessAgentWalletState({
+      privyId: 'dev_agent-3',
+      privyWalletId: 'dev_wallet_agent-3',
+      walletAddress: '0x0000000000000000000000000000000000000003',
+      offlineWalletReady: false,
+    });
+
+    expect(result.classification).toBe('recreate_privy_user');
+    expect(result.remediationAction).toBe('provision_with_new_privy_user');
+    expect(result.hasSyntheticPrivyId).toBe(true);
+    expect(result.hasSyntheticPrivyWalletId).toBe(true);
+  });
+
+  it('treats wallet-address-only state as requiring a new Privy user', () => {
+    const result = assessAgentWalletState({
+      privyId: null,
+      privyWalletId: null,
+      walletAddress: '0x0000000000000000000000000000000000000004',
+      offlineWalletReady: false,
+    });
+
+    expect(result.classification).toBe('recreate_privy_user');
+    expect(result.remediationAction).toBe('provision_with_new_privy_user');
+  });
+});

--- a/packages/agents/src/__tests__/agent-wallet-state.test.ts
+++ b/packages/agents/src/__tests__/agent-wallet-state.test.ts
@@ -64,4 +64,29 @@ describe('assessAgentWalletState', () => {
     expect(result.classification).toBe('recreate_privy_user');
     expect(result.remediationAction).toBe('provision_with_new_privy_user');
   });
+
+  it('classifies real privyId + partial wallet state as offline_signer_missing', () => {
+    const result = assessAgentWalletState({
+      privyId: 'did:privy:agent-5',
+      privyWalletId: 'wallet-5',
+      walletAddress: '0x0000000000000000000000000000000000000005',
+      offlineWalletReady: false,
+    });
+
+    expect(result.classification).toBe('offline_signer_missing');
+    expect(result.remediationAction).toBe('provision_with_existing_privy_user');
+    expect(result.isReady).toBe(false);
+  });
+
+  it('classifies real privyId + privyWalletId only (no address) as offline_signer_missing', () => {
+    const result = assessAgentWalletState({
+      privyId: 'did:privy:agent-6',
+      privyWalletId: 'wallet-6',
+      walletAddress: null,
+      offlineWalletReady: false,
+    });
+
+    expect(result.classification).toBe('offline_signer_missing');
+    expect(result.remediationAction).toBe('provision_with_existing_privy_user');
+  });
 });

--- a/packages/agents/src/identity/AgentIdentityService.ts
+++ b/packages/agents/src/identity/AgentIdentityService.ts
@@ -27,6 +27,7 @@ import {
 import { logger } from '../shared/logger';
 import { generateSnowflakeId } from '../shared/snowflake';
 import { agentWalletService } from './AgentWalletService';
+import { isAgentWalletReady } from './agent-wallet-state';
 
 /**
  * Service for agent identity management
@@ -98,8 +99,9 @@ export class AgentIdentityService {
 
     if (!agentUser || !agentUser.isAgent)
       throw new Error('Agent user not found');
-    if (!agentUser.walletAddress)
-      throw new Error('Agent must have wallet before Agent0 registration');
+    if (!isAgentWalletReady(agentUser)) {
+      throw new Error('Agent wallet is not ready for Agent0 registration');
+    }
 
     // Get agent config for capabilities
     const config = await getAgentConfig(agentUserId);

--- a/packages/agents/src/identity/AgentWalletService.ts
+++ b/packages/agents/src/identity/AgentWalletService.ts
@@ -85,10 +85,11 @@ export class AgentWalletService {
     );
     if (
       assessment.classification !== 'empty' &&
-      assessment.classification !== 'recover_with_existing_privy_user'
+      assessment.classification !== 'recover_with_existing_privy_user' &&
+      assessment.classification !== 'offline_signer_missing'
     ) {
       throw new Error(
-        'Agent wallet state is inconsistent; manual remediation required'
+        `Agent ${agentUserId} wallet state is inconsistent (${assessment.classification}); manual remediation required`
       );
     }
     const existingPrivyId =

--- a/packages/agents/src/identity/AgentWalletService.ts
+++ b/packages/agents/src/identity/AgentWalletService.ts
@@ -334,7 +334,9 @@ export class AgentWalletService {
       .select({
         id: users.id,
         isAgent: users.isAgent,
+        privyId: users.privyId,
         privyWalletId: users.privyWalletId,
+        walletAddress: users.walletAddress,
         offlineWalletReady: users.offlineWalletReady,
       })
       .from(users)
@@ -345,12 +347,12 @@ export class AgentWalletService {
       throw new Error('Agent not found');
     }
 
-    if (!agent.privyWalletId || !agent.offlineWalletReady) {
+    if (!isAgentWalletReady(agent)) {
       throw new Error('Agent wallet is not offline-ready');
     }
 
     const signedTransaction = await signPrivyEvmTransaction({
-      walletId: agent.privyWalletId,
+      walletId: agent.privyWalletId!,
       to: transactionData.to as `0x${string}`,
       data: transactionData.data as `0x${string}`,
       valueWei: parseTransactionValue(transactionData.value),

--- a/packages/agents/src/identity/AgentWalletService.ts
+++ b/packages/agents/src/identity/AgentWalletService.ts
@@ -32,7 +32,11 @@ function parseTransactionValue(value: string): bigint | undefined {
     return undefined;
   }
 
-  return BigInt(trimmed);
+  try {
+    return BigInt(trimmed);
+  } catch {
+    return undefined;
+  }
 }
 
 export class AgentWalletService {

--- a/packages/agents/src/identity/AgentWalletService.ts
+++ b/packages/agents/src/identity/AgentWalletService.ts
@@ -8,10 +8,11 @@
  * @packageDocumentation
  */
 
-import { getPrivyAppIdFromEnv, getTrimmedEnv } from '@babylon/api';
+import {
+  provisionAgentPrivyWallet,
+  signPrivyEvmTransaction,
+} from '@babylon/api';
 import { agentLogs, db, eq, type JsonValue, users } from '@babylon/db';
-import { PrivyClient } from '@privy-io/server-auth';
-import { ethers } from 'ethers';
 import { v4 as uuidv4 } from 'uuid';
 import { getAgent0SDK } from '../agent0/sdk-instance';
 import {
@@ -20,83 +21,54 @@ import {
 } from '../shared/agent-config';
 import { logger } from '../shared/logger';
 
-/**
- * Privy wallet structure
- * @internal
- */
-interface PrivyWallet {
-  address: string;
+type AgentWalletSnapshot = {
   id: string;
+  isAgent: boolean;
+  walletAddress: string | null;
+  privyId: string | null;
+  privyWalletId: string | null;
+  offlineWalletReady: boolean;
+};
+
+function isAgentWalletReady(agent: AgentWalletSnapshot): boolean {
+  return Boolean(
+    agent.privyId &&
+      agent.privyWalletId &&
+      agent.walletAddress &&
+      agent.offlineWalletReady
+  );
 }
 
-/**
- * Privy user structure
- * @internal
- */
-interface PrivyUser {
-  id: string;
-  wallet?: PrivyWallet;
+function canProvisionFromScratch(agent: AgentWalletSnapshot): boolean {
+  return (
+    !agent.privyId &&
+    !agent.privyWalletId &&
+    !agent.walletAddress &&
+    !agent.offlineWalletReady
+  );
 }
 
-/**
- * Privy create user parameters
- * @internal
- */
-interface PrivyCreateUserParams {
-  create_embedded_wallet: boolean;
-  linked_accounts: Array<Record<string, unknown>>;
+function canProvisionExistingPrivyUser(agent: AgentWalletSnapshot): boolean {
+  return (
+    Boolean(agent.privyId) &&
+    !agent.privyWalletId &&
+    !agent.walletAddress &&
+    !agent.offlineWalletReady
+  );
 }
 
-/**
- * Privy sign transaction parameters
- * @internal
- */
-interface PrivySignTransactionParams {
-  wallet_id: string;
-  transaction: {
-    to: string;
-    value: string;
-    data: string;
-  };
-}
-
-/**
- * Privy signed transaction response
- * @internal
- */
-interface PrivySignedTransaction {
-  signed_transaction: string;
-}
-
-/**
- * Extended Privy client with additional methods
- * @internal
- */
-interface ExtendedPrivyClient extends PrivyClient {
-  createUser(params: PrivyCreateUserParams): Promise<PrivyUser>;
-  signTransaction(
-    params: PrivySignTransactionParams
-  ): Promise<PrivySignedTransaction>;
-}
-
-let privyClient: ExtendedPrivyClient | null = null;
-
-function getPrivyServerClient(): ExtendedPrivyClient | null {
-  const appId = getPrivyAppIdFromEnv();
-  const appSecret = getTrimmedEnv('PRIVY_APP_SECRET');
-  if (!appId || !appSecret) return null;
-
-  if (!privyClient) {
-    privyClient = new PrivyClient(appId, appSecret) as ExtendedPrivyClient;
+function parseTransactionValue(value: string): bigint | undefined {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === '0' || trimmed === '0x0') {
+    return undefined;
   }
 
-  return privyClient;
+  return BigInt(trimmed);
 }
 
 export class AgentWalletService {
   /**
-   * Create embedded wallet for agent via Privy (server-side, no user interaction)
-   * Falls back to dev wallet in development if Privy is not configured.
+   * Provision a Privy-backed offline-ready wallet for an agent.
    */
   async createAgentEmbeddedWallet(agentUserId: string): Promise<{
     walletAddress: string;
@@ -104,7 +76,14 @@ export class AgentWalletService {
     privyWalletId: string;
   }> {
     const [agent] = await db
-      .select()
+      .select({
+        id: users.id,
+        isAgent: users.isAgent,
+        walletAddress: users.walletAddress,
+        privyId: users.privyId,
+        privyWalletId: users.privyWalletId,
+        offlineWalletReady: users.offlineWalletReady,
+      })
       .from(users)
       .where(eq(users.id, agentUserId))
       .limit(1);
@@ -113,121 +92,98 @@ export class AgentWalletService {
       throw new Error('Agent user not found');
     }
 
-    // Check if agent already has a wallet address
-    if (agent.walletAddress) {
+    if (isAgentWalletReady(agent)) {
       logger.info(
-        'Agent already has wallet address, skipping creation',
+        'Agent wallet already provisioned and ready',
         {
           agentUserId,
           walletAddress: agent.walletAddress,
+          privyId: agent.privyId,
+          privyWalletId: agent.privyWalletId,
         },
         'AgentWalletService'
       );
 
       return {
-        walletAddress: agent.walletAddress,
-        privyUserId: agent.privyId || `dev_${agentUserId}`,
-        privyWalletId: `dev_wallet_${agentUserId}`,
+        walletAddress: agent.walletAddress!,
+        privyUserId: agent.privyId!,
+        privyWalletId: agent.privyWalletId!,
       };
     }
 
-    // Check if Privy is configured and if createUser method exists
-    const privy = getPrivyServerClient();
-    const hasPrivyConfig = !!privy;
+    const existingPrivyId = canProvisionExistingPrivyUser(agent)
+      ? agent.privyId
+      : null;
+    const canProvision =
+      canProvisionFromScratch(agent) || Boolean(existingPrivyId);
 
-    // Check if createUser method exists (it may not in newer Privy SDK versions)
-    // PrivyClient may have createUser method that's not in the type definition
-    interface PrivyClientWithCreateUser {
-      createUser?: (params: PrivyCreateUserParams) => Promise<PrivyUser>;
-    }
-    const privyWithCreateUser = privy as PrivyClientWithCreateUser | null;
-    const hasCreateUserMethod =
-      typeof privyWithCreateUser?.createUser === 'function';
-
-    // If Privy is not available, skip directly to dev wallet (no error)
-    if (!hasPrivyConfig || !hasCreateUserMethod) {
-      logger.info(
-        'Privy not available, using development wallet',
-        {
-          agentUserId,
-          hasPrivyConfig,
-          hasCreateUserMethod,
-        },
-        'AgentWalletService'
+    if (!canProvision) {
+      throw new Error(
+        'Agent wallet state is inconsistent; manual remediation required'
       );
-
-      // Create dev wallet directly
-      const devWallet = ethers.Wallet.createRandom();
-      const walletAddress = devWallet.address;
-      const privyUserId = `dev_${agentUserId}`;
-      const privyWalletId = `dev_wallet_${agentUserId}`;
-
-      await db
-        .update(users)
-        .set({
-          walletAddress,
-          privyId: privyUserId,
-        })
-        .where(eq(users.id, agentUserId));
-
-      return { walletAddress, privyUserId, privyWalletId };
     }
 
-    // Try Privy wallet creation
     logger.info(
-      `Creating Privy embedded wallet for agent ${agentUserId}`,
-      undefined,
+      'Provisioning offline-ready Privy wallet for agent',
+      {
+        agentUserId,
+        existingPrivyId,
+      },
       'AgentWalletService'
     );
 
-    // Step 1: Create Privy user for the agent (server-side)
-    // Privy allows server-side user creation without user interaction
-    if (!privyWithCreateUser?.createUser) {
-      throw new Error('Privy createUser method not available');
-    }
-    const privyUser = await privyWithCreateUser.createUser({
-      create_embedded_wallet: true,
-      linked_accounts: [],
+    const provisionedWallet = await provisionAgentPrivyWallet({
+      agentUserId,
+      existingPrivyId,
     });
 
-    if (!privyUser.wallet) {
-      throw new Error('Failed to create embedded wallet');
-    }
-
-    const walletAddress = privyUser.wallet.address;
-    const privyUserId = privyUser.id;
-    const privyWalletId = privyUser.wallet.id;
-
-    // Step 2: Update agent user with wallet info
     await db
       .update(users)
       .set({
-        walletAddress,
-        privyId: privyUserId,
+        walletAddress: provisionedWallet.walletAddress,
+        privyId: provisionedWallet.privyId,
+        privyWalletId: provisionedWallet.privyWalletId,
+        offlineWalletReady: true,
+        offlineWalletReadyAt: new Date(),
+        updatedAt: new Date(),
       })
       .where(eq(users.id, agentUserId));
 
-    // Step 3: Log wallet creation
     await db.insert(agentLogs).values({
       id: uuidv4(),
       agentUserId,
       type: 'system',
       level: 'info',
-      message: `Privy embedded wallet created: ${walletAddress}`,
+      message: `Agent wallet provisioned: ${provisionedWallet.walletAddress}`,
       metadata: {
-        privyUserId,
-        privyWalletId,
-        walletAddress,
+        privyUserId: provisionedWallet.privyId,
+        privyWalletId: provisionedWallet.privyWalletId,
+        walletAddress: provisionedWallet.walletAddress,
+        createdPrivyUser: provisionedWallet.createdPrivyUser,
+        createdWallet: provisionedWallet.createdWallet,
+        updatedSigner: provisionedWallet.updatedSigner,
       },
     });
 
     logger.info(
-      `Privy wallet created for agent ${agentUserId}: ${walletAddress}`,
-      undefined,
+      'Agent wallet provisioned successfully',
+      {
+        agentUserId,
+        privyId: provisionedWallet.privyId,
+        privyWalletId: provisionedWallet.privyWalletId,
+        walletAddress: provisionedWallet.walletAddress,
+        createdPrivyUser: provisionedWallet.createdPrivyUser,
+        createdWallet: provisionedWallet.createdWallet,
+        updatedSigner: provisionedWallet.updatedSigner,
+      },
       'AgentWalletService'
     );
 
-    return { walletAddress, privyUserId, privyWalletId };
+    return {
+      walletAddress: provisionedWallet.walletAddress,
+      privyUserId: provisionedWallet.privyId,
+      privyWalletId: provisionedWallet.privyWalletId,
+    };
   }
 
   /**
@@ -254,8 +210,8 @@ export class AgentWalletService {
       throw new Error('Agent user not found');
     }
 
-    if (!agent.walletAddress) {
-      throw new Error('Agent must have wallet before on-chain registration');
+    if (!isAgentWalletReady(agent)) {
+      throw new Error('Agent wallet is not ready for on-chain registration');
     }
 
     // Get agent config for capabilities
@@ -404,7 +360,8 @@ export class AgentWalletService {
       .select({
         id: users.id,
         isAgent: users.isAgent,
-        privyId: users.privyId,
+        privyWalletId: users.privyWalletId,
+        offlineWalletReady: users.offlineWalletReady,
       })
       .from(users)
       .where(eq(users.id, agentUserId))
@@ -414,20 +371,15 @@ export class AgentWalletService {
       throw new Error('Agent not found');
     }
 
-    if (!agent.privyId) {
-      throw new Error('Agent does not have Privy wallet');
+    if (!agent.privyWalletId || !agent.offlineWalletReady) {
+      throw new Error('Agent wallet is not offline-ready');
     }
 
-    const privy = getPrivyServerClient();
-    if (!privy) {
-      throw new Error('Privy credentials not configured');
-    }
-
-    // Use Privy server client to sign transaction (no user interaction needed)
-    // Privy handles the private key management and signing server-side
-    const signedTx = await privy.signTransaction({
-      wallet_id: agent.privyId,
-      transaction: transactionData,
+    const signedTransaction = await signPrivyEvmTransaction({
+      walletId: agent.privyWalletId,
+      to: transactionData.to as `0x${string}`,
+      data: transactionData.data as `0x${string}`,
+      valueWei: parseTransactionValue(transactionData.value),
     });
 
     logger.info(
@@ -436,7 +388,7 @@ export class AgentWalletService {
       'AgentWalletService'
     );
 
-    return signedTx.signed_transaction;
+    return signedTransaction;
   }
 
   /**

--- a/packages/agents/src/identity/AgentWalletService.ts
+++ b/packages/agents/src/identity/AgentWalletService.ts
@@ -20,42 +20,11 @@ import {
   isAutonomousTradingEnabled,
 } from '../shared/agent-config';
 import { logger } from '../shared/logger';
-
-type AgentWalletSnapshot = {
-  id: string;
-  isAgent: boolean;
-  walletAddress: string | null;
-  privyId: string | null;
-  privyWalletId: string | null;
-  offlineWalletReady: boolean;
-};
-
-function isAgentWalletReady(agent: AgentWalletSnapshot): boolean {
-  return Boolean(
-    agent.privyId &&
-      agent.privyWalletId &&
-      agent.walletAddress &&
-      agent.offlineWalletReady
-  );
-}
-
-function canProvisionFromScratch(agent: AgentWalletSnapshot): boolean {
-  return (
-    !agent.privyId &&
-    !agent.privyWalletId &&
-    !agent.walletAddress &&
-    !agent.offlineWalletReady
-  );
-}
-
-function canProvisionExistingPrivyUser(agent: AgentWalletSnapshot): boolean {
-  return (
-    Boolean(agent.privyId) &&
-    !agent.privyWalletId &&
-    !agent.walletAddress &&
-    !agent.offlineWalletReady
-  );
-}
+import {
+  type AgentWalletStateSnapshot,
+  assessAgentWalletState,
+  isAgentWalletReady,
+} from './agent-wallet-state';
 
 function parseTransactionValue(value: string): bigint | undefined {
   const trimmed = value.trim();
@@ -111,23 +80,28 @@ export class AgentWalletService {
       };
     }
 
-    const existingPrivyId = canProvisionExistingPrivyUser(agent)
-      ? agent.privyId
-      : null;
-    const canProvision =
-      canProvisionFromScratch(agent) || Boolean(existingPrivyId);
-
-    if (!canProvision) {
+    const assessment = assessAgentWalletState(
+      agent as AgentWalletStateSnapshot
+    );
+    if (
+      assessment.classification !== 'empty' &&
+      assessment.classification !== 'recover_with_existing_privy_user'
+    ) {
       throw new Error(
         'Agent wallet state is inconsistent; manual remediation required'
       );
     }
+    const existingPrivyId =
+      assessment.remediationAction === 'provision_with_existing_privy_user'
+        ? agent.privyId
+        : null;
 
     logger.info(
       'Provisioning offline-ready Privy wallet for agent',
       {
         agentUserId,
         existingPrivyId,
+        classification: assessment.classification,
       },
       'AgentWalletService'
     );

--- a/packages/agents/src/identity/agent-wallet-state.ts
+++ b/packages/agents/src/identity/agent-wallet-state.ts
@@ -1,0 +1,176 @@
+export type AgentWalletStateSnapshot = {
+  walletAddress: string | null;
+  privyId: string | null;
+  privyWalletId: string | null;
+  offlineWalletReady: boolean;
+};
+
+export type AgentWalletStateClassification =
+  | 'ready'
+  | 'empty'
+  | 'recover_with_existing_privy_user'
+  | 'recreate_privy_user'
+  | 'inconsistent_partial_state';
+
+export type AgentWalletRemediationAction =
+  | 'none'
+  | 'provision_with_existing_privy_user'
+  | 'provision_with_new_privy_user'
+  | 'manual_review';
+
+export type AgentWalletStateAssessment = {
+  classification: AgentWalletStateClassification;
+  remediationAction: AgentWalletRemediationAction;
+  reasons: string[];
+  hasSyntheticPrivyId: boolean;
+  hasSyntheticPrivyWalletId: boolean;
+  isReady: boolean;
+};
+
+function hasValue(value: string | null | undefined): boolean {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+export function isSyntheticAgentPrivyId(
+  privyId: string | null | undefined
+): boolean {
+  return hasValue(privyId) && privyId!.startsWith('dev_');
+}
+
+export function isSyntheticAgentPrivyWalletId(
+  privyWalletId: string | null | undefined
+): boolean {
+  return hasValue(privyWalletId) && privyWalletId!.startsWith('dev_wallet_');
+}
+
+export function isAgentWalletReady(state: AgentWalletStateSnapshot): boolean {
+  return Boolean(
+    hasValue(state.privyId) &&
+      hasValue(state.privyWalletId) &&
+      hasValue(state.walletAddress) &&
+      state.offlineWalletReady
+  );
+}
+
+export function canProvisionAgentWalletFromScratch(
+  state: AgentWalletStateSnapshot
+): boolean {
+  return (
+    !hasValue(state.privyId) &&
+    !hasValue(state.privyWalletId) &&
+    !hasValue(state.walletAddress) &&
+    !state.offlineWalletReady
+  );
+}
+
+export function canProvisionAgentWalletFromExistingPrivyUser(
+  state: AgentWalletStateSnapshot
+): boolean {
+  return (
+    hasValue(state.privyId) &&
+    !isSyntheticAgentPrivyId(state.privyId) &&
+    !hasValue(state.privyWalletId) &&
+    !hasValue(state.walletAddress) &&
+    !state.offlineWalletReady
+  );
+}
+
+export function assessAgentWalletState(
+  state: AgentWalletStateSnapshot
+): AgentWalletStateAssessment {
+  const hasPrivyId = hasValue(state.privyId);
+  const hasPrivyWalletId = hasValue(state.privyWalletId);
+  const hasWalletAddress = hasValue(state.walletAddress);
+  const hasSyntheticPrivyId = isSyntheticAgentPrivyId(state.privyId);
+  const hasSyntheticPrivyWalletId = isSyntheticAgentPrivyWalletId(
+    state.privyWalletId
+  );
+
+  if (isAgentWalletReady(state)) {
+    return {
+      classification: 'ready',
+      remediationAction: 'none',
+      reasons: ['agent wallet is fully provisioned and offline-ready'],
+      hasSyntheticPrivyId,
+      hasSyntheticPrivyWalletId,
+      isReady: true,
+    };
+  }
+
+  if (canProvisionAgentWalletFromScratch(state)) {
+    return {
+      classification: 'empty',
+      remediationAction: 'provision_with_new_privy_user',
+      reasons: ['agent has no persisted Privy wallet state'],
+      hasSyntheticPrivyId,
+      hasSyntheticPrivyWalletId,
+      isReady: false,
+    };
+  }
+
+  if (canProvisionAgentWalletFromExistingPrivyUser(state)) {
+    return {
+      classification: 'recover_with_existing_privy_user',
+      remediationAction: 'provision_with_existing_privy_user',
+      reasons: ['agent has a reusable Privy user id but no wallet-ready state'],
+      hasSyntheticPrivyId,
+      hasSyntheticPrivyWalletId,
+      isReady: false,
+    };
+  }
+
+  if (hasSyntheticPrivyId || hasSyntheticPrivyWalletId) {
+    const reasons = ['agent uses synthetic legacy Privy identifiers'];
+    if (hasWalletAddress) {
+      reasons.push(
+        'stored wallet address is not trusted as a real custody source'
+      );
+    }
+
+    return {
+      classification: 'recreate_privy_user',
+      remediationAction: 'provision_with_new_privy_user',
+      reasons,
+      hasSyntheticPrivyId,
+      hasSyntheticPrivyWalletId,
+      isReady: false,
+    };
+  }
+
+  if (!hasPrivyId && !hasPrivyWalletId && hasWalletAddress) {
+    return {
+      classification: 'recreate_privy_user',
+      remediationAction: 'provision_with_new_privy_user',
+      reasons: [
+        'agent has only a wallet address with no trustworthy Privy ownership metadata',
+      ],
+      hasSyntheticPrivyId,
+      hasSyntheticPrivyWalletId,
+      isReady: false,
+    };
+  }
+
+  if (hasPrivyId && !isSyntheticAgentPrivyId(state.privyId)) {
+    return {
+      classification: 'recover_with_existing_privy_user',
+      remediationAction: 'provision_with_existing_privy_user',
+      reasons: [
+        'agent has a real Privy user id but the persisted wallet state is incomplete',
+      ],
+      hasSyntheticPrivyId,
+      hasSyntheticPrivyWalletId,
+      isReady: false,
+    };
+  }
+
+  return {
+    classification: 'inconsistent_partial_state',
+    remediationAction: 'manual_review',
+    reasons: [
+      'agent wallet state is inconsistent and cannot be repaired safely',
+    ],
+    hasSyntheticPrivyId,
+    hasSyntheticPrivyWalletId,
+    isReady: false,
+  };
+}

--- a/packages/agents/src/identity/agent-wallet-state.ts
+++ b/packages/agents/src/identity/agent-wallet-state.ts
@@ -9,6 +9,7 @@ export type AgentWalletStateClassification =
   | 'ready'
   | 'empty'
   | 'recover_with_existing_privy_user'
+  | 'offline_signer_missing'
   | 'recreate_privy_user'
   | 'inconsistent_partial_state';
 
@@ -143,6 +144,24 @@ export function assessAgentWalletState(
       remediationAction: 'provision_with_new_privy_user',
       reasons: [
         'agent has only a wallet address with no trustworthy Privy ownership metadata',
+      ],
+      hasSyntheticPrivyId,
+      hasSyntheticPrivyWalletId,
+      isReady: false,
+    };
+  }
+
+  if (
+    hasPrivyId &&
+    !isSyntheticAgentPrivyId(state.privyId) &&
+    (hasPrivyWalletId || hasWalletAddress) &&
+    !state.offlineWalletReady
+  ) {
+    return {
+      classification: 'offline_signer_missing',
+      remediationAction: 'provision_with_existing_privy_user',
+      reasons: [
+        'agent has real Privy identity and partial wallet state but offline signer is not configured',
       ],
       hasSyntheticPrivyId,
       hasSyntheticPrivyWalletId,

--- a/packages/agents/src/identity/index.ts
+++ b/packages/agents/src/identity/index.ts
@@ -8,3 +8,4 @@
 
 export * from './AgentIdentityService';
 export * from './AgentWalletService';
+export * from './agent-wallet-state';

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -31,6 +31,7 @@ export {
 // Identity and wallet management
 export * from './identity/AgentIdentityService';
 export * from './identity/AgentWalletService';
+export * from './identity/agent-wallet-state';
 // LLM integrations
 export * from './llm';
 // Plugins - Babylon plugin is the main export

--- a/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts
+++ b/packages/agents/src/plugins/babylon/integration-a2a-sdk.ts
@@ -14,7 +14,6 @@ import { A2AClient } from '@a2a-js/sdk/client';
 import { db } from '@babylon/db';
 import { StaticDataRegistry } from '@babylon/engine';
 import type { AgentRuntime, Plugin } from '@elizaos/core';
-import { agentWalletService } from '../../identity/AgentWalletService';
 import { logger } from '../../shared/logger';
 import type { JsonValue } from '../../types/common';
 
@@ -121,13 +120,6 @@ function cacheIdentity(
   }
 
   AGENT_IDENTITY_CACHE.set(agentUserId, identity);
-}
-
-/**
- * Invalidate agent identity cache (call after wallet provisioning)
- */
-function invalidateAgentIdentityCache(agentUserId: string): void {
-  AGENT_IDENTITY_CACHE.delete(agentUserId);
 }
 
 // =============================================================================
@@ -294,57 +286,6 @@ async function createA2AClientForAgent(
 // Helper Functions
 // =============================================================================
 
-function shouldAutoProvisionWallets(): boolean {
-  return process.env.AUTO_CREATE_AGENT_WALLETS !== 'false';
-}
-
-/**
- * Ensure agent has wallet provisioned (if auto-provisioning enabled)
- * Returns updated identity after provisioning
- */
-async function ensureAgentWallet(
-  agentUserId: string,
-  identity: CachedAgentIdentity
-): Promise<CachedAgentIdentity> {
-  if (identity.walletAddress || !shouldAutoProvisionWallets()) {
-    return identity;
-  }
-
-  try {
-    const walletResult =
-      await agentWalletService.createAgentEmbeddedWallet(agentUserId);
-
-    logger.info(
-      'Auto-provisioned embedded wallet for agent',
-      {
-        agentUserId,
-        walletAddress: walletResult.walletAddress,
-      },
-      'BabylonIntegration'
-    );
-
-    // Invalidate cache and return updated identity
-    invalidateAgentIdentityCache(agentUserId);
-    return {
-      ...identity,
-      walletAddress: walletResult.walletAddress,
-      cachedAt: Date.now(),
-    };
-  } catch (error) {
-    // Use debug level for NPC wallet provisioning failures - these are expected
-    // for NPCs that don't have user records. Only warn for actual user agents.
-    logger.debug(
-      'Wallet auto-provision skipped for agent',
-      {
-        agentUserId,
-        reason: error instanceof Error ? error.message : String(error),
-      },
-      'BabylonIntegration'
-    );
-    return identity;
-  }
-}
-
 /**
  * Initialize A2A SDK client for an agent
  *
@@ -363,27 +304,24 @@ async function initializeA2ASdkClient(
     throw new Error(`Agent user ${agentUserId} not found or not an agent`);
   }
 
-  // Auto-provision wallet if needed
-  const updatedIdentity = await ensureAgentWallet(agentUserId, identity);
-
   // Log ERC-8004 identity status (only on first init, not on cache hit)
   const hasFullIdentity =
-    updatedIdentity.walletAddress && updatedIdentity.agent0TokenId !== null;
+    identity.walletAddress && identity.agent0TokenId !== null;
 
   if (!hasFullIdentity) {
     logger.debug(
       'Agent missing ERC-8004 identity - A2A will work with limited auth headers',
       {
         agentUserId,
-        hasWallet: !!updatedIdentity.walletAddress,
-        hasTokenId: updatedIdentity.agent0TokenId !== null,
+        hasWallet: !!identity.walletAddress,
+        hasTokenId: identity.agent0TokenId !== null,
       },
       'BabylonIntegration'
     );
   }
 
   // Create A2A client with cached agent card and identity-specific headers
-  const client = await createA2AClientForAgent(updatedIdentity);
+  const client = await createA2AClientForAgent(identity);
 
   if (!client) {
     logger.warn(
@@ -396,11 +334,11 @@ async function initializeA2ASdkClient(
 
   logger.debug('A2A client ready for agent', {
     agentUserId,
-    agentName: updatedIdentity.displayName,
+    agentName: identity.displayName,
     hasErc8004Identity: hasFullIdentity,
   });
 
-  return { client, identity: updatedIdentity };
+  return { client, identity };
 }
 
 /**

--- a/packages/agents/src/services/AgentService.ts
+++ b/packages/agents/src/services/AgentService.ts
@@ -13,6 +13,7 @@
  * @packageDocumentation
  */
 
+import { assertPrivyOfflineConfig } from '@babylon/api';
 import {
   agentLogs,
   agentMessages,
@@ -90,9 +91,10 @@ export class AgentServiceV2 {
   /**
    * Creates a new agent (creates a full User with isAgent=true)
    *
-   * Creates a complete user account with agent capabilities, wallet, and
-   * initial configuration. The agent can immediately participate in all
-   * platform activities.
+   * Creates a complete user account with agent capabilities and initial
+   * configuration. Wallet readiness is provisioned asynchronously after
+   * creation; wallet-specific actions must remain gated until the agent
+   * reaches a ready state.
    *
    * @param params - Agent creation parameters
    * @returns Created user/agent entity
@@ -333,7 +335,16 @@ export class AgentServiceV2 {
     }
 
     if (this.shouldAutoSetupAgentIdentity()) {
-      void this.setupAgentIdentity(agentUserId);
+      void this.setupAgentIdentity(agentUserId).catch((error) => {
+        logger.error(
+          'Agent identity setup failed',
+          {
+            agentUserId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          'AgentService'
+        );
+      });
     }
 
     // Add agent to Agents (team chat)
@@ -1085,21 +1096,19 @@ export class AgentServiceV2 {
       return false;
     }
 
-    // Require Privy credentials outside development so we do not spam errors
-    const hasPrivyConfig = Boolean(
-      process.env.NEXT_PUBLIC_PRIVY_APP_ID && process.env.PRIVY_APP_SECRET
-    );
-
-    if (!hasPrivyConfig && process.env.NODE_ENV !== 'development') {
+    try {
+      assertPrivyOfflineConfig();
+      return true;
+    } catch (error) {
       logger.warn(
-        'Skipping automatic agent identity setup - Privy credentials missing',
-        undefined,
+        'Skipping automatic agent identity setup - Privy offline configuration is incomplete',
+        {
+          error: error instanceof Error ? error.message : String(error),
+        },
         'AgentService'
       );
       return false;
     }
-
-    return true;
   }
 
   private async setupAgentIdentity(agentUserId: string): Promise<void> {

--- a/packages/agents/src/services/__tests__/AgentChatService.test.ts
+++ b/packages/agents/src/services/__tests__/AgentChatService.test.ts
@@ -381,8 +381,16 @@ describe('dispatchAgentChat', () => {
       });
 
       expect(result.success).toBe(true);
-      expect(mockGetAgentWithConfig).toHaveBeenNthCalledWith(1, 'larry david', OWNER_ID);
-      expect(mockGetAgentWithConfig).toHaveBeenNthCalledWith(2, AGENT_ID, OWNER_ID);
+      expect(mockGetAgentWithConfig).toHaveBeenNthCalledWith(
+        1,
+        'larry david',
+        OWNER_ID
+      );
+      expect(mockGetAgentWithConfig).toHaveBeenNthCalledWith(
+        2,
+        AGENT_ID,
+        OWNER_ID
+      );
     });
 
     it('uses single-agent fallback only for generic references like "my agent"', async () => {
@@ -416,7 +424,11 @@ describe('dispatchAgentChat', () => {
       });
 
       expect(result.success).toBe(true);
-      expect(mockGetAgentWithConfig).toHaveBeenNthCalledWith(2, AGENT_ID, OWNER_ID);
+      expect(mockGetAgentWithConfig).toHaveBeenNthCalledWith(
+        2,
+        AGENT_ID,
+        OWNER_ID
+      );
     });
 
     it('does not dispatch to the only agent when the requested name is unknown', async () => {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -238,6 +238,11 @@ export {
 // Services
 export * from './services';
 export {
+  type ProvisionAgentPrivyWalletInput,
+  type ProvisionAgentPrivyWalletResult,
+  provisionAgentPrivyWallet,
+} from './services/privy/agent-wallet-provisioning';
+export {
   type AuthedPrivyUserContext,
   getAuthedUserContextFromPrivyToken,
   getAuthedUserContextFromPrivyTokenBundle,
@@ -250,7 +255,9 @@ export {
 export {
   safeDecodeJwtPayload,
   sendSponsoredEvmTransaction,
+  signPrivyEvmTransaction,
 } from './services/privy/evm-send-transaction';
+export { assertPrivyOfflineConfig } from './services/privy/offline-config';
 export { ensureOfflineWalletReady } from './services/privy/offline-wallet-provisioning';
 // Privy (embedded wallet server-side helpers)
 export {

--- a/packages/api/src/services/privy/__tests__/agent-wallet-provisioning.test.ts
+++ b/packages/api/src/services/privy/__tests__/agent-wallet-provisioning.test.ts
@@ -26,7 +26,7 @@ mock.module('../offline-wallet-provisioning', () => ({
   ensureOfflineWalletReady: mockEnsureOfflineWalletReady,
 }));
 
-const { provisionAgentPrivyWallet } = await import(
+const { provisionAgentPrivyWallet, isPrivyNotFoundError } = await import(
   '../agent-wallet-provisioning'
 );
 
@@ -173,5 +173,33 @@ describe('provisionAgentPrivyWallet', () => {
     ).rejects.toThrow('Failed to create Privy user for agent');
 
     expect(mockEnsureOfflineWalletReady).not.toHaveBeenCalled();
+  });
+});
+
+describe('isPrivyNotFoundError', () => {
+  it('returns true for an error containing "404"', () => {
+    expect(
+      isPrivyNotFoundError(new Error('Request failed with status 404'))
+    ).toBe(true);
+  });
+
+  it('returns true for an error containing "not found" (lowercase)', () => {
+    expect(isPrivyNotFoundError(new Error('user not found'))).toBe(true);
+  });
+
+  it('returns true for an error containing "Not Found" (mixed case)', () => {
+    expect(isPrivyNotFoundError(new Error('Not Found'))).toBe(true);
+  });
+
+  it('returns false for an error with an unrelated message', () => {
+    expect(isPrivyNotFoundError(new Error('internal server error'))).toBe(
+      false
+    );
+  });
+
+  it('returns false for a non-Error thrown value', () => {
+    expect(isPrivyNotFoundError('404 not found')).toBe(false);
+    expect(isPrivyNotFoundError({ message: 'not found' })).toBe(false);
+    expect(isPrivyNotFoundError(null)).toBe(false);
   });
 });

--- a/packages/api/src/services/privy/__tests__/agent-wallet-provisioning.test.ts
+++ b/packages/api/src/services/privy/__tests__/agent-wallet-provisioning.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test';
 
 const mockUsersCreate = mock();
+const mockGetByCustomAuthID = mock();
 const mockEnsureOfflineWalletReady = mock();
 
 mock.module('@babylon/shared', () => ({
@@ -16,6 +17,7 @@ mock.module('../privy-node', () => ({
   getPrivyNodeClient: () => ({
     users: () => ({
       create: mockUsersCreate,
+      getByCustomAuthID: mockGetByCustomAuthID,
     }),
   }),
 }));
@@ -31,7 +33,9 @@ const { provisionAgentPrivyWallet } = await import(
 describe('provisionAgentPrivyWallet', () => {
   beforeEach(() => {
     mockUsersCreate.mockReset();
+    mockGetByCustomAuthID.mockReset();
     mockEnsureOfflineWalletReady.mockReset();
+    mockGetByCustomAuthID.mockRejectedValue(new Error('404 not found'));
 
     process.env.PRIVY_APP_ID = 'test-app-id';
     process.env.PRIVY_APP_SECRET = 'test-secret';
@@ -92,8 +96,16 @@ describe('provisionAgentPrivyWallet', () => {
     });
 
     expect(mockUsersCreate).toHaveBeenCalledTimes(1);
+    expect(mockGetByCustomAuthID).toHaveBeenCalledWith({
+      custom_user_id: 'babylon-agent:agent-456',
+    });
     expect(mockUsersCreate).toHaveBeenCalledWith({
-      linked_accounts: [],
+      linked_accounts: [
+        {
+          type: 'custom_auth',
+          custom_user_id: 'babylon-agent:agent-456',
+        },
+      ],
       custom_metadata: {
         babylon_agent_user_id: 'agent-456',
         babylon_user_type: 'agent',
@@ -117,6 +129,35 @@ describe('provisionAgentPrivyWallet', () => {
     expect(result.createdPrivyUser).toBe(true);
     expect(result.privyId).toBe('did:privy:new-agent');
     expect(result.privyWalletId).toBe('wallet-created');
+  });
+
+  it('reuses an existing custom-auth Privy user before creating a new one', async () => {
+    mockGetByCustomAuthID.mockResolvedValue({
+      id: 'did:privy:existing-agent',
+      wallet: {
+        id: 'wallet-existing',
+        address: '0x00000000000000000000000000000000000000bb',
+        chain_type: 'ethereum',
+      },
+      linked_accounts: [],
+    });
+    mockEnsureOfflineWalletReady.mockResolvedValue({
+      privyWalletId: 'wallet-existing',
+      walletAddress: '0x00000000000000000000000000000000000000bb',
+      offlineWalletReady: true,
+      createdWallet: false,
+      updatedSigner: false,
+    });
+
+    const result = await provisionAgentPrivyWallet({
+      agentUserId: 'agent-999',
+    });
+
+    expect(mockUsersCreate).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      privyId: 'did:privy:existing-agent',
+      createdPrivyUser: false,
+    });
   });
 
   it('fails when Privy user creation does not return an id', async () => {

--- a/packages/api/src/services/privy/__tests__/agent-wallet-provisioning.test.ts
+++ b/packages/api/src/services/privy/__tests__/agent-wallet-provisioning.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+const mockUsersCreate = mock();
+const mockEnsureOfflineWalletReady = mock();
+
+mock.module('@babylon/shared', () => ({
+  logger: {
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  },
+}));
+
+mock.module('../privy-node', () => ({
+  getPrivyNodeClient: () => ({
+    users: () => ({
+      create: mockUsersCreate,
+    }),
+  }),
+}));
+
+mock.module('../offline-wallet-provisioning', () => ({
+  ensureOfflineWalletReady: mockEnsureOfflineWalletReady,
+}));
+
+const { provisionAgentPrivyWallet } = await import(
+  '../agent-wallet-provisioning'
+);
+
+describe('provisionAgentPrivyWallet', () => {
+  beforeEach(() => {
+    mockUsersCreate.mockReset();
+    mockEnsureOfflineWalletReady.mockReset();
+
+    process.env.PRIVY_APP_ID = 'test-app-id';
+    process.env.PRIVY_APP_SECRET = 'test-secret';
+    process.env.PRIVY_AUTHORIZATION_PRIVATE_KEY = 'test-authorization-key';
+    process.env.PRIVY_OFFLINE_SIGNER_ID = 'offline-signer-id';
+    process.env.PRIVY_OFFLINE_POLICY_ID = 'offline-policy-id';
+  });
+
+  it('reuses an existing Privy user when provided', async () => {
+    mockEnsureOfflineWalletReady.mockResolvedValue({
+      privyWalletId: 'wallet-1',
+      walletAddress: '0x0000000000000000000000000000000000000001',
+      offlineWalletReady: true,
+      createdWallet: false,
+      updatedSigner: false,
+    });
+
+    const result = await provisionAgentPrivyWallet({
+      agentUserId: 'agent-123',
+      existingPrivyId: 'did:privy:agent-123',
+    });
+
+    expect(mockUsersCreate).not.toHaveBeenCalled();
+    expect(mockEnsureOfflineWalletReady).toHaveBeenCalledWith({
+      privyId: 'did:privy:agent-123',
+    });
+    expect(result).toEqual({
+      privyId: 'did:privy:agent-123',
+      privyWalletId: 'wallet-1',
+      walletAddress: '0x0000000000000000000000000000000000000001',
+      offlineWalletReady: true,
+      createdPrivyUser: false,
+      createdWallet: false,
+      updatedSigner: false,
+    });
+  });
+
+  it('creates a server-managed Privy user and validates wallet readiness', async () => {
+    mockUsersCreate.mockResolvedValue({
+      id: 'did:privy:new-agent',
+      wallet: {
+        id: 'wallet-created',
+        address: '0x00000000000000000000000000000000000000aa',
+        chain_type: 'ethereum',
+      },
+      linked_accounts: [],
+    });
+    mockEnsureOfflineWalletReady.mockResolvedValue({
+      privyWalletId: 'wallet-created',
+      walletAddress: '0x00000000000000000000000000000000000000aa',
+      offlineWalletReady: true,
+      createdWallet: false,
+      updatedSigner: false,
+    });
+
+    const result = await provisionAgentPrivyWallet({
+      agentUserId: 'agent-456',
+    });
+
+    expect(mockUsersCreate).toHaveBeenCalledTimes(1);
+    expect(mockUsersCreate).toHaveBeenCalledWith({
+      linked_accounts: [],
+      custom_metadata: {
+        babylon_agent_user_id: 'agent-456',
+        babylon_user_type: 'agent',
+      },
+      wallets: [
+        {
+          chain_type: 'ethereum',
+          additional_signers: [
+            {
+              signer_id: 'offline-signer-id',
+              override_policy_ids: ['offline-policy-id'],
+            },
+          ],
+          policy_ids: [],
+        },
+      ],
+    });
+    expect(mockEnsureOfflineWalletReady).toHaveBeenCalledWith({
+      privyId: 'did:privy:new-agent',
+    });
+    expect(result.createdPrivyUser).toBe(true);
+    expect(result.privyId).toBe('did:privy:new-agent');
+    expect(result.privyWalletId).toBe('wallet-created');
+  });
+
+  it('fails when Privy user creation does not return an id', async () => {
+    mockUsersCreate.mockResolvedValue({
+      id: null,
+      linked_accounts: [],
+    });
+
+    await expect(
+      provisionAgentPrivyWallet({
+        agentUserId: 'agent-789',
+      })
+    ).rejects.toThrow('Failed to create Privy user for agent');
+
+    expect(mockEnsureOfflineWalletReady).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/services/privy/__tests__/evm-send-transaction.test.ts
+++ b/packages/api/src/services/privy/__tests__/evm-send-transaction.test.ts
@@ -171,6 +171,9 @@ describe('PrivyJwtPayloadSchema', () => {
 const mockSendTransaction = mock(() =>
   Promise.resolve({ hash: '0xabc', caip2: 'eip155:1' })
 );
+const mockSignTransaction = mock(() =>
+  Promise.resolve({ signed_transaction: '0xsigned', encoding: 'eip155' })
+);
 
 mock.module('@babylon/shared', () => ({
   CHAIN: { id: 1 },
@@ -187,19 +190,23 @@ mock.module('../privy-node', () => ({
     wallets: () => ({
       ethereum: () => ({
         sendTransaction: mockSendTransaction,
+        signTransaction: mockSignTransaction,
       }),
     }),
   }),
 }));
 
 // Dynamic import after mocks are set up
-const { sendSponsoredEvmTransaction } = await import('../evm-send-transaction');
+const { sendSponsoredEvmTransaction, signPrivyEvmTransaction } = await import(
+  '../evm-send-transaction'
+);
 
 describe('sendSponsoredEvmTransaction – offline delegated path', () => {
   const validAddress = '0x0000000000000000000000000000000000000001' as const;
 
   beforeEach(() => {
     mockSendTransaction.mockClear();
+    mockSignTransaction.mockClear();
     process.env.PRIVY_APP_ID = 'test-app-id';
     process.env.PRIVY_APP_SECRET = 'test-secret';
     process.env.PRIVY_AUTHORIZATION_PRIVATE_KEY = 'test-authorization-key';
@@ -280,5 +287,55 @@ describe('sendSponsoredEvmTransaction – offline delegated path', () => {
         to: validAddress,
       })
     ).rejects.toThrow('upstream failed');
+  });
+});
+
+describe('signPrivyEvmTransaction', () => {
+  const validAddress = '0x0000000000000000000000000000000000000001' as const;
+
+  beforeEach(() => {
+    mockSendTransaction.mockClear();
+    mockSignTransaction.mockClear();
+    process.env.PRIVY_APP_ID = 'test-app-id';
+    process.env.PRIVY_APP_SECRET = 'test-secret';
+    process.env.PRIVY_AUTHORIZATION_PRIVATE_KEY = 'test-authorization-key';
+    process.env.PRIVY_OFFLINE_SIGNER_ID = 'test-offline-signer-id';
+    process.env.PRIVY_OFFLINE_POLICY_ID = 'test-offline-policy-id';
+    delete process.env.NEXT_PUBLIC_PRIVY_APP_ID;
+  });
+
+  it('signs a transaction with the offline authorization context', async () => {
+    const result = await signPrivyEvmTransaction({
+      walletId: 'wallet-1',
+      to: validAddress,
+      valueWei: 0n,
+    });
+
+    expect(result).toBe('0xsigned');
+    expect(mockSignTransaction).toHaveBeenCalledTimes(1);
+    expect(mockSignTransaction).toHaveBeenCalledWith('wallet-1', {
+      authorization_context: {
+        authorization_private_keys: ['test-authorization-key'],
+      },
+      params: {
+        transaction: {
+          to: validAddress,
+          chain_id: 1,
+        },
+      },
+    });
+  });
+
+  it('propagates signing errors', async () => {
+    mockSignTransaction.mockImplementationOnce(() =>
+      Promise.reject(new Error('signing failed'))
+    );
+
+    await expect(
+      signPrivyEvmTransaction({
+        walletId: 'wallet-1',
+        to: validAddress,
+      })
+    ).rejects.toThrow('signing failed');
   });
 });

--- a/packages/api/src/services/privy/agent-wallet-provisioning.ts
+++ b/packages/api/src/services/privy/agent-wallet-provisioning.ts
@@ -24,6 +24,16 @@ export type ProvisionAgentPrivyWalletResult = EnsureOfflineWalletReadyResult & {
   createdPrivyUser: boolean;
 };
 
+function getAgentCustomAuthId(agentUserId: string): string {
+  return `babylon-agent:${agentUserId}`;
+}
+
+function isPrivyNotFoundError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const message = error.message.toLowerCase();
+  return message.includes('404') || message.includes('not found');
+}
+
 export async function provisionAgentPrivyWallet({
   agentUserId,
   existingPrivyId,
@@ -42,27 +52,46 @@ export async function provisionAgentPrivyWallet({
 
   const privy = getPrivyNodeClient();
   const offlineConfig = getPrivyOfflineConfig();
+  const customUserId = getAgentCustomAuthId(agentUserId);
 
-  const createdUser = (await privy.users().create({
-    // Backend-managed agent users intentionally have no end-user linked accounts.
-    linked_accounts: [],
-    custom_metadata: {
-      babylon_agent_user_id: agentUserId,
-      babylon_user_type: 'agent',
-    },
-    wallets: [
-      {
-        chain_type: 'ethereum',
-        additional_signers: [
-          {
-            signer_id: offlineConfig.offlineSignerId,
-            override_policy_ids: [offlineConfig.offlinePolicyId],
-          },
-        ],
-        policy_ids: [],
+  let createdPrivyUser = false;
+  let createdUser: PrivyCreateUserResponse | null = null;
+
+  try {
+    createdUser = (await privy.users().getByCustomAuthID({
+      custom_user_id: customUserId,
+    })) as PrivyCreateUserResponse;
+  } catch (error) {
+    if (!isPrivyNotFoundError(error)) {
+      throw error;
+    }
+
+    createdPrivyUser = true;
+    createdUser = (await privy.users().create({
+      linked_accounts: [
+        {
+          type: 'custom_auth',
+          custom_user_id: customUserId,
+        },
+      ],
+      custom_metadata: {
+        babylon_agent_user_id: agentUserId,
+        babylon_user_type: 'agent',
       },
-    ],
-  })) as PrivyCreateUserResponse;
+      wallets: [
+        {
+          chain_type: 'ethereum',
+          additional_signers: [
+            {
+              signer_id: offlineConfig.offlineSignerId,
+              override_policy_ids: [offlineConfig.offlinePolicyId],
+            },
+          ],
+          policy_ids: [],
+        },
+      ],
+    })) as PrivyCreateUserResponse;
+  }
 
   const privyId = createdUser.id?.trim();
   if (!privyId) {
@@ -85,7 +114,7 @@ export async function provisionAgentPrivyWallet({
 
   return {
     privyId,
-    createdPrivyUser: true,
+    createdPrivyUser,
     ...readyWallet,
   };
 }

--- a/packages/api/src/services/privy/agent-wallet-provisioning.ts
+++ b/packages/api/src/services/privy/agent-wallet-provisioning.ts
@@ -28,7 +28,7 @@ function getAgentCustomAuthId(agentUserId: string): string {
   return `babylon-agent:${agentUserId}`;
 }
 
-function isPrivyNotFoundError(error: unknown): boolean {
+export function isPrivyNotFoundError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   const message = error.message.toLowerCase();
   return message.includes('404') || message.includes('not found');

--- a/packages/api/src/services/privy/agent-wallet-provisioning.ts
+++ b/packages/api/src/services/privy/agent-wallet-provisioning.ts
@@ -1,0 +1,91 @@
+import { logger } from '@babylon/shared';
+import { getPrivyOfflineConfig } from './offline-config';
+import {
+  type EnsureOfflineWalletReadyResult,
+  ensureOfflineWalletReady,
+} from './offline-wallet-provisioning';
+import { getPrivyNodeClient } from './privy-node';
+import {
+  type PrivyUserWalletsLite,
+  pickEmbeddedEvmWallet,
+} from './user-wallets';
+
+type PrivyCreateUserResponse = PrivyUserWalletsLite & {
+  id?: string | null;
+};
+
+export type ProvisionAgentPrivyWalletInput = {
+  agentUserId: string;
+  existingPrivyId?: string | null;
+};
+
+export type ProvisionAgentPrivyWalletResult = EnsureOfflineWalletReadyResult & {
+  privyId: string;
+  createdPrivyUser: boolean;
+};
+
+export async function provisionAgentPrivyWallet({
+  agentUserId,
+  existingPrivyId,
+}: ProvisionAgentPrivyWalletInput): Promise<ProvisionAgentPrivyWalletResult> {
+  if (existingPrivyId) {
+    const readyWallet = await ensureOfflineWalletReady({
+      privyId: existingPrivyId,
+    });
+
+    return {
+      privyId: existingPrivyId,
+      createdPrivyUser: false,
+      ...readyWallet,
+    };
+  }
+
+  const privy = getPrivyNodeClient();
+  const offlineConfig = getPrivyOfflineConfig();
+
+  const createdUser = (await privy.users().create({
+    // Backend-managed agent users intentionally have no end-user linked accounts.
+    linked_accounts: [],
+    custom_metadata: {
+      babylon_agent_user_id: agentUserId,
+      babylon_user_type: 'agent',
+    },
+    wallets: [
+      {
+        chain_type: 'ethereum',
+        additional_signers: [
+          {
+            signer_id: offlineConfig.offlineSignerId,
+            override_policy_ids: [offlineConfig.offlinePolicyId],
+          },
+        ],
+        policy_ids: [],
+      },
+    ],
+  })) as PrivyCreateUserResponse;
+
+  const privyId = createdUser.id?.trim();
+  if (!privyId) {
+    throw new Error('Failed to create Privy user for agent');
+  }
+
+  const embeddedWallet = pickEmbeddedEvmWallet(createdUser);
+  logger.info(
+    'Created server-managed Privy user for agent',
+    {
+      agentUserId,
+      privyId,
+      walletId: embeddedWallet?.walletId ?? null,
+      walletAddress: embeddedWallet?.address ?? null,
+    },
+    'provisionAgentPrivyWallet'
+  );
+
+  const readyWallet = await ensureOfflineWalletReady({ privyId });
+
+  return {
+    privyId,
+    createdPrivyUser: true,
+    ...readyWallet,
+  };
+}

--- a/packages/api/src/services/privy/evm-send-transaction.ts
+++ b/packages/api/src/services/privy/evm-send-transaction.ts
@@ -17,6 +17,14 @@ export type SendSponsoredEvmTransactionInput = {
   idempotencyKey?: string;
 };
 
+export type SignPrivyEvmTransactionInput = {
+  walletId: string;
+  to: Address;
+  data?: Hex;
+  valueWei?: bigint;
+  chainId?: number;
+};
+
 /**
  * Runtime schema for a Privy JWT payload.
  * See: https://docs.privy.io/guide/server/authorization/verification
@@ -37,6 +45,39 @@ export const PrivyJwtPayloadSchema = z.object({
 });
 
 export type PrivyJwtPayload = z.infer<typeof PrivyJwtPayloadSchema>;
+
+function buildPrivyAuthorizationContext(): AuthorizationContext {
+  const offlineConfig = getPrivyOfflineConfig();
+  return {
+    authorization_private_keys: [offlineConfig.authorizationPrivateKey],
+  };
+}
+
+function buildPrivyTransactionParams({
+  to,
+  data,
+  valueWei,
+  chainId,
+}: {
+  to: Address;
+  data?: Hex;
+  valueWei?: bigint;
+  chainId: number;
+}) {
+  const valueHex =
+    typeof valueWei === 'bigint' && valueWei > 0n
+      ? `0x${valueWei.toString(16)}`
+      : undefined;
+
+  return {
+    transaction: {
+      to,
+      chain_id: chainId,
+      ...(valueHex ? { value: valueHex } : {}),
+      ...(data ? { data } : {}),
+    },
+  };
+}
 
 /**
  * Safely decodes and validates a JWT header using `jose`.
@@ -94,22 +135,12 @@ export async function sendSponsoredEvmTransaction({
   const appId = offlineConfig.appId;
 
   const privy = getPrivyNodeClient();
-  const authorizationPrivateKey = offlineConfig.authorizationPrivateKey;
-
-  // VALUE FIELD HANDLING:
-  // We omit the value field entirely for zero-value transactions rather than sending "0x0".
-  // This follows the common pattern where contract calls that don't transfer ETH simply
-  // don't include a value field. Privy's SDK handles this correctly - tested behavior:
-  // - Omitting value: works for all contract calls (most common case)
-  // - value: "0x0": also works, but adds unnecessary payload
-  // - value with positive amount: required for ETH transfers
-  //
-  // If a contract explicitly requires value=0 to be passed (extremely rare), this would
-  // need to be handled as a special case.
-  const valueHex =
-    typeof valueWei === 'bigint' && valueWei > 0n
-      ? `0x${valueWei.toString(16)}`
-      : undefined;
+  const transactionParams = buildPrivyTransactionParams({
+    to,
+    data,
+    valueWei,
+    chainId,
+  });
 
   logger.debug(
     'Submitting sponsored transaction via Privy',
@@ -119,16 +150,12 @@ export async function sendSponsoredEvmTransaction({
       to,
       chainId,
       hasData: !!data,
-      hasValue: !!valueHex,
+      hasValue: typeof valueWei === 'bigint' && valueWei > 0n,
       valueWei: valueWei?.toString(),
       hasIdempotencyKey: Boolean(idempotencyKey),
     },
     'sendSponsoredEvmTransaction'
   );
-
-  const authorizationContext: AuthorizationContext = {
-    authorization_private_keys: [authorizationPrivateKey],
-  };
 
   try {
     const response = await privy
@@ -137,16 +164,9 @@ export async function sendSponsoredEvmTransaction({
       .sendTransaction(walletId, {
         caip2,
         sponsor: true,
-        authorization_context: authorizationContext,
+        authorization_context: buildPrivyAuthorizationContext(),
         ...(idempotencyKey ? { idempotency_key: idempotencyKey } : {}),
-        params: {
-          transaction: {
-            to,
-            chain_id: chainId,
-            ...(valueHex ? { value: valueHex } : {}),
-            ...(data ? { data } : {}),
-          },
-        },
+        params: transactionParams,
       });
 
     logger.info(
@@ -179,5 +199,73 @@ export async function sendSponsoredEvmTransaction({
     throw error instanceof Error
       ? error
       : new Error('Failed to submit sponsored transaction via Privy');
+  }
+}
+
+export async function signPrivyEvmTransaction({
+  walletId,
+  to,
+  data,
+  valueWei,
+  chainId = CHAIN.id,
+}: SignPrivyEvmTransactionInput): Promise<string> {
+  const privy = getPrivyNodeClient();
+  const transactionParams = buildPrivyTransactionParams({
+    to,
+    data,
+    valueWei,
+    chainId,
+  });
+
+  logger.debug(
+    'Signing transaction via Privy',
+    {
+      walletId,
+      to,
+      chainId,
+      hasData: !!data,
+      hasValue: typeof valueWei === 'bigint' && valueWei > 0n,
+      valueWei: valueWei?.toString(),
+    },
+    'signPrivyEvmTransaction'
+  );
+
+  try {
+    const response = await privy
+      .wallets()
+      .ethereum()
+      .signTransaction(walletId, {
+        authorization_context: buildPrivyAuthorizationContext(),
+        params: transactionParams,
+      });
+
+    logger.info(
+      'Transaction signed via Privy',
+      {
+        walletId,
+        to,
+        chainId,
+      },
+      'signPrivyEvmTransaction'
+    );
+
+    return response.signed_transaction;
+  } catch (error) {
+    const diagnostics = extractPrivyApiDiagnostics(error);
+
+    logger.error(
+      'Failed to sign transaction via Privy',
+      {
+        chainId,
+        walletId,
+        to,
+        ...diagnostics,
+      },
+      'signPrivyEvmTransaction'
+    );
+
+    throw error instanceof Error
+      ? error
+      : new Error('Failed to sign transaction via Privy');
   }
 }

--- a/scripts/audit-agent-wallet-readiness.ts
+++ b/scripts/audit-agent-wallet-readiness.ts
@@ -106,6 +106,7 @@ async function main(): Promise<void> {
     ready: 0,
     empty: 0,
     recover_with_existing_privy_user: 0,
+    offline_signer_missing: 0,
     recreate_privy_user: 0,
     inconsistent_partial_state: 0,
   };

--- a/scripts/audit-agent-wallet-readiness.ts
+++ b/scripts/audit-agent-wallet-readiness.ts
@@ -1,0 +1,205 @@
+#!/usr/bin/env bun
+
+/**
+ * Audit agent wallet readiness against the canonical Privy-backed model.
+ *
+ * Usage:
+ *   bun run scripts/audit-agent-wallet-readiness.ts
+ *   bun run scripts/audit-agent-wallet-readiness.ts --agent=<agentUserId>
+ *   bun run scripts/audit-agent-wallet-readiness.ts --include-ready --limit=500
+ *   bun run scripts/audit-agent-wallet-readiness.ts --json
+ */
+
+import { and, closeDatabase, db, desc, eq, users } from '@babylon/db';
+import {
+  type AgentWalletStateClassification,
+  assessAgentWalletState,
+} from '../packages/agents/src/identity/agent-wallet-state';
+
+type CliOptions = {
+  agentId: string | null;
+  includeReady: boolean;
+  json: boolean;
+  limit: number;
+};
+
+type AgentWalletAuditRow = {
+  id: string;
+  username: string | null;
+  displayName: string | null;
+  managedBy: string | null;
+  privyId: string | null;
+  privyWalletId: string | null;
+  walletAddress: string | null;
+  offlineWalletReady: boolean;
+  offlineWalletReadyAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+function parseArgs(): CliOptions {
+  const args = process.argv.slice(2);
+  const findArg = (prefix: string): string | null =>
+    args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length) ?? null;
+
+  const limitRaw = findArg('--limit=');
+  const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : 100;
+  const limit =
+    Number.isFinite(parsedLimit) && parsedLimit > 0
+      ? Math.min(parsedLimit, 5000)
+      : 100;
+
+  return {
+    agentId: findArg('--agent='),
+    includeReady: args.includes('--include-ready'),
+    json: args.includes('--json'),
+    limit,
+  };
+}
+
+function incrementCount(
+  counts: Record<AgentWalletStateClassification, number>,
+  key: AgentWalletStateClassification
+): void {
+  counts[key] += 1;
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs();
+
+  const baseSelect = {
+    id: users.id,
+    username: users.username,
+    displayName: users.displayName,
+    managedBy: users.managedBy,
+    privyId: users.privyId,
+    privyWalletId: users.privyWalletId,
+    walletAddress: users.walletAddress,
+    offlineWalletReady: users.offlineWalletReady,
+    offlineWalletReadyAt: users.offlineWalletReadyAt,
+    createdAt: users.createdAt,
+    updatedAt: users.updatedAt,
+  };
+
+  const rows = options.agentId
+    ? ((await db
+        .select(baseSelect)
+        .from(users)
+        .where(and(eq(users.id, options.agentId!), eq(users.isAgent, true)))
+        .limit(1)) as AgentWalletAuditRow[])
+    : ((await db
+        .select(baseSelect)
+        .from(users)
+        .where(eq(users.isAgent, true))
+        .orderBy(desc(users.createdAt))
+        .limit(options.limit)) as AgentWalletAuditRow[]);
+
+  const assessed = rows.map((row) => {
+    const assessment = assessAgentWalletState(row);
+    return {
+      ...row,
+      assessment,
+    };
+  });
+
+  const counts: Record<AgentWalletStateClassification, number> = {
+    ready: 0,
+    empty: 0,
+    recover_with_existing_privy_user: 0,
+    recreate_privy_user: 0,
+    inconsistent_partial_state: 0,
+  };
+
+  for (const row of assessed) {
+    incrementCount(counts, row.assessment.classification);
+  }
+
+  const rowsToDisplay = options.includeReady
+    ? assessed
+    : assessed.filter((row) => !row.assessment.isReady);
+
+  if (options.json) {
+    console.log(
+      JSON.stringify(
+        {
+          totalAgentsScanned: assessed.length,
+          displayedAgents: rowsToDisplay.length,
+          counts,
+          agents: rowsToDisplay.map((row) => ({
+            id: row.id,
+            username: row.username,
+            displayName: row.displayName,
+            managedBy: row.managedBy,
+            privyId: row.privyId,
+            privyWalletId: row.privyWalletId,
+            walletAddress: row.walletAddress,
+            offlineWalletReady: row.offlineWalletReady,
+            offlineWalletReadyAt:
+              row.offlineWalletReadyAt?.toISOString() ?? null,
+            createdAt: row.createdAt.toISOString(),
+            updatedAt: row.updatedAt.toISOString(),
+            classification: row.assessment.classification,
+            remediationAction: row.assessment.remediationAction,
+            reasons: row.assessment.reasons,
+          })),
+        },
+        null,
+        2
+      )
+    );
+    await closeDatabase();
+    return;
+  }
+
+  console.log('Agent wallet readiness audit');
+  console.log(`- Agents scanned: ${assessed.length}`);
+  console.log(`- Showing: ${rowsToDisplay.length}`);
+  console.log(`- includeReady: ${options.includeReady ? 'yes' : 'no'}`);
+  console.log(`- limit: ${options.limit}`);
+  if (options.agentId) {
+    console.log(`- agent filter: ${options.agentId}`);
+  }
+
+  console.log('\nClassification counts:');
+  for (const [classification, count] of Object.entries(counts)) {
+    console.log(`- ${classification}: ${count}`);
+  }
+
+  if (rowsToDisplay.length === 0) {
+    console.log('\nNo matching agents found.');
+    await closeDatabase();
+    return;
+  }
+
+  console.log('\nAgents:');
+  for (const row of rowsToDisplay) {
+    console.log(
+      [
+        `id=${row.id}`,
+        `username=${row.username ?? 'null'}`,
+        `displayName=${row.displayName ?? 'null'}`,
+        `managedBy=${row.managedBy ?? 'null'}`,
+        `classification=${row.assessment.classification}`,
+        `action=${row.assessment.remediationAction}`,
+        `privyId=${row.privyId ?? 'null'}`,
+        `walletId=${row.privyWalletId ?? 'null'}`,
+        `walletAddress=${row.walletAddress ?? 'null'}`,
+        `offlineReady=${String(row.offlineWalletReady)}`,
+        `offlineReadyAt=${row.offlineWalletReadyAt?.toISOString() ?? 'null'}`,
+        `reasons=${row.assessment.reasons.join('; ')}`,
+      ].join(' | ')
+    );
+  }
+
+  await closeDatabase();
+}
+
+main()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch(async (error) => {
+    console.error('Agent wallet audit failed:', error);
+    await closeDatabase();
+    process.exit(1);
+  });

--- a/scripts/remediate-agent-wallets.ts
+++ b/scripts/remediate-agent-wallets.ts
@@ -14,7 +14,10 @@ import {
   type AgentWalletStateClassification,
   assessAgentWalletState,
 } from '../packages/agents/src/identity/agent-wallet-state';
-import { provisionAgentPrivyWallet } from '../packages/api/src/services/privy/agent-wallet-provisioning';
+import {
+  isPrivyNotFoundError,
+  provisionAgentPrivyWallet,
+} from '../packages/api/src/services/privy/agent-wallet-provisioning';
 import { assertPrivyOfflineConfig } from '../packages/api/src/services/privy/offline-config';
 
 /**
@@ -118,11 +121,6 @@ function formatPlannedAction(
     case 'manual_review':
       return 'manual review';
   }
-}
-
-function isPrivyUserNotFoundError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  return error.message.toLowerCase().includes('user not found');
 }
 
 async function main(): Promise<void> {
@@ -252,7 +250,7 @@ async function main(): Promise<void> {
           existingPrivyId: preferredExistingPrivyId,
         });
       } catch (error) {
-        if (!preferredExistingPrivyId || !isPrivyUserNotFoundError(error)) {
+        if (!preferredExistingPrivyId || !isPrivyNotFoundError(error)) {
           throw error;
         }
 

--- a/scripts/remediate-agent-wallets.ts
+++ b/scripts/remediate-agent-wallets.ts
@@ -1,0 +1,375 @@
+#!/usr/bin/env bun
+
+import {
+  agentLogs,
+  and,
+  closeDatabase,
+  db,
+  desc,
+  eq,
+  users,
+} from '@babylon/db';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  type AgentWalletStateClassification,
+  assessAgentWalletState,
+} from '../packages/agents/src/identity/agent-wallet-state';
+import { provisionAgentPrivyWallet } from '../packages/api/src/services/privy/agent-wallet-provisioning';
+import { assertPrivyOfflineConfig } from '../packages/api/src/services/privy/offline-config';
+
+/**
+ * Remediate agent wallet state into the canonical Privy-backed offline-ready model.
+ *
+ * Safe by default:
+ * - no writes unless `--apply` is provided
+ * - supports targeting a single agent or a classification bucket
+ *
+ * Usage:
+ *   bun run scripts/remediate-agent-wallets.ts
+ *   bun run scripts/remediate-agent-wallets.ts --classification=recreate_privy_user
+ *   bun run scripts/remediate-agent-wallets.ts --agent=<agentUserId> --apply
+ *   bun run scripts/remediate-agent-wallets.ts --apply --limit=50
+ */
+
+type CliOptions = {
+  agentId: string | null;
+  apply: boolean;
+  classification: AgentWalletStateClassification | null;
+  json: boolean;
+  limit: number;
+};
+
+type AgentWalletRow = {
+  id: string;
+  username: string | null;
+  displayName: string | null;
+  managedBy: string | null;
+  privyId: string | null;
+  privyWalletId: string | null;
+  walletAddress: string | null;
+  offlineWalletReady: boolean;
+  offlineWalletReadyAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type RemediationSummary = {
+  scanned: number;
+  matched: number;
+  readySkipped: number;
+  dryRunPlanned: number;
+  remediated: number;
+  manualReview: number;
+  failed: number;
+};
+
+const VALID_CLASSIFICATIONS: AgentWalletStateClassification[] = [
+  'ready',
+  'empty',
+  'recover_with_existing_privy_user',
+  'recreate_privy_user',
+  'inconsistent_partial_state',
+];
+
+function parseArgs(): CliOptions {
+  const args = process.argv.slice(2);
+  const findArg = (prefix: string): string | null =>
+    args.find((arg) => arg.startsWith(prefix))?.slice(prefix.length) ?? null;
+
+  const limitRaw = findArg('--limit=');
+  const parsedLimit = limitRaw ? Number.parseInt(limitRaw, 10) : 100;
+  const limit =
+    Number.isFinite(parsedLimit) && parsedLimit > 0
+      ? Math.min(parsedLimit, 5000)
+      : 100;
+
+  const classificationRaw = findArg('--classification=');
+  if (
+    classificationRaw &&
+    !VALID_CLASSIFICATIONS.includes(
+      classificationRaw as AgentWalletStateClassification
+    )
+  ) {
+    throw new Error(
+      `Invalid --classification value "${classificationRaw}". Expected one of: ${VALID_CLASSIFICATIONS.join(', ')}`
+    );
+  }
+
+  return {
+    agentId: findArg('--agent='),
+    apply: args.includes('--apply'),
+    classification:
+      (classificationRaw as AgentWalletStateClassification | null) ?? null,
+    json: args.includes('--json'),
+    limit,
+  };
+}
+
+function formatPlannedAction(
+  action: ReturnType<typeof assessAgentWalletState>['remediationAction']
+): string {
+  switch (action) {
+    case 'none':
+      return 'skip';
+    case 'provision_with_existing_privy_user':
+      return 'provision existing Privy user';
+    case 'provision_with_new_privy_user':
+      return 'provision new Privy user';
+    case 'manual_review':
+      return 'manual review';
+  }
+}
+
+function isPrivyUserNotFoundError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return error.message.toLowerCase().includes('user not found');
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs();
+  if (options.apply) {
+    assertPrivyOfflineConfig();
+  }
+
+  const baseSelect = {
+    id: users.id,
+    username: users.username,
+    displayName: users.displayName,
+    managedBy: users.managedBy,
+    privyId: users.privyId,
+    privyWalletId: users.privyWalletId,
+    walletAddress: users.walletAddress,
+    offlineWalletReady: users.offlineWalletReady,
+    offlineWalletReadyAt: users.offlineWalletReadyAt,
+    createdAt: users.createdAt,
+    updatedAt: users.updatedAt,
+  };
+
+  const rows = options.agentId
+    ? ((await db
+        .select(baseSelect)
+        .from(users)
+        .where(and(eq(users.id, options.agentId!), eq(users.isAgent, true)))
+        .limit(1)) as AgentWalletRow[])
+    : ((await db
+        .select(baseSelect)
+        .from(users)
+        .where(eq(users.isAgent, true))
+        .orderBy(desc(users.createdAt))
+        .limit(options.limit)) as AgentWalletRow[]);
+
+  const scopedRows = rows.filter((row) => {
+    if (options.agentId && row.id !== options.agentId) return false;
+    const assessment = assessAgentWalletState(row);
+    if (
+      options.classification &&
+      assessment.classification !== options.classification
+    ) {
+      return false;
+    }
+    return true;
+  });
+
+  const summary: RemediationSummary = {
+    scanned: rows.length,
+    matched: scopedRows.length,
+    readySkipped: 0,
+    dryRunPlanned: 0,
+    remediated: 0,
+    manualReview: 0,
+    failed: 0,
+  };
+
+  const reportRows: Array<Record<string, unknown>> = [];
+
+  console.log('Agent wallet remediation');
+  console.log(`- Scanned agents: ${summary.scanned}`);
+  console.log(`- Matching scope: ${summary.matched}`);
+  console.log(`- Apply changes: ${options.apply ? 'yes' : 'no (dry-run)'}`);
+  if (options.agentId) console.log(`- agent filter: ${options.agentId}`);
+  if (options.classification) {
+    console.log(`- classification filter: ${options.classification}`);
+  }
+  console.log(`- limit: ${options.limit}`);
+
+  for (const row of scopedRows) {
+    const assessment = assessAgentWalletState(row);
+
+    if (assessment.isReady) {
+      summary.readySkipped += 1;
+    }
+
+    const reportRow = {
+      id: row.id,
+      username: row.username,
+      classification: assessment.classification,
+      remediationAction: assessment.remediationAction,
+      privyId: row.privyId,
+      privyWalletId: row.privyWalletId,
+      walletAddress: row.walletAddress,
+      reasons: assessment.reasons,
+    };
+
+    if (assessment.remediationAction === 'none') {
+      reportRows.push({
+        ...reportRow,
+        outcome: 'skipped_ready',
+      });
+      continue;
+    }
+
+    if (assessment.remediationAction === 'manual_review') {
+      summary.manualReview += 1;
+      reportRows.push({
+        ...reportRow,
+        outcome: 'manual_review',
+      });
+      continue;
+    }
+
+    if (!options.apply) {
+      summary.dryRunPlanned += 1;
+      reportRows.push({
+        ...reportRow,
+        outcome: 'dry_run',
+        plannedAction: formatPlannedAction(assessment.remediationAction),
+      });
+      continue;
+    }
+
+    try {
+      const preferredExistingPrivyId =
+        assessment.remediationAction === 'provision_with_existing_privy_user'
+          ? row.privyId
+          : null;
+
+      let fallbackToNewPrivyUser = false;
+      let provisioned;
+
+      try {
+        provisioned = await provisionAgentPrivyWallet({
+          agentUserId: row.id,
+          existingPrivyId: preferredExistingPrivyId,
+        });
+      } catch (error) {
+        if (!preferredExistingPrivyId || !isPrivyUserNotFoundError(error)) {
+          throw error;
+        }
+
+        fallbackToNewPrivyUser = true;
+        provisioned = await provisionAgentPrivyWallet({
+          agentUserId: row.id,
+          existingPrivyId: null,
+        });
+      }
+      const remediationAt = new Date();
+
+      await db.transaction(async (tx) => {
+        await tx
+          .update(users)
+          .set({
+            privyId: provisioned.privyId,
+            privyWalletId: provisioned.privyWalletId,
+            walletAddress: provisioned.walletAddress,
+            offlineWalletReady: true,
+            offlineWalletReadyAt: remediationAt,
+            updatedAt: remediationAt,
+          })
+          .where(eq(users.id, row.id));
+
+        await tx.insert(agentLogs).values({
+          id: uuidv4(),
+          agentUserId: row.id,
+          type: 'system',
+          level: 'info',
+          message: `Agent wallet remediated: ${provisioned.walletAddress}`,
+          metadata: {
+            previousState: {
+              privyId: row.privyId,
+              privyWalletId: row.privyWalletId,
+              walletAddress: row.walletAddress,
+              offlineWalletReady: row.offlineWalletReady,
+            },
+            remediationClassification: assessment.classification,
+            remediationAction: assessment.remediationAction,
+            fallbackToNewPrivyUser,
+            privyId: provisioned.privyId,
+            privyWalletId: provisioned.privyWalletId,
+            walletAddress: provisioned.walletAddress,
+            createdPrivyUser: provisioned.createdPrivyUser,
+            createdWallet: provisioned.createdWallet,
+            updatedSigner: provisioned.updatedSigner,
+            remediatedAt: remediationAt.toISOString(),
+          },
+        });
+      });
+
+      summary.remediated += 1;
+      reportRows.push({
+        ...reportRow,
+        outcome: 'remediated',
+        fallbackToNewPrivyUser,
+        newPrivyId: provisioned.privyId,
+        newPrivyWalletId: provisioned.privyWalletId,
+        newWalletAddress: provisioned.walletAddress,
+      });
+    } catch (error) {
+      summary.failed += 1;
+      reportRows.push({
+        ...reportRow,
+        outcome: 'failed',
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  if (options.json) {
+    console.log(JSON.stringify({ summary, results: reportRows }, null, 2));
+    await closeDatabase();
+    return;
+  }
+
+  console.log('\nSummary:');
+  console.log(`- Ready skipped: ${summary.readySkipped}`);
+  console.log(`- Dry-run planned: ${summary.dryRunPlanned}`);
+  console.log(`- Remediated: ${summary.remediated}`);
+  console.log(`- Manual review: ${summary.manualReview}`);
+  console.log(`- Failed: ${summary.failed}`);
+
+  if (reportRows.length > 0) {
+    console.log('\nResults:');
+    for (const row of reportRows) {
+      console.log(
+        [
+          `id=${String(row.id)}`,
+          `username=${String(row.username ?? 'null')}`,
+          `classification=${String(row.classification)}`,
+          `action=${String(row.remediationAction)}`,
+          `outcome=${String(row.outcome)}`,
+          row.error ? `error=${String(row.error)}` : null,
+          row.newWalletAddress
+            ? `newWalletAddress=${String(row.newWalletAddress)}`
+            : null,
+        ]
+          .filter(Boolean)
+          .join(' | ')
+      );
+    }
+  }
+
+  if (!options.apply) {
+    console.log('\nDry-run only. Re-run with --apply to persist changes.');
+  }
+
+  await closeDatabase();
+}
+
+main()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch(async (error) => {
+    console.error('Agent wallet remediation failed:', error);
+    await closeDatabase();
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

- Replace the agent wallet fallback flow with a strict Privy-only offline-ready custody flow.
- Add audit and remediation tooling for corrupted agent wallet state, using the same canonical readiness model as runtime.
- Remediate all current staging and production agent records to the Privy-backed offline-ready model.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Fixes the agent wallet provisioning flow where agents could end up with a stored `walletAddress` and synthetic wallet identifiers but no recoverable signing capability.
- PR: https://github.com/BabylonSocial/babylon/pull/1251

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [x] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [x] Other: `scripts/*`

## Changes

- Added a dedicated Privy agent wallet provisioning helper in `packages/api/src/services/privy/agent-wallet-provisioning.ts`.
- Refactored `AgentWalletService` to provision only real Privy-backed offline-ready wallets and to reject partial or inconsistent wallet state in runtime.
- Corrected agent transaction signing to use `privyWalletId` as the canonical wallet identifier.
- Removed runtime auto-provisioning from the A2A integration path.
- Added agent wallet state classification helpers plus focused tests for readiness / remediation decisions.
- Added `scripts/audit-agent-wallet-readiness.ts` and `scripts/remediate-agent-wallets.ts`.
- Executed remediation successfully on both staging and production.

## Review guide

**Start here**
- `packages/api/src/services/privy/agent-wallet-provisioning.ts`
- `packages/agents/src/identity/agent-wallet-state.ts`
- `packages/agents/src/identity/AgentWalletService.ts`
- `scripts/remediate-agent-wallets.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- Runtime no longer hides provisioning failures behind local wallet fallbacks or synthetic identifiers.
- Remediation intentionally replaces fake / orphaned custody state with new canonical Privy-backed offline-ready wallets.
- Some remediated agents now have different canonical wallet addresses than the previous fake fallback addresses.

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Run `bun test packages/api/src/services/privy/__tests__/agent-wallet-provisioning.test.ts packages/agents/src/__tests__/agent-wallet-service.test.ts packages/agents/src/__tests__/agent-wallet-state.test.ts`.
2. Run `bun x tsc -b packages/api packages/agents`.
3. Run `bun run scripts/audit-agent-wallet-readiness.ts --limit=500` against staging and production.
4. Run `bun run scripts/remediate-agent-wallets.ts --apply ...` against staging and production with the appropriate Privy offline config.
5. Confirm post-run audit returns only `ready` agents.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `Executed via remediation script on 2026-03-16`

**Rollout / rollback plan**
- Rollout: runtime refactor plus remediation completed on staging and production.
- Rollback: revert runtime changes if needed; any data rollback would require a separate operational plan because agent wallet addresses were intentionally remediated to new canonical Privy wallets.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- N/A

## Security / privacy

- [ ] No security impact
- [x] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- Agent wallet signing now requires a full ready state: `privyId`, `privyWalletId`, `walletAddress`, and `offlineWalletReady=true`.

### Database
- No schema changes.
- Staging remediation result: `34 / 34` agents ready.
- Production remediation result: `228 / 228` agents ready.

### Contracts / on-chain
- No contract changes.
- Wallet custody references changed for remediated agents because fake fallback addresses were replaced with real Privy-backed wallets.

### Docs
- Added changelog entry under `changelogs/agent-offline-wallet-ready-remediation.md`.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend-only change, no UI impact.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`production` for this fix)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
