### PR TITLE
fix(api): use full Solana CAIP IDs for Privy sends

### DIFF
--- a/packages/api/src/services/agent-solana-registration-service.test.ts
+++ b/packages/api/src/services/agent-solana-registration-service.test.ts
@@ -184,7 +184,7 @@ describe('agent-solana-registration-service', () => {
     mockSendSolanaTransaction.mockResolvedValue({
       hash: 'tx-123',
       transactionId: 'tx-123',
-      caip2: 'solana:mainnet',
+      caip2: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
     });
   });
 

--- a/packages/api/src/services/privy/__tests__/solana-idempotency.test.ts
+++ b/packages/api/src/services/privy/__tests__/solana-idempotency.test.ts
@@ -1,17 +1,20 @@
 import { describe, expect, it } from 'bun:test';
 import { buildSolanaTransactionIdempotencyKey } from '../solana-idempotency';
 
+const SOLANA_MAINNET_CAIP2 =
+  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+
 describe('buildSolanaTransactionIdempotencyKey', () => {
   it('is stable for the same transaction payload', () => {
     const keyA = buildSolanaTransactionIdempotencyKey({
       walletId: 'wallet-1',
       transaction: 'tx-body-1',
-      caip2: 'solana:mainnet',
+      caip2: SOLANA_MAINNET_CAIP2,
     });
     const keyB = buildSolanaTransactionIdempotencyKey({
       walletId: 'wallet-1',
       transaction: 'tx-body-1',
-      caip2: 'solana:mainnet',
+      caip2: SOLANA_MAINNET_CAIP2,
     });
 
     expect(keyA).toBe(keyB);
@@ -22,12 +25,12 @@ describe('buildSolanaTransactionIdempotencyKey', () => {
     const keyA = buildSolanaTransactionIdempotencyKey({
       walletId: 'wallet-1',
       transaction: 'tx-body-1',
-      caip2: 'solana:mainnet',
+      caip2: SOLANA_MAINNET_CAIP2,
     });
     const keyB = buildSolanaTransactionIdempotencyKey({
       walletId: 'wallet-1',
       transaction: 'tx-body-2',
-      caip2: 'solana:mainnet',
+      caip2: SOLANA_MAINNET_CAIP2,
     });
 
     expect(keyA).not.toBe(keyB);

--- a/packages/api/src/services/privy/solana-send-transaction.ts
+++ b/packages/api/src/services/privy/solana-send-transaction.ts
@@ -5,7 +5,7 @@ import { getPrivyNodeClient } from './privy-node';
 import { buildSolanaTransactionIdempotencyKey } from './solana-idempotency';
 
 function resolveSolanaCaip2(): string {
-  const cluster = process.env.SOLANA_REGISTRY_CLUSTER ?? 'mainnet-beta';
+  const cluster = process.env.SOLANA_CLUSTER ?? 'mainnet-beta';
 
   switch (cluster) {
     case 'devnet':

--- a/packages/api/src/services/privy/solana-send-transaction.ts
+++ b/packages/api/src/services/privy/solana-send-transaction.ts
@@ -5,18 +5,18 @@ import { getPrivyNodeClient } from './privy-node';
 import { buildSolanaTransactionIdempotencyKey } from './solana-idempotency';
 
 function resolveSolanaCaip2(): string {
-  const cluster = process.env.SOLANA_CLUSTER ?? 'mainnet-beta';
+  const cluster = process.env.SOLANA_REGISTRY_CLUSTER ?? 'mainnet-beta';
 
   switch (cluster) {
     case 'devnet':
-      return 'solana:devnet';
+      return 'solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1';
     case 'testnet':
-      return 'solana:testnet';
+      return 'solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z';
     case 'localnet':
       return 'solana:localnet';
     case 'mainnet-beta':
     default:
-      return 'solana:mainnet';
+      return 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
   }
 }
 


### PR DESCRIPTION
## Summary

- switch the Solana Privy send path from shorthand CAIP IDs like `solana:mainnet` to the full CAIP IDs Privy expects
- align the cluster lookup with `SOLANA_REGISTRY_CLUSTER` instead of the unrelated `SOLANA_CLUSTER` env
- update the affected tests to use the full Solana mainnet CAIP

## Why

Production Solana registration now reaches the final non-sponsored send path, but Privy rejects the request with:

`Unsupported Solana CAIP2 chain ID: solana:mainnet`

We previously validated via the standalone debugger that the full mainnet CAIP form advances further:

- mainnet: `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`
- devnet: `solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1`
- testnet: `solana:4uhcVJyU9pJkvQyS88uRDiswHXSCkY3z`

This PR patches the server-side send path only.

## Test plan

- `bun test packages/api/src/services/agent-solana-registration-service.test.ts packages/api/src/services/privy/__tests__/solana-idempotency.test.ts`
