### PR TITLE
fix: align wallet totals with canonical portfolio breakdown

### DIFF
--- a/apps/web/src/app/api/markets/positions/[userId]/route.ts
+++ b/apps/web/src/app/api/markets/positions/[userId]/route.ts
@@ -75,7 +75,12 @@
  * @see {@link /lib/db/context} RLS context
  */
 
-import { optionalAuth, successResponse, withErrorHandling } from '@babylon/api';
+import {
+  findUserByIdentifier,
+  optionalAuth,
+  successResponse,
+  withErrorHandling,
+} from '@babylon/api';
 import { PredictionPricing } from '@babylon/core/markets/prediction';
 import { asPublic, asUser, db, eq, users } from '@babylon/db';
 import { FEE_CONFIG } from '@babylon/engine/config/fees';
@@ -176,6 +181,14 @@ export const GET = withErrorHandling(
 
     // Optional auth - positions are public for leaderboard but RLS still applies
     const authUser = await optionalAuth(request).catch(() => null);
+    const dbUser = await findUserByIdentifier(userId, {
+      id: true,
+      privyId: true,
+    });
+    const canonicalUserId = dbUser?.id ?? userId;
+    const positionUserIds = Array.from(
+      new Set([canonicalUserId, dbUser?.privyId, userId].filter(Boolean))
+    ) as string[];
 
     const status = queryParams.status as string;
 
@@ -191,7 +204,7 @@ export const GET = withErrorHandling(
           displayName: users.displayName,
         })
         .from(users)
-        .where(eq(users.managedBy, userId));
+        .where(eq(users.managedBy, canonicalUserId));
     });
 
     const agentIds = userAgents.map((a) => a.id);
@@ -199,7 +212,10 @@ export const GET = withErrorHandling(
 
     // Build perp where clause with status filtering
     const perpWhereBase = {
-      userId,
+      userId:
+        positionUserIds.length === 1
+          ? canonicalUserId
+          : { in: positionUserIds },
       ...(closedAtFilter !== undefined ? { closedAt: closedAtFilter } : {}),
     };
 
@@ -254,14 +270,20 @@ export const GET = withErrorHandling(
         ? await asUser(authUser, async (db) => {
             return await db.position.findMany({
               where: {
-                userId,
+                userId:
+                  positionUserIds.length === 1
+                    ? canonicalUserId
+                    : { in: positionUserIds },
               },
             });
           })
         : await asPublic(async (db) => {
             return await db.position.findMany({
               where: {
-                userId,
+                userId:
+                  positionUserIds.length === 1
+                    ? canonicalUserId
+                    : { in: positionUserIds },
               },
             });
           });
@@ -361,7 +383,7 @@ export const GET = withErrorHandling(
     logger.info(
       'User positions fetched successfully',
       {
-        userId,
+        userId: canonicalUserId,
         perpPositions: perpStats.totalPositions,
         predictionPositions: predictionPositions.length,
       },

--- a/apps/web/src/app/api/markets/positions/[userId]/route.ts
+++ b/apps/web/src/app/api/markets/positions/[userId]/route.ts
@@ -187,9 +187,13 @@ export const GET = withErrorHandling(
     });
     const canonicalUserId = dbUser?.id ?? userId;
     const positionUserIds = dbUser
-      ? [dbUser.id, dbUser.privyId].filter((candidate): candidate is string =>
-          Boolean(candidate)
-        )
+      ? [
+          ...new Set(
+            [dbUser.id, dbUser.privyId].filter(
+              (candidate): candidate is string => Boolean(candidate)
+            )
+          ),
+        ]
       : [userId];
 
     const status = queryParams.status as string;

--- a/apps/web/src/app/api/markets/positions/[userId]/route.ts
+++ b/apps/web/src/app/api/markets/positions/[userId]/route.ts
@@ -186,9 +186,11 @@ export const GET = withErrorHandling(
       privyId: true,
     });
     const canonicalUserId = dbUser?.id ?? userId;
-    const positionUserIds = Array.from(
-      new Set([canonicalUserId, dbUser?.privyId, userId].filter(Boolean))
-    ) as string[];
+    const positionUserIds = dbUser
+      ? [dbUser.id, dbUser.privyId].filter((candidate): candidate is string =>
+          Boolean(candidate)
+        )
+      : [userId];
 
     const status = queryParams.status as string;
 

--- a/apps/web/src/components/feed/PortfolioWidget.tsx
+++ b/apps/web/src/components/feed/PortfolioWidget.tsx
@@ -138,7 +138,10 @@ export function PortfolioWidget() {
     data: portfolioData,
     loading: portfolioLoading,
     refresh: refreshPortfolio,
-  } = usePortfolioPnL();
+  } = usePortfolioPnL({
+    userId,
+    pollingIntervalMs: 15_000,
+  });
   const { balance, lifetimePnL } = useWalletBalance(userId);
   const getPortfolioWidget = useWidgetCacheStore(
     (state) => state.getPortfolioWidget
@@ -195,7 +198,7 @@ export function PortfolioWidget() {
 
   return (
     <PortfolioWidgetContent
-      balance={balance}
+      balance={data?.wallet ?? balance}
       lifetimePnL={lifetimePnL}
       data={data}
       loading={loading}

--- a/apps/web/src/components/feed/PortfolioWidget.tsx
+++ b/apps/web/src/components/feed/PortfolioWidget.tsx
@@ -14,7 +14,10 @@ import { useCallback, useEffect, useState } from 'react';
 import { Skeleton } from '@/components/shared/Skeleton';
 import { useWidgetRefresh } from '@/contexts/WidgetRefreshContext';
 import { useAuth } from '@/hooks/useAuth';
-import { usePortfolioPnL } from '@/hooks/usePortfolioPnL';
+import {
+  usePortfolioPnL,
+  usePortfolioPnLPolling,
+} from '@/hooks/usePortfolioPnL';
 import { formatCurrencyDisplay } from '@/lib/format';
 import {
   useWalletBalance,
@@ -138,10 +141,8 @@ export function PortfolioWidget() {
     data: portfolioData,
     loading: portfolioLoading,
     refresh: refreshPortfolio,
-  } = usePortfolioPnL({
-    userId,
-    pollingIntervalMs: 15_000,
-  });
+  } = usePortfolioPnL({ userId });
+  usePortfolioPnLPolling({ userId, intervalMs: 15_000 });
   const { balance, lifetimePnL } = useWalletBalance(userId);
   const getPortfolioWidget = useWidgetCacheStore(
     (state) => state.getPortfolioWidget

--- a/apps/web/src/components/wallet/__tests__/portfolioBreakdown.test.ts
+++ b/apps/web/src/components/wallet/__tests__/portfolioBreakdown.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'bun:test';
+import { calculateWalletPortfolioSummary } from '../shared/portfolioBreakdown';
+
+describe('calculateWalletPortfolioSummary', () => {
+  it('keeps wallet totals aligned with the canonical snapshot and agent cash balances', () => {
+    const result = calculateWalletPortfolioSummary({
+      userId: 'owner-1',
+      snapshot: {
+        wallet: 100,
+        agents: 200,
+        positions: 150,
+        available: 300,
+        originalAmount: 0,
+        totalAssets: 450,
+        totalPnL: 0,
+        agentCount: 1,
+        totalPoints: 450,
+        members: [
+          {
+            id: 'owner-1',
+            name: 'Owner',
+            wallet: 100,
+            isAgent: false,
+          },
+          {
+            id: 'agent-1',
+            name: 'Apex Force',
+            wallet: 200,
+            isAgent: true,
+          },
+        ],
+      },
+      perpPositions: [
+        {
+          id: 'perp-1',
+          userId: 'owner-1',
+          ticker: 'BTC',
+          organizationId: 'BTC',
+          side: 'long',
+          entryPrice: 100,
+          currentPrice: 110,
+          size: 100,
+          leverage: 5,
+          liquidationPrice: 0,
+          unrealizedPnL: 10,
+          unrealizedPnLPercent: 10,
+          fundingPaid: 0,
+          openedAt: new Date().toISOString(),
+          lastUpdated: new Date().toISOString(),
+          closedAt: null,
+          isAgentPosition: false,
+        },
+      ],
+      predictionPositions: [
+        {
+          id: 'prediction-1',
+          marketId: 'market-1',
+          question: 'Will it rain?',
+          side: 'YES',
+          shares: 10,
+          avgPrice: 5,
+          currentPrice: 12,
+          currentValue: 120,
+          costBasis: 50,
+          unrealizedPnL: 70,
+          currentProbability: 0.6,
+          resolved: false,
+          resolution: null,
+          status: 'active',
+          createdAt: new Date().toISOString(),
+          isAgentPosition: true,
+          agentId: 'agent-1',
+          agentName: 'Apex Force',
+        },
+      ],
+    });
+
+    expect(result.summary).toEqual({
+      wallet: 100,
+      agents: 200,
+      positions: 150,
+      totalBalance: 450,
+      agentCount: 1,
+    });
+
+    expect(result.members).toEqual([
+      {
+        id: 'owner-1',
+        name: 'You (Owner)',
+        cash: 100,
+        openPositions: 30,
+        total: 130,
+        isOwner: true,
+      },
+      {
+        id: 'agent-1',
+        name: 'Apex Force',
+        cash: 200,
+        openPositions: 120,
+        total: 320,
+        isOwner: false,
+      },
+    ]);
+  });
+
+  it('creates a zero-cash fallback row when positions arrive before member metadata', () => {
+    const result = calculateWalletPortfolioSummary({
+      userId: 'owner-1',
+      snapshot: {
+        wallet: 100,
+        agents: 0,
+        positions: 40,
+        available: 100,
+        originalAmount: 0,
+        totalAssets: 140,
+        totalPnL: 0,
+        agentCount: 0,
+        totalPoints: 140,
+        members: [
+          {
+            id: 'owner-1',
+            name: 'Owner',
+            wallet: 100,
+            isAgent: false,
+          },
+        ],
+      },
+      perpPositions: [
+        {
+          id: 'perp-1',
+          userId: 'agent-2',
+          ticker: 'ETH',
+          organizationId: 'ETH',
+          side: 'long',
+          entryPrice: 100,
+          currentPrice: 120,
+          size: 40,
+          leverage: 1,
+          liquidationPrice: 0,
+          unrealizedPnL: 0,
+          unrealizedPnLPercent: 0,
+          fundingPaid: 0,
+          openedAt: new Date().toISOString(),
+          lastUpdated: new Date().toISOString(),
+          closedAt: null,
+          isAgentPosition: true,
+          agentId: 'agent-2',
+          agentName: 'Fallback Agent',
+        },
+      ],
+      predictionPositions: [],
+    });
+
+    expect(result.members).toContainEqual({
+      id: 'agent-2',
+      name: 'Fallback Agent',
+      cash: 0,
+      openPositions: 40,
+      total: 40,
+      isOwner: false,
+    });
+  });
+
+  it('does not duplicate the owner row when the requested userId is an alias', () => {
+    const result = calculateWalletPortfolioSummary({
+      userId: 'privy:owner-1',
+      snapshot: {
+        wallet: 100,
+        agents: 0,
+        positions: 0,
+        available: 100,
+        originalAmount: 0,
+        totalAssets: 100,
+        totalPnL: 0,
+        agentCount: 0,
+        totalPoints: 100,
+        members: [
+          {
+            id: 'owner-1',
+            name: 'Owner',
+            wallet: 100,
+            isAgent: false,
+          },
+        ],
+      },
+      perpPositions: [],
+      predictionPositions: [],
+    });
+
+    expect(result.members).toEqual([
+      {
+        id: 'owner-1',
+        name: 'You (Owner)',
+        cash: 100,
+        openPositions: 0,
+        total: 100,
+        isOwner: true,
+      },
+    ]);
+  });
+});

--- a/apps/web/src/components/wallet/shared/portfolioBreakdown.ts
+++ b/apps/web/src/components/wallet/shared/portfolioBreakdown.ts
@@ -1,0 +1,166 @@
+import type { PortfolioBreakdownSnapshot } from '@/hooks/usePortfolioPnL';
+import type {
+  PerpPosition,
+  UserPredictionPosition,
+} from '@/stores/userPositionsStore';
+
+export interface WalletPortfolioMember {
+  id: string;
+  name: string;
+  cash: number;
+  openPositions: number;
+  total: number;
+  isOwner: boolean;
+}
+
+export interface WalletPortfolioSummary {
+  agents: number;
+  agentCount: number;
+  positions: number;
+  totalBalance: number;
+  wallet: number;
+}
+
+export function calculateWalletPortfolioSummary(params: {
+  userId: string;
+  snapshot: PortfolioBreakdownSnapshot;
+  perpPositions: PerpPosition[];
+  predictionPositions: UserPredictionPosition[];
+}): {
+  members: WalletPortfolioMember[];
+  summary: WalletPortfolioSummary;
+} {
+  const { userId, snapshot, perpPositions, predictionPositions } = params;
+  const membersById = new Map<string, WalletPortfolioMember>();
+  const ownerMember = (snapshot.members ?? []).find(
+    (member) => !member.isAgent
+  );
+  const ownerMemberId = ownerMember?.id ?? userId;
+
+  const addMember = ({
+    id,
+    name,
+    wallet,
+    isAgent,
+  }: {
+    id: string;
+    isAgent: boolean;
+    name: string;
+    wallet: number;
+  }) => {
+    if (!id) return;
+
+    const existing = membersById.get(id);
+    if (existing) {
+      existing.cash = wallet;
+      existing.total = existing.cash + existing.openPositions;
+      return;
+    }
+
+    membersById.set(id, {
+      id,
+      name: isAgent ? name : 'You (Owner)',
+      cash: wallet,
+      openPositions: 0,
+      total: wallet,
+      isOwner: !isAgent,
+    });
+  };
+
+  for (const member of snapshot.members ?? []) {
+    addMember(member);
+  }
+
+  if (!membersById.has(ownerMemberId)) {
+    addMember({
+      id: ownerMemberId,
+      name: 'You (Owner)',
+      wallet: snapshot.wallet,
+      isAgent: false,
+    });
+  }
+
+  const addPositionValue = (
+    memberId: string,
+    fallbackName: string,
+    value: number,
+    isAgent: boolean
+  ) => {
+    if (!memberId) return;
+
+    const existing = membersById.get(memberId);
+    if (existing) {
+      existing.openPositions += value;
+      existing.total = existing.cash + existing.openPositions;
+      return;
+    }
+
+    membersById.set(memberId, {
+      id: memberId,
+      name: isAgent ? fallbackName : 'You (Owner)',
+      cash: 0,
+      openPositions: value,
+      total: value,
+      isOwner: !isAgent,
+    });
+  };
+
+  for (const position of perpPositions) {
+    const memberId = position.isAgentPosition
+      ? (position.agentId ?? '')
+      : ownerMemberId;
+    addPositionValue(
+      memberId,
+      position.agentName ?? 'Agent',
+      calculatePerpPositionValue(position),
+      Boolean(position.isAgentPosition)
+    );
+  }
+
+  for (const position of predictionPositions) {
+    const memberId = position.isAgentPosition
+      ? (position.agentId ?? '')
+      : ownerMemberId;
+    addPositionValue(
+      memberId,
+      position.agentName ?? 'Agent',
+      position.currentValue ?? position.shares * position.currentPrice,
+      Boolean(position.isAgentPosition)
+    );
+  }
+
+  const orderedIds = [
+    ...new Set([
+      ownerMemberId,
+      ...(snapshot.members ?? []).map((member) => member.id),
+      ...membersById.keys(),
+    ]),
+  ];
+
+  const members = orderedIds
+    .map((memberId) => membersById.get(memberId))
+    .filter((member): member is WalletPortfolioMember => member !== undefined);
+
+  return {
+    members,
+    summary: {
+      wallet: snapshot.wallet,
+      agents: snapshot.agents,
+      positions: snapshot.positions,
+      totalBalance: snapshot.totalAssets,
+      agentCount: snapshot.agentCount,
+    },
+  };
+}
+
+function calculatePerpPositionValue(
+  position: Pick<PerpPosition, 'leverage' | 'size' | 'unrealizedPnL'>
+) {
+  const leverage =
+    Number.isFinite(position.leverage) && position.leverage > 0
+      ? position.leverage
+      : 1;
+  const margin = Math.abs(position.size / leverage);
+
+  return margin + position.unrealizedPnL;
+}

--- a/apps/web/src/components/wallet/shared/portfolioBreakdown.ts
+++ b/apps/web/src/components/wallet/shared/portfolioBreakdown.ts
@@ -1,3 +1,4 @@
+import { calculatePerpPositionMarketValue } from '@babylon/engine/client';
 import type { PortfolioBreakdownSnapshot } from '@/hooks/usePortfolioPnL';
 import type {
   PerpPosition,
@@ -112,7 +113,7 @@ export function calculateWalletPortfolioSummary(params: {
     addPositionValue(
       memberId,
       position.agentName ?? 'Agent',
-      calculatePerpPositionValue(position),
+      calculatePerpPositionMarketValue(position),
       Boolean(position.isAgentPosition)
     );
   }
@@ -151,16 +152,4 @@ export function calculateWalletPortfolioSummary(params: {
       agentCount: snapshot.agentCount,
     },
   };
-}
-
-function calculatePerpPositionValue(
-  position: Pick<PerpPosition, 'leverage' | 'size' | 'unrealizedPnL'>
-) {
-  const leverage =
-    Number.isFinite(position.leverage) && position.leverage > 0
-      ? position.leverage
-      : 1;
-  const margin = Math.abs(position.size / leverage);
-
-  return margin + position.unrealizedPnL;
 }

--- a/apps/web/src/components/wallet/v2/balance-tab.tsx
+++ b/apps/web/src/components/wallet/v2/balance-tab.tsx
@@ -2,86 +2,39 @@
 
 import { formatCurrency } from '@babylon/shared';
 import { useMemo } from 'react';
+import { calculateWalletPortfolioSummary } from '@/components/wallet/shared/portfolioBreakdown';
+import { usePortfolioPnL } from '@/hooks/usePortfolioPnL';
 import { useUserPositions } from '@/stores/userPositionsStore';
-import { useWalletBalance } from '@/stores/walletBalanceStore';
 
 interface BalanceTabProps {
   userId: string;
 }
 
-interface Member {
-  name: string;
-  cash: number;
-  openPositions: number;
-  total: number;
-}
-
 export function BalanceTab({ userId }: BalanceTabProps) {
-  const { balance, loading: balanceLoading } = useWalletBalance(userId);
+  const { data: portfolioData, loading: portfolioLoading } = usePortfolioPnL({
+    userId,
+    pollingIntervalMs: 15_000,
+  });
   const {
     perpPositions,
     predictionPositions,
     loading: positionsLoading,
   } = useUserPositions(userId);
 
-  const loading = balanceLoading || positionsLoading;
+  const loading = portfolioLoading || positionsLoading;
 
-  const { members, totalBalance, agentsOnly } = useMemo(() => {
-    let ownerPositionValue = 0;
-    const agentPositionValues = new Map<string, number>();
-
-    for (const pos of perpPositions) {
-      const value = Math.abs(pos.unrealizedPnL) + pos.size;
-      if (pos.isAgentPosition && pos.agentName) {
-        agentPositionValues.set(
-          pos.agentName,
-          (agentPositionValues.get(pos.agentName) ?? 0) + value
-        );
-      } else {
-        ownerPositionValue += value;
-      }
+  const walletSummary = useMemo(() => {
+    if (!portfolioData) {
+      return null;
     }
 
-    for (const pos of predictionPositions) {
-      const value = pos.currentValue ?? pos.shares * pos.currentPrice;
-      if (pos.isAgentPosition && pos.agentName) {
-        agentPositionValues.set(
-          pos.agentName,
-          (agentPositionValues.get(pos.agentName) ?? 0) + value
-        );
-      } else {
-        ownerPositionValue += value;
-      }
-    }
-
-    const memberList: Member[] = [
-      {
-        name: 'You (Owner)',
-        cash: balance,
-        openPositions: ownerPositionValue,
-        total: balance + ownerPositionValue,
-      },
-    ];
-
-    let agentTotal = 0;
-    for (const [agentName, posValue] of agentPositionValues) {
-      memberList.push({
-        name: agentName,
-        cash: 0,
-        openPositions: posValue,
-        total: posValue,
-      });
-      agentTotal += posValue;
-    }
-
-    const total = balance + ownerPositionValue + agentTotal;
-
-    return {
-      members: memberList,
-      totalBalance: total,
-      agentsOnly: agentTotal,
-    };
-  }, [balance, perpPositions, predictionPositions]);
+    return calculateWalletPortfolioSummary({
+      userId,
+      snapshot: portfolioData,
+      perpPositions,
+      predictionPositions,
+    });
+  }, [portfolioData, predictionPositions, perpPositions, userId]);
 
   const fmt = (amount: number) =>
     formatCurrency(amount, { useThousandsSeparator: true });
@@ -108,14 +61,30 @@ export function BalanceTab({ userId }: BalanceTabProps) {
       <div className="mb-8">
         <div className="flex items-center justify-between py-3">
           <span className="text-foreground text-sm">Total Balance</span>
-          <span className="font-bold text-2xl">{fmt(totalBalance)}</span>
+          <span className="font-bold text-2xl">
+            {fmt(walletSummary?.summary.totalBalance ?? 0)}
+          </span>
         </div>
-        {agentsOnly > 0 && (
+        <div className="flex items-center justify-between border-border border-b py-3">
+          <span className="text-foreground text-sm">Wallet</span>
+          <span className="font-semibold text-lg">
+            {fmt(walletSummary?.summary.wallet ?? 0)}
+          </span>
+        </div>
+        {walletSummary && walletSummary.summary.agentCount > 0 && (
           <div className="flex items-center justify-between border-border border-b py-3">
-            <span className="text-foreground text-sm">Agents Only</span>
-            <span className="font-semibold text-lg">{fmt(agentsOnly)}</span>
+            <span className="text-foreground text-sm">Agents</span>
+            <span className="font-semibold text-lg">
+              {fmt(walletSummary.summary.agents)}
+            </span>
           </div>
         )}
+        <div className="flex items-center justify-between border-border border-b py-3">
+          <span className="text-foreground text-sm">Positions</span>
+          <span className="font-semibold text-lg">
+            {fmt(walletSummary?.summary.positions ?? 0)}
+          </span>
+        </div>
       </div>
 
       {/* Table */}
@@ -126,9 +95,9 @@ export function BalanceTab({ userId }: BalanceTabProps) {
           <div className="text-right">Open Positions</div>
           <div className="text-right">Total</div>
         </div>
-        {members.map((row) => (
+        {(walletSummary?.members ?? []).map((row) => (
           <div
-            key={row.name}
+            key={row.id}
             className="grid grid-cols-4 items-center gap-4 border-border border-t py-4"
           >
             <div className="font-medium text-sm">{row.name}</div>

--- a/apps/web/src/components/wallet/v2/balance-tab.tsx
+++ b/apps/web/src/components/wallet/v2/balance-tab.tsx
@@ -3,7 +3,10 @@
 import { formatCurrency } from '@babylon/shared';
 import { useMemo } from 'react';
 import { calculateWalletPortfolioSummary } from '@/components/wallet/shared/portfolioBreakdown';
-import { usePortfolioPnL } from '@/hooks/usePortfolioPnL';
+import {
+  usePortfolioPnL,
+  usePortfolioPnLPolling,
+} from '@/hooks/usePortfolioPnL';
 import { useUserPositions } from '@/stores/userPositionsStore';
 
 interface BalanceTabProps {
@@ -13,8 +16,8 @@ interface BalanceTabProps {
 export function BalanceTab({ userId }: BalanceTabProps) {
   const { data: portfolioData, loading: portfolioLoading } = usePortfolioPnL({
     userId,
-    pollingIntervalMs: 15_000,
   });
+  usePortfolioPnLPolling({ userId, intervalMs: 15_000 });
   const {
     perpPositions,
     predictionPositions,

--- a/apps/web/src/components/wallet/v2/wallet-preview-widget.tsx
+++ b/apps/web/src/components/wallet/v2/wallet-preview-widget.tsx
@@ -6,7 +6,10 @@ import Link from 'next/link';
 import { useMemo } from 'react';
 import { calculateWalletPortfolioSummary } from '@/components/wallet/shared/portfolioBreakdown';
 import { useMarketPrices } from '@/hooks/useMarketPrices';
-import { usePortfolioPnL } from '@/hooks/usePortfolioPnL';
+import {
+  usePortfolioPnL,
+  usePortfolioPnLPolling,
+} from '@/hooks/usePortfolioPnL';
 import { useUserPositions } from '@/stores/userPositionsStore';
 
 interface WalletPreviewWidgetProps {
@@ -16,8 +19,8 @@ interface WalletPreviewWidgetProps {
 export function WalletPreviewWidget({ userId }: WalletPreviewWidgetProps) {
   const { data: portfolioData, loading: portfolioLoading } = usePortfolioPnL({
     userId,
-    pollingIntervalMs: 15_000,
   });
+  usePortfolioPnLPolling({ userId, intervalMs: 15_000 });
   const {
     perpPositions,
     predictionPositions,

--- a/apps/web/src/components/wallet/v2/wallet-preview-widget.tsx
+++ b/apps/web/src/components/wallet/v2/wallet-preview-widget.tsx
@@ -4,23 +4,27 @@ import { calculateUnrealizedPnL, formatCurrency } from '@babylon/shared';
 import { ArrowRight } from 'lucide-react';
 import Link from 'next/link';
 import { useMemo } from 'react';
+import { calculateWalletPortfolioSummary } from '@/components/wallet/shared/portfolioBreakdown';
 import { useMarketPrices } from '@/hooks/useMarketPrices';
+import { usePortfolioPnL } from '@/hooks/usePortfolioPnL';
 import { useUserPositions } from '@/stores/userPositionsStore';
-import { useWalletBalance } from '@/stores/walletBalanceStore';
 
 interface WalletPreviewWidgetProps {
   userId: string;
 }
 
 export function WalletPreviewWidget({ userId }: WalletPreviewWidgetProps) {
-  const { balance, loading: balanceLoading } = useWalletBalance(userId);
+  const { data: portfolioData, loading: portfolioLoading } = usePortfolioPnL({
+    userId,
+    pollingIntervalMs: 15_000,
+  });
   const {
     perpPositions,
     predictionPositions,
     loading: positionsLoading,
   } = useUserPositions(userId);
 
-  const loading = balanceLoading || positionsLoading;
+  const loading = portfolioLoading || positionsLoading;
 
   // Live prices
   const tickers = useMemo(
@@ -29,34 +33,18 @@ export function WalletPreviewWidget({ userId }: WalletPreviewWidgetProps) {
   );
   const livePrices = useMarketPrices(tickers);
 
-  // Compute totals
-  const { totalBalance, agentsOnly } = useMemo(() => {
-    let ownerPositionValue = 0;
-    let agentTotal = 0;
-
-    for (const pos of perpPositions) {
-      const value = Math.abs(pos.unrealizedPnL) + pos.size;
-      if (pos.isAgentPosition) {
-        agentTotal += value;
-      } else {
-        ownerPositionValue += value;
-      }
+  const walletSummary = useMemo(() => {
+    if (!portfolioData) {
+      return null;
     }
 
-    for (const pos of predictionPositions) {
-      const value = pos.currentValue ?? pos.shares * pos.currentPrice;
-      if (pos.isAgentPosition) {
-        agentTotal += value;
-      } else {
-        ownerPositionValue += value;
-      }
-    }
-
-    return {
-      totalBalance: balance + ownerPositionValue + agentTotal,
-      agentsOnly: agentTotal,
-    };
-  }, [balance, perpPositions, predictionPositions]);
+    return calculateWalletPortfolioSummary({
+      userId,
+      snapshot: portfolioData,
+      perpPositions,
+      predictionPositions,
+    });
+  }, [portfolioData, predictionPositions, perpPositions, userId]);
 
   // Top 3 positions by PnL magnitude
   const latestPositions = useMemo(() => {
@@ -140,14 +128,30 @@ export function WalletPreviewWidget({ userId }: WalletPreviewWidgetProps) {
         <div className="space-y-2">
           <div className="flex items-center justify-between">
             <span className="text-muted-foreground text-sm">Total Balance</span>
-            <span className="font-bold text-base">{fmt(totalBalance)}</span>
+            <span className="font-bold text-base">
+              {fmt(walletSummary?.summary.totalBalance ?? 0)}
+            </span>
           </div>
-          {agentsOnly > 0 && (
+          <div className="flex items-center justify-between">
+            <span className="text-muted-foreground text-sm">Wallet</span>
+            <span className="font-semibold text-sm">
+              {fmt(walletSummary?.summary.wallet ?? 0)}
+            </span>
+          </div>
+          {walletSummary && walletSummary.summary.agentCount > 0 && (
             <div className="flex items-center justify-between">
-              <span className="text-muted-foreground text-sm">Agents Only</span>
-              <span className="font-semibold text-sm">{fmt(agentsOnly)}</span>
+              <span className="text-muted-foreground text-sm">Agents</span>
+              <span className="font-semibold text-sm">
+                {fmt(walletSummary.summary.agents)}
+              </span>
             </div>
           )}
+          <div className="flex items-center justify-between">
+            <span className="text-muted-foreground text-sm">Positions</span>
+            <span className="font-semibold text-sm">
+              {fmt(walletSummary?.summary.positions ?? 0)}
+            </span>
+          </div>
         </div>
       </div>
 

--- a/apps/web/src/components/wallet/wallet/wallet-balance.tsx
+++ b/apps/web/src/components/wallet/wallet/wallet-balance.tsx
@@ -3,7 +3,10 @@
 import { formatCurrency } from '@babylon/shared';
 import { useMemo } from 'react';
 import { calculateWalletPortfolioSummary } from '@/components/wallet/shared/portfolioBreakdown';
-import { usePortfolioPnL } from '@/hooks/usePortfolioPnL';
+import {
+  usePortfolioPnL,
+  usePortfolioPnLPolling,
+} from '@/hooks/usePortfolioPnL';
 import { useUserPositions } from '@/stores/userPositionsStore';
 
 interface WalletBalanceProps {
@@ -14,8 +17,8 @@ interface WalletBalanceProps {
 export function WalletBalance({ userId, mode = 'page' }: WalletBalanceProps) {
   const { data: portfolioData, loading: portfolioLoading } = usePortfolioPnL({
     userId,
-    pollingIntervalMs: 15_000,
   });
+  usePortfolioPnLPolling({ userId, intervalMs: 15_000 });
   const {
     perpPositions,
     predictionPositions,

--- a/apps/web/src/components/wallet/wallet/wallet-balance.tsx
+++ b/apps/web/src/components/wallet/wallet/wallet-balance.tsx
@@ -2,24 +2,20 @@
 
 import { formatCurrency } from '@babylon/shared';
 import { useMemo } from 'react';
+import { calculateWalletPortfolioSummary } from '@/components/wallet/shared/portfolioBreakdown';
+import { usePortfolioPnL } from '@/hooks/usePortfolioPnL';
 import { useUserPositions } from '@/stores/userPositionsStore';
-import { useWalletBalance } from '@/stores/walletBalanceStore';
 
 interface WalletBalanceProps {
   userId: string;
   mode?: 'sidebar' | 'page';
 }
 
-interface Member {
-  name: string;
-  cash: number;
-  openPositions: number;
-  total: number;
-  isOwner?: boolean;
-}
-
 export function WalletBalance({ userId, mode = 'page' }: WalletBalanceProps) {
-  const { balance, loading: balanceLoading } = useWalletBalance(userId);
+  const { data: portfolioData, loading: portfolioLoading } = usePortfolioPnL({
+    userId,
+    pollingIntervalMs: 15_000,
+  });
   const {
     perpPositions,
     predictionPositions,
@@ -27,68 +23,20 @@ export function WalletBalance({ userId, mode = 'page' }: WalletBalanceProps) {
   } = useUserPositions(userId);
 
   const isSidebar = mode === 'sidebar';
-  const loading = balanceLoading || positionsLoading;
+  const loading = portfolioLoading || positionsLoading;
 
-  const { members, totalBalance, agentsOnly } = useMemo(() => {
-    // Owner bucket
-    let ownerPositionValue = 0;
-    const agentPositionValues = new Map<string, number>();
-
-    for (const pos of perpPositions) {
-      const value = Math.abs(pos.unrealizedPnL) + pos.size;
-      if (pos.isAgentPosition && pos.agentName) {
-        agentPositionValues.set(
-          pos.agentName,
-          (agentPositionValues.get(pos.agentName) ?? 0) + value
-        );
-      } else {
-        ownerPositionValue += value;
-      }
+  const walletSummary = useMemo(() => {
+    if (!portfolioData) {
+      return null;
     }
 
-    for (const pos of predictionPositions) {
-      const value = pos.currentValue ?? pos.shares * pos.currentPrice;
-      if (pos.isAgentPosition && pos.agentName) {
-        agentPositionValues.set(
-          pos.agentName,
-          (agentPositionValues.get(pos.agentName) ?? 0) + value
-        );
-      } else {
-        ownerPositionValue += value;
-      }
-    }
-
-    // Build member rows
-    const memberList: Member[] = [
-      {
-        name: 'You (Owner)',
-        cash: balance,
-        openPositions: ownerPositionValue,
-        total: balance + ownerPositionValue,
-        isOwner: true,
-      },
-    ];
-
-    let agentTotal = 0;
-    for (const [agentName, posValue] of agentPositionValues) {
-      // Agents don't hold separate cash balances in current model
-      memberList.push({
-        name: agentName,
-        cash: 0,
-        openPositions: posValue,
-        total: posValue,
-      });
-      agentTotal += posValue;
-    }
-
-    const total = balance + ownerPositionValue + agentTotal;
-
-    return {
-      members: memberList,
-      totalBalance: total,
-      agentsOnly: agentTotal,
-    };
-  }, [balance, perpPositions, predictionPositions]);
+    return calculateWalletPortfolioSummary({
+      userId,
+      snapshot: portfolioData,
+      perpPositions,
+      predictionPositions,
+    });
+  }, [portfolioData, predictionPositions, perpPositions, userId]);
 
   const fmt = (amount: number) =>
     formatCurrency(amount, { useThousandsSeparator: true });
@@ -115,14 +63,30 @@ export function WalletBalance({ userId, mode = 'page' }: WalletBalanceProps) {
       <div className="mb-6 space-y-2">
         <div className="flex items-center justify-between">
           <span className="text-muted-foreground text-sm">Total Balance</span>
-          <span className="font-bold text-2xl">{fmt(totalBalance)}</span>
+          <span className="font-bold text-2xl">
+            {fmt(walletSummary?.summary.totalBalance ?? 0)}
+          </span>
         </div>
-        {agentsOnly > 0 && (
+        <div className="flex items-center justify-between">
+          <span className="text-muted-foreground text-sm">Wallet</span>
+          <span className="font-semibold text-lg">
+            {fmt(walletSummary?.summary.wallet ?? 0)}
+          </span>
+        </div>
+        {walletSummary && walletSummary.summary.agentCount > 0 && (
           <div className="flex items-center justify-between">
-            <span className="text-muted-foreground text-sm">Agents Only</span>
-            <span className="font-semibold text-lg">{fmt(agentsOnly)}</span>
+            <span className="text-muted-foreground text-sm">Agents</span>
+            <span className="font-semibold text-lg">
+              {fmt(walletSummary.summary.agents)}
+            </span>
           </div>
         )}
+        <div className="flex items-center justify-between">
+          <span className="text-muted-foreground text-sm">Positions</span>
+          <span className="font-semibold text-lg">
+            {fmt(walletSummary?.summary.positions ?? 0)}
+          </span>
+        </div>
       </div>
 
       {/* Table */}
@@ -136,9 +100,9 @@ export function WalletBalance({ userId, mode = 'page' }: WalletBalanceProps) {
             </tr>
           </thead>
           <tbody>
-            {members.map((member) => (
+            {(walletSummary?.members ?? []).map((member) => (
               <tr
-                key={member.name}
+                key={member.id}
                 className="border-border border-b last:border-0"
               >
                 <td className="py-3 font-medium text-sm">{member.name}</td>
@@ -161,9 +125,9 @@ export function WalletBalance({ userId, mode = 'page' }: WalletBalanceProps) {
             </tr>
           </thead>
           <tbody>
-            {members.map((member) => (
+            {(walletSummary?.members ?? []).map((member) => (
               <tr
-                key={member.name}
+                key={member.id}
                 className="border-border border-b last:border-0"
               >
                 <td className="py-4 font-medium text-sm">{member.name}</td>

--- a/apps/web/src/hooks/__tests__/usePortfolioPnL.test.ts
+++ b/apps/web/src/hooks/__tests__/usePortfolioPnL.test.ts
@@ -25,6 +25,20 @@ describe('fetchPortfolioBreakdownSnapshot', () => {
           totalPnL: '10',
           agentCount: '2',
           totalPoints: '99',
+          members: [
+            {
+              id: 'user-1',
+              name: 'Owner',
+              wallet: '12.5',
+              isAgent: false,
+            },
+            {
+              id: 'agent-1',
+              name: 'Apex Force',
+              wallet: 3,
+              isAgent: true,
+            },
+          ],
         }),
         { status: 200 }
       )
@@ -46,6 +60,20 @@ describe('fetchPortfolioBreakdownSnapshot', () => {
       totalPnL: 10,
       agentCount: 2,
       totalPoints: 99,
+      members: [
+        {
+          id: 'user-1',
+          name: 'Owner',
+          wallet: 12.5,
+          isAgent: false,
+        },
+        {
+          id: 'agent-1',
+          name: 'Apex Force',
+          wallet: 3,
+          isAgent: true,
+        },
+      ],
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });

--- a/apps/web/src/hooks/usePortfolioPnL.ts
+++ b/apps/web/src/hooks/usePortfolioPnL.ts
@@ -23,6 +23,11 @@ interface UsePortfolioPnLResult {
   lastUpdated: number | null;
 }
 
+interface UsePortfolioPnLOptions {
+  pollingIntervalMs?: number | null;
+  userId?: string | null;
+}
+
 function toNumber(value: unknown, fallback = 0): number {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
   if (typeof value === 'string') {
@@ -83,6 +88,19 @@ export async function fetchPortfolioBreakdownSnapshot(
     totalPnL: toNumber(breakdownJson.totalPnL),
     agentCount: toNumber(breakdownJson.agentCount),
     totalPoints: toNumber(breakdownJson.totalPoints),
+    members: Array.isArray(breakdownJson.members)
+      ? breakdownJson.members
+          .filter(
+            (member): member is Record<string, unknown> =>
+              typeof member === 'object' && member !== null
+          )
+          .map((member) => ({
+            id: String(member.id ?? ''),
+            name: String(member.name ?? 'Agent'),
+            wallet: toNumber(member.wallet),
+            isAgent: Boolean(member.isAgent),
+          }))
+      : [],
   };
 }
 
@@ -119,8 +137,13 @@ export async function fetchPortfolioBreakdownSnapshot(
  * }
  * ```
  */
-export function usePortfolioPnL(): UsePortfolioPnLResult {
+export function usePortfolioPnL(
+  options: UsePortfolioPnLOptions = {}
+): UsePortfolioPnLResult {
   const { user, authenticated } = useAuth();
+  const targetUserId =
+    options.userId ?? (authenticated ? (user?.id ?? null) : null);
+  const pollingIntervalMs = options.pollingIntervalMs ?? null;
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [data, setData] = useState<PortfolioBreakdownSnapshot | null>(null);
@@ -128,7 +151,7 @@ export function usePortfolioPnL(): UsePortfolioPnLResult {
   const abortControllerRef = useRef<AbortController | null>(null);
 
   const refresh = useCallback(async () => {
-    if (!authenticated || !user?.id) {
+    if (!targetUserId) {
       setData(null);
       setLoading(false);
       setError(null);
@@ -148,7 +171,7 @@ export function usePortfolioPnL(): UsePortfolioPnLResult {
 
     try {
       const nextData = await fetchPortfolioBreakdownSnapshot(
-        user.id,
+        targetUserId,
         abortController.signal
       );
 
@@ -172,7 +195,7 @@ export function usePortfolioPnL(): UsePortfolioPnLResult {
         setLoading(false);
       }
     }
-  }, [authenticated, user?.id]);
+  }, [targetUserId]);
 
   useEffect(() => {
     refresh();
@@ -181,6 +204,18 @@ export function usePortfolioPnL(): UsePortfolioPnLResult {
       abortControllerRef.current?.abort();
     };
   }, [refresh]);
+
+  useEffect(() => {
+    if (!targetUserId || !pollingIntervalMs || pollingIntervalMs <= 0) {
+      return;
+    }
+
+    const intervalId = setInterval(() => {
+      void refresh();
+    }, pollingIntervalMs);
+
+    return () => clearInterval(intervalId);
+  }, [pollingIntervalMs, refresh, targetUserId]);
 
   const memoizedData = useMemo(() => data, [data]);
 

--- a/apps/web/src/hooks/usePortfolioPnL.ts
+++ b/apps/web/src/hooks/usePortfolioPnL.ts
@@ -1,11 +1,18 @@
 'use client';
 
 import type { PortfolioBreakdownSnapshot } from '@babylon/engine/client';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo } from 'react';
 import { useAuth } from '@/hooks/useAuth';
+import {
+  fetchPortfolioBreakdownSnapshot,
+  isAbortError,
+  usePortfolioBreakdown,
+  usePortfolioBreakdownPolling,
+} from '@/stores/portfolioBreakdownStore';
 
 // Re-export for components that import from this hook
 export type { PortfolioBreakdownSnapshot } from '@babylon/engine/client';
+export { fetchPortfolioBreakdownSnapshot, isAbortError };
 
 /**
  * Return type for the usePortfolioPnL hook.
@@ -24,84 +31,11 @@ interface UsePortfolioPnLResult {
 }
 
 interface UsePortfolioPnLOptions {
-  pollingIntervalMs?: number | null;
   userId?: string | null;
 }
 
-function toNumber(value: unknown, fallback = 0): number {
-  if (typeof value === 'number' && Number.isFinite(value)) return value;
-  if (typeof value === 'string') {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : fallback;
-  }
-  return fallback;
-}
-
-export function isAbortError(error: unknown): boolean {
-  if (error instanceof DOMException && error.name === 'AbortError') {
-    return true;
-  }
-  if (error instanceof Error && error.name === 'AbortError') {
-    return true;
-  }
-  return false;
-}
-
-export async function fetchPortfolioBreakdownSnapshot(
-  userId: string,
-  signal: AbortSignal
-): Promise<PortfolioBreakdownSnapshot> {
-  let breakdownRes: Response;
-  try {
-    breakdownRes = await fetch(
-      `/api/users/${encodeURIComponent(userId)}/portfolio-breakdown`,
-      { signal }
-    );
-  } catch (error) {
-    if (signal.aborted || isAbortError(error)) {
-      throw error;
-    }
-    throw new Error('Failed to fetch portfolio breakdown');
-  }
-
-  if (!breakdownRes.ok) {
-    throw new Error('Failed to fetch portfolio breakdown');
-  }
-
-  let breakdownJson: Record<string, unknown>;
-  try {
-    breakdownJson = (await breakdownRes.json()) as Record<string, unknown>;
-  } catch (error) {
-    if (signal.aborted || isAbortError(error)) {
-      throw error;
-    }
-    throw new Error('Failed to parse portfolio breakdown');
-  }
-
-  return {
-    wallet: toNumber(breakdownJson.wallet),
-    agents: toNumber(breakdownJson.agents),
-    positions: toNumber(breakdownJson.positions),
-    available: toNumber(breakdownJson.available),
-    originalAmount: toNumber(breakdownJson.originalAmount),
-    totalAssets: toNumber(breakdownJson.totalAssets),
-    totalPnL: toNumber(breakdownJson.totalPnL),
-    agentCount: toNumber(breakdownJson.agentCount),
-    totalPoints: toNumber(breakdownJson.totalPoints),
-    members: Array.isArray(breakdownJson.members)
-      ? breakdownJson.members
-          .filter(
-            (member): member is Record<string, unknown> =>
-              typeof member === 'object' && member !== null
-          )
-          .map((member) => ({
-            id: String(member.id ?? ''),
-            name: String(member.name ?? 'Agent'),
-            wallet: toNumber(member.wallet),
-            isAgent: Boolean(member.isAgent),
-          }))
-      : [],
-  };
+interface UsePortfolioPnLPollingOptions extends UsePortfolioPnLOptions {
+  intervalMs?: number;
 }
 
 /**
@@ -115,27 +49,6 @@ export async function fetchPortfolioBreakdownSnapshot(
  * - Original amount (baseline)
  * - Total assets
  * - Total P/L
- *
- * Automatically fetches data when the user is authenticated and refreshes
- * when the user changes. Supports manual refresh and cancellation of
- * in-flight requests.
- *
- * @returns Portfolio PnL state including loading status, error, data, and refresh function.
- *
- * @example
- * ```tsx
- * const { data, loading, refresh } = usePortfolioPnL();
- *
- * if (loading) return <div>Loading...</div>;
- * if (data) {
- *   return (
- *     <div>
- *       <p>Total PnL: {data.totalPnL}</p>
- *       <p>Total Assets: {data.totalAssets}</p>
- *     </div>
- *   );
- * }
- * ```
  */
 export function usePortfolioPnL(
   options: UsePortfolioPnLOptions = {}
@@ -143,87 +56,24 @@ export function usePortfolioPnL(
   const { user, authenticated } = useAuth();
   const targetUserId =
     options.userId ?? (authenticated ? (user?.id ?? null) : null);
-  const pollingIntervalMs = options.pollingIntervalMs ?? null;
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [data, setData] = useState<PortfolioBreakdownSnapshot | null>(null);
-  const [lastUpdated, setLastUpdated] = useState<number | null>(null);
-  const abortControllerRef = useRef<AbortController | null>(null);
-
-  const refresh = useCallback(async () => {
-    if (!targetUserId) {
-      setData(null);
-      setLoading(false);
-      setError(null);
-      setLastUpdated(null);
-      return;
-    }
-
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
-    }
-
-    const abortController = new AbortController();
-    abortControllerRef.current = abortController;
-
-    setLoading(true);
-    setError(null);
-
-    try {
-      const nextData = await fetchPortfolioBreakdownSnapshot(
-        targetUserId,
-        abortController.signal
-      );
-
-      if (abortController.signal.aborted) {
-        return;
-      }
-
-      setData(nextData);
-      setLastUpdated(Date.now());
-    } catch (error) {
-      if (abortController.signal.aborted || isAbortError(error)) {
-        return;
-      }
-      setError(
-        error instanceof Error
-          ? error.message
-          : 'Failed to fetch portfolio breakdown'
-      );
-    } finally {
-      if (!abortController.signal.aborted) {
-        setLoading(false);
-      }
-    }
-  }, [targetUserId]);
-
-  useEffect(() => {
-    refresh();
-
-    return () => {
-      abortControllerRef.current?.abort();
-    };
-  }, [refresh]);
-
-  useEffect(() => {
-    if (!targetUserId || !pollingIntervalMs || pollingIntervalMs <= 0) {
-      return;
-    }
-
-    const intervalId = setInterval(() => {
-      void refresh();
-    }, pollingIntervalMs);
-
-    return () => clearInterval(intervalId);
-  }, [pollingIntervalMs, refresh, targetUserId]);
-
-  const memoizedData = useMemo(() => data, [data]);
+  const result = usePortfolioBreakdown(targetUserId);
+  const memoizedData = useMemo(() => result.data, [result.data]);
 
   return {
-    loading,
-    error,
+    loading: result.loading,
+    error: result.error,
     data: memoizedData,
-    refresh,
-    lastUpdated,
+    refresh: result.refresh,
+    lastUpdated: result.lastUpdated,
   };
+}
+
+export function usePortfolioPnLPolling(
+  options: UsePortfolioPnLPollingOptions = {}
+) {
+  const { user, authenticated } = useAuth();
+  const targetUserId =
+    options.userId ?? (authenticated ? (user?.id ?? null) : null);
+
+  usePortfolioBreakdownPolling(targetUserId, options.intervalMs ?? 15000);
 }

--- a/apps/web/src/stores/portfolioBreakdownStore.ts
+++ b/apps/web/src/stores/portfolioBreakdownStore.ts
@@ -1,0 +1,315 @@
+import type { PortfolioBreakdownSnapshot } from '@babylon/engine/client';
+import { useCallback, useEffect, useRef } from 'react';
+import { create } from 'zustand';
+import { useShallow } from 'zustand/react/shallow';
+
+interface PortfolioBreakdownState {
+  data: PortfolioBreakdownSnapshot | null;
+  loading: boolean;
+  error: string | null;
+  lastFetchedAt: number | null;
+  userId: string | null;
+  fetchPromise: Promise<void> | null;
+  pollingInterval: ReturnType<typeof setInterval> | null;
+  subscriberCount: number;
+  fetchPortfolioBreakdown: (userId: string, force?: boolean) => Promise<void>;
+  invalidate: () => void;
+  reset: () => void;
+  setUserId: (userId: string | null) => void;
+  subscribe: (userId: string, intervalMs: number) => () => void;
+}
+
+const CACHE_TTL = 5000;
+
+function toNumber(value: unknown, fallback = 0): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+  return fallback;
+}
+
+export function isAbortError(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    return true;
+  }
+  if (error instanceof Error && error.name === 'AbortError') {
+    return true;
+  }
+  return false;
+}
+
+export async function fetchPortfolioBreakdownSnapshot(
+  userId: string,
+  signal: AbortSignal
+): Promise<PortfolioBreakdownSnapshot> {
+  let breakdownRes: Response;
+  try {
+    breakdownRes = await fetch(
+      `/api/users/${encodeURIComponent(userId)}/portfolio-breakdown`,
+      { signal }
+    );
+  } catch (error) {
+    if (signal.aborted || isAbortError(error)) {
+      throw error;
+    }
+    throw new Error('Failed to fetch portfolio breakdown');
+  }
+
+  if (!breakdownRes.ok) {
+    throw new Error('Failed to fetch portfolio breakdown');
+  }
+
+  let breakdownJson: Record<string, unknown>;
+  try {
+    breakdownJson = (await breakdownRes.json()) as Record<string, unknown>;
+  } catch (error) {
+    if (signal.aborted || isAbortError(error)) {
+      throw error;
+    }
+    throw new Error('Failed to parse portfolio breakdown');
+  }
+
+  return {
+    wallet: toNumber(breakdownJson.wallet),
+    agents: toNumber(breakdownJson.agents),
+    positions: toNumber(breakdownJson.positions),
+    available: toNumber(breakdownJson.available),
+    originalAmount: toNumber(breakdownJson.originalAmount),
+    totalAssets: toNumber(breakdownJson.totalAssets),
+    totalPnL: toNumber(breakdownJson.totalPnL),
+    agentCount: toNumber(breakdownJson.agentCount),
+    totalPoints: toNumber(breakdownJson.totalPoints),
+    members: Array.isArray(breakdownJson.members)
+      ? breakdownJson.members
+          .filter(
+            (member): member is Record<string, unknown> =>
+              typeof member === 'object' && member !== null
+          )
+          .map((member) => ({
+            id: String(member.id ?? ''),
+            name: String(member.name ?? 'Agent'),
+            wallet: toNumber(member.wallet),
+            isAgent: Boolean(member.isAgent),
+          }))
+      : [],
+  };
+}
+
+export const usePortfolioBreakdownStore = create<PortfolioBreakdownState>(
+  (set, get) => ({
+    data: null,
+    loading: false,
+    error: null,
+    lastFetchedAt: null,
+    userId: null,
+    fetchPromise: null,
+    pollingInterval: null,
+    subscriberCount: 0,
+
+    fetchPortfolioBreakdown: async (userId: string, force = false) => {
+      const state = get();
+
+      if (state.fetchPromise && state.userId === userId) {
+        return state.fetchPromise;
+      }
+
+      if (state.fetchPromise && state.userId !== userId) {
+        await state.fetchPromise;
+      }
+
+      const currentState = get();
+
+      if (
+        !force &&
+        currentState.userId === userId &&
+        currentState.lastFetchedAt &&
+        Date.now() - currentState.lastFetchedAt < CACHE_TTL &&
+        currentState.data
+      ) {
+        return;
+      }
+
+      const requestedUserId = userId;
+
+      const fetchPromise = (async () => {
+        const isInitialLoad =
+          currentState.lastFetchedAt === null ||
+          currentState.userId !== requestedUserId;
+        if (isInitialLoad) {
+          set({ loading: true });
+        }
+        set({ error: null, userId: requestedUserId });
+
+        const abortController = new AbortController();
+
+        try {
+          const nextData = await fetchPortfolioBreakdownSnapshot(
+            requestedUserId,
+            abortController.signal
+          );
+
+          if (get().userId !== requestedUserId) {
+            return;
+          }
+
+          set({
+            data: nextData,
+            lastFetchedAt: Date.now(),
+            error: null,
+          });
+        } catch (error) {
+          if (get().userId === requestedUserId && !isAbortError(error)) {
+            set({
+              error:
+                error instanceof Error
+                  ? error.message
+                  : 'Failed to fetch portfolio breakdown',
+            });
+          }
+        } finally {
+          if (get().userId === requestedUserId) {
+            set({ loading: false, fetchPromise: null });
+          }
+        }
+      })();
+
+      set({ fetchPromise });
+      return fetchPromise;
+    },
+
+    setUserId: (userId: string | null) => {
+      const state = get();
+      if (state.userId !== userId) {
+        if (state.pollingInterval) {
+          clearInterval(state.pollingInterval);
+        }
+        set({
+          data: null,
+          error: null,
+          lastFetchedAt: null,
+          userId,
+          fetchPromise: null,
+          pollingInterval: null,
+          subscriberCount: 0,
+        });
+      }
+    },
+
+    invalidate: () => {
+      set({ lastFetchedAt: null });
+    },
+
+    reset: () => {
+      const state = get();
+      if (state.pollingInterval) {
+        clearInterval(state.pollingInterval);
+      }
+      set({
+        data: null,
+        loading: false,
+        error: null,
+        lastFetchedAt: null,
+        userId: null,
+        fetchPromise: null,
+        pollingInterval: null,
+        subscriberCount: 0,
+      });
+    },
+
+    subscribe: (userId: string, intervalMs: number) => {
+      const state = get();
+
+      if (state.pollingInterval && state.userId !== userId) {
+        clearInterval(state.pollingInterval);
+        set({ pollingInterval: null, subscriberCount: 0, userId });
+      }
+
+      const newCount = state.subscriberCount + 1;
+      set({ subscriberCount: newCount, userId });
+
+      if (newCount === 1) {
+        get().fetchPortfolioBreakdown(userId);
+
+        const interval = setInterval(() => {
+          const currentState = get();
+          if (currentState.userId === userId) {
+            currentState.fetchPortfolioBreakdown(userId, true);
+          }
+        }, intervalMs);
+
+        set({ pollingInterval: interval });
+      }
+
+      return () => {
+        const currentState = get();
+        const updatedCount = currentState.subscriberCount - 1;
+        set({ subscriberCount: updatedCount });
+
+        if (updatedCount === 0 && currentState.pollingInterval) {
+          clearInterval(currentState.pollingInterval);
+          set({ pollingInterval: null });
+        }
+      };
+    },
+  })
+);
+
+const portfolioBreakdownSelector = (state: PortfolioBreakdownState) => ({
+  data: state.data,
+  loading: state.loading,
+  error: state.error,
+  lastUpdated: state.lastFetchedAt,
+});
+
+export function usePortfolioBreakdown(userId?: string | null) {
+  const data = usePortfolioBreakdownStore(
+    useShallow(portfolioBreakdownSelector)
+  );
+  const fetchPortfolioBreakdown = usePortfolioBreakdownStore(
+    (state) => state.fetchPortfolioBreakdown
+  );
+  const setUserId = usePortfolioBreakdownStore((state) => state.setUserId);
+
+  useEffect(() => {
+    if (userId) {
+      setUserId(userId);
+      fetchPortfolioBreakdown(userId);
+    }
+  }, [userId, fetchPortfolioBreakdown, setUserId]);
+
+  const refresh = useCallback(() => {
+    if (userId) {
+      return fetchPortfolioBreakdown(userId, true);
+    }
+    return Promise.resolve();
+  }, [userId, fetchPortfolioBreakdown]);
+
+  return { ...data, refresh };
+}
+
+export function usePortfolioBreakdownPolling(
+  userId?: string | null,
+  intervalMs = 15000
+) {
+  const subscribe = usePortfolioBreakdownStore((state) => state.subscribe);
+  const intervalRef = useRef(intervalMs);
+
+  useEffect(() => {
+    if (!userId) return;
+
+    const unsubscribe = subscribe(userId, intervalRef.current);
+    return unsubscribe;
+  }, [userId, subscribe]);
+}
+
+export function invalidatePortfolioBreakdown() {
+  usePortfolioBreakdownStore.getState().invalidate();
+}
+
+export async function refreshPortfolioBreakdown(userId: string) {
+  return usePortfolioBreakdownStore
+    .getState()
+    .fetchPortfolioBreakdown(userId, true);
+}

--- a/apps/web/src/stores/portfolioBreakdownStore.ts
+++ b/apps/web/src/stores/portfolioBreakdownStore.ts
@@ -238,6 +238,10 @@ export const usePortfolioBreakdownStore = create<PortfolioBreakdownState>(
 
       return () => {
         const currentState = get();
+        // Stale cleanup from a previous userId — ignore to avoid
+        // decrementing the new userId's subscriber count.
+        if (currentState.userId !== userId) return;
+
         const updatedCount = currentState.subscriberCount - 1;
         set({ subscriberCount: updatedCount });
 

--- a/apps/web/src/stores/portfolioBreakdownStore.ts
+++ b/apps/web/src/stores/portfolioBreakdownStore.ts
@@ -1,4 +1,7 @@
-import type { PortfolioBreakdownSnapshot } from '@babylon/engine/client';
+import {
+  type PortfolioBreakdownSnapshot,
+  toNumber,
+} from '@babylon/engine/client';
 import { useCallback, useEffect, useRef } from 'react';
 import { create } from 'zustand';
 import { useShallow } from 'zustand/react/shallow';
@@ -20,15 +23,6 @@ interface PortfolioBreakdownState {
 }
 
 const CACHE_TTL = 5000;
-
-function toNumber(value: unknown, fallback = 0): number {
-  if (typeof value === 'number' && Number.isFinite(value)) return value;
-  if (typeof value === 'string') {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : fallback;
-  }
-  return fallback;
-}
 
 export function isAbortError(error: unknown): boolean {
   if (error instanceof DOMException && error.name === 'AbortError') {

--- a/packages/engine/src/client.ts
+++ b/packages/engine/src/client.ts
@@ -23,7 +23,10 @@ export {
   type FeeTransactionType,
   type FeeType,
 } from './config/fees';
-export { calculatePerpPositionMarketValue } from './portfolio-valuation';
+export {
+  calculatePerpPositionMarketValue,
+  toNumber,
+} from './portfolio-valuation';
 // Concentrated Liquidity (pure math)
 export {
   type AddPositionParams,

--- a/packages/engine/src/client.ts
+++ b/packages/engine/src/client.ts
@@ -149,4 +149,12 @@ export interface PortfolioBreakdownSnapshot {
   totalPnL: number;
   agentCount: number;
   totalPoints: number;
+  members?: PortfolioBreakdownMember[];
+}
+
+export interface PortfolioBreakdownMember {
+  id: string;
+  name: string;
+  wallet: number;
+  isAgent: boolean;
 }

--- a/packages/engine/src/client.ts
+++ b/packages/engine/src/client.ts
@@ -23,6 +23,7 @@ export {
   type FeeTransactionType,
   type FeeType,
 } from './config/fees';
+export { calculatePerpPositionMarketValue } from './portfolio-valuation';
 // Concentrated Liquidity (pure math)
 export {
   type AddPositionParams,

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -205,7 +205,10 @@ export {
   getPositionExposure,
   type PoolMetrics,
 } from './npc/portfolio-metrics';
-export { calculatePerpPositionMarketValue } from './portfolio-valuation';
+export {
+  calculatePerpPositionMarketValue,
+  toNumber,
+} from './portfolio-valuation';
 export {
   type ParsedPostMetadata,
   type ParseResult,

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -205,6 +205,7 @@ export {
   getPositionExposure,
   type PoolMetrics,
 } from './npc/portfolio-metrics';
+export { calculatePerpPositionMarketValue } from './portfolio-valuation';
 export {
   type ParsedPostMetadata,
   type ParseResult,

--- a/packages/engine/src/portfolio-valuation.ts
+++ b/packages/engine/src/portfolio-valuation.ts
@@ -18,7 +18,7 @@ export function calculatePerpPositionMarketValue(position: {
   leverage: unknown;
   size: unknown;
   unrealizedPnL: unknown;
-}) {
+}): number {
   const size = toNumber(position.size);
   const leverage = toNumber(position.leverage);
   const unrealizedPnL = toNumber(position.unrealizedPnL);

--- a/packages/engine/src/portfolio-valuation.ts
+++ b/packages/engine/src/portfolio-valuation.ts
@@ -1,4 +1,5 @@
-function toNumber(value: unknown, fallback = 0): number {
+/** Safely coerce an unknown value (DB column, JSON field) to a finite number. */
+export function toNumber(value: unknown, fallback = 0): number {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
   if (typeof value === 'string') {
     const parsed = Number.parseFloat(value);

--- a/packages/engine/src/portfolio-valuation.ts
+++ b/packages/engine/src/portfolio-valuation.ts
@@ -1,0 +1,29 @@
+function toNumber(value: unknown, fallback = 0): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  }
+  return fallback;
+}
+
+/**
+ * Canonical mark-to-market value for an open perpetual position.
+ *
+ * `size` is the leveraged notional, so we recover posted margin as
+ * `abs(size / leverage)` and then add current unrealized PnL.
+ */
+export function calculatePerpPositionMarketValue(position: {
+  leverage: unknown;
+  size: unknown;
+  unrealizedPnL: unknown;
+}) {
+  const size = toNumber(position.size);
+  const leverage = toNumber(position.leverage);
+  const unrealizedPnL = toNumber(position.unrealizedPnL);
+  const effectiveLeverage =
+    Number.isFinite(leverage) && leverage > 0 ? leverage : 1;
+  const margin = Math.abs(size / effectiveLeverage);
+
+  return margin + unrealizedPnL;
+}

--- a/packages/engine/src/services/portfolio-breakdown.ts
+++ b/packages/engine/src/services/portfolio-breakdown.ts
@@ -13,6 +13,7 @@ import {
 } from '@babylon/db';
 import { and, eq, inArray, isNull, or, sql } from 'drizzle-orm';
 import { FEE_CONFIG } from '../config/fees';
+import { calculatePerpPositionMarketValue } from '../portfolio-valuation';
 
 export interface PortfolioBreakdownSnapshot {
   wallet: number;
@@ -45,21 +46,6 @@ function toNumber(value: unknown, fallback = 0): number {
 
 function clampFeeRate(rate: number): number {
   return rate > 0 && rate < 1 ? rate : 0;
-}
-
-function calculatePerpPositionValue(position: {
-  size: unknown;
-  leverage: unknown;
-  unrealizedPnL: unknown;
-}): number {
-  const size = toNumber(position.size);
-  const leverage = toNumber(position.leverage);
-  const unrealizedPnL = toNumber(position.unrealizedPnL);
-
-  const effectiveLeverage =
-    Number.isFinite(leverage) && leverage > 0 ? leverage : 1;
-  const margin = Math.abs(size / effectiveLeverage);
-  return margin + unrealizedPnL;
 }
 
 function calculatePredictionPositionValue(position: {
@@ -194,7 +180,7 @@ export async function calculatePortfolioBreakdown(
   ]);
 
   const perpsValue = perpRows.reduce(
-    (sum, p) => sum + calculatePerpPositionValue(p),
+    (sum, p) => sum + calculatePerpPositionMarketValue(p),
     0
   );
 

--- a/packages/engine/src/services/portfolio-breakdown.ts
+++ b/packages/engine/src/services/portfolio-breakdown.ts
@@ -13,7 +13,10 @@ import {
 } from '@babylon/db';
 import { and, eq, inArray, isNull, or, sql } from 'drizzle-orm';
 import { FEE_CONFIG } from '../config/fees';
-import { calculatePerpPositionMarketValue } from '../portfolio-valuation';
+import {
+  calculatePerpPositionMarketValue,
+  toNumber,
+} from '../portfolio-valuation';
 
 export interface PortfolioBreakdownSnapshot {
   wallet: number;
@@ -33,15 +36,6 @@ export interface PortfolioBreakdownMember {
   name: string;
   wallet: number;
   isAgent: boolean;
-}
-
-function toNumber(value: unknown, fallback = 0): number {
-  if (typeof value === 'number' && Number.isFinite(value)) return value;
-  if (typeof value === 'string') {
-    const parsed = Number.parseFloat(value);
-    return Number.isFinite(parsed) ? parsed : fallback;
-  }
-  return fallback;
 }
 
 function clampFeeRate(rate: number): number {

--- a/packages/engine/src/services/portfolio-breakdown.ts
+++ b/packages/engine/src/services/portfolio-breakdown.ts
@@ -24,6 +24,14 @@ export interface PortfolioBreakdownSnapshot {
   totalPnL: number;
   agentCount: number;
   totalPoints: number;
+  members: PortfolioBreakdownMember[];
+}
+
+export interface PortfolioBreakdownMember {
+  id: string;
+  name: string;
+  wallet: number;
+  isAgent: boolean;
 }
 
 function toNumber(value: unknown, fallback = 0): number {
@@ -104,6 +112,8 @@ export async function calculatePortfolioBreakdown(
     .select({
       id: users.id,
       privyId: users.privyId,
+      displayName: users.displayName,
+      username: users.username,
       virtualBalance: users.virtualBalance,
       totalDeposited: users.totalDeposited,
       totalWithdrawn: users.totalWithdrawn,
@@ -117,6 +127,8 @@ export async function calculatePortfolioBreakdown(
     | {
         id: string;
         privyId: string | null;
+        displayName: string | null;
+        username: string | null;
         virtualBalance: unknown;
         totalDeposited: unknown;
         totalWithdrawn: unknown;
@@ -133,6 +145,8 @@ export async function calculatePortfolioBreakdown(
   const agentRows = await db
     .select({
       id: users.id,
+      displayName: users.displayName,
+      username: users.username,
       virtualBalance: users.virtualBalance,
     })
     .from(users)
@@ -226,6 +240,20 @@ export async function calculatePortfolioBreakdown(
   const totalAssets = wallet + agents + positionsValue;
   const totalPnL = totalAssets - originalAmount;
   const totalPoints = wallet + positionsValue + user.reputationPoints;
+  const members: PortfolioBreakdownMember[] = [
+    {
+      id: canonicalUserId,
+      name: user.displayName || user.username || 'You (Owner)',
+      wallet,
+      isAgent: false,
+    },
+    ...agentRows.map((agent) => ({
+      id: agent.id,
+      name: agent.displayName || agent.username || 'Agent',
+      wallet: toNumber(agent.virtualBalance),
+      isAgent: true,
+    })),
+  ];
 
   return {
     wallet,
@@ -237,5 +265,6 @@ export async function calculatePortfolioBreakdown(
     totalPnL,
     agentCount,
     totalPoints,
+    members,
   };
 }

--- a/packages/testing/unit/portfolio-valuation.test.ts
+++ b/packages/testing/unit/portfolio-valuation.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  calculatePerpPositionMarketValue,
+  toNumber,
+} from '@babylon/engine/client';
+
+describe('toNumber', () => {
+  it('returns the value when it is already a finite number', () => {
+    expect(toNumber(42)).toBe(42);
+    expect(toNumber(-3.14)).toBe(-3.14);
+    expect(toNumber(0)).toBe(0);
+  });
+
+  it('parses numeric strings', () => {
+    expect(toNumber('12.5')).toBe(12.5);
+    expect(toNumber('-7')).toBe(-7);
+    expect(toNumber('0')).toBe(0);
+  });
+
+  it('returns fallback for non-numeric strings', () => {
+    expect(toNumber('abc')).toBe(0);
+    expect(toNumber('abc', 99)).toBe(99);
+    expect(toNumber('')).toBe(0);
+  });
+
+  it('returns fallback for non-finite numbers', () => {
+    expect(toNumber(Number.NaN)).toBe(0);
+    expect(toNumber(Number.POSITIVE_INFINITY)).toBe(0);
+    expect(toNumber(Number.NEGATIVE_INFINITY)).toBe(0);
+  });
+
+  it('returns fallback for null, undefined, and objects', () => {
+    expect(toNumber(null)).toBe(0);
+    expect(toNumber(undefined)).toBe(0);
+    expect(toNumber({})).toBe(0);
+    expect(toNumber([])).toBe(0);
+  });
+});
+
+describe('calculatePerpPositionMarketValue', () => {
+  it('computes margin + unrealizedPnL for a standard leveraged position', () => {
+    // size=100, leverage=5 → margin=20, unrealizedPnL=10 → value=30
+    const value = calculatePerpPositionMarketValue({
+      size: 100,
+      leverage: 5,
+      unrealizedPnL: 10,
+    });
+    expect(value).toBe(30);
+  });
+
+  it('handles negative unrealizedPnL (losing position)', () => {
+    // size=100, leverage=5 → margin=20, unrealizedPnL=-15 → value=5
+    const value = calculatePerpPositionMarketValue({
+      size: 100,
+      leverage: 5,
+      unrealizedPnL: -15,
+    });
+    expect(value).toBe(5);
+  });
+
+  it('treats zero leverage as leverage=1 (no leverage)', () => {
+    // size=50, leverage=0 (falls back to 1) → margin=50, unrealizedPnL=5 → value=55
+    const value = calculatePerpPositionMarketValue({
+      size: 50,
+      leverage: 0,
+      unrealizedPnL: 5,
+    });
+    expect(value).toBe(55);
+  });
+
+  it('treats negative leverage as leverage=1', () => {
+    const value = calculatePerpPositionMarketValue({
+      size: 40,
+      leverage: -2,
+      unrealizedPnL: 0,
+    });
+    expect(value).toBe(40);
+  });
+
+  it('handles negative size (short position) by taking abs for margin', () => {
+    // size=-100, leverage=5 → margin=abs(-100/5)=20, unrealizedPnL=10 → value=30
+    const value = calculatePerpPositionMarketValue({
+      size: -100,
+      leverage: 5,
+      unrealizedPnL: 10,
+    });
+    expect(value).toBe(30);
+  });
+
+  it('coerces string inputs from DB/JSON payloads', () => {
+    const value = calculatePerpPositionMarketValue({
+      size: '200',
+      leverage: '10',
+      unrealizedPnL: '-5',
+    });
+    // margin=abs(200/10)=20, unrealizedPnL=-5 → value=15
+    expect(value).toBe(15);
+  });
+
+  it('returns 0 when all inputs are zero', () => {
+    const value = calculatePerpPositionMarketValue({
+      size: 0,
+      leverage: 0,
+      unrealizedPnL: 0,
+    });
+    expect(value).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Align wallet balance views with the canonical `portfolio-breakdown` model so wallet/sidebar totals reconcile with the portfolio widget.
- Surface agent cash balances in wallet member rows instead of assuming agents only hold open positions.
- Canonicalize `/api/markets/positions/[userId]` lookups so owner/agent positions stay consistent when requests use an alias user identifier.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-333/wallet-inconsistent-portfolio-totals-across-views-and-stale-agent

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Changes

- Extend the canonical portfolio breakdown snapshot with member wallet balances for the owner and owned agents.
- Add a shared wallet portfolio aggregator that reuses canonical snapshot totals and applies the same position valuation formula as the engine.
- Move wallet balance views and the wallet preview widget onto that shared canonical model.
- Make the portfolio widget poll the canonical snapshot and render the canonical wallet balance when available.
- Canonicalize the positions API user lookup so owner and agent positions resolve consistently across `id` / `privyId` aliases.
- Add regression tests for portfolio snapshot normalization and wallet portfolio aggregation.

## Review guide

**Start here**
- `packages/engine/src/services/portfolio-breakdown.ts`
- `apps/web/src/components/wallet/shared/portfolioBreakdown.ts`
- `apps/web/src/components/wallet/v2/balance-tab.tsx`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- I intentionally did not introduce a new store; wallet totals now read from the existing canonical portfolio endpoint and reuse the existing positions store for per-member open-position rows.
- Follow-up/non-goal: there is no new global invalidation bus for agent chat actions in this PR; freshness relies on existing polling plus the new canonical snapshot polling.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Manual verification**
1. Run targeted formatting on touched files with `bunx biome check --write ...`.
2. Run `bun test apps/web/src/hooks/__tests__/usePortfolioPnL.test.ts apps/web/src/components/feed/__tests__/PortfolioWidget.test.ts apps/web/src/components/wallet/__tests__/portfolioBreakdown.test.ts`.
3. Confirm the wallet balance tab now shows `Wallet`, `Agents`, `Positions`, and a reconciled `Total Balance` derived from the canonical snapshot.
4. Confirm wallet member rows include agent cash balances and use the canonical perp valuation formula (`margin + unrealizedPnL`).

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: deploy normally.
- Rollback: revert this PR to restore the previous wallet aggregation path.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- `portfolio-breakdown` now includes member wallet balances for owner + agents.
- `/api/markets/positions/[userId]` now canonicalizes user identifiers before loading owner + agent positions.

### Database
- No schema change.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: CLI-only session; I could not capture wallet screenshots/recordings here, but the UI change is limited to corrected wallet summary labels/values and the manual verification steps above cover the visible behavior to review.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
