### PR TITLE
fix(web): catch Privy access-token rejections in chats

### DIFF
--- a/apps/web/src/components/chats/hooks/useChatPage.ts
+++ b/apps/web/src/components/chats/hooks/useChatPage.ts
@@ -1,7 +1,6 @@
 'use client';
 
 import { logger } from '@babylon/shared';
-import { usePrivy } from '@privy-io/react-auth';
 import { useRouter } from 'next/navigation';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAuth } from '@/hooks/useAuth';
@@ -18,9 +17,8 @@ import type {
 
 export function useChatPage() {
   const router = useRouter();
-  const { ready, authenticated } = useAuth();
+  const { ready, authenticated, getAccessToken } = useAuth();
   const { user } = useAuthStore();
-  const { getAccessToken } = usePrivy();
 
   // UI state
   const [activeFilter, setActiveFilter] = useState<ChatFilter>('all');

--- a/apps/web/src/hooks/useUnreadMessages.ts
+++ b/apps/web/src/hooks/useUnreadMessages.ts
@@ -1,4 +1,3 @@
-import { usePrivy } from '@privy-io/react-auth';
 import { useEffect, useState } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 
@@ -44,8 +43,7 @@ interface UnreadCounts {
  * ```
  */
 export function useUnreadMessages() {
-  const { authenticated } = useAuth();
-  const { getAccessToken } = usePrivy();
+  const { authenticated, getAccessToken } = useAuth();
   const [counts, setCounts] = useState<UnreadCounts>({
     pendingDMs: 0,
     unreadMessages: 0,

--- a/apps/web/src/lib/auth/privyAccessToken.test.ts
+++ b/apps/web/src/lib/auth/privyAccessToken.test.ts
@@ -20,13 +20,35 @@ describe('privyAccessToken', () => {
 
     expect(onError).toHaveBeenCalledTimes(1);
     expect(onError.mock.calls[0]?.[0]).toBeInstanceOf(Error);
-    expect(onError.mock.calls[0]?.[0]?.message).toBe('null');
+    expect(onError.mock.calls[0]?.[0]?.message).toBe(
+      'An unknown error occurred'
+    );
   });
 
   it('returns null when onError is not provided', async () => {
     await expect(
       getPrivyAccessTokenSafely(() => Promise.reject(new Error('test')))
     ).resolves.toBeNull();
+  });
+
+  it('normalizes object-shaped Privy rejections before reporting them', async () => {
+    const onError = mock(() => {});
+
+    await expect(
+      getPrivyAccessTokenSafely(
+        () =>
+          Promise.reject({
+            code: 'privy_access_token_rejected',
+            data: { reason: 'session_expired' },
+            message: 'Session expired',
+          }),
+        { onError }
+      )
+    ).resolves.toBeNull();
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]).toBeInstanceOf(Error);
+    expect(onError.mock.calls[0]?.[0]?.message).toBe('Session expired');
   });
 
   it('retries retryable getter failures before succeeding', async () => {

--- a/apps/web/src/lib/auth/privyAccessToken.ts
+++ b/apps/web/src/lib/auth/privyAccessToken.ts
@@ -1,3 +1,5 @@
+import { extractErrorMessage } from '@babylon/shared';
+
 const RETRYABLE_PRIVY_ERROR_MESSAGES = [
   'failed to fetch',
   'fetch failed',
@@ -26,6 +28,10 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => globalThis.setTimeout(resolve, ms));
 }
 
+function normalizePrivyAccessTokenError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(extractErrorMessage(error));
+}
+
 export function isRetryablePrivyAccessTokenError(error: unknown): boolean {
   if (error instanceof TypeError) {
     return error.message.toLowerCase().includes('fetch');
@@ -38,8 +44,7 @@ export function isRetryablePrivyAccessTokenError(error: unknown): boolean {
     }
   }
 
-  const message =
-    error instanceof Error ? error.message.toLowerCase() : String(error);
+  const message = normalizePrivyAccessTokenError(error).message.toLowerCase();
 
   return RETRYABLE_PRIVY_ERROR_MESSAGES.some((pattern) =>
     message.includes(pattern)
@@ -64,13 +69,13 @@ export async function getPrivyAccessTokenWithRetry(
     try {
       return await getAccessToken();
     } catch (error) {
-      lastError = error instanceof Error ? error : new Error(String(error));
+      lastError = normalizePrivyAccessTokenError(error);
 
       if (
         !isRetryablePrivyAccessTokenError(error) ||
         attempt === maxAttempts - 1
       ) {
-        throw error;
+        throw lastError;
       }
 
       const delayMs = Math.min(
@@ -94,7 +99,7 @@ export async function getPrivyAccessTokenSafely(
   try {
     return await getPrivyAccessTokenWithRetry(getAccessToken, retryOptions);
   } catch (error) {
-    onError?.(error instanceof Error ? error : new Error(String(error)));
+    onError?.(normalizePrivyAccessTokenError(error));
     return null;
   }
 }


### PR DESCRIPTION
## Summary

- Route `/chats` bootstrap and unread polling through the existing safe auth path so Privy access-token rejections no longer escape as unhandled promise rejections.
- Normalize object-shaped Privy rejections into real `Error` instances so logs preserve the provider message instead of `[object Object]`.
- Add focused auth-token helper coverage for the production rejection shape reported by Sentry.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-457/bugchats-catch-privy-access-token-rejections-during-chat-bootstrap
- Sentry: https://babylon-0t.sentry.io/issues/7358988812/

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [x] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Non-goals / follow-ups

- None.

## Changes

- Switched `useChatPage` and `useUnreadMessages` from raw `usePrivy().getAccessToken()` calls to `useAuth().getAccessToken()` so chats reuse the existing retry + null-safe auth flow.
- Updated the shared Privy token helper to normalize non-`Error` rejections with `extractErrorMessage()` before retry classification and error reporting.
- Added a regression test for the object-shaped Privy rejection payload seen in production.

## Review guide

**Start here**
- `apps/web/src/components/chats/hooks/useChatPage.ts`
- `apps/web/src/hooks/useUnreadMessages.ts`
- `apps/web/src/lib/auth/privyAccessToken.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- The change intentionally reuses existing auth behavior instead of adding another chats-specific wrapper.
- No API contract changes; this is limited to client-side token retrieval and logging normalization.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bun x biome check apps/web/src/lib/auth/privyAccessToken.ts apps/web/src/lib/auth/privyAccessToken.test.ts apps/web/src/components/chats/hooks/useChatPage.ts apps/web/src/hooks/useUnreadMessages.ts`
2. `bun test apps/web/src/lib/auth/privyAccessToken.test.ts packages/testing/unit/privy-access-token-retry.test.ts --preload ./packages/testing/unit/preload.ts`
3. No browser demo recorded; the change is limited to client auth error handling and has no visual delta.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: ship normally; monitor Sentry for BAB-457 and `/chats` bootstrap errors.
- Rollback: revert this PR.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Client-side auth error-handling fix only; no UI or copy changes.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
