### PR TITLE
fix(web): prevent null promise rejection on /agents/team

### DIFF
--- a/apps/web/src/hooks/useChatMessages.ts
+++ b/apps/web/src/hooks/useChatMessages.ts
@@ -7,6 +7,7 @@ import {
   MessageTypeEnum,
   type ReplyToMessage,
 } from '@/components/chats/types';
+import { getPrivyAccessTokenSafely } from '@/lib/auth/privyAccessToken';
 import { CHAT_PAGE_SIZE } from '@/lib/constants';
 import { useAuthStore } from '@/stores/authStore';
 import { useSSEChannel } from './useSSE';
@@ -237,6 +238,20 @@ export function useChatMessages(chatId: string | null) {
     []
   );
 
+  const getSafeAccessToken = useCallback(
+    () =>
+      getPrivyAccessTokenSafely(getAccessToken, {
+        onError: (error) => {
+          logger.warn(
+            'Failed to retrieve chat access token',
+            { error: error.message },
+            'useChatMessages'
+          );
+        },
+      }),
+    [getAccessToken]
+  );
+
   // Load existing messages from API (initial load)
   const loadMessages = useCallback(
     async (chatId: string) => {
@@ -247,20 +262,84 @@ export function useChatMessages(chatId: string | null) {
 
       setIsLoading(true);
 
-      // Get auth token for authenticated request
-      const token = await getAccessToken();
+      try {
+        const token = await getSafeAccessToken();
+        if (!token) {
+          logger.error(
+            'Failed to load messages - no auth token',
+            { chatId },
+            'useChatMessages'
+          );
+          return;
+        }
+
+        const response = await fetch(
+          `/api/chats/${chatId}?limit=${CHAT_PAGE_SIZE}`,
+          {
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          }
+        );
+
+        if (response.ok) {
+          const data = await response.json();
+          if (data.messages) {
+            const formatted = (data.messages as RawApiMessage[]).map((msg) =>
+              formatMessage(msg, chatId)
+            );
+            setMessages(formatted);
+            setHasMore(data.pagination?.hasMore ?? false);
+            setNextCursor(data.pagination?.nextCursor ?? null);
+            hasLoadedRef.current.add(chatId);
+            logger.debug(
+              `Loaded ${formatted.length} messages`,
+              { chatId, count: formatted.length },
+              'useChatMessages'
+            );
+          }
+        } else {
+          logger.error(
+            'Failed to load messages',
+            { chatId, status: response.status },
+            'useChatMessages'
+          );
+        }
+      } catch (error) {
+        logger.error(
+          'Failed to load messages',
+          {
+            chatId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          'useChatMessages'
+        );
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [getSafeAccessToken]
+  );
+
+  // Load more older messages (pagination)
+  const loadMore = useCallback(async () => {
+    if (!chatId || !nextCursor || isLoadingMore || !hasMore) return;
+
+    setIsLoadingMore(true);
+
+    try {
+      const token = await getSafeAccessToken();
       if (!token) {
         logger.error(
-          'Failed to load messages - no auth token',
+          'Failed to load more messages - no auth token',
           { chatId },
           'useChatMessages'
         );
-        setIsLoading(false);
         return;
       }
 
       const response = await fetch(
-        `/api/chats/${chatId}?limit=${CHAT_PAGE_SIZE}`,
+        `/api/chats/${chatId}?cursor=${nextCursor}&limit=${CHAT_PAGE_SIZE}`,
         {
           headers: {
             Authorization: `Bearer ${token}`,
@@ -270,78 +349,34 @@ export function useChatMessages(chatId: string | null) {
 
       if (response.ok) {
         const data = await response.json();
-        if (data.messages) {
+        if (data.messages?.length > 0) {
           const formatted = (data.messages as RawApiMessage[]).map((msg) =>
             formatMessage(msg, chatId)
           );
-          setMessages(formatted);
+          setMessages((prev) => [...formatted, ...prev]);
           setHasMore(data.pagination?.hasMore ?? false);
           setNextCursor(data.pagination?.nextCursor ?? null);
-          hasLoadedRef.current.add(chatId);
-          logger.debug(
-            `Loaded ${formatted.length} messages`,
-            { chatId, count: formatted.length },
-            'useChatMessages'
-          );
         }
       } else {
         logger.error(
-          'Failed to load messages',
+          'Failed to load more messages',
           { chatId, status: response.status },
           'useChatMessages'
         );
       }
-      setIsLoading(false);
-    },
-    [getAccessToken]
-  );
-
-  // Load more older messages (pagination)
-  const loadMore = useCallback(async () => {
-    if (!chatId || !nextCursor || isLoadingMore || !hasMore) return;
-
-    setIsLoadingMore(true);
-
-    // Get auth token for authenticated request
-    const token = await getAccessToken();
-    if (!token) {
-      logger.error(
-        'Failed to load more messages - no auth token',
-        { chatId },
-        'useChatMessages'
-      );
-      setIsLoadingMore(false);
-      return;
-    }
-
-    const response = await fetch(
-      `/api/chats/${chatId}?cursor=${nextCursor}&limit=${CHAT_PAGE_SIZE}`,
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    );
-
-    if (response.ok) {
-      const data = await response.json();
-      if (data.messages?.length > 0) {
-        const formatted = (data.messages as RawApiMessage[]).map((msg) =>
-          formatMessage(msg, chatId)
-        );
-        setMessages((prev) => [...formatted, ...prev]);
-        setHasMore(data.pagination?.hasMore ?? false);
-        setNextCursor(data.pagination?.nextCursor ?? null);
-      }
-    } else {
+    } catch (error) {
       logger.error(
         'Failed to load more messages',
-        { chatId, status: response.status },
+        {
+          chatId,
+          error: error instanceof Error ? error.message : String(error),
+        },
         'useChatMessages'
       );
+    } finally {
+      setIsLoadingMore(false);
     }
-    setIsLoadingMore(false);
-  }, [chatId, nextCursor, isLoadingMore, hasMore, getAccessToken]);
+  }, [chatId, nextCursor, isLoadingMore, hasMore, getSafeAccessToken]);
 
   // Handle SSE updates for this chat
   const handleChatUpdate = useCallback(
@@ -447,7 +482,7 @@ export function useChatMessages(chatId: string | null) {
         setMessages([]);
         setHasMore(false);
         setNextCursor(null);
-        loadMessages(chatId);
+        void loadMessages(chatId);
       } else {
         setIsLoading(false);
         setMessages([]);
@@ -469,7 +504,7 @@ export function useChatMessages(chatId: string | null) {
       pollIntervalRef.current = setInterval(async () => {
         try {
           // Get auth token for authenticated request
-          const token = await getAccessToken();
+          const token = await getSafeAccessToken();
           if (!token) return;
 
           const response = await fetch(
@@ -553,7 +588,7 @@ export function useChatMessages(chatId: string | null) {
       clearTimeout(startTimeout);
       if (pollIntervalRef.current) clearInterval(pollIntervalRef.current);
     };
-  }, [chatId, getAccessToken]);
+  }, [chatId, getSafeAccessToken]);
 
   // SSE connected means we're ready
   useEffect(() => {
@@ -594,7 +629,7 @@ export function useChatMessages(chatId: string | null) {
   const reloadMessages = useCallback(() => {
     if (chatId) {
       hasLoadedRef.current.delete(chatId);
-      loadMessages(chatId);
+      void loadMessages(chatId);
     }
   }, [chatId, loadMessages]);
 

--- a/apps/web/src/hooks/useTeamChat.ts
+++ b/apps/web/src/hooks/useTeamChat.ts
@@ -43,6 +43,7 @@ const SCROLL_NEAR_BOTTOM_THRESHOLD = 150;
 const SCROLL_STABLE_FRAMES_REQUIRED = 5;
 // Maximum retries for scroll height stabilization (~2 seconds max)
 const MAX_SCROLL_STABLE_RETRIES = 20;
+const TEAM_CHAT_AUTH_FAILURE_MESSAGE = 'Authentication failed. Please retry.';
 
 /**
  * Extract agent IDs from @mentions in message content.
@@ -1223,6 +1224,10 @@ export function useTeamChat(): UseTeamChatReturn {
     try {
       setConversationsLoading(true);
       const token = await getSafeAccessToken();
+      if (!token) {
+        toast.error(TEAM_CHAT_AUTH_FAILURE_MESSAGE);
+        return;
+      }
       const response = await fetch('/api/agents/team-chat/conversations', {
         headers: { Authorization: `Bearer ${token}` },
       });
@@ -1296,6 +1301,10 @@ export function useTeamChat(): UseTeamChatReturn {
 
       try {
         const token = await getSafeAccessToken();
+        if (!token) {
+          toast.error(TEAM_CHAT_AUTH_FAILURE_MESSAGE);
+          return;
+        }
         const response = await fetch('/api/agents/team-chat/conversations', {
           method: 'POST',
           headers: {
@@ -1352,6 +1361,10 @@ export function useTeamChat(): UseTeamChatReturn {
 
       try {
         const token = await getSafeAccessToken();
+        if (!token) {
+          toast.error(TEAM_CHAT_AUTH_FAILURE_MESSAGE);
+          return;
+        }
         const response = await fetch(
           `/api/agents/team-chat/conversations/${chatId}`,
           {
@@ -1405,6 +1418,10 @@ export function useTeamChat(): UseTeamChatReturn {
 
       try {
         const token = await getSafeAccessToken();
+        if (!token) {
+          toast.error(TEAM_CHAT_AUTH_FAILURE_MESSAGE);
+          return;
+        }
         const response = await fetch(
           `/api/agents/team-chat/conversations/${chatId}`,
           {
@@ -1448,6 +1465,10 @@ export function useTeamChat(): UseTeamChatReturn {
 
       try {
         const token = await getSafeAccessToken();
+        if (!token) {
+          toast.error(TEAM_CHAT_AUTH_FAILURE_MESSAGE);
+          return;
+        }
         const response = await fetch(
           `/api/agents/team-chat/conversations/${chatId}`,
           {

--- a/apps/web/src/hooks/useTeamChat.ts
+++ b/apps/web/src/hooks/useTeamChat.ts
@@ -33,6 +33,7 @@ import {
   useChatMessages,
 } from '@/hooks/useChatMessages';
 import { useSSEChannel } from '@/hooks/useSSE';
+import { getPrivyAccessTokenSafely } from '@/lib/auth/privyAccessToken';
 import { useToggleReaction } from '@/hooks/useToggleReaction';
 import { getUserDisplayName } from '@/lib/user-display';
 import { useAuthStore } from '@/stores/authStore';
@@ -266,6 +267,20 @@ export function useTeamChat(): UseTeamChatReturn {
   // Conversations state (fresh chat feature)
   const [conversations, setConversations] = useState<ConversationInfo[]>([]);
   const [conversationsLoading, setConversationsLoading] = useState(false);
+
+  const getSafeAccessToken = useCallback(
+    () =>
+      getPrivyAccessTokenSafely(getAccessToken, {
+        onError: (error) => {
+          logger.warn(
+            'Failed to retrieve team chat access token',
+            { error: error.message },
+            'useTeamChat'
+          );
+        },
+      }),
+    [getAccessToken]
+  );
 
   // Refs
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
@@ -552,7 +567,7 @@ export function useTeamChat(): UseTeamChatReturn {
     async (isTyping: boolean) => {
       if (!teamChat) return;
 
-      const token = await getAccessToken();
+      const token = await getSafeAccessToken();
       if (!token) return;
 
       // Fire and forget - don't block on typing indicators
@@ -568,7 +583,7 @@ export function useTeamChat(): UseTeamChatReturn {
         logger.debug('Typing indicator failed', { error: err }, 'useTeamChat');
       });
     },
-    [teamChat, getAccessToken]
+    [teamChat, getSafeAccessToken]
   );
 
   // Debounced typing handler
@@ -628,7 +643,7 @@ export function useTeamChat(): UseTeamChatReturn {
     setError(null);
 
     try {
-      const token = await getAccessToken();
+      const token = await getSafeAccessToken();
       if (!token) {
         return;
       }
@@ -655,7 +670,7 @@ export function useTeamChat(): UseTeamChatReturn {
     } finally {
       setLoading(false);
     }
-  }, [getAccessToken]);
+  }, [getSafeAccessToken]);
 
   // Initial load
   useEffect(() => {
@@ -807,7 +822,7 @@ export function useTeamChat(): UseTeamChatReturn {
     setSendError(null);
 
     try {
-      const token = await getAccessToken();
+      const token = await getSafeAccessToken();
       if (!token) {
         // Rollback optimistic message on auth failure
         removeMessage(optimisticId);
@@ -1185,7 +1200,7 @@ export function useTeamChat(): UseTeamChatReturn {
     sending,
     user,
     processingAgentIds,
-    getAccessToken,
+    getSafeAccessToken,
     addMessage,
     updateMessage,
     removeMessage,
@@ -1206,7 +1221,7 @@ export function useTeamChat(): UseTeamChatReturn {
 
     try {
       setConversationsLoading(true);
-      const token = await getAccessToken();
+      const token = await getSafeAccessToken();
       const response = await fetch('/api/agents/team-chat/conversations', {
         headers: { Authorization: `Bearer ${token}` },
       });
@@ -1237,7 +1252,7 @@ export function useTeamChat(): UseTeamChatReturn {
     } finally {
       setConversationsLoading(false);
     }
-  }, [user, getAccessToken]);
+  }, [user, getSafeAccessToken]);
 
   /**
    * Create a new conversation (New Chat)
@@ -1279,7 +1294,7 @@ export function useTeamChat(): UseTeamChatReturn {
       }
 
       try {
-        const token = await getAccessToken();
+        const token = await getSafeAccessToken();
         const response = await fetch('/api/agents/team-chat/conversations', {
           method: 'POST',
           headers: {
@@ -1323,7 +1338,7 @@ export function useTeamChat(): UseTeamChatReturn {
         toast.error('Failed to create conversation');
       }
     },
-    [user, teamChat, conversations, getAccessToken, clearMessages]
+    [user, teamChat, conversations, getSafeAccessToken, clearMessages]
   );
 
   /**
@@ -1335,7 +1350,7 @@ export function useTeamChat(): UseTeamChatReturn {
       if (chatId === teamChat.chatId) return; // Already on this conversation
 
       try {
-        const token = await getAccessToken();
+        const token = await getSafeAccessToken();
         const response = await fetch(
           `/api/agents/team-chat/conversations/${chatId}`,
           {
@@ -1377,7 +1392,7 @@ export function useTeamChat(): UseTeamChatReturn {
         toast.error('Failed to switch conversation');
       }
     },
-    [user, teamChat, getAccessToken, clearMessages]
+    [user, teamChat, getSafeAccessToken, clearMessages]
   );
 
   /**
@@ -1388,7 +1403,7 @@ export function useTeamChat(): UseTeamChatReturn {
       if (!user) return;
 
       try {
-        const token = await getAccessToken();
+        const token = await getSafeAccessToken();
         const response = await fetch(
           `/api/agents/team-chat/conversations/${chatId}`,
           {
@@ -1420,7 +1435,7 @@ export function useTeamChat(): UseTeamChatReturn {
         toast.error('Failed to rename conversation');
       }
     },
-    [user, getAccessToken]
+    [user, getSafeAccessToken]
   );
 
   /**
@@ -1431,7 +1446,7 @@ export function useTeamChat(): UseTeamChatReturn {
       if (!user) return;
 
       try {
-        const token = await getAccessToken();
+        const token = await getSafeAccessToken();
         const response = await fetch(
           `/api/agents/team-chat/conversations/${chatId}`,
           {
@@ -1482,7 +1497,7 @@ export function useTeamChat(): UseTeamChatReturn {
         toast.error('Failed to delete conversation');
       }
     },
-    [user, getAccessToken, clearMessages, refreshConversations]
+    [user, getSafeAccessToken, clearMessages, refreshConversations]
   );
 
   // Fetch conversations when team chat loads

--- a/apps/web/src/hooks/useTeamChat.ts
+++ b/apps/web/src/hooks/useTeamChat.ts
@@ -645,6 +645,7 @@ export function useTeamChat(): UseTeamChatReturn {
     try {
       const token = await getSafeAccessToken();
       if (!token) {
+        setError('Authentication failed while loading Agents. Please retry.');
         return;
       }
 

--- a/apps/web/src/hooks/useTeamChat.ts
+++ b/apps/web/src/hooks/useTeamChat.ts
@@ -33,8 +33,8 @@ import {
   useChatMessages,
 } from '@/hooks/useChatMessages';
 import { useSSEChannel } from '@/hooks/useSSE';
-import { getPrivyAccessTokenSafely } from '@/lib/auth/privyAccessToken';
 import { useToggleReaction } from '@/hooks/useToggleReaction';
+import { getPrivyAccessTokenSafely } from '@/lib/auth/privyAccessToken';
 import { getUserDisplayName } from '@/lib/user-display';
 import { useAuthStore } from '@/stores/authStore';
 

--- a/apps/web/src/lib/auth/privyAccessToken.test.ts
+++ b/apps/web/src/lib/auth/privyAccessToken.test.ts
@@ -24,9 +24,7 @@ describe('privyAccessToken', () => {
   });
 
   it('retries retryable getter failures before succeeding', async () => {
-    const getAccessToken = mock<
-      () => Promise<string | null>
-    >(async () => {
+    const getAccessToken = mock<() => Promise<string | null>>(async () => {
       if (getAccessToken.mock.calls.length < 3) {
         throw new Error('Failed to fetch');
       }

--- a/apps/web/src/lib/auth/privyAccessToken.test.ts
+++ b/apps/web/src/lib/auth/privyAccessToken.test.ts
@@ -23,6 +23,12 @@ describe('privyAccessToken', () => {
     expect(onError.mock.calls[0]?.[0]?.message).toBe('null');
   });
 
+  it('returns null when onError is not provided', async () => {
+    await expect(
+      getPrivyAccessTokenSafely(() => Promise.reject(new Error('test')))
+    ).resolves.toBeNull();
+  });
+
   it('retries retryable getter failures before succeeding', async () => {
     const getAccessToken = mock<() => Promise<string | null>>(async () => {
       if (getAccessToken.mock.calls.length < 3) {

--- a/apps/web/src/lib/auth/privyAccessToken.test.ts
+++ b/apps/web/src/lib/auth/privyAccessToken.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, mock } from 'bun:test';
+import {
+  getPrivyAccessTokenSafely,
+  getPrivyAccessTokenWithRetry,
+} from './privyAccessToken';
+
+describe('privyAccessToken', () => {
+  it('returns the token when the getter succeeds', async () => {
+    await expect(
+      getPrivyAccessTokenSafely(() => Promise.resolve('token-123'))
+    ).resolves.toBe('token-123');
+  });
+
+  it('returns null and reports the error when the getter rejects with null', async () => {
+    const onError = mock(() => {});
+
+    await expect(
+      getPrivyAccessTokenSafely(() => Promise.reject(null), { onError })
+    ).resolves.toBeNull();
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+    expect(onError.mock.calls[0]?.[0]?.message).toBe('null');
+  });
+
+  it('retries retryable getter failures before succeeding', async () => {
+    const getAccessToken = mock<
+      () => Promise<string | null>
+    >(async () => {
+      if (getAccessToken.mock.calls.length < 3) {
+        throw new Error('Failed to fetch');
+      }
+      return 'recovered-token';
+    });
+
+    await expect(
+      getPrivyAccessTokenWithRetry(getAccessToken, {
+        initialDelayMs: 1,
+        maxDelayMs: 1,
+      })
+    ).resolves.toBe('recovered-token');
+
+    expect(getAccessToken).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/web/src/lib/auth/privyAccessToken.ts
+++ b/apps/web/src/lib/auth/privyAccessToken.ts
@@ -17,6 +17,11 @@ export interface PrivyAccessTokenRetryOptions {
   onRetry?: (attempt: number, error: Error, delayMs: number) => void;
 }
 
+export interface SafePrivyAccessTokenOptions
+  extends PrivyAccessTokenRetryOptions {
+  onError?: (error: Error) => void;
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => globalThis.setTimeout(resolve, ms));
 }
@@ -78,4 +83,18 @@ export async function getPrivyAccessTokenWithRetry(
   }
 
   throw lastError ?? new Error('Failed to fetch Privy access token');
+}
+
+export async function getPrivyAccessTokenSafely(
+  getAccessToken: () => Promise<string | null>,
+  options: SafePrivyAccessTokenOptions = {}
+): Promise<string | null> {
+  const { onError, ...retryOptions } = options;
+
+  try {
+    return await getPrivyAccessTokenWithRetry(getAccessToken, retryOptions);
+  } catch (error) {
+    onError?.(error instanceof Error ? error : new Error(String(error)));
+    return null;
+  }
 }


### PR DESCRIPTION
## Summary

- prevent `/agents/team` bootstrap flows from surfacing unhandled client-side rejections when Privy token refresh rejects
- route team chat token reads through the shared retrying helper instead of calling the raw Privy getter directly
- add focused coverage for the safe token helper, including `Promise.reject(null)`

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-405/bugweb-prevent-null-promise-rejection-on-agentsteam
- Sentry: https://babylon-0t.sentry.io/issues/7354529785/

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Shared types/utils (`packages/shared`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Non-goals / follow-ups

- No broader migration of every raw `usePrivy().getAccessToken()` call outside the `/agents/team` flow.

## Changes

- add `getPrivyAccessTokenSafely()` in the shared auth helper so callers can reuse retry logic without leaking promise rejections
- update `useChatMessages` to use the safe token helper and keep its effect-driven async loaders inside explicit `try/catch/finally` boundaries
- update `useTeamChat` to use the same safe token helper for bootstrap and user actions on the Agents team page
- add focused unit tests for successful, retrying, and `Promise.reject(null)` token getter cases

## Review guide

**Start here**
- `apps/web/src/lib/auth/privyAccessToken.ts`
- `apps/web/src/hooks/useChatMessages.ts`
- `apps/web/src/hooks/useTeamChat.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- The key behavior change is that rejected Privy token fetches are normalized to `null` for these team chat flows, so effect-started async work no longer bubbles an unhandled rejection to the browser.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bunx biome check apps/web/src/hooks/useChatMessages.ts apps/web/src/hooks/useTeamChat.ts apps/web/src/lib/auth/privyAccessToken.ts apps/web/src/lib/auth/privyAccessToken.test.ts`
2. `bun test apps/web/src/lib/auth/privyAccessToken.test.ts`
3. Attempted `bun test apps/web/src/lib/auth/privyAccessToken.test.ts apps/web/src/utils/api-fetch.test.ts`, but the worktree test environment currently fails resolving `clsx` from `packages/shared/src/utils/ui.ts` before the second file runs.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: Merge to `production`; the client hooks will start swallowing rejected Privy token fetches in `/agents/team` and log the failure instead of bubbling an unhandled rejection.
- Rollback: Revert this PR.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Client-side behavior fix only; no intentional visual/UI change.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
