### PR TITLE
chore: simplify CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,117 +4,56 @@
 # Notes:
 # - Patterns use gitignore-style matching.
 # - If multiple patterns match a file, the LAST match wins.
+# - Keep this file coarse-grained. It routes reviews; it does not define who may edit code.
 
-# ----------------------------
-# Agents (runtime / A2A / MCP)
-# ----------------------------
-/packages/agents/ @wtfsayo
-/packages/a2a/ @wtfsayo
-/packages/mcp/ @wtfsayo
-/packages/examples/babylon-typescript-agent/ @wtfsayo
-/packages/examples/babylon-langgraph-agent/ @wtfsayo
-/packages/examples/harness/ @wtfsayo
+# Fallback
+* @slkzgm @SYMBaiEX
 
-/apps/web/src/app/agents/ @wtfsayo
-/apps/web/src/app/api/agents/ @wtfsayo
-/apps/web/src/app/api/a2a/ @wtfsayo
-/apps/web/src/app/api/agent-templates/ @wtfsayo
-/apps/web/src/app/mcp/ @wtfsayo
-/apps/web/src/components/agents/ @wtfsayo
-/apps/web/public/agent-templates/ @wtfsayo
-/apps/web/src/app/api/cron/agent-tick/ @wtfsayo
+# Apps
+/apps/cli/ @slkzgm @odilitime
+/apps/docs/ @slkzgm @odilitime
+/apps/web/ @slkzgm @SYMBaiEX
 
-# --------------------------
-# Markets + trading + Privy
-# --------------------------
-/packages/core/markets/ @slkzgm
-/packages/contracts/src/prediction-markets/ @slkzgm
+# Agents platform
+/packages/agents/ @odilitime @SYMBaiEX
+/packages/a2a/ @odilitime @SYMBaiEX
+/packages/mcp/ @odilitime @SYMBaiEX
+/packages/examples/ @odilitime @SYMBaiEX
+/apps/web/src/app/agents/ @odilitime @SYMBaiEX
+/apps/web/src/app/api/agents/ @odilitime @SYMBaiEX
+/apps/web/src/app/api/a2a/ @odilitime @SYMBaiEX
+/apps/web/src/app/api/agent-templates/ @odilitime @SYMBaiEX
+/apps/web/src/app/mcp/ @odilitime @SYMBaiEX
+/apps/web/src/components/agents/ @odilitime @SYMBaiEX
 
-/apps/web/src/app/markets/ @slkzgm
-/apps/web/src/app/betting/ @slkzgm
-/apps/web/src/components/markets/ @slkzgm
-/apps/web/src/components/trades/ @slkzgm
-/apps/web/src/app/api/markets/ @slkzgm
-/apps/web/src/app/api/trades/ @slkzgm
-/apps/web/src/app/api/questions/ @slkzgm
-/apps/web/src/app/api/cron/perp-funding/ @slkzgm
+# Markets / trading
+/packages/core/markets/ @slkzgm @revlentless
+/packages/contracts/src/prediction-markets/ @slkzgm @revlentless
+/apps/web/src/app/markets/ @slkzgm @revlentless
+/apps/web/src/app/betting/ @slkzgm @revlentless
+/apps/web/src/components/markets/ @slkzgm @revlentless
+/apps/web/src/components/trades/ @slkzgm @revlentless
+/apps/web/src/app/api/markets/ @slkzgm @revlentless
+/apps/web/src/app/api/trades/ @slkzgm @revlentless
+/apps/web/src/app/api/questions/ @slkzgm @revlentless
 
-# Privy (auth/wallet plumbing)
-/packages/shared/src/auth/privy-config.ts @slkzgm
-/packages/shared/src/auth/wallet-utils.ts @slkzgm
-/packages/api/src/fetch.ts @slkzgm
-/packages/api/src/global.d.ts @slkzgm
+# Game engine
+/packages/engine/ @slkzgm @SYMBaiEX
+/apps/web/src/app/game/ @slkzgm @SYMBaiEX
+/apps/web/src/app/api/game/ @slkzgm @SYMBaiEX
+/apps/web/src/app/api/npc/ @slkzgm @SYMBaiEX
+/apps/web/src/components/npc/ @slkzgm @SYMBaiEX
 
-/apps/web/src/hooks/useAuth.ts @slkzgm
-/apps/web/src/hooks/useSmartWallet.ts @slkzgm
-/apps/web/src/utils/api-fetch.ts @slkzgm
-/apps/web/src/global.d.ts @slkzgm
-/apps/web/src/app/api/users/me/ @slkzgm
-
-# Auth flows (Twitter, shared auth wiring, etc.) — overridden below for Discord/Farcaster.
-/apps/web/src/app/api/auth/ @slkzgm
-
-# ----------------
-# Game engine core
-# ----------------
-/packages/engine/ @SYMBaiEX
-/apps/web/src/app/game/ @SYMBaiEX
-/apps/web/src/app/api/game/ @SYMBaiEX
-/apps/web/src/app/api/npc/ @SYMBaiEX
-/apps/web/src/components/npc/ @SYMBaiEX
-/apps/web/src/app/api/cron/game-tick/ @SYMBaiEX
-/apps/web/src/app/api/cron/world-facts/ @SYMBaiEX
-
-# -------------
-# RL / training
-# -------------
-/packages/training/ @revlentless
-/apps/web/src/app/admin/rl-training/ @revlentless
-/apps/web/src/app/api/training/ @revlentless
-/apps/web/src/app/api/_training/ @revlentless
-/apps/web/src/app/api/huggingface/ @revlentless
-/apps/web/src/app/api/admin/training/ @revlentless
-/apps/web/src/app/api/admin/training-data/ @revlentless
-/apps/web/src/app/api/admin/ai-models/ @revlentless
-/apps/web/src/app/api/cron/training/ @revlentless
-/apps/web/src/app/api/cron/training-check/ @revlentless
-/apps/web/src/app/api/cron/_training/ @revlentless
-/apps/web/src/app/api/cron/weekly-dataset-upload/ @revlentless
-
-# -----------------------------
-# Discord bot / automations
-# -----------------------------
-/apps/web/src/app/api/auth/discord/ @odilitime
-/apps/web/src/app/api/users/\[userId\]/verify-discord-join/ @odilitime
-
-# -------
-# Chats
-# -------
-/apps/web/src/app/chats/ @tcm390
-/apps/web/src/app/api/chats/ @tcm390
-/apps/web/src/components/chat/ @tcm390
-/apps/web/src/components/chats/ @tcm390
-/apps/web/src/app/api/realtime/token/ @tcm390
-
-/packages/db/src/schema/messaging.ts @tcm390
-/packages/api/src/realtime/ @tcm390
-/packages/api/src/sse/ @tcm390
-/packages/testing/synpress/07-chats.synpress.spec.ts @tcm390
-/packages/testing/synpress/helpers/test-data.ts @tcm390
-
-# -----------------------------------
-# Farcaster mini app / integration
-# -----------------------------------
-/apps/web/public/farcaster.json @xR0am
-/apps/web/next.config.ts @xR0am
-/apps/web/src/components/providers/FarcasterMiniAppProvider.tsx @xR0am
-/apps/web/src/app/api/frame/ @xR0am
-/apps/web/src/app/api/embed/post/ @xR0am
-/apps/web/src/app/api/auth/farcaster/ @xR0am
-/apps/web/src/app/api/auth/onboarding/farcaster/ @xR0am
-/apps/web/src/app/api/users/\[userId\]/verify-farcaster-follow/ @xR0am
-/apps/web/src/hooks/useSocialVerification.ts @xR0am @odilitime
-/apps/web/src/stores/authStore.ts @xR0am
-
-/packages/shared/src/auth/farcaster-auth-client.ts @xR0am
-/packages/shared/src/auth/farcaster-onboarding.ts @xR0am
+# Training
+/packages/training/ @revlentless @odilitime
+/apps/web/src/app/admin/rl-training/ @revlentless @odilitime
+/apps/web/src/app/api/training/ @revlentless @odilitime
+/apps/web/src/app/api/_training/ @revlentless @odilitime
+/apps/web/src/app/api/huggingface/ @revlentless @odilitime
+/apps/web/src/app/api/admin/training/ @revlentless @odilitime
+/apps/web/src/app/api/admin/training-data/ @revlentless @odilitime
+/apps/web/src/app/api/admin/ai-models/ @revlentless @odilitime
+/apps/web/src/app/api/cron/training/ @revlentless @odilitime
+/apps/web/src/app/api/cron/training-check/ @revlentless @odilitime
+/apps/web/src/app/api/cron/_training/ @revlentless @odilitime
+/apps/web/src/app/api/cron/weekly-dataset-upload/ @revlentless @odilitime


### PR DESCRIPTION
## Summary
- simplify CODEOWNERS into a coarse-grained routing file
- remove stale owners and micro-scoped path rules
- keep fallback plus core domains: apps, agents, markets, game, training

## Test plan
- not run (configuration-only change)

## Screenshots / recordings
- Reason: repository configuration change, no UI impact