### PR TITLE
fix(web): guard post comments fetch on post detail

### DIFF
--- a/apps/web/src/stores/interactionStore.ts
+++ b/apps/web/src/stores/interactionStore.ts
@@ -307,17 +307,35 @@ export const useInteractionStore = create<InteractionStore>()(
       },
 
       loadComments: async (postId: string) => {
-        const { setLoading } = get();
+        const { clearError, setError, setLoading } = get();
         const loadingKey = `load-comments-${postId}`;
 
         setLoading(loadingKey, true);
 
-        const response = await apiCall<{
-          data: { comments: CommentWithReplies[] };
-        }>(`/api/posts/${postId}/comments`);
+        try {
+          const response = await apiCall<{
+            data?: { comments?: CommentWithReplies[] };
+          }>(`/api/posts/${postId}/comments`);
 
-        setLoading(loadingKey, false);
-        return response.data.comments;
+          if (Array.isArray(response.data?.comments)) {
+            clearError(loadingKey);
+            return response.data.comments;
+          }
+
+          setError(loadingKey, {
+            code: 'UNKNOWN',
+            message: 'Unable to load comments right now.',
+          });
+          return [];
+        } catch {
+          setError(loadingKey, {
+            code: 'NETWORK_ERROR',
+            message: 'Unable to load comments right now.',
+          });
+          return [];
+        } finally {
+          setLoading(loadingKey, false);
+        }
       },
 
       // Share actions

--- a/packages/testing/unit/interaction-store.test.ts
+++ b/packages/testing/unit/interaction-store.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+
+const storage = new Map<string, string>();
+
+const storageMock = {
+  getItem(key: string) {
+    return storage.get(key) ?? null;
+  },
+  setItem(key: string, value: string) {
+    storage.set(key, value);
+  },
+  removeItem(key: string) {
+    storage.delete(key);
+  },
+  clear() {
+    storage.clear();
+  },
+  key(index: number) {
+    return Array.from(storage.keys())[index] ?? null;
+  },
+  get length() {
+    return storage.size;
+  },
+};
+
+Object.defineProperty(globalThis, 'localStorage', {
+  value: storageMock,
+  configurable: true,
+});
+
+type MockFetchResponse = {
+  json: () => Promise<unknown>;
+};
+
+type MockFetch = (
+  input: string,
+  init?: RequestInit
+) => Promise<MockFetchResponse>;
+
+const mockFetch = mock<MockFetch>(() =>
+  Promise.resolve({
+    json: () =>
+      Promise.resolve({
+        data: {
+          comments: [
+            {
+              id: 'comment-1',
+              content: 'Hello world',
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+              userId: 'user-1',
+              userName: 'Alice',
+              userUsername: 'alice',
+              userAvatar: null,
+              parentCommentId: null,
+              likeCount: 0,
+              isLiked: false,
+              replies: [],
+            },
+          ],
+        },
+      }),
+  })
+);
+
+// @ts-expect-error - test mock
+globalThis.fetch = mockFetch;
+
+mock.module('@/lib/auth', () => ({
+  getAuthToken: () => null,
+}));
+
+const { useInteractionStore } = await import('@/stores/interactionStore');
+
+beforeEach(() => {
+  storage.clear();
+  useInteractionStore.getState().resetStore();
+  mockFetch.mockClear();
+  mockFetch.mockImplementation(() =>
+    Promise.resolve({
+      json: () =>
+        Promise.resolve({
+          data: {
+            comments: [
+              {
+                id: 'comment-1',
+                content: 'Hello world',
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+                userId: 'user-1',
+                userName: 'Alice',
+                userUsername: 'alice',
+                userAvatar: null,
+                parentCommentId: null,
+                likeCount: 0,
+                isLiked: false,
+                replies: [],
+              },
+            ],
+          },
+        }),
+    })
+  );
+});
+
+afterEach(() => {
+  useInteractionStore.getState().resetStore();
+  storage.clear();
+});
+
+describe('interactionStore.loadComments', () => {
+  test('returns comments and clears the loading state on success', async () => {
+    const comments = await useInteractionStore
+      .getState()
+      .loadComments('post-success');
+
+    expect(comments).toHaveLength(1);
+    expect(comments[0]?.id).toBe('comment-1');
+    expect(
+      useInteractionStore
+        .getState()
+        .loadingStates.has('load-comments-post-success')
+    ).toBe(false);
+    expect(
+      useInteractionStore.getState().errors.has('load-comments-post-success')
+    ).toBe(false);
+  });
+
+  test('returns an empty list and stores an error when the response has no comments payload', async () => {
+    mockFetch.mockImplementationOnce(() =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            error: {
+              code: 'NOT_FOUND',
+              message: 'Post not found',
+            },
+          }),
+      })
+    );
+
+    const comments = await useInteractionStore
+      .getState()
+      .loadComments('post-missing');
+
+    expect(comments).toEqual([]);
+    expect(
+      useInteractionStore
+        .getState()
+        .loadingStates.has('load-comments-post-missing')
+    ).toBe(false);
+    expect(
+      useInteractionStore.getState().errors.get('load-comments-post-missing')
+    ).toEqual({
+      code: 'UNKNOWN',
+      message: 'Unable to load comments right now.',
+    });
+  });
+
+  test('returns an empty list and clears loading when fetch rejects', async () => {
+    mockFetch.mockImplementation(() =>
+      Promise.reject(new TypeError('fetch failed'))
+    );
+
+    const comments = await useInteractionStore
+      .getState()
+      .loadComments('post-network');
+
+    expect(comments).toEqual([]);
+    expect(
+      useInteractionStore
+        .getState()
+        .loadingStates.has('load-comments-post-network')
+    ).toBe(false);
+    expect(
+      useInteractionStore.getState().errors.get('load-comments-post-network')
+    ).toEqual({
+      code: 'NETWORK_ERROR',
+      message: 'Unable to load comments right now.',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Guard the post detail comments loader against non-success API payloads so `/post/[id]` no longer crashes when comments fetches return `{ error: ... }`.
- Clear the `load-comments-*` loading flag in all paths and store a lightweight interaction error instead of dereferencing `response.data.comments` blindly.
- Add a focused unit test covering success, malformed error payloads, and rejected fetch retries for `loadComments()`.

## Type

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links

- Linear: https://linear.app/eliza-labs/issue/BAB-442/bugweb-guard-post-comments-fetch-on-postid
- Sentry: https://babylon-0t.sentry.io/issues/7352702046/

## Scope (keep it focused)

- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Non-goals / follow-ups

- None.

## Changes

- Wrap `loadComments()` in a `try/catch/finally` and validate that `response.data.comments` is actually an array before using it.
- Reuse the existing interaction store error map for this failure path instead of adding a new fallback layer.
- Add a unit test for the success path, malformed `{ error: ... }` payloads, and rejected fetch retries.

## Review guide

**Start here**
- `apps/web/src/stores/interactionStore.ts`
- `packages/testing/unit/interaction-store.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- This intentionally does not change the shared `apiCall()` helper because that would change behavior for every interaction store request.

## Test plan

**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bun test packages/testing/unit/interaction-store.test.ts --preload ./packages/testing/unit/preload.ts`
2. `bun x biome check apps/web/src/stores/interactionStore.ts packages/testing/unit/interaction-store.test.ts`
3. No browser recording attached because this is a crash guard with no intentional visual UI change.

## Ops / Migration / Deployment

- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: Ship normally.
- Rollback: Revert this PR.

## Breaking changes

- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy

- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes

- Reason: Crash guard in the comments loading flow; there is no intentional visual change to capture.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [ ] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
