### PR TITLE
fix(shared): trim Privy primary login methods

### DIFF
--- a/packages/shared/src/auth/__tests__/privy-config.test.ts
+++ b/packages/shared/src/auth/__tests__/privy-config.test.ts
@@ -13,13 +13,25 @@ describe('privyConfig', () => {
       `${moduleUrl.href}?t=${Date.now()}`
     )) as typeof import('../privy-config');
 
-    const { appearance, defaultChain, supportedChains } = privyConfig.config;
+    const { appearance, defaultChain, supportedChains, loginMethodsAndOrder } =
+      privyConfig.config;
     if (!defaultChain) throw new Error('Expected defaultChain to be set');
     if (!supportedChains) throw new Error('Expected supportedChains to be set');
+    if (!loginMethodsAndOrder)
+      throw new Error('Expected loginMethodsAndOrder to be set');
 
     expect(defaultChain.id).toBe(1);
     expect(supportedChains.map((chain) => chain.id)).toEqual([1]);
     expect(appearance?.walletChainType).toBe('ethereum-and-solana');
+    expect(loginMethodsAndOrder.primary).toEqual([
+      'twitter',
+      'phantom',
+      'farcaster',
+      'email',
+    ]);
+    expect(loginMethodsAndOrder.primary).toHaveLength(4);
+    expect(loginMethodsAndOrder.overflow).toContain('telegram');
+    expect(loginMethodsAndOrder.overflow?.[0]).toBe('telegram');
 
     process.env.NEXT_PUBLIC_CHAIN_ID = previousChainId;
     process.env.NEXT_PUBLIC_RPC_URL = previousRpcUrl;

--- a/packages/shared/src/auth/privy-config.ts
+++ b/packages/shared/src/auth/privy-config.ts
@@ -53,8 +53,9 @@ const appearance: Appearance = {
 export const loginMethodsAndOrder: NonNullable<
   BabylonPrivyConfig['loginMethodsAndOrder']
 > = {
-  primary: ['telegram', 'twitter', 'phantom', 'farcaster', 'email'],
+  primary: ['twitter', 'phantom', 'farcaster', 'email'],
   overflow: [
+    'telegram',
     'metamask',
     'discord',
     'rabby_wallet',


### PR DESCRIPTION
## Summary

- Remove the invalid fifth primary Privy login method so the feed/login bootstrap stops initializing Privy with a known-bad modal config.
- Move `telegram` from `loginMethodsAndOrder.primary` to `overflow`, keeping the same login options while respecting Privy's documented 4-item primary limit.
- Add focused test coverage to lock the shared Privy config shape.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-410/bugauth-investigate-privy-pollforready-crash-on-feed
- Sentry: `BABYLONAPP-67`
- Production browser repro shows Privy warning repeatedly on `/feed`: `You should not specify greater than 4 login methods in loginMethodsAndOrder.primary`.

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [x] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Non-goals / follow-ups

- This PR does not claim to fully resolve the underlying Privy/Farcaster `pollForReady` crash path.
- This PR only removes a reproduced invalid Privy config warning from production and narrows one obvious source of SDK instability.

## Changes

- Update `packages/shared/src/auth/privy-config.ts` so `loginMethodsAndOrder.primary` has 4 items instead of 5.
- Move `telegram` into `loginMethodsAndOrder.overflow`.
- Add coverage in `packages/shared/src/auth/__tests__/privy-config.test.ts` for the primary/overflow ordering contract.

## Review guide

**Start here**
- `packages/shared/src/auth/privy-config.ts`
- `packages/shared/src/auth/__tests__/privy-config.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- This is intentionally narrow and only addresses a config state that is currently warned about by Privy in production.
- Telegram remains available in the modal, just no longer as a fifth primary option.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bun test packages/shared/src/auth/__tests__/privy-config.test.ts`
2. `bun x @biomejs/biome check packages/shared/src/auth/privy-config.ts packages/shared/src/auth/__tests__/privy-config.test.ts`
3. `bun x tsc -p packages/shared/tsconfig.json --noEmit`
4. Verified in production browser that `/feed` currently logs the invalid `loginMethodsAndOrder.primary` warning before this change.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: normal deploy.
- Rollback: revert this PR to restore the previous modal ordering.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: shared auth modal configuration change with no intended UI redesign.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
