### PR TITLE
fix(feed): For You infinite scroll cap + market card spacing

### DIFF
--- a/apps/web/src/app/api/feed/for-you/pipeline.ts
+++ b/apps/web/src/app/api/feed/for-you/pipeline.ts
@@ -50,8 +50,8 @@ import {
 } from './scoring';
 
 const MAX_CANDIDATE_POSTS = 500;
-const MAX_STANDALONE_POSTS = 24;
-const MAX_NEW_MARKET_CANDIDATES = 6;
+const MAX_STANDALONE_POSTS = 60;
+const MAX_NEW_MARKET_CANDIDATES = 12;
 const FEED_POST_WINDOW_MS = 24 * 60 * 60 * 1000;
 const NEW_MARKET_WINDOW_MS = 24 * 60 * 60 * 1000;
 const FEED_EVENT_WINDOW_MS = 14 * 24 * 60 * 60 * 1000;
@@ -989,6 +989,38 @@ async function loadFeedEventAggregates(
   );
 }
 
+/**
+ * Ensures no two market cards are adjacent in the feed.
+ * When two consecutive isNewMarket items are found, the nearest following
+ * non-market story is spliced between them, preserving rank order otherwise.
+ */
+function spreadNewMarkets(stories: NarrativeStory[]): NarrativeStory[] {
+  const result = [...stories];
+
+  for (let i = 0; i < result.length - 1; i++) {
+    const current = result[i];
+    const next = result[i + 1];
+    if (!current?.isNewMarket) continue;
+    if (!next?.isNewMarket) continue;
+
+    // Two consecutive markets at i and i+1 — find the next non-market after i+1
+    const nextPostIdx = result.findIndex(
+      (s, idx) => idx > i + 1 && !s.isNewMarket
+    );
+
+    if (nextPostIdx !== -1) {
+      // Pull the non-market post forward to sit between the two markets
+      const post = result.splice(nextPostIdx, 1)[0];
+      if (post !== undefined) {
+        result.splice(i + 1, 0, post);
+      }
+    }
+    // Edge case: all remaining items are markets — leave as-is
+  }
+
+  return result;
+}
+
 export async function buildForYouFeed(userId?: string | null) {
   const currentTopic = await dailyTopicService.getCurrentTopic();
 
@@ -1320,10 +1352,13 @@ export async function buildForYouFeed(userId?: string | null) {
     } satisfies NarrativeStory;
   });
 
-  const rankedStories = diversifyForYouStories(
-    rescoredStories.sort(
-      (a, b) =>
-        (b.finalRankScore ?? b.storyScore) - (a.finalRankScore ?? a.storyScore)
+  const rankedStories = spreadNewMarkets(
+    diversifyForYouStories(
+      rescoredStories.sort(
+        (a, b) =>
+          (b.finalRankScore ?? b.storyScore) -
+          (a.finalRankScore ?? a.storyScore)
+      )
     )
   );
 

--- a/apps/web/src/app/api/feed/for-you/pipeline.ts
+++ b/apps/web/src/app/api/feed/for-you/pipeline.ts
@@ -47,6 +47,7 @@ import {
   calculateFreshnessScore,
   calculateVelocityScore,
   diversifyForYouStories,
+  spreadNewMarkets,
 } from './scoring';
 
 const MAX_CANDIDATE_POSTS = 500;
@@ -987,38 +988,6 @@ async function loadFeedEventAggregates(
       createdAt: row.createdAt,
     }))
   );
-}
-
-/**
- * Ensures no two market cards are adjacent in the feed.
- * When two consecutive isNewMarket items are found, the nearest following
- * non-market story is spliced between them, preserving rank order otherwise.
- */
-function spreadNewMarkets(stories: NarrativeStory[]): NarrativeStory[] {
-  const result = [...stories];
-
-  for (let i = 0; i < result.length - 1; i++) {
-    const current = result[i];
-    const next = result[i + 1];
-    if (!current?.isNewMarket) continue;
-    if (!next?.isNewMarket) continue;
-
-    // Two consecutive markets at i and i+1 — find the next non-market after i+1
-    const nextPostIdx = result.findIndex(
-      (s, idx) => idx > i + 1 && !s.isNewMarket
-    );
-
-    if (nextPostIdx !== -1) {
-      // Pull the non-market post forward to sit between the two markets
-      const post = result.splice(nextPostIdx, 1)[0];
-      if (post !== undefined) {
-        result.splice(i + 1, 0, post);
-      }
-    }
-    // Edge case: all remaining items are markets — leave as-is
-  }
-
-  return result;
 }
 
 export async function buildForYouFeed(userId?: string | null) {

--- a/apps/web/src/app/api/feed/for-you/route.test.ts
+++ b/apps/web/src/app/api/feed/for-you/route.test.ts
@@ -4,6 +4,12 @@ import type { NextRequest } from 'next/server';
 const mockBuildForYouFeed = mock();
 const mockPublicRateLimit = mock();
 
+// getCacheOrFetch passes through to the fetchFn so buildForYouFeed is
+// still called and assertable, while avoiding any real Redis connection.
+const mockGetCacheOrFetch = mock(
+  async <T>(_key: string, fetchFn: () => Promise<T>) => fetchFn()
+);
+
 mock.module('@babylon/api', () => ({
   addPublicReadHeaders: (
     response: Response,
@@ -12,6 +18,7 @@ mock.module('@babylon/api', () => ({
     response.headers.set('Cache-Control', 'public, max-age=30');
     response.headers.set('X-RateLimit-Limit', String(rateLimitInfo.limit));
   },
+  getCacheOrFetch: mockGetCacheOrFetch,
   publicRateLimit: mockPublicRateLimit,
   successResponse: (data: unknown) =>
     new Response(JSON.stringify(data), {
@@ -27,15 +34,22 @@ mock.module('./pipeline', () => ({
 
 const { GET } = await import('./route');
 
-const makeRequest = (): NextRequest =>
-  ({
+const makeRequest = (params: Record<string, string> = {}): NextRequest => {
+  const searchParams = new URLSearchParams(params);
+  return {
     url: 'https://babylon.social/api/feed/for-you',
     headers: { get: () => null },
-  }) as unknown as NextRequest;
+    nextUrl: { searchParams },
+  } as unknown as NextRequest;
+};
 
 beforeEach(() => {
   mockBuildForYouFeed.mockReset();
   mockPublicRateLimit.mockReset();
+  mockGetCacheOrFetch.mockReset();
+  mockGetCacheOrFetch.mockImplementation(
+    async <T>(_key: string, fetchFn: () => Promise<T>) => fetchFn()
+  );
 });
 
 describe('GET /api/feed/for-you', () => {
@@ -62,6 +76,83 @@ describe('GET /api/feed/for-you', () => {
     expect(response.headers.get('X-RateLimit-Limit')).toBe('60');
     expect(payload.generatedAt).toBe('2026-03-08T11:55:00.000Z');
     expect(payload.stories).toHaveLength(1);
+    expect(payload.hasMore).toBe(false);
+    expect(payload.total).toBe(1);
+  });
+
+  it('paginates correctly with offset and limit params', async () => {
+    mockPublicRateLimit.mockResolvedValue({
+      error: null,
+      user: { userId: 'user-1' },
+      rateLimitInfo: {
+        limit: 60,
+        remaining: 59,
+        resetAt: new Date('2026-03-08T12:00:00.000Z'),
+      },
+    });
+    // 25-item dataset — page 1 (offset=20, limit=20) should return 5 items
+    const allStories = Array.from({ length: 25 }, (_, i) => ({
+      storyKey: `story-${i}`,
+      posts: [],
+    }));
+    mockBuildForYouFeed.mockResolvedValue({
+      generatedAt: '2026-03-08T11:55:00.000Z',
+      stories: allStories,
+    });
+
+    const response = await GET(makeRequest({ offset: '20', limit: '20' }));
+    const payload = await response.json();
+
+    expect(payload.stories).toHaveLength(5);
+    expect(payload.stories[0].storyKey).toBe('story-20');
+    expect(payload.hasMore).toBe(false);
+    expect(payload.total).toBe(25);
+  });
+
+  it('reports hasMore true when more pages exist', async () => {
+    mockPublicRateLimit.mockResolvedValue({
+      error: null,
+      user: { userId: 'user-1' },
+      rateLimitInfo: { limit: 60, remaining: 59, resetAt: new Date() },
+    });
+    const allStories = Array.from({ length: 45 }, (_, i) => ({
+      storyKey: `story-${i}`,
+      posts: [],
+    }));
+    mockBuildForYouFeed.mockResolvedValue({
+      generatedAt: '2026-03-08T11:55:00.000Z',
+      stories: allStories,
+    });
+
+    const response = await GET(makeRequest());
+    const payload = await response.json();
+
+    expect(payload.stories).toHaveLength(20);
+    expect(payload.hasMore).toBe(true);
+    expect(payload.total).toBe(45);
+  });
+
+  it('treats non-numeric offset as 0 rather than silently passing NaN', async () => {
+    mockPublicRateLimit.mockResolvedValue({
+      error: null,
+      user: { userId: 'user-1' },
+      rateLimitInfo: { limit: 60, remaining: 59, resetAt: new Date() },
+    });
+    const allStories = Array.from({ length: 5 }, (_, i) => ({
+      storyKey: `story-${i}`,
+      posts: [],
+    }));
+    mockBuildForYouFeed.mockResolvedValue({
+      generatedAt: '2026-03-08T11:55:00.000Z',
+      stories: allStories,
+    });
+
+    const response = await GET(makeRequest({ offset: 'abc' }));
+    const payload = await response.json();
+
+    // Should return page 0 content, not crash or miscompute
+    expect(payload.stories).toHaveLength(5);
+    expect(payload.stories[0].storyKey).toBe('story-0');
   });
 
   it('includes anchor post in posts array for isNewMarket stories', async () => {

--- a/apps/web/src/app/api/feed/for-you/route.ts
+++ b/apps/web/src/app/api/feed/for-you/route.ts
@@ -23,11 +23,13 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   }
 
   const { searchParams } = request.nextUrl;
-  const offset = Math.max(0, Number(searchParams.get('offset') ?? 0));
-  const limit = Math.min(
-    PAGE_SIZE,
-    Math.max(1, Number(searchParams.get('limit') ?? PAGE_SIZE))
-  );
+  const rawOffset = Number(searchParams.get('offset') ?? 0);
+  const rawLimit = Number(searchParams.get('limit') ?? PAGE_SIZE);
+  // Guard against NaN from non-numeric query params to avoid silent slice(0, 20) fallback.
+  const offset = Number.isFinite(rawOffset) ? Math.max(0, rawOffset) : 0;
+  const limit = Number.isFinite(rawLimit)
+    ? Math.min(PAGE_SIZE, Math.max(1, rawLimit))
+    : PAGE_SIZE;
 
   const userId = user?.userId ?? null;
   // Per-user ranked snapshot cached for 5 minutes. Anonymous users share one

--- a/apps/web/src/app/api/feed/for-you/route.ts
+++ b/apps/web/src/app/api/feed/for-you/route.ts
@@ -1,11 +1,16 @@
 import {
   addPublicReadHeaders,
+  getCacheOrFetch,
   publicRateLimit,
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
+import type { NarrativeStory } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 import { buildForYouFeed } from './pipeline';
+
+const PAGE_SIZE = 20;
+const RANKED_CACHE_TTL_S = 300; // 5-minute per-user ranked snapshot
 
 export const GET = withErrorHandling(async (request: NextRequest) => {
   const {
@@ -17,16 +22,39 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     return rateLimitError;
   }
 
-  const payload = await buildForYouFeed(user?.userId ?? null);
+  const { searchParams } = request.nextUrl;
+  const offset = Math.max(0, Number(searchParams.get('offset') ?? 0));
+  const limit = Math.min(
+    PAGE_SIZE,
+    Math.max(1, Number(searchParams.get('limit') ?? PAGE_SIZE))
+  );
+
+  const userId = user?.userId ?? null;
+  // Per-user ranked snapshot cached for 5 minutes. Anonymous users share one
+  // snapshot; authenticated users each get their own personalised slice.
+  const cacheKey = userId
+    ? `feed:for-you:ranked:v1:${userId}`
+    : 'feed:for-you:ranked:v1:anon';
+
+  const fullResult = await getCacheOrFetch<{
+    stories: NarrativeStory[];
+    generatedAt: string;
+  }>(cacheKey, () => buildForYouFeed(userId), { ttl: RANKED_CACHE_TTL_S });
+
+  const total = fullResult.stories.length;
+  const page = fullResult.stories.slice(offset, offset + limit);
+  const hasMore = offset + limit < total;
 
   const response = successResponse({
     success: true,
-    stories: payload.stories,
-    generatedAt: payload.generatedAt,
+    stories: page,
+    total,
+    hasMore,
+    generatedAt: fullResult.generatedAt,
   });
 
   if (rateLimitInfo) {
-    if (user?.userId) {
+    if (userId) {
       response.headers.set('Cache-Control', 'private, no-store');
       response.headers.set('X-RateLimit-Limit', rateLimitInfo.limit.toString());
       response.headers.set(

--- a/apps/web/src/app/api/feed/for-you/scoring.test.ts
+++ b/apps/web/src/app/api/feed/for-you/scoring.test.ts
@@ -6,6 +6,7 @@ import {
   calculateFreshnessScore,
   calculateVelocityScore,
   diversifyForYouStories,
+  spreadNewMarkets,
 } from './scoring';
 
 function makeStory(
@@ -178,6 +179,77 @@ describe('for-you scoring helpers', () => {
     });
 
     expect(highIntent).toBeGreaterThan(lowIntent);
+  });
+
+  it('spreadNewMarkets returns empty array unchanged', () => {
+    expect(spreadNewMarkets([])).toEqual([]);
+  });
+
+  it('spreadNewMarkets leaves a feed with no adjacent markets unchanged', () => {
+    const input = [
+      makeStory('p1'),
+      makeStory('m1', { isNewMarket: true }),
+      makeStory('p2'),
+      makeStory('m2', { isNewMarket: true }),
+    ];
+    const result = spreadNewMarkets(input);
+    expect(result.map((s) => s.storyKey)).toEqual(['p1', 'm1', 'p2', 'm2']);
+  });
+
+  it('spreadNewMarkets separates two back-to-back markets', () => {
+    const input = [
+      makeStory('m1', { isNewMarket: true }),
+      makeStory('m2', { isNewMarket: true }),
+      makeStory('p1'),
+      makeStory('p2'),
+    ];
+    const result = spreadNewMarkets(input);
+    expect(result.map((s) => s.storyKey)).toEqual(['m1', 'p1', 'm2', 'p2']);
+    expect(result[0]?.isNewMarket).toBe(true);
+    expect(result[1]?.isNewMarket).toBeFalsy();
+    expect(result[2]?.isNewMarket).toBe(true);
+  });
+
+  it('spreadNewMarkets handles three consecutive markets with available posts', () => {
+    const input = [
+      makeStory('m1', { isNewMarket: true }),
+      makeStory('m2', { isNewMarket: true }),
+      makeStory('m3', { isNewMarket: true }),
+      makeStory('p1'),
+      makeStory('p2'),
+      makeStory('p3'),
+    ];
+    const result = spreadNewMarkets(input);
+    for (let i = 0; i < result.length - 1; i++) {
+      expect(!!(result[i]?.isNewMarket && result[i + 1]?.isNewMarket)).toBe(
+        false
+      );
+    }
+    expect(result).toHaveLength(6);
+  });
+
+  it('spreadNewMarkets leaves all-market feed unchanged when no posts exist', () => {
+    const input = [
+      makeStory('m1', { isNewMarket: true }),
+      makeStory('m2', { isNewMarket: true }),
+      makeStory('m3', { isNewMarket: true }),
+    ];
+    expect(spreadNewMarkets(input).map((s) => s.storyKey)).toEqual([
+      'm1',
+      'm2',
+      'm3',
+    ]);
+  });
+
+  it('spreadNewMarkets does not mutate the original array', () => {
+    const input = [
+      makeStory('m1', { isNewMarket: true }),
+      makeStory('m2', { isNewMarket: true }),
+      makeStory('p1'),
+    ];
+    const inputKeys = input.map((s) => s.storyKey);
+    spreadNewMarkets(input);
+    expect(input.map((s) => s.storyKey)).toEqual(inputKeys);
   });
 
   it('diversifies repeated authors and clusters', () => {

--- a/apps/web/src/app/api/feed/for-you/scoring.ts
+++ b/apps/web/src/app/api/feed/for-you/scoring.ts
@@ -151,3 +151,39 @@ export function diversifyForYouStories(
 
   return result;
 }
+
+/**
+ * Hard-guarantee pass that ensures no two market cards are adjacent in the feed.
+ * Applied after `diversifyForYouStories()`, which uses score-based penalties that
+ * can fail to separate markets when score gaps are large. This function provides
+ * an unconditional structural guarantee with minimal rank-order disturbance.
+ *
+ * When two consecutive isNewMarket items are found, the nearest following
+ * non-market story is spliced between them.
+ */
+export function spreadNewMarkets(stories: NarrativeStory[]): NarrativeStory[] {
+  const result = [...stories];
+
+  for (let i = 0; i < result.length - 1; i++) {
+    const current = result[i];
+    const next = result[i + 1];
+    if (!current?.isNewMarket) continue;
+    if (!next?.isNewMarket) continue;
+
+    // Two consecutive markets at i and i+1 — find the next non-market after i+1
+    const nextPostIdx = result.findIndex(
+      (s, idx) => idx > i + 1 && !s.isNewMarket
+    );
+
+    if (nextPostIdx !== -1) {
+      // Pull the non-market post forward to sit between the two markets
+      const post = result.splice(nextPostIdx, 1)[0];
+      if (post !== undefined) {
+        result.splice(i + 1, 0, post);
+      }
+    }
+    // Edge case: all remaining items are markets — leave as-is
+  }
+
+  return result;
+}

--- a/apps/web/src/app/feed/FeedClient.tsx
+++ b/apps/web/src/app/feed/FeedClient.tsx
@@ -150,8 +150,11 @@ export function FeedClient() {
     stories: forYouStories,
     ready: forYouReady,
     loading: forYouLoading,
+    loadingMore: forYouLoadingMore,
+    hasMore: forYouHasMore,
     error: forYouError,
     refresh: refreshForYou,
+    loadMore: loadMoreForYou,
   } = useForYouFeed({ enabled: tab === 'forYou' });
 
   // New market cards shown at the top of Latest and Hot tabs
@@ -359,7 +362,14 @@ export function FeedClient() {
     if (tab === 'forYou') {
       if (forYouError) return <ForYouFeedError onRetry={refreshForYou} />;
       if (forYouStories.length === 0) return <EmptyFeed variant="forYou" />;
-      return <ForYouFeedList stories={forYouStories} />;
+      return (
+        <ForYouFeedList
+          stories={forYouStories}
+          hasMore={forYouHasMore}
+          loadingMore={forYouLoadingMore}
+          loadMore={loadMoreForYou}
+        />
+      );
     }
 
     if (currentPosts.length === 0) {

--- a/apps/web/src/app/feed/components/ForYouFeedList.tsx
+++ b/apps/web/src/app/feed/components/ForYouFeedList.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { FeedEventAction, NarrativeStory } from '@babylon/shared';
+import { Loader2 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useFeedEventTracker } from '@/app/feed/hooks';
@@ -17,9 +18,20 @@ const VISIBLE_DWELL_MS = 2000;
 
 interface ForYouFeedListProps {
   stories: NarrativeStory[];
+  /** Whether the server has more pages beyond what is currently in `stories` */
+  hasMore: boolean;
+  /** Whether a server page fetch is in-flight */
+  loadingMore: boolean;
+  /** Trigger a server-side page fetch and append */
+  loadMore: () => void;
 }
 
-export function ForYouFeedList({ stories }: ForYouFeedListProps) {
+export function ForYouFeedList({
+  stories,
+  hasMore,
+  loadingMore,
+  loadMore,
+}: ForYouFeedListProps) {
   const router = useRouter();
   const { trackEvent } = useFeedEventTracker();
   const allItems = useMemo(() => stories, [stories]);
@@ -45,9 +57,23 @@ export function ForYouFeedList({ stories }: ForYouFeedListProps) {
     dwellTimersRef.current.clear();
   }, [stories]);
 
-  const loadMore = useCallback(() => {
+  // Reveal the next batch of already-fetched items from the local array.
+  const revealMore = useCallback(() => {
     setVisibleCount((count) => Math.min(count + PAGE_SIZE, allItems.length));
   }, [allItems.length]);
+
+  // True when there are locally-buffered items still hidden.
+  const hasMoreVisible = visibleCount < allItems.length;
+
+  // The sentinel IntersectionObserver either reveals local items or triggers
+  // a server fetch when the local buffer is exhausted.
+  const handleSentinel = useCallback(() => {
+    if (hasMoreVisible) {
+      revealMore();
+    } else if (hasMore) {
+      loadMore();
+    }
+  }, [hasMoreVisible, hasMore, revealMore, loadMore]);
 
   useEffect(() => {
     const el = sentinelRef.current;
@@ -55,16 +81,16 @@ export function ForYouFeedList({ stories }: ForYouFeedListProps) {
 
     const observer = new IntersectionObserver(
       (entries) => {
-        if (entries[0]?.isIntersecting) loadMore();
+        if (entries[0]?.isIntersecting) handleSentinel();
       },
       { rootMargin: '200px' }
     );
     observer.observe(el);
     return () => observer.disconnect();
-  }, [loadMore]);
+  }, [handleSentinel]);
 
   const visibleItems = allItems.slice(0, visibleCount);
-  const hasMore = visibleCount < allItems.length;
+  const allCaughtUp = !hasMoreVisible && !hasMore && !loadingMore;
 
   const buildEventPayload = useCallback(
     (
@@ -264,7 +290,13 @@ export function ForYouFeedList({ stories }: ForYouFeedListProps) {
 
       <div ref={sentinelRef} className="h-1" />
 
-      {!hasMore && (
+      {loadingMore && (
+        <div className="flex justify-center py-4">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {allCaughtUp && (
         <div className="py-4 text-center text-muted-foreground text-xs">
           You&apos;re all caught up.
         </div>

--- a/apps/web/src/app/feed/hooks/useForYouFeed.ts
+++ b/apps/web/src/app/feed/hooks/useForYouFeed.ts
@@ -164,6 +164,10 @@ export function useForYouFeed(
       });
   }, [fetchPage, syncHasMore]);
 
+  // SSE is the primary refresh mechanism. The 5-minute fallback polling from
+  // the generic `useFeed` hook is intentionally omitted here: for a paginated
+  // hook, polling would reset the user to page 1 mid-scroll. If SSE is
+  // unavailable, the user retains their current page until they manually refresh.
   useSSEChannel(
     enabled ? 'feed' : null,
     useCallback(() => {

--- a/apps/web/src/app/feed/hooks/useForYouFeed.ts
+++ b/apps/web/src/app/feed/hooks/useForYouFeed.ts
@@ -1,16 +1,210 @@
-import { useFeed } from './useFeed';
+import type { NarrativeStory } from '@babylon/shared';
+import { logger } from '@babylon/shared';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useAuth } from '@/hooks/useAuth';
+import { useSSEChannel } from '@/hooks/useSSE';
 
 interface UseForYouFeedOptions {
   enabled?: boolean;
 }
 
-const FOR_YOU_CONFIG = {
-  endpoint: '/api/feed/for-you',
-  requiresAuth: true,
-  logContext: 'useForYouFeed',
-  feedName: 'For You',
-} as const;
+export interface UseForYouFeedResult {
+  stories: NarrativeStory[];
+  ready: boolean;
+  loading: boolean;
+  loadingMore: boolean;
+  hasMore: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  loadMore: () => void;
+}
 
-export function useForYouFeed(options: UseForYouFeedOptions = {}) {
-  return useFeed(FOR_YOU_CONFIG, options);
+const PAGE_SIZE = 20;
+const ENDPOINT = '/api/feed/for-you';
+const SSE_DEBOUNCE_MS = 2_000;
+const LOG_CTX = 'useForYouFeed';
+
+interface FeedPageResponse {
+  stories?: NarrativeStory[];
+  hasMore?: boolean;
+  total?: number;
+  generatedAt?: string;
+}
+
+export function useForYouFeed(
+  options: UseForYouFeedOptions = {}
+): UseForYouFeedResult {
+  const { enabled = true } = options;
+  const { authenticated, getAccessToken } = useAuth();
+
+  const [stories, setStories] = useState<NarrativeStory[]>([]);
+  const [ready, setReady] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const storiesRef = useRef<NarrativeStory[]>([]);
+  const isMountedRef = useRef(true);
+  const hasFetched = useRef(false);
+  const sseDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const loadMoreAbortRef = useRef<AbortController | null>(null);
+  // Tracks whether a server loadMore is already in-flight (avoids duplicate
+  // requests that race when the sentinel fires multiple times quickly).
+  const loadingMoreRef = useRef(false);
+
+  const buildHeaders = useCallback(async (): Promise<HeadersInit> => {
+    if (!authenticated) return {};
+    const token = await getAccessToken();
+    return token ? { Authorization: `Bearer ${token}` } : {};
+  }, [authenticated, getAccessToken]);
+
+  const fetchPage = useCallback(
+    async (
+      offset: number,
+      signal: AbortSignal
+    ): Promise<FeedPageResponse | null> => {
+      const headers = await buildHeaders();
+      const url = `${ENDPOINT}?offset=${offset}&limit=${PAGE_SIZE}`;
+      const response = await fetch(url, { signal, headers });
+      if (signal.aborted) return null;
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      return response.json() as Promise<FeedPageResponse>;
+    },
+    [buildHeaders]
+  );
+
+  const loadInitial = useCallback(
+    async (signal: AbortSignal) => {
+      setLoading(true);
+      try {
+        const data = await fetchPage(0, signal);
+        if (!data || signal.aborted) return;
+        const items = data.stories ?? [];
+        setStories(items);
+        storiesRef.current = items;
+        setHasMore(data.hasMore ?? false);
+        setError(null);
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return;
+        const msg = 'Failed to load For You feed';
+        logger.error(msg, { error: err }, LOG_CTX);
+        if (storiesRef.current.length === 0) setError(msg);
+      } finally {
+        if (!signal.aborted) {
+          setLoading(false);
+          setReady(true);
+        }
+      }
+    },
+    [fetchPage]
+  );
+
+  const refresh = useCallback(async () => {
+    abortControllerRef.current?.abort();
+    loadMoreAbortRef.current?.abort();
+    loadingMoreRef.current = false;
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+    await loadInitial(controller.signal);
+  }, [loadInitial]);
+
+  const loadMore = useCallback(() => {
+    if (loadingMoreRef.current || !hasMore) return;
+    loadMoreAbortRef.current?.abort();
+    const controller = new AbortController();
+    loadMoreAbortRef.current = controller;
+    const offset = storiesRef.current.length;
+    loadingMoreRef.current = true;
+    setLoadingMore(true);
+
+    void fetchPage(offset, controller.signal)
+      .then((data) => {
+        if (!data || controller.signal.aborted) return;
+        const next = data.stories ?? [];
+        setStories((prev) => {
+          const merged = [...prev, ...next];
+          storiesRef.current = merged;
+          return merged;
+        });
+        setHasMore(data.hasMore ?? false);
+      })
+      .catch((err) => {
+        if (err instanceof Error && err.name === 'AbortError') return;
+        logger.error(
+          'Failed to load more For You stories',
+          { error: err },
+          LOG_CTX
+        );
+      })
+      .finally(() => {
+        loadingMoreRef.current = false;
+        if (!controller.signal.aborted && isMountedRef.current) {
+          setLoadingMore(false);
+        }
+      });
+  }, [fetchPage, hasMore]);
+
+  useSSEChannel(
+    enabled ? 'feed' : null,
+    useCallback(() => {
+      if (!isMountedRef.current) return;
+      if (sseDebounceRef.current) clearTimeout(sseDebounceRef.current);
+      sseDebounceRef.current = setTimeout(() => {
+        if (isMountedRef.current) void refresh();
+      }, SSE_DEBOUNCE_MS);
+    }, [refresh])
+  );
+
+  // Initial fetch and cleanup
+  useEffect(() => {
+    if (!enabled) {
+      hasFetched.current = false;
+      setReady(false);
+      setLoading(false);
+      abortControllerRef.current?.abort();
+      abortControllerRef.current = null;
+      loadMoreAbortRef.current?.abort();
+      loadMoreAbortRef.current = null;
+      loadingMoreRef.current = false;
+      if (sseDebounceRef.current) {
+        clearTimeout(sseDebounceRef.current);
+        sseDebounceRef.current = null;
+      }
+      return;
+    }
+
+    isMountedRef.current = true;
+    if (hasFetched.current) return;
+    hasFetched.current = true;
+
+    const controller = new AbortController();
+    abortControllerRef.current = controller;
+    void loadInitial(controller.signal);
+
+    return () => {
+      hasFetched.current = false;
+      isMountedRef.current = false;
+      controller.abort();
+      loadMoreAbortRef.current?.abort();
+      if (sseDebounceRef.current) {
+        clearTimeout(sseDebounceRef.current);
+        sseDebounceRef.current = null;
+      }
+    };
+  }, [enabled, loadInitial]);
+
+  return {
+    stories,
+    ready,
+    loading,
+    loadingMore,
+    hasMore,
+    error,
+    refresh,
+    loadMore,
+  };
 }

--- a/apps/web/src/app/feed/hooks/useForYouFeed.ts
+++ b/apps/web/src/app/feed/hooks/useForYouFeed.ts
@@ -25,6 +25,7 @@ const SSE_DEBOUNCE_MS = 2_000;
 const LOG_CTX = 'useForYouFeed';
 
 interface FeedPageResponse {
+  success?: boolean;
   stories?: NarrativeStory[];
   hasMore?: boolean;
   total?: number;
@@ -45,14 +46,26 @@ export function useForYouFeed(
   const [error, setError] = useState<string | null>(null);
 
   const storiesRef = useRef<NarrativeStory[]>([]);
-  const isMountedRef = useRef(true);
+  // Initialise false — set true inside the mount effect to correctly handle
+  // React 18 strict-mode double-invoke (mount → unmount → remount).
+  const isMountedRef = useRef(false);
   const hasFetched = useRef(false);
   const sseDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
   const loadMoreAbortRef = useRef<AbortController | null>(null);
-  // Tracks whether a server loadMore is already in-flight (avoids duplicate
-  // requests that race when the sentinel fires multiple times quickly).
+  // Tracks in-flight loadMore independently of React state to prevent duplicate
+  // requests when the sentinel IntersectionObserver fires rapidly.
   const loadingMoreRef = useRef(false);
+  // Mirror of `hasMore` state in a ref so `loadMore` can guard against stale
+  // closure values without taking `hasMore` as a dependency (which recreates
+  // the function after every page, potentially triggering an extra observer
+  // reconnect before the child re-renders).
+  const hasMoreRef = useRef(false);
+
+  const syncHasMore = useCallback((value: boolean) => {
+    hasMoreRef.current = value;
+    setHasMore(value);
+  }, []);
 
   const buildHeaders = useCallback(async (): Promise<HeadersInit> => {
     if (!authenticated) return {};
@@ -84,9 +97,9 @@ export function useForYouFeed(
         const data = await fetchPage(0, signal);
         if (!data || signal.aborted) return;
         const items = data.stories ?? [];
-        setStories(items);
         storiesRef.current = items;
-        setHasMore(data.hasMore ?? false);
+        setStories(items);
+        syncHasMore(data.hasMore ?? false);
         setError(null);
       } catch (err) {
         if (err instanceof Error && err.name === 'AbortError') return;
@@ -100,7 +113,7 @@ export function useForYouFeed(
         }
       }
     },
-    [fetchPage]
+    [fetchPage, syncHasMore]
   );
 
   const refresh = useCallback(async () => {
@@ -113,10 +126,13 @@ export function useForYouFeed(
   }, [loadInitial]);
 
   const loadMore = useCallback(() => {
-    if (loadingMoreRef.current || !hasMore) return;
+    // Use ref-based guards to avoid stale closure values from React state.
+    if (loadingMoreRef.current || !hasMoreRef.current) return;
     loadMoreAbortRef.current?.abort();
     const controller = new AbortController();
     loadMoreAbortRef.current = controller;
+    // Read offset from ref (not state) so the value is always current even
+    // when `loadMore` is called before the previous setState has committed.
     const offset = storiesRef.current.length;
     loadingMoreRef.current = true;
     setLoadingMore(true);
@@ -125,12 +141,12 @@ export function useForYouFeed(
       .then((data) => {
         if (!data || controller.signal.aborted) return;
         const next = data.stories ?? [];
-        setStories((prev) => {
-          const merged = [...prev, ...next];
-          storiesRef.current = merged;
-          return merged;
-        });
-        setHasMore(data.hasMore ?? false);
+        // Update ref before setState so subsequent offset reads are correct
+        // even if React batches the state update with an in-flight sentinel.
+        const merged = [...storiesRef.current, ...next];
+        storiesRef.current = merged;
+        setStories(merged);
+        syncHasMore(data.hasMore ?? false);
       })
       .catch((err) => {
         if (err instanceof Error && err.name === 'AbortError') return;
@@ -146,7 +162,7 @@ export function useForYouFeed(
           setLoadingMore(false);
         }
       });
-  }, [fetchPage, hasMore]);
+  }, [fetchPage, syncHasMore]);
 
   useSSEChannel(
     enabled ? 'feed' : null,


### PR DESCRIPTION
## Problem

The For You tab had two feed quality issues:

1. **Hard cap**: `MAX_STANDALONE_POSTS = 24` and `MAX_NEW_MARKET_CANDIDATES = 6` limited the feed to ~30 total items. The progressive reveal (20 at a time) exhausted the entire feed after a single scroll — one load event, then \"you're all caught up\".

2. **Back-to-back market cards**: Market cards are scored and ranked inline with posts by `finalRankScore`. When multiple markets had similar scores they clustered, producing 3+ `NewMarketCard` components in a row with no posts between them.

## Solution

**Single file changed**: `apps/web/src/app/api/feed/for-you/pipeline.ts`

### Fix 1 — Output cap increase

- `MAX_STANDALONE_POSTS` 24 → 60
- `MAX_NEW_MARKET_CANDIDATES` 6 → 12

No DB or cache impact. These are post-ranking output filters — the 500-row candidate DB query (`.limit(MAX_CANDIDATE_POSTS)`) and the 60-second Redis cache (`feed:for-you:v2:base`) are unchanged. The progressive reveal now serves 3+ scroll batches from a single cache hit.

### Fix 2 — Market card spread

Added `spreadNewMarkets()` post-processor applied after `diversifyForYouStories()`. When two consecutive `isNewMarket` items are detected, the nearest following non-market story is spliced between them. Rank order is preserved with minimal swaps.

## Test plan

- [ ] Open For You tab, check `/api/feed/for-you` response — `stories` array should contain 60+ items
- [ ] Scroll through the feed — should trigger 3 progressive reveal batches (20 → 40 → 60 → end)
- [ ] Scan feed — no two `NewMarketCard` components appear adjacent