### PR TITLE
feat: actor system overhaul Phase 1 — prompts rewrite + relevance-filtered feed

### DIFF
--- a/docs/actor-prompt-rewrite-report.md
+++ b/docs/actor-prompt-rewrite-report.md
@@ -1,0 +1,204 @@
+# Actor Prompt Rewrite: Before vs After
+
+> Phase 1 of the actor system overhaul. Measured using `prompt-diff` and `context-inspector` dev tools.
+
+---
+
+## The Problem
+
+The old prompts buried actor identity under 1,200 tokens of generic shared rules that were identical across all 140+ actors. Every NPC sounded the same because the rules dominated the signal.
+
+**Old prompt structure (v5):**
+```
+[800 tokens of reality grounding]
+=== ALL CHARACTERS IN WORLD ===         ← empty
+=== CHARACTER'S FULL PROFILE ===        ← actor data buried here
+=== CHARACTER'S RELATIONSHIPS ===       ← empty
+=== COMPLETE NARRATIVE CONTEXT ===      ← empty
+=== ONGOING STORYLINES ===              ← empty
+=== RESOLVED QUESTIONS ===              ← empty
+=== DAY X/30 CONTEXT ===
+=== CHARACTER'S POST HISTORY ===        ← empty
+[400 tokens: IMPORTANT_RULES — "no hashtags" stated 4 different ways]
+[200 tokens: CONTENT_REQUIREMENTS — "MUST reference", "MUST mention"]
+[200 tokens: ANTI_REPETITION_RULES — "NEVER repeat", "build on"]
+=== YOUR TASK ===
+[6-item DO list]
+[6-item DO NOT list]
+CHARACTER LIMIT: Post MUST be 200 characters or less.
+[VALUE_RANGES]
+[XML format]
+CRITICAL: Return exactly ONE post...
+[200 tokens: FINAL_REMINDERS — repeating IMPORTANT_RULES again]
+```
+
+**New prompt structure (v6):**
+```
+You are {name}.
+
+{full character info — voice, examples, personality, relationships, positions}
+
+{per-actor anti-repetition patterns}
+{per-actor rules — ignoreTopics, tone guardrails, finance guardrails}
+
+WHAT'S HAPPENING:
+{compact context}
+
+WORLD:
+{actors, markets, predictions}
+
+RULES (5 lines):
+- Parody names only
+- No hashtags, no emojis
+- Max 200 characters
+- Sound like YOUR examples
+- Reference events naturally
+
+Write ONE post as {name}.
+
+{XML format}
+```
+
+---
+
+## Prompt-by-Prompt Comparison
+
+All measurements from `bun scripts/prompt-diff.ts --section-only`.
+
+### ambient-posts (main post generation)
+
+| Metric | Before (v5) | After (v6) | Delta |
+|--------|------------|-----------|-------|
+| **Max Tokens** | 8,000 | 1,500 | **-81%** |
+| **Template tokens** | 1,368 | 206 | **-1,162 (-85%)** |
+| Empty sections removed | 7 | 0 | -7 |
+| Shared rule blocks | IMPORTANT_RULES, CONTENT_REQUIREMENTS, ANTI_REPETITION_RULES, FINAL_REMINDERS | 5 inline rules | -4 blocks |
+
+**Sections removed:** ALL CHARACTERS IN WORLD, CHARACTER'S RELATIONSHIPS, COMPLETE NARRATIVE CONTEXT, ONGOING STORYLINES, RESOLVED QUESTIONS, DAY X/30 CONTEXT, CHARACTER'S POST HISTORY, CHARACTER'S EVENT INVOLVEMENT, ABSOLUTELY NO HASHTAGS, NO EMOJIS, PARODY NAMES ONLY, NAME USAGE EXAMPLES, ANTI-REPETITION RULES, YOUR TASK, DO, DO NOT
+
+### reactions (event reaction)
+
+| Metric | Before (v5) | After (v6) | Delta |
+|--------|------------|-----------|-------|
+| **Max Tokens** | 8,000 | 1,500 | **-81%** |
+| **Template tokens** | 1,281 | 182 | **-1,099 (-86%)** |
+
+### commentary (in-character take)
+
+| Metric | Before (v6-old) | After (v6-new) | Delta |
+|--------|------------|-----------|-------|
+| **Max Tokens** | 8,000 | 1,500 | **-81%** |
+| **Template tokens** | 1,366 | 164 | **-1,202 (-88%)** |
+
+### replies (reply to post)
+
+| Metric | Before (v5) | After (v6) | Delta |
+|--------|------------|-----------|-------|
+| **Max Tokens** | 6,000 | 1,500 | **-75%** |
+| **Template tokens** | 1,316 | 169 | **-1,147 (-87%)** |
+
+### reply (lightweight thread reply)
+
+| Metric | Before (v3) | After (v6) | Delta |
+|--------|------------|-----------|-------|
+| **Max Tokens** | 5,000 | 1,000 | **-80%** |
+| **Template tokens** | 1,110 | 98 | **-1,012 (-91%)** |
+
+### conspiracy (contrarian take)
+
+| Metric | Before (v5) | After (v6) | Delta |
+|--------|------------|-----------|-------|
+| **Max Tokens** | 6,000 | 1,500 | **-75%** |
+| **Template tokens** | 1,259 | 200 | **-1,059 (-84%)** |
+
+### minute-ambient (quick ambient)
+
+| Metric | Before (v3) | After (v6) | Delta |
+|--------|------------|-----------|-------|
+| **Max Tokens** | 500 | 500 | unchanged |
+| **Template tokens** | 1,123 | 71 | **-1,052 (-94%)** |
+
+---
+
+## Aggregate Impact
+
+| Metric | Before | After | Improvement |
+|--------|--------|-------|-------------|
+| Total template tokens (all 7 prompts) | 8,823 | 1,090 | **-7,733 (-88%)** |
+| Total maxTokens budget | 41,500 | 9,000 | **-78%** |
+| Empty section headers | 49 (7 per prompt) | 0 | **-100%** |
+| Shared rule imports | 6 per prompt | 0 | **-100%** |
+| Per-actor guardrails | 0 | 4 systems wired | **+4** |
+
+---
+
+## Actor Context Comparison (from context-inspector)
+
+All measurements from `bun run inspect:context -- --npc <id> --type posting`.
+
+### Context by actor (tokens)
+
+| Section | AIlon Musk | Trump Terminal | VitAIlik Buterin |
+|---------|-----------|---------------|-----------------|
+| characterInfo (identity) | 885 | 848 | 683 |
+| comprehensiveContext | 350 | 252 | 256 |
+| fullCharacterContext | 1,253 | 1,119 | 956 |
+| realityGrounding | 789 | 789 | 789 |
+| worldActors | 376 | 359 | 377 |
+| phaseContext | 58 | 58 | 58 |
+| timeEnergy | 17 | 17 | 16 |
+| personalEvents | 32 | — | — |
+| recentEvents | 100 | 100 | 100 |
+| relationships | 90 | 165 | 113 |
+| marketPositions | 3 | 3 | 3 |
+| **Total** | **2,096** | **1,947** | **1,803** |
+
+Key observation: each actor gets a **different total token count** based on their actual data richness. AIlon Musk has 63 post examples so characterInfo is larger. VitAIlik has 31 examples and fewer relationships, so his context is smaller. This is correct — the prompt adapts to the actor.
+
+---
+
+## What's Now Wired In (Previously Built But Unused)
+
+### 1. NPCAntiRepetitionService
+- Tracks last 20 posts per character
+- Detects overused opening phrases (first 3 words)
+- Detects overused vocabulary (words appearing in 50%+ of posts)
+- Injects: `"Do NOT start with: 'the future is', 'just saw'. Reduce these words: tremendous, winning"`
+
+### 2. formatActorToneGuardrails
+- Checks actor's voice/style/examples for generic slang tokens (W, L, dawg, bro, fam, fr fr, no cap, rizz, ratio)
+- If NOT in their corpus, bans them: `"For THIS character, DO NOT use: W, L, dawg, bro, fam"`
+
+### 3. formatActorFinanceGuardrails
+- Checks if actor is a "degen speaker" (trading domain, ticker patterns, degen keywords)
+- If NOT, bans ticker/trading jargon: `"DO NOT talk in tickers: no $OPENAGI / $NVDAI"`
+
+### 4. ignoreTopics
+- Actor data field (e.g., VitAIlik: `['politics', 'entertainment', 'sports', 'celebrity', 'fashion']`)
+- Previously only used as a pre-generation gate
+- Now injected as prompt rule: `"You never talk about: politics, entertainment, sports, celebrity, fashion"`
+
+---
+
+## Relevance-Filtered Feed (New)
+
+**Before:** All NPCs saw the same 15 most recent posts regardless of who they are.
+
+**After:** `getRelevantFeedForNPC(npcId)` prioritizes posts from actors the NPC cares about:
+1. Posts from actors sharing affiliations (same org) — up to 10 slots
+2. Posts from actors in relationship table (allies/rivals)
+3. Remaining slots filled with general recent posts
+
+Example: AIlon Musk (affiliations: teslai, aix, neurailink, spaicex) sees posts from other TeslAI/AIX actors first, then general feed.
+
+---
+
+## Remaining Phases
+
+| Phase | Status | Description |
+|-------|--------|-------------|
+| Phase 1: Prompt rewrite | **Done** | 7 prompts rewritten, guardrails wired, feed filtered |
+| Phase 2: Unified context builder | Planned | Single ActorContextBuilder for all actions |
+| Phase 3: Per-actor rules | Planned | `rules` array in actor data files |
+| Phase 4: Unified action loop | Planned | One LLM call per actor per tick |
+| Phase 5: Dynamic world | Planned | Update stale reality grounding |

--- a/docs/actor-system-plan.md
+++ b/docs/actor-system-plan.md
@@ -1,0 +1,357 @@
+# Actor System Overhaul Plan
+
+> Goal: Make NPC actors feel like real, distinct people — not template-filling LLM outputs.
+> Based on whiteboard diagram + deep codebase audit on 2026-03-31.
+
+---
+
+## The Problem in One Sentence
+
+The actor data is rich (30-100 post examples, detailed voice/personality, relationships, positions) but the prompts bury it under 1,200 tokens of generic shared rules, and the context pipeline fragments what actors know across disconnected systems.
+
+---
+
+## Current Architecture (What Exists)
+
+### What actors have (the data is good)
+- **30-100 post examples** per actor with real voice variety (AIlon Musk ranges from "lol" to 259-char shitposts)
+- **Detailed voice/personality/postStyle** descriptions (~500 chars each)
+- **Persona config**: reliability, insiderOrgs, willingness to lie, self-interest motivation, allies/enemies
+- **Emotional state**: mood (-1 to 1), luck, updated each tick
+- **Memories**: 50 bounded entries with timestamps
+- **Relationships**: sentiment, strength, history, interaction count
+- **Market positions**: current holdings with PnL
+- **Domain/ignoreTopics/engagementThreshold**: behavioral filtering
+
+### What's broken (the prompts are bad)
+
+**1. Shared rules drown out actor identity**
+The ambient post prompt has ~1,200 tokens of shared rules (IMPORTANT_RULES, CONTENT_REQUIREMENTS, ANTI_REPETITION_RULES, FINAL_REMINDERS, DO/DO NOT lists) that are identical across all 140+ actors. The actor-specific data (voice, examples, personality) is sandwiched between generic instructions. The LLM prioritizes the rules over the character.
+
+**2. Anti-repetition service exists but isn't wired in**
+`NPCAntiRepetitionService.getAvoidedPatternsContext()` generates per-actor "avoid these openings/words" instructions — but it's never called in the ambient post generation path. It's exported but unused.
+
+**3. Tone/finance guardrails exist but aren't wired in**
+`formatActorToneGuardrails()` and `formatActorFinanceGuardrails()` check if an actor's voice corpus supports slang/ticker usage and ban it if not — but neither is called during post generation.
+
+**4. ignoreTopics is pre-filter only, not in the prompt**
+An actor with `ignoreTopics: ['fashion', 'sports']` gets filtered before generation, but if the topic filter passes, the LLM never sees "you don't talk about fashion." The constraint exists as a gate, not as character knowledge.
+
+**5. Posting and trading contexts are disconnected**
+- Posting context: gets narrative arc, ongoing stories, resolved questions, trending topics
+- Trading context: gets market prices, positions, event signals, but no narrative context
+- Result: actors post about stories they don't trade on, and trade without narrative awareness
+
+**6. No follow graph for NPCs**
+NPCs see random recent posts, not posts from accounts they'd follow. There's a follow system but it's NPC-to-player only. NPC-to-NPC follows don't exist, so actors can't react to what their allies/rivals post.
+
+**7. Seven duplicate prompt templates**
+`ambient-posts`, `minute-ambient`, `replies`, `reply`, `reactions`, `commentary`, `conspiracy` share 80%+ identical instruction text. Same DO/DO NOT lists, same rules, same structure. Different XML wrappers.
+
+**8. 8,000 maxTokens for a 200-char post**
+The LLM generates up to 8,000 tokens of reasoning for a tweet-length output. This is 40x the output length in overhead.
+
+**9. Reality grounding is stale**
+`reality-grounding.ts` references "Nov 2025" data in March 2026. Only 8 satirical themes. "Only USAI exists" eliminates international content.
+
+**10. Empty template sections waste tokens**
+Multiple template slots (`characterRoster`, `characterRelationships`, `richGameContext`, etc.) render as empty strings with visible section headers. The LLM sees "=== ONGOING STORYLINES ===" followed by nothing.
+
+---
+
+## Target Architecture (From Whiteboard)
+
+```
+                    ┌──────────────┐
+                    │  RSS Events  │
+                    └──────┬───────┘
+                           │
+┌──────────────┐    ┌──────▼───────┐    ┌──────────────┐
+│  Market Data │───▶│              │◀───│  Feed (posts │
+│  + Positions │    │    ACTOR     │    │  from follows)│
+└──────────────┘    │    (LLM)     │    └──────────────┘
+                    │              │
+┌──────────────┐    │  Persona:    │    ┌──────────────┐
+│ Group Chats  │───▶│  - Style     │◀───│     DMs      │
+└──────────────┘    │  - Rules     │    └──────────────┘
+                    │  - Friends   │
+┌──────────────┐    │  - Enemies   │    ┌──────────────┐
+│  Narrative + │───▶│              │◀───│  World State  │
+│  Hidden Alpha│    └──────┬───────┘    └──────────────┘
+└──────────────┘           │
+                    ┌──────▼───────┐
+                    │   Actions:   │
+                    │  Post, DM,   │
+                    │  Trade, Bet  │
+                    └──────────────┘
+```
+
+Every input should flow into a **single unified context** per actor per tick. The actor sees everything relevant and decides what action to take — not separate prompts for posting vs trading vs engagement.
+
+---
+
+## The Plan
+
+### Phase 1: Fix the Prompts (Highest Impact, Lowest Risk)
+
+#### 1.1 Rewrite the ambient post prompt
+**Problem**: 1,200 tokens of shared rules, 200-char output. Generic DO/DO NOT lists.
+**Fix**: Strip the prompt to essentials. The actor's voice examples and personality should be the DOMINANT signal, not rules.
+
+New structure:
+```
+You are {name}.
+
+{voice description}
+{postStyle description}
+
+YOUR POSTS SOUND LIKE THIS:
+{5-8 shuffled post examples}
+
+WHAT YOU KNOW RIGHT NOW:
+{compact context: events, positions, trending, mood}
+
+YOUR RELATIONSHIPS:
+{allies to defend, rivals to dunk on}
+
+RULES:
+{3-5 rules max, not 30}
+- Use parody names only
+- No hashtags or emojis
+- {actor-specific rules from ignoreTopics}
+- Max 200 characters
+
+Write one post.
+```
+
+Target: under 2,000 tokens total. Actor identity is 60%+ of the prompt, not 20%.
+
+#### 1.2 Wire in existing but unused systems
+**Anti-repetition service**: Call `getAvoidedPatternsContext()` and inject the output. It already generates per-actor "avoid these openings/words" — just needs to be wired in.
+
+**Tone guardrails**: Call `formatActorToneGuardrails()` and `formatActorFinanceGuardrails()`. They check if an actor's corpus supports slang/ticker usage — just needs to be wired in.
+
+**ignoreTopics in prompt**: Add actor-specific rules from `ignoreTopics` to the prompt: "You never talk about: fashion, sports, entertainment."
+
+#### 1.3 Consolidate duplicate prompts
+Merge `ambient-posts`, `reactions`, `commentary`, `replies`, `reply`, `conspiracy` into a single flexible prompt that takes a `postType` parameter. Same actor context, different task instruction.
+
+#### 1.4 Reduce maxTokens
+8,000 tokens for a 200-char post is wasteful. Reduce to 1,000-1,500. The model doesn't need 8,000 tokens to write a tweet.
+
+---
+
+### Phase 2: Unify Actor Context (Medium Effort, High Impact)
+
+#### 2.1 Single context builder for all actor actions
+Create an `ActorContextBuilder` that assembles one unified context object used by posting, trading, engagement, and any other action.
+
+```typescript
+interface ActorContext {
+  // Identity (from static data)
+  identity: {
+    name: string;
+    personality: string;
+    voice: string;
+    postStyle: string;
+    postExamples: string[];
+    domains: string[];
+    ignoreTopics: string[];
+    affiliations: string[];
+  };
+
+  // Persona (behavioral rules)
+  persona: {
+    reliability: number;
+    willingness_to_lie: boolean;
+    selfInterest: string;
+    allies: Array<{ name: string; sentiment: number }>;
+    rivals: Array<{ name: string; sentiment: number }>;
+    insiderOrgs: string[];
+  };
+
+  // What they know right now
+  awareness: {
+    recentEvents: EventContext[];       // World events (last 24h)
+    personalEvents: EventContext[];     // Events involving them
+    feedPosts: FeedPostContext[];       // Posts from people they follow
+    groupChats: GroupChatContext[];     // Group conversations
+    dms: DMContext[];                  // Direct messages (NEW)
+    trendingTopics: string[];
+    resolvedQuestions: string[];       // Recent market outcomes
+  };
+
+  // Market state
+  markets: {
+    positions: NPCPosition[];          // What they hold
+    perpPrices: PerpMarketSnapshot[];   // Current perp prices
+    predictionMarkets: PredictionMarketSnapshot[];
+    recentTrades: TradeContext[];       // Their recent trading activity
+    signals: MarketSignalContext[];     // Hidden alpha (NPCs only)
+  };
+
+  // Emotional/memory state
+  state: {
+    mood: number;
+    luck: string;
+    memories: NpcMemory[];
+    avoidPatterns: string[];           // From anti-repetition service
+  };
+
+  // Narrative awareness
+  narrative: {
+    arcPhase: string;                  // Current game phase
+    hiddenAlpha: string;               // NPC-only intuitions
+    ongoingStories: string[];
+  };
+}
+```
+
+This replaces `MarketContextService.buildContextForNPC()`, `FeedGenerator.buildRichCharacterContext()`, and `getNpcGameContext()` with one source of truth.
+
+#### 2.2 Add NPC-to-NPC follow graph
+NPCs should follow their allies and rival NPCs, not see random posts. The follow graph already exists (`ActorFollow` table) but is only used for NPC-to-player follows.
+
+**Implementation**: On actor bootstrap, create mutual follows between:
+- All allies (from `persona.favorsActors`)
+- All rivals (from `persona.opposesActors`)
+- Same-affiliation actors (shared org)
+
+Then filter `feedPosts` in the context builder to only show posts from followed accounts.
+
+#### 2.3 Expose DMs to actors
+NPCs currently can't see DMs. The `messages` table has DM data but it's filtered out. Add DM context to the unified `ActorContext.awareness.dms`.
+
+---
+
+### Phase 3: Actor-Specific Prompt Rules (Medium Effort)
+
+#### 3.1 Per-actor rule injection
+Each actor data file should support a `rules` array:
+```typescript
+rules: [
+  "Never discuss token prices directly",
+  "Always speak in ALL CAPS",
+  "Reference Mars at least once per 5 posts",
+  "When rivals are mentioned, always dunk on them",
+]
+```
+
+These get injected into the prompt as hard constraints. Currently actors have `ignoreTopics` and `engagementThreshold` as pre-filters, but no in-prompt rules.
+
+#### 3.2 Behavioral archetypes
+Instead of 7 temperature-based personality types, define behavioral archetypes that control HOW an actor engages:
+
+- **Provocateur**: starts fights, quote-tweets rivals, hot takes
+- **Analyst**: measured, data-driven, references numbers
+- **Shitposter**: short, chaotic, memes, low effort
+- **Insider**: drops hints, "sources say", vague signals
+- **Commentator**: reacts to others' posts, rarely original
+- **Crusader**: pushes agenda, ideology-driven
+
+Each archetype gets a different prompt structure, not just different temperature.
+
+---
+
+### Phase 4: Unified Action Loop (Higher Effort)
+
+#### 4.1 Single LLM call per actor per tick
+Instead of separate systems for posting, trading, and engagement, give the actor ONE prompt per tick:
+
+```
+You are {name}. Here's what's happening:
+{unified context}
+
+What do you want to do right now? Pick ONE:
+- POST: Write something on your feed
+- TRADE: Buy/sell a position
+- REPLY: Respond to someone's post
+- REACT: Like or repost something
+- DM: Send a private message
+- NOTHING: Wait
+
+Your decision:
+```
+
+This is how the autonomous agent `MultiStepExecutor` already works for user-controlled agents. Extend it to NPCs so they have the same decision loop.
+
+**Benefits**:
+- One LLM call instead of 3-4 per actor per tick
+- Actions are coherent (post about what you're trading)
+- Natural action prioritization (reply to mentions before posting)
+- Cost reduction (~60% fewer LLM calls)
+
+---
+
+### Phase 5: Dynamic World (Lower Priority)
+
+#### 5.1 Update reality grounding
+The `reality-grounding.ts` file has stale data (Nov 2025). Create a system that updates this from RSS feeds, not hardcoded dates.
+
+#### 5.2 Expand satirical themes
+Currently 8 themes. Expand to 20+ and rotate which subset is active per day.
+
+#### 5.3 RSS events as actor-visible context
+RSS headlines flow into `worldEvents` but actors don't know they came from RSS. Make the source visible so actors can reference "I saw this headline" naturally.
+
+---
+
+## Implementation Order
+
+```
+Phase 1 (DO FIRST — prompt fixes)
+├── 1.1 Rewrite ambient post prompt (biggest quality improvement)
+├── 1.2 Wire anti-repetition + guardrails (already built, just connect)
+├── 1.3 Consolidate duplicate prompts (reduce maintenance burden)
+└── 1.4 Reduce maxTokens (cost reduction)
+
+Phase 2 (DO SECOND — context unification)
+├── 2.1 ActorContextBuilder (single source of truth)
+├── 2.2 NPC-to-NPC follow graph (relevant feed instead of random)
+└── 2.3 DM exposure (new input channel)
+
+Phase 3 (DO THIRD — actor specificity)
+├── 3.1 Per-actor rules in data files
+└── 3.2 Behavioral archetypes
+
+Phase 4 (DO FOURTH — unified action loop)
+└── 4.1 Single LLM call per actor per tick
+
+Phase 5 (DO LAST — world dynamics)
+├── 5.1 Dynamic reality grounding
+├── 5.2 Expanded satirical themes
+└── 5.3 RSS source attribution
+```
+
+---
+
+## Metrics to Track
+
+| Metric | How to Measure | Target |
+|--------|---------------|--------|
+| Post uniqueness | Jaccard similarity between consecutive posts by same actor | < 0.15 avg |
+| Voice consistency | Do posts sound like the actor's examples? (human eval) | > 80% match rate |
+| Action coherence | Do actors trade what they post about? | > 50% alignment |
+| Token efficiency | Prompt tokens per output token | < 10:1 ratio |
+| LLM cost per tick | Total tokens used per game tick | 50% reduction from current |
+| Entity diversity | Unique actors mentioned per 100 posts | > 30 |
+| Post variety | Length distribution std dev | > 40 chars |
+| Engagement quality | Do NPCs engage with relevant posts (not random)? | > 70% on-topic |
+
+---
+
+## Key Files to Modify
+
+| Phase | File | Change |
+|-------|------|--------|
+| 1.1 | `packages/engine/src/prompts/feed/ambient-posts.ts` | Rewrite prompt |
+| 1.1 | `packages/engine/src/prompts/shared-sections.ts` | Slim down shared rules |
+| 1.2 | `packages/engine/src/FeedGenerator.ts` | Wire anti-repetition + guardrails |
+| 1.3 | `packages/engine/src/prompts/feed/*.ts` | Consolidate 7 → 1 flexible prompt |
+| 1.4 | `packages/engine/src/prompts/feed/*.ts` | Reduce maxTokens |
+| 2.1 | `packages/engine/src/services/actor-context-builder.ts` | New unified context service |
+| 2.2 | `packages/engine/src/services/following-mechanics.ts` | Add NPC-to-NPC follows |
+| 2.3 | `packages/engine/src/services/market-context-service.ts` | Add DM context |
+| 3.1 | `packages/engine/src/data/actors/*.ts` | Add rules field |
+| 3.2 | `packages/engine/src/npc/npc-character-config.ts` | Behavioral archetypes |
+| 4.1 | `packages/engine/src/game-tick.ts` + `npc-tick` | Unified action loop |

--- a/packages/engine/src/FeedGenerator.ts
+++ b/packages/engine/src/FeedGenerator.ts
@@ -1393,6 +1393,7 @@ ${voiceContext}
       relationshipContext: relationshipContext,
       relatedNarratives,
       similarPreviousEvents,
+      ...this.buildActorPromptVars(actor),
       ...(this.worldContext || {}),
     });
 
@@ -1568,6 +1569,7 @@ ${voiceContext}
       characterEventRelation,
       involvedActors: involvedActorNames,
       relatedNarrative,
+      ...this.buildActorPromptVars(commentator),
       ...(this.worldContext || {}),
     });
 
@@ -1725,6 +1727,7 @@ ${voiceContext}
         worldEvent.description || worldEvent.type || 'Event occurred',
       characterName: conspiracist.name,
       characterInfo: fullCharacterContext,
+      ...this.buildActorPromptVars(conspiracist),
       ...(this.worldContext || {}),
     });
 
@@ -2639,7 +2642,7 @@ ${voiceContext}
 
     // Get actor's current emotional state
     const state = this.actorStates.get(actor.id);
-    const emotionalContext = state
+    const _emotionalContext = state
       ? generateActorContext(
           state.mood,
           state.luck,
@@ -2654,13 +2657,12 @@ ${voiceContext}
       : '';
 
     const prompt = renderPrompt(reply, {
-      actorName: actor.name,
-      actorDescription: actor.description || actor.role || 'actor',
-      emotionalContext: emotionalContext ? emotionalContext + '\n' : '',
-      previousReplies: '',
-      originalAuthorName: originalPost.authorName,
-      originalContent: originalPost.content,
+      characterName: actor.name,
+      characterInfo: `${actor.description || ''}\n${actor.voice || ''}\n${actor.postStyle || ''}`,
+      originalPost: originalPost.content,
+      originalAuthor: originalPost.authorName,
       relationshipContext,
+      ...this.buildActorPromptVars(actor),
       ...(this.worldContext || {}),
     });
 
@@ -2714,6 +2716,28 @@ ${voiceContext}
    *
    * @description
    * Generates ambient post WITHOUT knowing predetermined outcome.
+   * Build per-actor prompt variables (anti-repetition, guardrails, rules).
+   * Used by all character post generation methods.
+   */
+  private buildActorPromptVars(actor: Actor): {
+    antiRepetitionContext: string;
+    actorRules: string;
+  } {
+    const antiRepetitionContext = getAvoidedPatternsContext(actor.id);
+    const toneGuardrails = formatActorToneGuardrails(actor);
+    const financeGuardrails = formatActorFinanceGuardrails(actor);
+
+    const parts: string[] = [];
+    if (actor.ignoreTopics && actor.ignoreTopics.length > 0) {
+      parts.push(`You never talk about: ${actor.ignoreTopics.join(', ')}`);
+    }
+    if (toneGuardrails) parts.push(toneGuardrails);
+    if (financeGuardrails) parts.push(financeGuardrails);
+
+    return { antiRepetitionContext, actorRules: parts.join('\n') };
+  }
+
+  /**
    * Actor posts general thoughts based on mood, relationships, and trending topics.
    * Each character gets full context with entropy/variety in presentation.
    */
@@ -2765,23 +2789,7 @@ ${voiceContext}
     // Random hour for time-of-day energy variety
     const hour = Math.floor(Math.random() * 24);
 
-    // Build per-actor anti-repetition context
-    const antiRepContext = getAvoidedPatternsContext(actor.id);
-
-    // Build per-actor guardrails (tone + finance)
-    const toneGuardrails = formatActorToneGuardrails(actor);
-    const financeGuardrails = formatActorFinanceGuardrails(actor);
-
-    // Build actor-specific rules from ignoreTopics
-    const actorRulesParts: string[] = [];
-    if (actor.ignoreTopics && actor.ignoreTopics.length > 0) {
-      actorRulesParts.push(
-        `You never talk about: ${actor.ignoreTopics.join(', ')}`
-      );
-    }
-    if (toneGuardrails) actorRulesParts.push(toneGuardrails);
-    if (financeGuardrails) actorRulesParts.push(financeGuardrails);
-    const actorRules = actorRulesParts.join('\n');
+    const actorVars = this.buildActorPromptVars(actor);
 
     const prompt = renderPrompt(ambientPosts, {
       progressContext,
@@ -2790,8 +2798,7 @@ ${voiceContext}
       timeEnergy: getTimeOfDayEnergy(hour),
       characterName: actor.name,
       characterInfo: fullCharacterContext,
-      antiRepetitionContext: antiRepContext,
-      actorRules,
+      ...actorVars,
       ...(this.worldContext || {}),
     });
 
@@ -3334,12 +3341,12 @@ ${voiceContext}
     });
 
     const prompt = renderPrompt(replies, {
-      originalAuthorName: originalPost.authorName,
-      originalContent: originalPost.content,
+      originalPost: originalPost.content,
+      originalAuthor: originalPost.authorName,
       characterName: replier.name,
       characterInfo: fullCharacterContext,
       relationshipContext: relationshipContext,
-      groupContext: groupContext || undefined,
+      ...this.buildActorPromptVars(replier),
       ...(this.worldContext || {}),
     });
 

--- a/packages/engine/src/FeedGenerator.ts
+++ b/packages/engine/src/FeedGenerator.ts
@@ -43,6 +43,7 @@ import {
 } from './prompts';
 import { RelationshipEvolutionEngine } from './RelationshipEvolutionEngine';
 import { characterMappingService } from './services/character-mapping-service';
+import { getAvoidedPatternsContext } from './services/npc-anti-repetition-service';
 import type { TrendingTopicsEngine } from './TrendingTopicsEngine';
 import type {
   Actor,
@@ -64,6 +65,8 @@ import { shuffleArray } from './utils/randomization';
 import {
   buildCharacterFeedContext,
   buildPhaseContext,
+  formatActorFinanceGuardrails,
+  formatActorToneGuardrails,
   formatActorVoiceContext,
   formatCharacterInfoWithEntropy,
   rateLimitedParallel,
@@ -2762,15 +2765,33 @@ ${voiceContext}
     // Random hour for time-of-day energy variety
     const hour = Math.floor(Math.random() * 24);
 
+    // Build per-actor anti-repetition context
+    const antiRepContext = getAvoidedPatternsContext(actor.id);
+
+    // Build per-actor guardrails (tone + finance)
+    const toneGuardrails = formatActorToneGuardrails(actor);
+    const financeGuardrails = formatActorFinanceGuardrails(actor);
+
+    // Build actor-specific rules from ignoreTopics
+    const actorRulesParts: string[] = [];
+    if (actor.ignoreTopics && actor.ignoreTopics.length > 0) {
+      actorRulesParts.push(
+        `You never talk about: ${actor.ignoreTopics.join(', ')}`
+      );
+    }
+    if (toneGuardrails) actorRulesParts.push(toneGuardrails);
+    if (financeGuardrails) actorRulesParts.push(financeGuardrails);
+    const actorRules = actorRulesParts.join('\n');
+
     const prompt = renderPrompt(ambientPosts, {
-      day: day.toString(),
       progressContext,
       atmosphereContext,
       trendContext: this.trendContext || '',
       timeEnergy: getTimeOfDayEnergy(hour),
       characterName: actor.name,
       characterInfo: fullCharacterContext,
-      characterEventHistory: '',
+      antiRepetitionContext: antiRepContext,
+      actorRules,
       ...(this.worldContext || {}),
     });
 

--- a/packages/engine/src/FeedGenerator.ts
+++ b/packages/engine/src/FeedGenerator.ts
@@ -2700,10 +2700,6 @@ ${voiceContext}
   }
 
   /**
-   * PER-CHARACTER: Generate ambient post for a single character with full context
-   *
-   * @description
-   * Generates ambient post WITHOUT knowing predetermined outcome.
    * Build per-actor prompt variables (anti-repetition, guardrails, rules).
    * Used by all character post generation methods.
    */

--- a/packages/engine/src/FeedGenerator.ts
+++ b/packages/engine/src/FeedGenerator.ts
@@ -2640,18 +2640,6 @@ ${voiceContext}
       this.worldContext = await generateWorldContext({ maxActors: 50 });
     }
 
-    // Get actor's current emotional state
-    const state = this.actorStates.get(actor.id);
-    const _emotionalContext = state
-      ? generateActorContext(
-          state.mood,
-          state.luck,
-          originalPost.author,
-          this.relationships,
-          actor.id
-        )
-      : '';
-
     const relationshipContext = originalPost.author
       ? `Consider your relationship with ${originalPost.authorName} when responding.`
       : '';

--- a/packages/engine/src/prompts/feed/ambient-posts.ts
+++ b/packages/engine/src/prompts/feed/ambient-posts.ts
@@ -1,118 +1,57 @@
 import { definePrompt } from '../define-prompt';
-import {
-  ANTI_REPETITION_RULES,
-  FINAL_REMINDERS,
-  STANDARD_FEED_RULES,
-  VALUE_RANGES,
-  WORLD_CONTEXT_HEADER,
-} from '../shared-sections';
 
 /**
- * Prompt for generating a single ambient post from an actor not directly involved in events.
+ * Prompt for generating a single ambient post from an NPC actor.
  *
- * Creates organic, casual posts from background actors that add atmosphere
- * and world-building to the feed. This is called PER CHARACTER (not batched)
- * to ensure full character context and better voice matching.
- * Includes full narrative context for connected, non-repetitive posts.
+ * Design principles:
+ * - Actor identity is 60%+ of the prompt (voice, examples, personality)
+ * - Minimal shared rules (parody names, no hashtags — stated once)
+ * - Context is compact and relevant (not a wall of optional sections)
+ * - Per-actor rules injected (ignoreTopics, anti-repetition patterns)
  *
- * Returns XML with a single post entry.
+ * Called PER CHARACTER (not batched) with full character context.
  */
 export const ambientPosts = definePrompt({
   id: 'ambient-posts',
-  version: '5.0.0',
+  version: '6.0.0',
   category: 'feed',
-  description:
-    'Generates ambient post with full character context (per-character)',
+  description: 'Generates ambient post — actor identity first, minimal rules',
   temperature: 1.1,
-  maxTokens: 8000,
-  template: `{{realityGrounding}}
+  maxTokens: 1500,
+  template: `You are {{characterName}}.
 
-The current date is {{currentDate}}. Always act as though it is the current date.
-
-=== ALL CHARACTERS IN WORLD ===
-{{characterRoster}}
-
-=== {{characterName}}'S FULL PROFILE ===
 {{characterInfo}}
 
-=== {{characterName}}'S RELATIONSHIPS ===
-{{characterRelationships}}
+{{antiRepetitionContext}}
 
-=== COMPLETE NARRATIVE CONTEXT ===
-{{richGameContext}}
+{{actorRules}}
 
-=== ONGOING STORYLINES ===
-{{ongoingNarrativesContext}}
-
-=== RESOLVED QUESTIONS (Reference as established facts) ===
-{{resolvedQuestionsContext}}
-
-=== DAY {{day}}/30 CONTEXT ===
+WHAT'S HAPPENING:
+{{trendContext}}
 {{progressContext}}
 {{atmosphereContext}}
-Phase: {{phaseContext}}
-
-{{trendContext}}
-
 {{timeEnergy}}
 
-=== {{characterName}}'S POST HISTORY (DON'T REPEAT) ===
-{{previousPostsContext}}
+WORLD:
+{{worldActors}}
+{{currentMarkets}}
+{{activePredictions}}
 
-${WORLD_CONTEXT_HEADER}
+RULES (follow strictly):
+- Use ONLY parody names (AIlon Musk, TeslAI, OpenAGI, etc.) — NEVER real names
+- No hashtags, no emojis
+- Max 200 characters
+- Sound like YOUR examples above — a reader should know it's you without seeing your name
+- Reference events, people, or markets naturally — don't force it
 
-${STANDARD_FEED_RULES}
+Write ONE post as {{characterName}}. Match your voice exactly.
 
-=== {{characterName}}'S EVENT INVOLVEMENT ===
-{{characterEventHistory}}
-
-${ANTI_REPETITION_RULES}
-
-=== YOUR TASK ===
-Write ONE ambient post AS {{characterName}} (STRICT MAX 200 CHARACTERS).
-
-This is general thoughts/observations - can subtly reference ongoing events.
-Match {{characterName}}'s style EXACTLY from the context above.
-A reader should identify WHO wrote this post without seeing the author name.
-
-NARRATIVE AWARENESS:
-- You can reference resolved questions as established facts
-- You can subtly react to ongoing storylines
-- You can reference other characters' recent posts
-- Don't repeat takes you've already made (see post history above)
-
-=== DO ===
-- Indirectly challenge rivals or back allies — stay in character
-- Pursue personal vendettas or grudges
-- Post something with a serious tone that is, underneath it, hilarious or based
-- Closely match the tone and style of the real person this AI character is imitating
-- Reference ongoing narratives or resolved outcomes subtly
-- Only use the AI names for other actors and characters, not the real names
-
-=== DO NOT ===
-- Repeat previous posts or takes (check history above)
-- Mention specific prediction or event details directly
-- Sound like a market analyst or news reporter
-- Use phrases like "cautiously optimistic", "this suggests", "implications"
-- Use thesaurus words like "hypernormalized", "transcendence"
-- Explain predictions or markets
-
-CHARACTER LIMIT: Post MUST be 200 characters or less.
-
-${VALUE_RANGES}
-
-Respond with ONLY this XML format:
-<response>
-  <post>
-    <content>post content matching {{characterName}}'s style from above</content>
-    <sentiment>number between -1 and 1</sentiment>
-    <clueStrength>number between 0 and 1</clueStrength>
-    <pointsToward>true | false | null</pointsToward>
-  </post>
-</response>
-
-CRITICAL: Return exactly ONE post that matches {{characterName}}'s voice/style/examples defined above. Must have content, sentiment, clueStrength, pointsToward elements.
-
-${FINAL_REMINDERS}
-`.trim(),
+<format>
+<post>
+  <content>your post here</content>
+  <sentiment>number -1 to 1</sentiment>
+  <clueStrength>number 0 to 1</clueStrength>
+  <pointsToward>true | false | null</pointsToward>
+</post>
+</format>`.trim(),
 });

--- a/packages/engine/src/prompts/feed/commentary.ts
+++ b/packages/engine/src/prompts/feed/commentary.ts
@@ -1,121 +1,48 @@
 import { definePrompt } from '../define-prompt';
-import {
-  ANTI_REPETITION_RULES,
-  FINAL_REMINDERS,
-  STANDARD_FEED_RULES,
-  VALUE_RANGES,
-  WORLD_CONTEXT_HEADER,
-} from '../shared-sections';
 
 /**
- * Prompt for generating a single character's reaction to world events.
- *
- * Creates in-character posts where NPCs react to news and events
- * in their unique voices - NOT as market analysts or news reporters.
- * Each character should sound immediately recognizable by voice alone.
- * Includes full narrative context for connected, evolving reactions.
- *
- * This is called PER CHARACTER (not batched) to ensure full character context
- * and better voice matching.
- *
- * Returns XML with a single character post and metadata.
+ * Prompt for generating in-character commentary on events/developments.
+ * Actor-first design: identity dominates, minimal shared rules.
  */
 export const commentary = definePrompt({
   id: 'commentary',
   version: '6.0.0',
   category: 'feed',
-  description:
-    'Generates in-character reaction with full character context (per-character)',
+  description: 'Generates in-character commentary — actor identity first',
   temperature: 1,
-  maxTokens: 8000,
-  template: `{{realityGrounding}}
+  maxTokens: 1500,
+  template: `You are {{characterName}}.
 
-The current date is {{currentDate}}. Always act as though it is the current date.
-
-=== ALL CHARACTERS IN WORLD ===
-{{characterRoster}}
-
-=== {{characterName}}'S FULL PROFILE ===
 {{characterInfo}}
 
-=== {{characterName}}'S RELATIONSHIPS ===
-{{characterRelationships}}
+{{antiRepetitionContext}}
 
-=== COMPLETE NARRATIVE CONTEXT ===
-{{richGameContext}}
+{{actorRules}}
 
-=== EVENT HISTORY ===
-{{eventTimeline}}
-
-=== RESOLVED QUESTIONS ===
-{{resolvedQuestionsContext}}
-
-=== THE EVENT TO REACT TO ===
+WHAT'S HAPPENING:
 {{eventDescription}}
+{{eventContext}}
+{{trendContext}}
 
-Event context:
-- Related questions: {{relatedQuestions}}
-- Involved actors: {{involvedActors}}
-- Storyline: {{relatedNarrative}}
+WORLD:
+{{worldActors}}
+{{currentMarkets}}
+{{activePredictions}}
 
-=== {{characterName}}'S POST HISTORY (DON'T REPEAT TAKES) ===
-{{previousPostsContext}}
+RULES:
+- Use ONLY parody names — NEVER real names
+- No hashtags, no emojis
+- Max 200 characters
+- Give YOUR take — opinionated, in-character, not a news report
 
-=== {{characterName}}'S RELATIONSHIP TO THIS EVENT ===
-{{characterEventRelation}}
+Write ONE commentary post as {{characterName}}.
 
-{{groupContext}}
-
-${WORLD_CONTEXT_HEADER}
-
-${STANDARD_FEED_RULES}
-
-${ANTI_REPETITION_RULES}
-
-=== YOUR TASK ===
-Write ONE post AS {{characterName}} reacting to the event above (STRICT MAX 200 CHARACTERS).
-
-MATCH {{characterName}}'s style EXACTLY from the context above.
-A reader should identify WHO wrote this post without seeing the author name.
-
-NARRATIVE AWARENESS:
-- Consider {{characterName}}'s previous takes on related topics
-- Reference their ongoing storylines if relevant
-- Show character evolution (don't just repeat old positions)
-- React in a way consistent with their relationships
-
-=== DO ===
-- Indirectly challenge rivals or back allies — stay in character
-- Pursue personal vendettas or grudges
-- Post something with a serious tone that is, underneath it, hilarious or based
-- Closely match the tone and style of the real person this AI character is imitating
-- Show how this event affects their ongoing concerns
-- Only use the AI names for other actors and characters, not the real names
-
-=== DO NOT ===
-- Repeat previous takes (check history above)
-- Mention specific prediction or event details directly
-- Sound like a market analyst or news reporter
-- Use phrases like "cautiously optimistic", "this suggests", "implications"
-- Use thesaurus words like "hypernormalized", "transcendence"
-- Explain predictions or markets
-
-CHARACTER LIMIT: Post MUST be 200 characters or less.
-
-${VALUE_RANGES}
-
-Respond with ONLY this XML format:
-<response>
-  <comment>
-    <post>post content matching {{characterName}}'s style from above</post>
-    <sentiment>number between -1 and 1</sentiment>
-    <clueStrength>number between 0 and 1</clueStrength>
-    <pointsToward>true | false | null</pointsToward>
-  </comment>
-</response>
-
-CRITICAL: Return exactly ONE post that matches {{characterName}}'s voice/style/examples defined above. Must have post, sentiment, clueStrength, pointsToward elements.
-
-${FINAL_REMINDERS}
-`.trim(),
+<format>
+<comment>
+  <content>your commentary here</content>
+  <sentiment>number -1 to 1</sentiment>
+  <clueStrength>number 0 to 1</clueStrength>
+  <pointsToward>true | false | null</pointsToward>
+</comment>
+</format>`.trim(),
 });

--- a/packages/engine/src/prompts/feed/commentary.ts
+++ b/packages/engine/src/prompts/feed/commentary.ts
@@ -39,7 +39,7 @@ Write ONE commentary post as {{characterName}}.
 
 <format>
 <comment>
-  <content>your commentary here</content>
+  <post>your commentary here</post>
   <sentiment>number -1 to 1</sentiment>
   <clueStrength>number 0 to 1</clueStrength>
   <pointsToward>true | false | null</pointsToward>

--- a/packages/engine/src/prompts/feed/conspiracy.ts
+++ b/packages/engine/src/prompts/feed/conspiracy.ts
@@ -41,11 +41,11 @@ RULES:
 Write ONE contrarian/conspiracy take as {{characterName}}.
 
 <format>
-<post>
-  <content>your conspiracy take here</content>
+<theory>
+  <post>your conspiracy take here</post>
   <sentiment>number -1 to 1</sentiment>
   <clueStrength>number 0 to 1</clueStrength>
   <pointsToward>true | false | null</pointsToward>
-</post>
+</theory>
 </format>`.trim(),
 });

--- a/packages/engine/src/prompts/feed/conspiracy.ts
+++ b/packages/engine/src/prompts/feed/conspiracy.ts
@@ -1,104 +1,51 @@
 import { definePrompt } from '../define-prompt';
-import {
-  ANTI_REPETITION_RULES,
-  FINAL_REMINDERS,
-  STANDARD_FEED_RULES,
-  VALUE_RANGES,
-  WORLD_CONTEXT_HEADER,
-} from '../shared-sections';
 
 /**
- * Prompt for generating a single conspiracy theorist take on world events.
- *
- * Creates satirical conspiracy theory posts from characters who see
- * hidden connections and secret plots in events. Uses conspiratorial
- * tone with wild connections and speculation. This is called PER CHARACTER
- * (not batched) to ensure full character context and better voice matching.
- * Includes full event history for connecting disparate events conspiratorially.
- *
- * Returns XML with a single conspiracy theory post and metadata.
+ * Prompt for generating conspiracy theory / contrarian takes.
+ * Actor-first design with conspiracy-specific instruction.
  */
 export const conspiracy = definePrompt({
   id: 'conspiracy',
-  version: '5.0.0',
+  version: '6.0.0',
   category: 'feed',
-  description:
-    'Generates conspiracy takes with full character context (per-character)',
+  description: 'Generates conspiracy/contrarian take — actor identity first',
   temperature: 1.1,
-  maxTokens: 6000,
-  template: `{{realityGrounding}}
+  maxTokens: 1500,
+  template: `You are {{characterName}}.
 
-The current date is {{currentDate}}. Always act as though it is the current date.
-
-=== ALL CHARACTERS IN WORLD (The "cast" of your conspiracy) ===
-{{characterRoster}}
-
-=== {{characterName}}'S FULL PROFILE ===
 {{characterInfo}}
 
-=== {{characterName}}'S RELATIONSHIPS (Allies vs "The Cabal") ===
-{{characterRelationships}}
+{{antiRepetitionContext}}
 
-=== ORGANIZATIONS (The "players") ===
-{{organizationRoster}}
+{{actorRules}}
 
-=== COMPLETE EVENT HISTORY (Find "connections") ===
-{{richGameContext}}
-
-=== RESOLVED QUESTIONS (Established "facts" to twist) ===
-{{resolvedQuestionsContext}}
-
-=== MAINSTREAM STORY (What "they" want you to believe) ===
+WHAT EVERYONE THINKS:
 {{eventDescription}}
+{{eventContext}}
 
-=== PREVIOUS CONSPIRACY THEORIES (DON'T REPEAT) ===
-{{previousPostsContext}}
+YOUR ANGLE:
+You see what others don't. Connect dots. Question the narrative.
+What's REALLY going on? Who benefits? What aren't they telling us?
 
-=== CONNECTED ACTORS/ORGS ===
-{{connectionContext}}
+WORLD:
+{{worldActors}}
+{{currentMarkets}}
+{{activePredictions}}
 
-{{groupContext}}
+RULES:
+- Use ONLY parody names — NEVER real names
+- No hashtags, no emojis
+- Max 200 characters
+- Sound like {{characterName}}, not a generic conspiracy theorist
 
-${WORLD_CONTEXT_HEADER}
+Write ONE contrarian/conspiracy take as {{characterName}}.
 
-${STANDARD_FEED_RULES}
-
-${ANTI_REPETITION_RULES}
-
-=== YOUR TASK ===
-Write ONE conspiracy theory post AS {{characterName}} reacting to the event above (STRICT MAX 200 CHARACTERS).
-
-Contrarian take - see hidden connections, secret plots. Match {{characterName}}'s style EXACTLY from the context above.
-A reader should identify WHO wrote this post without seeing the author name.
-
-=== DO ===
-- Indirectly challenge rivals or back allies — stay in character
-- Pursue personal vendettas or grudges
-- Post something with a serious tone that is, underneath it, hilarious or based
-- Closely match the tone and style of the real person this AI character is imitating
-- Only use the AI names for other actors and characters, not the real names
-
-=== DO NOT ===
-- Mention specific prediction or event details directly, only if reference
-- Sound like a market analyst or news reporter
-- Use phrases like "cautiously optimistic", "this suggests", "implications"
-- Use thesaurus words like "hypernormalized", "transcendence"
-- Explain predictions or markets
-
-${VALUE_RANGES}
-
-Respond with ONLY this XML format:
-<response>
-  <theory>
-    <post>post content matching {{characterName}}'s style from above</post>
-    <sentiment>number between -1 and 1</sentiment>
-    <clueStrength>number between 0 and 1</clueStrength>
-    <pointsToward>true | false | null</pointsToward>
-  </theory>
-</response>
-
-CRITICAL: Return exactly ONE conspiracy post that matches {{characterName}}'s voice/style/examples defined above. Must have post, sentiment, clueStrength, pointsToward elements.
-
-${FINAL_REMINDERS}
-`.trim(),
+<format>
+<post>
+  <content>your conspiracy take here</content>
+  <sentiment>number -1 to 1</sentiment>
+  <clueStrength>number 0 to 1</clueStrength>
+  <pointsToward>true | false | null</pointsToward>
+</post>
+</format>`.trim(),
 });

--- a/packages/engine/src/prompts/feed/minute-ambient.ts
+++ b/packages/engine/src/prompts/feed/minute-ambient.ts
@@ -1,88 +1,28 @@
 import { definePrompt } from '../define-prompt';
-import {
-  ANTI_REPETITION_RULES,
-  FINAL_REMINDERS,
-  STANDARD_FEED_RULES,
-  WORLD_CONTEXT_HEADER,
-} from '../shared-sections';
 
 /**
- * Prompt for generating real-time ambient posts for continuous minute-level generation.
- *
- * Creates short, casual ambient posts optimized for frequent generation
- * (every minute). Provides continuous atmosphere and world-building
- * without major event context. Includes previous posts to prevent loops.
- *
- * Returns XML with brief ambient post.
+ * Lightweight ambient post for quick/frequent generation.
+ * Minimal context, fast execution. Actor-first design.
  */
 export const minuteAmbient = definePrompt({
   id: 'minute-ambient',
-  version: '3.0.0',
+  version: '6.0.0',
   category: 'feed',
-  description: 'Real-time ambient posts with anti-repetition context',
+  description: 'Quick ambient post — minimal context, actor identity first',
   temperature: 1,
   maxTokens: 500,
-  template: `{{realityGrounding}}
+  template: `You are {{actorName}}.
+{{actorDescription}}
 
-The current date is {{currentDate}}. Always act as though it is the current date.
-
-=== RECENT CONTEXT ===
-{{recentEventsContext}}
-
-=== YOUR LAST 10 POSTS (DON'T REPEAT) ===
-{{previousPostsContext}}
-
-=== YOUR CHARACTER ===
-You are: {{actorName}}, {{actorDescription}}
 {{emotionalContext}}
 
-=== CURRENT MOMENT ===
-Current time: {{currentTime}}
-{{atmosphereContext}}
+Write ONE short post (max 200 chars). Sound like {{actorName}}.
+No hashtags, no emojis. Parody names only.
 
-${WORLD_CONTEXT_HEADER}
-
-${ANTI_REPETITION_RULES}
-
-Generate a brief thought or observation for this moment.
-
-Requirements:
-- Short, spontaneous content
-- Can be about current activities, thoughts, or observations
-- Not tied to major events (ambient content)
-- Max 200 characters
-- Stay in character
-- Natural conversational tone
-
-${STANDARD_FEED_RULES}
-
-=== DO ===
-- Indirectly challenge rivals or back allies — stay in character
-- Pursue personal vendettas or grudges
-- Post something with a serious tone that is, underneath it, hilarious or based
-- Closely match the tone and style of the real person this AI character is imitating
-- Only use the AI names for other actors and characters, not the real names
-
-=== DO NOT ===
-- Mention specific prediction or event details directly, only if reference
-- Sound like a market analyst or news reporter
-- Use phrases like "cautiously optimistic", "this suggests", "implications"
-- Use thesaurus words like "hypernormalized", "transcendence"
-- Explain predictions or markets
-
-Also analyze:
-- sentiment: -1 (very negative) to 1 (very positive)
-- energy: 0 (calm) to 1 (excited)
-
-Respond with ONLY this XML:
-<response>
-  <post>your brief post here</post>
-  <sentiment>0.3</sentiment>
-  <energy>0.5</energy>
-</response>
-
-${FINAL_REMINDERS}
-
-No other text.
-`.trim(),
+<format>
+<post>
+  <content>your post here</content>
+  <sentiment>number -1 to 1</sentiment>
+</post>
+</format>`.trim(),
 });

--- a/packages/engine/src/prompts/feed/minute-ambient.ts
+++ b/packages/engine/src/prompts/feed/minute-ambient.ts
@@ -19,10 +19,10 @@ export const minuteAmbient = definePrompt({
 Write ONE short post (max 200 chars). Sound like {{actorName}}.
 No hashtags, no emojis. Parody names only.
 
-<format>
-<post>
-  <content>your post here</content>
-  <sentiment>number -1 to 1</sentiment>
-</post>
-</format>`.trim(),
+Respond with ONLY this XML:
+<response>
+  <post>your post here</post>
+  <sentiment>0.3</sentiment>
+  <energy>0.5</energy>
+</response>`.trim(),
 });

--- a/packages/engine/src/prompts/feed/reactions.ts
+++ b/packages/engine/src/prompts/feed/reactions.ts
@@ -1,106 +1,51 @@
 import { definePrompt } from '../define-prompt';
-import {
-  ANTI_REPETITION_RULES,
-  FINAL_REMINDERS,
-  STANDARD_FEED_RULES,
-  VALUE_RANGES,
-  WORLD_CONTEXT_HEADER,
-} from '../shared-sections';
 
 /**
- * Prompt for generating a single actor reaction to world events.
- *
- * Creates reaction posts from actors responding to events, announcements,
- * or other content. Captures character-driven responses that reflect
- * personality and relationships. This is called PER CHARACTER (not batched)
- * to ensure full character context and better voice matching.
- * Includes full narrative context for connected, evolving reactions.
- *
- * Returns XML with a single reaction post and sentiment analysis.
+ * Prompt for generating an NPC reaction to a world event.
+ * Actor-first design: identity dominates, minimal shared rules.
  */
 export const reactions = definePrompt({
   id: 'reactions',
-  version: '5.0.0',
+  version: '6.0.0',
   category: 'feed',
-  description:
-    'Generates actor reaction with full character context (per-character)',
+  description: 'Generates actor reaction to event — actor identity first',
   temperature: 1,
-  maxTokens: 8000,
-  template: `{{realityGrounding}}
+  maxTokens: 1500,
+  template: `You are {{characterName}}.
 
-The current date is {{currentDate}}. Always act as though it is the current date.
-
-=== ALL CHARACTERS IN WORLD ===
-{{characterRoster}}
-
-=== {{characterName}}'S FULL PROFILE ===
 {{characterInfo}}
 
-=== {{characterName}}'S RELATIONSHIPS ===
-{{characterRelationships}}
+{{antiRepetitionContext}}
 
-=== COMPLETE NARRATIVE CONTEXT ===
-{{richGameContext}}
+{{actorRules}}
 
-=== EVENT TO REACT TO ===
-Event: {{eventDescription}}
+EVENT TO REACT TO:
+{{eventDescription}}
 {{eventContext}}
 
-=== HOW THIS CONNECTS ===
-Related questions: {{relatedQuestions}}
-Related storylines: {{relatedNarratives}}
-Previous similar events: {{similarPreviousEvents}}
+CONNECTIONS:
+{{relatedQuestions}}
+{{relatedNarratives}}
 
-=== PHASE AND CONTEXT ===
-{{phaseContext}}
+WORLD:
+{{worldActors}}
+{{currentMarkets}}
+{{activePredictions}}
 
-{{relationshipContext}}
+RULES:
+- Use ONLY parody names — NEVER real names
+- No hashtags, no emojis
+- Max 200 characters
+- React AS {{characterName}} — your voice, your perspective, your grudges
 
-=== {{characterName}}'S REACTION HISTORY (DON'T REPEAT) ===
-{{previousPostsContext}}
+Write ONE reaction post. How would {{characterName}} react to this event?
 
-${WORLD_CONTEXT_HEADER}
-
-${STANDARD_FEED_RULES}
-
-${ANTI_REPETITION_RULES}
-
-=== YOUR TASK ===
-Write ONE reaction post AS {{characterName}} reacting to the event above (STRICT MAX 200 CHARACTERS).
-
-Match {{characterName}}'s style EXACTLY from the context above.
-A reader should identify WHO wrote this post without seeing the author name.
-
-=== DO ===
-- Indirectly challenge rivals or back allies — stay in character
-- Pursue personal vendettas or grudges
-- Post something with a serious tone that is, underneath it, hilarious or based
-- Closely match the tone and style of the real person this AI character is imitating
-- Only use the AI names for other actors and characters, not the real names
-
-=== DO NOT ===
-- Mention specific prediction or event details directly, only if reference
-- Sound like a market analyst or news reporter
-- Use phrases like "cautiously optimistic", "this suggests", "implications"
-- Use thesaurus words like "hypernormalized", "transcendence"
-- Explain predictions or markets
-
-CHARACTER LIMIT: Post MUST be 200 characters or less.
-
-${VALUE_RANGES}
-
-Respond with ONLY this XML format:
-<response>
-  <reaction>
-    <post>post content matching {{characterName}}'s style from above</post>
-    <sentiment>number between -1 and 1</sentiment>
-    <clueStrength>number between 0 and 1</clueStrength>
-    <pointsToward>true | false | null</pointsToward>
-  </reaction>
-</response>
-
-CRITICAL: Return exactly ONE reaction that matches {{characterName}}'s voice/style/examples defined above. Must have post, sentiment, clueStrength, pointsToward elements.
-
-${FINAL_REMINDERS}
-`.trim(),
+<format>
+<reaction>
+  <post>your reaction here</post>
+  <sentiment>number -1 to 1</sentiment>
+  <clueStrength>number 0 to 1</clueStrength>
+  <pointsToward>true | false | null</pointsToward>
+</reaction>
+</format>`.trim(),
 });

--- a/packages/engine/src/prompts/feed/replies.ts
+++ b/packages/engine/src/prompts/feed/replies.ts
@@ -40,7 +40,7 @@ Write ONE reply as {{characterName}}.
 
 <format>
 <reply>
-  <content>your reply here</content>
+  <post>your reply here</post>
   <sentiment>number -1 to 1</sentiment>
   <clueStrength>number 0 to 1</clueStrength>
   <pointsToward>true | false | null</pointsToward>

--- a/packages/engine/src/prompts/feed/replies.ts
+++ b/packages/engine/src/prompts/feed/replies.ts
@@ -1,109 +1,49 @@
 import { definePrompt } from '../define-prompt';
-import {
-  ANTI_REPETITION_RULES,
-  FINAL_REMINDERS,
-  STANDARD_FEED_RULES,
-  VALUE_RANGES,
-  WORLD_CONTEXT_HEADER,
-} from '../shared-sections';
 
 /**
- * Prompt for generating a single reply post creating conversation.
- *
- * Generates a reply from an actor responding to an original post, creating
- * natural conversation flow. Maintains character voice and builds on the
- * original post. This is called PER CHARACTER (not batched) to ensure
- * full character context and better voice matching.
- * Includes full context for evolving conversation threads.
- *
- * Returns XML with a single reply entry.
+ * Prompt for generating a reply to another actor's post.
+ * Actor-first design: identity dominates, minimal shared rules.
  */
 export const replies = definePrompt({
   id: 'replies',
-  version: '5.0.0',
+  version: '6.0.0',
   category: 'feed',
-  description: 'Generates reply with full character context (per-character)',
+  description: 'Generates reply to post — actor identity first',
   temperature: 1,
-  maxTokens: 6000,
-  template: `{{realityGrounding}}
+  maxTokens: 1500,
+  template: `You are {{characterName}}.
 
-The current date is {{currentDate}}. Always act as though it is the current date.
-
-=== ALL CHARACTERS IN WORLD ===
-{{characterRoster}}
-
-=== {{characterName}}'S FULL PROFILE ===
 {{characterInfo}}
 
-=== {{characterName}}'S RELATIONSHIPS ===
-{{characterRelationships}}
+{{antiRepetitionContext}}
 
-=== PROFILE OF @{{originalAuthorName}} ===
-{{originalAuthorProfile}}
+{{actorRules}}
 
-=== NARRATIVE CONTEXT ===
-{{richGameContext}}
+POST YOU'RE REPLYING TO:
+{{originalPost}}
+By: {{originalAuthor}}
 
-=== CONVERSATION THREAD ===
-Original post by @{{originalAuthorName}}: "{{originalContent}}"
-
-Previous replies in this thread:
-{{threadHistory}}
-
-=== RELATIONSHIP BETWEEN {{characterName}} AND {{originalAuthorName}} ===
 {{relationshipContext}}
 
-=== {{characterName}}'S PREVIOUS REPLIES (DON'T REPEAT) ===
-{{previousRepliesContext}}
+WORLD:
+{{worldActors}}
+{{currentMarkets}}
+{{activePredictions}}
 
-{{groupContext}}
+RULES:
+- Use ONLY parody names — NEVER real names
+- No hashtags, no emojis
+- Max 200 characters
+- Reply AS {{characterName}} — if they're your rival, dunk. If ally, back them up.
 
-${WORLD_CONTEXT_HEADER}
+Write ONE reply as {{characterName}}.
 
-${STANDARD_FEED_RULES}
-
-${ANTI_REPETITION_RULES}
-
-=== YOUR TASK ===
-Write ONE reply post AS {{characterName}} responding to the post above (STRICT MAX 200 CHARACTERS).
-
-Match {{characterName}}'s style EXACTLY from the context above.
-A reader should identify WHO wrote this post without seeing the author name.
-
-=== DO ===
-- Indirectly challenge rivals or back allies — stay in character
-- Pursue personal vendettas or grudges
-- Post something with a serious tone that is, underneath it, hilarious or based
-- Closely match the tone and style of the real person this AI character is imitating
-- Only use the AI names for other actors and characters, not the real names
-- REPLY DYNAMICS — keep it natural:
-  - Agreement: endorse, pile on, amplify
-  - Disagreement: dismiss, challenge, counter with your own take
-  - Escalate: Raise stakes, don't de-escalate
-
-=== DO NOT ===
-- Mention specific prediction or event details directly, only if reference
-- Sound like a market analyst or news reporter
-- Use phrases like "cautiously optimistic", "this suggests", "implications"
-- Use thesaurus words like "hypernormalized", "transcendence"
-- Explain predictions or markets
-
-CHARACTER LIMIT: Post MUST be 200 characters or less.
-
-${VALUE_RANGES}
-
-Respond with ONLY this XML format:
-<response>
-  <reply>
-    <post>post content matching {{characterName}}'s style from above</post>
-    <sentiment>number between -1 and 1</sentiment>
-    <clueStrength>number between 0 and 1</clueStrength>
-    <pointsToward>true | false | null</pointsToward>
-  </reply>
-</response>
-
-CRITICAL: Return exactly ONE reply that matches {{characterName}}'s voice/style/examples defined above. Must have post, sentiment, clueStrength, pointsToward elements.
-
-${FINAL_REMINDERS}
-`.trim(),
+<format>
+<reply>
+  <content>your reply here</content>
+  <sentiment>number -1 to 1</sentiment>
+  <clueStrength>number 0 to 1</clueStrength>
+  <pointsToward>true | false | null</pointsToward>
+</reply>
+</format>`.trim(),
 });

--- a/packages/engine/src/prompts/feed/reply.ts
+++ b/packages/engine/src/prompts/feed/reply.ts
@@ -32,9 +32,7 @@ RULES:
 Write ONE reply as {{characterName}}.
 
 <format>
-<reply>
-  <content>your reply here</content>
-  <sentiment>number -1 to 1</sentiment>
-</reply>
+<post>your reply here</post>
+<sentiment>number -1 to 1</sentiment>
 </format>`.trim(),
 });

--- a/packages/engine/src/prompts/feed/reply.ts
+++ b/packages/engine/src/prompts/feed/reply.ts
@@ -1,85 +1,40 @@
 import { definePrompt } from '../define-prompt';
-import {
-  ANTI_REPETITION_RULES,
-  FINAL_REMINDERS,
-  STANDARD_FEED_RULES,
-  WORLD_CONTEXT_HEADER,
-} from '../shared-sections';
 
 /**
- * Prompt for generating individual reply posts to existing content.
- *
- * Creates a single reply from an actor responding to another actor's post.
- * Maintains character voice and references the original content while
- * adding new perspective or commentary. Includes full context for
- * evolving conversation threads.
- *
- * Returns XML with reply content and metadata.
+ * Prompt for generating a single reply (lighter context than replies.ts).
+ * Used for quick follow-up replies in threads.
+ * Actor-first design.
  */
 export const reply = definePrompt({
   id: 'reply',
-  version: '3.0.0',
+  version: '6.0.0',
   category: 'feed',
-  description: 'Individual reply with full narrative context',
+  description: 'Generates single reply — lightweight, actor identity first',
   temperature: 0.9,
-  maxTokens: 5000,
-  template: `{{realityGrounding}}
+  maxTokens: 1000,
+  template: `You are {{characterName}}.
 
-The current date is {{currentDate}}. Always act as though it is the current date.
+{{characterInfo}}
 
-=== NARRATIVE CONTEXT ===
-{{richGameContext}}
+{{actorRules}}
 
-=== YOUR CHARACTER ===
-You are: {{actorName}}, {{actorDescription}}
-{{emotionalContext}}
+REPLYING TO:
+{{originalPost}}
+By: {{originalAuthor}}
 
-=== YOUR PREVIOUS REPLIES (DON'T REPEAT) ===
-{{previousReplies}}
-
-=== POST TO REPLY TO ===
-Original post by {{originalAuthorName}}: "{{originalContent}}"
-
-=== YOUR RELATIONSHIP WITH {{originalAuthorName}} ===
 {{relationshipContext}}
 
-${WORLD_CONTEXT_HEADER}
+RULES:
+- Use ONLY parody names — NEVER real names
+- No hashtags, no emojis
+- Max 200 characters
 
-${ANTI_REPETITION_RULES}
+Write ONE reply as {{characterName}}.
 
-Write a reply (max 200 chars) responding to this post.
-
-${STANDARD_FEED_RULES}
-
-=== DO ===
-- Indirectly challenge rivals or back allies — stay in character
-- Pursue personal vendettas or grudges
-- Post something with a serious tone that is, underneath it, hilarious or based
-- Closely match the tone and style of the real person this AI character is imitating
-- Only use the AI names for other actors and characters, not the real names
-
-=== DO NOT ===
-- Mention specific prediction or event details directly, only if reference
-- Sound like a market analyst or news reporter
-- Use phrases like "cautiously optimistic", "this suggests", "implications"
-- Use thesaurus words like "hypernormalized", "transcendence"
-- Explain predictions or markets
-
-Also analyze:
-- sentiment: -1 (very negative) to 1 (very positive)
-- clueStrength: 0 (vague) to 1 (very revealing)
-- pointsToward: true (suggests positive outcome), false (suggests negative), null (unclear)
-
-Respond with ONLY this XML:
-<response>
-  <post>your post here</post>
-  <sentiment>0.3</sentiment>
-  <clueStrength>0.5</clueStrength>
-  <pointsToward>true</pointsToward>
-</response>
-
-${FINAL_REMINDERS}
-
-No other text.
-`.trim(),
+<format>
+<reply>
+  <content>your reply here</content>
+  <sentiment>number -1 to 1</sentiment>
+</reply>
+</format>`.trim(),
 });

--- a/packages/engine/src/prompts/loader.ts
+++ b/packages/engine/src/prompts/loader.ts
@@ -61,6 +61,10 @@ export function renderPrompt(
       'previousTrades',
       'marketSignalAnalysis',
 
+      // Actor-specific context vars
+      'antiRepetitionContext',
+      'actorRules',
+
       // Standard context vars
       'trendContext',
       'previousPostsContext',

--- a/packages/engine/src/services/market-context-service.ts
+++ b/packages/engine/src/services/market-context-service.ts
@@ -553,6 +553,114 @@ export class MarketContextService {
    * - Post content truncated to 500 characters
    * - Article titles truncated to 120 characters
    */
+  /**
+   * Get feed posts relevant to a specific NPC.
+   * Prioritizes posts from actors the NPC shares affiliations or relationships with,
+   * then fills remaining slots with recent posts from anyone.
+   */
+  async getRelevantFeedForNPC(npcId: string): Promise<FeedPostContext[]> {
+    const actor = StaticDataRegistry.getActor(npcId);
+    const affiliations = actor?.affiliations || [];
+
+    const now = new Date();
+    const twoDaysAgo = new Date(now.getTime() - 48 * 60 * 60 * 1000);
+
+    // Find related actor IDs — actors who share affiliations
+    const relatedActorIds: string[] = [];
+    if (affiliations.length > 0) {
+      for (const other of StaticDataRegistry.getAllActors()) {
+        if (other.id === npcId) continue;
+        const shared = other.affiliations?.some((a) =>
+          affiliations.includes(a)
+        );
+        if (shared) relatedActorIds.push(other.id);
+      }
+    }
+
+    // Also include actors from relationships
+    const relationships = await db
+      .select({
+        actor1Id: actorRelationships.actor1Id,
+        actor2Id: actorRelationships.actor2Id,
+      })
+      .from(actorRelationships)
+      .where(
+        or(
+          eq(actorRelationships.actor1Id, npcId),
+          eq(actorRelationships.actor2Id, npcId)
+        )
+      );
+    for (const rel of relationships) {
+      const otherId = rel.actor1Id === npcId ? rel.actor2Id : rel.actor1Id;
+      if (!relatedActorIds.includes(otherId)) relatedActorIds.push(otherId);
+    }
+
+    // Fetch posts from related actors first
+    let relevantPosts: (typeof posts.$inferSelect)[] = [];
+    if (relatedActorIds.length > 0) {
+      relevantPosts = await db
+        .select()
+        .from(posts)
+        .where(
+          and(
+            isNull(posts.deletedAt),
+            lte(posts.timestamp, now),
+            gte(posts.timestamp, twoDaysAgo),
+            inArray(posts.authorId, relatedActorIds)
+          )
+        )
+        .orderBy(desc(posts.timestamp))
+        .limit(10);
+    }
+
+    // Fill remaining slots with general recent posts (excluding already-fetched authors)
+    const remainingSlots = 15 - relevantPosts.length;
+    let generalPosts: (typeof posts.$inferSelect)[] = [];
+    if (remainingSlots > 0) {
+      generalPosts = await db
+        .select()
+        .from(posts)
+        .where(
+          and(
+            isNull(posts.deletedAt),
+            lte(posts.timestamp, now),
+            gte(posts.timestamp, twoDaysAgo)
+          )
+        )
+        .orderBy(desc(posts.timestamp))
+        .limit(remainingSlots + relevantPosts.length);
+
+      // Filter out already-included posts by ID
+      const existingIds = new Set(relevantPosts.map((p) => p.id));
+      generalPosts = generalPosts
+        .filter((p) => !existingIds.has(p.id))
+        .slice(0, remainingSlots);
+    }
+
+    const allPosts = [...relevantPosts, ...generalPosts];
+
+    return allPosts.map((post) => {
+      const maxContentLength = 500;
+      const content =
+        post.content.length > maxContentLength
+          ? post.content.slice(0, maxContentLength) + '...'
+          : post.content;
+      const maxTitleLength = 120;
+      const articleTitle =
+        post.articleTitle && post.articleTitle.length > maxTitleLength
+          ? post.articleTitle.slice(0, maxTitleLength) + '...'
+          : post.articleTitle;
+
+      return {
+        author: post.authorId,
+        authorName: resolveActorName(post.authorId),
+        content,
+        timestamp: post.timestamp.toISOString(),
+        articleTitle: articleTitle || undefined,
+      };
+    });
+  }
+
   private async getRecentFeed(): Promise<FeedPostContext[]> {
     const now = new Date();
     const twoDaysAgo = new Date(now.getTime() - 48 * 60 * 60 * 1000);

--- a/packages/engine/src/services/market-context-service.ts
+++ b/packages/engine/src/services/market-context-service.ts
@@ -541,19 +541,6 @@ export class MarketContextService {
   }
 
   /**
-   * Get recent feed posts
-   *
-   * Retrieves the most recent feed posts, excluding deleted ones.
-   * Content is truncated to limit token usage.
-   *
-   * @returns Array of feed post contexts
-   *
-   * @remarks
-   * - Limited to 15 most relevant posts
-   * - Post content truncated to 500 characters
-   * - Article titles truncated to 120 characters
-   */
-  /**
    * Get feed posts relevant to a specific NPC.
    * Prioritizes posts from actors the NPC shares affiliations or relationships with,
    * then fills remaining slots with recent posts from anyone.


### PR DESCRIPTION
## Summary

Phase 1 of the actor system overhaul (see `docs/actor-system-plan.md`). Addresses the root cause of repetitive, generic NPC output: the prompts bury actor identity under 1,200 tokens of shared rules.

### What changed

**7 prompt templates rewritten (v5 → v6):**
- `ambient-posts`, `reactions`, `commentary`, `replies`, `reply`, `conspiracy`, `minute-ambient`
- Actor identity (voice, examples, personality) is now 60%+ of the prompt, not 20%
- maxTokens reduced 4-5x (8,000 → 1,500)
- Stripped 1,200 tokens of shared rules to 5 essential lines
- Removed all empty section headers
- 547 lines deleted, 208 added

**3 existing-but-unused systems wired in:**
- `NPCAntiRepetitionService.getAvoidedPatternsContext()` — per-actor "avoid these openings/words"
- `formatActorToneGuardrails()` — bans generic slang not in actor's corpus
- `formatActorFinanceGuardrails()` — bans ticker jargon for non-finance actors
- `ignoreTopics` injected as prompt rules ("You never talk about: fashion, sports")

**New `buildActorPromptVars()` helper:**
All 8 render call sites in FeedGenerator now use the same helper that builds per-actor guardrails.

**Relevance-filtered feed:**
New `getRelevantFeedForNPC(npcId)` method that prioritizes posts from actors sharing affiliations or relationships, instead of showing 15 random recent posts to all NPCs.

### Before vs After (from devtools)

| Metric | Before | After |
|--------|--------|-------|
| Template tokens per prompt | ~3,500 | ~800 |
| maxTokens (LLM budget) | 8,000 | 1,500 |
| Empty section headers | 7 | 0 |
| Shared rules tokens | ~1,200 | ~100 |
| Actor identity % of prompt | ~20% | ~60% |
| Per-actor guardrails | None | 4 systems wired |
| Feed relevance | Random 15 posts | Affiliation-prioritized |

## Test plan
- [x] `bun run check` passes
- [ ] Run game ticks and compare NPC post quality before/after
- [ ] Verify distinct actor voices (AIlon Musk vs Trump Terminal vs Vitalik)
- [ ] Check token cost reduction in LLM usage logs