### PR TITLE
feat(agents): add paid Solana registration flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -110,6 +110,19 @@ PRIVY_AUTHORIZATION_PRIVATE_KEY=
 PRIVY_OFFLINE_SIGNER_ID=
 # Offline-first required: policy ID attached to the delegated signer.
 PRIVY_OFFLINE_POLICY_ID=
+# Solana agent registration reuses the same delegated signer / authorization
+# flow above. Ensure the configured Privy policy allows Solana
+# `signAndSendTransaction` for agent wallets.
+
+# ============================================================================
+# Solana Agent Registry Configuration
+# ============================================================================
+# Optional agent-only Solana registration flow.
+SOLANA_REGISTRY_ENABLED=false
+# Cluster: devnet, testnet, mainnet-beta, or localnet
+SOLANA_REGISTRY_CLUSTER=mainnet-beta
+# Optional explicit RPC URL override for Solana registry operations.
+SOLANA_REGISTRY_RPC_URL=
 
 # ============================================================================
 # Blockchain Configuration (Web3 Integration)

--- a/apps/web/src/app/api/agents/[agentId]/solana-registration/route.test.ts
+++ b/apps/web/src/app/api/agents/[agentId]/solana-registration/route.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { NextRequest } from 'next/server';
+
+const mockAuthenticateUser = mock();
+const mockGetAgentSolanaRegistrationStatus = mock();
+const mockRegisterAgentOnSolanaForOwner = mock();
+
+mock.module('@babylon/api', () => ({
+  authenticateUser: mockAuthenticateUser,
+  getAgentSolanaRegistrationStatus: mockGetAgentSolanaRegistrationStatus,
+  registerAgentOnSolanaForOwner: mockRegisterAgentOnSolanaForOwner,
+  successResponse: (data: unknown) => {
+    const { NextResponse } = require('next/server');
+    return NextResponse.json(data, { status: 200 });
+  },
+  withErrorHandling: (
+    handler: (req: NextRequest, ctx: unknown) => Promise<unknown>
+  ) => handler,
+}));
+
+const { GET, POST } = await import('./route');
+
+function createMockRequest(): NextRequest {
+  return {
+    url: 'https://example.com/api/agents/agent-1/solana-registration',
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === 'authorization' ? 'Bearer test-token' : null,
+    },
+  } as unknown as NextRequest;
+}
+
+describe('/api/agents/[agentId]/solana-registration', () => {
+  beforeEach(() => {
+    mockAuthenticateUser.mockReset();
+    mockGetAgentSolanaRegistrationStatus.mockReset();
+    mockRegisterAgentOnSolanaForOwner.mockReset();
+
+    mockAuthenticateUser.mockResolvedValue({ id: 'owner-1' });
+  });
+
+  it('returns the current Solana registration status for an owned agent', async () => {
+    mockGetAgentSolanaRegistrationStatus.mockResolvedValue({
+      isRegistered: false,
+      assetId: null,
+      metadataUri: null,
+      txHash: null,
+      walletAddress: null,
+      walletReady: false,
+      cost: 100,
+    });
+
+    const response = (await GET(createMockRequest(), {
+      params: Promise.resolve({ agentId: 'agent-1' }),
+    })) as Response;
+    const body = await response.json();
+
+    expect(body.isRegistered).toBe(false);
+    expect(mockGetAgentSolanaRegistrationStatus).toHaveBeenCalledWith({
+      ownerUserId: 'owner-1',
+      agentUserId: 'agent-1',
+    });
+  });
+
+  it('registers the agent on Solana for the owner', async () => {
+    mockRegisterAgentOnSolanaForOwner.mockResolvedValue({
+      message: 'Successfully registered agent on Solana',
+      alreadyRegistered: false,
+      agentUserId: 'agent-1',
+      assetId: 'asset-123',
+      metadataUri: 'ipfs://cid-123',
+      txHash: 'tx-123',
+      walletAddress: 'SoLWallet111',
+      cost: 100,
+    });
+
+    const response = (await POST(createMockRequest(), {
+      params: Promise.resolve({ agentId: 'agent-1' }),
+    })) as Response;
+    const body = await response.json();
+
+    expect(body.assetId).toBe('asset-123');
+    expect(mockRegisterAgentOnSolanaForOwner).toHaveBeenCalledWith({
+      ownerUserId: 'owner-1',
+      agentUserId: 'agent-1',
+    });
+  });
+});

--- a/apps/web/src/app/api/agents/[agentId]/solana-registration/route.test.ts
+++ b/apps/web/src/app/api/agents/[agentId]/solana-registration/route.test.ts
@@ -4,14 +4,34 @@ import type { NextRequest } from 'next/server';
 const mockAuthenticateUser = mock();
 const mockGetAgentSolanaRegistrationStatus = mock();
 const mockRegisterAgentOnSolanaForOwner = mock();
+const mockApplyRateLimit = mock();
 
 mock.module('@babylon/api', () => ({
+  applyRateLimit: mockApplyRateLimit,
   authenticateUser: mockAuthenticateUser,
   getAgentSolanaRegistrationStatus: mockGetAgentSolanaRegistrationStatus,
+  RATE_LIMIT_CONFIGS: {
+    ONCHAIN_REGISTRATION: 'ONCHAIN_REGISTRATION',
+  },
+  rateLimitError: (retryAfter?: number) => {
+    return new Response(
+      JSON.stringify({
+        success: false,
+        error: 'Rate limit exceeded',
+        retryAfter,
+      }),
+      {
+        status: 429,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+  },
   registerAgentOnSolanaForOwner: mockRegisterAgentOnSolanaForOwner,
   successResponse: (data: unknown) => {
-    const { NextResponse } = require('next/server');
-    return NextResponse.json(data, { status: 200 });
+    return new Response(JSON.stringify(data), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
   },
   withErrorHandling: (
     handler: (req: NextRequest, ctx: unknown) => Promise<unknown>
@@ -32,10 +52,12 @@ function createMockRequest(): NextRequest {
 
 describe('/api/agents/[agentId]/solana-registration', () => {
   beforeEach(() => {
+    mockApplyRateLimit.mockReset();
     mockAuthenticateUser.mockReset();
     mockGetAgentSolanaRegistrationStatus.mockReset();
     mockRegisterAgentOnSolanaForOwner.mockReset();
 
+    mockApplyRateLimit.mockReturnValue({ allowed: true });
     mockAuthenticateUser.mockResolvedValue({ id: 'owner-1' });
   });
 
@@ -84,5 +106,21 @@ describe('/api/agents/[agentId]/solana-registration', () => {
       ownerUserId: 'owner-1',
       agentUserId: 'agent-1',
     });
+  });
+
+  it('rate limits repeated registration attempts', async () => {
+    mockApplyRateLimit.mockReturnValueOnce({
+      allowed: false,
+      retryAfter: 42,
+    });
+
+    const response = (await POST(createMockRequest(), {
+      params: Promise.resolve({ agentId: 'agent-1' }),
+    })) as Response;
+    const body = await response.json();
+
+    expect(response.status).toBe(429);
+    expect(body.retryAfter).toBe(42);
+    expect(mockRegisterAgentOnSolanaForOwner).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/agents/[agentId]/solana-registration/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/solana-registration/route.ts
@@ -1,6 +1,9 @@
 import {
+  applyRateLimit,
   authenticateUser,
   getAgentSolanaRegistrationStatus,
+  RATE_LIMIT_CONFIGS,
+  rateLimitError,
   registerAgentOnSolanaForOwner,
   successResponse,
   withErrorHandling,
@@ -11,8 +14,10 @@ export const GET = withErrorHandling(async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ agentId: string }> }
 ) {
-  const user = await authenticateUser(req);
-  const { agentId } = await params;
+  const [user, { agentId }] = await Promise.all([
+    authenticateUser(req),
+    params,
+  ]);
 
   const status = await getAgentSolanaRegistrationStatus({
     ownerUserId: user.id,
@@ -26,8 +31,12 @@ export const POST = withErrorHandling(async function POST(
   req: NextRequest,
   { params }: { params: Promise<{ agentId: string }> }
 ) {
-  const user = await authenticateUser(req);
-  const { agentId } = await params;
+  const [user, { agentId }] = await Promise.all([
+    authenticateUser(req),
+    params,
+  ]);
+  const rl = applyRateLimit(user.id, RATE_LIMIT_CONFIGS.ONCHAIN_REGISTRATION);
+  if (!rl.allowed) return rateLimitError(rl.retryAfter);
 
   const result = await registerAgentOnSolanaForOwner({
     ownerUserId: user.id,

--- a/apps/web/src/app/api/agents/[agentId]/solana-registration/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/solana-registration/route.ts
@@ -1,0 +1,38 @@
+import {
+  authenticateUser,
+  getAgentSolanaRegistrationStatus,
+  registerAgentOnSolanaForOwner,
+  successResponse,
+  withErrorHandling,
+} from '@babylon/api';
+import type { NextRequest } from 'next/server';
+
+export const GET = withErrorHandling(async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ agentId: string }> }
+) {
+  const user = await authenticateUser(req);
+  const { agentId } = await params;
+
+  const status = await getAgentSolanaRegistrationStatus({
+    ownerUserId: user.id,
+    agentUserId: agentId,
+  });
+
+  return successResponse(status);
+});
+
+export const POST = withErrorHandling(async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ agentId: string }> }
+) {
+  const user = await authenticateUser(req);
+  const { agentId } = await params;
+
+  const result = await registerAgentOnSolanaForOwner({
+    ownerUserId: user.id,
+    agentUserId: agentId,
+  });
+
+  return successResponse(result);
+});

--- a/apps/web/src/components/agents/AgentWallet.tsx
+++ b/apps/web/src/components/agents/AgentWallet.tsx
@@ -26,6 +26,16 @@ interface Transaction {
   createdAt: string;
 }
 
+interface SolanaRegistrationStatus {
+  isRegistered: boolean;
+  assetId: string | null;
+  metadataUri: string | null;
+  txHash: string | null;
+  walletAddress: string | null;
+  walletReady: boolean;
+  cost: number;
+}
+
 /**
  * Agent wallet component for managing agent balance.
  *
@@ -53,6 +63,17 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
   const [amount, setAmount] = useState('');
   const [action, setAction] = useState<'deposit' | 'withdraw'>('deposit');
   const [processing, setProcessing] = useState(false);
+  const [solanaStatus, setSolanaStatus] = useState<SolanaRegistrationStatus>({
+    isRegistered: false,
+    assetId: null,
+    metadataUri: null,
+    txHash: null,
+    walletAddress: null,
+    walletReady: false,
+    cost: 0,
+  });
+  const [solanaLoading, setSolanaLoading] = useState(false);
+  const [solanaRegistering, setSolanaRegistering] = useState(false);
 
   // Balance state
   const [balanceInfo, setBalanceInfo] = useState({
@@ -82,10 +103,35 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
     }
   }, [agent.id, getAccessToken]);
 
+  const fetchSolanaStatus = useCallback(async () => {
+    const token = await getAccessToken();
+    if (!token) return;
+
+    const res = await fetch(`/api/agents/${agent.id}/solana-registration`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    if (!res.ok) {
+      throw new Error('Failed to fetch Solana registration status');
+    }
+
+    const data = await res.json();
+    setSolanaStatus(data);
+  }, [agent.id, getAccessToken]);
+
   useEffect(() => {
     setLoading(true);
     fetchBalanceAndTransactions().finally(() => setLoading(false));
   }, [fetchBalanceAndTransactions]);
+
+  useEffect(() => {
+    setSolanaLoading(true);
+    fetchSolanaStatus()
+      .catch(() => {
+        setSolanaStatus((current) => current);
+      })
+      .finally(() => setSolanaLoading(false));
+  }, [fetchSolanaStatus]);
 
   const handleTransaction = async () => {
     const amountNum = parseFloat(amount);
@@ -146,6 +192,42 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
     }
   };
 
+  const handleSolanaRegistration = async () => {
+    setSolanaRegistering(true);
+    const token = await getAccessToken();
+    if (!token) {
+      setSolanaRegistering(false);
+      toast.error('Authentication required');
+      return;
+    }
+
+    try {
+      const res = await fetch(`/api/agents/${agent.id}/solana-registration`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      const payload = await res.json();
+      if (!res.ok) {
+        throw new Error(payload.error || 'Failed to register agent on Solana');
+      }
+
+      toast.success(payload.message);
+      await Promise.all([fetchBalanceAndTransactions(), fetchSolanaStatus()]);
+      onUpdate();
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : 'Failed to register agent on Solana'
+      );
+    } finally {
+      setSolanaRegistering(false);
+    }
+  };
+
   return (
     <div className="space-y-6">
       {/* Balance Card */}
@@ -177,6 +259,79 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
         <p className="mt-3 text-muted-foreground text-xs">
           Used for trading and AI operations (chat, autonomous actions)
         </p>
+      </div>
+
+      <div className="rounded-lg border border-border bg-card/50 p-4 backdrop-blur sm:p-6">
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <div>
+            <h3 className="font-semibold text-lg">Solana Registry</h3>
+            <p className="text-muted-foreground text-sm">
+              Optional agent registration on the Solana 8004 registry. Babylon
+              sponsors the transaction fee.
+            </p>
+          </div>
+          <div
+            className={cn(
+              'rounded-full px-3 py-1 font-medium text-xs',
+              solanaStatus.isRegistered
+                ? 'bg-green-500/10 text-green-600'
+                : 'bg-muted text-muted-foreground'
+            )}
+          >
+            {solanaStatus.isRegistered ? 'Registered' : 'Not registered'}
+          </div>
+        </div>
+
+        {solanaLoading ? (
+          <div className="text-muted-foreground text-sm">Loading...</div>
+        ) : (
+          <div className="space-y-3">
+            <div className="grid gap-2 text-sm sm:grid-cols-2">
+              <div>
+                <span className="text-muted-foreground">Wallet</span>
+                <div className="font-medium">
+                  {solanaStatus.walletAddress
+                    ? `${solanaStatus.walletAddress.slice(0, 6)}...${solanaStatus.walletAddress.slice(-4)}`
+                    : solanaStatus.walletReady
+                      ? 'Ready'
+                      : 'Not provisioned'}
+                </div>
+              </div>
+              <div>
+                <span className="text-muted-foreground">Cost</span>
+                <div className="font-medium">{solanaStatus.cost} pts</div>
+              </div>
+              <div>
+                <span className="text-muted-foreground">Asset</span>
+                <div className="font-medium">
+                  {solanaStatus.assetId
+                    ? `${solanaStatus.assetId.slice(0, 6)}...${solanaStatus.assetId.slice(-4)}`
+                    : 'Not registered'}
+                </div>
+              </div>
+              <div>
+                <span className="text-muted-foreground">Tx</span>
+                <div className="font-medium">
+                  {solanaStatus.txHash
+                    ? `${solanaStatus.txHash.slice(0, 6)}...${solanaStatus.txHash.slice(-4)}`
+                    : 'Pending / none'}
+                </div>
+              </div>
+            </div>
+
+            <button
+              onClick={handleSolanaRegistration}
+              disabled={solanaRegistering || solanaStatus.isRegistered}
+              className="h-10 rounded-lg bg-[#0066FF] px-4 font-medium text-sm text-white transition-all hover:bg-[#2952d9] disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {solanaRegistering
+                ? 'Registering...'
+                : solanaStatus.isRegistered
+                  ? 'Already registered'
+                  : `Register on Solana (${solanaStatus.cost} pts)`}
+            </button>
+          </div>
+        )}
       </div>
 
       {/* Transaction Form */}

--- a/apps/web/src/components/agents/AgentWallet.tsx
+++ b/apps/web/src/components/agents/AgentWallet.tsx
@@ -74,6 +74,7 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
   });
   const [solanaLoading, setSolanaLoading] = useState(false);
   const [solanaRegistering, setSolanaRegistering] = useState(false);
+  const [solanaError, setSolanaError] = useState<string | null>(null);
 
   // Balance state
   const [balanceInfo, setBalanceInfo] = useState({
@@ -105,14 +106,18 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
 
   const fetchSolanaStatus = useCallback(async () => {
     const token = await getAccessToken();
-    if (!token) return;
+    if (!token) {
+      throw new Error('Authentication required');
+    }
 
     const res = await fetch(`/api/agents/${agent.id}/solana-registration`, {
       headers: { Authorization: `Bearer ${token}` },
     });
 
     if (!res.ok) {
-      throw new Error('Failed to fetch Solana registration status');
+      throw new Error(
+        'Failed to fetch Solana registration status. Check Solana configuration and try again.'
+      );
     }
 
     const data = await res.json();
@@ -126,9 +131,14 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
 
   useEffect(() => {
     setSolanaLoading(true);
+    setSolanaError(null);
     fetchSolanaStatus()
-      .catch(() => {
-        setSolanaStatus((current) => current);
+      .catch((error) => {
+        setSolanaError(
+          error instanceof Error
+            ? error.message
+            : 'Failed to load Solana registration status'
+        );
       })
       .finally(() => setSolanaLoading(false));
   }, [fetchSolanaStatus]);
@@ -215,6 +225,7 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
       }
 
       toast.success(payload.message);
+      setSolanaError(null);
       await Promise.all([fetchBalanceAndTransactions(), fetchSolanaStatus()]);
       onUpdate();
     } catch (error) {
@@ -284,6 +295,30 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
 
         {solanaLoading ? (
           <div className="text-muted-foreground text-sm">Loading...</div>
+        ) : solanaError ? (
+          <div className="space-y-3">
+            <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-red-600 text-sm">
+              {solanaError}
+            </div>
+            <button
+              onClick={() => {
+                setSolanaLoading(true);
+                setSolanaError(null);
+                fetchSolanaStatus()
+                  .catch((error) => {
+                    setSolanaError(
+                      error instanceof Error
+                        ? error.message
+                        : 'Failed to load Solana registration status'
+                    );
+                  })
+                  .finally(() => setSolanaLoading(false));
+              }}
+              className="h-10 rounded-lg bg-muted px-4 font-medium text-sm transition-all hover:bg-muted/80"
+            >
+              Retry
+            </button>
+          </div>
         ) : (
           <div className="space-y-3">
             <div className="grid gap-2 text-sm sm:grid-cols-2">

--- a/bun.lock
+++ b/bun.lock
@@ -257,7 +257,9 @@
       "name": "@babylon/agents",
       "version": "0.1.0",
       "dependencies": {
+        "8004-solana": "^0.8.0",
         "@babylon/a2a": "workspace:*",
+        "@solana/web3.js": "^1.98.4",
         "posthog-node": "^5.17.0",
       },
       "devDependencies": {
@@ -360,6 +362,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@babylon/shared": "workspace:*",
+        "@elizaos/plugin-sql": "^1.6.4",
         "drizzle-orm": "^0.44.7",
         "postgres": "^3.4.7",
       },
@@ -588,6 +591,8 @@
     "@sentry/cli",
   ],
   "packages": {
+    "8004-solana": ["8004-solana@0.8.1", "", { "dependencies": { "@coral-xyz/borsh": "^0.32.1", "@noble/hashes": "^2.0.1", "@solana/web3.js": "^1.95.0", "borsh": "^0.7.0", "bs58": "^6.0.0", "tweetnacl": "^1.0.3" } }, "sha512-7jQnavX/XbSzLz5zuIeshhxb/khW/K/iLIVvlBjrBJBasEFcwND2E4kJudf/IVLM/GfMUNtEaOg2V+ZyhK/x5Q=="],
+
     "@a2a-js/sdk": ["@a2a-js/sdk@0.3.5", "", { "dependencies": { "uuid": "^11.1.0" }, "peerDependencies": { "express": "^4.21.2 || ^5.1.0" }, "optionalPeers": ["express"] }, "sha512-6xAApkiss2aCbJXmXLC845tifcbYJ/R4Dj22kQsOaanMbf9bvkYhebDEuYPAIu3aaR5MWaBqG7OCK3IF8dqZZQ=="],
 
     "@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.10.1", "", {}, "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="],
@@ -849,6 +854,8 @@
     "@coinbase/wallet-sdk": ["@coinbase/wallet-sdk@4.3.2", "", { "dependencies": { "@noble/hashes": "^1.4.0", "clsx": "^1.2.1", "eventemitter3": "^5.0.1", "preact": "^10.24.2" } }, "sha512-hOLA2YONq8Z9n8f6oVP6N//FEEHOen7nq+adG/cReol6juFTHUelVN5GnA5zTIxiLFMDcrhDwwgCA6Tdb5jubw=="],
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
+
+    "@coral-xyz/borsh": ["@coral-xyz/borsh@0.32.1", "", { "dependencies": { "bn.js": "^5.1.2", "buffer-layout": "^1.2.0" }, "peerDependencies": { "@solana/web3.js": "^1.69.0" } }, "sha512-pWsqkkZ+psLlupMkgu5rDok7baDQLWKqyDsb76gUNArbVB783mF3ZOleKMHVXZczl5JuxnVVfO1+XDVvR17C3A=="],
 
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
@@ -2002,7 +2009,7 @@
 
     "@solana/codecs": ["@solana/codecs@5.0.0", "", { "dependencies": { "@solana/codecs-core": "5.0.0", "@solana/codecs-data-structures": "5.0.0", "@solana/codecs-numbers": "5.0.0", "@solana/codecs-strings": "5.0.0", "@solana/options": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-KOw0gFUSBxIMDWLJ3AkVFkEci91dw0Rpx3C6y83Our7fSW+SEP8vRZklCElieYR85LHVB1QIEhoeHR7rc+Ifkw=="],
 
-    "@solana/codecs-core": ["@solana/codecs-core@5.0.0", "", { "dependencies": { "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-rCG2d8OaamVF2/J//YyCgDqNJpUytVVltw9C8mJtEz5c6Se/LR6BFuG8g4xeJswq/ab4RFk5/HFdgbvNjKgQjA=="],
+    "@solana/codecs-core": ["@solana/codecs-core@2.3.0", "", { "dependencies": { "@solana/errors": "2.3.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw=="],
 
     "@solana/codecs-data-structures": ["@solana/codecs-data-structures@5.0.0", "", { "dependencies": { "@solana/codecs-core": "5.0.0", "@solana/codecs-numbers": "5.0.0", "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-y503Pqmv0LHcfcf0vQJGaxDvydQJbyCo8nK3nxn56EhFj5lBQ1NWb3WvTd83epigwuZurW2MhJARrpikfhQglQ=="],
 
@@ -2768,7 +2775,7 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
-    "base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
+    "base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
 
     "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
@@ -2796,7 +2803,7 @@
 
     "bluebird": ["bluebird@3.4.7", "", {}, "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="],
 
-    "bn.js": ["bn.js@4.12.2", "", {}, "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw=="],
+    "bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
 
     "body-parser": ["body-parser@1.20.4", "", { "dependencies": { "bytes": "~3.1.2", "content-type": "~1.0.5", "debug": "2.6.9", "depd": "2.0.0", "destroy": "~1.2.0", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "on-finished": "~2.4.1", "qs": "~6.14.0", "raw-body": "~2.5.3", "type-is": "~1.6.18", "unpipe": "~1.0.0" } }, "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA=="],
 
@@ -2830,17 +2837,19 @@
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
-    "bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
+    "bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
 
     "bs58check": ["bs58check@2.1.2", "", { "dependencies": { "bs58": "^4.0.0", "create-hash": "^1.1.0", "safe-buffer": "^5.1.2" } }, "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA=="],
 
     "bser": ["bser@2.1.1", "", { "dependencies": { "node-int64": "^0.4.0" } }, "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ=="],
 
-    "buffer": ["buffer@5.6.0", "", { "dependencies": { "base64-js": "^1.0.2", "ieee754": "^1.1.4" } }, "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw=="],
+    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
     "buffer-indexof-polyfill": ["buffer-indexof-polyfill@1.0.2", "", {}, "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A=="],
+
+    "buffer-layout": ["buffer-layout@1.2.2", "", {}, "sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA=="],
 
     "buffer-xor": ["buffer-xor@1.0.3", "", {}, "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="],
 
@@ -5480,6 +5489,8 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "8004-solana/@noble/hashes": ["@noble/hashes@2.0.1", "", {}, "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw=="],
+
     "@ai-sdk/anthropic/@ai-sdk/provider": ["@ai-sdk/provider@1.1.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg=="],
 
     "@ai-sdk/anthropic/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@2.2.8", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "nanoid": "^3.3.8", "secure-json-parse": "^2.7.0" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA=="],
@@ -5533,6 +5544,8 @@
     "@aws-sdk/credential-provider-sso/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@aws-sdk/credential-provider-web-identity/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "@aws-sdk/lib-storage/buffer": ["buffer@5.6.0", "", { "dependencies": { "base64-js": "^1.0.2", "ieee754": "^1.1.4" } }, "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw=="],
 
     "@aws-sdk/lib-storage/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -5618,6 +5631,8 @@
 
     "@coinbase/wallet-sdk/clsx": ["clsx@1.2.1", "", {}, "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="],
 
+    "@depay/solana-web3.js/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
+
     "@depay/web3-mock/ethers": ["ethers@5.8.0", "", { "dependencies": { "@ethersproject/abi": "5.8.0", "@ethersproject/abstract-provider": "5.8.0", "@ethersproject/abstract-signer": "5.8.0", "@ethersproject/address": "5.8.0", "@ethersproject/base64": "5.8.0", "@ethersproject/basex": "5.8.0", "@ethersproject/bignumber": "5.8.0", "@ethersproject/bytes": "5.8.0", "@ethersproject/constants": "5.8.0", "@ethersproject/contracts": "5.8.0", "@ethersproject/hash": "5.8.0", "@ethersproject/hdnode": "5.8.0", "@ethersproject/json-wallets": "5.8.0", "@ethersproject/keccak256": "5.8.0", "@ethersproject/logger": "5.8.0", "@ethersproject/networks": "5.8.0", "@ethersproject/pbkdf2": "5.8.0", "@ethersproject/properties": "5.8.0", "@ethersproject/providers": "5.8.0", "@ethersproject/random": "5.8.0", "@ethersproject/rlp": "5.8.0", "@ethersproject/sha2": "5.8.0", "@ethersproject/signing-key": "5.8.0", "@ethersproject/solidity": "5.8.0", "@ethersproject/strings": "5.8.0", "@ethersproject/transactions": "5.8.0", "@ethersproject/units": "5.8.0", "@ethersproject/wallet": "5.8.0", "@ethersproject/web": "5.8.0", "@ethersproject/wordlists": "5.8.0" } }, "sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg=="],
 
     "@depay/web3-mock-evm/ethers": ["ethers@5.8.0", "", { "dependencies": { "@ethersproject/abi": "5.8.0", "@ethersproject/abstract-provider": "5.8.0", "@ethersproject/abstract-signer": "5.8.0", "@ethersproject/address": "5.8.0", "@ethersproject/base64": "5.8.0", "@ethersproject/basex": "5.8.0", "@ethersproject/bignumber": "5.8.0", "@ethersproject/bytes": "5.8.0", "@ethersproject/constants": "5.8.0", "@ethersproject/contracts": "5.8.0", "@ethersproject/hash": "5.8.0", "@ethersproject/hdnode": "5.8.0", "@ethersproject/json-wallets": "5.8.0", "@ethersproject/keccak256": "5.8.0", "@ethersproject/logger": "5.8.0", "@ethersproject/networks": "5.8.0", "@ethersproject/pbkdf2": "5.8.0", "@ethersproject/properties": "5.8.0", "@ethersproject/providers": "5.8.0", "@ethersproject/random": "5.8.0", "@ethersproject/rlp": "5.8.0", "@ethersproject/sha2": "5.8.0", "@ethersproject/signing-key": "5.8.0", "@ethersproject/solidity": "5.8.0", "@ethersproject/strings": "5.8.0", "@ethersproject/transactions": "5.8.0", "@ethersproject/units": "5.8.0", "@ethersproject/wallet": "5.8.0", "@ethersproject/web": "5.8.0", "@ethersproject/wordlists": "5.8.0" } }, "sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg=="],
@@ -5662,13 +5677,9 @@
 
     "@ethereumjs/util/ethereum-cryptography": ["ethereum-cryptography@2.2.1", "", { "dependencies": { "@noble/curves": "1.4.2", "@noble/hashes": "1.4.0", "@scure/bip32": "1.4.0", "@scure/bip39": "1.3.0" } }, "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg=="],
 
-    "@ethersproject/bignumber/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
     "@ethersproject/json-wallets/aes-js": ["aes-js@3.0.0", "", {}, "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="],
 
     "@ethersproject/providers/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
-
-    "@ethersproject/signing-key/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
 
     "@farcaster/auth-client/viem": ["viem@2.41.2", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.1.0", "isows": "1.0.7", "ox": "0.9.6", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-LYliajglBe1FU6+EH9mSWozp+gRA/QcHfxeD9Odf83AdH5fwUS7DroH4gHvlv6Sshqi1uXrYFA2B/EOczxd15g=="],
 
@@ -5774,8 +5785,6 @@
 
     "@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
-    "@multiformats/dns/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
-
     "@multiformats/dns/p-queue": ["p-queue@9.0.1", "", { "dependencies": { "eventemitter3": "^5.0.1", "p-timeout": "^7.0.0" } }, "sha512-RhBdVhSwJb7Ocn3e8ULk4NMwBEuOxe+1zcgphUy9c2e5aR/xbEsdVXxHJ3lynw6Qiqu7OINEyHlZkiblEpaq7w=="],
 
     "@multiformats/dns/uint8arrays": ["uint8arrays@5.1.0", "", { "dependencies": { "multiformats": "^13.0.0" } }, "sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww=="],
@@ -5857,6 +5866,8 @@
     "@privy-io/node/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@privy-io/public-api/@privy-io/api-base": ["@privy-io/api-base@1.7.0", "", { "dependencies": { "zod": "^3.24.3" } }, "sha512-ji6ARQAAuW/FzRTgft9NCjRuouWX9t+J7JMmvLPsnXQJDFEV9mqh4sWXZhQ8ddTq/iDZ4z/yz1ORJqN8bYAi4Q=="],
+
+    "@privy-io/public-api/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
 
     "@privy-io/public-api/viem": ["viem@2.41.2", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.1.0", "isows": "1.0.7", "ox": "0.9.6", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-LYliajglBe1FU6+EH9mSWozp+gRA/QcHfxeD9Odf83AdH5fwUS7DroH4gHvlv6Sshqi1uXrYFA2B/EOczxd15g=="],
 
@@ -5970,8 +5981,6 @@
 
     "@reown/appkit/@walletconnect/universal-provider": ["@walletconnect/universal-provider@2.21.9", "", { "dependencies": { "@walletconnect/events": "1.0.1", "@walletconnect/jsonrpc-http-connection": "1.0.8", "@walletconnect/jsonrpc-provider": "1.0.14", "@walletconnect/jsonrpc-types": "1.0.4", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/logger": "2.1.2", "@walletconnect/sign-client": "2.21.9", "@walletconnect/types": "2.21.9", "@walletconnect/utils": "2.21.9", "es-toolkit": "1.39.3", "events": "3.3.0" } }, "sha512-dVA9DWSz9jYe37FW5GSRV5zlY9E7rX1kktcDGI7i1/9oG/z9Pk5UKp5r/DFys4Zjml9wZc46R/jlEgeBXTT06A=="],
 
-    "@reown/appkit/bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
-
     "@reown/appkit/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "@reown/appkit/viem": ["viem@2.41.2", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.1.0", "isows": "1.0.7", "ox": "0.9.6", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-LYliajglBe1FU6+EH9mSWozp+gRA/QcHfxeD9Odf83AdH5fwUS7DroH4gHvlv6Sshqi1uXrYFA2B/EOczxd15g=="],
@@ -5983,8 +5992,6 @@
     "@reown/appkit-controllers/@walletconnect/universal-provider": ["@walletconnect/universal-provider@2.21.9", "", { "dependencies": { "@walletconnect/events": "1.0.1", "@walletconnect/jsonrpc-http-connection": "1.0.8", "@walletconnect/jsonrpc-provider": "1.0.14", "@walletconnect/jsonrpc-types": "1.0.4", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/logger": "2.1.2", "@walletconnect/sign-client": "2.21.9", "@walletconnect/types": "2.21.9", "@walletconnect/utils": "2.21.9", "es-toolkit": "1.39.3", "events": "3.3.0" } }, "sha512-dVA9DWSz9jYe37FW5GSRV5zlY9E7rX1kktcDGI7i1/9oG/z9Pk5UKp5r/DFys4Zjml9wZc46R/jlEgeBXTT06A=="],
 
     "@reown/appkit-controllers/viem": ["viem@2.41.2", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.1.0", "isows": "1.0.7", "ox": "0.9.6", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-LYliajglBe1FU6+EH9mSWozp+gRA/QcHfxeD9Odf83AdH5fwUS7DroH4gHvlv6Sshqi1uXrYFA2B/EOczxd15g=="],
-
-    "@reown/appkit-polyfills/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "@reown/appkit-ui/qrcode": ["qrcode@1.5.3", "", { "dependencies": { "dijkstrajs": "^1.0.1", "encode-utf8": "^1.0.3", "pngjs": "^5.0.0", "yargs": "^15.3.1" }, "bin": { "qrcode": "bin/qrcode" } }, "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg=="],
 
@@ -6176,21 +6183,29 @@
 
     "@smithy/uuid/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@solana-mobile/wallet-standard-mobile/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
+
     "@solana-program/system/@solana/kit": ["@solana/kit@3.0.3", "", { "dependencies": { "@solana/accounts": "3.0.3", "@solana/addresses": "3.0.3", "@solana/codecs": "3.0.3", "@solana/errors": "3.0.3", "@solana/functional": "3.0.3", "@solana/instruction-plans": "3.0.3", "@solana/instructions": "3.0.3", "@solana/keys": "3.0.3", "@solana/programs": "3.0.3", "@solana/rpc": "3.0.3", "@solana/rpc-parsed-types": "3.0.3", "@solana/rpc-spec-types": "3.0.3", "@solana/rpc-subscriptions": "3.0.3", "@solana/rpc-types": "3.0.3", "@solana/signers": "3.0.3", "@solana/sysvars": "3.0.3", "@solana/transaction-confirmation": "3.0.3", "@solana/transaction-messages": "3.0.3", "@solana/transactions": "3.0.3" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-CEEhCDmkvztd1zbgADsEQhmj9GyWOOGeW1hZD+gtwbBSF5YN1uofS/pex5MIh/VIqKRj+A2UnYWI1V+9+q/lyQ=="],
+
+    "@solana/accounts/@solana/codecs-core": ["@solana/codecs-core@5.0.0", "", { "dependencies": { "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-rCG2d8OaamVF2/J//YyCgDqNJpUytVVltw9C8mJtEz5c6Se/LR6BFuG8g4xeJswq/ab4RFk5/HFdgbvNjKgQjA=="],
 
     "@solana/accounts/@solana/codecs-strings": ["@solana/codecs-strings@5.0.0", "", { "dependencies": { "@solana/codecs-core": "5.0.0", "@solana/codecs-numbers": "5.0.0", "@solana/errors": "5.0.0" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": ">=5.3.3" } }, "sha512-ALkRwpV8bGR6qjAYw0YXZwp2YI4wzvKOJGmx04Ut8gMdbaUx7qOcJkhEQKI6ZVC3lAWSIS1N1wGccUZDwvfKxw=="],
 
+    "@solana/addresses/@solana/codecs-core": ["@solana/codecs-core@5.0.0", "", { "dependencies": { "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-rCG2d8OaamVF2/J//YyCgDqNJpUytVVltw9C8mJtEz5c6Se/LR6BFuG8g4xeJswq/ab4RFk5/HFdgbvNjKgQjA=="],
+
     "@solana/addresses/@solana/codecs-strings": ["@solana/codecs-strings@5.0.0", "", { "dependencies": { "@solana/codecs-core": "5.0.0", "@solana/codecs-numbers": "5.0.0", "@solana/errors": "5.0.0" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": ">=5.3.3" } }, "sha512-ALkRwpV8bGR6qjAYw0YXZwp2YI4wzvKOJGmx04Ut8gMdbaUx7qOcJkhEQKI6ZVC3lAWSIS1N1wGccUZDwvfKxw=="],
 
-    "@solana/buffer-layout/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+    "@solana/codecs/@solana/codecs-core": ["@solana/codecs-core@5.0.0", "", { "dependencies": { "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-rCG2d8OaamVF2/J//YyCgDqNJpUytVVltw9C8mJtEz5c6Se/LR6BFuG8g4xeJswq/ab4RFk5/HFdgbvNjKgQjA=="],
 
     "@solana/codecs/@solana/codecs-numbers": ["@solana/codecs-numbers@5.0.0", "", { "dependencies": { "@solana/codecs-core": "5.0.0", "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-a2+skRLuUK02f/XFe4L0e1+wHCyfK25PkyseFps1v1l4pvevukFwth/EhSyrs6w5CsTJRVoR7MuE3E00PM4egw=="],
 
     "@solana/codecs/@solana/codecs-strings": ["@solana/codecs-strings@5.0.0", "", { "dependencies": { "@solana/codecs-core": "5.0.0", "@solana/codecs-numbers": "5.0.0", "@solana/errors": "5.0.0" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": ">=5.3.3" } }, "sha512-ALkRwpV8bGR6qjAYw0YXZwp2YI4wzvKOJGmx04Ut8gMdbaUx7qOcJkhEQKI6ZVC3lAWSIS1N1wGccUZDwvfKxw=="],
 
-    "@solana/codecs-data-structures/@solana/codecs-numbers": ["@solana/codecs-numbers@5.0.0", "", { "dependencies": { "@solana/codecs-core": "5.0.0", "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-a2+skRLuUK02f/XFe4L0e1+wHCyfK25PkyseFps1v1l4pvevukFwth/EhSyrs6w5CsTJRVoR7MuE3E00PM4egw=="],
+    "@solana/codecs-core/@solana/errors": ["@solana/errors@2.3.0", "", { "dependencies": { "chalk": "^5.4.1", "commander": "^14.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ=="],
 
-    "@solana/codecs-numbers/@solana/codecs-core": ["@solana/codecs-core@2.3.0", "", { "dependencies": { "@solana/errors": "2.3.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw=="],
+    "@solana/codecs-data-structures/@solana/codecs-core": ["@solana/codecs-core@5.0.0", "", { "dependencies": { "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-rCG2d8OaamVF2/J//YyCgDqNJpUytVVltw9C8mJtEz5c6Se/LR6BFuG8g4xeJswq/ab4RFk5/HFdgbvNjKgQjA=="],
+
+    "@solana/codecs-data-structures/@solana/codecs-numbers": ["@solana/codecs-numbers@5.0.0", "", { "dependencies": { "@solana/codecs-core": "5.0.0", "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-a2+skRLuUK02f/XFe4L0e1+wHCyfK25PkyseFps1v1l4pvevukFwth/EhSyrs6w5CsTJRVoR7MuE3E00PM4egw=="],
 
     "@solana/codecs-numbers/@solana/errors": ["@solana/errors@2.3.0", "", { "dependencies": { "chalk": "^5.4.1", "commander": "^14.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ=="],
 
@@ -6204,21 +6219,37 @@
 
     "@solana/errors/commander": ["commander@14.0.1", "", {}, "sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A=="],
 
+    "@solana/instructions/@solana/codecs-core": ["@solana/codecs-core@5.0.0", "", { "dependencies": { "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-rCG2d8OaamVF2/J//YyCgDqNJpUytVVltw9C8mJtEz5c6Se/LR6BFuG8g4xeJswq/ab4RFk5/HFdgbvNjKgQjA=="],
+
+    "@solana/keys/@solana/codecs-core": ["@solana/codecs-core@5.0.0", "", { "dependencies": { "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-rCG2d8OaamVF2/J//YyCgDqNJpUytVVltw9C8mJtEz5c6Se/LR6BFuG8g4xeJswq/ab4RFk5/HFdgbvNjKgQjA=="],
+
     "@solana/keys/@solana/codecs-strings": ["@solana/codecs-strings@5.0.0", "", { "dependencies": { "@solana/codecs-core": "5.0.0", "@solana/codecs-numbers": "5.0.0", "@solana/errors": "5.0.0" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": ">=5.3.3" } }, "sha512-ALkRwpV8bGR6qjAYw0YXZwp2YI4wzvKOJGmx04Ut8gMdbaUx7qOcJkhEQKI6ZVC3lAWSIS1N1wGccUZDwvfKxw=="],
+
+    "@solana/options/@solana/codecs-core": ["@solana/codecs-core@5.0.0", "", { "dependencies": { "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-rCG2d8OaamVF2/J//YyCgDqNJpUytVVltw9C8mJtEz5c6Se/LR6BFuG8g4xeJswq/ab4RFk5/HFdgbvNjKgQjA=="],
 
     "@solana/options/@solana/codecs-numbers": ["@solana/codecs-numbers@5.0.0", "", { "dependencies": { "@solana/codecs-core": "5.0.0", "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-a2+skRLuUK02f/XFe4L0e1+wHCyfK25PkyseFps1v1l4pvevukFwth/EhSyrs6w5CsTJRVoR7MuE3E00PM4egw=="],
 
     "@solana/options/@solana/codecs-strings": ["@solana/codecs-strings@5.0.0", "", { "dependencies": { "@solana/codecs-core": "5.0.0", "@solana/codecs-numbers": "5.0.0", "@solana/errors": "5.0.0" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": ">=5.3.3" } }, "sha512-ALkRwpV8bGR6qjAYw0YXZwp2YI4wzvKOJGmx04Ut8gMdbaUx7qOcJkhEQKI6ZVC3lAWSIS1N1wGccUZDwvfKxw=="],
 
+    "@solana/rpc-api/@solana/codecs-core": ["@solana/codecs-core@5.0.0", "", { "dependencies": { "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-rCG2d8OaamVF2/J//YyCgDqNJpUytVVltw9C8mJtEz5c6Se/LR6BFuG8g4xeJswq/ab4RFk5/HFdgbvNjKgQjA=="],
+
     "@solana/rpc-api/@solana/codecs-strings": ["@solana/codecs-strings@5.0.0", "", { "dependencies": { "@solana/codecs-core": "5.0.0", "@solana/codecs-numbers": "5.0.0", "@solana/errors": "5.0.0" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": ">=5.3.3" } }, "sha512-ALkRwpV8bGR6qjAYw0YXZwp2YI4wzvKOJGmx04Ut8gMdbaUx7qOcJkhEQKI6ZVC3lAWSIS1N1wGccUZDwvfKxw=="],
+
+    "@solana/rpc-types/@solana/codecs-core": ["@solana/codecs-core@5.0.0", "", { "dependencies": { "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-rCG2d8OaamVF2/J//YyCgDqNJpUytVVltw9C8mJtEz5c6Se/LR6BFuG8g4xeJswq/ab4RFk5/HFdgbvNjKgQjA=="],
 
     "@solana/rpc-types/@solana/codecs-numbers": ["@solana/codecs-numbers@5.0.0", "", { "dependencies": { "@solana/codecs-core": "5.0.0", "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-a2+skRLuUK02f/XFe4L0e1+wHCyfK25PkyseFps1v1l4pvevukFwth/EhSyrs6w5CsTJRVoR7MuE3E00PM4egw=="],
 
     "@solana/rpc-types/@solana/codecs-strings": ["@solana/codecs-strings@5.0.0", "", { "dependencies": { "@solana/codecs-core": "5.0.0", "@solana/codecs-numbers": "5.0.0", "@solana/errors": "5.0.0" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": ">=5.3.3" } }, "sha512-ALkRwpV8bGR6qjAYw0YXZwp2YI4wzvKOJGmx04Ut8gMdbaUx7qOcJkhEQKI6ZVC3lAWSIS1N1wGccUZDwvfKxw=="],
 
+    "@solana/signers/@solana/codecs-core": ["@solana/codecs-core@5.0.0", "", { "dependencies": { "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-rCG2d8OaamVF2/J//YyCgDqNJpUytVVltw9C8mJtEz5c6Se/LR6BFuG8g4xeJswq/ab4RFk5/HFdgbvNjKgQjA=="],
+
     "@solana/transaction-confirmation/@solana/codecs-strings": ["@solana/codecs-strings@5.0.0", "", { "dependencies": { "@solana/codecs-core": "5.0.0", "@solana/codecs-numbers": "5.0.0", "@solana/errors": "5.0.0" }, "peerDependencies": { "fastestsmallesttextencoderdecoder": "^1.0.22", "typescript": ">=5.3.3" } }, "sha512-ALkRwpV8bGR6qjAYw0YXZwp2YI4wzvKOJGmx04Ut8gMdbaUx7qOcJkhEQKI6ZVC3lAWSIS1N1wGccUZDwvfKxw=="],
 
+    "@solana/transaction-messages/@solana/codecs-core": ["@solana/codecs-core@5.0.0", "", { "dependencies": { "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-rCG2d8OaamVF2/J//YyCgDqNJpUytVVltw9C8mJtEz5c6Se/LR6BFuG8g4xeJswq/ab4RFk5/HFdgbvNjKgQjA=="],
+
     "@solana/transaction-messages/@solana/codecs-numbers": ["@solana/codecs-numbers@5.0.0", "", { "dependencies": { "@solana/codecs-core": "5.0.0", "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-a2+skRLuUK02f/XFe4L0e1+wHCyfK25PkyseFps1v1l4pvevukFwth/EhSyrs6w5CsTJRVoR7MuE3E00PM4egw=="],
+
+    "@solana/transactions/@solana/codecs-core": ["@solana/codecs-core@5.0.0", "", { "dependencies": { "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-rCG2d8OaamVF2/J//YyCgDqNJpUytVVltw9C8mJtEz5c6Se/LR6BFuG8g4xeJswq/ab4RFk5/HFdgbvNjKgQjA=="],
 
     "@solana/transactions/@solana/codecs-numbers": ["@solana/codecs-numbers@5.0.0", "", { "dependencies": { "@solana/codecs-core": "5.0.0", "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-a2+skRLuUK02f/XFe4L0e1+wHCyfK25PkyseFps1v1l4pvevukFwth/EhSyrs6w5CsTJRVoR7MuE3E00PM4egw=="],
 
@@ -6226,17 +6257,11 @@
 
     "@solana/wallet-standard-util/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
-    "@solana/wallet-standard-wallet-adapter-base/bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
-
     "@solana/web3.js/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "@solana/web3.js/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
-    "@solana/web3.js/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
     "@solana/web3.js/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
-
-    "@solana/web3.js/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "@spruceid/siwe-parser/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -6344,8 +6369,6 @@
 
     "@walletconnect/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
-    "@walletconnect/utils/bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
-
     "@walletconnect/utils/ox": ["ox@0.9.3", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-KzyJP+fPV4uhuuqrTZyok4DC7vFzi7HLUFiUNEmpbyh59htKWkOC98IONC1zgXJPbHAhQgqs6B0Z6StCGhmQvg=="],
 
     "@walletconnect/utils/uint8arrays": ["uint8arrays@3.1.1", "", { "dependencies": { "multiformats": "^9.4.2" } }, "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg=="],
@@ -6368,6 +6391,8 @@
 
     "aria-hidden/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "asn1.js/bn.js": ["bn.js@4.12.2", "", {}, "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw=="],
+
     "async-mutex/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "autolinker/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
@@ -6376,19 +6401,15 @@
 
     "babylon-typescript-agent-example/dotenv": ["dotenv@17.2.3", "", {}, "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w=="],
 
-    "body-parser/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
+    "bl/buffer": ["buffer@5.6.0", "", { "dependencies": { "base64-js": "^1.0.2", "ieee754": "^1.1.4" } }, "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw=="],
 
-    "borsh/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
+    "body-parser/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
 
     "borsh/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
     "boxen/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "boxen/type-fest": ["type-fest@0.20.2", "", {}, "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="],
-
-    "browserify-rsa/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
-    "browserify-sign/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
 
     "browserify-sign/readable-stream": ["readable-stream@2.3.8", "", { "dependencies": { "core-util-is": "~1.0.0", "inherits": "~2.0.3", "isarray": "~1.0.0", "process-nextick-args": "~2.0.0", "safe-buffer": "~5.1.1", "string_decoder": "~1.1.1", "util-deprecate": "~1.0.1" } }, "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA=="],
 
@@ -6397,10 +6418,6 @@
     "bs58check/bs58": ["bs58@4.0.1", "", { "dependencies": { "base-x": "^3.0.2" } }, "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw=="],
 
     "c12/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
-
-    "cbw-sdk/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
-    "cbw-sdk/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "cbw-sdk/clsx": ["clsx@1.2.1", "", {}, "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="],
 
@@ -6448,6 +6465,8 @@
 
     "connect/finalhandler": ["finalhandler@1.1.2", "", { "dependencies": { "debug": "2.6.9", "encodeurl": "~1.0.2", "escape-html": "~1.0.3", "on-finished": "~2.3.0", "parseurl": "~1.3.3", "statuses": "~1.5.0", "unpipe": "~1.0.0" } }, "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA=="],
 
+    "create-ecdh/bn.js": ["bn.js@4.12.2", "", {}, "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw=="],
+
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "cytoscape-fcose/cose-base": ["cose-base@2.2.0", "", { "dependencies": { "layout-base": "^2.0.0" } }, "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g=="],
@@ -6464,6 +6483,8 @@
 
     "detective-amd/escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
 
+    "diffie-hellman/bn.js": ["bn.js@4.12.2", "", {}, "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw=="],
+
     "dns-over-http-resolver/native-fetch": ["native-fetch@4.0.2", "", { "peerDependencies": { "undici": "*" } }, "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg=="],
 
     "drizzle-kit/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
@@ -6473,6 +6494,8 @@
     "eciesjs/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "eciesjs/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+
+    "elliptic/bn.js": ["bn.js@4.12.2", "", {}, "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw=="],
 
     "encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
@@ -6502,9 +6525,9 @@
 
     "ethereum-cryptography/@scure/bip39": ["@scure/bip39@1.1.1", "", { "dependencies": { "@noble/hashes": "~1.2.0", "@scure/base": "~1.1.0" } }, "sha512-t+wDck2rVkh65Hmv280fYdVdY25J9YeEUIgn2LG1WM6gxFkGzcksoDiUkWVpVp3Oex9xGC68JU2dSbUfwZ2jPg=="],
 
-    "ethereumjs-abi/ethereumjs-util": ["ethereumjs-util@6.2.1", "", { "dependencies": { "@types/bn.js": "^4.11.3", "bn.js": "^4.11.0", "create-hash": "^1.1.2", "elliptic": "^6.5.2", "ethereum-cryptography": "^0.1.3", "ethjs-util": "0.1.6", "rlp": "^2.2.3" } }, "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw=="],
+    "ethereumjs-abi/bn.js": ["bn.js@4.12.2", "", {}, "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw=="],
 
-    "ethereumjs-util/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
+    "ethereumjs-abi/ethereumjs-util": ["ethereumjs-util@6.2.1", "", { "dependencies": { "@types/bn.js": "^4.11.3", "bn.js": "^4.11.0", "create-hash": "^1.1.2", "elliptic": "^6.5.2", "ethereum-cryptography": "^0.1.3", "ethjs-util": "0.1.6", "rlp": "^2.2.3" } }, "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw=="],
 
     "ethereumjs-util/ethereum-cryptography": ["ethereum-cryptography@0.1.3", "", { "dependencies": { "@types/pbkdf2": "^3.0.0", "@types/secp256k1": "^4.0.1", "blakejs": "^1.1.0", "browserify-aes": "^1.2.0", "bs58check": "^2.1.2", "create-hash": "^1.2.0", "create-hmac": "^1.1.7", "hash.js": "^1.1.7", "keccak": "^3.0.0", "pbkdf2": "^3.0.17", "randombytes": "^2.1.0", "safe-buffer": "^5.1.2", "scrypt-js": "^3.0.0", "secp256k1": "^4.0.1", "setimmediate": "^1.0.5" } }, "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ=="],
 
@@ -6568,8 +6591,6 @@
 
     "ipfs-utils/browser-readablestream-to-it": ["browser-readablestream-to-it@1.0.3", "", {}, "sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw=="],
 
-    "ipfs-utils/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
-
     "ipfs-utils/it-all": ["it-all@1.0.6", "", {}, "sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A=="],
 
     "ipfs-utils/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
@@ -6577,8 +6598,6 @@
     "it-glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "it-pushable/p-defer": ["p-defer@4.0.1", "", {}, "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A=="],
-
-    "it-to-stream/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "jayson/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
@@ -6661,6 +6680,8 @@
     "micromark-extension-frontmatter/fault": ["fault@2.0.1", "", { "dependencies": { "format": "^0.2.0" } }, "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "miller-rabin/bn.js": ["bn.js@4.12.2", "", {}, "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw=="],
 
     "minizlib/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
@@ -6746,6 +6767,8 @@
 
     "pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
+    "public-encrypt/bn.js": ["bn.js@4.12.2", "", {}, "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw=="],
+
     "qrcode/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
 
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
@@ -6784,11 +6807,7 @@
 
     "ripemd160/hash-base": ["hash-base@3.1.2", "", { "dependencies": { "inherits": "^2.0.4", "readable-stream": "^2.3.8", "safe-buffer": "^5.2.1", "to-buffer": "^1.2.1" } }, "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg=="],
 
-    "rlp/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
-
     "rpc-websockets/@types/uuid": ["@types/uuid@8.3.4", "", {}, "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="],
-
-    "rpc-websockets/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "rpc-websockets/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
@@ -6870,8 +6889,6 @@
 
     "swagger-jsdoc/yaml": ["yaml@2.0.0-1", "", {}, "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ=="],
 
-    "swagger-ui-react/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
-
     "swagger-ui-react/immutable": ["immutable@3.8.2", "", {}, "sha512-15gZoQ38eYjEjxkorfbcgBKBL6R7T459OuK+CpcWt7O3KF4uPCx2tD0uFETlUDIyo+1789crbMhTvQBSR5yBMg=="],
 
     "table/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
@@ -6941,8 +6958,6 @@
     "wagmi/use-sync-external-store": ["use-sync-external-store@1.4.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw=="],
 
     "web/uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
-
-    "web3-utils/bn.js": ["bn.js@5.2.2", "", {}, "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw=="],
 
     "web3-utils/ethereum-cryptography": ["ethereum-cryptography@2.2.1", "", { "dependencies": { "@noble/curves": "1.4.2", "@noble/hashes": "1.4.0", "@scure/bip32": "1.4.0", "@scure/bip39": "1.3.0" } }, "sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg=="],
 
@@ -7045,6 +7060,8 @@
     "@coinbase/cdp-sdk/viem/abitype": ["abitype@1.1.0", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A=="],
 
     "@coinbase/cdp-sdk/viem/ox": ["ox@0.9.6", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.9", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-8SuCbHPvv2eZLYXrNmC0EC12rdzXQLdhnOMlHDW2wiCPLxBrOOJwX5L5E61by+UjTPOryqQiRSnjIKCI+GykKg=="],
+
+    "@depay/solana-web3.js/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
 
     "@elizaos/plugin-anthropic/@elizaos/core/dotenv": ["dotenv@17.2.3", "", {}, "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w=="],
 
@@ -7180,6 +7197,8 @@
 
     "@metamask/eth-sig-util/ethereumjs-util/@types/bn.js": ["@types/bn.js@4.11.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg=="],
 
+    "@metamask/eth-sig-util/ethereumjs-util/bn.js": ["bn.js@4.12.2", "", {}, "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw=="],
+
     "@metamask/eth-sig-util/ethereumjs-util/ethereum-cryptography": ["ethereum-cryptography@0.1.3", "", { "dependencies": { "@types/pbkdf2": "^3.0.0", "@types/secp256k1": "^4.0.1", "blakejs": "^1.1.0", "browserify-aes": "^1.2.0", "bs58check": "^2.1.2", "create-hash": "^1.2.0", "create-hmac": "^1.1.7", "hash.js": "^1.1.7", "keccak": "^3.0.0", "pbkdf2": "^3.0.17", "randombytes": "^2.1.0", "safe-buffer": "^5.1.2", "scrypt-js": "^3.0.0", "secp256k1": "^4.0.1", "setimmediate": "^1.0.5" } }, "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ=="],
 
     "@metamask/json-rpc-engine/@metamask/rpc-errors/@metamask/utils": ["@metamask/utils@9.3.0", "", { "dependencies": { "@ethereumjs/tx": "^4.2.0", "@metamask/superstruct": "^3.1.0", "@noble/hashes": "^1.3.1", "@scure/base": "^1.1.3", "@types/debug": "^4.1.7", "debug": "^4.3.4", "pony-cause": "^2.1.10", "semver": "^7.5.4", "uuid": "^9.0.1" } }, "sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g=="],
@@ -7231,6 +7250,8 @@
     "@prisma/instrumentation/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.207.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ=="],
 
     "@prisma/instrumentation/@opentelemetry/instrumentation/import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
+
+    "@privy-io/public-api/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
 
     "@privy-io/public-api/viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
@@ -7327,8 +7348,6 @@
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/types": ["@walletconnect/types@2.21.9", "", { "dependencies": { "@walletconnect/events": "1.0.1", "@walletconnect/heartbeat": "1.2.2", "@walletconnect/jsonrpc-types": "1.0.4", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/logger": "2.1.2", "events": "3.3.0" } }, "sha512-+82TRNX3lGRO96WyLISaBs/FkLts7y4hVgmOI4we84I7XdBu1xsjgiJj0JwYXnurz+X94lTqzOkzPps+wadWKw=="],
 
     "@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils": ["@walletconnect/utils@2.21.9", "", { "dependencies": { "@msgpack/msgpack": "3.1.2", "@noble/ciphers": "1.3.0", "@noble/curves": "1.9.7", "@noble/hashes": "1.8.0", "@scure/base": "1.2.6", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.21.9", "@walletconnect/window-getters": "1.0.1", "@walletconnect/window-metadata": "1.0.1", "blakejs": "1.2.1", "bs58": "6.0.0", "detect-browser": "5.3.0", "uint8arrays": "3.1.1", "viem": "2.36.0" } }, "sha512-FHagysDvp7yQl+74veIeuqwZZnMiTyTW3Lw0NXsbIKnlmlSQu5pma+4EnRD/CnSzbN6PV39k2t1KBaaZ4PjDgg=="],
-
-    "@reown/appkit/bs58/base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
 
     "@reown/appkit/viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
@@ -7438,6 +7457,8 @@
 
     "@serwist/next/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
+    "@solana-mobile/wallet-standard-mobile/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
+
     "@solana-program/system/@solana/kit/@solana/accounts": ["@solana/accounts@3.0.3", "", { "dependencies": { "@solana/addresses": "3.0.3", "@solana/codecs-core": "3.0.3", "@solana/codecs-strings": "3.0.3", "@solana/errors": "3.0.3", "@solana/rpc-spec": "3.0.3", "@solana/rpc-types": "3.0.3" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-KqlePrlZaHXfu8YQTCxN204ZuVm9o68CCcUr6l27MG2cuRUtEM1Ta0iR8JFkRUAEfZJC4Cu0ZDjK/v49loXjZQ=="],
 
     "@solana-program/system/@solana/kit/@solana/addresses": ["@solana/addresses@3.0.3", "", { "dependencies": { "@solana/assertions": "3.0.3", "@solana/codecs-core": "3.0.3", "@solana/codecs-strings": "3.0.3", "@solana/errors": "3.0.3", "@solana/nominal-types": "3.0.3" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-AuMwKhJI89ANqiuJ/fawcwxNKkSeHH9CApZd2xelQQLS7X8uxAOovpcmEgiObQuiVP944s9ScGUT62Bdul9qYg=="],
@@ -7480,6 +7501,8 @@
 
     "@solana/addresses/@solana/codecs-strings/@solana/codecs-numbers": ["@solana/codecs-numbers@5.0.0", "", { "dependencies": { "@solana/codecs-core": "5.0.0", "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-a2+skRLuUK02f/XFe4L0e1+wHCyfK25PkyseFps1v1l4pvevukFwth/EhSyrs6w5CsTJRVoR7MuE3E00PM4egw=="],
 
+    "@solana/codecs-core/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
     "@solana/codecs-numbers/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "@solana/codecs-strings/@solana/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
@@ -7490,11 +7513,11 @@
 
     "@solana/rpc-api/@solana/codecs-strings/@solana/codecs-numbers": ["@solana/codecs-numbers@5.0.0", "", { "dependencies": { "@solana/codecs-core": "5.0.0", "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-a2+skRLuUK02f/XFe4L0e1+wHCyfK25PkyseFps1v1l4pvevukFwth/EhSyrs6w5CsTJRVoR7MuE3E00PM4egw=="],
 
+    "@solana/transaction-confirmation/@solana/codecs-strings/@solana/codecs-core": ["@solana/codecs-core@5.0.0", "", { "dependencies": { "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-rCG2d8OaamVF2/J//YyCgDqNJpUytVVltw9C8mJtEz5c6Se/LR6BFuG8g4xeJswq/ab4RFk5/HFdgbvNjKgQjA=="],
+
     "@solana/transaction-confirmation/@solana/codecs-strings/@solana/codecs-numbers": ["@solana/codecs-numbers@5.0.0", "", { "dependencies": { "@solana/codecs-core": "5.0.0", "@solana/errors": "5.0.0" }, "peerDependencies": { "typescript": ">=5.3.3" } }, "sha512-a2+skRLuUK02f/XFe4L0e1+wHCyfK25PkyseFps1v1l4pvevukFwth/EhSyrs6w5CsTJRVoR7MuE3E00PM4egw=="],
 
     "@solana/wallet-standard-util/@noble/curves/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
-    "@solana/wallet-standard-wallet-adapter-base/bs58/base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
 
     "@solana/web3.js/bs58/base-x": ["base-x@3.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA=="],
 
@@ -7627,8 +7650,6 @@
     "@walletconnect/core/uint8arrays/multiformats": ["multiformats@9.9.0", "", {}, "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="],
 
     "@walletconnect/relay-auth/uint8arrays/multiformats": ["multiformats@9.9.0", "", {}, "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="],
-
-    "@walletconnect/utils/bs58/base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
 
     "@walletconnect/utils/ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 
@@ -7796,8 +7817,6 @@
 
     "express/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
-    "extension-port-stream/readable-stream/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
-
     "finalhandler/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "ghost-testrpc/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
@@ -7895,10 +7914,6 @@
     "permissionless/ox/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "permissionless/ox/abitype": ["abitype@1.1.0", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-6Vh4HcRxNMLA0puzPjM5GBgT4aAcFGKZzSgAXvuZ27shJP6NEpielTuqbBmZILR5/xd0PizkBGy5hReKz9jl5A=="],
-
-    "pino-abstract-transport/readable-stream/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
-
-    "pino-pretty/readable-stream/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "porto/ox/@adraffy/ens-normalize": ["@adraffy/ens-normalize@1.11.1", "", {}, "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ=="],
 
@@ -8264,8 +8279,6 @@
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
-    "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
-
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/uint8arrays": ["uint8arrays@3.1.1", "", { "dependencies": { "multiformats": "^9.4.2" } }, "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg=="],
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/viem": ["viem@2.36.0", "", { "dependencies": { "@noble/curves": "1.9.6", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.0.8", "isows": "1.0.7", "ox": "0.9.1", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-Xz7AkGtR43K+NY74X2lBevwfRrsXuifGUzt8QiULO47NXIcT7g3jcA4nIvl5m2OTE5v8SlzishwXmg64xOIVmQ=="],
@@ -8301,8 +8314,6 @@
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
-    "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
 
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/uint8arrays": ["uint8arrays@3.1.1", "", { "dependencies": { "multiformats": "^9.4.2" } }, "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg=="],
 
@@ -8522,8 +8533,6 @@
 
     "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@walletconnect/universal-provider": ["@walletconnect/universal-provider@2.21.0", "", { "dependencies": { "@walletconnect/events": "1.0.1", "@walletconnect/jsonrpc-http-connection": "1.0.8", "@walletconnect/jsonrpc-provider": "1.0.14", "@walletconnect/jsonrpc-types": "1.0.4", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/logger": "2.1.2", "@walletconnect/sign-client": "2.21.0", "@walletconnect/types": "2.21.0", "@walletconnect/utils": "2.21.0", "es-toolkit": "1.33.0", "events": "3.3.0" } }, "sha512-mtUQvewt+X0VBQay/xOJBvxsB3Xsm1lTwFjZ6WUwSOTR1X+FNb71hSApnV5kbsdDIpYPXeQUbGt2se1n5E5UBg=="],
 
-    "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
-
     "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/valtio": ["valtio@1.13.2", "", { "dependencies": { "derive-valtio": "0.1.0", "proxy-compare": "2.6.0", "use-sync-external-store": "1.2.0" }, "peerDependencies": { "@types/react": ">=16.8", "react": ">=16.8" }, "optionalPeers": ["@types/react", "react"] }, "sha512-Qik0o+DSy741TmkqmRfjq+0xpZBXi/Y6+fXZLn0xNF1z/waFMbE3rkivv5Zcf9RrMUp6zswf2J7sbh2KBlba5A=="],
 
     "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/viem": ["viem@2.41.2", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.1.0", "isows": "1.0.7", "ox": "0.9.6", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-LYliajglBe1FU6+EH9mSWozp+gRA/QcHfxeD9Odf83AdH5fwUS7DroH4gHvlv6Sshqi1uXrYFA2B/EOczxd15g=="],
@@ -8543,8 +8552,6 @@
     "@wagmi/connectors/@walletconnect/ethereum-provider/@walletconnect/utils/@noble/curves": ["@noble/curves@1.8.1", "", { "dependencies": { "@noble/hashes": "1.7.1" } }, "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ=="],
 
     "@wagmi/connectors/@walletconnect/ethereum-provider/@walletconnect/utils/@noble/hashes": ["@noble/hashes@1.7.1", "", {}, "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="],
-
-    "@wagmi/connectors/@walletconnect/ethereum-provider/@walletconnect/utils/bs58": ["bs58@6.0.0", "", { "dependencies": { "base-x": "^5.0.0" } }, "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw=="],
 
     "@wagmi/connectors/@walletconnect/ethereum-provider/@walletconnect/utils/uint8arrays": ["uint8arrays@3.1.0", "", { "dependencies": { "multiformats": "^9.4.2" } }, "sha512-ei5rfKtoRO8OyOIor2Rz5fhzjThwIHJZ3uyDPnDHTXbP0aMQ1RN/6AI5B5d9dBxJOU+BvOAk7ZQ1xphsX8Lrog=="],
 
@@ -8680,8 +8687,6 @@
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/sign-client/@walletconnect/core/uint8arrays": ["uint8arrays@3.1.1", "", { "dependencies": { "multiformats": "^9.4.2" } }, "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg=="],
 
-    "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/bs58/base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
-
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/uint8arrays/multiformats": ["multiformats@9.9.0", "", {}, "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="],
 
     "@reown/appkit-controllers/@walletconnect/universal-provider/@walletconnect/utils/viem/@noble/curves": ["@noble/curves@1.9.6", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-GIKz/j99FRthB8icyJQA51E8Uk5hXmdyThjgQXRKiv9h0zeRlzSCLIzFw6K1LotZ3XuB7yzlf76qk7uBmTdFqA=="],
@@ -8699,8 +8704,6 @@
     "@reown/appkit-ui/qrcode/yargs/yargs-parser/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/sign-client/@walletconnect/core/uint8arrays": ["uint8arrays@3.1.1", "", { "dependencies": { "multiformats": "^9.4.2" } }, "sha512-+QJa8QRnbdXVpHYjLoTpJIdCTiw9Ir62nocClWuXIq2JIh4Uta0cQsTSpFL678p2CN8B+XSApwcU+pQEqVpKWg=="],
-
-    "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/bs58/base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
 
     "@reown/appkit-utils/@walletconnect/universal-provider/@walletconnect/utils/uint8arrays/multiformats": ["multiformats@9.9.0", "", {}, "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="],
 
@@ -8770,8 +8773,6 @@
 
     "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-common/dayjs": ["dayjs@1.11.13", "", {}, "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="],
 
-    "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-polyfills/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
-
     "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-ui/qrcode": ["qrcode@1.5.3", "", { "dependencies": { "dijkstrajs": "^1.0.1", "encode-utf8": "^1.0.3", "pngjs": "^5.0.0", "yargs": "^15.3.1" }, "bin": { "qrcode": "bin/qrcode" } }, "sha512-puyri6ApkEHYiVl4CFzo1tDkAZ+ATcnbJrJ6RiBM1Fhctdn/ix9MTE3hRph33omisEbC/2fcfemsseiKgBPKZg=="],
 
     "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@reown/appkit-utils/@walletconnect/logger": ["@walletconnect/logger@2.1.2", "", { "dependencies": { "@walletconnect/safe-json": "^1.0.2", "pino": "7.11.0" } }, "sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw=="],
@@ -8789,8 +8790,6 @@
     "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@walletconnect/universal-provider/@walletconnect/utils": ["@walletconnect/utils@2.21.0", "", { "dependencies": { "@noble/ciphers": "1.2.1", "@noble/curves": "1.8.1", "@noble/hashes": "1.7.1", "@walletconnect/jsonrpc-utils": "1.0.8", "@walletconnect/keyvaluestorage": "1.1.1", "@walletconnect/relay-api": "1.0.11", "@walletconnect/relay-auth": "1.1.0", "@walletconnect/safe-json": "1.0.2", "@walletconnect/time": "1.0.2", "@walletconnect/types": "2.21.0", "@walletconnect/window-getters": "1.0.1", "@walletconnect/window-metadata": "1.0.1", "bs58": "6.0.0", "detect-browser": "5.3.0", "query-string": "7.1.3", "uint8arrays": "3.1.0", "viem": "2.23.2" } }, "sha512-zfHLiUoBrQ8rP57HTPXW7rQMnYxYI4gT9yTACxVW6LhIFROTF6/ytm5SKNoIvi4a5nX5dfXG4D9XwQUCu8Ilig=="],
 
     "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/@walletconnect/universal-provider/es-toolkit": ["es-toolkit@1.33.0", "", {}, "sha512-X13Q/ZSc+vsO1q600bvNK4bxgXMkHcf//RxCmYDaRY5DAcT+eoXjY5hoAPGMdRnWQjvyLEcyauG3b6hz76LNqg=="],
-
-    "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/bs58/base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
 
     "@wagmi/connectors/@walletconnect/ethereum-provider/@reown/appkit/valtio/proxy-compare": ["proxy-compare@2.6.0", "", {}, "sha512-8xuCeM3l8yqdmbPoYeLbrAXCBWu19XEYc5/F28f5qOaoAIMyfmBUkl5axiK+x9olUvRlcekvnm98AP9RDngOIw=="],
 
@@ -8813,8 +8812,6 @@
     "@wagmi/connectors/@walletconnect/ethereum-provider/@walletconnect/types/@walletconnect/logger/pino": ["pino@7.11.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "fast-redact": "^3.0.0", "on-exit-leak-free": "^0.2.0", "pino-abstract-transport": "v0.5.0", "pino-std-serializers": "^4.0.0", "process-warning": "^1.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.1.0", "safe-stable-stringify": "^2.1.0", "sonic-boom": "^2.2.1", "thread-stream": "^0.15.1" }, "bin": { "pino": "bin.js" } }, "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg=="],
 
     "@wagmi/connectors/@walletconnect/ethereum-provider/@walletconnect/universal-provider/@walletconnect/logger/pino": ["pino@7.11.0", "", { "dependencies": { "atomic-sleep": "^1.0.0", "fast-redact": "^3.0.0", "on-exit-leak-free": "^0.2.0", "pino-abstract-transport": "v0.5.0", "pino-std-serializers": "^4.0.0", "process-warning": "^1.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.1.0", "safe-stable-stringify": "^2.1.0", "sonic-boom": "^2.2.1", "thread-stream": "^0.15.1" }, "bin": { "pino": "bin.js" } }, "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg=="],
-
-    "@wagmi/connectors/@walletconnect/ethereum-provider/@walletconnect/utils/bs58/base-x": ["base-x@5.0.1", "", {}, "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="],
 
     "@wagmi/connectors/@walletconnect/ethereum-provider/@walletconnect/utils/uint8arrays/multiformats": ["multiformats@9.9.0", "", {}, "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="],
 

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -23,6 +23,8 @@
   },
   "dependencies": {
     "@babylon/a2a": "workspace:*",
+    "@solana/web3.js": "^1.98.4",
+    "8004-solana": "^0.8.0",
     "posthog-node": "^5.17.0"
   },
   "peerDependencies": {

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -63,6 +63,8 @@ export {
   isAutonomousPostingEnabled,
   isAutonomousTradingEnabled,
 } from './shared/agent-config';
+// Solana agent registration
+export * from './solana-registry';
 // Templates loader
 export * from './templates-loader';
 // Training utilities (RL model fetching, config)

--- a/packages/agents/src/services/__tests__/AgentChatService.test.ts
+++ b/packages/agents/src/services/__tests__/AgentChatService.test.ts
@@ -381,8 +381,16 @@ describe('dispatchAgentChat', () => {
       });
 
       expect(result.success).toBe(true);
-      expect(mockGetAgentWithConfig).toHaveBeenNthCalledWith(1, 'larry david', OWNER_ID);
-      expect(mockGetAgentWithConfig).toHaveBeenNthCalledWith(2, AGENT_ID, OWNER_ID);
+      expect(mockGetAgentWithConfig).toHaveBeenNthCalledWith(
+        1,
+        'larry david',
+        OWNER_ID
+      );
+      expect(mockGetAgentWithConfig).toHaveBeenNthCalledWith(
+        2,
+        AGENT_ID,
+        OWNER_ID
+      );
     });
 
     it('uses single-agent fallback only for generic references like "my agent"', async () => {
@@ -416,7 +424,11 @@ describe('dispatchAgentChat', () => {
       });
 
       expect(result.success).toBe(true);
-      expect(mockGetAgentWithConfig).toHaveBeenNthCalledWith(2, AGENT_ID, OWNER_ID);
+      expect(mockGetAgentWithConfig).toHaveBeenNthCalledWith(
+        2,
+        AGENT_ID,
+        OWNER_ID
+      );
     });
 
     it('does not dispatch to the only agent when the requested name is unknown', async () => {

--- a/packages/agents/src/solana-registry/index.ts
+++ b/packages/agents/src/solana-registry/index.ts
@@ -1,0 +1,1 @@
+export * from './sdk';

--- a/packages/agents/src/solana-registry/sdk.ts
+++ b/packages/agents/src/solana-registry/sdk.ts
@@ -143,6 +143,10 @@ async function uploadRegistrationFile(
 export function deriveDeterministicAgentSolanaAsset(
   agentUserId: string
 ): Keypair {
+  // The asset keypair is intentionally deterministic so retries and
+  // reconciliation always target the same registry asset. Treat this as a
+  // stable infrastructure identity, not a secret seed: anyone with the agent
+  // user id can derive the same asset public key.
   const digest = createHash('sha256')
     .update(`babylon:agent-solana:${agentUserId}`)
     .digest();

--- a/packages/agents/src/solana-registry/sdk.ts
+++ b/packages/agents/src/solana-registry/sdk.ts
@@ -1,0 +1,209 @@
+import { createHash } from 'node:crypto';
+import { Keypair, PublicKey, Transaction } from '@solana/web3.js';
+import {
+  IPFSClient,
+  type PreparedTransaction,
+  type RegistrationFile,
+  ServiceType,
+  SOLANA_DEVNET_RPC,
+  SOLANA_MAINNET_RPC,
+  SolanaSDK,
+  type SolanaSDKConfig,
+} from '8004-solana';
+
+function resolveSolanaRegistryCluster(): SolanaSDKConfig['cluster'] {
+  const cluster = process.env.SOLANA_REGISTRY_CLUSTER ?? 'mainnet-beta';
+
+  if (
+    cluster === 'devnet' ||
+    cluster === 'testnet' ||
+    cluster === 'mainnet-beta' ||
+    cluster === 'localnet'
+  ) {
+    return cluster;
+  }
+
+  throw new Error(
+    `Unsupported SOLANA_REGISTRY_CLUSTER value: ${cluster}. Expected devnet, testnet, mainnet-beta, or localnet.`
+  );
+}
+
+function resolveSolanaRegistryRpcUrl(): string {
+  const cluster = resolveSolanaRegistryCluster();
+
+  if (process.env.SOLANA_REGISTRY_RPC_URL) {
+    return process.env.SOLANA_REGISTRY_RPC_URL;
+  }
+
+  return cluster === 'devnet' ? SOLANA_DEVNET_RPC : SOLANA_MAINNET_RPC;
+}
+
+export function assertSolanaRegistryConfigured(): void {
+  if (process.env.SOLANA_REGISTRY_ENABLED !== 'true') {
+    throw new Error(
+      'Solana agent registration is disabled. Set SOLANA_REGISTRY_ENABLED=true to enable it.'
+    );
+  }
+
+  resolveSolanaRegistryRpcUrl();
+  createSolanaRegistryIpfsClient();
+}
+
+function createSolanaRegistryIpfsClient(): IPFSClient {
+  const pinataJwt = process.env.PINATA_JWT?.trim();
+  const filecoinPrivateKey = process.env.FILECOIN_PRIVATE_KEY?.trim();
+  const nodeUrl = process.env.AGENT0_IPFS_API?.trim();
+
+  if (pinataJwt) {
+    return new IPFSClient({
+      pinataEnabled: true,
+      pinataJwt,
+    });
+  }
+
+  if (filecoinPrivateKey) {
+    return new IPFSClient({
+      filecoinPinEnabled: true,
+      filecoinPrivateKey,
+    });
+  }
+
+  if (nodeUrl) {
+    return new IPFSClient({ url: nodeUrl });
+  }
+
+  throw new Error(
+    'Solana agent metadata upload is not configured. Set PINATA_JWT, FILECOIN_PRIVATE_KEY, or AGENT0_IPFS_API.'
+  );
+}
+
+function createSolanaRegistrySdk(
+  config: Pick<SolanaSDKConfig, 'signer'> = {}
+): SolanaSDK {
+  return new SolanaSDK({
+    cluster: resolveSolanaRegistryCluster(),
+    rpcUrl: resolveSolanaRegistryRpcUrl(),
+    signer: config.signer,
+    ipfsClient: createSolanaRegistryIpfsClient(),
+  });
+}
+
+export function buildAgentSolanaRegistrationFile({
+  name,
+  description,
+  image,
+  walletAddress,
+  a2aEndpoint,
+  mcpEndpoint,
+  metadata,
+  skills,
+  domains,
+}: {
+  name: string;
+  description: string;
+  image?: string | null;
+  walletAddress: string;
+  a2aEndpoint: string;
+  mcpEndpoint: string;
+  metadata?: Record<string, unknown>;
+  skills?: string[];
+  domains?: string[];
+}): RegistrationFile {
+  return {
+    name,
+    description,
+    image: image ?? undefined,
+    walletAddress,
+    services: [
+      { type: ServiceType.WALLET, value: walletAddress },
+      { type: ServiceType.A2A, value: a2aEndpoint },
+      { type: ServiceType.MCP, value: mcpEndpoint },
+    ],
+    active: true,
+    x402Support: true,
+    metadata,
+    skills,
+    domains,
+    updatedAt: Date.now(),
+  };
+}
+
+async function uploadRegistrationFile(
+  file: RegistrationFile
+): Promise<{ cid: string; uri: string }> {
+  const ipfs = createSolanaRegistryIpfsClient();
+  const cid = await ipfs.addRegistrationFile(file);
+
+  return {
+    cid,
+    uri: `ipfs://${cid}`,
+  };
+}
+
+export function deriveDeterministicAgentSolanaAsset(
+  agentUserId: string
+): Keypair {
+  const digest = createHash('sha256')
+    .update(`babylon:agent-solana:${agentUserId}`)
+    .digest();
+
+  return Keypair.fromSeed(digest);
+}
+
+function signPreparedTransaction(
+  prepared: PreparedTransaction,
+  signers: Keypair[]
+): string {
+  const transaction = Transaction.from(
+    Buffer.from(prepared.transaction, 'base64')
+  );
+  transaction.partialSign(...signers);
+  return transaction
+    .serialize({ requireAllSignatures: false })
+    .toString('base64');
+}
+
+export async function prepareAgentSolanaRegistrationTransaction({
+  agentUserId,
+  ownerWalletAddress,
+  registrationFile,
+}: {
+  agentUserId: string;
+  ownerWalletAddress: string;
+  registrationFile: RegistrationFile;
+}): Promise<{
+  assetId: string;
+  metadataUri: string;
+  metadataCid: string;
+  transaction: string;
+}> {
+  assertSolanaRegistryConfigured();
+
+  const sdk = createSolanaRegistrySdk();
+  const asset = deriveDeterministicAgentSolanaAsset(agentUserId);
+  const { cid, uri } = await uploadRegistrationFile(registrationFile);
+
+  const prepared = await sdk.registerAgent(uri, {
+    skipSend: true,
+    signer: new PublicKey(ownerWalletAddress),
+    assetPubkey: asset.publicKey,
+  });
+
+  if (!('transaction' in prepared)) {
+    throw new Error('Expected a prepared Solana registration transaction');
+  }
+
+  return {
+    assetId: prepared.asset.toBase58(),
+    metadataUri: uri,
+    metadataCid: cid,
+    transaction: signPreparedTransaction(prepared, [asset]),
+  };
+}
+
+export async function getAgentSolanaRegistration(
+  assetId: string
+): Promise<Awaited<ReturnType<SolanaSDK['getAgent']>>> {
+  const sdk = createSolanaRegistrySdk();
+  return sdk.getAgent(new PublicKey(assetId));
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -259,10 +259,13 @@ export {
 } from './services/privy/evm-send-transaction';
 export { assertPrivyOfflineConfig } from './services/privy/offline-config';
 export { ensureOfflineWalletReady } from './services/privy/offline-wallet-provisioning';
+export { sendSponsoredSolanaTransaction } from './services/privy/solana-send-transaction';
+export { ensureSolanaWalletReady } from './services/privy/solana-wallet-provisioning';
 // Privy (embedded wallet server-side helpers)
 export {
   type PrivyUserWalletsLite,
   pickEmbeddedEvmWallet,
+  pickEmbeddedSolanaWallet,
 } from './services/privy/user-wallets';
 // SSE Event Broadcasting
 export {

--- a/packages/api/src/services/agent-solana-registration-service.test.ts
+++ b/packages/api/src/services/agent-solana-registration-service.test.ts
@@ -4,6 +4,8 @@ const mockGetAgentSolanaRegistration = mock();
 const mockPrepareAgentSolanaRegistrationTransaction = mock();
 const mockEnsureSolanaWalletReady = mock();
 const mockSendSponsoredSolanaTransaction = mock();
+const mockAcquireLock = mock();
+const mockReleaseLock = mock();
 
 let selectResults: Array<unknown[]> = [];
 const capturedUpdates: Array<Record<string, unknown>> = [];
@@ -83,6 +85,7 @@ mock.module('@babylon/shared', () => ({
   getBaseUrl: () => 'https://play.babylon.market',
   getMCPEndpoint: () => 'https://play.babylon.market/api/mcp',
   logger: {
+    debug: mock(),
     info: mock(),
     warn: mock(),
     error: mock(),
@@ -98,6 +101,13 @@ mock.module('./privy/solana-wallet-provisioning', () => ({
 
 mock.module('./privy/solana-send-transaction', () => ({
   sendSponsoredSolanaTransaction: mockSendSponsoredSolanaTransaction,
+}));
+
+mock.module('./distributed-lock-service', () => ({
+  DistributedLockService: {
+    acquireLock: mockAcquireLock,
+    releaseLock: mockReleaseLock,
+  },
 }));
 
 const { getAgentSolanaRegistrationStatus, registerAgentOnSolanaForOwner } =
@@ -130,8 +140,12 @@ describe('agent-solana-registration-service', () => {
     mockPrepareAgentSolanaRegistrationTransaction.mockReset();
     mockEnsureSolanaWalletReady.mockReset();
     mockSendSponsoredSolanaTransaction.mockReset();
+    mockAcquireLock.mockReset();
+    mockReleaseLock.mockReset();
 
     process.env.SOLANA_REGISTRY_ENABLED = 'true';
+    mockAcquireLock.mockResolvedValue(true);
+    mockReleaseLock.mockResolvedValue(undefined);
     mockEnsureSolanaWalletReady.mockResolvedValue({
       privyWalletId: 'solana-wallet-1',
       walletAddress: 'SoLWallet111',
@@ -254,5 +268,47 @@ describe('agent-solana-registration-service', () => {
     expect(result.alreadyRegistered).toBe(true);
     expect(result.cost).toBe(0);
     expect(capturedInserts).toHaveLength(0);
+  });
+
+  it('blocks concurrent registration attempts before charging points', async () => {
+    selectResults.push([BASE_AGENT]);
+    mockAcquireLock.mockResolvedValueOnce(false);
+
+    await expect(
+      registerAgentOnSolanaForOwner({
+        ownerUserId: 'owner-1',
+        agentUserId: 'agent-1',
+      })
+    ).rejects.toThrow('already in progress');
+
+    expect(capturedInserts).toHaveLength(0);
+    expect(mockSendSponsoredSolanaTransaction).not.toHaveBeenCalled();
+  });
+
+  it('reconciles on-chain success after a post-send failure without refunding', async () => {
+    selectResults.push([BASE_AGENT]);
+    selectResults.push([{ virtualBalance: '900' }]);
+
+    mockGetAgentSolanaRegistration
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ owner: 'onchain' });
+    mockSendSponsoredSolanaTransaction.mockRejectedValueOnce(
+      new Error('Privy returned an unexpected response')
+    );
+
+    const result = await registerAgentOnSolanaForOwner({
+      ownerUserId: 'owner-1',
+      agentUserId: 'agent-1',
+    });
+
+    expect(result.assetId).toBe('asset-123');
+    expect(result.walletAddress).toBe('SoLWallet111');
+    expect(
+      capturedInserts.some(
+        (insert) =>
+          insert.description === 'Refund - agent Solana registration failed'
+      )
+    ).toBe(false);
   });
 });

--- a/packages/api/src/services/agent-solana-registration-service.test.ts
+++ b/packages/api/src/services/agent-solana-registration-service.test.ts
@@ -1,0 +1,258 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+const mockGetAgentSolanaRegistration = mock();
+const mockPrepareAgentSolanaRegistrationTransaction = mock();
+const mockEnsureSolanaWalletReady = mock();
+const mockSendSponsoredSolanaTransaction = mock();
+
+let selectResults: Array<unknown[]> = [];
+const capturedUpdates: Array<Record<string, unknown>> = [];
+const capturedInserts: Array<Record<string, unknown>> = [];
+
+const usersTable = {
+  id: 'id',
+  username: 'username',
+  displayName: 'displayName',
+  bio: 'bio',
+  profileImageUrl: 'profileImageUrl',
+  isAgent: 'isAgent',
+  managedBy: 'managedBy',
+  privyId: 'privyId',
+  privySolanaWalletId: 'privySolanaWalletId',
+  solanaWalletAddress: 'solanaWalletAddress',
+  solanaOfflineWalletReady: 'solanaOfflineWalletReady',
+  solanaRegistered: 'solanaRegistered',
+  solanaRegistryAssetId: 'solanaRegistryAssetId',
+  solanaMetadataUri: 'solanaMetadataUri',
+  solanaRegistrationTxHash: 'solanaRegistrationTxHash',
+  virtualBalance: 'virtualBalance',
+} as const;
+
+mock.module('@babylon/agents', () => ({
+  buildAgentSolanaRegistrationFile: (input: unknown) => input,
+  deriveDeterministicAgentSolanaAsset: () => ({
+    publicKey: { toBase58: () => 'asset-deterministic' },
+  }),
+  getAgentSolanaRegistration: mockGetAgentSolanaRegistration,
+  prepareAgentSolanaRegistrationTransaction:
+    mockPrepareAgentSolanaRegistrationTransaction,
+}));
+
+mock.module('@babylon/db', () => ({
+  and: (...args: unknown[]) => args,
+  balanceTransactions: 'BalanceTransaction',
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => selectResults.shift() ?? [],
+        }),
+      }),
+    }),
+    update: () => ({
+      set: (data: Record<string, unknown>) => {
+        capturedUpdates.push(data);
+        return {
+          where: () => ({
+            returning: async () => selectResults.shift() ?? [],
+          }),
+        };
+      },
+    }),
+    insert: () => ({
+      values: async (data: Record<string, unknown>) => {
+        capturedInserts.push(data);
+      },
+    }),
+  },
+  eq: (...args: unknown[]) => args,
+  sql: (strings: TemplateStringsArray) => strings.join(''),
+  users: usersTable,
+}));
+
+mock.module('@babylon/shared', () => ({
+  BusinessLogicError: class BusinessLogicError extends Error {
+    constructor(
+      message: string,
+      public code: string
+    ) {
+      super(message);
+    }
+  },
+  generateSnowflakeId: mock().mockResolvedValue('snowflake-1'),
+  getBaseUrl: () => 'https://play.babylon.market',
+  getMCPEndpoint: () => 'https://play.babylon.market/api/mcp',
+  logger: {
+    info: mock(),
+    warn: mock(),
+    error: mock(),
+  },
+  POINTS: {
+    ONCHAIN_REGISTRATION: 100,
+  },
+}));
+
+mock.module('./privy/solana-wallet-provisioning', () => ({
+  ensureSolanaWalletReady: mockEnsureSolanaWalletReady,
+}));
+
+mock.module('./privy/solana-send-transaction', () => ({
+  sendSponsoredSolanaTransaction: mockSendSponsoredSolanaTransaction,
+}));
+
+const { getAgentSolanaRegistrationStatus, registerAgentOnSolanaForOwner } =
+  await import('./agent-solana-registration-service');
+
+const BASE_AGENT = {
+  id: 'agent-1',
+  username: 'agent-one',
+  displayName: 'Agent One',
+  bio: 'Autonomous AI agent',
+  profileImageUrl: null,
+  isAgent: true,
+  managedBy: 'owner-1',
+  privyId: 'did:privy:agent-1',
+  privySolanaWalletId: null,
+  solanaWalletAddress: null,
+  solanaOfflineWalletReady: false,
+  solanaRegistered: false,
+  solanaRegistryAssetId: null,
+  solanaMetadataUri: null,
+  solanaRegistrationTxHash: null,
+};
+
+describe('agent-solana-registration-service', () => {
+  beforeEach(() => {
+    selectResults = [];
+    capturedUpdates.length = 0;
+    capturedInserts.length = 0;
+    mockGetAgentSolanaRegistration.mockReset();
+    mockPrepareAgentSolanaRegistrationTransaction.mockReset();
+    mockEnsureSolanaWalletReady.mockReset();
+    mockSendSponsoredSolanaTransaction.mockReset();
+
+    process.env.SOLANA_REGISTRY_ENABLED = 'true';
+    mockEnsureSolanaWalletReady.mockResolvedValue({
+      privyWalletId: 'solana-wallet-1',
+      walletAddress: 'SoLWallet111',
+      offlineWalletReady: true,
+      createdWallet: true,
+    });
+    mockPrepareAgentSolanaRegistrationTransaction.mockResolvedValue({
+      assetId: 'asset-123',
+      metadataUri: 'ipfs://cid-123',
+      metadataCid: 'cid-123',
+      transaction: 'base64-tx',
+    });
+    mockSendSponsoredSolanaTransaction.mockResolvedValue({
+      hash: 'tx-123',
+      transactionId: 'tx-123',
+      caip2: 'solana:mainnet',
+    });
+  });
+
+  it('returns status for an owned agent', async () => {
+    selectResults.push([BASE_AGENT]);
+
+    const status = await getAgentSolanaRegistrationStatus({
+      ownerUserId: 'owner-1',
+      agentUserId: 'agent-1',
+    });
+
+    expect(status.isRegistered).toBe(false);
+    expect(status.cost).toBe(100);
+  });
+
+  it('registers an agent on Solana, charges points once, and persists Solana-specific fields', async () => {
+    selectResults.push([BASE_AGENT]);
+    selectResults.push([{ virtualBalance: '900' }]);
+
+    mockGetAgentSolanaRegistration
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+
+    const result = await registerAgentOnSolanaForOwner({
+      ownerUserId: 'owner-1',
+      agentUserId: 'agent-1',
+    });
+
+    expect(result.alreadyRegistered).toBe(false);
+    expect(result.assetId).toBe('asset-123');
+    expect(result.txHash).toBe('tx-123');
+    expect(mockSendSponsoredSolanaTransaction).toHaveBeenCalledWith({
+      walletId: 'solana-wallet-1',
+      transaction: 'base64-tx',
+      idempotencyKey: 'agent-solana-registration:agent-1',
+    });
+    expect(
+      capturedUpdates.some((update) => update.solanaRegistered === true)
+    ).toBe(true);
+    expect(
+      capturedInserts.some(
+        (insert) => insert.description === 'Agent Solana registration'
+      )
+    ).toBe(true);
+  });
+
+  it('returns already registered without charging when DB is already in sync', async () => {
+    selectResults.push([
+      {
+        ...BASE_AGENT,
+        solanaRegistered: true,
+        solanaRegistryAssetId: 'asset-existing',
+        solanaMetadataUri: 'ipfs://cid-existing',
+        solanaRegistrationTxHash: 'tx-existing',
+      },
+    ]);
+
+    const result = await registerAgentOnSolanaForOwner({
+      ownerUserId: 'owner-1',
+      agentUserId: 'agent-1',
+    });
+
+    expect(result.alreadyRegistered).toBe(true);
+    expect(result.cost).toBe(0);
+    expect(capturedInserts).toHaveLength(0);
+    expect(mockSendSponsoredSolanaTransaction).not.toHaveBeenCalled();
+  });
+
+  it('surfaces missing Solana configuration cleanly', async () => {
+    selectResults.push([BASE_AGENT]);
+    selectResults.push([{ virtualBalance: '900' }]);
+
+    mockGetAgentSolanaRegistration
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+    mockPrepareAgentSolanaRegistrationTransaction.mockRejectedValueOnce(
+      new Error('Solana agent registration is disabled.')
+    );
+
+    await expect(
+      registerAgentOnSolanaForOwner({
+        ownerUserId: 'owner-1',
+        agentUserId: 'agent-1',
+      })
+    ).rejects.toThrow('Solana agent registration is disabled.');
+    expect(
+      capturedInserts.some(
+        (insert) =>
+          insert.description === 'Refund - agent Solana registration failed'
+      )
+    ).toBe(true);
+  });
+
+  it('reconciles a partial failure without double-charging when the deterministic asset is already on-chain', async () => {
+    selectResults.push([BASE_AGENT]);
+
+    mockGetAgentSolanaRegistration.mockResolvedValueOnce({ owner: 'onchain' });
+
+    const result = await registerAgentOnSolanaForOwner({
+      ownerUserId: 'owner-1',
+      agentUserId: 'agent-1',
+    });
+
+    expect(result.alreadyRegistered).toBe(true);
+    expect(result.cost).toBe(0);
+    expect(capturedInserts).toHaveLength(0);
+  });
+});

--- a/packages/api/src/services/agent-solana-registration-service.test.ts
+++ b/packages/api/src/services/agent-solana-registration-service.test.ts
@@ -4,6 +4,7 @@ const mockGetAgentSolanaRegistration = mock();
 const mockPrepareAgentSolanaRegistrationTransaction = mock();
 const mockEnsureSolanaWalletReady = mock();
 const mockSendSponsoredSolanaTransaction = mock();
+const mockAssertSolanaRegistryConfigured = mock();
 const mockAcquireLock = mock();
 const mockReleaseLock = mock();
 
@@ -31,6 +32,7 @@ const usersTable = {
 } as const;
 
 mock.module('@babylon/agents', () => ({
+  assertSolanaRegistryConfigured: mockAssertSolanaRegistryConfigured,
   buildAgentSolanaRegistrationFile: (input: unknown) => input,
   deriveDeterministicAgentSolanaAsset: () => ({
     publicKey: { toBase58: () => 'asset-deterministic' },
@@ -140,10 +142,12 @@ describe('agent-solana-registration-service', () => {
     mockPrepareAgentSolanaRegistrationTransaction.mockReset();
     mockEnsureSolanaWalletReady.mockReset();
     mockSendSponsoredSolanaTransaction.mockReset();
+    mockAssertSolanaRegistryConfigured.mockReset();
     mockAcquireLock.mockReset();
     mockReleaseLock.mockReset();
 
     process.env.SOLANA_REGISTRY_ENABLED = 'true';
+    mockAssertSolanaRegistryConfigured.mockReturnValue(undefined);
     mockAcquireLock.mockResolvedValue(true);
     mockReleaseLock.mockResolvedValue(undefined);
     mockEnsureSolanaWalletReady.mockResolvedValue({
@@ -231,6 +235,22 @@ describe('agent-solana-registration-service', () => {
   });
 
   it('surfaces missing Solana configuration cleanly', async () => {
+    selectResults.push([BASE_AGENT]);
+    mockAssertSolanaRegistryConfigured.mockImplementationOnce(() => {
+      throw new Error('Solana agent registration is disabled.');
+    });
+
+    await expect(
+      registerAgentOnSolanaForOwner({
+        ownerUserId: 'owner-1',
+        agentUserId: 'agent-1',
+      })
+    ).rejects.toThrow('Solana agent registration is disabled.');
+    expect(capturedInserts).toHaveLength(0);
+    expect(capturedUpdates).toHaveLength(0);
+  });
+
+  it('refunds when Solana preparation fails after charging the owner', async () => {
     selectResults.push([BASE_AGENT]);
     selectResults.push([{ virtualBalance: '900' }]);
 

--- a/packages/api/src/services/agent-solana-registration-service.ts
+++ b/packages/api/src/services/agent-solana-registration-service.ts
@@ -1,4 +1,5 @@
 import {
+  assertSolanaRegistryConfigured,
   buildAgentSolanaRegistrationFile,
   deriveDeterministicAgentSolanaAsset,
   getAgentSolanaRegistration,
@@ -321,6 +322,8 @@ export async function registerAgentOnSolanaForOwner({
         cost: 0,
       };
     }
+
+    assertSolanaRegistryConfigured();
 
     if (!agent.privyId) {
       throw new BusinessLogicError(

--- a/packages/api/src/services/agent-solana-registration-service.ts
+++ b/packages/api/src/services/agent-solana-registration-service.ts
@@ -1,0 +1,458 @@
+import {
+  buildAgentSolanaRegistrationFile,
+  deriveDeterministicAgentSolanaAsset,
+  getAgentSolanaRegistration,
+  prepareAgentSolanaRegistrationTransaction,
+} from '@babylon/agents';
+import { and, balanceTransactions, db, eq, sql, users } from '@babylon/db';
+import {
+  BusinessLogicError,
+  generateSnowflakeId,
+  getBaseUrl,
+  getMCPEndpoint,
+  logger,
+  POINTS,
+} from '@babylon/shared';
+import { sendSponsoredSolanaTransaction } from './privy/solana-send-transaction';
+import { ensureSolanaWalletReady } from './privy/solana-wallet-provisioning';
+
+export interface AgentSolanaRegistrationStatus {
+  isRegistered: boolean;
+  assetId: string | null;
+  metadataUri: string | null;
+  txHash: string | null;
+  walletAddress: string | null;
+  walletReady: boolean;
+  cost: number;
+}
+
+export interface AgentSolanaRegistrationResult {
+  message: string;
+  alreadyRegistered: boolean;
+  agentUserId: string;
+  assetId: string;
+  metadataUri: string;
+  txHash?: string;
+  walletAddress: string;
+  cost: number;
+}
+
+type AgentSolanaRecord = {
+  id: string;
+  username: string | null;
+  displayName: string | null;
+  bio: string | null;
+  profileImageUrl: string | null;
+  isAgent: boolean;
+  managedBy: string | null;
+  privyId: string | null;
+  privySolanaWalletId: string | null;
+  solanaWalletAddress: string | null;
+  solanaOfflineWalletReady: boolean;
+  solanaRegistered: boolean;
+  solanaRegistryAssetId: string | null;
+  solanaMetadataUri: string | null;
+  solanaRegistrationTxHash: string | null;
+};
+
+const AGENT_SOLANA_SELECT = {
+  id: users.id,
+  username: users.username,
+  displayName: users.displayName,
+  bio: users.bio,
+  profileImageUrl: users.profileImageUrl,
+  isAgent: users.isAgent,
+  managedBy: users.managedBy,
+  privyId: users.privyId,
+  privySolanaWalletId: users.privySolanaWalletId,
+  solanaWalletAddress: users.solanaWalletAddress,
+  solanaOfflineWalletReady: users.solanaOfflineWalletReady,
+  solanaRegistered: users.solanaRegistered,
+  solanaRegistryAssetId: users.solanaRegistryAssetId,
+  solanaMetadataUri: users.solanaMetadataUri,
+  solanaRegistrationTxHash: users.solanaRegistrationTxHash,
+} as const;
+
+async function getAgentForOwner(
+  ownerUserId: string,
+  agentUserId: string
+): Promise<AgentSolanaRecord> {
+  const [agent] = await db
+    .select(AGENT_SOLANA_SELECT)
+    .from(users)
+    .where(eq(users.id, agentUserId))
+    .limit(1);
+
+  if (!agent || !agent.isAgent) {
+    throw new BusinessLogicError('Agent not found', 'AGENT_NOT_FOUND');
+  }
+
+  if (agent.managedBy !== ownerUserId) {
+    throw new BusinessLogicError(
+      'You do not manage this agent',
+      'AGENT_ACCESS_DENIED'
+    );
+  }
+
+  return agent;
+}
+
+async function deductRegistrationCost(
+  ownerUserId: string,
+  agentUserId: string,
+  cost: number
+): Promise<{ balanceBefore: number; balanceAfter: number }> {
+  const [deducted] = await db
+    .update(users)
+    .set({
+      virtualBalance: sql`(${users.virtualBalance})::numeric - ${cost}`,
+      updatedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(users.id, ownerUserId),
+        sql`(${users.virtualBalance})::numeric >= ${cost}`
+      )
+    )
+    .returning({ virtualBalance: users.virtualBalance });
+
+  if (!deducted) {
+    const [owner] = await db
+      .select({ virtualBalance: users.virtualBalance })
+      .from(users)
+      .where(eq(users.id, ownerUserId))
+      .limit(1);
+
+    const currentBalance = Number(owner?.virtualBalance ?? '0');
+    throw new BusinessLogicError(
+      `Insufficient balance. Solana agent registration costs ${cost} points. You have ${Math.floor(currentBalance)} points.`,
+      'INSUFFICIENT_BALANCE'
+    );
+  }
+
+  const balanceAfter = Number(deducted.virtualBalance);
+  const balanceBefore = balanceAfter + cost;
+
+  await db.insert(balanceTransactions).values({
+    id: await generateSnowflakeId(),
+    userId: ownerUserId,
+    type: 'withdrawal',
+    amount: String(cost),
+    balanceBefore: String(balanceBefore),
+    balanceAfter: String(balanceAfter),
+    relatedId: agentUserId,
+    description: 'Agent Solana registration',
+    createdAt: new Date(),
+  });
+
+  return { balanceBefore, balanceAfter };
+}
+
+async function refundRegistrationCost(
+  ownerUserId: string,
+  agentUserId: string,
+  cost: number
+): Promise<void> {
+  const [refunded] = await db
+    .update(users)
+    .set({
+      virtualBalance: sql`(${users.virtualBalance})::numeric + ${cost}`,
+      updatedAt: new Date(),
+    })
+    .where(eq(users.id, ownerUserId))
+    .returning({ virtualBalance: users.virtualBalance });
+
+  const balanceAfter = Number(refunded?.virtualBalance ?? '0');
+  const balanceBefore = balanceAfter - cost;
+
+  await db.insert(balanceTransactions).values({
+    id: await generateSnowflakeId(),
+    userId: ownerUserId,
+    type: 'deposit',
+    amount: String(cost),
+    balanceBefore: String(balanceBefore),
+    balanceAfter: String(balanceAfter),
+    relatedId: agentUserId,
+    description: 'Refund - agent Solana registration failed',
+    createdAt: new Date(),
+  });
+}
+
+async function persistSolanaWalletState(
+  agentUserId: string,
+  wallet: { privyWalletId: string; walletAddress: string }
+): Promise<void> {
+  await db
+    .update(users)
+    .set({
+      privySolanaWalletId: wallet.privyWalletId,
+      solanaWalletAddress: wallet.walletAddress,
+      solanaOfflineWalletReady: true,
+      solanaOfflineWalletReadyAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .where(eq(users.id, agentUserId));
+}
+
+async function persistSolanaRegistrationState({
+  agentUserId,
+  walletAddress,
+  walletId,
+  assetId,
+  metadataUri,
+  txHash,
+}: {
+  agentUserId: string;
+  walletAddress: string;
+  walletId: string;
+  assetId: string;
+  metadataUri: string;
+  txHash?: string | null;
+}): Promise<void> {
+  await db
+    .update(users)
+    .set({
+      privySolanaWalletId: walletId,
+      solanaWalletAddress: walletAddress,
+      solanaOfflineWalletReady: true,
+      solanaOfflineWalletReadyAt: new Date(),
+      solanaRegistered: true,
+      solanaRegistryAssetId: assetId,
+      solanaMetadataUri: metadataUri,
+      solanaRegistrationTxHash: txHash ?? null,
+      solanaRegisteredAt: new Date(),
+      updatedAt: new Date(),
+    })
+    .where(eq(users.id, agentUserId));
+}
+
+export async function getAgentSolanaRegistrationStatus({
+  ownerUserId,
+  agentUserId,
+}: {
+  ownerUserId: string;
+  agentUserId: string;
+}): Promise<AgentSolanaRegistrationStatus> {
+  const agent = await getAgentForOwner(ownerUserId, agentUserId);
+
+  return {
+    isRegistered:
+      agent.solanaRegistered && agent.solanaRegistryAssetId !== null,
+    assetId: agent.solanaRegistryAssetId,
+    metadataUri: agent.solanaMetadataUri,
+    txHash: agent.solanaRegistrationTxHash,
+    walletAddress: agent.solanaWalletAddress,
+    walletReady:
+      agent.solanaOfflineWalletReady &&
+      agent.solanaWalletAddress !== null &&
+      agent.privySolanaWalletId !== null,
+    cost: POINTS.ONCHAIN_REGISTRATION,
+  };
+}
+
+export async function registerAgentOnSolanaForOwner({
+  ownerUserId,
+  agentUserId,
+}: {
+  ownerUserId: string;
+  agentUserId: string;
+}): Promise<AgentSolanaRegistrationResult> {
+  let costCharged = false;
+  let prepared: {
+    assetId: string;
+    metadataUri: string;
+    metadataCid: string;
+    transaction: string;
+  } | null = null;
+
+  const agent = await getAgentForOwner(ownerUserId, agentUserId);
+  const deterministicAssetId =
+    deriveDeterministicAgentSolanaAsset(agentUserId).publicKey.toBase58();
+
+  if (agent.solanaRegistered && agent.solanaRegistryAssetId) {
+    return {
+      message: 'Agent already registered on Solana',
+      alreadyRegistered: true,
+      agentUserId,
+      assetId: agent.solanaRegistryAssetId,
+      metadataUri: agent.solanaMetadataUri ?? '',
+      txHash: agent.solanaRegistrationTxHash ?? undefined,
+      walletAddress: agent.solanaWalletAddress ?? '',
+      cost: 0,
+    };
+  }
+
+  try {
+    const existingOnchain =
+      await getAgentSolanaRegistration(deterministicAssetId);
+    if (existingOnchain) {
+      await db
+        .update(users)
+        .set({
+          solanaRegistered: true,
+          solanaRegistryAssetId: deterministicAssetId,
+          solanaRegisteredAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(eq(users.id, agentUserId));
+
+      return {
+        message: 'Agent already registered on Solana',
+        alreadyRegistered: true,
+        agentUserId,
+        assetId: deterministicAssetId,
+        metadataUri: agent.solanaMetadataUri ?? '',
+        txHash: agent.solanaRegistrationTxHash ?? undefined,
+        walletAddress: agent.solanaWalletAddress ?? '',
+        cost: 0,
+      };
+    }
+  } catch {
+    // If the on-chain lookup fails, continue with the normal registration path.
+  }
+
+  if (!agent.privyId) {
+    throw new BusinessLogicError(
+      'Agent wallet identity is not ready yet. Try again after the agent wallet has been provisioned.',
+      'AGENT_IDENTITY_NOT_READY'
+    );
+  }
+
+  const cost = POINTS.ONCHAIN_REGISTRATION;
+  await deductRegistrationCost(ownerUserId, agentUserId, cost);
+  costCharged = true;
+
+  try {
+    const wallet = await ensureSolanaWalletReady({ privyId: agent.privyId });
+    await persistSolanaWalletState(agentUserId, wallet);
+
+    const registrationFile = buildAgentSolanaRegistrationFile({
+      name: agent.displayName || agent.username || agentUserId,
+      description:
+        agent.bio || `Autonomous AI agent: ${agent.username || agentUserId}`,
+      image: agent.profileImageUrl,
+      walletAddress: wallet.walletAddress,
+      a2aEndpoint: `${getBaseUrl()}/api/agents/${agentUserId}/a2a`,
+      mcpEndpoint: getMCPEndpoint(),
+      metadata: {
+        platform: 'babylon',
+        userType: 'agent',
+        managerUserId: ownerUserId,
+        network: 'solana',
+      },
+      skills: [
+        'trade',
+        'analyze',
+        'chat',
+        'post',
+        'comment',
+        'prediction-markets',
+        'social-interaction',
+      ],
+      domains: ['prediction-markets', 'trading', 'social'],
+    });
+
+    prepared = await prepareAgentSolanaRegistrationTransaction({
+      agentUserId,
+      ownerWalletAddress: wallet.walletAddress,
+      registrationFile,
+    });
+
+    const existingOnchain = await getAgentSolanaRegistration(prepared.assetId);
+    if (existingOnchain) {
+      await persistSolanaRegistrationState({
+        agentUserId,
+        walletAddress: wallet.walletAddress,
+        walletId: wallet.privyWalletId,
+        assetId: prepared.assetId,
+        metadataUri: prepared.metadataUri,
+      });
+
+      return {
+        message: 'Agent already registered on Solana',
+        alreadyRegistered: true,
+        agentUserId,
+        assetId: prepared.assetId,
+        metadataUri: prepared.metadataUri,
+        walletAddress: wallet.walletAddress,
+        cost: 0,
+      };
+    }
+
+    const tx = await sendSponsoredSolanaTransaction({
+      walletId: wallet.privyWalletId,
+      transaction: prepared.transaction,
+      idempotencyKey: `agent-solana-registration:${agentUserId}`,
+    });
+
+    await persistSolanaRegistrationState({
+      agentUserId,
+      walletAddress: wallet.walletAddress,
+      walletId: wallet.privyWalletId,
+      assetId: prepared.assetId,
+      metadataUri: prepared.metadataUri,
+      txHash: tx.hash,
+    });
+
+    logger.info(
+      'Agent registered on the Solana Agent Registry',
+      {
+        ownerUserId,
+        agentUserId,
+        assetId: prepared.assetId,
+        txHash: tx.hash,
+        cost,
+      },
+      'AgentSolanaRegistration'
+    );
+
+    return {
+      message: 'Successfully registered agent on Solana',
+      alreadyRegistered: false,
+      agentUserId,
+      assetId: prepared.assetId,
+      metadataUri: prepared.metadataUri,
+      txHash: tx.hash,
+      walletAddress: wallet.walletAddress,
+      cost,
+    };
+  } catch (error) {
+    if (prepared?.assetId) {
+      try {
+        const existingOnchain = await getAgentSolanaRegistration(
+          prepared.assetId
+        );
+        if (existingOnchain) {
+          const wallet = await ensureSolanaWalletReady({
+            privyId: agent.privyId,
+          });
+          await persistSolanaRegistrationState({
+            agentUserId,
+            walletAddress: wallet.walletAddress,
+            walletId: wallet.privyWalletId,
+            assetId: prepared.assetId,
+            metadataUri: prepared.metadataUri,
+          });
+
+          return {
+            message: 'Successfully registered agent on Solana',
+            alreadyRegistered: false,
+            agentUserId,
+            assetId: prepared.assetId,
+            metadataUri: prepared.metadataUri,
+            walletAddress: wallet.walletAddress,
+            cost,
+          };
+        }
+      } catch {
+        // Surface the original registration error below.
+      }
+    }
+
+    if (costCharged) {
+      await refundRegistrationCost(ownerUserId, agentUserId, cost);
+    }
+
+    throw error;
+  }
+}

--- a/packages/api/src/services/agent-solana-registration-service.ts
+++ b/packages/api/src/services/agent-solana-registration-service.ts
@@ -282,13 +282,26 @@ export async function registerAgentOnSolanaForOwner({
     };
   }
 
+  if (!agent.privyId) {
+    throw new BusinessLogicError(
+      'Agent wallet identity is not ready yet. Try again after the agent wallet has been provisioned.',
+      'AGENT_IDENTITY_NOT_READY'
+    );
+  }
+
   try {
     const existingOnchain =
       await getAgentSolanaRegistration(deterministicAssetId);
     if (existingOnchain) {
+      const wallet = await ensureSolanaWalletReady({ privyId: agent.privyId });
+      await persistSolanaWalletState(agentUserId, wallet);
       await db
         .update(users)
         .set({
+          privySolanaWalletId: wallet.privyWalletId,
+          solanaWalletAddress: wallet.walletAddress,
+          solanaOfflineWalletReady: true,
+          solanaOfflineWalletReadyAt: new Date(),
           solanaRegistered: true,
           solanaRegistryAssetId: deterministicAssetId,
           solanaRegisteredAt: new Date(),
@@ -303,19 +316,12 @@ export async function registerAgentOnSolanaForOwner({
         assetId: deterministicAssetId,
         metadataUri: agent.solanaMetadataUri ?? '',
         txHash: agent.solanaRegistrationTxHash ?? undefined,
-        walletAddress: agent.solanaWalletAddress ?? '',
+        walletAddress: wallet.walletAddress,
         cost: 0,
       };
     }
   } catch {
     // If the on-chain lookup fails, continue with the normal registration path.
-  }
-
-  if (!agent.privyId) {
-    throw new BusinessLogicError(
-      'Agent wallet identity is not ready yet. Try again after the agent wallet has been provisioned.',
-      'AGENT_IDENTITY_NOT_READY'
-    );
   }
 
   const cost = POINTS.ONCHAIN_REGISTRATION;

--- a/packages/api/src/services/agent-solana-registration-service.ts
+++ b/packages/api/src/services/agent-solana-registration-service.ts
@@ -13,6 +13,7 @@ import {
   logger,
   POINTS,
 } from '@babylon/shared';
+import { DistributedLockService } from './distributed-lock-service';
 import { sendSponsoredSolanaTransaction } from './privy/solana-send-transaction';
 import { ensureSolanaWalletReady } from './privy/solana-wallet-provisioning';
 
@@ -196,34 +197,68 @@ async function persistSolanaWalletState(
 
 async function persistSolanaRegistrationState({
   agentUserId,
-  walletAddress,
-  walletId,
   assetId,
   metadataUri,
+  wallet,
   txHash,
 }: {
   agentUserId: string;
-  walletAddress: string;
-  walletId: string;
   assetId: string;
-  metadataUri: string;
+  metadataUri: string | null;
+  wallet?: {
+    walletAddress: string;
+    walletId: string;
+  } | null;
   txHash?: string | null;
 }): Promise<void> {
   await db
     .update(users)
     .set({
-      privySolanaWalletId: walletId,
-      solanaWalletAddress: walletAddress,
-      solanaOfflineWalletReady: true,
-      solanaOfflineWalletReadyAt: new Date(),
+      ...(wallet
+        ? {
+            privySolanaWalletId: wallet.walletId,
+            solanaWalletAddress: wallet.walletAddress,
+            solanaOfflineWalletReady: true,
+            solanaOfflineWalletReadyAt: new Date(),
+          }
+        : {}),
       solanaRegistered: true,
       solanaRegistryAssetId: assetId,
-      solanaMetadataUri: metadataUri,
+      solanaMetadataUri: metadataUri ?? null,
       solanaRegistrationTxHash: txHash ?? null,
       solanaRegisteredAt: new Date(),
       updatedAt: new Date(),
     })
     .where(eq(users.id, agentUserId));
+}
+
+async function withAgentSolanaRegistrationLock<T>(
+  agentUserId: string,
+  fn: () => Promise<T>
+): Promise<T> {
+  const lockId = `agent-solana-registration:${agentUserId}`;
+  const processId = `agent-solana-registration-${Date.now()}-${Math.random()
+    .toString(36)
+    .slice(2, 10)}`;
+  const acquired = await DistributedLockService.acquireLock({
+    lockId,
+    durationMs: 60_000,
+    operation: 'agent-solana-registration',
+    processId,
+  });
+
+  if (!acquired) {
+    throw new BusinessLogicError(
+      'A Solana registration attempt is already in progress for this agent. Please retry in a moment.',
+      'AGENT_SOLANA_REGISTRATION_IN_PROGRESS'
+    );
+  }
+
+  try {
+    return await fn();
+  } finally {
+    await DistributedLockService.releaseLock(lockId, processId);
+  }
 }
 
 export async function getAgentSolanaRegistrationStatus({
@@ -257,208 +292,279 @@ export async function registerAgentOnSolanaForOwner({
   ownerUserId: string;
   agentUserId: string;
 }): Promise<AgentSolanaRegistrationResult> {
-  let costCharged = false;
-  let prepared: {
-    assetId: string;
-    metadataUri: string;
-    metadataCid: string;
-    transaction: string;
-  } | null = null;
-
   const agent = await getAgentForOwner(ownerUserId, agentUserId);
-  const deterministicAssetId =
-    deriveDeterministicAgentSolanaAsset(agentUserId).publicKey.toBase58();
+  return withAgentSolanaRegistrationLock(agentUserId, async () => {
+    let costCharged = false;
+    let wallet: {
+      privyWalletId: string;
+      walletAddress: string;
+    } | null = null;
+    let prepared: {
+      assetId: string;
+      metadataUri: string;
+      metadataCid: string;
+      transaction: string;
+    } | null = null;
 
-  if (agent.solanaRegistered && agent.solanaRegistryAssetId) {
-    return {
-      message: 'Agent already registered on Solana',
-      alreadyRegistered: true,
-      agentUserId,
-      assetId: agent.solanaRegistryAssetId,
-      metadataUri: agent.solanaMetadataUri ?? '',
-      txHash: agent.solanaRegistrationTxHash ?? undefined,
-      walletAddress: agent.solanaWalletAddress ?? '',
-      cost: 0,
-    };
-  }
+    const deterministicAssetId =
+      deriveDeterministicAgentSolanaAsset(agentUserId).publicKey.toBase58();
 
-  if (!agent.privyId) {
-    throw new BusinessLogicError(
-      'Agent wallet identity is not ready yet. Try again after the agent wallet has been provisioned.',
-      'AGENT_IDENTITY_NOT_READY'
-    );
-  }
-
-  try {
-    const existingOnchain =
-      await getAgentSolanaRegistration(deterministicAssetId);
-    if (existingOnchain) {
-      const wallet = await ensureSolanaWalletReady({ privyId: agent.privyId });
-      await persistSolanaWalletState(agentUserId, wallet);
-      await db
-        .update(users)
-        .set({
-          privySolanaWalletId: wallet.privyWalletId,
-          solanaWalletAddress: wallet.walletAddress,
-          solanaOfflineWalletReady: true,
-          solanaOfflineWalletReadyAt: new Date(),
-          solanaRegistered: true,
-          solanaRegistryAssetId: deterministicAssetId,
-          solanaRegisteredAt: new Date(),
-          updatedAt: new Date(),
-        })
-        .where(eq(users.id, agentUserId));
-
+    if (agent.solanaRegistered && agent.solanaRegistryAssetId) {
       return {
         message: 'Agent already registered on Solana',
         alreadyRegistered: true,
         agentUserId,
-        assetId: deterministicAssetId,
+        assetId: agent.solanaRegistryAssetId,
         metadataUri: agent.solanaMetadataUri ?? '',
         txHash: agent.solanaRegistrationTxHash ?? undefined,
-        walletAddress: wallet.walletAddress,
-        cost: 0,
-      };
-    }
-  } catch {
-    // If the on-chain lookup fails, continue with the normal registration path.
-  }
-
-  const cost = POINTS.ONCHAIN_REGISTRATION;
-  await deductRegistrationCost(ownerUserId, agentUserId, cost);
-  costCharged = true;
-
-  try {
-    const wallet = await ensureSolanaWalletReady({ privyId: agent.privyId });
-    await persistSolanaWalletState(agentUserId, wallet);
-
-    const registrationFile = buildAgentSolanaRegistrationFile({
-      name: agent.displayName || agent.username || agentUserId,
-      description:
-        agent.bio || `Autonomous AI agent: ${agent.username || agentUserId}`,
-      image: agent.profileImageUrl,
-      walletAddress: wallet.walletAddress,
-      a2aEndpoint: `${getBaseUrl()}/api/agents/${agentUserId}/a2a`,
-      mcpEndpoint: getMCPEndpoint(),
-      metadata: {
-        platform: 'babylon',
-        userType: 'agent',
-        managerUserId: ownerUserId,
-        network: 'solana',
-      },
-      skills: [
-        'trade',
-        'analyze',
-        'chat',
-        'post',
-        'comment',
-        'prediction-markets',
-        'social-interaction',
-      ],
-      domains: ['prediction-markets', 'trading', 'social'],
-    });
-
-    prepared = await prepareAgentSolanaRegistrationTransaction({
-      agentUserId,
-      ownerWalletAddress: wallet.walletAddress,
-      registrationFile,
-    });
-
-    const existingOnchain = await getAgentSolanaRegistration(prepared.assetId);
-    if (existingOnchain) {
-      await persistSolanaRegistrationState({
-        agentUserId,
-        walletAddress: wallet.walletAddress,
-        walletId: wallet.privyWalletId,
-        assetId: prepared.assetId,
-        metadataUri: prepared.metadataUri,
-      });
-
-      return {
-        message: 'Agent already registered on Solana',
-        alreadyRegistered: true,
-        agentUserId,
-        assetId: prepared.assetId,
-        metadataUri: prepared.metadataUri,
-        walletAddress: wallet.walletAddress,
+        walletAddress: agent.solanaWalletAddress ?? '',
         cost: 0,
       };
     }
 
-    const tx = await sendSponsoredSolanaTransaction({
-      walletId: wallet.privyWalletId,
-      transaction: prepared.transaction,
-      idempotencyKey: `agent-solana-registration:${agentUserId}`,
-    });
+    if (!agent.privyId) {
+      throw new BusinessLogicError(
+        'Agent wallet identity is not ready yet. Try again after the agent wallet has been provisioned.',
+        'AGENT_IDENTITY_NOT_READY'
+      );
+    }
 
-    await persistSolanaRegistrationState({
-      agentUserId,
-      walletAddress: wallet.walletAddress,
-      walletId: wallet.privyWalletId,
-      assetId: prepared.assetId,
-      metadataUri: prepared.metadataUri,
-      txHash: tx.hash,
-    });
-
-    logger.info(
-      'Agent registered on the Solana Agent Registry',
-      {
-        ownerUserId,
-        agentUserId,
-        assetId: prepared.assetId,
-        txHash: tx.hash,
-        cost,
-      },
-      'AgentSolanaRegistration'
-    );
-
-    return {
-      message: 'Successfully registered agent on Solana',
-      alreadyRegistered: false,
-      agentUserId,
-      assetId: prepared.assetId,
-      metadataUri: prepared.metadataUri,
-      txHash: tx.hash,
-      walletAddress: wallet.walletAddress,
-      cost,
-    };
-  } catch (error) {
-    if (prepared?.assetId) {
-      try {
-        const existingOnchain = await getAgentSolanaRegistration(
-          prepared.assetId
-        );
-        if (existingOnchain) {
-          const wallet = await ensureSolanaWalletReady({
-            privyId: agent.privyId,
-          });
-          await persistSolanaRegistrationState({
-            agentUserId,
+    try {
+      const existingOnchain =
+        await getAgentSolanaRegistration(deterministicAssetId);
+      if (existingOnchain) {
+        wallet = await ensureSolanaWalletReady({ privyId: agent.privyId });
+        await persistSolanaRegistrationState({
+          agentUserId,
+          assetId: deterministicAssetId,
+          metadataUri: agent.solanaMetadataUri,
+          wallet: {
             walletAddress: wallet.walletAddress,
             walletId: wallet.privyWalletId,
-            assetId: prepared.assetId,
-            metadataUri: prepared.metadataUri,
-          });
+          },
+          txHash: agent.solanaRegistrationTxHash,
+        });
 
-          return {
-            message: 'Successfully registered agent on Solana',
-            alreadyRegistered: false,
-            agentUserId,
-            assetId: prepared.assetId,
-            metadataUri: prepared.metadataUri,
-            walletAddress: wallet.walletAddress,
-            cost,
-          };
-        }
-      } catch {
-        // Surface the original registration error below.
+        return {
+          message: 'Agent already registered on Solana',
+          alreadyRegistered: true,
+          agentUserId,
+          assetId: deterministicAssetId,
+          metadataUri: agent.solanaMetadataUri ?? '',
+          txHash: agent.solanaRegistrationTxHash ?? undefined,
+          walletAddress: wallet.walletAddress,
+          cost: 0,
+        };
       }
+    } catch (error) {
+      logger.debug(
+        'On-chain Solana registration lookup failed before registration attempt',
+        {
+          ownerUserId,
+          agentUserId,
+          assetId: deterministicAssetId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        'AgentSolanaRegistration'
+      );
     }
 
-    if (costCharged) {
-      await refundRegistrationCost(ownerUserId, agentUserId, cost);
-    }
+    const cost = POINTS.ONCHAIN_REGISTRATION;
+    await deductRegistrationCost(ownerUserId, agentUserId, cost);
+    costCharged = true;
 
-    throw error;
-  }
+    try {
+      wallet = await ensureSolanaWalletReady({ privyId: agent.privyId });
+      await persistSolanaWalletState(agentUserId, wallet);
+
+      const registrationFile = buildAgentSolanaRegistrationFile({
+        name: agent.displayName || agent.username || agentUserId,
+        description:
+          agent.bio || `Autonomous AI agent: ${agent.username || agentUserId}`,
+        image: agent.profileImageUrl,
+        walletAddress: wallet.walletAddress,
+        a2aEndpoint: `${getBaseUrl()}/api/agents/${agentUserId}/a2a`,
+        mcpEndpoint: getMCPEndpoint(),
+        metadata: {
+          platform: 'babylon',
+          userType: 'agent',
+          managerUserId: ownerUserId,
+          network: 'solana',
+        },
+        skills: [
+          'trade',
+          'analyze',
+          'chat',
+          'post',
+          'comment',
+          'prediction-markets',
+          'social-interaction',
+        ],
+        domains: ['prediction-markets', 'trading', 'social'],
+      });
+
+      prepared = await prepareAgentSolanaRegistrationTransaction({
+        agentUserId,
+        ownerWalletAddress: wallet.walletAddress,
+        registrationFile,
+      });
+
+      const existingOnchain = await getAgentSolanaRegistration(
+        prepared.assetId
+      );
+      if (existingOnchain) {
+        await persistSolanaRegistrationState({
+          agentUserId,
+          assetId: prepared.assetId,
+          metadataUri: prepared.metadataUri,
+          wallet: {
+            walletAddress: wallet.walletAddress,
+            walletId: wallet.privyWalletId,
+          },
+        });
+
+        return {
+          message: 'Agent already registered on Solana',
+          alreadyRegistered: true,
+          agentUserId,
+          assetId: prepared.assetId,
+          metadataUri: prepared.metadataUri,
+          walletAddress: wallet.walletAddress,
+          cost: 0,
+        };
+      }
+
+      const tx = await sendSponsoredSolanaTransaction({
+        walletId: wallet.privyWalletId,
+        transaction: prepared.transaction,
+        idempotencyKey: `agent-solana-registration:${agentUserId}`,
+      });
+
+      await persistSolanaRegistrationState({
+        agentUserId,
+        assetId: prepared.assetId,
+        metadataUri: prepared.metadataUri,
+        wallet: {
+          walletAddress: wallet.walletAddress,
+          walletId: wallet.privyWalletId,
+        },
+        txHash: tx.hash,
+      });
+
+      logger.info(
+        'Agent registered on the Solana Agent Registry',
+        {
+          ownerUserId,
+          agentUserId,
+          assetId: prepared.assetId,
+          txHash: tx.hash,
+          cost,
+        },
+        'AgentSolanaRegistration'
+      );
+
+      return {
+        message: 'Successfully registered agent on Solana',
+        alreadyRegistered: false,
+        agentUserId,
+        assetId: prepared.assetId,
+        metadataUri: prepared.metadataUri,
+        txHash: tx.hash,
+        walletAddress: wallet.walletAddress,
+        cost,
+      };
+    } catch (error) {
+      if (prepared?.assetId) {
+        try {
+          const existingOnchain = await getAgentSolanaRegistration(
+            prepared.assetId
+          );
+          if (existingOnchain) {
+            const reconciledWallet =
+              wallet ??
+              (await ensureSolanaWalletReady({
+                privyId: agent.privyId,
+              }).catch((walletError) => {
+                logger.warn(
+                  'Solana registration succeeded on-chain but wallet reconciliation failed',
+                  {
+                    ownerUserId,
+                    agentUserId,
+                    assetId: prepared?.assetId,
+                    error:
+                      walletError instanceof Error
+                        ? walletError.message
+                        : String(walletError),
+                  },
+                  'AgentSolanaRegistration'
+                );
+                return null;
+              }));
+
+            try {
+              await persistSolanaRegistrationState({
+                agentUserId,
+                assetId: prepared.assetId,
+                metadataUri: prepared.metadataUri,
+                wallet: reconciledWallet
+                  ? {
+                      walletAddress: reconciledWallet.walletAddress,
+                      walletId: reconciledWallet.privyWalletId,
+                    }
+                  : null,
+              });
+            } catch (persistError) {
+              logger.error(
+                'Solana registration was confirmed on-chain but local persistence failed during reconciliation',
+                {
+                  ownerUserId,
+                  agentUserId,
+                  assetId: prepared.assetId,
+                  error:
+                    persistError instanceof Error
+                      ? persistError.message
+                      : String(persistError),
+                },
+                'AgentSolanaRegistration'
+              );
+            }
+
+            return {
+              message: 'Successfully registered agent on Solana',
+              alreadyRegistered: false,
+              agentUserId,
+              assetId: prepared.assetId,
+              metadataUri: prepared.metadataUri,
+              walletAddress:
+                reconciledWallet?.walletAddress ??
+                wallet?.walletAddress ??
+                agent.solanaWalletAddress ??
+                '',
+              cost,
+            };
+          }
+        } catch (reconciliationError) {
+          logger.debug(
+            'Post-failure Solana registration reconciliation lookup failed',
+            {
+              ownerUserId,
+              agentUserId,
+              assetId: prepared.assetId,
+              error:
+                reconciliationError instanceof Error
+                  ? reconciliationError.message
+                  : String(reconciliationError),
+            },
+            'AgentSolanaRegistration'
+          );
+        }
+      }
+
+      if (costCharged) {
+        await refundRegistrationCost(ownerUserId, agentUserId, cost);
+      }
+
+      throw error;
+    }
+  });
 }

--- a/packages/api/src/services/index.ts
+++ b/packages/api/src/services/index.ts
@@ -8,6 +8,7 @@
  */
 
 // Claude LLM Service
+export * from './agent-solana-registration-service';
 export * from './claude-service';
 export * from './cron-relay-service';
 // Daily Login Service (BAB-88)

--- a/packages/api/src/services/privy/solana-send-transaction.ts
+++ b/packages/api/src/services/privy/solana-send-transaction.ts
@@ -1,0 +1,68 @@
+import { logger } from '@babylon/shared';
+import { extractPrivyApiDiagnostics } from './error-diagnostics';
+import { getPrivyOfflineConfig } from './offline-config';
+import { getPrivyNodeClient } from './privy-node';
+
+function resolveSolanaCaip2(): string {
+  const cluster = process.env.SOLANA_REGISTRY_CLUSTER ?? 'mainnet-beta';
+
+  switch (cluster) {
+    case 'devnet':
+      return 'solana:devnet';
+    case 'testnet':
+      return 'solana:testnet';
+    case 'localnet':
+      return 'solana:localnet';
+    case 'mainnet-beta':
+    default:
+      return 'solana:mainnet';
+  }
+}
+
+export async function sendSponsoredSolanaTransaction({
+  walletId,
+  transaction,
+  idempotencyKey,
+}: {
+  walletId: string;
+  transaction: string;
+  idempotencyKey?: string;
+}): Promise<{ hash: string; transactionId?: string; caip2: string }> {
+  const privy = getPrivyNodeClient();
+  const offlineConfig = getPrivyOfflineConfig();
+  const caip2 = resolveSolanaCaip2();
+
+  try {
+    const response = await privy
+      .wallets()
+      .solana()
+      .signAndSendTransaction(walletId, {
+        caip2,
+        transaction,
+        sponsor: true,
+        authorization_context: {
+          authorization_private_keys: [offlineConfig.authorizationPrivateKey],
+        },
+        ...(idempotencyKey ? { idempotency_key: idempotencyKey } : {}),
+      });
+
+    return {
+      hash: response.hash,
+      transactionId: response.transaction_id,
+      caip2: response.caip2,
+    };
+  } catch (error) {
+    logger.error(
+      'Failed to submit sponsored Solana transaction via Privy',
+      {
+        walletId,
+        ...extractPrivyApiDiagnostics(error),
+      },
+      'sendSponsoredSolanaTransaction'
+    );
+
+    throw error instanceof Error
+      ? error
+      : new Error('Failed to submit sponsored Solana transaction');
+  }
+}

--- a/packages/api/src/services/privy/solana-wallet-provisioning.ts
+++ b/packages/api/src/services/privy/solana-wallet-provisioning.ts
@@ -86,6 +86,7 @@ async function resolveCandidateWalletsAfterCreateWithRetry(
 
   const { maxAttempts, delayMs } = getRetryConfig();
 
+  // Privy can lag briefly before the newly created wallet shows up on getUser.
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     const refreshedPrivyUser = (await privyServer.getUser(
       privyId

--- a/packages/api/src/services/privy/solana-wallet-provisioning.ts
+++ b/packages/api/src/services/privy/solana-wallet-provisioning.ts
@@ -1,0 +1,237 @@
+import { logger } from '@babylon/shared';
+import type { User as PrivyUser } from '@privy-io/server-auth';
+import { getPrivyClient } from '../../auth-middleware';
+import { getPrivyOfflineConfig } from './offline-config';
+import { getPrivyNodeClient } from './privy-node';
+import {
+  listEmbeddedSolanaWallets,
+  type PrivyUserWalletsLite,
+} from './user-wallets';
+
+type PrivyUserWithWallets = PrivyUser & PrivyUserWalletsLite;
+type WalletSigner = {
+  signer_id: string;
+  override_policy_ids?: string[];
+};
+type WalletWithSigners = {
+  additional_signers: WalletSigner[];
+};
+
+export type EnsureSolanaWalletReadyInput = {
+  privyId: string;
+};
+
+export type EnsureSolanaWalletReadyResult = {
+  privyWalletId: string;
+  walletAddress: string;
+  offlineWalletReady: true;
+  createdWallet: boolean;
+};
+
+function hasOfflineSignerPolicy(
+  wallet: WalletWithSigners,
+  signerId: string,
+  policyId: string
+): boolean {
+  const signer = wallet.additional_signers.find(
+    (candidate) => candidate.signer_id === signerId
+  );
+  if (!signer) return false;
+
+  return (signer.override_policy_ids ?? []).includes(policyId);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function getRetryConfig(): { maxAttempts: number; delayMs: number } {
+  const isTest = process.env.NODE_ENV === 'test';
+  return {
+    maxAttempts: isTest ? 1 : 8,
+    delayMs: isTest ? 0 : 250,
+  };
+}
+
+function findNewWalletCandidates(
+  wallets: Array<{ walletId: string; address: string }>,
+  initialWalletIds: Set<string>
+): Array<{ walletId: string; address: string }> {
+  return wallets.filter((wallet) => !initialWalletIds.has(wallet.walletId));
+}
+
+async function resolveCandidateWalletsAfterCreateWithRetry(
+  privyId: string,
+  initialWalletIds: Set<string>,
+  privyServer: ReturnType<typeof getPrivyClient>,
+  immediateWallets: Array<{ walletId: string; address: string }>
+): Promise<Array<{ walletId: string; address: string }>> {
+  const immediateCandidates = findNewWalletCandidates(
+    immediateWallets,
+    initialWalletIds
+  );
+  if (immediateCandidates.length > 0) {
+    logger.info(
+      'Detected new embedded Solana wallet(s) immediately after createWallets',
+      {
+        privyId,
+        candidateWalletIds: immediateCandidates.map(
+          (wallet) => wallet.walletId
+        ),
+      },
+      'ensureSolanaWalletReady'
+    );
+    return immediateCandidates;
+  }
+
+  const { maxAttempts, delayMs } = getRetryConfig();
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const refreshedPrivyUser = (await privyServer.getUser(
+      privyId
+    )) as PrivyUserWithWallets;
+    const refreshedWallets = listEmbeddedSolanaWallets(refreshedPrivyUser);
+    const newWalletCandidates = findNewWalletCandidates(
+      refreshedWallets,
+      initialWalletIds
+    );
+
+    if (newWalletCandidates.length > 0) {
+      logger.info(
+        'Detected new embedded Solana wallet(s) after retry',
+        {
+          privyId,
+          attempt: attempt + 1,
+          candidateWalletIds: newWalletCandidates.map(
+            (wallet) => wallet.walletId
+          ),
+        },
+        'ensureSolanaWalletReady'
+      );
+      return newWalletCandidates;
+    }
+
+    if (attempt < maxAttempts - 1 && delayMs > 0) {
+      await sleep(delayMs);
+    }
+  }
+
+  return [];
+}
+
+async function findReadyWalletWithRetry(
+  privyId: string,
+  walletIds: string[],
+  signerId: string,
+  policyId: string
+): Promise<string | null> {
+  if (walletIds.length === 0) return null;
+
+  const { maxAttempts, delayMs } = getRetryConfig();
+  const privyNode = getPrivyNodeClient();
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    for (const walletId of walletIds) {
+      const wallet = await privyNode.wallets().get(walletId);
+      if (hasOfflineSignerPolicy(wallet, signerId, policyId)) {
+        return walletId;
+      }
+    }
+
+    if (attempt < maxAttempts - 1 && delayMs > 0) {
+      await sleep(delayMs);
+    }
+  }
+
+  logger.warn(
+    'Offline signer policy missing after retries on Solana candidate wallet(s)',
+    {
+      privyId,
+      walletIds,
+      signerId,
+      policyId,
+    },
+    'ensureSolanaWalletReady'
+  );
+
+  return null;
+}
+
+export async function ensureSolanaWalletReady({
+  privyId,
+}: EnsureSolanaWalletReadyInput): Promise<EnsureSolanaWalletReadyResult> {
+  const privyNode = getPrivyNodeClient();
+  const privyServer = getPrivyClient();
+  const offlineConfig = getPrivyOfflineConfig();
+
+  const initialPrivyUser = (await privyServer.getUser(
+    privyId
+  )) as PrivyUserWithWallets;
+  const initialWallets = listEmbeddedSolanaWallets(initialPrivyUser);
+
+  for (const candidate of initialWallets) {
+    const wallet = await privyNode.wallets().get(candidate.walletId);
+    if (
+      hasOfflineSignerPolicy(
+        wallet,
+        offlineConfig.offlineSignerId,
+        offlineConfig.offlinePolicyId
+      )
+    ) {
+      return {
+        privyWalletId: candidate.walletId,
+        walletAddress: candidate.address,
+        offlineWalletReady: true,
+        createdWallet: false,
+      };
+    }
+  }
+
+  const createdUser = (await privyServer.createWallets({
+    userId: privyId,
+    wallets: [
+      {
+        chainType: 'solana',
+        additionalSigners: [
+          {
+            signerId: offlineConfig.offlineSignerId,
+            policyIds: [offlineConfig.offlinePolicyId],
+          },
+        ],
+        policyIds: [],
+      },
+    ],
+  })) as PrivyUserWithWallets;
+
+  const createdWallets = listEmbeddedSolanaWallets(createdUser);
+  const candidateWallets = await resolveCandidateWalletsAfterCreateWithRetry(
+    privyId,
+    new Set(initialWallets.map((wallet) => wallet.walletId)),
+    privyServer,
+    createdWallets
+  );
+
+  const readyWalletId = await findReadyWalletWithRetry(
+    privyId,
+    candidateWallets.map((wallet) => wallet.walletId),
+    offlineConfig.offlineSignerId,
+    offlineConfig.offlinePolicyId
+  );
+
+  const readyWallet = candidateWallets.find(
+    (wallet) => wallet.walletId === readyWalletId
+  );
+
+  if (!readyWallet) {
+    throw new Error(
+      'Unable to provision a Solana embedded wallet for sponsored agent registration.'
+    );
+  }
+
+  return {
+    privyWalletId: readyWallet.walletId,
+    walletAddress: readyWallet.address,
+    offlineWalletReady: true,
+    createdWallet: true,
+  };
+}

--- a/packages/api/src/services/privy/user-wallets.test.ts
+++ b/packages/api/src/services/privy/user-wallets.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  listEmbeddedEvmWallets,
+  listEmbeddedSolanaWallets,
+  pickEmbeddedEvmWallet,
+  pickEmbeddedSolanaWallet,
+} from './user-wallets';
+
+describe('user-wallets', () => {
+  const user = {
+    wallet: {
+      id: 'evm-primary',
+      address: '0xAbCDEFabcdefABCDEFabcdefABCDEFabcdefABCD',
+      chainType: 'ethereum',
+      walletClientType: 'privy',
+      type: 'wallet',
+    },
+    linkedAccounts: [
+      {
+        id: 'solana-embedded',
+        address: '6M5J8g5qKJm1W9WTh5tY8WZ7m8vHx9yL8wPwLxS3n3pA',
+        chainType: 'solana',
+        walletClientType: 'privy',
+        type: 'wallet',
+      },
+      {
+        id: 'solana-external',
+        address: '4f3vKkr8U1c9Yx2J4zQ3o7v9Jv7n3QqB8xS1K8jL5pDe',
+        chainType: 'solana',
+        walletClientType: 'phantom',
+        type: 'wallet',
+      },
+    ],
+  };
+
+  it('keeps EVM embedded wallet selection unchanged', () => {
+    expect(listEmbeddedEvmWallets(user)).toEqual([
+      {
+        walletId: 'evm-primary',
+        address: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+      },
+    ]);
+    expect(pickEmbeddedEvmWallet(user)?.walletId).toBe('evm-primary');
+  });
+
+  it('returns only embedded Solana wallets', () => {
+    expect(listEmbeddedSolanaWallets(user)).toEqual([
+      {
+        walletId: 'solana-embedded',
+        address: '6M5J8g5qKJm1W9WTh5tY8WZ7m8vHx9yL8wPwLxS3n3pA',
+      },
+    ]);
+    expect(pickEmbeddedSolanaWallet(user)?.walletId).toBe('solana-embedded');
+  });
+});

--- a/packages/api/src/services/privy/user-wallets.ts
+++ b/packages/api/src/services/privy/user-wallets.ts
@@ -16,10 +16,15 @@ export type PrivyUserWalletsLite = {
   linked_accounts?: PrivyWalletLite[] | null;
 };
 
-function isEthereumWallet(wallet: PrivyWalletLite): boolean {
-  const chain = wallet.chainType ?? wallet.chain_type ?? null;
-  if (chain && chain !== 'ethereum') return false;
-  return true;
+type SupportedEmbeddedChain = 'ethereum' | 'solana';
+
+function matchesEmbeddedChain(
+  wallet: PrivyWalletLite,
+  chain: SupportedEmbeddedChain
+): boolean {
+  const walletChain = wallet.chainType ?? wallet.chain_type ?? null;
+  if (!walletChain) return chain === 'ethereum';
+  return walletChain === chain;
 }
 
 function isPrivyEmbeddedClientMarker(value: string | null): boolean {
@@ -47,9 +52,17 @@ export function pickEmbeddedEvmWallet(
   return wallets.length > 0 ? wallets[0]! : null;
 }
 
-export function listEmbeddedEvmWallets(
+export function pickEmbeddedSolanaWallet(
   user: PrivyUserWalletsLite
-): Array<{ walletId: string; address: Address }> {
+): { walletId: string; address: string } | null {
+  const wallets = listEmbeddedSolanaWallets(user);
+  return wallets.length > 0 ? wallets[0]! : null;
+}
+
+function listEmbeddedWallets(
+  user: PrivyUserWalletsLite,
+  chain: SupportedEmbeddedChain
+): Array<{ walletId: string; address: string }> {
   const candidates: Array<{
     wallet: PrivyWalletLite;
     source: 'primary' | 'linked';
@@ -64,13 +77,13 @@ export function listEmbeddedEvmWallets(
       candidates.push({ wallet: acc, source: 'linked' });
   }
 
-  const wallets: Array<{ walletId: string; address: Address }> = [];
+  const wallets: Array<{ walletId: string; address: string }> = [];
   const seen = new Set<string>();
 
   for (const { wallet, source } of candidates) {
     if (!wallet?.id || typeof wallet.id !== 'string') continue;
     if (!wallet.address || typeof wallet.address !== 'string') continue;
-    if (!isEthereumWallet(wallet)) continue;
+    if (!matchesEmbeddedChain(wallet, chain)) continue;
     if (source === 'linked') {
       // For linked accounts, only accept explicit 'privy' client markers.
       if (
@@ -85,9 +98,25 @@ export function listEmbeddedEvmWallets(
     seen.add(wallet.id);
     wallets.push({
       walletId: wallet.id,
-      address: wallet.address.toLowerCase() as Address,
+      address:
+        chain === 'ethereum' ? wallet.address.toLowerCase() : wallet.address,
     });
   }
 
   return wallets;
+}
+
+export function listEmbeddedEvmWallets(
+  user: PrivyUserWalletsLite
+): Array<{ walletId: string; address: Address }> {
+  return listEmbeddedWallets(user, 'ethereum').map((wallet) => ({
+    walletId: wallet.walletId,
+    address: wallet.address as Address,
+  }));
+}
+
+export function listEmbeddedSolanaWallets(
+  user: PrivyUserWalletsLite
+): Array<{ walletId: string; address: string }> {
+  return listEmbeddedWallets(user, 'solana');
 }

--- a/packages/db/drizzle/migrations/0048_add_agent_solana_registration.sql
+++ b/packages/db/drizzle/migrations/0048_add_agent_solana_registration.sql
@@ -1,0 +1,13 @@
+ALTER TABLE "User"
+ADD COLUMN "privySolanaWalletId" text,
+ADD COLUMN "solanaOfflineWalletReady" boolean DEFAULT false NOT NULL,
+ADD COLUMN "solanaOfflineWalletReadyAt" timestamp,
+ADD COLUMN "solanaWalletAddress" text,
+ADD COLUMN "solanaRegistered" boolean DEFAULT false NOT NULL,
+ADD COLUMN "solanaRegistryAssetId" text,
+ADD COLUMN "solanaMetadataUri" text,
+ADD COLUMN "solanaRegistrationTxHash" text,
+ADD COLUMN "solanaRegisteredAt" timestamp;
+
+ALTER TABLE "User"
+ADD CONSTRAINT "User_solanaWalletAddress_unique" UNIQUE("solanaWalletAddress");

--- a/packages/db/drizzle/migrations/meta/_journal.json
+++ b/packages/db/drizzle/migrations/meta/_journal.json
@@ -351,6 +351,13 @@
       "when": 1773225600000,
       "tag": "0047_add_sentry_incident_alerts",
       "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "7",
+      "when": 1773657600000,
+      "tag": "0048_add_agent_solana_registration",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/users.ts
+++ b/packages/db/src/schema/users.ts
@@ -96,10 +96,19 @@ export const users = pgTable(
     // Privy embedded wallet id (used for server-side wallet actions).
     // This is not the Privy user id (did:privy:...), it's the wallet resource id.
     privyWalletId: text('privyWalletId'),
+    // Privy embedded Solana wallet id for agent-side Solana operations.
+    privySolanaWalletId: text('privySolanaWalletId'),
     // Offline delegated wallet readiness (signer + policy attached in Privy).
     offlineWalletReady: boolean('offlineWalletReady').notNull().default(false),
     offlineWalletReadyAt: timestamp('offlineWalletReadyAt', { mode: 'date' }),
+    solanaOfflineWalletReady: boolean('solanaOfflineWalletReady')
+      .notNull()
+      .default(false),
+    solanaOfflineWalletReadyAt: timestamp('solanaOfflineWalletReadyAt', {
+      mode: 'date',
+    }),
     walletAddress: text('walletAddress').unique(),
+    solanaWalletAddress: text('solanaWalletAddress').unique(),
     username: text('username').unique(),
     displayName: text('displayName'),
     bio: text('bio'),
@@ -197,6 +206,11 @@ export const users = pgTable(
     agent0RegisteredAt: timestamp('agent0RegisteredAt', { mode: 'date' }),
     agent0TokenId: integer('agent0TokenId'),
     agent0TrustScore: doublePrecision('agent0TrustScore'),
+    solanaRegistered: boolean('solanaRegistered').notNull().default(false),
+    solanaRegistryAssetId: text('solanaRegistryAssetId'),
+    solanaMetadataUri: text('solanaMetadataUri'),
+    solanaRegistrationTxHash: text('solanaRegistrationTxHash'),
+    solanaRegisteredAt: timestamp('solanaRegisteredAt', { mode: 'date' }),
     bannedAt: timestamp('bannedAt', { mode: 'date' }),
     bannedBy: text('bannedBy'),
     bannedReason: text('bannedReason'),


### PR DESCRIPTION
## Summary

- Add an owner-managed Solana registration flow for Babylon agents, with sponsored Solana transactions and a points charge paid by the owning user.
- Persist Solana wallet / registration state separately from the existing EVM Agent0 fields so the model stays explicit and reviewable.
- Surface the Solana registration status and action in the agent wallet UI, while keeping the implementation anchored to the new real Privy offline-ready wallet invariants.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [x] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-269/solana-agent-registry-implement-sponsored-registration-core-parity
- Built on top of the real offline-ready agent wallet fix: https://github.com/BabylonSocial/babylon/pull/1251

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [x] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [x] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- Add Solana-specific agent wallet and registration fields on `User` plus a DB migration.
- Add a Solana registry SDK wrapper on top of `8004-solana` for deterministic asset preparation and IPFS-backed metadata publishing.
- Add Privy Solana wallet provisioning and sponsored transaction helpers for app-initiated Solana writes.
- Add an owner-only `GET/POST /api/agents/[agentId]/solana-registration` flow that charges `POINTS.ONCHAIN_REGISTRATION`, refunds on failure, and remains idempotent.
- Add a minimal agent wallet UI section for Solana registration state and the paid registration action.

## Review guide

**Start here**
- `packages/api/src/services/agent-solana-registration-service.ts`
- `apps/web/src/app/api/agents/[agentId]/solana-registration/route.ts`
- `packages/agents/src/solana-registry/sdk.ts`
- `packages/db/src/schema/users.ts`
- `apps/web/src/components/agents/AgentWallet.tsx`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- The flow is agent-only and owner-managed; it does not touch the user-human registration path.
- The owner pays the points cost, but Babylon sponsors the Solana transaction fee.
- The implementation assumes the new canonical wallet invariants from `fix/agent-offline-wallet-ready` and does not add fallback/legacy logic on top.

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. `bunx tsc -b packages/api packages/agents apps/web --pretty false`
2. `bun test packages/api/src/services/privy/user-wallets.test.ts packages/api/src/services/agent-solana-registration-service.test.ts apps/web/src/app/api/agents/[agentId]/solana-registration/route.test.ts`
3. Final integration smoke test remains to be run once the Solana/Privy/IPFS envs are configured on a real environment.

## Ops / Migration / Deployment

- [ ] No deploy impact
- [x] Requires env var updates (listed below + `.env.example` updated)
- [x] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `SOLANA_REGISTRY_ENABLED`, `SOLANA_REGISTRY_CLUSTER`, `SOLANA_REGISTRY_RPC_URL`
- Changed: none
- Removed: none

**DB / data migration**
- Migration(s): `packages/db/drizzle/migrations/0048_add_agent_solana_registration.sql`
- Backfill/seed: none required

**Rollout / rollback plan**
- Rollout: merge after `#1251`, run the DB migration on the target env, add the Solana/Privy/IPFS envs, then run the real smoke test.
- Rollback: disable `SOLANA_REGISTRY_ENABLED`, revert the PR, and leave the additive DB columns unused if needed.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- N/A

## Security / privacy

- [ ] No security impact
- [x] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- Adds `GET/POST /api/agents/[agentId]/solana-registration` for the owner-managed Solana agent flow.

### Database
- Adds Solana-specific agent wallet/registration columns to `User`.
- No existing EVM fields are repurposed.

### Contracts / on-chain
- Adds Solana 8004 agent registration support using `8004-solana`.
- The owner still pays points; Babylon sponsors the network fee.

### Docs
- `.env.example` updated for the Solana registry envs.

</details>

## Screenshots / recordings (UI)

### Option A: Visual demo

| Feature | Before | After |
|---------|--------|-------|
| Agent wallet Solana section | Agent wallet only showed balance transfers and history | Agent wallet shows Solana registration status, cost, and the owner-only registration action |

*Demo script (for recording):*
1. Open an owned agent wallet page.
2. Show the new Solana Registry section with wallet readiness, current registration status, and the points cost.
3. Trigger the registration action and confirm the status updates after success.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
