### PR TITLE
fix(BAB-323): correct resolved market notification P&L

### DIFF
--- a/packages/core/markets/prediction/PredictionMarketService.ts
+++ b/packages/core/markets/prediction/PredictionMarketService.ts
@@ -401,7 +401,11 @@ export class PredictionMarketService {
           (winningSide === 'yes' && p.side === 'yes') ||
           (winningSide === 'no' && p.side === 'no')
       )
-      .reduce((acc, p) => acc + p.shares, 0);
+      .reduce(
+        (acc, p) =>
+          acc + PredictionPricing.calculateExpectedPayout(p.shares, p.avgPrice),
+        0
+      );
 
     const liquidityReduction = Math.min(totalPayout, market.liquidity);
     const newLiquidity = market.liquidity - liquidityReduction;
@@ -418,7 +422,9 @@ export class PredictionMarketService {
       const isWinner =
         (winningSide === 'yes' && pos.side === 'yes') ||
         (winningSide === 'no' && pos.side === 'no');
-      const payout = isWinner ? pos.shares : 0;
+      const payout = isWinner
+        ? PredictionPricing.calculateExpectedPayout(pos.shares, pos.avgPrice)
+        : 0;
       const costBasisWithFees = grossUpBuyAmount(
         pos.avgPrice * pos.shares,
         this.deps.fees.tradingFeeRate

--- a/packages/core/markets/prediction/__tests__/PredictionMarketService.test.ts
+++ b/packages/core/markets/prediction/__tests__/PredictionMarketService.test.ts
@@ -506,15 +506,31 @@ describe('PredictionMarketService', () => {
     const pos2 = await db.getPosition('u2', 'm1', 'no');
     expect(pos1?.status).toBe('resolved');
     expect(pos2?.status).toBe('resolved');
+    expect(pos1?.outcome).toBe(true);
+    expect(pos2?.outcome).toBe(false);
     const postWinnerBalance = (await wallet.getBalance('u1')).balance;
     const postLoserBalance = (await wallet.getBalance('u2')).balance;
     expect(postWinnerBalance).toBeGreaterThan(preWinnerBalance);
     expect(postLoserBalance).toBeLessThanOrEqual(preLoserBalance);
 
+    const expectedWinnerPayout = PredictionPricing.calculateExpectedPayout(
+      pos1!.shares,
+      pos1!.avgPrice
+    );
+    const expectedWinnerPnl = expectedWinnerPayout - 100;
+    const expectedLoserPnl = -100;
+
+    expect(postWinnerBalance - preWinnerBalance).toBeCloseTo(
+      expectedWinnerPayout
+    );
+    expect(pos1?.pnl).toBeCloseTo(expectedWinnerPnl);
+    expect(pos1?.pnl).toBeGreaterThan(0);
+    expect(pos2?.pnl).toBeCloseTo(expectedLoserPnl);
+
     // Liquidity should decrease by total payouts (capped at available liquidity)
     const marketAfterResolve = await service.getMarket('m1');
     expect(marketAfterResolve?.resolved).toBe(true);
-    const payout = pos1?.shares ?? 0;
+    const payout = expectedWinnerPayout;
     const expectedReduction = Math.min(payout, marketPreResolve!.liquidity);
     expect(marketAfterResolve!.liquidity).toBeCloseTo(
       marketPreResolve!.liquidity - expectedReduction,
@@ -525,8 +541,47 @@ describe('PredictionMarketService', () => {
     const pnlByUser = new Map(wallet.pnls.map((p) => [p.userId, p.pnl]));
     const winnerPnl = pnlByUser.get('u1') ?? 0;
     const loserPnl = pnlByUser.get('u2') ?? 0;
+    expect(winnerPnl).toBeCloseTo(expectedWinnerPnl);
+    expect(loserPnl).toBeCloseTo(expectedLoserPnl);
     expect(loserPnl).toBeLessThan(0);
-    expect(winnerPnl).toBeGreaterThan(loserPnl);
+    expect(winnerPnl).toBeGreaterThan(0);
+  });
+
+  it('resolve should preserve zero pnl when payout matches cost basis', async () => {
+    await db.upsertPosition({
+      userId: 'u1',
+      marketId: 'm1',
+      side: 'yes',
+      shares: 10,
+      avgPrice: 999,
+      status: 'active',
+      pnl: 0,
+      outcome: null,
+      resolvedAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+
+    const preBalance = (await wallet.getBalance('u1')).balance;
+
+    await service.resolve({
+      marketId: 'm1',
+      winningSide: 'yes',
+      resolutionDescription: 'Synthetic break-even settlement',
+    });
+
+    const pos = await db.getPosition('u1', 'm1', 'yes');
+    const postBalance = (await wallet.getBalance('u1')).balance;
+
+    expect(pos?.status).toBe('resolved');
+    expect(pos?.outcome).toBe(true);
+    expect(pos?.pnl).toBe(0);
+    expect(postBalance - preBalance).toBe(10_000);
+    expect(
+      wallet.pnls.some(
+        (entry) => entry.userId === 'u1' && entry.reason === 'pred_resolve'
+      )
+    ).toBe(false);
   });
 
   it('pricing getCurrentPrice returns 0.5 when total is zero for display', () => {

--- a/packages/testing/unit/market-resolution-notifications.test.ts
+++ b/packages/testing/unit/market-resolution-notifications.test.ts
@@ -61,6 +61,40 @@ describe('groupResolvedMarketOutcomes', () => {
       marketId: 'market-1',
       points: -5.5,
       outcome: 'loss',
+      dedupeKey: 'market_resolved:market-1:user-1',
+      deepLink: '/markets/predictions/market-1',
+    });
+  });
+
+  test('treats a zero total as a win for notification grouping', () => {
+    const outcomes = groupResolvedMarketOutcomes([
+      {
+        holderId: 'user-1',
+        ownerUserId: 'user-1',
+        marketId: 'market-3',
+        marketName: 'Will SOL break $300?',
+        points: 10,
+        agentName: null,
+      },
+      {
+        holderId: 'user-1',
+        ownerUserId: 'user-1',
+        marketId: 'market-3',
+        marketName: 'Will SOL break $300?',
+        points: -10,
+        agentName: null,
+      },
+    ]);
+
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0]).toMatchObject({
+      ownerUserId: 'user-1',
+      holderId: 'user-1',
+      marketId: 'market-3',
+      points: 0,
+      outcome: 'win',
+      dedupeKey: 'market_resolved:market-3:user-1',
+      deepLink: '/markets/predictions/market-3',
     });
   });
 

--- a/packages/testing/unit/market-resolution-notifications.test.ts
+++ b/packages/testing/unit/market-resolution-notifications.test.ts
@@ -34,6 +34,36 @@ describe('groupResolvedMarketOutcomes', () => {
     });
   });
 
+  test('derives outcome from the final aggregated points total', () => {
+    const outcomes = groupResolvedMarketOutcomes([
+      {
+        holderId: 'user-1',
+        ownerUserId: 'user-1',
+        marketId: 'market-1',
+        marketName: 'Will ETH break $5k?',
+        points: 12.5,
+        agentName: null,
+      },
+      {
+        holderId: 'user-1',
+        ownerUserId: 'user-1',
+        marketId: 'market-1',
+        marketName: 'Will ETH break $5k?',
+        points: -18,
+        agentName: null,
+      },
+    ]);
+
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0]).toMatchObject({
+      ownerUserId: 'user-1',
+      holderId: 'user-1',
+      marketId: 'market-1',
+      points: -5.5,
+      outcome: 'loss',
+    });
+  });
+
   test('keeps agent-held outcomes separate and attributes the agent name', () => {
     const outcomes = groupResolvedMarketOutcomes([
       {

--- a/packages/testing/unit/prediction-market-events.test.ts
+++ b/packages/testing/unit/prediction-market-events.test.ts
@@ -6,7 +6,10 @@ import type {
   PredictionServiceDeps,
   QuestionRecord,
 } from '../../core/markets/prediction';
-import { PredictionMarketService } from '../../core/markets/prediction';
+import {
+  PredictionMarketService,
+  PredictionPricing,
+} from '../../core/markets/prediction';
 
 describe('PredictionMarketService broadcast events', () => {
   const mockBroadcast = {
@@ -168,7 +171,9 @@ describe('PredictionMarketService broadcast events', () => {
     expect(payload.type).toBe('prediction_resolution');
     expect(payload.marketId).toBe('market-1');
     expect(payload.winningSide).toBe('yes');
-    expect(payload.totalPayout).toBe(100); // Only winning side (yes) shares
+    expect(payload.totalPayout).toBe(
+      PredictionPricing.calculateExpectedPayout(100, 0.5)
+    );
   });
 
   test('no broadcast when broadcast dep is not provided', async () => {


### PR DESCRIPTION
## Summary

- Fix resolved prediction positions so winning settlements use the expected payout formula already used elsewhere in the product.
- Restore correct positive P&L values for won markets in the market-resolution notification flow and any downstream digest aggregation that reads `positions.pnl`.
- Add regression coverage for resolved winner, loser, zero-P&L, and grouped notification scenarios.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- [BAB-323](https://linear.app/eliza-labs/issue/BAB-323/bug-market-resolution-notification-shows-wrong-pandl-won-markets)
- Existing PR: https://github.com/BabylonSocial/babylon/pull/1300

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- Update `PredictionMarketService.resolve()` to reuse `PredictionPricing.calculateExpectedPayout(...)` for winning settlements instead of crediting raw `shares`.
- Reduce market liquidity by the same resolved payout amount so market state stays consistent with credited balances.
- Extend prediction-market service tests to cover positive winner P&L, negative loser P&L, and a zero-P&L settlement edge case.
- Keep notification aggregation regression tests in place for the shared grouping helper used by the popup and digest flows.

## Review guide

**Start here**
- `packages/core/markets/prediction/PredictionMarketService.ts`
- `packages/core/markets/prediction/__tests__/PredictionMarketService.test.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- The root cause was upstream of the notification UI: resolved positions were storing undercounted P&L because settlement used `shares` instead of the existing expected payout formula.
- This PR intentionally does not broaden scope into wallet/history display follow-ups beyond correcting the persisted settlement values.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. `bun test packages/core/markets/prediction/__tests__/PredictionMarketService.test.ts`
2. `bun test packages/testing/unit/market-resolution-notifications.test.ts`
3. `bunx biome check packages/core/markets/prediction/PredictionMarketService.ts packages/core/markets/prediction/__tests__/PredictionMarketService.test.ts`

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: merge normally.
- Rollback: revert `fix(prediction): settle resolved winners with expected payout`.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- No API shape changes. Existing notification payloads become numerically correct because persisted position P&L is corrected at settlement time.

### Database
- No schema changes. Existing rows created after deploy will store corrected `positions.pnl` values for resolved winners.

### Contracts / on-chain
- No contracts changes.

### Docs
- No docs changes.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Domain-service fix only; the existing notification UI receives corrected numbers but no layout or asset changed in this PR.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
