### PR TITLE
fix(shared): add explicit Privy login methods

### DIFF
--- a/packages/shared/src/auth/__tests__/privy-config.test.ts
+++ b/packages/shared/src/auth/__tests__/privy-config.test.ts
@@ -13,13 +13,38 @@ describe('privyConfig', () => {
       `${moduleUrl.href}?t=${Date.now()}`
     )) as typeof import('../privy-config');
 
-    const { appearance, defaultChain, supportedChains } = privyConfig.config;
+    const {
+      appearance,
+      defaultChain,
+      supportedChains,
+      loginMethods,
+      loginMethodsAndOrder,
+    } = privyConfig.config;
     if (!defaultChain) throw new Error('Expected defaultChain to be set');
     if (!supportedChains) throw new Error('Expected supportedChains to be set');
+    if (!loginMethods) throw new Error('Expected loginMethods to be set');
+    if (!loginMethodsAndOrder)
+      throw new Error('Expected loginMethodsAndOrder to be set');
 
     expect(defaultChain.id).toBe(1);
     expect(supportedChains.map((chain) => chain.id)).toEqual([1]);
     expect(appearance?.walletChainType).toBe('ethereum-and-solana');
+    expect(loginMethods).toContain('farcaster');
+    expect(loginMethods).toEqual([
+      'telegram',
+      'twitter',
+      'wallet',
+      'farcaster',
+      'email',
+      'discord',
+    ]);
+    expect(loginMethodsAndOrder.primary).toEqual([
+      'telegram',
+      'twitter',
+      'phantom',
+      'farcaster',
+      'email',
+    ]);
 
     process.env.NEXT_PUBLIC_CHAIN_ID = previousChainId;
     process.env.NEXT_PUBLIC_RPC_URL = previousRpcUrl;

--- a/packages/shared/src/auth/privy-config.ts
+++ b/packages/shared/src/auth/privy-config.ts
@@ -64,6 +64,35 @@ export const loginMethodsAndOrder: NonNullable<
   ],
 };
 
+const primaryLoginMethods = loginMethodsAndOrder.primary ?? [];
+const overflowLoginMethods = loginMethodsAndOrder.overflow ?? [];
+
+function toLoginMethod(
+  method:
+    | (typeof primaryLoginMethods)[number]
+    | (typeof overflowLoginMethods)[number]
+): NonNullable<BabylonPrivyConfig['loginMethods']>[number] {
+  switch (method) {
+    case 'phantom':
+    case 'metamask':
+    case 'rabby_wallet':
+    case 'coinbase_wallet':
+    case 'rainbow':
+    case 'backpack':
+      return 'wallet';
+    default:
+      // `loginMethodsAndOrder` is defined in this module, so the remaining
+      // configured values are already valid `loginMethods` entries.
+      return method as NonNullable<BabylonPrivyConfig['loginMethods']>[number];
+  }
+}
+
+export const loginMethods = [
+  ...new Set(
+    [...primaryLoginMethods, ...overflowLoginMethods].map(toLoginMethod)
+  ),
+] as NonNullable<BabylonPrivyConfig['loginMethods']>;
+
 const embeddedWallets: NonNullable<BabylonPrivyConfig['embeddedWallets']> = {
   ethereum: { createOnLogin: 'users-without-wallets' },
 };
@@ -80,6 +109,7 @@ export const privyConfig: { appId: string; config: BabylonPrivyConfig } = {
   appId: process.env.NEXT_PUBLIC_PRIVY_APP_ID || '',
   config: {
     appearance,
+    loginMethods,
     loginMethodsAndOrder,
     embeddedWallets,
     defaultChain: CHAIN,


### PR DESCRIPTION
## Summary

- Add an explicit `loginMethods` list to the shared Privy config so Farcaster is registered as an upfront login method during auth bootstrap.
- Derive `loginMethods` from the existing `loginMethodsAndOrder` source of truth, normalizing wallet-specific entries to Privy's generic `wallet` login method.
- Add focused coverage to keep the Farcaster and wallet login-method config aligned.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-410/bugauth-investigate-privy-pollforready-crash-on-feed
- Sentry: `BABYLONAPP-67`
- Privy Farcaster Mini App docs require `loginMethods: ['farcaster', ...]` on `PrivyProvider` in addition to the ordered config.

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [x] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Non-goals / follow-ups

- None.

## Changes

- Add a shared `loginMethods` config alongside `loginMethodsAndOrder` in `packages/shared/src/auth/privy-config.ts`.
- Normalize wallet-specific ordered entries (`phantom`, `metamask`, `coinbase_wallet`, etc.) to Privy's `wallet` login method when building the explicit login-method list.
- Extend `packages/shared/src/auth/__tests__/privy-config.test.ts` to lock the expected Farcaster and wallet login-method behavior.

## Review guide

**Start here**
- `packages/shared/src/auth/privy-config.ts`
- `packages/shared/src/auth/__tests__/privy-config.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- The fix is intentionally narrow: it only adjusts Privy's shared client config and preserves the existing ordering config as the single source of truth.
- `loginMethodsAndOrder` still controls modal ordering; the explicit `loginMethods` list is added to satisfy Privy's Farcaster bootstrap requirements.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bun test packages/shared/src/auth/__tests__/privy-config.test.ts`
2. `bun x @biomejs/biome check packages/shared/src/auth/privy-config.ts packages/shared/src/auth/__tests__/privy-config.test.ts`
3. `bun x tsc -p packages/shared/tsconfig.json --noEmit`

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: normal deploy.
- Rollback: revert this PR to restore the previous Privy config.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: shared auth config change with no intended UI delta.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
