### PR TITLE
fix(web): suppress Privy auth on waitlist hosts

### DIFF
--- a/apps/web/src/components/auth/GlobalLoginModal.tsx
+++ b/apps/web/src/components/auth/GlobalLoginModal.tsx
@@ -3,6 +3,7 @@
 import { usePathname, useSearchParams } from 'next/navigation';
 import { Suspense, useEffect } from 'react';
 import { useLoginModal } from '@/hooks/useLoginModal';
+import { isWaitlistHomePage } from '@/lib/host-routing';
 import { LoginModal } from './LoginModal';
 
 /**
@@ -30,13 +31,11 @@ function GlobalLoginModalContent() {
   // Check if dev mode is enabled via URL parameter
   const isDevMode = searchParams.get('dev') === 'true';
 
-  // Hide on production (babylon.market) on home page unless ?dev=true
-  const isProduction =
+  // Hide on waitlist home pages unless ?dev=true
+  const isWaitlistHome =
     typeof window !== 'undefined' &&
-    window.location.hostname === 'babylon.market';
-  const isHomePage =
-    typeof window !== 'undefined' && window.location.pathname === '/';
-  const shouldHide = isProduction && isHomePage && !isDevMode;
+    isWaitlistHomePage(window.location.hostname, window.location.pathname);
+  const shouldHide = isWaitlistHome && !isDevMode;
 
   useEffect(() => {
     if (!queuedModal || pathname === '/') {

--- a/apps/web/src/components/providers/OnboardingProvider.tsx
+++ b/apps/web/src/components/providers/OnboardingProvider.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/onboarding/OnboardingModal';
 import { useAuth } from '@/hooks/useAuth';
 import { useSignupTracking } from '@/hooks/usePostHog';
+import { isWaitlistHomePage } from '@/lib/host-routing';
 import { useAuthStore } from '@/stores/authStore';
 import { apiFetch } from '@/utils/api-fetch';
 
@@ -132,13 +133,15 @@ export function OnboardingProvider({
     if (typeof window !== 'undefined') {
       const params = new URLSearchParams(window.location.search);
       const isDevMode = params.get('dev') === 'true';
-      const isProduction = window.location.hostname === 'babylon.market';
-      const isHomePage = window.location.pathname === '/';
       const isWaitlistFlow = params.get('waitlist') === 'true';
+      const isWaitlistHome = isWaitlistHomePage(
+        window.location.hostname,
+        window.location.pathname
+      );
 
-      // Hide onboarding on production (babylon.market) on home page unless ?dev=true
+      // Hide onboarding on waitlist home pages unless ?dev=true
       // BUT allow it if user is in waitlist flow (coming from waitlist signup)
-      if (isProduction && isHomePage && !isDevMode && !isWaitlistFlow) {
+      if (isWaitlistHome && !isDevMode && !isWaitlistFlow) {
         return false;
       }
     }

--- a/apps/web/src/lib/host-routing.test.ts
+++ b/apps/web/src/lib/host-routing.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from 'bun:test';
+import { isWaitlistHomePage, isWaitlistHostname } from './host-routing';
+
+describe('host-routing', () => {
+  test('recognizes configured waitlist hostnames', () => {
+    expect(isWaitlistHostname('babylon.market')).toBe(true);
+    expect(isWaitlistHostname('www.babylon.market')).toBe(true);
+    expect(isWaitlistHostname('staging.babylon.market')).toBe(true);
+    expect(isWaitlistHostname('www.staging.babylon.market')).toBe(true);
+    expect(isWaitlistHostname('play.babylon.market')).toBe(false);
+  });
+
+  test('recognizes the waitlist homepage only on /', () => {
+    expect(isWaitlistHomePage('babylon.market', '/')).toBe(true);
+    expect(isWaitlistHomePage('www.babylon.market', '/')).toBe(true);
+    expect(isWaitlistHomePage('staging.babylon.market', '/')).toBe(true);
+    expect(isWaitlistHomePage('play.babylon.market', '/')).toBe(false);
+    expect(isWaitlistHomePage('babylon.market', '/feed')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/host-routing.ts
+++ b/apps/web/src/lib/host-routing.ts
@@ -54,6 +54,10 @@ export function isWaitlistHostname(hostname: string): boolean {
   return getWaitlistHostnames().has(normalizeHostname(hostname));
 }
 
+export function isWaitlistHomePage(hostname: string, pathname: string): boolean {
+  return isWaitlistHostname(hostname) && pathname === '/';
+}
+
 export function isLegacyCanonicalHostname(hostname: string): boolean {
   return normalizeHostname(hostname) in LEGACY_CANONICAL_HOSTS;
 }


### PR DESCRIPTION
## Summary

- Stop global Privy login/onboarding entrypoints from activating on waitlist home pages.
- Reuse the canonical waitlist host routing logic instead of hardcoding `babylon.market` checks in client providers.
- Add unit coverage for waitlist hostname and homepage detection.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-297/bugwaitlist-privy-origin-mismatch-on-babylonmarket-signup-flow
- Issue: `BAB-297`

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [x] Other: `apps/web/src/lib` test coverage

## Changes

- Added `isWaitlistHomePage()` in `host-routing` to reuse the existing canonical waitlist host list.
- Updated `GlobalLoginModal` to suppress Privy login on any waitlist homepage, not just `babylon.market`.
- Updated `OnboardingProvider` to apply the same waitlist-home gating while preserving `?dev=true` and `?waitlist=true` behavior.
- Added unit tests covering recognized waitlist hosts and homepage detection.

## Review guide

**Start here**
- `apps/web/src/lib/host-routing.ts`
- `apps/web/src/components/auth/GlobalLoginModal.tsx`
- `apps/web/src/components/providers/OnboardingProvider.tsx`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- This intentionally does not change Privy configuration or app-host auth flows.
- Non-goal: changing landing CTA behavior, which already redirects to `play.*`.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome format)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

Additional targeted checks:
- `bun test apps/web/src/lib/host-routing.test.ts`
- `bunx biome check apps/web/src/lib/host-routing.ts apps/web/src/lib/host-routing.test.ts apps/web/src/components/auth/GlobalLoginModal.tsx apps/web/src/components/providers/OnboardingProvider.tsx`

**Manual verification**
1. Open `https://babylon.market/` or another waitlist host and confirm the homepage does not trigger a Privy login/onboarding flow.
2. Open `https://play.babylon.market/` and confirm existing auth behavior remains unchanged.
3. Open a waitlist homepage with `?dev=true` and confirm the existing debug escape hatch still works.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: standard web deploy.
- Rollback: revert this PR.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: this is a host-based auth gating fix; the user-facing change is the absence of an unintended Privy modal on waitlist home pages, so screenshots add little signal beyond the reproduction steps above.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct (`staging` by default)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
