### PR TITLE
fix(BAB-323): exclude zero-share resolved positions from notifications

### DIFF
--- a/apps/web/src/lib/services/market-resolution-notifications.ts
+++ b/apps/web/src/lib/services/market-resolution-notifications.ts
@@ -3,6 +3,7 @@ import {
   and,
   db,
   eq,
+  gt,
   isNotNull,
   type JsonValue,
   markets,
@@ -106,7 +107,8 @@ export async function notifyResolvedMarketOwners(
         eq(positions.status, 'resolved'),
         isNotNull(positions.outcome),
         isNotNull(positions.pnl),
-        isNotNull(positions.resolvedAt)
+        isNotNull(positions.resolvedAt),
+        gt(positions.shares, '0')
       )
     );
 

--- a/apps/web/src/lib/services/notification-digest-service.ts
+++ b/apps/web/src/lib/services/notification-digest-service.ts
@@ -3,6 +3,7 @@ import {
   and,
   db,
   eq,
+  gt,
   gte,
   isNotNull,
   lt,
@@ -113,6 +114,7 @@ export async function buildDigestForUser(params: {
         isNotNull(positions.outcome),
         isNotNull(positions.pnl),
         isNotNull(positions.resolvedAt),
+        gt(positions.shares, '0'),
         gte(positions.resolvedAt, windowStart),
         lt(positions.resolvedAt, params.now),
         or(

--- a/packages/testing/unit/market-resolution-notification-queries.test.ts
+++ b/packages/testing/unit/market-resolution-notification-queries.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const positionsTable = {
+  marketId: 'positions.marketId',
+  status: 'positions.status',
+  outcome: 'positions.outcome',
+  pnl: 'positions.pnl',
+  resolvedAt: 'positions.resolvedAt',
+  shares: 'positions.shares',
+  userId: 'positions.userId',
+};
+
+const usersTable = {
+  id: 'users.id',
+  managedBy: 'users.managedBy',
+  isAgent: 'users.isAgent',
+  displayName: 'users.displayName',
+};
+
+const marketsTable = {
+  id: 'markets.id',
+  question: 'markets.question',
+};
+
+type Condition =
+  | {
+      op: 'and' | 'or';
+      conditions: Condition[];
+    }
+  | {
+      op: 'eq' | 'gt' | 'gte' | 'lt';
+      left: unknown;
+      right: unknown;
+    }
+  | {
+      op: 'isNotNull';
+      value: unknown;
+    };
+
+let capturedWhere: Condition | null = null;
+
+const mockWhere = mock(async (condition: Condition) => {
+  capturedWhere = condition;
+  return [];
+});
+
+const mockCreateNotification = mock(async () => ({ created: true }));
+const mockBroadcastToChannel = mock(async () => undefined);
+const mockSendNotificationEmail = mock(async () => undefined);
+
+mock.module('@babylon/api', () => ({
+  broadcastToChannel: mockBroadcastToChannel,
+  createNotification: mockCreateNotification,
+  sendNotificationEmail: mockSendNotificationEmail,
+}));
+
+mock.module('@babylon/shared', () => ({
+  logger: {
+    info: mock(),
+    warn: mock(),
+    error: mock(),
+    debug: mock(),
+  },
+}));
+
+mock.module('@babylon/db', () => ({
+  and: (...conditions: Condition[]) => ({ op: 'and', conditions }),
+  db: {
+    select: mock(() => ({
+      from: mock(() => ({
+        innerJoin: mock(() => ({
+          leftJoin: mock(() => ({
+            where: mockWhere,
+          })),
+        })),
+      })),
+    })),
+  },
+  eq: (left: unknown, right: unknown) => ({ op: 'eq', left, right }),
+  gt: (left: unknown, right: unknown) => ({ op: 'gt', left, right }),
+  gte: (left: unknown, right: unknown) => ({ op: 'gte', left, right }),
+  isNotNull: (value: unknown) => ({ op: 'isNotNull', value }),
+  lt: (left: unknown, right: unknown) => ({ op: 'lt', left, right }),
+  markets: marketsTable,
+  or: (...conditions: Condition[]) => ({ op: 'or', conditions }),
+  positions: positionsTable,
+  users: usersTable,
+}));
+
+const { notifyResolvedMarketOwners } = await import(
+  '../../../apps/web/src/lib/services/market-resolution-notifications'
+);
+const { buildDigestForUser } = await import(
+  '../../../apps/web/src/lib/services/notification-digest-service'
+);
+
+function expectSharesFilter(condition: Condition | null) {
+  expect(condition).not.toBeNull();
+  expect(condition).toMatchObject({ op: 'and' });
+  const conditions = (condition as Extract<Condition, { op: 'and' }>).conditions;
+  expect(conditions).toContainEqual({
+    op: 'gt',
+    left: 'positions.shares',
+    right: '0',
+  });
+}
+
+describe('market resolution notification queries', () => {
+  beforeEach(() => {
+    capturedWhere = null;
+    mockWhere.mockClear();
+    mockCreateNotification.mockClear();
+    mockBroadcastToChannel.mockClear();
+    mockSendNotificationEmail.mockClear();
+  });
+
+  test('notifyResolvedMarketOwners excludes zero-share positions', async () => {
+    const createdCount = await notifyResolvedMarketOwners('market-1');
+
+    expect(createdCount).toBe(0);
+    expectSharesFilter(capturedWhere);
+    expect(mockCreateNotification).not.toHaveBeenCalled();
+  });
+
+  test('buildDigestForUser excludes zero-share positions', async () => {
+    const digest = await buildDigestForUser({
+      userId: 'user-1',
+      frequency: 'daily',
+      now: new Date('2026-03-20T15:00:00.000Z'),
+    });
+
+    expect(digest).toBeNull();
+    expectSharesFilter(capturedWhere);
+    expect(mockSendNotificationEmail).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- exclude fully sold (`shares = 0`) positions from resolved-market notifications
- apply the same filter to notification digests so both delivery paths stay aligned
- add focused unit coverage that locks the `shares > 0` query guard in both services

## Type

- [x] Bug fix

## Context / Links

- [BAB-323](https://linear.app/eliza-labs/issue/BAB-323/bug-market-resolution-notification-shows-wrong-pandl-won-markets)
- Follow-up to merged PR #1300, which fixed the upstream settlement P&L but did not retain the zero-share notification filter

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR

**Areas touched**
- [x] Web API routes / SSE / A2A (`apps/web`)
- [x] Tests (`packages/testing`)

## Changes

- add `gt(positions.shares, '0')` back to `notifyResolvedMarketOwners`
- add the same `gt(positions.shares, '0')` filter to `buildDigestForUser`
- add unit tests that assert both queries include the zero-share exclusion

## Review guide

**Start here**
- `apps/web/src/lib/services/market-resolution-notifications.ts`
- `apps/web/src/lib/services/notification-digest-service.ts`
- `packages/testing/unit/market-resolution-notification-queries.test.ts`

**Risk**
- [x] Low

## Test plan

- [x] `bun test packages/testing/unit/market-resolution-notification-queries.test.ts`
- [x] `bun test packages/testing/unit/market-resolution-notifications.test.ts`
- [x] `bun test packages/testing/unit/notification-digest-service.test.ts`
- [x] `bunx biome check apps/web/src/lib/services/market-resolution-notifications.ts apps/web/src/lib/services/notification-digest-service.ts packages/testing/unit/market-resolution-notification-queries.test.ts`

## Ops / Migration / Deployment

- [x] No deploy impact
- [x] No DB migration
- [x] No env changes

## Breaking changes

- [x] None

## Security / privacy

- [x] No security impact
