### PR TITLE
feat: move agent team widgets into right rail

### DIFF
--- a/apps/web/src/app/agents/team/BottomPanel.tsx
+++ b/apps/web/src/app/agents/team/BottomPanel.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { cn } from '@babylon/shared';
-import { Check, ChevronDown, ChevronsUpDown, ChevronUp } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { Check, ChevronsUpDown } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -11,12 +10,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 
-export type BottomPanelTab =
-  | 'activity'
-  | 'wallet'
-  | 'pnl'
-  | 'registry'
-  | 'logs';
+export type TeamWidgetTab = 'activity' | 'wallet' | 'pnl' | 'registry' | 'logs';
 export type EntityType = 'user' | 'agent' | 'team';
 
 interface EntityOption {
@@ -27,40 +21,26 @@ interface EntityOption {
 
 const TEAM_ENTITY_ID = 'team';
 
-const MIN_HEIGHT = 150;
-const MAX_HEIGHT = 500;
-export const BOTTOM_PANEL_DEFAULT_HEIGHT = 240;
-export const BOTTOM_PANEL_COLLAPSED_HEIGHT = 40;
-
-interface BottomPanelProps {
-  isOpen: boolean;
-  onToggle: () => void;
-  activeTab: BottomPanelTab;
-  onTabChange: (tab: BottomPanelTab) => void;
+interface TeamWidgetsRailProps {
+  activeTab: TeamWidgetTab;
+  onTabChange: (tab: TeamWidgetTab) => void;
   selectedEntityId: string | null;
   selectedEntityType: EntityType | null;
   onEntityChange: (id: string, type: EntityType) => void;
   userId?: string;
   userName?: string;
   agents: { id: string; name: string }[];
-  height: number;
-  onHeightChange: (height: number) => void;
+  controlsOnly?: boolean;
   children: React.ReactNode;
 }
 
 /**
- * Bottom panel with tabs for Activity, Wallet, PnL, Registry, and Logs.
+ * Persistent widget rail for the team page desktop sidebar.
  *
- * Entity behavior:
- * - Team: Wallet + PnL + Registry
- * - User: Activity + Wallet + PnL + Registry
- * - Agent: Activity + Wallet + PnL + Registry + Logs
- *
- * Spans full width, collapsible, and resizable.
+ * Reuses the former bottom-panel tab and entity selection behavior in a
+ * sidebar-friendly layout.
  */
-export function BottomPanel({
-  isOpen,
-  onToggle,
+export function TeamWidgetsRail({
   activeTab,
   onTabChange,
   selectedEntityId,
@@ -69,217 +49,73 @@ export function BottomPanel({
   userId,
   userName,
   agents,
-  height,
-  onHeightChange,
+  controlsOnly = false,
   children,
-}: BottomPanelProps) {
-  const [isResizing, setIsResizing] = useState(false);
-  const panelRef = useRef<HTMLDivElement>(null);
-
-  // Store mouse event handlers in refs for proper cleanup
-  const handleMouseMoveRef = useRef<((e: MouseEvent) => void) | null>(null);
-  const handleMouseUpRef = useRef<(() => void) | null>(null);
-
-  // Cleanup mouse listeners on unmount
-  useEffect(() => {
-    return () => {
-      if (handleMouseMoveRef.current) {
-        document.removeEventListener('mousemove', handleMouseMoveRef.current);
-      }
-      if (handleMouseUpRef.current) {
-        document.removeEventListener('mouseup', handleMouseUpRef.current);
-      }
-    };
-  }, []);
-
-  // Build entity options list (team first, then user, then agents)
+}: TeamWidgetsRailProps) {
   const entities: EntityOption[] = [
     ...(userId
-      ? [{ id: TEAM_ENTITY_ID, name: 'Team', type: 'team' as EntityType }]
+      ? [{ id: TEAM_ENTITY_ID, name: 'Team', type: 'team' as const }]
       : []),
     ...(userId
-      ? [{ id: userId, name: userName || 'You', type: 'user' as EntityType }]
+      ? [{ id: userId, name: userName || 'You', type: 'user' as const }]
       : []),
-    ...agents.map((a) => ({
-      id: a.id,
-      name: a.name,
-      type: 'agent' as EntityType,
+    ...agents.map((agent) => ({
+      id: agent.id,
+      name: agent.name,
+      type: 'agent' as const,
     })),
   ];
 
-  // Get currently selected entity
   const selectedEntity = entities.find(
-    (e) => e.id === selectedEntityId && e.type === selectedEntityType
+    (entity) =>
+      entity.id === selectedEntityId && entity.type === selectedEntityType
   );
 
-  // Determine which tabs to show based on entity type
   const isUserSelected = selectedEntityType === 'user';
   const isTeamSelected = selectedEntityType === 'team';
-  const allTabs: { id: BottomPanelTab; label: string }[] = [
+  const allTabs: Array<{ id: TeamWidgetTab; label: string }> = [
     { id: 'activity', label: 'Activity' },
     { id: 'wallet', label: 'Wallet' },
     { id: 'pnl', label: 'PnL' },
     { id: 'registry', label: 'Agent Registry' },
     { id: 'logs', label: 'Logs' },
   ];
+
   const tabs = isTeamSelected
     ? allTabs.filter(
-        (t) => t.id === 'wallet' || t.id === 'pnl' || t.id === 'registry'
+        (tab) =>
+          tab.id === 'wallet' || tab.id === 'pnl' || tab.id === 'registry'
       )
     : isUserSelected
-      ? allTabs.filter((t) => t.id !== 'logs')
+      ? allTabs.filter((tab) => tab.id !== 'logs')
       : allTabs;
-
-  // Handle tab click - if clicking active tab while open, collapse
-  const handleTabClick = useCallback(
-    (tab: BottomPanelTab) => {
-      if (!isOpen) {
-        onTabChange(tab);
-        onToggle(); // Open
-      } else if (tab === activeTab) {
-        onToggle(); // Collapse
-      } else {
-        onTabChange(tab);
-      }
-    },
-    [isOpen, activeTab, onTabChange, onToggle]
-  );
-
-  // Handle resize drag
-  const handleMouseDown = useCallback(
-    (e: React.MouseEvent) => {
-      if (!isOpen) return;
-      e.preventDefault();
-      setIsResizing(true);
-
-      const startY = e.clientY;
-      const startHeight = height;
-
-      const handleMouseMove = (moveEvent: MouseEvent) => {
-        const delta = startY - moveEvent.clientY;
-        const newHeight = Math.min(
-          Math.max(startHeight + delta, MIN_HEIGHT),
-          MAX_HEIGHT
-        );
-        onHeightChange(newHeight);
-      };
-
-      const handleMouseUp = () => {
-        setIsResizing(false);
-        document.removeEventListener('mousemove', handleMouseMove);
-        document.removeEventListener('mouseup', handleMouseUp);
-        handleMouseMoveRef.current = null;
-        handleMouseUpRef.current = null;
-      };
-
-      // Store refs for cleanup on unmount
-      handleMouseMoveRef.current = handleMouseMove;
-      handleMouseUpRef.current = handleMouseUp;
-
-      document.addEventListener('mousemove', handleMouseMove);
-      document.addEventListener('mouseup', handleMouseUp);
-    },
-    [isOpen, height, onHeightChange]
-  );
 
   return (
     <div
-      ref={panelRef}
       data-tour="agents-bottom-panel"
       className={cn(
-        'relative shrink-0 border-border border-t bg-background transition-[height] duration-200',
-        isResizing && 'select-none transition-none'
+        'flex flex-col bg-background',
+        controlsOnly ? 'h-auto min-h-0' : 'h-full min-h-0'
       )}
-      style={{ height: isOpen ? height : BOTTOM_PANEL_COLLAPSED_HEIGHT }}
     >
-      {/* Resize Handle - only when open */}
-      {isOpen && (
-        <div
-          role="separator"
-          tabIndex={0}
-          aria-orientation="horizontal"
-          aria-valuemin={MIN_HEIGHT}
-          aria-valuemax={MAX_HEIGHT}
-          aria-valuenow={height}
-          aria-label="Resize panel"
-          onMouseDown={handleMouseDown}
-          onKeyDown={(e) => {
-            const STEP = 20;
-            const LARGE_STEP = 50;
-            let newHeight = height;
+      <div className="shrink-0 border-border border-b px-4 py-4">
+        <div className="mb-4 flex items-center justify-between gap-3">
+          <div>
+            <p className="font-semibold text-foreground text-sm">
+              Team widgets
+            </p>
+            <p className="text-muted-foreground text-xs">
+              Activity, portfolio, PnL, and agent tools
+            </p>
+          </div>
 
-            switch (e.key) {
-              case 'ArrowUp':
-                e.preventDefault();
-                newHeight = Math.min(height + STEP, MAX_HEIGHT);
-                break;
-              case 'ArrowDown':
-                e.preventDefault();
-                newHeight = Math.max(height - STEP, MIN_HEIGHT);
-                break;
-              case 'PageUp':
-                e.preventDefault();
-                newHeight = Math.min(height + LARGE_STEP, MAX_HEIGHT);
-                break;
-              case 'PageDown':
-                e.preventDefault();
-                newHeight = Math.max(height - LARGE_STEP, MIN_HEIGHT);
-                break;
-              case 'Home':
-                e.preventDefault();
-                newHeight = MAX_HEIGHT;
-                break;
-              case 'End':
-                e.preventDefault();
-                newHeight = MIN_HEIGHT;
-                break;
-              default:
-                return;
-            }
-
-            if (newHeight !== height) {
-              onHeightChange(newHeight);
-            }
-          }}
-          className={cn(
-            '-translate-y-1/2 absolute top-0 right-0 left-0 z-10 h-2 cursor-row-resize',
-            'hover:bg-primary/30 focus:bg-primary/40 focus:outline-none focus:ring-2 focus:ring-primary/50',
-            isResizing && 'bg-primary/50'
-          )}
-        />
-      )}
-
-      {/* Tab Bar */}
-      <div className="flex h-10 items-center border-border border-b bg-muted/30 px-2">
-        {/* Scrollable tabs area */}
-        <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
-          {tabs.map((tab) => (
-            <button
-              key={tab.id}
-              type="button"
-              onClick={() => handleTabClick(tab.id)}
-              className={cn(
-                'shrink-0 rounded-md px-3 py-1.5 font-medium text-xs transition-colors',
-                activeTab === tab.id && isOpen
-                  ? 'bg-background text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:bg-muted hover:text-foreground'
-              )}
-            >
-              {tab.label}
-            </button>
-          ))}
-        </div>
-
-        {/* Right controls - always visible */}
-        <div className="flex shrink-0 items-center gap-2 pl-2">
-          {/* Entity Selector Dropdown */}
           {entities.length > 0 && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button
                   type="button"
                   className={cn(
-                    'flex h-7 items-center gap-1.5 rounded-md border border-border bg-background px-2 text-xs transition-colors',
+                    'flex h-8 items-center gap-1.5 rounded-md border border-border bg-background px-2.5 text-xs transition-colors',
                     'hover:bg-muted focus:outline-none focus:ring-1 focus:ring-primary'
                   )}
                 >
@@ -293,7 +129,6 @@ export function BottomPanel({
                 align="end"
                 className="max-h-60 w-48 overflow-y-auto"
               >
-                {/* Team option first */}
                 {userId && (
                   <>
                     <DropdownMenuItem
@@ -310,7 +145,6 @@ export function BottomPanel({
                   </>
                 )}
 
-                {/* User option */}
                 {userId && (
                   <>
                     <DropdownMenuItem
@@ -328,7 +162,7 @@ export function BottomPanel({
                     {agents.length > 0 && <DropdownMenuSeparator />}
                   </>
                 )}
-                {/* Agent options */}
+
                 {agents.map((agent) => (
                   <DropdownMenuItem
                     key={agent.id}
@@ -345,34 +179,34 @@ export function BottomPanel({
               </DropdownMenuContent>
             </DropdownMenu>
           )}
+        </div>
 
-          {/* Collapse/Expand toggle */}
-          <button
-            type="button"
-            onClick={onToggle}
-            className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-            aria-label={isOpen ? 'Collapse panel' : 'Expand panel'}
-          >
-            {isOpen ? (
-              <ChevronDown className="h-4 w-4" />
-            ) : (
-              <ChevronUp className="h-4 w-4" />
-            )}
-          </button>
+        <div className="flex flex-wrap gap-2">
+          {tabs.map((tab) => (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => onTabChange(tab.id)}
+              className={cn(
+                'rounded-full border px-3 py-1.5 font-medium text-xs transition-colors',
+                activeTab === tab.id
+                  ? 'border-primary/40 bg-primary/10 text-primary'
+                  : 'border-border bg-background text-muted-foreground hover:border-muted-foreground/40 hover:text-foreground'
+              )}
+            >
+              {tab.label}
+            </button>
+          ))}
         </div>
       </div>
 
-      {/* Content Area */}
-      {isOpen && (
-        <div
-          className="overflow-auto"
-          style={{ height: height - BOTTOM_PANEL_COLLAPSED_HEIGHT }}
-        >
+      {!controlsOnly && (
+        <div className="min-h-0 flex-1 overflow-auto">
           {selectedEntityId ? (
             children
           ) : (
-            <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
-              Select an option from the dropdown to view details
+            <div className="flex h-full items-center justify-center px-6 text-center text-muted-foreground text-sm">
+              Select a team member to view details.
             </div>
           )}
         </div>

--- a/apps/web/src/app/agents/team/RightSidebar.tsx
+++ b/apps/web/src/app/agents/team/RightSidebar.tsx
@@ -191,7 +191,9 @@ export function RightSidebar({
   // Clamp width to valid range
   const clampedWidth = Math.min(Math.max(width, MIN_WIDTH), maxWidth);
 
-  const activePanelContent = activeTabId && tabs.length > 0 ? children : null;
+  const hasValidActiveTab =
+    !!activeTabId && tabs.some((tab) => tab.id === activeTabId);
+  const activePanelContent = hasValidActiveTab ? children : null;
   const emptyState = defaultContent ?? (
     <div className="flex flex-1 items-center justify-center">
       <span className="text-muted-foreground text-sm">No panels open</span>

--- a/apps/web/src/app/agents/team/RightSidebar.tsx
+++ b/apps/web/src/app/agents/team/RightSidebar.tsx
@@ -54,8 +54,8 @@ interface RightSidebarProps {
   onWidthChange: (width: number) => void;
   onClose: () => void;
   leftSidebarCollapsed?: boolean;
-  /** Height of the bottom panel (to shrink right sidebar accordingly) */
-  bottomPanelHeight?: number;
+  defaultContent?: React.ReactNode;
+  topContent?: React.ReactNode;
   children: React.ReactNode;
 }
 
@@ -72,7 +72,8 @@ export function RightSidebar({
   onWidthChange,
   onClose,
   leftSidebarCollapsed = false,
-  bottomPanelHeight = 0,
+  defaultContent,
+  topContent,
   children,
 }: RightSidebarProps) {
   const [isResizing, setIsResizing] = useState(false);
@@ -190,8 +191,8 @@ export function RightSidebar({
   // Clamp width to valid range
   const clampedWidth = Math.min(Math.max(width, MIN_WIDTH), maxWidth);
 
-  // Empty state
-  const emptyState = (
+  const activePanelContent = activeTabId && tabs.length > 0 ? children : null;
+  const emptyState = defaultContent ?? (
     <div className="flex flex-1 items-center justify-center">
       <span className="text-muted-foreground text-sm">No panels open</span>
     </div>
@@ -217,10 +218,7 @@ export function RightSidebar({
         )}
         style={{
           width: clampedWidth,
-          height:
-            bottomPanelHeight > 0
-              ? `calc(100% - ${bottomPanelHeight}px)`
-              : '100%',
+          height: '100%',
         }}
       >
         {/* Resize Handle - desktop only */}
@@ -246,67 +244,63 @@ export function RightSidebar({
           </button>
         </div>
 
-        {tabs.length === 0 ? (
-          emptyState
-        ) : (
-          <>
-            {/* Tab Bar */}
-            <div
-              role="tablist"
-              aria-orientation="horizontal"
-              className="shrink-0 overflow-x-auto border-border border-b bg-muted/30 px-2 py-1"
-            >
-              <div className="flex items-center gap-1">
-                {tabs.map((tab) => {
-                  return (
-                    <div
-                      key={tab.id}
-                      role="tab"
-                      aria-selected={activeTabId === tab.id}
-                      tabIndex={0}
-                      onClick={() => onTabSelect(tab.id)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault();
-                          onTabSelect(tab.id);
-                        }
+        {topContent && <div className="shrink-0">{topContent}</div>}
+
+        {tabs.length > 0 && (
+          <div
+            role="tablist"
+            aria-orientation="horizontal"
+            className="shrink-0 overflow-x-auto border-border border-b bg-muted/30 px-2 py-1"
+          >
+            <div className="flex items-center gap-1">
+              {tabs.map((tab) => {
+                return (
+                  <div
+                    key={tab.id}
+                    role="tab"
+                    aria-selected={activeTabId === tab.id}
+                    tabIndex={0}
+                    onClick={() => onTabSelect(tab.id)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        onTabSelect(tab.id);
+                      }
+                    }}
+                    className={cn(
+                      'group flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md px-2 py-1.5 text-sm transition-colors',
+                      activeTabId === tab.id
+                        ? 'bg-background text-foreground shadow-sm'
+                        : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                    )}
+                  >
+                    <span className="max-w-[100px] truncate">{tab.title}</span>
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onTabClose(tab.id);
                       }}
                       className={cn(
-                        'group flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md px-2 py-1.5 text-sm transition-colors',
-                        activeTabId === tab.id
-                          ? 'bg-background text-foreground shadow-sm'
-                          : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                        'rounded p-0.5 transition-colors',
+                        'text-muted-foreground hover:bg-muted hover:text-foreground',
+                        'opacity-0 group-hover:opacity-100',
+                        activeTabId === tab.id && 'opacity-100'
                       )}
+                      aria-label={`Close ${tab.title}`}
                     >
-                      <span className="max-w-[100px] truncate">
-                        {tab.title}
-                      </span>
-                      <button
-                        type="button"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onTabClose(tab.id);
-                        }}
-                        className={cn(
-                          'rounded p-0.5 transition-colors',
-                          'text-muted-foreground hover:bg-muted hover:text-foreground',
-                          'opacity-0 group-hover:opacity-100',
-                          activeTabId === tab.id && 'opacity-100'
-                        )}
-                        aria-label={`Close ${tab.title}`}
-                      >
-                        <X className="h-3 w-3" />
-                      </button>
-                    </div>
-                  );
-                })}
-              </div>
+                      <X className="h-3 w-3" />
+                    </button>
+                  </div>
+                );
+              })}
             </div>
-
-            {/* Content */}
-            <div className="flex-1 overflow-auto">{children}</div>
-          </>
+          </div>
         )}
+
+        <div className="flex-1 overflow-auto">
+          {activePanelContent ?? emptyState}
+        </div>
       </div>
     </>
   );

--- a/apps/web/src/app/agents/team/page.tsx
+++ b/apps/web/src/app/agents/team/page.tsx
@@ -78,11 +78,9 @@ import { useAgentsTutorial } from './_components/tutorial/useAgentsTutorial';
 import { AgentPnL } from './AgentPnL';
 import { AgentPortfolio } from './AgentPortfolio';
 import {
-  BOTTOM_PANEL_COLLAPSED_HEIGHT,
-  BOTTOM_PANEL_DEFAULT_HEIGHT,
-  BottomPanel,
-  type BottomPanelTab,
   type EntityType,
+  TeamWidgetsRail,
+  type TeamWidgetTab,
 } from './BottomPanel';
 import { ConversationList } from './ConversationList';
 import { MemberList } from './MemberList';
@@ -241,7 +239,7 @@ export default function TeamChatPage() {
   const [leftSidebarCollapsed, setLeftSidebarCollapsed] = useState(false);
 
   // Right sidebar state
-  const [rightSidebarOpen, setRightSidebarOpen] = useState(false);
+  const [rightSidebarOpen, setRightSidebarOpen] = useState(true);
   const [rightSidebarWidth, setRightSidebarWidth] = useState(
     RIGHT_SIDEBAR_DEFAULT_WIDTH
   );
@@ -250,28 +248,17 @@ export default function TeamChatPage() {
   );
   const [activeRightTabId, setActiveRightTabId] = useState<string | null>(null);
 
-  // Bottom panel state
-  const [bottomPanelOpen, setBottomPanelOpen] = useState(true);
-  const [bottomPanelTab, setBottomPanelTab] =
-    useState<BottomPanelTab>('activity');
-  const [bottomPanelEntityId, setBottomPanelEntityId] = useState<string | null>(
+  // Persistent widget rail state
+  const [widgetTab, setWidgetTab] = useState<TeamWidgetTab>('activity');
+  const [widgetEntityId, setWidgetEntityId] = useState<string | null>(null);
+  const [widgetEntityType, setWidgetEntityType] = useState<EntityType | null>(
     null
-  );
-  const [bottomPanelEntityType, setBottomPanelEntityType] =
-    useState<EntityType | null>(null);
-  const [bottomPanelHeight, setBottomPanelHeight] = useState(
-    BOTTOM_PANEL_DEFAULT_HEIGHT
   );
 
   // Registry tab: which agent is selected for registration when viewing team/user
   const [registryAgentId, setRegistryAgentId] = useState<string | null>(null);
 
   const [teamScope, setTeamScope] = useState<TeamScope>('owner_agents');
-
-  // Calculate current bottom panel height for RightSidebar
-  const currentBottomPanelHeight = bottomPanelOpen
-    ? bottomPanelHeight
-    : BOTTOM_PANEL_COLLAPSED_HEIGHT;
 
   // Create agent modal state
   const [showCreateAgentModal, setShowCreateAgentModal] = useState(false);
@@ -410,10 +397,10 @@ export default function TeamChatPage() {
       setRightSidebarOpen(true);
     }
 
-    // Step 6: close right sidebar for bottom panel step
+    // Step 6: return to the persistent widget rail
     if (step.target === '[data-tour="agents-bottom-panel"]') {
-      setRightSidebarOpen(false);
-      setBottomPanelOpen(true);
+      setActiveRightTabId(null);
+      setRightSidebarOpen(true);
     }
   }, [tutorial.isActive, tutorial.currentStep, tutorial.steps]);
 
@@ -421,80 +408,65 @@ export default function TeamChatPage() {
   useEffect(() => {
     if (tutorial.isActive) return;
     const tutorialTabId = `perps-id-${TUTORIAL_PERPS_ENTITY_ID}`;
-    setRightSidebarTabs((prev) => {
-      const filtered = prev.filter((t) => t.id !== tutorialTabId);
-      if (filtered.length === prev.length) return prev; // no change
-      if (filtered.length === 0) {
-        queueMicrotask(() => setRightSidebarOpen(false));
-      }
-      return filtered;
-    });
+    setRightSidebarTabs((prev) => prev.filter((t) => t.id !== tutorialTabId));
   }, [tutorial.isActive]);
 
-  // Set default entity for bottom panel - defaults to user
+  // Set default entity for widget rail - defaults to user
   // Also validates that selected agent still exists (handles agent removal)
   useEffect(() => {
     // Default to user if no selection
-    if (!bottomPanelEntityId && user?.id) {
-      setBottomPanelEntityId(user.id);
-      setBottomPanelEntityType('user');
-      // Keep current tab - activity is now available for users
+    if (!widgetEntityId && user?.id) {
+      setWidgetEntityId(user.id);
+      setWidgetEntityType('user');
       return;
     }
 
     // If an agent is selected, validate it still exists
-    if (bottomPanelEntityType === 'agent' && bottomPanelEntityId) {
+    if (widgetEntityType === 'agent' && widgetEntityId) {
       const agents = teamChat?.agents;
-      const agentExists = agents?.some((a) => a.id === bottomPanelEntityId);
+      const agentExists = agents?.some((a) => a.id === widgetEntityId);
       if (!agentExists) {
         // Agent was removed, fall back to user
         if (user?.id) {
-          setBottomPanelEntityId(user.id);
-          setBottomPanelEntityType('user');
+          setWidgetEntityId(user.id);
+          setWidgetEntityType('user');
           // Switch to activity if on logs (logs not available for users)
-          if (bottomPanelTab === 'logs') {
-            setBottomPanelTab('activity');
+          if (widgetTab === 'logs') {
+            setWidgetTab('activity');
           }
         } else {
-          setBottomPanelEntityId(null);
-          setBottomPanelEntityType(null);
+          setWidgetEntityId(null);
+          setWidgetEntityType(null);
         }
       }
     }
-  }, [
-    teamChat?.agents,
-    bottomPanelEntityId,
-    bottomPanelEntityType,
-    user?.id,
-    bottomPanelTab,
-  ]);
+  }, [teamChat?.agents, widgetEntityId, widgetEntityType, user?.id, widgetTab]);
 
-  // Handle entity change from bottom panel
-  const handleBottomPanelEntityChange = useCallback(
+  // Handle entity change from widget rail
+  const handleWidgetEntityChange = useCallback(
     (id: string, type: EntityType) => {
-      setBottomPanelEntityId(id);
-      setBottomPanelEntityType(type);
+      setWidgetEntityId(id);
+      setWidgetEntityType(type);
       // If switching to user/team and on logs tab, switch to activity/wallet (logs not available)
-      if (type === 'user' && bottomPanelTab === 'logs') {
-        setBottomPanelTab('activity');
+      if (type === 'user' && widgetTab === 'logs') {
+        setWidgetTab('activity');
       }
       if (
         type === 'team' &&
-        (bottomPanelTab === 'logs' || bottomPanelTab === 'activity')
+        (widgetTab === 'logs' || widgetTab === 'activity')
       ) {
-        setBottomPanelTab('wallet');
+        setWidgetTab('wallet');
       }
     },
-    [bottomPanelTab]
+    [widgetTab]
   );
 
   const teamSummaryEnabled =
     Boolean(user?.id) &&
     ready &&
     authenticated &&
-    bottomPanelOpen &&
-    bottomPanelEntityType === 'team' &&
-    (bottomPanelTab === 'wallet' || bottomPanelTab === 'pnl');
+    widgetEntityType === 'team' &&
+    (widgetTab === 'wallet' || widgetTab === 'pnl');
 
   const {
     summary: teamSummary,
@@ -554,17 +526,9 @@ export default function TeamChatPage() {
     [getAccessToken]
   );
 
-  // Close a right sidebar tab - auto-closes sidebar when last tab is closed
+  // Close an auxiliary right-rail tab and fall back to the persistent widgets.
   const closeRightTab = useCallback((tabId: string) => {
-    setRightSidebarTabs((prev) => {
-      const newTabs = prev.filter((t) => t.id !== tabId);
-      // Close sidebar if this was the last tab
-      if (newTabs.length === 0) {
-        // Schedule to avoid state update during render
-        queueMicrotask(() => setRightSidebarOpen(false));
-      }
-      return newTabs;
-    });
+    setRightSidebarTabs((prev) => prev.filter((t) => t.id !== tabId));
   }, []);
 
   // Effect to sync activeRightTabId when tabs change (e.g., after closing)
@@ -650,10 +614,10 @@ export default function TeamChatPage() {
     if (agentIdForWallet) {
       const agent = teamChat.agents.find((a) => a.id === agentIdForWallet);
       if (agent) {
-        setBottomPanelEntityId(agent.id);
-        setBottomPanelEntityType('agent');
-        setBottomPanelTab('wallet');
-        setBottomPanelOpen(true);
+        setWidgetEntityId(agent.id);
+        setWidgetEntityType('agent');
+        setWidgetTab('wallet');
+        setRightSidebarOpen(true);
       }
     }
 
@@ -755,6 +719,195 @@ export default function TeamChatPage() {
   if (ready && !authenticated) {
     return null;
   }
+
+  const widgetRailContent =
+    widgetEntityId && widgetEntityType ? (
+      <>
+        {widgetTab === 'activity' && (
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            {widgetEntityType === 'agent' ? (
+              <div className="p-4">
+                <AgentActivityFeed
+                  agentId={widgetEntityId}
+                  limit={20}
+                  showAgent={false}
+                  showConnectionStatus={false}
+                  emptyMessage="No activity from this agent yet."
+                />
+              </div>
+            ) : (
+              <div className="p-4">
+                <UserActivity userId={widgetEntityId} />
+              </div>
+            )}
+          </div>
+        )}
+
+        {widgetTab === 'wallet' &&
+          (() => {
+            if (widgetEntityType === 'team') {
+              return (
+                <TeamPortfolio
+                  summary={teamSummary}
+                  loading={teamSummaryLoading}
+                  error={teamSummaryError}
+                  scope={teamScope}
+                  onScopeChange={setTeamScope}
+                  onSelectMember={handleWidgetEntityChange}
+                />
+              );
+            }
+            if (widgetEntityType === 'user') {
+              return (
+                <AgentPortfolio
+                  entityType="user"
+                  userId={widgetEntityId}
+                  entityName={user?.displayName || user?.username || 'You'}
+                />
+              );
+            }
+            const selectedAgent = teamChat?.agents.find(
+              (agent) => agent.id === widgetEntityId
+            );
+            return (
+              <AgentPortfolio
+                entityType="agent"
+                agentId={widgetEntityId}
+                entityName={
+                  selectedAgent?.displayName ||
+                  selectedAgent?.username ||
+                  'Agent'
+                }
+              />
+            );
+          })()}
+
+        {widgetTab === 'pnl' &&
+          (() => {
+            if (widgetEntityType === 'team') {
+              return (
+                <TeamPnL
+                  summary={teamSummary}
+                  loading={teamSummaryLoading}
+                  error={teamSummaryError}
+                  scope={teamScope}
+                  onScopeChange={setTeamScope}
+                  onSelectMember={handleWidgetEntityChange}
+                />
+              );
+            }
+            if (widgetEntityType === 'user') {
+              return (
+                <AgentPnL
+                  entityType="user"
+                  userId={widgetEntityId}
+                  entityName={user?.displayName || user?.username || 'You'}
+                />
+              );
+            }
+            const selectedAgent = teamChat?.agents.find(
+              (agent) => agent.id === widgetEntityId
+            );
+            return (
+              <AgentPnL
+                entityType="agent"
+                agentId={widgetEntityId}
+                entityName={
+                  selectedAgent?.displayName ||
+                  selectedAgent?.username ||
+                  'Agent'
+                }
+              />
+            );
+          })()}
+
+        {widgetTab === 'registry' &&
+          (() => {
+            if (widgetEntityType === 'agent') {
+              const selectedAgent = teamChat?.agents.find(
+                (agent) => agent.id === widgetEntityId
+              );
+              return (
+                <div className="p-4">
+                  <AgentRegistry
+                    agent={{
+                      id: widgetEntityId,
+                      name:
+                        selectedAgent?.displayName ||
+                        selectedAgent?.username ||
+                        'Agent',
+                    }}
+                    onUpdate={() => void refreshTeamChat()}
+                  />
+                </div>
+              );
+            }
+
+            const agents = teamChat?.agents ?? [];
+            if (agents.length === 0) {
+              return (
+                <div className="flex h-full items-center justify-center px-6 text-center text-muted-foreground text-sm">
+                  No agents available. Create an agent first.
+                </div>
+              );
+            }
+
+            const selectedAgent = agents.find(
+              (agent) => agent.id === registryAgentId
+            );
+            const effectiveAgentId = selectedAgent
+              ? selectedAgent.id
+              : agents[0]?.id;
+            const effectiveAgent = selectedAgent ?? agents[0];
+
+            return (
+              <div className="p-4">
+                {agents.length > 1 && (
+                  <div className="mb-4">
+                    <label
+                      htmlFor="registry-agent-select"
+                      className="mb-1.5 block font-medium text-sm"
+                    >
+                      Select agent to register
+                    </label>
+                    <select
+                      id="registry-agent-select"
+                      value={effectiveAgentId ?? ''}
+                      onChange={(e) => setRegistryAgentId(e.target.value)}
+                      className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                    >
+                      {agents.map((agent) => (
+                        <option key={agent.id} value={agent.id}>
+                          {agent.displayName || agent.username || 'Agent'}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                )}
+                {effectiveAgent && effectiveAgentId && (
+                  <AgentRegistry
+                    key={effectiveAgentId}
+                    agent={{
+                      id: effectiveAgentId,
+                      name:
+                        effectiveAgent.displayName ||
+                        effectiveAgent.username ||
+                        'Agent',
+                    }}
+                    onUpdate={() => void refreshTeamChat()}
+                  />
+                )}
+              </div>
+            );
+          })()}
+
+        {widgetTab === 'logs' && widgetEntityType === 'agent' && (
+          <div className="p-4">
+            <AgentLogs agentId={widgetEntityId} />
+          </div>
+        )}
+      </>
+    ) : null;
 
   // Loading state
   if (loading) {
@@ -1180,231 +1333,7 @@ export default function TeamChatPage() {
         )}
       </div>
 
-      {/* Bottom Panel - spans full width, hidden on mobile */}
-      <div className="hidden lg:contents">
-        <BottomPanel
-          isOpen={bottomPanelOpen}
-          onToggle={() => setBottomPanelOpen((prev) => !prev)}
-          activeTab={bottomPanelTab}
-          onTabChange={setBottomPanelTab}
-          selectedEntityId={bottomPanelEntityId}
-          selectedEntityType={bottomPanelEntityType}
-          onEntityChange={handleBottomPanelEntityChange}
-          userId={user?.id}
-          userName={user?.displayName || user?.username || 'You'}
-          agents={
-            teamChat?.agents.map((a) => ({
-              id: a.id,
-              name: a.displayName || a.username || 'Agent',
-            })) || []
-          }
-          height={bottomPanelHeight}
-          onHeightChange={setBottomPanelHeight}
-        >
-          {bottomPanelEntityId && bottomPanelEntityType && (
-            <>
-              {/* Activity Tab */}
-              {bottomPanelTab === 'activity' && (
-                <div className="min-h-0 flex-1 overflow-y-auto">
-                  {bottomPanelEntityType === 'agent' ? (
-                    <div className="p-4">
-                      <AgentActivityFeed
-                        agentId={bottomPanelEntityId}
-                        limit={20}
-                        showAgent={false}
-                        showConnectionStatus={false}
-                        emptyMessage="No activity from this agent yet."
-                      />
-                    </div>
-                  ) : (
-                    <div className="p-4">
-                      <UserActivity userId={bottomPanelEntityId} />
-                    </div>
-                  )}
-                </div>
-              )}
-
-              {/* Wallet Tab */}
-              {bottomPanelTab === 'wallet' &&
-                (() => {
-                  if (bottomPanelEntityType === 'team') {
-                    return (
-                      <TeamPortfolio
-                        summary={teamSummary}
-                        loading={teamSummaryLoading}
-                        error={teamSummaryError}
-                        scope={teamScope}
-                        onScopeChange={setTeamScope}
-                        onSelectMember={handleBottomPanelEntityChange}
-                      />
-                    );
-                  }
-                  if (bottomPanelEntityType === 'user') {
-                    return (
-                      <AgentPortfolio
-                        entityType="user"
-                        userId={bottomPanelEntityId}
-                        entityName={
-                          user?.displayName || user?.username || 'You'
-                        }
-                      />
-                    );
-                  }
-                  const bottomAgent = teamChat?.agents.find(
-                    (a) => a.id === bottomPanelEntityId
-                  );
-                  return (
-                    <AgentPortfolio
-                      entityType="agent"
-                      agentId={bottomPanelEntityId}
-                      entityName={
-                        bottomAgent?.displayName ||
-                        bottomAgent?.username ||
-                        'Agent'
-                      }
-                    />
-                  );
-                })()}
-
-              {/* PnL Tab */}
-              {bottomPanelTab === 'pnl' &&
-                (() => {
-                  if (bottomPanelEntityType === 'team') {
-                    return (
-                      <TeamPnL
-                        summary={teamSummary}
-                        loading={teamSummaryLoading}
-                        error={teamSummaryError}
-                        scope={teamScope}
-                        onScopeChange={setTeamScope}
-                        onSelectMember={handleBottomPanelEntityChange}
-                      />
-                    );
-                  }
-                  if (bottomPanelEntityType === 'user') {
-                    return (
-                      <AgentPnL
-                        entityType={'user' as const}
-                        userId={bottomPanelEntityId}
-                        entityName={
-                          user?.displayName || user?.username || 'You'
-                        }
-                      />
-                    );
-                  }
-                  const bottomAgent = teamChat?.agents.find(
-                    (a) => a.id === bottomPanelEntityId
-                  );
-                  return (
-                    <AgentPnL
-                      entityType={'agent' as const}
-                      agentId={bottomPanelEntityId}
-                      entityName={
-                        bottomAgent?.displayName ||
-                        bottomAgent?.username ||
-                        'Agent'
-                      }
-                    />
-                  );
-                })()}
-
-              {/* Registry Tab */}
-              {bottomPanelTab === 'registry' &&
-                (() => {
-                  // For agents, render registry directly
-                  if (bottomPanelEntityType === 'agent') {
-                    const bottomAgent = teamChat?.agents.find(
-                      (a) => a.id === bottomPanelEntityId
-                    );
-                    return (
-                      <div className="p-4">
-                        <AgentRegistry
-                          agent={{
-                            id: bottomPanelEntityId,
-                            name:
-                              bottomAgent?.displayName ||
-                              bottomAgent?.username ||
-                              'Agent',
-                          }}
-                          onUpdate={() => void refreshTeamChat()}
-                        />
-                      </div>
-                    );
-                  }
-
-                  // For team/user, show agent picker then registry
-                  const agents = teamChat?.agents ?? [];
-                  if (agents.length === 0) {
-                    return (
-                      <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
-                        No agents available. Create an agent first.
-                      </div>
-                    );
-                  }
-
-                  // Auto-select first agent if none selected or selected no longer exists
-                  const selectedAgent = agents.find(
-                    (a) => a.id === registryAgentId
-                  );
-                  const effectiveAgentId = selectedAgent
-                    ? selectedAgent.id
-                    : agents[0]?.id;
-                  const effectiveAgent = selectedAgent ?? agents[0];
-
-                  return (
-                    <div className="p-4">
-                      {agents.length > 1 && (
-                        <div className="mb-4">
-                          <label
-                            htmlFor="registry-agent-select"
-                            className="mb-1.5 block font-medium text-sm"
-                          >
-                            Select agent to register
-                          </label>
-                          <select
-                            id="registry-agent-select"
-                            value={effectiveAgentId ?? ''}
-                            onChange={(e) => setRegistryAgentId(e.target.value)}
-                            className="h-9 w-full max-w-xs rounded-md border border-border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-                          >
-                            {agents.map((a) => (
-                              <option key={a.id} value={a.id}>
-                                {a.displayName || a.username || 'Agent'}
-                              </option>
-                            ))}
-                          </select>
-                        </div>
-                      )}
-                      {effectiveAgent && effectiveAgentId && (
-                        <AgentRegistry
-                          key={effectiveAgentId}
-                          agent={{
-                            id: effectiveAgentId,
-                            name:
-                              effectiveAgent.displayName ||
-                              effectiveAgent.username ||
-                              'Agent',
-                          }}
-                          onUpdate={() => void refreshTeamChat()}
-                        />
-                      )}
-                    </div>
-                  );
-                })()}
-
-              {/* Logs Tab - only for agents */}
-              {bottomPanelTab === 'logs' &&
-                bottomPanelEntityType === 'agent' && (
-                  <div className="p-4">
-                    <AgentLogs agentId={bottomPanelEntityId} />
-                  </div>
-                )}
-            </>
-          )}
-        </BottomPanel>
-      </div>
-
-      {/* Right Sidebar - Fixed position overlay, desktop only */}
+      {/* Right rail - desktop only */}
       {rightSidebarOpen && (
         <div className="hidden lg:block">
           <RightSidebar
@@ -1416,7 +1345,33 @@ export default function TeamChatPage() {
             onWidthChange={setRightSidebarWidth}
             onClose={() => setRightSidebarOpen(false)}
             leftSidebarCollapsed={leftSidebarCollapsed}
-            bottomPanelHeight={currentBottomPanelHeight}
+            topContent={
+              <TeamWidgetsRail
+                activeTab={widgetTab}
+                onTabChange={setWidgetTab}
+                selectedEntityId={widgetEntityId}
+                selectedEntityType={widgetEntityType}
+                onEntityChange={handleWidgetEntityChange}
+                userId={user?.id}
+                userName={user?.displayName || user?.username || 'You'}
+                agents={
+                  teamChat?.agents.map((agent) => ({
+                    id: agent.id,
+                    name: agent.displayName || agent.username || 'Agent',
+                  })) || []
+                }
+                controlsOnly
+              >
+                {widgetRailContent}
+              </TeamWidgetsRail>
+            }
+            defaultContent={
+              widgetRailContent ?? (
+                <div className="flex h-full items-center justify-center px-6 text-center text-muted-foreground text-sm">
+                  Select a team member to view details.
+                </div>
+              )
+            }
           >
             {rightSidebarTabs
               .filter((tab) => tab.id === activeRightTabId)

--- a/apps/web/src/app/agents/team/page.tsx
+++ b/apps/web/src/app/agents/team/page.tsx
@@ -465,6 +465,7 @@ export default function TeamChatPage() {
     Boolean(user?.id) &&
     ready &&
     authenticated &&
+    rightSidebarOpen &&
     widgetEntityType === 'team' &&
     (widgetTab === 'wallet' || widgetTab === 'pnl');
 
@@ -590,7 +591,7 @@ export default function TeamChatPage() {
 
   // Handle query parameters for agent actions
   // - selectAgent: Tags the agent in the input (from agent profile redirect)
-  // - openWallet: Opens bottom panel with wallet tab (from insufficient balance)
+  // - openWallet: Opens the widget rail on the wallet tab (from insufficient balance)
   // Combined into single effect to avoid race conditions if both params present
   useEffect(() => {
     if (loading || !teamChat) return;
@@ -609,7 +610,7 @@ export default function TeamChatPage() {
       }
     }
 
-    // Handle openWallet - open bottom panel with wallet tab
+    // Handle openWallet - open the widget rail on the wallet tab
     // (prioritize over selectAgent if both present)
     if (agentIdForWallet) {
       const agent = teamChat.agents.find((a) => a.id === agentIdForWallet);


### PR DESCRIPTION
## Summary
- Moves agent team widgets (portfolio chart, team stats, recent activity) from the bottom panel into the right sidebar rail
- Simplifies the bottom panel to focus on chat/terminal content
- Consolidates layout so key agent metrics are visible without scrolling

## Test plan
- [ ] Verify agent team page renders with widgets in right sidebar
- [ ] Confirm bottom panel shows chat/terminal content only
- [ ] Check responsive behavior at various viewport widths
- [ ] Verify no regressions in widget data display (portfolio chart, stats, activity)