### PR TITLE
fix(web): sanitize feed repost card mapping

### DIFF
--- a/apps/web/src/app/feed/components/MixedFeedList.tsx
+++ b/apps/web/src/app/feed/components/MixedFeedList.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import type { CommentPreviewData, FeedPost } from '@babylon/shared';
+import type { FeedPost } from '@babylon/shared';
 import { useRouter } from 'next/navigation';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { NewMarketEntry } from '@/app/api/feed/new-markets/route';
 import type { NarrativeStory } from '@/app/feed/types/narrative';
 import { mergeChronologically } from '@/app/feed/utils/feedAlgorithms';
+import { toFeedPostCardData } from '@/app/feed/utils/postMappers';
 import { ArticleCard } from '@/components/articles/ArticleCard';
-import type { PostCardProps } from '@/components/posts/PostCard';
 import { PostCard } from '@/components/posts/PostCard';
 import { InviteFriendsBanner } from '@/components/shared/InviteFriendsBanner';
 import { useAuthStore } from '@/stores/authStore';
@@ -133,53 +133,7 @@ export const MixedFeedList = memo(function MixedFeedList({
         const showBannerAfterThisPost =
           !bannerDismissed && i === bannerInterval.current - 1;
 
-        const postData = {
-          id: post.id,
-          type: ('type' in post ? post.type : undefined) || undefined,
-          content: post.content,
-          articleTitle:
-            ('articleTitle' in post ? post.articleTitle : null) || null,
-          byline: ('byline' in post ? post.byline : null) || null,
-          biasScore: ('biasScore' in post ? post.biasScore : null) ?? null,
-          category: ('category' in post ? post.category : null) || null,
-          authorId,
-          authorName,
-          authorUsername:
-            ('authorUsername' in post ? post.authorUsername : null) || null,
-          authorProfileImageUrl:
-            'authorProfileImageUrl' in post ? post.authorProfileImageUrl : null,
-          timestamp: post.timestamp,
-          likeCount:
-            ('likeCount' in post ? (post.likeCount as number) : 0) || 0,
-          commentCount:
-            ('commentCount' in post ? (post.commentCount as number) : 0) || 0,
-          shareCount:
-            ('shareCount' in post ? (post.shareCount as number) : 0) || 0,
-          isLiked:
-            ('isLiked' in post ? (post.isLiked as boolean) : false) || false,
-          isShared:
-            ('isShared' in post ? (post.isShared as boolean) : false) || false,
-          isRepost:
-            ('isRepost' in post ? (post.isRepost as boolean) : false) || false,
-          isQuote:
-            ('isQuote' in post ? (post.isQuote as boolean) : false) || false,
-          quoteComment:
-            ('quoteComment' in post
-              ? (post.quoteComment as string | null)
-              : null) || null,
-          originalPostId:
-            ('originalPostId' in post
-              ? (post.originalPostId as string | null)
-              : null) || null,
-          originalPost:
-            ('originalPost' in post
-              ? (post.originalPost as PostCardProps['post']['originalPost'])
-              : null) || null,
-          commentPreviews:
-            'commentPreviews' in post
-              ? (post.commentPreviews as CommentPreviewData[])
-              : undefined,
-        };
+        const postData = toFeedPostCardData(post, authorName);
 
         return (
           <div key={`post-wrapper-${post.id}-${i}`}>

--- a/apps/web/src/app/feed/components/MixedFeedList.tsx
+++ b/apps/web/src/app/feed/components/MixedFeedList.tsx
@@ -146,10 +146,10 @@ export const MixedFeedList = memo(function MixedFeedList({
                 showCommentInputBar={false}
                 onCommentClick={() => {
                   const postId =
-                    post.isRepost &&
-                    !post.isQuote &&
-                    post.originalPostId != null
-                      ? post.originalPostId
+                    postData.isRepost &&
+                    !postData.isQuote &&
+                    postData.originalPostId != null
+                      ? postData.originalPostId
                       : post.id;
                   router.push(`/post/${postId}`);
                 }}

--- a/apps/web/src/app/feed/components/PostList.tsx
+++ b/apps/web/src/app/feed/components/PostList.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import type { CommentPreviewData, FeedPost } from '@babylon/shared';
+import type { FeedPost } from '@babylon/shared';
 import { useRouter } from 'next/navigation';
 import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { toFeedPostCardData } from '@/app/feed/utils/postMappers';
 import { ArticleCard } from '@/components/articles/ArticleCard';
-import type { PostCardProps } from '@/components/posts/PostCard';
 import { PostCard } from '@/components/posts/PostCard';
 import { InviteFriendsBanner } from '@/components/shared/InviteFriendsBanner';
 import { useAuthStore } from '@/stores/authStore';
@@ -95,53 +95,7 @@ export const PostList = memo(function PostList({
         const showBannerAfterThisPost =
           !bannerDismissed && i === bannerInterval.current - 1;
 
-        const postData = {
-          id: post.id,
-          type: ('type' in post ? post.type : undefined) || undefined,
-          content: post.content,
-          articleTitle:
-            ('articleTitle' in post ? post.articleTitle : null) || null,
-          byline: ('byline' in post ? post.byline : null) || null,
-          biasScore: ('biasScore' in post ? post.biasScore : null) ?? null,
-          category: ('category' in post ? post.category : null) || null,
-          authorId,
-          authorName,
-          authorUsername:
-            ('authorUsername' in post ? post.authorUsername : null) || null,
-          authorProfileImageUrl:
-            'authorProfileImageUrl' in post ? post.authorProfileImageUrl : null,
-          timestamp: post.timestamp,
-          likeCount:
-            ('likeCount' in post ? (post.likeCount as number) : 0) || 0,
-          commentCount:
-            ('commentCount' in post ? (post.commentCount as number) : 0) || 0,
-          shareCount:
-            ('shareCount' in post ? (post.shareCount as number) : 0) || 0,
-          isLiked:
-            ('isLiked' in post ? (post.isLiked as boolean) : false) || false,
-          isShared:
-            ('isShared' in post ? (post.isShared as boolean) : false) || false,
-          isRepost:
-            ('isRepost' in post ? (post.isRepost as boolean) : false) || false,
-          isQuote:
-            ('isQuote' in post ? (post.isQuote as boolean) : false) || false,
-          quoteComment:
-            ('quoteComment' in post
-              ? (post.quoteComment as string | null)
-              : null) || null,
-          originalPostId:
-            ('originalPostId' in post
-              ? (post.originalPostId as string | null)
-              : null) || null,
-          originalPost:
-            ('originalPost' in post
-              ? (post.originalPost as PostCardProps['post']['originalPost'])
-              : null) || null,
-          commentPreviews:
-            'commentPreviews' in post
-              ? (post.commentPreviews as CommentPreviewData[])
-              : undefined,
-        };
+        const postData = toFeedPostCardData(post, authorName);
 
         return (
           <div key={`post-wrapper-${post.id}-${i}`}>

--- a/apps/web/src/app/feed/components/PostList.tsx
+++ b/apps/web/src/app/feed/components/PostList.tsx
@@ -109,10 +109,10 @@ export const PostList = memo(function PostList({
                 onCommentClick={() => {
                   // For simple reposts, comments live on the original post
                   const postId =
-                    post.isRepost &&
-                    !post.isQuote &&
-                    post.originalPostId != null
-                      ? post.originalPostId
+                    postData.isRepost &&
+                    !postData.isQuote &&
+                    postData.originalPostId != null
+                      ? postData.originalPostId
                       : post.id;
                   router.push(`/post/${postId}`);
                 }}

--- a/apps/web/src/app/feed/utils/postMappers.ts
+++ b/apps/web/src/app/feed/utils/postMappers.ts
@@ -1,12 +1,97 @@
 /**
  * Post data transformation utilities for the feed.
  *
- * `NarrativePost` (from the feed ranking APIs) has a slightly different shape
- * than the props expected by `PostCard` and `ArticleCard`. These helpers do the
- * mapping in one place so `ForYouFeedList` and `MixedFeedList` stay in sync.
+ * `NarrativePost` (from the feed ranking APIs) and `FeedPost` (from `/api/posts`)
+ * both need to be mapped into the shape `PostCard` expects. Keeping this logic in
+ * one place prevents drift between feed surfaces and lets us sanitize malformed
+ * repost payloads before they reach the client renderer.
  */
 
-import type { NarrativePost } from '@babylon/shared';
+import type { FeedPost, NarrativePost } from '@babylon/shared';
+
+type FeedLikePost = FeedPost | NarrativePost;
+
+function hasText(value: string | null | undefined): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function normalizeOriginalPost(post: FeedLikePost) {
+  const rawOriginalPostId = hasText(post.originalPostId)
+    ? post.originalPostId
+    : null;
+  if (!rawOriginalPostId || rawOriginalPostId === post.id) {
+    return {
+      originalPostId: null,
+      originalPost: null,
+    };
+  }
+
+  if (post.originalPost) {
+    const originalId = hasText(post.originalPost.id)
+      ? post.originalPost.id
+      : rawOriginalPostId;
+    if (originalId === post.id) {
+      return {
+        originalPostId: null,
+        originalPost: null,
+      };
+    }
+
+    return {
+      originalPostId: originalId,
+      originalPost: {
+        id: originalId,
+        content: post.originalPost.content,
+        authorId: post.originalPost.authorId,
+        authorName: post.originalPost.authorName,
+        authorUsername: post.originalPost.authorUsername ?? null,
+        authorProfileImageUrl: post.originalPost.authorProfileImageUrl ?? null,
+        timestamp: post.originalPost.timestamp,
+      },
+    };
+  }
+
+  if (
+    'originalContent' in post &&
+    (hasText(post.originalContent) ||
+      hasText(post.originalAuthorId) ||
+      hasText(post.originalAuthorName))
+  ) {
+    return {
+      originalPostId: rawOriginalPostId,
+      originalPost: {
+        id: rawOriginalPostId,
+        content: post.originalContent ?? '',
+        authorId: post.originalAuthorId ?? '',
+        authorName: post.originalAuthorName ?? post.originalAuthorId ?? '',
+        authorUsername: post.originalAuthorUsername ?? null,
+        authorProfileImageUrl: post.originalAuthorProfileImageUrl ?? null,
+        timestamp: post.timestamp,
+      },
+    };
+  }
+
+  return {
+    originalPostId: rawOriginalPostId,
+    originalPost: null,
+  };
+}
+
+function normalizeRepostFields(post: FeedLikePost) {
+  const { originalPostId, originalPost } = normalizeOriginalPost(post);
+  const isRepost =
+    Boolean(post.isRepost) || originalPostId !== null || originalPost !== null;
+  const isQuote =
+    isRepost && (Boolean(post.isQuote) || hasText(post.quoteComment));
+
+  return {
+    isRepost,
+    isQuote,
+    quoteComment: post.quoteComment ?? null,
+    originalPostId,
+    originalPost,
+  };
+}
 
 export function toPostCardData(post: NarrativePost) {
   return {
@@ -25,12 +110,31 @@ export function toPostCardData(post: NarrativePost) {
     shareCount: post.shareCount,
     isLiked: post.isLiked,
     isShared: post.isShared,
-    // Repost fields — passed through so PostCard renders the original content
-    isRepost: post.isRepost ?? false,
-    isQuote: post.isQuote ?? false,
-    quoteComment: post.quoteComment ?? null,
-    originalPostId: post.originalPostId ?? null,
-    originalPost: post.originalPost ?? null,
+    ...normalizeRepostFields(post),
+  };
+}
+
+export function toFeedPostCardData(post: FeedPost, authorName: string) {
+  return {
+    id: post.id,
+    type: post.type ?? undefined,
+    content: post.content,
+    articleTitle: post.articleTitle ?? null,
+    byline: post.byline ?? null,
+    biasScore: post.biasScore ?? null,
+    category: post.category ?? null,
+    authorId: post.authorId ?? post.author,
+    authorName,
+    authorUsername: post.authorUsername ?? null,
+    authorProfileImageUrl: post.authorProfileImageUrl ?? null,
+    timestamp: post.timestamp,
+    likeCount: post.likeCount ?? 0,
+    commentCount: post.commentCount ?? 0,
+    shareCount: post.shareCount ?? 0,
+    isLiked: post.isLiked ?? false,
+    isShared: post.isShared ?? false,
+    commentPreviews: post.commentPreviews,
+    ...normalizeRepostFields(post),
   };
 }
 

--- a/packages/testing/unit/feed-post-mappers.test.ts
+++ b/packages/testing/unit/feed-post-mappers.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'bun:test';
+import type { FeedPost, NarrativePost } from '@babylon/shared';
+import {
+  toFeedPostCardData,
+  toPostCardData,
+} from '../../../apps/web/src/app/feed/utils/postMappers';
+
+const BASE_TIMESTAMP = '2026-03-30T12:00:00.000Z';
+
+function makeFeedPost(overrides: Partial<FeedPost> = {}): FeedPost {
+  return {
+    id: 'post-1',
+    author: 'user-1',
+    authorId: 'user-1',
+    authorName: 'Feed User',
+    content: 'Hello world',
+    timestamp: BASE_TIMESTAMP,
+    ...overrides,
+  };
+}
+
+function makeNarrativePost(
+  overrides: Partial<NarrativePost> = {}
+): NarrativePost {
+  return {
+    id: 'story-post-1',
+    content: 'Story post',
+    fullContent: null,
+    articleTitle: null,
+    category: null,
+    imageUrl: null,
+    type: null,
+    timestamp: BASE_TIMESTAMP,
+    authorId: 'actor-1',
+    authorName: 'Actor One',
+    authorUsername: null,
+    authorProfileImageUrl: null,
+    likeCount: 0,
+    commentCount: 0,
+    shareCount: 0,
+    isLiked: false,
+    isShared: false,
+    relatedQuestion: null,
+    ...overrides,
+  };
+}
+
+describe('feed post mappers', () => {
+  it('drops self-referential originals before they reach PostCard', () => {
+    const post = makeFeedPost({
+      isRepost: true,
+      originalPostId: 'post-1',
+      originalPost: {
+        id: 'post-1',
+        content: 'Recursive original',
+        authorId: 'user-1',
+        authorName: 'Feed User',
+        authorUsername: 'feeduser',
+        authorProfileImageUrl: null,
+        timestamp: BASE_TIMESTAMP,
+      },
+    });
+
+    const result = toFeedPostCardData(post, 'Feed User');
+
+    expect(result.isRepost).toBe(true);
+    expect(result.originalPostId).toBeNull();
+    expect(result.originalPost).toBeNull();
+  });
+
+  it('rebuilds originalPost from flat repost metadata when nested data is absent', () => {
+    const post = makeFeedPost({
+      isRepost: true,
+      isQuote: true,
+      quoteComment: 'Worth sharing',
+      originalPostId: 'original-1',
+      originalAuthorId: 'author-2',
+      originalAuthorName: 'Original Author',
+      originalAuthorUsername: 'original-author',
+      originalAuthorProfileImageUrl: '/avatars/original.png',
+      originalContent: 'Original content',
+    });
+
+    const result = toFeedPostCardData(post, 'Feed User');
+
+    expect(result.isRepost).toBe(true);
+    expect(result.isQuote).toBe(true);
+    expect(result.originalPostId).toBe('original-1');
+    expect(result.originalPost).toEqual({
+      id: 'original-1',
+      content: 'Original content',
+      authorId: 'author-2',
+      authorName: 'Original Author',
+      authorUsername: 'original-author',
+      authorProfileImageUrl: '/avatars/original.png',
+      timestamp: BASE_TIMESTAMP,
+    });
+  });
+
+  it('normalizes falsy string quote flags from feed payloads to booleans', () => {
+    const post = makeFeedPost({
+      isRepost: true,
+      isQuote: '' as unknown as boolean,
+      originalPostId: 'original-1',
+      originalPost: {
+        id: 'original-1',
+        content: 'Original content',
+        authorId: 'author-2',
+        authorName: 'Original Author',
+        authorUsername: null,
+        authorProfileImageUrl: null,
+        timestamp: BASE_TIMESTAMP,
+      },
+    });
+
+    const result = toFeedPostCardData(post, 'Feed User');
+
+    expect(result.isRepost).toBe(true);
+    expect(result.isQuote).toBe(false);
+  });
+
+  it('sanitizes malformed narrative reposts with self-pointing originals too', () => {
+    const post = makeNarrativePost({
+      isRepost: true,
+      originalPostId: 'story-post-1',
+      originalPost: {
+        id: 'story-post-1',
+        content: 'Recursive original',
+        authorId: 'actor-1',
+        authorName: 'Actor One',
+        authorUsername: null,
+        authorProfileImageUrl: null,
+        timestamp: BASE_TIMESTAMP,
+      },
+    });
+
+    const result = toPostCardData(post);
+
+    expect(result.originalPostId).toBeNull();
+    expect(result.originalPost).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Centralize `FeedPost -> PostCard` mapping for the Latest and Following feed surfaces instead of rebuilding the props inline in two components.
- Sanitize malformed repost payloads before render by flattening `originalPost` to a single safe layer and dropping self-referential originals.
- Rebuild `originalPost` from the existing flat repost metadata when nested data is missing so optimistic quote posts and partial payloads stay render-safe.

## Type

- [x] Bug fix

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-455/bugfeed-investigate-max-call-stack-crash-on-feed
- Sentry: https://babylon-0t.sentry.io/issues/7357854185/

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)

## Non-goals / follow-ups

- None.

## Changes

- Add a shared feed post mapper for Latest/Following so repost normalization lives in one place.
- Normalize stringly/falsy repost flags from feed payloads before they reach `PostCard`.
- Drop self-pointing `originalPostId` / `originalPost` pairs so malformed repost payloads cannot keep bouncing through repost-specific rendering.
- Add a regression test covering self-referential reposts, flat optimistic repost metadata, and falsy quote flags.

## Review guide

**Start here**
- `apps/web/src/app/feed/utils/postMappers.ts`
- `packages/testing/unit/feed-post-mappers.test.ts`

**Risk**
- [x] Low

**Notes for reviewers**
- I could not recover the original Sentry stack trace from this machine, so the fix targets the most credible client-side data-shape hazard in the affected feed path: duplicated raw repost mapping that passed unsanitized `originalPost` payloads straight into `PostCard`.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bun x @biomejs/biome check --write apps/web/src/app/feed/utils/postMappers.ts apps/web/src/app/feed/components/PostList.tsx apps/web/src/app/feed/components/MixedFeedList.tsx packages/testing/unit/feed-post-mappers.test.ts`
2. `bun test packages/testing/unit/feed-post-mappers.test.ts`
3. Checked the live `/feed` surfaces and the `/api/posts` payload shape to confirm the current feed still emits stringly `isQuote` values and repost payloads that should be normalized before render.

## Ops / Migration / Deployment

- [x] No deploy impact

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: normal web deploy.
- Rollback: revert this PR.

## Breaking changes

- [x] None

**Migration guide**
- None.

## Security / privacy

- [x] No security impact

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: defensive feed rendering fix with no intended visual redesign; the only user-facing change is avoiding a crash when malformed repost payloads are present.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
