### PR TITLE
feat: add world context to autonomous agent prompts

### DIFF
--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -18,7 +18,11 @@ import {
   eq,
   users,
 } from '@babylon/db';
-import { StaticDataRegistry, WalletService } from '@babylon/engine';
+import {
+  generateWorldContext,
+  StaticDataRegistry,
+  WalletService,
+} from '@babylon/engine';
 import type { IAgentRuntime } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
 import { getNpcGameContext } from '../plugins/babylon/providers/npc-game-context';
@@ -545,6 +549,16 @@ export class MultiStepExecutor {
       'MultiStepExecutor'
     );
 
+    // Fetch world context for reality grounding (parody names, world state)
+    const worldCtx = await generateWorldContext({
+      includeActors: true,
+      includeMarkets: false,
+      includePredictions: false,
+      includeTrades: false,
+      realityGroundingLevel: 'concise',
+      maxActors: 30,
+    });
+
     return {
       balance,
       pnl,
@@ -565,6 +579,10 @@ export class MultiStepExecutor {
       agentOwnPosts,
       creator,
       contextRefreshSummary,
+      worldContext: {
+        realityGrounding: worldCtx.realityGrounding,
+        worldActors: worldCtx.worldActors,
+      },
     };
   }
 

--- a/packages/agents/src/autonomous/templates/multi-step-decision.ts
+++ b/packages/agents/src/autonomous/templates/multi-step-decision.ts
@@ -370,6 +370,11 @@ export interface AgentTickContext {
   creator?: CreatorInfo;
   // Continuity note persisted before runtime context refresh
   contextRefreshSummary?: string;
+  // World context (reality grounding, parody names, market setting)
+  worldContext?: {
+    realityGrounding: string;
+    worldActors: string;
+  };
 }
 
 export interface MultiStepDecision {
@@ -772,8 +777,18 @@ ${context.contextRefreshSummary}
 `
     : '';
 
+  // World context section — gives agents awareness of the game's satirical setting
+  const worldContextSection = context.worldContext
+    ? `
+# World Context
+${context.worldContext.worldActors}
+
+${context.worldContext.realityGrounding}
+`
+    : '';
+
   return `You are ${agentName}, an autonomous agent on Babylon prediction markets.
-${creatorSection}${npcContextSection}${tradePostEncouragement}${groupChatCoordinationEncouragement}# Current Execution Context
+${creatorSection}${worldContextSection}${npcContextSection}${tradePostEncouragement}${groupChatCoordinationEncouragement}# Current Execution Context
 **Step**: ${iterationCount}/${maxIterations}
 **Actions Completed This Tick**: ${traceActionResults.length}
 


### PR DESCRIPTION
## Summary

Addresses item #17 from `docs/agent-context-analysis.md`.

Autonomous agents previously had **zero world context**. NPCs get reality grounding (parody names, world state, running themes, content guidelines) via `generateWorldContext()`, but autonomous agents got none of it. They had no awareness of the game's satirical setting, couldn't use parody names correctly, and had no grounding in current events.

### Changes
- Add `worldContext` field to `AgentTickContext` interface (optional, backward compatible)
- Fetch world context in `MultiStepExecutor.gatherContext()` using `generateWorldContext({ realityGroundingLevel: 'concise', maxActors: 30 })`
- Inject `# World Context` section into agent prompt with parody name mappings and reality grounding

### Before
Agent prompt started with just:
```
You are Delta Lab, an autonomous agent on Babylon prediction markets.
# Current Execution Context
```

### After
```
You are Delta Lab, an autonomous agent on Babylon prediction markets.
# World Context
World Actors (USE THESE NAMES ONLY): AIlon Musk, Sam AIltman, ...

=== REALITY GROUNDING (March 31, 2026) ===
=== MANDATORY NAME MAPPINGS ===
Donald Trump → Trump Terminal
Elon Musk → AIlon Musk
...
# Current Execution Context
```

### Remaining items from analysis
- #14: Agent bankruptcy recovery (blocker, needs separate investigation)
- #15: Corrupted PnL/price data (blocker, needs AMM audit)
- #16: Shorter prompts for limited-action states
- #4: Unify post and trading context
- #11: Belief/theory persistence
- #13: Cross-agent info sharing

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run check` passes
- [x] `bun run test:unit` — 150 pass, 2 pre-existing failures
- [x] Verified via script: prompt contains `# World Context`, parody names, and reality grounding
- [ ] Deploy to staging and verify agent responses use parody names