### PR TITLE
fix(web): recover markets SSE from invalid cached realtime token

### DIFF
--- a/apps/web/src/lib/sse/SSEManager.test.ts
+++ b/apps/web/src/lib/sse/SSEManager.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import { SSEManager } from './SSEManager';
+
+const originalFetch = globalThis.fetch;
+const originalWindow = globalThis.window;
+const originalNavigator = globalThis.navigator;
+const originalEventSource = globalThis.EventSource;
+
+class MockEventSource {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 2;
+  static instances: MockEventSource[] = [];
+
+  readonly url: string;
+  readyState = MockEventSource.CONNECTING;
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(_type: string, _listener: (event: unknown) => void): void {}
+
+  close(): void {
+    this.readyState = MockEventSource.CLOSED;
+  }
+
+  emitOpen(): void {
+    this.readyState = MockEventSource.OPEN;
+    this.onopen?.();
+  }
+
+  emitError(): void {
+    this.readyState = MockEventSource.CLOSED;
+    this.onerror?.();
+  }
+}
+
+const waitForAsyncWork = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 20));
+};
+
+describe('SSEManager token recovery', () => {
+  beforeEach(() => {
+    MockEventSource.instances = [];
+
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        location: {
+          origin: 'https://babylon.test',
+        },
+      },
+    });
+
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: {
+        onLine: true,
+      },
+    });
+
+    Object.defineProperty(globalThis, 'EventSource', {
+      configurable: true,
+      value: MockEventSource,
+    });
+  });
+
+  afterEach(() => {
+    SSEManager.resetInstance();
+    globalThis.fetch = originalFetch;
+
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: originalWindow,
+    });
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      value: originalNavigator,
+    });
+    Object.defineProperty(globalThis, 'EventSource', {
+      configurable: true,
+      value: originalEventSource,
+    });
+  });
+
+  it('refetches a realtime token after a failed SSE handshake', async () => {
+    let tokenIndex = 0;
+    const fetchMock = mock(async () => {
+      tokenIndex += 1;
+      return new Response(
+        JSON.stringify({
+          token: `token-${tokenIndex}`,
+          expiresAt: Date.now() + 60_000,
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const manager = SSEManager.getInstance({
+      reconnectDelay: 1,
+      maxReconnectDelay: 1,
+    });
+    manager.setAuthProvider(async () => 'privy-token');
+    manager.setAuthenticated(true);
+
+    const unsubscribe = manager.subscribe('markets', () => {});
+    await waitForAsyncWork();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(
+      new URL(MockEventSource.instances[0]!.url).searchParams.get('token')
+    ).toBe('token-1');
+
+    MockEventSource.instances[0]!.emitError();
+    await waitForAsyncWork();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(MockEventSource.instances).toHaveLength(2);
+    expect(
+      new URL(MockEventSource.instances[1]!.url).searchParams.get('token')
+    ).toBe('token-2');
+
+    unsubscribe();
+  });
+
+  it('keeps using the cached token after a disconnect on an established connection', async () => {
+    let tokenIndex = 0;
+    const fetchMock = mock(async () => {
+      tokenIndex += 1;
+      return new Response(
+        JSON.stringify({
+          token: `token-${tokenIndex}`,
+          expiresAt: Date.now() + 60_000,
+        }),
+        {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const manager = SSEManager.getInstance({
+      reconnectDelay: 1,
+      maxReconnectDelay: 1,
+    });
+    manager.setAuthProvider(async () => 'privy-token');
+    manager.setAuthenticated(true);
+
+    const unsubscribe = manager.subscribe('markets', () => {});
+    await waitForAsyncWork();
+
+    const firstConnection = MockEventSource.instances[0]!;
+    firstConnection.emitOpen();
+    firstConnection.emitError();
+    await waitForAsyncWork();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(MockEventSource.instances).toHaveLength(2);
+    expect(
+      new URL(MockEventSource.instances[1]!.url).searchParams.get('token')
+    ).toBe('token-1');
+
+    unsubscribe();
+  });
+});

--- a/apps/web/src/lib/sse/SSEManager.ts
+++ b/apps/web/src/lib/sse/SSEManager.ts
@@ -565,6 +565,11 @@ export class SSEManager {
     this.activeRequestedChannels = null;
   }
 
+  private clearCachedToken(): void {
+    this.cachedToken = null;
+    this.pendingTokenFetch = null;
+  }
+
   private reconcileChannelDrift(): void {
     if (this.requestedChannels.size === 0) return;
     if (!this.pendingChannelReconnect && !this.activeRequestedChannels) return;
@@ -722,9 +727,11 @@ export class SSEManager {
 
     const eventSource = new EventSource(url);
     let errorHandled = false;
+    let handshakeCompleted = false;
 
     eventSource.onopen = () => {
       errorHandled = false;
+      handshakeCompleted = true;
       this.eventSource = eventSource;
       this.connectedChannels = new Set(channelsList);
       this.connectingChannels = null;
@@ -851,6 +858,10 @@ export class SSEManager {
 
       if (!this.config.autoReconnect) return;
       if (!this.isOnline) return;
+
+      if (!handshakeCompleted) {
+        this.clearCachedToken();
+      }
 
       if (this.reconnectAttempts >= this.config.maxReconnectAttempts) {
         this.notifyConnectionState(


### PR DESCRIPTION
## Summary

- Refresh the realtime SSE token when the initial `/api/sse/events` handshake fails, instead of retrying with the same cached token.
- Keep the existing cached-token behavior for established connections so transient disconnects do not add unnecessary token traffic.
- Add focused unit coverage for both the recovery path and the established-connection path.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-412/markets-sse-connections-fail-with-invalid-realtime-token
- Sentry incident referenced in the Linear issue description

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Non-goals / follow-ups

- None.

## Changes

- Invalidate the cached realtime token only when the SSE connection fails before the handshake completes.
- Leave the cached token intact for post-connect disconnects so normal reconnects keep their current behavior.
- Add `SSEManager` tests that verify both paths.

## Review guide

**Start here**
- `apps/web/src/lib/sse/SSEManager.ts`
- `apps/web/src/lib/sse/SSEManager.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- The fix is intentionally client-side only. The server behavior stays unchanged because the reproducible issue in code is repeated reuse of a token that has already failed the handshake.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bun test apps/web/src/lib/sse/SSEManager.test.ts`
2. `bun test apps/web/src/app/api/realtime/token/__tests__/route.test.ts apps/web/src/lib/sse/SSEManager.test.ts`
3. `bunx biome check apps/web/src/lib/sse/SSEManager.ts apps/web/src/lib/sse/SSEManager.test.ts`

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: Deploy normally; clients will refetch a fresh realtime token on failed SSE handshakes.
- Rollback: Revert this PR to restore the previous cached-token reconnect behavior.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend-adjacent client connection fix in SSE token recovery logic, with no UI changes.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
