### PR TITLE
fix(web): route buy points checkout through server-side Privy

### DIFF
--- a/apps/web/src/hooks/useBuyPointsTx.test.ts
+++ b/apps/web/src/hooks/useBuyPointsTx.test.ts
@@ -33,7 +33,8 @@ const { WALLET_ERROR_MESSAGES } = await import('@babylon/shared');
 const { useBuyPointsTx } = await import('./useBuyPointsTx');
 
 beforeEach(() => {
-  authState.embeddedWalletAddress = '0x1111111111111111111111111111111111111111';
+  authState.embeddedWalletAddress =
+    '0x1111111111111111111111111111111111111111';
   authState.embeddedWalletReady = true;
   authState.getAccessToken.mockReset();
   authState.getAccessToken.mockImplementation(async () => 'fresh-jwt');

--- a/apps/web/src/hooks/useBuyPointsTx.test.ts
+++ b/apps/web/src/hooks/useBuyPointsTx.test.ts
@@ -14,7 +14,7 @@ mock.module('react', () => ({
 const authState = {
   embeddedWalletAddress: '0x1111111111111111111111111111111111111111',
   embeddedWalletReady: true,
-  getAccessToken: mock(async () => 'fresh-jwt'),
+  getAccessToken: mock(async (): Promise<string | null> => 'fresh-jwt'),
 };
 
 const sendSponsoredEthTransferAction = mock(async () => ({

--- a/apps/web/src/hooks/useBuyPointsTx.test.ts
+++ b/apps/web/src/hooks/useBuyPointsTx.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const actualReact = await import('react');
+const reactMock = {
+  ...actualReact,
+  useCallback: (fn: Function) => fn,
+};
+
+mock.module('react', () => ({
+  ...reactMock,
+  default: actualReact.default ?? reactMock,
+}));
+
+const authState = {
+  embeddedWalletAddress: '0x1111111111111111111111111111111111111111',
+  embeddedWalletReady: true,
+  getAccessToken: mock(async () => 'fresh-jwt'),
+};
+
+const sendSponsoredEthTransferAction = mock(async () => ({
+  txHash: '0xabc123',
+}));
+
+mock.module('@/hooks/useAuth', () => ({
+  useAuth: () => authState,
+}));
+
+mock.module('@/app/_actions/onchain', () => ({
+  sendSponsoredEthTransferAction,
+}));
+
+const { WALLET_ERROR_MESSAGES } = await import('@babylon/shared');
+const { useBuyPointsTx } = await import('./useBuyPointsTx');
+
+beforeEach(() => {
+  authState.embeddedWalletAddress = '0x1111111111111111111111111111111111111111';
+  authState.embeddedWalletReady = true;
+  authState.getAccessToken.mockReset();
+  authState.getAccessToken.mockImplementation(async () => 'fresh-jwt');
+  sendSponsoredEthTransferAction.mockReset();
+  sendSponsoredEthTransferAction.mockImplementation(async () => ({
+    txHash: '0xabc123',
+  }));
+});
+
+describe('useBuyPointsTx', () => {
+  test('throws when the embedded wallet is not ready', async () => {
+    authState.embeddedWalletReady = false;
+
+    const { sendPointsPayment } = useBuyPointsTx();
+
+    await expect(
+      sendPointsPayment({
+        to: '0x2222222222222222222222222222222222222222',
+        amountWei: 123n,
+      })
+    ).rejects.toThrow(WALLET_ERROR_MESSAGES.NO_EMBEDDED_WALLET);
+
+    expect(authState.getAccessToken).not.toHaveBeenCalled();
+    expect(sendSponsoredEthTransferAction).not.toHaveBeenCalled();
+  });
+
+  test('throws when authentication is unavailable', async () => {
+    authState.getAccessToken.mockImplementation(async () => null);
+
+    const { sendPointsPayment } = useBuyPointsTx();
+
+    await expect(
+      sendPointsPayment({
+        to: '0x2222222222222222222222222222222222222222',
+        amountWei: 123n,
+      })
+    ).rejects.toThrow('Authentication required');
+
+    expect(sendSponsoredEthTransferAction).not.toHaveBeenCalled();
+  });
+
+  test('uses the server-side sponsored transfer action for point payments', async () => {
+    const { sendPointsPayment } = useBuyPointsTx();
+
+    await expect(
+      sendPointsPayment({
+        to: '0x2222222222222222222222222222222222222222',
+        amountWei: 123n,
+      })
+    ).resolves.toBe('0xabc123');
+
+    expect(authState.getAccessToken).toHaveBeenCalledTimes(1);
+    expect(sendSponsoredEthTransferAction).toHaveBeenCalledWith({
+      to: '0x2222222222222222222222222222222222222222',
+      amountWei: '123',
+      userJwt: 'fresh-jwt',
+    });
+  });
+});

--- a/apps/web/src/hooks/useBuyPointsTx.ts
+++ b/apps/web/src/hooks/useBuyPointsTx.ts
@@ -1,7 +1,7 @@
 import { WALLET_ERROR_MESSAGES } from '@babylon/shared';
-import { useSendTransaction } from '@privy-io/react-auth';
 import { useCallback } from 'react';
 import type { Address } from 'viem';
+import { sendSponsoredEthTransferAction } from '@/app/_actions/onchain';
 import { useAuth } from '@/hooks/useAuth';
 
 interface PointsPaymentInput {
@@ -12,12 +12,12 @@ interface PointsPaymentInput {
 /**
  * Hook for sending points payment transactions.
  *
- * Uses Privy's client-side sponsored transaction flow with embedded wallets.
- * Gas is sponsored by Privy (sponsor: true), but the wallet must hold the transferred ETH value.
+ * Uses the existing server-side sponsored transaction flow for embedded wallets.
+ * Gas is sponsored by Privy server-side, but the wallet must still hold the transferred ETH value.
  */
 export function useBuyPointsTx() {
-  const { embeddedWalletReady, embeddedWalletAddress } = useAuth();
-  const { sendTransaction } = useSendTransaction();
+  const { embeddedWalletReady, embeddedWalletAddress, getAccessToken } =
+    useAuth();
 
   const sendPointsPayment = useCallback(
     async ({ to, amountWei }: PointsPaymentInput) => {
@@ -28,20 +28,20 @@ export function useBuyPointsTx() {
       const normalizedValue =
         typeof amountWei === 'bigint' ? amountWei : BigInt(amountWei);
 
-      // Use Privy's client-side sendTransaction with gas sponsorship
-      const result = await sendTransaction(
-        {
-          to,
-          value: normalizedValue,
-        },
-        {
-          sponsor: true, // Privy covers gas fees
-        }
-      );
+      const userJwt = await getAccessToken().catch(() => null);
+      if (!userJwt) {
+        throw new Error('Authentication required');
+      }
 
-      return result.hash;
+      const { txHash } = await sendSponsoredEthTransferAction({
+        to,
+        amountWei: normalizedValue.toString(),
+        userJwt,
+      });
+
+      return txHash;
     },
-    [embeddedWalletReady, embeddedWalletAddress, sendTransaction]
+    [embeddedWalletReady, embeddedWalletAddress, getAccessToken]
   );
 
   return { sendPointsPayment };


### PR DESCRIPTION
## Summary

- Route Buy Points crypto payments through the existing server-side Privy sponsored transfer action instead of Privy's client-side `useSendTransaction(..., { sponsor: true })` flow.
- Remove the dependency on the client-sponsored path that fails when the Privy app secret is not available for sponsored transactions.
- Add a focused unit test for `useBuyPointsTx` covering wallet gating, auth gating, and the server-side transfer call.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-406/bugpayments-buypointsmodal-crypto-checkout-fails-without-privy-app
- Sentry: https://babylon-0t.sentry.io/issues/7354408122/

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Non-goals / follow-ups

- None.

## Changes

- Update `useBuyPointsTx` to call `sendSponsoredEthTransferAction` with a fresh Privy access token.
- Keep the existing wallet readiness checks and payment modal flow unchanged.
- Add `useBuyPointsTx.test.ts` to pin the expected transaction path.

## Review guide

**Start here**
- `apps/web/src/hooks/useBuyPointsTx.ts`
- `apps/web/src/hooks/useBuyPointsTx.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- This intentionally reuses the server-side sponsored transfer action that is already used elsewhere in the repo, rather than adding a new API route or fallback path.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bunx biome check --write apps/web/src/hooks/useBuyPointsTx.ts apps/web/src/hooks/useBuyPointsTx.test.ts`
2. `bun test apps/web/src/hooks/useBuyPointsTx.test.ts --preload ./packages/testing/unit/preload.ts`
3. No browser demo recorded: this is a behavior fix inside an existing payment flow with no visual changes.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: deploy normally.
- Rollback: revert this PR to restore the previous client-side transaction path.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: behavior fix in an existing crypto checkout flow, with no UI copy or layout changes.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
