### PR TITLE
feat(web): redesign agents team page with card view and unified right sidebar

### DIFF
--- a/apps/web/src/app/agents/team/AgentPnL.tsx
+++ b/apps/web/src/app/agents/team/AgentPnL.tsx
@@ -216,66 +216,69 @@ function UserPnL({
         </div>
       </div>
 
-      {/* P&L Summary + Quick Stats */}
-      <div className="grid grid-cols-2 gap-3">
-        {/* P&L Summary (matches profile page) */}
-        <div className="space-y-2 rounded-lg border border-border bg-card/50 p-3">
-          <div className="flex items-center justify-between text-xs">
-            <span className="text-muted-foreground">Total P&L</span>
-            <span
-              className={cn(
-                'font-semibold',
-                isProfitable ? 'text-green-600' : 'text-red-600'
-              )}
-            >
-              {totalPnL >= 0 ? '+' : ''}
-              {formatCompactCurrency(totalPnL)}
-            </span>
-          </div>
-          <div className="flex items-center justify-between text-xs">
-            <span className="text-muted-foreground">Total Assets</span>
-            <span className="font-medium">
-              {formatCompactCurrency(portfolio?.totalAssets ?? 0)}
-            </span>
-          </div>
-          <div className="flex items-center justify-between text-xs">
-            <span className="text-muted-foreground">Available</span>
-            <span className="font-medium">
-              {formatCompactCurrency(portfolio?.available ?? 0)}
-            </span>
-          </div>
-          <div className="border-border border-t pt-2">
-            <div className="flex items-center justify-between text-xs">
-              <span className="text-muted-foreground">In Positions</span>
-              <span className="font-medium">
-                {formatCompactCurrency(portfolio?.positions ?? 0)}
-              </span>
-            </div>
-          </div>
+      {/* Quick Stats Row */}
+      <div className="flex items-stretch rounded-lg border border-border/60 bg-card/50">
+        <div className="flex flex-1 flex-col items-center justify-center px-1 py-2">
+          <span className="font-semibold text-foreground text-xs">
+            {formatCompactCurrency(portfolio?.wallet ?? 0)}
+          </span>
+          <span className="text-[9px] text-muted-foreground uppercase tracking-wider">
+            Balance
+          </span>
         </div>
+        <div className="w-px bg-border/60" />
+        <div className="flex flex-1 flex-col items-center justify-center px-1 py-2">
+          <span className="font-semibold text-foreground text-xs">
+            {formatCompactCurrency(portfolio?.totalAssets ?? 0)}
+          </span>
+          <span className="text-[9px] text-muted-foreground uppercase tracking-wider">
+            Assets
+          </span>
+        </div>
+        <div className="w-px bg-border/60" />
+        <div className="flex flex-1 flex-col items-center justify-center px-1 py-2">
+          <span className="font-semibold text-foreground text-xs">
+            {predictions.length + perps.length}
+          </span>
+          <span className="text-[9px] text-muted-foreground uppercase tracking-wider">
+            Positions
+          </span>
+        </div>
+      </div>
 
-        {/* Quick Stats */}
-        <div className="grid grid-cols-2 gap-2">
-          <div className="rounded-lg bg-muted/30 p-2 text-center">
-            <div className="text-[10px] text-muted-foreground">Balance</div>
-            <div className="font-semibold text-sm">
-              {formatCompactCurrency(portfolio?.wallet ?? 0)}
-            </div>
-          </div>
-          <div className="rounded-lg bg-muted/30 p-2 text-center">
-            <div className="text-[10px] text-muted-foreground">Positions</div>
-            <div className="font-semibold text-sm">
-              {predictions.length + perps.length}
-            </div>
-          </div>
-          <div className="rounded-lg bg-muted/30 p-2 text-center">
-            <div className="text-[10px] text-muted-foreground">Predictions</div>
-            <div className="font-semibold text-sm">{predictions.length}</div>
-          </div>
-          <div className="rounded-lg bg-muted/30 p-2 text-center">
-            <div className="text-[10px] text-muted-foreground">Perpetuals</div>
-            <div className="font-semibold text-sm">{perps.length}</div>
-          </div>
+      {/* P&L Breakdown */}
+      <div className="space-y-1.5 rounded-lg border border-border bg-card/50 p-3">
+        <div className="flex items-center justify-between text-xs">
+          <span className="text-muted-foreground">Total P&L</span>
+          <span
+            className={cn(
+              'font-semibold',
+              isProfitable ? 'text-green-600' : 'text-red-600'
+            )}
+          >
+            {totalPnL >= 0 ? '+' : ''}
+            {formatCompactCurrency(totalPnL)}
+          </span>
+        </div>
+        <div className="flex items-center justify-between text-xs">
+          <span className="text-muted-foreground">Available</span>
+          <span className="font-medium">
+            {formatCompactCurrency(portfolio?.available ?? 0)}
+          </span>
+        </div>
+        <div className="flex items-center justify-between text-xs">
+          <span className="text-muted-foreground">In Positions</span>
+          <span className="font-medium">
+            {formatCompactCurrency(portfolio?.positions ?? 0)}
+          </span>
+        </div>
+        <div className="flex items-center justify-between border-border border-t pt-1.5 text-xs">
+          <span className="text-muted-foreground">Predictions</span>
+          <span className="font-medium">{predictions.length}</span>
+        </div>
+        <div className="flex items-center justify-between text-xs">
+          <span className="text-muted-foreground">Perpetuals</span>
+          <span className="font-medium">{perps.length}</span>
         </div>
       </div>
 
@@ -615,70 +618,76 @@ function AgentPnLView({
         </div>
       </div>
 
-      {/* P&L Summary + Quick Stats - Side by side */}
-      <div className="grid grid-cols-2 gap-3">
-        {/* P&L Summary (matches profile page) */}
-        <div className="space-y-2 rounded-lg border border-border bg-card/50 p-3">
-          <div className="flex items-center justify-between text-xs">
-            <span className="text-muted-foreground">Total P&L</span>
-            <span
-              className={cn(
-                'font-semibold',
-                isProfitable ? 'text-green-600' : 'text-red-600'
-              )}
-            >
-              {totalPnL >= 0 ? '+' : ''}
-              {formatCompactCurrency(totalPnL)}
-            </span>
-          </div>
-          <div className="flex items-center justify-between text-xs">
-            <span className="text-muted-foreground">Total Assets</span>
-            <span className="font-medium">
-              {formatCompactCurrency(portfolio?.totalAssets ?? 0)}
-            </span>
-          </div>
-          <div className="flex items-center justify-between text-xs">
-            <span className="text-muted-foreground">Available</span>
-            <span className="font-medium">
-              {formatCompactCurrency(portfolio?.available ?? 0)}
-            </span>
-          </div>
-          <div className="border-border border-t pt-2">
-            <div className="flex items-center justify-between text-xs">
-              <span className="text-muted-foreground">In Positions</span>
-              <span className="font-medium">
-                {formatCompactCurrency(portfolio?.positions ?? 0)}
-              </span>
-            </div>
-          </div>
+      {/* Quick Stats Row */}
+      <div className="flex items-stretch rounded-lg border border-border/60 bg-card/50">
+        <div className="flex flex-1 flex-col items-center justify-center px-1 py-2">
+          <span className="font-semibold text-foreground text-xs">
+            {agentStats.totalTrades}
+          </span>
+          <span className="text-[9px] text-muted-foreground uppercase tracking-wider">
+            Trades
+          </span>
         </div>
+        <div className="w-px bg-border/60" />
+        <div className="flex flex-1 flex-col items-center justify-center px-1 py-2">
+          <span className="font-semibold text-foreground text-xs">
+            {(agentStats.winRate * 100).toFixed(0)}%
+          </span>
+          <span className="text-[9px] text-muted-foreground uppercase tracking-wider">
+            Win Rate
+          </span>
+        </div>
+        <div className="w-px bg-border/60" />
+        <div className="flex flex-1 flex-col items-center justify-center px-1 py-2">
+          <span className="font-semibold text-foreground text-xs">
+            {positionsLoading ? '...' : predictions.length + perps.length}
+          </span>
+          <span className="text-[9px] text-muted-foreground uppercase tracking-wider">
+            Positions
+          </span>
+        </div>
+        <div className="w-px bg-border/60" />
+        <div className="flex flex-1 flex-col items-center justify-center px-1 py-2">
+          <span className="font-semibold text-green-600 text-xs">
+            {agentStats.profitableTrades}
+          </span>
+          <span className="text-[9px] text-muted-foreground uppercase tracking-wider">
+            Profitable
+          </span>
+        </div>
+      </div>
 
-        {/* Quick Stats */}
-        <div className="grid grid-cols-2 gap-2">
-          <div className="rounded-lg bg-muted/30 p-2 text-center">
-            <div className="text-[10px] text-muted-foreground">Trades</div>
-            <div className="font-semibold text-sm">
-              {agentStats.totalTrades}
-            </div>
-          </div>
-          <div className="rounded-lg bg-muted/30 p-2 text-center">
-            <div className="text-[10px] text-muted-foreground">Win Rate</div>
-            <div className="font-semibold text-sm">
-              {(agentStats.winRate * 100).toFixed(0)}%
-            </div>
-          </div>
-          <div className="rounded-lg bg-muted/30 p-2 text-center">
-            <div className="text-[10px] text-muted-foreground">Positions</div>
-            <div className="font-semibold text-sm">
-              {positionsLoading ? '...' : predictions.length + perps.length}
-            </div>
-          </div>
-          <div className="rounded-lg bg-muted/30 p-2 text-center">
-            <div className="text-[10px] text-muted-foreground">Profitable</div>
-            <div className="font-semibold text-green-600 text-sm">
-              {agentStats.profitableTrades}
-            </div>
-          </div>
+      {/* P&L Breakdown */}
+      <div className="space-y-1.5 rounded-lg border border-border bg-card/50 p-3">
+        <div className="flex items-center justify-between text-xs">
+          <span className="text-muted-foreground">Total P&L</span>
+          <span
+            className={cn(
+              'font-semibold',
+              isProfitable ? 'text-green-600' : 'text-red-600'
+            )}
+          >
+            {totalPnL >= 0 ? '+' : ''}
+            {formatCompactCurrency(totalPnL)}
+          </span>
+        </div>
+        <div className="flex items-center justify-between text-xs">
+          <span className="text-muted-foreground">Total Assets</span>
+          <span className="font-medium">
+            {formatCompactCurrency(portfolio?.totalAssets ?? 0)}
+          </span>
+        </div>
+        <div className="flex items-center justify-between text-xs">
+          <span className="text-muted-foreground">Available</span>
+          <span className="font-medium">
+            {formatCompactCurrency(portfolio?.available ?? 0)}
+          </span>
+        </div>
+        <div className="flex items-center justify-between text-xs">
+          <span className="text-muted-foreground">In Positions</span>
+          <span className="font-medium">
+            {formatCompactCurrency(portfolio?.positions ?? 0)}
+          </span>
         </div>
       </div>
 

--- a/apps/web/src/app/agents/team/AgentPortfolio.tsx
+++ b/apps/web/src/app/agents/team/AgentPortfolio.tsx
@@ -36,12 +36,10 @@ export function AgentPortfolio(props: AgentPortfolioProps) {
   }
 
   return (
-    <div className="p-4">
-      <SharedAgentWallet
-        agent={{ id: props.agentId, name: entityName }}
-        onUpdate={() => {}}
-      />
-    </div>
+    <SharedAgentWallet
+      agent={{ id: props.agentId, name: entityName }}
+      onUpdate={() => {}}
+    />
   );
 }
 

--- a/apps/web/src/app/agents/team/MemberList.tsx
+++ b/apps/web/src/app/agents/team/MemberList.tsx
@@ -100,15 +100,19 @@ export function MemberList({
                 : stats?.lastTickAt || stats?.lastChatAt || null;
 
             return (
-              <button
+              <div
                 key={agent.id}
-                type="button"
-                onClick={() => {
-                  onSelectAgent?.(agent.id);
-                  onTagAgent?.(agent);
+                role="button"
+                tabIndex={0}
+                onClick={() => onSelectAgent?.(agent.id)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onSelectAgent?.(agent.id);
+                  }
                 }}
                 className={cn(
-                  'w-full rounded-xl border p-3 text-left transition-all',
+                  'w-full cursor-pointer rounded-xl border p-3 text-left transition-all',
                   isSelected
                     ? 'border-primary/40 bg-primary/5'
                     : 'border-border bg-muted/30 hover:border-border/80 hover:bg-muted/50'
@@ -273,7 +277,7 @@ export function MemberList({
                     </Link>
                   )}
                 </div>
-              </button>
+              </div>
             );
           })}
         </div>

--- a/apps/web/src/app/agents/team/MemberList.tsx
+++ b/apps/web/src/app/agents/team/MemberList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { cn } from '@babylon/shared';
+import { cn, formatCompactCurrency } from '@babylon/shared';
 import { ExternalLink, MoreVertical, Settings, Square } from 'lucide-react';
 import Link from 'next/link';
 import { Avatar } from '@/components/shared/Avatar';
@@ -12,7 +12,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 
 /** Agent info for member list */
-interface TeamChatAgent {
+export interface TeamChatAgent {
   id: string;
   username: string | null;
   displayName: string | null;
@@ -20,6 +20,19 @@ interface TeamChatAgent {
   isAgent: boolean;
   modelTier: 'free' | 'pro';
   virtualBalance: number;
+}
+
+/** Agent stats from /api/agents */
+export interface AgentStats {
+  lifetimePnL: number;
+  totalTrades: number;
+  profitableTrades: number;
+  winRate: number;
+  lastTickAt: string | null;
+  lastChatAt: string | null;
+  isActive: boolean;
+  status: string;
+  openPositions: number;
 }
 
 /** Team chat info for member list */
@@ -30,25 +43,29 @@ interface TeamChatInfo {
 
 interface MemberListProps {
   teamChat: TeamChatInfo | null | undefined;
-  /** Called when a link is clicked (for closing drawer on mobile) */
   onClose?: () => void;
-  /** IDs of agents currently processing */
   processingAgentIds?: Set<string>;
-  /** Called when an agent is clicked (to tag in input) */
   onTagAgent?: (agent: TeamChatAgent) => void;
-  /** Called when "Stop" is clicked on a processing agent */
   onStopAgent?: (agentId: string) => void;
-  /** Called when "Settings" is clicked */
   onViewSettings?: (agentId: string) => void;
+  onSelectAgent?: (agentId: string) => void;
+  selectedAgentId?: string | null;
+  viewMode?: 'list' | 'cards';
+  agentStatsMap?: Map<string, AgentStats>;
 }
 
-/**
- * Member list component for Agents sidebar/drawer
- *
- * Shows all agents in the team chat.
- * Click on an agent to tag them in the message input.
- * Used by both desktop sidebar and mobile drawer.
- */
+function formatTimeAgo(dateStr: string | null): string {
+  if (!dateStr) return 'Never';
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'Just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d ago`;
+}
+
 export function MemberList({
   teamChat,
   onClose,
@@ -56,122 +73,321 @@ export function MemberList({
   onTagAgent,
   onStopAgent,
   onViewSettings,
+  onSelectAgent,
+  selectedAgentId,
+  viewMode = 'list',
+  agentStatsMap,
 }: MemberListProps) {
-  return (
-    <div className="min-h-0 flex-1 overflow-y-auto">
-      {/* Agents */}
-      <div>
-        {teamChat?.agents.length ? (
-          <nav role="list" aria-label="Team agents" className="space-y-1">
-            {teamChat.agents.map((agent) => {
-              const isProcessing = processingAgentIds.has(agent.id);
-              const agentName = agent.displayName || agent.username || 'Agent';
+  if (!teamChat?.agents.length) return null;
 
-              return (
-                <div
-                  key={agent.id}
-                  className={cn(
-                    'group flex min-w-0 items-center gap-2 rounded-lg p-2 transition-colors',
-                    'hover:bg-muted/50 has-[[data-state=open]]:bg-muted/50',
-                    isProcessing && 'opacity-70'
-                  )}
-                >
-                  {/* Agent info - clickable to tag in input */}
-                  <button
-                    type="button"
-                    onClick={() => onTagAgent?.(agent)}
-                    disabled={isProcessing}
-                    className={cn(
-                      'flex min-w-0 flex-1 items-center gap-3 text-left',
-                      isProcessing ? 'cursor-not-allowed' : 'cursor-pointer'
+  if (viewMode === 'cards') {
+    return (
+      <div className="min-h-0 flex-1 overflow-y-auto px-3 pb-3">
+        <div className="space-y-3">
+          {teamChat.agents.map((agent) => {
+            const agentName = agent.displayName || agent.username || 'Agent';
+            const isSelected = selectedAgentId === agent.id;
+            const isProcessing = processingAgentIds.has(agent.id);
+            const stats = agentStatsMap?.get(agent.id);
+            const hasStats = stats !== undefined;
+
+            // Determine last active time (most recent of lastTickAt or lastChatAt)
+            const lastActive =
+              stats?.lastTickAt && stats?.lastChatAt
+                ? new Date(stats.lastTickAt) > new Date(stats.lastChatAt)
+                  ? stats.lastTickAt
+                  : stats.lastChatAt
+                : stats?.lastTickAt || stats?.lastChatAt || null;
+
+            return (
+              <button
+                key={agent.id}
+                type="button"
+                onClick={() => {
+                  onSelectAgent?.(agent.id);
+                  onTagAgent?.(agent);
+                }}
+                className={cn(
+                  'w-full rounded-xl border p-3 text-left transition-all',
+                  isSelected
+                    ? 'border-primary/40 bg-primary/5'
+                    : 'border-border bg-muted/30 hover:border-border/80 hover:bg-muted/50'
+                )}
+              >
+                {/* Top: Avatar + Name + Status + Gear */}
+                <div className="mb-3 flex items-start gap-3">
+                  <div className="relative shrink-0">
+                    <Avatar
+                      src={agent.profileImageUrl ?? undefined}
+                      name={agentName}
+                      size="md"
+                    />
+                    {isProcessing && (
+                      <div className="-top-0.5 -right-0.5 absolute h-3 w-3 animate-pulse rounded-full bg-amber-500 ring-2 ring-background" />
                     )}
-                    aria-label={`Tag ${agentName}`}
-                  >
-                    <div className="relative">
-                      <Avatar
-                        src={agent.profileImageUrl ?? undefined}
-                        name={agentName}
-                        size="sm"
-                      />
-                    </div>
-                    <div className="min-w-0 flex-1">
-                      <div className="flex items-center gap-1.5">
-                        <p className="truncate font-medium text-foreground text-sm">
-                          {agentName}
-                        </p>
-                        {agent.modelTier === 'pro' && (
-                          <span className="shrink-0 rounded bg-primary/20 px-1.5 py-0.5 font-medium text-[10px] text-primary">
-                            PRO
-                          </span>
-                        )}
-                      </div>
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-1.5">
+                      <span className="truncate font-semibold text-foreground text-sm">
+                        {agentName}
+                      </span>
                       {agent.username && (
-                        <p className="truncate text-muted-foreground text-xs">
+                        <span className="truncate text-muted-foreground text-xs">
                           @{agent.username}
-                        </p>
+                        </span>
                       )}
                     </div>
-                  </button>
-
-                  {/* Stop button when processing, otherwise show menu button */}
-                  {isProcessing ? (
-                    <button
-                      type="button"
-                      className="relative flex h-7 w-7 flex-shrink-0 items-center justify-center rounded transition-colors hover:bg-primary/10"
-                      onClick={() => onStopAgent?.(agent.id)}
-                      aria-label={`Stop ${agentName}`}
-                    >
-                      {/* Spinning ring */}
-                      <div className="absolute inset-0.5 animate-spin rounded-full border-2 border-transparent border-t-primary" />
-                      {/* Stop square in center */}
-                      <Square className="relative h-3 w-3 fill-primary text-primary" />
-                    </button>
-                  ) : (
-                    <DropdownMenu modal={false}>
-                      <DropdownMenuTrigger asChild>
-                        <button
-                          type="button"
+                    <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                      {hasStats && (
+                        <span
                           className={cn(
-                            'flex h-7 w-7 flex-shrink-0 items-center justify-center rounded transition-colors',
-                            'text-muted-foreground hover:bg-muted hover:text-foreground',
-                            'focus:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100 lg:opacity-0'
+                            'inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-medium text-[10px]',
+                            stats.isActive
+                              ? 'bg-green-500/15 text-green-500'
+                              : 'bg-muted text-muted-foreground'
                           )}
-                          aria-label={`More options for ${agentName}`}
                         >
-                          <MoreVertical className="h-4 w-4" />
-                        </button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        {agent.username && (
-                          <DropdownMenuItem asChild>
-                            <Link
-                              href={`/profile/${agent.username}`}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              <ExternalLink className="mr-2 h-4 w-4" />
-                              <span>View Profile</span>
-                            </Link>
-                          </DropdownMenuItem>
-                        )}
-                        <DropdownMenuItem
-                          onClick={() => {
-                            onViewSettings?.(agent.id);
-                            onClose?.();
-                          }}
-                        >
-                          <Settings className="mr-2 h-4 w-4" />
-                          <span>Settings</span>
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
+                          <span
+                            className={cn(
+                              'h-1.5 w-1.5 rounded-full',
+                              stats.isActive
+                                ? 'bg-green-500'
+                                : 'bg-muted-foreground'
+                            )}
+                          />
+                          {stats.isActive ? 'Active' : 'Idle'}
+                        </span>
+                      )}
+                      {agent.modelTier === 'pro' && (
+                        <span className="rounded bg-primary/20 px-1.5 py-0.5 font-medium text-[10px] text-primary">
+                          PRO
+                        </span>
+                      )}
+                      {hasStats && stats.openPositions > 0 && (
+                        <span className="rounded bg-blue-500/15 px-1.5 py-0.5 font-medium text-[10px] text-blue-500">
+                          {stats.openPositions} open
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onViewSettings?.(agent.id);
+                    }}
+                    className="shrink-0 rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                    aria-label="Agent settings"
+                  >
+                    <Settings className="h-4 w-4" />
+                  </button>
+                </div>
+
+                {/* Stats row */}
+                <div className="mb-3 flex items-stretch rounded-lg border border-border/60 bg-background/50">
+                  <div className="flex flex-1 flex-col items-center justify-center px-1 py-2">
+                    <span className="font-semibold text-foreground text-xs">
+                      {formatCompactCurrency(agent.virtualBalance)}
+                    </span>
+                    <span className="text-[9px] text-muted-foreground uppercase tracking-wider">
+                      Wallet
+                    </span>
+                  </div>
+                  <div className="w-px bg-border/60" />
+                  <div className="flex flex-1 flex-col items-center justify-center px-1 py-2">
+                    <span
+                      className={cn(
+                        'font-semibold text-xs',
+                        hasStats
+                          ? stats.lifetimePnL >= 0
+                            ? 'text-green-600'
+                            : 'text-red-600'
+                          : 'text-foreground'
+                      )}
+                    >
+                      {hasStats
+                        ? `${stats.lifetimePnL >= 0 ? '+' : ''}${formatCompactCurrency(stats.lifetimePnL)}`
+                        : '—'}
+                    </span>
+                    <span className="text-[9px] text-muted-foreground uppercase tracking-wider">
+                      P&L
+                    </span>
+                  </div>
+                  <div className="w-px bg-border/60" />
+                  <div className="flex flex-1 flex-col items-center justify-center px-1 py-2">
+                    <span className="font-semibold text-foreground text-xs">
+                      {hasStats ? `${(stats.winRate * 100).toFixed(0)}%` : '—'}
+                    </span>
+                    <span className="text-[9px] text-muted-foreground uppercase tracking-wider">
+                      Win Rate
+                    </span>
+                  </div>
+                  <div className="w-px bg-border/60" />
+                  <div className="flex flex-1 flex-col items-center justify-center px-1 py-2">
+                    <span className="font-semibold text-foreground text-xs">
+                      {hasStats ? stats.totalTrades : '—'}
+                    </span>
+                    <span className="text-[9px] text-muted-foreground uppercase tracking-wider">
+                      Trades
+                    </span>
+                  </div>
+                </div>
+
+                {/* Bottom: Last active + actions */}
+                <div className="flex items-center justify-between">
+                  <span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                    {hasStats && lastActive ? (
+                      <>
+                        <span
+                          className={cn(
+                            'h-1.5 w-1.5 rounded-full',
+                            stats.isActive
+                              ? 'bg-green-500'
+                              : 'bg-muted-foreground'
+                          )}
+                        />
+                        Last active {formatTimeAgo(lastActive)}
+                      </>
+                    ) : hasStats ? (
+                      <>
+                        <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground" />
+                        No activity yet
+                      </>
+                    ) : (
+                      <>
+                        <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground" />
+                        Loading...
+                      </>
+                    )}
+                  </span>
+                  {agent.username && (
+                    <Link
+                      href={`/profile/${agent.username}`}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={(e) => e.stopPropagation()}
+                      className="flex items-center gap-1 text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+                    >
+                      View Profile
+                      <ExternalLink className="h-3 w-3" />
+                    </Link>
                   )}
                 </div>
-              );
-            })}
-          </nav>
-        ) : null}
+              </button>
+            );
+          })}
+        </div>
       </div>
+    );
+  }
+
+  // List view (default)
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto">
+      <nav role="list" aria-label="Team agents" className="space-y-1">
+        {teamChat.agents.map((agent) => {
+          const isProcessing = processingAgentIds.has(agent.id);
+          const agentName = agent.displayName || agent.username || 'Agent';
+
+          return (
+            <div
+              key={agent.id}
+              className={cn(
+                'group flex min-w-0 items-center gap-2 rounded-lg p-2 transition-colors',
+                'hover:bg-muted/50 has-[[data-state=open]]:bg-muted/50',
+                isProcessing && 'opacity-70'
+              )}
+            >
+              <button
+                type="button"
+                onClick={() => onTagAgent?.(agent)}
+                disabled={isProcessing}
+                className={cn(
+                  'flex min-w-0 flex-1 items-center gap-3 text-left',
+                  isProcessing ? 'cursor-not-allowed' : 'cursor-pointer'
+                )}
+                aria-label={`Tag ${agentName}`}
+              >
+                <div className="relative">
+                  <Avatar
+                    src={agent.profileImageUrl ?? undefined}
+                    name={agentName}
+                    size="sm"
+                  />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-1.5">
+                    <p className="truncate font-medium text-foreground text-sm">
+                      {agentName}
+                    </p>
+                    {agent.modelTier === 'pro' && (
+                      <span className="shrink-0 rounded bg-primary/20 px-1.5 py-0.5 font-medium text-[10px] text-primary">
+                        PRO
+                      </span>
+                    )}
+                  </div>
+                  {agent.username && (
+                    <p className="truncate text-muted-foreground text-xs">
+                      @{agent.username}
+                    </p>
+                  )}
+                </div>
+              </button>
+
+              {isProcessing ? (
+                <button
+                  type="button"
+                  className="relative flex h-7 w-7 flex-shrink-0 items-center justify-center rounded transition-colors hover:bg-primary/10"
+                  onClick={() => onStopAgent?.(agent.id)}
+                  aria-label={`Stop ${agentName}`}
+                >
+                  <div className="absolute inset-0.5 animate-spin rounded-full border-2 border-transparent border-t-primary" />
+                  <Square className="relative h-3 w-3 fill-primary text-primary" />
+                </button>
+              ) : (
+                <DropdownMenu modal={false}>
+                  <DropdownMenuTrigger asChild>
+                    <button
+                      type="button"
+                      className={cn(
+                        'flex h-7 w-7 flex-shrink-0 items-center justify-center rounded transition-colors',
+                        'text-muted-foreground hover:bg-muted hover:text-foreground',
+                        'focus:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100 lg:opacity-0'
+                      )}
+                      aria-label={`More options for ${agentName}`}
+                    >
+                      <MoreVertical className="h-4 w-4" />
+                    </button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    {agent.username && (
+                      <DropdownMenuItem asChild>
+                        <Link
+                          href={`/profile/${agent.username}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          <ExternalLink className="mr-2 h-4 w-4" />
+                          <span>View Profile</span>
+                        </Link>
+                      </DropdownMenuItem>
+                    )}
+                    <DropdownMenuItem
+                      onClick={() => {
+                        onViewSettings?.(agent.id);
+                        onClose?.();
+                      }}
+                    >
+                      <Settings className="mr-2 h-4 w-4" />
+                      <span>Settings</span>
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
+            </div>
+          );
+        })}
+      </nav>
     </div>
   );
 }

--- a/apps/web/src/app/agents/team/RightSidebar.tsx
+++ b/apps/web/src/app/agents/team/RightSidebar.tsx
@@ -12,6 +12,12 @@ import {
 import { X } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+/** Info tab IDs (formerly bottom panel tabs) */
+export type InfoTabId = 'activity' | 'wallet' | 'pnl' | 'logs';
+
+/** Entity type for info tab context */
+export type EntityType = 'user' | 'agent' | 'team';
+
 /** Tab types including action tag types */
 export type RightSidebarTabType =
   | 'agent-settings'
@@ -37,6 +43,12 @@ export interface RightSidebarTab {
   data?: TagDataPayload;
 }
 
+/** Info tab definition */
+interface InfoTab {
+  id: InfoTabId;
+  label: string;
+}
+
 // Width constraints
 const MIN_WIDTH = 320;
 const MAX_WIDTH_WITH_LEFT_SIDEBAR = 600;
@@ -46,21 +58,26 @@ const LEFT_SIDEBAR_WIDTH = 256; // w-64
 const MIN_CHAT_WIDTH = 450; // Minimum chat area width
 
 interface RightSidebarProps {
+  /** Dynamic closeable tabs (from message tags) */
   tabs: RightSidebarTab[];
   activeTabId: string | null;
   onTabSelect: (tabId: string) => void;
   onTabClose: (tabId: string) => void;
+  /** Info tabs (persistent, non-closeable) */
+  infoTabs: InfoTab[];
+  activeInfoTab: InfoTabId | null;
+  onInfoTabChange: (tab: InfoTabId) => void;
+  /** Content for the active info tab */
+  infoContent: React.ReactNode;
   width: number;
   onWidthChange: (width: number) => void;
   onClose: () => void;
   leftSidebarCollapsed?: boolean;
-  /** Height of the bottom panel (to shrink right sidebar accordingly) */
-  bottomPanelHeight?: number;
   children: React.ReactNode;
 }
 
 /**
- * Right sidebar panel.
+ * Right sidebar panel with info tabs and dynamic message tag tabs.
  * Resizable with drag handle. Respects minimum chat width.
  */
 export function RightSidebar({
@@ -68,11 +85,14 @@ export function RightSidebar({
   activeTabId,
   onTabSelect,
   onTabClose,
+  infoTabs,
+  activeInfoTab,
+  onInfoTabChange,
+  infoContent,
   width,
   onWidthChange,
   onClose,
   leftSidebarCollapsed = false,
-  bottomPanelHeight = 0,
   children,
 }: RightSidebarProps) {
   const [isResizing, setIsResizing] = useState(false);
@@ -96,43 +116,36 @@ export function RightSidebar({
   }, []);
 
   // Calculate max width based on available space
-  // Only recalculate on window resize or left sidebar state change, NOT on width change
   useEffect(() => {
     const calculateMaxWidth = () => {
-      // Find the page container using data attribute (more reliable than class selector)
       const pageContainer = sidebarRef.current?.closest(
         '[data-command-center-container]'
       );
-      // Use container width if found, otherwise fall back to a reasonable default
       const containerWidth = pageContainer
         ? pageContainer.getBoundingClientRect().width
-        : Math.min(window.innerWidth, 1280); // max-w-screen-xl fallback
+        : Math.min(window.innerWidth, 1280);
 
       const leftSidebarWidth = leftSidebarCollapsed ? 0 : LEFT_SIDEBAR_WIDTH;
       const maxLimit = leftSidebarCollapsed
         ? MAX_WIDTH_WITHOUT_LEFT_SIDEBAR
         : MAX_WIDTH_WITH_LEFT_SIDEBAR;
 
-      // Calculate available space for sidebar
-      // Container width - left sidebar - min chat width - buffer for borders
       const availableSpace =
         containerWidth - leftSidebarWidth - MIN_CHAT_WIDTH - 40;
 
-      // Max is the smaller of the limit or available space, but at least MIN_WIDTH
       const newMax = Math.max(MIN_WIDTH, Math.min(availableSpace, maxLimit));
       setMaxWidth(newMax);
     };
 
-    // Run after a short delay to ensure DOM is ready
     const timeoutId = setTimeout(calculateMaxWidth, 50);
     window.addEventListener('resize', calculateMaxWidth);
     return () => {
       clearTimeout(timeoutId);
       window.removeEventListener('resize', calculateMaxWidth);
     };
-  }, [leftSidebarCollapsed]); // Removed width and onWidthChange - only recalc on sidebar state/resize
+  }, [leftSidebarCollapsed]);
 
-  // Clamp width if it exceeds maxWidth (separate effect to handle width changes)
+  // Clamp width if it exceeds maxWidth
   useEffect(() => {
     if (width > maxWidth) {
       onWidthChange(maxWidth);
@@ -144,8 +157,6 @@ export function RightSidebar({
     (e: React.MouseEvent) => {
       e.preventDefault();
 
-      // Clean up any existing handlers first to prevent memory leaks
-      // This handles edge cases where mouseDown fires before mouseUp completes
       if (handleMouseMoveRef.current) {
         document.removeEventListener('mousemove', handleMouseMoveRef.current);
         handleMouseMoveRef.current = null;
@@ -177,7 +188,6 @@ export function RightSidebar({
         handleMouseUpRef.current = null;
       };
 
-      // Store refs for cleanup on unmount
       handleMouseMoveRef.current = handleMouseMove;
       handleMouseUpRef.current = handleMouseUp;
 
@@ -187,15 +197,10 @@ export function RightSidebar({
     [width, maxWidth, onWidthChange]
   );
 
-  // Clamp width to valid range
   const clampedWidth = Math.min(Math.max(width, MIN_WIDTH), maxWidth);
 
-  // Empty state
-  const emptyState = (
-    <div className="flex flex-1 items-center justify-center">
-      <span className="text-muted-foreground text-sm">No panels open</span>
-    </div>
-  );
+  const hasDynamicTabs = tabs.length > 0;
+  const isInfoTabActive = activeInfoTab !== null;
 
   return (
     <>
@@ -211,17 +216,11 @@ export function RightSidebar({
         ref={sidebarRef}
         data-tour="agents-right-sidebar"
         className={cn(
-          'fixed top-0 right-0 z-50 flex flex-col border-border border-l bg-background',
+          'fixed top-0 right-0 z-50 flex h-full flex-col border-border border-l bg-background',
           'shadow-xl lg:absolute lg:z-40 lg:shadow-none',
           isResizing && 'select-none'
         )}
-        style={{
-          width: clampedWidth,
-          height:
-            bottomPanelHeight > 0
-              ? `calc(100% - ${bottomPanelHeight}px)`
-              : '100%',
-        }}
+        style={{ width: clampedWidth }}
       >
         {/* Resize Handle - desktop only */}
         <div
@@ -246,67 +245,90 @@ export function RightSidebar({
           </button>
         </div>
 
-        {tabs.length === 0 ? (
-          emptyState
-        ) : (
-          <>
-            {/* Tab Bar */}
-            <div
-              role="tablist"
-              aria-orientation="horizontal"
-              className="shrink-0 overflow-x-auto border-border border-b bg-muted/30 px-2 py-1"
-            >
-              <div className="flex items-center gap-1">
-                {tabs.map((tab) => {
-                  return (
-                    <div
-                      key={tab.id}
-                      role="tab"
-                      aria-selected={activeTabId === tab.id}
-                      tabIndex={0}
-                      onClick={() => onTabSelect(tab.id)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault();
-                          onTabSelect(tab.id);
-                        }
-                      }}
-                      className={cn(
-                        'group flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md px-2 py-1.5 text-sm transition-colors',
-                        activeTabId === tab.id
-                          ? 'bg-background text-foreground shadow-sm'
-                          : 'text-muted-foreground hover:bg-muted hover:text-foreground'
-                      )}
-                    >
-                      <span className="max-w-[100px] truncate">
-                        {tab.title}
-                      </span>
-                      <button
-                        type="button"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onTabClose(tab.id);
-                        }}
-                        className={cn(
-                          'rounded p-0.5 transition-colors',
-                          'text-muted-foreground hover:bg-muted hover:text-foreground',
-                          'opacity-0 group-hover:opacity-100',
-                          activeTabId === tab.id && 'opacity-100'
-                        )}
-                        aria-label={`Close ${tab.title}`}
-                      >
-                        <X className="h-3 w-3" />
-                      </button>
-                    </div>
-                  );
-                })}
+        {/* Tab Bar */}
+        <div
+          role="tablist"
+          aria-orientation="horizontal"
+          className="shrink-0 overflow-x-auto border-border border-b bg-muted/30 px-2 py-1"
+        >
+          <div className="flex items-center gap-1">
+            {/* Info tabs (persistent, non-closeable) */}
+            {infoTabs.map((tab) => (
+              <div
+                key={tab.id}
+                role="tab"
+                aria-selected={activeInfoTab === tab.id}
+                tabIndex={0}
+                onClick={() => onInfoTabChange(tab.id)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onInfoTabChange(tab.id);
+                  }
+                }}
+                className={cn(
+                  'flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md px-2 py-1.5 font-medium text-xs transition-colors',
+                  activeInfoTab === tab.id
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                )}
+              >
+                <span>{tab.label}</span>
               </div>
-            </div>
+            ))}
 
-            {/* Content */}
-            <div className="flex-1 overflow-auto">{children}</div>
-          </>
-        )}
+            {/* Separator between info and dynamic tabs */}
+            {hasDynamicTabs && (
+              <div className="mx-1 h-4 w-px shrink-0 bg-border" />
+            )}
+
+            {/* Dynamic tabs (closeable, from message tags) */}
+            {tabs.map((tab) => (
+              <div
+                key={tab.id}
+                role="tab"
+                aria-selected={activeTabId === tab.id}
+                tabIndex={0}
+                onClick={() => onTabSelect(tab.id)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    onTabSelect(tab.id);
+                  }
+                }}
+                className={cn(
+                  'group flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md px-2 py-1.5 text-xs transition-colors',
+                  activeTabId === tab.id && !isInfoTabActive
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                )}
+              >
+                <span className="max-w-[100px] truncate">{tab.title}</span>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onTabClose(tab.id);
+                  }}
+                  className={cn(
+                    'rounded p-0.5 transition-colors',
+                    'text-muted-foreground hover:bg-muted hover:text-foreground',
+                    'opacity-0 group-hover:opacity-100',
+                    activeTabId === tab.id && !isInfoTabActive && 'opacity-100'
+                  )}
+                  aria-label={`Close ${tab.title}`}
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-auto">
+          {isInfoTabActive ? infoContent : children}
+        </div>
       </div>
     </>
   );

--- a/apps/web/src/app/agents/team/TeamPnL.tsx
+++ b/apps/web/src/app/agents/team/TeamPnL.tsx
@@ -203,10 +203,12 @@ export function TeamPnL({
                     {m.currentPnL >= 0 ? '+' : ''}
                     {formatCompactCurrency(m.currentPnL)}
                   </div>
-                  <div className="text-[11px] text-muted-foreground">
+                  <div className="text-[10px] text-muted-foreground">
                     L: {m.lifetimePnL >= 0 ? '+' : ''}
                     {formatCompactCurrency(m.lifetimePnL)}
-                    {'  '}U: {m.unrealizedPnL >= 0 ? '+' : ''}
+                  </div>
+                  <div className="text-[10px] text-muted-foreground">
+                    U: {m.unrealizedPnL >= 0 ? '+' : ''}
                     {formatCompactCurrency(m.unrealizedPnL)}
                   </div>
                 </div>

--- a/apps/web/src/app/agents/team/_components/tutorial/steps.ts
+++ b/apps/web/src/app/agents/team/_components/tutorial/steps.ts
@@ -70,11 +70,11 @@ export const DESKTOP_STEPS: TutorialStep[] = [
     placement: 'left',
   },
   {
-    target: '[data-tour="agents-bottom-panel"]',
+    target: '[data-tour="agents-right-sidebar"]',
     title: 'Activity & Portfolio',
     description:
-      'Monitor your agents\u2019 activity, wallet balances, P&L, and logs. Switch between agents using the dropdown to track each one individually.',
-    placement: 'top',
+      'Monitor your agents\u2019 activity, wallet balances, P&L, and logs from the sidebar tabs. Switch between agents using the dropdown to track each one individually.',
+    placement: 'left',
   },
 ];
 

--- a/apps/web/src/app/agents/team/page.tsx
+++ b/apps/web/src/app/agents/team/page.tsx
@@ -50,7 +50,15 @@ function isPnlTagData(data: unknown): data is PnlTagData {
   return 'balance' in d && typeof d.balance === 'number';
 }
 
-import { MessageCircle, PanelRight, Plus, Users, X } from 'lucide-react';
+import {
+  LayoutGrid,
+  LayoutList,
+  MessageCircle,
+  PanelRight,
+  Plus,
+  Users,
+  X,
+} from 'lucide-react';
 import dynamic from 'next/dynamic';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -77,13 +85,6 @@ import {
 import { useAgentsTutorial } from './_components/tutorial/useAgentsTutorial';
 import { AgentPnL } from './AgentPnL';
 import { AgentPortfolio } from './AgentPortfolio';
-import {
-  BOTTOM_PANEL_COLLAPSED_HEIGHT,
-  BOTTOM_PANEL_DEFAULT_HEIGHT,
-  BottomPanel,
-  type BottomPanelTab,
-  type EntityType,
-} from './BottomPanel';
 import { ConversationList } from './ConversationList';
 import { MemberList } from './MemberList';
 import {
@@ -95,6 +96,8 @@ import {
   PredictionsPanel,
 } from './panels';
 import {
+  type EntityType,
+  type InfoTabId,
   RIGHT_SIDEBAR_DEFAULT_WIDTH,
   RightSidebar,
   type RightSidebarTab,
@@ -167,22 +170,6 @@ const UserActivity = dynamic(
   }
 );
 
-// Lazy load agent registry for performance
-const AgentRegistry = dynamic(
-  () =>
-    import('@/components/agents/AgentRegistry').then((m) => ({
-      default: m.AgentRegistry,
-    })),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="flex h-full items-center justify-center">
-        <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
-      </div>
-    ),
-  }
-);
-
 /**
  * Agent Team Chat Page (Agents)
  *
@@ -237,11 +224,15 @@ export default function TeamChatPage() {
   type MobileView = 'chat' | 'agents' | 'panel';
   const [mobileView, setMobileView] = useState<MobileView>('agents');
 
+  // Agent list view mode
+  type AgentViewMode = 'list' | 'cards';
+  const [agentViewMode, setAgentViewMode] = useState<AgentViewMode>('cards');
+
   // Left sidebar collapse state (desktop only)
   const [leftSidebarCollapsed, setLeftSidebarCollapsed] = useState(false);
 
   // Right sidebar state
-  const [rightSidebarOpen, setRightSidebarOpen] = useState(false);
+  const [rightSidebarOpen, setRightSidebarOpen] = useState(true);
   const [rightSidebarWidth, setRightSidebarWidth] = useState(
     RIGHT_SIDEBAR_DEFAULT_WIDTH
   );
@@ -250,28 +241,110 @@ export default function TeamChatPage() {
   );
   const [activeRightTabId, setActiveRightTabId] = useState<string | null>(null);
 
-  // Bottom panel state
-  const [bottomPanelOpen, setBottomPanelOpen] = useState(true);
-  const [bottomPanelTab, setBottomPanelTab] =
-    useState<BottomPanelTab>('activity');
-  const [bottomPanelEntityId, setBottomPanelEntityId] = useState<string | null>(
-    null
+  // Info tabs state (formerly bottom panel)
+  const [activeInfoTab, setActiveInfoTab] = useState<InfoTabId | null>(
+    'activity'
   );
-  const [bottomPanelEntityType, setBottomPanelEntityType] =
-    useState<EntityType | null>(null);
-  const [bottomPanelHeight, setBottomPanelHeight] = useState(
-    BOTTOM_PANEL_DEFAULT_HEIGHT
-  );
-
-  // Registry tab: which agent is selected for registration when viewing team/user
-  const [registryAgentId, setRegistryAgentId] = useState<string | null>(null);
+  const [infoEntityId, setInfoEntityId] = useState<string | null>(null);
+  const [infoEntityType, setInfoEntityType] = useState<EntityType | null>(null);
 
   const [teamScope, setTeamScope] = useState<TeamScope>('owner_agents');
 
-  // Calculate current bottom panel height for RightSidebar
-  const currentBottomPanelHeight = bottomPanelOpen
-    ? bottomPanelHeight
-    : BOTTOM_PANEL_COLLAPSED_HEIGHT;
+  // Agent stats for card view (fetched from /api/agents)
+  interface AgentStats {
+    lifetimePnL: number;
+    totalTrades: number;
+    profitableTrades: number;
+    winRate: number;
+    lastTickAt: string | null;
+    lastChatAt: string | null;
+    isActive: boolean;
+    status: string;
+    openPositions: number;
+  }
+  const [agentStatsMap, setAgentStatsMap] = useState<Map<string, AgentStats>>(
+    new Map()
+  );
+
+  // Fetch agent stats for cards
+  useEffect(() => {
+    if (!authenticated || !ready) return;
+    let cancelled = false;
+
+    const fetchAgentStats = async () => {
+      const token = await getAccessToken();
+      if (!token || cancelled) return;
+
+      try {
+        // Fetch agent list with stats
+        const agentsRes = await fetch('/api/agents', {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!agentsRes.ok || cancelled) return;
+        const agentsData = (await agentsRes.json()) as {
+          agents: Array<{
+            id: string;
+            lifetimePnL: string;
+            totalTrades: number;
+            profitableTrades: number;
+            winRate: number;
+            lastTickAt: string | null;
+            lastChatAt: string | null;
+            isActive: boolean;
+            status: string;
+          }>;
+        };
+
+        // Fetch positions for open position counts
+        const positionsMap = new Map<string, number>();
+        for (const agent of agentsData.agents) {
+          try {
+            const posRes = await fetch(
+              `/api/markets/positions/${agent.id}?type=all&status=open`
+            );
+            if (posRes.ok) {
+              const posData = (await posRes.json()) as {
+                predictions?: unknown[];
+                perpetuals?: unknown[];
+              };
+              positionsMap.set(
+                agent.id,
+                (posData.predictions?.length ?? 0) +
+                  (posData.perpetuals?.length ?? 0)
+              );
+            }
+          } catch {
+            // ignore individual position fetch failures
+          }
+        }
+
+        if (cancelled) return;
+
+        const map = new Map<string, AgentStats>();
+        for (const agent of agentsData.agents) {
+          map.set(agent.id, {
+            lifetimePnL: Number(agent.lifetimePnL) || 0,
+            totalTrades: agent.totalTrades,
+            profitableTrades: agent.profitableTrades,
+            winRate: agent.winRate,
+            lastTickAt: agent.lastTickAt,
+            lastChatAt: agent.lastChatAt,
+            isActive: agent.isActive,
+            status: agent.status,
+            openPositions: positionsMap.get(agent.id) ?? 0,
+          });
+        }
+        setAgentStatsMap(map);
+      } catch {
+        // silently fail — cards will show dashes
+      }
+    };
+
+    void fetchAgentStats();
+    return () => {
+      cancelled = true;
+    };
+  }, [authenticated, ready, getAccessToken, teamChat?.agents?.length]);
 
   // Create agent modal state
   const [showCreateAgentModal, setShowCreateAgentModal] = useState(false);
@@ -407,13 +480,8 @@ export default function TeamChatPage() {
         ];
       });
       setActiveRightTabId(tabId);
+      setActiveInfoTab(null);
       setRightSidebarOpen(true);
-    }
-
-    // Step 6: close right sidebar for bottom panel step
-    if (step.target === '[data-tour="agents-bottom-panel"]') {
-      setRightSidebarOpen(false);
-      setBottomPanelOpen(true);
     }
   }, [tutorial.isActive, tutorial.currentStep, tutorial.steps]);
 
@@ -435,66 +503,82 @@ export default function TeamChatPage() {
   // Also validates that selected agent still exists (handles agent removal)
   useEffect(() => {
     // Default to user if no selection
-    if (!bottomPanelEntityId && user?.id) {
-      setBottomPanelEntityId(user.id);
-      setBottomPanelEntityType('user');
-      // Keep current tab - activity is now available for users
+    if (!infoEntityId && user?.id) {
+      setInfoEntityId(user.id);
+      setInfoEntityType('user');
       return;
     }
 
     // If an agent is selected, validate it still exists
-    if (bottomPanelEntityType === 'agent' && bottomPanelEntityId) {
+    if (infoEntityType === 'agent' && infoEntityId) {
       const agents = teamChat?.agents;
-      const agentExists = agents?.some((a) => a.id === bottomPanelEntityId);
+      const agentExists = agents?.some((a) => a.id === infoEntityId);
       if (!agentExists) {
-        // Agent was removed, fall back to user
         if (user?.id) {
-          setBottomPanelEntityId(user.id);
-          setBottomPanelEntityType('user');
-          // Switch to activity if on logs (logs not available for users)
-          if (bottomPanelTab === 'logs') {
-            setBottomPanelTab('activity');
+          setInfoEntityId(user.id);
+          setInfoEntityType('user');
+          if (activeInfoTab === 'logs') {
+            setActiveInfoTab('activity');
           }
         } else {
-          setBottomPanelEntityId(null);
-          setBottomPanelEntityType(null);
+          setInfoEntityId(null);
+          setInfoEntityType(null);
         }
       }
     }
-  }, [
-    teamChat?.agents,
-    bottomPanelEntityId,
-    bottomPanelEntityType,
-    user?.id,
-    bottomPanelTab,
-  ]);
+  }, [teamChat?.agents, infoEntityId, infoEntityType, user?.id, activeInfoTab]);
 
-  // Handle entity change from bottom panel
-  const handleBottomPanelEntityChange = useCallback(
+  // Handle entity change from info panel
+  const handleInfoEntityChange = useCallback(
     (id: string, type: EntityType) => {
-      setBottomPanelEntityId(id);
-      setBottomPanelEntityType(type);
-      // If switching to user/team and on logs tab, switch to activity/wallet (logs not available)
-      if (type === 'user' && bottomPanelTab === 'logs') {
-        setBottomPanelTab('activity');
+      setInfoEntityId(id);
+      setInfoEntityType(type);
+      if (type === 'user' && activeInfoTab === 'logs') {
+        setActiveInfoTab('activity');
       }
       if (
         type === 'team' &&
-        (bottomPanelTab === 'logs' || bottomPanelTab === 'activity')
+        (activeInfoTab === 'logs' || activeInfoTab === 'activity')
       ) {
-        setBottomPanelTab('wallet');
+        setActiveInfoTab('wallet');
       }
     },
-    [bottomPanelTab]
+    [activeInfoTab]
+  );
+
+  // Handle info tab change — deactivates dynamic tab
+  const handleInfoTabChange = useCallback(
+    (tab: InfoTabId) => {
+      setActiveInfoTab(tab);
+      setActiveRightTabId(null);
+      if (!rightSidebarOpen) {
+        setRightSidebarOpen(true);
+      }
+    },
+    [rightSidebarOpen]
+  );
+
+  // Handle agent card selection — sets sidebar to show that agent's tabs
+  const handleSelectAgent = useCallback(
+    (agentId: string) => {
+      setInfoEntityId(agentId);
+      setInfoEntityType('agent');
+      setActiveInfoTab((prev) => prev ?? 'activity');
+      setActiveRightTabId(null);
+      if (!rightSidebarOpen) {
+        setRightSidebarOpen(true);
+      }
+    },
+    [rightSidebarOpen]
   );
 
   const teamSummaryEnabled =
     Boolean(user?.id) &&
     ready &&
     authenticated &&
-    bottomPanelOpen &&
-    bottomPanelEntityType === 'team' &&
-    (bottomPanelTab === 'wallet' || bottomPanelTab === 'pnl');
+    rightSidebarOpen &&
+    infoEntityType === 'team' &&
+    (activeInfoTab === 'wallet' || activeInfoTab === 'pnl');
 
   const {
     summary: teamSummary,
@@ -554,14 +638,13 @@ export default function TeamChatPage() {
     [getAccessToken]
   );
 
-  // Close a right sidebar tab - auto-closes sidebar when last tab is closed
+  // Close a dynamic right sidebar tab - falls back to info tab when last one is closed
   const closeRightTab = useCallback((tabId: string) => {
     setRightSidebarTabs((prev) => {
       const newTabs = prev.filter((t) => t.id !== tabId);
-      // Close sidebar if this was the last tab
       if (newTabs.length === 0) {
-        // Schedule to avoid state update during render
-        queueMicrotask(() => setRightSidebarOpen(false));
+        // Fall back to info tab when no dynamic tabs remain
+        queueMicrotask(() => setActiveInfoTab('activity'));
       }
       return newTabs;
     });
@@ -582,6 +665,12 @@ export default function TeamChatPage() {
   // Toggle right sidebar
   const toggleRightSidebar = useCallback(() => {
     setRightSidebarOpen((prev) => !prev);
+  }, []);
+
+  // Select a dynamic tab — deactivates info tab
+  const selectDynamicTab = useCallback((tabId: string) => {
+    setActiveRightTabId(tabId);
+    setActiveInfoTab(null);
   }, []);
 
   // Handle tag click from message bubble - opens panel in right sidebar
@@ -619,8 +708,9 @@ export default function TeamChatPage() {
       ];
     });
 
-    // Set active tab and open sidebar outside the updater
+    // Set active tab and open sidebar, deactivate info tab
     setActiveRightTabId(tabId);
+    setActiveInfoTab(null);
     setRightSidebarOpen(true);
   }, []);
 
@@ -645,15 +735,16 @@ export default function TeamChatPage() {
       }
     }
 
-    // Handle openWallet - open bottom panel with wallet tab
+    // Handle openWallet - open right sidebar with wallet info tab
     // (prioritize over selectAgent if both present)
     if (agentIdForWallet) {
       const agent = teamChat.agents.find((a) => a.id === agentIdForWallet);
       if (agent) {
-        setBottomPanelEntityId(agent.id);
-        setBottomPanelEntityType('agent');
-        setBottomPanelTab('wallet');
-        setBottomPanelOpen(true);
+        setInfoEntityId(agent.id);
+        setInfoEntityType('agent');
+        setActiveInfoTab('wallet');
+        setActiveRightTabId(null);
+        setRightSidebarOpen(true);
       }
     }
 
@@ -743,6 +834,122 @@ export default function TeamChatPage() {
       if (idleTimeout) clearTimeout(idleTimeout);
     };
   }, [teamChat?.chatId, loading, scrollToBottom]);
+
+  // Compute info tabs based on entity type
+  const isTeamSelected = infoEntityType === 'team';
+  const isUserSelected = infoEntityType === 'user';
+  const allInfoTabs: { id: InfoTabId; label: string }[] = [
+    { id: 'activity', label: 'Activity' },
+    { id: 'wallet', label: 'Wallet' },
+    { id: 'pnl', label: 'PnL' },
+    { id: 'logs', label: 'Logs' },
+  ];
+  const visibleInfoTabs = isTeamSelected
+    ? allInfoTabs.filter((t) => t.id === 'wallet' || t.id === 'pnl')
+    : isUserSelected
+      ? allInfoTabs.filter((t) => t.id !== 'logs')
+      : allInfoTabs;
+
+  // Info tab content — renders the active info panel
+  const infoContent = infoEntityId && infoEntityType && (
+    <>
+      {activeInfoTab === 'activity' && (
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {infoEntityType === 'agent' ? (
+            <div className="p-4">
+              <AgentActivityFeed
+                agentId={infoEntityId}
+                limit={20}
+                showAgent={false}
+                showConnectionStatus={false}
+                emptyMessage="No activity from this agent yet."
+              />
+            </div>
+          ) : (
+            <div className="p-4">
+              <UserActivity userId={infoEntityId} />
+            </div>
+          )}
+        </div>
+      )}
+
+      {activeInfoTab === 'wallet' &&
+        (() => {
+          if (infoEntityType === 'team') {
+            return (
+              <TeamPortfolio
+                summary={teamSummary}
+                loading={teamSummaryLoading}
+                error={teamSummaryError}
+                scope={teamScope}
+                onScopeChange={setTeamScope}
+                onSelectMember={handleInfoEntityChange}
+              />
+            );
+          }
+          if (infoEntityType === 'user') {
+            return (
+              <AgentPortfolio
+                entityType="user"
+                userId={infoEntityId}
+                entityName={user?.displayName || user?.username || 'You'}
+              />
+            );
+          }
+          const infoAgent = teamChat?.agents.find((a) => a.id === infoEntityId);
+          return (
+            <AgentPortfolio
+              entityType="agent"
+              agentId={infoEntityId}
+              entityName={
+                infoAgent?.displayName || infoAgent?.username || 'Agent'
+              }
+            />
+          );
+        })()}
+
+      {activeInfoTab === 'pnl' &&
+        (() => {
+          if (infoEntityType === 'team') {
+            return (
+              <TeamPnL
+                summary={teamSummary}
+                loading={teamSummaryLoading}
+                error={teamSummaryError}
+                scope={teamScope}
+                onScopeChange={setTeamScope}
+                onSelectMember={handleInfoEntityChange}
+              />
+            );
+          }
+          if (infoEntityType === 'user') {
+            return (
+              <AgentPnL
+                entityType={'user' as const}
+                userId={infoEntityId}
+                entityName={user?.displayName || user?.username || 'You'}
+              />
+            );
+          }
+          const infoAgent = teamChat?.agents.find((a) => a.id === infoEntityId);
+          return (
+            <AgentPnL
+              entityType={'agent' as const}
+              agentId={infoEntityId}
+              entityName={
+                infoAgent?.displayName || infoAgent?.username || 'Agent'
+              }
+            />
+          );
+        })()}
+
+      {activeInfoTab === 'logs' && infoEntityType === 'agent' && (
+        <div className="p-4">
+          <AgentLogs agentId={infoEntityId} />
+        </div>
+      )}
+    </>
+  );
 
   // Auth required — redirect to feed and show login
   useEffect(() => {
@@ -881,91 +1088,160 @@ export default function TeamChatPage() {
           {/* Agents Header */}
           <div className="flex items-center justify-between p-3">
             <h2 className="font-bold text-foreground text-xl">Agents</h2>
-            <button
-              type="button"
-              data-tour="agents-mobile-add"
-              onClick={() => setShowCreateAgentModal(true)}
-              className="rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
-              aria-label="Add agent"
-            >
-              <Plus className="h-5 w-5" />
-            </button>
+            <div className="flex items-center gap-1">
+              <div className="flex items-center rounded-md border border-border">
+                <button
+                  type="button"
+                  onClick={() => setAgentViewMode('list')}
+                  className={cn(
+                    'rounded-l-md p-1 transition-colors',
+                    agentViewMode === 'list'
+                      ? 'bg-muted text-foreground'
+                      : 'text-muted-foreground hover:text-foreground'
+                  )}
+                  aria-label="List view"
+                >
+                  <LayoutList className="h-4 w-4" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setAgentViewMode('cards')}
+                  className={cn(
+                    'rounded-r-md p-1 transition-colors',
+                    agentViewMode === 'cards'
+                      ? 'bg-muted text-foreground'
+                      : 'text-muted-foreground hover:text-foreground'
+                  )}
+                  aria-label="Card view"
+                >
+                  <LayoutGrid className="h-4 w-4" />
+                </button>
+              </div>
+              <button
+                type="button"
+                data-tour="agents-mobile-add"
+                onClick={() => setShowCreateAgentModal(true)}
+                className="rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+                aria-label="Add agent"
+              >
+                <Plus className="h-5 w-5" />
+              </button>
+            </div>
           </div>
 
-          {/* Member list - no longer needs flex-1 since parent scrolls */}
+          {/* Agent list */}
           <MemberList
             teamChat={teamChat}
             processingAgentIds={processingAgentIds}
-            onTagAgent={(username) => {
-              tagAgentInInput(username);
+            onTagAgent={(agent) => {
+              tagAgentInInput(agent);
               setMobileView('chat');
             }}
             onStopAgent={stopAgent}
             onViewSettings={(agentId) => {
               handleViewSettings(agentId);
             }}
+            onSelectAgent={(agentId) => {
+              handleSelectAgent(agentId);
+              setMobileView('panel');
+            }}
+            selectedAgentId={infoEntityType === 'agent' ? infoEntityId : null}
+            viewMode={agentViewMode}
+            agentStatsMap={agentStatsMap}
           />
         </div>
       </div>
 
-      {/* Panel View (Mobile) - Right sidebar content */}
+      {/* Panel View (Mobile) - Info tabs + dynamic tag tabs */}
       <div
         className={`min-h-0 flex-1 flex-col overflow-hidden bg-background lg:hidden ${
           mobileView === 'panel' ? 'flex' : 'hidden'
         }`}
       >
-        {rightSidebarTabs.length === 0 ? (
-          <div className="flex flex-1 items-center justify-center">
-            <span className="text-muted-foreground text-sm">
-              No panels open. Click on message tags to open panels.
-            </span>
-          </div>
-        ) : (
-          <>
-            {/* Tab Bar */}
-            <div className="shrink-0 overflow-x-auto border-border border-b bg-muted/30 px-2 py-1">
-              <div className="flex items-center gap-1">
-                {rightSidebarTabs.map((tab) => (
-                  <div
-                    key={tab.id}
-                    role="tab"
-                    aria-selected={activeRightTabId === tab.id}
-                    tabIndex={0}
-                    onClick={() => setActiveRightTabId(tab.id)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        setActiveRightTabId(tab.id);
-                      }
-                    }}
-                    className={`group flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md px-2 py-1.5 text-sm transition-colors ${
-                      activeRightTabId === tab.id
-                        ? 'bg-background text-foreground shadow-sm'
-                        : 'text-muted-foreground hover:bg-muted hover:text-foreground'
-                    }`}
-                  >
-                    <span className="max-w-[100px] truncate">{tab.title}</span>
-                    <button
-                      type="button"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        closeRightTab(tab.id);
-                      }}
-                      className={`rounded p-0.5 text-muted-foreground opacity-0 transition-colors hover:bg-muted hover:text-foreground group-hover:opacity-100 ${
-                        activeRightTabId === tab.id ? 'opacity-100' : ''
-                      }`}
-                      aria-label={`Close ${tab.title}`}
-                    >
-                      <X className="h-3 w-3" />
-                    </button>
-                  </div>
-                ))}
+        {/* Tab Bar */}
+        <div className="shrink-0 overflow-x-auto border-border border-b bg-muted/30 px-2 py-1">
+          <div className="flex items-center gap-1">
+            {/* Info tabs */}
+            {visibleInfoTabs.map((tab) => (
+              <div
+                key={tab.id}
+                role="tab"
+                aria-selected={activeInfoTab === tab.id}
+                tabIndex={0}
+                onClick={() => handleInfoTabChange(tab.id)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    handleInfoTabChange(tab.id);
+                  }
+                }}
+                className={cn(
+                  'flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md px-2 py-1.5 font-medium text-xs transition-colors',
+                  activeInfoTab === tab.id
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                )}
+              >
+                <span>{tab.label}</span>
               </div>
-            </div>
+            ))}
 
-            {/* Panel Content */}
-            <div className="flex-1 overflow-auto">
-              {rightSidebarTabs.map((tab) => {
+            {/* Separator */}
+            {rightSidebarTabs.length > 0 && (
+              <div className="mx-1 h-4 w-px shrink-0 bg-border" />
+            )}
+
+            {/* Dynamic tabs */}
+            {rightSidebarTabs.map((tab) => (
+              <div
+                key={tab.id}
+                role="tab"
+                aria-selected={
+                  activeRightTabId === tab.id && activeInfoTab === null
+                }
+                tabIndex={0}
+                onClick={() => selectDynamicTab(tab.id)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    selectDynamicTab(tab.id);
+                  }
+                }}
+                className={cn(
+                  'group flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md px-2 py-1.5 text-xs transition-colors',
+                  activeRightTabId === tab.id && activeInfoTab === null
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+                )}
+              >
+                <span className="max-w-[100px] truncate">{tab.title}</span>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    closeRightTab(tab.id);
+                  }}
+                  className={cn(
+                    'rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground',
+                    'opacity-0 group-hover:opacity-100',
+                    activeRightTabId === tab.id &&
+                      activeInfoTab === null &&
+                      'opacity-100'
+                  )}
+                  aria-label={`Close ${tab.title}`}
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-auto">
+          {activeInfoTab !== null
+            ? infoContent
+            : rightSidebarTabs.map((tab) => {
                 if (tab.id !== activeRightTabId) return null;
 
                 let content: React.ReactNode = null;
@@ -993,9 +1269,7 @@ export default function TeamChatPage() {
                   </PanelErrorBoundary>
                 );
               })}
-            </div>
-          </>
-        )}
+        </div>
       </div>
 
       {/* Mobile Chat View */}
@@ -1085,6 +1359,34 @@ export default function TeamChatPage() {
               <div className="flex items-center justify-between p-3">
                 <h2 className="font-bold text-foreground text-xl">Agents</h2>
                 <div className="flex items-center gap-1">
+                  <div className="flex items-center rounded-md border border-border">
+                    <button
+                      type="button"
+                      onClick={() => setAgentViewMode('list')}
+                      className={cn(
+                        'rounded-l-md p-1 transition-colors',
+                        agentViewMode === 'list'
+                          ? 'bg-muted text-foreground'
+                          : 'text-muted-foreground hover:text-foreground'
+                      )}
+                      aria-label="List view"
+                    >
+                      <LayoutList className="h-4 w-4" />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setAgentViewMode('cards')}
+                      className={cn(
+                        'rounded-r-md p-1 transition-colors',
+                        agentViewMode === 'cards'
+                          ? 'bg-muted text-foreground'
+                          : 'text-muted-foreground hover:text-foreground'
+                      )}
+                      aria-label="Card view"
+                    >
+                      <LayoutGrid className="h-4 w-4" />
+                    </button>
+                  </div>
                   <TutorialHelpButton onClick={tutorial.restart} />
                   <button
                     type="button"
@@ -1098,13 +1400,19 @@ export default function TeamChatPage() {
                 </div>
               </div>
 
-              {/* Member list - extracted component */}
+              {/* Agent list */}
               <MemberList
                 teamChat={teamChat}
                 processingAgentIds={processingAgentIds}
                 onTagAgent={tagAgentInInput}
                 onStopAgent={stopAgent}
                 onViewSettings={handleViewSettings}
+                onSelectAgent={handleSelectAgent}
+                selectedAgentId={
+                  infoEntityType === 'agent' ? infoEntityId : null
+                }
+                viewMode={agentViewMode}
+                agentStatsMap={agentStatsMap}
               />
             </div>
           </>
@@ -1180,248 +1488,26 @@ export default function TeamChatPage() {
         )}
       </div>
 
-      {/* Bottom Panel - spans full width, hidden on mobile */}
-      <div className="hidden lg:contents">
-        <BottomPanel
-          isOpen={bottomPanelOpen}
-          onToggle={() => setBottomPanelOpen((prev) => !prev)}
-          activeTab={bottomPanelTab}
-          onTabChange={setBottomPanelTab}
-          selectedEntityId={bottomPanelEntityId}
-          selectedEntityType={bottomPanelEntityType}
-          onEntityChange={handleBottomPanelEntityChange}
-          userId={user?.id}
-          userName={user?.displayName || user?.username || 'You'}
-          agents={
-            teamChat?.agents.map((a) => ({
-              id: a.id,
-              name: a.displayName || a.username || 'Agent',
-            })) || []
-          }
-          height={bottomPanelHeight}
-          onHeightChange={setBottomPanelHeight}
-        >
-          {bottomPanelEntityId && bottomPanelEntityType && (
-            <>
-              {/* Activity Tab */}
-              {bottomPanelTab === 'activity' && (
-                <div className="min-h-0 flex-1 overflow-y-auto">
-                  {bottomPanelEntityType === 'agent' ? (
-                    <div className="p-4">
-                      <AgentActivityFeed
-                        agentId={bottomPanelEntityId}
-                        limit={20}
-                        showAgent={false}
-                        showConnectionStatus={false}
-                        emptyMessage="No activity from this agent yet."
-                      />
-                    </div>
-                  ) : (
-                    <div className="p-4">
-                      <UserActivity userId={bottomPanelEntityId} />
-                    </div>
-                  )}
-                </div>
-              )}
-
-              {/* Wallet Tab */}
-              {bottomPanelTab === 'wallet' &&
-                (() => {
-                  if (bottomPanelEntityType === 'team') {
-                    return (
-                      <TeamPortfolio
-                        summary={teamSummary}
-                        loading={teamSummaryLoading}
-                        error={teamSummaryError}
-                        scope={teamScope}
-                        onScopeChange={setTeamScope}
-                        onSelectMember={handleBottomPanelEntityChange}
-                      />
-                    );
-                  }
-                  if (bottomPanelEntityType === 'user') {
-                    return (
-                      <AgentPortfolio
-                        entityType="user"
-                        userId={bottomPanelEntityId}
-                        entityName={
-                          user?.displayName || user?.username || 'You'
-                        }
-                      />
-                    );
-                  }
-                  const bottomAgent = teamChat?.agents.find(
-                    (a) => a.id === bottomPanelEntityId
-                  );
-                  return (
-                    <AgentPortfolio
-                      entityType="agent"
-                      agentId={bottomPanelEntityId}
-                      entityName={
-                        bottomAgent?.displayName ||
-                        bottomAgent?.username ||
-                        'Agent'
-                      }
-                    />
-                  );
-                })()}
-
-              {/* PnL Tab */}
-              {bottomPanelTab === 'pnl' &&
-                (() => {
-                  if (bottomPanelEntityType === 'team') {
-                    return (
-                      <TeamPnL
-                        summary={teamSummary}
-                        loading={teamSummaryLoading}
-                        error={teamSummaryError}
-                        scope={teamScope}
-                        onScopeChange={setTeamScope}
-                        onSelectMember={handleBottomPanelEntityChange}
-                      />
-                    );
-                  }
-                  if (bottomPanelEntityType === 'user') {
-                    return (
-                      <AgentPnL
-                        entityType={'user' as const}
-                        userId={bottomPanelEntityId}
-                        entityName={
-                          user?.displayName || user?.username || 'You'
-                        }
-                      />
-                    );
-                  }
-                  const bottomAgent = teamChat?.agents.find(
-                    (a) => a.id === bottomPanelEntityId
-                  );
-                  return (
-                    <AgentPnL
-                      entityType={'agent' as const}
-                      agentId={bottomPanelEntityId}
-                      entityName={
-                        bottomAgent?.displayName ||
-                        bottomAgent?.username ||
-                        'Agent'
-                      }
-                    />
-                  );
-                })()}
-
-              {/* Registry Tab */}
-              {bottomPanelTab === 'registry' &&
-                (() => {
-                  // For agents, render registry directly
-                  if (bottomPanelEntityType === 'agent') {
-                    const bottomAgent = teamChat?.agents.find(
-                      (a) => a.id === bottomPanelEntityId
-                    );
-                    return (
-                      <div className="p-4">
-                        <AgentRegistry
-                          agent={{
-                            id: bottomPanelEntityId,
-                            name:
-                              bottomAgent?.displayName ||
-                              bottomAgent?.username ||
-                              'Agent',
-                          }}
-                          onUpdate={() => void refreshTeamChat()}
-                        />
-                      </div>
-                    );
-                  }
-
-                  // For team/user, show agent picker then registry
-                  const agents = teamChat?.agents ?? [];
-                  if (agents.length === 0) {
-                    return (
-                      <div className="flex h-full items-center justify-center text-muted-foreground text-sm">
-                        No agents available. Create an agent first.
-                      </div>
-                    );
-                  }
-
-                  // Auto-select first agent if none selected or selected no longer exists
-                  const selectedAgent = agents.find(
-                    (a) => a.id === registryAgentId
-                  );
-                  const effectiveAgentId = selectedAgent
-                    ? selectedAgent.id
-                    : agents[0]?.id;
-                  const effectiveAgent = selectedAgent ?? agents[0];
-
-                  return (
-                    <div className="p-4">
-                      {agents.length > 1 && (
-                        <div className="mb-4">
-                          <label
-                            htmlFor="registry-agent-select"
-                            className="mb-1.5 block font-medium text-sm"
-                          >
-                            Select agent to register
-                          </label>
-                          <select
-                            id="registry-agent-select"
-                            value={effectiveAgentId ?? ''}
-                            onChange={(e) => setRegistryAgentId(e.target.value)}
-                            className="h-9 w-full max-w-xs rounded-md border border-border bg-background px-3 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-                          >
-                            {agents.map((a) => (
-                              <option key={a.id} value={a.id}>
-                                {a.displayName || a.username || 'Agent'}
-                              </option>
-                            ))}
-                          </select>
-                        </div>
-                      )}
-                      {effectiveAgent && effectiveAgentId && (
-                        <AgentRegistry
-                          key={effectiveAgentId}
-                          agent={{
-                            id: effectiveAgentId,
-                            name:
-                              effectiveAgent.displayName ||
-                              effectiveAgent.username ||
-                              'Agent',
-                          }}
-                          onUpdate={() => void refreshTeamChat()}
-                        />
-                      )}
-                    </div>
-                  );
-                })()}
-
-              {/* Logs Tab - only for agents */}
-              {bottomPanelTab === 'logs' &&
-                bottomPanelEntityType === 'agent' && (
-                  <div className="p-4">
-                    <AgentLogs agentId={bottomPanelEntityId} />
-                  </div>
-                )}
-            </>
-          )}
-        </BottomPanel>
-      </div>
-
-      {/* Right Sidebar - Fixed position overlay, desktop only */}
+      {/* Right Sidebar - desktop only */}
       {rightSidebarOpen && (
         <div className="hidden lg:block">
           <RightSidebar
             tabs={rightSidebarTabs}
             activeTabId={activeRightTabId}
-            onTabSelect={setActiveRightTabId}
+            onTabSelect={selectDynamicTab}
             onTabClose={closeRightTab}
+            infoTabs={visibleInfoTabs}
+            activeInfoTab={activeInfoTab}
+            onInfoTabChange={handleInfoTabChange}
+            infoContent={infoContent}
             width={rightSidebarWidth}
             onWidthChange={setRightSidebarWidth}
             onClose={() => setRightSidebarOpen(false)}
             leftSidebarCollapsed={leftSidebarCollapsed}
-            bottomPanelHeight={currentBottomPanelHeight}
           >
             {rightSidebarTabs
               .filter((tab) => tab.id === activeRightTabId)
               .map((tab) => {
-                // Render panel based on tab type
                 let content: React.ReactNode = null;
 
                 if (tab.type === 'perps' && isPerpsTagData(tab.data)) {
@@ -1440,7 +1526,6 @@ export default function TeamChatPage() {
                 } else if (tab.type === 'owner-pnl' && isPnlTagData(tab.data)) {
                   content = <PnlPanel data={tab.data} type="owner-pnl" />;
                 } else if (content === null) {
-                  // Fallback for unrecognized tab types, invalid data, or missing agentId
                   content = (
                     <div className="flex h-full items-center justify-center p-8 text-muted-foreground">
                       <span className="text-sm">

--- a/apps/web/src/app/agents/team/page.tsx
+++ b/apps/web/src/app/agents/team/page.tsx
@@ -295,28 +295,30 @@ export default function TeamChatPage() {
           }>;
         };
 
-        // Fetch positions for open position counts
+        // Fetch positions for open position counts (parallel)
         const positionsMap = new Map<string, number>();
-        for (const agent of agentsData.agents) {
-          try {
-            const posRes = await fetch(
-              `/api/markets/positions/${agent.id}?type=all&status=open`
-            );
-            if (posRes.ok) {
-              const posData = (await posRes.json()) as {
-                predictions?: unknown[];
-                perpetuals?: unknown[];
-              };
-              positionsMap.set(
-                agent.id,
-                (posData.predictions?.length ?? 0) +
-                  (posData.perpetuals?.length ?? 0)
+        await Promise.all(
+          agentsData.agents.map(async (agent) => {
+            try {
+              const posRes = await fetch(
+                `/api/markets/positions/${agent.id}?type=all&status=open`
               );
+              if (posRes.ok) {
+                const posData = (await posRes.json()) as {
+                  predictions?: unknown[];
+                  perpetuals?: unknown[];
+                };
+                positionsMap.set(
+                  agent.id,
+                  (posData.predictions?.length ?? 0) +
+                    (posData.perpetuals?.length ?? 0)
+                );
+              }
+            } catch {
+              // ignore individual position fetch failures
             }
-          } catch {
-            // ignore individual position fetch failures
-          }
-        }
+          })
+        );
 
         if (cancelled) return;
 

--- a/apps/web/src/app/api/feed/for-you/pipeline.ts
+++ b/apps/web/src/app/api/feed/for-you/pipeline.ts
@@ -36,12 +36,12 @@ import type {
   NarrativeStory,
 } from '@babylon/shared';
 import { logger } from '@babylon/shared';
-import { dedupeQuestionMarketRows } from '../questionMarketRows';
 import {
   calculateArcStateMultiplier,
   calculateResolutionBoost,
   calculateStoryScore,
 } from '@/app/api/feed/narrative/scoring';
+import { dedupeQuestionMarketRows } from '../questionMarketRows';
 import {
   calculateConversationDepthScore,
   calculateForYouScore,

--- a/apps/web/src/app/api/feed/narrative/route.ts
+++ b/apps/web/src/app/api/feed/narrative/route.ts
@@ -54,12 +54,12 @@ import type {
 } from '@babylon/shared';
 import { logger, toISO } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
+import { dedupeQuestionMarketRows } from '../questionMarketRows';
 import {
   calculateArcStateMultiplier,
   calculateResolutionBoost,
   calculateStoryScore,
 } from './scoring';
-import { dedupeQuestionMarketRows } from '../questionMarketRows';
 
 // Query limits
 const MAX_CANDIDATE_POSTS = 500;

--- a/apps/web/src/app/api/feed/new-markets/route.test.ts
+++ b/apps/web/src/app/api/feed/new-markets/route.test.ts
@@ -204,12 +204,10 @@ describe('GET /api/feed/new-markets', () => {
     const payload = await response.json();
 
     expect(payload.markets).toHaveLength(5);
-    expect(payload.markets.map((market: { questionNumber: number }) => market.questionNumber)).toEqual([
-      1,
-      2,
-      3,
-      4,
-      5,
-    ]);
+    expect(
+      payload.markets.map(
+        (market: { questionNumber: number }) => market.questionNumber
+      )
+    ).toEqual([1, 2, 3, 4, 5]);
   });
 });

--- a/apps/web/src/app/api/feed/stories/pipeline.ts
+++ b/apps/web/src/app/api/feed/stories/pipeline.ts
@@ -35,13 +35,13 @@ import type {
   NarrativeStory,
 } from '@babylon/shared';
 import { logger } from '@babylon/shared';
-import { dedupeQuestionMarketRows } from '../questionMarketRows';
 import { spreadNewMarkets } from '@/app/api/feed/for-you/scoring';
 import {
   calculateArcStateMultiplier,
   calculateResolutionBoost,
   calculateStoryScore,
 } from '@/app/api/feed/narrative/scoring';
+import { dedupeQuestionMarketRows } from '../questionMarketRows';
 
 // Safety guard against runaway queries — NOT a content cap. The ranking
 // pipeline scores, diversifies, and orders all candidates regardless.

--- a/apps/web/src/components/agents/AgentEditModal.tsx
+++ b/apps/web/src/components/agents/AgentEditModal.tsx
@@ -9,6 +9,7 @@ import {
   Upload,
   X as XIcon,
 } from 'lucide-react';
+
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
@@ -16,6 +17,7 @@ import {
   AgentConfigurationData,
   AgentConfigurationForm,
 } from '@/components/agents/AgentConfigurationForm';
+import { AgentRegistry } from '@/components/agents/AgentRegistry';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -32,12 +34,6 @@ import { uploadImage, validateImageFile } from '@/utils/upload-image';
 const TOTAL_PROFILE_PICTURES = 100;
 const TOTAL_BANNERS = 100;
 const MAX_BIO_LENGTH = 160;
-
-enum Step {
-  Profile = 1,
-  Prompts = 2,
-  Settings = 3,
-}
 
 interface AgentData {
   id: string;
@@ -69,8 +65,8 @@ interface AgentEditModalProps {
 /**
  * Agent Edit Modal
  *
- * Multi-step modal for editing an existing agent.
- * Follows the same UI pattern as the create agent flow.
+ * Single-page modal for editing an existing agent.
+ * All sections (Profile, Prompts, Settings) are shown on one scrollable page.
  */
 export function AgentEditModal({
   agent,
@@ -80,12 +76,10 @@ export function AgentEditModal({
   const router = useRouter();
   const { getAccessToken } = useAuth();
 
-  const [currentStep, setCurrentStep] = useState<Step>(Step.Profile);
   const [saving, setSaving] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
-  // Profile data (step 1)
   const [profileData, setProfileData] = useState({
     name: agent.name,
     description: agent.description || '',
@@ -93,7 +87,6 @@ export function AgentEditModal({
     coverImageUrl: agent.coverImageUrl || '',
   });
 
-  // Prompts data (step 2)
   const [promptsData, setPromptsData] = useState({
     system: agent.system,
     personality:
@@ -102,7 +95,6 @@ export function AgentEditModal({
     tradingStrategy: agent.tradingStrategy || '',
   });
 
-  // Settings data (step 3)
   const [settingsData, setSettingsData] = useState<AgentConfigurationData>({
     modelTier: agent.modelTier,
     autonomousEnabled: agent.autonomousEnabled,
@@ -353,352 +345,274 @@ export function AgentEditModal({
     }
   };
 
-  // Step content
-  const stepContent = (
-    <>
-      {currentStep === Step.Profile && (
-        <div className="space-y-6">
-          {/* Profile Images Section */}
-          <div className="relative mb-14 sm:mb-16">
-            {/* Banner */}
-            <div className="group relative h-24 overflow-hidden rounded-lg bg-muted sm:h-32">
+  const modalContent = (
+    <div className="space-y-8">
+      {/* Profile Section */}
+      <div className="space-y-6">
+        <h3 className="font-semibold text-sm">Profile</h3>
+
+        {/* Profile Images */}
+        <div className="relative mb-14 sm:mb-16">
+          {/* Banner */}
+          <div className="group relative h-24 overflow-hidden rounded-lg bg-muted sm:h-32">
+            <img
+              src={currentBanner}
+              alt="Profile banner"
+              className="h-full w-full object-cover"
+            />
+            <div className="absolute inset-0 flex items-center justify-center gap-2 bg-black/40 opacity-100 sm:opacity-0 sm:transition-opacity sm:group-hover:opacity-100">
+              <button
+                type="button"
+                onClick={() => cycleBanner('prev')}
+                className="rounded-full bg-background/90 p-1.5 hover:bg-background sm:p-2"
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </button>
+              <label className="cursor-pointer rounded-full bg-background/90 p-1.5 hover:bg-background sm:p-2">
+                <Upload className="h-4 w-4" />
+                <input
+                  ref={coverInputRef}
+                  type="file"
+                  accept="image/*"
+                  onChange={handleBannerUpload}
+                  className="hidden"
+                />
+              </label>
+              <button
+                type="button"
+                onClick={() => cycleBanner('next')}
+                className="rounded-full bg-background/90 p-1.5 hover:bg-background sm:p-2"
+              >
+                <ChevronRight className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+
+          {/* Avatar - overlapping banner */}
+          <div className="-bottom-12 sm:-bottom-14 absolute left-3 sm:left-4">
+            <div className="group relative h-24 w-24 overflow-hidden rounded-full border-4 border-background bg-muted sm:h-28 sm:w-28">
               <img
-                src={currentBanner}
-                alt="Profile banner"
+                src={currentProfileImage}
+                alt="Profile picture"
                 className="h-full w-full object-cover"
               />
-              <div className="absolute inset-0 flex items-center justify-center gap-2 bg-black/40 opacity-100 sm:opacity-0 sm:transition-opacity sm:group-hover:opacity-100">
+              <div className="absolute inset-0 flex items-center justify-center gap-1 bg-black/40 opacity-100 sm:opacity-0 sm:transition-opacity sm:group-hover:opacity-100">
                 <button
                   type="button"
-                  onClick={() => cycleBanner('prev')}
-                  className="rounded-full bg-background/90 p-1.5 hover:bg-background sm:p-2"
+                  onClick={() => cycleProfilePicture('prev')}
+                  className="rounded-full bg-background/90 p-1 hover:bg-background sm:p-1.5"
                 >
-                  <ChevronLeft className="h-4 w-4" />
+                  <ChevronLeft className="h-3 w-3 sm:h-4 sm:w-4" />
                 </button>
-                <label className="cursor-pointer rounded-full bg-background/90 p-1.5 hover:bg-background sm:p-2">
-                  <Upload className="h-4 w-4" />
+                <label className="cursor-pointer rounded-full bg-background/90 p-1 hover:bg-background sm:p-1.5">
+                  <Upload className="h-3 w-3 sm:h-4 sm:w-4" />
                   <input
-                    ref={coverInputRef}
+                    ref={profileInputRef}
                     type="file"
                     accept="image/*"
-                    onChange={handleBannerUpload}
+                    onChange={handleProfileImageUpload}
                     className="hidden"
                   />
                 </label>
                 <button
                   type="button"
-                  onClick={() => cycleBanner('next')}
-                  className="rounded-full bg-background/90 p-1.5 hover:bg-background sm:p-2"
+                  onClick={() => cycleProfilePicture('next')}
+                  className="rounded-full bg-background/90 p-1 hover:bg-background sm:p-1.5"
                 >
-                  <ChevronRight className="h-4 w-4" />
+                  <ChevronRight className="h-3 w-3 sm:h-4 sm:w-4" />
                 </button>
               </div>
             </div>
+          </div>
+        </div>
 
-            {/* Avatar - overlapping banner */}
-            <div className="-bottom-12 sm:-bottom-14 absolute left-3 sm:left-4">
-              <div className="group relative h-24 w-24 overflow-hidden rounded-full border-4 border-background bg-muted sm:h-28 sm:w-28">
-                <img
-                  src={currentProfileImage}
-                  alt="Profile picture"
-                  className="h-full w-full object-cover"
-                />
-                <div className="absolute inset-0 flex items-center justify-center gap-1 bg-black/40 opacity-100 sm:opacity-0 sm:transition-opacity sm:group-hover:opacity-100">
-                  <button
-                    type="button"
-                    onClick={() => cycleProfilePicture('prev')}
-                    className="rounded-full bg-background/90 p-1 hover:bg-background sm:p-1.5"
-                  >
-                    <ChevronLeft className="h-3 w-3 sm:h-4 sm:w-4" />
-                  </button>
-                  <label className="cursor-pointer rounded-full bg-background/90 p-1 hover:bg-background sm:p-1.5">
-                    <Upload className="h-3 w-3 sm:h-4 sm:w-4" />
-                    <input
-                      ref={profileInputRef}
-                      type="file"
-                      accept="image/*"
-                      onChange={handleProfileImageUpload}
-                      className="hidden"
-                    />
-                  </label>
-                  <button
-                    type="button"
-                    onClick={() => cycleProfilePicture('next')}
-                    className="rounded-full bg-background/90 p-1 hover:bg-background sm:p-1.5"
-                  >
-                    <ChevronRight className="h-3 w-3 sm:h-4 sm:w-4" />
-                  </button>
-                </div>
-              </div>
-            </div>
+        <p className="text-muted-foreground text-xs">
+          Tap images to browse or upload custom.
+          <br />
+          Max 5MB, JPG/PNG/GIF/WebP.
+        </p>
+
+        {/* Form Fields */}
+        <div className="space-y-5">
+          <div>
+            <label
+              htmlFor="edit-name"
+              className="mb-2 block font-medium text-sm"
+            >
+              Display Name *
+            </label>
+            <input
+              id="edit-name"
+              type="text"
+              value={profileData.name}
+              onChange={(e) =>
+                setProfileData((prev) => ({ ...prev, name: e.target.value }))
+              }
+              className={cn(
+                'w-full rounded-lg border border-border bg-muted px-4 py-3',
+                'focus:outline-none focus:ring-2 focus:ring-[#0066FF]'
+              )}
+              placeholder="My Awesome Agent"
+            />
           </div>
 
-          {/* Image upload info */}
-          <p className="text-muted-foreground text-xs">
-            Tap images to browse or upload custom.
-            <br />
-            Max 5MB, JPG/PNG/GIF/WebP.
-          </p>
-
-          {/* Form Fields */}
-          <div className="space-y-5">
-            {/* Display Name */}
-            <div>
+          <div>
+            <div className="mb-2 flex items-center justify-between">
               <label
-                htmlFor="edit-name"
-                className="mb-2 block font-medium text-sm"
+                htmlFor="edit-description"
+                className="block font-medium text-sm"
               >
-                Display Name *
+                Bio
               </label>
-              <input
-                id="edit-name"
-                type="text"
-                value={profileData.name}
-                onChange={(e) =>
-                  setProfileData((prev) => ({ ...prev, name: e.target.value }))
-                }
-                className={cn(
-                  'w-full rounded-lg border border-border bg-muted px-4 py-3',
-                  'focus:outline-none focus:ring-2 focus:ring-[#0066FF]'
-                )}
-                placeholder="My Awesome Agent"
-              />
+              <span className="text-muted-foreground text-xs">
+                {profileData.description?.length ?? 0}/{MAX_BIO_LENGTH}
+              </span>
             </div>
-
-            {/* Bio/Description */}
-            <div>
-              <div className="mb-2 flex items-center justify-between">
-                <label
-                  htmlFor="edit-description"
-                  className="block font-medium text-sm"
-                >
-                  Bio
-                </label>
-                <span className="text-muted-foreground text-xs">
-                  {profileData.description?.length ?? 0}/{MAX_BIO_LENGTH}
-                </span>
-              </div>
-              <textarea
-                id="edit-description"
-                value={profileData.description ?? ''}
-                onChange={(e) =>
-                  setProfileData((prev) => ({
-                    ...prev,
-                    description: e.target.value,
-                  }))
-                }
-                maxLength={MAX_BIO_LENGTH}
-                rows={3}
-                className={cn(
-                  'w-full resize-none rounded-lg border border-border bg-muted px-4 py-3',
-                  'focus:outline-none focus:ring-2 focus:ring-[#0066FF]'
-                )}
-                placeholder="A short description of your agent..."
-              />
-              <p className="mt-1.5 text-muted-foreground text-xs">
-                This will appear on your agent's profile.
-              </p>
-            </div>
-          </div>
-
-          {/* Danger Zone */}
-          <div className="mt-8 border-red-500/20 border-t pt-6">
-            <div className="flex items-center justify-between gap-4">
-              <div className="min-w-0">
-                <p className="font-medium text-red-400 text-sm">Delete Agent</p>
-                <p className="text-muted-foreground text-xs">
-                  Permanently remove this agent. This cannot be undone.
-                </p>
-              </div>
-              <button
-                type="button"
-                onClick={() => setShowDeleteConfirm(true)}
-                disabled={deleting}
-                className="flex shrink-0 items-center gap-2 rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-2 font-medium text-red-500 text-sm transition-colors hover:bg-red-500/20 disabled:opacity-50"
-              >
-                {deleting ? (
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                ) : (
-                  <Trash2 className="h-4 w-4" />
-                )}
-                {deleting ? 'Deleting...' : 'Delete'}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {currentStep === Step.Prompts && (
-        <div className="space-y-4">
-          {/* System Prompt */}
-          <div className="space-y-2">
-            <label htmlFor="system" className="font-medium text-sm">
-              System Prompt
-            </label>
             <textarea
-              id="system"
-              value={promptsData.system}
+              id="edit-description"
+              value={profileData.description ?? ''}
               onChange={(e) =>
-                setPromptsData((prev) => ({ ...prev, system: e.target.value }))
-              }
-              placeholder="You are a trading agent focused on..."
-              rows={4}
-              className={cn(
-                'w-full resize-none rounded-lg border border-border bg-muted px-3 py-2 font-mono text-sm sm:px-4 sm:py-3',
-                'focus:outline-none focus:ring-2 focus:ring-[#0066FF]'
-              )}
-            />
-            <p className="text-muted-foreground text-xs">
-              Core instructions defining agent behavior and capabilities.
-            </p>
-          </div>
-
-          {/* Personality */}
-          <div className="space-y-2">
-            <label htmlFor="personality" className="font-medium text-sm">
-              Personality
-            </label>
-            <textarea
-              id="personality"
-              value={promptsData.personality}
-              onChange={(e) =>
-                setPromptsData((prev) => ({
+                setProfileData((prev) => ({
                   ...prev,
-                  personality: e.target.value,
+                  description: e.target.value,
                 }))
               }
-              placeholder="Analytical and methodical..."
+              maxLength={MAX_BIO_LENGTH}
               rows={3}
               className={cn(
-                'w-full resize-none rounded-lg border border-border bg-muted px-3 py-2 font-mono text-sm sm:px-4 sm:py-3',
+                'w-full resize-none rounded-lg border border-border bg-muted px-4 py-3',
                 'focus:outline-none focus:ring-2 focus:ring-[#0066FF]'
               )}
+              placeholder="A short description of your agent..."
             />
-            <p className="text-muted-foreground text-xs">
-              Character traits that influence communication style.
-            </p>
-          </div>
-
-          {/* Trading Strategy */}
-          <div className="space-y-2">
-            <label htmlFor="tradingStrategy" className="font-medium text-sm">
-              Trading Strategy
-            </label>
-            <textarea
-              id="tradingStrategy"
-              value={promptsData.tradingStrategy}
-              onChange={(e) =>
-                setPromptsData((prev) => ({
-                  ...prev,
-                  tradingStrategy: e.target.value,
-                }))
-              }
-              placeholder="Focus on momentum indicators..."
-              rows={3}
-              className={cn(
-                'w-full resize-none rounded-lg border border-border bg-muted px-3 py-2 font-mono text-sm sm:px-4 sm:py-3',
-                'focus:outline-none focus:ring-2 focus:ring-[#0066FF]'
-              )}
-            />
-            <p className="text-muted-foreground text-xs">
-              Market analysis approach and position sizing rules.
+            <p className="mt-1.5 text-muted-foreground text-xs">
+              This will appear on your agent's profile.
             </p>
           </div>
         </div>
-      )}
+      </div>
 
-      {currentStep === Step.Settings && (
+      {/* Prompts Section */}
+      <div className="space-y-4">
+        <h3 className="font-semibold text-sm">Prompts</h3>
+
+        <div className="space-y-2">
+          <label htmlFor="system" className="font-medium text-sm">
+            System Prompt
+          </label>
+          <textarea
+            id="system"
+            value={promptsData.system}
+            onChange={(e) =>
+              setPromptsData((prev) => ({ ...prev, system: e.target.value }))
+            }
+            placeholder="You are a trading agent focused on..."
+            rows={4}
+            className={cn(
+              'w-full resize-none rounded-lg border border-border bg-muted px-3 py-2 font-mono text-sm sm:px-4 sm:py-3',
+              'focus:outline-none focus:ring-2 focus:ring-[#0066FF]'
+            )}
+          />
+          <p className="text-muted-foreground text-xs">
+            Core instructions defining agent behavior and capabilities.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="personality" className="font-medium text-sm">
+            Personality
+          </label>
+          <textarea
+            id="personality"
+            value={promptsData.personality}
+            onChange={(e) =>
+              setPromptsData((prev) => ({
+                ...prev,
+                personality: e.target.value,
+              }))
+            }
+            placeholder="Analytical and methodical..."
+            rows={3}
+            className={cn(
+              'w-full resize-none rounded-lg border border-border bg-muted px-3 py-2 font-mono text-sm sm:px-4 sm:py-3',
+              'focus:outline-none focus:ring-2 focus:ring-[#0066FF]'
+            )}
+          />
+          <p className="text-muted-foreground text-xs">
+            Character traits that influence communication style.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="tradingStrategy" className="font-medium text-sm">
+            Trading Strategy
+          </label>
+          <textarea
+            id="tradingStrategy"
+            value={promptsData.tradingStrategy}
+            onChange={(e) =>
+              setPromptsData((prev) => ({
+                ...prev,
+                tradingStrategy: e.target.value,
+              }))
+            }
+            placeholder="Focus on momentum indicators..."
+            rows={3}
+            className={cn(
+              'w-full resize-none rounded-lg border border-border bg-muted px-3 py-2 font-mono text-sm sm:px-4 sm:py-3',
+              'focus:outline-none focus:ring-2 focus:ring-[#0066FF]'
+            )}
+          />
+          <p className="text-muted-foreground text-xs">
+            Market analysis approach and position sizing rules.
+          </p>
+        </div>
+      </div>
+
+      {/* Settings Section */}
+      <div>
         <AgentConfigurationForm
           data={settingsData}
           onChange={setSettingsData}
           agentId={agent.id}
         />
-      )}
-    </>
-  );
+      </div>
 
-  // Step actions
-  const stepActions = (
-    <div className="flex gap-3">
-      {currentStep === Step.Profile && (
-        <>
-          <span
-            className="pointer-events-none flex-1 rounded-lg border border-transparent px-4 py-2.5 font-medium text-transparent sm:py-3"
-            aria-hidden="true"
-          >
-            Back
-          </span>
+      {/* Blockchain Registry */}
+      <div>
+        <h3 className="mb-4 font-semibold text-sm">Blockchain Registry</h3>
+        <AgentRegistry
+          agent={{ id: agent.id, name: agent.name }}
+          onUpdate={onUpdate}
+        />
+      </div>
+
+      {/* Danger Zone */}
+      <div className="border-red-500/20 border-t pt-6">
+        <div className="flex items-center justify-between gap-4">
+          <div className="min-w-0">
+            <p className="font-medium text-red-400 text-sm">Delete Agent</p>
+            <p className="text-muted-foreground text-xs">
+              Permanently remove this agent. This cannot be undone.
+            </p>
+          </div>
           <button
-            onClick={() => setCurrentStep(Step.Prompts)}
-            className={cn(
-              'flex flex-1 items-center justify-center gap-2 rounded-lg px-4 py-2.5 font-medium transition-all sm:py-3',
-              'bg-[#0066FF] text-primary-foreground hover:bg-[#2952d9]'
-            )}
+            type="button"
+            onClick={() => setShowDeleteConfirm(true)}
+            disabled={deleting}
+            className="flex shrink-0 items-center gap-2 rounded-lg border border-red-500/30 bg-red-500/10 px-4 py-2 font-medium text-red-500 text-sm transition-colors hover:bg-red-500/20 disabled:opacity-50"
           >
-            Continue
-          </button>
-        </>
-      )}
-      {currentStep === Step.Prompts && (
-        <>
-          <button
-            onClick={() => setCurrentStep(Step.Profile)}
-            className={cn(
-              'flex-1 rounded-lg border border-border px-4 py-2.5 font-medium transition-colors sm:py-3',
-              'text-muted-foreground hover:bg-muted hover:text-foreground'
-            )}
-          >
-            Back
-          </button>
-          <button
-            onClick={() => setCurrentStep(Step.Settings)}
-            className={cn(
-              'flex flex-1 items-center justify-center gap-2 rounded-lg px-4 py-2.5 font-medium transition-all sm:py-3',
-              'bg-[#0066FF] text-primary-foreground hover:bg-[#2952d9]'
-            )}
-          >
-            Continue
-          </button>
-        </>
-      )}
-      {currentStep === Step.Settings && (
-        <>
-          <button
-            onClick={() => setCurrentStep(Step.Prompts)}
-            disabled={saving}
-            className={cn(
-              'flex-1 rounded-lg border border-border px-4 py-2.5 font-medium transition-colors sm:py-3',
-              'text-muted-foreground hover:bg-muted hover:text-foreground',
-              'disabled:cursor-not-allowed disabled:opacity-50'
-            )}
-          >
-            Back
-          </button>
-          <button
-            onClick={handleSave}
-            disabled={saving}
-            className={cn(
-              'flex flex-1 items-center justify-center gap-2 rounded-lg px-4 py-2.5 font-medium transition-all sm:py-3',
-              'bg-[#0066FF] text-primary-foreground hover:bg-[#2952d9]',
-              'disabled:cursor-not-allowed disabled:opacity-50'
-            )}
-          >
-            {saving ? (
+            {deleting ? (
               <Loader2 className="h-4 w-4 animate-spin" />
             ) : (
-              'Save Changes'
+              <Trash2 className="h-4 w-4" />
             )}
+            {deleting ? 'Deleting...' : 'Delete'}
           </button>
-        </>
-      )}
+        </div>
+      </div>
     </div>
   );
-
-  const stepTitles: Record<Step, string> = {
-    [Step.Profile]: 'Edit Profile',
-    [Step.Prompts]: 'Configure Prompts',
-    [Step.Settings]: 'Agent Settings',
-  };
 
   return (
     <div className="fixed inset-0 z-[110] flex items-center justify-center bg-black/60 p-0 backdrop-blur-sm md:p-4">
@@ -709,7 +623,7 @@ export function AgentEditModal({
         {/* Header - fixed */}
         <div className="shrink-0 border-border border-b px-4 py-3 sm:px-6 sm:py-4">
           <div className="flex items-center justify-between">
-            <h2 className="font-bold text-lg">{stepTitles[currentStep]}</h2>
+            <h2 className="font-bold text-lg">Edit Agent</h2>
             <button
               onClick={onClose}
               className="rounded-full p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
@@ -722,12 +636,26 @@ export function AgentEditModal({
 
         {/* Content - scrollable */}
         <div className="flex-1 overflow-y-auto overscroll-contain p-4 sm:p-6">
-          {stepContent}
+          {modalContent}
         </div>
 
         {/* Footer - fixed */}
         <div className="shrink-0 border-border border-t px-4 py-3 sm:px-6 sm:py-4">
-          {stepActions}
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className={cn(
+              'flex w-full items-center justify-center gap-2 rounded-lg px-4 py-2.5 font-medium transition-all sm:py-3',
+              'bg-[#0066FF] text-primary-foreground hover:bg-[#2952d9]',
+              'disabled:cursor-not-allowed disabled:opacity-50'
+            )}
+          >
+            {saving ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              'Save Changes'
+            )}
+          </button>
         </div>
       </div>
 

--- a/apps/web/src/components/agents/AgentLogs.tsx
+++ b/apps/web/src/components/agents/AgentLogs.tsx
@@ -137,143 +137,134 @@ export function AgentLogs({ agentId }: AgentLogsProps) {
   return (
     <div className="space-y-4">
       {/* Filters */}
-      <div className="rounded-lg border border-border bg-card/50 p-4 backdrop-blur">
-        <div className="flex flex-wrap items-center gap-4">
-          <Filter className="h-5 w-5 text-muted-foreground" />
-          <select
-            value={typeFilter}
-            onChange={(e) => setTypeFilter(e.target.value)}
-            className="rounded-lg border border-border bg-muted px-3 py-2 text-foreground"
-          >
-            <option value="all">All Types</option>
-            <option value="chat">Chat</option>
-            <option value="tick">Tick</option>
-            <option value="trade">Trade</option>
-            <option value="post">Post</option>
-            <option value="comment">Comment</option>
-            <option value="error">Error</option>
-            <option value="system">System</option>
-          </select>
-          <select
-            value={levelFilter}
-            onChange={(e) => setLevelFilter(e.target.value)}
-            className="rounded-lg border border-border bg-muted px-3 py-2 text-foreground"
-          >
-            <option value="all">All Levels</option>
-            <option value="info">Info</option>
-            <option value="warn">Warning</option>
-            <option value="error">Error</option>
-            <option value="debug">Debug</option>
-          </select>
-          <button
-            onClick={fetchLogs}
-            disabled={loading}
-            className="rounded-lg bg-muted px-4 py-2 font-medium text-foreground transition-all hover:bg-muted/80 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {loading ? 'Refreshing...' : 'Refresh'}
-          </button>
-        </div>
+      <div className="flex items-center gap-2">
+        <Filter className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <select
+          value={typeFilter}
+          onChange={(e) => setTypeFilter(e.target.value)}
+          className="min-w-0 flex-1 rounded-md border border-border bg-muted px-2 py-1.5 text-xs"
+        >
+          <option value="all">All Types</option>
+          <option value="chat">Chat</option>
+          <option value="tick">Tick</option>
+          <option value="trade">Trade</option>
+          <option value="post">Post</option>
+          <option value="comment">Comment</option>
+          <option value="error">Error</option>
+          <option value="system">System</option>
+        </select>
+        <select
+          value={levelFilter}
+          onChange={(e) => setLevelFilter(e.target.value)}
+          className="min-w-0 flex-1 rounded-md border border-border bg-muted px-2 py-1.5 text-xs"
+        >
+          <option value="all">All Levels</option>
+          <option value="info">Info</option>
+          <option value="warn">Warning</option>
+          <option value="error">Error</option>
+          <option value="debug">Debug</option>
+        </select>
+        <button
+          onClick={fetchLogs}
+          disabled={loading}
+          className="shrink-0 rounded-md border border-border px-2 py-1.5 font-medium text-xs transition-colors hover:bg-muted disabled:opacity-50"
+        >
+          {loading ? '...' : 'Refresh'}
+        </button>
       </div>
 
       {/* Logs */}
-      <div className="rounded-lg border border-border bg-card/50 p-4 backdrop-blur">
-        {logs.length === 0 ? (
-          <div className="py-12 text-center text-muted-foreground">
-            <FileText className="mx-auto mb-4 h-12 w-12 opacity-50" />
-            <p>No logs found</p>
-          </div>
-        ) : (
-          <div className="space-y-2">
-            {logs.map((log) => (
-              <div
-                key={log.id}
-                className={cn('rounded-lg border p-3', getTypeColor(log.type))}
-              >
-                <div className="flex items-start justify-between">
-                  <div className="flex-1">
-                    <div className="mb-1 flex flex-wrap items-center gap-2">
-                      <span
-                        className={cn(
-                          'font-mono font-semibold text-xs uppercase',
-                          getLevelColor(log.level)
-                        )}
-                      >
-                        {log.level}
-                      </span>
-                      <span className="text-muted-foreground text-xs">•</span>
-                      <span className="text-muted-foreground text-xs uppercase">
-                        {log.type}
-                      </span>
-                      <span className="text-muted-foreground text-xs">•</span>
-                      <span className="text-muted-foreground text-xs">
-                        {new Date(log.createdAt).toLocaleString()}
-                      </span>
-                    </div>
-                    <div className="text-sm">{log.message}</div>
-
-                    {(log.prompt ||
-                      log.completion ||
-                      log.thinking ||
-                      log.metadata) && (
-                      <button
-                        onClick={() => toggleExpanded(log.id)}
-                        className="mt-2 rounded bg-muted px-3 py-1 text-xs transition-all hover:bg-muted/80"
-                      >
-                        {expanded.has(log.id) ? 'Hide Details' : 'Show Details'}
-                      </button>
-                    )}
-
-                    {expanded.has(log.id) && (
-                      <div className="mt-3 space-y-2 text-xs">
-                        {log.prompt && (
-                          <div>
-                            <div className="mb-1 font-medium text-muted-foreground">
-                              Prompt:
-                            </div>
-                            <pre className="overflow-x-auto whitespace-pre-wrap rounded bg-black/30 p-2">
-                              {log.prompt}
-                            </pre>
-                          </div>
-                        )}
-                        {log.completion && (
-                          <div>
-                            <div className="mb-1 font-medium text-muted-foreground">
-                              Completion:
-                            </div>
-                            <pre className="overflow-x-auto whitespace-pre-wrap rounded bg-black/30 p-2">
-                              {log.completion}
-                            </pre>
-                          </div>
-                        )}
-                        {log.thinking && (
-                          <div>
-                            <div className="mb-1 font-medium text-muted-foreground">
-                              Thinking:
-                            </div>
-                            <pre className="overflow-x-auto whitespace-pre-wrap rounded bg-black/30 p-2">
-                              {log.thinking}
-                            </pre>
-                          </div>
-                        )}
-                        {log.metadata && (
-                          <div className="min-w-0">
-                            <div className="mb-1 font-medium text-muted-foreground">
-                              Metadata:
-                            </div>
-                            <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded bg-black/30 p-2">
-                              {JSON.stringify(log.metadata, null, 2)}
-                            </pre>
-                          </div>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                </div>
+      {logs.length === 0 ? (
+        <div className="py-8 text-center text-muted-foreground">
+          <FileText className="mx-auto mb-3 h-8 w-8 opacity-50" />
+          <p className="text-sm">No logs found</p>
+        </div>
+      ) : (
+        <div className="space-y-1.5">
+          {logs.map((log) => (
+            <div
+              key={log.id}
+              className={cn('rounded-lg border p-2.5', getTypeColor(log.type))}
+            >
+              <div className="mb-1 flex flex-wrap items-center gap-1.5">
+                <span
+                  className={cn(
+                    'font-mono font-semibold text-[10px] uppercase',
+                    getLevelColor(log.level)
+                  )}
+                >
+                  {log.level}
+                </span>
+                <span className="text-[10px] text-muted-foreground">·</span>
+                <span className="text-[10px] text-muted-foreground uppercase">
+                  {log.type}
+                </span>
+                <span className="ml-auto text-[10px] text-muted-foreground">
+                  {new Date(log.createdAt).toLocaleTimeString()}
+                </span>
               </div>
-            ))}
-          </div>
-        )}
-      </div>
+              <div className="text-xs leading-relaxed">{log.message}</div>
+
+              {(log.prompt ||
+                log.completion ||
+                log.thinking ||
+                log.metadata) && (
+                <button
+                  onClick={() => toggleExpanded(log.id)}
+                  className="mt-1.5 rounded bg-muted px-2 py-0.5 text-[10px] transition-colors hover:bg-muted/80"
+                >
+                  {expanded.has(log.id) ? 'Hide' : 'Details'}
+                </button>
+              )}
+
+              {expanded.has(log.id) && (
+                <div className="mt-2 space-y-2 text-[11px]">
+                  {log.prompt && (
+                    <div>
+                      <div className="mb-0.5 font-medium text-[10px] text-muted-foreground">
+                        Prompt
+                      </div>
+                      <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-words rounded bg-black/30 p-2">
+                        {log.prompt}
+                      </pre>
+                    </div>
+                  )}
+                  {log.completion && (
+                    <div>
+                      <div className="mb-0.5 font-medium text-[10px] text-muted-foreground">
+                        Completion
+                      </div>
+                      <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-words rounded bg-black/30 p-2">
+                        {log.completion}
+                      </pre>
+                    </div>
+                  )}
+                  {log.thinking && (
+                    <div>
+                      <div className="mb-0.5 font-medium text-[10px] text-muted-foreground">
+                        Thinking
+                      </div>
+                      <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-words rounded bg-black/30 p-2">
+                        {log.thinking}
+                      </pre>
+                    </div>
+                  )}
+                  {log.metadata && (
+                    <div>
+                      <div className="mb-0.5 font-medium text-[10px] text-muted-foreground">
+                        Metadata
+                      </div>
+                      <pre className="max-h-40 overflow-auto whitespace-pre-wrap break-words rounded bg-black/30 p-2">
+                        {JSON.stringify(log.metadata, null, 2)}
+                      </pre>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/agents/AgentRegistry.tsx
+++ b/apps/web/src/components/agents/AgentRegistry.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { cn } from '@babylon/shared';
-import { Check, Copy, RefreshCw } from 'lucide-react';
+import { Check, Copy, Loader2, RefreshCw } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
@@ -39,6 +39,48 @@ interface AgentRegistryProps {
     name: string;
   };
   onUpdate: () => void;
+}
+
+function StatusBadge({
+  registered,
+  loading,
+}: {
+  registered: boolean;
+  loading: boolean;
+}) {
+  if (loading) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 font-medium text-[10px] text-muted-foreground">
+        <Loader2 className="h-3 w-3 animate-spin" />
+        Checking
+      </span>
+    );
+  }
+  return registered ? (
+    <span className="inline-flex items-center gap-1 rounded bg-green-500/15 px-1.5 py-0.5 font-medium text-[10px] text-green-600">
+      <Check className="h-3 w-3" />
+      Registered
+    </span>
+  ) : (
+    <span className="rounded bg-muted px-1.5 py-0.5 font-medium text-[10px] text-muted-foreground">
+      Not registered
+    </span>
+  );
+}
+
+function InfoRow({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-2 rounded-lg bg-muted/30 px-3 py-2">
+      <span className="text-muted-foreground text-xs">{label}</span>
+      <span className="font-medium text-xs">{children}</span>
+    </div>
+  );
 }
 
 export function AgentRegistry({ agent, onUpdate }: AgentRegistryProps) {
@@ -247,232 +289,201 @@ export function AgentRegistry({ agent, onUpdate }: AgentRegistryProps) {
   };
 
   return (
-    <div className="space-y-6">
-      {/* EVM Registry */}
-      <div className="rounded-lg border border-border bg-card/50 p-4 backdrop-blur sm:p-6">
-        <div className="mb-3 flex items-center justify-between gap-3">
-          <div>
-            <h3 className="font-semibold text-lg">EVM Registry</h3>
-            <p className="text-muted-foreground text-sm">
-              Register this Babylon agent on the ERC-8004 registry via Agent0.
-              Registration is owner-managed and uses the agent&apos;s EVM
-              wallet.
-            </p>
+    <div className="space-y-4">
+      {/* EVM */}
+      <div className="rounded-lg border border-border p-3">
+        <div className="mb-3 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span className="font-medium text-sm">EVM (ERC-8004)</span>
+            <StatusBadge
+              registered={evmStatus.isRegistered}
+              loading={evmLoading}
+            />
           </div>
-          <div
+        </div>
+
+        <p className="mb-3 text-muted-foreground text-xs">
+          Register on the ERC-8004 registry via Agent0 using the agent&apos;s
+          EVM wallet.
+        </p>
+
+        <div className="space-y-1.5">
+          <InfoRow label="Wallet">
+            <span className="font-mono">
+              {evmStatus.walletAddress
+                ? `${evmStatus.walletAddress.slice(0, 6)}...${evmStatus.walletAddress.slice(-4)}`
+                : 'Provisioned on registration'}
+            </span>
+          </InfoRow>
+          {evmStatus.tokenId !== null && (
+            <InfoRow label="Token ID">
+              <span className="font-mono">{evmStatus.tokenId}</span>
+            </InfoRow>
+          )}
+        </div>
+
+        {evmError && <p className="mt-2 text-red-500 text-xs">{evmError}</p>}
+
+        {!evmStatus.isRegistered && (
+          <button
+            type="button"
+            onClick={handleEvmRegistration}
+            disabled={evmRegistering || !evmStatus.canRegister}
             className={cn(
-              'rounded-full px-3 py-1 font-medium text-xs',
-              evmStatus.isRegistered
-                ? 'bg-green-500/15 text-green-600'
-                : 'bg-muted text-muted-foreground'
+              'mt-3 flex w-full items-center justify-center gap-2 rounded-lg px-3 py-2 font-medium text-sm transition-colors',
+              'bg-[#0066FF] text-white hover:bg-[#2952d9]',
+              'disabled:cursor-not-allowed disabled:opacity-50'
             )}
           >
-            {evmLoading
-              ? 'Loading...'
-              : evmStatus.isRegistered
-                ? 'Registered'
-                : 'Not registered'}
-          </div>
-        </div>
-
-        <div className="space-y-3 rounded-lg border border-border/70 bg-background/70 p-4">
-          <div className="flex flex-wrap items-center gap-3 text-sm">
-            <span className="text-muted-foreground">
-              Wallet:{' '}
-              <span className="font-mono text-foreground">
-                {evmStatus.walletAddress ?? 'Provisioned on first registration'}
-              </span>
-            </span>
-            {evmStatus.tokenId !== null && (
-              <span className="text-muted-foreground">
-                Token ID:{' '}
-                <span className="font-mono text-foreground">
-                  {evmStatus.tokenId}
-                </span>
-              </span>
-            )}
-          </div>
-
-          {!evmStatus.isRegistered && (
-            <button
-              type="button"
-              onClick={handleEvmRegistration}
-              disabled={evmRegistering || !evmStatus.canRegister}
-              className="flex min-h-[44px] items-center gap-2 rounded-lg bg-[#0066FF] px-4 py-2 font-medium text-sm text-white transition-colors hover:bg-[#0055DD] disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              {evmRegistering ? (
-                <>
-                  <RefreshCw className="h-4 w-4 animate-spin" />
-                  Registering...
-                </>
-              ) : (
-                <>
-                  <Check className="h-4 w-4" />
-                  Register on EVM ({evmStatus.cost} pts)
-                </>
-              )}
-            </button>
-          )}
-
-          {evmError && <p className="text-red-500 text-xs">{evmError}</p>}
-        </div>
+            {evmRegistering ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : null}
+            {evmRegistering
+              ? 'Registering...'
+              : `Register on EVM (${evmStatus.cost} pts)`}
+          </button>
+        )}
       </div>
 
-      {/* Solana Registry */}
-      <div className="rounded-lg border border-border bg-card/50 p-4 backdrop-blur sm:p-6">
-        <div className="mb-3 flex items-center justify-between gap-3">
-          <div>
-            <h3 className="font-semibold text-lg">Solana Registry</h3>
-            <p className="text-muted-foreground text-sm">
-              Fund your agent&apos;s Solana wallet with enough SOL to cover
-              network fees, then register it on the Solana 8004 registry.
-              Babylon still handles metadata publishing.
-            </p>
+      {/* Solana */}
+      <div className="rounded-lg border border-border p-3">
+        <div className="mb-3 flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span className="font-medium text-sm">Solana (8004)</span>
+            <StatusBadge
+              registered={solanaStatus.isRegistered}
+              loading={solanaLoading}
+            />
           </div>
-          <div
-            className={cn(
-              'rounded-full px-3 py-1 font-medium text-xs',
-              solanaStatus.isRegistered
-                ? 'bg-green-500/10 text-green-600'
-                : 'bg-muted text-muted-foreground'
-            )}
-          >
-            {solanaStatus.isRegistered ? 'Registered' : 'Not registered'}
-          </div>
+          {!solanaStatus.isRegistered && !solanaLoading && (
+            <button
+              type="button"
+              onClick={() => void refreshSolanaStatus()}
+              disabled={solanaLoading || solanaRegistering}
+              className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground disabled:opacity-50"
+              title="Refresh balance"
+            >
+              <RefreshCw className="h-3.5 w-3.5" />
+            </button>
+          )}
         </div>
 
-        {solanaLoading ? (
-          <div className="text-muted-foreground text-sm">Loading...</div>
-        ) : solanaError ? (
-          <div className="space-y-3">
-            <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-3 text-red-600 text-sm">
+        <p className="mb-3 text-muted-foreground text-xs">
+          Fund the agent&apos;s Solana wallet with SOL to cover network fees,
+          then register on-chain.
+        </p>
+
+        {solanaError ? (
+          <div className="space-y-2">
+            <p className="rounded-lg bg-red-500/10 p-2 text-red-500 text-xs">
               {solanaError}
-            </div>
+            </p>
             <button
+              type="button"
               onClick={() => void refreshSolanaStatus()}
-              className="h-10 rounded-lg bg-muted px-4 font-medium text-sm transition-all hover:bg-muted/80"
+              className="rounded-lg border border-border px-3 py-1.5 font-medium text-xs transition-colors hover:bg-muted"
             >
               Retry
             </button>
           </div>
         ) : (
-          <div className="space-y-3">
-            <div className="grid gap-2 text-sm sm:grid-cols-2">
-              <div>
-                <span className="text-muted-foreground">Wallet</span>
-                <div className="font-medium">
+          <>
+            <div className="grid grid-cols-2 gap-1.5">
+              <InfoRow label="Wallet">
+                <span className="font-mono">
                   {solanaStatus.walletAddress
                     ? `${solanaStatus.walletAddress.slice(0, 6)}...${solanaStatus.walletAddress.slice(-4)}`
-                    : solanaStatus.walletReady
-                      ? 'Ready'
-                      : 'Not provisioned'}
-                </div>
-              </div>
-              <div>
-                <span className="text-muted-foreground">SOL balance</span>
-                <div className="font-medium">
-                  {solanaStatus.walletBalanceSol !== null
-                    ? `${solanaStatus.walletBalanceSol} SOL`
-                    : 'Unavailable'}
-                </div>
-              </div>
-              <div>
-                <span className="text-muted-foreground">Required</span>
-                <div className="font-medium">
-                  {solanaStatus.minimumBalanceSol} SOL
-                </div>
-              </div>
-              <div>
-                <span className="text-muted-foreground">Cost</span>
-                <div className="font-medium">{solanaStatus.cost} pts</div>
-              </div>
-              <div>
-                <span className="text-muted-foreground">Asset</span>
-                <div className="font-medium">
-                  {solanaStatus.assetId
-                    ? `${solanaStatus.assetId.slice(0, 6)}...${solanaStatus.assetId.slice(-4)}`
-                    : 'Not registered'}
-                </div>
-              </div>
-              <div>
-                <span className="text-muted-foreground">Tx</span>
-                <div className="font-medium">
-                  {solanaStatus.txHash
-                    ? `${solanaStatus.txHash.slice(0, 6)}...${solanaStatus.txHash.slice(-4)}`
-                    : 'Pending / none'}
-                </div>
-              </div>
+                    : 'Not provisioned'}
+                </span>
+              </InfoRow>
+              <InfoRow label="Balance">
+                {solanaStatus.walletBalanceSol !== null
+                  ? `${solanaStatus.walletBalanceSol} SOL`
+                  : '—'}
+              </InfoRow>
+              <InfoRow label="Required">
+                {solanaStatus.minimumBalanceSol} SOL
+              </InfoRow>
+              <InfoRow label="Cost">{solanaStatus.cost} pts</InfoRow>
+              {solanaStatus.assetId && (
+                <InfoRow label="Asset">
+                  <span className="font-mono">
+                    {`${solanaStatus.assetId.slice(0, 6)}...${solanaStatus.assetId.slice(-4)}`}
+                  </span>
+                </InfoRow>
+              )}
+              {solanaStatus.txHash && (
+                <InfoRow label="Tx">
+                  <span className="font-mono">
+                    {`${solanaStatus.txHash.slice(0, 6)}...${solanaStatus.txHash.slice(-4)}`}
+                  </span>
+                </InfoRow>
+              )}
             </div>
 
-            {solanaStatus.walletAddress ? (
-              <div className="rounded-lg border border-[#0066FF]/20 bg-[#0066FF]/5 p-3">
-                <div className="mb-2 flex items-center justify-between gap-3">
-                  <div>
-                    <div className="font-medium text-sm">
-                      Agent funding address
-                    </div>
-                    <div className="text-muted-foreground text-xs">
-                      Send at least {solanaStatus.minimumBalanceSol} SOL to this
-                      wallet before registering.
-                    </div>
-                  </div>
+            {/* Funding address */}
+            {solanaStatus.walletAddress && !solanaStatus.isRegistered && (
+              <div className="mt-3 rounded-lg bg-muted/50 p-2.5">
+                <div className="mb-1.5 flex items-center justify-between">
+                  <span className="text-muted-foreground text-xs">
+                    Send at least {solanaStatus.minimumBalanceSol} SOL to fund
+                    this wallet
+                  </span>
                   <button
+                    type="button"
                     onClick={copySolanaAddress}
-                    className="rounded-lg border border-border bg-background px-3 py-2 text-sm transition-all hover:bg-muted"
+                    className="flex items-center gap-1 rounded px-1.5 py-0.5 text-xs transition-colors hover:bg-muted"
                     title="Copy address"
                   >
-                    <span className="flex items-center gap-2">
-                      {copiedSolanaAddress ? (
-                        <Check className="h-4 w-4 text-green-600" />
-                      ) : (
-                        <Copy className="h-4 w-4" />
-                      )}
-                      {copiedSolanaAddress ? 'Copied' : 'Copy'}
-                    </span>
+                    {copiedSolanaAddress ? (
+                      <Check className="h-3 w-3 text-green-600" />
+                    ) : (
+                      <Copy className="h-3 w-3" />
+                    )}
+                    {copiedSolanaAddress ? 'Copied' : 'Copy'}
                   </button>
                 </div>
-                <code className="block overflow-x-auto rounded bg-background/80 p-3 text-xs">
+                <code className="block overflow-x-auto break-all rounded bg-background px-2 py-1.5 font-mono text-[11px]">
                   {solanaStatus.walletAddress}
                 </code>
               </div>
-            ) : null}
+            )}
 
-            {!solanaStatus.isRegistered && !solanaStatus.hasEnoughBalance ? (
-              <div className="rounded-lg border border-amber-500/20 bg-amber-500/5 p-3 text-amber-700 text-sm">
+            {/* Insufficient balance warning */}
+            {!solanaStatus.isRegistered && !solanaStatus.hasEnoughBalance && (
+              <p className="mt-2 rounded-lg bg-amber-500/10 p-2 text-amber-600 text-xs">
                 {solanaStatus.walletBalanceSol !== null
-                  ? `Fund this wallet first. Current balance: ${solanaStatus.walletBalanceSol} SOL. Required: ${solanaStatus.minimumBalanceSol} SOL.`
-                  : `Fund this wallet with at least ${solanaStatus.minimumBalanceSol} SOL before registering.`}
-              </div>
-            ) : null}
+                  ? `Insufficient balance: ${solanaStatus.walletBalanceSol} / ${solanaStatus.minimumBalanceSol} SOL`
+                  : `Fund with at least ${solanaStatus.minimumBalanceSol} SOL`}
+              </p>
+            )}
 
-            {!solanaStatus.isRegistered ? (
+            {!solanaStatus.isRegistered && (
               <button
-                onClick={() => void refreshSolanaStatus()}
-                disabled={solanaLoading || solanaRegistering}
-                className="h-10 rounded-lg border border-border bg-background px-4 font-medium text-sm transition-all hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+                type="button"
+                onClick={handleSolanaRegistration}
+                disabled={
+                  solanaRegistering ||
+                  solanaStatus.isRegistered ||
+                  !solanaStatus.canRegister
+                }
+                className={cn(
+                  'mt-3 flex w-full items-center justify-center gap-2 rounded-lg px-3 py-2 font-medium text-sm transition-colors',
+                  'bg-[#0066FF] text-white hover:bg-[#2952d9]',
+                  'disabled:cursor-not-allowed disabled:opacity-50'
+                )}
               >
-                Refresh balance
-              </button>
-            ) : null}
-
-            <button
-              onClick={handleSolanaRegistration}
-              disabled={
-                solanaRegistering ||
-                solanaStatus.isRegistered ||
-                !solanaStatus.canRegister
-              }
-              className="h-10 rounded-lg bg-[#0066FF] px-4 font-medium text-sm text-white transition-all hover:bg-[#2952d9] disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              {solanaRegistering
-                ? 'Registering...'
-                : solanaStatus.isRegistered
-                  ? 'Already registered'
+                {solanaRegistering ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : null}
+                {solanaRegistering
+                  ? 'Registering...'
                   : solanaStatus.canRegister
                     ? `Register on Solana (${solanaStatus.cost} pts)`
-                    : `Fund wallet with ${solanaStatus.minimumBalanceSol} SOL`}
-            </button>
-          </div>
+                    : `Fund wallet first`}
+              </button>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/apps/web/src/components/agents/AgentWallet.tsx
+++ b/apps/web/src/components/agents/AgentWallet.tsx
@@ -1,21 +1,18 @@
 'use client';
 
-import { cn } from '@babylon/shared';
+import { cn, formatCompactCurrency } from '@babylon/shared';
 import {
   ArrowDownToLine,
   ArrowUpFromLine,
   History,
+  Loader2,
+  TrendingDown,
   TrendingUp,
-  Wallet,
 } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
-import { Input } from '@/components/ui/input';
 import { useAuth } from '@/hooks/useAuth';
 
-/**
- * Transaction structure for agent wallet.
- */
 interface Transaction {
   id: string;
   type: string;
@@ -26,15 +23,6 @@ interface Transaction {
   createdAt: string;
 }
 
-/**
- * Agent wallet component for managing agent balance.
- *
- * Provides interface for depositing/withdrawing from agent's unified balance.
- * This balance is used for both AI operations (chat, tick, post) and trading.
- *
- * @param props - AgentWallet component props
- * @returns Agent wallet element
- */
 interface AgentWalletProps {
   agent: {
     id: string;
@@ -54,7 +42,6 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
   const [action, setAction] = useState<'deposit' | 'withdraw'>('deposit');
   const [processing, setProcessing] = useState(false);
 
-  // Balance state
   const [balanceInfo, setBalanceInfo] = useState({
     agentBalance: agent.virtualBalance ?? 0,
     userBalance: 0,
@@ -146,86 +133,80 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
     }
   };
 
+  const isProfitable = balanceInfo.lifetimePnL >= 0;
+
   return (
-    <div className="space-y-6">
-      {/* Balance Card */}
-      <div className="rounded-lg border border-[#0066FF]/30 bg-[#0066FF]/5 p-6">
-        <div className="mb-2 flex items-center gap-2 text-[#0066FF] text-sm">
-          <Wallet className="h-4 w-4" />
-          Agent Balance
+    <div className="flex flex-col gap-3 p-4">
+      {/* Balance Summary */}
+      <div className="divide-y divide-border/60 rounded-lg border border-border/60 bg-card/50">
+        <div className="flex items-center justify-between px-3 py-2.5">
+          <span className="text-muted-foreground text-xs">Agent Balance</span>
+          <span className="font-semibold text-foreground text-sm">
+            {formatCompactCurrency(balanceInfo.agentBalance)}
+          </span>
         </div>
-        <div className="mb-4 font-bold text-3xl">
-          {balanceInfo.agentBalance.toFixed(2)} pts
-        </div>
-        <div className="space-y-1 text-muted-foreground text-sm">
-          <div className="flex items-center justify-between">
-            <span className="flex items-center gap-1">
+        <div className="flex items-center justify-between px-3 py-2.5">
+          <span className="text-muted-foreground text-xs">Lifetime P&L</span>
+          <span
+            className={cn(
+              'flex items-center gap-1 font-semibold text-sm',
+              isProfitable ? 'text-green-600' : 'text-red-600'
+            )}
+          >
+            {isProfitable ? (
               <TrendingUp className="h-3 w-3" />
-              Lifetime P&L:
-            </span>
-            <span
-              className={cn(
-                'font-medium',
-                balanceInfo.lifetimePnL >= 0 ? 'text-green-600' : 'text-red-600'
-              )}
-            >
-              {balanceInfo.lifetimePnL >= 0 ? '+' : ''}
-              {balanceInfo.lifetimePnL.toFixed(2)} pts
-            </span>
-          </div>
+            ) : (
+              <TrendingDown className="h-3 w-3" />
+            )}
+            {isProfitable ? '+' : ''}
+            {formatCompactCurrency(balanceInfo.lifetimePnL)}
+          </span>
         </div>
-        <p className="mt-3 text-muted-foreground text-xs">
-          Used for trading and AI operations (chat, autonomous actions)
-        </p>
+        <div className="flex items-center justify-between px-3 py-2.5">
+          <span className="text-muted-foreground text-xs">Your Balance</span>
+          <span className="font-semibold text-foreground text-sm">
+            {formatCompactCurrency(balanceInfo.userBalance)}
+          </span>
+        </div>
       </div>
 
-      {/* Transaction Form */}
-      <div className="rounded-lg border border-border bg-card/50 p-4 backdrop-blur sm:p-6">
-        <div className="mb-4 flex items-center justify-between">
-          <h3 className="font-semibold text-lg">Transfer</h3>
-          <div className="text-right text-sm">
-            <span className="text-muted-foreground">Your Balance: </span>
-            <span className="font-medium">
-              {balanceInfo.userBalance.toFixed(2)} pts
-            </span>
-          </div>
-        </div>
-
-        {/* Action Toggle */}
-        <div className="mb-4 grid grid-cols-2 gap-2">
+      {/* Transfer */}
+      <div className="rounded-lg border border-border p-3">
+        <div className="mb-2.5 grid grid-cols-2 gap-1.5">
           <button
+            type="button"
             onClick={() => setAction('deposit')}
             className={cn(
-              'flex items-center justify-center gap-2 rounded-lg px-3 py-3 font-medium transition-all sm:px-4',
+              'flex items-center justify-center gap-1.5 rounded-md px-2 py-1.5 font-medium text-xs transition-colors',
               action === 'deposit'
-                ? 'bg-[#0066FF] text-primary-foreground'
+                ? 'bg-[#0066FF] text-white'
                 : 'bg-muted text-foreground hover:bg-muted/80'
             )}
           >
-            <ArrowDownToLine className="h-4 w-4 shrink-0" />
-            <span>Deposit</span>
+            <ArrowDownToLine className="h-3.5 w-3.5" />
+            Deposit
           </button>
           <button
+            type="button"
             onClick={() => setAction('withdraw')}
             className={cn(
-              'flex items-center justify-center gap-2 rounded-lg px-3 py-3 font-medium transition-all sm:px-4',
+              'flex items-center justify-center gap-1.5 rounded-md px-2 py-1.5 font-medium text-xs transition-colors',
               action === 'withdraw'
-                ? 'bg-[#0066FF] text-primary-foreground'
+                ? 'bg-[#0066FF] text-white'
                 : 'bg-muted text-foreground hover:bg-muted/80'
             )}
           >
-            <ArrowUpFromLine className="h-4 w-4 shrink-0" />
-            <span>Withdraw</span>
+            <ArrowUpFromLine className="h-3.5 w-3.5" />
+            Withdraw
           </button>
         </div>
 
-        {/* Amount input and submit */}
-        <div className="flex flex-col gap-3 sm:flex-row sm:gap-2">
-          <Input
+        <div className="flex gap-2">
+          <input
             type="number"
             value={amount}
             onChange={(e) => setAmount(e.target.value)}
-            placeholder="Enter amount (pts)..."
+            placeholder="Amount..."
             min={0.01}
             step={0.01}
             max={
@@ -233,73 +214,81 @@ export function AgentWallet({ agent, onUpdate }: AgentWalletProps) {
                 ? balanceInfo.userBalance
                 : balanceInfo.agentBalance
             }
-            className="h-12 w-full text-base sm:h-10 sm:flex-1 sm:text-sm"
+            className="min-w-0 flex-1 rounded-md border border-border bg-muted px-2.5 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-[#0066FF]"
           />
           <button
+            type="button"
             onClick={handleTransaction}
             disabled={processing || !amount}
-            className="h-12 w-full rounded-lg bg-[#0066FF] px-6 font-medium text-white transition-all hover:bg-[#2952d9] disabled:cursor-not-allowed disabled:opacity-50 sm:h-10 sm:w-auto"
+            className="shrink-0 rounded-md bg-[#0066FF] px-3 py-1.5 font-medium text-white text-xs transition-colors hover:bg-[#2952d9] disabled:opacity-50"
           >
-            {processing
-              ? 'Processing...'
-              : action === 'deposit'
-                ? 'Deposit'
-                : 'Withdraw'}
+            {processing ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : action === 'deposit' ? (
+              'Deposit'
+            ) : (
+              'Withdraw'
+            )}
           </button>
         </div>
 
-        <p className="mt-3 text-muted-foreground text-xs">
+        <p className="mt-2 text-[10px] text-muted-foreground">
           {action === 'deposit'
-            ? `Transfer pts from your balance to ${agent.name}`
-            : `Transfer pts from ${agent.name} to your balance`}
+            ? `Transfer from your balance to ${agent.name}`
+            : `Transfer from ${agent.name} to your balance`}
         </p>
       </div>
 
       {/* Transaction History */}
-      <div className="rounded-lg border border-border bg-card/50 p-6 backdrop-blur">
-        <div className="mb-4 flex items-center gap-2">
-          <History className="h-5 w-5" />
-          <h3 className="font-semibold text-lg">Transaction History</h3>
+      <div>
+        <div className="mb-2 flex items-center gap-1.5 px-1">
+          <History className="h-3.5 w-3.5 text-muted-foreground" />
+          <span className="font-medium text-xs">History</span>
         </div>
 
         {loading ? (
-          <div className="py-8 text-center text-muted-foreground">
-            Loading...
+          <div className="flex items-center justify-center py-6">
+            <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
           </div>
         ) : transactions.length === 0 ? (
-          <div className="py-8 text-center text-muted-foreground">
+          <div className="py-6 text-center text-muted-foreground text-xs">
             No transactions yet
           </div>
         ) : (
-          <div className="space-y-2">
+          <div className="space-y-1">
             {transactions.map((tx) => (
               <div
                 key={tx.id}
-                className="flex items-center justify-between rounded-lg bg-muted/30 p-3 transition-all hover:bg-muted"
+                className="flex items-center justify-between rounded-md bg-muted/30 px-2.5 py-2 transition-colors hover:bg-muted/50"
               >
-                <div className="flex-1">
-                  <div className="font-medium capitalize">
+                <div className="min-w-0 flex-1">
+                  <div className="truncate font-medium text-xs capitalize">
                     {tx.type.replace(/_/g, ' ')}
                   </div>
-                  <div className="text-muted-foreground text-sm">
+                  <div className="truncate text-[10px] text-muted-foreground">
                     {tx.description}
                   </div>
-                  <div className="text-muted-foreground text-xs">
-                    {new Date(tx.createdAt).toLocaleString()}
+                  <div className="text-[10px] text-muted-foreground">
+                    {new Date(tx.createdAt).toLocaleString(undefined, {
+                      month: 'short',
+                      day: 'numeric',
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })}
                   </div>
                 </div>
-                <div className="text-right">
+                <div className="shrink-0 pl-2 text-right">
                   <div
                     className={cn(
-                      'font-semibold',
+                      'font-semibold text-xs',
                       tx.amount > 0 ? 'text-green-600' : 'text-red-600'
                     )}
                   >
                     {tx.amount > 0 ? '+' : ''}
-                    {Math.abs(tx.amount).toFixed(2)} pts
+                    {formatCompactCurrency(Math.abs(tx.amount))}
                   </div>
-                  <div className="text-muted-foreground text-xs">
-                    Balance: {tx.balanceAfter.toFixed(2)} pts
+                  <div className="text-[10px] text-muted-foreground">
+                    Bal: {formatCompactCurrency(tx.balanceAfter)}
                   </div>
                 </div>
               </div>

--- a/apps/web/src/components/shared/MobileHeader.tsx
+++ b/apps/web/src/components/shared/MobileHeader.tsx
@@ -286,7 +286,7 @@ function MobileHeaderContent() {
           </div>
 
           {/* Center: Logo */}
-          <div className="absolute left-1/2 -translate-x-1/2 transform">
+          <div className="-translate-x-1/2 absolute left-1/2 transform">
             <Link
               href="/feed"
               className="transition-transform duration-300 hover:scale-105"
@@ -397,7 +397,7 @@ function MobileHeaderContent() {
                     <div className="relative">
                       <Icon className="h-5 w-5" />
                       {hasNotificationBadge && (
-                        <span className="absolute -top-1 -right-1 h-2 w-2 rounded-full bg-blue-500 ring-2 ring-sidebar" />
+                        <span className="-top-1 -right-1 absolute h-2 w-2 rounded-full bg-blue-500 ring-2 ring-sidebar" />
                       )}
                     </div>
                     <span className="text-base">{item.name}</span>


### PR DESCRIPTION
## Summary

Redesigns the agents team page with a new card-based agent view and consolidates the bottom panel into the right sidebar for a cleaner, more unified layout.

## Changes

### Agents Team Page Layout
- **Card/list toggle** for the agent sidebar, with **cards as default** view
- Agent cards display live stats: PnL, trade count, win rate, open positions, and activity timestamps
- Stats fetched from `/api/agents` and `/api/markets/positions` per agent
- **Bottom panel removed** — info tabs (Activity, Wallet, PnL, Logs) now live in the right sidebar
- Right sidebar opens by default; mobile defaults to agents tab
- Entity selector dropdown removed from sidebar header (no longer needed)
- Support `?create=true` query param to open create-agent modal (e.g. from game guide)
- Reply-to-message and conversation delete support added to team chat

### Right Sidebar
- Moved info tab and entity type definitions from the removed BottomPanel component
- Persistent non-closeable info tabs coexist with dynamic closeable message tag tabs
- Removed `entitySelector` prop and `bottomPanelHeight` prop

### Member List
- New card view mode rendering agent stat cards with status indicators
- List view preserved and togglable via header buttons

### Agent Wallet
- Redesigned balance summary from a cramped 3-column horizontal layout to **stacked rows** (label left, value right) — much better readability in narrow sidebar
- Uses `formatCompactCurrency` for consistent number formatting
- Compacted transfer controls and transaction history
- Fixed double `p-4` padding on agent wallet tab content

### Agent PnL
- Compacted layout with collapsible position sections for sidebar width
- Added position count badges and improved empty states

### Agent Logs
- Compacted filter controls and log entry rows for sidebar width
- Smaller typography and tighter spacing

### Agent Edit Modal
- Flattened from multi-step wizard to single-page modal
- AgentRegistry embedded inline instead of lazy-loaded separately

### Agent Registry
- Added `StatusBadge` component for registration state display
- Compacted layout for embedding inside edit modal

### Minor / Auto-fixes
- **TeamPnL**: Minor layout adjustments for sidebar context
- **Tutorial steps**: Updated targets for new sidebar structure
- **Feed pipelines**: Import ordering fix (Biome)
- **MobileHeader**: Tailwind class ordering fix (Biome)