### PR TITLE
feat: add profile-driven perp market simulation

### DIFF
--- a/packages/engine/src/game-tick.ts
+++ b/packages/engine/src/game-tick.ts
@@ -83,6 +83,14 @@ import {
   WalletService,
   worldFactsGenerator,
 } from './services';
+import {
+  buildMarketSimulationProfile,
+  createInitialMarketSimulationState,
+  evolveGlobalMarketSimulationState,
+  type GlobalMarketSimulationState,
+  generateProfileDrivenMarketMove,
+  getDefaultGlobalMarketSimulationState,
+} from './services/market-simulation-profiles';
 // Note: ActorSocialActions, FollowingMechanics, processNPCSocialEngagements,
 // npcSocialEngagementService moved to npc-tick
 import { broadcastToChannel } from './services/realtime-broadcaster';
@@ -2419,10 +2427,11 @@ const marketVolatilityState = new Map<
     recentVolatility: number;
     momentum: number;
     lastMove: number;
+    latentPrice: number;
   }
 >();
-
-const MIN_MARKET_VOLATILITY = 0.005;
+let globalMarketSimulationState: GlobalMarketSimulationState =
+  getDefaultGlobalMarketSimulationState();
 
 /**
  * Simulates natural market volatility for all perp markets.
@@ -2461,6 +2470,7 @@ export async function simulateMarketVolatility(options?: {
         ticker: perpMarketSnapshots.ticker,
         organizationId: perpMarketSnapshots.organizationId,
         currentPrice: perpMarketSnapshots.currentPrice,
+        openInterest: perpMarketSnapshots.openInterest,
       })
       .from(perpMarketSnapshots);
 
@@ -2481,6 +2491,9 @@ export async function simulateMarketVolatility(options?: {
     const basePriceByOrgId = new Map(
       orgStates.map((o) => [o.id, Number(o.basePrice ?? 100)])
     );
+    globalMarketSimulationState = evolveGlobalMarketSimulationState(
+      globalMarketSimulationState
+    );
 
     let updatedCount = 0;
     const priceUpdates: Array<{
@@ -2499,19 +2512,28 @@ export async function simulateMarketVolatility(options?: {
           ? basePrice
           : currentPrice;
 
-      // Get or initialize volatility state for this market
+      const organization = StaticDataRegistry.getOrganization(
+        market.organizationId
+      );
+      const profile = buildMarketSimulationProfile({
+        organizationId: market.organizationId,
+        ticker: market.ticker,
+        organization,
+      });
+
       let state = marketVolatilityState.get(market.ticker);
       if (!state) {
-        state = {
-          recentVolatility: MIN_MARKET_VOLATILITY,
-          momentum: 0,
-          lastMove: 0,
-        };
+        state = createInitialMarketSimulationState(currentPrice, profile);
         marketVolatilityState.set(market.ticker, state);
       }
 
-      // Calculate price move
-      const move = generateVolatilityMove(state, initialPrice, currentPrice);
+      const { move, nextState } = generateProfileDrivenMarketMove({
+        state,
+        profile,
+        globalState: globalMarketSimulationState,
+        currentPrice,
+        openInterest: Number(market.openInterest ?? 0),
+      });
 
       // Apply move
       const newPrice = currentPrice * (1 + move);
@@ -2521,14 +2543,7 @@ export async function simulateMarketVolatility(options?: {
       const maxPrice = initialPrice * PERP_MARKET_CONFIG.PRICE_CEILING_RATIO;
       const clampedPrice = Math.max(minPrice, Math.min(newPrice, maxPrice));
 
-      // Update state for next tick
-      state.lastMove = move;
-      state.momentum = move * 0.3; // 30% momentum carries forward
-      // Volatility clustering: if big move, stay volatile
-      state.recentVolatility = Math.max(
-        MIN_MARKET_VOLATILITY,
-        state.recentVolatility * 0.8 + Math.abs(move) * 0.2
-      );
+      marketVolatilityState.set(market.ticker, nextState);
 
       // Only update if price changed meaningfully (> 0.01%)
       if (Math.abs(clampedPrice - currentPrice) / currentPrice > 0.0001) {
@@ -2589,65 +2604,6 @@ export async function simulateMarketVolatility(options?: {
     );
     return 0;
   }
-}
-
-/**
- * Generates a realistic price movement with fat tails and volatility clustering.
- */
-function generateVolatilityMove(
-  state: { recentVolatility: number; momentum: number; lastMove: number },
-  initialPrice: number,
-  currentPrice: number
-): number {
-  // Base volatility with clustering effect
-  const baseVolatility = state.recentVolatility;
-  const volatilityMultiplier = 0.5 + Math.random(); // 0.5x to 1.5x
-  const currentVolatility = baseVolatility * volatilityMultiplier;
-
-  // Generate move with fat tails
-  let move: number;
-  const fatTailChance = Math.random();
-
-  if (fatTailChance < 0.01) {
-    // 1% chance: LARGE jump (3-6x normal volatility)
-    const direction = Math.random() > 0.5 ? 1 : -1;
-    move = direction * currentVolatility * (3 + Math.random() * 3);
-  } else if (fatTailChance < 0.05) {
-    // 4% chance: Notable move (2-3x normal)
-    move = (Math.random() - 0.5) * 2 * currentVolatility * (2 + Math.random());
-  } else if (fatTailChance < 0.15) {
-    // 10% chance: Above average move (1.5-2x normal)
-    move =
-      (Math.random() - 0.5) *
-      2 *
-      currentVolatility *
-      (1.5 + Math.random() * 0.5);
-  } else {
-    // 85% chance: Normal move
-    move = (Math.random() - 0.5) * 2 * currentVolatility;
-  }
-
-  // Add momentum (trend continuation)
-  move += state.momentum * (0.5 + Math.random() * 0.5);
-
-  // Mean reversion - slight pull toward initial price
-  const priceRatio = currentPrice / initialPrice;
-  if (priceRatio > 1.5) {
-    // If price is >150% of initial, slight downward pressure
-    move -= 0.001 * (priceRatio - 1);
-  } else if (priceRatio < 0.7) {
-    // If price is <70% of initial, slight upward pressure
-    move += 0.001 * (1 - priceRatio);
-  }
-
-  // Asymmetry: crashes are 20% faster than rallies
-  if (move < 0) {
-    move *= 1.2;
-  }
-
-  // Cap individual tick move at 5% (but still allow through fat tail distribution)
-  const maxMove = 0.05;
-  return Math.max(-maxMove, Math.min(move, maxMove));
 }
 
 /**

--- a/packages/engine/src/game-tick.ts
+++ b/packages/engine/src/game-tick.ts
@@ -88,6 +88,7 @@ import {
   createInitialMarketSimulationState,
   evolveGlobalMarketSimulationState,
   type GlobalMarketSimulationState,
+  type MarketSimulationState,
   generateProfileDrivenMarketMove,
   getDefaultGlobalMarketSimulationState,
 } from './services/market-simulation-profiles';
@@ -2423,12 +2424,7 @@ export async function updateWorldFactsIfNeeded(): Promise<{
  */
 const marketVolatilityState = new Map<
   string,
-  {
-    recentVolatility: number;
-    momentum: number;
-    lastMove: number;
-    latentPrice: number;
-  }
+  MarketSimulationState
 >();
 let globalMarketSimulationState: GlobalMarketSimulationState =
   getDefaultGlobalMarketSimulationState();

--- a/packages/engine/src/services/market-simulation-profiles.test.ts
+++ b/packages/engine/src/services/market-simulation-profiles.test.ts
@@ -117,4 +117,51 @@ describe('market-simulation-profiles', () => {
 
     expect(Math.abs(lowOiMove)).toBeGreaterThan(Math.abs(highOiMove));
   });
+
+  it('uses latent price carried from prior ticks', () => {
+    const profile = buildMarketSimulationProfile({
+      organizationId: 'openagi',
+      ticker: 'OPENAGI',
+      organization: {
+        type: 'company',
+        name: 'OpenAGI',
+        description: 'AI company',
+      },
+    });
+    const globalState = getDefaultGlobalMarketSimulationState();
+    const lowLatentState = createInitialMarketSimulationState(100, profile);
+    const highLatentState = createInitialMarketSimulationState(100, profile);
+    lowLatentState.latentPrice = 80;
+    highLatentState.latentPrice = 120;
+    const sequence = [0.91, 0.82, 0.73, 0.64, 0.55, 0.46, 0.37, 0.28];
+
+    const lowLatentMove = generateProfileDrivenMarketMove({
+      state: lowLatentState,
+      profile,
+      globalState,
+      currentPrice: 100,
+      openInterest: 5000,
+      rng: (() => {
+        let index = 0;
+        return () => sequence[index++ % sequence.length]!;
+      })(),
+    });
+
+    const highLatentMove = generateProfileDrivenMarketMove({
+      state: highLatentState,
+      profile,
+      globalState,
+      currentPrice: 100,
+      openInterest: 5000,
+      rng: (() => {
+        let index = 0;
+        return () => sequence[index++ % sequence.length]!;
+      })(),
+    });
+
+    expect(lowLatentMove.move).not.toBe(highLatentMove.move);
+    expect(lowLatentMove.nextState.latentPrice).toBeLessThan(
+      highLatentMove.nextState.latentPrice
+    );
+  });
 });

--- a/packages/engine/src/services/market-simulation-profiles.test.ts
+++ b/packages/engine/src/services/market-simulation-profiles.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  buildMarketSimulationProfile,
+  createInitialMarketSimulationState,
+  evolveGlobalMarketSimulationState,
+  generateProfileDrivenMarketMove,
+  getDefaultGlobalMarketSimulationState,
+} from './market-simulation-profiles';
+
+describe('market-simulation-profiles', () => {
+  it('builds deterministic profiles for the same market', () => {
+    const input = {
+      organizationId: 'openagi',
+      ticker: 'OPENAGI',
+      organization: {
+        type: 'company' as const,
+        name: 'OpenAGI',
+        description: 'AI research company',
+      },
+    };
+
+    expect(buildMarketSimulationProfile(input)).toEqual(
+      buildMarketSimulationProfile(input)
+    );
+  });
+
+  it('gives different organization types different baseline behavior', () => {
+    const company = buildMarketSimulationProfile({
+      organizationId: 'openagi',
+      ticker: 'OPENAGI',
+      organization: {
+        type: 'company',
+        name: 'OpenAGI',
+        description: 'AI company',
+      },
+    });
+    const media = buildMarketSimulationProfile({
+      organizationId: 'ainbc',
+      ticker: 'AINBC',
+      organization: {
+        type: 'media',
+        name: 'AINBC',
+        description: 'Media outlet',
+      },
+    });
+
+    expect(media.baseVolatility).toBeGreaterThan(company.baseVolatility);
+    expect(media.jumpChance).toBeGreaterThan(company.jumpChance);
+  });
+
+  it('keeps simulated moves inside the profile max tick move', () => {
+    const profile = buildMarketSimulationProfile({
+      organizationId: 'openagi',
+      ticker: 'OPENAGI',
+      organization: {
+        type: 'company',
+        name: 'OpenAGI',
+        description: 'AI company',
+      },
+    });
+    const state = createInitialMarketSimulationState(100, profile);
+    const globalState = getDefaultGlobalMarketSimulationState();
+    const sequence = [0.9, 0.8, 0.7, 0.6, 0.95, 0.85, 0.75, 0.65];
+    let index = 0;
+
+    const { move } = generateProfileDrivenMarketMove({
+      state,
+      profile,
+      globalState,
+      currentPrice: 100,
+      openInterest: 5000,
+      rng: () => sequence[index++ % sequence.length]!,
+    });
+
+    expect(Math.abs(move)).toBeLessThanOrEqual(profile.maxTickMove);
+  });
+
+  it('dampens noise when open interest is deeper', () => {
+    const profile = buildMarketSimulationProfile({
+      organizationId: 'openagi',
+      ticker: 'OPENAGI',
+      organization: {
+        type: 'company',
+        name: 'OpenAGI',
+        description: 'AI company',
+      },
+    });
+    const globalState = evolveGlobalMarketSimulationState(
+      getDefaultGlobalMarketSimulationState(),
+      () => 0.5
+    );
+    const sequence = [0.99, 0.98, 0.97, 0.96, 0.4, 0.99, 0.98, 0.97];
+
+    const lowOiMove = generateProfileDrivenMarketMove({
+      state: createInitialMarketSimulationState(100, profile),
+      profile,
+      globalState,
+      currentPrice: 100,
+      openInterest: 500,
+      rng: (() => {
+        let index = 0;
+        return () => sequence[index++ % sequence.length]!;
+      })(),
+    }).move;
+
+    const highOiMove = generateProfileDrivenMarketMove({
+      state: createInitialMarketSimulationState(100, profile),
+      profile,
+      globalState,
+      currentPrice: 100,
+      openInterest: 250000,
+      rng: (() => {
+        let index = 0;
+        return () => sequence[index++ % sequence.length]!;
+      })(),
+    }).move;
+
+    expect(Math.abs(lowOiMove)).toBeGreaterThan(Math.abs(highOiMove));
+  });
+});

--- a/packages/engine/src/services/market-simulation-profiles.ts
+++ b/packages/engine/src/services/market-simulation-profiles.ts
@@ -214,7 +214,12 @@ export function generateProfileDrivenMarketMove(params: {
     profile.idiosyncraticVolatility *
     globalState.volatilityLevel;
   const latentMove = commonShock + idiosyncraticShock;
-  const nextLatentPrice = currentPrice * (1 + latentMove);
+  // Evolve fair value independently so dislocations can persist across ticks.
+  const latentPrice =
+    Number.isFinite(state.latentPrice) && state.latentPrice > 0
+      ? state.latentPrice
+      : currentPrice;
+  const nextLatentPrice = latentPrice * (1 + latentMove);
 
   const gapToLatent = clamp(
     (nextLatentPrice - currentPrice) / Math.max(currentPrice, 1),

--- a/packages/engine/src/services/market-simulation-profiles.ts
+++ b/packages/engine/src/services/market-simulation-profiles.ts
@@ -1,0 +1,271 @@
+import type { StaticOrganization } from './static-data-registry';
+
+export interface MarketSimulationProfile {
+  baseVolatility: number;
+  jumpChance: number;
+  maxTickMove: number;
+  trendPersistence: number;
+  fairValuePull: number;
+  marketBeta: number;
+  liquiditySensitivity: number;
+  idiosyncraticVolatility: number;
+}
+
+export interface MarketSimulationState {
+  recentVolatility: number;
+  momentum: number;
+  lastMove: number;
+  latentPrice: number;
+}
+
+export interface GlobalMarketSimulationState {
+  marketDrift: number;
+  volatilityLevel: number;
+  riskSentiment: number;
+}
+
+const TYPE_PRESETS: Record<
+  StaticOrganization['type'],
+  MarketSimulationProfile
+> = {
+  company: {
+    baseVolatility: 0.0055,
+    jumpChance: 0.012,
+    maxTickMove: 0.04,
+    trendPersistence: 0.22,
+    fairValuePull: 0.28,
+    marketBeta: 1,
+    liquiditySensitivity: 1,
+    idiosyncraticVolatility: 0.0045,
+  },
+  media: {
+    baseVolatility: 0.0075,
+    jumpChance: 0.018,
+    maxTickMove: 0.05,
+    trendPersistence: 0.18,
+    fairValuePull: 0.24,
+    marketBeta: 1.12,
+    liquiditySensitivity: 1.15,
+    idiosyncraticVolatility: 0.006,
+  },
+  government: {
+    baseVolatility: 0.004,
+    jumpChance: 0.008,
+    maxTickMove: 0.03,
+    trendPersistence: 0.12,
+    fairValuePull: 0.35,
+    marketBeta: 0.72,
+    liquiditySensitivity: 0.82,
+    idiosyncraticVolatility: 0.003,
+  },
+  vc: {
+    baseVolatility: 0.0068,
+    jumpChance: 0.016,
+    maxTickMove: 0.045,
+    trendPersistence: 0.24,
+    fairValuePull: 0.22,
+    marketBeta: 1.05,
+    liquiditySensitivity: 1.08,
+    idiosyncraticVolatility: 0.0055,
+  },
+  organization: {
+    baseVolatility: 0.0058,
+    jumpChance: 0.011,
+    maxTickMove: 0.04,
+    trendPersistence: 0.2,
+    fairValuePull: 0.26,
+    marketBeta: 0.95,
+    liquiditySensitivity: 0.95,
+    idiosyncraticVolatility: 0.0045,
+  },
+  financial: {
+    baseVolatility: 0.0062,
+    jumpChance: 0.013,
+    maxTickMove: 0.04,
+    trendPersistence: 0.19,
+    fairValuePull: 0.3,
+    marketBeta: 1.08,
+    liquiditySensitivity: 0.88,
+    idiosyncraticVolatility: 0.004,
+  },
+};
+
+const DEFAULT_GLOBAL_STATE: GlobalMarketSimulationState = {
+  marketDrift: 0,
+  volatilityLevel: 1,
+  riskSentiment: 0,
+};
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function stableUnit(seed: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < seed.length; i++) {
+    hash ^= seed.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0) / 4294967295;
+}
+
+function sampleShock(rng: () => number): number {
+  return rng() - 0.5 + (rng() - 0.5) + (rng() - 0.5) + (rng() - 0.5);
+}
+
+export function getDefaultGlobalMarketSimulationState(): GlobalMarketSimulationState {
+  return { ...DEFAULT_GLOBAL_STATE };
+}
+
+export function evolveGlobalMarketSimulationState(
+  state: GlobalMarketSimulationState,
+  rng: () => number = Math.random
+): GlobalMarketSimulationState {
+  const regimeShift = rng() < 0.03;
+  const driftShock = sampleShock(rng) * 0.0015;
+  const sentimentShock = sampleShock(rng) * 0.12;
+  const volatilityShock = sampleShock(rng) * 0.08;
+
+  return {
+    marketDrift: clamp(
+      state.marketDrift * (regimeShift ? 0.35 : 0.82) + driftShock,
+      -0.01,
+      0.01
+    ),
+    riskSentiment: clamp(
+      state.riskSentiment * (regimeShift ? 0.4 : 0.88) + sentimentShock,
+      -1,
+      1
+    ),
+    volatilityLevel: clamp(
+      state.volatilityLevel * (regimeShift ? 0.7 : 0.9) + volatilityShock,
+      0.65,
+      1.85
+    ),
+  };
+}
+
+export function buildMarketSimulationProfile(input: {
+  organizationId: string;
+  ticker: string;
+  organization?: Pick<
+    StaticOrganization,
+    'type' | 'name' | 'description'
+  > | null;
+}): MarketSimulationProfile {
+  const preset =
+    TYPE_PRESETS[input.organization?.type ?? 'company'] ?? TYPE_PRESETS.company;
+  const seedBase = `${input.organizationId}:${input.ticker}`;
+  const volJitter = 0.85 + stableUnit(`${seedBase}:vol`) * 0.4;
+  const jumpJitter = 0.8 + stableUnit(`${seedBase}:jump`) * 0.5;
+  const betaJitter = 0.9 + stableUnit(`${seedBase}:beta`) * 0.25;
+  const liquidityJitter = 0.8 + stableUnit(`${seedBase}:liq`) * 0.5;
+  const trendJitter = 0.85 + stableUnit(`${seedBase}:trend`) * 0.35;
+  const pullJitter = 0.85 + stableUnit(`${seedBase}:pull`) * 0.35;
+
+  return {
+    baseVolatility: preset.baseVolatility * volJitter,
+    jumpChance: preset.jumpChance * jumpJitter,
+    maxTickMove: preset.maxTickMove,
+    trendPersistence: clamp(preset.trendPersistence * trendJitter, 0.08, 0.4),
+    fairValuePull: clamp(preset.fairValuePull * pullJitter, 0.12, 0.5),
+    marketBeta: clamp(preset.marketBeta * betaJitter, 0.55, 1.35),
+    liquiditySensitivity: clamp(
+      preset.liquiditySensitivity * liquidityJitter,
+      0.55,
+      1.5
+    ),
+    idiosyncraticVolatility: preset.idiosyncraticVolatility * volJitter,
+  };
+}
+
+export function createInitialMarketSimulationState(
+  currentPrice: number,
+  profile: MarketSimulationProfile
+): MarketSimulationState {
+  return {
+    recentVolatility: profile.baseVolatility,
+    momentum: 0,
+    lastMove: 0,
+    latentPrice: currentPrice,
+  };
+}
+
+export function generateProfileDrivenMarketMove(params: {
+  state: MarketSimulationState;
+  profile: MarketSimulationProfile;
+  globalState: GlobalMarketSimulationState;
+  currentPrice: number;
+  openInterest: number;
+  rng?: () => number;
+}): { move: number; nextState: MarketSimulationState } {
+  const rng = params.rng ?? Math.random;
+  const { currentPrice, globalState, openInterest, profile, state } = params;
+
+  const openInterestScale = Math.max(1, openInterest / 10_000);
+  const liquidityDamping =
+    profile.liquiditySensitivity / Math.sqrt(1 + openInterestScale);
+
+  const commonShock =
+    (globalState.marketDrift + globalState.riskSentiment * 0.0015) *
+    profile.marketBeta;
+  const idiosyncraticShock =
+    sampleShock(rng) *
+    profile.idiosyncraticVolatility *
+    globalState.volatilityLevel;
+  const latentMove = commonShock + idiosyncraticShock;
+  const nextLatentPrice = currentPrice * (1 + latentMove);
+
+  const gapToLatent = clamp(
+    (nextLatentPrice - currentPrice) / Math.max(currentPrice, 1),
+    -profile.maxTickMove,
+    profile.maxTickMove
+  );
+
+  let move =
+    gapToLatent * profile.fairValuePull +
+    state.momentum * profile.trendPersistence +
+    sampleShock(rng) *
+      state.recentVolatility *
+      globalState.volatilityLevel *
+      liquidityDamping;
+
+  const jumpChance = clamp(
+    profile.jumpChance * globalState.volatilityLevel * (1 + liquidityDamping),
+    0,
+    0.2
+  );
+  if (rng() < jumpChance) {
+    const jumpDirection =
+      Math.abs(gapToLatent) > 0.0005
+        ? Math.sign(gapToLatent)
+        : rng() > 0.5
+          ? 1
+          : -1;
+    const jumpMagnitude =
+      profile.baseVolatility *
+      (2.2 + rng() * 2.6) *
+      globalState.volatilityLevel;
+    move += jumpDirection * jumpMagnitude;
+  }
+
+  if (move < 0) {
+    move *= 1.08;
+  }
+
+  const clampedMove = clamp(move, -profile.maxTickMove, profile.maxTickMove);
+
+  return {
+    move: clampedMove,
+    nextState: {
+      recentVolatility: clamp(
+        state.recentVolatility * 0.78 + Math.abs(clampedMove) * 0.22,
+        profile.baseVolatility * 0.75,
+        profile.maxTickMove
+      ),
+      momentum: clampedMove,
+      lastMove: clampedMove,
+      latentPrice: nextLatentPrice,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- replace the uniform perp volatility simulator with profile-driven market dynamics
- introduce deterministic per-market simulation profiles with different volatility, jump, beta, liquidity, and trend characteristics
- add a lightweight global market regime state so all perps share a common drift/volatility backdrop while retaining idiosyncratic behavior
- make open-interest dampen simulated noise so deeper markets move less mechanically than thin ones
- cover the new simulation layer with focused unit tests

## Why
This is the next realism step after the market-context coherence pass. The existing simulator made most perp markets behave too similarly because they all used the same generic noise process. This change gives each market a stable identity and a latent fair-value/regime process without yet changing execution or introducing full microstructure.

## Testing
- `bun test packages/engine/src/services/market-simulation-profiles.test.ts`
- `bunx tsc -p packages/engine/tsconfig.json --noEmit`

## Follow-ups
- synthetic spread/depth and nonlinear impact
- better separation of fair value vs tradeable/quoted price
- richer calibration per asset class and event sensitivity