### PR TITLE
feat(web): add Agent Registry tab to team page bottom panel

### DIFF
--- a/apps/web/src/app/agents/team/BottomPanel.tsx
+++ b/apps/web/src/app/agents/team/BottomPanel.tsx
@@ -11,7 +11,12 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 
-export type BottomPanelTab = 'activity' | 'wallet' | 'pnl' | 'logs';
+export type BottomPanelTab =
+  | 'activity'
+  | 'wallet'
+  | 'pnl'
+  | 'registry'
+  | 'logs';
 export type EntityType = 'user' | 'agent' | 'team';
 
 interface EntityOption {
@@ -47,9 +52,9 @@ interface BottomPanelProps {
  * Bottom panel with tabs for Activity, Wallet, PnL, and Logs.
  *
  * Entity behavior:
- * - Team: Wallet + PnL
- * - User: Activity + Wallet + PnL
- * - Agent: Activity + Wallet + PnL + Logs
+ * - Team: Wallet + PnL + Registry
+ * - User: Activity + Wallet + PnL + Registry
+ * - Agent: Activity + Wallet + PnL + Registry + Logs
  *
  * Spans full width, collapsible, and resizable.
  */
@@ -114,10 +119,13 @@ export function BottomPanel({
     { id: 'activity', label: 'Activity' },
     { id: 'wallet', label: 'Wallet' },
     { id: 'pnl', label: 'PnL' },
+    { id: 'registry', label: 'Agent Registry' },
     { id: 'logs', label: 'Logs' },
   ];
   const tabs = isTeamSelected
-    ? allTabs.filter((t) => t.id === 'wallet' || t.id === 'pnl')
+    ? allTabs.filter(
+        (t) => t.id === 'wallet' || t.id === 'pnl' || t.id === 'registry'
+      )
     : isUserSelected
       ? allTabs.filter((t) => t.id !== 'logs')
       : allTabs;

--- a/apps/web/src/app/agents/team/BottomPanel.tsx
+++ b/apps/web/src/app/agents/team/BottomPanel.tsx
@@ -49,7 +49,7 @@ interface BottomPanelProps {
 }
 
 /**
- * Bottom panel with tabs for Activity, Wallet, PnL, and Logs.
+ * Bottom panel with tabs for Activity, Wallet, PnL, Registry, and Logs.
  *
  * Entity behavior:
  * - Team: Wallet + PnL + Registry

--- a/apps/web/src/app/agents/team/page.tsx
+++ b/apps/web/src/app/agents/team/page.tsx
@@ -167,6 +167,22 @@ const UserActivity = dynamic(
   }
 );
 
+// Lazy load agent registry for performance
+const AgentRegistry = dynamic(
+  () =>
+    import('@/components/agents/AgentRegistry').then((m) => ({
+      default: m.AgentRegistry,
+    })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex h-full items-center justify-center">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      </div>
+    ),
+  }
+);
+
 /**
  * Agent Team Chat Page (Agents)
  *
@@ -246,6 +262,9 @@ export default function TeamChatPage() {
   const [bottomPanelHeight, setBottomPanelHeight] = useState(
     BOTTOM_PANEL_DEFAULT_HEIGHT
   );
+
+  // Registry tab: which agent is selected for registration when viewing team/user
+  const [registryAgentId, setRegistryAgentId] = useState<string | null>(null);
 
   const [teamScope, setTeamScope] = useState<TeamScope>('owner_agents');
 
@@ -1286,6 +1305,90 @@ export default function TeamChatPage() {
                         'Agent'
                       }
                     />
+                  );
+                })()}
+
+              {/* Registry Tab */}
+              {bottomPanelTab === 'registry' &&
+                (() => {
+                  // For agents, render registry directly
+                  if (bottomPanelEntityType === 'agent') {
+                    const bottomAgent = teamChat?.agents.find(
+                      (a) => a.id === bottomPanelEntityId
+                    );
+                    return (
+                      <div className="p-4">
+                        <AgentRegistry
+                          agent={{
+                            id: bottomPanelEntityId,
+                            name:
+                              bottomAgent?.displayName ||
+                              bottomAgent?.username ||
+                              'Agent',
+                          }}
+                          onUpdate={() => void refreshTeamChat()}
+                        />
+                      </div>
+                    );
+                  }
+
+                  // For team/user, show agent picker then registry
+                  const agents = teamChat?.agents ?? [];
+                  if (agents.length === 0) {
+                    return (
+                      <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
+                        No agents available. Create an agent first.
+                      </div>
+                    );
+                  }
+
+                  // Auto-select first agent if none selected or selected no longer exists
+                  const selectedAgent = agents.find(
+                    (a) => a.id === registryAgentId
+                  );
+                  const effectiveAgentId = selectedAgent
+                    ? selectedAgent.id
+                    : agents[0]?.id;
+                  const effectiveAgent = selectedAgent ?? agents[0];
+
+                  return (
+                    <div className="p-4">
+                      {agents.length > 1 && (
+                        <div className="mb-4">
+                          <label
+                            htmlFor="registry-agent-select"
+                            className="mb-1.5 block font-medium text-sm"
+                          >
+                            Select agent to register
+                          </label>
+                          <select
+                            id="registry-agent-select"
+                            value={effectiveAgentId ?? ''}
+                            onChange={(e) => setRegistryAgentId(e.target.value)}
+                            className="h-9 w-full max-w-xs rounded-md border border-border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                          >
+                            {agents.map((a) => (
+                              <option key={a.id} value={a.id}>
+                                {a.displayName || a.username || 'Agent'}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                      )}
+                      {effectiveAgent && effectiveAgentId && (
+                        <AgentRegistry
+                          key={effectiveAgentId}
+                          agent={{
+                            id: effectiveAgentId,
+                            name:
+                              effectiveAgent.displayName ||
+                              effectiveAgent.username ||
+                              'Agent',
+                          }}
+                          onUpdate={() => void refreshTeamChat()}
+                        />
+                      )}
+                    </div>
                   );
                 })()}
 


### PR DESCRIPTION
## Summary
- Adds an **Agent Registry** tab to the team page bottom panel (between PnL and Logs)
- Visible for all entity types: Team, User, and Agent
- When a specific agent is selected, renders the registry directly
- When Team or User is selected, shows an agent picker dropdown so the user can choose which agent to register
- Lazy-loads `AgentRegistry` component via `next/dynamic` for performance

## Test plan
- [ ] Select an agent in the entity dropdown → verify "Agent Registry" tab appears and shows EVM/Solana registration
- [ ] Select "Team" in the entity dropdown → verify "Agent Registry" tab shows an agent picker, selecting an agent renders its registration
- [ ] Select "User" in the entity dropdown → same agent picker behavior as Team
- [ ] With only one agent, verify the picker is hidden and registration renders directly
- [ ] Verify tab order: Activity, Wallet, PnL, Agent Registry, Logs (agent) / Wallet, PnL, Agent Registry (team)