### PR TITLE
fix(web): deep link feed portfolio CTAs to wallet tabs

### DIFF
--- a/apps/web/src/app/wallet/page.tsx
+++ b/apps/web/src/app/wallet/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
 import { LoginButton } from '@/components/auth/LoginButton';
 import { PageContainer } from '@/components/shared/PageContainer';
 import { BalanceTab } from '@/components/wallet/v2/balance-tab';
@@ -10,6 +10,7 @@ import { PnLTab } from '@/components/wallet/v2/pnl-tab';
 import { PositionsTab } from '@/components/wallet/v2/positions-tab';
 import { useAuth } from '@/hooks/useAuth';
 import { useTeamTradingSummary } from '@/hooks/useTeamTradingSummary';
+import { parseWalletTab, type WalletTab } from '@/lib/wallet-tabs';
 import { useUserPositionsPolling } from '@/stores/userPositionsStore';
 import { useWalletBalancePolling } from '@/stores/walletBalanceStore';
 
@@ -24,12 +25,15 @@ const WidgetSidebar = dynamic(
   }
 );
 
-type PortfolioTab = 'balance' | 'pnl' | 'positions';
+type PortfolioTab = WalletTab | 'pnl';
 
 export default function WalletPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { ready, authenticated, getAccessToken, login, user } = useAuth();
-  const [activeTab, setActiveTab] = useState<PortfolioTab>('positions');
+  const [activeTab, setActiveTab] = useState<PortfolioTab>(() =>
+    parseWalletTab(searchParams.get('tab'))
+  );
 
   const userId = authenticated ? user?.id : undefined;
 
@@ -58,6 +62,21 @@ export default function WalletPage() {
     const timer = setTimeout(() => login(), 500);
     return () => clearTimeout(timer);
   }, [ready, authenticated, router, login]);
+
+  useEffect(() => {
+    const nextTab = parseWalletTab(searchParams.get('tab'));
+    if (nextTab !== activeTab) {
+      setActiveTab(nextTab);
+    }
+  }, [activeTab, searchParams]);
+
+  const handleTabChange = useCallback(
+    (tab: PortfolioTab) => {
+      setActiveTab(tab);
+      router.replace(`/wallet?tab=${tab}`, { scroll: false });
+    },
+    [router]
+  );
 
   if (!ready) {
     return <WalletPageSkeleton />;
@@ -92,7 +111,7 @@ export default function WalletPage() {
             ).map(([key, label]) => (
               <button
                 key={key}
-                onClick={() => setActiveTab(key)}
+                onClick={() => handleTabChange(key)}
                 className={`relative flex-1 py-3 text-center font-medium text-sm transition-colors ${
                   activeTab === key
                     ? 'text-foreground'

--- a/apps/web/src/components/feed/PortfolioWidget.tsx
+++ b/apps/web/src/components/feed/PortfolioWidget.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { PortfolioBreakdownSnapshot } from '@babylon/engine/client';
-import { cn, getProfileUrl } from '@babylon/shared';
+import { cn } from '@babylon/shared';
 import {
   Bot,
   ChevronRight,
@@ -19,6 +19,7 @@ import {
   usePortfolioPnLPolling,
 } from '@/hooks/usePortfolioPnL';
 import { formatCurrencyDisplay } from '@/lib/format';
+import { getWalletTabHref } from '@/lib/wallet-tabs';
 import {
   useWalletBalance,
   useWalletBalancePolling,
@@ -47,7 +48,7 @@ export interface PortfolioWidgetContentProps {
   lifetimePnL: number;
   data: PortfolioBreakdownSnapshot | null;
   loading: boolean;
-  onViewProfile?: () => void;
+  onViewWallet?: () => void;
 }
 
 export function PortfolioWidgetContent({
@@ -55,7 +56,7 @@ export function PortfolioWidgetContent({
   lifetimePnL,
   data,
   loading,
-  onViewProfile,
+  onViewWallet,
 }: PortfolioWidgetContentProps) {
   return (
     <div className="flex flex-col">
@@ -121,7 +122,7 @@ export function PortfolioWidgetContent({
           {/* View Full Portfolio */}
           <button
             type="button"
-            onClick={onViewProfile}
+            onClick={onViewWallet}
             className="flex w-full items-center justify-center gap-1 rounded-lg border border-border px-3 py-2 font-medium text-foreground text-sm transition-colors hover:bg-muted/50"
           >
             View Full Portfolio
@@ -184,11 +185,9 @@ export function PortfolioWidget() {
     return () => unregisterRefresh('portfolio-widget');
   }, [registerRefresh, unregisterRefresh, handleRefresh]);
 
-  const handleViewProfile = useCallback(() => {
-    if (user) {
-      router.push(getProfileUrl(user.id, user.username));
-    }
-  }, [router, user]);
+  const handleViewWallet = useCallback(() => {
+    router.push(getWalletTabHref('balance'));
+  }, [router]);
 
   if (!authenticated) {
     return null;
@@ -203,7 +202,7 @@ export function PortfolioWidget() {
       lifetimePnL={lifetimePnL}
       data={data}
       loading={loading}
-      onViewProfile={handleViewProfile}
+      onViewWallet={handleViewWallet}
     />
   );
 }

--- a/apps/web/src/components/feed/PositionsPreviewPanel.tsx
+++ b/apps/web/src/components/feed/PositionsPreviewPanel.tsx
@@ -15,6 +15,7 @@ import { PositionDetailModal } from '@/components/profile/PositionDetailModal';
 import { Skeleton } from '@/components/shared/Skeleton';
 import { useWidgetRefresh } from '@/contexts/WidgetRefreshContext';
 import { useAuth } from '@/hooks/useAuth';
+import { getWalletTabHref } from '@/lib/wallet-tabs';
 import { useWidgetCacheStore } from '@/stores/widgetCacheStore';
 
 const PREVIEW_COUNT = 3;
@@ -353,7 +354,7 @@ export function PositionsPreviewPanel() {
           </div>
 
           <button
-            onClick={() => router.push('/markets')}
+            onClick={() => router.push(getWalletTabHref('positions'))}
             className="mt-3 flex w-full items-center justify-center gap-1 rounded-lg border border-border px-3 py-2 font-medium text-foreground text-sm transition-colors hover:bg-muted/50"
           >
             View Positions

--- a/apps/web/src/lib/wallet-tabs.test.ts
+++ b/apps/web/src/lib/wallet-tabs.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  DEFAULT_WALLET_TAB,
+  getWalletTabHref,
+  parseWalletTab,
+} from './wallet-tabs';
+
+describe('parseWalletTab', () => {
+  it('returns balance for the balance tab query param', () => {
+    expect(parseWalletTab('balance')).toBe('balance');
+  });
+
+  it('returns positions for the positions tab query param', () => {
+    expect(parseWalletTab('positions')).toBe('positions');
+  });
+
+  it('falls back to the default tab when the query param is missing', () => {
+    expect(parseWalletTab(null)).toBe(DEFAULT_WALLET_TAB);
+    expect(parseWalletTab(undefined)).toBe(DEFAULT_WALLET_TAB);
+  });
+
+  it('falls back to the default tab when the query param is invalid', () => {
+    expect(parseWalletTab('pnl')).toBe(DEFAULT_WALLET_TAB);
+  });
+});
+
+describe('getWalletTabHref', () => {
+  it('builds the balance wallet tab URL', () => {
+    expect(getWalletTabHref('balance')).toBe('/wallet?tab=balance');
+  });
+
+  it('builds the positions wallet tab URL', () => {
+    expect(getWalletTabHref('positions')).toBe('/wallet?tab=positions');
+  });
+});

--- a/apps/web/src/lib/wallet-tabs.ts
+++ b/apps/web/src/lib/wallet-tabs.ts
@@ -1,0 +1,11 @@
+export type WalletTab = 'balance' | 'positions';
+
+export const DEFAULT_WALLET_TAB: WalletTab = 'positions';
+
+export function parseWalletTab(tab: string | null | undefined): WalletTab {
+  return tab === 'balance' || tab === 'positions' ? tab : DEFAULT_WALLET_TAB;
+}
+
+export function getWalletTabHref(tab: WalletTab): string {
+  return `/wallet?tab=${tab}`;
+}


### PR DESCRIPTION
## Summary

- Add a shared wallet tab routing helper for `balance` and `positions` deep links in `apps/web`.
- Make the wallet page URL-driven via `?tab=...` while keeping bare `/wallet` defaulted to the positions tab.
- Redirect the feed sidebar CTAs so `View Full Portfolio` opens the wallet balance tab and `View Positions` opens the wallet positions tab.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- None.

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [x] Other: `apps/web` local helper + unit tests

## Non-goals / follow-ups

- None.

## Changes

- Add `apps/web/src/lib/wallet-tabs.ts` with the wallet tab contract, query parsing, and href generation.
- Update `apps/web/src/app/wallet/page.tsx` to read the active tab from `useSearchParams()` and keep the URL in sync on tab clicks.
- Change `apps/web/src/components/feed/PortfolioWidget.tsx` to send `View Full Portfolio` to `/wallet?tab=balance`.
- Change `apps/web/src/components/feed/PositionsPreviewPanel.tsx` to send `View Positions` to `/wallet?tab=positions`.
- Add unit coverage for the helper in `apps/web/src/lib/wallet-tabs.test.ts`.

## Review guide

**Start here**
- `apps/web/src/lib/wallet-tabs.ts`
- `apps/web/src/app/wallet/page.tsx`
- `apps/web/src/components/feed/PortfolioWidget.tsx`
- `apps/web/src/components/feed/PositionsPreviewPanel.tsx`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- Query values outside `balance|positions` fall back to `positions`.
- This change is intentionally limited to the two feed/sidebar CTAs and the wallet page tab state.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. Ran `~/.bun/bin/bunx biome check --write apps/web/src/app/wallet/page.tsx apps/web/src/components/feed/PortfolioWidget.tsx apps/web/src/components/feed/PositionsPreviewPanel.tsx apps/web/src/lib/wallet-tabs.ts apps/web/src/lib/wallet-tabs.test.ts`.
2. Ran `PATH="$HOME/.bun/bin:$PATH" ~/.bun/bin/bun test apps/web/src/lib/wallet-tabs.test.ts apps/web/src/components/feed/__tests__/PortfolioWidget.test.ts`.
3. Attempted `PATH="$HOME/.bun/bin:$PATH" ~/.bun/bin/bun run typecheck` from the repo root, but it fails for unrelated pre-existing issues in `packages/testing/unit/market-resolution-notification-queries.test.ts`, `packages/testing/unit/markets/timeframe-arc-processor.test.ts`, and `packages/testing/unit/prediction-markets-store.test.ts`.
4. Attempted `PATH="$HOME/.bun/bin:$PATH" ~/.bun/bin/bun run typecheck` from `apps/web`, but it fails for unrelated pre-existing issues in `src/components/waitlist/dashboard/Leaderboard.tsx`, `src/components/waitlist/dashboard/ReferralProgress.tsx`, `src/components/waitlist/dashboard/StatsCards.tsx`, `src/components/waitlist/modals/ProfileModal.tsx`, and `src/lib/services/trading-fee-outbox.ts`.
5. Manual browser verification not run.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: ship normally.
- Rollback: revert this PR.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: navigation-only change; UI appearance is unchanged and the behavior difference is tab selection after redirect.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
