### PR TITLE
fix(web): guard browser storage access in global client providers

### DIFF
--- a/apps/web/src/components/providers/GameGuideProvider.tsx
+++ b/apps/web/src/components/providers/GameGuideProvider.tsx
@@ -14,6 +14,7 @@ import { GameGuideModal } from '@/components/onboarding/GameGuideModal';
 import { useAuth } from '@/hooks/useAuth';
 import { useAuthStore } from '@/stores/authStore';
 import { apiFetch } from '@/utils/api-fetch';
+import { readStorageJson, writeStorageItem } from '@/utils/browser-storage';
 
 /** LocalStorage key for tracking game guide completion (backup for API) */
 const GAME_GUIDE_COMPLETED_KEY = 'babylon-game-guide-completed';
@@ -30,14 +31,11 @@ function hasCompletedGameGuide(
   // Check localStorage backup (keyed by userId to support multiple accounts)
   if (typeof window === 'undefined' || !userId) return false;
 
-  try {
-    const stored = localStorage.getItem(GAME_GUIDE_COMPLETED_KEY);
-    if (!stored) return false;
-    const completedUsers = JSON.parse(stored) as Record<string, boolean>;
-    return completedUsers[userId] === true;
-  } catch {
-    return false;
-  }
+  const completedUsers = readStorageJson<Record<string, boolean>>(
+    'localStorage',
+    GAME_GUIDE_COMPLETED_KEY
+  );
+  return completedUsers?.[userId] === true;
 }
 
 /**
@@ -46,19 +44,17 @@ function hasCompletedGameGuide(
 function markGameGuideCompleted(userId: string): void {
   if (typeof window === 'undefined') return;
 
-  try {
-    const stored = localStorage.getItem(GAME_GUIDE_COMPLETED_KEY);
-    const completedUsers = stored
-      ? (JSON.parse(stored) as Record<string, boolean>)
-      : {};
-    completedUsers[userId] = true;
-    localStorage.setItem(
-      GAME_GUIDE_COMPLETED_KEY,
-      JSON.stringify(completedUsers)
-    );
-  } catch {
-    // Ignore localStorage errors
-  }
+  const completedUsers =
+    readStorageJson<Record<string, boolean>>(
+      'localStorage',
+      GAME_GUIDE_COMPLETED_KEY
+    ) ?? {};
+  completedUsers[userId] = true;
+  writeStorageItem(
+    'localStorage',
+    GAME_GUIDE_COMPLETED_KEY,
+    JSON.stringify(completedUsers)
+  );
 }
 
 interface GameGuideContextValue {

--- a/apps/web/src/components/providers/ReferralCaptureProvider.tsx
+++ b/apps/web/src/components/providers/ReferralCaptureProvider.tsx
@@ -3,6 +3,11 @@
 import { logger } from '@babylon/shared';
 import { useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
+import {
+  readStorageItem,
+  removeStorageItem,
+  writeStorageItem,
+} from '@/utils/browser-storage';
 
 /**
  * Referral capture provider component for capturing referral codes from URL.
@@ -29,7 +34,7 @@ export function ReferralCaptureProvider() {
 
     if (refCode) {
       // Store in sessionStorage (persists until browser tab is closed)
-      sessionStorage.setItem('referralCode', refCode);
+      writeStorageItem('sessionStorage', 'referralCode', refCode);
 
       logger.info(
         `Captured referral code: ${refCode}`,
@@ -38,18 +43,25 @@ export function ReferralCaptureProvider() {
       );
 
       // Also store timestamp to track how old the referral is
-      sessionStorage.setItem('referralCodeTimestamp', Date.now().toString());
+      writeStorageItem(
+        'sessionStorage',
+        'referralCodeTimestamp',
+        Date.now().toString()
+      );
     }
 
     // Clean up expired referral codes (older than 30 days)
-    const timestamp = sessionStorage.getItem('referralCodeTimestamp');
+    const timestamp = readStorageItem(
+      'sessionStorage',
+      'referralCodeTimestamp'
+    );
     if (timestamp) {
       const age = Date.now() - Number.parseInt(timestamp);
       const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
 
       if (age > thirtyDaysMs) {
-        sessionStorage.removeItem('referralCode');
-        sessionStorage.removeItem('referralCodeTimestamp');
+        removeStorageItem('sessionStorage', 'referralCode');
+        removeStorageItem('sessionStorage', 'referralCodeTimestamp');
         logger.info(
           'Removed expired referral code',
           undefined,
@@ -70,7 +82,7 @@ export function ReferralCaptureProvider() {
  * referral code that was captured from the URL.
  */
 export function getReferralCode(): string | null {
-  return sessionStorage.getItem('referralCode');
+  return readStorageItem('sessionStorage', 'referralCode');
 }
 
 /**
@@ -79,6 +91,6 @@ export function getReferralCode(): string | null {
  * Call this after successful signup to prevent reuse.
  */
 export function clearReferralCode(): void {
-  sessionStorage.removeItem('referralCode');
-  sessionStorage.removeItem('referralCodeTimestamp');
+  removeStorageItem('sessionStorage', 'referralCode');
+  removeStorageItem('sessionStorage', 'referralCodeTimestamp');
 }

--- a/apps/web/src/contexts/FontSizeContext.tsx
+++ b/apps/web/src/contexts/FontSizeContext.tsx
@@ -10,6 +10,7 @@
 
 import type { ReactNode } from 'react';
 import { createContext, useContext, useEffect, useState } from 'react';
+import { readStorageJson, writeStorageItem } from '@/utils/browser-storage';
 
 /**
  * Font size preset options or custom numeric value.
@@ -59,11 +60,13 @@ export function FontSizeProvider({ children }: { children: ReactNode }) {
 
   // Load from localStorage on mount
   useEffect(() => {
-    const stored = localStorage.getItem(STORAGE_KEY);
+    const stored = readStorageJson<{
+      fontSize?: number;
+      preset?: FontSize;
+    }>('localStorage', STORAGE_KEY);
     if (stored) {
-      const parsed = JSON.parse(stored);
-      setFontSizeState(parsed.fontSize || 1);
-      setFontSizePresetState(parsed.preset || 'medium');
+      setFontSizeState(stored.fontSize ?? 1);
+      setFontSizePresetState(stored.preset ?? 'medium');
     }
   }, []);
 
@@ -75,7 +78,8 @@ export function FontSizeProvider({ children }: { children: ReactNode }) {
         ([, value]) => value === size
       )?.[0] as FontSize) || size;
     setFontSizePresetState(preset);
-    localStorage.setItem(
+    writeStorageItem(
+      'localStorage',
       STORAGE_KEY,
       JSON.stringify({ fontSize: size, preset })
     );
@@ -86,7 +90,8 @@ export function FontSizeProvider({ children }: { children: ReactNode }) {
       const size = FONT_SIZE_PRESETS[preset];
       setFontSizeState(size);
       setFontSizePresetState(preset);
-      localStorage.setItem(
+      writeStorageItem(
+        'localStorage',
         STORAGE_KEY,
         JSON.stringify({ fontSize: size, preset })
       );

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -10,6 +10,11 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { getPrivyAccessTokenWithRetry } from '@/lib/auth/privyAccessToken';
 import { type User, useAuthStore } from '@/stores/authStore';
 import { apiFetch } from '@/utils/api-fetch';
+import {
+  listStorageKeys,
+  readStorageItem,
+  removeStorageItem,
+} from '@/utils/browser-storage';
 
 /**
  * Return type for the useAuth hook.
@@ -225,7 +230,7 @@ export function useAuth(): UseAuthReturn {
         // Get referral code from sessionStorage (if user clicked a referral link)
         const referralCode =
           typeof window !== 'undefined'
-            ? sessionStorage.getItem('referralCode')
+            ? readStorageItem('sessionStorage', 'referralCode')
             : null;
 
         // Build URL with referral code if present
@@ -595,23 +600,29 @@ export function useAuth(): UseAuthReturn {
 
       // Clear any stale localStorage cache
       if (typeof window !== 'undefined') {
-        const stored = localStorage.getItem('babylon-auth');
+        const stored = readStorageItem('localStorage', 'babylon-auth');
         if (stored) {
-          const parsed = JSON.parse(stored);
-          if (
-            parsed.state?.user?.id &&
-            privyUser &&
-            parsed.state.user.id !== privyUser.id
-          ) {
-            logger.info(
-              'Clearing stale auth cache for different user',
-              {
-                cachedUserId: parsed.state.user.id,
-                currentUserId: privyUser?.id,
-              },
-              'useAuth'
-            );
-            localStorage.removeItem('babylon-auth');
+          try {
+            const parsed = JSON.parse(stored) as {
+              state?: { user?: { id?: string } };
+            };
+            if (
+              parsed.state?.user?.id &&
+              privyUser &&
+              parsed.state.user.id !== privyUser.id
+            ) {
+              logger.info(
+                'Clearing stale auth cache for different user',
+                {
+                  cachedUserId: parsed.state.user.id,
+                  currentUserId: privyUser?.id,
+                },
+                'useAuth'
+              );
+              removeStorageItem('localStorage', 'babylon-auth');
+            }
+          } catch {
+            removeStorageItem('localStorage', 'babylon-auth');
           }
         }
       }
@@ -648,23 +659,23 @@ export function useAuth(): UseAuthReturn {
 
       // Explicitly remove the persisted auth storage
       // This ensures localStorage is cleared even if clearAuth() doesn't trigger storage update
-      localStorage.removeItem('babylon-auth');
+      removeStorageItem('localStorage', 'babylon-auth');
 
       // Clear any Privy localStorage keys that might persist
       // Privy's logout() should handle this, but we'll be thorough
-      const privyKeys = Object.keys(localStorage).filter(
+      const privyKeys = listStorageKeys('localStorage').filter(
         (key) => key.startsWith('privy:') || key.startsWith('privy-')
       );
       privyKeys.forEach((key) => {
-        localStorage.removeItem(key);
+        removeStorageItem('localStorage', key);
       });
 
       // Clear session storage as well
-      const sessionPrivyKeys = Object.keys(sessionStorage).filter(
+      const sessionPrivyKeys = listStorageKeys('sessionStorage').filter(
         (key) => key.startsWith('privy:') || key.startsWith('privy-')
       );
       sessionPrivyKeys.forEach((key) => {
-        sessionStorage.removeItem(key);
+        removeStorageItem('sessionStorage', key);
       });
     }
 

--- a/apps/web/src/hooks/useSessionHeartbeat.ts
+++ b/apps/web/src/hooks/useSessionHeartbeat.ts
@@ -11,6 +11,7 @@ import { generateUUID, logger } from '@babylon/shared';
 import { usePathname } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 import { useAuth } from '@/hooks/useAuth';
+import { readStorageItem, writeStorageItem } from '@/utils/browser-storage';
 
 const HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 const SESSION_KEY_PREFIX = 'bab_session_id';
@@ -23,12 +24,12 @@ function getSessionId(userId: string): string {
   if (typeof window === 'undefined') return generateUUID();
 
   const storageKey = `${SESSION_KEY_PREFIX}:${userId}`;
-  let id = sessionStorage.getItem(storageKey);
-  if (!id) {
-    id = generateUUID();
-    sessionStorage.setItem(storageKey, id);
-  }
-  return id;
+  const existingId = readStorageItem('sessionStorage', storageKey);
+  if (existingId) return existingId;
+
+  const newId = generateUUID();
+  writeStorageItem('sessionStorage', storageKey, newId);
+  return newId;
 }
 
 /**

--- a/apps/web/src/stores/authStore.test.ts
+++ b/apps/web/src/stores/authStore.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+
+const originalWindow = globalThis.window;
+
+function setWindow(windowValue: unknown) {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: windowValue,
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: originalWindow,
+  });
+});
+
+describe('authStore safe persistence', () => {
+  it('keeps the store usable when localStorage access throws', async () => {
+    const throwingWindow = {};
+
+    Object.defineProperty(throwingWindow, 'localStorage', {
+      configurable: true,
+      get() {
+        throw new DOMException('The operation is insecure.', 'SecurityError');
+      },
+    });
+
+    setWindow(throwingWindow);
+
+    const { useAuthStore } = await import('./authStore');
+
+    expect(() =>
+      useAuthStore.getState().setUser({ id: 'user-1', displayName: 'User 1' })
+    ).not.toThrow();
+    expect(useAuthStore.getState().user).toEqual({
+      id: 'user-1',
+      displayName: 'User 1',
+    });
+
+    expect(() => useAuthStore.getState().clearAuth()).not.toThrow();
+    expect(useAuthStore.getState().user).toBeNull();
+  });
+});

--- a/apps/web/src/stores/authStore.ts
+++ b/apps/web/src/stores/authStore.ts
@@ -7,6 +7,7 @@
 
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { createSafeJsonStorage } from '@/utils/browser-storage';
 
 /**
  * User profile data structure.
@@ -178,6 +179,7 @@ export const useAuthStore = create<AuthState>()(
     }),
     {
       name: 'babylon-auth',
+      storage: createSafeJsonStorage<PersistedAuthState>('localStorage'),
       // Bumping this triggers migrateAuthStoreState. Update the accepted
       // legacy versions above when the persisted schema changes again.
       version: CURRENT_AUTH_STORE_VERSION,

--- a/apps/web/src/utils/browser-storage.test.ts
+++ b/apps/web/src/utils/browser-storage.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import {
+  createSafeStorage,
+  listStorageKeys,
+  readStorageItem,
+  readStorageJson,
+  removeStorageItem,
+  writeStorageItem,
+} from './browser-storage';
+
+interface MockStorage {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
+  key: (index: number) => string | null;
+  readonly length: number;
+}
+
+const originalWindow = globalThis.window;
+
+function createMemoryStorage(
+  initialEntries: Record<string, string> = {}
+): MockStorage {
+  const store = new Map(Object.entries(initialEntries));
+
+  return {
+    getItem: (key) => store.get(key) ?? null,
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+    removeItem: (key) => {
+      store.delete(key);
+    },
+    key: (index) => Array.from(store.keys())[index] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+}
+
+function setWindow(windowValue: unknown) {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: windowValue,
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: originalWindow,
+  });
+});
+
+describe('browser-storage', () => {
+  it('reads, writes, removes, and lists keys when storage is available', () => {
+    const localStorage = createMemoryStorage({ existing: 'value' });
+    const sessionStorage = createMemoryStorage();
+
+    setWindow({ localStorage, sessionStorage });
+
+    expect(readStorageItem('localStorage', 'existing')).toBe('value');
+    expect(writeStorageItem('localStorage', 'new-key', 'new-value')).toBe(true);
+    expect(
+      readStorageJson<{ ok: boolean }>('localStorage', 'new-key')
+    ).toBeNull();
+
+    expect(
+      writeStorageItem('sessionStorage', 'json', JSON.stringify({ ok: true }))
+    ).toBe(true);
+    expect(readStorageJson<{ ok: boolean }>('sessionStorage', 'json')).toEqual({
+      ok: true,
+    });
+
+    expect(listStorageKeys('localStorage').sort()).toEqual([
+      'existing',
+      'new-key',
+    ]);
+
+    expect(removeStorageItem('localStorage', 'existing')).toBe(true);
+    expect(readStorageItem('localStorage', 'existing')).toBeNull();
+  });
+
+  it('returns neutral values when browser storage access throws', () => {
+    const throwingWindow = {};
+
+    Object.defineProperty(throwingWindow, 'localStorage', {
+      configurable: true,
+      get() {
+        throw new DOMException('The operation is insecure.', 'SecurityError');
+      },
+    });
+
+    Object.defineProperty(throwingWindow, 'sessionStorage', {
+      configurable: true,
+      get() {
+        throw new DOMException('The operation is insecure.', 'SecurityError');
+      },
+    });
+
+    setWindow(throwingWindow);
+
+    expect(readStorageItem('localStorage', 'key')).toBeNull();
+    expect(readStorageJson('sessionStorage', 'key')).toBeNull();
+    expect(writeStorageItem('localStorage', 'key', 'value')).toBe(false);
+    expect(removeStorageItem('sessionStorage', 'key')).toBe(false);
+    expect(listStorageKeys('localStorage')).toEqual([]);
+  });
+
+  it('exposes a zustand-compatible storage adapter', () => {
+    const localStorage = createMemoryStorage();
+    setWindow({ localStorage, sessionStorage: createMemoryStorage() });
+
+    const storage = createSafeStorage('localStorage');
+    storage.setItem('babylon-auth', '{"state":{}}');
+
+    expect(storage.getItem('babylon-auth')).toBe('{"state":{}}');
+
+    storage.removeItem('babylon-auth');
+    expect(storage.getItem('babylon-auth')).toBeNull();
+  });
+});

--- a/apps/web/src/utils/browser-storage.ts
+++ b/apps/web/src/utils/browser-storage.ts
@@ -1,0 +1,104 @@
+import { createJSONStorage, type StateStorage } from 'zustand/middleware';
+
+export type BrowserStorageType = 'localStorage' | 'sessionStorage';
+
+function getStorage(type: BrowserStorageType): Storage | null {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    return window[type];
+  } catch {
+    return null;
+  }
+}
+
+export function readStorageItem(
+  type: BrowserStorageType,
+  key: string
+): string | null {
+  const storage = getStorage(type);
+  if (!storage) return null;
+
+  try {
+    return storage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function readStorageJson<T>(
+  type: BrowserStorageType,
+  key: string
+): T | null {
+  const stored = readStorageItem(type, key);
+  if (!stored) return null;
+
+  try {
+    return JSON.parse(stored) as T;
+  } catch {
+    return null;
+  }
+}
+
+export function writeStorageItem(
+  type: BrowserStorageType,
+  key: string,
+  value: string
+): boolean {
+  const storage = getStorage(type);
+  if (!storage) return false;
+
+  try {
+    storage.setItem(key, value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function removeStorageItem(
+  type: BrowserStorageType,
+  key: string
+): boolean {
+  const storage = getStorage(type);
+  if (!storage) return false;
+
+  try {
+    storage.removeItem(key);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function listStorageKeys(type: BrowserStorageType): string[] {
+  const storage = getStorage(type);
+  if (!storage) return [];
+
+  try {
+    const keys: string[] = [];
+    for (let index = 0; index < storage.length; index += 1) {
+      const key = storage.key(index);
+      if (key !== null) keys.push(key);
+    }
+    return keys;
+  } catch {
+    return [];
+  }
+}
+
+export function createSafeStorage(type: BrowserStorageType): StateStorage {
+  return {
+    getItem: (key) => readStorageItem(type, key),
+    setItem: (key, value) => {
+      writeStorageItem(type, key, value);
+    },
+    removeItem: (key) => {
+      removeStorageItem(type, key);
+    },
+  };
+}
+
+export function createSafeJsonStorage<T>(type: BrowserStorageType) {
+  return createJSONStorage<T>(() => createSafeStorage(type));
+}


### PR DESCRIPTION
## Summary

- Guard `localStorage` / `sessionStorage` access in global client providers and auth/session hooks so restricted browser contexts do not throw `SecurityError` during app bootstrap.
- Reuse a shared browser storage helper and wire `authStore` persistence through a safe Zustand storage adapter instead of direct browser storage access.
- Add targeted tests covering secure fallback behavior for the storage helper and persisted auth store.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-400/guard-browser-storage-access-in-global-client-providers
- Sentry: https://babylon-0t.sentry.io/issues/7354659440/

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch‑all)
- [x] Drive‑by refactors are excluded or split into a separate PR
- [x] Non‑goals / follow‑ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Non-goals / follow-ups

- Other direct browser storage call sites outside the BAB-400 bootstrap path are intentionally left out.

## Changes

- Add `apps/web/src/utils/browser-storage.ts` to centralize safe storage reads, writes, removes, key listing, and Zustand persistence wiring.
- Replace direct storage access in `FontSizeContext`, `ReferralCaptureProvider`, `GameGuideProvider`, `useSessionHeartbeat`, and `useAuth` with guarded helper calls.
- Route `authStore` persistence through safe JSON storage and add focused unit tests for restricted-storage scenarios.

## Review guide

**Start here**
- `apps/web/src/utils/browser-storage.ts`
- `apps/web/src/stores/authStore.ts`
- `apps/web/src/hooks/useAuth.ts`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- The intended degradation is minimal: when browser storage is unavailable, bootstrap paths fall back to `null`/no-op behavior instead of throwing.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bun test apps/web/src/utils/browser-storage.test.ts apps/web/src/stores/authStore.test.ts`
2. `./node_modules/.bin/biome check --write apps/web/src/utils/browser-storage.ts apps/web/src/utils/browser-storage.test.ts apps/web/src/stores/authStore.test.ts apps/web/src/contexts/FontSizeContext.tsx apps/web/src/components/providers/ReferralCaptureProvider.tsx apps/web/src/components/providers/GameGuideProvider.tsx apps/web/src/hooks/useSessionHeartbeat.ts apps/web/src/hooks/useAuth.ts apps/web/src/stores/authStore.ts`
3. Manual browser verification not run.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: Deploy normally.
- Rollback: Revert this PR.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Client-side storage guard change only; no intentional visual/UI changes.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
