### PR TITLE
fix: mobile navigation parity with desktop sidebar

### DIFF
--- a/apps/web/src/app/agents/team/page.tsx
+++ b/apps/web/src/app/agents/team/page.tsx
@@ -235,7 +235,7 @@ export default function TeamChatPage() {
 
   // Mobile view state - which tab is active on mobile
   type MobileView = 'chat' | 'agents' | 'panel';
-  const [mobileView, setMobileView] = useState<MobileView>('chat');
+  const [mobileView, setMobileView] = useState<MobileView>('agents');
 
   // Left sidebar collapse state (desktop only)
   const [leftSidebarCollapsed, setLeftSidebarCollapsed] = useState(false);

--- a/apps/web/src/components/shared/BottomNav.tsx
+++ b/apps/web/src/components/shared/BottomNav.tsx
@@ -5,10 +5,9 @@ import { Bell, Bot, Home, MessageCircle, TrendingUp } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { useAuth } from '@/hooks/useAuth';
 import { usePostHog } from '@/hooks/usePostHog';
 import { useUnreadMessages } from '@/hooks/useUnreadMessages';
-import { getAuthToken } from '@/lib/auth';
+import { useUnreadNotifications } from '@/hooks/useUnreadNotifications';
 
 /**
  * Bottom navigation content component for mobile devices.
@@ -21,51 +20,14 @@ import { getAuthToken } from '@/lib/auth';
  */
 function BottomNavContent() {
   const pathname = usePathname();
-  const { authenticated, user } = useAuth();
   const { trackNavigation } = usePostHog();
-  const [unreadNotifications, setUnreadNotifications] = useState(0);
   const { totalUnread: unreadMessages } = useUnreadMessages();
+  const { unreadCount: unreadNotifications } = useUnreadNotifications();
 
   // Hide bottom nav when WAITLIST_MODE is enabled on home page
   const isWaitlistMode = process.env.NEXT_PUBLIC_WAITLIST_MODE === 'true';
   const isHomePage = pathname === '/';
   const shouldHide = isWaitlistMode && isHomePage;
-
-  // Poll for unread notifications
-  useEffect(() => {
-    if (!authenticated || !user) {
-      setUnreadNotifications(0);
-      return;
-    }
-
-    const fetchUnreadCount = async () => {
-      const token = getAuthToken();
-
-      if (!token) {
-        return;
-      }
-
-      const response = await fetch(
-        '/api/notifications?unreadOnly=true&limit=1',
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      );
-
-      if (response.ok) {
-        const data = await response.json();
-        setUnreadNotifications(data.unreadCount || 0);
-      }
-    };
-
-    fetchUnreadCount();
-
-    // Refresh every 1 minute
-    const interval = setInterval(fetchUnreadCount, 60000); // 60 seconds = 1 minute
-    return () => clearInterval(interval);
-  }, [authenticated, user]);
 
   // Hide when virtual keyboard is open (interactiveWidget: 'resizes-content'
   // shrinks the layout viewport, pushing the fixed nav up with the keyboard).
@@ -149,8 +111,8 @@ function BottomNavContent() {
           {navItems.map((item) => {
             const Icon = item.icon;
             const hasNotificationBadge =
-              (item.name === 'Notifications' && unreadNotifications > 0) ||
-              (item.name === 'Chats' && unreadMessages > 0);
+              (Icon === Bell && unreadNotifications > 0) ||
+              (Icon === MessageCircle && unreadMessages > 0);
             return (
               <Link
                 key={item.name}

--- a/apps/web/src/components/shared/MobileHeader.tsx
+++ b/apps/web/src/components/shared/MobileHeader.tsx
@@ -2,13 +2,17 @@
 
 import { cn, getDisplayReferralUrl, getReferralUrl } from '@babylon/shared';
 import {
+  Bell,
   Check,
   Copy,
   Gift,
   LogOut,
+  MessageCircle,
   Settings,
+  TrendingUp,
   Trophy,
   User,
+  Users,
   Wallet,
   X,
 } from 'lucide-react';
@@ -18,7 +22,9 @@ import { useEffect, useState } from 'react';
 import { GameFeedbackModal } from '@/components/feedback/GameFeedbackModal';
 import { Avatar } from '@/components/shared/Avatar';
 import { BabylonIcon } from '@/components/shared/icons/BabylonIcon';
+import { HouseIcon } from '@/components/shared/icons/HouseIcon';
 import { useAuth } from '@/hooks/useAuth';
+import { useUnreadMessages } from '@/hooks/useUnreadMessages';
 import { getAuthToken } from '@/lib/auth';
 import { useAuthStore } from '@/stores/authStore';
 
@@ -42,7 +48,9 @@ function MobileHeaderContent() {
   } | null>(null);
   const [copiedReferral, setCopiedReferral] = useState(false);
   const [showFeedbackModal, setShowFeedbackModal] = useState(false);
+  const [unreadNotifications, setUnreadNotifications] = useState(0);
   const pathname = usePathname();
+  const { totalUnread: unreadMessages } = useUnreadMessages();
 
   // Hide mobile header when WAITLIST_MODE is enabled on home page
   const isWaitlistMode = process.env.NEXT_PUBLIC_WAITLIST_MODE === 'true';
@@ -154,6 +162,37 @@ function MobileHeaderContent() {
     return () => clearInterval(interval);
   }, [authenticated, user?.id, user?.reputationPoints, setUser, user]);
 
+  // Poll for unread notifications
+  useEffect(() => {
+    if (!authenticated || !user) {
+      setUnreadNotifications(0);
+      return;
+    }
+
+    const fetchUnreadCount = async () => {
+      const token = getAuthToken();
+      if (!token) return;
+
+      const response = await fetch(
+        '/api/notifications?unreadOnly=true&limit=1',
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+
+      if (response.ok) {
+        const data = await response.json();
+        setUnreadNotifications(data.unreadCount || 0);
+      }
+    };
+
+    fetchUnreadCount();
+    const interval = setInterval(fetchUnreadCount, 60000);
+    return () => clearInterval(interval);
+  }, [authenticated, user]);
+
   const copyReferralCode = async () => {
     if (!user?.referralCode) return;
 
@@ -170,28 +209,58 @@ function MobileHeaderContent() {
 
   const menuItems = [
     {
+      name: 'Home',
+      href: '/feed',
+      icon: HouseIcon,
+      active: pathname === '/feed' || pathname === '/',
+    },
+    {
       name: 'Wallet',
       href: '/wallet',
       icon: Wallet,
       active: pathname === '/wallet',
     },
     {
-      name: 'Profile',
-      href: '/profile',
-      icon: User,
-      active: pathname === '/profile',
+      name: 'Notifications',
+      href: '/notifications',
+      icon: Bell,
+      active: pathname === '/notifications',
     },
     {
-      name: 'Leaderboards',
+      name: 'Leaderboard',
       href: '/leaderboard',
       icon: Trophy,
       active: pathname === '/leaderboard',
+    },
+    {
+      name: 'Terminal',
+      href: '/markets',
+      icon: TrendingUp,
+      active: pathname === '/markets',
+    },
+    {
+      name: 'Chats',
+      href: '/chats',
+      icon: MessageCircle,
+      active: pathname === '/chats',
+    },
+    {
+      name: 'Agents',
+      href: '/agents/team',
+      icon: Users,
+      active: pathname === '/agents' || pathname.startsWith('/agents/'),
     },
     {
       name: 'Rewards',
       href: '/rewards',
       icon: Gift,
       active: pathname === '/rewards',
+    },
+    {
+      name: 'Profile',
+      href: '/profile',
+      icon: User,
+      active: pathname === '/profile' || pathname.startsWith('/u/'),
     },
     {
       name: 'Settings',
@@ -327,6 +396,9 @@ function MobileHeaderContent() {
             <nav className="min-h-0 flex-1 overflow-y-auto pt-2.5">
               {menuItems.map((item) => {
                 const Icon = item.icon;
+                const hasNotificationBadge =
+                  (item.name === 'Notifications' && unreadNotifications > 0) ||
+                  (item.name === 'Chats' && unreadMessages > 0);
                 return (
                   <Link
                     key={item.name}
@@ -339,7 +411,12 @@ function MobileHeaderContent() {
                         : 'font-semibold text-sidebar-foreground hover:bg-sidebar-accent'
                     )}
                   >
-                    <Icon className="h-5 w-5" />
+                    <div className="relative">
+                      <Icon className="h-5 w-5" />
+                      {hasNotificationBadge && (
+                        <span className="-top-1 -right-1 absolute h-2 w-2 rounded-full bg-blue-500 ring-2 ring-sidebar" />
+                      )}
+                    </div>
                     <span className="text-base">{item.name}</span>
                   </Link>
                 );

--- a/apps/web/src/components/shared/MobileHeader.tsx
+++ b/apps/web/src/components/shared/MobileHeader.tsx
@@ -25,6 +25,7 @@ import { BabylonIcon } from '@/components/shared/icons/BabylonIcon';
 import { HouseIcon } from '@/components/shared/icons/HouseIcon';
 import { useAuth } from '@/hooks/useAuth';
 import { useUnreadMessages } from '@/hooks/useUnreadMessages';
+import { useUnreadNotifications } from '@/hooks/useUnreadNotifications';
 import { getAuthToken } from '@/lib/auth';
 import { useAuthStore } from '@/stores/authStore';
 
@@ -48,9 +49,9 @@ function MobileHeaderContent() {
   } | null>(null);
   const [copiedReferral, setCopiedReferral] = useState(false);
   const [showFeedbackModal, setShowFeedbackModal] = useState(false);
-  const [unreadNotifications, setUnreadNotifications] = useState(0);
   const pathname = usePathname();
   const { totalUnread: unreadMessages } = useUnreadMessages();
+  const { unreadCount: unreadNotifications } = useUnreadNotifications();
 
   // Hide mobile header when WAITLIST_MODE is enabled on home page
   const isWaitlistMode = process.env.NEXT_PUBLIC_WAITLIST_MODE === 'true';
@@ -161,37 +162,6 @@ function MobileHeaderContent() {
     const interval = setInterval(fetchPoints, 30000);
     return () => clearInterval(interval);
   }, [authenticated, user?.id, user?.reputationPoints, setUser, user]);
-
-  // Poll for unread notifications
-  useEffect(() => {
-    if (!authenticated || !user) {
-      setUnreadNotifications(0);
-      return;
-    }
-
-    const fetchUnreadCount = async () => {
-      const token = getAuthToken();
-      if (!token) return;
-
-      const response = await fetch(
-        '/api/notifications?unreadOnly=true&limit=1',
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      );
-
-      if (response.ok) {
-        const data = await response.json();
-        setUnreadNotifications(data.unreadCount || 0);
-      }
-    };
-
-    fetchUnreadCount();
-    const interval = setInterval(fetchUnreadCount, 60000);
-    return () => clearInterval(interval);
-  }, [authenticated, user]);
 
   const copyReferralCode = async () => {
     if (!user?.referralCode) return;
@@ -397,8 +367,8 @@ function MobileHeaderContent() {
               {menuItems.map((item) => {
                 const Icon = item.icon;
                 const hasNotificationBadge =
-                  (item.name === 'Notifications' && unreadNotifications > 0) ||
-                  (item.name === 'Chats' && unreadMessages > 0);
+                  (Icon === Bell && unreadNotifications > 0) ||
+                  (Icon === MessageCircle && unreadMessages > 0);
                 return (
                   <Link
                     key={item.name}

--- a/apps/web/src/components/shared/Sidebar.tsx
+++ b/apps/web/src/components/shared/Sidebar.tsx
@@ -31,7 +31,7 @@ import { HouseIcon } from '@/components/shared/icons/HouseIcon';
 import { useAuth } from '@/hooks/useAuth';
 import { usePostHog } from '@/hooks/usePostHog';
 import { useUnreadMessages } from '@/hooks/useUnreadMessages';
-import { getAuthToken } from '@/lib/auth';
+import { useUnreadNotifications } from '@/hooks/useUnreadNotifications';
 import { getUserDisplayName } from '@/lib/user-display';
 
 /**
@@ -47,7 +47,6 @@ function SidebarContent() {
   const [collapsed, setCollapsed] = useState(false);
   const [showMdMenu, setShowMdMenu] = useState(false);
   const [copiedReferral, setCopiedReferral] = useState(false);
-  const [unreadNotifications, setUnreadNotifications] = useState(0);
   const [feedbackModalOpen, setFeedbackModalOpen] = useState(false);
   const asideRef = useRef<HTMLElement>(null);
   const mdMenuRef = useRef<HTMLDivElement>(null);
@@ -55,6 +54,7 @@ function SidebarContent() {
   const { ready, authenticated, user, logout, login } = useAuth();
   const { trackNavigation, trackClick } = usePostHog();
   const { totalUnread: unreadMessages } = useUnreadMessages();
+  const { unreadCount: unreadNotifications } = useUnreadNotifications();
 
   // Hide sidebar when WAITLIST_MODE is enabled on home page
   const isWaitlistMode = process.env.NEXT_PUBLIC_WAITLIST_MODE === 'true';
@@ -83,42 +83,6 @@ function SidebarContent() {
     }
     return undefined;
   }, [showMdMenu]);
-
-  // Poll for unread notifications
-  useEffect(() => {
-    if (!authenticated || !user) {
-      setUnreadNotifications(0);
-      return;
-    }
-
-    const fetchUnreadCount = async () => {
-      const token = getAuthToken();
-
-      if (!token) {
-        return;
-      }
-
-      const response = await fetch(
-        '/api/notifications?unreadOnly=true&limit=1',
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      );
-
-      if (response.ok) {
-        const data = await response.json();
-        setUnreadNotifications(data.unreadCount || 0);
-      }
-    };
-
-    fetchUnreadCount();
-
-    // Refresh every 1 minute
-    const interval = setInterval(fetchUnreadCount, 60000); // 60 seconds = 1 minute
-    return () => clearInterval(interval);
-  }, [authenticated, user]);
 
   // Adjust sidebar height to account for elements above it (e.g. NFT banner)
   // so the user profile bar at the bottom is always visible
@@ -291,8 +255,8 @@ function SidebarContent() {
           {navItems.map((item) => {
             const Icon = item.icon;
             const hasNotificationBadge =
-              (item.name === 'Notifications' && unreadNotifications > 0) ||
-              (item.name === 'Chats' && unreadMessages > 0);
+              (Icon === Bell && unreadNotifications > 0) ||
+              (Icon === MessageCircle && unreadMessages > 0);
 
             const navContent = (
               <>

--- a/apps/web/src/hooks/useUnreadNotifications.ts
+++ b/apps/web/src/hooks/useUnreadNotifications.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import { useAuth } from '@/hooks/useAuth';
+import { getAuthToken } from '@/lib/auth';
+
+/**
+ * Hook for polling unread notification count.
+ *
+ * Polls `/api/notifications?unreadOnly=true&limit=1` every 60 seconds
+ * to check for unread notifications. Only polls when the user is
+ * authenticated. Automatically stops polling on unmount or logout.
+ *
+ * @returns An object containing:
+ * - `unreadCount`: Number of unread notifications
+ *
+ * @example
+ * ```tsx
+ * const { unreadCount } = useUnreadNotifications();
+ *
+ * return unreadCount > 0 && <Badge />;
+ * ```
+ */
+export function useUnreadNotifications() {
+  const { authenticated, user } = useAuth();
+  const [unreadCount, setUnreadCount] = useState(0);
+
+  useEffect(() => {
+    if (!authenticated || !user) {
+      setUnreadCount(0);
+      return;
+    }
+
+    const fetchUnreadCount = async () => {
+      const token = getAuthToken();
+      if (!token) return;
+
+      try {
+        const response = await fetch(
+          '/api/notifications?unreadOnly=true&limit=1',
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          }
+        );
+
+        if (response.ok) {
+          const data = await response.json();
+          setUnreadCount(data.unreadCount || 0);
+        }
+      } catch {
+        // Silently fail — badge will just not update on network errors
+      }
+    };
+
+    fetchUnreadCount();
+    const interval = setInterval(fetchUnreadCount, 60000);
+    return () => clearInterval(interval);
+  }, [authenticated, user]);
+
+  return { unreadCount };
+}


### PR DESCRIPTION
## Summary
- **Mobile side menu**: Added all missing navigation routes (Home, Notifications, Terminal, Chats, Agents) so the slide-out menu matches the desktop sidebar — previously only showed 5 of 10 items
- **Icon consistency**: Uses identical icons from the desktop sidebar (HouseIcon, Bell, TrendingUp, MessageCircle, Users)
- **Unread badges**: Notifications and Chats items now show blue dot indicators for unread counts, matching desktop behavior
- **Agents default tab**: Tapping "Agents" in bottom nav now lands on the agents list tab instead of the chat tab

## Test plan
- [ ] On mobile, tap profile icon to open side menu — verify all 10 nav items appear (Home, Wallet, Notifications, Leaderboard, Terminal, Chats, Agents, Rewards, Profile, Settings)
- [ ] Verify icons match the desktop sidebar
- [ ] With unread notifications/messages, verify blue badges show on Notifications and Chats items
- [ ] Tap "Agents" in bottom nav — verify it lands on the agents list tab, not chat
- [ ] Verify desktop sidebar behavior is unchanged