### PR TITLE
fix: replace missing mv_post_interaction_counts with inline engagement query

### DIFF
--- a/apps/web/src/app/api/feed/for-you/pipeline.ts
+++ b/apps/web/src/app/api/feed/for-you/pipeline.ts
@@ -416,9 +416,20 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
         )
       )
       .orderBy(
-        sql`(SELECT COALESCE(mic.engagement_score, 0)
-             FROM mv_post_interaction_counts mic
-             WHERE mic.post_id = ${posts.id}) DESC`
+        sql`(
+          SELECT COALESCE(SUM(
+            CASE WHEN src = 'like' THEN 1
+                 WHEN src = 'comment' THEN 2
+                 WHEN src = 'share' THEN 3 END
+          ), 0)
+          FROM (
+            SELECT 'like' AS src FROM "Reaction" WHERE type = 'like' AND "postId" = ${posts.id}
+            UNION ALL
+            SELECT 'comment' FROM "Comment" WHERE "deletedAt" IS NULL AND "postId" = ${posts.id}
+            UNION ALL
+            SELECT 'share' FROM "Share" WHERE "postId" = ${posts.id}
+          ) engagement
+        ) DESC`
       )
       .limit(backfillCapacity);
 


### PR DESCRIPTION
## Summary

- **Fix**: The for-you feed backfill query referenced `mv_post_interaction_counts`, a materialized view that was never created in production — the migration file (`0029`) exists but was never registered in Drizzle's `_journal.json`, so `db:migrate` never runs it.
- **Solution**: Replace the materialized view correlated subquery with an inline subquery that computes the same engagement score (`likes×1 + comments×2 + shares×3`) directly from `Reaction`, `Comment`, and `Share` tables.
- Both `babylon.market` and `play.babylon.market` were returning 500 errors on `/api/feed/for-you` due to this (`PostgresError: relation "mv_post_interaction_counts" does not exist`, code `42P01`).

## Type

- [x] Bug fix

## Context / Links

- Error: `PostgresError: relation "mv_post_interaction_counts" does not exist` (code `42P01`)
- Orphaned migration: `packages/db/drizzle/migrations/0029_add_interaction_count_materialized_views.sql` (not in `_journal.json`)
- Affected endpoints: `GET /api/feed/for-you` on both production domains

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web API routes / SSE / A2A (`apps/web`)

## Non-goals / follow-ups

- Cleaning up the orphaned `0029` migration files (harmless while unregistered)
- Actually creating the materialized view + refresh strategy (would be a performance optimization for later)

## Changes

- `apps/web/src/app/api/feed/for-you/pipeline.ts`: replaced `ORDER BY (SELECT ... FROM mv_post_interaction_counts ...)` with an inline `UNION ALL` subquery that computes engagement score on the fly from the source tables

## Review guide

**Start here**
- `apps/web/src/app/api/feed/for-you/pipeline.ts` — the only changed file, ~line 418

**Risk**
- [x] Low

**Notes for reviewers**
- The inline subquery computes the exact same formula as the materialized view definition: `likes×1 + comments×2 + shares×3`
- This is a correlated subquery inside `ORDER BY`, which is acceptable for the backfill query since it already has a `LIMIT` and date-range filter constraining the candidate set
- Verified against production DB: `mv_post_interaction_counts` does not exist, `bun db:migrate` does not create it (migration not in journal)

## Test plan

**Commands run**
- [x] `bun run check` (Biome `check --write .`)
- [x] `bun run typecheck`

**Focused verification / manual verification**
1. Connected to production DB and confirmed `SELECT matviewname FROM pg_matviews WHERE matviewname = 'mv_post_interaction_counts'` returns 0 rows
2. Confirmed `bun db:migrate` does not create the view (migration not in `_journal.json`)
3. Typecheck passes cleanly across all packages

## Ops / Migration / Deployment

- [x] No deploy impact

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: Deploy to production — the feed endpoint will immediately stop 500ing
- Rollback: Revert this commit (restores the broken MV reference)

## Breaking changes

- [x] None

## Security / privacy

- [x] No security impact

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend-only fix — replaces a broken SQL subquery. No UI changes.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)