### PR TITLE
feat(web): fund agent wallet before Solana registration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,9 +120,9 @@ PRIVY_SOLANA_OFFLINE_POLICY_ID=
 # Optional agent-only Solana registration flow.
 SOLANA_REGISTRY_ENABLED=false
 # Cluster: devnet, testnet, mainnet-beta, or localnet
-SOLANA_REGISTRY_CLUSTER=mainnet-beta
-# Optional explicit RPC URL override for Solana registry operations.
-SOLANA_REGISTRY_RPC_URL=
+SOLANA_CLUSTER=mainnet-beta
+# Optional explicit RPC URL override for Solana registration and wallet balance checks.
+SOLANA_RPC_URL=
 
 # ============================================================================
 # Blockchain Configuration (Web3 Integration)

--- a/apps/web/src/app/api/agents/[agentId]/solana-registration/route.test.ts
+++ b/apps/web/src/app/api/agents/[agentId]/solana-registration/route.test.ts
@@ -76,8 +76,14 @@ describe('/api/agents/[agentId]/solana-registration', () => {
       assetId: null,
       metadataUri: null,
       txHash: null,
-      walletAddress: null,
-      walletReady: false,
+      walletAddress: 'SoLWallet111',
+      walletReady: true,
+      walletBalanceLamports: '20000000',
+      walletBalanceSol: '0.02',
+      minimumBalanceLamports: '10000000',
+      minimumBalanceSol: '0.01',
+      hasEnoughBalance: true,
+      canRegister: true,
       cost: 100,
     });
 
@@ -87,6 +93,8 @@ describe('/api/agents/[agentId]/solana-registration', () => {
     const body = await response.json();
 
     expect(body.isRegistered).toBe(false);
+    expect(body.walletBalanceSol).toBe('0.02');
+    expect(body.canRegister).toBe(true);
     expect(mockGetAgentSolanaRegistrationStatus).toHaveBeenCalledWith({
       ownerUserId: 'owner-1',
       agentUserId: 'agent-1',

--- a/apps/web/src/components/agents/AgentWallet.tsx
+++ b/apps/web/src/components/agents/AgentWallet.tsx
@@ -264,10 +264,14 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
   const copySolanaAddress = async () => {
     if (!solanaStatus.walletAddress) return;
 
-    await navigator.clipboard.writeText(solanaStatus.walletAddress);
-    setCopiedSolanaAddress(true);
-    toast.success('Address copied to clipboard');
-    setTimeout(() => setCopiedSolanaAddress(false), 2000);
+    try {
+      await navigator.clipboard.writeText(solanaStatus.walletAddress);
+      setCopiedSolanaAddress(true);
+      toast.success('Address copied to clipboard');
+      setTimeout(() => setCopiedSolanaAddress(false), 2000);
+    } catch {
+      toast.error('Failed to copy address to clipboard');
+    }
   };
 
   return (

--- a/apps/web/src/components/agents/AgentWallet.tsx
+++ b/apps/web/src/components/agents/AgentWallet.tsx
@@ -4,6 +4,8 @@ import { cn } from '@babylon/shared';
 import {
   ArrowDownToLine,
   ArrowUpFromLine,
+  Check,
+  Copy,
   History,
   TrendingUp,
   Wallet,
@@ -33,6 +35,12 @@ interface SolanaRegistrationStatus {
   txHash: string | null;
   walletAddress: string | null;
   walletReady: boolean;
+  walletBalanceLamports: string | null;
+  walletBalanceSol: string | null;
+  minimumBalanceLamports: string;
+  minimumBalanceSol: string;
+  hasEnoughBalance: boolean;
+  canRegister: boolean;
   cost: number;
 }
 
@@ -70,11 +78,18 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
     txHash: null,
     walletAddress: null,
     walletReady: false,
+    walletBalanceLamports: null,
+    walletBalanceSol: null,
+    minimumBalanceLamports: '0',
+    minimumBalanceSol: '0',
+    hasEnoughBalance: false,
+    canRegister: false,
     cost: 0,
   });
   const [solanaLoading, setSolanaLoading] = useState(false);
   const [solanaRegistering, setSolanaRegistering] = useState(false);
   const [solanaError, setSolanaError] = useState<string | null>(null);
+  const [copiedSolanaAddress, setCopiedSolanaAddress] = useState(false);
 
   // Balance state
   const [balanceInfo, setBalanceInfo] = useState({
@@ -239,6 +254,15 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
     }
   };
 
+  const copySolanaAddress = async () => {
+    if (!solanaStatus.walletAddress) return;
+
+    await navigator.clipboard.writeText(solanaStatus.walletAddress);
+    setCopiedSolanaAddress(true);
+    toast.success('Address copied to clipboard');
+    setTimeout(() => setCopiedSolanaAddress(false), 2000);
+  };
+
   return (
     <div className="space-y-6">
       {/* Balance Card */}
@@ -277,8 +301,9 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
           <div>
             <h3 className="font-semibold text-lg">Solana Registry</h3>
             <p className="text-muted-foreground text-sm">
-              Optional agent registration on the Solana 8004 registry. Babylon
-              sponsors the transaction fee.
+              Fund your agent&apos;s Solana wallet with enough SOL to cover
+              network fees, then register it on the Solana 8004 registry.
+              Babylon still handles metadata publishing.
             </p>
           </div>
           <div
@@ -333,6 +358,20 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
                 </div>
               </div>
               <div>
+                <span className="text-muted-foreground">SOL balance</span>
+                <div className="font-medium">
+                  {solanaStatus.walletBalanceSol !== null
+                    ? `${solanaStatus.walletBalanceSol} SOL`
+                    : 'Unavailable'}
+                </div>
+              </div>
+              <div>
+                <span className="text-muted-foreground">Required</span>
+                <div className="font-medium">
+                  {solanaStatus.minimumBalanceSol} SOL
+                </div>
+              </div>
+              <div>
                 <span className="text-muted-foreground">Cost</span>
                 <div className="font-medium">{solanaStatus.cost} pts</div>
               </div>
@@ -354,16 +393,63 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
               </div>
             </div>
 
+            {solanaStatus.walletAddress ? (
+              <div className="rounded-lg border border-[#0066FF]/20 bg-[#0066FF]/5 p-3">
+                <div className="mb-2 flex items-center justify-between gap-3">
+                  <div>
+                    <div className="font-medium text-sm">
+                      Agent funding address
+                    </div>
+                    <div className="text-muted-foreground text-xs">
+                      Send at least {solanaStatus.minimumBalanceSol} SOL to this
+                      wallet before registering.
+                    </div>
+                  </div>
+                  <button
+                    onClick={copySolanaAddress}
+                    className="rounded-lg border border-border bg-background px-3 py-2 text-sm transition-all hover:bg-muted"
+                    title="Copy address"
+                  >
+                    <span className="flex items-center gap-2">
+                      {copiedSolanaAddress ? (
+                        <Check className="h-4 w-4 text-green-600" />
+                      ) : (
+                        <Copy className="h-4 w-4" />
+                      )}
+                      {copiedSolanaAddress ? 'Copied' : 'Copy'}
+                    </span>
+                  </button>
+                </div>
+                <code className="block overflow-x-auto rounded bg-background/80 p-3 text-xs">
+                  {solanaStatus.walletAddress}
+                </code>
+              </div>
+            ) : null}
+
+            {!solanaStatus.isRegistered && !solanaStatus.hasEnoughBalance ? (
+              <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-3 text-amber-700 text-sm">
+                {solanaStatus.walletBalanceSol !== null
+                  ? `Fund this wallet first. Current balance: ${solanaStatus.walletBalanceSol} SOL. Required: ${solanaStatus.minimumBalanceSol} SOL.`
+                  : `Fund this wallet with at least ${solanaStatus.minimumBalanceSol} SOL before registering.`}
+              </div>
+            ) : null}
+
             <button
               onClick={handleSolanaRegistration}
-              disabled={solanaRegistering || solanaStatus.isRegistered}
+              disabled={
+                solanaRegistering ||
+                solanaStatus.isRegistered ||
+                !solanaStatus.canRegister
+              }
               className="h-10 rounded-lg bg-[#0066FF] px-4 font-medium text-sm text-white transition-all hover:bg-[#2952d9] disabled:cursor-not-allowed disabled:opacity-50"
             >
               {solanaRegistering
                 ? 'Registering...'
                 : solanaStatus.isRegistered
                   ? 'Already registered'
-                  : `Register on Solana (${solanaStatus.cost} pts)`}
+                  : solanaStatus.canRegister
+                    ? `Register on Solana (${solanaStatus.cost} pts)`
+                    : `Fund wallet with ${solanaStatus.minimumBalanceSol} SOL`}
             </button>
           </div>
         )}

--- a/apps/web/src/components/agents/AgentWallet.tsx
+++ b/apps/web/src/components/agents/AgentWallet.tsx
@@ -139,24 +139,31 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
     setSolanaStatus(data);
   }, [agent.id, getAccessToken]);
 
+  const refreshSolanaStatus = useCallback(async () => {
+    setSolanaLoading(true);
+    setSolanaError(null);
+
+    try {
+      await fetchSolanaStatus();
+    } catch (error) {
+      setSolanaError(
+        error instanceof Error
+          ? error.message
+          : 'Failed to load Solana registration status'
+      );
+    } finally {
+      setSolanaLoading(false);
+    }
+  }, [fetchSolanaStatus]);
+
   useEffect(() => {
     setLoading(true);
     fetchBalanceAndTransactions().finally(() => setLoading(false));
   }, [fetchBalanceAndTransactions]);
 
   useEffect(() => {
-    setSolanaLoading(true);
-    setSolanaError(null);
-    fetchSolanaStatus()
-      .catch((error) => {
-        setSolanaError(
-          error instanceof Error
-            ? error.message
-            : 'Failed to load Solana registration status'
-        );
-      })
-      .finally(() => setSolanaLoading(false));
-  }, [fetchSolanaStatus]);
+    void refreshSolanaStatus();
+  }, [refreshSolanaStatus]);
 
   const handleTransaction = async () => {
     const amountNum = parseFloat(amount);
@@ -326,19 +333,7 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
               {solanaError}
             </div>
             <button
-              onClick={() => {
-                setSolanaLoading(true);
-                setSolanaError(null);
-                fetchSolanaStatus()
-                  .catch((error) => {
-                    setSolanaError(
-                      error instanceof Error
-                        ? error.message
-                        : 'Failed to load Solana registration status'
-                    );
-                  })
-                  .finally(() => setSolanaLoading(false));
-              }}
+              onClick={() => void refreshSolanaStatus()}
               className="h-10 rounded-lg bg-muted px-4 font-medium text-sm transition-all hover:bg-muted/80"
             >
               Retry
@@ -432,6 +427,16 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
                   ? `Fund this wallet first. Current balance: ${solanaStatus.walletBalanceSol} SOL. Required: ${solanaStatus.minimumBalanceSol} SOL.`
                   : `Fund this wallet with at least ${solanaStatus.minimumBalanceSol} SOL before registering.`}
               </div>
+            ) : null}
+
+            {!solanaStatus.isRegistered ? (
+              <button
+                onClick={() => void refreshSolanaStatus()}
+                disabled={solanaLoading || solanaRegistering}
+                className="h-10 rounded-lg border border-border bg-background px-4 font-medium text-sm transition-all hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Refresh balance
+              </button>
             ) : null}
 
             <button

--- a/packages/agents/src/solana-registry/sdk.ts
+++ b/packages/agents/src/solana-registry/sdk.ts
@@ -1,5 +1,11 @@
 import { createHash } from 'node:crypto';
-import { Keypair, PublicKey, Transaction } from '@solana/web3.js';
+import {
+  Connection,
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  Transaction,
+} from '@solana/web3.js';
 import {
   IPFSClient,
   type PreparedTransaction,
@@ -86,6 +92,10 @@ function createSolanaRegistrySdk(
     signer: config.signer,
     ipfsClient: createSolanaRegistryIpfsClient(),
   });
+}
+
+function createSolanaRegistryConnection(): Connection {
+  return new Connection(resolveSolanaRegistryRpcUrl(), 'confirmed');
 }
 
 export function buildAgentSolanaRegistrationFile({
@@ -210,4 +220,23 @@ export async function getAgentSolanaRegistration(
 ): Promise<Awaited<ReturnType<SolanaSDK['getAgent']>>> {
   const sdk = createSolanaRegistrySdk();
   return sdk.getAgent(new PublicKey(assetId));
+}
+
+export async function getSolanaWalletBalanceLamports(
+  walletAddress: string
+): Promise<bigint> {
+  const connection = createSolanaRegistryConnection();
+  const balance = await connection.getBalance(new PublicKey(walletAddress));
+  return BigInt(balance);
+}
+
+export function formatLamportsAsSol(lamports: bigint): string {
+  const divisor = BigInt(LAMPORTS_PER_SOL);
+  const whole = lamports / divisor;
+  const fractional = (lamports % divisor).toString().padStart(9, '0');
+  const trimmedFractional = fractional.replace(/0+$/, '');
+
+  return trimmedFractional.length > 0
+    ? `${whole}.${trimmedFractional}`
+    : whole.toString();
 }

--- a/packages/agents/src/solana-registry/sdk.ts
+++ b/packages/agents/src/solana-registry/sdk.ts
@@ -17,8 +17,8 @@ import {
   type SolanaSDKConfig,
 } from '8004-solana';
 
-function resolveSolanaRegistryCluster(): SolanaSDKConfig['cluster'] {
-  const cluster = process.env.SOLANA_REGISTRY_CLUSTER ?? 'mainnet-beta';
+function resolveSolanaCluster(): SolanaSDKConfig['cluster'] {
+  const cluster = process.env.SOLANA_CLUSTER ?? 'mainnet-beta';
 
   if (
     cluster === 'devnet' ||
@@ -30,15 +30,15 @@ function resolveSolanaRegistryCluster(): SolanaSDKConfig['cluster'] {
   }
 
   throw new Error(
-    `Unsupported SOLANA_REGISTRY_CLUSTER value: ${cluster}. Expected devnet, testnet, mainnet-beta, or localnet.`
+    `Unsupported SOLANA_CLUSTER value: ${cluster}. Expected devnet, testnet, mainnet-beta, or localnet.`
   );
 }
 
-function resolveSolanaRegistryRpcUrl(): string {
-  const cluster = resolveSolanaRegistryCluster();
+function resolveSolanaRpcUrl(): string {
+  const cluster = resolveSolanaCluster();
 
-  if (process.env.SOLANA_REGISTRY_RPC_URL) {
-    return process.env.SOLANA_REGISTRY_RPC_URL;
+  if (process.env.SOLANA_RPC_URL) {
+    return process.env.SOLANA_RPC_URL;
   }
 
   return cluster === 'devnet' ? SOLANA_DEVNET_RPC : SOLANA_MAINNET_RPC;
@@ -51,7 +51,7 @@ export function assertSolanaRegistryConfigured(): void {
     );
   }
 
-  resolveSolanaRegistryRpcUrl();
+  resolveSolanaRpcUrl();
   createSolanaRegistryIpfsClient();
 }
 
@@ -87,15 +87,15 @@ function createSolanaRegistrySdk(
   config: Pick<SolanaSDKConfig, 'signer'> = {}
 ): SolanaSDK {
   return new SolanaSDK({
-    cluster: resolveSolanaRegistryCluster(),
-    rpcUrl: resolveSolanaRegistryRpcUrl(),
+    cluster: resolveSolanaCluster(),
+    rpcUrl: resolveSolanaRpcUrl(),
     signer: config.signer,
     ipfsClient: createSolanaRegistryIpfsClient(),
   });
 }
 
 function createSolanaRegistryConnection(): Connection {
-  return new Connection(resolveSolanaRegistryRpcUrl(), 'confirmed');
+  return new Connection(resolveSolanaRpcUrl(), 'confirmed');
 }
 
 export function buildAgentSolanaRegistrationFile({

--- a/packages/api/src/env.ts
+++ b/packages/api/src/env.ts
@@ -29,7 +29,7 @@ export function getTrimmedEnv(name: SupportedEnvKey): string | undefined {
                   ? process.env.PRIVY_OFFLINE_POLICY_ID
                   : name === 'PRIVY_SOLANA_OFFLINE_POLICY_ID'
                     ? process.env.PRIVY_SOLANA_OFFLINE_POLICY_ID
-                  : process.env.PRIVY_OFFLINE_SIGNER_ID;
+                    : process.env.PRIVY_OFFLINE_SIGNER_ID;
 
   const trimmed = rawValue?.trim();
   return trimmed ? trimmed : undefined;

--- a/packages/api/src/services/agent-solana-registration-service.test.ts
+++ b/packages/api/src/services/agent-solana-registration-service.test.ts
@@ -206,6 +206,25 @@ describe('agent-solana-registration-service', () => {
     expect(status.cost).toBe(100);
   });
 
+  it('returns wallet funding details even when balance lookup fails', async () => {
+    selectResults.push([BASE_AGENT]);
+    mockGetSolanaWalletBalanceLamports.mockRejectedValueOnce(
+      new Error('RPC unavailable')
+    );
+
+    const status = await getAgentSolanaRegistrationStatus({
+      ownerUserId: 'owner-1',
+      agentUserId: 'agent-1',
+    });
+
+    expect(status.walletReady).toBe(true);
+    expect(status.walletAddress).toBe('SoLWallet111');
+    expect(status.walletBalanceLamports).toBeNull();
+    expect(status.walletBalanceSol).toBeNull();
+    expect(status.hasEnoughBalance).toBe(false);
+    expect(status.canRegister).toBe(false);
+  });
+
   it('registers an agent on Solana, charges points once, and persists Solana-specific fields', async () => {
     selectResults.push([BASE_AGENT]);
     selectResults.push([{ virtualBalance: '900' }]);

--- a/packages/api/src/services/agent-solana-registration-service.test.ts
+++ b/packages/api/src/services/agent-solana-registration-service.test.ts
@@ -2,8 +2,9 @@ import { beforeEach, describe, expect, it, mock } from 'bun:test';
 
 const mockGetAgentSolanaRegistration = mock();
 const mockPrepareAgentSolanaRegistrationTransaction = mock();
+const mockGetSolanaWalletBalanceLamports = mock();
 const mockEnsureSolanaWalletReady = mock();
-const mockSendSponsoredSolanaTransaction = mock();
+const mockSendSolanaTransaction = mock();
 const mockAssertSolanaRegistryConfigured = mock();
 const mockAcquireLock = mock();
 const mockReleaseLock = mock();
@@ -41,7 +42,18 @@ mock.module('@babylon/agents/solana-registry', () => ({
   deriveDeterministicAgentSolanaAsset: () => ({
     publicKey: { toBase58: () => 'asset-deterministic' },
   }),
+  formatLamportsAsSol: (lamports: bigint) => {
+    const divisor = 1_000_000_000n;
+    const whole = lamports / divisor;
+    const fractional = (lamports % divisor).toString().padStart(9, '0');
+    const trimmedFractional = fractional.replace(/0+$/, '');
+
+    return trimmedFractional.length > 0
+      ? `${whole}.${trimmedFractional}`
+      : whole.toString();
+  },
   getAgentSolanaRegistration: mockGetAgentSolanaRegistration,
+  getSolanaWalletBalanceLamports: mockGetSolanaWalletBalanceLamports,
   prepareAgentSolanaRegistrationTransaction:
     mockPrepareAgentSolanaRegistrationTransaction,
 }));
@@ -106,7 +118,7 @@ mock.module('./privy/solana-wallet-provisioning', () => ({
 }));
 
 mock.module('./privy/solana-send-transaction', () => ({
-  sendSponsoredSolanaTransaction: mockSendSponsoredSolanaTransaction,
+  sendSolanaTransaction: mockSendSolanaTransaction,
 }));
 
 mock.module('./distributed-lock-service', () => ({
@@ -145,8 +157,9 @@ describe('agent-solana-registration-service', () => {
     capturedRegistrationFileInput = null;
     mockGetAgentSolanaRegistration.mockReset();
     mockPrepareAgentSolanaRegistrationTransaction.mockReset();
+    mockGetSolanaWalletBalanceLamports.mockReset();
     mockEnsureSolanaWalletReady.mockReset();
-    mockSendSponsoredSolanaTransaction.mockReset();
+    mockSendSolanaTransaction.mockReset();
     mockAssertSolanaRegistryConfigured.mockReset();
     mockAcquireLock.mockReset();
     mockReleaseLock.mockReset();
@@ -167,7 +180,8 @@ describe('agent-solana-registration-service', () => {
       metadataCid: 'cid-123',
       transaction: 'base64-tx',
     });
-    mockSendSponsoredSolanaTransaction.mockResolvedValue({
+    mockGetSolanaWalletBalanceLamports.mockResolvedValue(20_000_000n);
+    mockSendSolanaTransaction.mockResolvedValue({
       hash: 'tx-123',
       transactionId: 'tx-123',
       caip2: 'solana:mainnet',
@@ -183,6 +197,12 @@ describe('agent-solana-registration-service', () => {
     });
 
     expect(status.isRegistered).toBe(false);
+    expect(status.walletReady).toBe(true);
+    expect(status.walletAddress).toBe('SoLWallet111');
+    expect(status.walletBalanceSol).toBe('0.02');
+    expect(status.minimumBalanceSol).toBe('0.01');
+    expect(status.hasEnoughBalance).toBe(true);
+    expect(status.canRegister).toBe(true);
     expect(status.cost).toBe(100);
   });
 
@@ -202,7 +222,10 @@ describe('agent-solana-registration-service', () => {
     expect(result.alreadyRegistered).toBe(false);
     expect(result.assetId).toBe('asset-123');
     expect(result.txHash).toBe('tx-123');
-    expect(mockSendSponsoredSolanaTransaction).toHaveBeenCalledWith({
+    expect(mockGetSolanaWalletBalanceLamports).toHaveBeenCalledWith(
+      'SoLWallet111'
+    );
+    expect(mockSendSolanaTransaction).toHaveBeenCalledWith({
       walletId: 'solana-wallet-1',
       transaction: 'base64-tx',
     });
@@ -216,6 +239,22 @@ describe('agent-solana-registration-service', () => {
         (insert) => insert.description === 'Agent Solana registration'
       )
     ).toBe(true);
+  });
+
+  it('blocks registration until the agent wallet is funded with enough SOL', async () => {
+    selectResults.push([BASE_AGENT]);
+    mockGetAgentSolanaRegistration.mockResolvedValueOnce(null);
+    mockGetSolanaWalletBalanceLamports.mockResolvedValueOnce(5_000_000n);
+
+    await expect(
+      registerAgentOnSolanaForOwner({
+        ownerUserId: 'owner-1',
+        agentUserId: 'agent-1',
+      })
+    ).rejects.toThrow('Fund the agent wallet with at least 0.01 SOL');
+
+    expect(capturedInserts).toHaveLength(0);
+    expect(mockSendSolanaTransaction).not.toHaveBeenCalled();
   });
 
   it('returns already registered without charging when DB is already in sync', async () => {
@@ -237,7 +276,7 @@ describe('agent-solana-registration-service', () => {
     expect(result.alreadyRegistered).toBe(true);
     expect(result.cost).toBe(0);
     expect(capturedInserts).toHaveLength(0);
-    expect(mockSendSponsoredSolanaTransaction).not.toHaveBeenCalled();
+    expect(mockSendSolanaTransaction).not.toHaveBeenCalled();
   });
 
   it('surfaces missing Solana configuration cleanly', async () => {
@@ -308,7 +347,7 @@ describe('agent-solana-registration-service', () => {
     ).rejects.toThrow('already in progress');
 
     expect(capturedInserts).toHaveLength(0);
-    expect(mockSendSponsoredSolanaTransaction).not.toHaveBeenCalled();
+    expect(mockSendSolanaTransaction).not.toHaveBeenCalled();
   });
 
   it('reconciles on-chain success after a post-send failure without refunding', async () => {
@@ -319,7 +358,7 @@ describe('agent-solana-registration-service', () => {
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce({ owner: 'onchain' });
-    mockSendSponsoredSolanaTransaction.mockRejectedValueOnce(
+    mockSendSolanaTransaction.mockRejectedValueOnce(
       new Error('Privy returned an unexpected response')
     );
 

--- a/packages/api/src/services/agent-solana-registration-service.test.ts
+++ b/packages/api/src/services/agent-solana-registration-service.test.ts
@@ -276,6 +276,46 @@ describe('agent-solana-registration-service', () => {
     expect(mockSendSolanaTransaction).not.toHaveBeenCalled();
   });
 
+  it('rejects registration when the agent has no Privy identity', async () => {
+    selectResults.push([
+      {
+        ...BASE_AGENT,
+        privyId: null,
+        solanaOfflineWalletReady: false,
+        solanaWalletAddress: null,
+        privySolanaWalletId: null,
+      },
+    ]);
+    mockGetAgentSolanaRegistration.mockResolvedValueOnce(null);
+
+    await expect(
+      registerAgentOnSolanaForOwner({
+        ownerUserId: 'owner-1',
+        agentUserId: 'agent-1',
+      })
+    ).rejects.toThrow('Agent wallet identity is not ready');
+
+    expect(capturedInserts).toHaveLength(0);
+    expect(mockSendSolanaTransaction).not.toHaveBeenCalled();
+  });
+
+  it('allows registration when wallet balance equals exactly the minimum threshold', async () => {
+    selectResults.push([BASE_AGENT]);
+    selectResults.push([{ virtualBalance: '900' }]);
+    mockGetAgentSolanaRegistration
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+    mockGetSolanaWalletBalanceLamports.mockResolvedValueOnce(10_000_000n);
+
+    const result = await registerAgentOnSolanaForOwner({
+      ownerUserId: 'owner-1',
+      agentUserId: 'agent-1',
+    });
+
+    expect(result.alreadyRegistered).toBe(false);
+    expect(mockSendSolanaTransaction).toHaveBeenCalled();
+  });
+
   it('returns already registered without charging when DB is already in sync', async () => {
     selectResults.push([
       {

--- a/packages/api/src/services/agent-solana-registration-service.ts
+++ b/packages/api/src/services/agent-solana-registration-service.ts
@@ -2,7 +2,9 @@ import {
   assertSolanaRegistryConfigured,
   buildAgentSolanaRegistrationFile,
   deriveDeterministicAgentSolanaAsset,
+  formatLamportsAsSol,
   getAgentSolanaRegistration,
+  getSolanaWalletBalanceLamports,
   prepareAgentSolanaRegistrationTransaction,
 } from '@babylon/agents/solana-registry';
 import { and, balanceTransactions, db, eq, sql, users } from '@babylon/db';
@@ -15,7 +17,7 @@ import {
   POINTS,
 } from '@babylon/shared';
 import { DistributedLockService } from './distributed-lock-service';
-import { sendSponsoredSolanaTransaction } from './privy/solana-send-transaction';
+import { sendSolanaTransaction } from './privy/solana-send-transaction';
 import { ensureSolanaWalletReady } from './privy/solana-wallet-provisioning';
 
 export interface AgentSolanaRegistrationStatus {
@@ -25,6 +27,12 @@ export interface AgentSolanaRegistrationStatus {
   txHash: string | null;
   walletAddress: string | null;
   walletReady: boolean;
+  walletBalanceLamports: string | null;
+  walletBalanceSol: string | null;
+  minimumBalanceLamports: string;
+  minimumBalanceSol: string;
+  hasEnoughBalance: boolean;
+  canRegister: boolean;
   cost: number;
 }
 
@@ -74,6 +82,51 @@ const AGENT_SOLANA_SELECT = {
   solanaMetadataUri: users.solanaMetadataUri,
   solanaRegistrationTxHash: users.solanaRegistrationTxHash,
 } as const;
+
+const MINIMUM_SOLANA_REGISTRATION_BALANCE_LAMPORTS = 10_000_000n;
+const MINIMUM_SOLANA_REGISTRATION_BALANCE_SOL = formatLamportsAsSol(
+  MINIMUM_SOLANA_REGISTRATION_BALANCE_LAMPORTS
+);
+
+function isSolanaRegistrationEnabled(): boolean {
+  return process.env.SOLANA_REGISTRY_ENABLED === 'true';
+}
+
+function isPersistedSolanaWalletReady(agent: AgentSolanaRecord): boolean {
+  return (
+    agent.solanaOfflineWalletReady &&
+    agent.solanaWalletAddress !== null &&
+    agent.privySolanaWalletId !== null
+  );
+}
+
+async function resolveAgentSolanaWallet(agent: AgentSolanaRecord): Promise<{
+  privyWalletId: string;
+  walletAddress: string;
+} | null> {
+  if (!agent.privyId) {
+    return null;
+  }
+
+  if (isPersistedSolanaWalletReady(agent)) {
+    return {
+      privyWalletId: agent.privySolanaWalletId!,
+      walletAddress: agent.solanaWalletAddress!,
+    };
+  }
+
+  if (!isSolanaRegistrationEnabled()) {
+    return null;
+  }
+
+  const wallet = await ensureSolanaWalletReady({ privyId: agent.privyId });
+  await persistSolanaWalletState(agent.id, wallet);
+
+  return {
+    privyWalletId: wallet.privyWalletId,
+    walletAddress: wallet.walletAddress,
+  };
+}
 
 async function getAgentForOwner(
   ownerUserId: string,
@@ -270,6 +323,14 @@ export async function getAgentSolanaRegistrationStatus({
   agentUserId: string;
 }): Promise<AgentSolanaRegistrationStatus> {
   const agent = await getAgentForOwner(ownerUserId, agentUserId);
+  const wallet = await resolveAgentSolanaWallet(agent);
+  const walletBalanceLamports =
+    wallet && isSolanaRegistrationEnabled()
+      ? await getSolanaWalletBalanceLamports(wallet.walletAddress)
+      : null;
+  const hasEnoughBalance =
+    walletBalanceLamports !== null &&
+    walletBalanceLamports >= MINIMUM_SOLANA_REGISTRATION_BALANCE_LAMPORTS;
 
   return {
     isRegistered:
@@ -277,11 +338,23 @@ export async function getAgentSolanaRegistrationStatus({
     assetId: agent.solanaRegistryAssetId,
     metadataUri: agent.solanaMetadataUri,
     txHash: agent.solanaRegistrationTxHash,
-    walletAddress: agent.solanaWalletAddress,
-    walletReady:
-      agent.solanaOfflineWalletReady &&
-      agent.solanaWalletAddress !== null &&
-      agent.privySolanaWalletId !== null,
+    walletAddress: wallet?.walletAddress ?? agent.solanaWalletAddress,
+    walletReady: wallet !== null,
+    walletBalanceLamports:
+      walletBalanceLamports !== null ? walletBalanceLamports.toString() : null,
+    walletBalanceSol:
+      walletBalanceLamports !== null
+        ? formatLamportsAsSol(walletBalanceLamports)
+        : null,
+    minimumBalanceLamports:
+      MINIMUM_SOLANA_REGISTRATION_BALANCE_LAMPORTS.toString(),
+    minimumBalanceSol: MINIMUM_SOLANA_REGISTRATION_BALANCE_SOL,
+    hasEnoughBalance,
+    canRegister:
+      isSolanaRegistrationEnabled() &&
+      !agent.solanaRegistered &&
+      wallet !== null &&
+      hasEnoughBalance,
     cost: POINTS.ONCHAIN_REGISTRATION,
   };
 }
@@ -295,6 +368,7 @@ export async function registerAgentOnSolanaForOwner({
 }): Promise<AgentSolanaRegistrationResult> {
   const agent = await getAgentForOwner(ownerUserId, agentUserId);
   return withAgentSolanaRegistrationLock(agentUserId, async () => {
+    const cost = POINTS.ONCHAIN_REGISTRATION;
     let costCharged = false;
     let wallet: {
       privyWalletId: string;
@@ -372,13 +446,29 @@ export async function registerAgentOnSolanaForOwner({
       );
     }
 
-    const cost = POINTS.ONCHAIN_REGISTRATION;
-    await deductRegistrationCost(ownerUserId, agentUserId, cost);
-    costCharged = true;
-
     try {
-      wallet = await ensureSolanaWalletReady({ privyId: agent.privyId });
-      await persistSolanaWalletState(agentUserId, wallet);
+      wallet = await resolveAgentSolanaWallet(agent);
+      if (!wallet) {
+        throw new BusinessLogicError(
+          'Agent wallet identity is not ready yet. Try again after the agent wallet has been provisioned.',
+          'AGENT_IDENTITY_NOT_READY'
+        );
+      }
+
+      const walletBalanceLamports = await getSolanaWalletBalanceLamports(
+        wallet.walletAddress
+      );
+      if (
+        walletBalanceLamports < MINIMUM_SOLANA_REGISTRATION_BALANCE_LAMPORTS
+      ) {
+        throw new BusinessLogicError(
+          `Fund the agent wallet with at least ${MINIMUM_SOLANA_REGISTRATION_BALANCE_SOL} SOL before registering. Current balance: ${formatLamportsAsSol(walletBalanceLamports)} SOL.`,
+          'AGENT_SOLANA_WALLET_NOT_FUNDED'
+        );
+      }
+
+      await deductRegistrationCost(ownerUserId, agentUserId, cost);
+      costCharged = true;
 
       const registrationFile = buildAgentSolanaRegistrationFile({
         name: agent.displayName || agent.username || agentUserId,
@@ -431,7 +521,7 @@ export async function registerAgentOnSolanaForOwner({
         };
       }
 
-      const tx = await sendSponsoredSolanaTransaction({
+      const tx = await sendSolanaTransaction({
         walletId: wallet.privyWalletId,
         transaction: prepared.transaction,
       });

--- a/packages/api/src/services/agent-solana-registration-service.ts
+++ b/packages/api/src/services/agent-solana-registration-service.ts
@@ -324,10 +324,27 @@ export async function getAgentSolanaRegistrationStatus({
 }): Promise<AgentSolanaRegistrationStatus> {
   const agent = await getAgentForOwner(ownerUserId, agentUserId);
   const wallet = await resolveAgentSolanaWallet(agent);
-  const walletBalanceLamports =
-    wallet && isSolanaRegistrationEnabled()
-      ? await getSolanaWalletBalanceLamports(wallet.walletAddress)
-      : null;
+  let walletBalanceLamports: bigint | null = null;
+
+  if (wallet && isSolanaRegistrationEnabled()) {
+    try {
+      walletBalanceLamports = await getSolanaWalletBalanceLamports(
+        wallet.walletAddress
+      );
+    } catch (error) {
+      logger.warn(
+        'Failed to load agent Solana wallet balance for registration status',
+        {
+          ownerUserId,
+          agentUserId,
+          walletAddress: wallet.walletAddress,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        'AgentSolanaRegistration'
+      );
+    }
+  }
+
   const hasEnoughBalance =
     walletBalanceLamports !== null &&
     walletBalanceLamports >= MINIMUM_SOLANA_REGISTRATION_BALANCE_LAMPORTS;

--- a/packages/api/src/services/privy/__tests__/offline-config.test.ts
+++ b/packages/api/src/services/privy/__tests__/offline-config.test.ts
@@ -2,10 +2,9 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 
 const ORIGINAL_ENV = { ...process.env };
 
-const {
-  getPrivyOfflineConfig,
-  getPrivySolanaOfflineConfig,
-} = await import('../offline-config');
+const { getPrivyOfflineConfig, getPrivySolanaOfflineConfig } = await import(
+  '../offline-config'
+);
 
 describe('offline-config', () => {
   beforeEach(() => {

--- a/packages/api/src/services/privy/__tests__/solana-idempotency.test.ts
+++ b/packages/api/src/services/privy/__tests__/solana-idempotency.test.ts
@@ -1,30 +1,30 @@
 import { describe, expect, it } from 'bun:test';
-import { buildSponsoredSolanaTransactionIdempotencyKey } from '../solana-idempotency';
+import { buildSolanaTransactionIdempotencyKey } from '../solana-idempotency';
 
-describe('buildSponsoredSolanaTransactionIdempotencyKey', () => {
-  it('is stable for the same sponsored request payload', () => {
-    const keyA = buildSponsoredSolanaTransactionIdempotencyKey({
+describe('buildSolanaTransactionIdempotencyKey', () => {
+  it('is stable for the same transaction payload', () => {
+    const keyA = buildSolanaTransactionIdempotencyKey({
       walletId: 'wallet-1',
       transaction: 'tx-body-1',
       caip2: 'solana:mainnet',
     });
-    const keyB = buildSponsoredSolanaTransactionIdempotencyKey({
+    const keyB = buildSolanaTransactionIdempotencyKey({
       walletId: 'wallet-1',
       transaction: 'tx-body-1',
       caip2: 'solana:mainnet',
     });
 
     expect(keyA).toBe(keyB);
-    expect(keyA.startsWith('solana-sponsored-tx:v1:')).toBe(true);
+    expect(keyA.startsWith('solana-tx:v1:')).toBe(true);
   });
 
-  it('changes when the sponsored request body changes', () => {
-    const keyA = buildSponsoredSolanaTransactionIdempotencyKey({
+  it('changes when the request body changes', () => {
+    const keyA = buildSolanaTransactionIdempotencyKey({
       walletId: 'wallet-1',
       transaction: 'tx-body-1',
       caip2: 'solana:mainnet',
     });
-    const keyB = buildSponsoredSolanaTransactionIdempotencyKey({
+    const keyB = buildSolanaTransactionIdempotencyKey({
       walletId: 'wallet-1',
       transaction: 'tx-body-2',
       caip2: 'solana:mainnet',

--- a/packages/api/src/services/privy/solana-idempotency.ts
+++ b/packages/api/src/services/privy/solana-idempotency.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 
-export function buildSponsoredSolanaTransactionIdempotencyKey({
+export function buildSolanaTransactionIdempotencyKey({
   walletId,
   transaction,
   caip2,
@@ -15,10 +15,9 @@ export function buildSponsoredSolanaTransactionIdempotencyKey({
         walletId,
         caip2,
         transaction,
-        sponsor: true,
       })
     )
     .digest('hex');
 
-  return `solana-sponsored-tx:v1:${digest}`;
+  return `solana-tx:v1:${digest}`;
 }

--- a/packages/api/src/services/privy/solana-send-transaction.ts
+++ b/packages/api/src/services/privy/solana-send-transaction.ts
@@ -2,7 +2,7 @@ import { logger } from '@babylon/shared';
 import { extractPrivyApiDiagnostics } from './error-diagnostics';
 import { getPrivyOfflineConfig } from './offline-config';
 import { getPrivyNodeClient } from './privy-node';
-import { buildSponsoredSolanaTransactionIdempotencyKey } from './solana-idempotency';
+import { buildSolanaTransactionIdempotencyKey } from './solana-idempotency';
 
 function resolveSolanaCaip2(): string {
   const cluster = process.env.SOLANA_REGISTRY_CLUSTER ?? 'mainnet-beta';
@@ -20,7 +20,7 @@ function resolveSolanaCaip2(): string {
   }
 }
 
-export async function sendSponsoredSolanaTransaction({
+export async function sendSolanaTransaction({
   walletId,
   transaction,
 }: {
@@ -30,7 +30,7 @@ export async function sendSponsoredSolanaTransaction({
   const privy = getPrivyNodeClient();
   const offlineConfig = getPrivyOfflineConfig();
   const caip2 = resolveSolanaCaip2();
-  const idempotencyKey = buildSponsoredSolanaTransactionIdempotencyKey({
+  const idempotencyKey = buildSolanaTransactionIdempotencyKey({
     walletId,
     transaction,
     caip2,
@@ -43,7 +43,6 @@ export async function sendSponsoredSolanaTransaction({
       .signAndSendTransaction(walletId, {
         caip2,
         transaction,
-        sponsor: true,
         authorization_context: {
           authorization_private_keys: [offlineConfig.authorizationPrivateKey],
         },
@@ -57,16 +56,16 @@ export async function sendSponsoredSolanaTransaction({
     };
   } catch (error) {
     logger.error(
-      'Failed to submit sponsored Solana transaction via Privy',
+      'Failed to submit Solana transaction via Privy',
       {
         walletId,
         ...extractPrivyApiDiagnostics(error),
       },
-      'sendSponsoredSolanaTransaction'
+      'sendSolanaTransaction'
     );
 
     throw error instanceof Error
       ? error
-      : new Error('Failed to submit sponsored Solana transaction');
+      : new Error('Failed to submit Solana transaction');
   }
 }

--- a/packages/api/src/services/privy/solana-send-transaction.ts
+++ b/packages/api/src/services/privy/solana-send-transaction.ts
@@ -5,7 +5,7 @@ import { getPrivyNodeClient } from './privy-node';
 import { buildSolanaTransactionIdempotencyKey } from './solana-idempotency';
 
 function resolveSolanaCaip2(): string {
-  const cluster = process.env.SOLANA_REGISTRY_CLUSTER ?? 'mainnet-beta';
+  const cluster = process.env.SOLANA_CLUSTER ?? 'mainnet-beta';
 
   switch (cluster) {
     case 'devnet':


### PR DESCRIPTION
## Summary
- Switch the Solana 8004 agent registration send path from Privy-sponsored to non-sponsored transactions.
- Provision and expose the agent Solana wallet earlier, surface the live SOL balance, and gate registration until the wallet holds at least `0.01 SOL` for network fees.
- Update the agent wallet UI copy and CTA so funding the agent wallet is the primary action before registration.

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [x] Contracts / on-chain
- [ ] Other: …

## Context / Links
- [BAB-289](https://linear.app/eliza-labs/issue/BAB-289/implement-non-sponsored-solana-8004-agent-registration-flow)

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [x] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- Add Solana wallet balance helpers on the registry SDK side so the registration service can reuse the existing Solana RPC configuration.
- Enrich the Solana registration status payload with wallet balance, minimum funding threshold, and a server-computed `canRegister` gate.
- Provision the agent Solana wallet on status reads when needed so the owner can fund the wallet before attempting registration.
- Reject registration attempts until the wallet has at least `0.01 SOL`, and only then deduct the existing Babylon points cost.
- Send the final Solana registration transaction through Privy without `sponsor: true` while keeping the existing offline authorization flow and idempotency protection.
- Update the agent wallet panel to show the funding address, copy action, current SOL balance, required minimum, and the gated CTA.

## Review guide
**Start here**
- `packages/api/src/services/agent-solana-registration-service.ts`

**Risk**
- [x] Medium
- [ ] Low
- [ ] High

**Notes for reviewers**
- I kept the existing points charge because BAB-289 does not include a final product decision to remove it.
- The minimum SOL threshold is hardcoded to `0.01 SOL` per the issue's working assumption; if product wants configurability, that should be a follow-up.
- Non-goal in this PR: broader product reconsideration of the points charge.

## Test plan
**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Reviewed the server-side registration path and confirmed the send step no longer sets `sponsor: true`.
2. Ran `bun test packages/api/src/services/agent-solana-registration-service.test.ts packages/api/src/services/privy/__tests__/solana-idempotency.test.ts apps/web/src/app/api/agents/[agentId]/solana-registration/route.test.ts`.
3. Ran `/home/slk/work/babylon/monorepo/node_modules/.bin/biome check packages/agents/src/solana-registry/sdk.ts packages/api/src/services/privy/solana-idempotency.ts packages/api/src/services/privy/__tests__/solana-idempotency.test.ts packages/api/src/services/privy/solana-send-transaction.ts packages/api/src/services/agent-solana-registration-service.ts packages/api/src/services/agent-solana-registration-service.test.ts apps/web/src/app/api/agents/[agentId]/solana-registration/route.test.ts apps/web/src/components/agents/AgentWallet.tsx`.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: Deploy normally; registration becomes available only when the agent Solana wallet meets the funding threshold.
- Rollback: Revert this PR to restore the previous sponsored send path and status payload.

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- `GET /api/agents/[agentId]/solana-registration` now returns wallet funding fields (`walletBalance*`, `minimumBalance*`, `hasEnoughBalance`, `canRegister`).

### Database
- No schema changes.

### Contracts / on-chain
- The agent wallet now pays its own Solana network fee for the 8004 registration transaction.

### Docs
- No docs update in this PR.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes
- Reason: The UI copy and CTA changed, but I did not spin up a full local app session or capture media in this pass to avoid adding another heavy app process on the shared machine.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
