### PR TITLE
fix(web): remove render-phase tutorial state updates on markets

### DIFF
--- a/apps/web/src/components/tutorial/SpotlightTutorial.tsx
+++ b/apps/web/src/components/tutorial/SpotlightTutorial.tsx
@@ -42,6 +42,22 @@ interface Rect {
   height: number;
 }
 
+export function getSpotlightActivationState(params: {
+  hasStep: boolean;
+  isActive: boolean;
+  wasActive: boolean;
+}) {
+  if (!params.isActive || !params.hasStep) {
+    return { justActivated: false, nextWasActive: false };
+  }
+
+  if (params.wasActive) {
+    return { justActivated: false, nextWasActive: true };
+  }
+
+  return { justActivated: true, nextWasActive: true };
+}
+
 /** Compute a padded rect for the target, unioning any data-tour-include elements. */
 function computeTargetRect(selector: string): Rect | null {
   const el = document.querySelector(selector);
@@ -97,6 +113,7 @@ export function SpotlightTutorial({
   const [tooltipReady, setTooltipReady] = useState(false);
   const tooltipRef = useRef<HTMLDivElement>(null);
   const wasActiveRef = useRef(false);
+  const justActivatedRef = useRef(false);
 
   useEffect(() => {
     setMounted(true);
@@ -106,18 +123,27 @@ export function SpotlightTutorial({
   const isLastStep = currentStep === steps.length - 1;
   const isFirstStep = currentStep === 0;
 
-  // Compute rect synchronously only on initial activation (not step changes)
-  // Step-to-step transitions use the delayed recomputation for smooth animation
-  if (isActive && !wasActiveRef.current && step) {
-    wasActiveRef.current = true;
+  // Sync the initial spotlight rect after activation without mutating state during render.
+  // Step-to-step transitions keep using the delayed recomputation below for smoother motion.
+  useLayoutEffect(() => {
+    const activation = getSpotlightActivationState({
+      hasStep: Boolean(step),
+      isActive,
+      wasActive: wasActiveRef.current,
+    });
+
+    wasActiveRef.current = activation.nextWasActive;
+    justActivatedRef.current = activation.justActivated;
+
+    if (!activation.justActivated || !step) {
+      return;
+    }
+
     const rect = computeTargetRect(step.target);
     if (rect) {
       setDynamicRect(rect);
-      setTooltipReady(true);
     }
-  } else if (!isActive && wasActiveRef.current) {
-    wasActiveRef.current = false;
-  }
+  }, [isActive, step]);
 
   const updateRect = useCallback(() => {
     if (!step) return;
@@ -154,9 +180,19 @@ export function SpotlightTutorial({
   // Then show tooltip after spotlight transition settles
   useEffect(() => {
     if (!isActive || !step) return;
-    setTooltipReady(false);
+
+    const justActivated = justActivatedRef.current;
+    justActivatedRef.current = false;
+
+    if (!justActivated) {
+      setTooltipReady(false);
+    }
+
     const rectTimer = setTimeout(updateRect, 200);
-    const tooltipTimer = setTimeout(() => setTooltipReady(true), 350);
+    const tooltipTimer = setTimeout(
+      () => setTooltipReady(true),
+      justActivated ? 0 : 350
+    );
     return () => {
       clearTimeout(rectTimer);
       clearTimeout(tooltipTimer);

--- a/packages/testing/unit/spotlight-tutorial.test.ts
+++ b/packages/testing/unit/spotlight-tutorial.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'bun:test';
+import { getSpotlightActivationState } from '../../../apps/web/src/components/tutorial/SpotlightTutorial';
+
+describe('getSpotlightActivationState', () => {
+  it('marks the first active step as a fresh activation', () => {
+    expect(
+      getSpotlightActivationState({
+        hasStep: true,
+        isActive: true,
+        wasActive: false,
+      })
+    ).toEqual({
+      justActivated: true,
+      nextWasActive: true,
+    });
+  });
+
+  it('does not re-trigger activation while the tutorial stays active', () => {
+    expect(
+      getSpotlightActivationState({
+        hasStep: true,
+        isActive: true,
+        wasActive: true,
+      })
+    ).toEqual({
+      justActivated: false,
+      nextWasActive: true,
+    });
+  });
+
+  it('resets the active flag when the tutorial is inactive or has no step', () => {
+    expect(
+      getSpotlightActivationState({
+        hasStep: true,
+        isActive: false,
+        wasActive: true,
+      })
+    ).toEqual({
+      justActivated: false,
+      nextWasActive: false,
+    });
+
+    expect(
+      getSpotlightActivationState({
+        hasStep: false,
+        isActive: true,
+        wasActive: true,
+      })
+    ).toEqual({
+      justActivated: false,
+      nextWasActive: false,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Remove render-phase state updates from the shared `SpotlightTutorial` used on `/markets`.
- Keep the initial spotlight activation behavior while moving the rect sync into effects so React hook order stays stable.
- Add a targeted unit test for the tutorial activation transition helper to lock the regression down.

## Type
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Linear: https://linear.app/eliza-labs/issue/BAB-440/bugmarkets-investigate-hook-order-crash-on-markets
- Sentry: https://babylon-0t.sentry.io/issues/7353013634/

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [ ] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [ ] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [ ] Shared types/utils (`packages/shared`)
- [x] Tests (`packages/testing`)
- [ ] Other: …

## Non-goals / follow-ups
- None.

## Changes
- Move initial tutorial spotlight activation out of render and into `useLayoutEffect`.
- Track activation transitions explicitly so the tooltip timing stays stable without render-phase `setState` calls.
- Cover the activation transition helper with a focused unit test.

## Review guide
**Start here**
- `apps/web/src/components/tutorial/SpotlightTutorial.tsx`
- `packages/testing/unit/spotlight-tutorial.test.ts`

**Risk**
- [x] Low
- [ ] Medium
- [ ] High

**Notes for reviewers**
- The root cause is the same class of issue we previously saw in feed: state updates during render before later hooks.
- This PR keeps the existing tutorial flow and only changes when the initial spotlight rect is synchronized.

## Test plan
**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bun test packages/testing/unit/spotlight-tutorial.test.ts --preload ./packages/testing/unit/preload.ts`
2. `bunx biome check apps/web/src/components/tutorial/SpotlightTutorial.tsx packages/testing/unit/spotlight-tutorial.test.ts`
3. Attempted `bunx tsc -p apps/web/tsconfig.typecheck.json --noEmit --pretty false`, but it currently fails on unrelated pre-existing issues in `apps/web/src/app/api/telegram/webhook/route.ts`, `apps/web/src/components/model-pilot/ModelPilotInquiryForm.tsx`, `apps/web/src/components/shared/MobileHeader.tsx`, `apps/web/src/components/ui/tooltip.tsx`, `apps/web/src/lib/auth/privyAccessToken.test.ts`, `apps/web/src/lib/posthog/client.test.ts`, and `packages/api/src/services/achievement-service.ts`.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: ship normally with the next web deploy.
- Rollback: revert this PR to restore the previous tutorial behavior.

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- None.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option B: No visual changes
- Reason: internal React lifecycle fix for an existing crash, with no intended visual/UI change.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
