### PR TITLE
fix(web): restore wallet pnl snapshots for production

### DIFF
--- a/apps/web/src/lib/wallet-tabs.test.ts
+++ b/apps/web/src/lib/wallet-tabs.test.ts
@@ -14,13 +14,17 @@ describe('parseWalletTab', () => {
     expect(parseWalletTab('positions')).toBe('positions');
   });
 
+  it('returns pnl for the pnl tab query param', () => {
+    expect(parseWalletTab('pnl')).toBe('pnl');
+  });
+
   it('falls back to the default tab when the query param is missing', () => {
     expect(parseWalletTab(null)).toBe(DEFAULT_WALLET_TAB);
     expect(parseWalletTab(undefined)).toBe(DEFAULT_WALLET_TAB);
   });
 
   it('falls back to the default tab when the query param is invalid', () => {
-    expect(parseWalletTab('pnl')).toBe(DEFAULT_WALLET_TAB);
+    expect(parseWalletTab('not-a-tab')).toBe(DEFAULT_WALLET_TAB);
   });
 });
 
@@ -31,5 +35,9 @@ describe('getWalletTabHref', () => {
 
   it('builds the positions wallet tab URL', () => {
     expect(getWalletTabHref('positions')).toBe('/wallet?tab=positions');
+  });
+
+  it('builds the pnl wallet tab URL', () => {
+    expect(getWalletTabHref('pnl')).toBe('/wallet?tab=pnl');
   });
 });

--- a/apps/web/src/lib/wallet-tabs.ts
+++ b/apps/web/src/lib/wallet-tabs.ts
@@ -1,9 +1,11 @@
-export type WalletTab = 'balance' | 'positions';
+export type WalletTab = 'balance' | 'pnl' | 'positions';
 
 export const DEFAULT_WALLET_TAB: WalletTab = 'positions';
 
 export function parseWalletTab(tab: string | null | undefined): WalletTab {
-  return tab === 'balance' || tab === 'positions' ? tab : DEFAULT_WALLET_TAB;
+  return tab === 'balance' || tab === 'pnl' || tab === 'positions'
+    ? tab
+    : DEFAULT_WALLET_TAB;
 }
 
 export function getWalletTabHref(tab: WalletTab): string {

--- a/apps/web/src/lib/wallet/pnlHistory.ts
+++ b/apps/web/src/lib/wallet/pnlHistory.ts
@@ -198,9 +198,12 @@ export async function loadCurrentUserPnlMetrics(
 ): Promise<Map<string, UserPnlMetrics>> {
   const userFilter =
     targetUserIds && targetUserIds.length > 0
-      ? or(
-          inArray(users.id, targetUserIds),
-          inArray(users.privyId, targetUserIds)
+      ? and(
+          eq(users.isActor, false),
+          or(
+            inArray(users.id, targetUserIds),
+            inArray(users.privyId, targetUserIds)
+          )
         )
       : eq(users.isActor, false);
 

--- a/apps/web/src/lib/wallet/pnlHistory.ts
+++ b/apps/web/src/lib/wallet/pnlHistory.ts
@@ -52,6 +52,19 @@ const TIMEFRAME_DURATIONS: Record<Exclude<PnlHistoryRange, 'ALL'>, number> = {
   '1W': 7 * 24 * 60 * 60 * 1000,
 };
 
+const PNL_SNAPSHOT_INSERT_BATCH_SIZE = 250;
+const PNL_METRIC_QUERY_BATCH_SIZE = 500;
+
+function chunkArray<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+
+  return chunks;
+}
+
 /**
  * Resolve the lower time boundary for a requested history range.
  */
@@ -218,71 +231,76 @@ export async function loadCurrentUserPnlMetrics(
     });
   }
 
-  const perpUnrealizedRows = await db
-    .select({
-      userId: perpPositions.userId,
-      unrealizedPnL: sql<number>`COALESCE(SUM(${perpPositions.unrealizedPnL}), 0)`,
-    })
-    .from(perpPositions)
-    .where(
-      and(
-        inArray(perpPositions.userId, positionUserIds),
-        isNull(perpPositions.closedAt)
+  for (const userIdBatch of chunkArray(
+    positionUserIds,
+    PNL_METRIC_QUERY_BATCH_SIZE
+  )) {
+    const perpUnrealizedRows = await db
+      .select({
+        userId: perpPositions.userId,
+        unrealizedPnL: sql<number>`COALESCE(SUM(${perpPositions.unrealizedPnL}), 0)`,
+      })
+      .from(perpPositions)
+      .where(
+        and(
+          inArray(perpPositions.userId, userIdBatch),
+          isNull(perpPositions.closedAt)
+        )
       )
-    )
-    .groupBy(perpPositions.userId);
+      .groupBy(perpPositions.userId);
 
-  for (const row of perpUnrealizedRows) {
-    const canonicalUserId = aliasToCanonicalUserId.get(row.userId);
-    if (!canonicalUserId) continue;
+    for (const row of perpUnrealizedRows) {
+      const canonicalUserId = aliasToCanonicalUserId.get(row.userId);
+      if (!canonicalUserId) continue;
 
-    const metrics = metricsByUserId.get(canonicalUserId);
-    if (!metrics) continue;
+      const metrics = metricsByUserId.get(canonicalUserId);
+      if (!metrics) continue;
 
-    const unrealizedPnL = toNumber(row.unrealizedPnL);
-    metrics.unrealizedPnL += unrealizedPnL;
-    metrics.currentPnL = metrics.lifetimePnL + metrics.unrealizedPnL;
-  }
+      const unrealizedPnL = toNumber(row.unrealizedPnL);
+      metrics.unrealizedPnL += unrealizedPnL;
+      metrics.currentPnL = metrics.lifetimePnL + metrics.unrealizedPnL;
+    }
 
-  const predictionRows = await db
-    .select({
-      userId: positions.userId,
-      shares: positions.shares,
-      avgPrice: positions.avgPrice,
-      side: positions.side,
-      yesShares: markets.yesShares,
-      noShares: markets.noShares,
-    })
-    .from(positions)
-    .innerJoin(markets, eq(positions.marketId, markets.id))
-    .where(
-      and(
-        inArray(positions.userId, positionUserIds),
-        eq(positions.status, 'active'),
-        eq(markets.resolved, false)
-      )
-    );
+    const predictionRows = await db
+      .select({
+        userId: positions.userId,
+        shares: positions.shares,
+        avgPrice: positions.avgPrice,
+        side: positions.side,
+        yesShares: markets.yesShares,
+        noShares: markets.noShares,
+      })
+      .from(positions)
+      .innerJoin(markets, eq(positions.marketId, markets.id))
+      .where(
+        and(
+          inArray(positions.userId, userIdBatch),
+          eq(positions.status, 'active'),
+          eq(markets.resolved, false)
+        )
+      );
 
-  for (const row of predictionRows) {
-    const canonicalUserId = aliasToCanonicalUserId.get(row.userId);
-    if (!canonicalUserId) continue;
+    for (const row of predictionRows) {
+      const canonicalUserId = aliasToCanonicalUserId.get(row.userId);
+      if (!canonicalUserId) continue;
 
-    const metrics = metricsByUserId.get(canonicalUserId);
-    if (!metrics) continue;
+      const metrics = metricsByUserId.get(canonicalUserId);
+      if (!metrics) continue;
 
-    const snapshot = calculatePredictionPositionSnapshot({
-      shares: toNumber(row.shares),
-      avgPrice: toNumber(row.avgPrice),
-      sideKey: row.side ? 'yes' : 'no',
-      yesShares: toNumber(row.yesShares),
-      noShares: toNumber(row.noShares),
-      feeRate: FEE_CONFIG.TRADING_FEE_RATE,
-      logContext: 'wallet/pnlHistory',
-      onSellPreviewError: options.onPredictionPricingError ?? 'fallback',
-    });
+      const snapshot = calculatePredictionPositionSnapshot({
+        shares: toNumber(row.shares),
+        avgPrice: toNumber(row.avgPrice),
+        sideKey: row.side ? 'yes' : 'no',
+        yesShares: toNumber(row.yesShares),
+        noShares: toNumber(row.noShares),
+        feeRate: FEE_CONFIG.TRADING_FEE_RATE,
+        logContext: 'wallet/pnlHistory',
+        onSellPreviewError: options.onPredictionPricingError ?? 'fallback',
+      });
 
-    metrics.unrealizedPnL += snapshot.unrealizedPnL;
-    metrics.currentPnL = metrics.lifetimePnL + metrics.unrealizedPnL;
+      metrics.unrealizedPnL += snapshot.unrealizedPnL;
+      metrics.currentPnL = metrics.lifetimePnL + metrics.unrealizedPnL;
+    }
   }
 
   return metricsByUserId;
@@ -332,17 +350,48 @@ export async function loadScopedPnlHistoryPoints(params: {
   });
 }
 
+async function loadSnapshotCandidateUserIds(): Promise<string[]> {
+  const [lifetimeRows, perpRows, predictionRows] = await Promise.all([
+    db
+      .select({ userId: users.id })
+      .from(users)
+      .where(and(eq(users.isActor, false), sql`${users.lifetimePnL} <> 0`)),
+    db
+      .selectDistinct({ userId: perpPositions.userId })
+      .from(perpPositions)
+      .where(isNull(perpPositions.closedAt)),
+    db
+      .selectDistinct({ userId: positions.userId })
+      .from(positions)
+      .innerJoin(markets, eq(positions.marketId, markets.id))
+      .where(and(eq(positions.status, 'active'), eq(markets.resolved, false))),
+  ]);
+
+  return Array.from(
+    new Set([
+      ...lifetimeRows.map((row) => row.userId),
+      ...perpRows.map((row) => row.userId),
+      ...predictionRows.map((row) => row.userId),
+    ])
+  );
+}
+
 /**
- * Persist one hourly canonical P&L snapshot row per non-actor user.
+ * Persist one hourly canonical P&L snapshot row per user with active or
+ * historical P&L relevance. Snapshotting every non-actor user does not scale
+ * in production and provides no extra chart value for dormant zero-P&L users.
  */
 export async function snapshotAllUserPnlMetrics(
   snapshotAt: Date
 ): Promise<number> {
   const normalizedSnapshotAt = getHourBoundary(snapshotAt);
-  // This is currently an hourly full snapshot over non-actor users.
-  // If user volume grows materially, split this into batches before widening
-  // the cron workload rather than adding silent partial writes here.
-  const metricsByUserId = await loadCurrentUserPnlMetrics(undefined, {
+  const targetUserIds = await loadSnapshotCandidateUserIds();
+
+  if (targetUserIds.length === 0) {
+    return 0;
+  }
+
+  const metricsByUserId = await loadCurrentUserPnlMetrics(targetUserIds, {
     onPredictionPricingError: 'throw',
   });
   const snapshotRows = Array.from(metricsByUserId.values()).map((metrics) => ({
@@ -358,13 +407,24 @@ export async function snapshotAllUserPnlMetrics(
     return 0;
   }
 
-  const inserted = await db
-    .insert(userPnLSnapshots)
-    .values(snapshotRows)
-    .onConflictDoNothing({
-      target: [userPnLSnapshots.userId, userPnLSnapshots.snapshotAt],
-    })
-    .returning({ id: userPnLSnapshots.id });
+  let insertedCount = 0;
 
-  return inserted.length;
+  for (
+    let i = 0;
+    i < snapshotRows.length;
+    i += PNL_SNAPSHOT_INSERT_BATCH_SIZE
+  ) {
+    const batch = snapshotRows.slice(i, i + PNL_SNAPSHOT_INSERT_BATCH_SIZE);
+    const inserted = await db
+      .insert(userPnLSnapshots)
+      .values(batch)
+      .onConflictDoNothing({
+        target: [userPnLSnapshots.userId, userPnLSnapshots.snapshotAt],
+      })
+      .returning({ id: userPnLSnapshots.id });
+
+    insertedCount += inserted.length;
+  }
+
+  return insertedCount;
 }

--- a/packages/db/drizzle/migrations/meta/_journal.json
+++ b/packages/db/drizzle/migrations/meta/_journal.json
@@ -400,6 +400,13 @@
       "when": 1774000000000,
       "tag": "0057_add_trading_fee_outbox",
       "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "7",
+      "when": 1774036182000,
+      "tag": "0058_add_user_pnl_snapshots",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Restore the wallet v2 P&L tab deep-link so `/wallet?tab=pnl` stays on the P&L panel instead of falling back to `positions`.
- Make hourly P&L snapshotting production-safe by batching large queries/inserts and snapshotting only users with actual P&L relevance.
- Register migration `0058_add_user_pnl_snapshots` in the Drizzle journal and document the migration/seed work already applied on staging and production on March 23, 2026.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [x] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-337/wallet-pandl-chart-replace-balance-history-graph-with-canonical-per
- Linear: https://linear.app/eliza-labs/issue/BAB-336/wallet-pandl-rebuild-entity-rows-from-canonical-per-entity-metrics
- This follows the temporary production hide of the wallet P&L panel and restores the production path with the canonical snapshot flow.

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [x] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Non-goals / follow-ups

- This does not re-enable or refactor the legacy wallet P&L panel under `components/wallet/wallet/*`.
- This does not backfill snapshots older than the hours seeded on March 23, 2026.

## Changes

- Add `pnl` as a valid wallet tab and cover the URL helpers with tests.
- Batch `loadCurrentUserPnlMetrics()` position queries to avoid stack overflows on large `IN (...)` lists.
- Batch snapshot inserts into `UserPnLSnapshot`.
- Change the hourly snapshot candidate set from all non-actor users to users with non-zero lifetime P&L or currently open perp/prediction positions.
- Add `0058_add_user_pnl_snapshots` to the Drizzle migration journal.

## Review guide

**Start here**
- `apps/web/src/lib/wallet/pnlHistory.ts`
- `apps/web/src/lib/wallet-tabs.ts`
- `packages/db/drizzle/migrations/meta/_journal.json`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- The key decision is the snapshot scope reduction. In production on March 23, 2026, snapshotting all non-actor users meant ~680k candidate users per hour; the activity-scoped version reduced that to ~1.4k users for the seeded prod hours.
- The DB migration and initial seeds were already executed manually on staging and production on March 23, 2026 because `bun run db:migrate` was not completing against the Neon endpoints from this environment.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bun test apps/web/src/lib/wallet-tabs.test.ts apps/web/src/hooks/usePnlHistory.test.ts apps/web/src/lib/wallet/pnlHistory.test.ts apps/web/src/components/wallet/__tests__/pnlBreakdown.test.ts apps/web/src/hooks/__tests__/useTeamTradingSummary.test.ts`
2. `bunx biome check --write apps/web/src/lib/wallet-tabs.ts apps/web/src/lib/wallet-tabs.test.ts apps/web/src/lib/wallet/pnlHistory.ts packages/db/drizzle/migrations/meta/_journal.json`
3. Applied `packages/db/drizzle/migrations/0058_add_user_pnl_snapshots.sql` manually on staging and production, inserted the migration record into `drizzle.__drizzle_migrations`, and verified `UserPnLSnapshot` row counts with `psql`.
4. Seeded `UserPnLSnapshot` directly against staging and production with `snapshotAllUserPnlMetrics(new Date())` after the batching changes.
5. Attempted `bun run check`, but the repo-level command currently fails on unrelated pre-existing lint errors in `.tmp/wrap-api-routes-withErrorHandling.mjs`.

## Ops / Migration / Deployment

- [ ] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [x] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `0058_add_user_pnl_snapshots`
- Backfill/seed: applied and seeded on March 23, 2026
  - `production`: `1408` rows at `2026-03-23 21:00:00 UTC` and `1408` rows at `2026-03-23 22:00:00 UTC`
  - `staging`: `169` rows at `2026-03-23 21:00:00 UTC` and `200` rows at `2026-03-23 22:00:00 UTC`

**Rollout / rollback plan**
- Rollout: merge into `production`, deploy production, and let `/api/cron/metrics-snapshot` continue writing activity-scoped P&L snapshots each hour.
- Rollback: revert this PR; the `UserPnLSnapshot` table can remain in place and become unused, with no urgent data rollback required.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- Adds `UserPnLSnapshot` persistence and changes the effective cron workload from all non-actor users to users with non-zero lifetime P&L or open positions.
- Verified on March 23, 2026 against Neon staging and production databases.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option A: Visual demo

| Feature | Before | After |
|---------|--------|-------|
| Wallet v2 P&L tab deep-link | `/wallet?tab=pnl` was parsed as an invalid tab and the page snapped back to `positions`. | `/wallet?tab=pnl` remains on the P&L tab. |
| Wallet v2 P&L chart data | Production had no persisted `UserPnLSnapshot` table/rows to back the chart. | Production and staging now have seeded `UserPnLSnapshot` rows and the chart has persisted hourly data to read from. |

*Demo script (for recording):*
1. Log in and open `/wallet?tab=pnl`.
2. Refresh the page and confirm the P&L tab stays selected.
3. Confirm the P&L chart renders historical points instead of falling back to a live-only empty state.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
