### PR TITLE
feat: add synthetic perp execution microstructure

### DIFF
--- a/packages/core/markets/perps/PerpMarketService.ts
+++ b/packages/core/markets/perps/PerpMarketService.ts
@@ -1,4 +1,5 @@
 import { logger, PERP_MARKET_CONFIG } from '@babylon/shared';
+import { getSyntheticPerpExecutionPrice } from './microstructure';
 import type {
   PerpCloseInput,
   PerpDbPort,
@@ -453,7 +454,8 @@ export class PerpMarketService {
       );
     }
 
-    const entryPrice = market.currentPrice;
+    const entryQuote = this.getOpenExecutionQuote(market, side, size);
+    const entryPrice = entryQuote.executionPrice;
 
     // Reject non-finite or extreme prices to prevent NaN/Infinity PnL
     if (!Number.isFinite(entryPrice) || entryPrice <= 0) {
@@ -605,7 +607,20 @@ export class PerpMarketService {
       );
     }
 
-    const requestedExitPrice = input.exitPriceOverride ?? market.currentPrice;
+    // Determine close percentage (default to full close)
+    const closePercentage = Math.min(1, Math.max(0, input.percentage ?? 1));
+    if (closePercentage <= 0) {
+      throw new Error('Close percentage must be greater than 0');
+    }
+
+    const closeSize = position.size * closePercentage;
+    const remainingSize = position.size - closeSize;
+    const isFullClose = remainingSize < 0.01; // Treat tiny remainders as full close
+
+    const requestedExitPrice =
+      input.exitPriceOverride ??
+      this.getCloseExecutionQuote(market, position.side, closeSize)
+        .executionPrice;
 
     // Reject non-finite or extreme prices to prevent NaN/Infinity PnL
     if (!Number.isFinite(requestedExitPrice) || requestedExitPrice <= 0) {
@@ -629,16 +644,6 @@ export class PerpMarketService {
         );
       }
     }
-
-    // Determine close percentage (default to full close)
-    const closePercentage = Math.min(1, Math.max(0, input.percentage ?? 1));
-    if (closePercentage <= 0) {
-      throw new Error('Close percentage must be greater than 0');
-    }
-
-    const closeSize = position.size * closePercentage;
-    const remainingSize = position.size - closeSize;
-    const isFullClose = remainingSize < 0.01; // Treat tiny remainders as full close
 
     // BF-75: determine average-fill execution price up front so persistence,
     // events, and response all use the same close price.
@@ -1116,7 +1121,11 @@ export class PerpMarketService {
     market: PerpMarketRecord
   ): Promise<PerpTradeResult> {
     const { size: addedSize } = input;
-    const currentPrice = market.currentPrice;
+    const currentPrice = this.getOpenExecutionQuote(
+      market,
+      existing.side,
+      addedSize
+    ).executionPrice;
 
     // Validate added size
     const minOrderSize = market.minOrderSize ?? DEFAULT_MIN_ORDER_SIZE;
@@ -1377,7 +1386,12 @@ export class PerpMarketService {
       // Use transaction for atomicity - all DB operations use tx
       const flipResult =
         await this.db.transaction<FlipPositionTransactionResult>(async (tx) => {
-          const exitPrice = market.currentPrice;
+          const closeExecution = this.getCloseExecutionQuote(
+            market,
+            existing.side,
+            existing.size
+          );
+          const exitPrice = closeExecution.executionPrice;
 
           // === STEP 1: Close existing position (inline logic for atomicity) ===
 
@@ -1421,7 +1435,11 @@ export class PerpMarketService {
           const maxLeverage = market.maxLeverage ?? DEFAULT_MAX_LEVERAGE;
           const effectiveLeverage = Math.min(leverage, maxLeverage);
 
-          const entryPrice = market.currentPrice;
+          const entryPrice = this.getOpenExecutionQuote(
+            market,
+            tradeSide,
+            inverseSize
+          ).executionPrice;
           const liquidationPrice = calculateLiquidationPrice(
             entryPrice,
             tradeSide,
@@ -1594,6 +1612,30 @@ export class PerpMarketService {
   private calculateMaxPositionSize(openInterest: number): number {
     const fromOi = openInterest * OPEN_INTEREST_LIMIT_RATIO;
     return Math.max(fromOi, MIN_MAX_POSITION_SIZE);
+  }
+
+  private getOpenExecutionQuote(
+    market: PerpMarketRecord,
+    side: PerpSide,
+    size: number
+  ) {
+    return getSyntheticPerpExecutionPrice({
+      market,
+      side: side === 'long' ? 'buy' : 'sell',
+      size,
+    });
+  }
+
+  private getCloseExecutionQuote(
+    market: PerpMarketRecord,
+    side: PerpSide,
+    size: number
+  ) {
+    return getSyntheticPerpExecutionPrice({
+      market,
+      side: side === 'long' ? 'sell' : 'buy',
+      size,
+    });
   }
 
   /**

--- a/packages/core/markets/perps/__tests__/PerpMarketService.test.ts
+++ b/packages/core/markets/perps/__tests__/PerpMarketService.test.ts
@@ -292,22 +292,30 @@ describe('PerpMarketService', () => {
       positionId: open.positionId,
     });
 
-    expect(close.realizedPnL).toBeCloseTo(20, 4); // (120-100)/100 * 100
+    const expectedPnl =
+      ((close.exitPrice! - open.entryPrice) / open.entryPrice) * 100;
+    expect(close.realizedPnL).toBeCloseTo(expectedPnl, 4);
     const markets = await db.listMarkets();
     const m = markets[0]!;
     expect(m.openInterest).toBeCloseTo(0, 4);
     expect(m.volume24h).toBeCloseTo(200, 4); // open + close size
 
     const balance = await wallet.getBalance('u1');
-    // initial 10000 - 10.1 + net close (margin 10 + pnl 20 - fee 0.1) = 10000 + 19.8
-    expect(balance.balance).toBeCloseTo(10019.8, 4);
+    const expectedBalance =
+      10_000 -
+      (open.marginPaid! + open.feePaid) +
+      ((close.marginPaid ?? 0) + close.realizedPnL! - close.feePaid);
+    expect(balance.balance).toBeCloseTo(expectedBalance, 4);
 
     // PnL should include fees:
     // - perp_open records -openFee
     // - perp_close records (netSettlement - marginPaid) which includes close fee
     const pnls = wallet.getPnLs('u1');
     const totalPnL = pnls.reduce((sum, p) => sum + p.pnl, 0);
-    expect(totalPnL).toBeCloseTo(19.8, 4);
+    expect(totalPnL).toBeCloseTo(
+      close.realizedPnL! - open.feePaid - close.feePaid,
+      4
+    );
   });
 
   it('closes a SHORT position with profit when price drops (direction + fees)', async () => {
@@ -326,15 +334,23 @@ describe('PerpMarketService', () => {
       positionId: open.positionId,
     });
 
-    // Short profits when price drops.
-    expect(close.realizedPnL).toBeCloseTo(20, 4);
+    const expectedPnl =
+      ((open.entryPrice - close.exitPrice!) / open.entryPrice) * 100;
+    expect(close.realizedPnL).toBeCloseTo(expectedPnl, 4);
 
     const balance = await wallet.getBalance('u1');
-    expect(balance.balance).toBeCloseTo(10019.8, 4);
+    const expectedBalance =
+      10_000 -
+      (open.marginPaid! + open.feePaid) +
+      ((close.marginPaid ?? 0) + close.realizedPnL! - close.feePaid);
+    expect(balance.balance).toBeCloseTo(expectedBalance, 4);
 
     const pnls = wallet.getPnLs('u1');
     const totalPnL = pnls.reduce((sum, p) => sum + p.pnl, 0);
-    expect(totalPnL).toBeCloseTo(19.8, 4);
+    expect(totalPnL).toBeCloseTo(
+      close.realizedPnL! - open.feePaid - close.feePaid,
+      4
+    );
   });
 
   it('calculates realized PnL from notional size while leverage only affects margin', async () => {
@@ -355,7 +371,9 @@ describe('PerpMarketService', () => {
 
     expect(open.marginPaid).toBeCloseTo(100, 4);
     expect(close.marginPaid).toBeCloseTo(100, 4);
-    expect(close.realizedPnL).toBeCloseTo(100, 4);
+    const expectedPnl =
+      ((close.exitPrice! - open.entryPrice) / open.entryPrice) * 1000;
+    expect(close.realizedPnL).toBeCloseTo(expectedPnl, 4);
   });
 
   it('liquidates a position on price drop and records loss', async () => {
@@ -396,8 +414,10 @@ describe('PerpMarketService', () => {
 
     await service.applyPriceUpdates({ 'org-abc': 110 });
     const pos = await db.getPositionById(open.positionId);
-    expect(pos?.unrealizedPnL).toBeCloseTo(10, 4);
-    expect(pos?.unrealizedPnLPercent).toBeCloseTo(10, 4);
+    const expectedPnl = ((110 - open.entryPrice) / open.entryPrice) * 100;
+    const expectedPnlPercent = (expectedPnl / 100) * 100;
+    expect(pos?.unrealizedPnL).toBeCloseTo(expectedPnl, 4);
+    expect(pos?.unrealizedPnLPercent).toBeCloseTo(expectedPnlPercent, 4);
     expect(pos?.closedAt).toBeNull();
   });
 
@@ -524,7 +544,9 @@ describe('PerpMarketService', () => {
     });
 
     expect(close.fullyClosed).toBe(true);
-    expect(close.realizedPnL).toBeCloseTo(5, 4);
+    const expectedPnl =
+      ((close.exitPrice! - open.entryPrice) / open.entryPrice) * 100;
+    expect(close.realizedPnL).toBeCloseTo(expectedPnl, 4);
   });
 
   describe('position rebalancing', () => {
@@ -555,18 +577,19 @@ describe('PerpMarketService', () => {
       expect(result.isRebalance).toBe(true);
       expect(result.rebalanceType).toBe('add');
       expect(result.previousSize).toBe(100);
-      expect(result.previousEntryPrice).toBe(100);
+      expect(result.previousEntryPrice).toBeCloseTo(initial.entryPrice, 4);
 
       // New size should be 200
       expect(result.size).toBe(200);
 
-      // Entry price should be weighted average: (100*100 + 100*120) / 200 = 110
-      expect(result.entryPrice).toBeCloseTo(110, 4);
+      // Averaged entry should move upward after adding to a rising market.
+      expect(result.entryPrice).toBeGreaterThan(initial.entryPrice);
+      expect(result.entryPrice).toBeLessThan(130);
 
       // Verify position in DB
       const pos = await db.getPositionById(initial.positionId);
       expect(pos?.size).toBe(200);
-      expect(pos?.entryPrice).toBeCloseTo(110, 4);
+      expect(pos?.entryPrice).toBeCloseTo(result.entryPrice, 4);
     });
 
     it('reduces position when opening opposite side with smaller size', async () => {

--- a/packages/core/markets/perps/__tests__/microstructure.test.ts
+++ b/packages/core/markets/perps/__tests__/microstructure.test.ts
@@ -84,4 +84,20 @@ describe('getSyntheticPerpExecutionPrice', () => {
     );
     expect(thin.askDepth).toBeLessThan(liquid.askDepth);
   });
+
+  it('falls back to a safe positive reference price when market inputs are invalid', () => {
+    const quote = getSyntheticPerpExecutionPrice({
+      market: createMarket({
+        currentPrice: Number.NaN,
+        markPrice: Number.NaN,
+        indexPrice: Number.NEGATIVE_INFINITY,
+      }),
+      side: 'buy',
+      size: 100,
+    });
+
+    expect(quote.midPrice).toBe(100);
+    expect(Number.isFinite(quote.executionPrice)).toBe(true);
+    expect(quote.executionPrice).toBeGreaterThan(0);
+  });
 });

--- a/packages/core/markets/perps/__tests__/microstructure.test.ts
+++ b/packages/core/markets/perps/__tests__/microstructure.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'bun:test';
+import { getSyntheticPerpExecutionPrice } from '../microstructure';
+import type { PerpMarketRecord } from '../types';
+
+function createMarket(
+  overrides: Partial<PerpMarketRecord> = {}
+): PerpMarketRecord {
+  return {
+    ticker: 'OPENAGI',
+    organizationId: 'openagi',
+    name: 'OpenAGI',
+    currentPrice: 100,
+    price24hAgo: 98,
+    change24h: 2,
+    changePercent24h: 2.04,
+    high24h: 103,
+    low24h: 96,
+    volume24h: 50_000,
+    openInterest: 20_000,
+    fundingRate: {
+      ticker: 'OPENAGI',
+      rate: 0.01,
+      nextFundingTime: new Date().toISOString(),
+      predictedRate: 0.01,
+    },
+    maxLeverage: 100,
+    minOrderSize: 10,
+    markPrice: 100.5,
+    indexPrice: 100,
+    ...overrides,
+  };
+}
+
+describe('getSyntheticPerpExecutionPrice', () => {
+  it('executes buys above sells around the mid price', () => {
+    const market = createMarket();
+    const buy = getSyntheticPerpExecutionPrice({
+      market,
+      side: 'buy',
+      size: 1_000,
+    });
+    const sell = getSyntheticPerpExecutionPrice({
+      market,
+      side: 'sell',
+      size: 1_000,
+    });
+
+    expect(buy.executionPrice).toBeGreaterThan(buy.midPrice);
+    expect(sell.executionPrice).toBeLessThan(sell.midPrice);
+    expect(buy.askPrice).toBeGreaterThan(buy.bidPrice);
+  });
+
+  it('penalizes large trades more than small trades', () => {
+    const market = createMarket();
+    const small = getSyntheticPerpExecutionPrice({
+      market,
+      side: 'buy',
+      size: 500,
+    });
+    const large = getSyntheticPerpExecutionPrice({
+      market,
+      side: 'buy',
+      size: 10_000,
+    });
+
+    expect(large.executionPrice).toBeGreaterThan(small.executionPrice);
+    expect(large.impactBps).toBeGreaterThan(small.impactBps);
+  });
+
+  it('widens slippage for thinner markets', () => {
+    const liquid = getSyntheticPerpExecutionPrice({
+      market: createMarket({ openInterest: 200_000, volume24h: 500_000 }),
+      side: 'buy',
+      size: 2_000,
+    });
+    const thin = getSyntheticPerpExecutionPrice({
+      market: createMarket({ openInterest: 500, volume24h: 2_000 }),
+      side: 'buy',
+      size: 2_000,
+    });
+
+    expect(thin.executionPrice - thin.midPrice).toBeGreaterThan(
+      liquid.executionPrice - liquid.midPrice
+    );
+    expect(thin.askDepth).toBeLessThan(liquid.askDepth);
+  });
+});

--- a/packages/core/markets/perps/index.ts
+++ b/packages/core/markets/perps/index.ts
@@ -1,4 +1,5 @@
 export * from './adapters/drizzle/PerpDbAdapter';
+export * from './microstructure';
 export * from './PerpMarketService';
 export * from './types';
 export * from './utils';

--- a/packages/core/markets/perps/microstructure.ts
+++ b/packages/core/markets/perps/microstructure.ts
@@ -18,6 +18,14 @@ function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
 }
 
+function getFinitePositivePrice(
+  ...candidates: Array<number | undefined>
+): number | undefined {
+  return candidates.find((candidate) =>
+    Number.isFinite(candidate) && (candidate ?? 0) > 0
+  );
+}
+
 function safeRatio(numerator: number, denominator: number): number {
   if (
     !Number.isFinite(numerator) ||
@@ -41,13 +49,19 @@ export function getSyntheticPerpExecutionPrice(params: {
   size: number;
 }): SyntheticPerpExecution {
   const { market, side, size } = params;
-  const midPrice =
-    Number.isFinite(market.currentPrice) && market.currentPrice > 0
-      ? market.currentPrice
-      : (market.markPrice ?? market.indexPrice ?? 100);
+  const midPrice = getFinitePositivePrice(
+    market.currentPrice,
+    market.markPrice,
+    market.indexPrice,
+    100
+  )!;
 
-  const indexReference = market.indexPrice ?? market.markPrice ?? midPrice;
-  const markReference = market.markPrice ?? market.indexPrice ?? midPrice;
+  const indexReference =
+    getFinitePositivePrice(market.indexPrice, market.markPrice, midPrice) ??
+    midPrice;
+  const markReference =
+    getFinitePositivePrice(market.markPrice, market.indexPrice, midPrice) ??
+    midPrice;
 
   const changeMagnitude = Math.abs(market.changePercent24h ?? 0);
   const volatilityBps = clamp(changeMagnitude * 3, 0, 120);

--- a/packages/core/markets/perps/microstructure.ts
+++ b/packages/core/markets/perps/microstructure.ts
@@ -1,0 +1,121 @@
+import type { PerpMarketRecord } from './types';
+
+export type SyntheticQuoteSide = 'buy' | 'sell';
+
+export interface SyntheticPerpExecution {
+  midPrice: number;
+  bidPrice: number;
+  askPrice: number;
+  spreadBps: number;
+  bidDepth: number;
+  askDepth: number;
+  impactBps: number;
+  executionPrice: number;
+  nextMidPrice: number;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function safeRatio(numerator: number, denominator: number): number {
+  if (
+    !Number.isFinite(numerator) ||
+    !Number.isFinite(denominator) ||
+    denominator <= 0
+  ) {
+    return 0;
+  }
+  return numerator / denominator;
+}
+
+function getBaseDepth(market: PerpMarketRecord): number {
+  const minOrderSize = market.minOrderSize ?? 10;
+  const baseDepth = 500 + market.openInterest * 0.08 + market.volume24h * 0.02;
+  return Math.max(minOrderSize * 10, baseDepth);
+}
+
+export function getSyntheticPerpExecutionPrice(params: {
+  market: PerpMarketRecord;
+  side: SyntheticQuoteSide;
+  size: number;
+}): SyntheticPerpExecution {
+  const { market, side, size } = params;
+  const midPrice =
+    Number.isFinite(market.currentPrice) && market.currentPrice > 0
+      ? market.currentPrice
+      : (market.markPrice ?? market.indexPrice ?? 100);
+
+  const indexReference = market.indexPrice ?? market.markPrice ?? midPrice;
+  const markReference = market.markPrice ?? market.indexPrice ?? midPrice;
+
+  const changeMagnitude = Math.abs(market.changePercent24h ?? 0);
+  const volatilityBps = clamp(changeMagnitude * 3, 0, 120);
+  const premiumBps = clamp(
+    Math.abs(safeRatio(markReference - indexReference, indexReference)) * 10000,
+    0,
+    180
+  );
+  const liquidityBps = clamp(
+    45 / Math.sqrt(1 + market.openInterest / 25_000),
+    8,
+    45
+  );
+
+  const spreadBps = clamp(
+    12 + volatilityBps + premiumBps * 0.35 + liquidityBps,
+    8,
+    160
+  );
+  const halfSpread = (midPrice * spreadBps) / 20_000;
+
+  const bidPrice = Math.max(0.0001, midPrice - halfSpread);
+  const askPrice = Math.max(bidPrice, midPrice + halfSpread);
+
+  const imbalanceSignal = clamp(
+    safeRatio(markReference - indexReference, indexReference),
+    -0.35,
+    0.35
+  );
+  const baseDepth = getBaseDepth(market);
+  const bidDepth = Math.max(
+    market.minOrderSize ?? 10,
+    baseDepth * (1 + imbalanceSignal * 0.45)
+  );
+  const askDepth = Math.max(
+    market.minOrderSize ?? 10,
+    baseDepth * (1 - imbalanceSignal * 0.45)
+  );
+
+  const sideDepth = side === 'buy' ? askDepth : bidDepth;
+  const depthRatio = clamp(size / Math.max(sideDepth, 1), 0, 8);
+  const impactBps = clamp(
+    6 + spreadBps * 0.12 + depthRatio ** 1.2 * 180,
+    0,
+    320
+  );
+  const impactPrice = (midPrice * impactBps) / 10_000;
+
+  const executionPrice =
+    side === 'buy'
+      ? askPrice + impactPrice
+      : Math.max(0.0001, bidPrice - impactPrice);
+
+  const midShiftBps = clamp(impactBps * 0.35, 0, 140);
+  const nextMidPrice =
+    side === 'buy'
+      ? midPrice * (1 + midShiftBps / 10_000)
+      : midPrice * (1 - midShiftBps / 10_000);
+
+  return {
+    midPrice,
+    bidPrice,
+    askPrice,
+    spreadBps,
+    bidDepth,
+    askDepth,
+    impactBps,
+    executionPrice,
+    nextMidPrice,
+  };
+}


### PR DESCRIPTION
## Summary
- add a synthetic perp microstructure layer with bid/ask quotes, spread, depth, and nonlinear slippage
- execute perp opens, closes, adds, and flips against synthetic quotes instead of the raw market price
- expose the microstructure helper via `@babylon/core/markets/perps`
- update perp service tests to validate economic behavior under execution friction
- add focused unit tests for quote generation and thin-vs-deep market behavior

## Why
Phase 2 gave each perp a more realistic latent/fair-value process, but execution was still too frictionless. This change is the next step: trades now experience synthetic market microstructure, so thin markets slip more, spreads matter, and execution feels less like filling against a single abstract price.

## Testing
- `bun test packages/core/markets/perps/__tests__/microstructure.test.ts`
- `bun test packages/core/markets/perps/__tests__/PerpMarketService.test.ts`
- `bunx tsc -p packages/core/tsconfig.json --noEmit`

## Follow-ups
- quote resilience / recovery over time
- exposing bid/ask/spread/depth through API/UI
- converging trade-impact and quote-state evolution into a single canonical market-state model