### PR TITLE
refactor: DI cleanup for QuestionManager, GameLoop + fix ghost variables

### DIFF
--- a/packages/engine/src/GameLoop.ts
+++ b/packages/engine/src/GameLoop.ts
@@ -56,25 +56,24 @@ export interface SimulationTickResult {
  *
  * Used by both live game ticks (cron jobs) and game simulation (full game generation).
  */
+export interface GameLoopServices {
+  tradeExecutionService?: TradeExecutionService;
+  perpMarketService?: PerpMarketService;
+}
+
 export class GameLoop {
   private trendingTopics?: TrendingTopicsEngine;
   private recentPosts: FeedPost[] = [];
   private tickCount = 0;
 
-  private injectedServices?: {
-    tradeExecutionService?: TradeExecutionService;
-    perpMarketService?: PerpMarketService;
-  };
+  private injectedServices?: GameLoopServices;
 
   constructor(
     private world: GameWorld,
     private feed: FeedGenerator,
     private marketDecisions: MarketDecisionEnginePort,
     private relationships: RelationshipEvolutionEngine,
-    services?: {
-      tradeExecutionService?: TradeExecutionService;
-      perpMarketService?: PerpMarketService;
-    }
+    services?: GameLoopServices
   ) {
     this.injectedServices = services;
   }

--- a/packages/engine/src/GameLoop.ts
+++ b/packages/engine/src/GameLoop.ts
@@ -61,12 +61,23 @@ export class GameLoop {
   private recentPosts: FeedPost[] = [];
   private tickCount = 0;
 
+  private injectedServices?: {
+    tradeExecutionService?: TradeExecutionService;
+    perpMarketService?: PerpMarketService;
+  };
+
   constructor(
     private world: GameWorld,
     private feed: FeedGenerator,
     private marketDecisions: MarketDecisionEnginePort,
-    private relationships: RelationshipEvolutionEngine
-  ) {}
+    private relationships: RelationshipEvolutionEngine,
+    services?: {
+      tradeExecutionService?: TradeExecutionService;
+      perpMarketService?: PerpMarketService;
+    }
+  ) {
+    this.injectedServices = services;
+  }
 
   /**
    * Set the trending topics engine for trend-aware feed generation
@@ -119,7 +130,9 @@ export class GameLoop {
 
     if (decisions.length > 0) {
       try {
-        const executionService = new TradeExecutionService();
+        const executionService =
+          this.injectedServices?.tradeExecutionService ??
+          new TradeExecutionService();
         const executionResult =
           await executionService.executeDecisionBatch(decisions);
         tradeCount = executionResult.successfulTrades;
@@ -173,16 +186,18 @@ export class GameLoop {
       getBalance: (userId) => WalletService.getBalance(userId),
     };
 
-    const perpService = new PerpMarketService({
-      db: new PerpDbAdapter(),
-      wallet: walletAdapter,
-      fees: {
-        tradingFeeRate: FEE_CONFIG.TRADING_FEE_RATE,
-        platformShare: FEE_CONFIG.PLATFORM_SHARE,
-        referrerShare: FEE_CONFIG.REFERRER_SHARE,
-        minFeeAmount: FEE_CONFIG.MIN_FEE_AMOUNT,
-      },
-    });
+    const perpService =
+      this.injectedServices?.perpMarketService ??
+      new PerpMarketService({
+        db: new PerpDbAdapter(),
+        wallet: walletAdapter,
+        fees: {
+          tradingFeeRate: FEE_CONFIG.TRADING_FEE_RATE,
+          platformShare: FEE_CONFIG.PLATFORM_SHARE,
+          referrerShare: FEE_CONFIG.REFERRER_SHARE,
+          minFeeAmount: FEE_CONFIG.MIN_FEE_AMOUNT,
+        },
+      });
 
     let marketState;
     // Simulation Mode Bypass - uses centralized constants from config/simulation.ts

--- a/packages/engine/src/QuestionManager.ts
+++ b/packages/engine/src/QuestionManager.ts
@@ -202,22 +202,17 @@ export interface ResolutionWithProof {
  * @usage
  * Instantiated once by GameEngine and used throughout the game lifecycle.
  */
+export interface QuestionManagerServices {
+  contextService?: MarketContextService;
+  decisionEngine?: MarketDecisionEngine;
+  executionService?: TradeExecutionService;
+}
+
 export class QuestionManager {
   private llm: BabylonLLMClient;
-  private injectedServices?: {
-    contextService?: MarketContextService;
-    decisionEngine?: MarketDecisionEngine;
-    executionService?: TradeExecutionService;
-  };
+  private injectedServices?: QuestionManagerServices;
 
-  constructor(
-    llm: BabylonLLMClient,
-    services?: {
-      contextService?: MarketContextService;
-      decisionEngine?: MarketDecisionEngine;
-      executionService?: TradeExecutionService;
-    }
-  ) {
+  constructor(llm: BabylonLLMClient, services?: QuestionManagerServices) {
     this.llm = llm;
     this.injectedServices = services;
   }
@@ -1545,27 +1540,26 @@ XML: <response><questions><question><text>...</text><resolutionCriteria>...</res
       }
 
       // Trigger NPC betting on this new question
-      const contextService =
-        this.injectedServices?.contextService ?? new MarketContextService();
-
-      // Create LLM client for market decisions
-      const marketDecisionLLM = BabylonLLMClientValue.forGameTick();
-
-      const modelName = process.env.MARKET_DECISION_MODEL || 'qwen/qwen3-32b';
-      const isKimiModel = modelName.toLowerCase().includes('kimi');
-      const defaultMaxOutput = isKimiModel ? 16000 : 32000;
-      const maxOutputTokens = Number.parseInt(
-        process.env.MARKET_DECISION_MAX_OUTPUT_TOKENS ||
-          defaultMaxOutput.toString(),
-        10
-      );
-
       const decisionEngine =
         this.injectedServices?.decisionEngine ??
-        new MarketDecisionEngine(marketDecisionLLM, contextService, {
-          model: modelName,
-          maxOutputTokens,
-        });
+        (() => {
+          const contextService =
+            this.injectedServices?.contextService ?? new MarketContextService();
+          const marketDecisionLLM = BabylonLLMClientValue.forGameTick();
+          const modelName =
+            process.env.MARKET_DECISION_MODEL || 'qwen/qwen3-32b';
+          const isKimiModel = modelName.toLowerCase().includes('kimi');
+          const defaultMaxOutput = isKimiModel ? 16000 : 32000;
+          const maxOutputTokens = Number.parseInt(
+            process.env.MARKET_DECISION_MAX_OUTPUT_TOKENS ||
+              defaultMaxOutput.toString(),
+            10
+          );
+          return new MarketDecisionEngine(marketDecisionLLM, contextService, {
+            model: modelName,
+            maxOutputTokens,
+          });
+        })();
 
       // Generate decisions for NPCs - they will see the new question in context
       const decisions = await decisionEngine.generateBatchDecisions();

--- a/packages/engine/src/QuestionManager.ts
+++ b/packages/engine/src/QuestionManager.ts
@@ -204,14 +204,22 @@ export interface ResolutionWithProof {
  */
 export class QuestionManager {
   private llm: BabylonLLMClient;
+  private injectedServices?: {
+    contextService?: MarketContextService;
+    decisionEngine?: MarketDecisionEngine;
+    executionService?: TradeExecutionService;
+  };
 
-  /**
-   * Create a new QuestionManager instance
-   *
-   * @param llm - Babylon LLM client for question generation
-   */
-  constructor(llm: BabylonLLMClient) {
+  constructor(
+    llm: BabylonLLMClient,
+    services?: {
+      contextService?: MarketContextService;
+      decisionEngine?: MarketDecisionEngine;
+      executionService?: TradeExecutionService;
+    }
+  ) {
     this.llm = llm;
+    this.injectedServices = services;
   }
 
   /**
@@ -1537,7 +1545,8 @@ XML: <response><questions><question><text>...</text><resolutionCriteria>...</res
       }
 
       // Trigger NPC betting on this new question
-      const contextService = new MarketContextService();
+      const contextService =
+        this.injectedServices?.contextService ?? new MarketContextService();
 
       // Create LLM client for market decisions
       const marketDecisionLLM = BabylonLLMClientValue.forGameTick();
@@ -1551,14 +1560,12 @@ XML: <response><questions><question><text>...</text><resolutionCriteria>...</res
         10
       );
 
-      const decisionEngine = new MarketDecisionEngine(
-        marketDecisionLLM,
-        contextService,
-        {
+      const decisionEngine =
+        this.injectedServices?.decisionEngine ??
+        new MarketDecisionEngine(marketDecisionLLM, contextService, {
           model: modelName,
           maxOutputTokens,
-        }
-      );
+        });
 
       // Generate decisions for NPCs - they will see the new question in context
       const decisions = await decisionEngine.generateBatchDecisions();
@@ -1569,7 +1576,9 @@ XML: <response><questions><question><text>...</text><resolutionCriteria>...</res
       );
 
       if (questionDecisions.length > 0) {
-        const executionService = new TradeExecutionService();
+        const executionService =
+          this.injectedServices?.executionService ??
+          new TradeExecutionService();
         const executionResult =
           await executionService.executeDecisionBatch(questionDecisions);
 

--- a/packages/engine/src/game-tick.ts
+++ b/packages/engine/src/game-tick.ts
@@ -88,9 +88,9 @@ import {
   createInitialMarketSimulationState,
   evolveGlobalMarketSimulationState,
   type GlobalMarketSimulationState,
-  type MarketSimulationState,
   generateProfileDrivenMarketMove,
   getDefaultGlobalMarketSimulationState,
+  type MarketSimulationState,
 } from './services/market-simulation-profiles';
 // Note: ActorSocialActions, FollowingMechanics, processNPCSocialEngagements,
 // npcSocialEngagementService moved to npc-tick
@@ -2422,10 +2422,7 @@ export async function updateWorldFactsIfNeeded(): Promise<{
  * Market volatility state for realistic price movements.
  * Tracks recent volatility and momentum per market for clustering effects.
  */
-const marketVolatilityState = new Map<
-  string,
-  MarketSimulationState
->();
+const marketVolatilityState = new Map<string, MarketSimulationState>();
 let globalMarketSimulationState: GlobalMarketSimulationState =
   getDefaultGlobalMarketSimulationState();
 

--- a/packages/engine/src/prompts/loader.ts
+++ b/packages/engine/src/prompts/loader.ts
@@ -176,6 +176,12 @@ export function renderPrompt(
     rendered = rendered.replace(pattern, stringValue);
   }
 
+  // Replace any remaining unpopulated optional vars with empty string
+  for (const optVar of optionalVars) {
+    const pattern = new RegExp(`\\{\\{${optVar}\\}\\}`, 'g');
+    rendered = rendered.replace(pattern, '');
+  }
+
   return rendered;
 }
 

--- a/packages/engine/src/services/market-context-helpers.test.ts
+++ b/packages/engine/src/services/market-context-helpers.test.ts
@@ -66,14 +66,18 @@ describe('market-context-helpers', () => {
 
   it('truncates long prediction questions for token discipline', () => {
     const longQuestion = 'Q'.repeat(MAX_MARKET_QUESTION_LENGTH + 20);
-    const snapshot = buildPredictionMarketSnapshot({
-      id: 'market-2',
-      question: longQuestion,
-      yesShares: 50,
-      noShares: 50,
-      liquidity: 1000,
-      endDate: new Date('2026-04-05T12:00:00.000Z'),
-    }, undefined, { maxQuestionLength: MAX_MARKET_QUESTION_LENGTH });
+    const snapshot = buildPredictionMarketSnapshot(
+      {
+        id: 'market-2',
+        question: longQuestion,
+        yesShares: 50,
+        noShares: 50,
+        liquidity: 1000,
+        endDate: new Date('2026-04-05T12:00:00.000Z'),
+      },
+      undefined,
+      { maxQuestionLength: MAX_MARKET_QUESTION_LENGTH }
+    );
 
     expect(snapshot.text.length).toBe(MAX_MARKET_QUESTION_LENGTH + 3);
     expect(snapshot.text.endsWith('...')).toBe(true);

--- a/packages/testing/unit/render-prompt-optional-vars.test.ts
+++ b/packages/testing/unit/render-prompt-optional-vars.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'bun:test';
+import { renderPrompt } from '@babylon/engine';
+
+const testPrompt = {
+  id: 'test-prompt',
+  version: '1.0.0',
+  category: 'test',
+  description: 'Test prompt',
+  template: `Hello {{name}}!
+Required: {{requiredVar}}
+Optional1: {{previousTrades}}
+Optional2: {{characterRoster}}
+Optional3: {{resolvedQuestionsContext}}
+End.`,
+};
+
+describe('renderPrompt optional variable cleanup', () => {
+  it('should replace supplied variables normally', () => {
+    const result = renderPrompt(testPrompt, {
+      name: 'Alice',
+      requiredVar: 'present',
+      previousTrades: 'some trades',
+    });
+
+    expect(result).toContain('Hello Alice!');
+    expect(result).toContain('Required: present');
+    expect(result).toContain('Optional1: some trades');
+  });
+
+  it('should strip unpopulated optional vars instead of leaving literal {{varName}}', () => {
+    const result = renderPrompt(testPrompt, {
+      name: 'Alice',
+      requiredVar: 'present',
+    });
+
+    expect(result).not.toContain('{{previousTrades}}');
+    expect(result).not.toContain('{{characterRoster}}');
+    expect(result).not.toContain('{{resolvedQuestionsContext}}');
+    expect(result).toContain('Optional1: ');
+    expect(result).toContain('Optional2: ');
+    expect(result).toContain('Optional3: ');
+  });
+
+  it('should not contain any double-brace placeholders after rendering', () => {
+    const result = renderPrompt(testPrompt, {
+      name: 'Bob',
+      requiredVar: 'here',
+    });
+
+    expect(result).not.toMatch(/\{\{[a-zA-Z]+\}\}/);
+  });
+
+  it('should keep supplied optional vars and strip only unsupplied ones', () => {
+    const result = renderPrompt(testPrompt, {
+      name: 'Charlie',
+      requiredVar: 'yes',
+      previousTrades: 'BTC long $500',
+    });
+
+    expect(result).toContain('Optional1: BTC long $500');
+    expect(result).not.toContain('{{characterRoster}}');
+    expect(result).not.toContain('{{resolvedQuestionsContext}}');
+  });
+});


### PR DESCRIPTION
## Summary

- **Fix renderPrompt ghost variables**: Unpopulated optional template vars (e.g. `{{characterRoster}}`, `{{previousTrades}}`) were being sent as literal text to the LLM. Now replaced with empty string.
- **QuestionManager DI**: Constructor accepts optional `services` object for `MarketContextService`, `MarketDecisionEngine`, `TradeExecutionService`. Falls back to `new` when not provided — fully backward compatible.
- **GameLoop DI**: Constructor accepts optional 5th arg for `TradeExecutionService` and `PerpMarketService`. Same fallback pattern.

## Why

Prerequisite for the dev tools suite (context-inspector, question-gen-bench, arc-simulator, trading-replay). These components couldn't be tested in isolation because they hardcoded `new` for their dependencies. The ghost variable fix is also a standalone production bug — 6 template placeholders were being sent verbatim to the LLM in every NPC trading decision prompt.

## Test plan

- [ ] `bun run typecheck` passes
- [ ] `bun run check` passes
- [ ] Existing callers of `QuestionManager(llm)` and `GameLoop(world, feed, decisions, relationships)` still work (no signature break)
- [ ] Verify rendered trading prompts no longer contain literal `{{variableName}}` strings