### PR TITLE
fix: harden buy points RPC balance checks

### DIFF
--- a/apps/web/src/hooks/useWalletFunding.ts
+++ b/apps/web/src/hooks/useWalletFunding.ts
@@ -9,6 +9,7 @@ import {
   http,
   isAddress,
 } from 'viem';
+import { retryWalletBalanceRpcOperation } from '@/lib/wallet-balance-rpc';
 
 interface EnsureFundsOptions {
   signal?: AbortSignal;
@@ -46,8 +47,11 @@ export function useWalletFunding(): UseWalletFundingResult {
   const toastIdRef = useRef<string | number | null>(null);
 
   const getBalance = useCallback(
-    async (address: Address) => {
-      return await publicClient.getBalance({ address });
+    async (address: Address, signal?: AbortSignal) => {
+      return await retryWalletBalanceRpcOperation(
+        async () => publicClient.getBalance({ address }),
+        { signal }
+      );
     },
     [publicClient]
   );
@@ -74,7 +78,7 @@ export function useWalletFunding(): UseWalletFundingResult {
         throw new Error('Operation cancelled');
       }
 
-      const currentBalance = await getBalance(address);
+      const currentBalance = await getBalance(address, signal);
       if (currentBalance >= requiredAmountWei) return true;
 
       const deficit = requiredAmountWei - currentBalance;
@@ -101,7 +105,7 @@ export function useWalletFunding(): UseWalletFundingResult {
           throw new Error('Operation cancelled');
         }
 
-        const updatedBalance = await getBalance(address);
+        const updatedBalance = await getBalance(address, signal);
         if (updatedBalance >= requiredAmountWei) {
           if (showToasts) toast.success('Funds received!');
           return true;

--- a/apps/web/src/lib/wallet-balance-rpc.ts
+++ b/apps/web/src/lib/wallet-balance-rpc.ts
@@ -1,0 +1,103 @@
+import { HttpRequestError, RpcRequestError, TimeoutError } from 'viem';
+
+interface RetryWalletBalanceOptions {
+  signal?: AbortSignal;
+  maxAttempts?: number;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  onRetry?: (attempt: number, error: Error, delayMs: number) => void;
+}
+
+const DEFAULT_RETRY_OPTIONS = {
+  maxAttempts: 3,
+  initialDelayMs: 250,
+  maxDelayMs: 1000,
+} as const;
+
+function getCancelledError(): Error {
+  return new Error('Operation cancelled');
+}
+
+export function isRetryableWalletBalanceRpcError(error: unknown): boolean {
+  return (
+    error instanceof HttpRequestError ||
+    error instanceof RpcRequestError ||
+    error instanceof TimeoutError
+  );
+}
+
+async function sleepWithSignal(
+  delayMs: number,
+  signal: AbortSignal | undefined
+): Promise<void> {
+  if (!signal) {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+    return;
+  }
+
+  if (signal.aborted) {
+    throw getCancelledError();
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, delayMs);
+
+    const onAbort = () => {
+      clearTimeout(timeoutId);
+      signal.removeEventListener('abort', onAbort);
+      reject(getCancelledError());
+    };
+
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
+export async function retryWalletBalanceRpcOperation<T>(
+  operation: () => Promise<T>,
+  options: RetryWalletBalanceOptions = {}
+): Promise<T> {
+  const { signal, maxAttempts, initialDelayMs, maxDelayMs, onRetry } = {
+    ...DEFAULT_RETRY_OPTIONS,
+    ...options,
+  };
+
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    if (signal?.aborted) {
+      throw getCancelledError();
+    }
+
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+
+      if (signal?.aborted) {
+        throw getCancelledError();
+      }
+
+      if (
+        !isRetryableWalletBalanceRpcError(error) ||
+        attempt === maxAttempts - 1
+      ) {
+        throw error;
+      }
+
+      const delayMs = Math.min(initialDelayMs * 2 ** attempt, maxDelayMs);
+      onRetry?.(
+        attempt + 1,
+        error instanceof Error ? error : new Error(String(error)),
+        delayMs
+      );
+      await sleepWithSignal(delayMs, signal);
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error('Wallet balance check failed');
+}

--- a/packages/shared/src/config/index.ts
+++ b/packages/shared/src/config/index.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Address } from 'viem';
+import { sepolia } from 'viem/chains';
 import configData from './public-config.json';
 
 // =============================================================================
@@ -97,6 +98,10 @@ export function getRpcUrlForChainId(chainId: number): string {
 
   const networkId = CHAIN_ID_TO_NETWORK[chainId];
   if (networkId) return PUBLIC_CONFIG.networks[networkId].rpcUrl;
+
+  if (chainId === sepolia.id) {
+    return sepolia.rpcUrls.default.http[0] ?? getCurrentNetwork().rpcUrl;
+  }
 
   return getCurrentNetwork().rpcUrl;
 }

--- a/packages/shared/src/config/index.ts
+++ b/packages/shared/src/config/index.ts
@@ -75,7 +75,7 @@ const CHAIN_ID_TO_NETWORK: Record<number, NetworkId> = {
 };
 
 export function getCurrentChainId(): number {
-  const envChainId = process.env.NEXT_PUBLIC_CHAIN_ID;
+  const envChainId = process.env.NEXT_PUBLIC_CHAIN_ID || process.env.CHAIN_ID;
   if (envChainId) return Number.parseInt(envChainId, 10);
 
   // Default to local for development, Base Sepolia for test
@@ -89,6 +89,16 @@ export function getCurrentChainId(): number {
 function getCurrentNetwork(): NetworkConfig | EthereumNetworkConfig {
   const networkId = CHAIN_ID_TO_NETWORK[getCurrentChainId()] || 'local';
   return PUBLIC_CONFIG.networks[networkId];
+}
+
+export function getRpcUrlForChainId(chainId: number): string {
+  const envRpcUrl = process.env.NEXT_PUBLIC_RPC_URL || process.env.RPC_URL;
+  if (envRpcUrl) return envRpcUrl.trim();
+
+  const networkId = CHAIN_ID_TO_NETWORK[chainId];
+  if (networkId) return PUBLIC_CONFIG.networks[networkId].rpcUrl;
+
+  return getCurrentNetwork().rpcUrl;
 }
 
 // =============================================================================
@@ -124,8 +134,7 @@ export const IDENTITY_REGISTRY_BASE_SEPOLIA = PUBLIC_CONFIG.networks.baseSepolia
 // =============================================================================
 
 export function getCurrentRpcUrl(): string {
-  if (process.env.NEXT_PUBLIC_RPC_URL) return process.env.NEXT_PUBLIC_RPC_URL;
-  return getCurrentNetwork().rpcUrl;
+  return getRpcUrlForChainId(getCurrentChainId());
 }
 
 /**

--- a/packages/shared/src/constants/chains.ts
+++ b/packages/shared/src/constants/chains.ts
@@ -7,6 +7,7 @@
 
 import { defineChain } from 'viem';
 import { base, baseSepolia, mainnet, sepolia } from 'viem/chains';
+import { getRpcUrlForChainId } from '../config';
 
 // Local Hardhat chain definition
 const hardhat = defineChain({
@@ -33,13 +34,6 @@ function getChainIdFromEnv(): number {
   return Number(chainId);
 }
 
-/**
- * Get RPC URL from environment, supporting both NEXT_PUBLIC_ and plain env vars
- */
-function getRpcUrlFromEnv(): string {
-  return (process.env.NEXT_PUBLIC_RPC_URL || process.env.RPC_URL || '').trim();
-}
-
 const rawChainId = getChainIdFromEnv();
 
 const resolveChain = () => {
@@ -60,8 +54,7 @@ export const CHAIN = resolveChain();
 export const CHAIN_ID = CHAIN.id;
 export const NETWORK: 'mainnet' | 'testnet' =
   CHAIN_ID === base.id || CHAIN_ID === mainnet.id ? 'mainnet' : 'testnet';
-const DEFAULT_RPC = CHAIN.rpcUrls?.default?.http?.[0] ?? '';
-export const RPC_URL = getRpcUrlFromEnv() || DEFAULT_RPC;
+export const RPC_URL = getRpcUrlForChainId(CHAIN_ID);
 
 // Re-export chain definitions for direct use
 export { hardhat, base, baseSepolia, mainnet, sepolia };

--- a/packages/testing/unit/shared-config-rpc.test.ts
+++ b/packages/testing/unit/shared-config-rpc.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import {
+  getCurrentChainId,
+  getRpcUrlForChainId,
+} from '../../shared/src/config';
+
+const originalChainId = process.env.CHAIN_ID;
+const originalNextPublicChainId = process.env.NEXT_PUBLIC_CHAIN_ID;
+const originalRpcUrl = process.env.RPC_URL;
+const originalNextPublicRpcUrl = process.env.NEXT_PUBLIC_RPC_URL;
+
+function restoreEnv() {
+  process.env.CHAIN_ID = originalChainId;
+  process.env.NEXT_PUBLIC_CHAIN_ID = originalNextPublicChainId;
+  process.env.RPC_URL = originalRpcUrl;
+  process.env.NEXT_PUBLIC_RPC_URL = originalNextPublicRpcUrl;
+}
+
+describe('shared RPC configuration', () => {
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it('supports plain CHAIN_ID overrides', () => {
+    delete process.env.NEXT_PUBLIC_CHAIN_ID;
+    process.env.CHAIN_ID = '1';
+
+    expect(getCurrentChainId()).toBe(1);
+  });
+
+  it('returns the canonical ethereum RPC when no override is provided', () => {
+    delete process.env.RPC_URL;
+    delete process.env.NEXT_PUBLIC_RPC_URL;
+
+    expect(getRpcUrlForChainId(1)).toBe('https://eth.llamarpc.com');
+  });
+
+  it('prefers explicit RPC overrides and trims whitespace', () => {
+    process.env.RPC_URL = '  https://rpc.example  ';
+    delete process.env.NEXT_PUBLIC_RPC_URL;
+
+    expect(getRpcUrlForChainId(1)).toBe('https://rpc.example');
+  });
+});

--- a/packages/testing/unit/shared-config-rpc.test.ts
+++ b/packages/testing/unit/shared-config-rpc.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from 'bun:test';
+import { sepolia } from 'viem/chains';
 import {
   getCurrentChainId,
   getRpcUrlForChainId,
@@ -33,6 +34,15 @@ describe('shared RPC configuration', () => {
     delete process.env.NEXT_PUBLIC_RPC_URL;
 
     expect(getRpcUrlForChainId(1)).toBe('https://eth.llamarpc.com');
+  });
+
+  it('preserves viem defaults for supported chains outside public config', () => {
+    delete process.env.RPC_URL;
+    delete process.env.NEXT_PUBLIC_RPC_URL;
+
+    expect(getRpcUrlForChainId(sepolia.id)).toBe(
+      sepolia.rpcUrls.default.http[0]
+    );
   });
 
   it('prefers explicit RPC overrides and trims whitespace', () => {

--- a/packages/testing/unit/wallet-balance-rpc.test.ts
+++ b/packages/testing/unit/wallet-balance-rpc.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'bun:test';
+import { HttpRequestError, RpcRequestError, TimeoutError } from 'viem';
+import {
+  isRetryableWalletBalanceRpcError,
+  retryWalletBalanceRpcOperation,
+} from '../../../apps/web/src/lib/wallet-balance-rpc';
+
+function createHttpRequestError() {
+  return new HttpRequestError({
+    cause: new Error('fetch failed'),
+    details: 'HTTP request failed',
+    url: 'https://eth.llamarpc.com',
+  });
+}
+
+describe('wallet balance RPC retry', () => {
+  it('classifies viem transport errors as retryable', () => {
+    expect(isRetryableWalletBalanceRpcError(createHttpRequestError())).toBe(
+      true
+    );
+    expect(
+      isRetryableWalletBalanceRpcError(
+        new RpcRequestError({
+          body: { method: 'eth_getBalance' },
+          error: { code: -32000, message: 'upstream unavailable' },
+          url: 'https://eth.llamarpc.com',
+        })
+      )
+    ).toBe(true);
+    expect(
+      isRetryableWalletBalanceRpcError(
+        new TimeoutError({
+          body: { method: 'eth_getBalance' },
+          url: 'https://eth.llamarpc.com',
+        })
+      )
+    ).toBe(true);
+    expect(isRetryableWalletBalanceRpcError(new Error('nope'))).toBe(false);
+  });
+
+  it('retries transient RPC errors and eventually succeeds', async () => {
+    let attempts = 0;
+
+    const result = await retryWalletBalanceRpcOperation(
+      async () => {
+        attempts++;
+        if (attempts < 3) {
+          throw createHttpRequestError();
+        }
+
+        return 42n;
+      },
+      { initialDelayMs: 1, maxDelayMs: 1 }
+    );
+
+    expect(result).toBe(42n);
+    expect(attempts).toBe(3);
+  });
+
+  it('does not retry non-RPC errors', async () => {
+    let attempts = 0;
+
+    await expect(
+      retryWalletBalanceRpcOperation(
+        async () => {
+          attempts++;
+          throw new Error('unexpected');
+        },
+        { initialDelayMs: 1, maxDelayMs: 1 }
+      )
+    ).rejects.toThrow('unexpected');
+
+    expect(attempts).toBe(1);
+  });
+
+  it('stops retrying when the operation is aborted', async () => {
+    const controller = new AbortController();
+    let attempts = 0;
+
+    await expect(
+      retryWalletBalanceRpcOperation(
+        async () => {
+          attempts++;
+          throw createHttpRequestError();
+        },
+        {
+          signal: controller.signal,
+          initialDelayMs: 50,
+          maxDelayMs: 50,
+          onRetry: () => controller.abort(),
+        }
+      )
+    ).rejects.toThrow('Operation cancelled');
+
+    expect(attempts).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Retry transient viem RPC balance-check failures before the buy-points crypto flow aborts.
- Stop falling back to viem's Ethereum mainnet default RPC by reusing Babylon's canonical per-chain RPC config.
- Add focused unit tests for the retry policy and shared RPC resolution helpers.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Linear: https://linear.app/eliza-labs/issue/BAB-408/bugpayments-buypointsmodal-crypto-flow-fails-on-rpc-balance-check
- Sentry: https://babylon-0t.sentry.io/issues/7354379259/

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [x] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Non-goals / follow-ups
- None.

## Changes
- Added an abort-aware retry helper for wallet balance RPC reads used by `useWalletFunding()`.
- Routed shared RPC resolution through Babylon's canonical per-chain config so Ethereum mainnet no longer falls back to `https://eth.merkle.io`.
- Added focused tests for retryable viem transport errors and RPC env/canonical resolution.

## Review guide
**Start here**
- `apps/web/src/hooks/useWalletFunding.ts`
- `apps/web/src/lib/wallet-balance-rpc.ts`
- `packages/shared/src/config/index.ts`
- `packages/shared/src/constants/chains.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- I kept the change scoped to balance checks only: no payment request or transaction flow changes.
- I evaluated the shared generic retry helper, but kept this retry policy local because wallet funding needs viem-specific error matching plus abort-aware waits.

## Test plan
**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bunx biome check --write apps/web/src/hooks/useWalletFunding.ts apps/web/src/lib/wallet-balance-rpc.ts packages/shared/src/config/index.ts packages/shared/src/constants/chains.ts packages/testing/unit/wallet-balance-rpc.test.ts packages/testing/unit/shared-config-rpc.test.ts`
2. `bun test packages/testing/unit/wallet-balance-rpc.test.ts packages/testing/unit/shared-config-rpc.test.ts --preload ./packages/testing/unit/preload.ts`
3. No browser recording included: this changes resilience in an existing payment path without altering the visual UI.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: Deploy normally; the change only affects client-side balance-check retries and shared RPC selection.
- Rollback: Revert this PR to restore the previous single-attempt balance check behavior and prior RPC fallback.

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- None.

### Contracts / on-chain
- No contract changes; the PR only hardens RPC reads used before funding/payment.

### Docs
- None.

</details>

## Screenshots / recordings (UI)
### Option B: No visual changes
- Reason: Existing UI flow only; this PR hardens RPC balance checks and shared RPC selection without changing the rendered interface.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
