### PR TITLE
fix(auth): make concurrent user bootstrap idempotent

### DIFF
--- a/apps/web/src/app/api/users/[userId]/balance/route.ts
+++ b/apps/web/src/app/api/users/[userId]/balance/route.ts
@@ -59,13 +59,12 @@ import {
   BusinessLogicError,
   cachedDb,
   checkRateLimitAsync,
-  findUserByIdentifier,
+  ensureMinimalUserByIdentifier,
   getClientIp,
   RATE_LIMIT_CONFIGS,
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
-import { db, users } from '@babylon/db';
 import {
   convertBalanceToStrings,
   logger,
@@ -142,29 +141,7 @@ export const GET = withErrorHandling(
     }
 
     const { userId } = UserIdParamSchema.parse(await context.params);
-
-    // Ensure user exists in database
-    let dbUser = await findUserByIdentifier(userId, {
-      id: true,
-    });
-
-    if (!dbUser) {
-      const [newUser] = await db
-        .insert(users)
-        .values({
-          id: userId,
-          privyId: userId,
-          isActor: false,
-          updatedAt: new Date(),
-        })
-        .returning();
-      if (!newUser) {
-        throw new Error('Failed to create user');
-      }
-      dbUser = newUser;
-    }
-
-    const canonicalUserId = dbUser.id;
+    const { id: canonicalUserId } = await ensureMinimalUserByIdentifier(userId);
 
     // Get balance info with caching (balance is publicly viewable)
     const balanceData = await cachedDb.getUserBalance(canonicalUserId);

--- a/apps/web/src/app/api/users/[userId]/portfolio-breakdown/route.ts
+++ b/apps/web/src/app/api/users/[userId]/portfolio-breakdown/route.ts
@@ -13,11 +13,10 @@
 
 import {
   BusinessLogicError,
-  findUserByIdentifier,
+  ensureMinimalUserByIdentifier,
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
-import { db, users } from '@babylon/db';
 import { calculatePortfolioBreakdown } from '@babylon/engine';
 import { logger, UserIdParamSchema } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
@@ -28,27 +27,7 @@ export const GET = withErrorHandling(
     context: { params: Promise<{ userId: string }> }
   ) => {
     const { userId } = UserIdParamSchema.parse(await context.params);
-
-    let dbUser = await findUserByIdentifier(userId, { id: true });
-
-    if (!dbUser) {
-      const [newUser] = await db
-        .insert(users)
-        .values({
-          id: userId,
-          privyId: userId,
-          isActor: false,
-          updatedAt: new Date(),
-        })
-        .returning();
-
-      if (!newUser) {
-        throw new Error('Failed to create user');
-      }
-      dbUser = newUser;
-    }
-
-    const canonicalUserId = dbUser.id;
+    const { id: canonicalUserId } = await ensureMinimalUserByIdentifier(userId);
     const snapshot = await calculatePortfolioBreakdown(canonicalUserId);
 
     if (!snapshot) {

--- a/apps/web/src/app/api/users/me/route.ts
+++ b/apps/web/src/app/api/users/me/route.ts
@@ -1012,30 +1012,42 @@ export const GET = withErrorHandling(async (request: NextRequest) => {
         isAdmin: shouldBeAdmin,
         updatedAt: new Date(),
       })
+      .onConflictDoNothing()
       .returning(userSelectFields);
 
     if (!newUser) {
-      throw new InternalServerError('Failed to create user record');
+      const [concurrentUser] = await db
+        .select(userSelectFields)
+        .from(users)
+        .where(or(eq(users.privyId, privyId), eq(users.id, canonicalUserId)))
+        .limit(1);
+
+      if (!concurrentUser) {
+        throw new InternalServerError('Failed to create or find user record');
+      }
+
+      dbUser = concurrentUser;
+    } else {
+      dbUser = newUser;
+
+      logger.info(
+        'Minimal user record created',
+        {
+          userId: dbUser.id,
+          privyId,
+          referredBy: dbUser.referredBy,
+          email: dbUser.email,
+        },
+        'GET /api/users/me'
+      );
+
+      // Invalidate identifier caches for the new user (clears negative cache)
+      await cachedDb.invalidateUserIdentifierCaches({
+        id: dbUser.id,
+        privyId: dbUser.privyId,
+        username: dbUser.username,
+      });
     }
-    dbUser = newUser;
-
-    logger.info(
-      'Minimal user record created',
-      {
-        userId: dbUser.id,
-        privyId,
-        referredBy: dbUser.referredBy,
-        email: dbUser.email,
-      },
-      'GET /api/users/me'
-    );
-
-    // Invalidate identifier caches for the new user (clears negative cache)
-    await cachedDb.invalidateUserIdentifierCaches({
-      id: dbUser.id,
-      privyId: dbUser.privyId,
-      username: dbUser.username,
-    });
   } else if (referralCode && dbUser && !dbUser.profileComplete) {
     // User exists BUT profile not complete - update referredBy with latest referral code (latest wins!)
     // ⚠️ IMPORTANT: Only allow referral changes BEFORE profile completion to prevent gaming

--- a/packages/api/src/__tests__/ensure-user.test.ts
+++ b/packages/api/src/__tests__/ensure-user.test.ts
@@ -108,6 +108,19 @@ describe('ensure-user', () => {
     expect(mockInvalidateUserIdentifierCaches).not.toHaveBeenCalled();
   });
 
+  it('reloads the minimal user by primary key after a username insert conflict', async () => {
+    const identifier = 'testuser';
+    mockResolveUserIdentifierKind.mockImplementation(() => 'username');
+    insertReturningResponses.push([]);
+    selectResponses.push([]);
+    selectResponses.push([{ id: identifier }]);
+
+    const user = await ensureMinimalUserByIdentifier(identifier);
+
+    expect(user).toEqual({ id: identifier });
+    expect(mockInvalidateUserIdentifierCaches).not.toHaveBeenCalled();
+  });
+
   it('invalidates identifier caches when minimal bootstrap wins the insert', async () => {
     const identifier = 'did:privy:test-public-created';
     insertReturningResponses.push([{ id: identifier }]);

--- a/packages/api/src/__tests__/ensure-user.test.ts
+++ b/packages/api/src/__tests__/ensure-user.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+
+const mockFindUserByIdentifier = mock(() => Promise.resolve(null));
+const mockInvalidateUserIdentifierCaches = mock(() => Promise.resolve());
+const mockResolveUserIdentifierKind = mock(() => 'privyId');
+
+const selectResponses: unknown[][] = [];
+const insertReturningResponses: unknown[][] = [];
+
+const mockSelect = mock(() => {
+  const chain = {
+    from: (_table?: unknown) => chain,
+    where: (_condition?: unknown) => chain,
+    limit: () => Promise.resolve(selectResponses.shift() ?? []),
+  };
+  return chain;
+});
+
+const mockInsertReturning = mock(() =>
+  Promise.resolve(insertReturningResponses.shift() ?? [])
+);
+const mockOnConflictDoNothing = mock(() => ({
+  returning: mockInsertReturning,
+}));
+const mockInsertValues = mock(() => ({
+  onConflictDoNothing: mockOnConflictDoNothing,
+}));
+const mockInsert = mock(() => ({
+  values: mockInsertValues,
+}));
+
+const mockUpdateReturning = mock(() => Promise.resolve([]));
+const mockUpdateWhere = mock(() => ({ returning: mockUpdateReturning }));
+const mockUpdateSet = mock(() => ({ where: mockUpdateWhere }));
+const mockUpdate = mock(() => ({ set: mockUpdateSet }));
+
+mock.module('@babylon/db', () => ({
+  db: {
+    insert: mockInsert,
+    select: mockSelect,
+    update: mockUpdate,
+  },
+  eq: (left: unknown, right: unknown) => ({ left, right }),
+  users: {
+    id: 'id',
+    privyId: 'privyId',
+    username: 'username',
+    displayName: 'displayName',
+    walletAddress: 'walletAddress',
+    isActor: 'isActor',
+    profileImageUrl: 'profileImageUrl',
+  },
+}));
+
+mock.module('@babylon/shared', () => ({
+  resolveUserIdentifierKind: mockResolveUserIdentifierKind,
+}));
+
+mock.module('drizzle-orm', () => ({
+  sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings,
+    values,
+  }),
+}));
+
+mock.module('../cache/cached-database-service', () => ({
+  cachedDb: {
+    invalidateUserIdentifierCaches: mockInvalidateUserIdentifierCaches,
+  },
+}));
+
+mock.module('../users/user-lookup', () => ({
+  findUserByIdentifier: mockFindUserByIdentifier,
+}));
+
+const { ensureMinimalUserByIdentifier, ensureUserForAuth } = await import(
+  '../users/ensure-user'
+);
+
+describe('ensure-user', () => {
+  beforeEach(() => {
+    mockFindUserByIdentifier.mockClear();
+    mockInvalidateUserIdentifierCaches.mockClear();
+    mockResolveUserIdentifierKind.mockClear();
+    mockSelect.mockClear();
+    mockInsert.mockClear();
+    mockInsertValues.mockClear();
+    mockOnConflictDoNothing.mockClear();
+    mockInsertReturning.mockClear();
+    mockUpdate.mockClear();
+    selectResponses.length = 0;
+    insertReturningResponses.length = 0;
+    mockFindUserByIdentifier.mockImplementation(() => Promise.resolve(null));
+    mockResolveUserIdentifierKind.mockImplementation(() => 'privyId');
+  });
+
+  it('returns the concurrently created minimal user after an insert conflict', async () => {
+    const identifier = 'did:privy:test-public-bootstrap';
+    insertReturningResponses.push([]);
+    selectResponses.push([{ id: identifier }]);
+
+    const user = await ensureMinimalUserByIdentifier(identifier);
+
+    expect(user).toEqual({ id: identifier });
+    expect(mockFindUserByIdentifier).toHaveBeenCalledWith(identifier, {
+      id: true,
+    });
+    expect(mockInvalidateUserIdentifierCaches).not.toHaveBeenCalled();
+  });
+
+  it('invalidates identifier caches when minimal bootstrap wins the insert', async () => {
+    const identifier = 'did:privy:test-public-created';
+    insertReturningResponses.push([{ id: identifier }]);
+
+    const user = await ensureMinimalUserByIdentifier(identifier);
+
+    expect(user).toEqual({ id: identifier });
+    expect(mockInvalidateUserIdentifierCaches).toHaveBeenCalledWith({
+      id: identifier,
+      privyId: identifier,
+      username: null,
+    });
+  });
+
+  it('reloads the authenticated user after a concurrent insert conflict', async () => {
+    const identifier = 'did:privy:test-auth-bootstrap';
+    insertReturningResponses.push([]);
+    selectResponses.push([]);
+    selectResponses.push([
+      {
+        id: identifier,
+        privyId: identifier,
+        username: null,
+        displayName: null,
+        walletAddress: null,
+        isActor: false,
+        profileImageUrl: null,
+      },
+    ]);
+
+    const authUser = {
+      userId: identifier,
+      privyId: identifier,
+      isAgent: false,
+    };
+
+    const result = await ensureUserForAuth(authUser);
+
+    expect(result.user.id).toBe(identifier);
+    expect(authUser.dbUserId).toBe(identifier);
+    expect(mockInvalidateUserIdentifierCaches).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -295,6 +295,7 @@ export type { ErrorLike, JsonValue, StringRecord } from './types';
 export {
   type CanonicalUser,
   type EnsureUserOptions,
+  ensureMinimalUserByIdentifier,
   ensureUserForAuth,
   findTargetByIdentifier,
   findUserByIdentifier,

--- a/packages/api/src/users/ensure-user.ts
+++ b/packages/api/src/users/ensure-user.ts
@@ -7,8 +7,11 @@
  */
 
 import { db, eq, type User, users } from '@babylon/db';
+import { resolveUserIdentifierKind } from '@babylon/shared';
+import { sql } from 'drizzle-orm';
 import type { AuthenticatedUser } from '../auth-middleware';
 import { cachedDb } from '../cache/cached-database-service';
+import { findUserByIdentifier } from './user-lookup';
 
 /**
  * Options for ensuring user exists
@@ -32,12 +35,138 @@ export type CanonicalUser = Pick<
   | 'profileImageUrl'
 >;
 
+type MinimalUser = Pick<User, 'id'>;
+
+const canonicalUserSelect = {
+  id: users.id,
+  privyId: users.privyId,
+  username: users.username,
+  displayName: users.displayName,
+  walletAddress: users.walletAddress,
+  isActor: users.isActor,
+  profileImageUrl: users.profileImageUrl,
+};
+
+async function findMinimalUserByIdentifierDirect(
+  identifier: string
+): Promise<MinimalUser | null> {
+  const normalizedIdentifier = identifier.trim();
+
+  if (!normalizedIdentifier) {
+    return null;
+  }
+
+  const kind = resolveUserIdentifierKind(normalizedIdentifier);
+  const condition =
+    kind === 'id'
+      ? eq(users.id, normalizedIdentifier)
+      : kind === 'privyId'
+        ? eq(users.privyId, normalizedIdentifier)
+        : sql`lower(${users.username}) = lower(${normalizedIdentifier})`;
+
+  const [user] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(condition)
+    .limit(1);
+
+  if (user) {
+    return user;
+  }
+
+  if (kind === 'privyId') {
+    const [byId] = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.id, normalizedIdentifier))
+      .limit(1);
+    return byId ?? null;
+  }
+
+  return null;
+}
+
+async function findCanonicalUserByAuthIdentifiersDirect(
+  privyId: string,
+  userId: string
+): Promise<CanonicalUser | null> {
+  const [byPrivyId] = await db
+    .select(canonicalUserSelect)
+    .from(users)
+    .where(eq(users.privyId, privyId))
+    .limit(1);
+
+  if (byPrivyId) {
+    return byPrivyId;
+  }
+
+  const [byId] = await db
+    .select(canonicalUserSelect)
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  return byId ?? null;
+}
+
+/**
+ * Ensure a minimal user row exists for public identifier-based endpoints.
+ *
+ * Uses insert-or-reload so concurrent first access does not fail with a duplicate
+ * key error if another request creates the same user between the initial lookup
+ * and insert attempt.
+ */
+export async function ensureMinimalUserByIdentifier(
+  identifier: string
+): Promise<MinimalUser> {
+  const normalizedIdentifier = identifier.trim();
+
+  const existingUser = await findUserByIdentifier(normalizedIdentifier, {
+    id: true,
+  });
+
+  if (existingUser) {
+    return { id: existingUser.id };
+  }
+
+  const [createdUser] = await db
+    .insert(users)
+    .values({
+      id: normalizedIdentifier,
+      privyId: normalizedIdentifier,
+      isActor: false,
+      updatedAt: new Date(),
+    })
+    .onConflictDoNothing()
+    .returning({ id: users.id });
+
+  if (createdUser) {
+    await cachedDb.invalidateUserIdentifierCaches({
+      id: createdUser.id,
+      privyId: normalizedIdentifier,
+      username: null,
+    });
+
+    return createdUser;
+  }
+
+  const concurrentUser =
+    await findMinimalUserByIdentifierDirect(normalizedIdentifier);
+
+  if (!concurrentUser) {
+    throw new Error('Failed to create or find user');
+  }
+
+  return concurrentUser;
+}
+
 /**
  * Ensure user exists in database for authenticated user
  *
  * @description Creates or updates a user record based on authenticated user
- * information. Uses upsert to handle both new and existing users. Updates
- * dbUserId on the authenticated user object.
+ * information. Uses an insert-or-reload flow so concurrent requests can race
+ * safely without surfacing duplicate-key errors. Updates dbUserId on the
+ * authenticated user object.
  *
  * @param {AuthenticatedUser} user - Authenticated user information
  * @param {EnsureUserOptions} [options={}] - Options for user creation/update
@@ -56,18 +185,11 @@ export async function ensureUserForAuth(
   options: EnsureUserOptions = {}
 ): Promise<{ user: CanonicalUser }> {
   const privyId = user.privyId ?? user.userId;
+  const canonicalUserId = user.dbUserId ?? user.userId;
 
   // Check if user exists
   const existing = await db
-    .select({
-      id: users.id,
-      privyId: users.privyId,
-      username: users.username,
-      displayName: users.displayName,
-      walletAddress: users.walletAddress,
-      isActor: users.isActor,
-      profileImageUrl: users.profileImageUrl,
-    })
+    .select(canonicalUserSelect)
     .from(users)
     .where(eq(users.privyId, privyId))
     .limit(1);
@@ -107,15 +229,7 @@ export async function ensureUserForAuth(
         .update(users)
         .set(updateData)
         .where(eq(users.id, existingUser.id))
-        .returning({
-          id: users.id,
-          privyId: users.privyId,
-          username: users.username,
-          displayName: users.displayName,
-          walletAddress: users.walletAddress,
-          isActor: users.isActor,
-          profileImageUrl: users.profileImageUrl,
-        });
+        .returning(canonicalUserSelect);
 
       const updatedUser = updated[0]!;
       user.dbUserId = updatedUser.id;
@@ -147,7 +261,7 @@ export async function ensureUserForAuth(
 
   // Create new user
   const createData: typeof users.$inferInsert = {
-    id: user.dbUserId ?? user.userId,
+    id: canonicalUserId,
     privyId,
     isActor: options.isActor ?? false,
     // New users start with 1000 virtual balance + 1000 base reputation (see db schema defaults).
@@ -167,17 +281,26 @@ export async function ensureUserForAuth(
     createData.displayName = options.displayName;
   }
 
-  const created = await db.insert(users).values(createData).returning({
-    id: users.id,
-    privyId: users.privyId,
-    username: users.username,
-    displayName: users.displayName,
-    walletAddress: users.walletAddress,
-    isActor: users.isActor,
-    profileImageUrl: users.profileImageUrl,
-  });
+  const [createdUser] = await db
+    .insert(users)
+    .values(createData)
+    .onConflictDoNothing()
+    .returning(canonicalUserSelect);
 
-  const createdUser = created[0]!;
+  if (!createdUser) {
+    const concurrentUser = await findCanonicalUserByAuthIdentifiersDirect(
+      privyId,
+      canonicalUserId
+    );
+
+    if (!concurrentUser) {
+      throw new Error('Failed to create or find user');
+    }
+
+    user.dbUserId = concurrentUser.id;
+    return { user: concurrentUser };
+  }
+
   user.dbUserId = createdUser.id;
 
   // Invalidate identifier caches for the new user (clears negative cache)

--- a/packages/api/src/users/ensure-user.ts
+++ b/packages/api/src/users/ensure-user.ts
@@ -74,7 +74,10 @@ async function findMinimalUserByIdentifierDirect(
     return user;
   }
 
-  if (kind === 'privyId') {
+  // Minimal public bootstrap stores the incoming identifier in users.id even
+  // when the original lookup was by username, so the conflict-reload path must
+  // also retry by primary key for any non-ID identifier kind.
+  if (kind !== 'id') {
     const [byId] = await db
       .select({ id: users.id })
       .from(users)

--- a/packages/api/src/users/index.ts
+++ b/packages/api/src/users/index.ts
@@ -7,6 +7,7 @@
 export {
   type CanonicalUser,
   type EnsureUserOptions,
+  ensureMinimalUserByIdentifier,
   ensureUserForAuth,
   getCanonicalUserId,
 } from './ensure-user';


### PR DESCRIPTION
## Summary

- Prevent duplicate-key 500s during first-load user bootstrap by making `/api/users/me` reload the user after a conflicting insert instead of failing.
- Reuse the same idempotent minimal-user bootstrap helper in `/api/users/[userId]/portfolio-breakdown` and `/api/users/[userId]/balance` so adjacent public profile reads do not race each other.
- Add focused unit coverage for the conflict-and-reload paths, including the negative-cache case.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-461/bugauth-concurrent-user-bootstrap-causes-500s-on-rewards
- Related issue: https://linear.app/eliza-labs/issue/BAB-436/bugprofile-profile-widget-fails-when-all-profile-data-requests-500
- Sentry: https://babylon-0t.sentry.io/issues/7359649332/

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Non-goals / follow-ups

- No broader auth/bootstrap redesign.
- No changes to referral, social auto-linking, or Privy identity sync rules beyond conflict recovery.

## Changes

- Added `ensureMinimalUserByIdentifier()` in `packages/api` to make public user bootstrap insert-or-reload and bypass stale negative-cache lookups on retry.
- Updated `/api/users/[userId]/portfolio-breakdown` and `/api/users/[userId]/balance` to reuse the shared helper instead of duplicating `find -> insert` logic.
- Updated `/api/users/me` to use `onConflictDoNothing()` and then reload by `privyId` / canonical id when another request wins the insert race.
- Hardened `ensureUserForAuth()` with the same conflict-recovery pattern.
- Added unit tests for the conflict-reload branches.

## Review guide

**Start here**
- `packages/api/src/users/ensure-user.ts`
- `apps/web/src/app/api/users/me/route.ts`
- `packages/api/src/__tests__/ensure-user.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- The behavior change is intentionally narrow: only duplicate bootstrap inserts now reload the winner instead of surfacing a 500.
- The public helper uses a direct DB reload after conflict so a prior negative cache miss cannot mask the row created by a concurrent request.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bunx biome check --write packages/api/src/__tests__/ensure-user.test.ts packages/api/src/users/ensure-user.ts apps/web/src/app/api/users/[userId]/balance/route.ts apps/web/src/app/api/users/[userId]/portfolio-breakdown/route.ts apps/web/src/app/api/users/me/route.ts packages/api/src/index.ts packages/api/src/users/index.ts`
2. `bun test packages/api/src/__tests__/ensure-user.test.ts`
3. Attempted `bunx tsc --noEmit --pretty false`, but the repo currently has many unrelated pre-existing TypeScript errors outside this change.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: Deploy normally; monitor `/api/users/me` and `/api/users/[userId]/portfolio-breakdown` for duplicate-key errors.
- Rollback: Revert this PR if bootstrap behavior regresses.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- No schema changes. This only makes existing user-row bootstrap idempotent under concurrency.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend-only/API bootstrap fix, no visual change.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
