### PR TITLE
fix(web): handle rewards auth refresh rejections

### DIFF
--- a/apps/web/src/app/rewards/page.tsx
+++ b/apps/web/src/app/rewards/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import {
+  extractErrorMessage,
   getProfileUrl,
   getReferralShareText,
   getReferralUrl,
@@ -102,6 +103,26 @@ export default function RewardsPage() {
     totalPoints: number;
   } | null>(null);
 
+  const refreshAuthState = useCallback(
+    async (
+      source: 'twitter_linked' | 'discord_linked' | 'onchain_registration'
+    ) => {
+      try {
+        await refresh();
+      } catch (error) {
+        logger.warn(
+          'Failed to refresh auth state on rewards page',
+          {
+            source,
+            error: extractErrorMessage(error),
+          },
+          'RewardsPage'
+        );
+      }
+    },
+    [refresh]
+  );
+
   // Handle OAuth callback from Twitter/Discord linking
   useEffect(() => {
     const success = searchParams.get('success');
@@ -113,13 +134,13 @@ export default function RewardsPage() {
       // Dispatch event to notify other components (like UserMenu) to refresh
       window.dispatchEvent(new CustomEvent('rewards-updated'));
       // Refresh auth state to get latest reputation points
-      refresh();
+      void refreshAuthState('twitter_linked');
       // Clean up URL params
       window.history.replaceState({}, '', '/rewards');
     } else if (success === 'discord_linked' && points) {
       toast.success(`Discord account linked! +${points} points awarded`);
       window.dispatchEvent(new CustomEvent('rewards-updated'));
-      refresh();
+      void refreshAuthState('discord_linked');
       window.history.replaceState({}, '', '/rewards');
     } else if (errorParam) {
       const errorMessages: Record<string, string> = {
@@ -136,7 +157,7 @@ export default function RewardsPage() {
       );
       window.history.replaceState({}, '', '/rewards');
     }
-  }, [searchParams, refresh]);
+  }, [searchParams, refreshAuthState]);
 
   const fetchReferralData = useCallback(async () => {
     if (!user?.id || !authenticated) return;
@@ -293,7 +314,7 @@ export default function RewardsPage() {
           toast.success('On-chain registration complete!');
         }
         window.dispatchEvent(new CustomEvent('rewards-updated'));
-        refresh();
+        void refreshAuthState('onchain_registration');
         fetchReferralData();
         fetchPortfolio();
       } catch {

--- a/apps/web/src/components/auth/UserMenu.tsx
+++ b/apps/web/src/components/auth/UserMenu.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import { getDisplayReferralUrl, getReferralUrl } from '@babylon/shared';
+import {
+  extractErrorMessage,
+  getDisplayReferralUrl,
+  getReferralUrl,
+  logger,
+} from '@babylon/shared';
 import {
   BookOpen,
   Check,
@@ -74,7 +79,15 @@ export function UserMenu() {
   useEffect(() => {
     const handleRewardsUpdated = () => {
       // Refresh the auth state to get latest reputation points
-      refresh();
+      void refresh().catch((error) => {
+        logger.warn(
+          'Failed to refresh auth state after rewards update',
+          {
+            error: extractErrorMessage(error),
+          },
+          'UserMenu'
+        );
+      });
     };
 
     window.addEventListener('rewards-updated', handleRewardsUpdated);

--- a/apps/web/src/utils/api-fetch.test.ts
+++ b/apps/web/src/utils/api-fetch.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { apiFetch, getPrivyAccessToken } from './api-fetch';
+
+const originalFetch = globalThis.fetch;
+const originalWindow = globalThis.window;
+
+function setWindow(getAccessToken?: () => Promise<string | null>) {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      __privyGetAccessToken: getAccessToken,
+    },
+  });
+}
+
+describe('apiFetch', () => {
+  beforeEach(() => {
+    globalThis.fetch = originalFetch;
+    setWindow();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: originalWindow,
+    });
+  });
+
+  it('returns null when the Privy access token getter rejects', async () => {
+    setWindow(() =>
+      Promise.reject({
+        code: 'session_expired',
+        message: 'Session expired',
+        stack: 'stack',
+      })
+    );
+
+    await expect(getPrivyAccessToken()).resolves.toBeNull();
+  });
+
+  it('still performs the request when token retrieval rejects', async () => {
+    const fetchMock = mock((_input: RequestInfo | URL, init?: RequestInit) =>
+      Promise.resolve(
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+    );
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    setWindow(() =>
+      Promise.reject({
+        code: 'session_expired',
+        message: 'Session expired',
+        stack: 'stack',
+      })
+    );
+
+    const response = await apiFetch('/api/users/me');
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[1]?.credentials).toBe('include');
+    expect(
+      new Headers(fetchMock.mock.calls[0]?.[1]?.headers).has('Authorization')
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/utils/api-fetch.test.ts
+++ b/apps/web/src/utils/api-fetch.test.ts
@@ -40,7 +40,7 @@ describe('apiFetch', () => {
   });
 
   it('still performs the request when token retrieval rejects', async () => {
-    const fetchMock = mock((_input: RequestInfo | URL, init?: RequestInit) =>
+    const fetchMock = mock((_input: RequestInfo | URL, _init?: RequestInit) =>
       Promise.resolve(
         new Response(JSON.stringify({ ok: true }), {
           status: 200,

--- a/apps/web/src/utils/api-fetch.ts
+++ b/apps/web/src/utils/api-fetch.ts
@@ -5,7 +5,7 @@
  * Uses Privy's HTTP-only cookie authentication.
  */
 
-import { logger } from '@babylon/shared';
+import { extractErrorMessage, logger } from '@babylon/shared';
 
 /**
  * API Fetch Options
@@ -34,11 +34,25 @@ export interface ApiFetchOptions extends RequestInit {
  */
 export async function getPrivyAccessToken(): Promise<string | null> {
   if (typeof window === 'undefined') return null;
+  const privyWindow = window as Window & {
+    __privyGetAccessToken?: () => Promise<string | null>;
+  };
 
   // ALWAYS call getAccessToken() on-demand - it auto-refreshes expired tokens
-  if (window.__privyGetAccessToken) {
-    const token = await window.__privyGetAccessToken();
-    return token;
+  if (privyWindow.__privyGetAccessToken) {
+    try {
+      const token = await privyWindow.__privyGetAccessToken();
+      return token;
+    } catch (error) {
+      logger.warn(
+        'Failed to retrieve Privy access token',
+        {
+          error: extractErrorMessage(error),
+        },
+        'apiFetch'
+      );
+      return null;
+    }
   }
 
   // No token available - user not authenticated via Privy hook

--- a/packages/shared/src/types/errors.ts
+++ b/packages/shared/src/types/errors.ts
@@ -11,7 +11,6 @@ import {
   LLMError,
   ValidationError,
 } from '../errors';
-import type { JsonValue } from './common';
 
 /**
  * Base error interface for all application errors
@@ -72,9 +71,7 @@ export function isValidationError(error: Error): error is ValidationError {
 /**
  * Extract error message from any error-like object
  */
-export function extractErrorMessage(
-  error: Error | AppError | string | JsonValue | { message?: string }
-): string {
+export function extractErrorMessage(error: unknown): string {
   if (typeof error === 'string') {
     return error;
   }


### PR DESCRIPTION
## Summary
- catch fire-and-forget auth refresh failures triggered from `/rewards` after social-link and on-chain registration success flows
- harden `apiFetch()` so unexpected Privy token getter rejections are converted into handled warnings instead of uncaught client promise rejections
- add targeted unit coverage for the Privy token retrieval failure path

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- [BAB-291](https://linear.app/eliza-labs/issue/BAB-291)

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [x] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes
- add a local `refreshAuthState` wrapper in the rewards page so auth refresh promises are explicitly handled after OAuth and on-chain success flows
- reuse `extractErrorMessage` for readable client logs when refresh or token retrieval fails
- wrap the global Privy token getter in `apiFetch()` so structured Privy rejections fall back to `null` instead of surfacing as uncaught promise rejections
- add `apps/web/src/utils/api-fetch.test.ts` to cover the rejected token getter path

## Review guide
**Start here**
- `apps/web/src/app/rewards/page.tsx`
- `apps/web/src/utils/api-fetch.ts`
- `apps/web/src/utils/api-fetch.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- Scope is intentionally narrow: no auth flow redesign, no extra fallback layers, and no build-time changes.
- I did not broaden this into generic rewards data fetch error handling because the verified failure path for BAB-291 was unhandled auth refresh/token-refresh rejection.

## Test plan
**Commands run**
- [x] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Run `bun test apps/web/src/utils/api-fetch.test.ts`.
2. On `/rewards`, trigger a social-link or on-chain success path while forcing Privy token retrieval to reject.
3. Confirm the page no longer emits an unhandled promise rejection and the failure is logged as a handled warning.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `…`
- Changed: `…`
- Removed: `…`

**DB / data migration**
- Migration(s): `…`
- Backfill/seed: `…` (command/script + expected runtime)

**Rollout / rollback plan**
- Rollout: standard deploy.
- Rollback: revert this PR.

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- …

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)
### Option B: No visual changes
- Reason: Client-side error handling and logging only; no intentional visual/UI changes.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
