### PR TITLE
fix(web): prevent widget refresh provider crashes

### DIFF
--- a/apps/web/src/contexts/WidgetRefreshContext.test.ts
+++ b/apps/web/src/contexts/WidgetRefreshContext.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { createElement } from 'react';
+import { renderToString } from 'react-dom/server';
+import {
+  useWidgetRefresh,
+  WidgetRefreshProvider,
+} from './WidgetRefreshContext';
+
+function HookConsumer({
+  onContext,
+}: {
+  onContext: (context: ReturnType<typeof useWidgetRefresh>) => void;
+}) {
+  onContext(useWidgetRefresh());
+  return null;
+}
+
+describe('useWidgetRefresh', () => {
+  const env = process.env as Record<string, string | undefined>;
+  const originalNodeEnv = env.NODE_ENV;
+
+  beforeEach(() => {
+    env.NODE_ENV = originalNodeEnv;
+  });
+
+  afterEach(() => {
+    env.NODE_ENV = originalNodeEnv;
+  });
+
+  it('exposes registered refresh callbacks when mounted under the provider', () => {
+    let refreshCount = 0;
+
+    renderToString(
+      createElement(
+        WidgetRefreshProvider,
+        null,
+        createElement(HookConsumer, {
+          onContext: ({ registerRefresh, unregisterRefresh, refreshAll }) => {
+            registerRefresh('sidebar-widget', () => {
+              refreshCount += 1;
+            });
+
+            refreshAll();
+            unregisterRefresh('sidebar-widget');
+            refreshAll();
+          },
+        })
+      )
+    );
+
+    expect(refreshCount).toBe(1);
+  });
+
+  it('throws outside the provider in non-production environments', () => {
+    env.NODE_ENV = 'test';
+
+    expect(() =>
+      renderToString(createElement(HookConsumer, { onContext: () => {} }))
+    ).toThrow('useWidgetRefresh must be used within WidgetRefreshProvider');
+  });
+
+  it('returns a no-op context outside the provider in production', () => {
+    env.NODE_ENV = 'production';
+
+    expect(() =>
+      renderToString(
+        createElement(HookConsumer, {
+          onContext: ({ registerRefresh, unregisterRefresh, refreshAll }) => {
+            registerRefresh('sidebar-widget', () => {
+              throw new Error('no-op context should not run refresh callbacks');
+            });
+            refreshAll();
+            unregisterRefresh('sidebar-widget');
+          },
+        })
+      )
+    ).not.toThrow();
+  });
+});

--- a/apps/web/src/contexts/WidgetRefreshContext.tsx
+++ b/apps/web/src/contexts/WidgetRefreshContext.tsx
@@ -8,6 +8,7 @@
 
 'use client';
 
+import { logger } from '@babylon/shared';
 import type { ReactNode } from 'react';
 import { createContext, useContext, useRef } from 'react';
 
@@ -27,6 +28,14 @@ interface WidgetRefreshContextType {
 const WidgetRefreshContext = createContext<WidgetRefreshContextType | null>(
   null
 );
+
+const noopWidgetRefreshContext: WidgetRefreshContextType = {
+  registerRefresh: () => {},
+  unregisterRefresh: () => {},
+  refreshAll: () => {},
+};
+
+let hasLoggedMissingWidgetRefreshProvider = false;
 
 /**
  * Widget refresh context provider component.
@@ -76,10 +85,24 @@ export function WidgetRefreshProvider({ children }: { children: ReactNode }) {
  */
 export function useWidgetRefresh() {
   const context = useContext(WidgetRefreshContext);
-  if (!context) {
+  if (context) {
+    return context;
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
     throw new Error(
       'useWidgetRefresh must be used within WidgetRefreshProvider'
     );
   }
-  return context;
+
+  if (!hasLoggedMissingWidgetRefreshProvider) {
+    hasLoggedMissingWidgetRefreshProvider = true;
+    logger.error(
+      'WidgetRefreshProvider missing in production, using no-op refresh context',
+      undefined,
+      'WidgetRefreshContext'
+    );
+  }
+
+  return noopWidgetRefreshContext;
 }


### PR DESCRIPTION
## Summary

- Prevent `useWidgetRefresh` from crashing production pages when a widget mounts outside `WidgetRefreshProvider` during an intermittent runtime mismatch.
- Keep the strict failure in non-production so provider wiring bugs still fail loudly in development and tests.
- Add focused coverage for provider, non-production failure, and production no-op behavior.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-462/investigate-intermittent-usewidgetrefresh-crash-on-notifications
- Sentry: https://babylon-0t.sentry.io/issues/7359680978/

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Non-goals / follow-ups

- None.

## Changes

- Return a no-op widget refresh context in production when the provider is unexpectedly missing, while logging the incident once for observability.
- Preserve the existing throw in non-production environments so incorrect provider wiring still fails fast locally.
- Add a focused unit test for provider registration, non-production failure, and production fallback behavior.

## Review guide

**Start here**
- `apps/web/src/contexts/WidgetRefreshContext.tsx`
- `apps/web/src/contexts/WidgetRefreshContext.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- The refresh context only powers widget refresh orchestration, so the production fallback degrades to no-op instead of crashing the whole page.
- This keeps the developer-facing invariant intact by still throwing outside production.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bunx @biomejs/biome check --write apps/web/src/contexts/WidgetRefreshContext.tsx apps/web/src/contexts/WidgetRefreshContext.test.ts`
2. `bun test ./apps/web/src/contexts/WidgetRefreshContext.test.ts`
3. Attempted `bunx tsc --noEmit --pretty false --project apps/web/tsconfig.json`, which still fails on pre-existing unrelated errors in `apps/web/src/app/api/feed/for-you/pipeline.ts`, `apps/web/src/app/api/telegram/webhook/route.ts`, `apps/web/src/components/model-pilot/ModelPilotInquiryForm.tsx`, `apps/web/src/components/shared/MobileHeader.tsx`, `apps/web/src/components/ui/tooltip.tsx`, `apps/web/src/lib/auth/privyAccessToken.test.ts`, `apps/web/src/lib/posthog/client.test.ts`, and `packages/api/src/services/achievement-service.ts`.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: ship normally; production now logs and no-ops instead of crashing when the widget refresh provider is unexpectedly missing.
- Rollback: revert this PR to restore the previous hard-throw behavior.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: runtime-only resilience fix for an existing client crash; no intended UI change.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
