### PR TITLE
feat: enrich agent trading context — populate ghost variables, fix truncation, add memories

### DIFF
--- a/packages/agents/src/autonomous/AutonomousGroupChatService.ts
+++ b/packages/agents/src/autonomous/AutonomousGroupChatService.ts
@@ -76,16 +76,16 @@ export class AutonomousGroupChatService {
         continue;
       }
 
-      // Get recent messages in this group
-      const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+      // Get recent messages in this group (24h lookback for strategic continuity)
+      const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
       const recentMessages = await db
         .select()
         .from(messages)
         .where(
-          and(eq(messages.chatId, chat.id), gte(messages.createdAt, oneHourAgo))
+          and(eq(messages.chatId, chat.id), gte(messages.createdAt, oneDayAgo))
         )
         .orderBy(desc(messages.createdAt))
-        .limit(10);
+        .limit(15);
 
       if (recentMessages.length === 0) continue;
 

--- a/packages/engine/src/MarketDecisionEngine.ts
+++ b/packages/engine/src/MarketDecisionEngine.ts
@@ -67,6 +67,7 @@
  */
 
 import {
+  actorState,
   and,
   db,
   desc,
@@ -2179,8 +2180,9 @@ ${prompt}`
     }
 
     const text = resolved
+      .filter((q) => q.resolvedOutcome != null)
       .map((q) => {
-        const outcome = q.outcome ? 'YES' : 'NO';
+        const outcome = q.resolvedOutcome ? 'YES' : 'NO';
         return `- "${q.text}" → ${outcome}`;
       })
       .join('\n');
@@ -2231,19 +2233,36 @@ ${prompt}`
     npcIds: string[]
   ): Promise<Map<string, string>> {
     const result = new Map<string, string>();
+    if (npcIds.length === 0) return result;
 
-    const settled = await Promise.allSettled(
-      npcIds.map(async (npcId) => {
-        const memories = await this.memoryService.getRecentMemories(npcId, 8);
+    try {
+      // Single batched query instead of N round trips
+      const states = await db
+        .select({
+          id: actorState.id,
+          recentMemories: actorState.recentMemories,
+        })
+        .from(actorState)
+        .where(inArray(actorState.id, npcIds));
+
+      for (const state of states) {
+        if (!state.recentMemories) continue;
+        const memories = this.memoryService.getRecentMemoriesFromRaw(
+          state.recentMemories,
+          state.id,
+          8
+        );
         const formatted = this.memoryService.formatMemoriesForPrompt(memories);
-        return { npcId, formatted };
-      })
-    );
-
-    for (const entry of settled) {
-      if (entry.status === 'fulfilled' && entry.value.formatted) {
-        result.set(entry.value.npcId, entry.value.formatted);
+        if (formatted) {
+          result.set(state.id, formatted);
+        }
       }
+    } catch (error) {
+      logger.warn(
+        'Failed to batch-fetch NPC memories',
+        { error: formatError(error), npcCount: npcIds.length },
+        'MarketDecisionEngine'
+      );
     }
 
     return result;

--- a/packages/engine/src/MarketDecisionEngine.ts
+++ b/packages/engine/src/MarketDecisionEngine.ts
@@ -66,7 +66,17 @@
  * ```
  */
 
-import { and, db, desc, eq, gte, inArray, posts, questions } from '@babylon/db';
+import {
+  and,
+  db,
+  desc,
+  eq,
+  gte,
+  inArray,
+  npcTrades,
+  posts,
+  questions,
+} from '@babylon/db';
 import { logger } from '@babylon/shared';
 import { loadActorById } from './actors-loader';
 import { getTradingProbability } from './config/npc-activity';
@@ -90,6 +100,7 @@ import {
 } from './prompts';
 import { EventMarketLinkerService } from './services/event-market-linker';
 import type { MarketContextService } from './services/market-context-service';
+import { NpcMemoryService } from './services/npc-memory-service';
 import { StaticDataRegistry } from './services/static-data-registry';
 import { isSimulationMode } from './storage-bridge';
 import type { JsonValue } from './types/common';
@@ -165,6 +176,14 @@ export class MarketDecisionEngine {
   } | null = null;
   private recentEventsCache: { events: string; timestamp: number } | null =
     null;
+  private resolvedQuestionsCache: {
+    text: string;
+    timestamp: number;
+  } | null = null;
+  private previousTradesCache: {
+    text: string;
+    timestamp: number;
+  } | null = null;
   private eventMarketSignalsCache: {
     signals: string;
     timestamp: number;
@@ -565,6 +584,32 @@ export class MarketDecisionEngine {
     // Get event-market signals for trading context (BAB-5)
     const eventMarketSignals = await this.getCachedEventMarketSignals();
 
+    // Get resolved questions and previous trades (formerly ghost variables)
+    const resolvedQuestionsContext = await this.getCachedResolvedQuestions();
+    const npcIds = contexts.map((ctx) => ctx.npcId);
+    const previousTrades = await this.getCachedPreviousTrades(npcIds);
+
+    // Get NPC memories and append to dashboards
+    const npcMemories = await this.getMemoriesForNPCs(npcIds);
+    if (npcMemories.size > 0) {
+      const dashboards = npcsList.split(
+        '\n----------------------------------------\n'
+      );
+      npcsList = dashboards
+        .map((dashboard) => {
+          const idMatch = dashboard.match(/ID:\s*(\S+)/);
+          if (idMatch?.[1]) {
+            const npcId = idMatch[1];
+            const memories = npcMemories.get(npcId);
+            if (memories) {
+              return `${dashboard}\n${memories}`;
+            }
+          }
+          return dashboard;
+        })
+        .join('\n----------------------------------------\n');
+    }
+
     // Build valid IDs/tickers for the prompt
     // Note: Removed redundant fields (validNpcIds, validTickers) as they are now in the dashboards
     const validNpcIds = contexts.map((ctx) => ctx.npcId).join(', ');
@@ -594,10 +639,10 @@ export class MarketDecisionEngine {
       realityGrounding: worldContext.realityGrounding,
       activeQuestions: activeQuestionsText,
       recentEvents: recentEventsText,
-      // Add rich narrative context if available
       richGameContext: worldContext.richGameContext || '',
-      // BAB-5: Event-market signals for informed trading decisions
       eventMarketSignals,
+      resolvedQuestionsContext,
+      previousTrades,
     });
 
     // Count tokens and enforce limit
@@ -639,8 +684,9 @@ export class MarketDecisionEngine {
         activeQuestions: activeQuestionsText,
         recentEvents: recentEventsText,
         richGameContext: worldContext.richGameContext || '',
-        // BAB-5: Event-market signals (required variable)
         eventMarketSignals,
+        resolvedQuestionsContext,
+        previousTrades,
       });
       const prefixTokens = countTokensSync(promptPrefix);
       const bufferTokens = Math.floor(this.tokenConfig.maxContextTokens * 0.1); // 10% buffer
@@ -663,8 +709,9 @@ export class MarketDecisionEngine {
         activeQuestions: activeQuestionsText,
         recentEvents: recentEventsText,
         richGameContext: worldContext.richGameContext || '',
-        // BAB-5: Event-market signals (required variable)
         eventMarketSignals,
+        resolvedQuestionsContext,
+        previousTrades,
       });
 
       promptTokens = countTokensSync(prompt);
@@ -2030,7 +2077,7 @@ ${prompt}`
     const context = await generateWorldContext({
       maxActors: 0,
       includeActors: false,
-      realityGroundingLevel: 'minimal',
+      realityGroundingLevel: 'concise',
     });
 
     // Cache it
@@ -2102,6 +2149,105 @@ ${prompt}`
     logger.debug('Cached recent events', {}, 'MarketDecisionEngine');
 
     return events;
+  }
+
+  private async getCachedResolvedQuestions(): Promise<string> {
+    const now = Date.now();
+    if (
+      this.resolvedQuestionsCache &&
+      now - this.resolvedQuestionsCache.timestamp < this.CACHE_TTL_MS
+    ) {
+      return this.resolvedQuestionsCache.text;
+    }
+
+    if (isSimulationMode()) {
+      this.resolvedQuestionsCache = { text: '', timestamp: now };
+      return '';
+    }
+
+    const resolved = await db
+      .select()
+      .from(questions)
+      .where(eq(questions.status, 'resolved'))
+      .orderBy(desc(questions.resolutionDate))
+      .limit(10);
+
+    if (resolved.length === 0) {
+      this.resolvedQuestionsCache = { text: '', timestamp: now };
+      return '';
+    }
+
+    const text = resolved
+      .map((q) => {
+        const outcome = q.outcome ? 'YES' : 'NO';
+        return `- "${q.text}" → ${outcome}`;
+      })
+      .join('\n');
+
+    this.resolvedQuestionsCache = { text, timestamp: now };
+    return text;
+  }
+
+  private async getCachedPreviousTrades(npcIds: string[]): Promise<string> {
+    const now = Date.now();
+    if (
+      this.previousTradesCache &&
+      now - this.previousTradesCache.timestamp < this.CACHE_TTL_MS
+    ) {
+      return this.previousTradesCache.text;
+    }
+
+    if (isSimulationMode() || npcIds.length === 0) {
+      this.previousTradesCache = { text: '', timestamp: now };
+      return '';
+    }
+
+    const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const recentTrades = await db
+      .select()
+      .from(npcTrades)
+      .where(
+        and(
+          inArray(npcTrades.npcActorId, npcIds),
+          gte(npcTrades.executedAt, oneDayAgo)
+        )
+      )
+      .orderBy(desc(npcTrades.executedAt))
+      .limit(30);
+
+    if (recentTrades.length === 0) {
+      this.previousTradesCache = { text: '', timestamp: now };
+      return '';
+    }
+
+    const text = recentTrades
+      .map((t) => {
+        const symbol = t.ticker || `Q${t.marketId}`;
+        return `- ${t.npcActorId}: ${t.action} ${symbol} $${t.amount.toFixed(0)} @ $${t.price.toFixed(2)}${t.reason ? ` (${t.reason.substring(0, 80)})` : ''}`;
+      })
+      .join('\n');
+
+    this.previousTradesCache = { text, timestamp: now };
+    return text;
+  }
+
+  private async getMemoriesForNPCs(
+    npcIds: string[]
+  ): Promise<Map<string, string>> {
+    const memoryService = new NpcMemoryService();
+    const result = new Map<string, string>();
+
+    await Promise.all(
+      npcIds.map(async (npcId) => {
+        const memories = await memoryService.getRecentMemories(npcId, 8);
+        const formatted = memoryService.formatMemoriesForPrompt(memories);
+        if (formatted) {
+          result.set(npcId, formatted);
+        }
+      })
+    );
+
+    return result;
   }
 
   /**
@@ -2280,6 +2426,8 @@ ${prompt}`
     this.worldContextCache = null;
     this.activeQuestionsCache = null;
     this.recentEventsCache = null;
+    this.resolvedQuestionsCache = null;
+    this.previousTradesCache = null;
     this.eventMarketSignalsCache = null;
     logger.debug('Cleared all caches', {}, 'MarketDecisionEngine');
   }

--- a/packages/engine/src/MarketDecisionEngine.ts
+++ b/packages/engine/src/MarketDecisionEngine.ts
@@ -164,6 +164,7 @@ interface TokenConfig {
  */
 export class MarketDecisionEngine {
   private tokenConfig: TokenConfig;
+  private memoryService = new NpcMemoryService();
 
   // Caches to avoid redundant queries within same tick
   private worldContextCache: {
@@ -586,8 +587,8 @@ export class MarketDecisionEngine {
 
     // Get resolved questions and previous trades (formerly ghost variables)
     const resolvedQuestionsContext = await this.getCachedResolvedQuestions();
+    const previousTrades = await this.getCachedPreviousTrades();
     const npcIds = contexts.map((ctx) => ctx.npcId);
-    const previousTrades = await this.getCachedPreviousTrades(npcIds);
 
     // Get NPC memories and append to dashboards
     const npcMemories = await this.getMemoriesForNPCs(npcIds);
@@ -2188,7 +2189,7 @@ ${prompt}`
     return text;
   }
 
-  private async getCachedPreviousTrades(npcIds: string[]): Promise<string> {
+  private async getCachedPreviousTrades(): Promise<string> {
     const now = Date.now();
     if (
       this.previousTradesCache &&
@@ -2197,7 +2198,7 @@ ${prompt}`
       return this.previousTradesCache.text;
     }
 
-    if (isSimulationMode() || npcIds.length === 0) {
+    if (isSimulationMode()) {
       this.previousTradesCache = { text: '', timestamp: now };
       return '';
     }
@@ -2206,12 +2207,7 @@ ${prompt}`
     const recentTrades = await db
       .select()
       .from(npcTrades)
-      .where(
-        and(
-          inArray(npcTrades.npcActorId, npcIds),
-          gte(npcTrades.executedAt, oneDayAgo)
-        )
-      )
+      .where(gte(npcTrades.executedAt, oneDayAgo))
       .orderBy(desc(npcTrades.executedAt))
       .limit(30);
 
@@ -2234,18 +2230,21 @@ ${prompt}`
   private async getMemoriesForNPCs(
     npcIds: string[]
   ): Promise<Map<string, string>> {
-    const memoryService = new NpcMemoryService();
     const result = new Map<string, string>();
 
-    await Promise.all(
+    const settled = await Promise.allSettled(
       npcIds.map(async (npcId) => {
-        const memories = await memoryService.getRecentMemories(npcId, 8);
-        const formatted = memoryService.formatMemoriesForPrompt(memories);
-        if (formatted) {
-          result.set(npcId, formatted);
-        }
+        const memories = await this.memoryService.getRecentMemories(npcId, 8);
+        const formatted = this.memoryService.formatMemoriesForPrompt(memories);
+        return { npcId, formatted };
       })
     );
+
+    for (const entry of settled) {
+      if (entry.status === 'fulfilled' && entry.value.formatted) {
+        result.set(entry.value.npcId, entry.value.formatted);
+      }
+    }
 
     return result;
   }

--- a/packages/engine/src/services/market-context-service.ts
+++ b/packages/engine/src/services/market-context-service.ts
@@ -54,7 +54,6 @@ import { parseStringArraySafe } from './jsonb-validators';
 import {
   buildPerpMarketSnapshot,
   buildPredictionMarketSnapshot,
-  MAX_MARKET_QUESTION_LENGTH,
 } from './market-context-helpers';
 import { SignalExtractionService } from './signal-extraction-service';
 import { StaticDataRegistry } from './static-data-registry';
@@ -515,9 +514,8 @@ export class MarketContextService {
         .orderBy(desc(messages.createdAt))
         .limit(20);
 
-      for (const msg of chatMessages.slice(0, 15)) {
-        // Truncate long messages
-        const maxMsgLength = 120;
+      for (const msg of chatMessages.slice(0, 8)) {
+        const maxMsgLength = 300;
         const message =
           msg.content.length > maxMsgLength
             ? msg.content.slice(0, maxMsgLength) + '...'
@@ -546,9 +544,9 @@ export class MarketContextService {
    * @returns Array of feed post contexts
    *
    * @remarks
-   * - Limited to 50 most recent posts
-   * - Post content truncated to 200 characters
-   * - Article titles truncated to 80 characters
+   * - Limited to 15 most relevant posts
+   * - Post content truncated to 500 characters
+   * - Article titles truncated to 120 characters
    */
   private async getRecentFeed(): Promise<FeedPostContext[]> {
     const now = new Date();
@@ -557,17 +555,16 @@ export class MarketContextService {
       .from(posts)
       .where(and(isNull(posts.deletedAt), lte(posts.timestamp, now)))
       .orderBy(desc(posts.timestamp))
-      .limit(50);
+      .limit(15);
 
     return postList.map((post) => {
-      // Truncate long posts to save tokens
-      const maxContentLength = 200;
+      const maxContentLength = 500;
       const content =
         post.content.length > maxContentLength
           ? post.content.slice(0, maxContentLength) + '...'
           : post.content;
 
-      const maxTitleLength = 80;
+      const maxTitleLength = 120;
       const articleTitle =
         post.articleTitle && post.articleTitle.length > maxTitleLength
           ? post.articleTitle.slice(0, maxTitleLength) + '...'
@@ -592,8 +589,8 @@ export class MarketContextService {
    * @returns Array of event contexts
    *
    * @remarks
-   * - Limited to 30 most recent events
-   * - Event descriptions truncated to 150 characters
+   * - Limited to 20 most recent events
+   * - Event descriptions truncated to 300 characters
    * - Only includes events with timestamp <= now()
    */
   private async getRecentEvents(): Promise<EventContext[]> {
@@ -603,11 +600,10 @@ export class MarketContextService {
       .from(worldEvents)
       .where(lte(worldEvents.timestamp, now))
       .orderBy(desc(worldEvents.timestamp))
-      .limit(30);
+      .limit(20);
 
     return eventList.map((event) => {
-      // Truncate long descriptions
-      const maxDescLength = 150;
+      const maxDescLength = 300;
       const description =
         event.description.length > maxDescLength
           ? event.description.slice(0, maxDescLength) + '...'
@@ -797,7 +793,7 @@ export class MarketContextService {
    *
    * @remarks
    * - Limited to 15 most active markets (by yesShares)
-   * - Question text truncated to 120 characters
+   * - Question text is never truncated
    * - Only includes unresolved markets with endDate >= now
    */
   private async getPredictionMarketSnapshots(): Promise<
@@ -821,8 +817,7 @@ export class MarketContextService {
           liquidity: Number.parseFloat(market.liquidity.toString()),
           endDate: market.endDate,
         },
-        now,
-        { maxQuestionLength: MAX_MARKET_QUESTION_LENGTH }
+        now
       )
     );
   }

--- a/packages/engine/src/services/npc-memory-service.ts
+++ b/packages/engine/src/services/npc-memory-service.ts
@@ -625,6 +625,19 @@ export class NpcMemoryService {
   }
 
   /**
+   * Parse recent memories from raw JSONB data without a DB query.
+   * Used for batched reads where actorState is already fetched.
+   */
+  getRecentMemoriesFromRaw(
+    rawMemories: unknown,
+    actorId: string,
+    limit = 10
+  ): NpcMemory[] {
+    const memories = parseMemoriesSafe(rawMemories, { actorId });
+    return memories.slice(-limit).reverse();
+  }
+
+  /**
    * Format memories for inclusion in NPC prompts.
    */
   formatMemoriesForPrompt(memories: NpcMemory[]): string {


### PR DESCRIPTION
## Summary

Addresses recommendations from `docs/agent-context-analysis.md`. Agents were making trading decisions with severely impoverished context — 6 template variables were empty (literal `{{varName}}` sent to the LLM), posts were truncated to 200 chars, questions to 120 chars, and group chats showed only 2 messages at 120 chars.

### Tier 1: Wire up what already exists
- **Populate `{{resolvedQuestionsContext}}`** — last 10 resolved questions with YES/NO outcomes, so agents can learn from past market resolutions
- **Populate `{{previousTrades}}`** — last 24h of NPC trades with action, price, and reasoning, so agents see what they and others have done
- **Append NPC memories to trader dashboards** — `NpcMemoryService.formatMemoriesForPrompt()` already exists for posting; now wired into trading
- **Fix `renderPrompt` ghost variables** — unpopulated optional vars now replaced with empty string instead of sent as literal template text
- **Upgrade reality grounding** from `'minimal'` to `'concise'` for richer world context

### Tier 2: Fix truncation strategy
| Data | Before | After |
|------|--------|-------|
| Feed posts | 50 posts × 200 chars | 15 posts × 500 chars |
| World events | 30 events × 150 chars | 20 events × 300 chars |
| Prediction questions | Truncated at 120 chars | **Never truncated** |
| Group chat messages | 15 msgs × 120 chars | 8 msgs × 300 chars |
| Dashboard positions | Top 3 by PnL | **All positions** |
| Dashboard group chat | 2 messages shown | 5 messages shown |
| Dashboard relationships | Max 4 | Max 6 |
| "Current Focus" | 3 posts × 20 chars | **Removed** (was noise) |

### Tier 3: Extended capabilities
- **Autonomous agent group chat lookback**: 24 hours / 15 messages (was 1 hour / 10 messages)

## Test plan
- [ ] `bun run typecheck` passes (pre-existing `achievement-service.ts` errors are unrelated)
- [ ] `bun run check` passes
- [ ] Deploy to staging and verify NPC trading decisions reference resolved questions and past trades
- [ ] Verify rendered trading prompts no longer contain literal `{{variableName}}` strings
- [ ] Verify prediction market questions appear untruncated in market table