### PR TITLE
fix(api): split Privy Solana policy from EVM policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,11 +108,11 @@ PRIVY_APP_SECRET=your_privy_app_secret_here
 PRIVY_AUTHORIZATION_PRIVATE_KEY=
 # Offline-first required: key quorum ID configured as signer for delegated wallet actions.
 PRIVY_OFFLINE_SIGNER_ID=
-# Offline-first required: policy ID attached to the delegated signer.
+# Offline-first required: Ethereum policy ID attached to the delegated signer.
 PRIVY_OFFLINE_POLICY_ID=
-# Solana agent registration reuses the same delegated signer / authorization
-# flow above. Ensure the configured Privy policy allows Solana
-# `signAndSendTransaction` for agent wallets.
+# Offline-first required when SOLANA_REGISTRY_ENABLED=true: Solana policy ID
+# attached to the same delegated signer for sponsored agent registrations.
+PRIVY_SOLANA_OFFLINE_POLICY_ID=
 
 # ============================================================================
 # Solana Agent Registry Configuration

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "ruler:revert": "ruler revert",
     "audit:offline-wallet-readiness": "bun run scripts/audit-offline-wallet-readiness.ts",
     "privy:setup:offline-controls": "bun run scripts/setup-privy-offline-controls.ts",
+    "privy:setup:solana-policy": "bun run scripts/create-privy-solana-policy.ts",
     "seed:nft-snapshot:csv": "bun run scripts/seed-nft-snapshot-csv.ts",
     "users:export:newsletter": "bun run scripts/export-newsletter-users-csv.ts"
   },

--- a/packages/api/src/env.ts
+++ b/packages/api/src/env.ts
@@ -6,6 +6,7 @@ type SupportedEnvKey =
   | 'PRIVY_APP_SECRET'
   | 'PRIVY_AUTHORIZATION_PRIVATE_KEY'
   | 'PRIVY_OFFLINE_POLICY_ID'
+  | 'PRIVY_SOLANA_OFFLINE_POLICY_ID'
   | 'PRIVY_OFFLINE_SIGNER_ID';
 
 export function getTrimmedEnv(name: SupportedEnvKey): string | undefined {
@@ -26,6 +27,8 @@ export function getTrimmedEnv(name: SupportedEnvKey): string | undefined {
                 ? process.env.PRIVY_AUTHORIZATION_PRIVATE_KEY
                 : name === 'PRIVY_OFFLINE_POLICY_ID'
                   ? process.env.PRIVY_OFFLINE_POLICY_ID
+                  : name === 'PRIVY_SOLANA_OFFLINE_POLICY_ID'
+                    ? process.env.PRIVY_SOLANA_OFFLINE_POLICY_ID
                   : process.env.PRIVY_OFFLINE_SIGNER_ID;
 
   const trimmed = rawValue?.trim();

--- a/packages/api/src/services/privy/__tests__/offline-config.test.ts
+++ b/packages/api/src/services/privy/__tests__/offline-config.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+const ORIGINAL_ENV = { ...process.env };
+
+const {
+  getPrivyOfflineConfig,
+  getPrivySolanaOfflineConfig,
+} = await import('../offline-config');
+
+describe('offline-config', () => {
+  beforeEach(() => {
+    process.env.PRIVY_APP_ID = 'test-app-id';
+    process.env.PRIVY_APP_SECRET = 'test-secret';
+    process.env.PRIVY_AUTHORIZATION_PRIVATE_KEY = 'test-authorization-key';
+    process.env.PRIVY_OFFLINE_SIGNER_ID = 'offline-signer-id';
+    process.env.PRIVY_OFFLINE_POLICY_ID = 'evm-policy-id';
+    process.env.PRIVY_SOLANA_OFFLINE_POLICY_ID = 'solana-policy-id';
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  it('keeps the existing EVM policy wiring unchanged', () => {
+    const config = getPrivyOfflineConfig();
+
+    expect(config.offlinePolicyId).toBe('evm-policy-id');
+    expect(config.offlineSignerId).toBe('offline-signer-id');
+  });
+
+  it('uses the dedicated Solana policy env for Solana flows', () => {
+    const config = getPrivySolanaOfflineConfig();
+
+    expect(config.offlinePolicyId).toBe('solana-policy-id');
+    expect(config.offlineSignerId).toBe('offline-signer-id');
+  });
+
+  it('fails clearly when the Solana policy env is missing', () => {
+    delete process.env.PRIVY_SOLANA_OFFLINE_POLICY_ID;
+
+    expect(() => getPrivySolanaOfflineConfig()).toThrow(
+      'PRIVY_SOLANA_OFFLINE_POLICY_ID'
+    );
+  });
+});

--- a/packages/api/src/services/privy/offline-config.ts
+++ b/packages/api/src/services/privy/offline-config.ts
@@ -13,20 +13,30 @@ function formatMissingFields(missing: string[]): string {
 }
 
 export function getPrivyOfflineConfig(): PrivyOfflineConfig {
+  return getPrivyOfflineConfigForPolicyEnv('PRIVY_OFFLINE_POLICY_ID');
+}
+
+export function getPrivySolanaOfflineConfig(): PrivyOfflineConfig {
+  return getPrivyOfflineConfigForPolicyEnv('PRIVY_SOLANA_OFFLINE_POLICY_ID');
+}
+
+function getPrivyOfflineConfigForPolicyEnv(
+  policyEnvName: 'PRIVY_OFFLINE_POLICY_ID' | 'PRIVY_SOLANA_OFFLINE_POLICY_ID'
+): PrivyOfflineConfig {
   const appId = getPrivyAppIdFromEnv();
   const appSecret = getTrimmedEnv('PRIVY_APP_SECRET');
   const authorizationPrivateKey = getTrimmedEnv(
     'PRIVY_AUTHORIZATION_PRIVATE_KEY'
   );
   const offlineSignerId = getTrimmedEnv('PRIVY_OFFLINE_SIGNER_ID');
-  const offlinePolicyId = getTrimmedEnv('PRIVY_OFFLINE_POLICY_ID');
+  const offlinePolicyId = getTrimmedEnv(policyEnvName);
 
   const missing: string[] = [];
   if (!appId) missing.push('PRIVY_APP_ID (or NEXT_PUBLIC_PRIVY_APP_ID)');
   if (!appSecret) missing.push('PRIVY_APP_SECRET');
   if (!authorizationPrivateKey) missing.push('PRIVY_AUTHORIZATION_PRIVATE_KEY');
   if (!offlineSignerId) missing.push('PRIVY_OFFLINE_SIGNER_ID');
-  if (!offlinePolicyId) missing.push('PRIVY_OFFLINE_POLICY_ID');
+  if (!offlinePolicyId) missing.push(policyEnvName);
 
   if (missing.length > 0) {
     throw new Error(

--- a/packages/api/src/services/privy/solana-wallet-provisioning.ts
+++ b/packages/api/src/services/privy/solana-wallet-provisioning.ts
@@ -1,7 +1,7 @@
 import { logger } from '@babylon/shared';
 import type { User as PrivyUser } from '@privy-io/server-auth';
 import { getPrivyClient } from '../../auth-middleware';
-import { getPrivyOfflineConfig } from './offline-config';
+import { getPrivySolanaOfflineConfig } from './offline-config';
 import { getPrivyNodeClient } from './privy-node';
 import {
   listEmbeddedSolanaWallets,
@@ -163,7 +163,7 @@ export async function ensureSolanaWalletReady({
 }: EnsureSolanaWalletReadyInput): Promise<EnsureSolanaWalletReadyResult> {
   const privyNode = getPrivyNodeClient();
   const privyServer = getPrivyClient();
-  const offlineConfig = getPrivyOfflineConfig();
+  const offlineConfig = getPrivySolanaOfflineConfig();
 
   const initialPrivyUser = (await privyServer.getUser(
     privyId

--- a/scripts/create-privy-solana-policy.ts
+++ b/scripts/create-privy-solana-policy.ts
@@ -111,32 +111,39 @@ async function main() {
     appSecret: options.appSecret,
   });
 
+  const alwaysAllowCondition = {
+    field: 'current_unix_timestamp' as const,
+    field_source: 'system' as const,
+    operator: 'gte' as const,
+    value: '0',
+  };
+
   const rules: Array<{
     name: string;
     method: 'signAndSendTransaction' | 'signTransaction';
-    conditions: [];
+    conditions: [typeof alwaysAllowCondition];
     action: 'ALLOW';
   }> = [
     {
-      name: 'Allow Solana signAndSendTransaction for Babylon agent registration',
+      name: 'Allow Solana send tx',
       method: 'signAndSendTransaction',
-      conditions: [],
+      conditions: [alwaysAllowCondition],
       action: 'ALLOW',
     },
   ];
 
   if (options.allowSignTransaction) {
     rules.push({
-      name: 'Allow Solana signTransaction for Babylon agent operations',
+      name: 'Allow Solana sign tx',
       method: 'signTransaction',
-      conditions: [],
+      conditions: [alwaysAllowCondition],
       action: 'ALLOW',
     });
   }
 
   const policy = await privy.policies().create({
     version: '1.0',
-    name: `${options.namePrefix}-policy-${timestampTag()}`,
+    name: `${options.namePrefix}-${timestampTag()}`.slice(0, 49),
     chain_type: 'solana',
     ...(options.ownerId ? { owner_id: options.ownerId } : {}),
     rules,

--- a/scripts/create-privy-solana-policy.ts
+++ b/scripts/create-privy-solana-policy.ts
@@ -1,0 +1,171 @@
+import { PrivyClient } from '@privy-io/node';
+
+type CliOptions = {
+  appId: string;
+  appSecret: string;
+  namePrefix: string;
+  ownerId?: string;
+  allowSignTransaction: boolean;
+  json: boolean;
+};
+
+function printUsage(): void {
+  console.log(`
+Create a Privy Solana policy for Babylon agent registrations
+
+Usage:
+  bun run scripts/create-privy-solana-policy.ts [options]
+
+Options:
+  --app-id <value>             Privy app ID (fallback: PRIVY_APP_ID or NEXT_PUBLIC_PRIVY_APP_ID)
+  --app-secret <value>         Privy app secret (fallback: PRIVY_APP_SECRET)
+  --name-prefix <value>        Prefix for the created policy name
+                               (default: babylon-solana-registration)
+  --owner-id <value>           Optional key quorum owner ID
+                               (fallback: PRIVY_OFFLINE_SIGNER_ID)
+  --allow-sign-transaction     Also allow signTransaction
+  --json                       Output machine-readable JSON only
+  -h, --help                   Show this help
+
+What this creates:
+  - A Solana-only Privy policy
+  - Default scope: ALLOW signAndSendTransaction, default-deny everything else
+
+Recommended next step:
+  - Set PRIVY_SOLANA_OFFLINE_POLICY_ID to the returned policy ID
+`);
+}
+
+function readEnv(name: string): string | undefined {
+  const value = process.env[name];
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function readArgValue(args: string[], name: string): string | undefined {
+  const index = args.findIndex((arg) => arg === name);
+  if (index === -1) return undefined;
+
+  const value = args[index + 1];
+  if (!value) {
+    throw new Error(`Missing value after ${name}`);
+  }
+
+  return value.trim();
+}
+
+function hasFlag(args: string[], flag: string): boolean {
+  return args.includes(flag);
+}
+
+function timestampTag(): string {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+function parseOptions(): CliOptions {
+  const args = process.argv.slice(2);
+
+  if (hasFlag(args, '-h') || hasFlag(args, '--help')) {
+    printUsage();
+    process.exit(0);
+  }
+
+  const appId =
+    readArgValue(args, '--app-id') ??
+    readEnv('PRIVY_APP_ID') ??
+    readEnv('NEXT_PUBLIC_PRIVY_APP_ID');
+  const appSecret =
+    readArgValue(args, '--app-secret') ?? readEnv('PRIVY_APP_SECRET');
+  const namePrefix =
+    readArgValue(args, '--name-prefix') ?? 'babylon-solana-registration';
+  const ownerId =
+    readArgValue(args, '--owner-id') ?? readEnv('PRIVY_OFFLINE_SIGNER_ID');
+  const allowSignTransaction = hasFlag(args, '--allow-sign-transaction');
+  const json = hasFlag(args, '--json');
+
+  const missing: string[] = [];
+  if (!appId) missing.push('app ID (--app-id or PRIVY_APP_ID)');
+  if (!appSecret) {
+    missing.push('app secret (--app-secret or PRIVY_APP_SECRET)');
+  }
+
+  if (missing.length > 0) {
+    throw new Error(`Missing required inputs: ${missing.join(', ')}`);
+  }
+
+  return {
+    appId: appId!,
+    appSecret: appSecret!,
+    namePrefix,
+    ...(ownerId ? { ownerId } : {}),
+    allowSignTransaction,
+    json,
+  };
+}
+
+async function main() {
+  const options = parseOptions();
+  const privy = new PrivyClient({
+    appId: options.appId,
+    appSecret: options.appSecret,
+  });
+
+  const rules: Array<{
+    name: string;
+    method: 'signAndSendTransaction' | 'signTransaction';
+    conditions: [];
+    action: 'ALLOW';
+  }> = [
+    {
+      name: 'Allow Solana signAndSendTransaction for Babylon agent registration',
+      method: 'signAndSendTransaction',
+      conditions: [],
+      action: 'ALLOW',
+    },
+  ];
+
+  if (options.allowSignTransaction) {
+    rules.push({
+      name: 'Allow Solana signTransaction for Babylon agent operations',
+      method: 'signTransaction',
+      conditions: [],
+      action: 'ALLOW',
+    });
+  }
+
+  const policy = await privy.policies().create({
+    version: '1.0',
+    name: `${options.namePrefix}-policy-${timestampTag()}`,
+    chain_type: 'solana',
+    ...(options.ownerId ? { owner_id: options.ownerId } : {}),
+    rules,
+  });
+
+  const result = {
+    appId: options.appId,
+    policyId: policy.id,
+    chainType: policy.chain_type,
+    ownerId: policy.owner_id,
+    methods: rules.map((rule) => rule.method),
+  };
+
+  if (options.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  console.log('Privy Solana policy created successfully.\n');
+  console.log(`Policy ID: ${result.policyId}`);
+  console.log(`Chain type: ${result.chainType}`);
+  console.log(`Methods: ${result.methods.join(', ')}`);
+  console.log(`Owner ID: ${result.ownerId ?? 'none'}\n`);
+  console.log('Set this env var in the target environment:\n');
+  console.log(`PRIVY_SOLANA_OFFLINE_POLICY_ID=${result.policyId}`);
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Failed to create Privy Solana policy: ${message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- add a dedicated `PRIVY_SOLANA_OFFLINE_POLICY_ID` env so the Solana agent registration flow no longer reuses the EVM offline policy
- keep the existing EVM signer / authorization key wiring unchanged while switching Solana wallet provisioning to the Solana-specific policy
- add a small ops script to create the correctly scoped Solana Privy policy and document the new env in `.env.example`

## Why

The production Solana agent registration flow is currently blocked by a Privy policy chain mismatch: the shared `PRIVY_OFFLINE_POLICY_ID` points to an Ethereum policy, but Solana wallet provisioning requires a Solana policy. Replacing that env would risk breaking the EVM flow, so this PR separates the policy IDs by chain type.

## Changes

- introduce `getPrivySolanaOfflineConfig()` alongside the existing EVM offline config
- update `ensureSolanaWalletReady()` to read `PRIVY_SOLANA_OFFLINE_POLICY_ID`
- keep `ensureOfflineWalletReady()` and existing EVM flows on `PRIVY_OFFLINE_POLICY_ID`
- add `scripts/create-privy-solana-policy.ts` to create a Solana-only Privy policy for Babylon agent registrations
- update `.env.example` and add targeted tests for config selection

## Test plan

- `bun test packages/api/src/services/privy/__tests__/offline-config.test.ts`
- validated the new policy creation script help output via `tsx` using the shared workspace dependencies

## Ops

After merge/deploy, create a Solana policy and set:

- `PRIVY_SOLANA_OFFLINE_POLICY_ID=<new solana policy id>`

The existing EVM env stays unchanged:

- `PRIVY_OFFLINE_POLICY_ID=<existing evm policy id>`
