### PR TITLE
fix(agents): notify owners about agent team chat replies

### DIFF
--- a/apps/web/src/app/api/agents/[agentId]/chat/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/chat/route.ts
@@ -13,6 +13,7 @@
 import {
   agentRuntimeManager,
   agentService,
+  notifyTeamChatMessage,
   teamChatService,
 } from '@babylon/agents';
 import {
@@ -776,6 +777,13 @@ export const POST = withErrorHandling(
         content: responseText,
         createdAt: assistantMessageTime,
         metadata: messageMetadata,
+      });
+
+      await notifyTeamChatMessage({
+        chatId: teamChatId,
+        messageId: responseMessageId,
+        senderId: agentId,
+        messagePreview: responseText,
       });
 
       // Broadcast agent response to team chat

--- a/apps/web/src/app/api/agents/[agentId]/chat/route.ts
+++ b/apps/web/src/app/api/agents/[agentId]/chat/route.ts
@@ -779,7 +779,7 @@ export const POST = withErrorHandling(
         metadata: messageMetadata,
       });
 
-      await notifyTeamChatMessage({
+      void notifyTeamChatMessage({
         chatId: teamChatId,
         messageId: responseMessageId,
         senderId: agentId,

--- a/packages/agents/src/services/AgentChatService.ts
+++ b/packages/agents/src/services/AgentChatService.ts
@@ -37,6 +37,7 @@ import { AuthorizationError } from '../errors';
 import { agentRuntimeManager } from '../runtime/AgentRuntimeManager';
 import { generateSnowflakeId } from '../shared/snowflake';
 import { agentService } from './AgentService';
+import { notifyTeamChatMessage } from './team-chat-notifications';
 
 // =============================================================================
 // Types
@@ -864,6 +865,13 @@ export async function dispatchAgentChat(
     content: responseText,
     createdAt: responseTime,
     metadata: messageMetadata,
+  });
+
+  await notifyTeamChatMessage({
+    chatId: teamChatId,
+    messageId: responseMessageId,
+    senderId: resolvedAgentId,
+    messagePreview: responseText,
   });
 
   // Update agent's lastChatAt

--- a/packages/agents/src/services/AgentChatService.ts
+++ b/packages/agents/src/services/AgentChatService.ts
@@ -867,7 +867,7 @@ export async function dispatchAgentChat(
     metadata: messageMetadata,
   });
 
-  await notifyTeamChatMessage({
+  void notifyTeamChatMessage({
     chatId: teamChatId,
     messageId: responseMessageId,
     senderId: resolvedAgentId,

--- a/packages/agents/src/services/index.ts
+++ b/packages/agents/src/services/index.ts
@@ -26,3 +26,4 @@ export {
 } from './interfaces';
 export * from './npc-bootstrap.service';
 export * from './TeamChatService';
+export * from './team-chat-notifications';

--- a/packages/agents/src/services/team-chat-notifications.ts
+++ b/packages/agents/src/services/team-chat-notifications.ts
@@ -1,0 +1,91 @@
+import { createNotification } from '@babylon/api';
+import { and, chatParticipants, chats, db, eq, users } from '@babylon/db';
+import { logger } from '@babylon/shared';
+
+interface NotifyTeamChatMessageParams {
+  chatId: string;
+  messageId: string;
+  senderId: string;
+  messagePreview: string;
+}
+
+/**
+ * Team chat notifications only target human participants and dedupe per
+ * persisted message ID so retries do not create duplicate unread items.
+ */
+export async function notifyTeamChatMessage({
+  chatId,
+  messageId,
+  senderId,
+  messagePreview,
+}: NotifyTeamChatMessageParams): Promise<void> {
+  try {
+    const [senderRows, participantRows, chatRows] = await Promise.all([
+      db
+        .select({
+          displayName: users.displayName,
+          username: users.username,
+        })
+        .from(users)
+        .where(eq(users.id, senderId))
+        .limit(1),
+      db
+        .select({
+          userId: chatParticipants.userId,
+          isAgent: users.isAgent,
+        })
+        .from(chatParticipants)
+        .innerJoin(users, eq(chatParticipants.userId, users.id))
+        .where(
+          and(
+            eq(chatParticipants.chatId, chatId),
+            eq(chatParticipants.isActive, true)
+          )
+        ),
+      db.select({ name: chats.name }).from(chats).where(eq(chats.id, chatId)).limit(1),
+    ]);
+
+    const recipientUserIds = participantRows
+      .filter((participant) => !participant.isAgent)
+      .map((participant) => participant.userId)
+      .filter((userId) => userId !== senderId);
+
+    if (recipientUserIds.length === 0) {
+      return;
+    }
+
+    const sender = senderRows[0];
+    const senderName = sender?.displayName || sender?.username || 'Someone';
+    const preview =
+      messagePreview.length > 50
+        ? `${messagePreview.substring(0, 50)}...`
+        : messagePreview;
+    const chatName = chatRows[0]?.name || 'Agents';
+    const message = `${senderName} in "${chatName}": ${preview}`;
+
+    await Promise.all(
+      recipientUserIds.map((userId) =>
+        createNotification({
+          userId,
+          type: 'system',
+          actorId: senderId,
+          chatId,
+          title: 'New Group Message',
+          message,
+          dedupeKey: `team-chat-message:${messageId}:${userId}`,
+        })
+      )
+    );
+  } catch (error) {
+    logger.warn(
+      'Failed to notify team chat message',
+      {
+        chatId,
+        messageId,
+        senderId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      'TeamChatNotifications'
+    );
+  }
+}

--- a/packages/testing/unit/team-chat-notifications.test.ts
+++ b/packages/testing/unit/team-chat-notifications.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+const mockCreateNotification = mock(async () => ({ created: true }));
+const mockLogger = {
+  warn: mock(),
+};
+
+const selectBuilders: Array<() => { from: (...args: unknown[]) => unknown }> =
+  [];
+
+const mockDbSelect = mock(() => {
+  const nextBuilder = selectBuilders.shift();
+  if (!nextBuilder) {
+    throw new Error('Unexpected db.select() call');
+  }
+
+  return nextBuilder();
+});
+
+mock.module('@babylon/api', () => ({
+  createNotification: mockCreateNotification,
+}));
+
+mock.module('@babylon/db', () => ({
+  and: (...conditions: unknown[]) => conditions,
+  chatParticipants: {
+    chatId: 'chatParticipants.chatId',
+    isActive: 'chatParticipants.isActive',
+    userId: 'chatParticipants.userId',
+  },
+  chats: {
+    id: 'chats.id',
+    name: 'chats.name',
+  },
+  db: {
+    select: mockDbSelect,
+  },
+  eq: (left: unknown, right: unknown) => ({ left, right }),
+  users: {
+    displayName: 'users.displayName',
+    id: 'users.id',
+    isAgent: 'users.isAgent',
+    username: 'users.username',
+  },
+}));
+
+mock.module('@babylon/shared', () => ({
+  logger: mockLogger,
+}));
+
+const { notifyTeamChatMessage } = await import(
+  '../../agents/src/services/team-chat-notifications'
+);
+
+function queueSenderSelect(rows: Array<{ displayName: string | null; username: string | null }>) {
+  selectBuilders.push(() => ({
+    from: () => ({
+      where: () => ({
+        limit: async () => rows,
+      }),
+    }),
+  }));
+}
+
+function queueParticipantsSelect(
+  rows: Array<{ userId: string; isAgent: boolean }>
+) {
+  selectBuilders.push(() => ({
+    from: () => ({
+      innerJoin: () => ({
+        where: async () => rows,
+      }),
+    }),
+  }));
+}
+
+function queueChatSelect(rows: Array<{ name: string | null }>) {
+  selectBuilders.push(() => ({
+    from: () => ({
+      where: () => ({
+        limit: async () => rows,
+      }),
+    }),
+  }));
+}
+
+describe('notifyTeamChatMessage', () => {
+  beforeEach(() => {
+    selectBuilders.length = 0;
+    mockDbSelect.mockClear();
+    mockCreateNotification.mockClear();
+    mockCreateNotification.mockResolvedValue({ created: true });
+    mockLogger.warn.mockClear();
+  });
+
+  it('notifies only human team chat participants with a per-message dedupe key', async () => {
+    queueSenderSelect([{ displayName: 'Apex Force', username: 'apexforce890569' }]);
+    queueParticipantsSelect([
+      { userId: 'owner-1', isAgent: false },
+      { userId: 'agent-1', isAgent: true },
+      { userId: 'agent-2', isAgent: true },
+    ]);
+    queueChatSelect([{ name: 'Close NVDAI' }]);
+
+    await notifyTeamChatMessage({
+      chatId: 'chat-1',
+      messageId: 'message-1',
+      senderId: 'agent-1',
+      messagePreview: 'Closed NVDAI and realized +$12.50 in profit.',
+    });
+
+    expect(mockCreateNotification).toHaveBeenCalledTimes(1);
+    expect(mockCreateNotification).toHaveBeenCalledWith({
+      userId: 'owner-1',
+      type: 'system',
+      actorId: 'agent-1',
+      chatId: 'chat-1',
+      title: 'New Group Message',
+      message: 'Apex Force in "Close NVDAI": Closed NVDAI and realized +$12.50 in profit.',
+      dedupeKey: 'team-chat-message:message-1:owner-1',
+    });
+  });
+
+  it('skips notification creation when no human recipients remain', async () => {
+    queueSenderSelect([{ displayName: 'Apex Force', username: 'apexforce890569' }]);
+    queueParticipantsSelect([
+      { userId: 'agent-1', isAgent: true },
+      { userId: 'agent-2', isAgent: true },
+    ]);
+    queueChatSelect([{ name: null }]);
+
+    await notifyTeamChatMessage({
+      chatId: 'chat-1',
+      messageId: 'message-1',
+      senderId: 'agent-1',
+      messagePreview: 'Closed NVDAI.',
+    });
+
+    expect(mockCreateNotification).not.toHaveBeenCalled();
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it('logs and swallows notification failures', async () => {
+    queueSenderSelect([{ displayName: 'Apex Force', username: 'apexforce890569' }]);
+    queueParticipantsSelect([{ userId: 'owner-1', isAgent: false }]);
+    queueChatSelect([{ name: 'Agents' }]);
+    mockCreateNotification.mockRejectedValueOnce(new Error('db unavailable'));
+
+    await notifyTeamChatMessage({
+      chatId: 'chat-1',
+      messageId: 'message-1',
+      senderId: 'agent-1',
+      messagePreview: 'Closed NVDAI.',
+    });
+
+    expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      'Failed to notify team chat message',
+      {
+        chatId: 'chat-1',
+        messageId: 'message-1',
+        senderId: 'agent-1',
+        error: 'db unavailable',
+      },
+      'TeamChatNotifications'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Create owner notifications for agent replies written to the Agents team chat.
- Reuse a dedicated helper in `@babylon/agents` so both direct agent replies and coordinator-dispatched agent replies follow the same notification path.
- Deduplicate notifications per persisted team chat message and keep notification failures non-blocking.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-334/notifications-agent-close-position-success-does-not-create-an-owner

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [x] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- Add a team chat notification helper that targets only human participants, formats the unread notification preview, and deduplicates per stored message ID.
- Call that helper when an agent reply is persisted in `/api/agents/[agentId]/chat` team-chat mode.
- Call that helper when coordinator-dispatched agent replies are persisted by `dispatchAgentChat()`.
- Add unit coverage for human-recipient filtering, dedupe keys, and non-blocking failure handling.

## Review guide

**Start here**
- `packages/agents/src/services/team-chat-notifications.ts`
- `apps/web/src/app/api/agents/[agentId]/chat/route.ts`
- `packages/agents/src/services/AgentChatService.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- This intentionally fixes the team-chat reply path instead of reviving the older DM-based agent trade notification service, because agent-owner DMs are explicitly blocked.
- Non-goals: coordinator-authored summaries in team chat still follow their existing path; this PR only fixes agent-authored replies, which are the user-visible completion signal in the reported bug.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

Additional targeted checks run:
- `bunx biome check --write apps/web/src/app/api/agents/[agentId]/chat/route.ts packages/agents/src/services/AgentChatService.ts packages/agents/src/services/index.ts packages/agents/src/services/team-chat-notifications.ts packages/testing/unit/team-chat-notifications.test.ts`
- `bun test packages/testing/unit/team-chat-notifications.test.ts`

**Manual verification**
1. In Agents chat, ask an owned agent to close a position.
2. Wait for the agent success reply in the team chat.
3. Confirm a new unread notification appears for the owner and links back to the team chat.
4. Repeat through a coordinator-dispatched agent flow and confirm the same notification behavior.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: deploy normally.
- Rollback: revert this PR to restore the previous team-chat reply path.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- No external API shape changes. The change is internal to notification side effects after team chat message persistence.

### Database
- No schema changes. This only inserts notification rows using an explicit per-message dedupe key.

### Contracts / on-chain
- Not applicable.

### Docs
- Not applicable.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend-only behavior change in notification creation for existing team chat replies.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
