### PR TITLE
chore: move metamask to overflow in privy login

### DIFF
--- a/packages/shared/src/auth/privy-config.ts
+++ b/packages/shared/src/auth/privy-config.ts
@@ -53,8 +53,9 @@ const appearance: Appearance = {
 export const loginMethodsAndOrder: NonNullable<
   BabylonPrivyConfig['loginMethodsAndOrder']
 > = {
-  primary: ['twitter', 'phantom', 'metamask', 'farcaster', 'email'],
+  primary: ['twitter', 'phantom', 'farcaster', 'email'],
   overflow: [
+    'metamask',
     'discord',
     'telegram',
     'rabby_wallet',


### PR DESCRIPTION
## Summary
- Moves MetaMask from the primary login row to the overflow ("More options") section
- Primary login order is now: Twitter, Phantom, Farcaster, Email

## Test plan
- [ ] Verify Privy login modal shows Twitter, Phantom, Farcaster, Email as primary options
- [ ] Verify MetaMask appears under "More options" alongside Discord, Telegram, etc.