### PR TITLE
feat: context-inspector dev tool

### DIFF
--- a/docs/agent-context-analysis.md
+++ b/docs/agent-context-analysis.md
@@ -1,0 +1,389 @@
+# Deep Analysis: Agent Context Gaps in Babylon Simulation
+
+> Analysis of what context agents actually receive, what's missing, and why it produces poor simulation quality.
+> Audited against the codebase on 2026-03-30. All claims verified — see audit annotations throughout.
+> Updated 2026-03-31: Added Section 11 with live inspection results from production DB using `context-inspector`.
+
+---
+
+## Executive Summary
+
+The agent context system is a paradox: **it's simultaneously over-engineered and under-delivering**. There are elaborate context assembly pipelines, but critical data is either truncated to uselessness, built but never wired into prompts, or simply absent. The result is agents that feel like amnesiacs performing in a play they haven't read.
+
+**The core problem is not that the system lacks data — it's that the data doesn't reach the agents in a useful form.**
+
+---
+
+## 1. What Agents Actually Receive for Trading Decisions
+
+### The Trading Context Pipeline
+
+`MarketDecisionEngine` → `MarketContextService` → `npc-market-decisions.ts` prompt
+
+Each NPC gets a "TRADER DASHBOARD" (`MarketDecisionEngine.ts` lines 641-649):
+
+```
+ID: {npcId} | Name: {npcName}
+Archetype: {mapped_personality} | Strategy: {trend/contrarian/random}
+Bias: {strategy_bias} | Cash: ${availableBalance}
+Total PnL: {totalPnL} | Exposure: {exposure%}
+Network: {top_4_relationships}           ← max 4, sentiment > |0.4| only
+Positions: {top_3_positions}             ← top 3 by PnL only
+Current Focus: {last_3_posts_20chars}    ← 20 characters each
+PRIVATE INTEL: {last_2_group_msgs}       ← 2 messages, 120 chars each
+```
+
+### What IS provided (and how it's crippled)
+
+| Data | Included? | Limit | Problem |
+|------|-----------|-------|---------|
+| Current portfolio positions | Yes | Top 3 by PnL | Agents can't see their full book; may have 10 positions but only see 3 |
+| Available balance | Yes | None | Works correctly |
+| Perp market prices | Yes | All companies | Only current price + 24h change — no history, no trends |
+| Prediction market prices | Yes | 15 markets max | Question text truncated to 120 chars; no price history |
+| Recent feed posts | Yes | 50 posts, 200 chars each | Truncated to the point of losing meaning |
+| Group chat messages | Partially | 2 messages, 120 chars each | Almost useless — 2 messages with 120 chars provides no conversational context |
+| World events | Yes | 30 events, 150 chars each | Truncated descriptions lose critical detail |
+| Relationships | Yes | Top 4 by sentiment | Just "Ally:Name, Rival:Name" — no history, no context for why |
+| Event-market signals | Yes | Cached, all markets | Shows which events affect which markets — actually useful |
+| Active questions | Yes | Top 10 | Question text + days until resolution |
+
+### What is NOT provided for trading
+
+| Missing Data | Impact | Data Exists in DB? |
+|-------------|--------|-------------------|
+| **Trading history** | Agents can't learn from past trades; repeat same mistakes | Yes — `npcTrades` table |
+| **Price history beyond 24h** | No trend analysis, no support/resistance | Yes — `predictionPriceHistory`, `stockPrices` |
+| **Order book / liquidity depth** | Can't assess slippage or market depth | Partially — AMM formulas exist |
+| **Other NPCs' positions** | No awareness of market consensus or crowding | Yes — `poolPositions` table |
+| **Resolved question outcomes** | Can't learn from what happened before | Yes — `questions` table with outcomes |
+| **Ongoing narrative arcs** | Template variable `{{ongoingNarrativesContext}}` exists but is **never populated** | Yes — arc plans in DB |
+| **Previous trades** | Template variable `{{previousTrades}}` exists but is **never populated** | Yes — trade records in DB |
+| **Detailed character profiles** | Template variable `{{detailedCharacterProfiles}}` exists but is **never populated** | Yes — static data |
+| **Character roster** | Template variable `{{characterRoster}}` exists but is **never populated** | Yes — static data |
+| **Resolved questions** | Template variable `{{resolvedQuestionsContext}}` exists but is **never populated** | Yes — DB |
+| **Market signal analysis** | `extractMarketSignals()` is built (lines 1005-1071 in market-context-service.ts) — analyzes YES/NO signal strength, confidence — but **never exposed to NPCs** | Built in code, never wired |
+
+### The "Ghost Variables" Problem
+
+The prompt template (`npc-market-decisions.ts`) defines these variables that are **never populated** by the engine:
+
+- `{{characterRoster}}` — empty
+- `{{detailedCharacterProfiles}}` — empty
+- `{{relationshipContext}}` — empty
+- `{{resolvedQuestionsContext}}` — empty
+- `{{previousTrades}}` — empty
+- `{{ongoingNarrativesContext}}` — empty
+
+**[CONFIRMED]** These are in the prompt loader's `optionalVars` list (`prompts/loader.ts` lines 55-141), so they don't throw errors — but they also don't render as empty. The literal strings like `{{characterRoster}}` are sent **verbatim** to the LLM alongside section headers like "=== ALL TRADERS IN WORLD ===". The LLM sees template syntax where content should be, which actively degrades output quality.
+
+---
+
+## 2. What Agents Receive for Social/Posting Decisions
+
+The posting pipeline is **significantly richer** than the trading pipeline. `FeedGenerator` assembles per-character context via `buildRichCharacterContext()` (lines 455-539):
+
+### Context provided for posts
+
+- Full character identity (description, bio, domain, affiliations, tier)
+- Personality, voice style, post examples (up to 5, shuffled)
+- Social dynamics (allies/rivals with behavioral instructions)
+- Motivations (wealth/reputation/ideology/chaos)
+- Deception tendency
+- Emotional state (mood, luck, and how they affect tone)
+- Personal event history
+- Recent own posts (for anti-repetition)
+- Market positions and P&L
+- Relationship history with interaction notes
+- Complete event timeline (all previous days)
+- Recent feed posts from all NPCs
+- Ongoing storylines
+- Resolved question outcomes
+- World facts
+- Phase guidance (WILD/CONNECTION/CONVERGENCE/CLIMAX/RESOLUTION)
+- Trending topics
+- Group chat messages
+- Time-of-day energy modifiers
+
+### The asymmetry problem
+
+**Posts get far more context than trading decisions.** An NPC writing a shitpost about a stock gets the full event timeline, resolved questions, ongoing narratives, and rich relationship history. The same NPC making a $10,000 trade gets 3 truncated positions, 2 group chat messages at 120 chars, and an empty `{{ongoingNarrativesContext}}` section.
+
+This means NPC posts reference narratives and events that their trading decisions are blind to. An NPC might post "TSLAI is going to moon based on the leaked partnership" but then make a trading decision without any awareness of that leaked partnership, because the trading context doesn't include the narrative arc.
+
+---
+
+## 3. Agent Memory System: Exists But Shallow
+
+### What persists between ticks
+
+**NPC Memory Service** (`npc-memory-service.ts`, 697 lines):
+
+| State | Persists? | Storage | Cap |
+|-------|-----------|---------|-----|
+| Recent memories | Yes | `ActorState.recentMemories` (JSONB) | 50 entries, FIFO eviction |
+| Relationship sentiment | Yes | `ActorState.relationships` (JSONB) | Per-pair, 10 notes max |
+| Activity state | Yes | `ActorState` columns | Posts today, last active, mood |
+| Conversation history | Yes | `messages` table | Permanent storage |
+| Trading positions | Yes | `poolPositions` / `perpPositions` | Until closed |
+
+Memory types tracked: `posted`, `replied_to`, `mentioned_by`, `witnessed_event`, `traded`, `running_bit`
+
+### What does NOT persist
+
+- **No decision reasoning** — agents don't remember WHY they made a trade
+- **No beliefs or theories** — no "I think TSLAI will go up because..." state
+- **No learning from outcomes** — resolved questions don't update agent beliefs
+- **No cross-agent knowledge** — agents can't share private conclusions
+- **No conversation summaries** — raw messages stored, but no distilled takeaways
+- **No strategy evolution** — trading strategy is static (mapped from personality), never adapts
+
+### How memory actually reaches the LLM
+
+For **posting**: `formatMemoriesForPrompt()` creates a `## Recent Memories` section with time-ago labels. This works reasonably well.
+
+For **trading**: Memories are **not included in the trading prompt at all**. The `npc-market-decisions.ts` template has no `{{memories}}` variable. NPCs trade without any memory of their past actions or observations.
+
+---
+
+## 4. Autonomous Agent System (User-Controlled Agents)
+
+**File**: `packages/agents/src/autonomous/AutonomousCoordinator.ts`
+
+User-controlled autonomous agents have an even thinner context than NPCs:
+
+### Per-tick context gathering
+
+Each `executeAutonomousTick()` starts completely fresh (line 66). No in-memory state survives between ticks. Context is re-fetched every tick:
+
+- `getAgentPositions()` — current positions
+- `getRecentPosts()` — last 24h of posts (all users)
+- `getAgentOwnPosts()` — last 5 of agent's own posts
+- `getAgentGroupChats()` — list of group chats
+
+### Group chat context
+
+- Looks back only **1 hour** of messages
+- Limited to **10 messages** per chat
+- Only last **5 messages** included in DM context
+
+This means an autonomous agent that had a detailed strategic conversation in a group chat 2 hours ago has **zero memory** of that conversation when making its next decision.
+
+### No trajectory or learning
+
+- Trajectory recording is disabled by default (line 69)
+- When enabled, it's for RL training data, not runtime behavior
+- No mechanism to learn from past trades, conversations, or market outcomes
+
+---
+
+## 5. The Production Path is Worse Than the Dev Path
+
+A critical finding: the production code paths are **more context-impoverished** than the development/GameGenerator paths.
+
+| Feature | GameGenerator Path | Production Path |
+|---------|-------------------|-----------------|
+| Actor/org shuffling | Yes (lines 431-440) | **No** — fixed order from StaticDataRegistry |
+| Scenarios | LLM-generated, varied | **Hardcoded `scenarioId = 1`** (line 1357) |
+| Rich game context | Full event timeline | Cached, potentially stale (60s TTL) |
+| World context detail | Comprehensive | `realityGroundingLevel: 'minimal'` |
+
+---
+
+## 6. Truncation Destroys Context Value
+
+The system aggressively truncates everything to fit token budgets, but the truncation points destroy the informational value:
+
+| Content | Truncation | What's Lost |
+|---------|-----------|-------------|
+| Feed posts | 200 chars | A typical insight is 300-500 chars; agents see sentence fragments |
+| Group chat msgs | 120 chars | Conversations are incomprehensible at this length |
+| Event descriptions | 150 chars | Complex events ("Company X acquires Y for $Z, pending regulatory...") get cut mid-sentence |
+| Question text | 120 chars | Prediction market questions are often >120 chars, so agents can't read the full question they're betting on |
+| Post "focus" | 20 chars per post | "Current Focus: TSLAI looks like i..." — meaningless |
+
+The token budget is real (4-20 NPCs batched per LLM call), but the current approach of "include everything, truncate everything" produces quantity without quality. Agents see 50 posts they can't understand rather than 5 posts they can.
+
+---
+
+## 7. The Information Asymmetry That Breaks Immersion
+
+### What players see vs. what agents "see"
+
+A human player reading the feed sees:
+- Full-length posts with complete arguments
+- Complete news articles with analysis
+- Full prediction market questions with resolution dates
+- Price charts with historical trends
+- Complete group chat conversations
+
+An NPC agent deciding to trade sees:
+- 3 truncated positions
+- 2 group chat snippets (120 chars)
+- 50 truncated posts (200 chars) — but only "Current Focus" shows 3 at 20 chars in the dashboard
+- No price history
+- No article content
+- Empty narrative context sections
+
+The result: **agents make decisions that are obviously uninformed compared to what a human player can see**, breaking the illusion that they're participants in the same simulation.
+
+---
+
+## 8. Root Cause Map
+
+```
+WHY ARE AGENTS BAD?
+├── Trading context is thin
+│   ├── 6 prompt template variables are never populated (ghost variables)
+│   ├── Market signal analysis is built but never wired to trading
+│   ├── Only top 3 positions shown (agents don't know their full book)
+│   ├── No trading history (can't learn from past trades)
+│   └── No resolved question context (can't learn from outcomes)
+│
+├── Memory doesn't reach trading
+│   ├── NPC memories exist (50 entries) but aren't in trading prompt
+│   ├── No beliefs/theories persist between ticks
+│   └── No decision reasoning is stored or recalled
+│
+├── Truncation destroys meaning
+│   ├── 120-char group chat messages are incomprehensible
+│   ├── 20-char "current focus" is meaningless
+│   ├── 200-char post truncation loses core arguments
+│   └── 120-char question text means agents can't read what they're betting on
+│
+├── Posting/trading context mismatch
+│   ├── Posts get full narrative arc context; trades get empty sections
+│   ├── Posts reference events that trading decisions are blind to
+│   └── Creates incoherent agent behavior (posts contradict trades)
+│
+├── Autonomous agents are amnesiac
+│   ├── 1-hour lookback on group chats
+│   ├── No cross-tick state
+│   ├── No learning from outcomes
+│   └── Fresh context fetch every tick with no continuity
+│
+└── Production path is impoverished
+    ├── No actor/org shuffling (deterministic LLM inputs)
+    ├── Minimal reality grounding
+    └── Hardcoded scenarioId = 1
+```
+
+---
+
+## 9. Structural Weaknesses Summary
+
+| Issue | Location | Severity | Impact |
+|-------|----------|----------|--------|
+| Ghost template variables (6 empty sections) | `npc-market-decisions.ts` | **Critical** | Trading decisions made without narrative, history, or character context |
+| Market signals built but never used | `market-context-service.ts:1005-1071` | **High** | Signal analysis exists but NPCs can't see it |
+| Memories excluded from trading prompt | `MarketDecisionEngine.ts` | **High** | NPCs trade without any memory of past actions |
+| Aggressive truncation | `market-context-service.ts` (multiple) | **High** | Context becomes noise — quantity without quality |
+| Post-trade context asymmetry | `FeedGenerator.ts` vs `MarketDecisionEngine.ts` | **High** | Posts reference things trading decisions can't see |
+| 1-hour group chat lookback for autonomous agents | `AutonomousGroupChatService.ts:80` | **Medium** | Strategic conversations forgotten after 1 hour |
+| No trading history in context | `MarketDecisionEngine.ts` | **Medium** | Agents repeat mistakes, can't develop strategies |
+| No resolved question outcomes | `MarketDecisionEngine.ts` | **Medium** | Agents can't learn from market resolutions |
+| Top-3-only position visibility | `MarketDecisionEngine.ts:602` | **Medium** | Agents unaware of their full exposure |
+| No price history beyond 24h | `market-context-service.ts` | **Medium** | No trend analysis possible |
+| Production path lacks shuffling | `QuestionManager.ts:1072-1097` | **Low** | Deterministic inputs reduce variety |
+| Fixed trading archetypes | `MarketDecisionEngine.ts` | **Low** | Strategy never adapts based on performance |
+
+---
+
+## 10. Recommendations
+
+### Tier 1: Wire Up What Already Exists (Low effort, high impact)
+
+1. **Populate the ghost variables** — `{{previousTrades}}`, `{{resolvedQuestionsContext}}`, `{{ongoingNarrativesContext}}` are already in the template. The data exists in the DB. Just wire them up in `MarketDecisionEngine.generateDecisionsForContexts()`.
+
+2. **Include NPC memories in trading context** — `NpcMemoryService.formatMemoriesForPrompt()` already exists and works for posting. Add a `{{memories}}` section to the trading prompt.
+
+3. **Expose market signal analysis** — `extractMarketSignals()` already computes YES/NO signal strength and confidence. Add it to the trading prompt.
+
+4. **Unify post and trading context** — Use the same `buildRichCharacterContext()` pipeline for trading that posting already uses, or at minimum share the narrative/event context.
+
+### Tier 2: Fix Truncation Strategy (Medium effort, high impact)
+
+5. **Quality over quantity** — Instead of 50 posts at 200 chars, provide 10 most relevant posts at 500 chars. Use topic relevance (daily topic, held positions) to select which posts matter.
+
+6. **Full question text** — Never truncate prediction market questions. If agents can't read the question, they can't bet intelligently. Cut something else.
+
+7. **Meaningful group chat context** — Increase from 2 messages at 120 chars to 5-8 messages at 300 chars, or provide a summary of recent conversation themes.
+
+8. **Remove "Current Focus" at 20 chars** — It's noise. Either show full recent posts or remove the field entirely.
+
+### Tier 3: Add Missing Capabilities (Higher effort)
+
+9. **Trading history context** — Include last 5-10 trades with outcomes in the prompt. Let agents learn from their past decisions.
+
+10. **Price trend data** — Include 7-day price trend (direction, volatility, key levels) for held positions. The `predictionPriceHistory` and `stockPrices` tables already have this data.
+
+11. **Belief/theory persistence** — After each trading decision, store the agent's reasoning. Include it in the next tick's context so agents develop consistent strategies.
+
+12. **Extend autonomous agent lookback** — Increase group chat lookback from 1 hour to 24 hours, or implement conversation summarization.
+
+13. **Cross-agent information sharing** — Let agents who are "allies" share position information or trading theses through the relationship system.
+
+---
+
+## 11. Live Inspection Results (2026-03-31)
+
+Using `bun run inspect:context -- --agent <userId> --raw` against the production DB, we inspected multiple autonomous agents. The findings below are **observed behavior**, not code analysis.
+
+### Most autonomous agents are effectively dead
+
+Every agent inspected showed the same pattern:
+
+| Agent | Balance | Lifetime PnL | Open Positions | Available Actions |
+|-------|---------|-------------|----------------|-------------------|
+| Delta Lab | $0.00 | -$198B | 0 | REPLY_CHAT, FINISH, WAIT |
+| Beta Edge | $0.39 | -$1.7T | 0 | REPLY_CHAT, FINISH, WAIT |
+| Iota One | $0.00 | -$124B | 10 (all -100%) | REPLY_CHAT, FINISH, WAIT |
+| Cosmic AI | $0.00 | -$74 | 0 | REPLY_CHAT, FINISH, WAIT |
+
+**Key observations:**
+- Every agent has $0 or near-$0 balance with astronomical negative PnL
+- With $0 balance, the prompt correctly disables TRADE/POST/COMMENT actions
+- Agents can only REPLY_CHAT, FINISH, or WAIT — they are functionally inert
+- Agents with open positions (e.g., Iota One) have all positions at -100% with 0 shares
+- The simulation has essentially bankrupted every autonomous agent
+
+### The prompt is technically correct but practically useless
+
+The `buildMultiStepDecisionPrompt` correctly reflects the agent's state. But the state itself is broken:
+- Balance: $0.00 with no mechanism to recover
+- PnL values in the trillions of dollars negative (suggests overflow or compounding bugs in the trading/settlement system)
+- Positions with entry prices in the billions of cents (e.g., `entry: 250768773974¢`) — clearly corrupted data
+- Even agents with `autonomousTrading: true` in config can't trade because they have no funds
+
+### Context utilization is extremely low
+
+Even for the "richest" agent context inspected:
+- **Total rendered prompt: ~2,300 tokens** out of a 30,000 token budget
+- **Utilization: 5-8%** — the prompt is 92-95% empty
+- Markets, posts, and positions ARE gathered (shown in actionability summary) but sections like trading actions are gated behind balance checks
+- The quality rules, banned patterns, and examples consume more tokens (~800) than the actual agent-specific context (~400)
+
+### Comparison: NPC prompt vs Agent prompt
+
+| Metric | NPC Trading Prompt | Autonomous Agent Prompt |
+|--------|-------------------|------------------------|
+| Total tokens | ~3,100 | ~2,300 |
+| Lines | ~340 | ~210 |
+| Market data | Full table with all perps + predictions | Counts only (sections gated) |
+| Positions | All positions with PnL | None rendered (gated by features) |
+| World context | Reality grounding + parody names + themes | None |
+| Narrative context | Event signals, resolved questions | None |
+| Character identity | Archetype, strategy, bias, relationships | Name only |
+| Quality rules | Minimal | ~60% of prompt is quality/ban rules |
+
+The autonomous agent prompt is dominated by quality/formatting rules rather than actual decision-relevant context. When an agent CAN trade, it gets less market/world context than NPCs.
+
+### New issues discovered
+
+14. **Agent bankruptcy with no recovery** — Agents that hit $0 are permanently stuck. There is no mechanism to refund, reset, or gradually restore agent balances. The simulation needs either balance resets, minimum balance guarantees, or income mechanics.
+
+15. **Corrupted PnL/price data** — Entry prices in the billions of cents and PnL in the trillions suggest either overflow bugs in the AMM, settlement errors, or missing validation in trade execution. This needs investigation before any context enrichment will matter.
+
+16. **Prompt is mostly boilerplate when agents can't act** — When balance is $0, the 2,300-token prompt is ~60% quality rules for content the agent will never generate (since it can only REPLY_CHAT). The prompt should be dramatically shorter for limited-action states.
+
+17. **No world context for autonomous agents** — Unlike NPCs which get reality grounding (parody names, world state, running themes), autonomous agents get zero world context. They have no awareness of the game's satirical setting, current events, or market narratives.

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "privy:setup:solana-policy": "bun run scripts/create-privy-solana-policy.ts",
     "solana:registration:debug": "bun run scripts/debug-solana-registration.ts",
     "seed:nft-snapshot:csv": "bun run scripts/seed-nft-snapshot-csv.ts",
-    "users:export:newsletter": "bun run scripts/export-newsletter-users-csv.ts"
+    "users:export:newsletter": "bun run scripts/export-newsletter-users-csv.ts",
+    "inspect:context": "bun run scripts/context-inspector.ts"
   },
   "dependencies": {
     "@a2a-js/sdk": "^0.3.5",

--- a/packages/engine/src/MarketDecisionEngine.ts
+++ b/packages/engine/src/MarketDecisionEngine.ts
@@ -83,11 +83,6 @@ import {
 } from './llm/token-counter';
 import { parseXML } from './llm/xml-parser';
 import {
-  formatTradingStrategyBias,
-  getNpcTradingStrategy,
-  TRADING_STRATEGIES,
-} from './npc/trading-strategies';
-import {
   generateWorldContext,
   getShuffledExamplesText,
   npcMarketDecisions,
@@ -103,6 +98,12 @@ import type { TradingDecision } from './types/market-decisions';
 import { first, firstOrThrow } from './utils/array-utils';
 import { formatError } from './utils/error-utils';
 import { clamp01 } from './utils/math-utils';
+import {
+  calculatePortfolioExposure,
+  formatMarketDataTable,
+  formatNPCsDashboardList,
+  mapPersonalityToArchetype,
+} from './utils/trading-dashboard-format';
 
 /**
  * Token management configuration
@@ -506,149 +507,36 @@ export class MarketDecisionEngine {
   }
 
   /**
-   * Calculate Portfolio Exposure %
-   * (Total Position Value) / (Cash + Total Position Value)
+   * Calculate Portfolio Exposure %.
+   * Delegates to shared utility `calculatePortfolioExposure`.
    */
   private calculateExposure(balance: number, positions: NPCPosition[]): number {
-    const totalPositionValue = positions.reduce(
-      (sum, p) => sum + p.size + p.unrealizedPnL,
-      0
-    );
-    const totalEquity = balance + totalPositionValue;
-
-    if (totalEquity <= 0) return 0; // Avoid division by zero/negative equity
-    return Math.min(100, Math.max(0, (totalPositionValue / totalEquity) * 100));
+    return calculatePortfolioExposure(balance, positions);
   }
 
   /**
-   * Map generic personality traits to a Trading Archetype
+   * Map generic personality traits to a Trading Archetype.
+   * Delegates to shared utility `mapPersonalityToArchetype`.
    */
   private mapPersonalityToArchetype(personality: string): string {
-    const p = personality.toLowerCase();
-    if (
-      p.includes('risk') ||
-      p.includes('aggressive') ||
-      p.includes('degen') ||
-      p.includes('speculator')
-    ) {
-      return 'DEGEN_TRADER';
-    }
-    if (
-      p.includes('cautious') ||
-      p.includes('conservative') ||
-      p.includes('manager')
-    ) {
-      return 'RISK_MANAGER';
-    }
-    if (p.includes('analytical') || p.includes('quant') || p.includes('math')) {
-      return 'QUANT_TRADER';
-    }
-    if (p.includes('insider') || p.includes('connected')) {
-      return 'INSIDER';
-    }
-    return 'SYSTEMATIC_TRADER'; // Default
+    return mapPersonalityToArchetype(personality);
   }
 
   /**
-   * Format Market Data as a structured ASCII Table
+   * Format Market Data as a structured ASCII Table.
+   * Delegates to shared utility `formatMarketDataTable`.
    */
   private formatMarketTable(contexts: NPCMarketContext[]): string {
-    // Assume all contexts see the same market, so take the first one
     if (!contexts[0]) return 'No Market Data Available';
-
-    const perps = contexts[0].perpMarkets || [];
-    const predictions = contexts[0].predictionMarkets || [];
-
-    let table =
-      '| Ticker/ID | Type | Price | 24h Change | Volume/Liq |\n|---|---|---|---|---|\n';
-
-    // Add Perps
-    for (const p of perps) {
-      const sign = p.changePercent24h >= 0 ? '+' : '';
-      table += `| ${p.ticker} | PERP | $${p.currentPrice.toFixed(2)} | ${sign}${p.changePercent24h.toFixed(2)}% | Vol: $${(p.volume24h / 1000).toFixed(1)}k |\n`;
-    }
-
-    // Add Predictions
-    for (const p of predictions) {
-      // Assuming binary YES/NO prices sum to ~100
-      table += `| ${p.id} | PRED | Yes: ${p.yesPrice.toFixed(0)}¢ | No: ${p.noPrice.toFixed(0)}¢ | Vol: $${(p.totalVolume / 1000).toFixed(1)}k |\n`;
-    }
-
-    return table;
+    return formatMarketDataTable(contexts[0]);
   }
 
   /**
-   * Format NPCs list into "Trader Dashboard" blocks
+   * Format NPCs list into "Trader Dashboard" blocks.
+   * Delegates to shared utility `formatNPCsDashboardList`.
    */
   private formatNPCsList(contexts: NPCMarketContext[]): string {
-    return contexts
-      .map((ctx, i) => {
-        const archetype = this.mapPersonalityToArchetype(ctx.personality);
-        const strategyKey = getNpcTradingStrategy(ctx.npcId);
-        const strategy = TRADING_STRATEGIES[strategyKey];
-        const exposure = this.calculateExposure(
-          ctx.availableBalance,
-          ctx.currentPositions
-        );
-
-        // Calculate Total PnL for display
-        const totalPnL = ctx.currentPositions.reduce(
-          (sum, p) => sum + p.unrealizedPnL,
-          0
-        );
-        const pnlSign = totalPnL >= 0 ? '+' : '';
-
-        // Format Top Positions (Max 3)
-        const topPositions = ctx.currentPositions
-          .sort((a, b) => Math.abs(b.unrealizedPnL) - Math.abs(a.unrealizedPnL))
-          .slice(0, 3)
-          .map((p) => {
-            const symbol =
-              p.marketType === 'perp' ? p.ticker : `Q${p.marketId}`;
-            const posSign = p.unrealizedPnL >= 0 ? '+' : '';
-            return `${symbol} ${p.side} ($${p.size.toFixed(0)}, PnL: ${posSign}$${p.unrealizedPnL.toFixed(0)}) [ID:${p.id}]`;
-          })
-          .join(', ');
-
-        // RESTORED: Relationships (Network) - Compact format
-        const relationships =
-          ctx.relationships && ctx.relationships.length > 0
-            ? ctx.relationships
-                .filter((r) => Math.abs(r.sentiment) > 0.4) // Only show strong relationships
-                .slice(0, 4)
-                .map(
-                  (r) => `${r.sentiment > 0 ? 'Ally' : 'Rival'}:${r.actorName}`
-                )
-                .join(', ')
-            : 'None';
-
-        // Identity & Bias
-        const recentTopics = ctx.recentPosts
-          .slice(0, 3) // Last 3 posts
-          .map((p) => p.content.substring(0, 20) + '...')
-          .join(' | ');
-
-        // Format Private Intel (Group Chats)
-        // Only show the last 2 messages to keep context tight
-        const privateIntel =
-          ctx.groupChatMessages.length > 0
-            ? ctx.groupChatMessages
-                .slice(0, 2)
-                .map((m) => `"${m.fromName}: ${m.message}"`)
-                .join(' | ')
-            : 'None';
-
-        return `[${i + 1}] TRADER DASHBOARD
-ID: ${ctx.npcId} | Name: ${ctx.npcName}
-Archetype: ${archetype} | Strategy: ${strategy.label} (${strategyKey})
-Bias: ${formatTradingStrategyBias(strategy)} | Cash: $${ctx.availableBalance.toLocaleString()}
-Total PnL: ${pnlSign}$${totalPnL.toFixed(0)} | Exposure: ${exposure.toFixed(1)}%
-Network: ${relationships}
-Positions: ${topPositions || 'None'}
-Current Focus: ${recentTopics || 'Market General'}
-🔒 PRIVATE INTEL: ${privateIntel}`;
-      })
-      .join('\n----------------------------------------\n');
+    return formatNPCsDashboardList(contexts);
   }
 
   /**

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -206,6 +206,13 @@ export {
   getPositionExposure,
   type PoolMetrics,
 } from './npc/portfolio-metrics';
+// NPC Trading Strategies (strategy assignment, bias formatting)
+export {
+  formatTradingStrategyBias,
+  getNpcTradingStrategy,
+  type NPCTradingStrategyKey,
+  TRADING_STRATEGIES,
+} from './npc/trading-strategies';
 export {
   calculatePerpPositionMarketValue,
   toNumber,
@@ -415,6 +422,12 @@ export {
   calculateEstimatedCost,
   TOKEN_COST_PER_MILLION,
 } from './types/token-stats';
+// Utils - Context Building (comprehensive NPC context for posting/feed)
+export {
+  buildComprehensiveNPCContext,
+  type ComprehensiveNPCContext,
+  formatComprehensiveContext,
+} from './utils/context-builder';
 // Utils - Entropy (secure random, weighted picks, cooldowns)
 export {
   biasedRandomCount,
@@ -443,6 +456,21 @@ export {
   sampleRandom,
   shuffleArray,
 } from './utils/randomization';
+// Utils - Shared Character/Feed Context (entropy, phase, time-of-day)
+export {
+  buildCharacterFeedContext,
+  buildPhaseContext,
+  formatCharacterInfoWithEntropy,
+  getPhaseForDay,
+} from './utils/shared-utils';
+// Utils - Trading Dashboard Formatting (shared NPC dashboard + market table)
+export {
+  calculatePortfolioExposure,
+  formatMarketDataTable,
+  formatNPCsDashboardList,
+  formatSingleNPCDashboard,
+  mapPersonalityToArchetype,
+} from './utils/trading-dashboard-format';
 // World Facts Service
 export {
   type WorldFactsContext,

--- a/packages/engine/src/utils/trading-dashboard-format.ts
+++ b/packages/engine/src/utils/trading-dashboard-format.ts
@@ -1,0 +1,180 @@
+/**
+ * Shared Trading Dashboard Formatting
+ *
+ * Canonical helpers for formatting NPC trading dashboards and market tables.
+ * Used by both MarketDecisionEngine (LLM prompt) and dev tools (context-inspector).
+ *
+ * Extracted from MarketDecisionEngine private methods to enable reuse
+ * without behavioral drift.
+ */
+
+import {
+  formatTradingStrategyBias,
+  getNpcTradingStrategy,
+  TRADING_STRATEGIES,
+} from '../npc/trading-strategies';
+import type { NPCMarketContext, NPCPosition } from '../types/market-context';
+
+/**
+ * Map a free-text personality description to a trading archetype label.
+ *
+ * Mirrors the logic previously private on MarketDecisionEngine.
+ */
+export function mapPersonalityToArchetype(personality: string): string {
+  const p = personality.toLowerCase();
+  if (
+    p.includes('risk') ||
+    p.includes('aggressive') ||
+    p.includes('degen') ||
+    p.includes('speculator')
+  ) {
+    return 'DEGEN_TRADER';
+  }
+  if (
+    p.includes('cautious') ||
+    p.includes('conservative') ||
+    p.includes('manager')
+  ) {
+    return 'RISK_MANAGER';
+  }
+  if (p.includes('analytical') || p.includes('quant') || p.includes('math')) {
+    return 'QUANT_TRADER';
+  }
+  if (p.includes('insider') || p.includes('connected')) {
+    return 'INSIDER';
+  }
+  return 'SYSTEMATIC_TRADER';
+}
+
+/**
+ * Calculate portfolio exposure as a percentage of total equity.
+ *
+ * Formula: (totalPositionValue / totalEquity) × 100
+ * where totalPositionValue = Σ(size + unrealizedPnL)
+ * and   totalEquity        = cash + totalPositionValue
+ *
+ * Clamped to [0, 100].
+ */
+export function calculatePortfolioExposure(
+  balance: number,
+  positions: Pick<NPCPosition, 'size' | 'unrealizedPnL'>[]
+): number {
+  const totalPositionValue = positions.reduce(
+    (sum, p) => sum + p.size + p.unrealizedPnL,
+    0
+  );
+  const totalEquity = balance + totalPositionValue;
+
+  if (totalEquity <= 0) return 0;
+  return Math.min(100, Math.max(0, (totalPositionValue / totalEquity) * 100));
+}
+
+/**
+ * Format a single NPC's trading dashboard block.
+ *
+ * Produces the same output as MarketDecisionEngine.formatNPCsList per entry.
+ * @param ctx   - Full NPC market context
+ * @param index - Optional 1-based index for multi-NPC listings
+ */
+export function formatSingleNPCDashboard(
+  ctx: NPCMarketContext,
+  index?: number
+): string {
+  const archetype = mapPersonalityToArchetype(ctx.personality);
+  const strategyKey = getNpcTradingStrategy(ctx.npcId);
+  const strategy = TRADING_STRATEGIES[strategyKey];
+  const exposure = calculatePortfolioExposure(
+    ctx.availableBalance,
+    ctx.currentPositions
+  );
+
+  const totalPnL = ctx.currentPositions.reduce(
+    (sum, p) => sum + p.unrealizedPnL,
+    0
+  );
+  const pnlSign = totalPnL >= 0 ? '+' : '';
+
+  const topPositions = ctx.currentPositions
+    .sort((a, b) => Math.abs(b.unrealizedPnL) - Math.abs(a.unrealizedPnL))
+    .slice(0, 3)
+    .map((p) => {
+      const symbol = p.marketType === 'perp' ? p.ticker : `Q${p.marketId}`;
+      const posSign = p.unrealizedPnL >= 0 ? '+' : '';
+      return `${symbol} ${p.side} ($${p.size.toFixed(0)}, PnL: ${posSign}$${p.unrealizedPnL.toFixed(0)}) [ID:${p.id}]`;
+    })
+    .join(', ');
+
+  const relationships =
+    ctx.relationships && ctx.relationships.length > 0
+      ? ctx.relationships
+          .filter((r) => Math.abs(r.sentiment) > 0.4)
+          .slice(0, 4)
+          .map((r) => `${r.sentiment > 0 ? 'Ally' : 'Rival'}:${r.actorName}`)
+          .join(', ')
+      : 'None';
+
+  const recentTopics = ctx.recentPosts
+    .slice(0, 3)
+    .map((p) => p.content.substring(0, 20) + '...')
+    .join(' | ');
+
+  const privateIntel =
+    ctx.groupChatMessages.length > 0
+      ? ctx.groupChatMessages
+          .slice(0, 2)
+          .map((m) => `"${m.fromName}: ${m.message}"`)
+          .join(' | ')
+      : 'None';
+
+  const prefix = index !== undefined ? `[${index}] ` : '';
+
+  return `${prefix}TRADER DASHBOARD
+ID: ${ctx.npcId} | Name: ${ctx.npcName}
+Archetype: ${archetype} | Strategy: ${strategy.label} (${strategyKey})
+Bias: ${formatTradingStrategyBias(strategy)} | Cash: $${ctx.availableBalance.toLocaleString()}
+Total PnL: ${pnlSign}$${totalPnL.toFixed(0)} | Exposure: ${exposure.toFixed(1)}%
+Network: ${relationships}
+Positions: ${topPositions || 'None'}
+Current Focus: ${recentTopics || 'Market General'}
+🔒 PRIVATE INTEL: ${privateIntel}`;
+}
+
+/**
+ * Format an array of NPC contexts into a separator-delimited dashboard list.
+ *
+ * Direct replacement for MarketDecisionEngine.formatNPCsList.
+ */
+export function formatNPCsDashboardList(contexts: NPCMarketContext[]): string {
+  return contexts
+    .map((ctx, i) => formatSingleNPCDashboard(ctx, i + 1))
+    .join('\n----------------------------------------\n');
+}
+
+/**
+ * Format the shared market data table shown to all NPCs.
+ *
+ * Direct replacement for MarketDecisionEngine.formatMarketTable.
+ * Takes a single context (all NPCs see the same market state).
+ */
+export function formatMarketDataTable(ctx: NPCMarketContext): string {
+  const perps = ctx.perpMarkets || [];
+  const predictions = ctx.predictionMarkets || [];
+
+  if (perps.length === 0 && predictions.length === 0) {
+    return 'No Market Data Available';
+  }
+
+  let table =
+    '| Ticker/ID | Type | Price | 24h Change | Volume/Liq |\n|---|---|---|---|---|\n';
+
+  for (const p of perps) {
+    const sign = p.changePercent24h >= 0 ? '+' : '';
+    table += `| ${p.ticker} | PERP | $${p.currentPrice.toFixed(2)} | ${sign}${p.changePercent24h.toFixed(2)}% | Vol: $${(p.volume24h / 1000).toFixed(1)}k |\n`;
+  }
+
+  for (const p of predictions) {
+    table += `| ${p.id} | PRED | Yes: ${p.yesPrice.toFixed(0)}¢ | No: ${p.noPrice.toFixed(0)}¢ | Vol: $${(p.totalVolume / 1000).toFixed(1)}k |\n`;
+  }
+
+  return table;
+}

--- a/packages/engine/src/utils/trading-dashboard-format.ts
+++ b/packages/engine/src/utils/trading-dashboard-format.ts
@@ -94,7 +94,7 @@ export function formatSingleNPCDashboard(
   );
   const pnlSign = totalPnL >= 0 ? '+' : '';
 
-  const topPositions = ctx.currentPositions
+  const topPositions = [...ctx.currentPositions]
     .sort((a, b) => Math.abs(b.unrealizedPnL) - Math.abs(a.unrealizedPnL))
     .slice(0, 3)
     .map((p) => {

--- a/scripts/context-inspector.ts
+++ b/scripts/context-inspector.ts
@@ -20,65 +20,13 @@
 import { parseArgs } from 'node:util';
 import {
   generateWorldContext,
-  getShuffledExamplesText,
   MarketContextService,
+  MarketDecisionEngine,
   type NPCMarketContext,
   npcMarketDecisions,
   renderPrompt,
   StaticDataRegistry,
 } from '@babylon/engine';
-
-// ---------------------------------------------------------------------------
-// Inlined trading strategy logic (from engine/src/npc/trading-strategies.ts)
-// These are private internals not exported from @babylon/engine.
-// ---------------------------------------------------------------------------
-const TRADING_STRATEGIES = {
-  momentum: {
-    label: 'Momentum',
-    followTrend: 0.7,
-    contrarian: 0.2,
-    random: 0.1,
-  },
-  contrarian: {
-    label: 'Contrarian',
-    followTrend: 0.2,
-    contrarian: 0.7,
-    random: 0.1,
-  },
-  value: { label: 'Value', followTrend: 0.3, contrarian: 0.4, random: 0.3 },
-  random: {
-    label: 'Random',
-    followTrend: 0.33,
-    contrarian: 0.33,
-    random: 0.34,
-  },
-} as const;
-
-type StrategyKey = keyof typeof TRADING_STRATEGIES;
-
-function hashStringToUint32(value: string): number {
-  let hash = 0;
-  for (let i = 0; i < value.length; i++) {
-    hash = (hash << 5) - hash + value.charCodeAt(i);
-    hash |= 0;
-  }
-  return hash >>> 0;
-}
-
-function getNpcTradingStrategy(npcId: string): StrategyKey {
-  const keys = Object.keys(TRADING_STRATEGIES) as StrategyKey[];
-  const hash = hashStringToUint32(npcId);
-  return keys[hash % keys.length] as StrategyKey;
-}
-
-function formatTradingStrategyBias(bias: {
-  followTrend: number;
-  contrarian: number;
-  random: number;
-}): string {
-  const toPct = (v: number) => `${Math.round(v * 100)}%`;
-  return `Follow trend: ${toPct(bias.followTrend)} | Contrarian: ${toPct(bias.contrarian)} | Random: ${toPct(bias.random)}`;
-}
 
 // ---------------------------------------------------------------------------
 // ANSI helpers
@@ -150,101 +98,9 @@ Options:
 }
 
 // ---------------------------------------------------------------------------
-// Replicate MarketDecisionEngine formatting (private methods)
+// No inlined engine formatting — we use the real MarketDecisionEngine
+// and renderPrompt to produce the actual prompt NPCs receive.
 // ---------------------------------------------------------------------------
-
-function mapPersonalityToArchetype(personality: string): string {
-  const p = personality.toLowerCase();
-  if (
-    p.includes('risk') ||
-    p.includes('aggressive') ||
-    p.includes('degen') ||
-    p.includes('speculator')
-  )
-    return 'DEGEN_TRADER';
-  if (
-    p.includes('cautious') ||
-    p.includes('conservative') ||
-    p.includes('manager')
-  )
-    return 'RISK_MANAGER';
-  if (p.includes('analytical') || p.includes('quant') || p.includes('math'))
-    return 'QUANT_TRADER';
-  if (p.includes('insider') || p.includes('connected')) return 'INSIDER';
-  return 'SYSTEMATIC_TRADER';
-}
-
-function formatMarketTable(ctx: NPCMarketContext): string {
-  const perps = ctx.perpMarkets || [];
-  const predictions = ctx.predictionMarkets || [];
-  let table =
-    '| Ticker/ID | Type | Price | 24h Change | Volume/Liq |\n|---|---|---|---|---|\n';
-  for (const p of perps) {
-    const sign = p.changePercent24h >= 0 ? '+' : '';
-    table += `| ${p.ticker} | PERP | $${p.currentPrice.toFixed(2)} | ${sign}${p.changePercent24h.toFixed(2)}% | Vol: $${(p.volume24h / 1000).toFixed(1)}k |\n`;
-  }
-  for (const p of predictions) {
-    table += `| ${p.id} | PRED | Yes: ${p.yesPrice.toFixed(0)}c | No: ${p.noPrice.toFixed(0)}c | Vol: $${(p.totalVolume / 1000).toFixed(1)}k |\n`;
-  }
-  return table;
-}
-
-function formatNPCDashboard(ctx: NPCMarketContext): string {
-  const archetype = mapPersonalityToArchetype(ctx.personality);
-  const strategyKey = getNpcTradingStrategy(ctx.npcId);
-  const strategy = TRADING_STRATEGIES[strategyKey];
-
-  const totalSize = ctx.currentPositions.reduce((s, p) => s + p.size, 0);
-  const exposure =
-    ctx.availableBalance > 0 ? (totalSize / ctx.availableBalance) * 100 : 0;
-  const totalPnL = ctx.currentPositions.reduce(
-    (s, p) => s + p.unrealizedPnL,
-    0
-  );
-  const pnlSign = totalPnL >= 0 ? '+' : '';
-
-  const topPositions = ctx.currentPositions
-    .sort((a, b) => Math.abs(b.unrealizedPnL) - Math.abs(a.unrealizedPnL))
-    .slice(0, 3)
-    .map((p) => {
-      const symbol = p.marketType === 'perp' ? p.ticker : `Q${p.marketId}`;
-      const posSign = p.unrealizedPnL >= 0 ? '+' : '';
-      return `${symbol} ${p.side} ($${p.size.toFixed(0)}, PnL: ${posSign}$${p.unrealizedPnL.toFixed(0)}) [ID:${p.id}]`;
-    })
-    .join(', ');
-
-  const relationships =
-    ctx.relationships && ctx.relationships.length > 0
-      ? ctx.relationships
-          .filter((r) => Math.abs(r.sentiment) > 0.4)
-          .slice(0, 4)
-          .map((r) => `${r.sentiment > 0 ? 'Ally' : 'Rival'}:${r.actorName}`)
-          .join(', ')
-      : 'None';
-
-  const recentTopics = ctx.recentPosts
-    .slice(0, 3)
-    .map((p) => p.content.substring(0, 20) + '...')
-    .join(' | ');
-
-  const privateIntel =
-    ctx.groupChatMessages.length > 0
-      ? ctx.groupChatMessages
-          .slice(0, 2)
-          .map((m) => `"${m.fromName}: ${m.message}"`)
-          .join(' | ')
-      : 'None';
-
-  return `TRADER DASHBOARD
-ID: ${ctx.npcId} | Name: ${ctx.npcName}
-Archetype: ${archetype} | Strategy: ${strategy.label} (${strategyKey})
-Bias: ${formatTradingStrategyBias(strategy)} | Cash: $${ctx.availableBalance.toLocaleString()}
-Total PnL: ${pnlSign}$${totalPnL.toFixed(0)} | Exposure: ${exposure.toFixed(1)}%
-Network: ${relationships}
-Positions: ${topPositions || 'None'}
-Current Focus: ${recentTopics || 'Market General'}
-PRIVATE INTEL: ${privateIntel}`;
-}
 
 // ---------------------------------------------------------------------------
 // Template variable extraction
@@ -255,14 +111,18 @@ function extractTemplateVars(template: string): string[] {
 }
 
 // ---------------------------------------------------------------------------
-// Trading context inspection
+// Trading context inspection — uses the real MarketDecisionEngine pipeline
 // ---------------------------------------------------------------------------
+
+const { getShuffledExamplesText } = await import(
+  '../packages/engine/src/prompts'
+);
+
 async function inspectTradingContext(npcId: string): Promise<{
   sections: Array<{
     name: string;
     tokens: number;
     populated: boolean;
-    truncated?: boolean;
   }>;
   ghostVars: string[];
   totalTokens: number;
@@ -272,18 +132,33 @@ async function inspectTradingContext(npcId: string): Promise<{
   const svc = new MarketContextService();
   const ctx = await svc.buildContextForNPC(npcId);
 
+  // Create engine with a stub LLM — we only need formatting, not generation
+  const stubLlm = { getProvider: () => 'groq' } as never;
+  const engine = new MarketDecisionEngine(stubLlm, svc);
+
+  // Call the same methods the engine calls in generateDecisionsForContexts
+  // Since formatNPCsList and formatMarketTable are private, we access them
+  // through the prototype (acceptable for a dev tool)
+  const formatNPCsList = (engine as never as Record<string, Function>)[
+    'formatNPCsList'
+  ].bind(engine);
+  const formatMarketTable = (engine as never as Record<string, Function>)[
+    'formatMarketTable'
+  ].bind(engine);
+
+  const npcsList = formatNPCsList([ctx]) as string;
+  const marketTable = formatMarketTable([ctx]) as string;
+
   const worldContext = await generateWorldContext();
   const examples = getShuffledExamplesText();
-  const npcsList = formatNPCDashboard(ctx);
-  const marketTable = formatMarketTable(ctx);
 
   const validNpcIds = ctx.npcId;
   const allTickers = new Set<string>();
-  ctx.perpMarkets.forEach((m) => allTickers.add(m.ticker));
+  ctx.perpMarkets.forEach((m: { ticker: string }) => allTickers.add(m.ticker));
   const validTickers =
     allTickers.size > 0 ? Array.from(allTickers).join(', ') : 'N/A';
 
-  // Assemble the variables passed to renderPrompt
+  // Assemble the exact same variables the engine passes to renderPrompt
   const vars: Record<string, string> = {
     examples,
     marketTable,
@@ -292,20 +167,18 @@ async function inspectTradingContext(npcId: string): Promise<{
     validNpcIds,
     validTickers,
     realityGrounding: worldContext.realityGrounding,
-    activeQuestions: '', // optional in prompt
-    recentEvents: '', // optional in prompt
+    activeQuestions: '',
+    recentEvents: '',
     richGameContext: worldContext.richGameContext || '',
     eventMarketSignals: 'No event-market signals available',
   };
 
-  // Render and measure
   const rendered = renderPrompt(npcMarketDecisions, vars, {
     allowEmpty: true,
   });
 
-  // Find ghost vars (in template but not in vars)
+  // Find ghost vars (in template but not supplied)
   const templateVars = extractTemplateVars(npcMarketDecisions.template);
-  // Auto-injected date vars from renderPrompt
   const autoVars = new Set([
     'currentDateTime',
     'currentDate',
@@ -317,16 +190,16 @@ async function inspectTradingContext(npcId: string): Promise<{
   const suppliedVarKeys = new Set([...Object.keys(vars), ...autoVars]);
   const ghostVars = templateVars.filter((v) => !suppliedVarKeys.has(v));
 
-  // Build section report
   const sections = Object.entries(vars).map(([name, value]) => ({
     name,
     tokens: estimateTokens(value),
     populated: value.trim().length > 0,
   }));
 
-  // Position visibility
+  // Position count — the engine now shows all positions (not capped at 3)
   const totalPositions = ctx.currentPositions.length;
-  const shownPositions = Math.min(totalPositions, 3); // formatNPCDashboard shows max 3
+  // Count how many actually appear in the rendered dashboard
+  const shownPositions = (npcsList.match(/\[ID:/g) || []).length;
 
   return {
     sections,
@@ -339,6 +212,10 @@ async function inspectTradingContext(npcId: string): Promise<{
 
 // ---------------------------------------------------------------------------
 // Posting context inspection
+// NOTE: FeedGenerator.buildRichCharacterContext is private and deeply stateful
+// (requires LLM, event history, relationship engine, etc.). This inspection
+// shows the data that WOULD be available to the posting pipeline, but does
+// not render the exact posting prompt. Use --type trading for exact prompts.
 // ---------------------------------------------------------------------------
 async function inspectPostingContext(npcId: string): Promise<{
   sections: Array<{ name: string; tokens: number; populated: boolean }>;
@@ -351,8 +228,11 @@ async function inspectPostingContext(npcId: string): Promise<{
     return { sections: [], totalTokens: 0 };
   }
 
-  // Build character context sections manually since buildRichCharacterContext
-  // is private on FeedGenerator
+  console.log(
+    `${YELLOW}NOTE: Posting context is an approximation. FeedGenerator.buildRichCharacterContext ` +
+      `is private and stateful. Use --type trading for exact engine prompts.${RESET}`
+  );
+
   const svc = new MarketContextService();
   const events = await svc.getEventsForNPC(npcId, actor.name);
   const recentPosts = await svc.getRecentPostsByNPC(npcId);
@@ -423,7 +303,8 @@ async function inspectPostingContext(npcId: string): Promise<{
   const totalTokens = sections.reduce((s, sec) => s + sec.tokens, 0);
 
   const rawPrompt = showRaw
-    ? [
+    ? `${YELLOW}[APPROXIMATION — not the exact FeedGenerator prompt]${RESET}\n` +
+      [
         characterInfo,
         eventsText,
         postsText,
@@ -794,18 +675,27 @@ async function main() {
     }
 
     if (inspectType === 'posting' || inspectType === 'both') {
-      subheading(`Posting Context (${allActors.length} NPCs)`);
-      for (const actor of allActors.slice(0, 5)) {
+      subheading(`Posting Context — approximation (${allActors.length} NPCs)`);
+      let totalPostingTokens = 0;
+      let totalPopulated = 0;
+      let totalSections = 0;
+
+      for (const actor of allActors) {
         const result = await inspectPostingContext(actor.id);
-        console.log(
-          `  ${actor.id.padEnd(24)} ${String(result.totalTokens).padStart(5)} tokens  ${result.sections.filter((s) => s.populated).length}/${result.sections.length} sections populated`
-        );
+        totalPostingTokens += result.totalTokens;
+        totalPopulated += result.sections.filter((s) => s.populated).length;
+        totalSections += result.sections.length;
+
+        if (!showSummary) {
+          console.log(
+            `  ${actor.id.padEnd(24)} ${String(result.totalTokens).padStart(5)} tokens  ${result.sections.filter((s) => s.populated).length}/${result.sections.length} sections`
+          );
+        }
       }
-      if (allActors.length > 5) {
-        console.log(
-          `  ${DIM}... and ${allActors.length - 5} more (use --npc <id> for full detail)${RESET}`
-        );
-      }
+
+      console.log(
+        `\nTotal posting tokens: ${totalPostingTokens} | Avg per NPC: ${Math.round(totalPostingTokens / allActors.length)} | Populated: ${totalPopulated}/${totalSections} sections`
+      );
     }
 
     process.exit(0);

--- a/scripts/context-inspector.ts
+++ b/scripts/context-inspector.ts
@@ -7,6 +7,10 @@
  * and posting decisions. Renders the full prompt and reports on token usage,
  * truncation, ghost variables, and position visibility.
  *
+ * Uses the canonical engine pipelines:
+ * - Trading: MarketContextService → shared dashboard formatters → renderPrompt(npcMarketDecisions)
+ * - Posting: buildComprehensiveNPCContext → formatComprehensiveContext → buildCharacterFeedContext → renderPrompt(ambientPosts)
+ *
  * Usage (NPCs):
  *   bun run inspect:context -- --npc ailon-musk --type trading
  *   bun run inspect:context -- --npc all --type both --summary
@@ -19,14 +23,25 @@
 
 import { parseArgs } from 'node:util';
 import {
+  ambientPosts,
+  buildCharacterFeedContext,
+  buildComprehensiveNPCContext,
+  buildPhaseContext,
+  calculatePortfolioExposure,
+  formatCharacterInfoWithEntropy,
+  formatComprehensiveContext,
+  formatMarketDataTable,
+  formatSingleNPCDashboard,
   generateWorldContext,
+  getShuffledExamplesText,
+  getTimeOfDayEnergy,
   MarketContextService,
-  MarketDecisionEngine,
   type NPCMarketContext,
   npcMarketDecisions,
   renderPrompt,
   StaticDataRegistry,
 } from '@babylon/engine';
+import type { Actor } from '@babylon/shared';
 
 // ---------------------------------------------------------------------------
 // ANSI helpers
@@ -77,7 +92,14 @@ const { values: args } = parseArgs({
 
 const npcArg = args.npc || '';
 const agentArg = args.agent || '';
-const inspectType = args.type as 'trading' | 'posting' | 'both';
+const validTypes = new Set(['trading', 'posting', 'both']);
+if (args.type && !validTypes.has(args.type)) {
+  console.error(
+    `${RED}Invalid --type "${args.type}". Must be one of: trading, posting, both${RESET}`
+  );
+  process.exit(1);
+}
+const inspectType = (args.type || 'trading') as 'trading' | 'posting' | 'both';
 const showDiff = args.diff ?? false;
 const showSummary = args.summary ?? false;
 const showRaw = args.raw ?? false;
@@ -98,11 +120,6 @@ Options:
 }
 
 // ---------------------------------------------------------------------------
-// No inlined engine formatting — we use the real MarketDecisionEngine
-// and renderPrompt to produce the actual prompt NPCs receive.
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
 // Template variable extraction
 // ---------------------------------------------------------------------------
 function extractTemplateVars(template: string): string[] {
@@ -111,54 +128,37 @@ function extractTemplateVars(template: string): string[] {
 }
 
 // ---------------------------------------------------------------------------
-// Trading context inspection — uses the real MarketDecisionEngine pipeline
+// Trading context inspection
+// Uses MarketContextService + shared dashboard formatters + renderPrompt
 // ---------------------------------------------------------------------------
-
-const { getShuffledExamplesText } = await import(
-  '../packages/engine/src/prompts'
-);
-
 async function inspectTradingContext(npcId: string): Promise<{
   sections: Array<{
     name: string;
     tokens: number;
     populated: boolean;
+    truncated?: boolean;
   }>;
   ghostVars: string[];
   totalTokens: number;
   positionVisibility: { total: number; shown: number };
   rawPrompt?: string;
+  rawContext: NPCMarketContext;
 }> {
   const svc = new MarketContextService();
   const ctx = await svc.buildContextForNPC(npcId);
 
-  // Create engine with a stub LLM — we only need formatting, not generation
-  const stubLlm = { getProvider: () => 'groq' } as never;
-  const engine = new MarketDecisionEngine(stubLlm, svc);
-
-  // Call the same methods the engine calls in generateDecisionsForContexts
-  // Since formatNPCsList and formatMarketTable are private, we access them
-  // through the prototype (acceptable for a dev tool)
-  const formatNPCsList = (engine as never as Record<string, Function>)[
-    'formatNPCsList'
-  ].bind(engine);
-  const formatMarketTable = (engine as never as Record<string, Function>)[
-    'formatMarketTable'
-  ].bind(engine);
-
-  const npcsList = formatNPCsList([ctx]) as string;
-  const marketTable = formatMarketTable([ctx]) as string;
-
   const worldContext = await generateWorldContext();
   const examples = getShuffledExamplesText();
+  const npcsList = formatSingleNPCDashboard(ctx);
+  const marketTable = formatMarketDataTable(ctx);
 
   const validNpcIds = ctx.npcId;
   const allTickers = new Set<string>();
-  ctx.perpMarkets.forEach((m: { ticker: string }) => allTickers.add(m.ticker));
+  ctx.perpMarkets.forEach((m) => allTickers.add(m.ticker));
   const validTickers =
     allTickers.size > 0 ? Array.from(allTickers).join(', ') : 'N/A';
 
-  // Assemble the exact same variables the engine passes to renderPrompt
+  // Assemble the variables passed to renderPrompt
   const vars: Record<string, string> = {
     examples,
     marketTable,
@@ -173,12 +173,14 @@ async function inspectTradingContext(npcId: string): Promise<{
     eventMarketSignals: 'No event-market signals available',
   };
 
+  // Render and measure
   const rendered = renderPrompt(npcMarketDecisions, vars, {
     allowEmpty: true,
   });
 
-  // Find ghost vars (in template but not supplied)
+  // Find ghost vars (in template but not in vars)
   const templateVars = extractTemplateVars(npcMarketDecisions.template);
+  // Auto-injected date vars from renderPrompt
   const autoVars = new Set([
     'currentDateTime',
     'currentDate',
@@ -190,16 +192,16 @@ async function inspectTradingContext(npcId: string): Promise<{
   const suppliedVarKeys = new Set([...Object.keys(vars), ...autoVars]);
   const ghostVars = templateVars.filter((v) => !suppliedVarKeys.has(v));
 
+  // Build section report
   const sections = Object.entries(vars).map(([name, value]) => ({
     name,
     tokens: estimateTokens(value),
     populated: value.trim().length > 0,
   }));
 
-  // Position count — the engine now shows all positions (not capped at 3)
+  // Position visibility
   const totalPositions = ctx.currentPositions.length;
-  // Count how many actually appear in the rendered dashboard
-  const shownPositions = (npcsList.match(/\[ID:/g) || []).length;
+  const shownPositions = Math.min(totalPositions, 3); // formatSingleNPCDashboard shows max 3
 
   return {
     sections,
@@ -207,15 +209,15 @@ async function inspectTradingContext(npcId: string): Promise<{
     totalTokens: estimateTokens(rendered),
     positionVisibility: { total: totalPositions, shown: shownPositions },
     rawPrompt: showRaw ? rendered : undefined,
+    rawContext: ctx,
   };
 }
 
 // ---------------------------------------------------------------------------
 // Posting context inspection
-// NOTE: FeedGenerator.buildRichCharacterContext is private and deeply stateful
-// (requires LLM, event history, relationship engine, etc.). This inspection
-// shows the data that WOULD be available to the posting pipeline, but does
-// not render the exact posting prompt. Use --type trading for exact prompts.
+// Uses the canonical pipeline: buildComprehensiveNPCContext →
+// formatComprehensiveContext → buildCharacterFeedContext →
+// renderPrompt(ambientPosts, ...)
 // ---------------------------------------------------------------------------
 async function inspectPostingContext(npcId: string): Promise<{
   sections: Array<{ name: string; tokens: number; populated: boolean }>;
@@ -228,91 +230,188 @@ async function inspectPostingContext(npcId: string): Promise<{
     return { sections: [], totalTokens: 0 };
   }
 
-  console.log(
-    `${YELLOW}NOTE: Posting context is an approximation. FeedGenerator.buildRichCharacterContext ` +
-      `is private and stateful. Use --type trading for exact engine prompts.${RESET}`
+  // 1. Build comprehensive context (same as FeedGenerator.buildRichCharacterContext)
+  // Cast StaticActor → Actor: StaticActor is a structural subset loaded from JSON;
+  // buildComprehensiveNPCContext only reads fields that overlap.
+  const currentDay = 15; // Mid-game default for inspection
+  const comprehensiveContext = await buildComprehensiveNPCContext(
+    actor as Actor,
+    currentDay
   );
 
-  const svc = new MarketContextService();
-  const events = await svc.getEventsForNPC(npcId, actor.name);
-  const recentPosts = await svc.getRecentPostsByNPC(npcId);
-  const worldContext = await generateWorldContext();
+  // 2. Format comprehensive context into text sections
+  const comprehensiveContextText =
+    formatComprehensiveContext(comprehensiveContext);
 
+  // 3. Format character info with entropy (same as FeedGenerator)
+  const relationshipContextStr =
+    comprehensiveContext.relationships
+      ?.map(
+        (r) =>
+          `${r.strength} ${r.type} with ${r.otherActorName} (${r.sentiment})${r.history ? ` - ${r.history}` : ''}`
+      )
+      .join('\n') || '';
+
+  const positionsContextStr =
+    comprehensiveContext.marketPositions
+      ?.map(
+        (p) =>
+          `${p.market}: ${p.side}${p.pnl !== undefined ? ` (${p.pnl >= 0 ? '+' : ''}${p.pnl.toFixed(2)})` : ''}`
+      )
+      .join('\n') || '';
+
+  // StaticActor doesn't carry persona data (it's loaded from static JSON).
+  // The persona fields are optional in formatCharacterInfoWithEntropy, so
+  // we pass what StaticActor has and let persona-dependent sections be skipped.
+  const characterInfo = formatCharacterInfoWithEntropy({
+    name: actor.name,
+    description: actor.description || undefined,
+    profileDescription: actor.profileDescription || undefined,
+    domain: actor.domain || undefined,
+    postStyle: actor.postStyle || undefined,
+    postExample: actor.postExample || undefined,
+    voice: actor.voice || undefined,
+    personality: actor.personality || undefined,
+    affiliations: actor.affiliations || undefined,
+    tier: actor.tier || undefined,
+    relationshipContext: relationshipContextStr || undefined,
+    currentPositions: positionsContextStr || undefined,
+  });
+
+  // 4. Build full character feed context with entropy-based section ordering
+  const fullCharacterContext = buildCharacterFeedContext({
+    characterInfo,
+    comprehensiveContext: comprehensiveContextText,
+  });
+
+  // 5. Build phase and world context
+  const worldContext = await generateWorldContext();
+  const phaseContext = buildPhaseContext(currentDay);
+  const hour = Math.floor(Math.random() * 24);
+
+  // 6. Render the actual prompt template (ambientPosts)
+  const rendered = renderPrompt(
+    ambientPosts,
+    {
+      day: currentDay.toString(),
+      progressContext: phaseContext,
+      atmosphereContext:
+        'Increasing activity and developments in various areas. Individual perspectives vary.',
+      trendContext: '',
+      timeEnergy: getTimeOfDayEnergy(hour),
+      characterName: actor.name,
+      characterInfo: fullCharacterContext,
+      ...worldContext,
+    },
+    { allowEmpty: true }
+  );
+
+  // Build section report from the context components
   const sections: Array<{ name: string; tokens: number; populated: boolean }> =
     [];
 
-  const characterInfo = [
-    `Name: ${actor.name}`,
-    actor.description ? `Description: ${actor.description}` : '',
-    actor.personality ? `Personality: ${actor.personality}` : '',
-    actor.voice ? `Voice: ${actor.voice}` : '',
-    actor.postStyle ? `Post Style: ${actor.postStyle}` : '',
-    actor.postExample.length > 0
-      ? `Examples: ${actor.postExample.join(' | ')}`
-      : '',
-    actor.domain.length > 0 ? `Domains: ${actor.domain.join(', ')}` : '',
-    actor.affiliations.length > 0
-      ? `Affiliations: ${actor.affiliations.join(', ')}`
-      : '',
-    actor.tier ? `Tier: ${actor.tier}` : '',
-  ]
-    .filter(Boolean)
-    .join('\n');
-
   sections.push({
-    name: 'characterInfo',
+    name: 'characterInfo (with entropy)',
     tokens: estimateTokens(characterInfo),
     populated: characterInfo.length > 0,
   });
-
-  const eventsText = events
-    .map((e) => `[${e.type}] ${e.description}`)
-    .join('\n');
   sections.push({
-    name: 'personalEvents',
-    tokens: estimateTokens(eventsText),
-    populated: eventsText.length > 0,
+    name: 'comprehensiveContext',
+    tokens: estimateTokens(comprehensiveContextText),
+    populated: comprehensiveContextText.length > 0,
   });
-
-  const postsText = recentPosts.map((p) => p.content).join('\n');
   sections.push({
-    name: 'previousPosts',
-    tokens: estimateTokens(postsText),
-    populated: postsText.length > 0,
+    name: 'fullCharacterContext (composed)',
+    tokens: estimateTokens(fullCharacterContext),
+    populated: fullCharacterContext.length > 0,
   });
-
   sections.push({
     name: 'realityGrounding',
     tokens: estimateTokens(worldContext.realityGrounding),
     populated: worldContext.realityGrounding.length > 0,
   });
-
   sections.push({
-    name: 'worldActors',
+    name: 'worldActors (characterRoster)',
     tokens: estimateTokens(worldContext.worldActors),
     populated: worldContext.worldActors.length > 0,
   });
-
-  const richCtx = worldContext.richGameContext || '';
   sections.push({
     name: 'richGameContext',
-    tokens: estimateTokens(richCtx),
-    populated: richCtx.length > 0,
+    tokens: estimateTokens(worldContext.richGameContext || ''),
+    populated: (worldContext.richGameContext || '').length > 0,
+  });
+  sections.push({
+    name: 'phaseContext',
+    tokens: estimateTokens(phaseContext),
+    populated: phaseContext.length > 0,
+  });
+  sections.push({
+    name: 'timeEnergy',
+    tokens: estimateTokens(getTimeOfDayEnergy(hour)),
+    populated: true,
   });
 
-  const totalTokens = sections.reduce((s, sec) => s + sec.tokens, 0);
+  // Detailed sub-sections from comprehensiveContext
+  if (comprehensiveContext.personalEvents.length > 0) {
+    sections.push({
+      name: '  └ personalEvents',
+      tokens: estimateTokens(
+        comprehensiveContext.personalEvents.map((e) => e.description).join('\n')
+      ),
+      populated: true,
+    });
+  }
+  if (comprehensiveContext.recentEvents.length > 0) {
+    sections.push({
+      name: '  └ recentEvents',
+      tokens: estimateTokens(
+        comprehensiveContext.recentEvents.map((e) => e.description).join('\n')
+      ),
+      populated: true,
+    });
+  }
+  if (comprehensiveContext.previousPosts.length > 0) {
+    sections.push({
+      name: '  └ previousPosts',
+      tokens: estimateTokens(
+        comprehensiveContext.previousPosts.map((p) => p.content).join('\n')
+      ),
+      populated: true,
+    });
+  }
+  if ((comprehensiveContext.relationships?.length ?? 0) > 0) {
+    sections.push({
+      name: '  └ relationships',
+      tokens: estimateTokens(relationshipContextStr),
+      populated: true,
+    });
+  }
+  if ((comprehensiveContext.marketPositions?.length ?? 0) > 0) {
+    sections.push({
+      name: '  └ marketPositions',
+      tokens: estimateTokens(positionsContextStr),
+      populated: true,
+    });
+  }
+  if ((comprehensiveContext.relatedQuestions?.length ?? 0) > 0) {
+    sections.push({
+      name: '  └ relatedQuestions',
+      tokens: estimateTokens(
+        (comprehensiveContext.relatedQuestions ?? [])
+          .map((q) => q.text)
+          .join('\n')
+      ),
+      populated: true,
+    });
+  }
 
-  const rawPrompt = showRaw
-    ? `${YELLOW}[APPROXIMATION — not the exact FeedGenerator prompt]${RESET}\n` +
-      [
-        characterInfo,
-        eventsText,
-        postsText,
-        worldContext.realityGrounding,
-      ].join('\n---\n')
-    : undefined;
+  const totalTokens = estimateTokens(rendered);
 
-  return { sections, totalTokens, rawPrompt };
+  return {
+    sections,
+    totalTokens,
+    rawPrompt: showRaw ? rendered : undefined,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -430,7 +529,8 @@ async function inspectAgentContext(agentUserId: string): Promise<{
       context: context as never,
       isNpc: agentCtx.isNpc,
     });
-  } catch {
+  } catch (e) {
+    warn(`Prompt render error: ${e instanceof Error ? e.message : String(e)}`);
     renderedPrompt =
       '[Failed to render prompt — missing template dependencies]';
   }
@@ -655,7 +755,7 @@ async function main() {
       for (const actor of allActors) {
         const ctx = contexts.get(actor.id);
         if (!ctx) continue;
-        const dashboard = formatNPCDashboard(ctx);
+        const dashboard = formatSingleNPCDashboard(ctx);
         const tokens = estimateTokens(dashboard);
         totalTokensAll += tokens;
         const posCount = ctx.currentPositions.length;
@@ -663,8 +763,12 @@ async function main() {
         if (posCount > 0) npcsWithPositions++;
 
         if (!showSummary) {
+          const exposure = calculatePortfolioExposure(
+            ctx.availableBalance,
+            ctx.currentPositions
+          );
           console.log(
-            `  ${actor.id.padEnd(24)} ${String(tokens).padStart(5)} tokens  ${posCount} positions  $${ctx.availableBalance.toLocaleString()} balance`
+            `  ${actor.id.padEnd(24)} ${String(tokens).padStart(5)} tokens  ${posCount} positions  $${ctx.availableBalance.toLocaleString()} balance  ${exposure.toFixed(1)}% exposure`
           );
         }
       }
@@ -675,26 +779,40 @@ async function main() {
     }
 
     if (inspectType === 'posting' || inspectType === 'both') {
-      subheading(`Posting Context — approximation (${allActors.length} NPCs)`);
-      let totalPostingTokens = 0;
-      let totalPopulated = 0;
+      subheading(`Posting Context (${allActors.length} NPCs)`);
+
+      let totalTokensAll = 0;
+      let minTokens = Number.POSITIVE_INFINITY;
+      let maxTokens = 0;
+      let totalSectionsPopulated = 0;
       let totalSections = 0;
 
       for (const actor of allActors) {
         const result = await inspectPostingContext(actor.id);
-        totalPostingTokens += result.totalTokens;
-        totalPopulated += result.sections.filter((s) => s.populated).length;
+        totalTokensAll += result.totalTokens;
+        if (result.totalTokens < minTokens) minTokens = result.totalTokens;
+        if (result.totalTokens > maxTokens) maxTokens = result.totalTokens;
+        totalSectionsPopulated += result.sections.filter(
+          (s) => s.populated
+        ).length;
         totalSections += result.sections.length;
 
         if (!showSummary) {
           console.log(
-            `  ${actor.id.padEnd(24)} ${String(result.totalTokens).padStart(5)} tokens  ${result.sections.filter((s) => s.populated).length}/${result.sections.length} sections`
+            `  ${actor.id.padEnd(24)} ${String(result.totalTokens).padStart(5)} tokens  ${result.sections.filter((s) => s.populated).length}/${result.sections.length} sections populated`
           );
         }
       }
 
+      const avgTokens =
+        allActors.length > 0
+          ? Math.round(totalTokensAll / allActors.length)
+          : 0;
       console.log(
-        `\nTotal posting tokens: ${totalPostingTokens} | Avg per NPC: ${Math.round(totalPostingTokens / allActors.length)} | Populated: ${totalPopulated}/${totalSections} sections`
+        `\nPosting context: ${allActors.length} NPCs | Total: ${totalTokensAll} tokens | Avg: ${avgTokens} | Min: ${minTokens === Number.POSITIVE_INFINITY ? 0 : minTokens} | Max: ${maxTokens}`
+      );
+      console.log(
+        `Sections populated: ${totalSectionsPopulated}/${totalSections} (${totalSections > 0 ? ((totalSectionsPopulated / totalSections) * 100).toFixed(1) : 0}%)`
       );
     }
 
@@ -737,17 +855,17 @@ async function main() {
           console.log(`\n${GREEN}No ghost variables detected.${RESET}`);
         }
 
-        // Truncation report
+        // Truncation report — reuse rawContext from inspectTradingContext
         subheading('Truncation Report');
-        const ctx = await new MarketContextService().buildContextForNPC(npcArg);
+        const ctx = result.rawContext;
         const truncations = [];
         if (ctx.recentPosts.length >= 50)
-          truncations.push(`  Posts: capped at 50 (may have more)`);
+          truncations.push('  Posts: capped at 50 (may have more)');
         if (ctx.recentEvents.length >= 30)
-          truncations.push(`  Events: capped at 30 (may have more)`);
+          truncations.push('  Events: capped at 30 (may have more)');
         if (ctx.predictionMarkets.length >= 15)
           truncations.push(
-            `  Prediction markets: capped at 15 (may have more)`
+            '  Prediction markets: capped at 15 (may have more)'
           );
         if (ctx.groupChatMessages.length > 2)
           truncations.push(

--- a/scripts/context-inspector.ts
+++ b/scripts/context-inspector.ts
@@ -1,16 +1,20 @@
 #!/usr/bin/env bun
 
 /**
- * Context Inspector — Dev tool for NPC prompt debugging
+ * Context Inspector — Dev tool for NPC and autonomous agent prompt debugging
  *
- * Shows exactly what context an NPC/agent receives for trading and posting
- * decisions. Renders the full prompt and reports on token usage, truncation,
- * ghost variables, and position visibility.
+ * Shows exactly what context an NPC or autonomous agent receives for trading
+ * and posting decisions. Renders the full prompt and reports on token usage,
+ * truncation, ghost variables, and position visibility.
  *
- * Usage:
+ * Usage (NPCs):
  *   bun run inspect:context -- --npc ailon-musk --type trading
  *   bun run inspect:context -- --npc all --type both --summary
  *   bun run inspect:context -- --npc ailon-musk --type posting --raw
+ *
+ * Usage (Autonomous Agents):
+ *   bun run inspect:context -- --agent <userId> --raw
+ *   bun run inspect:context -- --agent <userId>
  */
 
 import { parseArgs } from 'node:util';
@@ -113,6 +117,7 @@ function estimateTokens(text: string): number {
 const { values: args } = parseArgs({
   options: {
     npc: { type: 'string', default: '' },
+    agent: { type: 'string', default: '' },
     type: { type: 'string', default: 'trading' },
     diff: { type: 'boolean', default: false },
     summary: { type: 'boolean', default: false },
@@ -123,16 +128,20 @@ const { values: args } = parseArgs({
 });
 
 const npcArg = args.npc || '';
+const agentArg = args.agent || '';
 const inspectType = args.type as 'trading' | 'posting' | 'both';
 const showDiff = args.diff ?? false;
 const showSummary = args.summary ?? false;
 const showRaw = args.raw ?? false;
 
-if (!npcArg) {
-  console.log(`Usage: bun run inspect:context -- --npc <id|all> [options]
+if (!npcArg && !agentArg) {
+  console.log(`Usage:
+  bun run inspect:context -- --npc <id|all> [options]     # Inspect NPC context
+  bun run inspect:context -- --agent <userId> [options]    # Inspect autonomous agent context
 
 Options:
   --npc <id>           NPC ID (e.g. ailon-musk) or "all" for summary
+  --agent <userId>     Autonomous agent user ID (from DB)
   --type <type>        trading | posting | both (default: trading)
   --diff               Side-by-side comparison (only with --type both)
   --summary            Aggregate stats instead of full prompt
@@ -426,6 +435,223 @@ async function inspectPostingContext(npcId: string): Promise<{
 }
 
 // ---------------------------------------------------------------------------
+// Autonomous agent context inspection
+// ---------------------------------------------------------------------------
+async function inspectAgentContext(agentUserId: string): Promise<{
+  sections: Array<{
+    name: string;
+    tokens: number;
+    populated: boolean;
+    count?: number;
+  }>;
+  totalTokens: number;
+  rawPrompt?: string;
+}> {
+  // Dynamic imports from @babylon/agents (not in @babylon/engine)
+  const {
+    getPredictionMarkets,
+    getPerpMarkets,
+    getAgentPositions,
+    getRecentPosts,
+    getAgentGroupChats,
+    getAgentOwnPosts,
+  } = await import('../packages/agents/src/autonomous/utils/context-gatherers');
+  const { gatherPendingCommentReplies, gatherPendingChatMessages } =
+    await import(
+      '../packages/agents/src/autonomous/utils/interaction-gatherers'
+    );
+  const { buildMultiStepDecisionPrompt } = await import(
+    '../packages/agents/src/autonomous/templates/multi-step-decision'
+  );
+  const { getAgentContext } = await import(
+    '../packages/agents/src/autonomous/agent-context'
+  );
+  const { db, eq, users } = await import('@babylon/db');
+
+  // Verify agent exists
+  const [user] = await db
+    .select({ id: users.id, displayName: users.displayName })
+    .from(users)
+    .where(eq(users.id, agentUserId))
+    .limit(1);
+
+  if (!user) {
+    error(`Agent user not found: ${agentUserId}`);
+    process.exit(1);
+  }
+
+  const agentCtx = await getAgentContext(agentUserId);
+  const agentName = agentCtx.displayName || user.displayName || agentUserId;
+
+  // Gather all context (same as MultiStepExecutor.gatherContext)
+  const [
+    predictionMarkets,
+    perpMarkets,
+    agentPositions,
+    recentPosts,
+    pendingCommentReplies,
+    pendingChatMessages,
+    agentGroupChats,
+    agentOwnPosts,
+  ] = await Promise.all([
+    getPredictionMarkets(),
+    getPerpMarkets(),
+    getAgentPositions(agentUserId),
+    getRecentPosts(agentUserId),
+    gatherPendingCommentReplies(agentUserId).catch(() => []),
+    gatherPendingChatMessages(agentUserId).catch(() => []),
+    getAgentGroupChats(agentUserId),
+    getAgentOwnPosts(agentUserId),
+  ]);
+
+  const { WalletService } = await import('@babylon/engine');
+  let balance = 0;
+  let pnl = 0;
+  try {
+    const walletBalance = await WalletService.getBalance(agentUserId);
+    balance = walletBalance.balance;
+    pnl = walletBalance.lifetimePnL;
+  } catch {
+    // NPC or missing wallet — use 0
+  }
+
+  const sections: Array<{
+    name: string;
+    tokens: number;
+    populated: boolean;
+    count?: number;
+  }> = [];
+
+  // Build the actual prompt to measure it
+  const context = {
+    balance,
+    pnl,
+    openPositions:
+      agentPositions.predictions.length + agentPositions.perps.length,
+    pendingCommentReplies: pendingCommentReplies.slice(0, 3),
+    pendingChatMessages: pendingChatMessages.slice(0, 3),
+    enabledFeatures: ['TRADING', 'POSTING', 'COMMENTING', 'DMS', 'GROUP_CHATS'],
+    predictionMarkets,
+    perpMarkets,
+    recentPosts,
+    agentPositions,
+    groupChats: agentGroupChats,
+    agentOwnPosts,
+  };
+
+  let renderedPrompt: string;
+  try {
+    renderedPrompt = buildMultiStepDecisionPrompt({
+      agentName,
+      iterationCount: 1,
+      maxIterations: 5,
+      traceActionResults: [],
+      context: context as never,
+      isNpc: agentCtx.isNpc,
+    });
+  } catch {
+    renderedPrompt =
+      '[Failed to render prompt — missing template dependencies]';
+  }
+
+  // Section breakdown
+  sections.push({
+    name: 'identity',
+    tokens: estimateTokens(agentName),
+    populated: true,
+  });
+  sections.push({
+    name: 'balance & PnL',
+    tokens: estimateTokens(`$${balance} / PnL: $${pnl}`),
+    populated: balance > 0 || pnl !== 0,
+  });
+
+  const predMktsText = predictionMarkets
+    .map((m: { question: string }) => m.question)
+    .join('\n');
+  sections.push({
+    name: 'predictionMarkets',
+    tokens: estimateTokens(predMktsText),
+    populated: predictionMarkets.length > 0,
+    count: predictionMarkets.length,
+  });
+
+  const perpMktsText = perpMarkets
+    .map((m: { name: string }) => m.name)
+    .join('\n');
+  sections.push({
+    name: 'perpMarkets',
+    tokens: estimateTokens(perpMktsText),
+    populated: perpMarkets.length > 0,
+    count: perpMarkets.length,
+  });
+
+  const predPositions = agentPositions.predictions || [];
+  const perpPositions = agentPositions.perps || [];
+  sections.push({
+    name: 'positions (prediction)',
+    tokens: estimateTokens(JSON.stringify(predPositions)),
+    populated: predPositions.length > 0,
+    count: predPositions.length,
+  });
+  sections.push({
+    name: 'positions (perp)',
+    tokens: estimateTokens(JSON.stringify(perpPositions)),
+    populated: perpPositions.length > 0,
+    count: perpPositions.length,
+  });
+
+  const postsText = recentPosts
+    .map((p: { content: string }) => p.content)
+    .join('\n');
+  sections.push({
+    name: 'recentPosts',
+    tokens: estimateTokens(postsText),
+    populated: recentPosts.length > 0,
+    count: recentPosts.length,
+  });
+
+  const ownPostsText = agentOwnPosts
+    .map((p: { content: string }) => p.content)
+    .join('\n');
+  sections.push({
+    name: 'agentOwnPosts',
+    tokens: estimateTokens(ownPostsText),
+    populated: agentOwnPosts.length > 0,
+    count: agentOwnPosts.length,
+  });
+
+  sections.push({
+    name: 'pendingCommentReplies',
+    tokens: estimateTokens(JSON.stringify(pendingCommentReplies.slice(0, 3))),
+    populated: pendingCommentReplies.length > 0,
+    count: pendingCommentReplies.length,
+  });
+
+  sections.push({
+    name: 'pendingChatMessages',
+    tokens: estimateTokens(JSON.stringify(pendingChatMessages.slice(0, 3))),
+    populated: pendingChatMessages.length > 0,
+    count: pendingChatMessages.length,
+  });
+
+  sections.push({
+    name: 'groupChats',
+    tokens: estimateTokens(JSON.stringify(agentGroupChats)),
+    populated: agentGroupChats.length > 0,
+    count: agentGroupChats.length,
+  });
+
+  const totalTokens = estimateTokens(renderedPrompt);
+
+  return {
+    sections,
+    totalTokens,
+    rawPrompt: showRaw ? renderedPrompt : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Report rendering
 // ---------------------------------------------------------------------------
 function printSectionReport(
@@ -456,6 +682,58 @@ function printSectionReport(
 // ---------------------------------------------------------------------------
 async function main() {
   heading('Context Inspector');
+
+  // Handle agent mode
+  if (agentArg) {
+    heading(`Autonomous Agent Context: ${agentArg}`);
+    try {
+      const result = await inspectAgentContext(agentArg);
+
+      if (showRaw && result.rawPrompt) {
+        console.log(result.rawPrompt);
+      } else {
+        subheading('Section Breakdown');
+        const maxName = Math.max(
+          ...result.sections.map((s) => s.name.length),
+          8
+        );
+        console.log(`${'Section'.padEnd(maxName)}  Tokens    Count   Status`);
+        console.log('-'.repeat(maxName + 40));
+        for (const s of result.sections) {
+          const status = s.populated
+            ? `${GREEN}populated${RESET}`
+            : `${DIM}empty${RESET}`;
+          const count =
+            s.count !== undefined ? String(s.count).padStart(5) : '    -';
+          console.log(
+            `${s.name.padEnd(maxName)}  ${String(s.tokens).padStart(6)}    ${count}   ${status}`
+          );
+        }
+
+        subheading('Token Budget');
+        console.log(`  Total rendered prompt tokens: ${result.totalTokens}`);
+        console.log(
+          `  Budget: 30,000 tokens | Utilization: ${((result.totalTokens / 30000) * 100).toFixed(1)}%`
+        );
+
+        subheading('Data Limits');
+        console.log('  Prediction markets: max 8 (24h window)');
+        console.log('  Perp markets: max 8 (top by price)');
+        console.log('  Positions: max 10 each type');
+        console.log('  Recent posts: max 8 (24h window)');
+        console.log('  Pending replies: max 3');
+        console.log('  Pending chats: max 3');
+        console.log('  Group chats: max 5');
+        console.log('  Own posts: max 5');
+      }
+    } catch (e) {
+      error(
+        `Failed to build agent context: ${e instanceof Error ? e.message : String(e)}`
+      );
+    }
+
+    process.exit(0);
+  }
 
   // Validate NPC
   if (npcArg !== 'all') {

--- a/scripts/context-inspector.ts
+++ b/scripts/context-inspector.ts
@@ -1,0 +1,658 @@
+#!/usr/bin/env bun
+
+/**
+ * Context Inspector — Dev tool for NPC prompt debugging
+ *
+ * Shows exactly what context an NPC/agent receives for trading and posting
+ * decisions. Renders the full prompt and reports on token usage, truncation,
+ * ghost variables, and position visibility.
+ *
+ * Usage:
+ *   bun run inspect:context -- --npc ailon-musk --type trading
+ *   bun run inspect:context -- --npc all --type both --summary
+ *   bun run inspect:context -- --npc ailon-musk --type posting --raw
+ */
+
+import { parseArgs } from 'node:util';
+import {
+  generateWorldContext,
+  getShuffledExamplesText,
+  MarketContextService,
+  type NPCMarketContext,
+  npcMarketDecisions,
+  renderPrompt,
+  StaticDataRegistry,
+} from '@babylon/engine';
+
+// ---------------------------------------------------------------------------
+// Inlined trading strategy logic (from engine/src/npc/trading-strategies.ts)
+// These are private internals not exported from @babylon/engine.
+// ---------------------------------------------------------------------------
+const TRADING_STRATEGIES = {
+  momentum: {
+    label: 'Momentum',
+    followTrend: 0.7,
+    contrarian: 0.2,
+    random: 0.1,
+  },
+  contrarian: {
+    label: 'Contrarian',
+    followTrend: 0.2,
+    contrarian: 0.7,
+    random: 0.1,
+  },
+  value: { label: 'Value', followTrend: 0.3, contrarian: 0.4, random: 0.3 },
+  random: {
+    label: 'Random',
+    followTrend: 0.33,
+    contrarian: 0.33,
+    random: 0.34,
+  },
+} as const;
+
+type StrategyKey = keyof typeof TRADING_STRATEGIES;
+
+function hashStringToUint32(value: string): number {
+  let hash = 0;
+  for (let i = 0; i < value.length; i++) {
+    hash = (hash << 5) - hash + value.charCodeAt(i);
+    hash |= 0;
+  }
+  return hash >>> 0;
+}
+
+function getNpcTradingStrategy(npcId: string): StrategyKey {
+  const keys = Object.keys(TRADING_STRATEGIES) as StrategyKey[];
+  const hash = hashStringToUint32(npcId);
+  return keys[hash % keys.length] as StrategyKey;
+}
+
+function formatTradingStrategyBias(bias: {
+  followTrend: number;
+  contrarian: number;
+  random: number;
+}): string {
+  const toPct = (v: number) => `${Math.round(v * 100)}%`;
+  return `Follow trend: ${toPct(bias.followTrend)} | Contrarian: ${toPct(bias.contrarian)} | Random: ${toPct(bias.random)}`;
+}
+
+// ---------------------------------------------------------------------------
+// ANSI helpers
+// ---------------------------------------------------------------------------
+const YELLOW = '\x1b[33m';
+const RED = '\x1b[31m';
+const GREEN = '\x1b[32m';
+const CYAN = '\x1b[36m';
+const DIM = '\x1b[2m';
+const BOLD = '\x1b[1m';
+const RESET = '\x1b[0m';
+
+function warn(msg: string) {
+  console.log(`${YELLOW}WARNING: ${msg}${RESET}`);
+}
+function error(msg: string) {
+  console.log(`${RED}ERROR: ${msg}${RESET}`);
+}
+function heading(msg: string) {
+  console.log(`\n${BOLD}${CYAN}=== ${msg} ===${RESET}`);
+}
+function subheading(msg: string) {
+  console.log(`\n${BOLD}${msg}${RESET}`);
+}
+
+// ---------------------------------------------------------------------------
+// Token estimation (matches engine: Math.ceil(text.length / 4))
+// ---------------------------------------------------------------------------
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+// ---------------------------------------------------------------------------
+// CLI args
+// ---------------------------------------------------------------------------
+const { values: args } = parseArgs({
+  options: {
+    npc: { type: 'string', default: '' },
+    type: { type: 'string', default: 'trading' },
+    diff: { type: 'boolean', default: false },
+    summary: { type: 'boolean', default: false },
+    raw: { type: 'boolean', default: false },
+  },
+  strict: true,
+  allowPositionals: false,
+});
+
+const npcArg = args.npc || '';
+const inspectType = args.type as 'trading' | 'posting' | 'both';
+const showDiff = args.diff ?? false;
+const showSummary = args.summary ?? false;
+const showRaw = args.raw ?? false;
+
+if (!npcArg) {
+  console.log(`Usage: bun run inspect:context -- --npc <id|all> [options]
+
+Options:
+  --npc <id>           NPC ID (e.g. ailon-musk) or "all" for summary
+  --type <type>        trading | posting | both (default: trading)
+  --diff               Side-by-side comparison (only with --type both)
+  --summary            Aggregate stats instead of full prompt
+  --raw                Output raw rendered prompt text`);
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Replicate MarketDecisionEngine formatting (private methods)
+// ---------------------------------------------------------------------------
+
+function mapPersonalityToArchetype(personality: string): string {
+  const p = personality.toLowerCase();
+  if (
+    p.includes('risk') ||
+    p.includes('aggressive') ||
+    p.includes('degen') ||
+    p.includes('speculator')
+  )
+    return 'DEGEN_TRADER';
+  if (
+    p.includes('cautious') ||
+    p.includes('conservative') ||
+    p.includes('manager')
+  )
+    return 'RISK_MANAGER';
+  if (p.includes('analytical') || p.includes('quant') || p.includes('math'))
+    return 'QUANT_TRADER';
+  if (p.includes('insider') || p.includes('connected')) return 'INSIDER';
+  return 'SYSTEMATIC_TRADER';
+}
+
+function formatMarketTable(ctx: NPCMarketContext): string {
+  const perps = ctx.perpMarkets || [];
+  const predictions = ctx.predictionMarkets || [];
+  let table =
+    '| Ticker/ID | Type | Price | 24h Change | Volume/Liq |\n|---|---|---|---|---|\n';
+  for (const p of perps) {
+    const sign = p.changePercent24h >= 0 ? '+' : '';
+    table += `| ${p.ticker} | PERP | $${p.currentPrice.toFixed(2)} | ${sign}${p.changePercent24h.toFixed(2)}% | Vol: $${(p.volume24h / 1000).toFixed(1)}k |\n`;
+  }
+  for (const p of predictions) {
+    table += `| ${p.id} | PRED | Yes: ${p.yesPrice.toFixed(0)}c | No: ${p.noPrice.toFixed(0)}c | Vol: $${(p.totalVolume / 1000).toFixed(1)}k |\n`;
+  }
+  return table;
+}
+
+function formatNPCDashboard(ctx: NPCMarketContext): string {
+  const archetype = mapPersonalityToArchetype(ctx.personality);
+  const strategyKey = getNpcTradingStrategy(ctx.npcId);
+  const strategy = TRADING_STRATEGIES[strategyKey];
+
+  const totalSize = ctx.currentPositions.reduce((s, p) => s + p.size, 0);
+  const exposure =
+    ctx.availableBalance > 0 ? (totalSize / ctx.availableBalance) * 100 : 0;
+  const totalPnL = ctx.currentPositions.reduce(
+    (s, p) => s + p.unrealizedPnL,
+    0
+  );
+  const pnlSign = totalPnL >= 0 ? '+' : '';
+
+  const topPositions = ctx.currentPositions
+    .sort((a, b) => Math.abs(b.unrealizedPnL) - Math.abs(a.unrealizedPnL))
+    .slice(0, 3)
+    .map((p) => {
+      const symbol = p.marketType === 'perp' ? p.ticker : `Q${p.marketId}`;
+      const posSign = p.unrealizedPnL >= 0 ? '+' : '';
+      return `${symbol} ${p.side} ($${p.size.toFixed(0)}, PnL: ${posSign}$${p.unrealizedPnL.toFixed(0)}) [ID:${p.id}]`;
+    })
+    .join(', ');
+
+  const relationships =
+    ctx.relationships && ctx.relationships.length > 0
+      ? ctx.relationships
+          .filter((r) => Math.abs(r.sentiment) > 0.4)
+          .slice(0, 4)
+          .map((r) => `${r.sentiment > 0 ? 'Ally' : 'Rival'}:${r.actorName}`)
+          .join(', ')
+      : 'None';
+
+  const recentTopics = ctx.recentPosts
+    .slice(0, 3)
+    .map((p) => p.content.substring(0, 20) + '...')
+    .join(' | ');
+
+  const privateIntel =
+    ctx.groupChatMessages.length > 0
+      ? ctx.groupChatMessages
+          .slice(0, 2)
+          .map((m) => `"${m.fromName}: ${m.message}"`)
+          .join(' | ')
+      : 'None';
+
+  return `TRADER DASHBOARD
+ID: ${ctx.npcId} | Name: ${ctx.npcName}
+Archetype: ${archetype} | Strategy: ${strategy.label} (${strategyKey})
+Bias: ${formatTradingStrategyBias(strategy)} | Cash: $${ctx.availableBalance.toLocaleString()}
+Total PnL: ${pnlSign}$${totalPnL.toFixed(0)} | Exposure: ${exposure.toFixed(1)}%
+Network: ${relationships}
+Positions: ${topPositions || 'None'}
+Current Focus: ${recentTopics || 'Market General'}
+PRIVATE INTEL: ${privateIntel}`;
+}
+
+// ---------------------------------------------------------------------------
+// Template variable extraction
+// ---------------------------------------------------------------------------
+function extractTemplateVars(template: string): string[] {
+  const matches = template.match(/\{\{(\w+)\}\}/g) || [];
+  return [...new Set(matches.map((m) => m.replace(/\{\{|\}\}/g, '')))];
+}
+
+// ---------------------------------------------------------------------------
+// Trading context inspection
+// ---------------------------------------------------------------------------
+async function inspectTradingContext(npcId: string): Promise<{
+  sections: Array<{
+    name: string;
+    tokens: number;
+    populated: boolean;
+    truncated?: boolean;
+  }>;
+  ghostVars: string[];
+  totalTokens: number;
+  positionVisibility: { total: number; shown: number };
+  rawPrompt?: string;
+}> {
+  const svc = new MarketContextService();
+  const ctx = await svc.buildContextForNPC(npcId);
+
+  const worldContext = await generateWorldContext();
+  const examples = getShuffledExamplesText();
+  const npcsList = formatNPCDashboard(ctx);
+  const marketTable = formatMarketTable(ctx);
+
+  const validNpcIds = ctx.npcId;
+  const allTickers = new Set<string>();
+  ctx.perpMarkets.forEach((m) => allTickers.add(m.ticker));
+  const validTickers =
+    allTickers.size > 0 ? Array.from(allTickers).join(', ') : 'N/A';
+
+  // Assemble the variables passed to renderPrompt
+  const vars: Record<string, string> = {
+    examples,
+    marketTable,
+    npcCount: '1',
+    npcsList,
+    validNpcIds,
+    validTickers,
+    realityGrounding: worldContext.realityGrounding,
+    activeQuestions: '', // optional in prompt
+    recentEvents: '', // optional in prompt
+    richGameContext: worldContext.richGameContext || '',
+    eventMarketSignals: 'No event-market signals available',
+  };
+
+  // Render and measure
+  const rendered = renderPrompt(npcMarketDecisions, vars, {
+    allowEmpty: true,
+  });
+
+  // Find ghost vars (in template but not in vars)
+  const templateVars = extractTemplateVars(npcMarketDecisions.template);
+  // Auto-injected date vars from renderPrompt
+  const autoVars = new Set([
+    'currentDateTime',
+    'currentDate',
+    'currentTime',
+    'currentYear',
+    'currentMonth',
+    'currentDay',
+  ]);
+  const suppliedVarKeys = new Set([...Object.keys(vars), ...autoVars]);
+  const ghostVars = templateVars.filter((v) => !suppliedVarKeys.has(v));
+
+  // Build section report
+  const sections = Object.entries(vars).map(([name, value]) => ({
+    name,
+    tokens: estimateTokens(value),
+    populated: value.trim().length > 0,
+  }));
+
+  // Position visibility
+  const totalPositions = ctx.currentPositions.length;
+  const shownPositions = Math.min(totalPositions, 3); // formatNPCDashboard shows max 3
+
+  return {
+    sections,
+    ghostVars,
+    totalTokens: estimateTokens(rendered),
+    positionVisibility: { total: totalPositions, shown: shownPositions },
+    rawPrompt: showRaw ? rendered : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Posting context inspection
+// ---------------------------------------------------------------------------
+async function inspectPostingContext(npcId: string): Promise<{
+  sections: Array<{ name: string; tokens: number; populated: boolean }>;
+  totalTokens: number;
+  rawPrompt?: string;
+}> {
+  const actor = StaticDataRegistry.getActor(npcId);
+  if (!actor) {
+    error(`Actor not found: ${npcId}`);
+    return { sections: [], totalTokens: 0 };
+  }
+
+  // Build character context sections manually since buildRichCharacterContext
+  // is private on FeedGenerator
+  const svc = new MarketContextService();
+  const events = await svc.getEventsForNPC(npcId, actor.name);
+  const recentPosts = await svc.getRecentPostsByNPC(npcId);
+  const worldContext = await generateWorldContext();
+
+  const sections: Array<{ name: string; tokens: number; populated: boolean }> =
+    [];
+
+  const characterInfo = [
+    `Name: ${actor.name}`,
+    actor.description ? `Description: ${actor.description}` : '',
+    actor.personality ? `Personality: ${actor.personality}` : '',
+    actor.voice ? `Voice: ${actor.voice}` : '',
+    actor.postStyle ? `Post Style: ${actor.postStyle}` : '',
+    actor.postExample.length > 0
+      ? `Examples: ${actor.postExample.join(' | ')}`
+      : '',
+    actor.domain.length > 0 ? `Domains: ${actor.domain.join(', ')}` : '',
+    actor.affiliations.length > 0
+      ? `Affiliations: ${actor.affiliations.join(', ')}`
+      : '',
+    actor.tier ? `Tier: ${actor.tier}` : '',
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  sections.push({
+    name: 'characterInfo',
+    tokens: estimateTokens(characterInfo),
+    populated: characterInfo.length > 0,
+  });
+
+  const eventsText = events
+    .map((e) => `[${e.type}] ${e.description}`)
+    .join('\n');
+  sections.push({
+    name: 'personalEvents',
+    tokens: estimateTokens(eventsText),
+    populated: eventsText.length > 0,
+  });
+
+  const postsText = recentPosts.map((p) => p.content).join('\n');
+  sections.push({
+    name: 'previousPosts',
+    tokens: estimateTokens(postsText),
+    populated: postsText.length > 0,
+  });
+
+  sections.push({
+    name: 'realityGrounding',
+    tokens: estimateTokens(worldContext.realityGrounding),
+    populated: worldContext.realityGrounding.length > 0,
+  });
+
+  sections.push({
+    name: 'worldActors',
+    tokens: estimateTokens(worldContext.worldActors),
+    populated: worldContext.worldActors.length > 0,
+  });
+
+  const richCtx = worldContext.richGameContext || '';
+  sections.push({
+    name: 'richGameContext',
+    tokens: estimateTokens(richCtx),
+    populated: richCtx.length > 0,
+  });
+
+  const totalTokens = sections.reduce((s, sec) => s + sec.tokens, 0);
+
+  const rawPrompt = showRaw
+    ? [
+        characterInfo,
+        eventsText,
+        postsText,
+        worldContext.realityGrounding,
+      ].join('\n---\n')
+    : undefined;
+
+  return { sections, totalTokens, rawPrompt };
+}
+
+// ---------------------------------------------------------------------------
+// Report rendering
+// ---------------------------------------------------------------------------
+function printSectionReport(
+  sections: Array<{
+    name: string;
+    tokens: number;
+    populated: boolean;
+    truncated?: boolean;
+  }>
+) {
+  const maxName = Math.max(...sections.map((s) => s.name.length), 8);
+  console.log(`${'Section'.padEnd(maxName)}  Tokens    Status`);
+  console.log('-'.repeat(maxName + 30));
+
+  for (const s of sections) {
+    const status = s.populated
+      ? `${GREEN}populated${RESET}`
+      : `${DIM}empty${RESET}`;
+    const truncNote = s.truncated ? ` ${YELLOW}(truncated)${RESET}` : '';
+    console.log(
+      `${s.name.padEnd(maxName)}  ${String(s.tokens).padStart(6)}    ${status}${truncNote}`
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+async function main() {
+  heading('Context Inspector');
+
+  // Validate NPC
+  if (npcArg !== 'all') {
+    const actor = StaticDataRegistry.getActor(npcArg);
+    if (!actor) {
+      error(`NPC not found: ${npcArg}`);
+      const allIds = StaticDataRegistry.getActorIds().slice(0, 10);
+      console.log(`Available NPCs (first 10): ${allIds.join(', ')}`);
+      process.exit(1);
+    }
+  }
+
+  // Handle "all" summary mode
+  if (npcArg === 'all') {
+    heading('All NPCs Summary');
+    const allActors = StaticDataRegistry.getAllActors().filter(
+      (a) => !a.isTest && !a.name.includes('Group Test')
+    );
+
+    if (inspectType === 'trading' || inspectType === 'both') {
+      subheading(`Trading Context (${allActors.length} NPCs)`);
+      const svc = new MarketContextService();
+      let contexts: Map<string, NPCMarketContext>;
+      try {
+        contexts = await svc.buildContextForAllNPCs();
+      } catch (e) {
+        warn(
+          `Could not build contexts from DB: ${e instanceof Error ? e.message : String(e)}`
+        );
+        console.log('Ensure DATABASE_URL is set and the database has data.');
+        process.exit(1);
+      }
+
+      let totalTokensAll = 0;
+      let totalPositionsAll = 0;
+      let npcsWithPositions = 0;
+
+      for (const actor of allActors) {
+        const ctx = contexts.get(actor.id);
+        if (!ctx) continue;
+        const dashboard = formatNPCDashboard(ctx);
+        const tokens = estimateTokens(dashboard);
+        totalTokensAll += tokens;
+        const posCount = ctx.currentPositions.length;
+        totalPositionsAll += posCount;
+        if (posCount > 0) npcsWithPositions++;
+
+        if (!showSummary) {
+          console.log(
+            `  ${actor.id.padEnd(24)} ${String(tokens).padStart(5)} tokens  ${posCount} positions  $${ctx.availableBalance.toLocaleString()} balance`
+          );
+        }
+      }
+
+      console.log(
+        `\nTotal dashboard tokens: ${totalTokensAll} | NPCs with positions: ${npcsWithPositions}/${allActors.length} | Total positions: ${totalPositionsAll}`
+      );
+    }
+
+    if (inspectType === 'posting' || inspectType === 'both') {
+      subheading(`Posting Context (${allActors.length} NPCs)`);
+      for (const actor of allActors.slice(0, 5)) {
+        const result = await inspectPostingContext(actor.id);
+        console.log(
+          `  ${actor.id.padEnd(24)} ${String(result.totalTokens).padStart(5)} tokens  ${result.sections.filter((s) => s.populated).length}/${result.sections.length} sections populated`
+        );
+      }
+      if (allActors.length > 5) {
+        console.log(
+          `  ${DIM}... and ${allActors.length - 5} more (use --npc <id> for full detail)${RESET}`
+        );
+      }
+    }
+
+    process.exit(0);
+  }
+
+  // Single NPC inspection
+  if (inspectType === 'trading' || inspectType === 'both') {
+    heading(`Trading Context: ${npcArg}`);
+    try {
+      const result = await inspectTradingContext(npcArg);
+
+      if (showRaw && result.rawPrompt) {
+        console.log(result.rawPrompt);
+      } else {
+        subheading('Section Breakdown');
+        printSectionReport(result.sections);
+
+        subheading('Position Visibility');
+        console.log(
+          `  Total positions: ${result.positionVisibility.total} | Shown in prompt: ${result.positionVisibility.shown}`
+        );
+        if (result.positionVisibility.total > result.positionVisibility.shown) {
+          warn(
+            `${result.positionVisibility.total - result.positionVisibility.shown} positions hidden from prompt (max 3 shown)`
+          );
+        }
+
+        subheading('Token Budget');
+        console.log(`  Total prompt tokens: ${result.totalTokens}`);
+
+        if (result.ghostVars.length > 0) {
+          subheading('Ghost Variables');
+          for (const v of result.ghostVars) {
+            console.log(
+              `  ${RED}{{${v}}}${RESET} - in template but not supplied`
+            );
+          }
+        } else {
+          console.log(`\n${GREEN}No ghost variables detected.${RESET}`);
+        }
+
+        // Truncation report
+        subheading('Truncation Report');
+        const ctx = await new MarketContextService().buildContextForNPC(npcArg);
+        const truncations = [];
+        if (ctx.recentPosts.length >= 50)
+          truncations.push(`  Posts: capped at 50 (may have more)`);
+        if (ctx.recentEvents.length >= 30)
+          truncations.push(`  Events: capped at 30 (may have more)`);
+        if (ctx.predictionMarkets.length >= 15)
+          truncations.push(
+            `  Prediction markets: capped at 15 (may have more)`
+          );
+        if (ctx.groupChatMessages.length > 2)
+          truncations.push(
+            `  Group chat: ${ctx.groupChatMessages.length} messages, only 2 shown in prompt`
+          );
+        if (truncations.length > 0) {
+          for (const t of truncations) {
+            console.log(`${YELLOW}${t}${RESET}`);
+          }
+        } else {
+          console.log(`  ${GREEN}No truncation detected.${RESET}`);
+        }
+      }
+    } catch (e) {
+      error(
+        `Failed to build trading context: ${e instanceof Error ? e.message : String(e)}`
+      );
+    }
+  }
+
+  if (inspectType === 'posting' || inspectType === 'both') {
+    heading(`Posting Context: ${npcArg}`);
+    try {
+      const result = await inspectPostingContext(npcArg);
+
+      if (showRaw && result.rawPrompt) {
+        console.log(result.rawPrompt);
+      } else {
+        subheading('Section Breakdown');
+        printSectionReport(result.sections);
+
+        subheading('Token Budget');
+        console.log(`  Total context tokens: ${result.totalTokens}`);
+      }
+    } catch (e) {
+      error(
+        `Failed to build posting context: ${e instanceof Error ? e.message : String(e)}`
+      );
+    }
+  }
+
+  // Diff mode
+  if (showDiff && inspectType === 'both') {
+    heading('Trading vs Posting Comparison');
+    try {
+      const trading = await inspectTradingContext(npcArg);
+      const posting = await inspectPostingContext(npcArg);
+
+      console.log(
+        `${''.padEnd(20)}  ${'Trading'.padStart(10)}  ${'Posting'.padStart(10)}`
+      );
+      console.log('-'.repeat(45));
+      console.log(
+        `${'Total tokens'.padEnd(20)}  ${String(trading.totalTokens).padStart(10)}  ${String(posting.totalTokens).padStart(10)}`
+      );
+      console.log(
+        `${'Sections'.padEnd(20)}  ${String(trading.sections.length).padStart(10)}  ${String(posting.sections.length).padStart(10)}`
+      );
+      console.log(
+        `${'Populated'.padEnd(20)}  ${String(trading.sections.filter((s) => s.populated).length).padStart(10)}  ${String(posting.sections.filter((s) => s.populated).length).padStart(10)}`
+      );
+      console.log(
+        `${'Ghost vars'.padEnd(20)}  ${String(trading.ghostVars.length).padStart(10)}  ${'N/A'.padStart(10)}`
+      );
+    } catch (e) {
+      error(`Diff failed: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+
+  process.exit(0);
+}
+
+main().catch((e) => {
+  error(e instanceof Error ? e.message : String(e));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

CLI dev tool that shows exactly what context NPCs and autonomous agents receive for their decisions. Renders the actual prompt and reports on token usage, section breakdown, ghost variables, truncation, and position visibility.

Supports **both** context pipelines:
- **NPCs** — `MarketDecisionEngine` + `MarketContextService` pipeline
- **Autonomous Agents** — `MultiStepExecutor` + context-gatherers pipeline (ElizaOS-based agents)

## Usage

### NPC Inspection
```bash
# Single NPC trading context — section breakdown, ghost vars, truncation
bun run inspect:context -- --npc ailon-musk --type trading

# Full rendered prompt output
bun run inspect:context -- --npc ailon-musk --type trading --raw

# Posting context
bun run inspect:context -- --npc ailon-musk --type posting

# Side-by-side trading vs posting comparison
bun run inspect:context -- --npc ailon-musk --type both --diff

# All NPCs aggregate stats
bun run inspect:context -- --npc all --type trading --summary
```

### Autonomous Agent Inspection
```bash
# Agent context — section breakdown with counts and token budget
bun run inspect:context -- --agent <userId>

# Full rendered prompt the agent LLM would see
bun run inspect:context -- --agent <userId> --raw
```

### Flags

| Flag | What it does |
|------|-------------|
| `--npc <id>` | NPC ID (e.g. `ailon-musk`) or `all` for aggregate |
| `--agent <userId>` | Autonomous agent user ID from DB |
| `--type <trading\|posting\|both>` | Which context pipeline (NPC only, default: `trading`) |
| `--diff` | Side-by-side trading vs posting comparison |
| `--raw` | Output the full rendered prompt text |
| `--summary` | Aggregate stats only |

## Test plan

- [x] `bun run inspect:context -- --npc ailon-musk --type trading` works against production DB
- [x] `bun run inspect:context -- --agent <userId>` works against production DB
- [x] `bun run inspect:context -- --agent <userId> --raw` renders full MultiStepExecutor prompt
- [ ] Handles empty DB gracefully (no crash)