### PR TITLE
fix: resolve author names, group chat labels, align limits, add time window

### DIFF
--- a/packages/agents/src/autonomous/AutonomousGroupChatService.ts
+++ b/packages/agents/src/autonomous/AutonomousGroupChatService.ts
@@ -6,7 +6,17 @@
  * @packageDocumentation
  */
 
-import { and, db, desc, eq, groups, gte, messages, users } from '@babylon/db';
+import {
+  and,
+  db,
+  desc,
+  eq,
+  groups,
+  gte,
+  inArray,
+  messages,
+  users,
+} from '@babylon/db';
 import { StaticDataRegistry, shuffleArray } from '@babylon/engine';
 import type { IAgentRuntime } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
@@ -116,17 +126,22 @@ export class AutonomousGroupChatService {
         ),
       ];
       const senderNames = new Map<string, string>();
+      const userIdsToLookup: string[] = [];
       for (const id of senderIds) {
         const npc = StaticDataRegistry.getActor(id);
         if (npc) {
           senderNames.set(id, npc.name);
         } else {
-          const [u] = await db
-            .select({ displayName: users.displayName })
-            .from(users)
-            .where(eq(users.id, id))
-            .limit(1);
-          senderNames.set(id, u?.displayName || id);
+          userIdsToLookup.push(id);
+        }
+      }
+      if (userIdsToLookup.length > 0) {
+        const userRows = await db
+          .select({ id: users.id, displayName: users.displayName })
+          .from(users)
+          .where(inArray(users.id, userIdsToLookup));
+        for (const u of userRows) {
+          senderNames.set(u.id, u.displayName || u.id);
         }
       }
 

--- a/packages/agents/src/autonomous/AutonomousGroupChatService.ts
+++ b/packages/agents/src/autonomous/AutonomousGroupChatService.ts
@@ -6,8 +6,8 @@
  * @packageDocumentation
  */
 
-import { and, db, desc, eq, groups, gte, messages } from '@babylon/db';
-import { shuffleArray } from '@babylon/engine';
+import { and, db, desc, eq, groups, gte, messages, users } from '@babylon/db';
+import { StaticDataRegistry, shuffleArray } from '@babylon/engine';
 import type { IAgentRuntime } from '@elizaos/core';
 import { callGroqDirect } from '../llm/direct-groq';
 import { getAgentConfig } from '../shared/agent-config';
@@ -107,6 +107,29 @@ export class AutonomousGroupChatService {
         continue;
       }
 
+      // Resolve sender names for multi-party conversation clarity
+      const senderIds = [
+        ...new Set(
+          recentMessages
+            .map((m: { senderId: string }) => m.senderId)
+            .filter((id: string) => id !== agentUserId)
+        ),
+      ];
+      const senderNames = new Map<string, string>();
+      for (const id of senderIds) {
+        const npc = StaticDataRegistry.getActor(id);
+        if (npc) {
+          senderNames.set(id, npc.name);
+        } else {
+          const [u] = await db
+            .select({ displayName: users.displayName })
+            .from(users)
+            .where(eq(users.id, id))
+            .limit(1);
+          senderNames.set(id, u?.displayName || id);
+        }
+      }
+
       // Generate contextual response
       const prompt = `${config?.systemPrompt ?? 'You are an AI agent on Babylon.'}
 
@@ -117,7 +140,7 @@ ${recentMessages
   .reverse()
   .map(
     (m: { content: string; senderId: string }) =>
-      `${m.senderId === agentUserId ? 'You' : 'User'}: ${m.content}`
+      `${m.senderId === agentUserId ? 'You' : senderNames.get(m.senderId) || 'User'}: ${m.content}`
   )
   .join('\n')}
 

--- a/packages/agents/src/autonomous/MultiStepExecutor.ts
+++ b/packages/agents/src/autonomous/MultiStepExecutor.ts
@@ -16,6 +16,9 @@ import {
   db,
   desc,
   eq,
+  gte,
+  npcTrades,
+  questions,
   users,
 } from '@babylon/db';
 import {
@@ -559,6 +562,37 @@ export class MultiStepExecutor {
       maxActors: 30,
     });
 
+    // Fetch narrative context (resolved questions, recent trades)
+    const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const [resolvedQs, recentNpcTrades] = await Promise.all([
+      db
+        .select()
+        .from(questions)
+        .where(eq(questions.status, 'resolved'))
+        .orderBy(desc(questions.resolutionDate))
+        .limit(10),
+      db
+        .select()
+        .from(npcTrades)
+        .where(gte(npcTrades.executedAt, oneDayAgo))
+        .orderBy(desc(npcTrades.executedAt))
+        .limit(20),
+    ]);
+
+    const resolvedQuestionsText = resolvedQs
+      .filter((q) => q.resolvedOutcome != null)
+      .map((q) => `- "${q.text}" → ${q.resolvedOutcome ? 'YES' : 'NO'}`)
+      .join('\n');
+
+    const recentTradesText = recentNpcTrades
+      .map((t) => {
+        const symbol = t.ticker || `Q${t.marketId}`;
+        const name =
+          StaticDataRegistry.getActor(t.npcActorId)?.name ?? t.npcActorId;
+        return `- ${name}: ${t.action} ${symbol} $${t.amount.toFixed(0)}`;
+      })
+      .join('\n');
+
     return {
       balance,
       pnl,
@@ -582,6 +616,11 @@ export class MultiStepExecutor {
       worldContext: {
         realityGrounding: worldCtx.realityGrounding,
         worldActors: worldCtx.worldActors,
+      },
+      narrativeContext: {
+        resolvedQuestions: resolvedQuestionsText,
+        recentTrades: recentTradesText,
+        eventSignals: '',
       },
     };
   }

--- a/packages/agents/src/autonomous/templates/multi-step-decision.ts
+++ b/packages/agents/src/autonomous/templates/multi-step-decision.ts
@@ -375,6 +375,12 @@ export interface AgentTickContext {
     realityGrounding: string;
     worldActors: string;
   };
+  // Narrative context (resolved questions, recent trades, event signals)
+  narrativeContext?: {
+    resolvedQuestions: string;
+    recentTrades: string;
+    eventSignals: string;
+  };
 }
 
 export interface MultiStepDecision {
@@ -791,8 +797,24 @@ ${context.worldContext.realityGrounding}
 `
     : '';
 
+  // Narrative context — resolved questions, recent trades, event signals
+  const nc = context.narrativeContext;
+  const narrativeParts: string[] = [];
+  if (nc?.resolvedQuestions)
+    narrativeParts.push(`Recent Resolutions:\n${nc.resolvedQuestions}`);
+  if (nc?.recentTrades)
+    narrativeParts.push(`Recent NPC Trades:\n${nc.recentTrades}`);
+  if (nc?.eventSignals) narrativeParts.push(nc.eventSignals);
+  const narrativeSection =
+    narrativeParts.length > 0
+      ? `
+# Market Narrative
+${narrativeParts.join('\n\n')}
+`
+      : '';
+
   return `You are ${agentName}, an autonomous agent on Babylon prediction markets.
-${creatorSection}${worldContextSection}${npcContextSection}${tradePostEncouragement}${groupChatCoordinationEncouragement}# Current Execution Context
+${creatorSection}${worldContextSection}${narrativeSection}${npcContextSection}${tradePostEncouragement}${groupChatCoordinationEncouragement}# Current Execution Context
 **Step**: ${iterationCount}/${maxIterations}
 **Actions Completed This Tick**: ${traceActionResults.length}
 

--- a/packages/engine/src/MarketDecisionEngine.ts
+++ b/packages/engine/src/MarketDecisionEngine.ts
@@ -2245,7 +2245,9 @@ ${prompt}`
     const text = recentTrades
       .map((t) => {
         const symbol = t.ticker || `Q${t.marketId}`;
-        return `- ${t.npcActorId}: ${t.action} ${symbol} $${t.amount.toFixed(0)} @ $${t.price.toFixed(2)}${t.reason ? ` (${t.reason.substring(0, 80)})` : ''}`;
+        const name =
+          StaticDataRegistry.getActor(t.npcActorId)?.name ?? t.npcActorId;
+        return `- ${name}: ${t.action} ${symbol} $${t.amount.toFixed(0)} @ $${t.price.toFixed(2)}${t.reason ? ` (${t.reason.substring(0, 80)})` : ''}`;
       })
       .join('\n');
 

--- a/packages/engine/src/MarketDecisionEngine.ts
+++ b/packages/engine/src/MarketDecisionEngine.ts
@@ -613,7 +613,9 @@ export class MarketDecisionEngine {
     // Format signal analysis from feed content for prediction markets
     const marketSignalAnalysis = this.formatMarketSignals(contexts);
 
-    // Get NPC memories and append to dashboards
+    // Append NPC memories to each trader dashboard block.
+    // NOTE: Coupled to formatSingleNPCDashboard() output format in trading-dashboard-format.ts.
+    // The separator and "ID: <npcId>" line must stay in sync.
     const npcMemories = await this.getMemoriesForNPCs(npcIds);
     if (npcMemories.size > 0) {
       const dashboards = npcsList.split(

--- a/packages/engine/src/services/market-context-service.ts
+++ b/packages/engine/src/services/market-context-service.ts
@@ -58,6 +58,11 @@ import {
 import { SignalExtractionService } from './signal-extraction-service';
 import { StaticDataRegistry } from './static-data-registry';
 
+function resolveActorName(actorId: string): string {
+  const actor = StaticDataRegistry.getActor(actorId);
+  return actor?.name ?? actorId;
+}
+
 export class MarketContextService {
   /**
    * Build market context for all NPCs in the system
@@ -514,7 +519,7 @@ export class MarketContextService {
         .orderBy(desc(messages.createdAt))
         .limit(20);
 
-      for (const msg of chatMessages.slice(0, 8)) {
+      for (const msg of chatMessages.slice(0, 5)) {
         const maxMsgLength = 300;
         const message =
           msg.content.length > maxMsgLength
@@ -525,7 +530,7 @@ export class MarketContextService {
           chatId: chat.id,
           chatName: chat.name || 'Group Chat',
           from: msg.senderId,
-          fromName: msg.senderId,
+          fromName: resolveActorName(msg.senderId),
           message,
           timestamp: msg.createdAt.toISOString(),
         });
@@ -550,10 +555,17 @@ export class MarketContextService {
    */
   private async getRecentFeed(): Promise<FeedPostContext[]> {
     const now = new Date();
+    const twoDaysAgo = new Date(now.getTime() - 48 * 60 * 60 * 1000);
     const postList = await db
       .select()
       .from(posts)
-      .where(and(isNull(posts.deletedAt), lte(posts.timestamp, now)))
+      .where(
+        and(
+          isNull(posts.deletedAt),
+          lte(posts.timestamp, now),
+          gte(posts.timestamp, twoDaysAgo)
+        )
+      )
       .orderBy(desc(posts.timestamp))
       .limit(15);
 
@@ -572,7 +584,7 @@ export class MarketContextService {
 
       return {
         author: post.authorId,
-        authorName: post.authorId,
+        authorName: resolveActorName(post.authorId),
         content,
         timestamp: post.timestamp.toISOString(),
         articleTitle: articleTitle || undefined,

--- a/packages/engine/src/utils/trading-dashboard-format.ts
+++ b/packages/engine/src/utils/trading-dashboard-format.ts
@@ -168,7 +168,8 @@ export function formatMarketDataTable(ctx: NPCMarketContext): string {
 
   for (const p of predictions) {
     const daysLeft = p.daysUntilResolution;
-    table += `| ${p.id} | PRED | Yes: ${p.yesPrice.toFixed(0)}¢ / No: ${p.noPrice.toFixed(0)}¢ | ${daysLeft}d left | "${p.text}" | $${(p.totalVolume / 1000).toFixed(1)}k |\n`;
+    const safeText = p.text.replace(/\|/g, '/');
+    table += `| ${p.id} | PRED | Yes: ${p.yesPrice.toFixed(0)}¢ / No: ${p.noPrice.toFixed(0)}¢ | ${daysLeft}d left | "${safeText}" | $${(p.totalVolume / 1000).toFixed(1)}k |\n`;
   }
 
   return table;

--- a/packages/testing/unit/agent-context-name-resolution.test.ts
+++ b/packages/testing/unit/agent-context-name-resolution.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'bun:test';
+import { StaticDataRegistry } from '@babylon/engine';
+
+describe('Author name resolution', () => {
+  it('should resolve known NPC IDs to display names', () => {
+    const actor = StaticDataRegistry.getActor('ailon-musk');
+    expect(actor).toBeDefined();
+    expect(actor!.name).toBeTruthy();
+    expect(actor!.name).not.toBe('ailon-musk');
+  });
+
+  it('should return null/undefined for unknown IDs', () => {
+    const actor = StaticDataRegistry.getActor('nonexistent-user-12345');
+    expect(actor).toBeFalsy();
+  });
+
+  it('resolveActorName logic: known ID returns name, unknown returns ID', () => {
+    // Replicate the resolveActorName helper logic
+    function resolveActorName(actorId: string): string {
+      const actor = StaticDataRegistry.getActor(actorId);
+      return actor?.name ?? actorId;
+    }
+
+    // Known NPC
+    const knownName = resolveActorName('ailon-musk');
+    expect(knownName).not.toBe('ailon-musk');
+    expect(knownName.length).toBeGreaterThan(0);
+
+    // Unknown ID falls back to raw ID
+    const unknownName = resolveActorName('unknown-user-xyz');
+    expect(unknownName).toBe('unknown-user-xyz');
+  });
+});
+
+describe('Feed post time windowing', () => {
+  it('48-hour window calculation is correct', () => {
+    const now = new Date();
+    const twoDaysAgo = new Date(now.getTime() - 48 * 60 * 60 * 1000);
+
+    // Should be roughly 48 hours difference
+    const diffMs = now.getTime() - twoDaysAgo.getTime();
+    const diffHours = diffMs / (1000 * 60 * 60);
+    expect(diffHours).toBeCloseTo(48, 0);
+
+    // A post from 47 hours ago should be within window
+    const recentPost = new Date(now.getTime() - 47 * 60 * 60 * 1000);
+    expect(recentPost.getTime()).toBeGreaterThan(twoDaysAgo.getTime());
+
+    // A post from 49 hours ago should be outside window
+    const oldPost = new Date(now.getTime() - 49 * 60 * 60 * 1000);
+    expect(oldPost.getTime()).toBeLessThan(twoDaysAgo.getTime());
+  });
+});
+
+describe('Group chat message limit alignment', () => {
+  it('dashboard shows 5 messages, context should fetch 5', () => {
+    // The dashboard formatter slices to 5
+    const dashboardLimit = 5;
+    // The context service should match
+    const contextLimit = 5;
+    expect(contextLimit).toBe(dashboardLimit);
+  });
+
+  it('slicing behavior is correct', () => {
+    const messages = Array.from({ length: 10 }, (_, i) => ({
+      id: `msg-${i}`,
+      content: `Message ${i}`,
+    }));
+
+    // Both paths should produce the same 5 messages
+    const dashboardSlice = messages.slice(0, 5);
+    const contextSlice = messages.slice(0, 5);
+    expect(dashboardSlice).toEqual(contextSlice);
+    expect(dashboardSlice.length).toBe(5);
+  });
+});
+
+describe('Group chat sender name resolution', () => {
+  it('should resolve NPC sender to display name via StaticDataRegistry', () => {
+    const npc = StaticDataRegistry.getActor('ailon-musk');
+    expect(npc).toBeDefined();
+
+    // Simulate the resolution logic from AutonomousGroupChatService
+    const senderId = 'ailon-musk';
+    const agentUserId = 'some-agent-id';
+    const senderNames = new Map<string, string>();
+    const actor = StaticDataRegistry.getActor(senderId);
+    if (actor) {
+      senderNames.set(senderId, actor.name);
+    }
+
+    const label =
+      senderId === agentUserId ? 'You' : senderNames.get(senderId) || 'User';
+    expect(label).not.toBe('User');
+    expect(label).toBe(npc!.name);
+  });
+
+  it('should fall back to "User" only for truly unknown senders', () => {
+    const senderId = 'completely-unknown-id';
+    const agentUserId = 'some-agent-id';
+    const senderNames = new Map<string, string>();
+    // Don't add to map — simulates no NPC match and no DB result
+
+    const label =
+      senderId === agentUserId ? 'You' : senderNames.get(senderId) || 'User';
+    expect(label).toBe('User');
+  });
+
+  it('should label self as "You"', () => {
+    const senderId = 'my-agent-id';
+    const agentUserId = 'my-agent-id';
+
+    const label = senderId === agentUserId ? 'You' : 'Someone';
+    expect(label).toBe('You');
+  });
+});

--- a/scripts/context-inspector.ts
+++ b/scripts/context-inspector.ts
@@ -36,6 +36,7 @@ import {
   getShuffledExamplesText,
   getTimeOfDayEnergy,
   MarketContextService,
+  MarketDecisionEngine,
   type NPCMarketContext,
   npcMarketDecisions,
   renderPrompt,
@@ -158,7 +159,21 @@ async function inspectTradingContext(npcId: string): Promise<{
   const validTickers =
     allTickers.size > 0 ? Array.from(allTickers).join(', ') : 'N/A';
 
-  // Assemble the variables passed to renderPrompt
+  // Use the real MarketDecisionEngine's private methods via prototype access
+  // to fetch narrative data exactly as the engine does (DRY — no reimplementation)
+  const stubLlm = { getProvider: () => 'groq' } as never;
+  const engine = new MarketDecisionEngine(stubLlm, svc);
+  const enginePrivate = engine as never as Record<string, Function>;
+
+  const resolvedQuestionsContext: string =
+    await enginePrivate['getCachedResolvedQuestions'].call(engine);
+  const previousTrades: string =
+    await enginePrivate['getCachedPreviousTrades'].call(engine);
+  const marketSignalAnalysis: string = enginePrivate[
+    'formatMarketSignals'
+  ].call(engine, [ctx]);
+
+  // Assemble the exact same variables the real engine passes to renderPrompt
   const vars: Record<string, string> = {
     examples,
     marketTable,
@@ -171,6 +186,9 @@ async function inspectTradingContext(npcId: string): Promise<{
     recentEvents: '',
     richGameContext: worldContext.richGameContext || '',
     eventMarketSignals: 'No event-market signals available',
+    resolvedQuestionsContext,
+    previousTrades,
+    marketSignalAnalysis,
   };
 
   // Render and measure
@@ -199,9 +217,9 @@ async function inspectTradingContext(npcId: string): Promise<{
     populated: value.trim().length > 0,
   }));
 
-  // Position visibility
+  // Position visibility — dashboard now shows all positions
   const totalPositions = ctx.currentPositions.length;
-  const shownPositions = Math.min(totalPositions, 3); // formatSingleNPCDashboard shows max 3
+  const shownPositions = (npcsList.match(/\[ID:/g) || []).length;
 
   return {
     sections,
@@ -891,9 +909,9 @@ async function main() {
           truncations.push(
             '  Prediction markets: capped at 15 (may have more)'
           );
-        if (ctx.groupChatMessages.length > 2)
+        if (ctx.groupChatMessages.length > 5)
           truncations.push(
-            `  Group chat: ${ctx.groupChatMessages.length} messages, only 2 shown in prompt`
+            `  Group chat: ${ctx.groupChatMessages.length} messages, 5 shown in dashboard`
           );
         if (truncations.length > 0) {
           for (const t of truncations) {


### PR DESCRIPTION
## Summary

Fixes S1, S3, S5, S6 from `docs/agent-context-audit-v2.md`. Stacks on #1401.

### S1: Resolve author names
- Feed posts: `authorName` now resolved via `resolveActorName()` (uses `StaticDataRegistry`)
- Group chat (single-NPC path): `fromName` resolved instead of raw `senderId`
- Previous trades: NPC names shown instead of raw actor IDs (e.g., "AIlon Musk" not "ailon-musk")

### S3: Fix group chat sender names
- `AutonomousGroupChatService` now resolves sender names via `StaticDataRegistry` for NPCs and `users` table for agents
- Multi-party conversations show actual names instead of "User" for every participant

### S5: Align context-service and dashboard limits
- Reduced context-service group chat fetch from 8 to 5 messages (matches what the dashboard formatter actually uses)

### S6: Add 48-hour time window to feed posts
- `getRecentFeed()` now filters to last 48 hours via `gte(posts.timestamp, twoDaysAgo)`
- Prevents stale weeks-old posts from appearing in agent context

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run check` passes
- [x] `bun run test:unit` — 152 pass, 2 pre-existing failures
- [ ] Verify feed posts show resolved names in trading prompt
- [ ] Verify group chat messages show participant names