### PR TITLE
fix(engine): keep expired timeframed markets active until resolution

### DIFF
--- a/packages/engine/src/services/timeframe-arc-processor.ts
+++ b/packages/engine/src/services/timeframe-arc-processor.ts
@@ -183,10 +183,14 @@ export class TimeframeArcProcessor {
           try {
             result.marketsProcessed++;
 
-            // Check for resolution
+            // markets-tick owns actual market resolution and payouts. Once a
+            // market reaches endTime, we only advance its narrative arc to the
+            // terminal state and stop generating new arc events for it.
             if (now >= market.endTime) {
-              await this.resolveMarket(market);
-              result.transitionsOccurred++;
+              const transition = await this.markResolutionPending(market, now);
+              if (transition.transitioned) {
+                result.transitionsOccurred++;
+              }
               continue;
             }
 
@@ -371,31 +375,55 @@ export class TimeframeArcProcessor {
   }
 
   /**
-   * Resolve a market that has reached its end time
+   * Advance an expired market to its terminal arc state without closing it.
+   *
+   * Actual market/question settlement is handled by markets-tick so prediction
+   * markets are not removed from the active lifecycle before payouts run.
    */
-  async resolveMarket(market: TimeframedMarket): Promise<void> {
-    const now = new Date();
+  async markResolutionPending(
+    market: TimeframedMarket,
+    now: Date = new Date()
+  ): Promise<ArcTransitionResult> {
+    const terminalState = getCurrentArcState(
+      market.startTime,
+      market.endTime,
+      market.timeframe,
+      now
+    );
+
+    if (market.arcState === terminalState) {
+      return {
+        transitioned: false,
+        marketId: market.id,
+      };
+    }
 
     await db
       .update(timeframedMarkets)
       .set({
-        isActive: false,
-        isResolved: true,
-        resolvedAt: now,
-        arcState: 'resolution',
+        arcState: terminalState,
+        arcStateEnteredAt: now,
         updatedAt: now,
       })
       .where(eq(timeframedMarkets.id, market.id));
 
     logger.info(
-      `Market resolved`,
+      `Market reached end time and is awaiting markets-tick resolution`,
       {
         marketId: market.id,
         timeframe: market.timeframe,
-        duration: (now.getTime() - market.startTime.getTime()) / 1000 / 60,
+        previousState: market.arcState,
+        terminalState,
       },
       'TimeframeArcProcessor'
     );
+
+    return {
+      transitioned: true,
+      previousState: market.arcState,
+      newState: terminalState,
+      marketId: market.id,
+    };
   }
 
   /**

--- a/packages/testing/unit/markets/timeframe-arc-processor.test.ts
+++ b/packages/testing/unit/markets/timeframe-arc-processor.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+let mockDbSelectOffset: ReturnType<typeof mock>;
+let mockDbSelectLimit: ReturnType<typeof mock>;
+let mockDbSelectOrderBy: ReturnType<typeof mock>;
+let mockDbSelectWhere: ReturnType<typeof mock>;
+let mockDbSelectFrom: ReturnType<typeof mock>;
+let mockDbSelect: ReturnType<typeof mock>;
+let mockDbUpdateWhere: ReturnType<typeof mock>;
+let mockDbUpdateSet: ReturnType<typeof mock>;
+let mockDbUpdate: ReturnType<typeof mock>;
+
+function resetDbMocks() {
+  mockDbSelectOffset = mock(async () => []);
+  mockDbSelectLimit = mock(() => ({ offset: mockDbSelectOffset }));
+  mockDbSelectOrderBy = mock(() => ({ limit: mockDbSelectLimit }));
+  mockDbSelectWhere = mock(() => ({ orderBy: mockDbSelectOrderBy }));
+  mockDbSelectFrom = mock(() => ({ where: mockDbSelectWhere }));
+  mockDbSelect = mock(() => ({ from: mockDbSelectFrom }));
+
+  mockDbUpdateWhere = mock(async () => []);
+  mockDbUpdateSet = mock(() => ({ where: mockDbUpdateWhere }));
+  mockDbUpdate = mock(() => ({ set: mockDbUpdateSet }));
+}
+
+resetDbMocks();
+
+mock.module('@babylon/db', () => ({
+  db: {
+    get select() {
+      return mockDbSelect;
+    },
+    get update() {
+      return mockDbUpdate;
+    },
+  },
+  asc: (column: unknown) => ({ op: 'asc', column }),
+  eq: (left: unknown, right: unknown) => ({ op: 'eq', left, right }),
+  timeframedMarkets: {
+    id: 'timeframedMarkets.id',
+    isActive: 'timeframedMarkets.isActive',
+  },
+}));
+
+const mockLoggerInfo = mock();
+
+mock.module('@babylon/shared', () => ({
+  logger: {
+    debug: mock(),
+    error: mock(),
+    info: mockLoggerInfo,
+    warn: mock(),
+  },
+}));
+
+const { TimeframeArcProcessor } = await import(
+  '../../../engine/src/services/timeframe-arc-processor.ts'
+);
+
+describe('TimeframeArcProcessor', () => {
+  beforeEach(() => {
+    resetDbMocks();
+    mockLoggerInfo.mockClear();
+  });
+
+  test('keeps expired markets active while moving them to the terminal arc state', async () => {
+    const now = new Date('2026-03-19T20:50:00.000Z');
+    const expiredMarket = {
+      id: 'market-1',
+      timeframe: 'intraday',
+      startTime: new Date('2026-03-19T18:50:00.000Z'),
+      endTime: new Date('2026-03-19T19:50:00.000Z'),
+      arcState: 'active',
+      eventsGenerated: 0,
+    };
+
+    mockDbSelectOffset.mockResolvedValueOnce([expiredMarket]);
+
+    const processor = new TimeframeArcProcessor();
+    const result = await processor.processTick(now);
+
+    expect(result.marketsProcessed).toBe(1);
+    expect(result.transitionsOccurred).toBe(1);
+    expect(mockDbUpdateSet).toHaveBeenCalledTimes(1);
+    expect(mockDbUpdateSet).toHaveBeenCalledWith({
+      arcState: 'resolution',
+      arcStateEnteredAt: now,
+      updatedAt: now,
+    });
+
+    const updatePayload = mockDbUpdateSet.mock.calls[0]?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(updatePayload).toBeDefined();
+    expect(updatePayload).not.toHaveProperty('isActive');
+    expect(updatePayload).not.toHaveProperty('isResolved');
+    expect(updatePayload).not.toHaveProperty('resolvedAt');
+  });
+
+  test('does not rewrite expired markets already in their terminal arc state', async () => {
+    const now = new Date('2026-03-19T20:50:00.000Z');
+    const expiredMarket = {
+      id: 'market-2',
+      timeframe: 'flash',
+      startTime: new Date('2026-03-19T20:15:00.000Z'),
+      endTime: new Date('2026-03-19T20:30:00.000Z'),
+      arcState: 'resolving',
+      eventsGenerated: 0,
+    };
+
+    mockDbSelectOffset.mockResolvedValueOnce([expiredMarket]);
+
+    const processor = new TimeframeArcProcessor();
+    const result = await processor.processTick(now);
+
+    expect(result.marketsProcessed).toBe(1);
+    expect(result.transitionsOccurred).toBe(0);
+    expect(mockDbUpdateSet).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Prevent `game-tick` from deactivating expired `TimeframedMarket` rows before `markets-tick` settles the underlying prediction market.
- Keep expired markets in their terminal narrative state so payouts, question status, and market status remain owned by the resolution cron.
- Add focused unit coverage for expired markets to prevent future regressions in market closing.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-305/fix-market-closing-bug-system-stability-pre-launch

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Docs site (`apps/docs`) / vendor docs (`docs/vendors/*`)
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- Replace premature end-of-window deactivation in `TimeframeArcProcessor` with a terminal-state transition that leaves the market active for `markets-tick`.
- Skip further arc event generation for markets that have passed `endTime` while they await real settlement.
- Add unit tests that assert expired markets are not marked `isActive=false` / `isResolved=true` by the timeframe processor.

## Review guide

**Start here**
- `packages/engine/src/services/timeframe-arc-processor.ts`
- `packages/testing/unit/markets/timeframe-arc-processor.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- Root cause was a split-brain lifecycle: `game-tick` was closing `TimeframedMarket` rows independently from the actual prediction market settlement flow in `markets-tick`.
- Existing desynced markets should be recoverable by the next resolution cron because the mature-question query does not depend on `TimeframedMarket.isActive`.
- Non-goal: this PR does not backfill already desynced rows directly; it stops the ongoing source of corruption.

## Test plan

**Commands run**
- [x] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [x] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Run `bun test packages/testing/unit/markets/timeframe-arc-processor.test.ts`.
2. Confirm expired markets are moved to their terminal arc state without `isActive` / `isResolved` writes.
3. Confirm `markets-tick` remains the only path that fully resolves prediction markets.

**Validation notes**
- `bun run typecheck` currently fails on pre-existing branch issues in `packages/api/src/services/agent-solana-registration-service.ts` (missing `@babylon/agents/solana-registry` import resolution and nullable `prepared` access).
- `bun run test:unit` currently fails in unrelated suites: `packages/testing/unit/babylon-integration-wallet.test.ts` and `packages/testing/unit/shared/error-handler-sentry.test.ts`.
- `bun run build` currently fails in `apps/web` while collecting page data for `/api/auth/twitter/scopes/callback` because Base mainnet contracts are not deployed in this environment.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: deploy normally; the next `markets-tick` run can close already-mature unresolved questions.
- Rollback: revert this PR to restore the old timeframe processor behavior.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend-only engine change, no UI impact.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)

