### PR TITLE
fix(web): handle Privy MetaMask login failures

### DIFF
--- a/apps/web/src/components/auth/LoginModal.tsx
+++ b/apps/web/src/components/auth/LoginModal.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { logger } from '@babylon/shared';
-import { usePrivy } from '@privy-io/react-auth';
 import { useEffect, useRef } from 'react';
+import { useAuth } from '@/hooks/useAuth';
 
 /**
  * Login modal component that triggers Privy's native login modal.
@@ -40,7 +40,7 @@ export function LoginModal({
   title,
   message,
 }: LoginModalProps) {
-  const { login, authenticated, ready } = usePrivy();
+  const { login, authenticated, ready } = useAuth();
   const attemptedLoginRef = useRef(false);
 
   // Close modal when user logs in
@@ -59,9 +59,12 @@ export function LoginModal({
 
     if (!attemptedLoginRef.current) {
       attemptedLoginRef.current = true;
-      login();
+      void Promise.resolve(login()).finally(() => {
+        attemptedLoginRef.current = false;
+        onClose();
+      });
     }
-  }, [isOpen, ready, authenticated, login]);
+  }, [isOpen, ready, authenticated, login, onClose]);
 
   // Log title/message if provided for debugging
   useEffect(() => {

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -7,7 +7,13 @@ import {
   useWallets,
 } from '@privy-io/react-auth';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { toast } from 'sonner';
 import { getPrivyAccessTokenWithRetry } from '@/lib/auth/privyAccessToken';
+import {
+  getPrivyErrorMessage,
+  getPrivyLoginErrorMessage,
+  isPrivyAuthFlowCancellationError,
+} from '@/lib/privy-link-account-errors';
 import { type User, useAuthStore } from '@/stores/authStore';
 import { apiFetch } from '@/utils/api-fetch';
 import {
@@ -95,7 +101,7 @@ export function useAuth(): UseAuthReturn {
     ready,
     authenticated,
     user: privyUser,
-    login,
+    login: privyLogin,
     logout,
     getAccessToken: getPrivyAccessToken,
   } = usePrivy();
@@ -646,6 +652,26 @@ export function useAuth(): UseAuthReturn {
     await fetchCurrentUser();
   };
 
+  const handleLogin = useCallback(async () => {
+    try {
+      await privyLogin();
+    } catch (error) {
+      if (isPrivyAuthFlowCancellationError(error)) {
+        logger.info('Privy login cancelled by user', undefined, 'useAuth');
+        return;
+      }
+
+      logger.warn(
+        'Privy login failed',
+        {
+          error: getPrivyErrorMessage(error) ?? String(error),
+        },
+        'useAuth'
+      );
+      toast.error(getPrivyLoginErrorMessage(error));
+    }
+  }, [privyLogin]);
+
   const handleLogout = async () => {
     // Call Privy's logout first to clear Privy state
     await logout();
@@ -706,7 +732,7 @@ export function useAuth(): UseAuthReturn {
     embeddedWalletAddress,
     embeddedWalletReady,
     needsOnboarding,
-    login,
+    login: handleLogin,
     logout: handleLogout,
     refresh,
     getAccessToken,

--- a/apps/web/src/lib/privy-link-account-errors.test.ts
+++ b/apps/web/src/lib/privy-link-account-errors.test.ts
@@ -1,11 +1,52 @@
 import { describe, expect, it } from 'bun:test';
 import {
+  getPrivyErrorMessage,
+  getPrivyLoginErrorMessage,
+  isPrivyAuthFlowCancellationError,
   isPrivyLinkFlowCancellationError,
   isPrivyTwitterLinkConflictError,
+  PRIVY_LOGIN_ERROR_MESSAGES,
   X_ACCOUNT_ALREADY_LINKED_MESSAGE,
 } from './privy-link-account-errors';
 
 describe('privy-link-account-errors', () => {
+  describe('getPrivyErrorMessage', () => {
+    it('extracts a string message from an Error instance', () => {
+      expect(
+        getPrivyErrorMessage(new Error('Failed to connect to MetaMask'))
+      ).toBe('Failed to connect to MetaMask');
+    });
+
+    it('returns null for values without a string message', () => {
+      expect(getPrivyErrorMessage({ code: 'exited_auth_flow' })).toBeNull();
+      expect(getPrivyErrorMessage(null)).toBeNull();
+    });
+  });
+
+  describe('isPrivyAuthFlowCancellationError', () => {
+    it('detects the exited_auth_flow string code', () => {
+      expect(isPrivyAuthFlowCancellationError('exited_auth_flow')).toBe(true);
+    });
+
+    it('treats the Authentication cancelled message as a user cancellation', () => {
+      expect(isPrivyAuthFlowCancellationError('Authentication cancelled')).toBe(
+        true
+      );
+      expect(
+        isPrivyAuthFlowCancellationError(new Error('Authentication cancelled'))
+      ).toBe(true);
+    });
+
+    it('detects a PrivyClientError-shaped object with code exited_link_flow', () => {
+      expect(
+        isPrivyAuthFlowCancellationError({
+          code: 'exited_link_flow',
+          message: 'User exited link account flow',
+        })
+      ).toBe(true);
+    });
+  });
+
   describe('isPrivyLinkFlowCancellationError', () => {
     it('detects the exited_auth_flow string code from useLinkAccount onError', () => {
       expect(isPrivyLinkFlowCancellationError('exited_auth_flow')).toBe(true);
@@ -78,6 +119,23 @@ describe('privy-link-account-errors', () => {
         )
       ).toBe(false);
       expect(isPrivyTwitterLinkConflictError(null)).toBe(false);
+    });
+  });
+
+  describe('getPrivyLoginErrorMessage', () => {
+    it('maps the MetaMask connection failure to a user-safe message', () => {
+      expect(
+        getPrivyLoginErrorMessage(new Error('Failed to connect to MetaMask'))
+      ).toBe(PRIVY_LOGIN_ERROR_MESSAGES.METAMASK);
+    });
+
+    it('falls back to a generic message for other login failures', () => {
+      expect(
+        getPrivyLoginErrorMessage(new Error('Wallet provider timeout'))
+      ).toBe(PRIVY_LOGIN_ERROR_MESSAGES.DEFAULT);
+      expect(getPrivyLoginErrorMessage(null)).toBe(
+        PRIVY_LOGIN_ERROR_MESSAGES.DEFAULT
+      );
     });
   });
 

--- a/apps/web/src/lib/privy-link-account-errors.ts
+++ b/apps/web/src/lib/privy-link-account-errors.ts
@@ -1,7 +1,13 @@
 export const X_ACCOUNT_ALREADY_LINKED_MESSAGE =
   'This X account is already linked to another user';
 
-function getPrivyErrorMessage(error: unknown): string | null {
+export const PRIVY_LOGIN_ERROR_MESSAGES = {
+  DEFAULT: 'Failed to log in. Please try again.',
+  METAMASK:
+    'Failed to connect to MetaMask. Please try again or choose a different login method.',
+} as const;
+
+export function getPrivyErrorMessage(error: unknown): string | null {
   if (typeof error === 'string') return error;
 
   if (
@@ -17,9 +23,9 @@ function getPrivyErrorMessage(error: unknown): string | null {
 }
 
 /**
- * Returns true when the Privy link-account flow was cancelled by the user.
+ * Returns true when the Privy auth flow was cancelled by the user.
  */
-export function isPrivyLinkFlowCancellationError(error: unknown): boolean {
+export function isPrivyAuthFlowCancellationError(error: unknown): boolean {
   if (error === 'exited_auth_flow' || error === 'exited_link_flow') return true;
   if (error === 'Authentication cancelled') return true;
 
@@ -36,6 +42,27 @@ export function isPrivyLinkFlowCancellationError(error: unknown): boolean {
   if (message === 'Authentication cancelled') return true;
 
   return false;
+}
+
+/**
+ * Returns true when the Privy link-account flow was cancelled by the user.
+ */
+export function isPrivyLinkFlowCancellationError(error: unknown): boolean {
+  return isPrivyAuthFlowCancellationError(error);
+}
+
+/**
+ * Returns a user-safe message for handled Privy login failures.
+ */
+export function getPrivyLoginErrorMessage(error: unknown): string {
+  const message = getPrivyErrorMessage(error)?.toLowerCase();
+  if (!message) return PRIVY_LOGIN_ERROR_MESSAGES.DEFAULT;
+
+  if (message.includes('failed to connect to metamask')) {
+    return PRIVY_LOGIN_ERROR_MESSAGES.METAMASK;
+  }
+
+  return PRIVY_LOGIN_ERROR_MESSAGES.DEFAULT;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Handle Privy login rejections so MetaMask connection failures no longer bubble up as unhandled client-side errors.
- Reuse the existing Privy error classification pattern to treat user cancellations as non-errors and show a safe toast for real login failures.
- Close the global login modal after each login attempt so users can immediately retry after a cancellation or wallet connection failure.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Linear: https://linear.app/eliza-labs/issue/BAB-458/bugauth-handle-metamask-connect-failures-in-privy-login-flow
- Sentry: https://babylon-0t.sentry.io/issues/7359163059/

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Non-goals / follow-ups
- None.

## Changes
- Generalize the existing Privy auth/link error helper so login flows can reuse the same cancellation detection and safe message mapping.
- Wrap `useAuth().login` so Privy login failures are handled locally instead of surfacing as unhandled promise rejections.
- Route `LoginModal` through the safe login wrapper and always close the modal after an attempt completes.
- Add focused tests for Privy auth cancellation detection and login error message mapping.

## Review guide
**Start here**
- `apps/web/src/hooks/useAuth.ts`
- `apps/web/src/components/auth/LoginModal.tsx`
- `apps/web/src/lib/privy-link-account-errors.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- The fix intentionally stays client-side and does not change the configured login methods or Privy provider setup.
- The modal close behavior change is deliberate so a cancelled/failed attempt does not leave the wrapper stuck in an already-open state.

## Test plan
**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bunx @biomejs/biome check --write apps/web/src/lib/privy-link-account-errors.ts apps/web/src/lib/privy-link-account-errors.test.ts apps/web/src/hooks/useAuth.ts apps/web/src/components/auth/LoginModal.tsx`
2. `bun test apps/web/src/lib/privy-link-account-errors.test.ts`
3. Attempted `bun x tsc --noEmit --pretty false -p tsconfig.json --ignoreDeprecations 6.0`, but the repo currently fails broadly because local dependencies/types are not installed in this environment (for example missing `react`, `lucide-react`, and JSX runtime types).
4. Manual browser verification not run in this session.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: deploy normally.
- Rollback: revert this PR.

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

## Screenshots / recordings (UI)
### Option B: No visual changes
- Reason: client-side auth error handling fix with no intended visual/UI layout changes.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [ ] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
