### PR TITLE
ci: add manual Vercel preview GitHub workflow

### DIFF
--- a/.github/workflows/vercel-preview-manual.yml
+++ b/.github/workflows/vercel-preview-manual.yml
@@ -1,0 +1,116 @@
+# Manual Vercel preview deployments for pull requests.
+#
+# Triggers:
+# 1. Actions → "Vercel preview (manual)" → Run workflow → enter PR number.
+# 2. Add the label `vercel-preview` to a PR (same-repo branches only).
+#
+# Setup:
+# - Repository secrets: VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID (same as the Vercel GitHub app).
+# - In Vercel: Project → Settings → Git → disable automatic Preview deployments for pull requests
+#   if you only want previews from this workflow (avoids duplicate builds).
+#
+# The PR must be mergeable (no conflicts) so refs/pull/N/merge exists.
+
+name: Vercel preview (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number (uses GitHub merge ref)
+        required: true
+        type: string
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  # inputs are empty on pull_request; pull_request is absent on workflow_dispatch
+  group: vercel-manual-preview-${{ github.event.inputs.pr_number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.label.name == 'vercel-preview')
+    steps:
+      - name: Resolve PR number
+        id: meta
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "pr=${{ github.event.inputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "pr=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate PR (open, same repository)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          PR="${{ steps.meta.outputs.pr }}"
+          DATA=$(gh pr view "$PR" --repo "${{ github.repository }}" --json state,headRepository)
+          STATE=$(echo "$DATA" | jq -r .state)
+          REPO=$(echo "$DATA" | jq -r '.headRepository.nameWithOwner')
+          if [ "$STATE" != "OPEN" ]; then
+            echo "PR #$PR is not open (state=$STATE)"
+            exit 1
+          fi
+          if [ "$REPO" != "${{ github.repository }}" ]; then
+            echo "Refusing deploy: head repo is $REPO (fork or wrong repo)."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ steps.meta.outputs.pr }}/merge
+          fetch-depth: 1
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Pull Vercel preview environment
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: bunx vercel@latest pull --yes --environment=preview --token="$VERCEL_TOKEN"
+
+      - name: Build (Vercel)
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: bunx vercel@latest build --token="$VERCEL_TOKEN"
+
+      - name: Deploy prebuilt preview
+        id: deploy
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          set -euo pipefail
+          OUT=$(mktemp)
+          bunx vercel@latest deploy --prebuilt --token="$VERCEL_TOKEN" --yes 2>&1 | tee "$OUT"
+          URL=$(grep -oE 'https://[^[:space:]]+\.vercel\.app' "$OUT" | tail -1 || true)
+          if [ -z "$URL" ]; then
+            echo "Could not parse a *.vercel.app URL from deploy output."
+            exit 1
+          fi
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Comment preview URL on PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr comment "${{ steps.meta.outputs.pr }}" --repo "${{ github.repository }}" --body \
+            "🔗 **Manual Vercel preview:** ${{ steps.deploy.outputs.url }}"


### PR DESCRIPTION
Made-with: Cursor

<!--
Babylon PR template

Goal: make PRs easy to review + easy to ship.
- Prefer small, focused PRs (one theme). Avoid catch‑all PRs.
- Keep app-layer thin and portable (validate → service → map errors).
- Put domain logic in packages (framework-agnostic), not in Next handlers/components.
- Match the active release branch. Recent fixes/hotfixes usually target `production`; use `staging` when intentionally batching work ahead of release.
- Before requesting review, run the relevant checks (see "Test plan").
-->

## Summary

- Add a **manual Vercel preview** path via GitHub Actions: run from the Actions tab with a PR number, or add the **`vercel-preview`** label to a PR.
- Stops relying on “every PR auto-builds” alone when paired with Vercel **Ignored Build Step** (configured in the Vercel dashboard separately): skip Git-triggered PR builds, keep **CLI/Actions** previews.
- After deploy, the workflow **comments the `*.vercel.app` URL** on the PR (same-repo PRs only; forks rejected before secrets).

## Type

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [x] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Vercel Git overview: [Deploying Git Repositories with Vercel](https://vercel.com/docs/git)
- Ignored Build Step lives under **Project → Settings → Build and Deployment** (not the Git tab); optional bash snippet to skip PR builds: `if [ -n "${VERCEL_GIT_PULL_REQUEST_ID:-}" ]; then exit 1; fi; exit 0`

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**

- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [x] Other: **CI** — `.github/workflows/vercel-preview-manual.yml`

## Non-goals / follow-ups

- Documenting Vercel dashboard steps in-repo (workflow header comments cover setup).
- Adding `ignoreCommand` to `vercel.json` (optional; Ignored Build Step can stay UI-only).
- Hardening deploy URL parsing if Vercel CLI output format changes.

## Changes

- **New** [`.github/workflows/vercel-preview-manual.yml`](.github/workflows/vercel-preview-manual.yml): `workflow_dispatch` (input: PR number) + `pull_request` (`labeled` → `vercel-preview`).
- Checkout **`refs/pull/<N>/merge`** (PR must be mergeable / no conflicts).
- **Validate** PR open + head repo equals `github.repository`.
- **Build path:** `bun install` → `vercel pull` (preview env) → `vercel build` → `vercel deploy --prebuilt`.
- **Secrets** (repo): `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`.

## Review guide

**Start here**

- [`.github/workflows/vercel-preview-manual.yml`](.github/workflows/vercel-preview-manual.yml)

**Risk**

- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**

- Git integration stays connected; **Ignored Build Step** (dashboard) avoids duplicate Git + Actions previews if desired.
- Fork PRs fail validation before checkout; no Vercel secrets exposed to forks.

## Test plan

**Commands run**

- [x] `bun run check` (Biome `check --write .`)
- [x] `bun run typecheck`
- [x] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**

1. `bun run check`, `bun run typecheck`, `bun run lint` — **passed** on the feature branch.
2. `bun run test:unit` — **not** run to green on this branch; `landing-cta-formatting.unit.test.ts` fails with **ENOENT** for missing `apps/web/src/components/landing/*` in this checkout (unrelated to this workflow). Re-run on a branch that includes those files before merge if required by policy.
3. **Post-merge ops:** Add repo secrets if missing; run workflow once against a test PR or use label `vercel-preview`; confirm Vercel Ignored Build Step matches intended behavior.

## Ops / Migration / Deployment

- [ ] No deploy impact
- [x] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**

- **Added (GitHub Actions secrets, not app runtime):** `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID` — same values as the Vercel GitHub integration / `vercel link` project metadata.
- Changed: `None` (app)
- Removed: `None`

**DB / data migration**

- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**

- **Rollout:** Merge PR → configure secrets → optional Ignored Build Step for PRs → trigger manual workflow or label.
- **Rollback:** Revert PR or disable workflow; re-enable default Vercel PR previews if needed.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**

- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services

- None.

### Database

- None.

### Contracts / on-chain

- None.

### Docs

- None.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- **Reason:** CI-only change (GitHub Actions + Vercel CLI); no user-facing UI.

## Checklist (author)

- [x] Self-review done (diff + critical paths)
- [ ] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors) — N/A
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core) — N/A
- [x] `.env.example` updated (if env changed) and variables documented above — N/A for app env; GitHub secrets documented above
- [x] Docs updated (and `bun run docs:generate` if needed) — N/A
- [x] Tests added/updated for behavior changes (or rationale provided) — workflow-only; no app behavior change
- [x] Dependency changes are intentional (`bun.lock` updated) — none
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)