### PR TITLE
fix: update agent settings banner copy

### DIFF
--- a/apps/web/src/app/agents/create/components/AgentSettingsStep.tsx
+++ b/apps/web/src/app/agents/create/components/AgentSettingsStep.tsx
@@ -24,10 +24,7 @@ export const AgentSettingsStep = memo(function AgentSettingsStep({
       {/* Info Banner - compact */}
       <div className="flex items-start gap-2 text-muted-foreground text-xs">
         <Info className="h-4 w-4 shrink-0 text-[#0066FF]" />
-        <p>
-          Configure capabilities below. You can change these anytime from
-          settings.
-        </p>
+        <p>Bring your own model. Train it in Babylon.</p>
       </div>
 
       {/* Shared Configuration Form */}


### PR DESCRIPTION
## Summary

This updates the informational banner shown during agent creation to use the new Babylon investor-pitch messaging.

Previously, the banner read "Configure capabilities below. You can change these anytime from settings." That copy no longer reflects the positioning we want to show in the creation flow.

## User impact

Users creating an agent will now see the updated message:

"Bring your own model. Train it in Babylon."

That keeps the agent setup experience aligned with the current Babylon narrative and removes the older capability-configuration framing.

## Root cause

The agent creation step still contained legacy static banner copy in the UI component responsible for rendering the settings section.

## Fix

The banner text in the agent settings step was replaced with the new Babylon messaging. No logic or behavior changes were made.

## Validation

Ran:

- `bun run check`

The branch was also pushed successfully to GitHub from this workspace.
