### PR TITLE
fix(api): serialize BigInt in success responses

### DIFF
--- a/packages/api/src/error-handler.ts
+++ b/packages/api/src/error-handler.ts
@@ -658,16 +658,19 @@ export function successResponse<T>(
 ): NextResponse {
   const responseHeaders = new Headers(headers);
   if (!responseHeaders.has('content-type')) {
-    responseHeaders.set('content-type', 'application/json');
+    responseHeaders.set('content-type', 'application/json; charset=utf-8');
   }
 
-  return new NextResponse(
-    JSON.stringify(data, (_key, value) =>
-      typeof value === 'bigint' ? value.toString() : value
-    ) ?? 'null',
-    {
-      status: statusCode,
-      headers: responseHeaders,
-    }
+  const body = JSON.stringify(data, (_key, value) =>
+    typeof value === 'bigint' ? value.toString() : value
   );
+
+  if (body === undefined) {
+    throw new TypeError('Value is not JSON serializable');
+  }
+
+  return new NextResponse(body, {
+    status: statusCode,
+    headers: responseHeaders,
+  });
 }

--- a/packages/api/src/error-handler.ts
+++ b/packages/api/src/error-handler.ts
@@ -656,5 +656,18 @@ export function successResponse<T>(
   statusCode = 200,
   headers?: HeadersInit
 ): NextResponse {
-  return NextResponse.json(data, { status: statusCode, headers });
+  const responseHeaders = new Headers(headers);
+  if (!responseHeaders.has('content-type')) {
+    responseHeaders.set('content-type', 'application/json');
+  }
+
+  return new NextResponse(
+    JSON.stringify(data, (_key, value) =>
+      typeof value === 'bigint' ? value.toString() : value
+    ) ?? 'null',
+    {
+      status: statusCode,
+      headers: responseHeaders,
+    }
+  );
 }

--- a/packages/testing/unit/shared/error-handler-sentry.test.ts
+++ b/packages/testing/unit/shared/error-handler-sentry.test.ts
@@ -251,4 +251,10 @@ describe('successResponse', () => {
       },
     });
   });
+
+  it('preserves non-serializable top-level payload failures', () => {
+    expect(() => successResponse(undefined)).toThrow(
+      'Value is not JSON serializable'
+    );
+  });
 });

--- a/packages/testing/unit/shared/error-handler-sentry.test.ts
+++ b/packages/testing/unit/shared/error-handler-sentry.test.ts
@@ -19,6 +19,7 @@ let AuthenticationError: new (message?: string) => Error;
 let BadRequestError: new (message: string) => Error;
 let ValidationError: new (message: string) => Error;
 let setDefaultErrorCapture: ErrorHandlerModule['setDefaultErrorCapture'];
+let successResponse: ErrorHandlerModule['successResponse'];
 let withErrorHandling: ErrorHandlerModule['withErrorHandling'];
 
 function createRequest(): import('next/server').NextRequest {
@@ -101,6 +102,7 @@ describe('withErrorHandling + default Sentry capture', () => {
       `../../../api/src/error-handler.ts?isolation=${Date.now()}-${Math.random()}`
     )) as ErrorHandlerModule;
     setDefaultErrorCapture = freshModule.setDefaultErrorCapture;
+    successResponse = freshModule.successResponse;
     withErrorHandling = freshModule.withErrorHandling;
   });
 
@@ -226,6 +228,27 @@ describe('Notification digest validation functions', () => {
       expect(isValidDeliveryChannel('in_app')).toBe(false);
       expect(isValidDeliveryChannel('')).toBe(false);
       expect(isValidDeliveryChannel('EMAIL')).toBe(false);
+    });
+  });
+});
+
+describe('successResponse', () => {
+  it('serializes bigint payload values as strings', async () => {
+    const response = successResponse({
+      id: 'position-1',
+      amount: 42n,
+      nested: {
+        total: 9007199254740993n,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      id: 'position-1',
+      amount: '42',
+      nested: {
+        total: '9007199254740993',
+      },
     });
   });
 });


### PR DESCRIPTION
## Summary

- Prevent API success responses from crashing when a payload contains `bigint` values.
- Fix the production failure path behind `/api/markets/positions/[userId]`, which was returning `500` for affected users.
- Add a focused regression test covering `successResponse()` bigint serialization.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-424/fixapi-serialize-bigint-in-user-positions-endpoint
- Sentry: https://babylon-0t.sentry.io/issues/7355702534/

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [ ] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [x] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Non-goals / follow-ups

- None.

## Changes

- Replace `successResponse()`'s direct `NextResponse.json(...)` call with explicit JSON serialization that converts `bigint` values to strings.
- Preserve normal JSON response behavior, including default `application/json` headers.
- Add a regression test proving nested bigint values are serialized safely.

## Review guide

**Start here**
- `packages/api/src/error-handler.ts`
- `packages/testing/unit/shared/error-handler-sentry.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- This stays intentionally narrow: no route-specific fallback logic was added in the positions endpoint.
- The fix is centralized in the shared success response helper because the failure mode is generic to any JSON API payload containing `bigint`.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bun test packages/testing/unit/shared/error-handler-sentry.test.ts`
2. `bunx biome check packages/api/src/error-handler.ts packages/testing/unit/shared/error-handler-sentry.test.ts`
3. Confirmed the added regression test passes and covers nested `bigint` payload serialization.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: ship normally; the change is isolated to JSON success serialization.
- Rollback: revert this PR to restore the previous response helper behavior.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- Responses that previously crashed on `bigint` now serialize those values as strings.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Backend-only API serialization fix, no direct UI changes.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
