### PR TITLE
fix(web): remove NFT promo banner and Buy Points icons

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -12,7 +12,6 @@ import { Toaster } from 'sonner';
 import { AchievementToastListener } from '@/components/achievements';
 import { FeedAuthBanner } from '@/components/auth/FeedAuthBanner';
 import { GlobalLoginModal } from '@/components/auth/GlobalLoginModal';
-import { NftPromoBanner } from '@/components/nft';
 import { Providers } from '@/components/providers/Providers';
 import { BottomNav } from '@/components/shared/BottomNav';
 import { MobileHeader } from '@/components/shared/MobileHeader';
@@ -115,11 +114,6 @@ export default async function RootLayout({
             children
           ) : (
             <>
-              {/* NFT Collection Promo Banner - at the very top */}
-              <Suspense fallback={null}>
-                <NftPromoBanner />
-              </Suspense>
-
               {/* Mobile Header - Fixed, not affected by pull-to-refresh */}
               <Suspense fallback={null}>
                 <MobileHeader />

--- a/apps/web/src/components/points/BuyPointsModal.tsx
+++ b/apps/web/src/components/points/BuyPointsModal.tsx
@@ -7,7 +7,6 @@ import {
   CheckCircle2,
   CreditCard,
   DollarSign,
-  Sparkles,
   Wallet,
   X,
 } from 'lucide-react';
@@ -926,7 +925,6 @@ export function BuyPointsModal({
                   You'll receive
                 </p>
                 <div className="flex items-center justify-center gap-2">
-                  <Sparkles className="h-6 w-6 text-yellow-500" />
                   <span
                     data-testid="points-amount-display"
                     className="font-bold text-3xl text-foreground"
@@ -1074,7 +1072,6 @@ export function BuyPointsModal({
               Purchase Successful!
             </h3>
             <div className="mb-6 flex items-center gap-2">
-              <Sparkles className="h-5 w-5 text-yellow-500" />
               <span
                 data-testid="points-awarded-amount"
                 className="font-bold text-2xl text-foreground"
@@ -1161,7 +1158,6 @@ export function BuyPointsModal({
         <div className="shrink-0 border-border border-b px-4 py-3 sm:px-6 sm:py-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <Sparkles className="h-5 w-5 text-yellow-500" />
               <h2 className="font-bold text-lg">Buy Points</h2>
             </div>
             <button


### PR DESCRIPTION
## Summary

- Remove the global NFT promo banner from the app layout.
- Remove decorative sparkles icons from the `Buy Points` modal header and points summary/success states.
- Keep the payment flow behavior unchanged while applying the requested UI cleanup.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Requested small UI cleanup for production.

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Non-goals / follow-ups

- None.

## Changes

- Remove `NftPromoBanner` from the root app layout.
- Remove `Sparkles` icons from `BuyPointsModal`.

## Review guide

**Start here**
- `apps/web/src/app/layout.tsx`
- `apps/web/src/components/points/BuyPointsModal.tsx`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- This is a presentation-only change. No payment logic or modal state flow was changed.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. Ran `bun x biome check apps/web/src/app/layout.tsx apps/web/src/components/points/BuyPointsModal.tsx`.
2. `bun run check` / git hooks currently fail because `.tmp/wrap-api-routes-withErrorHandling.mjs` contains `console.*` usages outside the scope of this PR.
3. Visual expectation: the NFT banner no longer appears at the top of the app, and the Buy Points modal no longer shows decorative sparkles icons.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: deploy normally.
- Rollback: revert this PR.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option A: Visual demo

| Feature | Before | After |
|---------|--------|-------|
| Global top banner | NFT promo banner visible in app layout | NFT promo banner removed |
| Buy Points modal | Decorative sparkles icons visible | Decorative sparkles icons removed |

*Demo script (for recording):*
1. Open any standard app page and confirm there is no NFT promo banner above the mobile header/content.
2. Open the `Buy Points` modal from wallet, markets, settings, or agent portfolio.
3. Confirm the modal title and points summary render without the sparkles icons, while the payment flow remains unchanged.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [ ] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
