### PR TITLE
fix(api): remove invalid OASF skills from Solana registration

### DIFF
--- a/packages/api/src/services/agent-solana-registration-service.test.ts
+++ b/packages/api/src/services/agent-solana-registration-service.test.ts
@@ -7,6 +7,7 @@ const mockSendSponsoredSolanaTransaction = mock();
 const mockAssertSolanaRegistryConfigured = mock();
 const mockAcquireLock = mock();
 const mockReleaseLock = mock();
+let capturedRegistrationFileInput: Record<string, unknown> | null = null;
 
 let selectResults: Array<unknown[]> = [];
 const capturedUpdates: Array<Record<string, unknown>> = [];
@@ -31,9 +32,12 @@ const usersTable = {
   virtualBalance: 'virtualBalance',
 } as const;
 
-mock.module('@babylon/agents', () => ({
+mock.module('@babylon/agents/solana-registry', () => ({
   assertSolanaRegistryConfigured: mockAssertSolanaRegistryConfigured,
-  buildAgentSolanaRegistrationFile: (input: unknown) => input,
+  buildAgentSolanaRegistrationFile: (input: Record<string, unknown>) => {
+    capturedRegistrationFileInput = input;
+    return input;
+  },
   deriveDeterministicAgentSolanaAsset: () => ({
     publicKey: { toBase58: () => 'asset-deterministic' },
   }),
@@ -138,6 +142,7 @@ describe('agent-solana-registration-service', () => {
     selectResults = [];
     capturedUpdates.length = 0;
     capturedInserts.length = 0;
+    capturedRegistrationFileInput = null;
     mockGetAgentSolanaRegistration.mockReset();
     mockPrepareAgentSolanaRegistrationTransaction.mockReset();
     mockEnsureSolanaWalletReady.mockReset();
@@ -202,6 +207,8 @@ describe('agent-solana-registration-service', () => {
       transaction: 'base64-tx',
       idempotencyKey: 'agent-solana-registration:agent-1',
     });
+    expect(capturedRegistrationFileInput?.skills).toEqual([]);
+    expect(capturedRegistrationFileInput?.domains).toEqual([]);
     expect(
       capturedUpdates.some((update) => update.solanaRegistered === true)
     ).toBe(true);

--- a/packages/api/src/services/agent-solana-registration-service.ts
+++ b/packages/api/src/services/agent-solana-registration-service.ts
@@ -394,16 +394,10 @@ export async function registerAgentOnSolanaForOwner({
           managerUserId: ownerUserId,
           network: 'solana',
         },
-        skills: [
-          'trade',
-          'analyze',
-          'chat',
-          'post',
-          'comment',
-          'prediction-markets',
-          'social-interaction',
-        ],
-        domains: ['prediction-markets', 'trading', 'social'],
+        // Do not publish Babylon-specific labels as OASF skills/domains until
+        // they are mapped to valid registry slugs.
+        skills: [],
+        domains: [],
       });
 
       prepared = await prepareAgentSolanaRegistrationTransaction({


### PR DESCRIPTION
## Summary

- stop sending Babylon-specific skills/domains as OASF slugs in the Solana agent registration flow
- publish empty `skills` / `domains` arrays until we have a valid Babylon -> OASF taxonomy mapping
- add a targeted test to lock this behavior

## Why

Production registration currently fails with:

`Invalid OASF skills: trade, analyze, chat, post, comment, prediction-markets, social-interaction`

The Solana 8004 registry validates OASF slugs, and the current Babylon labels are not valid registry skills. The safest fix is to stop sending invalid taxonomy data rather than guessing replacements.

## Test plan

- `bun test packages/api/src/services/agent-solana-registration-service.test.ts`
