### PR TITLE
fix(build): prune next server sourcemaps before vercel packaging

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "bun x next dev",
     "dev:next-only": "SKIP_ENV_VALIDATION=1 bun x next dev",
-    "build": "NODE_OPTIONS='--max-old-space-size=8192' bun x next build --webpack",
+    "build": "NODE_OPTIONS='--max-old-space-size=8192' bun x next build --webpack && bun ../../scripts/prune-next-server-sourcemaps.ts .next",
     "start": "bun x next start",
     "lint": "biome lint .",
     "lint:fix": "biome check --write .",

--- a/scripts/prune-next-server-sourcemaps.ts
+++ b/scripts/prune-next-server-sourcemaps.ts
@@ -1,0 +1,65 @@
+import { readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+async function walk(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) return walk(fullPath);
+      return [fullPath];
+    })
+  );
+
+  return files.flat();
+}
+
+async function main() {
+  const nextDirArg = process.argv[2] ?? '.next';
+  const nextDir = path.resolve(process.cwd(), nextDirArg);
+  const serverDir = path.join(nextDir, 'server');
+
+  try {
+    await stat(serverDir);
+  } catch {
+    console.log(
+      `[prune-next-server-sourcemaps] skipping: missing server directory at ${serverDir}`
+    );
+    return;
+  }
+
+  const allFiles = await walk(nextDir);
+  const nftFiles = allFiles.filter((file) => file.endsWith('.nft.json'));
+  const serverMapFiles = allFiles.filter(
+    (file) => file.startsWith(serverDir) && file.endsWith('.map')
+  );
+
+  let removedManifestEntries = 0;
+
+  for (const nftFile of nftFiles) {
+    const raw = await readFile(nftFile, 'utf8');
+    const parsed = JSON.parse(raw) as { files?: string[] };
+
+    if (!Array.isArray(parsed.files)) continue;
+
+    const filteredFiles = parsed.files.filter((file) => !file.endsWith('.map'));
+    removedManifestEntries += parsed.files.length - filteredFiles.length;
+
+    if (filteredFiles.length !== parsed.files.length) {
+      parsed.files = filteredFiles;
+      await writeFile(nftFile, `${JSON.stringify(parsed)}\n`, 'utf8');
+    }
+  }
+
+  let deletedMapFiles = 0;
+  for (const mapFile of serverMapFiles) {
+    await rm(mapFile, { force: true });
+    deletedMapFiles += 1;
+  }
+
+  console.log(
+    `[prune-next-server-sourcemaps] updated ${nftFiles.length} nft files, removed ${removedManifestEntries} sourcemap references, deleted ${deletedMapFiles} server sourcemaps`
+  );
+}
+
+await main();


### PR DESCRIPTION
## Summary
- prune Next.js server sourcemaps from `.nft.json` manifests after `next build` and before Vercel packages functions
- keep Sentry runtime instrumentation intact while preventing server sourcemaps from being bundled into every serverless function
- make the `web` build explicitly run the prune step so Vercel packages the lean traced graph, not the raw build graph

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [x] Performance
- [x] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Production deploys kept failing with `A Serverless Function has exceeded the unzipped maximum size of 250 MB`
- Related attempts: #1257 and #1259
- Root-cause analysis was done with `VERCEL_ANALYZE_BUILD_OUTPUT=1 vercel build` using production env locally

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] Web UI (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- add `scripts/prune-next-server-sourcemaps.ts`
- run the prune script at the end of `apps/web` production builds
- remove `*.map` entries from Next route/function `.nft.json` manifests
- delete server-side `.map` files from `.next/server` after build artifacts have already been produced/uploaded for Sentry

## Review guide
**Start here**
- `scripts/prune-next-server-sourcemaps.ts`
- `apps/web/package.json`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- This is not a guessy Sentry tweak. It is a post-build packaging fix based on traced-output inspection.
- The issue is that Next route manifests (`route.js.nft.json`) contained many `*.js.map` references, so Vercel bundled server sourcemaps into functions.
- Example from local production analysis before this patch: `/api/users/me` traced `31` sourcemap files for about `51.7 MB` by itself.
- After the prune step, the same route trace dropped from about `95.2 MB` to about `43.5 MB` locally, with `0` traced sourcemaps.

## Test plan
**Commands run**
- [x] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [x] `bun run build` (via local `vercel build` with production env)
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Pull production env locally.
2. Run `VERCEL_ANALYZE_BUILD_OUTPUT=1 vercel build`.
3. Confirm the pre-patch problem: hundreds of oversized functions and `apps/web/.next` contributing ~223 MB.
4. Confirm with this branch that `vercel build` completes successfully under production env.
5. Confirm the prune script logs removal of sourcemap references and server `.map` files.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `none`
- Changed: `none`
- Removed: `none`

**DB / data migration**
- Migration(s): `none`
- Backfill/seed: `none`

**Rollout / rollback plan**
- Rollout: merge to `production` and redeploy production on Vercel.
- Rollback: revert this single commit.

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)
### Option B: No visual changes
- Reason: build/package-only change, no UI impact.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`production` intentionally for this hotfix)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

## Non-goals / follow-ups
- shrinking the `public/` contribution to traced functions (~12.75 MB in the analyzed prod build)
- broader cleanup of prod-only build differences between preview and production
