### PR TITLE
fix(web): restore transactional signup referral code flow

### DIFF
--- a/apps/web/src/app/api/users/signup/route.ts
+++ b/apps/web/src/app/api/users/signup/route.ts
@@ -93,7 +93,6 @@ import {
   cachedDb,
   ensureOfflineWalletReady,
   getHashedClientIp,
-  getOrCreateReferralCode,
   getPrivyClient,
   InternalServerError,
   isReferralCodeAvailableForUser,
@@ -530,9 +529,6 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
     }
     throw error;
   });
-
-  // Generate referral code for new user (ensures they can refer others immediately)
-  await getOrCreateReferralCode(result.user.id);
 
   // Invalidate identifier caches for the new/updated user (clears negative cache)
   await cachedDb.invalidateUserIdentifierCaches({

--- a/packages/testing/unit/signup-route-referral-code.test.ts
+++ b/packages/testing/unit/signup-route-referral-code.test.ts
@@ -170,6 +170,9 @@ mock.module('@babylon/shared', () => ({
     INITIAL_SIGNUP: 1000,
     REFERRAL_BONUS: 100,
   },
+  toISO: mock((value: Date | string) =>
+    value instanceof Date ? value.toISOString() : value
+  ),
 }));
 
 mock.module('@/lib/posthog/server', () => ({
@@ -261,9 +264,7 @@ describe('signup route referral code handling', () => {
     mockWithTransaction.mockResolvedValue(undefined);
   });
 
-  it('returns success after post-signup referral code ensure + cache invalidation', async () => {
-    mockGetOrCreateReferralCode.mockResolvedValue('alice');
-
+  it('returns success without a post-signup referral code regeneration call', async () => {
     const request = new MockNextRequest(
       'https://babylon.market/api/users/signup',
       {
@@ -284,7 +285,7 @@ describe('signup route referral code handling', () => {
 
     expect(response.status).toBe(200);
     expect(data.user.referralCode).toBe('alice');
-    expect(mockGetOrCreateReferralCode).toHaveBeenCalledWith('user_1');
+    expect(mockGetOrCreateReferralCode).not.toHaveBeenCalled();
     expect(mockInvalidateUserIdentifierCaches).toHaveBeenCalled();
     expect(mockNotifyNewAccount).toHaveBeenCalledWith('user_1');
     expect(mockTrackServerEvent).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- Remove the regressed post-signup referral-code regeneration call from `/api/users/signup`.
- Keep referral code assignment inside the transactional signup upsert so social onboarding does not fail after the user row is written.
- Add a focused regression assertion that signup succeeds without calling `getOrCreateReferralCode()` after signup.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Linear: https://linear.app/eliza-labs/issue/BAB-443/bugonboarding-twitter-social-signup-can-fail-when-referral-code
- Sentry: `BABYLONAPP-4S`
- Related precedent: `BAB-340`

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web API routes / SSE / A2A (`apps/web`)
- [x] Tests (`packages/testing`)
- [ ] Web UI (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [ ] Other: …

## Non-goals / follow-ups
- None.

## Changes
- Remove `getOrCreateReferralCode(result.user.id)` from the post-transaction path in `apps/web/src/app/api/users/signup/route.ts`.
- Rely on the existing transactional signup behavior that already persists `referralCode: parsedProfile.username` during user insert/update.
- Update the signup route regression test to assert that no post-signup referral-code regeneration call happens.
- Fix the route test mock to export `toISO`, which the route already imports.

## Review guide
**Start here**
- `apps/web/src/app/api/users/signup/route.ts`
- `packages/testing/unit/signup-route-referral-code.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- This restores the intended `BAB-340` pattern. The bug came from a later reintroduction of the old post-signup call.

## Test plan
**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bun test packages/testing/unit/signup-route-referral-code.test.ts`
2. `bun test packages/api/src/services/__tests__/referral-service.test.ts`
3. `bunx biome check apps/web/src/app/api/users/signup/route.ts packages/testing/unit/signup-route-referral-code.test.ts`

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: Deploy normally.
- Rollback: Revert this PR.

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)
### Option B: No visual changes
- Reason: Backend-only onboarding bug fix with a focused route/test change; no UI surface or visual behavior changed.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [ ] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [ ] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
