### PR TITLE
feat: Add resolved market cards and post spillover to For You feed

### DIFF
--- a/apps/web/src/app/api/feed/for-you/pipeline.ts
+++ b/apps/web/src/app/api/feed/for-you/pipeline.ts
@@ -40,6 +40,7 @@ import {
   calculateResolutionBoost,
   calculateStoryScore,
 } from '@/app/api/feed/narrative/scoring';
+import { dedupeQuestionMarketRows } from '../questionMarketRows';
 import {
   calculateConversationDepthScore,
   calculateForYouScore,
@@ -409,6 +410,10 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
         originalPostId: posts.originalPostId,
       })
       .from(posts)
+      .leftJoin(
+        sql`mv_post_interaction_counts mic`,
+        sql`mic.post_id = ${posts.id}`
+      )
       .where(
         and(
           isNull(posts.deletedAt),
@@ -418,11 +423,7 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
           isNull(posts.parentCommentId)
         )
       )
-      .orderBy(
-        sql`(SELECT COALESCE(mic.engagement_score, 0)
-             FROM mv_post_interaction_counts mic
-             WHERE mic.post_id = ${posts.id}) DESC`
-      )
+      .orderBy(sql`COALESCE(mic.engagement_score, 0) DESC`)
       .limit(backfillCapacity);
 
     const primaryPostIds = new Set(recentPosts.map((p) => p.id));
@@ -870,6 +871,7 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
           new Date(post.timestamp)
         ) * 0.85;
 
+      const parsedQuestionNumber = Number.parseInt(storyKey, 10);
       stories.push({
         storyKey: `post:${post.id}`,
         storyTitle:
@@ -877,7 +879,9 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
           (post.content.length > 80
             ? `${post.content.slice(0, 80).replace(/\s+\S*$/, '')}…`
             : post.content),
-        questionNumber: Number.parseInt(storyKey, 10),
+        questionNumber: Number.isNaN(parsedQuestionNumber)
+          ? null
+          : parsedQuestionNumber,
         arcState: null,
         storyScore: Math.round(spillScore * 10000) / 10000,
         postCount: 1,
@@ -940,10 +944,11 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
         markets,
         sql`lower(trim(${markets.question})) = lower(trim(${questions.text}))`
       )
-      .where(inArray(questions.questionNumber, storyQuestionNumbers));
+      .where(inArray(questions.questionNumber, storyQuestionNumbers))
+      .orderBy(desc(markets.createdAt));
 
     const questionToMarket = new Map(
-      marketRows.map((row) => [
+      dedupeQuestionMarketRows(marketRows).map((row) => [
         row.questionNumber,
         {
           marketId: row.marketId,
@@ -965,7 +970,7 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
     }
   }
 
-  const newMarketQuestions = await db
+  const newMarketRows = await db
     .select({
       questionNumber: questions.questionNumber,
       text: questions.text,
@@ -994,8 +999,12 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
         )
       )
     )
-    .orderBy(desc(questions.createdAt))
-    .limit(MAX_NEW_MARKET_CANDIDATES);
+    .orderBy(desc(questions.createdAt), desc(markets.createdAt));
+
+  const newMarketQuestions = dedupeQuestionMarketRows(newMarketRows).slice(
+    0,
+    MAX_NEW_MARKET_CANDIDATES
+  );
 
   for (const question of newMarketQuestions) {
     const hoursSinceOpen =
@@ -1067,8 +1076,9 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
     .limit(MAX_RESOLVED_MARKET_CANDIDATES);
 
   for (const q of resolvedMarketQuestions) {
+    const resDate = q.resolutionDate ?? now;
     const hoursSinceResolution =
-      (now.getTime() - q.resolutionDate.getTime()) / (1000 * 60 * 60);
+      (now.getTime() - resDate.getTime()) / (1000 * 60 * 60);
     const recencyScore = Math.exp((-Math.LN2 * hoursSinceResolution) / 4);
 
     stories.push({
@@ -1083,7 +1093,7 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
       isNewMarket: true,
       isResolved: true,
       resolvedOutcome: q.resolution ?? null,
-      resolutionDate: q.resolutionDate.toISOString(),
+      resolutionDate: resDate.toISOString(),
       marketId: q.marketId ?? null,
       rootMarketId: q.marketId ?? null,
       yesShares: Number(q.yesShares ?? 0),
@@ -1148,10 +1158,10 @@ async function loadFeedEventAggregates(
 /**
  * Load discovery candidates — high-engagement posts from 14-30 days ago.
  * These always rank below fresh content and serve as an "endless feed" tail.
+ * Returns a global candidate list (not filtered by existingPostIds) so the
+ * result can be safely cached under a static key.
  */
-async function loadDiscoveryCandidates(
-  existingPostIds: Set<string>
-): Promise<NarrativeStory[]> {
+async function loadDiscoveryCandidates(): Promise<NarrativeStory[]> {
   const now = new Date();
   const backfillEnd = new Date(now.getTime() - BACKFILL_WINDOW_MS);
   const discoveryStart = new Date(now.getTime() - DISCOVERY_WINDOW_MS);
@@ -1167,6 +1177,10 @@ async function loadDiscoveryCandidates(
       relatedQuestion: posts.relatedQuestion,
     })
     .from(posts)
+    .leftJoin(
+      sql`mv_post_interaction_counts mic`,
+      sql`mic.post_id = ${posts.id}`
+    )
     .where(
       and(
         isNull(posts.deletedAt),
@@ -1176,22 +1190,74 @@ async function loadDiscoveryCandidates(
         isNull(posts.parentCommentId)
       )
     )
-    .orderBy(
-      sql`(SELECT COALESCE(mic.engagement_score, 0)
-           FROM mv_post_interaction_counts mic
-           WHERE mic.post_id = ${posts.id}) DESC`
-    )
+    .orderBy(sql`COALESCE(mic.engagement_score, 0) DESC`)
     .limit(DISCOVERY_LIMIT);
+
+  if (discoveryPosts.length === 0) return [];
+
+  // Hydrate authors in a single batched query
+  const authorIds = [...new Set(discoveryPosts.map((p) => p.authorId))];
+  const authorRows =
+    authorIds.length > 0
+      ? await db
+          .select({
+            id: users.id,
+            username: users.username,
+            displayName: users.displayName,
+            profileImageUrl: users.profileImageUrl,
+          })
+          .from(users)
+          .where(inArray(users.id, authorIds))
+      : [];
+  const authorMap = new Map(authorRows.map((u) => [u.id, u]));
+
+  // Hydrate engagement counts in a single batched query
+  const discoveryPostIds = discoveryPosts.map((p) => p.id);
+  const discoveryPostIdsArray = sql`ARRAY[${sql.join(
+    discoveryPostIds.map((id) => sql`${id}`),
+    sql`, `
+  )}]::text[]`;
+
+  const engRows = await db.execute(sql`
+    WITH target AS (SELECT unnest(${discoveryPostIdsArray}) AS post_id)
+    SELECT
+      t.post_id,
+      COALESCE((SELECT COUNT(*) FROM "Reaction" r WHERE r."postId" = t.post_id AND r.type = 'like'), 0) AS like_count,
+      COALESCE((SELECT COUNT(*) FROM "Comment" c WHERE c."postId" = t.post_id AND c."deletedAt" IS NULL), 0) AS comment_count,
+      COALESCE((SELECT COUNT(*) FROM "Share" s WHERE s."postId" = t.post_id), 0) AS share_count
+    FROM target t
+  `);
+
+  const engMap = new Map<
+    string,
+    { likes: number; comments: number; shares: number }
+  >();
+  for (const row of Array.isArray(engRows)
+    ? (engRows as Record<string, unknown>[])
+    : []) {
+    const postId = String(row['post_id'] ?? '');
+    if (!postId) continue;
+    engMap.set(postId, {
+      likes: Number(row['like_count'] ?? 0),
+      comments: Number(row['comment_count'] ?? 0),
+      shares: Number(row['share_count'] ?? 0),
+    });
+  }
 
   const stories: NarrativeStory[] = [];
   for (const post of discoveryPosts) {
-    if (existingPostIds.has(post.id)) continue;
-
     const title =
       post.articleTitle ??
       (post.content.length > 80
         ? `${post.content.slice(0, 80).replace(/\s+\S*$/, '')}…`
         : post.content);
+
+    const author = authorMap.get(post.authorId);
+    const actorRecord = StaticDataRegistry.getActor(post.authorId);
+    const orgRecord = actorRecord
+      ? null
+      : StaticDataRegistry.getOrganization(post.authorId);
+    const eng = engMap.get(post.id);
 
     stories.push({
       storyKey: `discovery:${post.id}`,
@@ -1214,12 +1280,22 @@ async function loadDiscoveryCandidates(
               ? post.timestamp.toISOString()
               : String(post.timestamp),
           authorId: post.authorId,
-          authorName: '',
-          authorUsername: null,
-          authorProfileImageUrl: null,
-          likeCount: 0,
-          commentCount: 0,
-          shareCount: 0,
+          authorName:
+            actorRecord?.name ??
+            orgRecord?.name ??
+            author?.displayName ??
+            author?.username ??
+            post.authorId,
+          authorUsername:
+            actorRecord?.username ?? orgRecord?.id ?? author?.username ?? null,
+          authorProfileImageUrl:
+            actorRecord?.profileImageUrl ??
+            orgRecord?.imageUrl ??
+            author?.profileImageUrl ??
+            null,
+          likeCount: eng?.likes ?? 0,
+          commentCount: eng?.comments ?? 0,
+          shareCount: eng?.shares ?? 0,
           isLiked: false,
           isShared: false,
           relatedQuestion: post.relatedQuestion,
@@ -1577,11 +1653,15 @@ export async function buildForYouFeed(userId?: string | null) {
   );
 
   // ── Discovery tier: endless feed tail ──
+  // Cache the global candidate list, then filter per-request to avoid dupes.
   const existingPostIds = new Set(baseResult.postIds);
-  const discoveryStories = await getCacheOrFetch<NarrativeStory[]>(
+  const discoveryCandidates = await getCacheOrFetch<NarrativeStory[]>(
     'feed:for-you:discovery:v1',
-    () => loadDiscoveryCandidates(existingPostIds),
+    () => loadDiscoveryCandidates(),
     { namespace: 'feed', ttl: DISCOVERY_CACHE_TTL_S }
+  );
+  const discoveryStories = discoveryCandidates.filter(
+    (s) => !existingPostIds.has(s.posts[0]?.id ?? '')
   );
 
   return {

--- a/apps/web/src/app/api/feed/for-you/pipeline.ts
+++ b/apps/web/src/app/api/feed/for-you/pipeline.ts
@@ -14,7 +14,6 @@ import {
   lt,
   lte,
   markets,
-  not,
   positions,
   posts,
   questions,
@@ -41,13 +40,13 @@ import {
   calculateResolutionBoost,
   calculateStoryScore,
 } from '@/app/api/feed/narrative/scoring';
-import { dedupeQuestionMarketRows } from '../questionMarketRows';
 import {
   calculateConversationDepthScore,
   calculateForYouScore,
   calculateFreshnessScore,
   calculateVelocityScore,
   diversifyForYouStories,
+  ensureArticleSpacing,
   spreadNewMarkets,
 } from './scoring';
 
@@ -57,10 +56,13 @@ const SAFETY_CANDIDATE_LIMIT = 5000;
 const MAX_NEW_MARKET_CANDIDATES = 12;
 const FEED_POST_WINDOW_MS = 24 * 60 * 60 * 1000;
 const NEW_MARKET_WINDOW_MS = 24 * 60 * 60 * 1000;
-const BACKFILL_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+const BACKFILL_WINDOW_MS = 14 * 24 * 60 * 60 * 1000;
 const FEED_EVENT_WINDOW_MS = 14 * 24 * 60 * 60 * 1000;
 const BASE_CACHE_TTL_S = 60;
 const USER_ENRICHMENT_TTL_S = 30;
+const DISCOVERY_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
+const DISCOVERY_LIMIT = 200;
+const DISCOVERY_CACHE_TTL_S = 300;
 const GENERAL_STORY_KEY = '__general__';
 
 interface BaseForYouResult {
@@ -832,6 +834,61 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
     });
   }
 
+  // ── Post spillover: promote high-engagement secondary posts ──
+  // Each question-story only shows its lead post in the UI. Promote
+  // engaging secondary posts as standalone stories to boost feed volume.
+  const MIN_SPILLOVER_ENGAGEMENT = 3;
+  const MAX_SPILLOVER_PER_STORY = 2;
+
+  for (const [storyKey, storyPosts] of storyPostMap) {
+    if (storyKey === GENERAL_STORY_KEY) continue;
+    if (storyPosts.length <= 1) continue;
+
+    const sorted = [...storyPosts].sort((a, b) => {
+      const aEng = a.likeCount + a.commentCount * 2 + a.shareCount * 3;
+      const bEng = b.likeCount + b.commentCount * 2 + b.shareCount * 3;
+      return bEng - aEng;
+    });
+
+    let spillCount = 0;
+    for (
+      let i = 1;
+      i < sorted.length && spillCount < MAX_SPILLOVER_PER_STORY;
+      i++
+    ) {
+      const post = sorted[i]!;
+      const engagement =
+        post.likeCount + post.commentCount * 2 + post.shareCount * 3;
+      if (engagement < MIN_SPILLOVER_ENGAGEMENT) break;
+
+      const spillScore =
+        calculateStoryScore(
+          post.likeCount,
+          post.commentCount,
+          post.shareCount,
+          1,
+          new Date(post.timestamp)
+        ) * 0.85;
+
+      stories.push({
+        storyKey: `post:${post.id}`,
+        storyTitle:
+          post.articleTitle ??
+          (post.content.length > 80
+            ? `${post.content.slice(0, 80).replace(/\s+\S*$/, '')}…`
+            : post.content),
+        questionNumber: Number.parseInt(storyKey, 10),
+        arcState: null,
+        storyScore: Math.round(spillScore * 10000) / 10000,
+        postCount: 1,
+        posts: [post],
+        hasUserPosition: false,
+        itemType: post.type === 'article' ? 'article' : 'post',
+      });
+      spillCount++;
+    }
+  }
+
   const generalPosts = storyPostMap.get(GENERAL_STORY_KEY) ?? [];
   const standalonePostCards = generalPosts
     .map((post) => ({
@@ -883,11 +940,10 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
         markets,
         sql`lower(trim(${markets.question})) = lower(trim(${questions.text}))`
       )
-      .where(inArray(questions.questionNumber, storyQuestionNumbers))
-      .orderBy(desc(markets.createdAt));
+      .where(inArray(questions.questionNumber, storyQuestionNumbers));
 
     const questionToMarket = new Map(
-      dedupeQuestionMarketRows(marketRows).map((row) => [
+      marketRows.map((row) => [
         row.questionNumber,
         {
           marketId: row.marketId,
@@ -909,15 +965,7 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
     }
   }
 
-  const existingQuestionNumbers = new Set(
-    stories
-      .map((story) => story.questionNumber)
-      .filter(
-        (questionNumber): questionNumber is number => questionNumber !== null
-      )
-  );
-
-  const newMarketRows = await db
+  const newMarketQuestions = await db
     .select({
       questionNumber: questions.questionNumber,
       text: questions.text,
@@ -932,7 +980,7 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
     })
     .from(questions)
     .leftJoin(arcStates, eq(arcStates.questionId, questions.id))
-    .leftJoin(
+    .innerJoin(
       markets,
       sql`lower(trim(${markets.question})) = lower(trim(${questions.text}))`
     )
@@ -943,25 +991,11 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
         lt(
           questions.resolutionDate,
           new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000)
-        ),
-        not(
-          inArray(
-            questions.questionNumber,
-            existingQuestionNumbers.size > 0
-              ? [...existingQuestionNumbers]
-              : [-1]
-          )
         )
       )
     )
-    .orderBy(desc(questions.createdAt), desc(markets.createdAt));
-
-  // Dedupe before slicing so duplicate join rows cannot crowd out later
-  // unique questions from the surfaced new-market set.
-  const newMarketQuestions = dedupeQuestionMarketRows(newMarketRows).slice(
-    0,
-    MAX_NEW_MARKET_CANDIDATES
-  );
+    .orderBy(desc(questions.createdAt))
+    .limit(MAX_NEW_MARKET_CANDIDATES);
 
   for (const question of newMarketQuestions) {
     const hoursSinceOpen =
@@ -972,7 +1006,7 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
     );
 
     stories.push({
-      storyKey: `market:${question.questionNumber}`,
+      storyKey: `market-card:${question.questionNumber}`,
       storyTitle: question.text,
       questionNumber: question.questionNumber,
       arcState: (question.arcState as ArcStateType | null) ?? null,
@@ -993,7 +1027,71 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
       topicKey: question.topicKey ?? null,
       topicLabel: question.topicLabel ?? null,
       itemType: 'market',
-      clusterId: question.marketId ?? `market:${question.questionNumber}`,
+      clusterId: question.marketId ?? `market-card:${question.questionNumber}`,
+    });
+  }
+
+  // ── Recently resolved market cards ──
+  const RESOLVED_MARKET_WINDOW_MS = 12 * 60 * 60 * 1000;
+  const MAX_RESOLVED_MARKET_CANDIDATES = 6;
+  const resolvedMarketCutoff = new Date(
+    now.getTime() - RESOLVED_MARKET_WINDOW_MS
+  );
+
+  const resolvedMarketQuestions = await db
+    .select({
+      questionNumber: questions.questionNumber,
+      text: questions.text,
+      resolutionDate: questions.resolutionDate,
+      createdAt: questions.createdAt,
+      marketId: markets.id,
+      yesShares: markets.yesShares,
+      noShares: markets.noShares,
+      resolved: markets.resolved,
+      resolution: markets.resolution,
+      topicKey: questions.topicKey,
+      topicLabel: questions.topicLabel,
+    })
+    .from(questions)
+    .innerJoin(
+      markets,
+      sql`lower(trim(${markets.question})) = lower(trim(${questions.text}))`
+    )
+    .where(
+      and(
+        eq(questions.status, 'resolved'),
+        gte(questions.resolutionDate, resolvedMarketCutoff)
+      )
+    )
+    .orderBy(desc(questions.resolutionDate))
+    .limit(MAX_RESOLVED_MARKET_CANDIDATES);
+
+  for (const q of resolvedMarketQuestions) {
+    const hoursSinceResolution =
+      (now.getTime() - q.resolutionDate.getTime()) / (1000 * 60 * 60);
+    const recencyScore = Math.exp((-Math.LN2 * hoursSinceResolution) / 4);
+
+    stories.push({
+      storyKey: `resolved-market:${q.questionNumber}`,
+      storyTitle: q.text,
+      questionNumber: q.questionNumber,
+      arcState: 'resolution',
+      storyScore: Math.round(recencyScore * 10000) / 10000,
+      postCount: 0,
+      posts: [],
+      hasUserPosition: false,
+      isNewMarket: true,
+      isResolved: true,
+      resolvedOutcome: q.resolution ?? null,
+      resolutionDate: q.resolutionDate.toISOString(),
+      marketId: q.marketId ?? null,
+      rootMarketId: q.marketId ?? null,
+      yesShares: Number(q.yesShares ?? 0),
+      noShares: Number(q.noShares ?? 0),
+      itemType: 'market',
+      clusterId: q.marketId ?? `resolved-market:${q.questionNumber}`,
+      topicKey: q.topicKey ?? null,
+      topicLabel: q.topicLabel ?? null,
     });
   }
 
@@ -1045,6 +1143,94 @@ async function loadFeedEventAggregates(
       createdAt: row.createdAt,
     }))
   );
+}
+
+/**
+ * Load discovery candidates — high-engagement posts from 14-30 days ago.
+ * These always rank below fresh content and serve as an "endless feed" tail.
+ */
+async function loadDiscoveryCandidates(
+  existingPostIds: Set<string>
+): Promise<NarrativeStory[]> {
+  const now = new Date();
+  const backfillEnd = new Date(now.getTime() - BACKFILL_WINDOW_MS);
+  const discoveryStart = new Date(now.getTime() - DISCOVERY_WINDOW_MS);
+
+  const discoveryPosts = await db
+    .select({
+      id: posts.id,
+      content: posts.content,
+      authorId: posts.authorId,
+      timestamp: posts.timestamp,
+      type: posts.type,
+      articleTitle: posts.articleTitle,
+      relatedQuestion: posts.relatedQuestion,
+    })
+    .from(posts)
+    .where(
+      and(
+        isNull(posts.deletedAt),
+        gte(posts.timestamp, discoveryStart),
+        lt(posts.timestamp, backfillEnd),
+        isNull(posts.commentOnPostId),
+        isNull(posts.parentCommentId)
+      )
+    )
+    .orderBy(
+      sql`(SELECT COALESCE(mic.engagement_score, 0)
+           FROM mv_post_interaction_counts mic
+           WHERE mic.post_id = ${posts.id}) DESC`
+    )
+    .limit(DISCOVERY_LIMIT);
+
+  const stories: NarrativeStory[] = [];
+  for (const post of discoveryPosts) {
+    if (existingPostIds.has(post.id)) continue;
+
+    const title =
+      post.articleTitle ??
+      (post.content.length > 80
+        ? `${post.content.slice(0, 80).replace(/\s+\S*$/, '')}…`
+        : post.content);
+
+    stories.push({
+      storyKey: `discovery:${post.id}`,
+      storyTitle: title,
+      questionNumber: post.relatedQuestion,
+      arcState: null,
+      storyScore: 0.01,
+      postCount: 1,
+      posts: [
+        {
+          id: post.id,
+          content: post.content,
+          fullContent: null,
+          articleTitle: post.articleTitle,
+          category: null,
+          imageUrl: null,
+          type: post.type,
+          timestamp:
+            post.timestamp instanceof Date
+              ? post.timestamp.toISOString()
+              : String(post.timestamp),
+          authorId: post.authorId,
+          authorName: '',
+          authorUsername: null,
+          authorProfileImageUrl: null,
+          likeCount: 0,
+          commentCount: 0,
+          shareCount: 0,
+          isLiked: false,
+          isShared: false,
+          relatedQuestion: post.relatedQuestion,
+        },
+      ],
+      hasUserPosition: false,
+      itemType: post.type === 'article' ? 'article' : 'post',
+      isCarryover: true,
+    });
+  }
+  return stories;
 }
 
 export async function buildForYouFeed(userId?: string | null) {
@@ -1378,18 +1564,28 @@ export async function buildForYouFeed(userId?: string | null) {
     } satisfies NarrativeStory;
   });
 
-  const rankedStories = spreadNewMarkets(
-    diversifyForYouStories(
-      rescoredStories.sort(
-        (a, b) =>
-          (b.finalRankScore ?? b.storyScore) -
-          (a.finalRankScore ?? a.storyScore)
+  const rankedStories = ensureArticleSpacing(
+    spreadNewMarkets(
+      diversifyForYouStories(
+        rescoredStories.sort(
+          (a, b) =>
+            (b.finalRankScore ?? b.storyScore) -
+            (a.finalRankScore ?? a.storyScore)
+        )
       )
     )
   );
 
+  // ── Discovery tier: endless feed tail ──
+  const existingPostIds = new Set(baseResult.postIds);
+  const discoveryStories = await getCacheOrFetch<NarrativeStory[]>(
+    'feed:for-you:discovery:v1',
+    () => loadDiscoveryCandidates(existingPostIds),
+    { namespace: 'feed', ttl: DISCOVERY_CACHE_TTL_S }
+  );
+
   return {
-    stories: rankedStories,
+    stories: [...rankedStories, ...discoveryStories],
     generatedAt: baseResult.generatedAt,
   };
 }

--- a/apps/web/src/app/api/feed/for-you/pipeline.ts
+++ b/apps/web/src/app/api/feed/for-you/pipeline.ts
@@ -65,6 +65,7 @@ const USER_ENRICHMENT_TTL_S = 30;
 const DISCOVERY_WINDOW_MS = 30 * 24 * 60 * 60 * 1000;
 const DISCOVERY_LIMIT = 200;
 const DISCOVERY_CACHE_TTL_S = 300;
+const SPILLOVER_SCORE_PENALTY = 0.85;
 const GENERAL_STORY_KEY = '__general__';
 
 interface BaseForYouResult {
@@ -870,7 +871,7 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
           post.shareCount,
           1,
           new Date(post.timestamp)
-        ) * 0.85;
+        ) * SPILLOVER_SCORE_PENALTY;
 
       const parsedQuestionNumber = Number.parseInt(storyKey, 10);
       stories.push({

--- a/apps/web/src/app/api/feed/for-you/pipeline.ts
+++ b/apps/web/src/app/api/feed/for-you/pipeline.ts
@@ -14,6 +14,7 @@ import {
   lt,
   lte,
   markets,
+  not,
   positions,
   posts,
   questions,
@@ -927,9 +928,12 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
     });
   }
 
-  const storyQuestionNumbers = stories
-    .filter((story) => story.questionNumber !== null)
-    .map((story) => story.questionNumber as number);
+  const existingQuestionNumbers = new Set(
+    stories
+      .filter((story) => story.questionNumber !== null)
+      .map((story) => story.questionNumber as number)
+  );
+  const storyQuestionNumbers = [...existingQuestionNumbers];
 
   if (storyQuestionNumbers.length > 0) {
     const marketRows = await db
@@ -996,6 +1000,14 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
         lt(
           questions.resolutionDate,
           new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000)
+        ),
+        not(
+          inArray(
+            questions.questionNumber,
+            existingQuestionNumbers.size > 0
+              ? [...existingQuestionNumbers]
+              : [-1]
+          )
         )
       )
     )
@@ -1245,7 +1257,8 @@ async function loadDiscoveryCandidates(): Promise<NarrativeStory[]> {
   }
 
   const stories: NarrativeStory[] = [];
-  for (const post of discoveryPosts) {
+  for (let idx = 0; idx < discoveryPosts.length; idx++) {
+    const post = discoveryPosts[idx]!;
     const title =
       post.articleTitle ??
       (post.content.length > 80
@@ -1264,7 +1277,11 @@ async function loadDiscoveryCandidates(): Promise<NarrativeStory[]> {
       storyTitle: title,
       questionNumber: post.relatedQuestion,
       arcState: null,
-      storyScore: 0.01,
+      // Assign unique descending scores so the cursor's binary search
+      // (which assumes score DESC, storyKey ASC) works correctly across
+      // the discovery tail. Engagement ordering is preserved because
+      // discoveryPosts are already sorted by engagement DESC.
+      storyScore: 0.009 - idx * 0.00001,
       postCount: 1,
       posts: [
         {

--- a/apps/web/src/app/api/feed/for-you/scoring.ts
+++ b/apps/web/src/app/api/feed/for-you/scoring.ts
@@ -153,17 +153,9 @@ export function diversifyForYouStories(
 }
 
 /**
- * Hard-guarantee pass that ensures no two market cards are adjacent in the feed.
- * Applied after `diversifyForYouStories()`, which uses score-based penalties that
- * can fail to separate markets when score gaps are large. This function provides
- * an unconditional structural guarantee with minimal rank-order disturbance.
- *
- * When two consecutive isNewMarket items are found, the nearest following
- * non-market story is spliced between them.
- */
-/**
  * Guarantee at least one article every ARTICLE_MAX_GAP items.
- * When a gap exceeds the limit, pull the next article forward.
+ * Uses a single forward pass: collect article positions first, then
+ * rebuild the array once — O(n) instead of O(n²) splice-in-loop.
  */
 const ARTICLE_MAX_GAP = 40;
 
@@ -174,31 +166,79 @@ function isArticleStory(story: NarrativeStory): boolean {
 export function ensureArticleSpacing(
   stories: NarrativeStory[]
 ): NarrativeStory[] {
-  const result = [...stories];
-  let lastArticleIndex = -1;
+  if (stories.length === 0) return stories;
 
-  for (let i = 0; i < result.length; i++) {
-    if (isArticleStory(result[i]!)) {
-      lastArticleIndex = i;
+  // Collect indices of all articles in original order
+  const articleIndices: number[] = [];
+  for (let i = 0; i < stories.length; i++) {
+    if (isArticleStory(stories[i]!)) articleIndices.push(i);
+  }
+  if (articleIndices.length === 0) return [...stories];
+
+  // Determine which articles need to be pulled forward and to where
+  const pulled = new Set<number>(); // original indices consumed early
+  const insertions: Array<{ before: number; fromIndex: number }> = [];
+  let lastArticlePos = -1;
+  let nextArticlePtr = 0; // pointer into articleIndices
+
+  for (let i = 0; i < stories.length; i++) {
+    if (isArticleStory(stories[i]!)) {
+      lastArticlePos = i;
+      // advance pointer past any articles at or before i
+      while (
+        nextArticlePtr < articleIndices.length &&
+        articleIndices[nextArticlePtr]! <= i
+      ) {
+        nextArticlePtr++;
+      }
       continue;
     }
 
-    if (i - lastArticleIndex >= ARTICLE_MAX_GAP) {
-      const nextArticleIdx = result.findIndex(
-        (s, idx) => idx > i && isArticleStory(s)
-      );
-      if (nextArticleIdx !== -1) {
-        const [article] = result.splice(nextArticleIdx, 1);
-        if (article) {
-          result.splice(i, 0, article);
-          lastArticleIndex = i;
-        }
+    if (i - lastArticlePos >= ARTICLE_MAX_GAP) {
+      // Find next unpulled article after current position
+      while (
+        nextArticlePtr < articleIndices.length &&
+        pulled.has(articleIndices[nextArticlePtr]!)
+      ) {
+        nextArticlePtr++;
+      }
+      if (nextArticlePtr < articleIndices.length) {
+        const srcIdx = articleIndices[nextArticlePtr]!;
+        pulled.add(srcIdx);
+        insertions.push({ before: i, fromIndex: srcIdx });
+        lastArticlePos = i; // this position will hold the article
+        nextArticlePtr++;
       }
     }
+  }
+
+  if (insertions.length === 0) return [...stories];
+
+  // Build result: walk original array, inserting pulled articles at their targets
+  const result: NarrativeStory[] = [];
+  let insPtr = 0;
+  for (let i = 0; i < stories.length; i++) {
+    // Insert any articles scheduled before this index
+    while (insPtr < insertions.length && insertions[insPtr]!.before === i) {
+      result.push(stories[insertions[insPtr]!.fromIndex]!);
+      insPtr++;
+    }
+    // Skip items that were pulled forward
+    if (pulled.has(i)) continue;
+    result.push(stories[i]!);
   }
   return result;
 }
 
+/**
+ * Hard-guarantee pass that ensures no two market cards are adjacent in the feed.
+ * Applied after `diversifyForYouStories()`, which uses score-based penalties that
+ * can fail to separate markets when score gaps are large. This function provides
+ * an unconditional structural guarantee with minimal rank-order disturbance.
+ *
+ * When two consecutive isNewMarket items are found, the nearest following
+ * non-market story is spliced between them.
+ */
 export function spreadNewMarkets(stories: NarrativeStory[]): NarrativeStory[] {
   const result = [...stories];
 

--- a/apps/web/src/app/api/feed/for-you/scoring.ts
+++ b/apps/web/src/app/api/feed/for-you/scoring.ts
@@ -161,6 +161,44 @@ export function diversifyForYouStories(
  * When two consecutive isNewMarket items are found, the nearest following
  * non-market story is spliced between them.
  */
+/**
+ * Guarantee at least one article every ARTICLE_MAX_GAP items.
+ * When a gap exceeds the limit, pull the next article forward.
+ */
+const ARTICLE_MAX_GAP = 40;
+
+function isArticleStory(story: NarrativeStory): boolean {
+  return story.itemType === 'article' || story.posts[0]?.type === 'article';
+}
+
+export function ensureArticleSpacing(
+  stories: NarrativeStory[]
+): NarrativeStory[] {
+  const result = [...stories];
+  let lastArticleIndex = -1;
+
+  for (let i = 0; i < result.length; i++) {
+    if (isArticleStory(result[i]!)) {
+      lastArticleIndex = i;
+      continue;
+    }
+
+    if (i - lastArticleIndex >= ARTICLE_MAX_GAP) {
+      const nextArticleIdx = result.findIndex(
+        (s, idx) => idx > i && isArticleStory(s)
+      );
+      if (nextArticleIdx !== -1) {
+        const [article] = result.splice(nextArticleIdx, 1);
+        if (article) {
+          result.splice(i, 0, article);
+          lastArticleIndex = i;
+        }
+      }
+    }
+  }
+  return result;
+}
+
 export function spreadNewMarkets(stories: NarrativeStory[]): NarrativeStory[] {
   const result = [...stories];
 

--- a/apps/web/src/app/feed/FeedClient.tsx
+++ b/apps/web/src/app/feed/FeedClient.tsx
@@ -402,6 +402,7 @@ export function FeedClient() {
           hasMore={forYouHasMore}
           loadingMore={forYouLoadingMore}
           loadMore={loadMoreForYou}
+          refresh={refreshForYou}
         />
       );
     }

--- a/apps/web/src/app/feed/components/ForYouFeedList.tsx
+++ b/apps/web/src/app/feed/components/ForYouFeedList.tsx
@@ -16,6 +16,7 @@ import {
 import { ArticleCard } from '@/components/articles/ArticleCard';
 import { PostCard } from '@/components/posts/PostCard';
 import { NewMarketCard } from './NewMarketCard';
+import { ResolvedMarketFeedCard } from './ResolvedMarketFeedCard';
 
 const PAGE_SIZE = 20;
 const VISIBLE_DWELL_MS = 2000;
@@ -30,6 +31,8 @@ interface ForYouFeedListProps {
   loadingMore: boolean;
   /** Trigger a server-side page fetch and append */
   loadMore: () => void;
+  /** Trigger a full feed refresh (invalidate cache + reload) */
+  refresh?: () => void;
 }
 
 export function ForYouFeedList({
@@ -38,6 +41,7 @@ export function ForYouFeedList({
   hasMore,
   loadingMore,
   loadMore,
+  refresh,
 }: ForYouFeedListProps) {
   const router = useRouter();
   const { trackEvent } = useFeedEventTracker();
@@ -230,6 +234,23 @@ export function ForYouFeedList({
     <div className="w-full">
       {visibleItems.map((story, index) => {
         if (story.isNewMarket) {
+          if (story.isResolved) {
+            return (
+              <div
+                key={story.storyKey}
+                ref={(node) => setItemRef(story.storyKey, node)}
+                data-story-key={story.storyKey}
+              >
+                <ResolvedMarketFeedCard
+                  story={story}
+                  onOpenMarket={() =>
+                    trackStoryEvent(story, index, 'open_market')
+                  }
+                />
+              </div>
+            );
+          }
+
           return (
             <div
               key={story.storyKey}
@@ -274,22 +295,42 @@ export function ForYouFeedList({
                 }}
               />
             ) : (
-              <PostCard
-                post={toPostCardData(leadPost)}
-                density="default"
-                showCommentInputBar={false}
-                onOpen={() => trackStoryEvent(story, index, 'open_post')}
-                onLikeChange={(isLiked) => {
-                  if (isLiked) trackStoryEvent(story, index, 'like');
-                }}
-                onShareChange={(isShared) => {
-                  if (isShared) trackStoryEvent(story, index, 'share');
-                }}
-                onCommentClick={() => {
-                  trackStoryEvent(story, index, 'open_post');
-                  router.push(`/post/${leadPost.id}`);
-                }}
-              />
+              <>
+                <PostCard
+                  post={toPostCardData(leadPost)}
+                  density="default"
+                  showCommentInputBar={false}
+                  onOpen={() => trackStoryEvent(story, index, 'open_post')}
+                  onLikeChange={(isLiked) => {
+                    if (isLiked) trackStoryEvent(story, index, 'like');
+                  }}
+                  onShareChange={(isShared) => {
+                    if (isShared) trackStoryEvent(story, index, 'share');
+                  }}
+                  onCommentClick={() => {
+                    trackStoryEvent(story, index, 'open_post');
+                    router.push(`/post/${leadPost.id}`);
+                  }}
+                />
+                {story.marketId && (
+                  <NewMarketCard
+                    story={story}
+                    embedded
+                    onOpenMarket={() =>
+                      trackStoryEvent(story, index, 'open_market')
+                    }
+                    onTradeComplete={() =>
+                      trackStoryEvent(story, index, 'trade_after_view')
+                    }
+                    onLikeChange={(isLiked) => {
+                      if (isLiked) trackStoryEvent(story, index, 'like');
+                    }}
+                    onShareChange={(isShared) => {
+                      if (isShared) trackStoryEvent(story, index, 'share');
+                    }}
+                  />
+                )}
+              </>
             )}
           </div>
         );
@@ -304,8 +345,19 @@ export function ForYouFeedList({
       )}
 
       {allCaughtUp && (
-        <div className="py-4 text-center text-muted-foreground text-xs">
-          You&apos;re all caught up.
+        <div className="flex flex-col items-center gap-2 py-6 text-center">
+          <p className="text-muted-foreground text-xs">
+            You&apos;ve seen everything for now.
+          </p>
+          {refresh && (
+            <button
+              type="button"
+              onClick={refresh}
+              className="text-primary text-xs underline"
+            >
+              Refresh for new content
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/apps/web/src/app/feed/components/ForYouFeedList.tsx
+++ b/apps/web/src/app/feed/components/ForYouFeedList.tsx
@@ -312,6 +312,7 @@ export function ForYouFeedList({
                 }}
               />
             )}
+            {/* Post stories with an associated market get an embedded trade card below the post */}
             {!story.isNewMarket && story.marketId && (
               <NewMarketCard
                 story={story}

--- a/apps/web/src/app/feed/components/ForYouFeedList.tsx
+++ b/apps/web/src/app/feed/components/ForYouFeedList.tsx
@@ -295,42 +295,40 @@ export function ForYouFeedList({
                 }}
               />
             ) : (
-              <>
-                <PostCard
-                  post={toPostCardData(leadPost)}
-                  density="default"
-                  showCommentInputBar={false}
-                  onOpen={() => trackStoryEvent(story, index, 'open_post')}
-                  onLikeChange={(isLiked) => {
-                    if (isLiked) trackStoryEvent(story, index, 'like');
-                  }}
-                  onShareChange={(isShared) => {
-                    if (isShared) trackStoryEvent(story, index, 'share');
-                  }}
-                  onCommentClick={() => {
-                    trackStoryEvent(story, index, 'open_post');
-                    router.push(`/post/${leadPost.id}`);
-                  }}
-                />
-                {story.marketId && (
-                  <NewMarketCard
-                    story={story}
-                    embedded
-                    onOpenMarket={() =>
-                      trackStoryEvent(story, index, 'open_market')
-                    }
-                    onTradeComplete={() =>
-                      trackStoryEvent(story, index, 'trade_after_view')
-                    }
-                    onLikeChange={(isLiked) => {
-                      if (isLiked) trackStoryEvent(story, index, 'like');
-                    }}
-                    onShareChange={(isShared) => {
-                      if (isShared) trackStoryEvent(story, index, 'share');
-                    }}
-                  />
-                )}
-              </>
+              <PostCard
+                post={toPostCardData(leadPost)}
+                density="default"
+                showCommentInputBar={false}
+                onOpen={() => trackStoryEvent(story, index, 'open_post')}
+                onLikeChange={(isLiked) => {
+                  if (isLiked) trackStoryEvent(story, index, 'like');
+                }}
+                onShareChange={(isShared) => {
+                  if (isShared) trackStoryEvent(story, index, 'share');
+                }}
+                onCommentClick={() => {
+                  trackStoryEvent(story, index, 'open_post');
+                  router.push(`/post/${leadPost.id}`);
+                }}
+              />
+            )}
+            {!story.isNewMarket && story.marketId && (
+              <NewMarketCard
+                story={story}
+                embedded
+                onOpenMarket={() =>
+                  trackStoryEvent(story, index, 'open_market')
+                }
+                onTradeComplete={() =>
+                  trackStoryEvent(story, index, 'trade_after_view')
+                }
+                onLikeChange={(isLiked) => {
+                  if (isLiked) trackStoryEvent(story, index, 'like');
+                }}
+                onShareChange={(isShared) => {
+                  if (isShared) trackStoryEvent(story, index, 'share');
+                }}
+              />
             )}
           </div>
         );

--- a/apps/web/src/app/feed/components/NewMarketCard.tsx
+++ b/apps/web/src/app/feed/components/NewMarketCard.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { CheckCircle, ExternalLink, XCircle } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
@@ -236,9 +235,8 @@ export function NewMarketCard({
                 onOpenMarket?.();
                 setTradeSide('YES');
               }}
-              className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-green-600 py-2.5 font-bold text-sm text-white transition-colors hover:bg-green-700 active:scale-95"
+              className="flex flex-1 items-center justify-center rounded-lg bg-green-600 py-2.5 font-bold text-sm text-white transition-colors hover:bg-green-700 active:scale-[0.98]"
             >
-              <CheckCircle size={15} />
               BUY YES
             </button>
             <button
@@ -247,9 +245,8 @@ export function NewMarketCard({
                 onOpenMarket?.();
                 setTradeSide('NO');
               }}
-              className="flex flex-1 items-center justify-center gap-1.5 rounded-lg bg-red-600 py-2.5 font-bold text-sm text-white transition-colors hover:bg-red-700 active:scale-95"
+              className="flex flex-1 items-center justify-center rounded-lg bg-red-600 py-2.5 font-bold text-sm text-white transition-colors hover:bg-red-700 active:scale-[0.98]"
             >
-              <XCircle size={15} />
               BUY NO
             </button>
           </>
@@ -275,10 +272,10 @@ export function NewMarketCard({
         <Link
           href={viewHref}
           onClick={() => onOpenMarket?.()}
-          className="inline-flex items-center gap-1 px-2 py-2.5 text-muted-foreground text-sm transition-colors hover:text-foreground"
+          className="inline-flex items-center gap-1 px-3 py-2.5 text-muted-foreground text-sm transition-colors hover:text-foreground"
           aria-label="View full market"
         >
-          <ExternalLink size={15} />
+          Details &rarr;
         </Link>
       </div>
 

--- a/apps/web/src/app/feed/components/ResolvedMarketFeedCard.tsx
+++ b/apps/web/src/app/feed/components/ResolvedMarketFeedCard.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { cn } from '@babylon/shared';
+import Link from 'next/link';
+import type { NarrativeStory } from '@/app/feed/types/narrative';
+
+interface ResolvedMarketFeedCardProps {
+  story: NarrativeStory;
+  onOpenMarket?: () => void;
+}
+
+function computePercentages(
+  yesShares: number,
+  noShares: number
+): { yesPercent: number; noPercent: number } {
+  const total = yesShares + noShares;
+  if (total === 0) return { yesPercent: 50, noPercent: 50 };
+  const yesPercent = Math.round((yesShares / total) * 100);
+  return { yesPercent, noPercent: 100 - yesPercent };
+}
+
+/**
+ * Feed card for recently resolved prediction markets.
+ *
+ * Shows the final outcome (YES/NO), frozen probability bars, and a link to
+ * the full market results. No trade buttons since the market is closed.
+ */
+export function ResolvedMarketFeedCard({
+  story,
+  onOpenMarket,
+}: ResolvedMarketFeedCardProps) {
+  const { yesPercent, noPercent } = computePercentages(
+    story.yesShares ?? 0,
+    story.noShares ?? 0
+  );
+
+  const outcomeLabel =
+    story.resolvedOutcome === true
+      ? 'YES'
+      : story.resolvedOutcome === false
+        ? 'NO'
+        : 'Pending';
+
+  const viewHref = story.marketId
+    ? `/markets/predictions/${encodeURIComponent(story.marketId)}`
+    : '/markets?tab=predictions';
+
+  return (
+    <div className="border-border border-b px-4 py-4 opacity-90">
+      {/* Header row */}
+      <div className="mb-2 flex items-center justify-between">
+        <span className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+          Resolved Market
+        </span>
+        <span
+          className={cn(
+            'rounded-full px-2 py-0.5 font-bold text-xs',
+            story.resolvedOutcome === true &&
+              'bg-green-500/15 text-green-600 dark:text-green-400',
+            story.resolvedOutcome === false &&
+              'bg-red-500/15 text-red-600 dark:text-red-400',
+            story.resolvedOutcome == null &&
+              'bg-amber-500/15 text-amber-600 dark:text-amber-400'
+          )}
+        >
+          {outcomeLabel}
+        </span>
+      </div>
+
+      {/* Market question */}
+      <p className="mb-3 font-semibold text-foreground text-sm leading-snug">
+        {story.storyTitle}
+      </p>
+
+      {/* Frozen probability bars */}
+      <div className="mb-4 space-y-2">
+        <div className="flex items-center gap-2">
+          <span className="w-12 shrink-0 text-right font-semibold text-muted-foreground text-xs">
+            {yesPercent}%
+          </span>
+          <div className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
+            <div
+              className={cn(
+                'h-full rounded-full',
+                story.resolvedOutcome === true
+                  ? 'bg-green-500'
+                  : 'bg-green-500/40'
+              )}
+              style={{ width: `${yesPercent}%` }}
+            />
+          </div>
+          <span className="w-7 shrink-0 font-medium text-muted-foreground text-xs">
+            YES
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="w-12 shrink-0 text-right font-semibold text-muted-foreground text-xs">
+            {noPercent}%
+          </span>
+          <div className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
+            <div
+              className={cn(
+                'h-full rounded-full',
+                story.resolvedOutcome === false ? 'bg-red-500' : 'bg-red-500/40'
+              )}
+              style={{ width: `${noPercent}%` }}
+            />
+          </div>
+          <span className="w-7 shrink-0 font-medium text-muted-foreground text-xs">
+            NO
+          </span>
+        </div>
+      </div>
+
+      {/* View results link */}
+      <Link
+        href={viewHref}
+        onClick={() => onOpenMarket?.()}
+        className="inline-flex items-center gap-1 text-muted-foreground text-sm transition-colors hover:text-foreground"
+      >
+        View results &rarr;
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/app/feed/components/ResolvedMarketFeedCard.tsx
+++ b/apps/web/src/app/feed/components/ResolvedMarketFeedCard.tsx
@@ -46,13 +46,17 @@ export function ResolvedMarketFeedCard({
     : '/markets?tab=predictions';
 
   return (
-    <div className="border-border border-b px-4 py-4 opacity-90">
+    <article
+      className="border-border border-b px-4 py-4 opacity-90"
+      aria-label={`Resolved market: ${story.storyTitle}`}
+    >
       {/* Header row */}
       <div className="mb-2 flex items-center justify-between">
         <span className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
           Resolved Market
         </span>
         <span
+          aria-label={`Outcome: ${outcomeLabel}`}
           className={cn(
             'rounded-full px-2 py-0.5 font-bold text-xs',
             story.resolvedOutcome === true &&
@@ -73,12 +77,23 @@ export function ResolvedMarketFeedCard({
       </p>
 
       {/* Frozen probability bars */}
-      <div className="mb-4 space-y-2">
+      <div
+        className="mb-4 space-y-2"
+        role="group"
+        aria-label="Final probabilities"
+      >
         <div className="flex items-center gap-2">
           <span className="w-12 shrink-0 text-right font-semibold text-muted-foreground text-xs">
             {yesPercent}%
           </span>
-          <div className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-2 flex-1 overflow-hidden rounded-full bg-muted"
+            role="progressbar"
+            aria-valuenow={yesPercent}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label={`YES: ${yesPercent}%`}
+          >
             <div
               className={cn(
                 'h-full rounded-full',
@@ -97,7 +112,14 @@ export function ResolvedMarketFeedCard({
           <span className="w-12 shrink-0 text-right font-semibold text-muted-foreground text-xs">
             {noPercent}%
           </span>
-          <div className="h-2 flex-1 overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-2 flex-1 overflow-hidden rounded-full bg-muted"
+            role="progressbar"
+            aria-valuenow={noPercent}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-label={`NO: ${noPercent}%`}
+          >
             <div
               className={cn(
                 'h-full rounded-full',
@@ -120,6 +142,6 @@ export function ResolvedMarketFeedCard({
       >
         View results &rarr;
       </Link>
-    </div>
+    </article>
   );
 }

--- a/packages/db/drizzle/migrations/0060_add_feed_pipeline_indexes.sql
+++ b/packages/db/drizzle/migrations/0060_add_feed_pipeline_indexes.sql
@@ -1,14 +1,14 @@
 -- Expression indexes for the lower(trim(...)) join between questions and markets.
 -- These joins run 3x per feed build and cause full table scans without indexes.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_questions_text_lower_trim
+CREATE INDEX IF NOT EXISTS idx_questions_text_lower_trim
   ON "Question" (lower(trim(text)));
 
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_markets_question_lower_trim
+CREATE INDEX IF NOT EXISTS idx_markets_question_lower_trim
   ON "Market" (lower(trim(question)));
 
 -- Partial composite index for the discovery candidates query which scans
 -- non-deleted posts in a 14-30 day window ordered by engagement.
-CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_posts_active_timestamp
+CREATE INDEX IF NOT EXISTS idx_posts_active_timestamp
   ON "Post" ("timestamp" DESC)
   WHERE "deletedAt" IS NULL
     AND "commentOnPostId" IS NULL

--- a/packages/db/drizzle/migrations/0060_add_feed_pipeline_indexes.sql
+++ b/packages/db/drizzle/migrations/0060_add_feed_pipeline_indexes.sql
@@ -1,5 +1,8 @@
 -- Expression indexes for the lower(trim(...)) join between questions and markets.
 -- These joins run 3x per feed build and cause full table scans without indexes.
+-- Note: Using blocking CREATE INDEX (not CONCURRENTLY) — acceptable while
+-- Question/Market/Post tables are <100k rows. Rewrite with CONCURRENTLY
+-- (in a manual out-of-transaction migration) before tables exceed that threshold.
 CREATE INDEX IF NOT EXISTS idx_questions_text_lower_trim
   ON "Question" (lower(trim(text)));
 

--- a/packages/db/drizzle/migrations/0060_add_feed_pipeline_indexes.sql
+++ b/packages/db/drizzle/migrations/0060_add_feed_pipeline_indexes.sql
@@ -1,0 +1,15 @@
+-- Expression indexes for the lower(trim(...)) join between questions and markets.
+-- These joins run 3x per feed build and cause full table scans without indexes.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_questions_text_lower_trim
+  ON "Question" (lower(trim(text)));
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_markets_question_lower_trim
+  ON "Market" (lower(trim(question)));
+
+-- Partial composite index for the discovery candidates query which scans
+-- non-deleted posts in a 14-30 day window ordered by engagement.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_posts_active_timestamp
+  ON "Post" ("timestamp" DESC)
+  WHERE "deletedAt" IS NULL
+    AND "commentOnPostId" IS NULL
+    AND "parentCommentId" IS NULL;

--- a/packages/db/drizzle/migrations/meta/_journal.json
+++ b/packages/db/drizzle/migrations/meta/_journal.json
@@ -414,6 +414,13 @@
       "when": 1774100000000,
       "tag": "0059_add_telegram_fields",
       "breakpoints": true
+    },
+    {
+      "idx": 59,
+      "version": "7",
+      "when": 1774150000000,
+      "tag": "0060_add_feed_pipeline_indexes",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/shared/src/types/feed.ts
+++ b/packages/shared/src/types/feed.ts
@@ -118,6 +118,10 @@ export interface NarrativeStory {
    * but is filtered from the feed to avoid duplication with the card itself.
    */
   anchorPostId?: string | null;
+  /** True when this market card represents a recently resolved market */
+  isResolved?: boolean;
+  /** Resolution outcome for resolved markets (true = YES, false = NO, null = expired/unresolved) */
+  resolvedOutcome?: boolean | null;
 }
 
 export type FeedSurface =


### PR DESCRIPTION
## Summary
- Adds resolved market cards to the For You feed with a new `ResolvedMarketFeedCard` component
- Implements post spillover logic in the feed pipeline so posts from resolved markets surface in the feed
- Adds scoring support for resolved market content in the feed ranking

## Changed files
- `apps/web/src/app/api/feed/for-you/pipeline.ts` — feed pipeline updates for resolved markets and spillover
- `apps/web/src/app/api/feed/for-you/scoring.ts` — scoring additions for resolved market cards
- `apps/web/src/app/feed/FeedClient.tsx` — minor feed client update
- `apps/web/src/app/feed/components/ForYouFeedList.tsx` — render resolved market cards in feed list
- `apps/web/src/app/feed/components/NewMarketCard.tsx` — minor adjustment
- `apps/web/src/app/feed/components/ResolvedMarketFeedCard.tsx` — new component for resolved market cards
- `packages/shared/src/types/feed.ts` — new feed type definitions

## Test plan
- [ ] Verify resolved market cards render correctly in the For You feed
- [ ] Confirm post spillover surfaces relevant posts from resolved markets
- [ ] Check feed scoring ranks resolved market content appropriately
- [ ] Ensure no regression in existing feed card types