### PR TITLE
fix(api): derive Solana Privy idempotency key from payload

### DIFF
--- a/packages/api/src/services/agent-solana-registration-service.test.ts
+++ b/packages/api/src/services/agent-solana-registration-service.test.ts
@@ -205,7 +205,6 @@ describe('agent-solana-registration-service', () => {
     expect(mockSendSponsoredSolanaTransaction).toHaveBeenCalledWith({
       walletId: 'solana-wallet-1',
       transaction: 'base64-tx',
-      idempotencyKey: 'agent-solana-registration:agent-1',
     });
     expect(capturedRegistrationFileInput?.skills).toEqual([]);
     expect(capturedRegistrationFileInput?.domains).toEqual([]);

--- a/packages/api/src/services/agent-solana-registration-service.ts
+++ b/packages/api/src/services/agent-solana-registration-service.ts
@@ -434,7 +434,6 @@ export async function registerAgentOnSolanaForOwner({
       const tx = await sendSponsoredSolanaTransaction({
         walletId: wallet.privyWalletId,
         transaction: prepared.transaction,
-        idempotencyKey: `agent-solana-registration:${agentUserId}`,
       });
 
       await persistSolanaRegistrationState({

--- a/packages/api/src/services/privy/__tests__/solana-idempotency.test.ts
+++ b/packages/api/src/services/privy/__tests__/solana-idempotency.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'bun:test';
+import { buildSponsoredSolanaTransactionIdempotencyKey } from '../solana-idempotency';
+
+describe('buildSponsoredSolanaTransactionIdempotencyKey', () => {
+  it('is stable for the same sponsored request payload', () => {
+    const keyA = buildSponsoredSolanaTransactionIdempotencyKey({
+      walletId: 'wallet-1',
+      transaction: 'tx-body-1',
+      caip2: 'solana:mainnet',
+    });
+    const keyB = buildSponsoredSolanaTransactionIdempotencyKey({
+      walletId: 'wallet-1',
+      transaction: 'tx-body-1',
+      caip2: 'solana:mainnet',
+    });
+
+    expect(keyA).toBe(keyB);
+    expect(keyA.startsWith('solana-sponsored-tx:v1:')).toBe(true);
+  });
+
+  it('changes when the sponsored request body changes', () => {
+    const keyA = buildSponsoredSolanaTransactionIdempotencyKey({
+      walletId: 'wallet-1',
+      transaction: 'tx-body-1',
+      caip2: 'solana:mainnet',
+    });
+    const keyB = buildSponsoredSolanaTransactionIdempotencyKey({
+      walletId: 'wallet-1',
+      transaction: 'tx-body-2',
+      caip2: 'solana:mainnet',
+    });
+
+    expect(keyA).not.toBe(keyB);
+  });
+});

--- a/packages/api/src/services/privy/solana-idempotency.ts
+++ b/packages/api/src/services/privy/solana-idempotency.ts
@@ -1,0 +1,24 @@
+import { createHash } from 'node:crypto';
+
+export function buildSponsoredSolanaTransactionIdempotencyKey({
+  walletId,
+  transaction,
+  caip2,
+}: {
+  walletId: string;
+  transaction: string;
+  caip2: string;
+}): string {
+  const digest = createHash('sha256')
+    .update(
+      JSON.stringify({
+        walletId,
+        caip2,
+        transaction,
+        sponsor: true,
+      })
+    )
+    .digest('hex');
+
+  return `solana-sponsored-tx:v1:${digest}`;
+}

--- a/packages/api/src/services/privy/solana-send-transaction.ts
+++ b/packages/api/src/services/privy/solana-send-transaction.ts
@@ -2,6 +2,7 @@ import { logger } from '@babylon/shared';
 import { extractPrivyApiDiagnostics } from './error-diagnostics';
 import { getPrivyOfflineConfig } from './offline-config';
 import { getPrivyNodeClient } from './privy-node';
+import { buildSponsoredSolanaTransactionIdempotencyKey } from './solana-idempotency';
 
 function resolveSolanaCaip2(): string {
   const cluster = process.env.SOLANA_REGISTRY_CLUSTER ?? 'mainnet-beta';
@@ -22,15 +23,18 @@ function resolveSolanaCaip2(): string {
 export async function sendSponsoredSolanaTransaction({
   walletId,
   transaction,
-  idempotencyKey,
 }: {
   walletId: string;
   transaction: string;
-  idempotencyKey?: string;
 }): Promise<{ hash: string; transactionId?: string; caip2: string }> {
   const privy = getPrivyNodeClient();
   const offlineConfig = getPrivyOfflineConfig();
   const caip2 = resolveSolanaCaip2();
+  const idempotencyKey = buildSponsoredSolanaTransactionIdempotencyKey({
+    walletId,
+    transaction,
+    caip2,
+  });
 
   try {
     const response = await privy
@@ -43,7 +47,7 @@ export async function sendSponsoredSolanaTransaction({
         authorization_context: {
           authorization_private_keys: [offlineConfig.authorizationPrivateKey],
         },
-        ...(idempotencyKey ? { idempotency_key: idempotencyKey } : {}),
+        idempotency_key: idempotencyKey,
       });
 
     return {


### PR DESCRIPTION
## Summary

- derive the Privy Solana idempotency key from the actual sponsored transaction payload instead of using a static per-agent key
- keep retries idempotent when the request body is unchanged, while allowing new keys when the prepared transaction changes
- add a focused helper test for the key derivation behavior

## Why

Production Solana agent registration is currently blocked for previously attempted agents because Privy rejects reusing the same idempotency key with a different request body:

`Idempotency key was reused for a request with a new body.`

A static `agent-solana-registration:${agentUserId}` key is too coarse once the request body evolves across retries, config fixes, or wallet/policy changes. The clean fix is to derive the key from the canonical request payload itself.

## Test plan

- `bun test packages/api/src/services/agent-solana-registration-service.test.ts packages/api/src/services/privy/__tests__/solana-idempotency.test.ts`
