### PR TITLE
fix(web): avoid unhandled prediction market fetch rejections

### DIFF
--- a/apps/web/src/stores/predictionMarketsStore.ts
+++ b/apps/web/src/stores/predictionMarketsStore.ts
@@ -83,25 +83,34 @@ export const usePredictionMarketsStore = create<PredictionMarketsState>(
         }
         set({ error: null });
 
-        const url = userId
-          ? `/api/markets/predictions?userId=${encodeURIComponent(userId)}`
-          : '/api/markets/predictions';
-        const response = await fetch(url);
-        if (!response.ok) {
-          throw new Error(
-            `Failed to fetch prediction markets: ${response.status}`
-          );
-        }
+        try {
+          const url = userId
+            ? `/api/markets/predictions?userId=${encodeURIComponent(userId)}`
+            : '/api/markets/predictions';
+          const response = await fetch(url);
+          if (!response.ok) {
+            throw new Error(
+              `Failed to fetch prediction markets: ${response.status}`
+            );
+          }
 
-        const data = await response.json();
-        if (data.questions && Array.isArray(data.questions)) {
-          set({
-            markets: data.questions,
-            lastFetchedAt: Date.now(),
-            error: null,
-          });
+          const data = await response.json();
+          if (data.questions && Array.isArray(data.questions)) {
+            set({
+              markets: data.questions,
+              lastFetchedAt: Date.now(),
+              error: null,
+            });
+          }
+        } catch (err) {
+          const errorMessage =
+            err instanceof Error
+              ? err.message
+              : 'Failed to fetch prediction markets';
+          set({ error: errorMessage });
+        } finally {
+          set({ loading: false, fetchPromise: null });
         }
-        set({ loading: false, fetchPromise: null });
       })();
 
       set({ fetchPromise });

--- a/changelogs/BAB-266--prediction-fetch-rejections.md
+++ b/changelogs/BAB-266--prediction-fetch-rejections.md
@@ -1,0 +1,8 @@
+**PR:** https://github.com/BabylonSocial/babylon/pull/1277
+**Linear:** [BAB-266](https://linear.app/eliza-labs/issue/BAB-266/bugmarkets-avoid-unhandled-promise-rejections-when-prediction-market)
+
+### Prediction Market Fetch Error Handling
+- Stop `/markets` prediction fetch failures from surfacing as extra unhandled promise rejections in the browser.
+- Keep the existing "Failed to load markets." fallback while routing fetch failures through store error state instead of rejected promises.
+- Allow the prediction markets store to recover cleanly on the next retry or polling cycle after a failed request.
+- Add a regression test covering failed prediction fetches and successful retry recovery.

--- a/changelogs/BAB-266--prediction-fetch-rejections.md
+++ b/changelogs/BAB-266--prediction-fetch-rejections.md
@@ -1,8 +1,0 @@
-**PR:** https://github.com/BabylonSocial/babylon/pull/1277
-**Linear:** [BAB-266](https://linear.app/eliza-labs/issue/BAB-266/bugmarkets-avoid-unhandled-promise-rejections-when-prediction-market)
-
-### Prediction Market Fetch Error Handling
-- Stop `/markets` prediction fetch failures from surfacing as extra unhandled promise rejections in the browser.
-- Keep the existing "Failed to load markets." fallback while routing fetch failures through store error state instead of rejected promises.
-- Allow the prediction markets store to recover cleanly on the next retry or polling cycle after a failed request.
-- Add a regression test covering failed prediction fetches and successful retry recovery.

--- a/packages/testing/unit/prediction-markets-store.test.ts
+++ b/packages/testing/unit/prediction-markets-store.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit Tests: Prediction Markets Zustand Store
+ *
+ * Tests the Zustand store logic directly without React.
+ * Exercises real code paths in apps/web/src/stores/predictionMarketsStore.ts.
+ *
+ * Run with: bun test packages/testing/unit/prediction-markets-store.test.ts --preload ./packages/testing/unit/preload.ts
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+type MockFetchResponse = {
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+};
+
+type MockFetch = (input: string) => Promise<MockFetchResponse>;
+
+function createResponse({
+  ok,
+  status,
+  body,
+}: {
+  ok: boolean;
+  status: number;
+  body: unknown;
+}): MockFetchResponse {
+  return {
+    ok,
+    status,
+    json: () => Promise.resolve(body),
+  };
+}
+
+const mockFetch = mock<MockFetch>(() =>
+  Promise.resolve(
+    createResponse({
+      ok: true,
+      status: 200,
+      body: {
+        questions: [{ id: 'market-1', question: 'Will ETH go up?' }],
+      },
+    })
+  )
+);
+
+// @ts-expect-error - mock global fetch
+globalThis.fetch = mockFetch;
+
+const actualReact = await import('react');
+const reactMock = {
+  ...actualReact,
+  useCallback: (fn: Function) => fn,
+  useEffect: () => {},
+  useMemo: (factory: Function) => factory(),
+  useRef: (value: unknown) => ({ current: value }),
+};
+mock.module('react', () => ({
+  ...reactMock,
+  default: actualReact.default ?? reactMock,
+}));
+
+mock.module('zustand/react/shallow', () => ({
+  useShallow: (fn: Function) => fn,
+}));
+
+const { usePredictionMarketsStore } = await import(
+  '@/stores/predictionMarketsStore'
+);
+
+function resetStore() {
+  const { pollingInterval } = usePredictionMarketsStore.getState();
+  if (pollingInterval) {
+    clearInterval(pollingInterval);
+  }
+
+  usePredictionMarketsStore.setState({
+    markets: [],
+    loading: false,
+    error: null,
+    lastFetchedAt: null,
+    fetchPromise: null,
+    pollingInterval: null,
+    subscriberCount: 0,
+  });
+}
+
+beforeEach(() => {
+  resetStore();
+  mockFetch.mockClear();
+  mockFetch.mockImplementation(() =>
+    Promise.resolve(
+      createResponse({
+        ok: true,
+        status: 200,
+        body: {
+          questions: [{ id: 'market-1', question: 'Will ETH go up?' }],
+        },
+      })
+    )
+  );
+});
+
+afterEach(() => {
+  resetStore();
+});
+
+describe('Prediction Markets Store', () => {
+  test('stores fetch failures in state instead of rejecting', async () => {
+    mockFetch.mockImplementation(() =>
+      Promise.resolve(
+        createResponse({
+          ok: false,
+          status: 503,
+          body: {},
+        })
+      )
+    );
+
+    await expect(
+      usePredictionMarketsStore.getState().fetchMarkets()
+    ).resolves.toBeUndefined();
+
+    const state = usePredictionMarketsStore.getState();
+    expect(state.error).toBe('Failed to fetch prediction markets: 503');
+    expect(state.loading).toBe(false);
+    expect(state.fetchPromise).toBeNull();
+    expect(state.markets).toEqual([]);
+  });
+
+  test('clears failed fetchPromise so a later retry can succeed', async () => {
+    mockFetch
+      .mockImplementationOnce(() =>
+        Promise.resolve(
+          createResponse({
+            ok: false,
+            status: 429,
+            body: {},
+          })
+        )
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve(
+          createResponse({
+            ok: true,
+            status: 200,
+            body: {
+              questions: [{ id: 'market-2', question: 'Will BTC rally?' }],
+            },
+          })
+        )
+      );
+
+    await usePredictionMarketsStore.getState().fetchMarkets();
+    await usePredictionMarketsStore.getState().fetchMarkets(true);
+
+    const state = usePredictionMarketsStore.getState();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(state.error).toBeNull();
+    expect(state.fetchPromise).toBeNull();
+    expect(state.markets).toEqual([
+      { id: 'market-2', question: 'Will BTC rally?' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- Normalize prediction market fetch failures into store state so `/markets` no longer emits unhandled promise rejections when `/api/markets/predictions` fails.
- Clear the store's in-flight promise on failure so polling and manual retries can recover on the next successful request.
- Add a focused unit test covering failed fetches and retry recovery for the prediction markets store.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- [BAB-266](https://linear.app/eliza-labs/issue/BAB-266/bugmarkets-avoid-unhandled-promise-rejections-when-prediction-market)

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- Wrap `predictionMarketsStore.fetchMarkets()` in `try/catch/finally` so failed prediction market requests update store error state instead of rejecting to callers.
- Preserve the existing UI fallback while making sure `loading` and `fetchPromise` are always reset after failures.
- Add a unit test that proves failed requests resolve cleanly and that a later forced retry can succeed.

## Review guide

**Start here**
- `apps/web/src/stores/predictionMarketsStore.ts`
- `packages/testing/unit/prediction-markets-store.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- This intentionally mirrors the existing error-handling pattern already used in `perpMarketsStore` instead of introducing a new abstraction.
- Non-goal: changing the existing `/markets` fallback UI copy or behavior beyond removing the extra unhandled promise rejection.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Ran `bun test packages/testing/unit/prediction-markets-store.test.ts --preload ./packages/testing/unit/preload.ts`.
2. Ran `node_modules/.bin/biome check --write apps/web/src/stores/predictionMarketsStore.ts packages/testing/unit/prediction-markets-store.test.ts`.
3. Did not run `build`, full `typecheck`, or full `lint` because this change is isolated to a client-side store and the requested workflow avoids heavy repo-wide commands by default.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: Ship normally with the markets UI update.
- Rollback: Revert this PR.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Client-side state handling fix only; no intended visual change beyond removing an extra unhandled promise rejection reported to Sentry.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
