### PR TITLE
fix(build): trim sentry sourcemaps from vercel output

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -419,8 +419,15 @@ const sentryWebpackPluginOptions = {
   // For all available options, see:
   // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
 
-  // Upload a larger set of source maps for prettier stack traces (increases build time)
-  widenClientFileUpload: true,
+  // Keep uploads narrow so Sentry source maps don't bloat Vercel build artifacts.
+  widenClientFileUpload: false,
+
+  sourcemaps: {
+    // Vercel's serverless size limit applies to deployed output, not just runtime code.
+    // Remove uploaded source maps from `.next` after Sentry has them to keep the
+    // production build path aligned with preview output size.
+    deleteSourcemapsAfterUpload: true,
+  },
 
   // Route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
   // This can increase your server load as well as your hosting bill.


### PR DESCRIPTION
## Summary
- reduce the Sentry build footprint on Vercel production while keeping Sentry runtime instrumentation enabled
- stop widening client sourcemap uploads and let the Sentry build plugin delete uploaded sourcemaps from `.next`
- keep preview/prod output size closer by avoiding prod-only sourcemap residue in serverless artifacts

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [x] Performance
- [x] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Production deploy still failing after #1257: `babylon-kiizt032b-eliza-os.vercel.app`
- Preview deploy on the same app code path was ready: `babylon-baj11ciaz-eliza-os.vercel.app`
- Prod-only difference observed during investigation: `SENTRY_AUTH_TOKEN` / `SENTRY_*` envs exist in Production but not in Preview

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] Web UI (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- set `widenClientFileUpload` to `false`
- enable `sourcemaps.deleteSourcemapsAfterUpload: true` in the Sentry Next.js build plugin config
- document in config why this matters for Vercel serverless output size

## Review guide
**Start here**
- `apps/web/next.config.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- This keeps Sentry runtime instrumentation and release upload enabled.
- The change only narrows sourcemap handling during the build step so uploaded maps are not kept in the deployed artifact set.

## Test plan
**Commands run**
- [x] `bun run check` (Biome format)
- [x] `bun run typecheck` (web only: `bun run --cwd apps/web typecheck`)
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Confirm `apps/web/next.config.ts` still enables Sentry only when `SENTRY_AUTH_TOKEN` is present.
2. Confirm sourcemaps are configured for deletion after upload.
3. Redeploy production and verify the build no longer fails on the 250 MB unzipped function limit.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `none`
- Changed: `none`
- Removed: `none`

**DB / data migration**
- Migration(s): `none`
- Backfill/seed: `none`

**Rollout / rollback plan**
- Rollout: merge and redeploy production, then compare the production output path to the successful preview path.
- Rollback: revert this single commit.

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)
### Option B: No visual changes
- Reason: build/config-only change, no UI impact.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`production` intentionally for this hotfix)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

## Non-goals / follow-ups
- if production still fails after this, move sourcemap upload entirely out of Vercel builds and into CI with `sentry-cli`
