### PR TITLE
feat: structural question deduplication — 3-layer similarity checking

### DIFF
--- a/packages/engine/src/QuestionManager.ts
+++ b/packages/engine/src/QuestionManager.ts
@@ -100,6 +100,7 @@ import { MarketMetricsService } from './services/market-metrics-service';
 import { saveArcPlan } from './services/narrative-state-service';
 import { ensureMarketOnChain } from './services/onchain-market-service';
 import { QuestionArcPlanner } from './services/question-arc-planner';
+import { checkQuestionSimilarity } from './services/question-dedup-service';
 import { StaticDataRegistry } from './services/static-data-registry';
 import { TradeExecutionService } from './services/trade-execution-service';
 import type {
@@ -1411,6 +1412,25 @@ XML: <response><questions><question><text>...</text><resolutionCriteria>...</res
 
       // Update the question text with sanitized version
       questionData.text = sanitizedText;
+
+      // Structural dedup: reject questions too similar to active or recently resolved
+      const existingTexts = [
+        ...activeQuestions.map((q) => q.text),
+        ...resolvedQuestions.map((q) => q.text),
+      ];
+      const similarity = checkQuestionSimilarity(sanitizedText, existingTexts);
+      if (similarity.isTooSimilar) {
+        logger.info(
+          'Question rejected by structural dedup',
+          {
+            question: sanitizedText.substring(0, 80),
+            reason: similarity.reason,
+            score: similarity.score,
+          },
+          'QuestionManager'
+        );
+        continue;
+      }
 
       // Convert "yes"/"no" to boolean
       const expectedOutcomeStr = String(questionData.expectedOutcome || '')

--- a/packages/engine/src/QuestionManager.ts
+++ b/packages/engine/src/QuestionManager.ts
@@ -1380,6 +1380,9 @@ XML: <response><questions><question><text>...</text><resolutionCriteria>...</res
       },
     });
 
+    // Track accepted questions within this batch for intra-batch dedup
+    const acceptedInBatch: string[] = [];
+
     // Create each question
     for (const questionData of questionsData.slice(0, count)) {
       if (Date.now() > deadlineMs) {
@@ -1413,10 +1416,12 @@ XML: <response><questions><question><text>...</text><resolutionCriteria>...</res
       // Update the question text with sanitized version
       questionData.text = sanitizedText;
 
-      // Structural dedup: reject questions too similar to active or recently resolved
+      // Structural dedup: reject questions too similar to active, recently resolved,
+      // or other questions accepted earlier in this same batch
       const existingTexts = [
         ...activeQuestions.map((q) => q.text),
         ...resolvedQuestions.map((q) => q.text),
+        ...acceptedInBatch,
       ];
       const similarity = checkQuestionSimilarity(sanitizedText, existingTexts);
       if (similarity.isTooSimilar) {
@@ -1426,6 +1431,7 @@ XML: <response><questions><question><text>...</text><resolutionCriteria>...</res
             question: sanitizedText.substring(0, 80),
             reason: similarity.reason,
             score: similarity.score,
+            matchedWith: similarity.matchedQuestionText?.substring(0, 80),
           },
           'QuestionManager'
         );
@@ -1610,6 +1616,7 @@ XML: <response><questions><question><text>...</text><resolutionCriteria>...</res
       }
 
       questionsCreated++;
+      acceptedInBatch.push(sanitizedText);
     }
 
     return questionsCreated;

--- a/packages/engine/src/services/index.ts
+++ b/packages/engine/src/services/index.ts
@@ -42,6 +42,7 @@ export * from './npc-social-engagement-service';
 export * from './npc-trade-rate-limiter';
 export * from './player-influence-service';
 export * from './posting-probability-service';
+export * from './question-dedup-service';
 export * from './reply-rate-limiter';
 export * from './tier-config';
 export * from './tiered-group-service';

--- a/packages/engine/src/services/question-dedup-service.ts
+++ b/packages/engine/src/services/question-dedup-service.ts
@@ -1,0 +1,342 @@
+/**
+ * Question Deduplication Service
+ *
+ * Structural similarity checking for prediction market questions.
+ * Prevents the LLM from generating near-duplicate questions that
+ * prompt-only anti-repetition rules fail to catch.
+ *
+ * Uses multi-layer comparison:
+ * 1. Entity overlap — shared actors/organizations
+ * 2. Token Jaccard similarity — significant word overlap
+ * 3. Template detection — same sentence scaffold with swapped nouns
+ */
+
+import { logger } from '@babylon/shared';
+import { StaticDataRegistry } from './static-data-registry';
+
+// Words that don't contribute to question meaning
+const STOP_WORDS = new Set([
+  'a',
+  'an',
+  'the',
+  'is',
+  'are',
+  'was',
+  'were',
+  'will',
+  'be',
+  'been',
+  'by',
+  'to',
+  'of',
+  'in',
+  'for',
+  'and',
+  'or',
+  'on',
+  'at',
+  'it',
+  'its',
+  'as',
+  'if',
+  'do',
+  'does',
+  'did',
+  'has',
+  'have',
+  'had',
+  'not',
+  'no',
+  'but',
+  'that',
+  'this',
+  'with',
+  'from',
+  'they',
+  'them',
+  'their',
+  'what',
+  'which',
+  'who',
+  'whom',
+  'how',
+  'when',
+  'where',
+  'why',
+  'all',
+  'each',
+  'every',
+  'both',
+  'few',
+  'more',
+  'most',
+  'other',
+  'some',
+  'such',
+  'than',
+  'too',
+  'very',
+  'can',
+  'could',
+  'may',
+  'might',
+  'must',
+  'shall',
+  'should',
+  'would',
+  'about',
+  'above',
+  'after',
+  'again',
+  'before',
+  'below',
+  'between',
+  'during',
+  'into',
+  'through',
+  'under',
+  'until',
+  'while',
+  'just',
+  'also',
+  'over',
+  'only',
+  'then',
+  'here',
+  'there',
+  'once',
+  'any',
+  'new',
+]);
+
+// Similarity thresholds
+const JACCARD_THRESHOLD = 0.45;
+// Entity overlap alone is not enough — need substantial token overlap too.
+// Raised to 0.40 to avoid false positives on questions with same subject
+// but different predicates (e.g., "Will X announce Y?" vs "Will X resign from Z?")
+const ENTITY_OVERLAP_WITH_JACCARD_THRESHOLD = 0.4;
+
+/**
+ * Extract significant tokens from a question text.
+ * Removes stop words, lowercases, strips punctuation, filters short tokens.
+ */
+export function extractSignificantTokens(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, ' ')
+      .split(/\s+/)
+      .filter((t) => t.length >= 3 && !STOP_WORDS.has(t))
+  );
+}
+
+/**
+ * Extract entity names (actors and organizations) mentioned in text.
+ * Uses StaticDataRegistry for known entity matching.
+ */
+export function extractQuestionEntities(text: string): Set<string> {
+  const lower = text.toLowerCase();
+  const entities = new Set<string>();
+
+  for (const actor of StaticDataRegistry.getAllActors()) {
+    if (lower.includes(actor.name.toLowerCase())) {
+      entities.add(actor.id);
+    }
+  }
+
+  for (const org of StaticDataRegistry.getAllOrganizations()) {
+    if (lower.includes(org.name.toLowerCase())) {
+      entities.add(org.id);
+    }
+  }
+
+  return entities;
+}
+
+/**
+ * Compute Jaccard similarity between two token sets.
+ * Returns 0-1 where 1 means identical sets.
+ */
+export function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 0;
+
+  let intersection = 0;
+  for (const token of a) {
+    if (b.has(token)) intersection++;
+  }
+
+  const union = a.size + b.size - intersection;
+  return union > 0 ? intersection / union : 0;
+}
+
+/**
+ * Extract a structural template by replacing entity names with placeholders.
+ * "Will AIlon Musk announce TeslAI partnership?" → "will [ENTITY] announce [ENTITY] partnership"
+ */
+export function extractTemplate(text: string): string {
+  let template = text.toLowerCase();
+
+  // Replace known actor and org names with [ENTITY]
+  for (const actor of StaticDataRegistry.getAllActors()) {
+    const name = actor.name.toLowerCase();
+    if (template.includes(name)) {
+      template = template.replaceAll(name, '[ENTITY]');
+    }
+  }
+
+  for (const org of StaticDataRegistry.getAllOrganizations()) {
+    const name = org.name.toLowerCase();
+    if (template.includes(name)) {
+      template = template.replaceAll(name, '[ENTITY]');
+    }
+  }
+
+  // Normalize numbers and time references
+  template = template.replace(/\d+/g, '[NUM]');
+  template = template.replace(
+    /\b(monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b/gi,
+    '[DAY]'
+  );
+  template = template.replace(
+    /\b(january|february|march|april|may|june|july|august|september|october|november|december)\b/gi,
+    '[MONTH]'
+  );
+
+  // Collapse whitespace
+  template = template.replace(/\s+/g, ' ').trim();
+
+  return template;
+}
+
+export interface SimilarityResult {
+  isTooSimilar: boolean;
+  score: number;
+  reason: string;
+  matchedQuestionText?: string;
+}
+
+/**
+ * Check if a new question is too similar to any existing question.
+ * Returns the first match found, or a "not similar" result.
+ */
+export function checkQuestionSimilarity(
+  newQuestion: string,
+  existingQuestions: string[]
+): SimilarityResult {
+  if (existingQuestions.length === 0) {
+    return { isTooSimilar: false, score: 0, reason: 'no existing questions' };
+  }
+
+  const newTokens = extractSignificantTokens(newQuestion);
+  const newEntities = extractQuestionEntities(newQuestion);
+  const newTemplate = extractTemplate(newQuestion);
+
+  for (const existing of existingQuestions) {
+    const existingTokens = extractSignificantTokens(existing);
+    const existingEntities = extractQuestionEntities(existing);
+
+    // Layer 1: Token Jaccard similarity
+    const jaccard = jaccardSimilarity(newTokens, existingTokens);
+
+    if (jaccard >= JACCARD_THRESHOLD) {
+      return {
+        isTooSimilar: true,
+        score: jaccard,
+        reason: `token similarity ${(jaccard * 100).toFixed(0)}% exceeds ${JACCARD_THRESHOLD * 100}% threshold`,
+        matchedQuestionText: existing,
+      };
+    }
+
+    // Layer 2: Entity overlap + moderate Jaccard
+    // If questions share entities AND have moderate token overlap, they're likely duplicates
+    if (newEntities.size > 0 && existingEntities.size > 0) {
+      const entityOverlap = jaccardSimilarity(newEntities, existingEntities);
+      if (
+        entityOverlap >= 0.5 &&
+        jaccard >= ENTITY_OVERLAP_WITH_JACCARD_THRESHOLD
+      ) {
+        return {
+          isTooSimilar: true,
+          score: jaccard,
+          reason: `shared entities (${(entityOverlap * 100).toFixed(0)}% overlap) with ${(jaccard * 100).toFixed(0)}% token similarity`,
+          matchedQuestionText: existing,
+        };
+      }
+    }
+
+    // Layer 3: Template detection
+    // If the structural template is identical (same scaffold, different entity/number slots)
+    const existingTemplate = extractTemplate(existing);
+    if (
+      newTemplate === existingTemplate &&
+      newTemplate.includes('[ENTITY]') &&
+      newTemplate.length > 20
+    ) {
+      return {
+        isTooSimilar: true,
+        score: 1.0,
+        reason: 'identical question template with different entities/numbers',
+        matchedQuestionText: existing,
+      };
+    }
+  }
+
+  return {
+    isTooSimilar: false,
+    score: 0,
+    reason: 'no similar questions found',
+  };
+}
+
+/**
+ * Filter a batch of new questions, removing those too similar to existing
+ * or to each other within the batch.
+ */
+export function deduplicateQuestions(
+  newQuestions: string[],
+  existingQuestions: string[]
+): { accepted: string[]; rejected: Array<{ text: string; reason: string }> } {
+  const accepted: string[] = [];
+  const rejected: Array<{ text: string; reason: string }> = [];
+
+  // Include existing + already-accepted questions in the comparison set
+  const comparisonSet = [...existingQuestions];
+
+  for (const question of newQuestions) {
+    const result = checkQuestionSimilarity(question, comparisonSet);
+
+    if (result.isTooSimilar) {
+      rejected.push({
+        text: question,
+        reason: result.reason,
+      });
+      logger.debug(
+        'Question rejected by dedup',
+        {
+          question: question.substring(0, 80),
+          reason: result.reason,
+          score: result.score,
+          matchedWith: result.matchedQuestionText?.substring(0, 80),
+        },
+        'QuestionDedup'
+      );
+    } else {
+      accepted.push(question);
+      comparisonSet.push(question);
+    }
+  }
+
+  if (rejected.length > 0) {
+    logger.info(
+      'Question dedup results',
+      {
+        total: newQuestions.length,
+        accepted: accepted.length,
+        rejected: rejected.length,
+      },
+      'QuestionDedup'
+    );
+  }
+
+  return { accepted, rejected };
+}

--- a/packages/testing/unit/question-dedup.test.ts
+++ b/packages/testing/unit/question-dedup.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  checkQuestionSimilarity,
+  deduplicateQuestions,
+  extractSignificantTokens,
+  extractTemplate,
+  jaccardSimilarity,
+} from '@babylon/engine';
+
+describe('extractSignificantTokens', () => {
+  it('removes stop words and short tokens', () => {
+    const tokens = extractSignificantTokens(
+      'Will the SEC classify Bitcoin as a security?'
+    );
+    expect(tokens.has('will')).toBe(false);
+    expect(tokens.has('the')).toBe(false);
+    expect(tokens.has('sec')).toBe(true);
+    expect(tokens.has('classify')).toBe(true);
+    expect(tokens.has('bitcoin')).toBe(true);
+    expect(tokens.has('security')).toBe(true);
+  });
+
+  it('handles parody names correctly', () => {
+    const tokens = extractSignificantTokens(
+      'Will AIlon Musk announce TeslAI partnership?'
+    );
+    expect(tokens.has('ailon')).toBe(true);
+    expect(tokens.has('musk')).toBe(true);
+    expect(tokens.has('teslai')).toBe(true);
+    expect(tokens.has('announce')).toBe(true);
+    expect(tokens.has('partnership')).toBe(true);
+  });
+
+  it('strips punctuation', () => {
+    const tokens = extractSignificantTokens("What's happening with OpenAGI?!");
+    expect(tokens.has('happening')).toBe(true);
+    expect(tokens.has('openagi')).toBe(true);
+    for (const t of tokens) {
+      expect(t).toMatch(/^[a-z0-9]+$/);
+    }
+  });
+});
+
+describe('jaccardSimilarity', () => {
+  it('returns 1 for identical sets', () => {
+    const s = new Set(['foo', 'bar', 'baz']);
+    expect(jaccardSimilarity(s, s)).toBe(1);
+  });
+
+  it('returns 0 for disjoint sets', () => {
+    const a = new Set(['foo', 'bar']);
+    const b = new Set(['baz', 'qux']);
+    expect(jaccardSimilarity(a, b)).toBe(0);
+  });
+
+  it('returns correct value for partial overlap', () => {
+    const a = new Set(['foo', 'bar', 'baz']);
+    const b = new Set(['bar', 'baz', 'qux']);
+    expect(jaccardSimilarity(a, b)).toBe(0.5);
+  });
+
+  it('returns 0 for two empty sets', () => {
+    expect(jaccardSimilarity(new Set(), new Set())).toBe(0);
+  });
+});
+
+describe('extractTemplate', () => {
+  it('replaces known entity names with [ENTITY]', () => {
+    const template = extractTemplate(
+      'Will AIlon Musk announce TeslAI partnership?'
+    );
+    // Template uses uppercase [ENTITY] placeholders
+    expect(template).toContain('[ENTITY]');
+    expect(template).not.toContain('ailon musk');
+    expect(template).not.toContain('teslai');
+  });
+
+  it('replaces numbers with [NUM]', () => {
+    const template = extractTemplate(
+      'Will NVIDAI release 5000 units by December 15?'
+    );
+    expect(template).toContain('[NUM]');
+    expect(template).not.toMatch(/\d/);
+  });
+
+  it('replaces day names with [DAY]', () => {
+    const template = extractTemplate('Will X happen by Friday?');
+    expect(template).toContain('[DAY]');
+    expect(template.toLowerCase()).not.toContain('friday');
+  });
+
+  it('produces identical template for entity-swapped questions', () => {
+    const t1 = extractTemplate(
+      'Will AIlon Musk announce a major partnership with MetAI by Friday?'
+    );
+    const t2 = extractTemplate(
+      'Will Sam AIltman announce a major partnership with TeslAI by Friday?'
+    );
+    expect(t1).toBe(t2);
+  });
+});
+
+describe('checkQuestionSimilarity', () => {
+  it('detects near-duplicate questions (high token overlap)', () => {
+    const result = checkQuestionSimilarity(
+      'Will AIlon Musk deploy TeslAI to cause a 10-minute AI-activated dill dilemma at a farmer market?',
+      [
+        'Will AIlon Musk deploy TeslAI to stage a 12-minute AI-caused fennel feud at a farmer market?',
+      ]
+    );
+    expect(result.isTooSimilar).toBe(true);
+    expect(result.score).toBeGreaterThan(0.3);
+  });
+
+  it('allows genuinely different questions', () => {
+    const result = checkQuestionSimilarity(
+      'Will the SEC classify ZcAIsh as a security?',
+      [
+        'Will NVIDAI release a new GPU that requires a second GPU just to run the driver?',
+      ]
+    );
+    expect(result.isTooSimilar).toBe(false);
+  });
+
+  it('detects same-template different-entity questions', () => {
+    // Use real entity names from StaticDataRegistry
+    const result = checkQuestionSimilarity(
+      'Will Sam AIltman announce a major partnership with TeslAI by Friday?',
+      ['Will AIlon Musk announce a major partnership with MetAI by Friday?']
+    );
+    expect(result.isTooSimilar).toBe(true);
+    expect(result.reason).toContain('template');
+  });
+
+  it('allows same entity with genuinely different predicates', () => {
+    const result = checkQuestionSimilarity(
+      'Will AIlon Musk launch a satellite constellation for global internet?',
+      ['Will AIlon Musk resign from TeslAI board of directors?']
+    );
+    expect(result.isTooSimilar).toBe(false);
+  });
+
+  it('returns not similar for empty existing list', () => {
+    const result = checkQuestionSimilarity('Any question here', []);
+    expect(result.isTooSimilar).toBe(false);
+  });
+
+  it('detects entity overlap with high token similarity', () => {
+    const result = checkQuestionSimilarity(
+      'Will TeslAI stock price surge above 500 dollars after the quarterly earnings call this week?',
+      [
+        'Will TeslAI stock price rise above 400 dollars after the quarterly earnings report this week?',
+      ]
+    );
+    expect(result.isTooSimilar).toBe(true);
+  });
+});
+
+describe('deduplicateQuestions', () => {
+  it('removes duplicates from batch while keeping originals', () => {
+    const result = deduplicateQuestions(
+      [
+        'Will AIlon Musk deploy TeslAI to cause a dill dilemma?',
+        'Will AIlon Musk deploy TeslAI to stage a fennel feud?',
+        'Will the SEC investigate BitcAIn manipulation?',
+      ],
+      []
+    );
+    expect(result.accepted.length).toBeGreaterThanOrEqual(2);
+    expect(result.accepted).toContain(
+      'Will the SEC investigate BitcAIn manipulation?'
+    );
+  });
+
+  it('deduplicates within batch — first wins', () => {
+    const result = deduplicateQuestions(
+      [
+        'Will AIlon Musk deploy TeslAI to cause a dill dilemma?',
+        'Will AIlon Musk deploy TeslAI to stage a fennel feud?',
+      ],
+      []
+    );
+    expect(result.accepted.length).toBe(1);
+    expect(result.accepted[0]).toContain('dill dilemma');
+    expect(result.rejected.length).toBe(1);
+  });
+
+  it('deduplicates against existing questions with high overlap', () => {
+    const result = deduplicateQuestions(
+      [
+        'Will TeslAI stock price surge above 500 dollars after the quarterly earnings call this week?',
+      ],
+      [
+        'Will TeslAI stock price rise above 400 dollars after the quarterly earnings report this week?',
+      ]
+    );
+    expect(result.rejected.length).toBe(1);
+  });
+
+  it('returns all when no duplicates', () => {
+    const result = deduplicateQuestions(
+      [
+        'Will the SEC classify ZcAIsh as a security?',
+        'Will NVIDAI release a new GPU architecture?',
+        'Will AIlon Musk resign from TeslAI?',
+      ],
+      []
+    );
+    expect(result.accepted.length).toBe(3);
+    expect(result.rejected.length).toBe(0);
+  });
+});

--- a/packages/testing/unit/question-dedup.test.ts
+++ b/packages/testing/unit/question-dedup.test.ts
@@ -210,3 +210,56 @@ describe('deduplicateQuestions', () => {
     expect(result.rejected.length).toBe(0);
   });
 });
+
+describe('Edge cases', () => {
+  it('handles very short questions without crashing', () => {
+    const result = checkQuestionSimilarity('Yes or no?', ['Maybe?']);
+    expect(result.isTooSimilar).toBe(false);
+  });
+
+  it('handles questions with no known entities', () => {
+    const result = checkQuestionSimilarity(
+      'Will the weather be sunny tomorrow in an imaginary city?',
+      ['Will the market crash next week due to unknown factors?']
+    );
+    expect(result.isTooSimilar).toBe(false);
+  });
+
+  it('handles identical questions', () => {
+    const question = 'Will AIlon Musk announce TeslAI partnership?';
+    const result = checkQuestionSimilarity(question, [question]);
+    expect(result.isTooSimilar).toBe(true);
+    expect(result.score).toBe(1);
+  });
+
+  it('handles unicode and special characters', () => {
+    const result = checkQuestionSimilarity(
+      'Will the price hit $1,000 (USD) — a new record?',
+      ['Will the price reach €500 — another milestone?']
+    );
+    // Should not crash, should handle gracefully
+    expect(typeof result.isTooSimilar).toBe('boolean');
+  });
+
+  it('handles single-word questions', () => {
+    const tokens = extractSignificantTokens('Bitcoin?');
+    expect(tokens.size).toBeGreaterThanOrEqual(1);
+  });
+
+  it('empty string produces empty token set', () => {
+    const tokens = extractSignificantTokens('');
+    expect(tokens.size).toBe(0);
+  });
+
+  it('deduplicateQuestions handles empty inputs', () => {
+    const result = deduplicateQuestions([], []);
+    expect(result.accepted.length).toBe(0);
+    expect(result.rejected.length).toBe(0);
+  });
+
+  it('deduplicateQuestions handles empty new with existing', () => {
+    const result = deduplicateQuestions([], ['Some existing question here']);
+    expect(result.accepted.length).toBe(0);
+    expect(result.rejected.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds programmatic similarity checking to prevent near-duplicate prediction market questions. The LLM is told "don't repeat" via prompt instructions, but it frequently generates variations of the same question ("Will TeslAI deploy to cause a dill dilemma?" vs "Will TeslAI deploy to stage a fennel feud?"). This PR adds structural enforcement.

### Three-layer detection

**Layer 1: Token Jaccard (threshold: 45%)**
Extracts significant tokens (after stop word removal), computes Jaccard similarity. Catches obvious rewording.

**Layer 2: Entity overlap + Jaccard (threshold: 50% entity + 40% token)**
Extracts known actor/org names via StaticDataRegistry. If two questions share the same subjects AND have moderate token overlap, they're flagged. Calibrated to allow same-entity-different-predicate (e.g., "Will X announce Y?" vs "Will X resign?").

**Layer 3: Template detection**
Replaces entity names with `[ENTITY]`, numbers with `[NUM]`, days with `[DAY]`. If two questions produce identical templates, one is rejected. Catches "Will [ENTITY] announce partnership with [ENTITY] by [DAY]?" patterns.

### Integration point

Inserted in `generateQuestionsForContinuousGame()` after text sanitization, before DB insert. Checks each new question against:
- All active questions (up to 20)
- Recently resolved questions (last 7 days, up to 10)
- Previously accepted questions in the same batch (first-wins)

Rejected questions are logged and skipped. No retry — the LLM already generated them, we just filter.

### Test coverage

21 tests covering all layers, edge cases, and batch behavior.

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun run check` passes
- [x] `bun run test:unit` — 156 pass, 0 failures
- [x] 21 dedup-specific tests all pass
- [ ] Run game ticks and verify duplicate questions are logged and rejected
- [ ] Run `bun run report:markets` to verify question diversity improves