### PR TITLE
fix(web): avoid for-you 500 when interaction view is missing

### DIFF
--- a/apps/web/src/app/api/feed/for-you/historicalBackfill.test.ts
+++ b/apps/web/src/app/api/feed/for-you/historicalBackfill.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+const mockDbSelect = mock();
+const mockLoggerWarn = mock();
+
+const postsMock = {
+  id: 'posts.id',
+  content: 'posts.content',
+  authorId: 'posts.authorId',
+  timestamp: 'posts.timestamp',
+  type: 'posts.type',
+  articleTitle: 'posts.articleTitle',
+  fullContent: 'posts.fullContent',
+  category: 'posts.category',
+  imageUrl: 'posts.imageUrl',
+  relatedQuestion: 'posts.relatedQuestion',
+  originalPostId: 'posts.originalPostId',
+  deletedAt: 'posts.deletedAt',
+  commentOnPostId: 'posts.commentOnPostId',
+  parentCommentId: 'posts.parentCommentId',
+};
+
+type QueryResult = {
+  type: 'resolve';
+  value: unknown[];
+} | {
+  type: 'reject';
+  error: unknown;
+};
+
+function makeChain(result: QueryResult) {
+  const chain: Record<string, unknown> = {};
+  const noop = () => chain;
+  chain.from = noop;
+  chain.where = noop;
+  chain.orderBy = noop;
+  chain.limit = noop;
+  chain.then = (
+    resolve: (value: unknown[]) => unknown,
+    reject?: (error: unknown) => unknown
+  ) =>
+    (result.type === 'resolve'
+      ? Promise.resolve(result.value)
+      : Promise.reject(result.error)
+    ).then(resolve, reject);
+  chain.catch = (reject: (error: unknown) => unknown) =>
+    (result.type === 'resolve'
+      ? Promise.resolve(result.value)
+      : Promise.reject(result.error)
+    ).catch(reject);
+  chain.finally = (cb: () => void) =>
+    (result.type === 'resolve'
+      ? Promise.resolve(result.value)
+      : Promise.reject(result.error)
+    ).finally(cb);
+  return chain;
+}
+
+mock.module('@babylon/db', () => ({
+  and: (...args: unknown[]) => args,
+  db: { select: mockDbSelect },
+  gte: (a: unknown, b: unknown) => [a, b],
+  isNull: (value: unknown) => value,
+  lt: (a: unknown, b: unknown) => [a, b],
+  posts: postsMock,
+  sql: (_strings: TemplateStringsArray, ..._values: unknown[]) => ({
+    sql: true,
+  }),
+}));
+
+mock.module('@babylon/shared', () => ({
+  logger: {
+    warn: mockLoggerWarn,
+  },
+}));
+
+const { loadHistoricalForYouBackfillPosts } = await import('./historicalBackfill');
+
+describe('loadHistoricalForYouBackfillPosts', () => {
+  beforeEach(() => {
+    mockDbSelect.mockReset();
+    mockLoggerWarn.mockReset();
+  });
+
+  it('returns no rows without querying when backfill capacity is zero', async () => {
+    const result = await loadHistoricalForYouBackfillPosts(
+      new Date('2026-03-01T00:00:00.000Z'),
+      new Date('2026-03-15T00:00:00.000Z'),
+      0
+    );
+
+    expect(result).toEqual([]);
+    expect(mockDbSelect).not.toHaveBeenCalled();
+  });
+
+  it('uses the materialized-view query when it succeeds', async () => {
+    const rows = [
+      {
+        id: 'post-1',
+        content: 'hello',
+        authorId: 'author-1',
+        timestamp: new Date('2026-03-14T00:00:00.000Z'),
+        type: 'post',
+        articleTitle: null,
+        fullContent: null,
+        category: null,
+        imageUrl: null,
+        relatedQuestion: null,
+        originalPostId: null,
+      },
+    ];
+
+    mockDbSelect.mockImplementation(() =>
+      makeChain({
+        type: 'resolve',
+        value: rows,
+      })
+    );
+
+    const result = await loadHistoricalForYouBackfillPosts(
+      new Date('2026-03-01T00:00:00.000Z'),
+      new Date('2026-03-15T00:00:00.000Z'),
+      10
+    );
+
+    expect(result).toEqual(rows);
+    expect(mockDbSelect).toHaveBeenCalledTimes(1);
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+  });
+
+  it('retries with live engagement ordering when mv_post_interaction_counts is missing', async () => {
+    const rows = [
+      {
+        id: 'post-2',
+        content: 'fallback',
+        authorId: 'author-2',
+        timestamp: new Date('2026-03-10T00:00:00.000Z'),
+        type: 'post',
+        articleTitle: null,
+        fullContent: null,
+        category: null,
+        imageUrl: null,
+        relatedQuestion: null,
+        originalPostId: null,
+      },
+    ];
+    const missingViewError = Object.assign(
+      new Error('relation "mv_post_interaction_counts" does not exist'),
+      {
+        code: '42P01',
+      }
+    );
+
+    mockDbSelect
+      .mockImplementationOnce(() =>
+        makeChain({
+          type: 'reject',
+          error: missingViewError,
+        })
+      )
+      .mockImplementationOnce(() =>
+        makeChain({
+          type: 'resolve',
+          value: rows,
+        })
+      );
+
+    const result = await loadHistoricalForYouBackfillPosts(
+      new Date('2026-03-01T00:00:00.000Z'),
+      new Date('2026-03-15T00:00:00.000Z'),
+      10
+    );
+
+    expect(result).toEqual(rows);
+    expect(mockDbSelect).toHaveBeenCalledTimes(2);
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not swallow unrelated database errors', async () => {
+    const otherMissingRelationError = Object.assign(
+      new Error('relation "mv_other_counts" does not exist'),
+      {
+        code: '42P01',
+      }
+    );
+
+    mockDbSelect.mockImplementation(() =>
+      makeChain({
+        type: 'reject',
+        error: otherMissingRelationError,
+      })
+    );
+
+    await expect(
+      loadHistoricalForYouBackfillPosts(
+        new Date('2026-03-01T00:00:00.000Z'),
+        new Date('2026-03-15T00:00:00.000Z'),
+        10
+      )
+    ).rejects.toBe(otherMissingRelationError);
+    expect(mockDbSelect).toHaveBeenCalledTimes(1);
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/feed/for-you/historicalBackfill.test.ts
+++ b/apps/web/src/app/api/feed/for-you/historicalBackfill.test.ts
@@ -74,7 +74,10 @@ mock.module('@babylon/shared', () => ({
   },
 }));
 
-const { loadHistoricalForYouBackfillPosts } = await import('./historicalBackfill');
+const {
+  loadDiscoveryForYouCandidatePosts,
+  loadHistoricalForYouBackfillPosts,
+} = await import('./historicalBackfill');
 
 describe('loadHistoricalForYouBackfillPosts', () => {
   beforeEach(() => {
@@ -169,6 +172,54 @@ describe('loadHistoricalForYouBackfillPosts', () => {
       new Date('2026-03-01T00:00:00.000Z'),
       new Date('2026-03-15T00:00:00.000Z'),
       10
+    );
+
+    expect(result).toEqual(rows);
+    expect(mockDbSelect).toHaveBeenCalledTimes(2);
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies the same missing-view retry for discovery candidates', async () => {
+    const rows = [
+      {
+        id: 'post-3',
+        content: 'discovery',
+        authorId: 'author-3',
+        timestamp: new Date('2026-03-05T00:00:00.000Z'),
+        type: 'post',
+        articleTitle: null,
+        fullContent: null,
+        category: null,
+        imageUrl: null,
+        relatedQuestion: null,
+        originalPostId: null,
+      },
+    ];
+    const missingViewError = Object.assign(
+      new Error('relation "mv_post_interaction_counts" does not exist'),
+      {
+        code: '42P01',
+      }
+    );
+
+    mockDbSelect
+      .mockImplementationOnce(() =>
+        makeChain({
+          type: 'reject',
+          error: missingViewError,
+        })
+      )
+      .mockImplementationOnce(() =>
+        makeChain({
+          type: 'resolve',
+          value: rows,
+        })
+      );
+
+    const result = await loadDiscoveryForYouCandidatePosts(
+      new Date('2026-03-01T00:00:00.000Z'),
+      new Date('2026-03-15T00:00:00.000Z'),
+      20
     );
 
     expect(result).toEqual(rows);

--- a/apps/web/src/app/api/feed/for-you/historicalBackfill.ts
+++ b/apps/web/src/app/api/feed/for-you/historicalBackfill.ts
@@ -1,0 +1,129 @@
+import {
+  and,
+  db,
+  gte,
+  isNull,
+  lt,
+  posts,
+  sql,
+} from '@babylon/db';
+import { logger } from '@babylon/shared';
+
+const POST_INTERACTION_COUNTS_VIEW = 'mv_post_interaction_counts';
+
+export interface ForYouCandidatePost {
+  id: string;
+  content: string;
+  authorId: string;
+  timestamp: Date;
+  type: string | null;
+  articleTitle: string | null;
+  fullContent: string | null;
+  category: string | null;
+  imageUrl: string | null;
+  relatedQuestion: number | null;
+  originalPostId: string | null;
+}
+
+const forYouCandidatePostSelection = {
+  id: posts.id,
+  content: posts.content,
+  authorId: posts.authorId,
+  timestamp: posts.timestamp,
+  type: posts.type,
+  articleTitle: posts.articleTitle,
+  fullContent: posts.fullContent,
+  category: posts.category,
+  imageUrl: posts.imageUrl,
+  relatedQuestion: posts.relatedQuestion,
+  originalPostId: posts.originalPostId,
+};
+
+function isMissingPostInteractionCountsViewError(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'object' && error !== null && 'message' in error
+        ? String((error as { message?: unknown }).message ?? '')
+        : String(error ?? '');
+  const normalizedMessage = message.toLowerCase();
+  const code =
+    (error as { cause?: { code?: string } } | null)?.cause?.code ??
+    (error as { code?: string } | null)?.code;
+
+  return (
+    normalizedMessage.includes(POST_INTERACTION_COUNTS_VIEW) &&
+    (code === '42P01' || normalizedMessage.includes('does not exist'))
+  );
+}
+
+const liveEngagementOrder = sql`
+  (
+    (SELECT COUNT(*)
+     FROM "Reaction" r
+     WHERE r."postId" = ${posts.id}
+       AND r.type = 'like') +
+    (SELECT COUNT(*)
+     FROM "Comment" c
+     WHERE c."postId" = ${posts.id}
+       AND c."deletedAt" IS NULL) * 2 +
+    (SELECT COUNT(*)
+     FROM "Share" s
+     WHERE s."postId" = ${posts.id}) * 3
+  ) DESC
+`;
+
+export async function loadHistoricalForYouBackfillPosts(
+  backfillCutoff: Date,
+  cutoff: Date,
+  backfillCapacity: number
+): Promise<ForYouCandidatePost[]> {
+  if (backfillCapacity <= 0) {
+    return [];
+  }
+
+  const backfillWhere = and(
+    isNull(posts.deletedAt),
+    gte(posts.timestamp, backfillCutoff),
+    lt(posts.timestamp, cutoff),
+    isNull(posts.commentOnPostId),
+    isNull(posts.parentCommentId)
+  );
+
+  try {
+    return await db
+      .select(forYouCandidatePostSelection)
+      .from(posts)
+      .where(backfillWhere)
+      .orderBy(
+        sql`(SELECT COALESCE(mic.engagement_score, 0)
+             FROM mv_post_interaction_counts mic
+             WHERE mic.post_id = ${posts.id}) DESC`
+      )
+      .limit(backfillCapacity);
+  } catch (error) {
+    if (!isMissingPostInteractionCountsViewError(error)) {
+      throw error;
+    }
+
+    logger.warn(
+      'mv_post_interaction_counts missing; falling back to live engagement ordering for For You backfill',
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : String(
+                (error as { message?: unknown } | null)?.message ?? error
+              ),
+      },
+      'ForYouPipeline'
+    );
+
+    return db
+      .select(forYouCandidatePostSelection)
+      .from(posts)
+      .where(backfillWhere)
+      .orderBy(liveEngagementOrder)
+      .limit(backfillCapacity);
+  }
+}

--- a/apps/web/src/app/api/feed/for-you/historicalBackfill.ts
+++ b/apps/web/src/app/api/feed/for-you/historicalBackfill.ts
@@ -73,19 +73,20 @@ const liveEngagementOrder = sql`
   ) DESC
 `;
 
-export async function loadHistoricalForYouBackfillPosts(
-  backfillCutoff: Date,
-  cutoff: Date,
-  backfillCapacity: number
+async function loadForYouEngagementRankedPosts(
+  windowStart: Date,
+  windowEnd: Date,
+  limit: number,
+  context: 'backfill' | 'discovery'
 ): Promise<ForYouCandidatePost[]> {
-  if (backfillCapacity <= 0) {
+  if (limit <= 0) {
     return [];
   }
 
-  const backfillWhere = and(
+  const rankedPostsWhere = and(
     isNull(posts.deletedAt),
-    gte(posts.timestamp, backfillCutoff),
-    lt(posts.timestamp, cutoff),
+    gte(posts.timestamp, windowStart),
+    lt(posts.timestamp, windowEnd),
     isNull(posts.commentOnPostId),
     isNull(posts.parentCommentId)
   );
@@ -94,20 +95,20 @@ export async function loadHistoricalForYouBackfillPosts(
     return await db
       .select(forYouCandidatePostSelection)
       .from(posts)
-      .where(backfillWhere)
+      .where(rankedPostsWhere)
       .orderBy(
         sql`(SELECT COALESCE(mic.engagement_score, 0)
              FROM mv_post_interaction_counts mic
              WHERE mic.post_id = ${posts.id}) DESC`
       )
-      .limit(backfillCapacity);
+      .limit(limit);
   } catch (error) {
     if (!isMissingPostInteractionCountsViewError(error)) {
       throw error;
     }
 
     logger.warn(
-      'mv_post_interaction_counts missing; falling back to live engagement ordering for For You backfill',
+      `mv_post_interaction_counts missing; falling back to live engagement ordering for For You ${context}`,
       {
         error:
           error instanceof Error
@@ -122,8 +123,34 @@ export async function loadHistoricalForYouBackfillPosts(
     return db
       .select(forYouCandidatePostSelection)
       .from(posts)
-      .where(backfillWhere)
+      .where(rankedPostsWhere)
       .orderBy(liveEngagementOrder)
-      .limit(backfillCapacity);
+      .limit(limit);
   }
+}
+
+export async function loadHistoricalForYouBackfillPosts(
+  backfillCutoff: Date,
+  cutoff: Date,
+  backfillCapacity: number
+): Promise<ForYouCandidatePost[]> {
+  return loadForYouEngagementRankedPosts(
+    backfillCutoff,
+    cutoff,
+    backfillCapacity,
+    'backfill'
+  );
+}
+
+export async function loadDiscoveryForYouCandidatePosts(
+  discoveryStart: Date,
+  backfillEnd: Date,
+  discoveryLimit: number
+): Promise<ForYouCandidatePost[]> {
+  return loadForYouEngagementRankedPosts(
+    discoveryStart,
+    backfillEnd,
+    discoveryLimit,
+    'discovery'
+  );
 }

--- a/apps/web/src/app/api/feed/for-you/pipeline.ts
+++ b/apps/web/src/app/api/feed/for-you/pipeline.ts
@@ -51,7 +51,10 @@ import {
   ensureArticleSpacing,
   spreadNewMarkets,
 } from './scoring';
-import { loadHistoricalForYouBackfillPosts } from './historicalBackfill';
+import {
+  loadDiscoveryForYouCandidatePosts,
+  loadHistoricalForYouBackfillPosts,
+} from './historicalBackfill';
 
 // Safety guard against runaway queries — NOT a content cap. The ranking
 // pipeline scores, diversifies, and orders all candidates regardless.
@@ -1155,32 +1158,11 @@ async function loadDiscoveryCandidates(): Promise<NarrativeStory[]> {
   const backfillEnd = new Date(now.getTime() - BACKFILL_WINDOW_MS);
   const discoveryStart = new Date(now.getTime() - DISCOVERY_WINDOW_MS);
 
-  const discoveryPosts = await db
-    .select({
-      id: posts.id,
-      content: posts.content,
-      authorId: posts.authorId,
-      timestamp: posts.timestamp,
-      type: posts.type,
-      articleTitle: posts.articleTitle,
-      relatedQuestion: posts.relatedQuestion,
-    })
-    .from(posts)
-    .leftJoin(
-      sql`mv_post_interaction_counts mic`,
-      sql`mic.post_id = ${posts.id}`
-    )
-    .where(
-      and(
-        isNull(posts.deletedAt),
-        gte(posts.timestamp, discoveryStart),
-        lt(posts.timestamp, backfillEnd),
-        isNull(posts.commentOnPostId),
-        isNull(posts.parentCommentId)
-      )
-    )
-    .orderBy(sql`COALESCE(mic.engagement_score, 0) DESC`)
-    .limit(DISCOVERY_LIMIT);
+  const discoveryPosts = await loadDiscoveryForYouCandidatePosts(
+    discoveryStart,
+    backfillEnd,
+    DISCOVERY_LIMIT
+  );
 
   if (discoveryPosts.length === 0) return [];
 

--- a/apps/web/src/app/api/feed/for-you/pipeline.ts
+++ b/apps/web/src/app/api/feed/for-you/pipeline.ts
@@ -51,6 +51,7 @@ import {
   ensureArticleSpacing,
   spreadNewMarkets,
 } from './scoring';
+import { loadHistoricalForYouBackfillPosts } from './historicalBackfill';
 
 // Safety guard against runaway queries — NOT a content cap. The ranking
 // pipeline scores, diversifies, and orders all candidates regardless.
@@ -397,36 +398,11 @@ async function loadBaseCandidates(): Promise<BaseForYouResult> {
   const backfillCapacity = SAFETY_CANDIDATE_LIMIT - recentPosts.length;
   if (backfillCapacity > 0) {
     const backfillCutoff = new Date(now.getTime() - BACKFILL_WINDOW_MS);
-    const backfillPosts = await db
-      .select({
-        id: posts.id,
-        content: posts.content,
-        authorId: posts.authorId,
-        timestamp: posts.timestamp,
-        type: posts.type,
-        articleTitle: posts.articleTitle,
-        fullContent: posts.fullContent,
-        category: posts.category,
-        imageUrl: posts.imageUrl,
-        relatedQuestion: posts.relatedQuestion,
-        originalPostId: posts.originalPostId,
-      })
-      .from(posts)
-      .leftJoin(
-        sql`mv_post_interaction_counts mic`,
-        sql`mic.post_id = ${posts.id}`
-      )
-      .where(
-        and(
-          isNull(posts.deletedAt),
-          gte(posts.timestamp, backfillCutoff),
-          lt(posts.timestamp, cutoff),
-          isNull(posts.commentOnPostId),
-          isNull(posts.parentCommentId)
-        )
-      )
-      .orderBy(sql`COALESCE(mic.engagement_score, 0) DESC`)
-      .limit(backfillCapacity);
+    const backfillPosts = await loadHistoricalForYouBackfillPosts(
+      backfillCutoff,
+      cutoff,
+      backfillCapacity
+    );
 
     const primaryPostIds = new Set(recentPosts.map((p) => p.id));
     for (const p of backfillPosts) {


### PR DESCRIPTION
## Summary

- Prevent `/api/feed/for-you` from returning HTTP 500 when the `mv_post_interaction_counts` materialized view is missing.
- Keep the existing fast path when the view exists, but retry the historical backfill query with live engagement ordering for that specific missing-view case.
- Add targeted regression coverage so we do not swallow unrelated database errors.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-454/fixfeed-for-you-feed-500s-when-mv-post-interaction-counts-is-missing
- Sentry: https://babylon-0t.sentry.io/issues/7357630848/

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Non-goals / follow-ups

- None.

## Changes

- Extract the historical For You backfill query into a dedicated helper.
- Detect the specific `mv_post_interaction_counts` missing-view failure and retry with a live engagement sort.
- Log the fallback path for observability while letting unrelated database errors continue to fail normally.
- Add unit coverage for the fast path, missing-view retry path, and non-targeted error path.

## Review guide

**Start here**
- `apps/web/src/app/api/feed/for-you/historicalBackfill.ts`
- `apps/web/src/app/api/feed/for-you/historicalBackfill.test.ts`
- `apps/web/src/app/api/feed/for-you/pipeline.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- The retry only applies when Postgres reports that `mv_post_interaction_counts` itself is missing.
- The normal materialized-view path stays unchanged for healthy environments.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bun test apps/web/src/app/api/feed/for-you/historicalBackfill.test.ts`
2. `bunx biome check --write apps/web/src/app/api/feed/for-you/pipeline.ts apps/web/src/app/api/feed/for-you/historicalBackfill.ts apps/web/src/app/api/feed/for-you/historicalBackfill.test.ts`
3. No browser verification; backend-only API-path change.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: deploy normally; the view-backed path remains the default and the fallback only activates when the view is missing.
- Rollback: revert this PR to restore the previous single-path query behavior.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- No schema change. This only makes an existing read path resilient when a production view is absent.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend-only API change, no UI surface was modified.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
