### PR TITLE
hotfix: disable user-to-user point transfers

### DIFF
--- a/apps/web/src/app/api/points/transfer/route.ts
+++ b/apps/web/src/app/api/points/transfer/route.ts
@@ -136,6 +136,8 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
       where: { id: recipientId },
       select: {
         id: true,
+        isActor: true,
+        isAgent: true,
         reputationPoints: true,
         displayName: true,
         username: true,
@@ -149,6 +151,23 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
 
   if (!recipient) {
     return NextResponse.json({ error: 'Recipient not found' }, { status: 404 });
+  }
+
+  if (!recipient.isAgent) {
+    return NextResponse.json(
+      {
+        error:
+          'User-to-user point transfers are temporarily disabled while we review the points model.',
+      },
+      { status: 400 }
+    );
+  }
+
+  if (recipient.isActor) {
+    return NextResponse.json(
+      { error: 'Cannot send points to NPCs/actors' },
+      { status: 400 }
+    );
   }
 
   // Check if sender has enough points

--- a/apps/web/src/app/api/points/transfer/route.ts
+++ b/apps/web/src/app/api/points/transfer/route.ts
@@ -79,6 +79,9 @@ const TransferPointsSchema = z.object({
   message: z.string().max(200).optional(),
 });
 
+const USER_TO_USER_TRANSFERS_DISABLED_ERROR =
+  'User-to-user point transfers are temporarily disabled while the points model is under review.';
+
 /**
  * POST /api/points/transfer
  * Transfer points from authenticated user to another user
@@ -153,19 +156,18 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
     return NextResponse.json({ error: 'Recipient not found' }, { status: 404 });
   }
 
-  if (!recipient.isAgent) {
+  if (recipient.isActor) {
     return NextResponse.json(
-      {
-        error:
-          'User-to-user point transfers are temporarily disabled while we review the points model.',
-      },
+      { error: 'Cannot send points to NPCs/actors' },
       { status: 400 }
     );
   }
 
-  if (recipient.isActor) {
+  if (!recipient.isAgent) {
     return NextResponse.json(
-      { error: 'Cannot send points to NPCs/actors' },
+      {
+        error: USER_TO_USER_TRANSFERS_DISABLED_ERROR,
+      },
       { status: 400 }
     );
   }

--- a/apps/web/src/components/profile/ProfilePageClient.tsx
+++ b/apps/web/src/components/profile/ProfilePageClient.tsx
@@ -943,13 +943,15 @@ export function ProfilePageClient({
                             <MessageCircle className="h-5 w-5" />
                           </button>
                         )}
-                        <button
-                          onClick={() => setSendPointsModalOpen(true)}
-                          className="rounded-full border border-border p-2 transition-colors hover:bg-muted/50"
-                          title="Send points"
-                        >
-                          <Coins className="h-5 w-5" />
-                        </button>
+                        {actorInfo.isAgent && (
+                          <button
+                            onClick={() => setSendPointsModalOpen(true)}
+                            className="rounded-full border border-border p-2 transition-colors hover:bg-muted/50"
+                            title="Send points"
+                          >
+                            <Coins className="h-5 w-5" />
+                          </button>
+                        )}
                         <FollowButton
                           userId={actorInfo.id}
                           size="md"

--- a/packages/a2a/src/executors/babylon-executor.ts
+++ b/packages/a2a/src/executors/babylon-executor.ts
@@ -57,6 +57,9 @@ import {
 const DEFAULT_FETCH_TIMEOUT_MS =
   Number(process.env.A2A_FETCH_TIMEOUT_MS) || 30000;
 
+const USER_TO_USER_TRANSFERS_DISABLED_ERROR =
+  'User-to-user point transfers are temporarily disabled while the points model is under review.';
+
 /**
  * Main executor implementing all Babylon game operations
  * via A2A protocol
@@ -3566,13 +3569,11 @@ export class BabylonAgentExecutor implements AgentExecutor {
 
       if (!sender) throw new Error('Sender not found');
       if (!recipient) throw new Error('Recipient not found');
-      if (!recipient.isAgent) {
-        throw new Error(
-          'User-to-user point transfers are temporarily disabled while the points model is under review'
-        );
-      }
       if (recipient.isActor)
         throw new Error('Cannot transfer points to NPCs/actors');
+      if (!recipient.isAgent) {
+        throw new Error(USER_TO_USER_TRANSFERS_DISABLED_ERROR);
+      }
 
       const senderPoints = sender.reputationPoints ?? 0;
       if (senderPoints < amount) {

--- a/packages/a2a/src/executors/babylon-executor.ts
+++ b/packages/a2a/src/executors/babylon-executor.ts
@@ -3555,7 +3555,12 @@ export class BabylonAgentExecutor implements AgentExecutor {
         }),
         tx.user.findUnique({
           where: { id: recipientId },
-          select: { id: true, reputationPoints: true, isActor: true, isAgent: true },
+          select: {
+            id: true,
+            reputationPoints: true,
+            isActor: true,
+            isAgent: true,
+          },
         }),
       ]);
 

--- a/packages/a2a/src/executors/babylon-executor.ts
+++ b/packages/a2a/src/executors/babylon-executor.ts
@@ -3555,12 +3555,17 @@ export class BabylonAgentExecutor implements AgentExecutor {
         }),
         tx.user.findUnique({
           where: { id: recipientId },
-          select: { id: true, reputationPoints: true, isActor: true },
+          select: { id: true, reputationPoints: true, isActor: true, isAgent: true },
         }),
       ]);
 
       if (!sender) throw new Error('Sender not found');
       if (!recipient) throw new Error('Recipient not found');
+      if (!recipient.isAgent) {
+        throw new Error(
+          'User-to-user point transfers are temporarily disabled while the points model is under review'
+        );
+      }
       if (recipient.isActor)
         throw new Error('Cannot transfer points to NPCs/actors');
 

--- a/packages/mcp/src/handlers/tool-handlers.ts
+++ b/packages/mcp/src/handlers/tool-handlers.ts
@@ -82,6 +82,9 @@ import {
   retryIfRetryable,
 } from '@babylon/shared';
 
+const USER_TO_USER_TRANSFERS_DISABLED_ERROR =
+  'User-to-user point transfers are temporarily disabled while the points model is under review.';
+
 /**
  * Safe fetch helper that validates response status and returns typed JSON.
  * Throws a descriptive error if the response is not OK.
@@ -3638,13 +3641,11 @@ export async function executeTransferPoints(
           if (!recipient) {
             throw new Error('Recipient not found');
           }
-          if (!recipient.isAgent) {
-            throw new Error(
-              'User-to-user point transfers are temporarily disabled while the points model is under review'
-            );
-          }
           if (recipient.isActor) {
             throw new Error('Cannot transfer points to NPCs/actors');
+          }
+          if (!recipient.isAgent) {
+            throw new Error(USER_TO_USER_TRANSFERS_DISABLED_ERROR);
           }
 
           // Check balance inside transaction

--- a/packages/mcp/src/handlers/tool-handlers.ts
+++ b/packages/mcp/src/handlers/tool-handlers.ts
@@ -3603,7 +3603,6 @@ export async function executeTransferPoints(
     return executeWithRetry(
       'transfer_points',
       async () => {
-        // Generate transaction IDs before the transaction
         const senderTxId = await generateSnowflakeId();
         const recipientTxId = await generateSnowflakeId();
 
@@ -3627,6 +3626,8 @@ export async function executeTransferPoints(
                 reputationPoints: true,
                 displayName: true,
                 username: true,
+                isActor: true,
+                isAgent: true,
               },
             }),
           ]);
@@ -3636,6 +3637,14 @@ export async function executeTransferPoints(
           }
           if (!recipient) {
             throw new Error('Recipient not found');
+          }
+          if (!recipient.isAgent) {
+            throw new Error(
+              'User-to-user point transfers are temporarily disabled while the points model is under review'
+            );
+          }
+          if (recipient.isActor) {
+            throw new Error('Cannot transfer points to NPCs/actors');
           }
 
           // Check balance inside transaction


### PR DESCRIPTION
## What
Temporarily disables user-to-user point transfers while we clarify the points model.

## Changes
- reject non-agent recipients in the points transfer API
- reject non-agent recipients in A2A and MCP transfer flows
- hide the send points button on user profiles and keep it available for agents only

## Why
The current points model is ambiguous and user-to-user transfers are producing inconsistent user-facing behavior. This patch stops the flow immediately without changing the broader model yet.

## Test plan
- backend guard returns 400 for user-to-user transfer attempts
- send points button no longer appears on user profiles
- agent transfer entry points remain available

## Notes
I did not apply any DB reconciliation in this patch. This is a stop-the-bleed change only.