### PR TITLE
feat: Telegram MiniApp seamless auth + bot launcher

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -498,6 +498,9 @@ NEXT_PUBLIC_DISCORD_ACTIVITY_CLIENT_ID=
 # Get this from @BotFather when creating/managing your Telegram bot.
 # Without this token, initData validation is skipped (insecure in production).
 TELEGRAM_BOT_TOKEN=
+# Random secret string for verifying Telegram webhook requests.
+# Generate with: openssl rand -hex 32
+TELEGRAM_WEBHOOK_SECRET=
 
 # ============================================
 # ADD THESE TO YOUR .env FILE

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -88,6 +88,7 @@
     "ethers": "^6.16.0",
     "framer-motion": "^12.23.25",
     "geist": "^1.5.1",
+    "grammy": "^1.41.1",
     "html-to-image": "^1.11.13",
     "ioredis": "^5.8.2",
     "lucide-react": "^0.555.0",

--- a/apps/web/src/app/api/telegram/webhook/route.ts
+++ b/apps/web/src/app/api/telegram/webhook/route.ts
@@ -1,0 +1,121 @@
+/**
+ * Telegram Bot Webhook Handler
+ *
+ * @route POST /api/telegram/webhook
+ * @access Telegram servers only (verified via webhook secret)
+ *
+ * Lightweight MiniApp launcher bot. Responds to /start and /help with
+ * a welcome message and an inline button to open the Babylon MiniApp.
+ *
+ * Uses grammY's webhookCallback with the "std/http" adapter for
+ * compatibility with Next.js App Router (Web standard Request/Response).
+ */
+
+import { logger } from '@babylon/shared';
+import { Bot, InlineKeyboard, webhookCallback } from 'grammy';
+
+const token = process.env.TELEGRAM_BOT_TOKEN;
+const webhookSecret = process.env.TELEGRAM_WEBHOOK_SECRET;
+
+const MINIAPP_URL = process.env.NEXT_PUBLIC_APP_URL || 'https://babylon.market';
+
+function createBot(): Bot {
+  if (!token) {
+    throw new Error('TELEGRAM_BOT_TOKEN is not configured');
+  }
+
+  const bot = new Bot(token);
+
+  const openAppKeyboard = new InlineKeyboard().webApp(
+    'Open Babylon',
+    MINIAPP_URL
+  );
+
+  bot.command('start', async (ctx) => {
+    const firstName = ctx.from?.first_name ?? 'there';
+
+    logger.info(
+      'Telegram bot /start command received',
+      { userId: ctx.from?.id, username: ctx.from?.username },
+      'TelegramBot'
+    );
+
+    await ctx.reply(
+      `Hey ${firstName}! Welcome to Babylon.\n\nTap the button below to jump in.`,
+      { reply_markup: openAppKeyboard }
+    );
+  });
+
+  bot.command('help', async (ctx) => {
+    logger.info(
+      'Telegram bot /help command received',
+      { userId: ctx.from?.id },
+      'TelegramBot'
+    );
+
+    await ctx.reply(
+      'Babylon is a prediction market game where you bet on what happens next.\n\nTap below to open the app and start playing.',
+      { reply_markup: openAppKeyboard }
+    );
+  });
+
+  bot.on('message', async (ctx) => {
+    await ctx.reply(
+      "Tap the button below to open Babylon. That's where the action is.",
+      {
+        reply_markup: openAppKeyboard,
+      }
+    );
+  });
+
+  bot.catch((err) => {
+    logger.error('Telegram bot error', { error: err.message }, 'TelegramBot');
+  });
+
+  return bot;
+}
+
+let botInstance: Bot | null = null;
+
+function getBot(): Bot {
+  if (!botInstance) {
+    botInstance = createBot();
+  }
+  return botInstance;
+}
+
+type WebhookHandler = (req: Request) => Response | Promise<Response>;
+
+let handler: WebhookHandler | null = null;
+
+function getHandler(): WebhookHandler {
+  if (!handler) {
+    handler = webhookCallback(getBot(), 'std/http', {
+      secretToken: webhookSecret,
+    }) as WebhookHandler;
+  }
+  return handler;
+}
+
+export async function POST(request: Request): Promise<Response> {
+  if (!token) {
+    return new Response(JSON.stringify({ error: 'Bot not configured' }), {
+      status: 503,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  try {
+    return await getHandler()(request);
+  } catch (error) {
+    logger.error(
+      'Telegram webhook handler failed',
+      { error: error instanceof Error ? error.message : String(error) },
+      'TelegramBot'
+    );
+    return new Response(JSON.stringify({ error: 'Internal error' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}

--- a/apps/web/src/app/api/telegram/webhook/route.ts
+++ b/apps/web/src/app/api/telegram/webhook/route.ts
@@ -11,6 +11,7 @@
  * compatibility with Next.js App Router (Web standard Request/Response).
  */
 
+import { withErrorHandling } from '@babylon/api';
 import { logger } from '@babylon/shared';
 import { Bot, InlineKeyboard, webhookCallback } from 'grammy';
 
@@ -97,7 +98,9 @@ function getHandler(): WebhookHandler {
   return handler;
 }
 
-export async function POST(request: Request): Promise<Response> {
+export const POST = withErrorHandling(async function POST(
+  request: Request
+): Promise<Response> {
   if (!token) {
     return new Response(JSON.stringify({ error: 'Bot not configured' }), {
       status: 503,
@@ -105,17 +108,15 @@ export async function POST(request: Request): Promise<Response> {
     });
   }
 
-  try {
-    return await getHandler()(request);
-  } catch (error) {
-    logger.error(
-      'Telegram webhook handler failed',
-      { error: error instanceof Error ? error.message : String(error) },
-      'TelegramBot'
+  if (!webhookSecret) {
+    return new Response(
+      JSON.stringify({ error: 'Webhook secret not configured' }),
+      {
+        status: 503,
+        headers: { 'Content-Type': 'application/json' },
+      }
     );
-    return new Response(JSON.stringify({ error: 'Internal error' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' },
-    });
   }
-}
+
+  return await getHandler()(request);
+});

--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -385,6 +385,7 @@ async function syncMissingPrivyIdentityFields(
     } else {
       updateData.hasTelegram = true;
       updateData.telegramId = privyIdentity.telegramUserId;
+      updateData.telegramVerifiedAt = new Date();
       if (privyIdentity.telegramUsername) {
         updateData.telegramUsername = privyIdentity.telegramUsername;
       }
@@ -1001,6 +1002,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
         hasTelegram: !!telegramUserId,
         telegramId: telegramUserId,
         telegramUsername,
+        telegramVerifiedAt: telegramUserId ? new Date() : null,
         profileComplete: false,
         hasUsername: false,
         hasBio: false,

--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -212,6 +212,9 @@ const userSelectFields = {
   twitterUsername: users.twitterUsername,
   twitterId: users.twitterId,
   discordUsername: users.discordUsername,
+  hasTelegram: users.hasTelegram,
+  telegramId: users.telegramId,
+  telegramUsername: users.telegramUsername,
   showTwitterPublic: users.showTwitterPublic,
   showFarcasterPublic: users.showFarcasterPublic,
   showWalletPublic: users.showWalletPublic,
@@ -260,6 +263,9 @@ type UserSelectResult = {
   hasFarcaster: boolean;
   hasTwitter: boolean;
   hasDiscord: boolean;
+  hasTelegram: boolean;
+  telegramId: string | null;
+  telegramUsername: string | null;
   farcasterUsername: string | null;
   farcasterFid: string | null;
   twitterUsername: string | null;
@@ -280,10 +286,10 @@ async function syncMissingPrivyIdentityFields(
   privyIdentity: PrivyIdentitySnapshot
 ): Promise<{
   user: UserSelectResult;
-  newlyLinked: Array<'farcaster' | 'twitter'>;
+  newlyLinked: Array<'farcaster' | 'twitter' | 'telegram'>;
 }> {
   const updateData: Partial<typeof users.$inferInsert> = {};
-  const newlyLinked: Array<'farcaster' | 'twitter'> = [];
+  const newlyLinked: Array<'farcaster' | 'twitter' | 'telegram'> = [];
 
   if ((!dbUser.email || !dbUser.emailVerified) && privyIdentity.email) {
     updateData.email = privyIdentity.email;
@@ -354,6 +360,38 @@ async function syncMissingPrivyIdentityFields(
     }
   }
 
+  if (!dbUser.hasTelegram && privyIdentity.telegramUserId) {
+    const [existingTelegramUser] = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(
+        and(
+          eq(users.telegramId, privyIdentity.telegramUserId),
+          ne(users.id, dbUser.id)
+        )
+      )
+      .limit(1);
+
+    if (existingTelegramUser) {
+      logger.warn(
+        'Privy Telegram identity already linked to another user, skipping sync',
+        {
+          userId: dbUser.id,
+          telegramUserId: privyIdentity.telegramUserId,
+          conflictingUserId: existingTelegramUser.id,
+        },
+        'GET /api/users/me'
+      );
+    } else {
+      updateData.hasTelegram = true;
+      updateData.telegramId = privyIdentity.telegramUserId;
+      if (privyIdentity.telegramUsername) {
+        updateData.telegramUsername = privyIdentity.telegramUsername;
+      }
+      newlyLinked.push('telegram');
+    }
+  }
+
   if (Object.keys(updateData).length === 0) {
     return { user: dbUser, newlyLinked };
   }
@@ -392,20 +430,27 @@ async function syncMissingPrivyIdentityFields(
 
 async function awardPointsForNewPrivyIdentityLinks(
   userId: string,
-  newlyLinked: Array<'farcaster' | 'twitter'>,
+  newlyLinked: Array<'farcaster' | 'twitter' | 'telegram'>,
   privyIdentity: PrivyIdentitySnapshot
 ): Promise<void> {
   for (const platform of newlyLinked) {
-    const pointsResult =
-      platform === 'farcaster'
-        ? await PointsService.awardFarcasterLink(
-            userId,
-            privyIdentity.farcasterUsername ?? undefined
-          )
-        : await PointsService.awardTwitterLink(
-            userId,
-            privyIdentity.twitterUsername ?? undefined
-          );
+    let pointsResult: Awaited<ReturnType<typeof PointsService.awardFarcasterLink>>;
+    if (platform === 'farcaster') {
+      pointsResult = await PointsService.awardFarcasterLink(
+        userId,
+        privyIdentity.farcasterUsername ?? undefined
+      );
+    } else if (platform === 'telegram') {
+      pointsResult = await PointsService.awardTelegramLink(
+        userId,
+        privyIdentity.telegramUsername ?? undefined
+      );
+    } else {
+      pointsResult = await PointsService.awardTwitterLink(
+        userId,
+        privyIdentity.twitterUsername ?? undefined
+      );
+    }
 
     if (!pointsResult.success) {
       logger.warn(
@@ -472,9 +517,11 @@ function buildUserResponse(
     hasFarcaster: dbUser.hasFarcaster,
     hasTwitter: dbUser.hasTwitter,
     hasDiscord: dbUser.hasDiscord,
+    hasTelegram: dbUser.hasTelegram,
     farcasterUsername: dbUser.farcasterUsername,
     twitterUsername: dbUser.twitterUsername,
     discordUsername: dbUser.discordUsername,
+    telegramUsername: dbUser.telegramUsername,
     showTwitterPublic: dbUser.showTwitterPublic,
     showFarcasterPublic: dbUser.showFarcasterPublic,
     showWalletPublic: dbUser.showWalletPublic,
@@ -600,6 +647,8 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     let farcasterFid: string | null = null;
     let twitterUsername: string | null = null;
     let twitterId: string | null = null;
+    let telegramUserId: string | null = null;
+    let telegramUsername: string | null = null;
     let embeddedWalletAddress: string | null = null;
     let embeddedWalletId: string | null = null;
 
@@ -624,6 +673,12 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       twitterId = privyUser.twitter.subject ?? null;
     }
 
+    // Extract Telegram info
+    if (privyUser.telegram) {
+      telegramUserId = privyUser.telegram.telegramUserId ?? null;
+      telegramUsername = privyUser.telegram.username ?? null;
+    }
+
     const embedded = pickEmbeddedEvmWallet(privyUser);
     if (embedded) {
       embeddedWalletId = embedded.walletId;
@@ -638,6 +693,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
         hasEmail: !!email,
         hasFarcaster: !!farcasterUsername,
         hasTwitter: !!twitterUsername,
+        hasTelegram: !!telegramUserId,
         hasEmbeddedWallet: !!embeddedWalletAddress,
       },
       'GET /api/users/me'
@@ -940,6 +996,9 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
         twitterId,
         hasFarcaster: !!farcasterUsername,
         hasTwitter: !!twitterUsername,
+        hasTelegram: !!telegramUserId,
+        telegramId: telegramUserId,
+        telegramUsername,
         profileComplete: false,
         hasUsername: false,
         hasBio: false,
@@ -1078,6 +1137,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
     shouldSyncMissingPrivyIdentity({
       hasFarcaster: dbUser.hasFarcaster,
       hasTwitter: dbUser.hasTwitter,
+      hasTelegram: dbUser.hasTelegram,
       email: dbUser.email,
       emailVerified: dbUser.emailVerified,
     });

--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -434,7 +434,9 @@ async function awardPointsForNewPrivyIdentityLinks(
   privyIdentity: PrivyIdentitySnapshot
 ): Promise<void> {
   for (const platform of newlyLinked) {
-    let pointsResult: Awaited<ReturnType<typeof PointsService.awardFarcasterLink>>;
+    let pointsResult: Awaited<
+      ReturnType<typeof PointsService.awardFarcasterLink>
+    >;
     if (platform === 'farcaster') {
       pointsResult = await PointsService.awardFarcasterLink(
         userId,

--- a/apps/web/src/app/wallet/page.tsx
+++ b/apps/web/src/app/wallet/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import dynamic from 'next/dynamic';
 import { Sparkles } from 'lucide-react';
+import dynamic from 'next/dynamic';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 import { LoginButton } from '@/components/auth/LoginButton';
@@ -13,7 +13,10 @@ import { useAuth } from '@/hooks/useAuth';
 import { useTeamTradingSummary } from '@/hooks/useTeamTradingSummary';
 import { parseWalletTab, type WalletTab } from '@/lib/wallet-tabs';
 import { useUserPositionsPolling } from '@/stores/userPositionsStore';
-import { invalidateWalletBalance, useWalletBalancePolling } from '@/stores/walletBalanceStore';
+import {
+  invalidateWalletBalance,
+  useWalletBalancePolling,
+} from '@/stores/walletBalanceStore';
 
 const BuyPointsModal = dynamic(
   () =>

--- a/apps/web/src/app/wallet/page.tsx
+++ b/apps/web/src/app/wallet/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Sparkles } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
@@ -141,9 +140,8 @@ export default function WalletPage() {
             </div>
             <button
               onClick={() => setShowBuyPoints(true)}
-              className="mr-3 flex shrink-0 items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 font-medium text-primary-foreground text-xs transition-colors hover:bg-primary/90"
+              className="mr-3 shrink-0 rounded-lg bg-primary px-3 py-1.5 font-medium text-primary-foreground text-xs transition-colors hover:bg-primary/90"
             >
-              <Sparkles className="h-3.5 w-3.5" />
               Buy Points
             </button>
           </div>

--- a/apps/web/src/app/wallet/page.tsx
+++ b/apps/web/src/app/wallet/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import dynamic from 'next/dynamic';
+import { Sparkles } from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useState } from 'react';
 import { LoginButton } from '@/components/auth/LoginButton';
@@ -12,7 +13,15 @@ import { useAuth } from '@/hooks/useAuth';
 import { useTeamTradingSummary } from '@/hooks/useTeamTradingSummary';
 import { parseWalletTab, type WalletTab } from '@/lib/wallet-tabs';
 import { useUserPositionsPolling } from '@/stores/userPositionsStore';
-import { useWalletBalancePolling } from '@/stores/walletBalanceStore';
+import { invalidateWalletBalance, useWalletBalancePolling } from '@/stores/walletBalanceStore';
+
+const BuyPointsModal = dynamic(
+  () =>
+    import('@/components/points/BuyPointsModal').then((m) => ({
+      default: m.BuyPointsModal,
+    })),
+  { ssr: false }
+);
 
 const WidgetSidebar = dynamic(
   () =>
@@ -34,6 +43,7 @@ export default function WalletPage() {
   const [activeTab, setActiveTab] = useState<PortfolioTab>(() =>
     parseWalletTab(searchParams.get('tab'))
   );
+  const [showBuyPoints, setShowBuyPoints] = useState(false);
 
   const userId = authenticated ? user?.id : undefined;
 
@@ -101,29 +111,38 @@ export default function WalletPage() {
         {/* Main wallet content */}
         <div className="flex min-w-0 flex-1 flex-col border-border lg:border-r lg:border-l">
           {/* Tab Navigation */}
-          <div className="flex border-border border-b">
-            {(
-              [
-                ['balance', 'Balance'],
-                ['pnl', 'P&L'],
-                ['positions', 'Positions'],
-              ] as const
-            ).map(([key, label]) => (
-              <button
-                key={key}
-                onClick={() => handleTabChange(key)}
-                className={`relative flex-1 py-3 text-center font-medium text-sm transition-colors ${
-                  activeTab === key
-                    ? 'text-foreground'
-                    : 'text-muted-foreground hover:text-foreground'
-                }`}
-              >
-                {label}
-                {activeTab === key && (
-                  <div className="absolute inset-x-0 bottom-0 h-0.5 bg-[#1a365d]" />
-                )}
-              </button>
-            ))}
+          <div className="flex items-center border-border border-b">
+            <div className="flex flex-1">
+              {(
+                [
+                  ['balance', 'Balance'],
+                  ['pnl', 'P&L'],
+                  ['positions', 'Positions'],
+                ] as const
+              ).map(([key, label]) => (
+                <button
+                  key={key}
+                  onClick={() => handleTabChange(key)}
+                  className={`relative flex-1 py-3 text-center font-medium text-sm transition-colors ${
+                    activeTab === key
+                      ? 'text-foreground'
+                      : 'text-muted-foreground hover:text-foreground'
+                  }`}
+                >
+                  {label}
+                  {activeTab === key && (
+                    <div className="absolute inset-x-0 bottom-0 h-0.5 bg-[#1a365d]" />
+                  )}
+                </button>
+              ))}
+            </div>
+            <button
+              onClick={() => setShowBuyPoints(true)}
+              className="mr-3 flex shrink-0 items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 font-medium text-primary-foreground text-xs transition-colors hover:bg-primary/90"
+            >
+              <Sparkles className="h-3.5 w-3.5" />
+              Buy Points
+            </button>
           </div>
 
           {/* Tab Content */}
@@ -144,6 +163,17 @@ export default function WalletPage() {
         {/* Same sidebar as feed/notifications — search, portfolio, positions, news, trending, markets */}
         <WidgetSidebar showPositions />
       </div>
+
+      {showBuyPoints && (
+        <BuyPointsModal
+          isOpen={showBuyPoints}
+          onClose={() => setShowBuyPoints(false)}
+          onSuccess={() => {
+            invalidateWalletBalance();
+            window.dispatchEvent(new CustomEvent('rewards-updated'));
+          }}
+        />
+      )}
     </PageContainer>
   );
 }

--- a/apps/web/src/components/profile/LinkSocialAccountsModal.tsx
+++ b/apps/web/src/components/profile/LinkSocialAccountsModal.tsx
@@ -9,6 +9,7 @@ import {
   isLinkEmailAlreadyLinkedError,
   isLinkEmailFlowCancellationError,
 } from '@/components/profile/link-email-utils';
+import { useTelegramMiniApp } from '@/components/providers/TelegramMiniAppProvider';
 import { useAuth } from '@/hooks/useAuth';
 import { getAuthToken } from '@/lib/auth';
 import { useAuthStore } from '@/stores/authStore';
@@ -51,8 +52,10 @@ export function LinkSocialAccountsModal({
   onClose,
 }: LinkSocialAccountsModalProps) {
   const { user, setUser } = useAuthStore();
-  const { user: privyUser } = usePrivy();
+  const { user: privyUser, linkTelegram: privyLinkTelegram } = usePrivy();
   const { refresh } = useAuth();
+  const { isMiniApp, linkAccount: linkTelegramSeamless } =
+    useTelegramMiniApp();
   const [linking, setLinking] = useState<string | null>(null);
   const [confirmUnlinkTwitter, setConfirmUnlinkTwitter] = useState(false);
   const [unlinkingTwitter, setUnlinkingTwitter] = useState(false);
@@ -164,6 +167,27 @@ export function LinkSocialAccountsModal({
     if (!user?.id) return;
     setLinking('farcaster');
     linkFarcaster();
+  };
+
+  const handleTelegramLink = () => {
+    if (!user?.id) return;
+    setLinking('telegram');
+
+    if (isMiniApp) {
+      // Inside Telegram MiniApp — use captured initData for seamless linking.
+      const started = linkTelegramSeamless();
+      if (started) {
+        toast.success('Telegram account linked!');
+        void refresh();
+        onClose();
+      } else {
+        setLinking(null);
+        toast.error('Unable to link Telegram. Please try again.');
+      }
+    } else {
+      // Outside Telegram — use Privy's standard link flow (shows modal).
+      privyLinkTelegram();
+    }
   };
 
   return (
@@ -415,6 +439,73 @@ export function LinkSocialAccountsModal({
                     <>
                       <Shield className="h-4 w-4" />
                       <span>Sign in with Farcaster</span>
+                    </>
+                  )}
+                </button>
+              </div>
+            )}
+          </div>
+
+          {/* Telegram */}
+          <div className="space-y-3">
+            <div className="flex items-center gap-2">
+              <svg className="h-5 w-5" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.479.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z" />
+              </svg>
+              <h3 className="font-semibold">Telegram</h3>
+              {user?.hasTelegram && (
+                <span className="ml-auto flex items-center gap-1 text-green-500 text-sm">
+                  <Check className="h-4 w-4" />
+                  Verified
+                </span>
+              )}
+            </div>
+
+            {user?.hasTelegram ? (
+              <div className="flex items-center gap-2 rounded-lg border border-green-500/20 bg-green-500/10 p-3">
+                <Check className="h-4 w-4 text-green-500" />
+                <span className="font-medium text-sm">
+                  {user.telegramUsername
+                    ? `@${user.telegramUsername}`
+                    : 'Connected'}
+                </span>
+                {user.telegramUsername && (
+                  <a
+                    href={`https://t.me/${user.telegramUsername}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="ml-auto text-primary hover:text-primary/80"
+                  >
+                    <ExternalLink className="h-4 w-4" />
+                  </a>
+                )}
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <div className="flex items-start gap-2 rounded-lg border border-sky-500/20 bg-sky-500/10 p-3">
+                  <Shield className="mt-0.5 h-4 w-4 shrink-0 text-sky-500" />
+                  <p className="text-muted-foreground text-xs">
+                    {isMiniApp
+                      ? 'Link your Telegram account to earn points and unlock rewards.'
+                      : 'Open Babylon in Telegram to seamlessly link your account, or connect via Privy.'}
+                  </p>
+                </div>
+                <button
+                  onClick={handleTelegramLink}
+                  disabled={linking === 'telegram'}
+                  className={cn(
+                    'w-full rounded-lg px-4 py-2 font-semibold transition-colors',
+                    'bg-[#229ED9] text-white hover:bg-[#1d8abf]',
+                    'disabled:cursor-not-allowed disabled:opacity-50',
+                    'flex items-center justify-center gap-2'
+                  )}
+                >
+                  {linking === 'telegram' ? (
+                    <span>Connecting...</span>
+                  ) : (
+                    <>
+                      <Shield className="h-4 w-4" />
+                      <span>Link Telegram</span>
                     </>
                   )}
                 </button>

--- a/apps/web/src/components/profile/LinkSocialAccountsModal.tsx
+++ b/apps/web/src/components/profile/LinkSocialAccountsModal.tsx
@@ -73,6 +73,8 @@ export function LinkSocialAccountsModal({
       const linkedType = String(linkedAccount.type);
       if (linkedType === 'farcaster' || linkedType === 'farcaster_account') {
         toast.success('Farcaster account linked successfully!');
+      } else if (linkedType === 'telegram') {
+        toast.success('Telegram account linked!');
       } else {
         toast.success('Email linked successfully');
       }
@@ -174,17 +176,15 @@ export function LinkSocialAccountsModal({
 
     if (isMiniApp) {
       // Inside Telegram MiniApp — use captured initData for seamless linking.
+      // Success/error handled by useLinkAccount onSuccess/onError callbacks.
       const started = linkTelegramSeamless();
-      if (started) {
-        toast.success('Telegram account linked!');
-        void refresh();
-        onClose();
-      } else {
+      if (!started) {
         setLinking(null);
         toast.error('Unable to link Telegram. Please try again.');
       }
     } else {
       // Outside Telegram — use Privy's standard link flow (shows modal).
+      // Success/error handled by useLinkAccount onSuccess/onError callbacks.
       privyLinkTelegram();
     }
   };

--- a/apps/web/src/components/profile/LinkSocialAccountsModal.tsx
+++ b/apps/web/src/components/profile/LinkSocialAccountsModal.tsx
@@ -54,8 +54,7 @@ export function LinkSocialAccountsModal({
   const { user, setUser } = useAuthStore();
   const { user: privyUser, linkTelegram: privyLinkTelegram } = usePrivy();
   const { refresh } = useAuth();
-  const { isMiniApp, linkAccount: linkTelegramSeamless } =
-    useTelegramMiniApp();
+  const { isMiniApp, linkAccount: linkTelegramSeamless } = useTelegramMiniApp();
   const [linking, setLinking] = useState<string | null>(null);
   const [confirmUnlinkTwitter, setConfirmUnlinkTwitter] = useState(false);
   const [unlinkingTwitter, setUnlinkingTwitter] = useState(false);

--- a/apps/web/src/components/providers/TelegramMiniAppProvider.tsx
+++ b/apps/web/src/components/providers/TelegramMiniAppProvider.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { logger } from '@babylon/shared';
-import { usePrivy } from '@privy-io/react-auth';
+import { useLoginWithTelegram, usePrivy } from '@privy-io/react-auth';
 import { createContext, useContext, useEffect, useRef, useState } from 'react';
 
 /**
@@ -80,11 +80,34 @@ export function TelegramMiniAppProvider({
 
   const hasInitialized = useRef(false);
   const hasAttemptedLogin = useRef(false);
+  const hasAttemptedLink = useRef(false);
 
   // Keep a ref to the dynamically loaded SDK module so actions can use it.
   const sdkRef = useRef<typeof import('@telegram-apps/sdk-react') | null>(null);
+  // Store raw initData for seamless Telegram account linking via Privy's
+  // linkTelegram. Privy treats initData as expired after 5 minutes, so we
+  // capture it during initialization and use it promptly.
+  const initDataRawRef = useRef<string | null>(null);
 
-  const { login, ready, authenticated } = usePrivy();
+  const { ready, authenticated, user: privyAuthUser, linkTelegram } = usePrivy();
+
+  const { login: loginWithTelegram } = useLoginWithTelegram({
+    onComplete: ({ user, isNewUser }) => {
+      logger.info(
+        'Telegram seamless auth completed',
+        { userId: user.id, isNewUser },
+        'TelegramMiniApp'
+      );
+    },
+    onError: (error) => {
+      logger.error(
+        'Telegram seamless auth failed',
+        { error: String(error) },
+        'TelegramMiniApp'
+      );
+      setError('Telegram authentication failed. Please refresh to try again.');
+    },
+  });
 
   // ── Detect & Initialize ──────────────────────────────────────────────────
 
@@ -157,6 +180,9 @@ export function TelegramMiniAppProvider({
         const rawInitData = (lp as Record<string, unknown>).tgWebAppDataRaw as
           | string
           | undefined;
+
+        // Capture raw initData for Privy's linkTelegram (seamless account linking).
+        initDataRawRef.current = rawInitData ?? null;
 
         let userValidated = false;
 
@@ -263,7 +289,7 @@ export function TelegramMiniAppProvider({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // ── Auto-login via Privy ─────────────────────────────────────────────────
+  // ── Seamless auto-login via Privy ──────────────────────────────────────────
 
   useEffect(() => {
     if (!isMiniApp || !ready || authenticated || isLoading) return;
@@ -271,31 +297,51 @@ export function TelegramMiniAppProvider({
     hasAttemptedLogin.current = true;
 
     logger.info(
-      'Attempting Telegram Mini App auto-login via Privy',
+      'Attempting Telegram Mini App seamless auth via Privy',
       { telegramUserId: telegramUser?.id },
       'TelegramMiniApp'
     );
 
-    // Trigger Privy's login modal. Because we're inside the Telegram WebView
-    // the Telegram login option is available and will use the existing session.
+    // Use Privy's headless Telegram login — authenticates using the Telegram
+    // initData already present in the WebView environment. No modal is shown.
     //
     // NOTE: We intentionally do NOT reset hasAttemptedLogin on failure.
     // A failed attempt is still an attempt — resetting would cause an infinite
     // retry loop on subsequent re-renders if login consistently fails (e.g.
     // network error, Privy misconfiguration). Users can manually retry by
     // refreshing the Mini App.
-    try {
-      login();
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      logger.error(
-        'Telegram Mini App auto-login failed',
-        { error: message },
-        'TelegramMiniApp'
-      );
-      setError(message);
-    }
-  }, [isMiniApp, ready, authenticated, isLoading, login, telegramUser?.id]);
+    //
+    // Error handling: onError (hook config) sets the user-facing error state.
+    // This .catch() only prevents unhandled promise rejections.
+    loginWithTelegram().catch(() => {
+      // Handled by onError callback above.
+    });
+  }, [isMiniApp, ready, authenticated, isLoading, loginWithTelegram, telegramUser?.id]);
+
+  // ── Seamless Telegram account linking ────────────────────────────────────
+  // For users who are already authenticated (e.g. logged in via email/wallet
+  // on desktop, then opened the MiniApp): silently link their Telegram
+  // identity to their existing Privy account using the MiniApp's initData.
+  // This enables the server-side identity sync to pick up the Telegram link.
+
+  useEffect(() => {
+    if (!isMiniApp || !ready || !authenticated || isLoading) return;
+    // Skip if Privy account already has Telegram linked.
+    if (privyAuthUser?.telegram) return;
+    if (!initDataRawRef.current) return;
+    if (hasAttemptedLink.current) return;
+    hasAttemptedLink.current = true;
+
+    logger.info(
+      'Linking Telegram to existing Privy account',
+      { telegramUserId: telegramUser?.id },
+      'TelegramMiniApp'
+    );
+
+    // linkTelegram is fire-and-forget (returns void). Privy updates the user
+    // object on success, which triggers identity sync via useAuth.
+    linkTelegram({ launchParams: { initDataRaw: initDataRawRef.current } });
+  }, [isMiniApp, ready, authenticated, isLoading, privyAuthUser?.telegram, linkTelegram, telegramUser?.id]);
 
   // ── Back button ──────────────────────────────────────────────────────────
 

--- a/apps/web/src/components/providers/TelegramMiniAppProvider.tsx
+++ b/apps/web/src/components/providers/TelegramMiniAppProvider.tsx
@@ -37,6 +37,14 @@ interface TelegramMiniAppContextType {
   share: (url: string, text?: string) => void;
   /** Close the Telegram Mini App. */
   close: () => void;
+  /**
+   * Link the current user's Privy account to their Telegram identity.
+   * Uses the captured initData from the MiniApp environment for seamless
+   * linking (no modal). Only available when running inside Telegram.
+   * Returns false if linking is not possible (not in MiniApp, no initData,
+   * or Telegram already linked).
+   */
+  linkAccount: () => boolean;
 }
 
 const TelegramMiniAppContext = createContext<TelegramMiniAppContextType | null>(
@@ -80,7 +88,6 @@ export function TelegramMiniAppProvider({
 
   const hasInitialized = useRef(false);
   const hasAttemptedLogin = useRef(false);
-  const hasAttemptedLink = useRef(false);
 
   // Keep a ref to the dynamically loaded SDK module so actions can use it.
   const sdkRef = useRef<typeof import('@telegram-apps/sdk-react') | null>(null);
@@ -330,39 +337,6 @@ export function TelegramMiniAppProvider({
     telegramUser?.id,
   ]);
 
-  // ── Seamless Telegram account linking ────────────────────────────────────
-  // For users who are already authenticated (e.g. logged in via email/wallet
-  // on desktop, then opened the MiniApp): silently link their Telegram
-  // identity to their existing Privy account using the MiniApp's initData.
-  // This enables the server-side identity sync to pick up the Telegram link.
-
-  useEffect(() => {
-    if (!isMiniApp || !ready || !authenticated || isLoading) return;
-    // Skip if Privy account already has Telegram linked.
-    if (privyAuthUser?.telegram) return;
-    if (!initDataRawRef.current) return;
-    if (hasAttemptedLink.current) return;
-    hasAttemptedLink.current = true;
-
-    logger.info(
-      'Linking Telegram to existing Privy account',
-      { telegramUserId: telegramUser?.id },
-      'TelegramMiniApp'
-    );
-
-    // linkTelegram is fire-and-forget (returns void). Privy updates the user
-    // object on success, which triggers identity sync via useAuth.
-    linkTelegram({ launchParams: { initDataRaw: initDataRawRef.current } });
-  }, [
-    isMiniApp,
-    ready,
-    authenticated,
-    isLoading,
-    privyAuthUser?.telegram,
-    linkTelegram,
-    telegramUser?.id,
-  ]);
-
   // ── Back button ──────────────────────────────────────────────────────────
 
   useEffect(() => {
@@ -429,6 +403,20 @@ export function TelegramMiniAppProvider({
     if (sdk.miniApp.close.isAvailable()) sdk.miniApp.close();
   };
 
+  const linkAccount = (): boolean => {
+    if (!isMiniApp || !initDataRawRef.current) return false;
+    if (privyAuthUser?.telegram) return false;
+
+    logger.info(
+      'User-initiated Telegram account linking',
+      { telegramUserId: telegramUser?.id },
+      'TelegramMiniApp'
+    );
+
+    linkTelegram({ launchParams: { initDataRaw: initDataRawRef.current } });
+    return true;
+  };
+
   // ── Context ──────────────────────────────────────────────────────────────
 
   const value: TelegramMiniAppContextType = {
@@ -438,6 +426,7 @@ export function TelegramMiniAppProvider({
     user: telegramUser,
     share,
     close,
+    linkAccount,
   };
 
   return (

--- a/apps/web/src/components/providers/TelegramMiniAppProvider.tsx
+++ b/apps/web/src/components/providers/TelegramMiniAppProvider.tsx
@@ -89,7 +89,12 @@ export function TelegramMiniAppProvider({
   // capture it during initialization and use it promptly.
   const initDataRawRef = useRef<string | null>(null);
 
-  const { ready, authenticated, user: privyAuthUser, linkTelegram } = usePrivy();
+  const {
+    ready,
+    authenticated,
+    user: privyAuthUser,
+    linkTelegram,
+  } = usePrivy();
 
   const { login: loginWithTelegram } = useLoginWithTelegram({
     onComplete: ({ user, isNewUser }) => {
@@ -316,7 +321,14 @@ export function TelegramMiniAppProvider({
     loginWithTelegram().catch(() => {
       // Handled by onError callback above.
     });
-  }, [isMiniApp, ready, authenticated, isLoading, loginWithTelegram, telegramUser?.id]);
+  }, [
+    isMiniApp,
+    ready,
+    authenticated,
+    isLoading,
+    loginWithTelegram,
+    telegramUser?.id,
+  ]);
 
   // ── Seamless Telegram account linking ────────────────────────────────────
   // For users who are already authenticated (e.g. logged in via email/wallet
@@ -341,7 +353,15 @@ export function TelegramMiniAppProvider({
     // linkTelegram is fire-and-forget (returns void). Privy updates the user
     // object on success, which triggers identity sync via useAuth.
     linkTelegram({ launchParams: { initDataRaw: initDataRawRef.current } });
-  }, [isMiniApp, ready, authenticated, isLoading, privyAuthUser?.telegram, linkTelegram, telegramUser?.id]);
+  }, [
+    isMiniApp,
+    ready,
+    authenticated,
+    isLoading,
+    privyAuthUser?.telegram,
+    linkTelegram,
+    telegramUser?.id,
+  ]);
 
   // ── Back button ──────────────────────────────────────────────────────────
 

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -239,7 +239,8 @@ export function useAuth(): UseAuthReturn {
           (!!verifiedPrivyEmail &&
             (!currentUser?.email || !currentUser?.emailVerified)) ||
           (!!privyUser.farcaster && !currentUser?.hasFarcaster) ||
-          (!!privyUser.twitter && !currentUser?.hasTwitter);
+          (!!privyUser.twitter && !currentUser?.hasTwitter) ||
+          (!!privyUser.telegram && !currentUser?.hasTelegram);
 
         const response = await apiFetch(url, {
           headers: shouldForcePrivyIdentitySync
@@ -312,6 +313,7 @@ export function useAuth(): UseAuthReturn {
             hasFarcaster: me.user.hasFarcaster ?? undefined,
             hasTwitter: me.user.hasTwitter ?? undefined,
             hasDiscord: me.user.hasDiscord ?? undefined,
+            hasTelegram: me.user.hasTelegram ?? undefined,
             pointsAwardedForFarcasterFollow:
               me.user.pointsAwardedForFarcasterFollow ?? undefined,
             pointsAwardedForTwitterFollow:
@@ -321,6 +323,7 @@ export function useAuth(): UseAuthReturn {
             farcasterUsername: me.user.farcasterUsername ?? undefined,
             twitterUsername: me.user.twitterUsername ?? undefined,
             discordUsername: me.user.discordUsername ?? undefined,
+            telegramUsername: me.user.telegramUsername ?? undefined,
             showTwitterPublic: me.user.showTwitterPublic ?? undefined,
             showFarcasterPublic: me.user.showFarcasterPublic ?? undefined,
             showWalletPublic: me.user.showWalletPublic ?? undefined,
@@ -368,6 +371,7 @@ export function useAuth(): UseAuthReturn {
             currentUser.hasFarcaster !== hydratedUser.hasFarcaster ||
             currentUser.hasTwitter !== hydratedUser.hasTwitter ||
             currentUser.hasDiscord !== hydratedUser.hasDiscord ||
+            currentUser.hasTelegram !== hydratedUser.hasTelegram ||
             currentUser.pointsAwardedForFarcasterFollow !==
               hydratedUser.pointsAwardedForFarcasterFollow ||
             currentUser.pointsAwardedForTwitterFollow !==
@@ -377,6 +381,7 @@ export function useAuth(): UseAuthReturn {
             currentUser.farcasterUsername !== hydratedUser.farcasterUsername ||
             currentUser.twitterUsername !== hydratedUser.twitterUsername ||
             currentUser.discordUsername !== hydratedUser.discordUsername ||
+            currentUser.telegramUsername !== hydratedUser.telegramUsername ||
             currentUser.isAdmin !== hydratedUser.isAdmin ||
             currentUser.isActor !== hydratedUser.isActor ||
             currentUser.isBanned !== hydratedUser.isBanned ||

--- a/apps/web/src/lib/auth/privyIdentitySync.test.ts
+++ b/apps/web/src/lib/auth/privyIdentitySync.test.ts
@@ -18,6 +18,8 @@ describe('privyIdentitySync', () => {
       farcasterFid: '12345',
       twitterUsername: 'alice_x',
       twitterId: 'tw_123',
+      telegramUserId: null,
+      telegramUsername: null,
     });
   });
 
@@ -30,6 +32,8 @@ describe('privyIdentitySync', () => {
       farcasterFid: null,
       twitterUsername: null,
       twitterId: null,
+      telegramUserId: null,
+      telegramUsername: null,
     });
   });
 
@@ -52,6 +56,7 @@ describe('privyIdentitySync', () => {
       shouldSyncMissingPrivyIdentity({
         hasFarcaster: false,
         hasTwitter: true,
+        hasTelegram: true,
         email: 'a@example.com',
         emailVerified: true,
       })
@@ -61,6 +66,7 @@ describe('privyIdentitySync', () => {
       shouldSyncMissingPrivyIdentity({
         hasFarcaster: true,
         hasTwitter: true,
+        hasTelegram: true,
         email: null,
         emailVerified: false,
       })
@@ -72,6 +78,7 @@ describe('privyIdentitySync', () => {
       shouldSyncMissingPrivyIdentity({
         hasFarcaster: true,
         hasTwitter: true,
+        hasTelegram: true,
         email: 'a@example.com',
         emailVerified: true,
       })

--- a/apps/web/src/lib/auth/privyIdentitySync.ts
+++ b/apps/web/src/lib/auth/privyIdentitySync.ts
@@ -7,18 +7,21 @@ export type PrivyIdentitySnapshot = {
   farcasterFid: string | null;
   twitterUsername: string | null;
   twitterId: string | null;
+  telegramUserId: string | null;
+  telegramUsername: string | null;
 };
 
 export type UserIdentitySyncState = {
   hasFarcaster: boolean;
   hasTwitter: boolean;
+  hasTelegram: boolean;
   email: string | null;
   emailVerified: boolean;
 };
 
 type PrivyIdentityUserLike = Pick<
   PrivyUser,
-  'email' | 'farcaster' | 'twitter' | 'linkedAccounts'
+  'email' | 'farcaster' | 'twitter' | 'telegram' | 'linkedAccounts'
 >;
 
 export function extractPrivyIdentitySnapshot(
@@ -32,6 +35,8 @@ export function extractPrivyIdentitySnapshot(
       : null,
     twitterUsername: privyUser.twitter?.username ?? null,
     twitterId: privyUser.twitter?.subject ?? null,
+    telegramUserId: privyUser.telegram?.telegramUserId ?? null,
+    telegramUsername: privyUser.telegram?.username ?? null,
   };
 }
 
@@ -39,6 +44,10 @@ export function shouldSyncMissingPrivyIdentity(
   user: UserIdentitySyncState
 ): boolean {
   return (
-    !user.hasFarcaster || !user.hasTwitter || !user.email || !user.emailVerified
+    !user.hasFarcaster ||
+    !user.hasTwitter ||
+    !user.hasTelegram ||
+    !user.email ||
+    !user.emailVerified
   );
 }

--- a/apps/web/src/stores/authStore.ts
+++ b/apps/web/src/stores/authStore.ts
@@ -45,6 +45,7 @@ export interface User {
   hasFarcaster?: boolean;
   hasTwitter?: boolean;
   hasDiscord?: boolean;
+  hasTelegram?: boolean;
   pointsAwardedForEmail?: boolean;
   pointsAwardedForFarcasterFollow?: boolean;
   pointsAwardedForTwitterFollow?: boolean;
@@ -52,6 +53,7 @@ export interface User {
   farcasterUsername?: string;
   twitterUsername?: string;
   discordUsername?: string;
+  telegramUsername?: string;
   showTwitterPublic?: boolean;
   showFarcasterPublic?: boolean;
   showWalletPublic?: boolean;

--- a/bun.lock
+++ b/bun.lock
@@ -152,6 +152,7 @@
         "ethers": "^6.16.0",
         "framer-motion": "^12.23.25",
         "geist": "^1.5.1",
+        "grammy": "^1.41.1",
         "html-to-image": "^1.11.13",
         "ioredis": "^5.8.2",
         "lucide-react": "^0.555.0",
@@ -1022,6 +1023,8 @@
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
 
     "@gemini-wallet/core": ["@gemini-wallet/core@0.3.2", "", { "dependencies": { "@metamask/rpc-errors": "7.0.2", "eventemitter3": "5.0.1" }, "peerDependencies": { "viem": ">=2.0.0" } }, "sha512-Z4aHi3ECFf5oWYWM3F1rW83GJfB9OvhBYPTmb5q+VyK3uvzvS48lwo+jwh2eOoCRWEuT/crpb9Vwp2QaS5JqgQ=="],
+
+    "@grammyjs/types": ["@grammyjs/types@3.25.0", "", {}, "sha512-iN9i5p+8ZOu9OMxWNcguojQfz4K/PDyMPOnL7PPCON+SoA/F8OKMH3uR7CVUkYfdNe0GCz8QOzAWrnqusQYFOg=="],
 
     "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
 
@@ -3434,6 +3437,8 @@
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "gradient-string": ["gradient-string@2.0.2", "", { "dependencies": { "chalk": "^4.1.2", "tinygradient": "^1.1.5" } }, "sha512-rEDCuqUQ4tbD78TpzsMtt5OIf0cBCSDWSJtUDaF6JsAh+k0v9r++NzxNEG87oDZx9ZwGhD8DaezR2L/yrw0Jdw=="],
+
+    "grammy": ["grammy@1.41.1", "", { "dependencies": { "@grammyjs/types": "3.25.0", "abort-controller": "^3.0.0", "debug": "^4.4.3", "node-fetch": "^2.7.0" } }, "sha512-wcHAQ1e7svL3fJMpDchcQVcWUmywhuepOOjHUHmMmWAwUJEIyK5ea5sbSjZd+Gy1aMpZeP8VYJa+4tP+j1YptQ=="],
 
     "graphql": ["graphql@16.12.0", "", {}, "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ=="],
 

--- a/packages/api/src/services/points-service.ts
+++ b/packages/api/src/services/points-service.ts
@@ -125,6 +125,7 @@ export class PointsService {
         pointsAwardedForShare: users.pointsAwardedForShare,
         pointsAwardedForPrivateGroup: users.pointsAwardedForPrivateGroup,
         pointsAwardedForPrivateChannel: users.pointsAwardedForPrivateChannel,
+        pointsAwardedForTelegram: users.pointsAwardedForTelegram,
       })
       .from(users)
       .where(eq(users.id, userId))
@@ -172,6 +173,7 @@ export class PointsService {
       pointsAwardedForShare: boolean;
       pointsAwardedForPrivateGroup: boolean;
       pointsAwardedForPrivateChannel: boolean;
+      pointsAwardedForTelegram: boolean;
     }> = {
       reputationPoints: pointsAfter,
     };
@@ -208,6 +210,10 @@ export class PointsService {
       case 'discord_join':
         updateData.bonusPoints = user.bonusPoints + amount;
         updateData.pointsAwardedForDiscordJoin = true;
+        break;
+      case 'telegram_link':
+        updateData.bonusPoints = user.bonusPoints + amount;
+        updateData.pointsAwardedForTelegram = true;
         break;
       case 'wallet_connect':
         updateData.bonusPoints = user.bonusPoints + amount;
@@ -1310,6 +1316,7 @@ export class PointsService {
       pointsAwardedForWallet: boolean;
       pointsAwardedForReferralBonus: boolean;
       pointsAwardedForShare: boolean;
+      pointsAwardedForTelegram: boolean;
     },
     reason: PointsReason
   ): boolean {
@@ -1328,6 +1335,8 @@ export class PointsService {
         return user.pointsAwardedForDiscord;
       case 'discord_join':
         return user.pointsAwardedForDiscordJoin;
+      case 'telegram_link':
+        return user.pointsAwardedForTelegram;
       case 'wallet_connect':
         return user.pointsAwardedForWallet;
       case 'referral_bonus':

--- a/packages/api/src/services/points-service.ts
+++ b/packages/api/src/services/points-service.ts
@@ -351,6 +351,18 @@ export class PointsService {
     );
   }
 
+  static async awardTelegramLink(
+    userId: string,
+    telegramUsername?: string
+  ): Promise<AwardPointsResult> {
+    return PointsService.awardPoints(
+      userId,
+      POINTS.TELEGRAM_LINK,
+      'telegram_link',
+      telegramUsername ? { telegramUsername } : undefined
+    );
+  }
+
   /**
    * Award points for Twitter link
    */

--- a/packages/db/drizzle/migrations/0059_add_telegram_fields.sql
+++ b/packages/db/drizzle/migrations/0059_add_telegram_fields.sql
@@ -1,0 +1,11 @@
+-- Add Telegram identity fields to the User table
+-- Follows the same pattern as Discord (discordId, discordUsername, hasDiscord, pointsAwardedForDiscord)
+
+ALTER TABLE "User" ADD COLUMN "hasTelegram" boolean NOT NULL DEFAULT false;
+ALTER TABLE "User" ADD COLUMN "pointsAwardedForTelegram" boolean NOT NULL DEFAULT false;
+ALTER TABLE "User" ADD COLUMN "telegramId" text;
+ALTER TABLE "User" ADD COLUMN "telegramUsername" text;
+ALTER TABLE "User" ADD COLUMN "telegramVerifiedAt" timestamp;
+
+-- Add unique constraint on telegramId (prevents duplicate Telegram accounts)
+ALTER TABLE "User" ADD CONSTRAINT "User_telegramId_unique" UNIQUE("telegramId");

--- a/packages/db/drizzle/migrations/meta/_journal.json
+++ b/packages/db/drizzle/migrations/meta/_journal.json
@@ -400,6 +400,13 @@
       "when": 1774000000000,
       "tag": "0057_add_trading_fee_outbox",
       "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1774100000000,
+      "tag": "0059_add_telegram_fields",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/drizzle/migrations/meta/_journal.json
+++ b/packages/db/drizzle/migrations/meta/_journal.json
@@ -404,6 +404,13 @@
     {
       "idx": 57,
       "version": "7",
+      "when": 1774050000000,
+      "tag": "0058_add_user_pnl_snapshots",
+      "breakpoints": true
+    },
+    {
+      "idx": 58,
+      "version": "7",
       "when": 1774100000000,
       "tag": "0059_add_telegram_fields",
       "breakpoints": true

--- a/packages/db/src/schema/users.ts
+++ b/packages/db/src/schema/users.ts
@@ -142,6 +142,7 @@ export const users = pgTable(
     hasFarcaster: boolean('hasFarcaster').notNull().default(false),
     hasTwitter: boolean('hasTwitter').notNull().default(false),
     hasDiscord: boolean('hasDiscord').notNull().default(false),
+    hasTelegram: boolean('hasTelegram').notNull().default(false),
     nftTokenId: integer('nftTokenId').unique(),
     onChainRegistered: boolean('onChainRegistered').notNull().default(false),
     pointsAwardedForFarcaster: boolean('pointsAwardedForFarcaster')
@@ -166,6 +167,9 @@ export const users = pgTable(
       .notNull()
       .default(false),
     pointsAwardedForDiscordJoin: boolean('pointsAwardedForDiscordJoin')
+      .notNull()
+      .default(false),
+    pointsAwardedForTelegram: boolean('pointsAwardedForTelegram')
       .notNull()
       .default(false),
     pointsAwardedForUsername: boolean('pointsAwardedForUsername')
@@ -257,6 +261,9 @@ export const users = pgTable(
     discordRefreshToken: text('discordRefreshToken'),
     discordTokenExpiresAt: timestamp('discordTokenExpiresAt', { mode: 'date' }),
     discordVerifiedAt: timestamp('discordVerifiedAt', { mode: 'date' }),
+    telegramId: text('telegramId').unique(),
+    telegramUsername: text('telegramUsername'),
+    telegramVerifiedAt: timestamp('telegramVerifiedAt', { mode: 'date' }),
     tosAccepted: boolean('tosAccepted').notNull().default(false),
     tosAcceptedAt: timestamp('tosAcceptedAt', { mode: 'date' }),
     tosAcceptedVersion: text('tosAcceptedVersion').default('2025-11-11'),

--- a/packages/shared/src/auth/privy-config.ts
+++ b/packages/shared/src/auth/privy-config.ts
@@ -53,11 +53,10 @@ const appearance: Appearance = {
 export const loginMethodsAndOrder: NonNullable<
   BabylonPrivyConfig['loginMethodsAndOrder']
 > = {
-  primary: ['twitter', 'phantom', 'farcaster', 'email'],
+  primary: ['telegram', 'twitter', 'phantom', 'farcaster', 'email'],
   overflow: [
     'metamask',
     'discord',
-    'telegram',
     'rabby_wallet',
     'coinbase_wallet',
     'rainbow',

--- a/packages/shared/src/constants/points.ts
+++ b/packages/shared/src/constants/points.ts
@@ -22,6 +22,7 @@ export const POINTS = {
   TWITTER_FOLLOW: 100, // Follow Babylon on Twitter/X
   DISCORD_LINK: 300, // Link Discord account
   DISCORD_JOIN: 100, // Join Babylon Discord server
+  TELEGRAM_LINK: 300, // Link Telegram account
   WALLET_CONNECT: 300,
   EMAIL_SUBMIT: 100,
   SHARE_ACTION: 500,
@@ -81,6 +82,7 @@ export type PointsReason =
   | 'twitter_follow'
   | 'discord_link'
   | 'discord_join'
+  | 'telegram_link'
   | 'wallet_connect'
   | 'share_action'
   | 'share_to_twitter'

--- a/scripts/register-telegram-webhook.ts
+++ b/scripts/register-telegram-webhook.ts
@@ -1,0 +1,67 @@
+/**
+ * Register Telegram Bot Webhook
+ *
+ * One-time setup script to register the bot's webhook URL with Telegram
+ * and set the bot's command menu.
+ *
+ * Usage:
+ *   bun scripts/register-telegram-webhook.ts
+ *
+ * Required env vars:
+ *   TELEGRAM_BOT_TOKEN       — Bot token from @BotFather
+ *   TELEGRAM_WEBHOOK_SECRET  — Random string for webhook signature verification
+ *
+ * Optional env vars:
+ *   WEBHOOK_URL              — Override webhook URL (defaults to babylon.market)
+ */
+
+import { Bot } from 'grammy';
+
+const token = process.env.TELEGRAM_BOT_TOKEN;
+const secret = process.env.TELEGRAM_WEBHOOK_SECRET;
+const webhookUrl =
+  process.env.WEBHOOK_URL || 'https://babylon.market/api/telegram/webhook';
+
+if (!token) {
+  console.error('TELEGRAM_BOT_TOKEN is required');
+  process.exit(1);
+}
+
+if (!secret) {
+  console.error('TELEGRAM_WEBHOOK_SECRET is required');
+  process.exit(1);
+}
+
+const bot = new Bot(token);
+
+async function register() {
+  // Set the webhook URL with secret token verification
+  await bot.api.setWebhook(webhookUrl, {
+    secret_token: secret,
+    allowed_updates: ['message'],
+    drop_pending_updates: true,
+  });
+  console.log(`Webhook registered: ${webhookUrl}`);
+
+  // Set the bot's command menu (shown in Telegram's command picker)
+  await bot.api.setMyCommands([
+    { command: 'start', description: 'Open Babylon' },
+    { command: 'help', description: 'How to use this bot' },
+  ]);
+  console.log('Bot commands registered');
+
+  // Verify the webhook info
+  const info = await bot.api.getWebhookInfo();
+  console.log('Webhook info:', {
+    url: info.url,
+    hasCustomCertificate: info.has_custom_certificate,
+    pendingUpdateCount: info.pending_update_count,
+    maxConnections: info.max_connections,
+    allowedUpdates: info.allowed_updates,
+  });
+}
+
+register().catch((err) => {
+  console.error('Failed to register webhook:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **Seamless auto-authentication**: Users opening Babylon from Telegram are authenticated automatically — no login modal. Uses Privy's headless `useLoginWithTelegram` hook with server-side HMAC-SHA-256 initData validation.
- **Identity linking for existing users**: If a user is already logged in (e.g. via email/wallet), their Telegram identity is silently linked to their Privy account via `linkTelegram`.
- **Telegram identity sync**: Telegram userId and username are synced from Privy to the DB, with 300 points awarded for linking.
- **Bot MiniApp launcher**: A lightweight grammY-based bot webhook at `/api/telegram/webhook` responds to `/start` and `/help` with a welcome message and an inline "Open Babylon" button.

## Changes

### Telegram Auto-Auth
- `TelegramMiniAppProvider.tsx` — Replace `login()` with `useLoginWithTelegram`, add `linkTelegram` for already-authenticated users
- `useAuth.ts` — Hydrate `hasTelegram`/`telegramUsername`, trigger identity sync when Telegram is linked in Privy but missing locally
- `privyIdentitySync.ts` — Extract `telegramUserId`/`telegramUsername` from Privy user, include `hasTelegram` in sync check
- `/api/users/me/route.ts` — Sync Telegram fields to DB, award points for Telegram linking
- `authStore.ts` — Add `hasTelegram`, `telegramUsername` to User interface
- `privy-config.ts` — Promote Telegram to first position in login methods

### Database
- `users.ts` schema — Add `hasTelegram`, `telegramId` (unique), `telegramUsername`, `telegramVerifiedAt`, `pointsAwardedForTelegram`
- Migration `0059_add_telegram_fields.sql`

### Points
- `points.ts` — Add `TELEGRAM_LINK: 300` constant and `'telegram_link'` reason type
- `points-service.ts` — Add `awardTelegramLink()` method

### Bot Launcher
- `apps/web/src/app/api/telegram/webhook/route.ts` — grammY webhook handler with `/start`, `/help`, and fallback
- `scripts/register-telegram-webhook.ts` — One-time script to register webhook URL with Telegram
- `apps/web/package.json` — Add `grammy@^1.41.1`
- `.env.example` — Add `TELEGRAM_WEBHOOK_SECRET`

## Post-merge steps

1. Run migration `0059_add_telegram_fields.sql` on production DB
2. Set `TELEGRAM_WEBHOOK_SECRET` env var on Vercel (generate with `openssl rand -hex 32`)
3. Verify Privy Dashboard: Telegram login enabled, seamless auth ON, bot token entered, app domains added
4. Deploy to production
5. Run `WEBHOOK_URL=https://babylon.market/api/telegram/webhook bun scripts/register-telegram-webhook.ts`

## Test plan

- [ ] Open `t.me/PlayBabylonDotMarket_bot/babylon` in Telegram — should auto-authenticate without modal
- [ ] Verify Telegram identity (userId, username) appears in DB after login
- [ ] Verify 300 points awarded for Telegram link
- [ ] Log in via email on desktop, then open MiniApp in Telegram — Telegram should silently link
- [ ] Send `/start` to `@PlayBabylonDotMarket_bot` — should receive welcome message with "Open Babylon" button
- [ ] Send `/help` — should receive help text with button
- [ ] Send random text — should receive redirect message with button
- [ ] Tap "Open Babylon" button — MiniApp opens, seamless auth kicks in