### PR TITLE
fix(build): isolate solana registry imports from shared lambdas

### DIFF
--- a/apps/web/src/app/api/agents/[agentId]/solana-registration/route.test.ts
+++ b/apps/web/src/app/api/agents/[agentId]/solana-registration/route.test.ts
@@ -6,10 +6,17 @@ const mockGetAgentSolanaRegistrationStatus = mock();
 const mockRegisterAgentOnSolanaForOwner = mock();
 const mockApplyRateLimit = mock();
 
-mock.module('@babylon/api', () => ({
-  applyRateLimit: mockApplyRateLimit,
+mock.module('@babylon/api/auth-middleware', () => ({
   authenticateUser: mockAuthenticateUser,
+}));
+
+mock.module('@babylon/api/services/agent-solana-registration-service', () => ({
   getAgentSolanaRegistrationStatus: mockGetAgentSolanaRegistrationStatus,
+  registerAgentOnSolanaForOwner: mockRegisterAgentOnSolanaForOwner,
+}));
+
+mock.module('@babylon/api/rate-limiting', () => ({
+  applyRateLimit: mockApplyRateLimit,
   RATE_LIMIT_CONFIGS: {
     ONCHAIN_REGISTRATION: 'ONCHAIN_REGISTRATION',
   },
@@ -26,7 +33,9 @@ mock.module('@babylon/api', () => ({
       }
     );
   },
-  registerAgentOnSolanaForOwner: mockRegisterAgentOnSolanaForOwner,
+}));
+
+mock.module('@babylon/api/error-handler', () => ({
   successResponse: (data: unknown) => {
     return new Response(JSON.stringify(data), {
       status: 200,

--- a/apps/web/src/app/api/agents/[agentId]/solana-registration/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/solana-registration/route.ts
@@ -1,13 +1,14 @@
+import { authenticateUser } from '@babylon/api/auth-middleware';
+import { successResponse, withErrorHandling } from '@babylon/api/error-handler';
 import {
   applyRateLimit,
-  authenticateUser,
-  getAgentSolanaRegistrationStatus,
   RATE_LIMIT_CONFIGS,
   rateLimitError,
+} from '@babylon/api/rate-limiting';
+import {
+  getAgentSolanaRegistrationStatus,
   registerAgentOnSolanaForOwner,
-  successResponse,
-  withErrorHandling,
-} from '@babylon/api';
+} from '@babylon/api/services/agent-solana-registration-service';
 import type { NextRequest } from 'next/server';
 
 export const GET = withErrorHandling(async function GET(

--- a/bun.lock
+++ b/bun.lock
@@ -362,11 +362,11 @@
       "version": "0.1.0",
       "dependencies": {
         "@babylon/shared": "workspace:*",
-        "@elizaos/plugin-sql": "^1.6.4",
         "drizzle-orm": "^0.44.7",
         "postgres": "^3.4.7",
       },
       "devDependencies": {
+        "@elizaos/plugin-sql": "^1.6.4",
         "@types/node": "^24.10.0",
         "drizzle-kit": "^0.31.8",
         "tsx": "^4.19.4",

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -63,8 +63,8 @@ export {
   isAutonomousPostingEnabled,
   isAutonomousTradingEnabled,
 } from './shared/agent-config';
-// Solana agent registration
-export * from './solana-registry';
+// Keep Solana registry helpers off the root barrel so non-Solana routes do not
+// pull Solana SDK dependencies into shared serverless bundles.
 // Templates loader
 export * from './templates-loader';
 // Training utilities (RL model fetching, config)

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -259,13 +259,12 @@ export {
 } from './services/privy/evm-send-transaction';
 export { assertPrivyOfflineConfig } from './services/privy/offline-config';
 export { ensureOfflineWalletReady } from './services/privy/offline-wallet-provisioning';
-export { sendSponsoredSolanaTransaction } from './services/privy/solana-send-transaction';
-export { ensureSolanaWalletReady } from './services/privy/solana-wallet-provisioning';
+// Keep Solana-specific Privy helpers off the root barrel to avoid pulling them
+// into every route that imports @babylon/api.
 // Privy (embedded wallet server-side helpers)
 export {
   type PrivyUserWalletsLite,
   pickEmbeddedEvmWallet,
-  pickEmbeddedSolanaWallet,
 } from './services/privy/user-wallets';
 // SSE Event Broadcasting
 export {

--- a/packages/api/src/services/agent-solana-registration-service.ts
+++ b/packages/api/src/services/agent-solana-registration-service.ts
@@ -4,7 +4,7 @@ import {
   deriveDeterministicAgentSolanaAsset,
   getAgentSolanaRegistration,
   prepareAgentSolanaRegistrationTransaction,
-} from '@babylon/agents';
+} from '@babylon/agents/solana-registry';
 import { and, balanceTransactions, db, eq, sql, users } from '@babylon/db';
 import {
   BusinessLogicError,

--- a/packages/api/src/services/index.ts
+++ b/packages/api/src/services/index.ts
@@ -7,8 +7,9 @@
  * Infrastructure and API-related services for user management, notifications, and system operations.
  */
 
+// Keep Solana registration service out of this barrel so lightweight routes
+// importing @babylon/api do not pull Solana SDK dependencies into shared Lambdas.
 // Claude LLM Service
-export * from './agent-solana-registration-service';
 export * from './claude-service';
 export * from './cron-relay-service';
 // Daily Login Service (BAB-88)


### PR DESCRIPTION
## Summary
- isolate the Solana registration flow from the `@babylon/api` and `@babylon/agents` root barrels so lightweight routes do not inherit Solana SDK dependencies
- switch the Solana registration route to targeted imports and keep the Solana service reachable only through direct module paths
- resync `bun.lock` so `@elizaos/plugin-sql` stays under `@babylon/db` devDependencies metadata instead of the runtime dependency bucket

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [x] Performance
- [x] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Vercel production deploy failure: `dpl_662oXqjTNARZCdyTLEYvsxHpQW6h`
- Related production merge: `2323c29f4` (`feat/bab-269-agent-solana-register-r2`)
- This branch is based on `production` intentionally because the broken deploy is on `production` and `staging` is behind it

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web API routes / SSE / A2A (`apps/web`)
- [x] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [ ] Web UI (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`apps/web` route test)
- [ ] Other: …

## Changes
- remove Solana registration service exports from `packages/api/src/services/index.ts`
- remove Solana-specific Privy helper exports from `packages/api/src/index.ts`
- remove Solana registry exports from `packages/agents/src/index.ts`
- update `apps/web/src/app/api/agents/[agentId]/solana-registration/route.ts` to import only the modules it needs
- update the route test to mock the targeted modules instead of the root API barrel
- keep the lockfile aligned with the existing `packages/db/package.json` dependency split

## Review guide
**Start here**
- `apps/web/src/app/api/agents/[agentId]/solana-registration/route.ts`
- `packages/api/src/services/index.ts`
- `packages/api/src/index.ts`
- `packages/agents/src/index.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- The behavioral goal is no product change. This is a bundling isolation fix.
- The key guarantee is that importing `@babylon/api` or `@babylon/agents` root barrels should no longer drag Solana registry code into shared serverless bundles.

## Test plan
**Commands run**
- [x] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. `bun test apps/web/src/app/api/agents/[agentId]/solana-registration/route.test.ts`
2. Confirm the route still returns status / registration responses and rate-limit behavior in tests.
3. Confirm the root barrels no longer export Solana-specific entry points.

**Validation blockers observed locally**
- `bun x turbo typecheck --filter=web --filter=@babylon/api --filter=@babylon/agents` still hits pre-existing `packages/api` typecheck issues outside this diff, including the existing `@babylon/agents` circular-resolution gap and nullable warnings in `agent-solana-registration-service.ts`.
- `bun x turbo build --filter=web` still fails on a pre-existing page-data collection error for `/api/auth/twitter/scopes/initiate` with `Base mainnet contracts are not yet deployed. Use localnet or base-sepolia.`

## Ops / Migration / Deployment
- [ ] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `none`
- Changed: `none`
- Removed: `none`

**DB / data migration**
- Migration(s): `none`
- Backfill/seed: `none`

**Rollout / rollback plan**
- Rollout: deploy this branch to Vercel and confirm the production build no longer trips the 250 MB unzipped serverless limit.
- Rollback: revert this single commit.

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)
### Option B: No visual changes
- Reason: Backend/build-system change, no UI impact.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`production` intentionally for this hotfix)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

## Non-goals / follow-ups
- fix the broader `packages/api` ↔ `packages/agents` typecheck/circular dependency problem
- fix the unrelated `web` build failure on `/api/auth/twitter/scopes/initiate`
