### PR TITLE
fix(web): contain settings Privy restore crashes

### DIFF
--- a/apps/web/src/app/settings/error.test.tsx
+++ b/apps/web/src/app/settings/error.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import SettingsError from './error';
+
+describe('SettingsError', () => {
+  it('renders settings-specific recovery copy', () => {
+    const html = renderToStaticMarkup(
+      <SettingsError
+        error={new Error('No matching key. session topic does not exist')}
+        reset={() => {}}
+      />
+    );
+
+    expect(html).toContain('Settings unavailable');
+    expect(html).toContain('Reload settings');
+    expect(html).toContain('Go home');
+  });
+
+  it('renders the error digest when present', () => {
+    const html = renderToStaticMarkup(
+      <SettingsError
+        error={Object.assign(new Error('boom'), { digest: 'abc123' })}
+        reset={() => {}}
+      />
+    );
+
+    expect(html).toContain('Error ID: abc123');
+  });
+});

--- a/apps/web/src/app/settings/error.test.tsx
+++ b/apps/web/src/app/settings/error.test.tsx
@@ -12,7 +12,7 @@ describe('SettingsError', () => {
     );
 
     expect(html).toContain('Settings unavailable');
-    expect(html).toContain('Reload settings');
+    expect(html).toContain('Reload page');
     expect(html).toContain('Go home');
   });
 

--- a/apps/web/src/app/settings/error.tsx
+++ b/apps/web/src/app/settings/error.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import * as Sentry from '@sentry/nextjs';
+import { AlertTriangle } from 'lucide-react';
+import { useEffect } from 'react';
+
+export default function SettingsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.withScope((scope) => {
+      scope.setTag('errorBoundary', 'settings');
+      scope.setTag('page', 'settings');
+      if (error.digest) {
+        scope.setTag('errorDigest', error.digest);
+      }
+      Sentry.captureException(error);
+    });
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[400px] flex-col items-center justify-center p-8">
+      <div className="max-w-md text-center">
+        <AlertTriangle className="mx-auto mb-4 h-16 w-16 text-orange-500" />
+        <h2 className="mb-2 font-bold text-2xl">Settings unavailable</h2>
+        <p className="mb-6 text-muted-foreground">
+          We hit an unexpected error while loading your settings. Reload the
+          page to retry.
+        </p>
+        {error.digest && (
+          <p className="mb-4 text-muted-foreground text-xs">
+            Error ID: {error.digest}
+          </p>
+        )}
+        <div className="flex justify-center gap-4">
+          <button
+            onClick={reset}
+            className="rounded-md bg-primary px-6 py-2 text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            Reload settings
+          </button>
+          <button
+            onClick={() => (window.location.href = '/')}
+            className="rounded-md bg-secondary px-6 py-2 text-secondary-foreground transition-colors hover:bg-secondary/90"
+          >
+            Go home
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/settings/error.tsx
+++ b/apps/web/src/app/settings/error.tsx
@@ -3,10 +3,10 @@
 import * as Sentry from '@sentry/nextjs';
 import { AlertTriangle } from 'lucide-react';
 import { useEffect } from 'react';
+import { posthog } from '@/lib/posthog';
 
 export default function SettingsError({
   error,
-  reset,
 }: {
   error: Error & { digest?: string };
   reset: () => void;
@@ -20,6 +20,16 @@ export default function SettingsError({
       }
       Sentry.captureException(error);
     });
+
+    if (posthog) {
+      posthog.capture('$exception', {
+        $exception_type: error.name || 'Error',
+        $exception_message: error.message,
+        $exception_stack: error.stack,
+        errorBoundary: 'settings',
+        digest: error.digest,
+      });
+    }
   }, [error]);
 
   return (
@@ -38,10 +48,10 @@ export default function SettingsError({
         )}
         <div className="flex justify-center gap-4">
           <button
-            onClick={reset}
+            onClick={() => window.location.reload()}
             className="rounded-md bg-primary px-6 py-2 text-primary-foreground transition-colors hover:bg-primary/90"
           >
-            Reload settings
+            Reload page
           </button>
           <button
             onClick={() => (window.location.href = '/')}


### PR DESCRIPTION
## Summary
- Add a `/settings` route error boundary so a client-side Privy/WalletConnect restore failure does not white-screen the settings surface.
- Capture the route failure in Sentry with settings-specific tags and expose a clear recovery UI.
- Add a focused regression test for the settings error fallback copy and digest rendering.

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Linear: https://linear.app/eliza-labs/issue/BAB-432/bugauth-investigate-privy-session-topic-restore-crash-on-settings
- Sentry: BABYLONAPP-76
- The mixed-chain Privy config fix is already present on `production`; this PR contains the remaining route-level containment for `/settings`.

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Non-goals / follow-ups
- None.

## Changes
- Add `apps/web/src/app/settings/error.tsx` to contain route render failures on `/settings`.
- Show settings-specific recovery copy with retry and home navigation actions.
- Add `apps/web/src/app/settings/error.test.tsx` to cover the fallback output.

## Review guide
**Start here**
- `apps/web/src/app/settings/error.tsx`
- `apps/web/src/app/settings/error.test.tsx`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- This intentionally does not add custom Privy storage clearing or broader `useAuth` refactors without stronger runtime evidence.
- The goal is to keep `/settings` recoverable when a third-party client restore error occurs.

## Test plan
**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bun test apps/web/src/app/settings/error.test.tsx`
2. `bun x biome check apps/web/src/app/settings/error.tsx apps/web/src/app/settings/error.test.tsx`
3. Verified the change is isolated to the `/settings` route fallback path.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: standard deploy.
- Rollback: revert this PR to remove the route-specific error boundary.

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)
### Option B: No visual changes
- Reason: Error-state-only route containment for an unexpected client crash path; no normal-state UI was changed.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
