### PR TITLE
fix(perps): quarantine invalid persisted positions

### DIFF
--- a/apps/web/src/app/api/markets/perps/_adapters.ts
+++ b/apps/web/src/app/api/markets/perps/_adapters.ts
@@ -10,6 +10,7 @@
 
 import { broadcastToChannel } from '@babylon/api';
 import {
+  isOpenPerpPositionStateValid,
   PerpDbAdapter,
   PerpMarketService,
   type PerpServiceDeps,
@@ -308,6 +309,8 @@ export async function applyUserTradePriceImpact(ticker: string): Promise<void> {
       .select({
         side: perpPositions.side,
         size: perpPositions.size,
+        leverage: perpPositions.leverage,
+        userId: perpPositions.userId,
       })
       .from(perpPositions)
       .where(
@@ -319,9 +322,26 @@ export async function applyUserTradePriceImpact(ticker: string): Promise<void> {
 
     // 4. Calculate net holdings (longs - shorts)
     let netHoldings = 0;
+    let invalidPositions = 0;
     for (const pos of openPositions) {
+      if (!isOpenPerpPositionStateValid(pos)) {
+        invalidPositions++;
+        continue;
+      }
+
       const size = Number(pos.size);
       netHoldings += pos.side === 'long' ? size : -size;
+    }
+
+    if (invalidPositions > 0) {
+      logger.warn(
+        'Ignoring invalid open perp positions during price impact calculation',
+        {
+          ticker: normalizedTicker,
+          invalidPositions,
+        },
+        'PerpPriceImpact'
+      );
     }
 
     // 5. Calculate new price using centralized vAMM formula with liquidity factor

--- a/packages/core/markets/perps/PerpMarketService.ts
+++ b/packages/core/markets/perps/PerpMarketService.ts
@@ -9,6 +9,11 @@ import type {
   PerpSide,
   PerpTradeResult,
 } from './types';
+import {
+  getOpenPerpPositionIntegrityIssue,
+  isOpenPerpPositionStateValid,
+  MAX_PERP_USER_EXPOSURE,
+} from './utils';
 
 /** Summary of price update operations */
 export interface PriceUpdateSummary {
@@ -66,8 +71,6 @@ const BASE_FUNDING_RATE = 0.01; // 1% APR base
 const MAX_FUNDING_RATE = 0.5; // 50% APR cap
 const IMBALANCE_EXPONENT = 3.0;
 
-/** Maximum total notional exposure per user across all positions */
-const MAX_USER_EXPOSURE = 1_000_000;
 /** Maximum number of open positions per user */
 const MAX_POSITIONS_PER_USER = 50;
 
@@ -89,6 +92,33 @@ export class PerpMarketService {
   constructor(deps: PerpServiceDeps) {
     this.deps = deps;
     this.db = deps.db;
+  }
+
+  private assertOpenPositionIntegrity(
+    position: Pick<
+      PerpPositionRecord,
+      'id' | 'ticker' | 'userId' | 'size' | 'leverage'
+    >
+  ): void {
+    const issue = getOpenPerpPositionIntegrityIssue(position);
+    if (!issue) return;
+
+    logger.error(
+      'Invalid open perp position state detected',
+      {
+        positionId: position.id,
+        userId: position.userId,
+        ticker: position.ticker,
+        size: position.size,
+        leverage: position.leverage,
+        issue,
+      },
+      'PerpService'
+    );
+
+    throw new Error(
+      'Invalid persisted perp position state detected. Manual intervention required.'
+    );
   }
 
   /**
@@ -391,6 +421,7 @@ export class PerpMarketService {
       ticker
     );
     if (existingPosition) {
+      this.assertOpenPositionIntegrity(existingPosition);
       if (existingPosition.side === side) {
         // Same side → add to position (increase size, average entry price)
         return this.addToPosition(existingPosition, input, market);
@@ -402,15 +433,18 @@ export class PerpMarketService {
 
     // Check total user exposure across all positions
     const userPositions = await this.db.getOpenPositionsByUser(input.userId);
+    for (const position of userPositions) {
+      this.assertOpenPositionIntegrity(position);
+    }
     const currentExposure = userPositions.reduce(
       (sum, p) => sum + p.size * p.leverage,
       0
     );
     const newNotional = size * leverage;
-    if (currentExposure + newNotional > MAX_USER_EXPOSURE) {
+    if (currentExposure + newNotional > MAX_PERP_USER_EXPOSURE) {
       throw new Error(
         `Total exposure would exceed limit: current ${currentExposure.toLocaleString()}, ` +
-          `new ${newNotional.toLocaleString()}, max ${MAX_USER_EXPOSURE.toLocaleString()}`
+          `new ${newNotional.toLocaleString()}, max ${MAX_PERP_USER_EXPOSURE.toLocaleString()}`
       );
     }
     if (userPositions.length >= MAX_POSITIONS_PER_USER) {
@@ -1101,6 +1135,9 @@ export class PerpMarketService {
 
     // Check total user exposure
     const userPositions = await this.db.getOpenPositionsByUser(input.userId);
+    for (const position of userPositions) {
+      this.assertOpenPositionIntegrity(position);
+    }
     const currentExposure = userPositions.reduce(
       (sum, p) => sum + p.size * p.leverage,
       0
@@ -1108,10 +1145,10 @@ export class PerpMarketService {
     // Use existing leverage for the added portion (consistent with industry standard)
     const effectiveLeverage = existing.leverage;
     const addedNotional = addedSize * effectiveLeverage;
-    if (currentExposure + addedNotional > MAX_USER_EXPOSURE) {
+    if (currentExposure + addedNotional > MAX_PERP_USER_EXPOSURE) {
       throw new Error(
         `Total exposure would exceed limit: current ${currentExposure.toLocaleString()}, ` +
-          `adding ${addedNotional.toLocaleString()}, max ${MAX_USER_EXPOSURE.toLocaleString()}`
+          `adding ${addedNotional.toLocaleString()}, max ${MAX_PERP_USER_EXPOSURE.toLocaleString()}`
       );
     }
 
@@ -1138,6 +1175,9 @@ export class PerpMarketService {
         const freshPosition = await tx.getPositionById(existing.id);
         if (!freshPosition || freshPosition.closedAt) {
           throw new Error('Position no longer exists or was closed');
+        }
+        if (!isOpenPerpPositionStateValid(freshPosition)) {
+          this.assertOpenPositionIntegrity(freshPosition);
         }
 
         // Recalculate with fresh position data to handle concurrent updates

--- a/packages/core/markets/perps/__tests__/PerpMarketService.test.ts
+++ b/packages/core/markets/perps/__tests__/PerpMarketService.test.ts
@@ -735,4 +735,38 @@ describe('PerpMarketService', () => {
 
     expect(pos2.positionId).toBeDefined();
   });
+
+  it('rejects trading on top of an invalid persisted open position', async () => {
+    const now = new Date();
+
+    await db.upsertPosition({
+      id: 'pos-corrupt',
+      userId: 'u-corrupt',
+      ticker: 'ABC',
+      organizationId: 'org-abc',
+      side: 'long',
+      entryPrice: 100,
+      currentPrice: 100,
+      size: 2_000_000,
+      leverage: 1,
+      liquidationPrice: 50,
+      unrealizedPnL: 0,
+      unrealizedPnLPercent: 0,
+      fundingPaid: 0,
+      openedAt: now,
+      lastUpdated: now,
+      closedAt: null,
+      realizedPnL: null,
+    });
+
+    await expect(
+      service.openPosition({
+        userId: 'u-corrupt',
+        ticker: 'ABC',
+        side: 'long',
+        size: 100,
+        leverage: 1,
+      })
+    ).rejects.toThrow(/Invalid persisted perp position state detected/);
+  });
 });

--- a/packages/core/markets/perps/utils.ts
+++ b/packages/core/markets/perps/utils.ts
@@ -1,5 +1,7 @@
 import type { PerpSide } from './types';
 
+export const MAX_PERP_USER_EXPOSURE = 1_000_000;
+
 export function shouldLiquidate(
   currentPrice: number,
   liquidationPrice: number,
@@ -9,4 +11,62 @@ export function shouldLiquidate(
     return currentPrice <= liquidationPrice;
   }
   return currentPrice >= liquidationPrice;
+}
+
+function toFiniteNumber(value: unknown): number | null {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null;
+  }
+
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+export function getEffectivePerpLeverage(leverage: unknown): number {
+  const numericLeverage = toFiniteNumber(leverage);
+  return numericLeverage && numericLeverage > 0 ? numericLeverage : 1;
+}
+
+export function getPerpPositionExposure(position: {
+  size: unknown;
+  leverage: unknown;
+}): number | null {
+  const numericSize = toFiniteNumber(position.size);
+  if (numericSize === null) return null;
+
+  const exposure =
+    Math.abs(numericSize) * getEffectivePerpLeverage(position.leverage);
+  return Number.isFinite(exposure) ? exposure : null;
+}
+
+export function getOpenPerpPositionIntegrityIssue(position: {
+  size: unknown;
+  leverage: unknown;
+}): 'invalid_size' | 'invalid_exposure' | 'exposure_cap_exceeded' | null {
+  const numericSize = toFiniteNumber(position.size);
+  if (numericSize === null || Math.abs(numericSize) === 0) {
+    return 'invalid_size';
+  }
+
+  const exposure = getPerpPositionExposure(position);
+  if (exposure === null || exposure <= 0) {
+    return 'invalid_exposure';
+  }
+
+  if (exposure > MAX_PERP_USER_EXPOSURE) {
+    return 'exposure_cap_exceeded';
+  }
+
+  return null;
+}
+
+export function isOpenPerpPositionStateValid(position: {
+  size: unknown;
+  leverage: unknown;
+}): boolean {
+  return getOpenPerpPositionIntegrityIssue(position) === null;
 }

--- a/packages/engine/src/game-tick.ts
+++ b/packages/engine/src/game-tick.ts
@@ -4,6 +4,7 @@
  * Handles content generation, market decisions, question resolution, and system updates.
  */
 
+import { isOpenPerpPositionStateValid } from '@babylon/core/markets/perps';
 import {
   PredictionDbAdapter as CorePredictionDbAdapter,
   PredictionMarketService as CorePredictionMarketService,
@@ -1306,6 +1307,8 @@ export async function updateMarketPricesFromTrades(
       ticker: perpPositions.ticker,
       side: perpPositions.side,
       size: perpPositions.size,
+      leverage: perpPositions.leverage,
+      userId: perpPositions.userId,
     })
     .from(perpPositions)
     .where(
@@ -1316,10 +1319,30 @@ export async function updateMarketPricesFromTrades(
     );
 
   const holdingsByTicker = new Map<string, number>();
+  const invalidPositionsByTicker = new Map<string, number>();
   for (const pos of positionsOpen) {
+    if (!isOpenPerpPositionStateValid(pos)) {
+      invalidPositionsByTicker.set(
+        pos.ticker,
+        (invalidPositionsByTicker.get(pos.ticker) ?? 0) + 1
+      );
+      continue;
+    }
+
     const current = holdingsByTicker.get(pos.ticker) ?? 0;
     const delta = pos.side === 'long' ? Number(pos.size) : -Number(pos.size);
     holdingsByTicker.set(pos.ticker, current + delta);
+  }
+
+  for (const [ticker, invalidPositions] of invalidPositionsByTicker) {
+    logger.warn(
+      'Ignoring invalid open perp positions during tick price recomputation',
+      {
+        ticker,
+        invalidPositions,
+      },
+      'GameTick'
+    );
   }
 
   const updates = selected

--- a/packages/engine/src/portfolio-valuation.ts
+++ b/packages/engine/src/portfolio-valuation.ts
@@ -1,3 +1,5 @@
+import { isOpenPerpPositionStateValid } from '@babylon/core/markets/perps';
+
 /** Safely coerce an unknown value (DB column, JSON field) to a finite number. */
 export function toNumber(value: unknown, fallback = 0): number {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
@@ -19,6 +21,10 @@ export function calculatePerpPositionMarketValue(position: {
   size: unknown;
   unrealizedPnL: unknown;
 }): number {
+  if (!isOpenPerpPositionStateValid(position)) {
+    return 0;
+  }
+
   const size = toNumber(position.size);
   const leverage = toNumber(position.leverage);
   const unrealizedPnL = toNumber(position.unrealizedPnL);

--- a/packages/engine/src/portfolio-valuation.ts
+++ b/packages/engine/src/portfolio-valuation.ts
@@ -1,4 +1,4 @@
-import { isOpenPerpPositionStateValid } from '@babylon/core/markets/perps';
+import { isOpenPerpPositionStateValid } from '@babylon/core/markets/perps/utils';
 
 /** Safely coerce an unknown value (DB column, JSON field) to a finite number. */
 export function toNumber(value: unknown, fallback = 0): number {

--- a/packages/engine/src/services/perp-price-impact-port.ts
+++ b/packages/engine/src/services/perp-price-impact-port.ts
@@ -1,4 +1,5 @@
 import {
+  isOpenPerpPositionStateValid,
   PerpDbAdapter,
   type PriceImpactPort,
 } from '@babylon/core/markets/perps';
@@ -78,6 +79,8 @@ export async function applyPerpUserTradePriceImpact(
       .select({
         side: perpPositions.side,
         size: perpPositions.size,
+        leverage: perpPositions.leverage,
+        userId: perpPositions.userId,
       })
       .from(perpPositions)
       .where(
@@ -88,9 +91,26 @@ export async function applyPerpUserTradePriceImpact(
       );
 
     let netHoldings = 0;
+    let invalidPositions = 0;
     for (const pos of openPositions) {
+      if (!isOpenPerpPositionStateValid(pos)) {
+        invalidPositions++;
+        continue;
+      }
+
       const size = Number(pos.size);
       netHoldings += pos.side === 'long' ? size : -size;
+    }
+
+    if (invalidPositions > 0) {
+      logger.warn(
+        'Ignoring invalid open perp positions during price impact calculation',
+        {
+          ticker: normalizedTicker,
+          invalidPositions,
+        },
+        'PerpPriceImpact'
+      );
     }
 
     const newPrice = calculatePriceFromHoldings(

--- a/packages/engine/src/services/portfolio-breakdown.ts
+++ b/packages/engine/src/services/portfolio-breakdown.ts
@@ -2,6 +2,7 @@
  * Server-side portfolio breakdown (wallet + agents + positions) for consistent P/L.
  */
 
+import { isOpenPerpPositionStateValid } from '@babylon/core/markets/perps';
 import { PredictionPricing } from '@babylon/core/markets/prediction';
 import {
   db,
@@ -11,7 +12,7 @@ import {
   positions,
   users,
 } from '@babylon/db';
-import { resolveUserIdentifierKind } from '@babylon/shared';
+import { logger, resolveUserIdentifierKind } from '@babylon/shared';
 import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
 import { FEE_CONFIG } from '../config/fees';
 import {
@@ -217,6 +218,20 @@ export async function calculatePortfolioBreakdown(
         )
       ),
   ]);
+
+  const invalidPerpRows = perpRows.filter(
+    (position) => !isOpenPerpPositionStateValid(position)
+  );
+  if (invalidPerpRows.length > 0) {
+    logger.warn(
+      'Excluding invalid open perp positions from portfolio breakdown',
+      {
+        userId: canonicalUserId,
+        invalidPerpPositions: invalidPerpRows.length,
+      },
+      'PortfolioBreakdown'
+    );
+  }
 
   const perpsValue = perpRows.reduce(
     (sum, p) => sum + calculatePerpPositionMarketValue(p),

--- a/packages/engine/src/services/total-points-service.ts
+++ b/packages/engine/src/services/total-points-service.ts
@@ -13,6 +13,7 @@
  * Further detail: `packages/engine/src/services/TOTAL_POINTS_OPTIMIZATION.md`.
  */
 
+import { isOpenPerpPositionStateValid } from '@babylon/core/markets/perps';
 import { PredictionPricing } from '@babylon/core/markets/prediction';
 import {
   db,
@@ -30,6 +31,7 @@ import {
 } from '@babylon/shared';
 import { and, eq, gt, inArray, isNotNull, isNull, lte, sql } from 'drizzle-orm';
 import { FEE_CONFIG } from '../config/fees';
+import { calculatePerpPositionMarketValue } from '../portfolio-valuation';
 
 // ---------------------------------------------------------------------------
 // Helpers (mirrored from portfolio-breakdown.ts)
@@ -46,21 +48,6 @@ function toNumber(value: unknown, fallback = 0): number {
 
 function clampFeeRate(rate: number): number {
   return rate > 0 && rate < 1 ? rate : 0;
-}
-
-function calculatePerpPositionValue(position: {
-  size: unknown;
-  leverage: unknown;
-  unrealizedPnL: unknown;
-}): number {
-  const size = toNumber(position.size);
-  const leverage = toNumber(position.leverage);
-  const unrealizedPnL = toNumber(position.unrealizedPnL);
-
-  const effectiveLeverage =
-    Number.isFinite(leverage) && leverage > 0 ? leverage : 1;
-  const margin = Math.abs(size / effectiveLeverage);
-  return margin + unrealizedPnL;
 }
 
 function calculatePredictionPositionValue(position: {
@@ -226,8 +213,22 @@ export const TotalPointsService = {
         ),
     ]);
 
+    const invalidPerpRows = perpRows.filter(
+      (position) => !isOpenPerpPositionStateValid(position)
+    );
+    if (invalidPerpRows.length > 0) {
+      logger.warn(
+        'Excluding invalid open perp positions from total points calculation',
+        {
+          userId: canonicalUserId,
+          invalidPerpPositions: invalidPerpRows.length,
+        },
+        'TotalPointsService'
+      );
+    }
+
     const perpsValue = perpRows.reduce(
-      (sum, p) => sum + calculatePerpPositionValue(p),
+      (sum, p) => sum + calculatePerpPositionMarketValue(p),
       0
     );
 

--- a/packages/testing/integration/perp-avg-fill-integration.test.ts
+++ b/packages/testing/integration/perp-avg-fill-integration.test.ts
@@ -22,6 +22,7 @@ import {
 } from 'bun:test';
 import type { WalletPort } from '@babylon/core/markets/perps';
 import {
+  isOpenPerpPositionStateValid,
   PerpDbAdapter,
   PerpMarketService,
   type PerpServiceDeps,
@@ -157,7 +158,12 @@ function createTestPriceImpact(): PriceImpactPort {
       );
 
       const openPositions = await db
-        .select({ side: perpPositions.side, size: perpPositions.size })
+        .select({
+          side: perpPositions.side,
+          size: perpPositions.size,
+          leverage: perpPositions.leverage,
+          userId: perpPositions.userId,
+        })
         .from(perpPositions)
         .where(
           and(
@@ -168,6 +174,10 @@ function createTestPriceImpact(): PriceImpactPort {
 
       let netHoldings = 0;
       for (const pos of openPositions) {
+        if (!isOpenPerpPositionStateValid(pos)) {
+          continue;
+        }
+
         const size = Number(pos.size);
         netHoldings += pos.side === 'long' ? size : -size;
       }

--- a/packages/testing/unit/portfolio-valuation.test.ts
+++ b/packages/testing/unit/portfolio-valuation.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'bun:test';
 import {
   calculatePerpPositionMarketValue,
   toNumber,
-} from '@babylon/engine/client';
+} from '../../engine/src/portfolio-valuation';
 
 describe('toNumber', () => {
   it('returns the value when it is already a finite number', () => {
@@ -102,6 +102,15 @@ describe('calculatePerpPositionMarketValue', () => {
       size: 0,
       leverage: 0,
       unrealizedPnL: 0,
+    });
+    expect(value).toBe(0);
+  });
+
+  it('returns 0 for persisted perp positions above the exposure cap', () => {
+    const value = calculatePerpPositionMarketValue({
+      size: 45_002_000,
+      leverage: 1,
+      unrealizedPnL: 3_719_032_361.1754107,
     });
     expect(value).toBe(0);
   });

--- a/packages/testing/unit/portfolio-valuation.test.ts
+++ b/packages/testing/unit/portfolio-valuation.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'bun:test';
 import {
   calculatePerpPositionMarketValue,
   toNumber,
-} from '../../engine/src/portfolio-valuation';
+} from '@babylon/engine/client';
 
 describe('toNumber', () => {
   it('returns the value when it is already a finite number', () => {

--- a/packages/testing/unit/total-points-service.test.ts
+++ b/packages/testing/unit/total-points-service.test.ts
@@ -7,6 +7,7 @@
 
 import { afterEach, describe, expect, it } from 'bun:test';
 import { resolveUserIdentifierKind } from '@babylon/shared';
+import { isOpenPerpPositionStateValid } from '../../core/markets/perps/utils';
 
 // ---------------------------------------------------------------------------
 // Helper function replicas for testing (same logic as in total-points-service.ts)
@@ -31,6 +32,10 @@ function calculatePerpPositionValue(position: {
   leverage: unknown;
   unrealizedPnL: unknown;
 }): number {
+  if (!isOpenPerpPositionStateValid(position)) {
+    return 0;
+  }
+
   const size = toNumber(position.size);
   const leverage = toNumber(position.leverage);
   const unrealizedPnL = toNumber(position.unrealizedPnL);
@@ -438,8 +443,17 @@ describe('Edge Cases and Data Integrity', () => {
     };
 
     const value = calculatePerpPositionValue(position);
-    expect(value).toBe(1e12 + 1e9);
-    expect(Number.isFinite(value)).toBe(true);
+    expect(value).toBe(0);
+  });
+
+  it('should quarantine persisted perp positions above the exposure cap', () => {
+    const position = {
+      size: 20_000_000,
+      leverage: 1,
+      unrealizedPnL: 3_333_491_091.7949996,
+    };
+
+    expect(calculatePerpPositionValue(position)).toBe(0);
   });
 
   it('should not produce NaN for edge case inputs', () => {


### PR DESCRIPTION
## Summary
- Quarantine invalid persisted perp positions so they no longer inflate leaderboard totals, portfolio totals, or perp price impact.
- Block further perp trade mutations when an existing open position is already in an impossible persisted state and requires manual remediation.
- Reuse one shared perp integrity guard across core service, pricing flows, and valuation paths to keep the fix simple and consistent.

## Type
- [x] Bug fix

## Context / Links
- Linear: https://linear.app/eliza-labs/issue/BAB-394/bug-invalid-aix-perp-position-sizes-are-inflating-leaderboard-totals

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web API routes / SSE / A2A (`apps/web`)
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [x] Tests (`packages/testing`)

## Non-goals / follow-ups
- Manual production remediation of already-corrupted `PerpPosition` and `PerpMarketSnapshot` rows is out of scope for this PR.
- This PR does not claim to identify the original corruption writer with certainty; it contains the blast radius by quarantining invalid persisted state in sensitive flows.

## Changes
- Added a shared open-perp integrity guard in core and reused it where persisted perp rows are consumed.
- Excluded invalid open perp positions from price-impact net holdings in both real-time user trade pricing and engine tick recomputation.
- Excluded invalid open perp positions from total-points and portfolio valuation so leaderboard and wallet views no longer inherit impossible notional values.
- Rejected new rebalance/trade attempts when the existing open perp row is already beyond the supported exposure invariant.
- Added focused tests for the quarantine behavior and corrupted-position trade rejection.

## Review guide
**Start here**
- `packages/core/markets/perps/utils.ts`
- `packages/core/markets/perps/PerpMarketService.ts`
- `packages/engine/src/portfolio-valuation.ts`
- `packages/engine/src/services/total-points-service.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- The exposure invariant matches the existing service cap behavior so the quarantine logic stays aligned with the current product rule instead of introducing a second threshold.
- I intentionally kept this as a quarantine/hardening fix. Reconstructing corrupted production rows still needs ops-side remediation.

## Test plan
**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bunx biome check --write apps/web/src/app/api/markets/perps/_adapters.ts packages/core/markets/perps/PerpMarketService.ts packages/core/markets/perps/utils.ts packages/core/markets/perps/__tests__/PerpMarketService.test.ts packages/engine/src/game-tick.ts packages/engine/src/portfolio-valuation.ts packages/engine/src/services/perp-price-impact-port.ts packages/engine/src/services/portfolio-breakdown.ts packages/engine/src/services/total-points-service.ts packages/testing/integration/perp-avg-fill-integration.test.ts packages/testing/unit/portfolio-valuation.test.ts packages/testing/unit/total-points-service.test.ts`
2. `bun test packages/core/markets/perps/__tests__/PerpMarketService.test.ts`
3. `bun test packages/testing/unit/portfolio-valuation.test.ts --preload ./packages/testing/unit/preload.ts`
4. `bun test packages/testing/unit/total-points-service.test.ts --preload ./packages/testing/unit/preload.ts`
5. I did not run the DB-backed integration test file because it requires a live test database and this task explicitly avoids heavy/full validation by default.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: deploy normally, then manually remediate corrupted production perp rows and recompute affected user totals.
- Rollback: revert this PR if the quarantine blocks legitimate positions unexpectedly.

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)
### Option B: No visual changes
- Reason: Backend/domain integrity fix with no direct UI changes.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
