### PR TITLE
feat: expose market signal analysis and enrich market table for NPC trading

### DIFF
--- a/packages/engine/src/MarketDecisionEngine.ts
+++ b/packages/engine/src/MarketDecisionEngine.ts
@@ -531,6 +531,25 @@ export class MarketDecisionEngine {
     return formatMarketDataTable(contexts[0]);
   }
 
+  private formatMarketSignals(contexts: NPCMarketContext[]): string {
+    if (!contexts[0]) return '';
+    const signals = contexts[0].marketSignals;
+    if (!signals || signals.length === 0) return '';
+
+    const lines = signals.map((s) => {
+      const direction =
+        s.suggestedOutcome === 'YES'
+          ? '↑ YES'
+          : s.suggestedOutcome === 'NO'
+            ? '↓ NO'
+            : '? UNCERTAIN';
+      const conf = (s.confidence * 100).toFixed(0);
+      return `- Q${s.marketId}: ${direction} (confidence: ${conf}%, signal: ${s.netSignal > 0 ? '+' : ''}${s.netSignal.toFixed(2)})`;
+    });
+
+    return `SIGNAL ANALYSIS (from feed/event content):\n${lines.join('\n')}`;
+  }
+
   /**
    * Format NPCs list into "Trader Dashboard" blocks.
    * Delegates to shared utility `formatNPCsDashboardList`.
@@ -565,8 +584,10 @@ export class MarketDecisionEngine {
     // Get event-market signals for trading context (BAB-5)
     const eventMarketSignals = await this.getCachedEventMarketSignals();
 
+    // Format signal analysis from feed content for prediction markets
+    const marketSignalAnalysis = this.formatMarketSignals(contexts);
+
     // Build valid IDs/tickers for the prompt
-    // Note: Removed redundant fields (validNpcIds, validTickers) as they are now in the dashboards
     const validNpcIds = contexts.map((ctx) => ctx.npcId).join(', ');
 
     // Collect all tickers for validation/safety
@@ -594,10 +615,9 @@ export class MarketDecisionEngine {
       realityGrounding: worldContext.realityGrounding,
       activeQuestions: activeQuestionsText,
       recentEvents: recentEventsText,
-      // Add rich narrative context if available
       richGameContext: worldContext.richGameContext || '',
-      // BAB-5: Event-market signals for informed trading decisions
       eventMarketSignals,
+      marketSignalAnalysis,
     });
 
     // Count tokens and enforce limit
@@ -639,11 +659,11 @@ export class MarketDecisionEngine {
         activeQuestions: activeQuestionsText,
         recentEvents: recentEventsText,
         richGameContext: worldContext.richGameContext || '',
-        // BAB-5: Event-market signals (required variable)
         eventMarketSignals,
+        marketSignalAnalysis,
       });
       const prefixTokens = countTokensSync(promptPrefix);
-      const bufferTokens = Math.floor(this.tokenConfig.maxContextTokens * 0.1); // 10% buffer
+      const bufferTokens = Math.floor(this.tokenConfig.maxContextTokens * 0.1);
       const availableForNPCs =
         this.tokenConfig.maxContextTokens - prefixTokens - bufferTokens;
 
@@ -663,8 +683,8 @@ export class MarketDecisionEngine {
         activeQuestions: activeQuestionsText,
         recentEvents: recentEventsText,
         richGameContext: worldContext.richGameContext || '',
-        // BAB-5: Event-market signals (required variable)
         eventMarketSignals,
+        marketSignalAnalysis,
       });
 
       promptTokens = countTokensSync(prompt);

--- a/packages/engine/src/prompts/loader.ts
+++ b/packages/engine/src/prompts/loader.ts
@@ -59,6 +59,7 @@ export function renderPrompt(
       'validNpcIds',
       'validTickers',
       'previousTrades',
+      'marketSignalAnalysis',
 
       // Standard context vars
       'trendContext',

--- a/packages/engine/src/prompts/trading/npc-market-decisions.ts
+++ b/packages/engine/src/prompts/trading/npc-market-decisions.ts
@@ -292,6 +292,8 @@ EVENTS:
 
 {{eventMarketSignals}}
 
+{{marketSignalAnalysis}}
+
 TRADERS:
 {{npcsList}}
 

--- a/packages/engine/src/utils/trading-dashboard-format.ts
+++ b/packages/engine/src/utils/trading-dashboard-format.ts
@@ -165,15 +165,17 @@ export function formatMarketDataTable(ctx: NPCMarketContext): string {
   }
 
   let table =
-    '| Ticker/ID | Type | Price | 24h Change | Volume/Liq |\n|---|---|---|---|---|\n';
+    '| Ticker/ID | Type | Price | 24h Change | 24h Range | Volume |\n|---|---|---|---|---|---|\n';
 
   for (const p of perps) {
     const sign = p.changePercent24h >= 0 ? '+' : '';
-    table += `| ${p.ticker} | PERP | $${p.currentPrice.toFixed(2)} | ${sign}${p.changePercent24h.toFixed(2)}% | Vol: $${(p.volume24h / 1000).toFixed(1)}k |\n`;
+    const range = `$${p.low24h.toFixed(2)}-$${p.high24h.toFixed(2)}`;
+    table += `| ${p.ticker} | PERP | $${p.currentPrice.toFixed(2)} | ${sign}${p.changePercent24h.toFixed(2)}% | ${range} | $${(p.volume24h / 1000).toFixed(1)}k |\n`;
   }
 
   for (const p of predictions) {
-    table += `| ${p.id} | PRED | Yes: ${p.yesPrice.toFixed(0)}¢ | No: ${p.noPrice.toFixed(0)}¢ | Vol: $${(p.totalVolume / 1000).toFixed(1)}k |\n`;
+    const daysLeft = p.daysUntilResolution;
+    table += `| ${p.id} | PRED | Yes: ${p.yesPrice.toFixed(0)}¢ / No: ${p.noPrice.toFixed(0)}¢ | ${daysLeft}d left | "${p.text}" | $${(p.totalVolume / 1000).toFixed(1)}k |\n`;
   }
 
   return table;

--- a/packages/testing/unit/market-signal-analysis.test.ts
+++ b/packages/testing/unit/market-signal-analysis.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'bun:test';
+import { renderPrompt } from '@babylon/engine';
+
+const testPrompt = {
+  id: 'test-market-signals',
+  version: '1.0.0',
+  category: 'test',
+  description: 'Test prompt for market signal analysis',
+  template: `MARKETS:
+{{marketTable}}
+
+{{eventMarketSignals}}
+
+{{marketSignalAnalysis}}
+
+TRADERS:
+{{npcsList}}`,
+};
+
+describe('Market signal analysis in trading prompt', () => {
+  it('should render marketSignalAnalysis when provided', () => {
+    const result = renderPrompt(
+      testPrompt,
+      {
+        marketTable: 'some table',
+        eventMarketSignals: 'some signals',
+        marketSignalAnalysis:
+          'SIGNAL ANALYSIS (from feed/event content):\n- Q123: ↑ YES (confidence: 72%, signal: +0.44)',
+        npcsList: 'some npcs',
+      },
+      { allowEmpty: true }
+    );
+
+    expect(result).toContain('SIGNAL ANALYSIS (from feed/event content)');
+    expect(result).toContain('↑ YES (confidence: 72%');
+    expect(result).toContain('signal: +0.44');
+  });
+
+  it('should render empty when marketSignalAnalysis is not provided', () => {
+    const result = renderPrompt(
+      testPrompt,
+      {
+        marketTable: 'some table',
+        eventMarketSignals: 'some signals',
+        npcsList: 'some npcs',
+      },
+      { allowEmpty: true }
+    );
+
+    expect(result).not.toContain('{{marketSignalAnalysis}}');
+    expect(result).not.toContain('SIGNAL ANALYSIS');
+  });
+});
+
+describe('Enriched market table format', () => {
+  it('should include 24h range column header', () => {
+    const table =
+      '| Ticker/ID | Type | Price | 24h Change | 24h Range | Volume |\n|---|---|---|---|---|---|';
+    expect(table).toContain('24h Range');
+    expect(table).toContain('Volume');
+    // Old format had "Volume/Liq" in 5 columns; new has 6 columns
+    expect(table.split('|').length).toBeGreaterThan(6);
+  });
+
+  it('should format perp market row with range', () => {
+    const row =
+      '| TSLA | PERP | $450.00 | +15.20% | $380.00-$460.00 | $5000.0k |';
+    expect(row).toContain('$380.00-$460.00');
+    expect(row).toContain('+15.20%');
+  });
+
+  it('should format prediction market row with question text and days', () => {
+    const row =
+      '| 123456 | PRED | Yes: 60¢ / No: 40¢ | 3d left | "Will TeslAI announce partnership?" | $5.2k |';
+    expect(row).toContain('Will TeslAI announce partnership?');
+    expect(row).toContain('3d left');
+    expect(row).toContain('Yes: 60¢ / No: 40¢');
+  });
+
+  it('prediction row should not truncate question text', () => {
+    const longQuestion =
+      'Will AIlon Musk deploy TeslAI to cause a 10-minute AI-activated dill dilemma at a farmer market?';
+    const row = `| 789 | PRED | Yes: 50¢ / No: 50¢ | 5d left | "${longQuestion}" | $1.0k |`;
+    // Question is 97 chars — old limit was 120, now unlimited
+    expect(row).toContain(longQuestion);
+    expect(row).not.toContain('...');
+  });
+});
+
+describe('formatMarketSignals output format', () => {
+  it('should produce correct format for YES signal', () => {
+    // Simulate the format the engine produces
+    const signal = {
+      marketId: '123',
+      suggestedOutcome: 'YES' as const,
+      confidence: 0.72,
+      netSignal: 0.44,
+    };
+    const direction = signal.suggestedOutcome === 'YES' ? '↑ YES' : '↓ NO';
+    const conf = (signal.confidence * 100).toFixed(0);
+    const line = `- Q${signal.marketId}: ${direction} (confidence: ${conf}%, signal: +${signal.netSignal.toFixed(2)})`;
+
+    expect(line).toBe('- Q123: ↑ YES (confidence: 72%, signal: +0.44)');
+  });
+
+  it('should produce correct format for NO signal', () => {
+    const signal = {
+      marketId: '456',
+      suggestedOutcome: 'NO' as const,
+      confidence: 0.61,
+      netSignal: -0.22,
+    };
+    const direction = signal.suggestedOutcome === 'NO' ? '↓ NO' : '↑ YES';
+    const conf = (signal.confidence * 100).toFixed(0);
+    const signStr = signal.netSignal > 0 ? '+' : '';
+    const line = `- Q${signal.marketId}: ${direction} (confidence: ${conf}%, signal: ${signStr}${signal.netSignal.toFixed(2)})`;
+
+    expect(line).toBe('- Q456: ↓ NO (confidence: 61%, signal: -0.22)');
+  });
+
+  it('should produce correct format for UNCERTAIN signal', () => {
+    const signal = {
+      marketId: '789',
+      suggestedOutcome: 'UNCERTAIN' as const,
+      confidence: 0.45,
+      netSignal: 0.02,
+    };
+    const direction =
+      signal.suggestedOutcome === 'YES'
+        ? '↑ YES'
+        : signal.suggestedOutcome === 'NO'
+          ? '↓ NO'
+          : '? UNCERTAIN';
+    const conf = (signal.confidence * 100).toFixed(0);
+    const signStr = signal.netSignal > 0 ? '+' : '';
+    const line = `- Q${signal.marketId}: ${direction} (confidence: ${conf}%, signal: ${signStr}${signal.netSignal.toFixed(2)})`;
+
+    expect(line).toBe('- Q789: ? UNCERTAIN (confidence: 45%, signal: +0.02)');
+  });
+});


### PR DESCRIPTION
## Summary

Addresses items #3 and #10 from `docs/agent-context-analysis.md`.

### Market signal analysis exposed (item #3)
`extractMarketSignals()` in `MarketContextService` already computes YES/NO signal direction, confidence, and net signal strength for each active prediction market. This data was stored on the context object but never formatted into the trading prompt. Now wired via `{{marketSignalAnalysis}}` section.

Example output in prompt:
```
SIGNAL ANALYSIS (from feed/event content):
- Q297083881411051520: ↑ YES (confidence: 72%, signal: +0.44)
- Q296784433992695808: ↓ NO (confidence: 61%, signal: -0.22)
```

### Market table enriched (item #10 + readability)
- **Perp markets**: Added 24h high/low range column so agents can see intraday volatility and trend
- **Prediction markets**: Added full question text and days remaining. Previously agents saw only market IDs and prices with no way to know what they were betting on

Before:
```
| 297083881411051520 | PRED | Yes: 60¢ | No: 40¢ | Vol: $5.2k |
```

After:
```
| 297083881411051520 | PRED | Yes: 60¢ / No: 40¢ | 3d left | "Will TeslAI announce partnership?" | $5.2k |
```

## Test plan
- [ ] `bun run typecheck` passes (pre-existing errors only)
- [ ] `bun run check` passes
- [ ] Verify signal analysis appears in rendered NPC trading prompts
- [ ] Verify market table shows 24h range for perps and full question text for predictions