### PR TITLE
fix: viewport-aware Tooltip component, migrate OnChainBadge

### DIFF
--- a/apps/web/src/components/profile/OnChainBadge.tsx
+++ b/apps/web/src/components/profile/OnChainBadge.tsx
@@ -2,35 +2,8 @@
 
 import { cn } from '@babylon/shared';
 import { Shield, ShieldCheck } from 'lucide-react';
-import { useState } from 'react';
+import { Tooltip } from '@/components/ui/tooltip';
 
-/**
- * On-chain badge component for displaying blockchain verification status.
- *
- * Displays a badge indicating whether a user's identity is verified on-chain
- * via NFT registration. Shows different icons and tooltips for verified vs
- * unverified states. Includes hover tooltip with NFT token ID for verified users.
- *
- * Features:
- * - Verified/unverified state display
- * - NFT token ID display in tooltip
- * - Size variants (sm, md, lg)
- * - Optional label text
- * - Hover tooltips
- *
- * @param props - OnChainBadge component props
- * @returns On-chain badge element
- *
- * @example
- * ```tsx
- * <OnChainBadge
- *   isRegistered={true}
- *   nftTokenId={123}
- *   size="md"
- *   showLabel={true}
- * />
- * ```
- */
 interface OnChainBadgeProps {
   isRegistered: boolean;
   nftTokenId?: number | null;
@@ -46,8 +19,6 @@ export function OnChainBadge({
   showLabel = false,
   className,
 }: OnChainBadgeProps) {
-  const [showTooltip, setShowTooltip] = useState(false);
-
   const sizeClasses = {
     sm: 'w-4 h-4',
     md: 'w-5 h-5',
@@ -56,71 +27,56 @@ export function OnChainBadge({
 
   if (isRegistered && nftTokenId) {
     return (
-      <div
-        className={cn('relative inline-flex items-center gap-1', className)}
-        onMouseEnter={() => setShowTooltip(true)}
-        onMouseLeave={() => setShowTooltip(false)}
-      >
-        <ShieldCheck
-          className={cn(sizeClasses[size], 'shrink-0 text-green-500')}
-          fill="currentColor"
-        />
-        {showLabel && (
-          <span className="font-medium text-green-600 text-xs dark:text-green-400">
-            Verified On-Chain
-          </span>
-        )}
-        {showTooltip && (
-          <div className="-translate-x-1/2 absolute top-full left-1/2 z-50 mt-2 whitespace-nowrap rounded-lg border border-border bg-popover px-3 py-2 shadow-lg">
-            <div className="-translate-x-1/2 -mb-[1px] absolute bottom-full left-1/2">
-              <div className="border-4 border-transparent border-b-border" />
-            </div>
-            <div className="space-y-1 text-xs">
-              <p className="font-semibold text-green-500">Verified On-Chain</p>
-              <p className="text-muted-foreground">
-                NFT Token ID: #{nftTokenId}
-              </p>
-              <p className="text-muted-foreground">
-                Blockchain identity verified
-              </p>
-            </div>
+      <Tooltip
+        content={
+          <div className="space-y-1 text-xs">
+            <p className="font-semibold text-green-500">Verified On-Chain</p>
+            <p className="text-muted-foreground">NFT Token ID: #{nftTokenId}</p>
+            <p className="text-muted-foreground">
+              Blockchain identity verified
+            </p>
           </div>
-        )}
-      </div>
+        }
+      >
+        <div className={cn('inline-flex items-center gap-1', className)}>
+          <ShieldCheck
+            className={cn(sizeClasses[size], 'shrink-0 text-green-500')}
+            fill="currentColor"
+          />
+          {showLabel && (
+            <span className="font-medium text-green-600 text-xs dark:text-green-400">
+              Verified On-Chain
+            </span>
+          )}
+        </div>
+      </Tooltip>
     );
   }
 
-  // Not registered on-chain
   return (
-    <div
-      className={cn('relative inline-flex items-center gap-1', className)}
-      onMouseEnter={() => setShowTooltip(true)}
-      onMouseLeave={() => setShowTooltip(false)}
-    >
-      <Shield
-        className={cn(sizeClasses[size], 'shrink-0 text-muted-foreground/50')}
-      />
-      {showLabel && (
-        <span className="font-medium text-muted-foreground text-xs">
-          Not Verified
-        </span>
-      )}
-      {showTooltip && (
-        <div className="-translate-x-1/2 absolute top-full left-1/2 z-50 mt-2 whitespace-nowrap rounded-lg border border-border bg-popover px-3 py-2 shadow-lg">
-          <div className="-translate-x-1/2 -mb-[1px] absolute bottom-full left-1/2">
-            <div className="border-4 border-transparent border-b-border" />
-          </div>
-          <div className="space-y-1 text-xs">
-            <p className="font-semibold text-muted-foreground">
-              Not Verified On-Chain
-            </p>
-            <p className="text-muted-foreground/70">No blockchain identity</p>
-            <p className="text-muted-foreground/70">
-              Limited reputation features
-            </p>
-          </div>
+    <Tooltip
+      content={
+        <div className="space-y-1 text-xs">
+          <p className="font-semibold text-muted-foreground">
+            Not Verified On-Chain
+          </p>
+          <p className="text-muted-foreground/70">No blockchain identity</p>
+          <p className="text-muted-foreground/70">
+            Limited reputation features
+          </p>
         </div>
-      )}
-    </div>
+      }
+    >
+      <div className={cn('inline-flex items-center gap-1', className)}>
+        <Shield
+          className={cn(sizeClasses[size], 'shrink-0 text-muted-foreground/50')}
+        />
+        {showLabel && (
+          <span className="font-medium text-muted-foreground text-xs">
+            Not Verified
+          </span>
+        )}
+      </div>
+    </Tooltip>
   );
 }

--- a/apps/web/src/components/providers/Providers.tsx
+++ b/apps/web/src/components/providers/Providers.tsx
@@ -9,6 +9,7 @@ import { PostHogErrorBoundary } from '@/components/analytics/PostHogErrorBoundar
 import { PostHogIdentifier } from '@/components/analytics/PostHogIdentifier';
 import { DevThemeToggle } from '@/components/shared/DevThemeToggle';
 import { ThemeProvider } from '@/components/shared/ThemeProvider';
+import { TooltipProvider } from '@/components/ui/tooltip';
 import { FontSizeProvider } from '@/contexts/FontSizeContext';
 import { WidgetRefreshProvider } from '@/contexts/WidgetRefreshContext';
 import { SessionHeartbeatProvider } from '@/hooks/useSessionHeartbeat';
@@ -254,29 +255,31 @@ export function Providers({ children }: { children: React.ReactNode }) {
           enableSystem
           disableTransitionOnChange={false}
         >
-          <DevThemeToggle />
-          <FontSizeProvider>
-            <QueryClientProvider client={queryClient}>
-              <GamePlaybackManager />
-              <WidgetRefreshProvider>
-                {mounted ? (
-                  <Fragment>
-                    {/* Debug banner - shows when Privy is not configured (visible in all environments for E2E test detection) */}
-                    <div
-                      data-testid="privy-not-configured-warning"
-                      className="fixed top-0 right-0 left-0 z-[9999] bg-yellow-500 py-1 text-center font-medium text-black text-sm"
-                    >
-                      ⚠️ Privy authentication not configured -
-                      NEXT_PUBLIC_PRIVY_APP_ID missing at build time
-                    </div>
-                    {children}
-                  </Fragment>
-                ) : (
-                  <div className="min-h-dvh bg-sidebar md:min-h-screen" />
-                )}
-              </WidgetRefreshProvider>
-            </QueryClientProvider>
-          </FontSizeProvider>
+          <TooltipProvider delayDuration={200}>
+            <DevThemeToggle />
+            <FontSizeProvider>
+              <QueryClientProvider client={queryClient}>
+                <GamePlaybackManager />
+                <WidgetRefreshProvider>
+                  {mounted ? (
+                    <Fragment>
+                      {/* Debug banner - shows when Privy is not configured (visible in all environments for E2E test detection) */}
+                      <div
+                        data-testid="privy-not-configured-warning"
+                        className="fixed top-0 right-0 left-0 z-[9999] bg-yellow-500 py-1 text-center font-medium text-black text-sm"
+                      >
+                        ⚠️ Privy authentication not configured -
+                        NEXT_PUBLIC_PRIVY_APP_ID missing at build time
+                      </div>
+                      {children}
+                    </Fragment>
+                  ) : (
+                    <div className="min-h-dvh bg-sidebar md:min-h-screen" />
+                  )}
+                </WidgetRefreshProvider>
+              </QueryClientProvider>
+            </FontSizeProvider>
+          </TooltipProvider>
         </ThemeProvider>
       </div>
     );
@@ -293,46 +296,48 @@ export function Providers({ children }: { children: React.ReactNode }) {
               enableSystem
               disableTransitionOnChange={false}
             >
-              <DevThemeToggle />
-              <FontSizeProvider>
-                <QueryClientProvider client={queryClient}>
-                  <GamePlaybackManager />
-                  <ThemedPrivyProvider>
-                    <FarcasterMiniAppProvider>
-                      <TelegramMiniAppProvider>
-                        <DiscordActivityProvider>
-                          {/* Solana MWA registration (side-effect only, no UI) */}
-                          <SolanaMobileProvider />
-                          {/* PostHog user identification */}
-                          <PostHogIdentifier />
-                          {/* Capture referral code from URL if present */}
-                          <Suspense fallback={null}>
-                            <ReferralCaptureProvider />
-                          </Suspense>
-                          {/* Onboarding provider for username setup */}
-                          <OnboardingProvider>
-                            {/* Session heartbeat for engagement metrics */}
-                            <SessionHeartbeatProvider>
-                              {/* Game guide provider for first-time tutorial */}
-                              <GameGuideProvider>
-                                <OutcomeNotificationProvider>
-                                  <WidgetRefreshProvider>
-                                    {mounted ? (
-                                      <Fragment>{children}</Fragment>
-                                    ) : (
-                                      <div className="min-h-dvh bg-sidebar md:min-h-screen" />
-                                    )}
-                                  </WidgetRefreshProvider>
-                                </OutcomeNotificationProvider>
-                              </GameGuideProvider>
-                            </SessionHeartbeatProvider>
-                          </OnboardingProvider>
-                        </DiscordActivityProvider>
-                      </TelegramMiniAppProvider>
-                    </FarcasterMiniAppProvider>
-                  </ThemedPrivyProvider>
-                </QueryClientProvider>
-              </FontSizeProvider>
+              <TooltipProvider delayDuration={200}>
+                <DevThemeToggle />
+                <FontSizeProvider>
+                  <QueryClientProvider client={queryClient}>
+                    <GamePlaybackManager />
+                    <ThemedPrivyProvider>
+                      <FarcasterMiniAppProvider>
+                        <TelegramMiniAppProvider>
+                          <DiscordActivityProvider>
+                            {/* Solana MWA registration (side-effect only, no UI) */}
+                            <SolanaMobileProvider />
+                            {/* PostHog user identification */}
+                            <PostHogIdentifier />
+                            {/* Capture referral code from URL if present */}
+                            <Suspense fallback={null}>
+                              <ReferralCaptureProvider />
+                            </Suspense>
+                            {/* Onboarding provider for username setup */}
+                            <OnboardingProvider>
+                              {/* Session heartbeat for engagement metrics */}
+                              <SessionHeartbeatProvider>
+                                {/* Game guide provider for first-time tutorial */}
+                                <GameGuideProvider>
+                                  <OutcomeNotificationProvider>
+                                    <WidgetRefreshProvider>
+                                      {mounted ? (
+                                        <Fragment>{children}</Fragment>
+                                      ) : (
+                                        <div className="min-h-dvh bg-sidebar md:min-h-screen" />
+                                      )}
+                                    </WidgetRefreshProvider>
+                                  </OutcomeNotificationProvider>
+                                </GameGuideProvider>
+                              </SessionHeartbeatProvider>
+                            </OnboardingProvider>
+                          </DiscordActivityProvider>
+                        </TelegramMiniAppProvider>
+                      </FarcasterMiniAppProvider>
+                    </ThemedPrivyProvider>
+                  </QueryClientProvider>
+                </FontSizeProvider>
+              </TooltipProvider>
             </ThemeProvider>
           </PostHogProvider>
         </Suspense>

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -23,6 +23,9 @@ import type { ReactNode } from 'react';
  * ```
  */
 
+/** Re-exported for use at the app root (see Providers.tsx). */
+export const TooltipProvider = TooltipPrimitive.Provider;
+
 interface TooltipProps {
   children: ReactNode;
   content: ReactNode;
@@ -30,8 +33,6 @@ interface TooltipProps {
   side?: 'top' | 'bottom' | 'left' | 'right';
   /** Alignment along the side */
   align?: 'start' | 'center' | 'end';
-  /** Delay before showing in ms (default: 200) */
-  delayDuration?: number;
   /** Additional class for the content container */
   className?: string;
   /** Whether to show an arrow pointer */
@@ -77,22 +78,19 @@ export function Tooltip({
   content,
   side,
   align,
-  delayDuration = 200,
   className,
   arrow,
 }: TooltipProps) {
   return (
-    <TooltipPrimitive.Provider delayDuration={delayDuration}>
-      <TooltipPrimitive.Root>
-        <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
-        <TooltipContent
-          content={content}
-          side={side}
-          align={align}
-          className={className}
-          arrow={arrow}
-        />
-      </TooltipPrimitive.Root>
-    </TooltipPrimitive.Provider>
+    <TooltipPrimitive.Root>
+      <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
+      <TooltipContent
+        content={content}
+        side={side}
+        align={align}
+        className={className}
+        arrow={arrow}
+      />
+    </TooltipPrimitive.Root>
   );
 }

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { cn } from '@babylon/shared';
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import type { ReactNode } from 'react';
+
+/**
+ * Viewport-aware tooltip built on Radix UI.
+ *
+ * Automatically repositions when near viewport edges — no clipping.
+ * Use this instead of hand-rolled absolute-positioned tooltips.
+ *
+ * @example
+ * ```tsx
+ * <Tooltip content="Verified on-chain">
+ *   <ShieldCheck className="h-4 w-4" />
+ * </Tooltip>
+ *
+ * // With rich content
+ * <Tooltip content={<div><p>Title</p><p>Description</p></div>}>
+ *   <button>Hover me</button>
+ * </Tooltip>
+ * ```
+ */
+
+interface TooltipProps {
+  children: ReactNode;
+  content: ReactNode;
+  /** Side to prefer — will flip if not enough space */
+  side?: 'top' | 'bottom' | 'left' | 'right';
+  /** Alignment along the side */
+  align?: 'start' | 'center' | 'end';
+  /** Delay before showing in ms (default: 200) */
+  delayDuration?: number;
+  /** Additional class for the content container */
+  className?: string;
+  /** Whether to show an arrow pointer */
+  arrow?: boolean;
+}
+
+function TooltipContent({
+  content,
+  side = 'bottom',
+  align = 'center',
+  className,
+  arrow = true,
+}: Omit<TooltipProps, 'children' | 'delayDuration'>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        side={side}
+        align={align}
+        sideOffset={6}
+        collisionPadding={8}
+        className={cn(
+          'z-50 rounded-lg border border-border bg-popover px-3 py-2 shadow-lg',
+          'fade-in-0 zoom-in-95 data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 animate-in data-[state=closed]:animate-out',
+          'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+          className
+        )}
+      >
+        {content}
+        {arrow && (
+          <TooltipPrimitive.Arrow
+            className="fill-border"
+            width={8}
+            height={4}
+          />
+        )}
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export function Tooltip({
+  children,
+  content,
+  side,
+  align,
+  delayDuration = 200,
+  className,
+  arrow,
+}: TooltipProps) {
+  return (
+    <TooltipPrimitive.Provider delayDuration={delayDuration}>
+      <TooltipPrimitive.Root>
+        <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
+        <TooltipContent
+          content={content}
+          side={side}
+          align={align}
+          className={className}
+          arrow={arrow}
+        />
+      </TooltipPrimitive.Root>
+    </TooltipPrimitive.Provider>
+  );
+}


### PR DESCRIPTION
## Summary

- Add a shared `Tooltip` component (`components/ui/tooltip.tsx`) built on `@radix-ui/react-tooltip` (already a dependency, previously unused)
- Migrate `OnChainBadge` from a hand-rolled absolute-positioned tooltip to the shared component

## Problem

Tooltips positioned with `absolute + left-1/2 + -translate-x-1/2` get clipped when near viewport edges. For example, the "Verified On-Chain" badge tooltip on profile pages clips behind the left sidebar when the user's display name is short, pushing the badge close to the sidebar edge. The same issue affects the leaderboard page.

## Solution

The shared `Tooltip` component solves this by:
- **Portal rendering** — tooltip appends to `document.body`, escaping any `overflow-hidden` ancestor (like the sidebar)
- **Collision detection** — `collisionPadding={8}` shifts the tooltip to stay within viewport bounds
- **Auto-flipping** — preferred `side` is a hint; Radix flips to the opposite side when space is insufficient

## Usage

```tsx
import { Tooltip } from '@/components/ui/tooltip';

<Tooltip content="Simple text tooltip">
  <button>Hover me</button>
</Tooltip>

<Tooltip
  content={<div><p>Rich content</p></div>}
  side="right"
  align="start"
>
  <span>Hover me</span>
</Tooltip>
```

## Scope

This PR migrates `OnChainBadge` only (highest risk — appears on profile pages and leaderboard near sidebar edge). Other components with the same clipping issue (`GameOnboardingTooltip`, `LikeButton` reaction picker, `Dropdown`) are candidates for follow-up PRs — they require different approaches since they're interactive popups, not simple hover tooltips.

## Files Changed
- `apps/web/src/components/ui/tooltip.tsx` — new shared component
- `apps/web/src/components/profile/OnChainBadge.tsx` — migrated from hand-rolled tooltip to shared component, removed manual `useState` hover state