### PR TITLE
chore: reorder Privy login methods — promote Twitter, Phantom, MetaMask

### DIFF
--- a/packages/shared/src/auth/privy-config.ts
+++ b/packages/shared/src/auth/privy-config.ts
@@ -50,7 +50,7 @@ const appearance: Appearance = {
   walletChainType: 'ethereum-and-solana',
 };
 
-const loginMethodsAndOrder: NonNullable<
+export const loginMethodsAndOrder: NonNullable<
   BabylonPrivyConfig['loginMethodsAndOrder']
 > = {
   primary: ['twitter', 'phantom', 'metamask', 'farcaster', 'email'],

--- a/packages/shared/src/auth/privy-config.ts
+++ b/packages/shared/src/auth/privy-config.ts
@@ -53,13 +53,10 @@ const appearance: Appearance = {
 const loginMethodsAndOrder: NonNullable<
   BabylonPrivyConfig['loginMethodsAndOrder']
 > = {
-  primary: ['farcaster', 'email'],
+  primary: ['twitter', 'phantom', 'metamask', 'farcaster', 'email'],
   overflow: [
-    'metamask',
-    'twitter',
     'discord',
     'telegram',
-    'phantom',
     'rabby_wallet',
     'coinbase_wallet',
     'rainbow',


### PR DESCRIPTION
## Summary

- Reorder Privy login modal to show Twitter, Phantom (Solana), MetaMask, and Farcaster as the primary visible methods
- Email remains primary but on secondary page (5th item)
- Discord, Telegram, and remaining wallets moved to overflow

## Before → After

**Before:** Farcaster, Email | overflow: MetaMask, Twitter, Discord, Telegram, Phantom, Rabby, Coinbase, Rainbow, Backpack

**After:** Twitter, Phantom, MetaMask, Farcaster | secondary: Email | overflow: Discord, Telegram, Rabby, Coinbase, Rainbow, Backpack

## Test plan

- [ ] Verify login modal shows Twitter, Phantom, MetaMask, Farcaster buttons
- [ ] Verify "More options" shows Email + remaining wallets
- [ ] Verify each login method still works end-to-end