### PR TITLE
fix(web): degrade notification reads during schema drift

### DIFF
--- a/apps/web/src/app/api/notifications/digest-settings/route.ts
+++ b/apps/web/src/app/api/notifications/digest-settings/route.ts
@@ -2,10 +2,12 @@ import { authenticate, successResponse, withErrorHandling } from '@babylon/api';
 import { db, eq, users } from '@babylon/db';
 import {
   DEFAULT_NOTIFICATION_DIGEST_SETTINGS,
+  logger,
   type NotificationDigestSettings,
 } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 import { z } from 'zod';
+import { getMissingNotificationSchemaErrorCode } from '../schema-compat';
 
 const DigestSettingsSchema = z.object({
   digestEnabled: z.boolean(),
@@ -30,21 +32,40 @@ function toSettings(row: {
 export const GET = withErrorHandling(async (request: NextRequest) => {
   const authUser = await authenticate(request);
 
-  const [user] = await db
-    .select({
-      notificationDigestEnabled: users.notificationDigestEnabled,
-      notificationDigestFrequency: users.notificationDigestFrequency,
-      notificationDigestDeliveryChannel:
-        users.notificationDigestDeliveryChannel,
-    })
-    .from(users)
-    .where(eq(users.id, authUser.userId))
-    .limit(1);
+  try {
+    const [user] = await db
+      .select({
+        notificationDigestEnabled: users.notificationDigestEnabled,
+        notificationDigestFrequency: users.notificationDigestFrequency,
+        notificationDigestDeliveryChannel:
+          users.notificationDigestDeliveryChannel,
+      })
+      .from(users)
+      .where(eq(users.id, authUser.userId))
+      .limit(1);
 
-  return successResponse({
-    success: true,
-    settings: user ? toSettings(user) : DEFAULT_NOTIFICATION_DIGEST_SETTINGS,
-  });
+    return successResponse({
+      success: true,
+      settings: user ? toSettings(user) : DEFAULT_NOTIFICATION_DIGEST_SETTINGS,
+    });
+  } catch (error) {
+    const missingSchemaCode = getMissingNotificationSchemaErrorCode(error);
+    if (!missingSchemaCode) {
+      throw error;
+    }
+
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.warn(
+      'Notification digest settings unavailable because the database schema is pending',
+      { userId: authUser.userId, code: missingSchemaCode, errorMessage },
+      'GET /api/notifications/digest-settings'
+    );
+
+    return successResponse({
+      success: true,
+      settings: DEFAULT_NOTIFICATION_DIGEST_SETTINGS,
+    });
+  }
 });
 
 export const PUT = withErrorHandling(async (request: NextRequest) => {

--- a/apps/web/src/app/api/notifications/route.ts
+++ b/apps/web/src/app/api/notifications/route.ts
@@ -209,6 +209,7 @@ import {
 } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 import { z } from 'zod';
+import { getMissingNotificationSchemaErrorCode } from './schema-compat';
 
 const ClearNotificationsSchema = z
   .object({
@@ -319,96 +320,117 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   // OPTIMIZED: Cache notifications with short TTL (high-frequency polling endpoint)
   const cacheKey = `notifications:${authUser.userId}:${validatedUnreadOnly}:${validatedType}:${validatedLimit}`;
 
-  // Get blocked/muted user IDs to filter notifications
-  const [blockedIds, mutedIds, blockedByIds] = await Promise.all([
-    getBlockedUserIds(authUser.userId),
-    getMutedUserIds(authUser.userId),
-    getBlockedByUserIds(authUser.userId),
-  ]);
+  try {
+    // Get blocked/muted user IDs to filter notifications
+    const [blockedIds, mutedIds, blockedByIds] = await Promise.all([
+      getBlockedUserIds(authUser.userId),
+      getMutedUserIds(authUser.userId),
+      getBlockedByUserIds(authUser.userId),
+    ]);
 
-  const excludedUserIds = new Set([
-    ...blockedIds,
-    ...mutedIds,
-    ...blockedByIds,
-  ]);
+    const excludedUserIds = new Set([
+      ...blockedIds,
+      ...mutedIds,
+      ...blockedByIds,
+    ]);
 
-  const { notificationsList, unreadCount } = await getCacheOrFetch(
-    cacheKey,
-    async () => {
-      // Fetch notifications
-      const allNotifications = await db
-        .select()
-        .from(notifications)
-        .where(and(...conditions))
-        .orderBy(desc(notifications.createdAt))
-        .limit(validatedLimit * 2); // Fetch more to account for filtering
+    const { notificationsList, unreadCount } = await getCacheOrFetch(
+      cacheKey,
+      async () => {
+        // Fetch notifications
+        const allNotifications = await db
+          .select()
+          .from(notifications)
+          .where(and(...conditions))
+          .orderBy(desc(notifications.createdAt))
+          .limit(validatedLimit * 2); // Fetch more to account for filtering
 
-      // Get actor IDs to fetch user info
-      const actorIds = [
-        ...new Set(
-          allNotifications
-            .map((n) => n.actorId)
-            .filter((id): id is string => id !== null)
-        ),
-      ];
+        // Get actor IDs to fetch user info
+        const actorIds = [
+          ...new Set(
+            allNotifications
+              .map((n) => n.actorId)
+              .filter((id): id is string => id !== null)
+          ),
+        ];
 
-      // Fetch actor info
-      const actorsResult =
-        actorIds.length > 0
-          ? await db
-              .select({
-                id: users.id,
-                displayName: users.displayName,
-                username: users.username,
-                profileImageUrl: users.profileImageUrl,
-              })
-              .from(users)
-              .where(inArray(users.id, actorIds))
-          : [];
+        // Fetch actor info
+        const actorsResult =
+          actorIds.length > 0
+            ? await db
+                .select({
+                  id: users.id,
+                  displayName: users.displayName,
+                  username: users.username,
+                  profileImageUrl: users.profileImageUrl,
+                })
+                .from(users)
+                .where(inArray(users.id, actorIds))
+            : [];
 
-      const actorMap = new Map(actorsResult.map((a) => [a.id, a]));
+        const actorMap = new Map(actorsResult.map((a) => [a.id, a]));
 
-      // Filter out notifications from blocked/muted users and add actor info
-      const notificationsList = allNotifications
-        .filter((n) => !n.actorId || !excludedUserIds.has(n.actorId))
-        .slice(0, validatedLimit) // Limit to requested amount after filtering
-        .map((n) => ({
-          ...n,
-          actor: n.actorId ? actorMap.get(n.actorId) || null : null,
-        }));
+        // Filter out notifications from blocked/muted users and add actor info
+        const notificationsList = allNotifications
+          .filter((n) => !n.actorId || !excludedUserIds.has(n.actorId))
+          .slice(0, validatedLimit) // Limit to requested amount after filtering
+          .map((n) => ({
+            ...n,
+            actor: n.actorId ? actorMap.get(n.actorId) || null : null,
+          }));
 
-      // Get unread count
-      const [unreadCountResult] = await db
-        .select({ count: count() })
-        .from(notifications)
-        .where(
-          and(
-            eq(notifications.userId, authUser.userId),
-            eq(notifications.read, false)
-          )
-        );
+        // Get unread count
+        const [unreadCountResult] = await db
+          .select({ count: count() })
+          .from(notifications)
+          .where(
+            and(
+              eq(notifications.userId, authUser.userId),
+              eq(notifications.read, false)
+            )
+          );
 
-      return {
-        notificationsList,
-        unreadCount: Number(unreadCountResult?.count ?? 0),
-      };
-    },
-    {
-      namespace: CACHE_KEYS.USER,
-      ttl: 10, // 10 second cache (high-frequency endpoint, needs to be fresh)
+        return {
+          notificationsList,
+          unreadCount: Number(unreadCountResult?.count ?? 0),
+        };
+      },
+      {
+        namespace: CACHE_KEYS.USER,
+        ttl: 10, // 10 second cache (high-frequency endpoint, needs to be fresh)
+      }
+    );
+
+    logger.info(
+      'Notifications fetched successfully',
+      { userId: authUser.userId, count: notificationsList.length, unreadCount },
+      'GET /api/notifications'
+    );
+
+    return successResponse({
+      notifications: notificationsList.map((n) =>
+        serializeNotificationForApi(n)
+      ),
+      unreadCount,
+    });
+  } catch (error) {
+    const missingSchemaCode = getMissingNotificationSchemaErrorCode(error);
+    if (!missingSchemaCode) {
+      throw error;
     }
-  );
 
-  logger.info(
-    'Notifications fetched successfully',
-    { userId: authUser.userId, count: notificationsList.length, unreadCount },
-    'GET /api/notifications'
-  );
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    logger.warn(
+      'Notifications unavailable because the database schema is pending',
+      { userId: authUser.userId, code: missingSchemaCode, errorMessage },
+      'GET /api/notifications'
+    );
 
-  return successResponse({
-    notifications: notificationsList.map((n) => serializeNotificationForApi(n)),
-    unreadCount,
-  });
+    return successResponse({
+      notifications: [],
+      unreadCount: 0,
+    });
+  }
 });
 
 /**

--- a/apps/web/src/app/api/notifications/route.ts
+++ b/apps/web/src/app/api/notifications/route.ts
@@ -279,6 +279,16 @@ export function serializeNotificationForApi(
   };
 }
 
+type NotificationReadPayload = {
+  notificationsList: Array<
+    Record<string, unknown> & {
+      actor?: Record<string, unknown> | null;
+    }
+  >;
+  unreadCount: number;
+  degraded?: boolean;
+};
+
 /**
  * GET /api/notifications - Get user notifications
  */
@@ -320,37 +330,77 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
   // OPTIMIZED: Cache notifications with short TTL (high-frequency polling endpoint)
   const cacheKey = `notifications:${authUser.userId}:${validatedUnreadOnly}:${validatedType}:${validatedLimit}`;
 
-  try {
-    // Get blocked/muted user IDs to filter notifications
-    const [blockedIds, mutedIds, blockedByIds] = await Promise.all([
-      getBlockedUserIds(authUser.userId),
-      getMutedUserIds(authUser.userId),
-      getBlockedByUserIds(authUser.userId),
-    ]);
+  // Keep moderation failures visible; only the notification-schema reads degrade.
+  const [blockedIds, mutedIds, blockedByIds] = await Promise.all([
+    getBlockedUserIds(authUser.userId),
+    getMutedUserIds(authUser.userId),
+    getBlockedByUserIds(authUser.userId),
+  ]);
 
-    const excludedUserIds = new Set([
-      ...blockedIds,
-      ...mutedIds,
-      ...blockedByIds,
-    ]);
+  const excludedUserIds = new Set([
+    ...blockedIds,
+    ...mutedIds,
+    ...blockedByIds,
+  ]);
 
-    const { notificationsList, unreadCount } = await getCacheOrFetch(
+  const { notificationsList, unreadCount, degraded } =
+    await getCacheOrFetch<NotificationReadPayload>(
       cacheKey,
       async () => {
-        // Fetch notifications
-        const allNotifications = await db
-          .select()
-          .from(notifications)
-          .where(and(...conditions))
-          .orderBy(desc(notifications.createdAt))
-          .limit(validatedLimit * 2); // Fetch more to account for filtering
+        let allNotifications:
+          | Array<Record<string, unknown> & { actorId?: string | null }>
+          | undefined;
+        let unreadCount = 0;
+
+        try {
+          // Fetch notifications
+          allNotifications = await db
+            .select()
+            .from(notifications)
+            .where(and(...conditions))
+            .orderBy(desc(notifications.createdAt))
+            .limit(validatedLimit * 2); // Fetch more to account for filtering
+
+          // Get unread count
+          const [unreadCountResult] = await db
+            .select({ count: count() })
+            .from(notifications)
+            .where(
+              and(
+                eq(notifications.userId, authUser.userId),
+                eq(notifications.read, false)
+              )
+            );
+
+          unreadCount = Number(unreadCountResult?.count ?? 0);
+        } catch (error) {
+          const missingSchemaCode =
+            getMissingNotificationSchemaErrorCode(error);
+          if (!missingSchemaCode) {
+            throw error;
+          }
+
+          const errorMessage =
+            error instanceof Error ? error.message : String(error);
+          logger.warn(
+            'Notifications unavailable because the database schema is pending',
+            { userId: authUser.userId, code: missingSchemaCode, errorMessage },
+            'GET /api/notifications'
+          );
+
+          return {
+            notificationsList: [],
+            unreadCount: 0,
+            degraded: true,
+          };
+        }
+
+        const rows = allNotifications ?? [];
 
         // Get actor IDs to fetch user info
         const actorIds = [
           ...new Set(
-            allNotifications
-              .map((n) => n.actorId)
-              .filter((id): id is string => id !== null)
+            rows.map((n) => n.actorId).filter((id): id is string => id !== null)
           ),
         ];
 
@@ -371,7 +421,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
         const actorMap = new Map(actorsResult.map((a) => [a.id, a]));
 
         // Filter out notifications from blocked/muted users and add actor info
-        const notificationsList = allNotifications
+        const notificationsList = rows
           .filter((n) => !n.actorId || !excludedUserIds.has(n.actorId))
           .slice(0, validatedLimit) // Limit to requested amount after filtering
           .map((n) => ({
@@ -379,20 +429,9 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
             actor: n.actorId ? actorMap.get(n.actorId) || null : null,
           }));
 
-        // Get unread count
-        const [unreadCountResult] = await db
-          .select({ count: count() })
-          .from(notifications)
-          .where(
-            and(
-              eq(notifications.userId, authUser.userId),
-              eq(notifications.read, false)
-            )
-          );
-
         return {
           notificationsList,
-          unreadCount: Number(unreadCountResult?.count ?? 0),
+          unreadCount,
         };
       },
       {
@@ -401,36 +440,18 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       }
     );
 
+  if (!degraded) {
     logger.info(
       'Notifications fetched successfully',
       { userId: authUser.userId, count: notificationsList.length, unreadCount },
       'GET /api/notifications'
     );
-
-    return successResponse({
-      notifications: notificationsList.map((n) =>
-        serializeNotificationForApi(n)
-      ),
-      unreadCount,
-    });
-  } catch (error) {
-    const missingSchemaCode = getMissingNotificationSchemaErrorCode(error);
-    if (!missingSchemaCode) {
-      throw error;
-    }
-
-    const errorMessage = error instanceof Error ? error.message : String(error);
-    logger.warn(
-      'Notifications unavailable because the database schema is pending',
-      { userId: authUser.userId, code: missingSchemaCode, errorMessage },
-      'GET /api/notifications'
-    );
-
-    return successResponse({
-      notifications: [],
-      unreadCount: 0,
-    });
   }
+
+  return successResponse({
+    notifications: notificationsList.map((n) => serializeNotificationForApi(n)),
+    unreadCount,
+  });
 });
 
 /**

--- a/apps/web/src/app/api/notifications/schema-compat.ts
+++ b/apps/web/src/app/api/notifications/schema-compat.ts
@@ -1,0 +1,17 @@
+const MISSING_NOTIFICATION_SCHEMA_ERROR_CODES = new Set(['42P01', '42703']);
+
+export function getMissingNotificationSchemaErrorCode(
+  error: unknown
+): string | null {
+  const causeCode = (error as { cause?: { code?: string } } | null)?.cause
+    ?.code;
+  const code = causeCode ?? (error as { code?: string } | null)?.code ?? null;
+
+  return code && MISSING_NOTIFICATION_SCHEMA_ERROR_CODES.has(code)
+    ? code
+    : null;
+}
+
+export function isMissingNotificationSchemaError(error: unknown): boolean {
+  return getMissingNotificationSchemaErrorCode(error) !== null;
+}

--- a/packages/testing/unit/notification-route-fallback.test.ts
+++ b/packages/testing/unit/notification-route-fallback.test.ts
@@ -1,0 +1,308 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { NextRequest } from 'next/server';
+
+const notificationsTable = {
+  id: 'notifications.id',
+  userId: 'notifications.userId',
+  actorId: 'notifications.actorId',
+  createdAt: 'notifications.createdAt',
+  read: 'notifications.read',
+  type: 'notifications.type',
+};
+
+const usersTable = {
+  id: 'users.id',
+  displayName: 'users.displayName',
+  username: 'users.username',
+  profileImageUrl: 'users.profileImageUrl',
+  notificationDigestEnabled: 'users.notificationDigestEnabled',
+  notificationDigestFrequency: 'users.notificationDigestFrequency',
+  notificationDigestDeliveryChannel: 'users.notificationDigestDeliveryChannel',
+};
+
+const mockAuthenticate = mock(async () => ({ userId: 'user-1' }));
+const mockGetCacheOrFetch = mock(
+  async <T>(_key: string, fetchFn: () => Promise<T>) => await fetchFn()
+);
+const mockSuccessResponse = mock(
+  (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    })
+);
+const mockGetBlockedUserIds = mock(async () => []);
+const mockGetMutedUserIds = mock(async () => []);
+const mockGetBlockedByUserIds = mock(async () => []);
+const mockLoggerInfo = mock(() => undefined);
+const mockLoggerWarn = mock(() => undefined);
+const mockLoggerError = mock(() => undefined);
+
+let notificationRows: Array<
+  Record<string, unknown> & { actorId?: string | null }
+>;
+let unreadCountRows: Array<{ count: number | string }>;
+let actorRows: Array<Record<string, unknown>>;
+let digestRows: Array<Record<string, unknown>>;
+let notificationSelectError: unknown;
+let unreadCountError: unknown;
+let actorSelectError: unknown;
+let digestSelectError: unknown;
+
+const mockNotificationLimit = mock(async () => {
+  if (notificationSelectError) {
+    throw notificationSelectError;
+  }
+  return notificationRows;
+});
+const mockNotificationOrderBy = mock(() => ({ limit: mockNotificationLimit }));
+const mockNotificationWhere = mock(() => ({
+  orderBy: mockNotificationOrderBy,
+}));
+
+const mockUnreadWhere = mock(async () => {
+  if (unreadCountError) {
+    throw unreadCountError;
+  }
+  return unreadCountRows;
+});
+
+const mockActorWhere = mock(async () => {
+  if (actorSelectError) {
+    throw actorSelectError;
+  }
+  return actorRows;
+});
+
+const mockDigestLimit = mock(async () => {
+  if (digestSelectError) {
+    throw digestSelectError;
+  }
+  return digestRows;
+});
+const mockDigestWhere = mock(() => ({ limit: mockDigestLimit }));
+
+const mockDbSelect = mock((shape?: unknown) => ({
+  from: (table: unknown) => {
+    if (table === notificationsTable) {
+      const isCountQuery =
+        !!shape &&
+        typeof shape === 'object' &&
+        shape !== null &&
+        'count' in shape;
+
+      return isCountQuery
+        ? { where: mockUnreadWhere }
+        : { where: mockNotificationWhere };
+    }
+
+    if (table === usersTable) {
+      const keys =
+        shape && typeof shape === 'object' && shape !== null
+          ? Object.keys(shape as Record<string, unknown>)
+          : [];
+
+      if (keys.includes('notificationDigestEnabled')) {
+        return { where: mockDigestWhere };
+      }
+
+      return { where: mockActorWhere };
+    }
+
+    throw new Error('Unexpected table mock');
+  },
+}));
+
+mock.module('@babylon/api', () => ({
+  authenticate: mockAuthenticate,
+  CACHE_KEYS: { USER: 'user' },
+  getCacheOrFetch: mockGetCacheOrFetch,
+  InternalServerError: class InternalServerError extends Error {},
+  invalidateCachePattern: mock(async () => undefined),
+  successResponse: mockSuccessResponse,
+  withErrorHandling:
+    (handler: (request: NextRequest) => Promise<Response>) =>
+    (request: NextRequest) =>
+      handler(request),
+}));
+
+mock.module('@babylon/db', () => ({
+  and: (...conditions: unknown[]) => ({ op: 'and', conditions }),
+  count: () => ({ op: 'count' }),
+  db: {
+    select: mockDbSelect,
+  },
+  desc: (value: unknown) => ({ op: 'desc', value }),
+  eq: (left: unknown, right: unknown) => ({ op: 'eq', left, right }),
+  getBlockedByUserIds: mockGetBlockedByUserIds,
+  getBlockedUserIds: mockGetBlockedUserIds,
+  getMutedUserIds: mockGetMutedUserIds,
+  inArray: (column: unknown, values: unknown[]) => ({
+    op: 'inArray',
+    column,
+    values,
+  }),
+  notifications: notificationsTable,
+  users: usersTable,
+}));
+
+mock.module('@babylon/shared', () => ({
+  DEFAULT_NOTIFICATION_DIGEST_SETTINGS: {
+    digestEnabled: true,
+    frequency: 'daily',
+    deliveryChannel: 'both',
+  },
+  logger: {
+    info: mockLoggerInfo,
+    warn: mockLoggerWarn,
+    error: mockLoggerError,
+  },
+  MarkNotificationsReadSchema: {
+    parse: (value: unknown) => value,
+  },
+  NotificationsQuerySchema: {
+    parse: (input: Record<string, string>) => ({
+      limit: Number(input.limit ?? '50'),
+      unreadOnly: input.unreadOnly === 'true',
+      type: input.type ?? undefined,
+    }),
+  },
+}));
+
+const { GET: getNotifications } = await import(
+  '../../../apps/web/src/app/api/notifications/route'
+);
+const { GET: getDigestSettings } = await import(
+  '../../../apps/web/src/app/api/notifications/digest-settings/route'
+);
+
+function makeRequest(path: string): NextRequest {
+  return new Request(`http://localhost${path}`, {
+    headers: { Authorization: 'Bearer test-token' },
+  }) as NextRequest;
+}
+
+describe('notification route fallbacks', () => {
+  beforeEach(() => {
+    notificationRows = [
+      {
+        id: 'notif-1',
+        type: 'follow',
+        title: 'New follower',
+        actorId: 'actor-1',
+        postId: null,
+        commentId: null,
+        chatId: null,
+        groupId: null,
+        inviteId: null,
+        message: 'Alpha followed you',
+        data: null,
+        read: false,
+        createdAt: new Date('2026-03-19T10:00:00.000Z'),
+      },
+    ];
+    unreadCountRows = [{ count: 1 }];
+    actorRows = [
+      {
+        id: 'actor-1',
+        displayName: 'Alpha',
+        username: 'alpha',
+        profileImageUrl: null,
+      },
+    ];
+    digestRows = [
+      {
+        notificationDigestEnabled: false,
+        notificationDigestFrequency: 'weekly',
+        notificationDigestDeliveryChannel: 'email',
+      },
+    ];
+    notificationSelectError = undefined;
+    unreadCountError = undefined;
+    actorSelectError = undefined;
+    digestSelectError = undefined;
+
+    mockAuthenticate.mockClear();
+    mockGetCacheOrFetch.mockClear();
+    mockSuccessResponse.mockClear();
+    mockGetBlockedUserIds.mockClear();
+    mockGetMutedUserIds.mockClear();
+    mockGetBlockedByUserIds.mockClear();
+    mockLoggerInfo.mockClear();
+    mockLoggerWarn.mockClear();
+    mockLoggerError.mockClear();
+    mockDbSelect.mockClear();
+    mockNotificationWhere.mockClear();
+    mockNotificationOrderBy.mockClear();
+    mockNotificationLimit.mockClear();
+    mockUnreadWhere.mockClear();
+    mockActorWhere.mockClear();
+    mockDigestWhere.mockClear();
+    mockDigestLimit.mockClear();
+  });
+
+  test('returns an empty notifications payload when the notification schema is missing', async () => {
+    notificationSelectError = Object.assign(
+      new Error('column "data" does not exist'),
+      {
+        code: '42703',
+      }
+    );
+
+    const response = await getNotifications(
+      makeRequest('/api/notifications?unreadOnly=true&limit=1')
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      notifications: [],
+      unreadCount: 0,
+    });
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
+    expect(mockActorWhere).not.toHaveBeenCalled();
+  });
+
+  test('does not swallow unrelated schema failures from moderation lookups', async () => {
+    const moderationError = Object.assign(
+      new Error('relation "UserMute" does not exist'),
+      {
+        code: '42P01',
+      }
+    );
+    mockGetMutedUserIds.mockRejectedValueOnce(moderationError);
+
+    const response = await getNotifications(makeRequest('/api/notifications'));
+    const body = await response.json();
+
+    expect(response.status).toBeGreaterThanOrEqual(500);
+    expect(body.notifications).toBeUndefined();
+    expect(mockGetCacheOrFetch).not.toHaveBeenCalled();
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+  });
+
+  test('returns default digest settings when digest columns are missing', async () => {
+    digestSelectError = Object.assign(
+      new Error('column "notificationDigestEnabled" does not exist'),
+      {
+        code: '42703',
+      }
+    );
+
+    const response = await getDigestSettings(
+      makeRequest('/api/notifications/digest-settings')
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({
+      success: true,
+      settings: {
+        digestEnabled: true,
+        frequency: 'daily',
+        deliveryChannel: 'both',
+      },
+    });
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/testing/unit/notification-route-fallback.test.ts
+++ b/packages/testing/unit/notification-route-fallback.test.ts
@@ -122,8 +122,17 @@ mock.module('@babylon/api', () => ({
   successResponse: mockSuccessResponse,
   withErrorHandling:
     (handler: (request: NextRequest) => Promise<Response>) =>
-    (request: NextRequest) =>
-      handler(request),
+    async (request: NextRequest) => {
+      try {
+        return await handler(request);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return new Response(JSON.stringify({ error: message }), {
+          status: 500,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+    },
 }));
 
 mock.module('@babylon/db', () => ({

--- a/packages/testing/unit/notification-schema-compat.test.ts
+++ b/packages/testing/unit/notification-schema-compat.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  getMissingNotificationSchemaErrorCode,
+  isMissingNotificationSchemaError,
+} from '../../../apps/web/src/app/api/notifications/schema-compat';
+
+describe('notification schema compatibility helpers', () => {
+  test('detects direct undefined column errors', () => {
+    const error = { code: '42703' };
+
+    expect(getMissingNotificationSchemaErrorCode(error)).toBe('42703');
+    expect(isMissingNotificationSchemaError(error)).toBe(true);
+  });
+
+  test('detects nested undefined table errors', () => {
+    const error = { cause: { code: '42P01' } };
+
+    expect(getMissingNotificationSchemaErrorCode(error)).toBe('42P01');
+    expect(isMissingNotificationSchemaError(error)).toBe(true);
+  });
+
+  test('ignores unrelated errors', () => {
+    const error = { code: '23505' };
+
+    expect(getMissingNotificationSchemaErrorCode(error)).toBeNull();
+    expect(isMissingNotificationSchemaError(error)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Degrade notification reads when production is behind the latest notification schema instead of surfacing `/api/notifications` failures to authenticated page loads.
- Return default digest settings when the digest columns are not available yet, so settings reads do not fail during the same schema drift window.
- Add a focused unit test for the schema-drift error detection helper used by both read paths.

## Type

- [x] Bug fix

## Context / Links

- [BAB-290](https://linear.app/eliza-labs/issue/BAB-290/fix-production-notification-schema-mismatch-causing-apinotifications)
- Production symptom: `/api/notifications?unreadOnly=true&limit=1` failing while authenticated surfaces continue rendering.

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web API routes / SSE / A2A (`apps/web`)
- [x] Tests (`packages/testing`)

## Changes

- Add a small notification schema compatibility helper that recognizes `42P01` / `42703` runtime drift errors.
- Wrap `GET /api/notifications` so it logs the degraded state and returns an empty payload instead of failing during a pending migration window.
- Wrap `GET /api/notifications/digest-settings` so it logs the degraded state and returns existing default digest settings instead of failing.
- Leave notification writes unchanged so we do not pretend persistence succeeded when the database is still missing required columns.

## Review guide

**Start here**
- `apps/web/src/app/api/notifications/route.ts`
- `apps/web/src/app/api/notifications/digest-settings/route.ts`
- `apps/web/src/app/api/notifications/schema-compat.ts`

**Risk**
- [x] Low

**Notes for reviewers**
- The fallback is intentionally limited to read paths with an observed production failure. It keeps the UI usable during schema drift without adding broad compatibility logic to writes.
- Follow-up outside this PR: ensure production schema sync for the existing notification columns added in migration `0049_add_market_resolution_notifications.sql`.

## Test plan

**Commands run**
- [x] `bun test packages/testing/unit/notifications-serialization.test.ts packages/testing/unit/notification-schema-compat.test.ts`
- [x] `bun test packages/testing/unit/market-resolution-notifications.test.ts`
- [x] `bunx biome check apps/web/src/app/api/notifications/route.ts apps/web/src/app/api/notifications/digest-settings/route.ts apps/web/src/app/api/notifications/schema-compat.ts packages/testing/unit/notification-schema-compat.test.ts`
- [x] Attempted `bun run --cwd apps/web typecheck`

**Manual verification**
1. Confirm the notifications route returns the normal payload when the schema is present.
2. Simulate a `42P01` / `42703` error in the notifications read path and confirm the API returns an empty notifications payload instead of failing.
3. Simulate the same error in the digest settings read path and confirm the API returns `DEFAULT_NOTIFICATION_DIGEST_SETTINGS`.

## Ops / Migration / Deployment

- [x] Requires DB migration (`bun run db:migrate`) / backfill / seed

**Env vars (added/changed/removed)**
- Added: `none`
- Changed: `none`
- Removed: `none`

**DB / data migration**
- Migration(s): existing production schema still needs the notification columns from `0049_add_market_resolution_notifications.sql` if they are missing.
- Backfill/seed: none.

**Rollout / rollback plan**
- Rollout: deploy this API fallback, then confirm production schema sync so the degraded path stops being used.
- Rollback: revert the PR to restore strict failures after the schema is confirmed healthy.

## Breaking changes

- [x] None

**Migration guide**
- None.

## Security / privacy

- [x] No security impact

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- Successful responses stay shape-compatible with the existing client code.

### Database
- This does not change schema. It only degrades reads while the database is temporarily behind the application schema.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: backend-only API resilience change, no direct UI changes.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

## Typecheck note

- `bun run --cwd apps/web typecheck` is currently failing on pre-existing issues in `src/app/api/cron/notifications-digest/route.ts` and `src/lib/services/notification-digest-service.ts`, outside this diff.
