### PR TITLE
fix(web): handle Privy email link conflicts in settings

### DIFF
--- a/apps/web/src/app/api/users/[userId]/notification-email-preferences/route.ts
+++ b/apps/web/src/app/api/users/[userId]/notification-email-preferences/route.ts
@@ -17,6 +17,7 @@ import {
 } from '@babylon/api';
 import { db, eq, users } from '@babylon/db';
 import {
+  getAllVerifiedEmails,
   logger,
   type PrivyUserWithEmails,
   UserIdParamSchema,
@@ -54,8 +55,7 @@ async function getVerifiedEmailFromPrivy(
   const privyUser = (await privyClient.getUser(
     privyId
   )) as PrivyUserWithOptionalEmail;
-  const email = privyUser.email?.address?.trim().toLowerCase() ?? null;
-  return email;
+  return getAllVerifiedEmails(privyUser)[0] ?? null;
 }
 
 export const GET = withErrorHandling(

--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -157,6 +157,7 @@ import {
 import { and, db, eq, ne, or, sql, users } from '@babylon/db';
 import {
   checkForAdminEmail,
+  getAllVerifiedEmails,
   logger,
   type PrivyUserWithEmails,
 } from '@babylon/shared';
@@ -596,10 +597,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       privyId
     )) as PrivyUserWithWallets;
 
-    // Extract email from linked accounts
-    if (privyUser.email?.address) {
-      email = privyUser.email.address;
-    }
+    email = getAllVerifiedEmails(privyUser)[0] ?? null;
 
     // Extract Farcaster info
     if (privyUser.farcaster) {

--- a/apps/web/src/components/profile/LinkSocialAccountsModal.tsx
+++ b/apps/web/src/components/profile/LinkSocialAccountsModal.tsx
@@ -1,11 +1,15 @@
 'use client';
 
-import { cn, logger } from '@babylon/shared';
+import { cn, getAllVerifiedEmails, logger } from '@babylon/shared';
 import { useLinkAccount, usePrivy } from '@privy-io/react-auth';
 import { Check, ExternalLink, Mail, Shield, X as XIcon } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
-import { isLinkEmailFlowCancellationError } from '@/components/profile/link-email-utils';
+import {
+  isLinkEmailAlreadyLinkedError,
+  isLinkEmailFlowCancellationError,
+} from '@/components/profile/link-email-utils';
+import { useAuth } from '@/hooks/useAuth';
 import { getAuthToken } from '@/lib/auth';
 import { useAuthStore } from '@/stores/authStore';
 
@@ -48,17 +52,22 @@ export function LinkSocialAccountsModal({
 }: LinkSocialAccountsModalProps) {
   const { user, setUser } = useAuthStore();
   const { user: privyUser } = usePrivy();
+  const { refresh } = useAuth();
   const [linking, setLinking] = useState<string | null>(null);
   const [confirmUnlinkTwitter, setConfirmUnlinkTwitter] = useState(false);
   const [unlinkingTwitter, setUnlinkingTwitter] = useState(false);
 
   // Only treat the email as verified/linked when Privy holds it — the stored
   // user.email may be unverified (e.g. imported from a previous auth method).
-  const privyEmail = privyUser?.email?.address?.trim() || null;
+  const privyEmail =
+    privyUser?.email?.address?.trim() ||
+    getAllVerifiedEmails(privyUser)[0] ||
+    null;
 
   const { linkEmail, linkFarcaster } = useLinkAccount({
     onSuccess: ({ linkedAccount }) => {
       setLinking(null);
+      void refresh();
       const linkedType = String(linkedAccount.type);
       if (linkedType === 'farcaster' || linkedType === 'farcaster_account') {
         toast.success('Farcaster account linked successfully!');
@@ -70,6 +79,12 @@ export function LinkSocialAccountsModal({
     onError: (error) => {
       setLinking(null);
       if (isLinkEmailFlowCancellationError(error)) return;
+      if (isLinkEmailAlreadyLinkedError(error)) {
+        void refresh();
+        toast.info('An email is already linked to this account.');
+        onClose();
+        return;
+      }
       logger.error(
         'Failed to link account via Privy',
         { error: String(error) },

--- a/apps/web/src/components/profile/link-email-utils.test.ts
+++ b/apps/web/src/components/profile/link-email-utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import {
   getLinkedEmail,
+  isLinkEmailAlreadyLinkedError,
   isLinkEmailFlowCancellationError,
 } from './link-email-utils';
 
@@ -59,6 +60,29 @@ describe('link-email-utils', () => {
         code: 'network_error',
       });
       expect(isLinkEmailFlowCancellationError(errWrongCode)).toBe(false);
+    });
+  });
+
+  describe('isLinkEmailAlreadyLinkedError', () => {
+    it('detects the cannot_link_more_of_type string code from useLinkAccount onError', () => {
+      expect(isLinkEmailAlreadyLinkedError('cannot_link_more_of_type')).toBe(
+        true
+      );
+    });
+
+    it('detects Error instances that expose a Privy error code', () => {
+      const err = Object.assign(new Error('Email already linked'), {
+        privyErrorCode: 'cannot_link_more_of_type',
+      });
+
+      expect(isLinkEmailAlreadyLinkedError(err)).toBe(true);
+    });
+
+    it('returns false for other error codes', () => {
+      expect(isLinkEmailAlreadyLinkedError('exited_auth_flow')).toBe(false);
+      expect(isLinkEmailAlreadyLinkedError(new Error('Network failure'))).toBe(
+        false
+      );
     });
   });
 });

--- a/apps/web/src/components/profile/link-email-utils.ts
+++ b/apps/web/src/components/profile/link-email-utils.ts
@@ -1,4 +1,7 @@
-import { isPrivyLinkFlowCancellationError } from '@/lib/privy-link-account-errors';
+import {
+  isPrivyAlreadyLinkedError,
+  isPrivyLinkFlowCancellationError,
+} from '@/lib/privy-link-account-errors';
 
 export function getLinkedEmail(
   privyEmail?: string | null,
@@ -21,3 +24,11 @@ export function getLinkedEmail(
  */
 export const isLinkEmailFlowCancellationError =
   isPrivyLinkFlowCancellationError;
+
+/**
+ * Returns true when Privy reports that an email is already linked for the user.
+ *
+ * Delegates to the shared Privy link-account helper for the
+ * `cannot_link_more_of_type` error code.
+ */
+export const isLinkEmailAlreadyLinkedError = isPrivyAlreadyLinkedError;

--- a/apps/web/src/components/shared/ComingSoon.tsx
+++ b/apps/web/src/components/shared/ComingSoon.tsx
@@ -33,12 +33,12 @@ import {
 import { MarketingFooter } from '@/components/shared/MarketingFooter';
 import { PlayerStatsModal } from '@/components/shared/PlayerStatsModal';
 import { useAuth } from '@/hooks/useAuth';
+import { EXTERNAL_LINKS } from '@/lib/constants';
 import {
   isPrivyLinkFlowCancellationError,
   isPrivyTwitterLinkConflictError,
   X_ACCOUNT_ALREADY_LINKED_MESSAGE,
 } from '@/lib/privy-link-account-errors';
-import { EXTERNAL_LINKS } from '@/lib/constants';
 import type {
   EligibilityApiResponse,
   EligibilityResponse,

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { logger } from '@babylon/shared';
+import { getAllVerifiedEmails, logger } from '@babylon/shared';
 import {
   type ConnectedWallet,
   usePrivy,
@@ -238,8 +238,9 @@ export function useAuth(): UseAuthReturn {
           : '/api/users/me';
 
         const currentUser = useAuthStore.getState().user;
+        const verifiedPrivyEmail = getAllVerifiedEmails(privyUser)[0] ?? null;
         const shouldForcePrivyIdentitySync =
-          (!!privyUser.email?.address &&
+          (!!verifiedPrivyEmail &&
             (!currentUser?.email || !currentUser?.emailVerified)) ||
           (!!privyUser.farcaster && !currentUser?.hasFarcaster) ||
           (!!privyUser.twitter && !currentUser?.hasTwitter);
@@ -291,8 +292,8 @@ export function useAuth(): UseAuthReturn {
             displayName:
               me.user.displayName && me.user.displayName.trim() !== ''
                 ? me.user.displayName
-                : privyUser.email?.address || wallet?.address || 'Anonymous',
-            email: privyUser.email?.address ?? me.user.email ?? undefined,
+                : (verifiedPrivyEmail ?? wallet?.address ?? 'Anonymous'),
+            email: verifiedPrivyEmail ?? me.user.email ?? undefined,
             emailVerified: me.user.emailVerified ?? undefined,
             emailNotificationsEnabled:
               me.user.emailNotificationsEnabled ?? undefined,
@@ -396,9 +397,8 @@ export function useAuth(): UseAuthReturn {
             setUser({
               id: privyUser.id,
               walletAddress: wallet?.address,
-              displayName:
-                privyUser.email?.address ?? wallet?.address ?? 'Anonymous',
-              email: privyUser.email?.address,
+              displayName: verifiedPrivyEmail ?? wallet?.address ?? 'Anonymous',
+              email: verifiedPrivyEmail ?? undefined,
               onChainRegistered: false,
             });
           }

--- a/apps/web/src/lib/auth/privyIdentitySync.test.ts
+++ b/apps/web/src/lib/auth/privyIdentitySync.test.ts
@@ -33,6 +33,20 @@ describe('privyIdentitySync', () => {
     });
   });
 
+  it('prefers verified linked-account email when the primary email is missing', () => {
+    const snapshot = extractPrivyIdentitySnapshot({
+      linkedAccounts: [
+        {
+          type: 'email',
+          address: 'linked@example.com',
+          verified_at: 1,
+        },
+      ],
+    } as never);
+
+    expect(snapshot.email).toBe('linked@example.com');
+  });
+
   it('requires sync when any identity field is still missing locally', () => {
     expect(
       shouldSyncMissingPrivyIdentity({

--- a/apps/web/src/lib/auth/privyIdentitySync.ts
+++ b/apps/web/src/lib/auth/privyIdentitySync.ts
@@ -1,3 +1,4 @@
+import { getAllVerifiedEmails } from '@babylon/shared';
 import type { User as PrivyUser } from '@privy-io/server-auth';
 
 export type PrivyIdentitySnapshot = {
@@ -15,13 +16,16 @@ export type UserIdentitySyncState = {
   emailVerified: boolean;
 };
 
-type PrivyIdentityUserLike = Pick<PrivyUser, 'email' | 'farcaster' | 'twitter'>;
+type PrivyIdentityUserLike = Pick<
+  PrivyUser,
+  'email' | 'farcaster' | 'twitter' | 'linkedAccounts'
+>;
 
 export function extractPrivyIdentitySnapshot(
   privyUser: PrivyIdentityUserLike
 ): PrivyIdentitySnapshot {
   return {
-    email: privyUser.email?.address ?? null,
+    email: getAllVerifiedEmails(privyUser)[0] ?? null,
     farcasterUsername: privyUser.farcaster?.username ?? null,
     farcasterFid: privyUser.farcaster?.fid
       ? String(privyUser.farcaster.fid)

--- a/apps/web/src/lib/privy-link-account-errors.test.ts
+++ b/apps/web/src/lib/privy-link-account-errors.test.ts
@@ -16,9 +16,7 @@ describe('privy-link-account-errors', () => {
         true
       );
       expect(
-        isPrivyLinkFlowCancellationError(
-          new Error('Authentication cancelled')
-        )
+        isPrivyLinkFlowCancellationError(new Error('Authentication cancelled'))
       ).toBe(true);
     });
 

--- a/apps/web/src/lib/privy-link-account-errors.ts
+++ b/apps/web/src/lib/privy-link-account-errors.ts
@@ -39,6 +39,26 @@ export function isPrivyLinkFlowCancellationError(error: unknown): boolean {
 }
 
 /**
+ * Returns true when Privy reports that a linked-account type is already
+ * present (e.g. email already linked).
+ */
+export function isPrivyAlreadyLinkedError(error: unknown): boolean {
+  if (error === 'cannot_link_more_of_type') return true;
+
+  if (typeof error === 'object' && error !== null) {
+    const e = error as { code?: string; privyErrorCode?: string };
+    if (
+      e.code === 'cannot_link_more_of_type' ||
+      e.privyErrorCode === 'cannot_link_more_of_type'
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
  * Returns true when Privy rejects X linking because the account is already
  * attached to another user.
  */


### PR DESCRIPTION
## Summary

- Handle Privy `cannot_link_more_of_type` email-link conflicts as an expected settings-state mismatch instead of a client error.
- Reuse the existing verified-email extraction helper so settings, auth refresh, and notification-email fallback all recognize verified emails from Privy `linkedAccounts`.
- Refresh local auth state after successful or conflicting email-link flows so Settings reflects the synced identity sooner.

## Type

- [x] Bug fix

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-265/bugsettings-handle-privy-email-link-conflicts-without-noisy-client
- Sentry: https://eliza-uv.sentry.io/issues/7309012328/

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)

## Changes

- Treat Privy email-link conflicts as a non-error path with a clearer toast instead of a Sentry-noisy generic failure.
- Show linked email state in the account-link modal when Privy exposes the verified email through `linkedAccounts`.
- Use the same verified-email extraction path when syncing `/api/users/me` and when enabling notification emails from settings.
- Extend the link-email/auth sync unit coverage for linked-account email cases and Privy conflict codes.

## Review guide

**Start here**
- `apps/web/src/components/profile/LinkSocialAccountsModal.tsx`
- `apps/web/src/hooks/useAuth.ts`
- `apps/web/src/lib/auth/privyIdentitySync.ts`

**Risk**
- [x] Low

**Notes for reviewers**
- I kept the change narrowly scoped to Privy email-linking state. No new fallback layer was introduced; the PR reuses `getAllVerifiedEmails(...)` instead.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

Executed targeted checks:
- `bun test apps/web/src/components/profile/link-email-utils.test.ts apps/web/src/lib/auth/privyIdentitySync.test.ts`
- `bunx biome check apps/web/src/components/profile/link-email-utils.ts apps/web/src/components/profile/link-email-utils.test.ts apps/web/src/components/profile/LinkSocialAccountsModal.tsx apps/web/src/lib/auth/privyIdentitySync.ts apps/web/src/lib/auth/privyIdentitySync.test.ts apps/web/src/hooks/useAuth.ts apps/web/src/app/api/users/me/route.ts apps/web/src/app/api/users/[userId]/notification-email-preferences/route.ts`

**Manual verification**
1. In `Settings > Link Accounts`, open the email-link flow for a user whose Privy account already has a verified email in `linkedAccounts`.
2. Confirm the flow no longer logs a client error for `cannot_link_more_of_type`, shows a clear informational toast, and closes cleanly.
3. Reopen settings and confirm the linked email is recognized for notification-email flows.

## Ops / Migration / Deployment

- [x] No deploy impact

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: normal web deploy
- Rollback: revert this PR

## Breaking changes

- [x] None

**Migration guide**
- None

## Security / privacy

- [x] No security impact

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Small settings-state fix. The only user-facing delta is corrected email-link recognition and a clearer toast for an expected Privy conflict.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
