### PR TITLE
fix(web): guard mobile header points polling fetch failures

### DIFF
--- a/apps/web/src/components/shared/MobileHeader.tsx
+++ b/apps/web/src/components/shared/MobileHeader.tsx
@@ -23,6 +23,10 @@ import { GameFeedbackModal } from '@/components/feedback/GameFeedbackModal';
 import { Avatar } from '@/components/shared/Avatar';
 import { BabylonIcon } from '@/components/shared/icons/BabylonIcon';
 import { HouseIcon } from '@/components/shared/icons/HouseIcon';
+import {
+  fetchMobileHeaderPointsSnapshot,
+  isAbortError,
+} from '@/components/shared/mobileHeaderPoints';
 import { useAuth } from '@/hooks/useAuth';
 import { useUnreadMessages } from '@/hooks/useUnreadMessages';
 import { useUnreadNotifications } from '@/hooks/useUnreadNotifications';
@@ -103,6 +107,8 @@ function MobileHeaderContent() {
   ]);
 
   useEffect(() => {
+    let activeController: AbortController | null = null;
+
     const fetchPoints = async () => {
       if (!authenticated || !user?.id) {
         setPointsData(null);
@@ -115,52 +121,59 @@ function MobileHeaderContent() {
         return;
       }
 
-      const headers: HeadersInit = {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${token}`,
-      };
+      activeController?.abort();
+      const controller = new AbortController();
+      activeController = controller;
 
-      // Fetch both trading balance and profile for reputation points
-      const [balanceResponse, profileResponse] = await Promise.all([
-        fetch(`/api/users/${encodeURIComponent(user.id)}/balance`, { headers }),
-        fetch(`/api/users/${encodeURIComponent(user.id)}/profile`, { headers }),
-      ]);
-
-      if (balanceResponse.ok) {
-        const balanceData = await balanceResponse.json();
-        setPointsData({
-          available: Number(balanceData.balance || 0),
-          total: user.reputationPoints || 0, // Use reputation points from authStore as fallback
+      try {
+        const snapshot = await fetchMobileHeaderPointsSnapshot({
+          userId: user.id,
+          token,
+          signal: controller.signal,
         });
-      }
 
-      // Update reputation points from profile if changed
-      if (profileResponse.ok) {
-        const profileData = await profileResponse.json();
-        if (
-          profileData.user?.reputationPoints !== undefined &&
-          profileData.user.reputationPoints !== user.reputationPoints
-        ) {
-          setUser({
-            ...user,
-            reputationPoints: profileData.user.reputationPoints,
+        if (controller.signal.aborted) {
+          return;
+        }
+
+        if (snapshot.available !== null) {
+          setPointsData({
+            available: snapshot.available,
+            total: snapshot.reputationPoints ?? user.reputationPoints ?? 0,
           });
-          // Update local state with new reputation points
+        } else if (snapshot.reputationPoints !== null) {
           setPointsData((prev) =>
             prev
               ? {
                   ...prev,
-                  total: profileData.user.reputationPoints,
+                  total: snapshot.reputationPoints,
                 }
               : null
           );
         }
+
+        if (
+          snapshot.reputationPoints !== null &&
+          snapshot.reputationPoints !== user.reputationPoints
+        ) {
+          setUser({
+            ...user,
+            reputationPoints: snapshot.reputationPoints,
+          });
+        }
+      } catch (error) {
+        if (controller.signal.aborted || isAbortError(error)) {
+          return;
+        }
       }
     };
 
-    fetchPoints();
+    void fetchPoints();
     const interval = setInterval(fetchPoints, 30000);
-    return () => clearInterval(interval);
+    return () => {
+      clearInterval(interval);
+      activeController?.abort();
+    };
   }, [authenticated, user?.id, user?.reputationPoints, setUser, user]);
 
   const copyReferralCode = async () => {
@@ -273,7 +286,7 @@ function MobileHeaderContent() {
           </div>
 
           {/* Center: Logo */}
-          <div className="-translate-x-1/2 absolute left-1/2 transform">
+          <div className="absolute left-1/2 -translate-x-1/2 transform">
             <Link
               href="/feed"
               className="transition-transform duration-300 hover:scale-105"
@@ -384,7 +397,7 @@ function MobileHeaderContent() {
                     <div className="relative">
                       <Icon className="h-5 w-5" />
                       {hasNotificationBadge && (
-                        <span className="-top-1 -right-1 absolute h-2 w-2 rounded-full bg-blue-500 ring-2 ring-sidebar" />
+                        <span className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-blue-500 ring-2 ring-sidebar" />
                       )}
                     </div>
                     <span className="text-base">{item.name}</span>

--- a/apps/web/src/components/shared/mobileHeaderPoints.test.ts
+++ b/apps/web/src/components/shared/mobileHeaderPoints.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
+import {
+  fetchMobileHeaderPointsSnapshot,
+  isAbortError,
+} from './mobileHeaderPoints';
+
+describe('fetchMobileHeaderPointsSnapshot', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns the balance and reputation points when both requests succeed', async () => {
+    const fetchMock = mock((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+
+      if (url.endsWith('/balance')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ balance: '125.5' }), { status: 200 })
+        );
+      }
+
+      expect(url.endsWith('/profile')).toBe(true);
+      expect(new Headers(init?.headers).get('Authorization')).toBe(
+        'Bearer token-123'
+      );
+
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            user: {
+              reputationPoints: 77,
+            },
+          }),
+          { status: 200 }
+        )
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const snapshot = await fetchMobileHeaderPointsSnapshot({
+      userId: 'user-1',
+      token: 'token-123',
+      signal: new AbortController().signal,
+    });
+
+    expect(snapshot).toEqual({
+      available: 125.5,
+      reputationPoints: 77,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps partial data when one request fails with a network error', async () => {
+    const fetchMock = mock((input: RequestInfo | URL) => {
+      const url = String(input);
+
+      if (url.endsWith('/balance')) {
+        return Promise.reject(new TypeError('Load failed'));
+      }
+
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            user: {
+              reputationPoints: 42,
+            },
+          }),
+          { status: 200 }
+        )
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const snapshot = await fetchMobileHeaderPointsSnapshot({
+      userId: 'user-1',
+      token: 'token-123',
+      signal: new AbortController().signal,
+    });
+
+    expect(snapshot).toEqual({
+      available: null,
+      reputationPoints: 42,
+    });
+  });
+
+  it('preserves AbortError rejections so callers can ignore intentional aborts', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const abortError = new DOMException(
+      'The user aborted a request.',
+      'AbortError'
+    );
+
+    globalThis.fetch = mock().mockRejectedValue(
+      abortError
+    ) as unknown as typeof fetch;
+
+    expect(isAbortError(abortError)).toBe(true);
+    await expect(
+      fetchMobileHeaderPointsSnapshot({
+        userId: 'user-1',
+        token: 'token-123',
+        signal: controller.signal,
+      })
+    ).rejects.toBe(abortError);
+  });
+});

--- a/apps/web/src/components/shared/mobileHeaderPoints.ts
+++ b/apps/web/src/components/shared/mobileHeaderPoints.ts
@@ -1,0 +1,93 @@
+interface MobileHeaderBalanceResponse {
+  balance?: number | string | null;
+}
+
+interface MobileHeaderProfileResponse {
+  user?: {
+    reputationPoints?: number;
+  } | null;
+}
+
+export interface MobileHeaderPointsSnapshot {
+  available: number | null;
+  reputationPoints: number | null;
+}
+
+interface FetchMobileHeaderPointsSnapshotOptions {
+  userId: string;
+  token: string;
+  signal: AbortSignal;
+}
+
+export function isAbortError(error: unknown): boolean {
+  if (error instanceof DOMException && error.name === 'AbortError') {
+    return true;
+  }
+
+  if (error instanceof Error && error.name === 'AbortError') {
+    return true;
+  }
+
+  return false;
+}
+
+async function fetchJsonSafely<T>(
+  input: RequestInfo,
+  init: RequestInit,
+  signal: AbortSignal
+): Promise<T | null> {
+  try {
+    const response = await fetch(input, {
+      ...init,
+      signal,
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    return (await response.json()) as T;
+  } catch (error) {
+    if (signal.aborted || isAbortError(error)) {
+      throw error;
+    }
+
+    return null;
+  }
+}
+
+export async function fetchMobileHeaderPointsSnapshot({
+  userId,
+  token,
+  signal,
+}: FetchMobileHeaderPointsSnapshotOptions): Promise<MobileHeaderPointsSnapshot> {
+  const headers: HeadersInit = {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${token}`,
+  };
+  const encodedUserId = encodeURIComponent(userId);
+
+  const [balanceData, profileData] = await Promise.all([
+    fetchJsonSafely<MobileHeaderBalanceResponse>(
+      `/api/users/${encodedUserId}/balance`,
+      { headers },
+      signal
+    ),
+    fetchJsonSafely<MobileHeaderProfileResponse>(
+      `/api/users/${encodedUserId}/profile`,
+      { headers },
+      signal
+    ),
+  ]);
+
+  return {
+    available:
+      balanceData?.balance === undefined || balanceData.balance === null
+        ? null
+        : Number(balanceData.balance),
+    reputationPoints:
+      typeof profileData?.user?.reputationPoints === 'number'
+        ? profileData.user.reputationPoints
+        : null,
+  };
+}


### PR DESCRIPTION
## Summary

- Guard the authenticated mobile header polling so browser `fetch` failures no longer escape as unhandled client-side rejections.
- Extract the balance/profile polling into a small helper that keeps partial data when one request fails and preserves abort semantics.
- Add focused unit coverage for the new polling helper to lock the fetch-failure behavior.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-409/bugmobile-guard-mobileheader-points-polling-against-fetch-failures
- Sentry: https://babylon-0t.sentry.io/issues/7354257109/

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Non-goals / follow-ups

- None.

## Changes

- Move the MobileHeader points polling fetch logic into a dedicated helper so the component effect stays focused on state updates.
- Abort in-flight polling requests before starting the next cycle and on cleanup.
- Treat transient fetch failures as non-fatal for this background poll, while still applying any successful balance/profile response.
- Add unit tests covering the success path, partial network failure, and abort behavior.

## Review guide

**Start here**
- `apps/web/src/components/shared/mobileHeaderPoints.ts`
- `apps/web/src/components/shared/MobileHeader.tsx`
- `apps/web/src/components/shared/mobileHeaderPoints.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- This keeps the existing UI behavior and auth flow unchanged; the fix is limited to making the background poll abort-safe and rejection-safe.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bun test apps/web/src/components/shared/mobileHeaderPoints.test.ts`
2. `bunx @biomejs/biome check apps/web/src/components/shared/MobileHeader.tsx apps/web/src/components/shared/mobileHeaderPoints.ts apps/web/src/components/shared/mobileHeaderPoints.test.ts`
3. Not run: full build, full typecheck, and E2E because this fix is isolated to a small client polling path and the current workflow explicitly avoids heavyweight repo-wide jobs by default.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: ship normally with the next `production` deploy.
- Rollback: revert this PR to restore the previous polling implementation.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: client-side polling hardening only, with no intended visual or interaction change.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
