### PR TITLE
fix: add privyId→PK fallback for did:privy users stored as id

### DIFF
--- a/packages/api/src/cache/cached-database-service.ts
+++ b/packages/api/src/cache/cached-database-service.ts
@@ -38,7 +38,7 @@ import {
   users,
 } from '@babylon/db';
 import { StaticDataRegistry } from '@babylon/engine';
-import { logger } from '@babylon/shared';
+import { logger, resolveUserIdentifierKind } from '@babylon/shared';
 import {
   CACHE_KEYS,
   DEFAULT_TTLS,
@@ -566,6 +566,13 @@ class CachedDatabaseService {
     // WHY always invalidate by ID? ID never changes, but we invalidate to ensure fresh data
     // after user updates (e.g., profile changes that affect cached user object)
     await invalidateCache(`id:${user.id}`, { namespace });
+
+    // Some users have their did:privy:… value stored as users.id rather than
+    // users.privyId. Lookups for those users cache under privy:${user.id}, so
+    // we must invalidate that key too — otherwise stale/negative entries persist.
+    if (resolveUserIdentifierKind(user.id) === 'privyId') {
+      await invalidateCache(`privy:${user.id}`, { namespace });
+    }
 
     // WHY check oldValues?.privyId? Only invalidate old privyId if it actually changed
     // This avoids unnecessary cache operations when privyId hasn't changed

--- a/packages/api/src/users/user-lookup.ts
+++ b/packages/api/src/users/user-lookup.ts
@@ -19,6 +19,41 @@ import { NotFoundError } from '../errors';
 type User = InferSelectModel<typeof users>;
 
 /**
+ * Fetch a user row by classified identifier kind.
+ *
+ * For `privyId` lookups that miss, falls back to a PK lookup because some
+ * users have their `did:privy:…` value stored as `users.id` rather than
+ * `users.privyId`. Both queries use single-column indexes (no OR).
+ */
+async function fetchUserByClassifiedIdentifier(
+  identifier: string,
+  kind: 'id' | 'privyId' | 'username'
+): Promise<User | null> {
+  const condition =
+    kind === 'id'
+      ? eq(users.id, identifier)
+      : kind === 'privyId'
+        ? eq(users.privyId, identifier)
+        : sql`lower(${users.username}) = lower(${identifier})`;
+
+  const [user] = await db.select().from(users).where(condition).limit(1);
+  if (user) return user;
+
+  // Fallback: did:privy: identifiers may be stored as the primary key
+  // instead of in the privyId column. PK lookup is O(1).
+  if (kind === 'privyId') {
+    const [byId] = await db
+      .select()
+      .from(users)
+      .where(eq(users.id, identifier))
+      .limit(1);
+    return byId ?? null;
+  }
+
+  return null;
+}
+
+/**
  * Generate cache key for user identifier lookup
  *
  * @description Creates a cache key based on the identifier kind and value.
@@ -109,28 +144,7 @@ export async function findUserByIdentifier(
   // If cache miss, executes the fetch function and caches the result (including null for negative caching)
   return getCacheOrFetch(
     cacheKey,
-    async () => {
-      // WHY exactly ONE query? Classification routes to the optimal index for this identifier type
-      // No OR condition means PostgreSQL planner can use the optimal index scan
-      // This is the core performance win - single indexed query vs multi-predicate OR
-      let condition;
-      if (kind === 'id') {
-        condition = eq(users.id, identifier);
-      } else if (kind === 'privyId') {
-        condition = eq(users.privyId, identifier);
-      } else {
-        // WHY sql template with lower()? Username matching must be case-insensitive
-        // Using eq() would be case-sensitive. The functional index idx_users_username_lower
-        // supports this query pattern efficiently
-        condition = sql`lower(${users.username}) = lower(${identifier})`;
-      }
-
-      // WHY always fetch full user? This function shares cache keys with
-      // findUserByIdentifierWithSelect(), so storing projected rows here would let
-      // a partial cache entry leak into later full-user lookups.
-      const [user] = await db.select().from(users).where(condition).limit(1);
-      return user ?? null;
-    },
+    async () => fetchUserByClassifiedIdentifier(identifier, kind),
     {
       namespace: CACHE_KEYS.USER_IDENTIFIER,
       ttl: DEFAULT_TTLS.USER,
@@ -184,28 +198,7 @@ export async function findUserByIdentifierWithSelect<
   // Fetch from cache or database
   const user = await getCacheOrFetch(
     cacheKey,
-    async () => {
-      // Run exactly ONE query based on classification
-      let condition;
-      if (kind === 'id') {
-        condition = eq(users.id, identifier);
-      } else if (kind === 'privyId') {
-        condition = eq(users.privyId, identifier);
-      } else {
-        condition = sql`lower(${users.username}) = lower(${identifier})`;
-      }
-
-      // WHY always fetch full user? To maximize cache hits across different select patterns
-      // If caller A requests {id, username} and caller B requests {id, displayName},
-      // both can use the same cached full user object
-      const [fullUser] = await db
-        .select()
-        .from(users)
-        .where(condition)
-        .limit(1);
-
-      return fullUser ?? null;
-    },
+    async () => fetchUserByClassifiedIdentifier(identifier, kind),
     {
       namespace: CACHE_KEYS.USER_IDENTIFIER,
       ttl: DEFAULT_TTLS.USER, // WHY 300s? Same as other user caches - balances freshness vs hit rate

--- a/packages/engine/src/services/portfolio-breakdown.ts
+++ b/packages/engine/src/services/portfolio-breakdown.ts
@@ -112,6 +112,17 @@ export async function calculatePortfolioBreakdown(
   // Route to single WHERE condition based on classification
   // WHY sql template for username? Username matching must be case-insensitive to use
   // the functional index idx_users_username_lower. Using eq() would be case-sensitive.
+  const portfolioSelect = {
+    id: users.id,
+    privyId: users.privyId,
+    displayName: users.displayName,
+    username: users.username,
+    virtualBalance: users.virtualBalance,
+    totalDeposited: users.totalDeposited,
+    totalWithdrawn: users.totalWithdrawn,
+    reputationPoints: users.reputationPoints,
+  };
+
   const whereClause =
     kind === 'id'
       ? eq(users.id, normalizedUserId)
@@ -120,32 +131,35 @@ export async function calculatePortfolioBreakdown(
         : sql`lower(${users.username}) = lower(${normalizedUserId})`; // Case-insensitive for functional index
 
   const userResult = await db
-    .select({
-      id: users.id,
-      privyId: users.privyId,
-      displayName: users.displayName,
-      username: users.username,
-      virtualBalance: users.virtualBalance,
-      totalDeposited: users.totalDeposited,
-      totalWithdrawn: users.totalWithdrawn,
-      reputationPoints: users.reputationPoints,
-    })
+    .select(portfolioSelect)
     .from(users)
     .where(whereClause)
     .limit(1);
 
-  const user = userResult[0] as
-    | {
-        id: string;
-        privyId: string | null;
-        displayName: string | null;
-        username: string | null;
-        virtualBalance: unknown;
-        totalDeposited: unknown;
-        totalWithdrawn: unknown;
-        reputationPoints: number;
-      }
-    | undefined;
+  type PortfolioUserRow = {
+    id: string;
+    privyId: string | null;
+    displayName: string | null;
+    username: string | null;
+    virtualBalance: unknown;
+    totalDeposited: unknown;
+    totalWithdrawn: unknown;
+    reputationPoints: number;
+  };
+
+  let user = userResult[0] as PortfolioUserRow | undefined;
+
+  // Fallback: did:privy: identifiers may be stored as the primary key
+  // instead of in the privyId column. PK lookup is O(1).
+  if (!user && kind === 'privyId') {
+    const fallbackResult = await db
+      .select(portfolioSelect)
+      .from(users)
+      .where(eq(users.id, normalizedUserId))
+      .limit(1);
+    user = fallbackResult[0] as PortfolioUserRow | undefined;
+  }
+
   if (!user) return null;
 
   const canonicalUserId = user.id;


### PR DESCRIPTION
## Summary

- Fixes production `duplicate key violates unique constraint "User_pkey"` errors on `GET /api/users/[userId]/portfolio-breakdown` and `balance` routes
- After PR #1327's classification-based routing, `did:privy:…` identifiers are classified as `privyId` and only query `users.privyId` — missing users where that value is stored as `users.id` (primary key)
- Adds a PK fallback for `privyId`-classified lookups that miss, keeping single-column indexed queries (no OR reversion)
- Applied in both `packages/api` lookup layer and `packages/engine` portfolio breakdown

## Root cause

PR #1327 optimized `findUserByIdentifier` from `WHERE id = $1 OR privyId = $1 OR lower(username) = lower($1)` to classification-based single-column routing. Some users have their `did:privy:…` value stored as `users.id` (not `users.privyId`). The classifier routes these to `WHERE privyId = $1` which misses → null → inline INSERT → PK violation.

## Fix

When a `privyId`-classified lookup returns no rows, fall back to `WHERE id = $1`. Both queries hit single-column indexes (PK is O(1)), preserving the performance optimization.

## Test plan

- [ ] Verify `did:privy:…` users stored as `users.id` are found by `findUserByIdentifier`
- [ ] Verify `GET /api/users/{did:privy:...}/portfolio-breakdown` returns data (not 500)
- [ ] Verify `GET /api/users/{did:privy:...}/balance` returns data (not 500)
- [ ] Verify normal UUID/username lookups are unaffected
- [ ] Verify no duplicate key errors in production logs