### PR TITLE
fix(web): disable PostHog exception autocapture

### DIFF
--- a/apps/web/src/lib/posthog/client.test.ts
+++ b/apps/web/src/lib/posthog/client.test.ts
@@ -1,0 +1,70 @@
+import { afterAll, expect, it, mock } from 'bun:test';
+
+const initMock = mock(() => {});
+const infoMock = mock(() => {});
+const warnMock = mock(() => {});
+
+mock.module('posthog-js', () => ({
+  default: {
+    init: initMock,
+  },
+}));
+
+mock.module('@babylon/shared', () => ({
+  logger: {
+    info: infoMock,
+    warn: warnMock,
+  },
+}));
+
+const originalWindow = globalThis.window;
+const originalPostHogProjectId = process.env.NEXT_PUBLIC_POSTHOG_PROJECT_ID;
+const originalPostHogHost = process.env.NEXT_PUBLIC_POSTHOG_HOST;
+const originalVercelEnv = process.env.NEXT_PUBLIC_VERCEL_ENV;
+
+afterAll(() => {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: originalWindow,
+  });
+
+  if (originalPostHogProjectId === undefined) {
+    delete process.env.NEXT_PUBLIC_POSTHOG_PROJECT_ID;
+  } else {
+    process.env.NEXT_PUBLIC_POSTHOG_PROJECT_ID = originalPostHogProjectId;
+  }
+
+  if (originalPostHogHost === undefined) {
+    delete process.env.NEXT_PUBLIC_POSTHOG_HOST;
+  } else {
+    process.env.NEXT_PUBLIC_POSTHOG_HOST = originalPostHogHost;
+  }
+
+  if (originalVercelEnv === undefined) {
+    delete process.env.NEXT_PUBLIC_VERCEL_ENV;
+  } else {
+    process.env.NEXT_PUBLIC_VERCEL_ENV = originalVercelEnv;
+  }
+});
+
+it('initializes PostHog without automatic exception capture', async () => {
+  process.env.NEXT_PUBLIC_POSTHOG_PROJECT_ID = 'phc_test_key';
+  process.env.NEXT_PUBLIC_POSTHOG_HOST = 'https://us.i.posthog.com';
+  process.env.NEXT_PUBLIC_VERCEL_ENV = 'production';
+
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: { location: { origin: 'https://babylon.market' } },
+  });
+
+  const { initPostHog } = await import('./client');
+
+  initPostHog();
+
+  expect(initMock).toHaveBeenCalledTimes(1);
+
+  const options = initMock.mock.calls[0]?.[1];
+  expect(options).toBeDefined();
+  expect(options?.capture_pageview).toBe(false);
+  expect(options?.capture_exceptions).toBeUndefined();
+});

--- a/apps/web/src/lib/posthog/client.test.ts
+++ b/apps/web/src/lib/posthog/client.test.ts
@@ -66,5 +66,5 @@ it('initializes PostHog without automatic exception capture', async () => {
   const options = initMock.mock.calls[0]?.[1];
   expect(options).toBeDefined();
   expect(options?.capture_pageview).toBe(false);
-  expect(options?.capture_exceptions).toBeUndefined();
+  expect(options?.capture_exceptions).toBe(false);
 });

--- a/apps/web/src/lib/posthog/client.ts
+++ b/apps/web/src/lib/posthog/client.ts
@@ -104,9 +104,6 @@ export function initPostHog(): PostHogClient | null {
 
       // Advanced features
       enable_recording_console_log: process.env.NODE_ENV === 'development', // Log console in dev
-
-      // Error tracking
-      capture_exceptions: true, // Automatically capture errors
     });
     initialized = true;
   }

--- a/apps/web/src/lib/posthog/client.ts
+++ b/apps/web/src/lib/posthog/client.ts
@@ -104,6 +104,9 @@ export function initPostHog(): PostHogClient | null {
 
       // Advanced features
       enable_recording_console_log: process.env.NODE_ENV === 'development', // Log console in dev
+
+      // Keep global browser exception wrappers disabled; app-owned reporting stays explicit.
+      capture_exceptions: false,
     });
     initialized = true;
   }


### PR DESCRIPTION
## Summary

- Disable PostHog's global browser exception autocapture during client bootstrap to stop the circular JSON crash reported on `/`.
- Keep explicit analytics and error reporting intact: pageviews, identify, manual PostHog captures, and Sentry continue to work.
- Add a focused unit test that locks the PostHog init config so the exception autocapture flag is not reintroduced silently.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-301/bughome-investigate-htmlmetaelement-circular-json-crash-on
- Sentry: https://babylon-0t.sentry.io/issues/7348706502/

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Non-goals / follow-ups

- None.

## Changes

- Remove `capture_exceptions` from the global `posthog.init()` config in the web client bootstrap.
- Leave existing app-owned error reporting paths unchanged, including the PostHog error boundary and Sentry capture.
- Add `apps/web/src/lib/posthog/client.test.ts` to verify the init config keeps exception autocapture disabled.

## Review guide

**Start here**
- `apps/web/src/lib/posthog/client.ts`
- `apps/web/src/lib/posthog/client.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- The fix intentionally avoids speculative sanitization/fallback logic inside Babylon code because the failing path is PostHog's global exception wrapper, not our explicit capture calls.
- We still retain Sentry and explicit PostHog `$exception` capture from `PostHogErrorBoundary`.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bun test apps/web/src/lib/posthog/client.test.ts`
2. `bunx biome check --write apps/web/src/lib/posthog/client.ts apps/web/src/lib/posthog/client.test.ts`
3. No browser build/run was executed to avoid heavy parallel builds; the change is limited to PostHog init config plus a focused unit test.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: deploy normally; the client will stop enabling PostHog's automatic exception wrapper on page load.
- Rollback: revert this PR to restore the previous PostHog init config.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Client analytics bootstrap change only; no UI changes.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
