### PR TITLE
fix(web): handle waitlist X link conflicts

### DIFF
--- a/apps/web/src/components/profile/link-email-utils.test.ts
+++ b/apps/web/src/components/profile/link-email-utils.test.ts
@@ -39,7 +39,13 @@ describe('link-email-utils', () => {
       expect(isLinkEmailFlowCancellationError(err)).toBe(true);
     });
 
-    it('returns false when the thrown value is not an Error instance', () => {
+    it('treats the Authentication cancelled message as a cancellation', () => {
+      expect(isLinkEmailFlowCancellationError('Authentication cancelled')).toBe(
+        true
+      );
+    });
+
+    it('returns false for unrelated primitive values', () => {
       expect(isLinkEmailFlowCancellationError('exited')).toBe(false);
       expect(isLinkEmailFlowCancellationError(null)).toBe(false);
       expect(isLinkEmailFlowCancellationError(42)).toBe(false);

--- a/apps/web/src/components/profile/link-email-utils.ts
+++ b/apps/web/src/components/profile/link-email-utils.ts
@@ -1,3 +1,5 @@
+import { isPrivyLinkFlowCancellationError } from '@/lib/privy-link-account-errors';
+
 export function getLinkedEmail(
   privyEmail?: string | null,
   storedEmail?: string | null
@@ -16,12 +18,5 @@ export function getLinkedEmail(
  * - The string error code `'exited_auth_flow'` passed to `useLinkAccount` onError callbacks.
  * - A PrivyClientError (or similar) thrown synchronously with `code === 'exited_auth_flow'`.
  */
-export function isLinkEmailFlowCancellationError(error: unknown): boolean {
-  if (error === 'exited_auth_flow') return true;
-  if (
-    error instanceof Error &&
-    (error as { code?: string }).code === 'exited_auth_flow'
-  )
-    return true;
-  return false;
-}
+export const isLinkEmailFlowCancellationError =
+  isPrivyLinkFlowCancellationError;

--- a/apps/web/src/components/profile/link-email-utils.ts
+++ b/apps/web/src/components/profile/link-email-utils.ts
@@ -14,9 +14,10 @@ export function getLinkedEmail(
 /**
  * Returns true when the Privy link-email flow was cancelled by the user.
  *
- * Handles two shapes:
- * - The string error code `'exited_auth_flow'` passed to `useLinkAccount` onError callbacks.
- * - A PrivyClientError (or similar) thrown synchronously with `code === 'exited_auth_flow'`.
+ * Delegates to the shared Privy link-account helper so the email flow stays
+ * aligned with other social-linking flows. This treats the known cancellation
+ * shapes observed from Privy as user intent, including raw string codes/messages
+ * and Privy-like error objects.
  */
 export const isLinkEmailFlowCancellationError =
   isPrivyLinkFlowCancellationError;

--- a/apps/web/src/components/shared/ComingSoon.tsx
+++ b/apps/web/src/components/shared/ComingSoon.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { getReferralUrl, logger, POINTS } from '@babylon/shared';
-import { usePrivy } from '@privy-io/react-auth';
+import { useLinkAccount, usePrivy } from '@privy-io/react-auth';
 import {
   Check,
   ChevronDown,
@@ -33,6 +33,11 @@ import {
 import { MarketingFooter } from '@/components/shared/MarketingFooter';
 import { PlayerStatsModal } from '@/components/shared/PlayerStatsModal';
 import { useAuth } from '@/hooks/useAuth';
+import {
+  isPrivyLinkFlowCancellationError,
+  isPrivyTwitterLinkConflictError,
+  X_ACCOUNT_ALREADY_LINKED_MESSAGE,
+} from '@/lib/privy-link-account-errors';
 import { EXTERNAL_LINKS } from '@/lib/constants';
 import type {
   EligibilityApiResponse,
@@ -138,15 +143,61 @@ interface ReferralUser {
  * @returns Coming soon page element
  */
 export function ComingSoon() {
-  const {
-    login,
-    authenticated,
-    user: privyUser,
-    logout,
-    linkTwitter,
-    linkFarcaster,
-  } = usePrivy();
+  const { login, authenticated, user: privyUser, logout } = usePrivy();
   const { user: dbUser, refresh, getAccessToken } = useAuth();
+  const { linkTwitter, linkFarcaster } = useLinkAccount({
+    onSuccess: async ({ linkedAccount }) => {
+      const linkedType = String(linkedAccount.type);
+      if (
+        linkedType !== 'farcaster' &&
+        linkedType !== 'farcaster_account' &&
+        linkedType !== 'twitter_oauth'
+      ) {
+        return;
+      }
+
+      await refresh();
+
+      if (dbUser?.id) {
+        await fetchWaitlistPosition(dbUser.id);
+      }
+
+      if (linkedType === 'farcaster' || linkedType === 'farcaster_account') {
+        toast.success('Farcaster account linked successfully!');
+      } else {
+        toast.success('X account linked successfully!');
+      }
+    },
+    onError: (error) => {
+      if (isPrivyLinkFlowCancellationError(error)) {
+        logger.info(
+          'Social account linking cancelled by user',
+          { userId: dbUser?.id },
+          'ComingSoon'
+        );
+        return;
+      }
+
+      if (isPrivyTwitterLinkConflictError(error)) {
+        logger.info(
+          'Handled X link conflict during waitlist social linking',
+          { userId: dbUser?.id },
+          'ComingSoon'
+        );
+        toast.error(X_ACCOUNT_ALREADY_LINKED_MESSAGE);
+        return;
+      }
+
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      logger.error(
+        'Failed to link social account via Privy',
+        { error: errorMessage, userId: dbUser?.id },
+        'ComingSoon'
+      );
+      toast.error('Failed to link account. Please try again.');
+    },
+  });
   const router = useRouter();
   const searchParams = useSearchParams();
   const [waitlistData, setWaitlistData] = useState<WaitlistData | null>(null);
@@ -278,11 +329,6 @@ export function ComingSoon() {
       return;
     }
 
-    if (!linkTwitter) {
-      toast.error('X linking is currently unavailable');
-      return;
-    }
-
     linkTwitter();
   };
 
@@ -309,11 +355,6 @@ export function ComingSoon() {
         {},
         'ComingSoon'
       );
-      return;
-    }
-
-    if (!linkFarcaster) {
-      toast.error('Farcaster linking is currently unavailable');
       return;
     }
 

--- a/apps/web/src/hooks/useSocialVerification.ts
+++ b/apps/web/src/hooks/useSocialVerification.ts
@@ -5,6 +5,11 @@ import { useLinkAccount } from '@privy-io/react-auth';
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
+import {
+  isPrivyLinkFlowCancellationError,
+  isPrivyTwitterLinkConflictError,
+  X_ACCOUNT_ALREADY_LINKED_MESSAGE,
+} from '@/lib/privy-link-account-errors';
 
 interface UseSocialVerificationOptions {
   authenticated: boolean;
@@ -75,14 +80,7 @@ export function useSocialVerification({
       }
     },
     onError: (error) => {
-      const rawError = error as unknown;
-      const errorMessage =
-        rawError instanceof Error ? rawError.message : String(rawError);
-
-      if (
-        error === 'exited_auth_flow' ||
-        errorMessage === 'Authentication cancelled'
-      ) {
+      if (isPrivyLinkFlowCancellationError(error)) {
         logger.info(
           'Social account linking cancelled by user',
           { userId },
@@ -90,6 +88,19 @@ export function useSocialVerification({
         );
         return;
       }
+
+      if (isPrivyTwitterLinkConflictError(error)) {
+        logger.info(
+          'Handled X link conflict during social account linking',
+          { userId },
+          'useSocialVerification'
+        );
+        toast.error(X_ACCOUNT_ALREADY_LINKED_MESSAGE);
+        return;
+      }
+
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
 
       logger.error(
         'Failed to link social account via Privy',

--- a/apps/web/src/lib/privy-link-account-errors.test.ts
+++ b/apps/web/src/lib/privy-link-account-errors.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  isPrivyLinkFlowCancellationError,
+  isPrivyTwitterLinkConflictError,
+  X_ACCOUNT_ALREADY_LINKED_MESSAGE,
+} from './privy-link-account-errors';
+
+describe('privy-link-account-errors', () => {
+  describe('isPrivyLinkFlowCancellationError', () => {
+    it('detects the exited_auth_flow string code from useLinkAccount onError', () => {
+      expect(isPrivyLinkFlowCancellationError('exited_auth_flow')).toBe(true);
+    });
+
+    it('treats the Authentication cancelled message as a user cancellation', () => {
+      expect(isPrivyLinkFlowCancellationError('Authentication cancelled')).toBe(
+        true
+      );
+      expect(
+        isPrivyLinkFlowCancellationError(
+          new Error('Authentication cancelled')
+        )
+      ).toBe(true);
+    });
+
+    it('detects a PrivyClientError-shaped object with code exited_auth_flow', () => {
+      expect(
+        isPrivyLinkFlowCancellationError({
+          code: 'exited_auth_flow',
+          message: 'User exited link email flow',
+        })
+      ).toBe(true);
+    });
+
+    it('returns false for other values', () => {
+      expect(isPrivyLinkFlowCancellationError('exited')).toBe(false);
+      expect(isPrivyLinkFlowCancellationError(null)).toBe(false);
+      expect(
+        isPrivyLinkFlowCancellationError({
+          code: 'network_error',
+          message: 'Network failure',
+        })
+      ).toBe(false);
+    });
+  });
+
+  describe('isPrivyTwitterLinkConflictError', () => {
+    it('detects the Privy twitter conflict error message', () => {
+      expect(
+        isPrivyTwitterLinkConflictError(
+          new Error('User already has an account of type twitter linked.')
+        )
+      ).toBe(true);
+    });
+
+    it('handles the message when passed as a string', () => {
+      expect(
+        isPrivyTwitterLinkConflictError(
+          'User already has an account of type twitter linked.'
+        )
+      ).toBe(true);
+    });
+
+    it('returns false for unrelated errors', () => {
+      expect(
+        isPrivyTwitterLinkConflictError(
+          new Error('Failed to link account. Please try again.')
+        )
+      ).toBe(false);
+      expect(isPrivyTwitterLinkConflictError(null)).toBe(false);
+    });
+  });
+
+  it('exports the handled X conflict toast message', () => {
+    expect(X_ACCOUNT_ALREADY_LINKED_MESSAGE).toBe(
+      'This X account is already linked to another user'
+    );
+  });
+});

--- a/apps/web/src/lib/privy-link-account-errors.ts
+++ b/apps/web/src/lib/privy-link-account-errors.ts
@@ -1,0 +1,52 @@
+export const X_ACCOUNT_ALREADY_LINKED_MESSAGE =
+  'This X account is already linked to another user';
+
+function getPrivyErrorMessage(error: unknown): string | null {
+  if (typeof error === 'string') return error;
+
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof error.message === 'string'
+  ) {
+    return error.message;
+  }
+
+  return null;
+}
+
+/**
+ * Returns true when the Privy link-account flow was cancelled by the user.
+ */
+export function isPrivyLinkFlowCancellationError(error: unknown): boolean {
+  if (error === 'exited_auth_flow') return true;
+  if (error === 'Authentication cancelled') return true;
+
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === 'exited_auth_flow'
+  ) {
+    return true;
+  }
+
+  const message = getPrivyErrorMessage(error);
+  if (message === 'Authentication cancelled') return true;
+
+  return false;
+}
+
+/**
+ * Returns true when Privy rejects X linking because the account is already
+ * attached to another user.
+ */
+export function isPrivyTwitterLinkConflictError(error: unknown): boolean {
+  const message = getPrivyErrorMessage(error);
+  if (!message) return false;
+
+  return message
+    .toLowerCase()
+    .includes('already has an account of type twitter linked');
+}

--- a/changelogs/BAB-262--waitlist-x-link-conflict.md
+++ b/changelogs/BAB-262--waitlist-x-link-conflict.md
@@ -1,0 +1,8 @@
+**PR:** https://github.com/BabylonSocial/babylon/pull/1273
+**Linear:** [BAB-262](https://linear.app/eliza-labs/issue/BAB-262/bugwaitlist-handle-privy-x-link-conflicts-without-unhandled-error)
+
+### Waitlist X Link Conflict Handling
+- Stop surfacing the expected Privy X account conflict as an unhandled waitlist client error.
+- Show a clear message when the X account is already linked to another user.
+- Keep the Privy-native waitlist linking flow and refresh waitlist state after successful social linking.
+- Reuse the same handled Privy error mapping in the shared social-linking flow to avoid divergent behavior.

--- a/changelogs/BAB-262--waitlist-x-link-conflict.md
+++ b/changelogs/BAB-262--waitlist-x-link-conflict.md
@@ -1,8 +1,0 @@
-**PR:** https://github.com/BabylonSocial/babylon/pull/1273
-**Linear:** [BAB-262](https://linear.app/eliza-labs/issue/BAB-262/bugwaitlist-handle-privy-x-link-conflicts-without-unhandled-error)
-
-### Waitlist X Link Conflict Handling
-- Stop surfacing the expected Privy X account conflict as an unhandled waitlist client error.
-- Show a clear message when the X account is already linked to another user.
-- Keep the Privy-native waitlist linking flow and refresh waitlist state after successful social linking.
-- Reuse the same handled Privy error mapping in the shared social-linking flow to avoid divergent behavior.


### PR DESCRIPTION
## Summary

- Handle waitlist X linking conflicts from Privy as a controlled UX case instead of an unhandled client error.
- Reuse a shared Privy link-account error helper so waitlist and shared social-linking flows stay aligned.
- Keep the direct Privy linking flow and refresh waitlist/auth state after successful linking.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-262/bugwaitlist-handle-privy-x-link-conflicts-without-unhandled-error

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [x] Other: app-level shared link-account helpers/tests under `apps/web/src/lib`

## Changes

- Add a shared Privy link-account error helper for cancellation and handled X conflict detection.
- Switch `ComingSoon` social linking to `useLinkAccount` callbacks so the waitlist flow can intercept handled Privy errors and refresh state on success.
- Align `useSocialVerification` with the same handled-conflict messaging and add targeted unit coverage for the helper.

## Review guide

**Start here**
- `apps/web/src/components/shared/ComingSoon.tsx`
- `apps/web/src/lib/privy-link-account-errors.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- The functional change is limited to the Privy X-link conflict path plus shared handling for the same error shape.
- I intentionally did not reintroduce the previous custom waitlist OAuth route; this keeps the current Privy-native flow and only restores handled UX/error mapping.
- Non-goal: broader refactor of `ComingSoon` social verification into the existing hook.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)
- [x] `bunx biome check --write apps/web/src/components/shared/ComingSoon.tsx apps/web/src/hooks/useSocialVerification.ts apps/web/src/components/profile/link-email-utils.ts apps/web/src/lib/privy-link-account-errors.ts apps/web/src/lib/privy-link-account-errors.test.ts`
- [x] `bun test apps/web/src/lib/privy-link-account-errors.test.ts apps/web/src/components/profile/link-email-utils.test.ts`
- [ ] `bunx tsc -p apps/web/tsconfig.json --noEmit` (blocked in this worktree by missing type definitions: `@serwist/next/typings`, `bun-types`)

**Manual verification**
1. Sign in on the waitlist flow and try to link an X account already linked to another Babylon/Privy user.
2. Confirm the UI shows `This X account is already linked to another user` instead of surfacing an unhandled client error.
3. Confirm successful X/Farcaster linking still refreshes the waitlist state and shows the success toast.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: ship normally with the web release.
- Rollback: revert this PR to restore the prior waitlist linking behavior.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: this is a behavior-only fix on an existing waitlist linking flow. It changes error handling/toast messaging without changing layout or persistent UI structure.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`production` for this PR)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
