### PR TITLE
fix(db): remove elizaEmbeddingTable re-export that requires pgvector extension

### DIFF
--- a/packages/db/src/schema/eliza.ts
+++ b/packages/db/src/schema/eliza.ts
@@ -17,7 +17,9 @@ export const elizaAgentTable = pluginSchema.agentTable;
 export const elizaRoomTable = pluginSchema.roomTable;
 export const elizaParticipantTable = pluginSchema.participantTable;
 export const elizaMemoryTable = pluginSchema.memoryTable;
-export const elizaEmbeddingTable = pluginSchema.embeddingTable;
+// NOTE: embeddingTable omitted — it uses pgvector `vector` columns which
+// require `CREATE EXTENSION vector` and break `db:push` / `db:generate` on
+// databases without the extension. ElizaOS runtime creates it when needed.
 export const elizaEntityTable = pluginSchema.entityTable;
 export const elizaRelationshipTable = pluginSchema.relationshipTable;
 export const elizaComponentTable = pluginSchema.componentTable;


### PR DESCRIPTION
## Summary

- `bun db:push` / `db:generate` fails with `type "vector" does not exist` because `eliza.ts` re-exports the ElizaOS `embeddingTable` which uses pgvector `vector` columns
- Removes the `elizaEmbeddingTable` re-export — no runtime or migration code references it, and ElizaOS creates the table at agent startup when needed

## Type

- [x] Bug fix

## Context / Links

- Regression introduced by PR #1248 (`fix: skip elizaOS runtime migrations, manage tables via Drizzle`)
- Related: PR #1254, PR #1255 (Vercel Lambda size fixes that touched the same area)

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] DB (`packages/db`)

## Changes

- `packages/db/src/schema/eliza.ts` — removed `elizaEmbeddingTable` export (the only table using pgvector `vector` columns)

## Review guide

**Start here**
- `packages/db/src/schema/eliza.ts`

**Risk**
- [x] Low

**Notes for reviewers**
- Confirmed via grep: `elizaEmbeddingTable` is not referenced anywhere in the codebase (it was removed from the barrel export in PR #1255)
- The embeddings table is created by ElizaOS runtime when an agent needs it — no Drizzle migration needed

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck`

**Manual verification**
1. Run `bun db:push` — should no longer error with "type vector does not exist"

## Ops / Migration / Deployment

- [x] No deploy impact

## Breaking changes

- [x] None

## Security / privacy

- [x] No security impact

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend-only DB schema config fix, no UI impact

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
