### PR TITLE
fix(feed): dedupe new market rows in feed pipelines

### DIFF
--- a/apps/web/src/app/api/feed/for-you/pipeline.ts
+++ b/apps/web/src/app/api/feed/for-you/pipeline.ts
@@ -36,6 +36,7 @@ import type {
   NarrativeStory,
 } from '@babylon/shared';
 import { logger } from '@babylon/shared';
+import { dedupeQuestionMarketRows } from '../questionMarketRows';
 import {
   calculateArcStateMultiplier,
   calculateResolutionBoost,
@@ -882,10 +883,11 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
         markets,
         sql`lower(trim(${markets.question})) = lower(trim(${questions.text}))`
       )
-      .where(inArray(questions.questionNumber, storyQuestionNumbers));
+      .where(inArray(questions.questionNumber, storyQuestionNumbers))
+      .orderBy(desc(markets.createdAt));
 
     const questionToMarket = new Map(
-      marketRows.map((row) => [
+      dedupeQuestionMarketRows(marketRows).map((row) => [
         row.questionNumber,
         {
           marketId: row.marketId,
@@ -952,10 +954,10 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
         )
       )
     )
-    .orderBy(desc(questions.createdAt))
+    .orderBy(desc(questions.createdAt), desc(markets.createdAt))
     .limit(MAX_NEW_MARKET_CANDIDATES);
 
-  for (const question of newMarketQuestions) {
+  for (const question of dedupeQuestionMarketRows(newMarketQuestions)) {
     const hoursSinceOpen =
       (now.getTime() - question.createdAt.getTime()) / (1000 * 60 * 60);
     const recencyScore = Math.exp((-Math.LN2 * hoursSinceOpen) / 6);

--- a/apps/web/src/app/api/feed/for-you/pipeline.ts
+++ b/apps/web/src/app/api/feed/for-you/pipeline.ts
@@ -917,7 +917,7 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
       )
   );
 
-  const newMarketQuestions = await db
+  const newMarketRows = await db
     .select({
       questionNumber: questions.questionNumber,
       text: questions.text,
@@ -954,10 +954,16 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
         )
       )
     )
-    .orderBy(desc(questions.createdAt), desc(markets.createdAt))
-    .limit(MAX_NEW_MARKET_CANDIDATES);
+    .orderBy(desc(questions.createdAt), desc(markets.createdAt));
 
-  for (const question of dedupeQuestionMarketRows(newMarketQuestions)) {
+  // Dedupe before slicing so duplicate join rows cannot crowd out later
+  // unique questions from the surfaced new-market set.
+  const newMarketQuestions = dedupeQuestionMarketRows(newMarketRows).slice(
+    0,
+    MAX_NEW_MARKET_CANDIDATES
+  );
+
+  for (const question of newMarketQuestions) {
     const hoursSinceOpen =
       (now.getTime() - question.createdAt.getTime()) / (1000 * 60 * 60);
     const recencyScore = Math.exp((-Math.LN2 * hoursSinceOpen) / 6);

--- a/apps/web/src/app/api/feed/narrative/route.ts
+++ b/apps/web/src/app/api/feed/narrative/route.ts
@@ -59,6 +59,7 @@ import {
   calculateResolutionBoost,
   calculateStoryScore,
 } from './scoring';
+import { dedupeQuestionMarketRows } from '../questionMarketRows';
 
 // Query limits
 const MAX_CANDIDATE_POSTS = 500;
@@ -615,9 +616,13 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
             markets,
             sql`lower(trim(${markets.question})) = lower(trim(${questions.text}))`
           )
-          .where(inArray(questions.questionNumber, storyQuestionNumbers));
+          .where(inArray(questions.questionNumber, storyQuestionNumbers))
+          .orderBy(desc(markets.createdAt));
         const questionToMarket = new Map(
-          marketRows.map((r) => [r.questionNumber, r.marketId])
+          dedupeQuestionMarketRows(marketRows).map((r) => [
+            r.questionNumber,
+            r.marketId,
+          ])
         );
         for (const story of stories) {
           if (!story.isNewMarket && story.questionNumber !== null) {
@@ -684,10 +689,10 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
             )
           )
         )
-        .orderBy(desc(questions.createdAt))
+        .orderBy(desc(questions.createdAt), desc(markets.createdAt))
         .limit(5);
 
-      for (const q of newMarketQuestions) {
+      for (const q of dedupeQuestionMarketRows(newMarketQuestions)) {
         // New market cards score on recency alone — they float near top on open day
         const hoursSinceOpen =
           (now.getTime() - q.createdAt.getTime()) / (1000 * 60 * 60);

--- a/apps/web/src/app/api/feed/narrative/route.ts
+++ b/apps/web/src/app/api/feed/narrative/route.ts
@@ -648,7 +648,7 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
       // Join markets on question text to get the market UUID (for deep-linking
       // to /markets/predictions/[id]) and live share counts (for probability bars).
       // LEFT JOIN since a question may not yet have a market entry.
-      const newMarketQuestions = await db
+      const newMarketRows = await db
         .select({
           questionNumber: questions.questionNumber,
           text: questions.text,
@@ -689,10 +689,16 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
             )
           )
         )
-        .orderBy(desc(questions.createdAt), desc(markets.createdAt))
-        .limit(5);
+        .orderBy(desc(questions.createdAt), desc(markets.createdAt));
 
-      for (const q of dedupeQuestionMarketRows(newMarketQuestions)) {
+      // Dedupe before slicing so duplicate join rows cannot crowd out
+      // later unique questions from the final feed payload.
+      const newMarketQuestions = dedupeQuestionMarketRows(newMarketRows).slice(
+        0,
+        5
+      );
+
+      for (const q of newMarketQuestions) {
         // New market cards score on recency alone — they float near top on open day
         const hoursSinceOpen =
           (now.getTime() - q.createdAt.getTime()) / (1000 * 60 * 60);

--- a/apps/web/src/app/api/feed/new-markets/route.test.ts
+++ b/apps/web/src/app/api/feed/new-markets/route.test.ts
@@ -130,4 +130,86 @@ describe('GET /api/feed/new-markets', () => {
       noShares: 8,
     });
   });
+
+  it('fills the page with unique questions even when duplicates appear before later rows', async () => {
+    const createdAt = new Date('2026-03-26T10:00:00.000Z');
+    const resolutionDate = new Date('2026-04-01T10:00:00.000Z');
+
+    mockDbSelect.mockImplementation(() =>
+      makeChain([
+        {
+          questionNumber: 1,
+          text: 'Q1',
+          resolutionDate,
+          createdAt,
+          arcState: 'active',
+          marketId: 'market-1-new',
+          yesShares: '10',
+          noShares: '5',
+        },
+        {
+          questionNumber: 1,
+          text: 'Q1',
+          resolutionDate,
+          createdAt,
+          arcState: 'active',
+          marketId: 'market-1-old',
+          yesShares: '1',
+          noShares: '1',
+        },
+        {
+          questionNumber: 2,
+          text: 'Q2',
+          resolutionDate,
+          createdAt,
+          arcState: 'active',
+          marketId: 'market-2',
+          yesShares: '2',
+          noShares: '2',
+        },
+        {
+          questionNumber: 3,
+          text: 'Q3',
+          resolutionDate,
+          createdAt,
+          arcState: 'active',
+          marketId: 'market-3',
+          yesShares: '3',
+          noShares: '3',
+        },
+        {
+          questionNumber: 4,
+          text: 'Q4',
+          resolutionDate,
+          createdAt,
+          arcState: 'active',
+          marketId: 'market-4',
+          yesShares: '4',
+          noShares: '4',
+        },
+        {
+          questionNumber: 5,
+          text: 'Q5',
+          resolutionDate,
+          createdAt,
+          arcState: 'active',
+          marketId: 'market-5',
+          yesShares: '5',
+          noShares: '5',
+        },
+      ])
+    );
+
+    const response = await GET({} as NextRequest);
+    const payload = await response.json();
+
+    expect(payload.markets).toHaveLength(5);
+    expect(payload.markets.map((market: { questionNumber: number }) => market.questionNumber)).toEqual([
+      1,
+      2,
+      3,
+      4,
+      5,
+    ]);
+  });
 });

--- a/apps/web/src/app/api/feed/new-markets/route.test.ts
+++ b/apps/web/src/app/api/feed/new-markets/route.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { NextRequest } from 'next/server';
+
+const mockDbSelect = mock();
+const mockGetCacheOrFetch = mock(
+  async <T>(_key: string, fetchFn: () => Promise<T>) => fetchFn()
+);
+const mockPublicRateLimit = mock();
+
+const makeChain = (data: unknown[]) => {
+  const chain: Record<string, unknown> = {};
+  const noop = () => chain;
+  chain.from = noop;
+  chain.leftJoin = noop;
+  chain.where = noop;
+  chain.orderBy = noop;
+  chain.limit = noop;
+  chain.then = (
+    resolve: (value: unknown) => unknown,
+    reject?: (reason: unknown) => unknown
+  ) => Promise.resolve(data).then(resolve, reject);
+  chain.catch = (reject: (reason: unknown) => unknown) =>
+    Promise.resolve(data).catch(reject);
+  chain.finally = (cb: () => void) => Promise.resolve(data).finally(cb);
+  return chain;
+};
+
+mock.module('@babylon/api', () => ({
+  getCacheOrFetch: mockGetCacheOrFetch,
+  publicRateLimit: mockPublicRateLimit,
+  successResponse: (data: unknown) =>
+    new Response(JSON.stringify(data), {
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  withErrorHandling: (handler: (request: NextRequest) => Promise<Response>) =>
+    handler,
+}));
+
+mock.module('@babylon/db', () => ({
+  and: (...args: unknown[]) => args,
+  arcStates: {
+    questionId: 'arcStates.questionId',
+    currentState: 'arcStates.currentState',
+  },
+  db: { select: mockDbSelect },
+  desc: (value: unknown) => value,
+  eq: (left: unknown, right: unknown) => [left, right],
+  gte: (left: unknown, right: unknown) => [left, right],
+  lt: (left: unknown, right: unknown) => [left, right],
+  markets: {
+    id: 'markets.id',
+    question: 'markets.question',
+    yesShares: 'markets.yesShares',
+    noShares: 'markets.noShares',
+    createdAt: 'markets.createdAt',
+  },
+  questions: {
+    id: 'questions.id',
+    questionNumber: 'questions.questionNumber',
+    text: 'questions.text',
+    resolutionDate: 'questions.resolutionDate',
+    createdAt: 'questions.createdAt',
+    status: 'questions.status',
+  },
+  sql: (_strings: TemplateStringsArray, ..._values: unknown[]) => ({
+    _sql: true,
+  }),
+}));
+
+mock.module('@babylon/shared', () => ({
+  toISO: (value: Date | string) => new Date(value).toISOString(),
+}));
+
+const { GET } = await import('./route');
+
+describe('GET /api/feed/new-markets', () => {
+  beforeEach(() => {
+    mockDbSelect.mockReset();
+    mockGetCacheOrFetch.mockReset();
+    mockPublicRateLimit.mockReset();
+
+    mockDbSelect.mockImplementation((_) => makeChain([]));
+    mockGetCacheOrFetch.mockImplementation(
+      async <T>(_key: string, fetchFn: () => Promise<T>) => fetchFn()
+    );
+    mockPublicRateLimit.mockResolvedValue({
+      error: null,
+      rateLimitInfo: null,
+    });
+  });
+
+  it('dedupes duplicate question rows produced by the market text join', async () => {
+    const createdAt = new Date('2026-03-26T10:00:00.000Z');
+    const resolutionDate = new Date('2026-04-01T10:00:00.000Z');
+
+    mockDbSelect.mockImplementation(() =>
+      makeChain([
+        {
+          questionNumber: 42,
+          text: 'Will Bitcoin hit 100k?',
+          resolutionDate,
+          createdAt,
+          arcState: 'active',
+          marketId: 'market-newer',
+          yesShares: '12',
+          noShares: '8',
+        },
+        {
+          questionNumber: 42,
+          text: 'Will Bitcoin hit 100k?',
+          resolutionDate,
+          createdAt,
+          arcState: 'active',
+          marketId: 'market-older',
+          yesShares: '2',
+          noShares: '1',
+        },
+      ])
+    );
+
+    const response = await GET({} as NextRequest);
+    const payload = await response.json();
+
+    expect(payload.success).toBe(true);
+    expect(payload.markets).toHaveLength(1);
+    expect(payload.markets[0]).toMatchObject({
+      questionNumber: 42,
+      marketId: 'market-newer',
+      yesShares: 12,
+      noShares: 8,
+    });
+  });
+});

--- a/apps/web/src/app/api/feed/new-markets/route.ts
+++ b/apps/web/src/app/api/feed/new-markets/route.ts
@@ -28,6 +28,7 @@ import {
 import type { ArcStateType } from '@babylon/shared';
 import { toISO } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
+import { dedupeQuestionMarketRows } from '../questionMarketRows';
 
 const NEW_MARKET_WINDOW_MS = 24 * 60 * 60 * 1000;
 
@@ -100,10 +101,10 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
             )
           )
         )
-        .orderBy(desc(questions.createdAt))
+        .orderBy(desc(questions.createdAt), desc(markets.createdAt))
         .limit(5);
 
-      return rows.map((r) => ({
+      return dedupeQuestionMarketRows(rows).map((r) => ({
         questionNumber: r.questionNumber,
         text: r.text,
         resolutionDate: toISO(r.resolutionDate),

--- a/apps/web/src/app/api/feed/new-markets/route.ts
+++ b/apps/web/src/app/api/feed/new-markets/route.ts
@@ -101,19 +101,22 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
             )
           )
         )
-        .orderBy(desc(questions.createdAt), desc(markets.createdAt))
-        .limit(5);
+        .orderBy(desc(questions.createdAt), desc(markets.createdAt));
 
-      return dedupeQuestionMarketRows(rows).map((r) => ({
-        questionNumber: r.questionNumber,
-        text: r.text,
-        resolutionDate: toISO(r.resolutionDate),
-        createdAt: toISO(r.createdAt),
-        arcState: (r.arcState as ArcStateType | null) ?? null,
-        marketId: r.marketId ?? null,
-        yesShares: Number(r.yesShares ?? 0),
-        noShares: Number(r.noShares ?? 0),
-      }));
+      // Dedupe before slicing so duplicate join rows cannot crowd out
+      // later unique questions from the final feed payload.
+      return dedupeQuestionMarketRows(rows)
+        .slice(0, 5)
+        .map((r) => ({
+          questionNumber: r.questionNumber,
+          text: r.text,
+          resolutionDate: toISO(r.resolutionDate),
+          createdAt: toISO(r.createdAt),
+          arcState: (r.arcState as ArcStateType | null) ?? null,
+          marketId: r.marketId ?? null,
+          yesShares: Number(r.yesShares ?? 0),
+          noShares: Number(r.noShares ?? 0),
+        }));
     },
     { namespace: 'feed', ttl: 60 } // shorter TTL since odds can change
   );

--- a/apps/web/src/app/api/feed/questionMarketRows.test.ts
+++ b/apps/web/src/app/api/feed/questionMarketRows.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'bun:test';
+import { dedupeQuestionMarketRows } from './questionMarketRows';
+
+describe('dedupeQuestionMarketRows', () => {
+  it('keeps one row per questionNumber', () => {
+    const rows = [
+      { questionNumber: 42, marketId: 'market-a' },
+      { questionNumber: 42, marketId: 'market-b' },
+      { questionNumber: 7, marketId: 'market-c' },
+    ];
+
+    expect(dedupeQuestionMarketRows(rows)).toEqual([
+      { questionNumber: 42, marketId: 'market-a' },
+      { questionNumber: 7, marketId: 'market-c' },
+    ]);
+  });
+
+  it('replaces a null marketId when a later match has a real marketId', () => {
+    const rows = [
+      { questionNumber: 42, marketId: null, yesShares: '0', noShares: '0' },
+      {
+        questionNumber: 42,
+        marketId: 'market-a',
+        yesShares: '12',
+        noShares: '8',
+      },
+    ];
+
+    expect(dedupeQuestionMarketRows(rows)).toEqual([
+      {
+        questionNumber: 42,
+        marketId: 'market-a',
+        yesShares: '12',
+        noShares: '8',
+      },
+    ]);
+  });
+});

--- a/apps/web/src/app/api/feed/questionMarketRows.ts
+++ b/apps/web/src/app/api/feed/questionMarketRows.ts
@@ -1,3 +1,7 @@
+/**
+ * Dedupes rows by questionNumber, keeping the first row seen.
+ * Callers should order rows so the preferred market match comes first.
+ */
 interface QuestionMarketRow {
   questionNumber: number;
   marketId: string | null;

--- a/apps/web/src/app/api/feed/questionMarketRows.ts
+++ b/apps/web/src/app/api/feed/questionMarketRows.ts
@@ -1,0 +1,26 @@
+interface QuestionMarketRow {
+  questionNumber: number;
+  marketId: string | null;
+}
+
+function shouldReplaceRow<T extends QuestionMarketRow>(
+  current: T,
+  candidate: T
+): boolean {
+  return current.marketId === null && candidate.marketId !== null;
+}
+
+export function dedupeQuestionMarketRows<T extends QuestionMarketRow>(
+  rows: T[]
+): T[] {
+  const deduped = new Map<number, T>();
+
+  for (const row of rows) {
+    const current = deduped.get(row.questionNumber);
+    if (!current || shouldReplaceRow(current, row)) {
+      deduped.set(row.questionNumber, row);
+    }
+  }
+
+  return [...deduped.values()];
+}

--- a/apps/web/src/app/api/feed/stories/pipeline.ts
+++ b/apps/web/src/app/api/feed/stories/pipeline.ts
@@ -683,7 +683,7 @@ export async function buildStoriesFeed(): Promise<StoriesPipelineResult> {
       .filter((qn): qn is number => qn !== null)
   );
 
-  const newMarketQuestions = await db
+  const newMarketRows = await db
     .select({
       questionNumber: questions.questionNumber,
       text: questions.text,
@@ -720,10 +720,16 @@ export async function buildStoriesFeed(): Promise<StoriesPipelineResult> {
         )
       )
     )
-    .orderBy(desc(questions.createdAt), desc(markets.createdAt))
-    .limit(MAX_NEW_MARKET_CANDIDATES);
+    .orderBy(desc(questions.createdAt), desc(markets.createdAt));
 
-  for (const question of dedupeQuestionMarketRows(newMarketQuestions)) {
+  // Dedupe before slicing so duplicate join rows cannot crowd out later
+  // unique questions from the surfaced new-market set.
+  const newMarketQuestions = dedupeQuestionMarketRows(newMarketRows).slice(
+    0,
+    MAX_NEW_MARKET_CANDIDATES
+  );
+
+  for (const question of newMarketQuestions) {
     const hoursSinceOpen =
       (now.getTime() - question.createdAt.getTime()) / (1000 * 60 * 60);
     const recencyScore = Math.exp((-Math.LN2 * hoursSinceOpen) / 6);

--- a/apps/web/src/app/api/feed/stories/pipeline.ts
+++ b/apps/web/src/app/api/feed/stories/pipeline.ts
@@ -35,6 +35,7 @@ import type {
   NarrativeStory,
 } from '@babylon/shared';
 import { logger } from '@babylon/shared';
+import { dedupeQuestionMarketRows } from '../questionMarketRows';
 import { spreadNewMarkets } from '@/app/api/feed/for-you/scoring';
 import {
   calculateArcStateMultiplier,
@@ -656,9 +657,13 @@ export async function buildStoriesFeed(): Promise<StoriesPipelineResult> {
         markets,
         sql`lower(trim(${markets.question})) = lower(trim(${questions.text}))`
       )
-      .where(inArray(questions.questionNumber, storyQuestionNumbers));
+      .where(inArray(questions.questionNumber, storyQuestionNumbers))
+      .orderBy(desc(markets.createdAt));
     const questionToMarket = new Map(
-      marketRows.map((r) => [r.questionNumber, r.marketId])
+      dedupeQuestionMarketRows(marketRows).map((r) => [
+        r.questionNumber,
+        r.marketId,
+      ])
     );
     for (const story of stories) {
       if (story.questionNumber !== null) {
@@ -715,10 +720,10 @@ export async function buildStoriesFeed(): Promise<StoriesPipelineResult> {
         )
       )
     )
-    .orderBy(desc(questions.createdAt))
+    .orderBy(desc(questions.createdAt), desc(markets.createdAt))
     .limit(MAX_NEW_MARKET_CANDIDATES);
 
-  for (const question of newMarketQuestions) {
+  for (const question of dedupeQuestionMarketRows(newMarketQuestions)) {
     const hoursSinceOpen =
       (now.getTime() - question.createdAt.getTime()) / (1000 * 60 * 60);
     const recencyScore = Math.exp((-Math.LN2 * hoursSinceOpen) / 6);


### PR DESCRIPTION
## Summary

- Deduplicate new-market question rows before building feed cards so `/feed` no longer emits duplicate `market:<questionNumber>` entries.
- Reuse the same dedupe path across `/api/feed/new-markets`, `/api/feed/narrative`, `/api/feed/stories`, and `/api/feed/for-you` to keep market hydration consistent.
- Add focused coverage for the shared dedupe helper and the `new-markets` route.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-300/bugfeed-investigate-feed-sharecount-crash-in-narrative-stories
- Sentry: https://babylon-0t.sentry.io/issues/7348630111/

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: feed API logic + route-local tests

## Non-goals / follow-ups

- None.

## Changes

- Add `dedupeQuestionMarketRows()` to collapse duplicate `questionNumber` rows returned by the normalized text join.
- Apply the helper before building `questionNumber -> market` maps and before injecting new-market cards in all affected feed pipelines.
- Prefer the newest joined market row by ordering duplicate candidates on `markets.createdAt DESC` before deduping.
- Add focused tests for the helper and `/api/feed/new-markets` duplicate-row behavior.

## Review guide

**Start here**
- `apps/web/src/app/api/feed/questionMarketRows.ts`
- `apps/web/src/app/api/feed/new-markets/route.ts`
- `apps/web/src/app/api/feed/for-you/pipeline.ts`
- `apps/web/src/app/api/feed/stories/pipeline.ts`
- `apps/web/src/app/api/feed/narrative/route.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- The concrete code-level bug confirmed in production-path code was duplicate market rows from the `questions -> markets` text join. This PR removes those duplicate cards without changing the rest of the ranking logic.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bun test apps/web/src/app/api/feed/questionMarketRows.test.ts apps/web/src/app/api/feed/new-markets/route.test.ts`
2. `bunx biome check --write apps/web/src/app/api/feed/questionMarketRows.ts apps/web/src/app/api/feed/questionMarketRows.test.ts apps/web/src/app/api/feed/new-markets/route.ts apps/web/src/app/api/feed/new-markets/route.test.ts apps/web/src/app/api/feed/narrative/route.ts apps/web/src/app/api/feed/for-you/pipeline.ts apps/web/src/app/api/feed/stories/pipeline.ts`
3. No browser demo recorded; this is a feed API stability fix with no direct UI change.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: ship normally.
- Rollback: revert this PR to restore the previous join handling.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend/feed pipeline stability fix, no direct UI redesign.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
