### PR TITLE
fix(feed): remove render-phase pagination reset

### DIFF
--- a/apps/web/src/app/feed/components/NarrativeStoryList.tsx
+++ b/apps/web/src/app/feed/components/NarrativeStoryList.tsx
@@ -34,15 +34,12 @@ export function NarrativeStoryList({ stories }: NarrativeStoryListProps) {
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
   const sentinelRef = useRef<HTMLDivElement>(null);
 
-  // Reset visible count when stories changes (tab switch / refresh).
-  // Using a ref comparison during render is the React-idiomatic way to
-  // reset derived state without a useEffect, since the effect body wouldn't
-  // reference the dependency and Biome would flag it as unnecessary.
   const prevStoriesRef = useRef(stories);
-  if (prevStoriesRef.current !== stories) {
+  useEffect(() => {
+    if (prevStoriesRef.current === stories) return;
     prevStoriesRef.current = stories;
     setVisibleCount(PAGE_SIZE);
-  }
+  }, [stories]);
 
   const loadMore = useCallback(() => {
     setVisibleCount((n) => Math.min(n + PAGE_SIZE, allItems.length));


### PR DESCRIPTION
## Summary
- Move `NarrativeStoryList` pagination reset back into a `useEffect` so it no longer mutates state during render.
- Match the reset pattern already used by `ForYouFeedList`, keeping the change minimal and easy to review.
- Document the important triage finding: `NarrativeStoryList` is currently not mounted by `FeedClient`, so this removes a confirmed hook-order hazard without claiming a wider runtime refactor.

## Type
- [x] Bug fix

## Context / Links
- [BAB-292](https://linear.app/eliza-labs/issue/BAB-292/bugfeed-investigate-hook-order-crash-on-feed-narrative-rendering)
- Sentry issue: `BABYLONAPP-D`

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Tests (`packages/testing`)

## Changes
- Replace the render-phase `setVisibleCount(PAGE_SIZE)` branch in `apps/web/src/app/feed/components/NarrativeStoryList.tsx` with an effect-driven reset keyed by `stories`.
- Keep the existing `prevStoriesRef` guard so pagination resets only when the stories reference actually changes.
- Leave the current `/feed` runtime path unchanged; `FeedClient` currently renders `ForYouFeedList`, `MixedFeedList`, and `PostList`, not `NarrativeStoryList`.

## Review guide
**Start here**
- `apps/web/src/app/feed/components/NarrativeStoryList.tsx`

**Risk**
- [x] Low

**Notes for reviewers**
- The issue description called out `NarrativeStoryList` as suspicious, and Git history shows the render-phase reset was introduced by `f4b7b7c66`.
- While tracing the current codepath, I verified that `FeedClient` does not currently mount `NarrativeStoryList`; this PR still removes the known hook-order hazard instead of broadening scope without proof.

## Test plan
**Commands run**
- [x] `bunx biome check apps/web/src/app/feed/components/NarrativeStoryList.tsx`
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)

**Manual verification**
1. Confirm the diff only removes the render-phase state update and restores effect-based reset semantics.
2. Confirm `FeedClient` still uses `ForYouFeedList`/`MixedFeedList` for the current `/feed` runtime path.

## Ops / Migration / Deployment
- [x] No deploy impact

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: ship normally.
- Rollback: revert this PR.

## Breaking changes
- [x] None

## Security / privacy
- [x] No security impact

## Screenshots / recordings (UI)
### Option B: No visual changes
- Reason: internal React state-management fix in a client component, no intended visual delta.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`production` for this repo)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
