### PR TITLE
fix(web): catch WalletConnect proposal expiry in Privy wallet actions

### DIFF
--- a/apps/web/src/components/settings/SecurityTab.tsx
+++ b/apps/web/src/components/settings/SecurityTab.tsx
@@ -1,9 +1,11 @@
 'use client';
 
+import { logger } from '@babylon/shared';
 import { usePrivy, useWallets } from '@privy-io/react-auth';
 import { Copy, ExternalLink, Key } from 'lucide-react';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
+import { isPrivyLinkFlowCancellationError } from '@/lib/privy-link-account-errors';
 
 /**
  * Security tab component for managing account security settings.
@@ -34,6 +36,84 @@ export function SecurityTab() {
   const copyToClipboard = async (text: string, label: string) => {
     await navigator.clipboard.writeText(text);
     toast.success(`${label} copied to clipboard`);
+  };
+
+  const getErrorMessage = (error: unknown) => {
+    if (typeof error === 'string') return error;
+    if (error instanceof Error) return error.message;
+    return String(error);
+  };
+
+  const handleWalletActionError = (
+    action: 'link' | 'unlink' | 'export',
+    error: unknown
+  ) => {
+    const errorMessage = getErrorMessage(error);
+
+    if (isPrivyLinkFlowCancellationError(error)) {
+      logger.info(
+        'Wallet action cancelled in Privy flow',
+        {
+          action,
+          error: errorMessage,
+          privyUserId: privyUser?.id,
+        },
+        'SecurityTab'
+      );
+      return;
+    }
+
+    logger.error(
+      'Wallet action failed in Privy flow',
+      {
+        action,
+        error: errorMessage,
+        privyUserId: privyUser?.id,
+      },
+      'SecurityTab'
+    );
+
+    switch (action) {
+      case 'link':
+        toast.error('Failed to link wallet. Please try again.');
+        return;
+      case 'unlink':
+        toast.error('Failed to unlink wallet. Please try again.');
+        return;
+      case 'export':
+        toast.error('Failed to export wallet. Please try again.');
+        return;
+    }
+  };
+
+  const handleLinkWallet = async () => {
+    if (!linkWallet) return;
+
+    try {
+      await linkWallet();
+    } catch (error) {
+      handleWalletActionError('link', error);
+    }
+  };
+
+  const handleExportWallet = async (address: string) => {
+    if (!exportWallet) return;
+
+    try {
+      await exportWallet({ address });
+    } catch (error) {
+      handleWalletActionError('export', error);
+    }
+  };
+
+  const handleUnlinkWallet = async (address: string) => {
+    if (!unlinkWallet) return;
+
+    try {
+      await unlinkWallet(address);
+    } catch (error) {
+      handleWalletActionError('unlink', error);
+    }
   };
 
   const getWalletTypeDisplay = (walletClientType: string) => {
@@ -108,7 +188,7 @@ export function SecurityTab() {
           </div>
           {linkWallet && (
             <button
-              onClick={linkWallet}
+              onClick={() => void handleLinkWallet()}
               className="rounded-lg bg-[#0066FF] px-4 py-2 font-medium text-primary-foreground text-sm hover:bg-[#0066FF]/90"
             >
               Link Wallet
@@ -161,9 +241,7 @@ export function SecurityTab() {
                   {isEmbeddedWallet(wallet.walletClientType) &&
                     exportWallet && (
                       <button
-                        onClick={() =>
-                          exportWallet({ address: wallet.address })
-                        }
+                        onClick={() => void handleExportWallet(wallet.address)}
                         className="flex items-center gap-1 rounded border border-border bg-background px-3 py-1.5 font-medium text-xs hover:bg-accent"
                         title="Export wallet private key"
                       >
@@ -173,7 +251,7 @@ export function SecurityTab() {
                     )}
                   {wallets.length > 1 && unlinkWallet && (
                     <button
-                      onClick={() => unlinkWallet(wallet.address)}
+                      onClick={() => void handleUnlinkWallet(wallet.address)}
                       className="rounded px-3 py-1.5 font-medium text-red-500 text-xs hover:bg-red-500/10"
                     >
                       Unlink

--- a/apps/web/src/lib/privy-link-account-errors.test.ts
+++ b/apps/web/src/lib/privy-link-account-errors.test.ts
@@ -20,6 +20,13 @@ describe('privy-link-account-errors', () => {
       ).toBe(true);
     });
 
+    it('treats WalletConnect proposal expiry as a handled cancellation', () => {
+      expect(isPrivyLinkFlowCancellationError('Proposal expired')).toBe(true);
+      expect(
+        isPrivyLinkFlowCancellationError(new Error('Proposal expired'))
+      ).toBe(true);
+    });
+
     it('detects the exited_link_flow string code from useLinkAccount onError', () => {
       expect(isPrivyLinkFlowCancellationError('exited_link_flow')).toBe(true);
     });

--- a/apps/web/src/lib/privy-link-account-errors.ts
+++ b/apps/web/src/lib/privy-link-account-errors.ts
@@ -34,6 +34,7 @@ export function isPrivyLinkFlowCancellationError(error: unknown): boolean {
 
   const message = getPrivyErrorMessage(error);
   if (message === 'Authentication cancelled') return true;
+  if (message === 'Proposal expired') return true;
 
   return false;
 }


### PR DESCRIPTION
## Summary

- Catch rejected Privy wallet actions in the settings security tab instead of letting them surface as unhandled client-side promise rejections.
- Treat WalletConnect `Proposal expired` rejections as a handled cancellation path, aligned with other Privy link-flow cancellations.
- Keep other wallet action failures user-safe with stable toasts and structured logs.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-460/bugauth-catch-walletconnect-proposal-expired-rejection-in-privy-flow
- Sentry: BABYLONAPP-9B

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [x] Other: app-level unit tests in `apps/web`

## Non-goals / follow-ups

- None.

## Changes

- Extend the existing Privy link-flow cancellation helper to recognize WalletConnect `Proposal expired` rejections.
- Wrap `linkWallet`, `unlinkWallet`, and `exportWallet` in `SecurityTab` so rejected Privy promises are handled explicitly.
- Log handled cancellations at `info` level and unexpected wallet action failures at `error` level.
- Add focused unit coverage for the new `Proposal expired` classification.

## Review guide

**Start here**
- `apps/web/src/components/settings/SecurityTab.tsx`
- `apps/web/src/lib/privy-link-account-errors.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- I intentionally did not add a global `unhandledrejection` listener because the only proven callsite in the current codebase is the settings wallet actions, and the repo already centralizes Privy error classification in the existing helper.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bun test apps/web/src/lib/privy-link-account-errors.test.ts`
2. `bun x biome check apps/web/src/lib/privy-link-account-errors.ts apps/web/src/lib/privy-link-account-errors.test.ts apps/web/src/components/settings/SecurityTab.tsx`
3. Attempted `bun x tsc -p apps/web/tsconfig.typecheck.json --noEmit`, but it currently fails for unrelated pre-existing config/environment issues: missing type definition files for `@serwist/next/typings` and `bun-types`, plus the existing `baseUrl` deprecation error from TypeScript 6.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: ship normally with the next production release.
- Rollback: revert this PR to restore the previous wallet action handlers.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: this change only adds error handling around existing Privy wallet actions in Settings; the UI layout and visuals are unchanged.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
