### PR TITLE
fix(feed): drop invalid narrative posts before flattening

### DIFF
--- a/apps/web/src/app/feed/utils/feedAlgorithms.ts
+++ b/apps/web/src/app/feed/utils/feedAlgorithms.ts
@@ -62,7 +62,7 @@ export function flattenStories(stories: NarrativeStory[]): FlatItem[] {
 
   const queues = postStories.map((s) => ({
     story: s,
-    posts: [...s.posts],
+    posts: s.posts.filter((post): post is NarrativePost => Boolean(post)),
     firstAppearance: true,
   }));
 

--- a/packages/testing/unit/narrative-feed-algorithms.test.ts
+++ b/packages/testing/unit/narrative-feed-algorithms.test.ts
@@ -172,6 +172,23 @@ describe('flattenStories', () => {
       expect(items[0]!.story).toBe(story);
     }
   });
+
+  it('drops undefined posts instead of emitting invalid flat items', () => {
+    const story = makeStory('A', 3);
+    const malformedStory = {
+      ...story,
+      posts: [story.posts[0], undefined, story.posts[2]],
+    } as unknown as NarrativeStory;
+
+    const items = flattenStories([malformedStory]);
+
+    expect(items).toHaveLength(2);
+    expect(items.every((item) => item.type === 'post')).toBe(true);
+    expect(items.map((item) => item.key)).toEqual([
+      `A:${story.posts[0]!.id}`,
+      `A:${story.posts[2]!.id}`,
+    ]);
+  });
 });
 
 // ─── mergeChronologically tests ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Drop malformed `undefined` narrative posts during story flattening so they never become renderable feed items.
- Add a regression test covering the exact malformed-post shape that would otherwise reach the narrative post mapper.
- Keep the change scoped to the shared feed algorithm so valid story ordering stays unchanged.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- [BAB-295](https://linear.app/eliza-labs/issue/BAB-295/bugfeed-investigate-undefined-narrative-post-causing-likecount-crash)

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- Filter falsy post entries out of `flattenStories()` before slotting and key generation.
- Add a unit test proving malformed story payloads no longer emit invalid flat items.
- Leave valid story ordering, slotting, and market insertion behavior unchanged.

## Review guide

**Start here**
- `apps/web/src/app/feed/utils/feedAlgorithms.ts`
- `packages/testing/unit/narrative-feed-algorithms.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- The active `/feed` renderer already skips empty `posts` arrays; this PR hardens the remaining narrative flattening path against malformed `undefined` entries without inventing fallback post data.
- Non-goal: broader cleanup of unused narrative feed code paths.

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Run `bun test packages/testing/unit/narrative-feed-algorithms.test.ts`.
2. Confirm the new regression test passes and existing flatten/slotting tests remain green.
3. Run `bunx biome check --write apps/web/src/app/feed/utils/feedAlgorithms.ts packages/testing/unit/narrative-feed-algorithms.test.ts`.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `…`
- Changed: `…`
- Removed: `…`

**DB / data migration**
- Migration(s): `…`
- Backfill/seed: `…` (command/script + expected runtime)

**Rollout / rollback plan**
- Rollout: regular deploy.
- Rollback: revert this PR.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- `…`

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Feed algorithm hardening plus unit-test coverage only; no intended UI change.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [ ] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
