### PR TITLE
fix: allow game guide completion behind NFT gating

### DIFF
--- a/changelogs/BAB-263--game-guide-nft-gating.md
+++ b/changelogs/BAB-263--game-guide-nft-gating.md
@@ -1,0 +1,8 @@
+**PR:** https://github.com/BabylonSocial/babylon/pull/1276
+**Linear:** [BAB-263](https://linear.app/eliza-labs/issue/BAB-263)
+
+### Game Guide Completion Works Behind NFT Gating
+- Stop rejecting game guide completion with a false `403` when NFT gating is enabled.
+- Persist `gameGuideCompletedAt` server-side for authenticated users who can finish onboarding but do not have NFT access.
+- Keep the change narrowly scoped by allowlisting only the exact completion endpoint instead of broadening `/api/users/me/*`.
+- Add focused middleware coverage so this endpoint stays exempt from NFT gating checks.

--- a/changelogs/BAB-263--game-guide-nft-gating.md
+++ b/changelogs/BAB-263--game-guide-nft-gating.md
@@ -1,8 +1,0 @@
-**PR:** https://github.com/BabylonSocial/babylon/pull/1276
-**Linear:** [BAB-263](https://linear.app/eliza-labs/issue/BAB-263)
-
-### Game Guide Completion Works Behind NFT Gating
-- Stop rejecting game guide completion with a false `403` when NFT gating is enabled.
-- Persist `gameGuideCompletedAt` server-side for authenticated users who can finish onboarding but do not have NFT access.
-- Keep the change narrowly scoped by allowlisting only the exact completion endpoint instead of broadening `/api/users/me/*`.
-- Add focused middleware coverage so this endpoint stays exempt from NFT gating checks.

--- a/packages/api/src/__tests__/auth-middleware.test.ts
+++ b/packages/api/src/__tests__/auth-middleware.test.ts
@@ -289,6 +289,24 @@ describe('authenticate middleware', () => {
     });
   });
 
+  it('does not enforce NFT gating for /api/users/me/game-guide', async () => {
+    process.env.NFT_GATING_ENABLED = 'true';
+
+    mockVerifyAgentSession.mockReturnValueOnce(null);
+    mockVerifyAuthToken.mockResolvedValueOnce({ userId: 'privy-user' });
+    usersRows = [{ id: 'db-user-id', walletAddress: '0xabc', isAdmin: false }];
+    snapshotRows = [];
+    ownershipRows = [];
+
+    const request = createRequest('privy-token', '/api/users/me/game-guide');
+    const result = await authenticate(request);
+
+    expect(result).toMatchObject({
+      userId: 'db-user-id',
+      dbUserId: 'db-user-id',
+    });
+  });
+
   it('does not enforce NFT gating for /api/users/{id}/update-profile', async () => {
     process.env.NFT_GATING_ENABLED = 'true';
 

--- a/packages/shared/src/nft/gating.ts
+++ b/packages/shared/src/nft/gating.ts
@@ -8,6 +8,7 @@ const EXACT_ALLOWLIST = new Set<string>([
 
   // API routes (exact)
   '/api/users/me',
+  '/api/users/me/game-guide',
   '/api/users/signup',
   '/api/upload',
 ]);


### PR DESCRIPTION
## Summary
- Allow authenticated users to complete the game guide even when NFT gating is enabled.
- Fix the false 403 on `POST /api/users/me/game-guide` by allowlisting the exact endpoint in the shared NFT gating helper.
- Add a targeted auth middleware test to prevent regressions on this path.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: 

## Context / Links
- Linear: https://linear.app/eliza-labs/issue/BAB-263/game-guide-completion-endpoint-returns-403-behind-nft-gating
- Sentry: https://eliza-uv.sentry.io/issues/7322206684/

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [x] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: 

## Changes
- Add `/api/users/me/game-guide` to the exact NFT gating allowlist.
- Keep the fix centralized in the shared gating helper instead of branching inside the route.
- Cover the exact endpoint with a middleware unit test.

## Review guide
**Start here**
- `packages/shared/src/nft/gating.ts`
- `packages/api/src/__tests__/auth-middleware.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- The change intentionally avoids allowlisting a broader `/api/users/me/` prefix.
- No route-level fallback or alternate auth path was added.

## Test plan
**Commands run**
- [x] `bunx biome check packages/shared/src/nft/gating.ts packages/api/src/__tests__/auth-middleware.test.ts`
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Run `bun test packages/api/src/__tests__/auth-middleware.test.ts`.
2. Confirm the new `/api/users/me/game-guide` allowlist case passes under `NFT_GATING_ENABLED=true`.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: regular deploy.
- Rollback: revert this PR.

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)
### Option B: No visual changes
- Reason: Backend-only auth gating change, no UI changes.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`production` for this PR)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
