### PR TITLE
fix(web): wait for auth readiness before For You feed fetch

### DIFF
--- a/apps/web/src/app/feed/hooks/useForYouFeed.test.ts
+++ b/apps/web/src/app/feed/hooks/useForYouFeed.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  getForYouFeedSseChannel,
+  shouldStartInitialForYouFetch,
+} from './useForYouFeed';
+
+describe('useForYouFeed auth readiness guards', () => {
+  it('waits for auth readiness before the initial fetch', () => {
+    expect(
+      shouldStartInitialForYouFetch({
+        enabled: true,
+        authReady: false,
+        hasFetched: false,
+      })
+    ).toBe(false);
+  });
+
+  it('starts the initial fetch once auth is ready', () => {
+    expect(
+      shouldStartInitialForYouFetch({
+        enabled: true,
+        authReady: true,
+        hasFetched: false,
+      })
+    ).toBe(true);
+  });
+
+  it('does not re-run the initial fetch after it already started', () => {
+    expect(
+      shouldStartInitialForYouFetch({
+        enabled: true,
+        authReady: true,
+        hasFetched: true,
+      })
+    ).toBe(false);
+  });
+
+  it('subscribes to feed SSE only after auth is ready', () => {
+    expect(getForYouFeedSseChannel(true, false)).toBeNull();
+    expect(getForYouFeedSseChannel(false, true)).toBeNull();
+    expect(getForYouFeedSseChannel(true, true)).toBe('feed');
+  });
+});

--- a/apps/web/src/app/feed/hooks/useForYouFeed.ts
+++ b/apps/web/src/app/feed/hooks/useForYouFeed.ts
@@ -32,11 +32,32 @@ interface FeedPageResponse {
   generatedAt?: string;
 }
 
+interface InitialForYouFetchState {
+  enabled: boolean;
+  authReady: boolean;
+  hasFetched: boolean;
+}
+
+export function shouldStartInitialForYouFetch({
+  enabled,
+  authReady,
+  hasFetched,
+}: InitialForYouFetchState): boolean {
+  return enabled && authReady && !hasFetched;
+}
+
+export function getForYouFeedSseChannel(
+  enabled: boolean,
+  authReady: boolean
+): 'feed' | null {
+  return enabled && authReady ? 'feed' : null;
+}
+
 export function useForYouFeed(
   options: UseForYouFeedOptions = {}
 ): UseForYouFeedResult {
   const { enabled = true } = options;
-  const { authenticated, getAccessToken } = useAuth();
+  const { ready: authReady, authenticated, getAccessToken } = useAuth();
 
   const [stories, setStories] = useState<NarrativeStory[]>([]);
   const [ready, setReady] = useState(false);
@@ -124,6 +145,7 @@ export function useForYouFeed(
   );
 
   const refresh = useCallback(async () => {
+    if (!authReady) return;
     abortControllerRef.current?.abort();
     loadMoreAbortRef.current?.abort();
     loadingMoreRef.current = false;
@@ -131,7 +153,7 @@ export function useForYouFeed(
     const controller = new AbortController();
     abortControllerRef.current = controller;
     await loadInitial(controller.signal);
-  }, [loadInitial]);
+  }, [authReady, loadInitial]);
 
   const loadMore = useCallback(() => {
     // Use ref-based guards to avoid stale closure values from React state.
@@ -178,7 +200,7 @@ export function useForYouFeed(
   // hook, polling would reset the user to page 1 mid-scroll. If SSE is
   // unavailable, the user retains their current page until they manually refresh.
   useSSEChannel(
-    enabled ? 'feed' : null,
+    getForYouFeedSseChannel(enabled, authReady),
     useCallback(() => {
       if (!isMountedRef.current) return;
       if (sseDebounceRef.current) clearTimeout(sseDebounceRef.current);
@@ -208,7 +230,22 @@ export function useForYouFeed(
     }
 
     isMountedRef.current = true;
-    if (hasFetched.current) return;
+    if (
+      !shouldStartInitialForYouFetch({
+        enabled,
+        authReady,
+        hasFetched: hasFetched.current,
+      })
+    ) {
+      return () => {
+        isMountedRef.current = false;
+        if (sseDebounceRef.current) {
+          clearTimeout(sseDebounceRef.current);
+          sseDebounceRef.current = null;
+        }
+      };
+    }
+
     hasFetched.current = true;
 
     const controller = new AbortController();
@@ -225,7 +262,7 @@ export function useForYouFeed(
         sseDebounceRef.current = null;
       }
     };
-  }, [enabled, loadInitial]);
+  }, [authReady, enabled, loadInitial]);
 
   return {
     stories,


### PR DESCRIPTION
## Summary
- Wait for `useForYouFeed` auth readiness before the first `/api/feed/for-you` request so authenticated users do not fall into the public rate-limit bucket during boot.
- Block premature For You SSE refreshes until auth is resolved, matching the same readiness gate as the initial fetch.
- Add focused regression tests for the auth-readiness guard used by the For You hook.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Linear: https://linear.app/eliza-labs/issue/BAB-404/bugfeed-for-you-feed-can-hit-public-429-before-auth-is-ready
- Sentry: https://babylon-0t.sentry.io/issues/7354663645/

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Non-goals / follow-ups
- None.

## Changes
- Gate the first For You fetch on `useAuth().ready` instead of assuming auth has resolved on mount.
- Prevent early For You refresh/SSE activity before auth readiness to avoid an anonymous first request for logged-in users.
- Add regression coverage for the auth-readiness decision helpers in `useForYouFeed`.

## Review guide
**Start here**
- `apps/web/src/app/feed/hooks/useForYouFeed.ts`
- `apps/web/src/app/feed/hooks/useForYouFeed.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- Anonymous users still fetch the public For You feed once Privy has resolved `ready`; the change only removes the pre-ready race window.

## Test plan
**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bunx biome check --write apps/web/src/app/feed/hooks/useForYouFeed.ts apps/web/src/app/feed/hooks/useForYouFeed.test.ts`
2. `bun test apps/web/src/app/feed/hooks/useForYouFeed.test.ts`
3. `bun test apps/web/src/app/api/feed/for-you/route.test.ts`

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: Ship normally.
- Rollback: Revert this PR.

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)
### Option B: No visual changes
- Reason: Client hook timing fix only; no UI copy or layout changed.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
