### PR TITLE
chore: sync staging with production hotfixes

### DIFF
--- a/apps/web/src/app/agents/team/AgentPnL.tsx
+++ b/apps/web/src/app/agents/team/AgentPnL.tsx
@@ -13,7 +13,7 @@ import { Switch } from '@/components/ui/switch';
 import { useAuth } from '@/hooks/useAuth';
 import { useCollapsibleHeight } from '@/hooks/useCollapsibleHeight';
 import { usePortfolioPnL } from '@/hooks/usePortfolioPnL';
-import type { UserPositionsSnapshot } from '@/lib/markets/user-positions';
+import type { UserPositionsSnapshot } from '@/lib/markets/user-positions-types';
 import {
   usePerpPositions,
   usePredictionPositions,

--- a/apps/web/src/components/wallet/v2/pnl-chart.tsx
+++ b/apps/web/src/components/wallet/v2/pnl-chart.tsx
@@ -10,7 +10,7 @@ import {
   YAxis,
 } from 'recharts';
 import { usePnlHistory } from '@/hooks/usePnlHistory';
-import type { PnlHistoryScope } from '@/lib/wallet/pnlHistory';
+import type { PnlHistoryScope } from '@/lib/wallet/pnl-history-types';
 
 interface PnLChartProps {
   entityId?: string | null;

--- a/apps/web/src/components/wallet/v2/pnl-tab.tsx
+++ b/apps/web/src/components/wallet/v2/pnl-tab.tsx
@@ -5,7 +5,7 @@ import { ChevronDown } from 'lucide-react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useOnClickOutside } from '@/hooks/useOnClickOutside';
 import type { TeamTradingSummary } from '@/lib/agents/team-trading-summary';
-import type { PnlHistoryScope } from '@/lib/wallet/pnlHistory';
+import type { PnlHistoryScope } from '@/lib/wallet/pnl-history-types';
 import { PnLChart } from './pnl-chart';
 
 interface PnLTabProps {

--- a/apps/web/src/hooks/useAgentsTeamDashboard.ts
+++ b/apps/web/src/hooks/useAgentsTeamDashboard.ts
@@ -2,7 +2,7 @@
 
 import { logger } from '@babylon/shared';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import type { TeamDashboardAgent } from '@/lib/agents/team-dashboard';
+import type { TeamDashboardAgent } from '@/lib/agents/team-dashboard-types';
 import type { TeamTradingSummary } from '@/lib/agents/team-trading-summary';
 
 interface TeamDashboardResponse {

--- a/apps/web/src/hooks/usePnlHistory.ts
+++ b/apps/web/src/hooks/usePnlHistory.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { PnlHistoryScope } from '@/lib/wallet/pnlHistory';
+import type { PnlHistoryScope } from '@/lib/wallet/pnl-history-types';
 
 interface PnlPoint {
   time: number;

--- a/apps/web/src/lib/agents/team-dashboard-types.ts
+++ b/apps/web/src/lib/agents/team-dashboard-types.ts
@@ -1,0 +1,40 @@
+import type { TeamTradingSummary } from './team-trading-summary';
+
+export type AgentModelTier = 'free' | 'pro';
+
+export interface TeamDashboardAgent {
+  id: string;
+  username: string | null;
+  name: string | null;
+  description: string | null;
+  profileImageUrl: string | null;
+  virtualBalance: number;
+  autonomousEnabled: boolean;
+  autonomousTrading: boolean;
+  autonomousPosting: boolean;
+  autonomousCommenting: boolean;
+  autonomousDMs: boolean;
+  autonomousGroupChats: boolean;
+  a2aEnabled: boolean;
+  modelTier: AgentModelTier;
+  status: string;
+  isActive: boolean;
+  lifetimePnL: number;
+  totalTrades: number;
+  profitableTrades: number;
+  winRate: number;
+  lastTickAt: string | null;
+  lastChatAt: string | null;
+  walletAddress: string | null;
+  onChainRegistered: boolean;
+  agent0TokenId: number | null;
+  createdAt: string;
+  updatedAt: string;
+  displayName: string | null;
+  openPositions: number;
+}
+
+export interface TeamDashboardData {
+  agents: TeamDashboardAgent[];
+  summary: TeamTradingSummary;
+}

--- a/apps/web/src/lib/agents/team-dashboard.ts
+++ b/apps/web/src/lib/agents/team-dashboard.ts
@@ -1,23 +1,15 @@
+import 'server-only';
+
 import { db, eq, users } from '@babylon/db';
 import { getUserPositionsSnapshot } from '@/lib/markets/user-positions';
-import {
-  listOwnedAgentSummaries,
-  type OwnedAgentSummary,
-} from './owned-agent-summaries';
-import {
-  buildTeamTradingSummary,
-  type TeamTradingSummary,
-} from './team-trading-summary';
+import { listOwnedAgentSummaries } from './owned-agent-summaries';
+import type { TeamDashboardData } from './team-dashboard-types';
+import { buildTeamTradingSummary } from './team-trading-summary';
 
-export interface TeamDashboardAgent extends OwnedAgentSummary {
-  displayName: string | null;
-  openPositions: number;
-}
-
-export interface TeamDashboardData {
-  agents: TeamDashboardAgent[];
-  summary: TeamTradingSummary;
-}
+export type {
+  TeamDashboardAgent,
+  TeamDashboardData,
+} from './team-dashboard-types';
 
 export async function getTeamDashboardData({
   ownerId,

--- a/apps/web/src/lib/agents/team-trading-summary.ts
+++ b/apps/web/src/lib/agents/team-trading-summary.ts
@@ -1,7 +1,7 @@
 import {
   isOpenPredictionPosition,
   type UserPositionsSnapshot,
-} from '@/lib/markets/user-positions';
+} from '@/lib/markets/user-positions-types';
 
 export type TeamScope = 'owner_agents' | 'agents_only';
 

--- a/apps/web/src/lib/markets/user-positions-types.ts
+++ b/apps/web/src/lib/markets/user-positions-types.ts
@@ -1,0 +1,76 @@
+export type UserPositionsType = 'all' | 'perp' | 'prediction';
+export type UserPositionsStatus = 'open' | 'closed' | 'all';
+
+export interface UserPerpPositionSnapshot {
+  id: string;
+  ticker: string;
+  side: 'long' | 'short';
+  entryPrice: number;
+  currentPrice: number;
+  size: number;
+  leverage: number;
+  unrealizedPnL: number;
+  unrealizedPnLPercent: number;
+  liquidationPrice: number;
+  fundingPaid: number;
+  realizedPnL: number;
+  openedAt: string;
+  closedAt: string | null;
+  isAgentPosition: boolean;
+  agentId: string | null;
+  agentName: string | null;
+}
+
+export interface UserPredictionPositionSnapshot {
+  id: string;
+  marketId: string;
+  question: string;
+  side: 'YES' | 'NO';
+  shares: number;
+  avgPrice: number;
+  currentPrice: number;
+  currentProbability: number;
+  currentValue: number;
+  costBasis: number;
+  unrealizedPnL: number;
+  resolved: boolean;
+  resolution: boolean | null;
+  closesAt: string | null;
+  status: string;
+  createdAt: string | null;
+  outcome: boolean | string | null;
+  pnl: number | null;
+  resolvedAt: string | null;
+  isAgentPosition: boolean;
+  agentId: string | null;
+  agentName: string | null;
+}
+
+export interface UserPositionsSnapshot {
+  perpetuals: {
+    positions: UserPerpPositionSnapshot[];
+    stats: {
+      totalPositions: number;
+      totalPnL: number;
+      totalFunding: number;
+    };
+    total: number;
+    hasMore: boolean;
+  };
+  predictions: {
+    positions: UserPredictionPositionSnapshot[];
+    stats: {
+      totalPositions: number;
+    };
+    total: number;
+    hasMore: boolean;
+  };
+  timestamp: string;
+}
+
+export function isOpenPredictionPosition(position: {
+  resolved?: boolean;
+  status?: string;
+}) {
+  return position.resolved === false && position.status === 'active';
+}

--- a/apps/web/src/lib/markets/user-positions.ts
+++ b/apps/web/src/lib/markets/user-positions.ts
@@ -1,11 +1,24 @@
+import 'server-only';
+
 import { findUserByIdentifier } from '@babylon/api';
 import { asPublic, asUser, db, eq, users } from '@babylon/db';
 import { FEE_CONFIG } from '@babylon/engine/config/fees';
 import { toISO, toISOOrNull } from '@babylon/shared';
 import { calculatePredictionPositionSnapshot } from '@/lib/wallet/predictionPositionSnapshot';
+import type {
+  UserPositionsSnapshot,
+  UserPositionsStatus,
+  UserPositionsType,
+} from './user-positions-types';
 
-export type UserPositionsType = 'all' | 'perp' | 'prediction';
-export type UserPositionsStatus = 'open' | 'closed' | 'all';
+export {
+  isOpenPredictionPosition,
+  type UserPerpPositionSnapshot,
+  type UserPositionsSnapshot,
+  type UserPositionsStatus,
+  type UserPositionsType,
+  type UserPredictionPositionSnapshot,
+} from './user-positions-types';
 
 interface UserLookup {
   id: string;
@@ -22,73 +35,6 @@ interface ViewerDb {
   market: {
     findMany: typeof db.market.findMany;
   };
-}
-
-export interface UserPerpPositionSnapshot {
-  id: string;
-  ticker: string;
-  side: 'long' | 'short';
-  entryPrice: number;
-  currentPrice: number;
-  size: number;
-  leverage: number;
-  unrealizedPnL: number;
-  unrealizedPnLPercent: number;
-  liquidationPrice: number;
-  fundingPaid: number;
-  realizedPnL: number;
-  openedAt: string;
-  closedAt: string | null;
-  isAgentPosition: boolean;
-  agentId: string | null;
-  agentName: string | null;
-}
-
-export interface UserPredictionPositionSnapshot {
-  id: string;
-  marketId: string;
-  question: string;
-  side: 'YES' | 'NO';
-  shares: number;
-  avgPrice: number;
-  currentPrice: number;
-  currentProbability: number;
-  currentValue: number;
-  costBasis: number;
-  unrealizedPnL: number;
-  resolved: boolean;
-  resolution: boolean | null;
-  closesAt: string | null;
-  status: string;
-  createdAt: string | null;
-  outcome: boolean | string | null;
-  pnl: number | null;
-  resolvedAt: string | null;
-  isAgentPosition: boolean;
-  agentId: string | null;
-  agentName: string | null;
-}
-
-export interface UserPositionsSnapshot {
-  perpetuals: {
-    positions: UserPerpPositionSnapshot[];
-    stats: {
-      totalPositions: number;
-      totalPnL: number;
-      totalFunding: number;
-    };
-    total: number;
-    hasMore: boolean;
-  };
-  predictions: {
-    positions: UserPredictionPositionSnapshot[];
-    stats: {
-      totalPositions: number;
-    };
-    total: number;
-    hasMore: boolean;
-  };
-  timestamp: string;
 }
 
 async function getCanonicalUser(userId: string): Promise<UserLookup | null> {
@@ -401,11 +347,4 @@ export async function getUserPositionsSnapshot({
     },
     timestamp: new Date().toISOString(),
   };
-}
-
-export function isOpenPredictionPosition(position: {
-  resolved?: boolean;
-  status?: string;
-}) {
-  return position.resolved === false && position.status === 'active';
 }

--- a/apps/web/src/lib/wallet/pnl-history-types.ts
+++ b/apps/web/src/lib/wallet/pnl-history-types.ts
@@ -1,0 +1,14 @@
+export type PnlHistoryRange = '1H' | '4H' | '1D' | '1W' | 'ALL';
+export type PnlHistoryScope = 'team' | 'owner' | 'agent';
+
+export interface PnlHistoryPoint {
+  time: number;
+  value: number;
+}
+
+export interface UserPnlMetrics {
+  userId: string;
+  lifetimePnL: number;
+  unrealizedPnL: number;
+  currentPnL: number;
+}

--- a/apps/web/src/lib/wallet/pnlHistory.ts
+++ b/apps/web/src/lib/wallet/pnlHistory.ts
@@ -1,3 +1,5 @@
+import 'server-only';
+
 import {
   and,
   asc,
@@ -16,22 +18,19 @@ import {
 import { FEE_CONFIG } from '@babylon/engine/config/fees';
 import { toNumber } from '@babylon/engine/portfolio-valuation';
 import { sql } from 'drizzle-orm';
+import type {
+  PnlHistoryPoint,
+  PnlHistoryRange,
+  UserPnlMetrics,
+} from './pnl-history-types';
 import { calculatePredictionPositionSnapshot } from './predictionPositionSnapshot';
 
-export type PnlHistoryRange = '1H' | '4H' | '1D' | '1W' | 'ALL';
-export type PnlHistoryScope = 'team' | 'owner' | 'agent';
-
-export interface PnlHistoryPoint {
-  time: number;
-  value: number;
-}
-
-export interface UserPnlMetrics {
-  userId: string;
-  lifetimePnL: number;
-  unrealizedPnL: number;
-  currentPnL: number;
-}
+export type {
+  PnlHistoryPoint,
+  PnlHistoryRange,
+  PnlHistoryScope,
+  UserPnlMetrics,
+} from './pnl-history-types';
 
 interface SnapshotMetricRow {
   currentPnL: number;

--- a/packages/engine/src/portfolio-valuation.ts
+++ b/packages/engine/src/portfolio-valuation.ts
@@ -1,4 +1,4 @@
-import { isOpenPerpPositionStateValid } from '@babylon/core/markets/perps';
+import { isOpenPerpPositionStateValid } from '@babylon/core/markets/perps/utils';
 
 /** Safely coerce an unknown value (DB column, JSON field) to a finite number. */
 export function toNumber(value: unknown, fallback = 0): number {


### PR DESCRIPTION
## Summary
Merge `production` into `staging` to bring over the March 31, 2026 production hotfixes for the client-side `@babylon/db` bundle regression.

## Why
Production received two direct hotfixes that must be reflected in `staging` to keep branches aligned and avoid reintroducing the regression.

## Included
- `fix(web): keep db-only modules out of client bundles`
- `fix(engine): keep client exports off perp db barrel`

## Validation
- `bun x biome check --write apps/web/src/lib/markets/user-positions.ts apps/web/src/lib/markets/user-positions-types.ts packages/engine/src/portfolio-valuation.ts`
- `SKIP_ENV_VALIDATION=1 bun x next build --webpack --experimental-app-only --debug-build-paths 'src/app/feed/page.tsx,src/app/markets/trending/page.tsx'`

## Notes
Conflicts were resolved by preserving staging-specific fields while keeping the production client-safe import boundaries intact.
