### PR TITLE
fix(ci): add CI_ADMIN_TOKEN for integration test admin auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -807,6 +807,9 @@ ALLOW_TEST_PRIVY_DID_AUTH=
 ANTHROPIC_API_KEY=
 ATROPOS_API_URL=
 AVAILABLE_VRAM_GB=
+# Optional: static admin token for CI integration tests. Only checked when CI=true.
+# Set to any string value. The same value must be used by both server and test runner.
+CI_ADMIN_TOKEN=
 BABYLON_A2A_ENDPOINT=
 BABYLON_AGENT0_PRIVATE_KEY=
 BABYLON_DIAMOND_ADDRESS=

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -277,6 +277,29 @@ jobs:
           # NEXT_PUBLIC_* variables are embedded at build time, but ensure they're available
           # at runtime for any server-side rendering or API routes that might need them
           NEXT_PUBLIC_PRIVY_APP_ID: ${{ secrets.NEXT_PUBLIC_PRIVY_APP_ID || secrets.PRIVY_APP_ID || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'cl_ci_fork_dummy') || '' }}
+          CI_ADMIN_TOKEN: ci-integration-test-admin-token
+
+      - name: Run Integration Tests
+        continue-on-error: true
+        timeout-minutes: 10
+        run: |
+          echo "🧪 Running integration tests..."
+          bun test packages/testing/integration/ \
+            --preload ./packages/testing/integration/preload.ts \
+            --timeout 30000
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db
+          DIRECT_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db
+          TEST_API_URL: http://localhost:3000
+          PLAYWRIGHT_BASE_URL: http://localhost:3000
+          PRIVY_APP_ID: ${{ secrets.PRIVY_APP_ID || secrets.NEXT_PUBLIC_PRIVY_APP_ID || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'cl_ci_fork_dummy') || '' }}
+          PRIVY_APP_SECRET: ${{ secrets.PRIVY_APP_SECRET || '' }}
+          NEXT_PUBLIC_PRIVY_APP_ID: ${{ secrets.NEXT_PUBLIC_PRIVY_APP_ID || secrets.PRIVY_APP_ID || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork && 'cl_ci_fork_dummy') || '' }}
+          CRON_SECRET: ${{ secrets.CRON_SECRET || 'test-cron-secret' }}
+          CI_ADMIN_TOKEN: ci-integration-test-admin-token
+          NODE_ENV: test
+          CI: true
+          LLM_TIMEOUT_MS: '30000'
 
       - name: Run Chroma E2E Tests
         if: ${{ env.HAS_CHROMA_SECRETS == 'true' }}

--- a/packages/api/src/admin-middleware.ts
+++ b/packages/api/src/admin-middleware.ts
@@ -141,15 +141,35 @@ export async function getAdminRole(
 export async function requireAdmin(
   request: NextRequest
 ): Promise<AuthenticatedAdminUser> {
-  // In CI, accept a static test token for integration tests
+  // In CI, accept a static test token for integration tests.
+  // The token is only checked when CI=true (never in production deployments).
+  // We provision a real DB-backed user so FK-dependent admin write paths
+  // (whitelist grantedBy, role grants, etc.) don't 500.
   const ciAdminToken = process.env.CI_ADMIN_TOKEN;
   if (ciAdminToken && process.env.CI === 'true') {
     const headerToken = request.headers.get('x-dev-admin-token');
     if (headerToken && headerToken === ciAdminToken) {
+      const ciUserId = 'ci-admin-user';
+      const ciWallet = '0xCI00000000000000000000000000000000000001';
+
+      // Upsert a real user row so FK constraints are satisfied
+      await db
+        .insert(users)
+        .values({
+          id: ciUserId,
+          walletAddress: ciWallet,
+          isAdmin: true,
+          updatedAt: new Date(),
+        })
+        .onConflictDoUpdate({
+          target: users.id,
+          set: { isAdmin: true, updatedAt: new Date() },
+        });
+
       return {
-        userId: 'ci-admin-user',
-        dbUserId: 'ci-admin-user',
-        walletAddress: '0x0000000000000000000000000000000000000000',
+        userId: ciUserId,
+        dbUserId: ciUserId,
+        walletAddress: ciWallet,
         role: 'SUPER_ADMIN',
         permissions: ROLE_PERMISSIONS.SUPER_ADMIN,
       };

--- a/packages/api/src/admin-middleware.ts
+++ b/packages/api/src/admin-middleware.ts
@@ -141,6 +141,21 @@ export async function getAdminRole(
 export async function requireAdmin(
   request: NextRequest
 ): Promise<AuthenticatedAdminUser> {
+  // In CI, accept a static test token for integration tests
+  const ciAdminToken = process.env.CI_ADMIN_TOKEN;
+  if (ciAdminToken && process.env.CI === 'true') {
+    const headerToken = request.headers.get('x-dev-admin-token');
+    if (headerToken && headerToken === ciAdminToken) {
+      return {
+        userId: 'ci-admin-user',
+        dbUserId: 'ci-admin-user',
+        walletAddress: '0x0000000000000000000000000000000000000000',
+        role: 'SUPER_ADMIN',
+        permissions: ROLE_PERMISSIONS.SUPER_ADMIN,
+      };
+    }
+  }
+
   // In development, check for dev admin token first
   if (isDevelopment) {
     const devAdminToken =

--- a/packages/testing/integration/admin-agents-reputation.integration.test.ts
+++ b/packages/testing/integration/admin-agents-reputation.integration.test.ts
@@ -13,9 +13,9 @@ import {
   expect,
   test,
 } from 'bun:test';
-import { getDevCredentials } from '@babylon/api';
 import { db, userAgentConfigs, users } from '@babylon/db';
 import { generateSnowflakeId } from '@babylon/shared';
+import { getAdminToken } from './helpers';
 
 const BASE_URL =
   process.env.TEST_API_URL ||
@@ -105,11 +105,7 @@ describe('Admin Agents Reputation Integration', () => {
     });
 
     // Try to get admin access token (if available)
-    adminAccessToken =
-      process.env.DEV_ADMIN_TOKEN ||
-      process.env.TEST_ADMIN_TOKEN ||
-      getDevCredentials()?.devAdminToken ||
-      null;
+    adminAccessToken = getAdminToken();
   });
 
   afterEach(async () => {

--- a/packages/testing/integration/admin-dashboard-rbac.integration.test.ts
+++ b/packages/testing/integration/admin-dashboard-rbac.integration.test.ts
@@ -2,7 +2,7 @@
 // Run: bun test integration/admin-dashboard-rbac.integration.test.ts --preload ./integration/preload.ts
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { getAllAdmins, getDevCredentials } from '@babylon/api';
+import { getAllAdmins } from '@babylon/api';
 import {
   ADMIN_PERMISSIONS,
   ADMIN_ROLES,
@@ -14,6 +14,7 @@ import {
 } from '@babylon/db';
 import { generateSnowflakeId } from '@babylon/shared';
 import {
+  getAdminToken,
   requireAuth as requireAuthShared,
   requireServer as requireServerShared,
   waitForServerAvailability,
@@ -126,13 +127,12 @@ describe('Admin Dashboard RBAC Integration Tests', () => {
       console.warn('⚠️  Server not available - API tests will be skipped');
     }
 
-    // Get dev credentials for authenticated tests
-    const creds = getDevCredentials();
-    if (creds) {
-      devAdminToken = creds.devAdminToken;
-      console.log('✅ Dev admin token available');
+    // Get admin token (CI_ADMIN_TOKEN in CI, dev credentials locally)
+    devAdminToken = getAdminToken();
+    if (devAdminToken) {
+      console.log('✅ Admin token available');
     } else {
-      console.warn('⚠️  Dev credentials not available - auth tests limited');
+      console.warn('⚠️  Admin token not available - auth tests limited');
     }
   });
 

--- a/packages/testing/integration/admin-endpoints.integration.test.ts
+++ b/packages/testing/integration/admin-endpoints.integration.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { beforeAll, describe, expect, test } from 'bun:test';
-import { getDevCredentials } from '@babylon/api';
+import { getAdminToken } from './helpers';
 
 const BASE_URL =
   process.env.TEST_API_URL ||
@@ -59,11 +59,7 @@ describe('Admin API Endpoints Integration', () => {
       console.warn('⚠️  Server not available - Admin API tests will be skipped');
     }
 
-    adminToken =
-      process.env.DEV_ADMIN_TOKEN ||
-      process.env.TEST_ADMIN_TOKEN ||
-      getDevCredentials()?.devAdminToken ||
-      null;
+    adminToken = getAdminToken();
   });
 
   // ============================================

--- a/packages/testing/integration/alpha-group-admin-api.integration.test.ts
+++ b/packages/testing/integration/alpha-group-admin-api.integration.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { beforeAll, describe, expect, test } from 'bun:test';
-import { getDevCredentials } from '@babylon/api';
+import { getAdminToken } from './helpers';
 
 const BASE_URL =
   process.env.TEST_API_URL ||
@@ -78,11 +78,7 @@ describe('Alpha Group Admin API Integration', () => {
       );
     }
 
-    adminToken =
-      process.env.DEV_ADMIN_TOKEN ||
-      process.env.TEST_ADMIN_TOKEN ||
-      getDevCredentials()?.devAdminToken ||
-      null;
+    adminToken = getAdminToken();
   });
 
   // ============================================

--- a/packages/testing/integration/growth-metrics-api.integration.test.ts
+++ b/packages/testing/integration/growth-metrics-api.integration.test.ts
@@ -20,10 +20,10 @@ import {
   setDefaultTimeout,
   test,
 } from 'bun:test';
-import { getDevCredentials } from '@babylon/api';
 import { db, eq, userSessions, users } from '@babylon/db';
 import { generateSnowflakeId } from '@babylon/shared';
 import {
+  getAdminToken,
   requireAuth as requireAuthShared,
   requireServer as requireServerShared,
   waitForServerAvailability,
@@ -136,12 +136,7 @@ describe('Growth Metrics API', () => {
     }
 
     // Get dev admin token
-    try {
-      const creds = getDevCredentials();
-      devAdminToken = creds?.devAdminToken ?? null;
-    } catch {
-      console.log('Dev credentials not available');
-    }
+    devAdminToken = getAdminToken();
   });
 
   afterAll(async () => {

--- a/packages/testing/integration/heatmap-api.integration.test.ts
+++ b/packages/testing/integration/heatmap-api.integration.test.ts
@@ -9,8 +9,8 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { getDevCredentials } from '@babylon/api';
 import {
+  getAdminToken,
   requireAuth as requireAuthShared,
   requireServer as requireServerShared,
 } from './helpers';
@@ -71,12 +71,7 @@ describe('Heatmap API', () => {
       console.log('Server not available - tests will be skipped');
     }
 
-    try {
-      const creds = getDevCredentials();
-      devAdminToken = creds?.devAdminToken ?? null;
-    } catch {
-      console.log('Dev credentials not available');
-    }
+    devAdminToken = getAdminToken();
   });
 
   afterAll(async () => {

--- a/packages/testing/integration/helpers.ts
+++ b/packages/testing/integration/helpers.ts
@@ -67,13 +67,16 @@ export function requireServer(
 
 /**
  * Get admin token for integration tests.
- * Prefers CI_ADMIN_TOKEN env var (for CI where server runs in production mode),
- * falls back to dev credentials (for local development).
+ * Checks (in order): explicit env overrides, CI token, dev credentials.
+ * Uses the x-dev-admin-token header for authentication.
  */
 export function getAdminToken(): string | null {
-  if (process.env.CI_ADMIN_TOKEN) {
-    return process.env.CI_ADMIN_TOKEN;
-  }
+  // Preserve existing explicit env overrides used by local/staging harnesses
+  if (process.env.DEV_ADMIN_TOKEN) return process.env.DEV_ADMIN_TOKEN;
+  if (process.env.TEST_ADMIN_TOKEN) return process.env.TEST_ADMIN_TOKEN;
+  // CI production mode: dev credentials are disabled, use the CI token
+  if (process.env.CI_ADMIN_TOKEN) return process.env.CI_ADMIN_TOKEN;
+  // Local development fallback
   return getDevCredentials()?.devAdminToken ?? null;
 }
 

--- a/packages/testing/integration/helpers.ts
+++ b/packages/testing/integration/helpers.ts
@@ -1,4 +1,5 @@
 import { setTimeout as delay } from 'node:timers/promises';
+import { getDevCredentials } from '@babylon/api';
 
 const DEFAULT_BASE_URL =
   process.env.TEST_API_URL ||
@@ -62,6 +63,18 @@ export function requireServer(
   if (!serverAvailable) {
     throw new Error(`Integration test requires a live server at ${baseUrl}`);
   }
+}
+
+/**
+ * Get admin token for integration tests.
+ * Prefers CI_ADMIN_TOKEN env var (for CI where server runs in production mode),
+ * falls back to dev credentials (for local development).
+ */
+export function getAdminToken(): string | null {
+  if (process.env.CI_ADMIN_TOKEN) {
+    return process.env.CI_ADMIN_TOKEN;
+  }
+  return getDevCredentials()?.devAdminToken ?? null;
 }
 
 export function requireAuth(

--- a/packages/testing/integration/metrics-snapshot-cron.integration.test.ts
+++ b/packages/testing/integration/metrics-snapshot-cron.integration.test.ts
@@ -8,8 +8,8 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { getDevCredentials } from '@babylon/api';
 import { db, eq, inArray, systemMetricsSnapshots } from '@babylon/db';
+import { getAdminToken } from './helpers';
 
 const BASE_URL =
   process.env.TEST_API_URL ||
@@ -71,12 +71,7 @@ describe('Metrics Snapshot Cron Job', () => {
     }
 
     // Get dev admin token
-    try {
-      const creds = getDevCredentials();
-      devAdminToken = creds?.devAdminToken ?? null;
-    } catch {
-      console.log('Dev credentials not available');
-    }
+    devAdminToken = getAdminToken();
   });
 
   afterAll(async () => {

--- a/packages/testing/integration/timeseries-api.integration.test.ts
+++ b/packages/testing/integration/timeseries-api.integration.test.ts
@@ -8,9 +8,9 @@
  */
 
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { getDevCredentials } from '@babylon/api';
 import { db, inArray, systemMetricsSnapshots } from '@babylon/db';
 import { generateSnowflakeId } from '@babylon/shared';
+import { getAdminToken } from './helpers';
 
 const BASE_URL =
   process.env.TEST_API_URL ||
@@ -120,21 +120,11 @@ describe('Time-Series API', () => {
     }
 
     // Get dev admin token from env or credentials
-    try {
-      // Try environment variable first
-      devAdminToken =
-        process.env.DEV_ADMIN_TOKEN || process.env.TEST_ADMIN_TOKEN || null;
-
-      if (!devAdminToken) {
-        const creds = getDevCredentials();
-        devAdminToken = creds?.devAdminToken ?? null;
-      }
-
-      if (devAdminToken) {
-        authAvailable = true;
-        console.log('Admin auth available');
-      }
-    } catch {
+    devAdminToken = getAdminToken();
+    if (devAdminToken) {
+      authAvailable = true;
+      console.log('Admin auth available');
+    } else {
       console.log('Dev credentials not available - auth tests will be skipped');
       authAvailable = false;
     }


### PR DESCRIPTION
## Summary
- Admin integration tests (52 of 88 failures) fail because the server runs with `NODE_ENV=production`, which disables the dev admin token path
- Add `CI_ADMIN_TOKEN` env var support to admin middleware — only checked when `CI=true`
- Add shared `getAdminToken()` helper to integration test helpers
- Update all 8 admin test files to use the shared helper
- Add integration test step to staging CI workflow (was only on production)

## Root Cause
The `requireAdmin` middleware only accepts `x-dev-admin-token` when `isDevelopment` is true (`NODE_ENV !== 'production'`). In CI, the Next.js server must run with `NODE_ENV=production` for a proper production build test, so the dev token path is disabled.

## Security
- `CI_ADMIN_TOKEN` is only checked when `process.env.CI === 'true'`
- The token is a static value set in the CI workflow, not a secret (it's only used against the ephemeral CI database)
- Production deployments never have `CI=true`

## Test plan
- [ ] Integration tests for admin endpoints pass with `CI_ADMIN_TOKEN`
- [ ] Quality Gate (unit tests + typecheck + lint) passes
- [ ] Existing dev token auth still works locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)