### PR TITLE
feat(web): add perp execution preview and quote refresh cleanup

### DIFF
--- a/apps/web/src/app/api/markets/perps/preview/route.test.ts
+++ b/apps/web/src/app/api/markets/perps/preview/route.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
+import type { NextRequest } from 'next/server';
+
+const mockPublicRateLimit = mock(async () => ({
+  error: null,
+  rateLimitInfo: null,
+}));
+const mockPreviewOpenPosition = mock();
+
+mock.module('@babylon/api', () => ({
+  addPublicReadHeaders: mock(() => undefined),
+  publicRateLimit: mockPublicRateLimit,
+  successResponse: (body: unknown, status = 200) =>
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    }),
+  withErrorHandling:
+    (handler: (request: NextRequest) => Promise<Response>) =>
+    async (request: NextRequest) =>
+      await handler(request),
+}));
+
+mock.module('../_adapters', () => ({
+  createPerpMarketService: () => ({
+    previewOpenPosition: mockPreviewOpenPosition,
+  }),
+}));
+
+const { POST } = await import('./route');
+
+describe('POST /api/markets/perps/preview', () => {
+  beforeEach(() => {
+    mockPublicRateLimit.mockClear();
+    mockPreviewOpenPosition.mockReset();
+  });
+
+  it('returns the canonical preview payload from the perp service', async () => {
+    mockPreviewOpenPosition.mockResolvedValue({
+      ticker: 'ABC',
+      side: 'long',
+      size: 100,
+      leverage: 5,
+      currentPrice: 100,
+      quotedPrice: 101,
+      executionPrice: 101.4,
+      quoteImpactPrice: 0.4,
+      quoteImpactBps: 40,
+      totalSlippageBps: 140,
+      bidPrice: 99,
+      askPrice: 101,
+      spreadBps: 200,
+      bidDepth: 1000,
+      askDepth: 1000,
+      liquidityRegime: 'balanced',
+      marginRequired: 20,
+      estimatedFee: 0.1,
+      totalRequired: 20.1,
+      liquidationPrice: 81.12,
+      liquidationDistancePercent: 18.88,
+    });
+
+    const response = await POST(
+      new Request('http://localhost/api/markets/perps/preview', {
+        method: 'POST',
+        body: JSON.stringify({
+          ticker: 'abc',
+          side: 'long',
+          size: 100,
+          leverage: 5,
+        }),
+      }) as NextRequest
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockPreviewOpenPosition).toHaveBeenCalledWith({
+      ticker: 'abc',
+      side: 'long',
+      size: 100,
+      leverage: 5,
+    });
+    expect(await response.json()).toEqual({
+      preview: expect.objectContaining({
+        executionPrice: 101.4,
+        totalRequired: 20.1,
+      }),
+    });
+  });
+
+  it('rejects invalid preview payloads', async () => {
+    const response = await POST(
+      new Request('http://localhost/api/markets/perps/preview', {
+        method: 'POST',
+        body: JSON.stringify({
+          ticker: '',
+          side: 'long',
+          size: -1,
+          leverage: 0,
+        }),
+      }) as NextRequest
+    );
+
+    expect(response.status).toBe(400);
+    expect(mockPreviewOpenPosition).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/markets/perps/preview/route.test.ts
+++ b/apps/web/src/app/api/markets/perps/preview/route.test.ts
@@ -5,10 +5,20 @@ const mockPublicRateLimit = mock(async () => ({
   error: null,
   rateLimitInfo: null,
 }));
+const mockAuthenticate = mock(async () => ({ userId: 'user-1' }));
+const mockAuthenticateOnchainPerpUser = mock(async () => ({
+  userId: 'user-1',
+  dbUserId: 'db-user-1',
+  walletAddress: '0xabc',
+}));
 const mockPreviewOpenPosition = mock();
+const mockGetOpenPositionByUserAndTicker = mock(async () => null);
+const mockPrepareOpenOrder = mock();
+const mockIsOnchainPerpModeEnabled = mock(() => false);
 
 mock.module('@babylon/api', () => ({
   addPublicReadHeaders: mock(() => undefined),
+  authenticate: mockAuthenticate,
   publicRateLimit: mockPublicRateLimit,
   successResponse: (body: unknown, status = 200) =>
     new Response(JSON.stringify(body), {
@@ -21,10 +31,33 @@ mock.module('@babylon/api', () => ({
       await handler(request),
 }));
 
+mock.module('@babylon/core/markets/perps', () => ({
+  PerpDbAdapter: class PerpDbAdapter {
+    getOpenPositionByUserAndTicker = mockGetOpenPositionByUserAndTicker;
+  },
+}));
+
+mock.module('@babylon/shared', () => ({
+  PerpOpenPositionSchema: {
+    parse: (value: Record<string, unknown>) => value,
+  },
+}));
+
 mock.module('../_adapters', () => ({
   createPerpMarketService: () => ({
     previewOpenPosition: mockPreviewOpenPosition,
   }),
+}));
+
+mock.module('../_onchain', () => ({
+  authenticateOnchainPerpUser: mockAuthenticateOnchainPerpUser,
+  getOnchainPerpService: () => ({
+    prepareOpenOrder: mockPrepareOpenOrder,
+  }),
+  isOnchainPerpModeEnabled: mockIsOnchainPerpModeEnabled,
+  resolvePerpUserWallet: mock(async () => ({
+    walletAddress: '0xabc',
+  })),
 }));
 
 const { POST } = await import('./route');
@@ -32,10 +65,22 @@ const { POST } = await import('./route');
 describe('POST /api/markets/perps/preview', () => {
   beforeEach(() => {
     mockPublicRateLimit.mockClear();
+    mockAuthenticate.mockClear();
+    mockAuthenticate.mockResolvedValue({ userId: 'user-1' });
+    mockAuthenticateOnchainPerpUser.mockClear();
+    mockAuthenticateOnchainPerpUser.mockResolvedValue({
+      userId: 'user-1',
+      dbUserId: 'db-user-1',
+      walletAddress: '0xabc',
+    });
     mockPreviewOpenPosition.mockReset();
+    mockGetOpenPositionByUserAndTicker.mockReset();
+    mockPrepareOpenOrder.mockReset();
+    mockIsOnchainPerpModeEnabled.mockReset();
+    mockIsOnchainPerpModeEnabled.mockReturnValue(false);
   });
 
-  it('returns the canonical preview payload from the perp service', async () => {
+  it('returns the canonical offchain preview payload from the perp service', async () => {
     mockPreviewOpenPosition.mockResolvedValue({
       ticker: 'ABC',
       side: 'long',
@@ -81,26 +126,73 @@ describe('POST /api/markets/perps/preview', () => {
     });
     expect(await response.json()).toEqual({
       preview: expect.objectContaining({
+        settlementMode: 'offchain',
         executionPrice: 101.4,
         totalRequired: 20.1,
       }),
     });
   });
 
-  it('rejects invalid preview payloads', async () => {
+  it('rejects canonical preview for rebalance flows', async () => {
+    mockGetOpenPositionByUserAndTicker.mockResolvedValue({
+      id: 'position-1',
+    } as never);
+
     const response = await POST(
       new Request('http://localhost/api/markets/perps/preview', {
         method: 'POST',
+        headers: {
+          Authorization: 'Bearer token',
+        },
         body: JSON.stringify({
-          ticker: '',
+          ticker: 'abc',
           side: 'long',
-          size: -1,
-          leverage: 0,
+          size: 100,
+          leverage: 5,
         }),
       }) as NextRequest
     );
 
-    expect(response.status).toBe(400);
+    expect(response.status).toBe(409);
     expect(mockPreviewOpenPosition).not.toHaveBeenCalled();
+    expect(await response.json()).toEqual({
+      error:
+        'Canonical preview is unavailable for rebalance orders on this endpoint.',
+      code: 'PERP_PREVIEW_REBALANCE_UNSUPPORTED',
+    });
+  });
+
+  it('branches to the onchain preview path when onchain mode is enabled', async () => {
+    mockIsOnchainPerpModeEnabled.mockReturnValue(true);
+    mockPrepareOpenOrder.mockResolvedValue({
+      sizeUsd: 100,
+      indexPrice: 10_000_000_000n,
+      estimatedExecutionPrice: 10_120_000_000n,
+      estimatedFee: 100_000_000_000_000_000n,
+      collateralRequired: 2_100_000_000_000_000_000n,
+    });
+
+    const response = await POST(
+      new Request('http://localhost/api/markets/perps/preview', {
+        method: 'POST',
+        body: JSON.stringify({
+          ticker: 'abc',
+          side: 'long',
+          size: 100,
+          leverage: 5,
+        }),
+      }) as NextRequest
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockPrepareOpenOrder).toHaveBeenCalled();
+    expect(await response.json()).toEqual({
+      preview: expect.objectContaining({
+        settlementMode: 'onchain',
+        executionPrice: 101.2,
+        currentPrice: 100,
+        totalRequired: 2.1,
+      }),
+    });
   });
 });

--- a/apps/web/src/app/api/markets/perps/preview/route.ts
+++ b/apps/web/src/app/api/markets/perps/preview/route.ts
@@ -1,0 +1,52 @@
+import {
+  addPublicReadHeaders,
+  publicRateLimit,
+  successResponse,
+  withErrorHandling,
+} from '@babylon/api';
+import type { NextRequest } from 'next/server';
+import { z } from 'zod';
+import { createPerpMarketService } from '../_adapters';
+
+const PreviewBodySchema = z.object({
+  ticker: z.string().trim().min(1),
+  side: z.enum(['long', 'short']),
+  size: z.number().finite().positive(),
+  leverage: z.number().int().min(1).max(100),
+});
+
+/**
+ * POST /api/markets/perps/preview
+ * Returns the canonical open-order execution preview for a perp order.
+ *
+ * This route intentionally reuses the same execution engine as the actual
+ * order placement flow. The preview is stateful to the current market snapshot:
+ * if the market changes before submit, the preview can become stale even though
+ * the pricing logic remains identical.
+ */
+export const POST = withErrorHandling(async (request: NextRequest) => {
+  const { error, rateLimitInfo } = await publicRateLimit(request);
+  if (error) return error;
+
+  const body = await request.json();
+  const parsed = PreviewBodySchema.safeParse(body);
+
+  if (!parsed.success) {
+    const res = successResponse(
+      {
+        error: 'Invalid preview payload',
+        details: parsed.error.flatten(),
+      },
+      400
+    );
+    if (rateLimitInfo) addPublicReadHeaders(res, rateLimitInfo);
+    return res;
+  }
+
+  const service = createPerpMarketService();
+  const preview = await service.previewOpenPosition(parsed.data);
+
+  const res = successResponse({ preview });
+  if (rateLimitInfo) addPublicReadHeaders(res, rateLimitInfo);
+  return res;
+});

--- a/apps/web/src/app/api/markets/perps/preview/route.ts
+++ b/apps/web/src/app/api/markets/perps/preview/route.ts
@@ -1,50 +1,141 @@
 import {
   addPublicReadHeaders,
+  authenticate,
   publicRateLimit,
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
+import { PerpDbAdapter } from '@babylon/core/markets/perps';
+import { PerpOpenPositionSchema } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
-import { z } from 'zod';
 import { createPerpMarketService } from '../_adapters';
+import {
+  authenticateOnchainPerpUser,
+  getOnchainPerpService,
+  isOnchainPerpModeEnabled,
+  resolvePerpUserWallet,
+} from '../_onchain';
 
-const PreviewBodySchema = z.object({
-  ticker: z.string().trim().min(1),
-  side: z.enum(['long', 'short']),
-  size: z.number().finite().positive(),
-  leverage: z.number().int().min(1).max(100),
-});
+function fromPriceUnits(value: bigint): number {
+  return Number(value / 10n ** 6n) / 100;
+}
+
+function fromCollateralUnits(value: bigint): number {
+  return Number(value / 10n ** 16n) / 100;
+}
 
 /**
  * POST /api/markets/perps/preview
  * Returns the canonical open-order execution preview for a perp order.
  *
  * This route intentionally reuses the same execution engine as the actual
- * order placement flow. The preview is stateful to the current market snapshot:
- * if the market changes before submit, the preview can become stale even though
- * the pricing logic remains identical.
+ * order placement flow for supported cases. If the market changes before submit,
+ * the preview can become stale even though the pricing logic remains identical.
  */
 export const POST = withErrorHandling(async (request: NextRequest) => {
   const { error, rateLimitInfo } = await publicRateLimit(request);
   if (error) return error;
 
   const body = await request.json();
-  const parsed = PreviewBodySchema.safeParse(body);
+  const { ticker, side, size, leverage, maxSlippage, orderType, limitPrice } =
+    PerpOpenPositionSchema.parse(body);
+  const normalizedSide = side.toLowerCase() as 'long' | 'short';
+  const numericSize = typeof size === 'string' ? Number(size) : size;
+  const onchainMode = isOnchainPerpModeEnabled();
 
-  if (!parsed.success) {
-    const res = successResponse(
-      {
-        error: 'Invalid preview payload',
-        details: parsed.error.flatten(),
-      },
-      400
+  let preview:
+    | Awaited<
+        ReturnType<
+          ReturnType<typeof createPerpMarketService>['previewOpenPosition']
+        >
+      >
+    | Record<string, unknown>;
+
+  if (onchainMode) {
+    const user = await authenticateOnchainPerpUser(request);
+    const wallet = await resolvePerpUserWallet(
+      user.dbUserId ?? user.userId,
+      user.walletAddress
     );
-    if (rateLimitInfo) addPublicReadHeaders(res, rateLimitInfo);
-    return res;
-  }
+    const service = getOnchainPerpService();
+    const prepared = await service.prepareOpenOrder({
+      account: wallet.walletAddress,
+      ticker,
+      side: normalizedSide,
+      sizeUsd: numericSize,
+      leverage,
+      maxSlippage,
+      orderType,
+      limitPrice,
+    });
+    const currentPrice = fromPriceUnits(prepared.indexPrice);
+    const executionPrice = fromPriceUnits(prepared.estimatedExecutionPrice);
+    const quoteImpactPrice = Math.max(
+      0,
+      Math.abs(executionPrice - currentPrice)
+    );
+    const totalSlippageBps =
+      (quoteImpactPrice / Math.max(currentPrice, 1)) * 10_000;
+    const estimatedFee = fromCollateralUnits(prepared.estimatedFee);
+    const totalRequired = fromCollateralUnits(prepared.collateralRequired);
 
-  const service = createPerpMarketService();
-  const preview = await service.previewOpenPosition(parsed.data);
+    preview = {
+      settlementMode: 'onchain',
+      ticker: ticker.toUpperCase(),
+      side: normalizedSide,
+      size: prepared.sizeUsd,
+      leverage,
+      currentPrice,
+      markPrice: currentPrice,
+      indexPrice: currentPrice,
+      quotedPrice: currentPrice,
+      executionPrice,
+      quoteImpactPrice,
+      quoteImpactBps: totalSlippageBps,
+      totalSlippageBps,
+      marginRequired: Math.max(0, totalRequired - estimatedFee),
+      estimatedFee,
+      totalRequired,
+    };
+  } else {
+    let authenticatedUser: Awaited<ReturnType<typeof authenticate>> | null =
+      null;
+    if (request.headers.get('authorization')) {
+      authenticatedUser = await authenticate(request);
+    }
+
+    if (authenticatedUser) {
+      const existingPosition =
+        await new PerpDbAdapter().getOpenPositionByUserAndTicker(
+          authenticatedUser.userId,
+          ticker.toUpperCase()
+        );
+
+      if (existingPosition) {
+        const res = successResponse(
+          {
+            error:
+              'Canonical preview is unavailable for rebalance orders on this endpoint.',
+            code: 'PERP_PREVIEW_REBALANCE_UNSUPPORTED',
+          },
+          409
+        );
+        if (rateLimitInfo) addPublicReadHeaders(res, rateLimitInfo);
+        return res;
+      }
+    }
+
+    const service = createPerpMarketService();
+    preview = {
+      settlementMode: 'offchain',
+      ...(await service.previewOpenPosition({
+        ticker,
+        side: normalizedSide,
+        size: numericSize,
+        leverage,
+      })),
+    };
+  }
 
   const res = successResponse({ preview });
   if (rateLimitInfo) addPublicReadHeaders(res, rateLimitInfo);

--- a/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
+++ b/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
@@ -13,6 +13,10 @@ import { Skeleton } from '@/components/shared/Skeleton';
 import { useAuth } from '@/hooks/useAuth';
 import { usePerpOpenPreview } from '@/hooks/usePerpOpenPreview';
 import { usePerpTrade } from '@/hooks/usePerpTrade';
+import {
+  getPerpRebalanceInfo,
+  shouldApplyPerpBalanceGate,
+} from '@/lib/perps/rebalance';
 import { invalidatePerpMarketsCache } from '@/stores/perpMarketsStore';
 import {
   invalidateUserPositions,
@@ -123,61 +127,58 @@ export function PerpsOrderEntryPanel({
   const quotedExecutionPrice = openPreview?.quotedPrice ?? topOfBookPrice;
   const estimatedExecutionPrice =
     openPreview?.executionPrice ?? quotedExecutionPrice;
+  const rebalanceInfo = useMemo(() => {
+    const info = getPerpRebalanceInfo({
+      existingPosition,
+      nextSide: side,
+      requestedSize: sizeNum,
+    });
+    if (!info || !existingPosition) return null;
+
+    const descriptions = {
+      add: `Adding ${formatPrice(sizeNum)} to your ${existingPosition.side.toUpperCase()} position`,
+      reduce: `Reducing your ${existingPosition.side.toUpperCase()} by ${formatPrice(sizeNum)}`,
+      close: `Closing your ${existingPosition.side.toUpperCase()} position`,
+      flip: `Closing ${existingPosition.side.toUpperCase()} and opening ${side.toUpperCase()} ${formatPrice(info.newSize)}`,
+    } as const;
+    const labels = {
+      add: 'Add to Position',
+      reduce: 'Reduce Position',
+      close: 'Close Position',
+      flip: 'Flip Position',
+    } as const;
+
+    return {
+      ...info,
+      label: labels[info.type],
+      description: descriptions[info.type],
+    };
+  }, [existingPosition, side, sizeNum]);
+
+  const requiresAdditionalCapital = shouldApplyPerpBalanceGate(rebalanceInfo);
+  const capitalCheckLeverage =
+    rebalanceInfo?.type === 'add'
+      ? (existingPosition?.leverage ?? clampedLeverage)
+      : clampedLeverage;
   const baseMargin =
     openPreview?.marginRequired ??
-    (sizeNum > 0 ? sizeNum / clampedLeverage : 0);
+    (requiresAdditionalCapital && sizeNum > 0
+      ? sizeNum / capitalCheckLeverage
+      : 0);
   const estimatedFee =
     openPreview?.estimatedFee ??
-    (sizeNum > 0 ? sizeNum * FEE_CONFIG.TRADING_FEE_RATE : 0);
+    (requiresAdditionalCapital && sizeNum > 0
+      ? sizeNum * FEE_CONFIG.TRADING_FEE_RATE
+      : 0);
   const totalRequired =
-    openPreview?.totalRequired ?? (sizeNum > 0 ? baseMargin + estimatedFee : 0);
+    openPreview?.totalRequired ??
+    (requiresAdditionalCapital ? baseMargin + estimatedFee : 0);
   const hasSufficientBalance = !authenticated || balance >= totalRequired;
   const showBalanceWarning =
-    authenticated && sizeNum > 0 && !hasSufficientBalance;
-
-  const rebalanceInfo = useMemo(() => {
-    if (!market) return null;
-    if (!existingPosition) return null;
-    if (sizeNum <= 0) return null;
-
-    const isSameSide = existingPosition.side === side;
-    const newTotalSize = existingPosition.size + sizeNum;
-
-    if (isSameSide) {
-      return {
-        type: 'add' as const,
-        label: 'Add to Position',
-        description: `Adding ${formatPrice(sizeNum)} to your ${existingPosition.side.toUpperCase()} position`,
-        newSize: newTotalSize,
-      };
-    }
-
-    if (sizeNum < existingPosition.size) {
-      return {
-        type: 'reduce' as const,
-        label: 'Reduce Position',
-        description: `Reducing your ${existingPosition.side.toUpperCase()} by ${formatPrice(sizeNum)}`,
-        newSize: existingPosition.size - sizeNum,
-      };
-    }
-
-    if (Math.abs(sizeNum - existingPosition.size) < 0.01) {
-      return {
-        type: 'close' as const,
-        label: 'Close Position',
-        description: `Closing your ${existingPosition.side.toUpperCase()} position`,
-        newSize: 0,
-      };
-    }
-
-    const flipSize = sizeNum - existingPosition.size;
-    return {
-      type: 'flip' as const,
-      label: 'Flip Position',
-      description: `Closing ${existingPosition.side.toUpperCase()} and opening ${side.toUpperCase()} ${formatPrice(flipSize)}`,
-      newSize: flipSize,
-    };
-  }, [existingPosition, market, side, sizeNum]);
+    requiresAdditionalCapital &&
+    authenticated &&
+    sizeNum > 0 &&
+    !hasSufficientBalance;
 
   const submitLabel = useMemo(() => {
     if (submitting) return 'Processing…';

--- a/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
+++ b/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/markets/TradeConfirmationDialog';
 import { Skeleton } from '@/components/shared/Skeleton';
 import { useAuth } from '@/hooks/useAuth';
+import { usePerpOpenPreview } from '@/hooks/usePerpOpenPreview';
 import { usePerpTrade } from '@/hooks/usePerpTrade';
 import { invalidatePerpMarketsCache } from '@/stores/perpMarketsStore';
 import {
@@ -100,16 +101,36 @@ export function PerpsOrderEntryPanel({
   const sizeNum = Number.parseFloat(size) || 0;
   const effectiveMaxLeverage = market?.maxLeverage ?? 100;
   const clampedLeverage = Math.min(Math.max(leverage, 1), effectiveMaxLeverage);
-  const quotedExecutionPrice = useMemo(() => {
+  const topOfBookPrice = useMemo(() => {
     if (!market) return 0;
     return side === 'long'
       ? (market.askPrice ?? market.currentPrice)
       : (market.bidPrice ?? market.currentPrice);
   }, [market, side]);
+  const {
+    preview: openPreview,
+    loading: previewLoading,
+    error: previewError,
+  } = usePerpOpenPreview({
+    ticker: market?.ticker ?? null,
+    side,
+    size: sizeNum,
+    leverage: clampedLeverage,
+    enabled: orderType === 'market',
+    getAccessToken,
+  });
 
-  const baseMargin = sizeNum > 0 ? sizeNum / clampedLeverage : 0;
-  const estimatedFee = sizeNum > 0 ? sizeNum * FEE_CONFIG.TRADING_FEE_RATE : 0;
-  const totalRequired = sizeNum > 0 ? baseMargin + estimatedFee : 0;
+  const quotedExecutionPrice = openPreview?.quotedPrice ?? topOfBookPrice;
+  const estimatedExecutionPrice =
+    openPreview?.executionPrice ?? quotedExecutionPrice;
+  const baseMargin =
+    openPreview?.marginRequired ??
+    (sizeNum > 0 ? sizeNum / clampedLeverage : 0);
+  const estimatedFee =
+    openPreview?.estimatedFee ??
+    (sizeNum > 0 ? sizeNum * FEE_CONFIG.TRADING_FEE_RATE : 0);
+  const totalRequired =
+    openPreview?.totalRequired ?? (sizeNum > 0 ? baseMargin + estimatedFee : 0);
   const hasSufficientBalance = !authenticated || balance >= totalRequired;
   const showBalanceWarning =
     authenticated && sizeNum > 0 && !hasSufficientBalance;
@@ -263,21 +284,22 @@ export function PerpsOrderEntryPanel({
   ]);
 
   const liquidationPrice = useMemo(() => {
+    if (openPreview) return openPreview.liquidationPrice;
     if (!market) return 0;
-    const price = quotedExecutionPrice;
     return side === 'long'
-      ? price * (1 - 0.9 / clampedLeverage)
-      : price * (1 + 0.9 / clampedLeverage);
-  }, [market, side, clampedLeverage, quotedExecutionPrice]);
+      ? quotedExecutionPrice * (1 - 0.9 / clampedLeverage)
+      : quotedExecutionPrice * (1 + 0.9 / clampedLeverage);
+  }, [clampedLeverage, market, openPreview, quotedExecutionPrice, side]);
 
   const liquidationDistance = useMemo(() => {
+    if (openPreview) return openPreview.liquidationDistancePercent;
     if (!market) return 0;
     const price = market.currentPrice;
     if (price <= 0) return 0;
     return side === 'long'
       ? ((price - liquidationPrice) / price) * 100
       : ((liquidationPrice - price) / price) * 100;
-  }, [market, side, liquidationPrice]);
+  }, [liquidationPrice, market, openPreview, side]);
 
   if (!market) {
     return (
@@ -445,18 +467,28 @@ export function PerpsOrderEntryPanel({
           <div className="space-y-2 rounded bg-muted/50 p-3 text-xs">
             <Row
               label="Bid / Ask"
-              value={`${formatPrice(market.bidPrice ?? market.currentPrice)} / ${formatPrice(
-                market.askPrice ?? market.currentPrice
+              value={`${formatPrice(openPreview?.bidPrice ?? market.bidPrice ?? market.currentPrice)} / ${formatPrice(
+                openPreview?.askPrice ?? market.askPrice ?? market.currentPrice
               )}`}
             />
             <Row
-              label="Quoted Entry"
+              label="Top of Book"
               value={formatPrice(quotedExecutionPrice)}
             />
-            {market.spreadBps !== undefined && (
+            <Row
+              label="Est. Entry"
+              value={formatPrice(estimatedExecutionPrice)}
+            />
+            {(openPreview?.spreadBps ?? market.spreadBps) !== undefined && (
               <Row
                 label="Spread"
-                value={`${market.spreadBps.toFixed(0)} bps`}
+                value={`${(openPreview?.spreadBps ?? market.spreadBps ?? 0).toFixed(0)} bps`}
+              />
+            )}
+            {openPreview && (
+              <Row
+                label="Size Impact"
+                value={`${openPreview.quoteImpactBps.toFixed(0)} bps`}
               />
             )}
             <Row label="Liq. Price" value={formatPrice(liquidationPrice)} />
@@ -465,6 +497,18 @@ export function PerpsOrderEntryPanel({
             <div className="border-border border-t" />
             <Row label="Total" value={formatPrice(totalRequired)} strong />
           </div>
+
+          {previewLoading && sizeNum > 0 && (
+            <div className="text-muted-foreground text-xs">
+              Updating execution preview…
+            </div>
+          )}
+
+          {previewError && sizeNum > 0 && (
+            <div className="rounded bg-amber-500/10 p-3 text-amber-400 text-xs">
+              Preview unavailable. Order submission still uses canonical engine.
+            </div>
+          )}
 
           {showBalanceWarning && (
             <div className="rounded bg-red-500/10 p-3 text-red-400 text-xs">
@@ -533,7 +577,7 @@ export function PerpsOrderEntryPanel({
                 side,
                 size: sizeNum,
                 leverage: clampedLeverage,
-                entryPrice: quotedExecutionPrice,
+                entryPrice: estimatedExecutionPrice,
                 margin: baseMargin,
                 estimatedFee,
                 liquidationPrice,

--- a/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
+++ b/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
@@ -116,7 +116,7 @@ export function PerpsOrderEntryPanel({
     side,
     size: sizeNum,
     leverage: clampedLeverage,
-    enabled: orderType === 'market',
+    enabled: orderType === 'market' && !existingPosition,
     getAccessToken,
   });
 
@@ -215,6 +215,11 @@ export function PerpsOrderEntryPanel({
       return;
     }
 
+    if (rebalanceInfo) {
+      void handleConfirmOpen();
+      return;
+    }
+
     setConfirmDialogOpen(true);
   };
 
@@ -284,7 +289,7 @@ export function PerpsOrderEntryPanel({
   ]);
 
   const liquidationPrice = useMemo(() => {
-    if (openPreview) return openPreview.liquidationPrice;
+    if (openPreview) return openPreview.liquidationPrice ?? 0;
     if (!market) return 0;
     return side === 'long'
       ? quotedExecutionPrice * (1 - 0.9 / clampedLeverage)
@@ -292,7 +297,7 @@ export function PerpsOrderEntryPanel({
   }, [clampedLeverage, market, openPreview, quotedExecutionPrice, side]);
 
   const liquidationDistance = useMemo(() => {
-    if (openPreview) return openPreview.liquidationDistancePercent;
+    if (openPreview) return openPreview.liquidationDistancePercent ?? 0;
     if (!market) return 0;
     const price = market.currentPrice;
     if (price <= 0) return 0;
@@ -464,49 +469,87 @@ export function PerpsOrderEntryPanel({
             />
           </div>
 
-          <div className="space-y-2 rounded bg-muted/50 p-3 text-xs">
-            <Row
-              label="Bid / Ask"
-              value={`${formatPrice(openPreview?.bidPrice ?? market.bidPrice ?? market.currentPrice)} / ${formatPrice(
-                openPreview?.askPrice ?? market.askPrice ?? market.currentPrice
-              )}`}
-            />
-            <Row
-              label="Top of Book"
-              value={formatPrice(quotedExecutionPrice)}
-            />
-            <Row
-              label="Est. Entry"
-              value={formatPrice(estimatedExecutionPrice)}
-            />
-            {(openPreview?.spreadBps ?? market.spreadBps) !== undefined && (
-              <Row
-                label="Spread"
-                value={`${(openPreview?.spreadBps ?? market.spreadBps ?? 0).toFixed(0)} bps`}
-              />
-            )}
-            {openPreview && (
-              <Row
-                label="Size Impact"
-                value={`${openPreview.quoteImpactBps.toFixed(0)} bps`}
-              />
-            )}
-            <Row label="Liq. Price" value={formatPrice(liquidationPrice)} />
-            <Row label="Margin" value={formatPrice(baseMargin)} />
-            <Row label="Fees" value={formatPrice(estimatedFee)} />
-            <div className="border-border border-t" />
-            <Row label="Total" value={formatPrice(totalRequired)} strong />
-          </div>
+          {!existingPosition ? (
+            <>
+              <div className="space-y-2 rounded bg-muted/50 p-3 text-xs">
+                {(openPreview?.bidPrice ?? market.bidPrice) !== undefined &&
+                  (openPreview?.askPrice ?? market.askPrice) !== undefined && (
+                    <Row
+                      label="Bid / Ask"
+                      value={`${formatPrice(openPreview?.bidPrice ?? market.bidPrice ?? market.currentPrice)} / ${formatPrice(
+                        openPreview?.askPrice ??
+                          market.askPrice ??
+                          market.currentPrice
+                      )}`}
+                    />
+                  )}
+                <Row
+                  label="Top of Book"
+                  value={formatPrice(quotedExecutionPrice)}
+                />
+                <Row
+                  label="Est. Entry"
+                  value={formatPrice(estimatedExecutionPrice)}
+                />
+                {(openPreview?.spreadBps ?? market.spreadBps) !== undefined && (
+                  <Row
+                    label="Spread"
+                    value={`${(openPreview?.spreadBps ?? market.spreadBps ?? 0).toFixed(0)} bps`}
+                  />
+                )}
+                {openPreview?.quoteImpactBps !== undefined && (
+                  <Row
+                    label="Size Impact"
+                    value={`${openPreview.quoteImpactBps.toFixed(0)} bps`}
+                  />
+                )}
+                {liquidationPrice > 0 && (
+                  <Row
+                    label="Liq. Price"
+                    value={formatPrice(liquidationPrice)}
+                  />
+                )}
+                <Row label="Margin" value={formatPrice(baseMargin)} />
+                <Row label="Fees" value={formatPrice(estimatedFee)} />
+                <div className="border-border border-t" />
+                <Row label="Total" value={formatPrice(totalRequired)} strong />
+              </div>
 
-          {previewLoading && sizeNum > 0 && (
-            <div className="text-muted-foreground text-xs">
-              Updating execution preview…
-            </div>
-          )}
+              {previewLoading && sizeNum > 0 && (
+                <div className="text-muted-foreground text-xs">
+                  Updating execution preview…
+                </div>
+              )}
 
-          {previewError && sizeNum > 0 && (
-            <div className="rounded bg-amber-500/10 p-3 text-amber-400 text-xs">
-              Preview unavailable. Order submission still uses canonical engine.
+              {previewError && sizeNum > 0 && (
+                <div className="rounded bg-amber-500/10 p-3 text-amber-400 text-xs">
+                  Preview unavailable. Order submission still uses canonical
+                  engine.
+                </div>
+              )}
+            </>
+          ) : (
+            <div className="space-y-2 rounded bg-muted/50 p-3 text-xs">
+              <Row
+                label="Action"
+                value={rebalanceInfo?.label ?? 'Modify Position'}
+              />
+              <Row
+                label="Current Position"
+                value={formatPrice(existingPosition.size)}
+              />
+              <Row label="Requested Trade" value={formatPrice(sizeNum)} />
+              <Row
+                label="Resulting Size"
+                value={formatPrice(
+                  rebalanceInfo?.newSize ?? existingPosition.size
+                )}
+              />
+              <div className="border-border border-t" />
+              <div className="text-muted-foreground text-xs">
+                Canonical preview is hidden for rebalance orders in this
+                surface. Submit still follows the real rebalance execution path.
+              </div>
             </div>
           )}
 
@@ -570,7 +613,7 @@ export function PerpsOrderEntryPanel({
         onConfirm={handleConfirmOpen}
         isSubmitting={submitting}
         tradeDetails={
-          market
+          market && !rebalanceInfo
             ? ({
                 type: 'open-perp',
                 ticker: market.ticker,

--- a/apps/web/src/components/markets/PerpTradingModal.tsx
+++ b/apps/web/src/components/markets/PerpTradingModal.tsx
@@ -10,6 +10,10 @@ import { useBodyScrollLock } from '@/hooks/useBodyScrollLock';
 import { usePerpOpenPreview } from '@/hooks/usePerpOpenPreview';
 import { usePerpTrade } from '@/hooks/usePerpTrade';
 import { useMarketTracking } from '@/hooks/usePostHog';
+import {
+  getPerpRebalanceInfo,
+  shouldApplyPerpBalanceGate,
+} from '@/lib/perps/rebalance';
 import { invalidatePerpMarketsCache } from '@/stores/perpMarketsStore';
 import { usePerpPositions } from '@/stores/userPositionsStore';
 import {
@@ -118,11 +122,18 @@ export function PerpTradingModal({
   }, [isOpen, loading, onClose]);
 
   const sizeNum = Number.parseFloat(size) || 0;
-  const hasExistingPosition = perpPositions.some(
-    (position) =>
-      !position.closedAt &&
-      position.ticker.toUpperCase() === market.ticker.toUpperCase()
-  );
+  const existingPosition =
+    perpPositions.find(
+      (position) =>
+        !position.closedAt &&
+        position.ticker.toUpperCase() === market.ticker.toUpperCase()
+    ) ?? null;
+  const rebalanceInfo = getPerpRebalanceInfo({
+    existingPosition,
+    nextSide: side,
+    requestedSize: sizeNum,
+  });
+  const hasExistingPosition = existingPosition !== null;
   const topOfBookPrice =
     side === 'long'
       ? (market.askPrice ?? market.currentPrice)
@@ -141,8 +152,16 @@ export function PerpTradingModal({
   });
   const quotedExecutionPrice = openPreview?.quotedPrice ?? topOfBookPrice;
   const executionPrice = openPreview?.executionPrice ?? quotedExecutionPrice;
+  const requiresAdditionalCapital = shouldApplyPerpBalanceGate(rebalanceInfo);
+  const capitalCheckLeverage =
+    rebalanceInfo?.type === 'add'
+      ? (existingPosition?.leverage ?? leverage)
+      : leverage;
   const marginRequired =
-    openPreview?.marginRequired ?? (sizeNum > 0 ? sizeNum / leverage : 0);
+    openPreview?.marginRequired ??
+    (requiresAdditionalCapital && sizeNum > 0
+      ? sizeNum / capitalCheckLeverage
+      : 0);
   const liquidationPrice =
     openPreview?.liquidationPrice ??
     (side === 'long'
@@ -158,18 +177,27 @@ export function PerpTradingModal({
 
   const estimatedFee = useMemo(() => {
     if (openPreview) return openPreview.estimatedFee;
-    if (sizeNum <= 0) return 0;
+    if (!requiresAdditionalCapital || sizeNum <= 0) return 0;
     return sizeNum * FEE_CONFIG.TRADING_FEE_RATE;
-  }, [openPreview, sizeNum]);
+  }, [openPreview, requiresAdditionalCapital, sizeNum]);
 
   const totalRequired = useMemo(() => {
     if (openPreview) return openPreview.totalRequired;
-    if (sizeNum <= 0) return 0;
+    if (!requiresAdditionalCapital || sizeNum <= 0) return 0;
     return marginRequired + estimatedFee;
-  }, [estimatedFee, marginRequired, openPreview, sizeNum]);
+  }, [
+    estimatedFee,
+    marginRequired,
+    openPreview,
+    requiresAdditionalCapital,
+    sizeNum,
+  ]);
 
   const showBalanceWarning =
-    authenticated && sizeNum > 0 && balance < totalRequired;
+    requiresAdditionalCapital &&
+    authenticated &&
+    sizeNum > 0 &&
+    balance < totalRequired;
 
   if (!isOpen) return null;
 

--- a/apps/web/src/components/markets/PerpTradingModal.tsx
+++ b/apps/web/src/components/markets/PerpTradingModal.tsx
@@ -11,6 +11,7 @@ import { usePerpOpenPreview } from '@/hooks/usePerpOpenPreview';
 import { usePerpTrade } from '@/hooks/usePerpTrade';
 import { useMarketTracking } from '@/hooks/usePostHog';
 import { invalidatePerpMarketsCache } from '@/stores/perpMarketsStore';
+import { usePerpPositions } from '@/stores/userPositionsStore';
 import {
   invalidateWalletBalance,
   useWalletBalance,
@@ -77,6 +78,9 @@ export function PerpTradingModal({
     loading: balanceLoading,
     refresh: refreshBalance,
   } = useWalletBalance(isOpen ? user?.id : null);
+  const { positions: perpPositions } = usePerpPositions(
+    isOpen && authenticated ? (user?.id ?? null) : null
+  );
 
   // Track previous isOpen to detect open transition
   const prevIsOpenRef = useRef(false);
@@ -114,6 +118,11 @@ export function PerpTradingModal({
   }, [isOpen, loading, onClose]);
 
   const sizeNum = Number.parseFloat(size) || 0;
+  const hasExistingPosition = perpPositions.some(
+    (position) =>
+      !position.closedAt &&
+      position.ticker.toUpperCase() === market.ticker.toUpperCase()
+  );
   const topOfBookPrice =
     side === 'long'
       ? (market.askPrice ?? market.currentPrice)
@@ -127,7 +136,7 @@ export function PerpTradingModal({
     side,
     size: sizeNum,
     leverage,
-    enabled: isOpen,
+    enabled: isOpen && !hasExistingPosition,
     getAccessToken,
   });
   const quotedExecutionPrice = openPreview?.quotedPrice ?? topOfBookPrice;
@@ -372,75 +381,95 @@ export function PerpTradingModal({
             </div>
           </div>
 
-          <div className="mb-6 rounded bg-muted/20 p-4">
-            <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
-              <span className="text-muted-foreground">Margin Required</span>
-              <span className="text-right font-bold text-foreground">
-                {formatPrice(marginRequired)}
-              </span>
+          {!hasExistingPosition ? (
+            <div className="mb-6 rounded bg-muted/20 p-4">
+              <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+                <span className="text-muted-foreground">Margin Required</span>
+                <span className="text-right font-bold text-foreground">
+                  {formatPrice(marginRequired)}
+                </span>
 
-              <span className="text-muted-foreground">Position Value</span>
-              <span className="text-right font-bold text-foreground">
-                {formatPrice(positionValue)}
-              </span>
+                <span className="text-muted-foreground">Position Value</span>
+                <span className="text-right font-bold text-foreground">
+                  {formatPrice(positionValue)}
+                </span>
 
-              <span className="text-muted-foreground">Entry Price</span>
-              <span className="text-right font-medium text-foreground">
-                {formatPrice(executionPrice)}
-              </span>
+                <span className="text-muted-foreground">Entry Price</span>
+                <span className="text-right font-medium text-foreground">
+                  {formatPrice(executionPrice)}
+                </span>
 
-              <span className="text-muted-foreground">Top of Book</span>
-              <span className="text-right font-medium text-foreground">
-                {formatPrice(quotedExecutionPrice)}
-              </span>
+                <span className="text-muted-foreground">Top of Book</span>
+                <span className="text-right font-medium text-foreground">
+                  {formatPrice(quotedExecutionPrice)}
+                </span>
 
-              {openPreview && (
-                <>
-                  <span className="text-muted-foreground">Size Impact</span>
-                  <span className="text-right font-medium text-foreground">
-                    {openPreview.quoteImpactBps.toFixed(0)} bps
-                  </span>
-                </>
-              )}
-
-              <span className="text-muted-foreground">Liquidation Price</span>
-              <span className="text-right font-bold text-red-600">
-                {formatPrice(liquidationPrice)}
-              </span>
-
-              <span className="text-muted-foreground">Distance to Liq</span>
-              <span
-                className={cn(
-                  'text-right font-medium',
-                  liquidationDistance > 5
-                    ? 'text-green-600'
-                    : liquidationDistance > 2
-                      ? 'text-yellow-600'
-                      : 'text-red-600'
+                {openPreview?.quoteImpactBps !== undefined && (
+                  <>
+                    <span className="text-muted-foreground">Size Impact</span>
+                    <span className="text-right font-medium text-foreground">
+                      {openPreview.quoteImpactBps.toFixed(0)} bps
+                    </span>
+                  </>
                 )}
-              >
-                {liquidationDistance.toFixed(2)}%
-              </span>
 
-              <span className="text-muted-foreground">
-                Est. Trading Fee (
-                {(FEE_CONFIG.TRADING_FEE_RATE * 100).toFixed(2)}%)
-              </span>
-              <span className="text-right font-bold text-foreground">
-                {formatPrice(estimatedFee)}
-              </span>
-
-              <span className="text-muted-foreground">Total Required</span>
-              <span
-                className={cn(
-                  'text-right font-bold',
-                  showBalanceWarning ? 'text-red-600' : 'text-foreground'
+                {liquidationPrice > 0 && (
+                  <>
+                    <span className="text-muted-foreground">
+                      Liquidation Price
+                    </span>
+                    <span className="text-right font-bold text-red-600">
+                      {formatPrice(liquidationPrice)}
+                    </span>
+                  </>
                 )}
-              >
-                {formatPrice(totalRequired)}
-              </span>
+
+                {liquidationPrice > 0 && (
+                  <>
+                    <span className="text-muted-foreground">
+                      Distance to Liq
+                    </span>
+                    <span
+                      className={cn(
+                        'text-right font-medium',
+                        liquidationDistance > 5
+                          ? 'text-green-600'
+                          : liquidationDistance > 2
+                            ? 'text-yellow-600'
+                            : 'text-red-600'
+                      )}
+                    >
+                      {liquidationDistance.toFixed(2)}%
+                    </span>
+                  </>
+                )}
+
+                <span className="text-muted-foreground">
+                  Est. Trading Fee (
+                  {(FEE_CONFIG.TRADING_FEE_RATE * 100).toFixed(2)}%)
+                </span>
+                <span className="text-right font-bold text-foreground">
+                  {formatPrice(estimatedFee)}
+                </span>
+
+                <span className="text-muted-foreground">Total Required</span>
+                <span
+                  className={cn(
+                    'text-right font-bold',
+                    showBalanceWarning ? 'text-red-600' : 'text-foreground'
+                  )}
+                >
+                  {formatPrice(totalRequired)}
+                </span>
+              </div>
             </div>
-          </div>
+          ) : (
+            <div className="mb-6 rounded border border-amber-500/30 bg-amber-500/10 p-4 text-amber-500 text-sm">
+              This trade will rebalance your existing {market.ticker} position.
+              Canonical preview is hidden in this surface for rebalance flows so
+              we do not show misleading numbers before submit.
+            </div>
+          )}
 
           {authenticated && sizeNum > 0 && (
             <div className="mb-4 text-muted-foreground text-xs">
@@ -453,13 +482,13 @@ export function PerpTradingModal({
             </div>
           )}
 
-          {previewLoading && sizeNum > 0 && (
+          {!hasExistingPosition && previewLoading && sizeNum > 0 && (
             <div className="mb-4 text-muted-foreground text-xs">
               Updating execution preview…
             </div>
           )}
 
-          {previewError && sizeNum > 0 && (
+          {!hasExistingPosition && previewError && sizeNum > 0 && (
             <div className="mb-4 rounded border border-amber-500/30 bg-amber-500/10 p-3 text-amber-500 text-sm">
               Preview unavailable. Order submission still uses the canonical
               execution engine.

--- a/apps/web/src/components/markets/PerpTradingModal.tsx
+++ b/apps/web/src/components/markets/PerpTradingModal.tsx
@@ -7,6 +7,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { useAuth } from '@/hooks/useAuth';
 import { useBodyScrollLock } from '@/hooks/useBodyScrollLock';
+import { usePerpOpenPreview } from '@/hooks/usePerpOpenPreview';
 import { usePerpTrade } from '@/hooks/usePerpTrade';
 import { useMarketTracking } from '@/hooks/usePostHog';
 import { invalidatePerpMarketsCache } from '@/stores/perpMarketsStore';
@@ -112,37 +113,56 @@ export function PerpTradingModal({
     };
   }, [isOpen, loading, onClose]);
 
-  if (!isOpen) return null;
-
   const sizeNum = Number.parseFloat(size) || 0;
-  const quotedExecutionPrice =
+  const topOfBookPrice =
     side === 'long'
       ? (market.askPrice ?? market.currentPrice)
       : (market.bidPrice ?? market.currentPrice);
-  const marginRequired = sizeNum > 0 ? sizeNum / leverage : 0;
+  const {
+    preview: openPreview,
+    loading: previewLoading,
+    error: previewError,
+  } = usePerpOpenPreview({
+    ticker: market.ticker,
+    side,
+    size: sizeNum,
+    leverage,
+    enabled: isOpen,
+    getAccessToken,
+  });
+  const quotedExecutionPrice = openPreview?.quotedPrice ?? topOfBookPrice;
+  const executionPrice = openPreview?.executionPrice ?? quotedExecutionPrice;
+  const marginRequired =
+    openPreview?.marginRequired ?? (sizeNum > 0 ? sizeNum / leverage : 0);
   const liquidationPrice =
-    side === 'long'
+    openPreview?.liquidationPrice ??
+    (side === 'long'
       ? quotedExecutionPrice * (1 - 0.9 / leverage)
-      : quotedExecutionPrice * (1 + 0.9 / leverage);
+      : quotedExecutionPrice * (1 + 0.9 / leverage));
 
   const positionValue = sizeNum * leverage;
   const liquidationDistance =
-    side === 'long'
+    openPreview?.liquidationDistancePercent ??
+    (side === 'long'
       ? ((market.currentPrice - liquidationPrice) / market.currentPrice) * 100
-      : ((liquidationPrice - market.currentPrice) / market.currentPrice) * 100;
+      : ((liquidationPrice - market.currentPrice) / market.currentPrice) * 100);
 
   const estimatedFee = useMemo(() => {
+    if (openPreview) return openPreview.estimatedFee;
     if (sizeNum <= 0) return 0;
     return sizeNum * FEE_CONFIG.TRADING_FEE_RATE;
-  }, [sizeNum]);
+  }, [openPreview, sizeNum]);
 
   const totalRequired = useMemo(() => {
+    if (openPreview) return openPreview.totalRequired;
     if (sizeNum <= 0) return 0;
     return marginRequired + estimatedFee;
-  }, [estimatedFee, marginRequired, sizeNum]);
+  }, [estimatedFee, marginRequired, openPreview, sizeNum]);
 
   const showBalanceWarning =
     authenticated && sizeNum > 0 && balance < totalRequired;
+
+  if (!isOpen) return null;
 
   const handleSubmit = async () => {
     if (!authenticated) {
@@ -366,8 +386,22 @@ export function PerpTradingModal({
 
               <span className="text-muted-foreground">Entry Price</span>
               <span className="text-right font-medium text-foreground">
+                {formatPrice(executionPrice)}
+              </span>
+
+              <span className="text-muted-foreground">Top of Book</span>
+              <span className="text-right font-medium text-foreground">
                 {formatPrice(quotedExecutionPrice)}
               </span>
+
+              {openPreview && (
+                <>
+                  <span className="text-muted-foreground">Size Impact</span>
+                  <span className="text-right font-medium text-foreground">
+                    {openPreview.quoteImpactBps.toFixed(0)} bps
+                  </span>
+                </>
+              )}
 
               <span className="text-muted-foreground">Liquidation Price</span>
               <span className="text-right font-bold text-red-600">
@@ -416,6 +450,19 @@ export function PerpTradingModal({
                   Balance too low for this trade.
                 </span>
               )}
+            </div>
+          )}
+
+          {previewLoading && sizeNum > 0 && (
+            <div className="mb-4 text-muted-foreground text-xs">
+              Updating execution preview…
+            </div>
+          )}
+
+          {previewError && sizeNum > 0 && (
+            <div className="mb-4 rounded border border-amber-500/30 bg-amber-500/10 p-3 text-amber-500 text-sm">
+              Preview unavailable. Order submission still uses the canonical
+              execution engine.
             </div>
           )}
 

--- a/apps/web/src/components/profile/PositionDetailModal.tsx
+++ b/apps/web/src/components/profile/PositionDetailModal.tsx
@@ -4,7 +4,6 @@ import {
   calculateExpectedPayout,
   PredictionPricing,
 } from '@babylon/core/markets/prediction/client';
-import { FEE_CONFIG } from '@babylon/engine/config/fees';
 import type { PerpPositionFromAPI, PredictionPosition } from '@babylon/shared';
 import {
   BABYLON_POINTS_SYMBOL,
@@ -28,7 +27,6 @@ import { toast } from 'sonner';
 import { formatPrice } from '@/app/markets/_lib/formatters';
 import { FollowButton } from '@/components/interactions';
 import { useAuth } from '@/hooks/useAuth';
-import { usePerpOpenPreview } from '@/hooks/usePerpOpenPreview';
 import { usePredictionTrading } from '@/hooks/usePredictionTrading';
 import { usePerpMarketsStore } from '@/stores/perpMarketsStore';
 
@@ -352,54 +350,9 @@ export function PositionDetailModal({
     : 0;
   const expectedProfit = expectedPayout - (parseFloat(amount) || 0);
 
-  // Calculate perp trade preview
+  // Perp trade tab modifies an existing position, so a fresh-open preview
+  // would be misleading here.
   const sizeNum = parseFloat(size) || 0;
-  const {
-    preview: openPreview,
-    loading: previewLoading,
-    error: previewError,
-  } = usePerpOpenPreview({
-    ticker: perpMarket?.ticker ?? null,
-    side: side === 'long' || side === 'short' ? side : 'long',
-    size: sizeNum,
-    leverage,
-    enabled: type === 'perp',
-    getAccessToken,
-  });
-  const topOfBookPrice =
-    perpMarket && (side === 'long' || side === 'short')
-      ? side === 'long'
-        ? (perpMarket.askPrice ?? perpMarket.currentPrice)
-        : (perpMarket.bidPrice ?? perpMarket.currentPrice)
-      : 0;
-  const marginRequired =
-    openPreview?.marginRequired ?? (perpMarket ? sizeNum / leverage : 0);
-  const positionValue = sizeNum * leverage;
-  const executionPrice = openPreview?.executionPrice ?? topOfBookPrice;
-  const quotedPrice = openPreview?.quotedPrice ?? topOfBookPrice;
-  const liquidationPrice =
-    openPreview?.liquidationPrice ??
-    (perpMarket && data && type === 'perp' && 'currentPrice' in data
-      ? side === 'long'
-        ? executionPrice * (1 - 0.9 / leverage)
-        : executionPrice * (1 + 0.9 / leverage)
-      : 0);
-  const liquidationDistance =
-    openPreview?.liquidationDistancePercent ??
-    (perpMarket && liquidationPrice > 0
-      ? side === 'long'
-        ? ((perpMarket.currentPrice - liquidationPrice) /
-            perpMarket.currentPrice) *
-          100
-        : ((liquidationPrice - perpMarket.currentPrice) /
-            perpMarket.currentPrice) *
-          100
-      : 0);
-  const estimatedFee =
-    openPreview?.estimatedFee ??
-    (sizeNum > 0 ? sizeNum * FEE_CONFIG.TRADING_FEE_RATE : 0);
-  const totalRequired =
-    openPreview?.totalRequired ?? marginRequired + estimatedFee;
 
   if (!isOpen || !data) return null;
 
@@ -942,86 +895,12 @@ export function PositionDetailModal({
                     </div>
                   </div>
 
-                  <div className="rounded bg-muted/20 p-4">
-                    <div className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
-                      <span className="text-muted-foreground">
-                        Margin Required
-                      </span>
-                      <span className="text-right font-bold text-foreground">
-                        {formatPrice(marginRequired)}
-                      </span>
-                      <span className="text-muted-foreground">
-                        Position Value
-                      </span>
-                      <span className="text-right font-bold text-foreground">
-                        {formatPrice(positionValue)}
-                      </span>
-                      <span className="text-muted-foreground">Top of Book</span>
-                      <span className="text-right font-medium text-foreground">
-                        {formatPrice(quotedPrice)}
-                      </span>
-                      <span className="text-muted-foreground">Est. Entry</span>
-                      <span className="text-right font-medium text-foreground">
-                        {formatPrice(executionPrice)}
-                      </span>
-                      {openPreview && (
-                        <>
-                          <span className="text-muted-foreground">
-                            Size Impact
-                          </span>
-                          <span className="text-right font-medium text-foreground">
-                            {openPreview.quoteImpactBps.toFixed(0)} bps
-                          </span>
-                        </>
-                      )}
-                      <span className="text-muted-foreground">
-                        Liquidation Price
-                      </span>
-                      <span className="text-right font-bold text-red-600">
-                        {formatPrice(liquidationPrice)}
-                      </span>
-                      <span className="text-muted-foreground">
-                        Distance to Liq
-                      </span>
-                      <span
-                        className={cn(
-                          'text-right font-medium',
-                          liquidationDistance > 5
-                            ? 'text-green-600'
-                            : liquidationDistance > 2
-                              ? 'text-yellow-600'
-                              : 'text-red-600'
-                        )}
-                      >
-                        {liquidationDistance.toFixed(2)}%
-                      </span>
-                      <span className="text-muted-foreground">
-                        Est. Trading Fee
-                      </span>
-                      <span className="text-right font-bold text-foreground">
-                        {formatPrice(estimatedFee)}
-                      </span>
-                      <span className="text-muted-foreground">
-                        Total Required
-                      </span>
-                      <span className="text-right font-bold text-foreground">
-                        {formatPrice(totalRequired)}
-                      </span>
-                    </div>
+                  <div className="rounded border border-amber-500/30 bg-amber-500/10 p-4 text-amber-500 text-sm">
+                    This trade modifies your existing position. Canonical
+                    preview is intentionally hidden in this surface for
+                    rebalance flows so we do not show misleading pre-submit
+                    numbers.
                   </div>
-
-                  {previewLoading && sizeNum > 0 && (
-                    <div className="text-muted-foreground text-xs">
-                      Updating execution preview…
-                    </div>
-                  )}
-
-                  {previewError && sizeNum > 0 && (
-                    <div className="rounded border border-amber-500/30 bg-amber-500/10 p-4 text-amber-500 text-sm">
-                      Preview unavailable. Order submission still uses the
-                      canonical execution engine.
-                    </div>
-                  )}
 
                   {leverage > 50 && (
                     <div className="flex items-start gap-3 rounded bg-yellow-500/15 p-3">

--- a/apps/web/src/components/profile/PositionDetailModal.tsx
+++ b/apps/web/src/components/profile/PositionDetailModal.tsx
@@ -4,6 +4,7 @@ import {
   calculateExpectedPayout,
   PredictionPricing,
 } from '@babylon/core/markets/prediction/client';
+import { FEE_CONFIG } from '@babylon/engine/config/fees';
 import type { PerpPositionFromAPI, PredictionPosition } from '@babylon/shared';
 import {
   BABYLON_POINTS_SYMBOL,
@@ -27,6 +28,7 @@ import { toast } from 'sonner';
 import { formatPrice } from '@/app/markets/_lib/formatters';
 import { FollowButton } from '@/components/interactions';
 import { useAuth } from '@/hooks/useAuth';
+import { usePerpOpenPreview } from '@/hooks/usePerpOpenPreview';
 import { usePredictionTrading } from '@/hooks/usePredictionTrading';
 import { usePerpMarketsStore } from '@/stores/perpMarketsStore';
 
@@ -122,6 +124,9 @@ interface PerpMarket {
   ticker: string;
   name: string;
   currentPrice: number;
+  bidPrice?: number;
+  askPrice?: number;
+  spreadBps?: number;
   fundingRate: {
     rate: number;
     nextFundingTime: string;
@@ -302,8 +307,6 @@ export function PositionDetailModal({
     }
   };
 
-  if (!isOpen || !data) return null;
-
   const formatPoints = (points: number) => {
     return points.toLocaleString('en-US', {
       maximumFractionDigits: 0,
@@ -351,16 +354,39 @@ export function PositionDetailModal({
 
   // Calculate perp trade preview
   const sizeNum = parseFloat(size) || 0;
-  const marginRequired = perpMarket ? sizeNum / leverage : 0;
-  const positionValue = sizeNum * leverage;
-  const liquidationPrice =
-    perpMarket && type === 'perp' && 'currentPrice' in data
+  const {
+    preview: openPreview,
+    loading: previewLoading,
+    error: previewError,
+  } = usePerpOpenPreview({
+    ticker: perpMarket?.ticker ?? null,
+    side: side === 'long' || side === 'short' ? side : 'long',
+    size: sizeNum,
+    leverage,
+    enabled: type === 'perp',
+    getAccessToken,
+  });
+  const topOfBookPrice =
+    perpMarket && (side === 'long' || side === 'short')
       ? side === 'long'
-        ? perpMarket.currentPrice * (1 - 0.9 / leverage)
-        : perpMarket.currentPrice * (1 + 0.9 / leverage)
+        ? (perpMarket.askPrice ?? perpMarket.currentPrice)
+        : (perpMarket.bidPrice ?? perpMarket.currentPrice)
       : 0;
+  const marginRequired =
+    openPreview?.marginRequired ?? (perpMarket ? sizeNum / leverage : 0);
+  const positionValue = sizeNum * leverage;
+  const executionPrice = openPreview?.executionPrice ?? topOfBookPrice;
+  const quotedPrice = openPreview?.quotedPrice ?? topOfBookPrice;
+  const liquidationPrice =
+    openPreview?.liquidationPrice ??
+    (perpMarket && data && type === 'perp' && 'currentPrice' in data
+      ? side === 'long'
+        ? executionPrice * (1 - 0.9 / leverage)
+        : executionPrice * (1 + 0.9 / leverage)
+      : 0);
   const liquidationDistance =
-    perpMarket && liquidationPrice > 0
+    openPreview?.liquidationDistancePercent ??
+    (perpMarket && liquidationPrice > 0
       ? side === 'long'
         ? ((perpMarket.currentPrice - liquidationPrice) /
             perpMarket.currentPrice) *
@@ -368,7 +394,14 @@ export function PositionDetailModal({
         : ((liquidationPrice - perpMarket.currentPrice) /
             perpMarket.currentPrice) *
           100
-      : 0;
+      : 0);
+  const estimatedFee =
+    openPreview?.estimatedFee ??
+    (sizeNum > 0 ? sizeNum * FEE_CONFIG.TRADING_FEE_RATE : 0);
+  const totalRequired =
+    openPreview?.totalRequired ?? marginRequired + estimatedFee;
+
+  if (!isOpen || !data) return null;
 
   return (
     <div
@@ -923,6 +956,24 @@ export function PositionDetailModal({
                       <span className="text-right font-bold text-foreground">
                         {formatPrice(positionValue)}
                       </span>
+                      <span className="text-muted-foreground">Top of Book</span>
+                      <span className="text-right font-medium text-foreground">
+                        {formatPrice(quotedPrice)}
+                      </span>
+                      <span className="text-muted-foreground">Est. Entry</span>
+                      <span className="text-right font-medium text-foreground">
+                        {formatPrice(executionPrice)}
+                      </span>
+                      {openPreview && (
+                        <>
+                          <span className="text-muted-foreground">
+                            Size Impact
+                          </span>
+                          <span className="text-right font-medium text-foreground">
+                            {openPreview.quoteImpactBps.toFixed(0)} bps
+                          </span>
+                        </>
+                      )}
                       <span className="text-muted-foreground">
                         Liquidation Price
                       </span>
@@ -944,8 +995,33 @@ export function PositionDetailModal({
                       >
                         {liquidationDistance.toFixed(2)}%
                       </span>
+                      <span className="text-muted-foreground">
+                        Est. Trading Fee
+                      </span>
+                      <span className="text-right font-bold text-foreground">
+                        {formatPrice(estimatedFee)}
+                      </span>
+                      <span className="text-muted-foreground">
+                        Total Required
+                      </span>
+                      <span className="text-right font-bold text-foreground">
+                        {formatPrice(totalRequired)}
+                      </span>
                     </div>
                   </div>
+
+                  {previewLoading && sizeNum > 0 && (
+                    <div className="text-muted-foreground text-xs">
+                      Updating execution preview…
+                    </div>
+                  )}
+
+                  {previewError && sizeNum > 0 && (
+                    <div className="rounded border border-amber-500/30 bg-amber-500/10 p-4 text-amber-500 text-sm">
+                      Preview unavailable. Order submission still uses the
+                      canonical execution engine.
+                    </div>
+                  )}
 
                   {leverage > 50 && (
                     <div className="flex items-start gap-3 rounded bg-yellow-500/15 p-3">

--- a/apps/web/src/hooks/usePerpOpenPreview.ts
+++ b/apps/web/src/hooks/usePerpOpenPreview.ts
@@ -1,0 +1,119 @@
+'use client';
+
+import { useDeferredValue, useEffect, useMemo, useState } from 'react';
+import type { TradeSide } from '@/types/markets';
+import { type OpenPerpPreviewResponse, usePerpTrade } from './usePerpTrade';
+
+interface UsePerpOpenPreviewParams {
+  ticker: string | null;
+  side: TradeSide;
+  size: number;
+  leverage: number;
+  enabled?: boolean;
+  getAccessToken?: () => Promise<string | null> | string | null;
+}
+
+interface PreviewState {
+  preview: OpenPerpPreviewResponse['preview'] | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export function usePerpOpenPreview({
+  ticker,
+  side,
+  size,
+  leverage,
+  enabled = true,
+  getAccessToken,
+}: UsePerpOpenPreviewParams): PreviewState {
+  const { previewOpenPosition } = usePerpTrade({ getAccessToken });
+  const deferredSize = useDeferredValue(size);
+  const deferredLeverage = useDeferredValue(leverage);
+  const normalizedTicker = useMemo(
+    () => ticker?.trim().toUpperCase() ?? null,
+    [ticker]
+  );
+  const [state, setState] = useState<PreviewState>({
+    preview: null,
+    loading: false,
+    error: null,
+  });
+
+  useEffect(() => {
+    if (
+      !enabled ||
+      !normalizedTicker ||
+      !Number.isFinite(deferredSize) ||
+      deferredSize <= 0 ||
+      !Number.isFinite(deferredLeverage) ||
+      deferredLeverage < 1
+    ) {
+      setState((current) =>
+        current.preview === null &&
+        current.loading === false &&
+        current.error === null
+          ? current
+          : {
+              preview: null,
+              loading: false,
+              error: null,
+            }
+      );
+      return;
+    }
+
+    const controller = new AbortController();
+    const timeoutId = window.setTimeout(() => {
+      setState((current) => ({
+        preview: current.preview,
+        loading: true,
+        error: null,
+      }));
+
+      void previewOpenPosition(
+        {
+          ticker: normalizedTicker,
+          side,
+          size: deferredSize,
+          leverage: deferredLeverage,
+        },
+        controller.signal
+      )
+        .then((result) => {
+          if (controller.signal.aborted) return;
+          setState({
+            preview: result.preview,
+            loading: false,
+            error: null,
+          });
+        })
+        .catch((error: unknown) => {
+          if (controller.signal.aborted) return;
+          const message =
+            error instanceof Error
+              ? error.message
+              : 'Failed to fetch perp preview';
+          setState((current) => ({
+            preview: current.preview,
+            loading: false,
+            error: message,
+          }));
+        });
+    }, 120);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+      controller.abort();
+    };
+  }, [
+    deferredLeverage,
+    deferredSize,
+    enabled,
+    normalizedTicker,
+    previewOpenPosition,
+    side,
+  ]);
+
+  return state;
+}

--- a/apps/web/src/hooks/usePerpTrade.ts
+++ b/apps/web/src/hooks/usePerpTrade.ts
@@ -33,6 +33,7 @@ export interface OpenPerpPreviewPayload extends OpenPerpPayload {}
 
 export interface OpenPerpPreviewResponse {
   preview: {
+    settlementMode: 'offchain' | 'onchain';
     ticker: string;
     side: TradeSide;
     size: number;
@@ -45,17 +46,17 @@ export interface OpenPerpPreviewResponse {
     quoteImpactPrice: number;
     quoteImpactBps: number;
     totalSlippageBps: number;
-    bidPrice: number;
-    askPrice: number;
-    spreadBps: number;
-    bidDepth: number;
-    askDepth: number;
-    liquidityRegime: 'thin' | 'balanced' | 'deep';
+    bidPrice?: number;
+    askPrice?: number;
+    spreadBps?: number;
+    bidDepth?: number;
+    askDepth?: number;
+    liquidityRegime?: 'thin' | 'balanced' | 'deep';
     marginRequired: number;
     estimatedFee: number;
     totalRequired: number;
-    liquidationPrice: number;
-    liquidationDistancePercent: number;
+    liquidationPrice?: number;
+    liquidationDistancePercent?: number;
   };
 }
 

--- a/apps/web/src/hooks/usePerpTrade.ts
+++ b/apps/web/src/hooks/usePerpTrade.ts
@@ -29,6 +29,36 @@ interface OpenPerpPayload {
   leverage: number;
 }
 
+export interface OpenPerpPreviewPayload extends OpenPerpPayload {}
+
+export interface OpenPerpPreviewResponse {
+  preview: {
+    ticker: string;
+    side: TradeSide;
+    size: number;
+    leverage: number;
+    currentPrice: number;
+    markPrice?: number;
+    indexPrice?: number;
+    quotedPrice: number;
+    executionPrice: number;
+    quoteImpactPrice: number;
+    quoteImpactBps: number;
+    totalSlippageBps: number;
+    bidPrice: number;
+    askPrice: number;
+    spreadBps: number;
+    bidDepth: number;
+    askDepth: number;
+    liquidityRegime: 'thin' | 'balanced' | 'deep';
+    marginRequired: number;
+    estimatedFee: number;
+    totalRequired: number;
+    liquidationPrice: number;
+    liquidationDistancePercent: number;
+  };
+}
+
 interface ApiPerpPosition {
   id: string;
   ticker: string;
@@ -187,8 +217,23 @@ export function usePerpTrade(options: UsePerpTradeOptions = {}) {
     [callApi]
   );
 
+  const previewOpenPosition = useCallback(
+    async (
+      payload: OpenPerpPreviewPayload,
+      signal?: AbortSignal
+    ): Promise<OpenPerpPreviewResponse> => {
+      return await callApi('/api/markets/perps/preview', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+        signal,
+      });
+    },
+    [callApi]
+  );
+
   return {
     openPosition,
     closePosition,
+    previewOpenPosition,
   };
 }

--- a/apps/web/src/lib/perps/rebalance.test.ts
+++ b/apps/web/src/lib/perps/rebalance.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'bun:test';
+import { getPerpRebalanceInfo, shouldApplyPerpBalanceGate } from './rebalance';
+
+describe('perp rebalance helpers', () => {
+  it('returns null when there is no existing position', () => {
+    expect(
+      getPerpRebalanceInfo({
+        existingPosition: null,
+        nextSide: 'long',
+        requestedSize: 100,
+      })
+    ).toBeNull();
+  });
+
+  it('classifies same-side trades as add', () => {
+    expect(
+      getPerpRebalanceInfo({
+        existingPosition: { side: 'long', size: 100 },
+        nextSide: 'long',
+        requestedSize: 40,
+      })
+    ).toEqual({
+      type: 'add',
+      newSize: 140,
+    });
+  });
+
+  it('classifies smaller opposite trades as reduce', () => {
+    expect(
+      getPerpRebalanceInfo({
+        existingPosition: { side: 'long', size: 100 },
+        nextSide: 'short',
+        requestedSize: 40,
+      })
+    ).toEqual({
+      type: 'reduce',
+      newSize: 60,
+    });
+  });
+
+  it('classifies equal opposite trades as close', () => {
+    expect(
+      getPerpRebalanceInfo({
+        existingPosition: { side: 'long', size: 100 },
+        nextSide: 'short',
+        requestedSize: 100,
+      })
+    ).toEqual({
+      type: 'close',
+      newSize: 0,
+    });
+  });
+
+  it('classifies larger opposite trades as flip', () => {
+    expect(
+      getPerpRebalanceInfo({
+        existingPosition: { side: 'long', size: 100 },
+        nextSide: 'short',
+        requestedSize: 140,
+      })
+    ).toEqual({
+      type: 'flip',
+      newSize: 40,
+    });
+  });
+
+  it('applies balance gating only to fresh opens and add flows', () => {
+    expect(shouldApplyPerpBalanceGate(null)).toBe(true);
+    expect(shouldApplyPerpBalanceGate({ type: 'add', newSize: 150 })).toBe(
+      true
+    );
+    expect(shouldApplyPerpBalanceGate({ type: 'reduce', newSize: 50 })).toBe(
+      false
+    );
+    expect(shouldApplyPerpBalanceGate({ type: 'close', newSize: 0 })).toBe(
+      false
+    );
+    expect(shouldApplyPerpBalanceGate({ type: 'flip', newSize: 25 })).toBe(
+      false
+    );
+  });
+});

--- a/apps/web/src/lib/perps/rebalance.ts
+++ b/apps/web/src/lib/perps/rebalance.ts
@@ -1,0 +1,53 @@
+import type { PerpPosition } from '@babylon/shared';
+import type { TradeSide } from '@/types/markets';
+
+export type PerpRebalanceType = 'add' | 'reduce' | 'close' | 'flip';
+
+export interface PerpRebalanceInfo {
+  type: PerpRebalanceType;
+  newSize: number;
+}
+
+export function getPerpRebalanceInfo(params: {
+  existingPosition: Pick<PerpPosition, 'side' | 'size'> | null;
+  nextSide: TradeSide;
+  requestedSize: number;
+}): PerpRebalanceInfo | null {
+  const { existingPosition, nextSide, requestedSize } = params;
+  if (!existingPosition || requestedSize <= 0) {
+    return null;
+  }
+
+  if (existingPosition.side === nextSide) {
+    return {
+      type: 'add',
+      newSize: existingPosition.size + requestedSize,
+    };
+  }
+
+  if (requestedSize < existingPosition.size) {
+    return {
+      type: 'reduce',
+      newSize: existingPosition.size - requestedSize,
+    };
+  }
+
+  if (Math.abs(requestedSize - existingPosition.size) < 0.01) {
+    return {
+      type: 'close',
+      newSize: 0,
+    };
+  }
+
+  return {
+    type: 'flip',
+    newSize: requestedSize - existingPosition.size,
+  };
+}
+
+export function shouldApplyPerpBalanceGate(
+  rebalanceInfo: PerpRebalanceInfo | null
+): boolean {
+  if (!rebalanceInfo) return true;
+  return rebalanceInfo.type === 'add';
+}

--- a/packages/core/markets/perps/PerpMarketService.ts
+++ b/packages/core/markets/perps/PerpMarketService.ts
@@ -1,13 +1,19 @@
-import { calculateTradeImpact, logger, PERP_MARKET_CONFIG } from '@babylon/shared';
+import {
+  calculateTradeImpact,
+  logger,
+  PERP_MARKET_CONFIG,
+} from '@babylon/shared';
 import {
   evolveSyntheticPerpQuoteState,
   getSyntheticPerpExecutionPrice,
   getSyntheticPerpQuoteState,
 } from './microstructure';
+import { PerpQuoteStateService } from './PerpQuoteStateService';
 import type {
   PerpCloseInput,
   PerpDbPort,
   PerpMarketRecord,
+  PerpOpenExecutionPreview,
   PerpOpenInput,
   PerpPositionRecord,
   PerpServiceDeps,
@@ -399,6 +405,28 @@ export class PerpMarketService {
   /** Row count for the full snapshot table (used for pagination metadata). */
   async countMarkets(): Promise<number> {
     return this.db.countMarkets();
+  }
+
+  /**
+   * Preview the exact quote/execution engine used for opening a position.
+   *
+   * Convention:
+   * - `currentPrice` is the canonical public market mid/spot
+   * - quote state is derived around `currentPrice`
+   * - execution price is side/size specific and may differ materially
+   */
+  async previewOpenPosition(
+    input: Pick<PerpOpenInput, 'ticker' | 'side' | 'size' | 'leverage'>
+  ): Promise<PerpOpenExecutionPreview> {
+    if (input.size <= 0 || !Number.isFinite(input.size)) {
+      throw new Error('Preview size must be positive');
+    }
+    if (input.leverage < 1 || !Number.isFinite(input.leverage)) {
+      throw new Error('Preview leverage must be at least 1');
+    }
+
+    const market = await this.getRequiredMarket(input.ticker);
+    return this.buildOpenExecutionPreview(market, input);
   }
 
   /**
@@ -1027,43 +1055,10 @@ export class PerpMarketService {
    * during quieter periods where the mid price barely moves.
    */
   async refreshQuoteStates(): Promise<number> {
-    const markets = await this.db.listMarkets();
-    const now = this.deps.clock?.now() ?? new Date();
-    let refreshed = 0;
-
-    for (const market of markets) {
-      const elapsedMs = market.quoteUpdatedAt
-        ? Math.max(0, now.getTime() - market.quoteUpdatedAt.getTime())
-        : undefined;
-      const nextQuote = evolveSyntheticPerpQuoteState({
-        market,
-        previousQuote: getSyntheticPerpQuoteState(market),
-        elapsedMs,
-      });
-
-      const changed =
-        Math.abs((market.spreadBps ?? 0) - nextQuote.spreadBps) > 0.01 ||
-        Math.abs((market.bidDepth ?? 0) - nextQuote.bidDepth) > 0.01 ||
-        Math.abs((market.askDepth ?? 0) - nextQuote.askDepth) > 0.01 ||
-        Math.abs((market.bidPrice ?? 0) - nextQuote.bidPrice) > 0.0001 ||
-        Math.abs((market.askPrice ?? 0) - nextQuote.askPrice) > 0.0001 ||
-        market.liquidityRegime !== nextQuote.liquidityRegime;
-
-      if (!changed) continue;
-
-      await this.db.updateMarketStats(market.ticker, {
-        bidPrice: nextQuote.bidPrice,
-        askPrice: nextQuote.askPrice,
-        spreadBps: nextQuote.spreadBps,
-        bidDepth: nextQuote.bidDepth,
-        askDepth: nextQuote.askDepth,
-        liquidityRegime: nextQuote.liquidityRegime,
-        quoteUpdatedAt: now,
-      });
-      refreshed++;
-    }
-
-    return refreshed;
+    return new PerpQuoteStateService({
+      db: this.db,
+      clock: this.deps.clock,
+    }).refreshQuoteStates();
   }
 
   /**
@@ -1689,6 +1684,82 @@ export class PerpMarketService {
   private calculateMaxPositionSize(openInterest: number): number {
     const fromOi = openInterest * OPEN_INTEREST_LIMIT_RATIO;
     return Math.max(fromOi, MIN_MAX_POSITION_SIZE);
+  }
+
+  private async getRequiredMarket(ticker: string): Promise<PerpMarketRecord> {
+    const normalizedTicker = ticker.toUpperCase();
+    const markets = await this.db.listMarkets();
+    const market = markets.find(
+      (candidate) => candidate.ticker.toUpperCase() === normalizedTicker
+    );
+    if (!market) {
+      throw new Error(`Market not found: ${ticker}`);
+    }
+    return market;
+  }
+
+  private buildOpenExecutionPreview(
+    market: PerpMarketRecord,
+    input: Pick<PerpOpenInput, 'ticker' | 'side' | 'size' | 'leverage'>
+  ): PerpOpenExecutionPreview {
+    const execution = this.getOpenExecutionQuote(
+      market,
+      input.side,
+      input.size
+    );
+    const currentPrice =
+      Number.isFinite(market.currentPrice) && market.currentPrice > 0
+        ? market.currentPrice
+        : execution.midPrice;
+    const quotedPrice =
+      input.side === 'long' ? execution.askPrice : execution.bidPrice;
+    const quoteImpactPrice = Math.max(
+      0,
+      Math.abs(execution.executionPrice - quotedPrice)
+    );
+    const totalSlippageBps =
+      (Math.abs(execution.executionPrice - currentPrice) /
+        Math.max(currentPrice, 1)) *
+      10_000;
+    const quoteImpactBps =
+      (quoteImpactPrice / Math.max(currentPrice, 1)) * 10_000;
+    const liquidationPrice = calculateLiquidationPrice(
+      execution.executionPrice,
+      input.side,
+      input.leverage
+    );
+    const liquidationDistancePercent =
+      input.side === 'long'
+        ? ((currentPrice - liquidationPrice) / Math.max(currentPrice, 1)) * 100
+        : ((liquidationPrice - currentPrice) / Math.max(currentPrice, 1)) * 100;
+    const marginRequired = input.size / input.leverage;
+    const estimatedFee = this.calculateFee(input.size);
+
+    return {
+      ticker: input.ticker.toUpperCase(),
+      side: input.side,
+      size: input.size,
+      leverage: input.leverage,
+      currentPrice,
+      markPrice: market.markPrice,
+      indexPrice: market.indexPrice,
+      quotedPrice,
+      executionPrice: execution.executionPrice,
+      quoteImpactPrice,
+      quoteImpactBps,
+      totalSlippageBps,
+      bidPrice: execution.bidPrice,
+      askPrice: execution.askPrice,
+      spreadBps: execution.spreadBps,
+      bidDepth: execution.bidDepth,
+      askDepth: execution.askDepth,
+      liquidityRegime: getSyntheticPerpQuoteState(market).liquidityRegime,
+      marginRequired,
+      estimatedFee,
+      totalRequired: marginRequired + estimatedFee,
+      liquidationPrice,
+      liquidationDistancePercent,
+    };
   }
 
   private getOpenExecutionQuote(

--- a/packages/core/markets/perps/PerpQuoteStateService.ts
+++ b/packages/core/markets/perps/PerpQuoteStateService.ts
@@ -1,0 +1,79 @@
+import type { ClockPort } from '../shared/common';
+import {
+  evolveSyntheticPerpQuoteState,
+  getSyntheticPerpQuoteState,
+} from './microstructure';
+import type { PerpDbPort } from './types';
+
+interface PerpQuoteStateServiceDeps {
+  db: PerpDbPort;
+  clock?: ClockPort;
+}
+
+/**
+ * Lightweight service for quote-state maintenance.
+ *
+ * Responsibilities are intentionally narrow:
+ * - evolve persisted bid/ask/spread/depth over time
+ * - keep quote-state logic in the core perp domain
+ *
+ * It does not depend on wallet, fees, or trade execution wiring.
+ */
+export class PerpQuoteStateService {
+  private readonly db: PerpDbPort;
+  private readonly clock?: ClockPort;
+
+  constructor(deps: PerpQuoteStateServiceDeps) {
+    this.db = deps.db;
+    this.clock = deps.clock;
+  }
+
+  /**
+   * Refresh quote state for all markets so spread/depth can relax over time
+   * during quieter periods where the canonical market price does not move much.
+   *
+   * Convention:
+   * - `currentPrice` remains the canonical public market price
+   * - refresh evolves quote-state around `currentPrice`
+   * - refresh never mutates `currentPrice`
+   */
+  async refreshQuoteStates(): Promise<number> {
+    const markets = await this.db.listMarkets();
+    const now = this.clock?.now() ?? new Date();
+    let refreshed = 0;
+
+    for (const market of markets) {
+      const elapsedMs = market.quoteUpdatedAt
+        ? Math.max(0, now.getTime() - market.quoteUpdatedAt.getTime())
+        : undefined;
+      const nextQuote = evolveSyntheticPerpQuoteState({
+        market,
+        previousQuote: getSyntheticPerpQuoteState(market),
+        elapsedMs,
+      });
+
+      const changed =
+        Math.abs((market.spreadBps ?? 0) - nextQuote.spreadBps) > 0.01 ||
+        Math.abs((market.bidDepth ?? 0) - nextQuote.bidDepth) > 0.01 ||
+        Math.abs((market.askDepth ?? 0) - nextQuote.askDepth) > 0.01 ||
+        Math.abs((market.bidPrice ?? 0) - nextQuote.bidPrice) > 0.0001 ||
+        Math.abs((market.askPrice ?? 0) - nextQuote.askPrice) > 0.0001 ||
+        market.liquidityRegime !== nextQuote.liquidityRegime;
+
+      if (!changed) continue;
+
+      await this.db.updateMarketStats(market.ticker, {
+        bidPrice: nextQuote.bidPrice,
+        askPrice: nextQuote.askPrice,
+        spreadBps: nextQuote.spreadBps,
+        bidDepth: nextQuote.bidDepth,
+        askDepth: nextQuote.askDepth,
+        liquidityRegime: nextQuote.liquidityRegime,
+        quoteUpdatedAt: now,
+      });
+      refreshed++;
+    }
+
+    return refreshed;
+  }
+}

--- a/packages/core/markets/perps/__tests__/PerpMarketService.test.ts
+++ b/packages/core/markets/perps/__tests__/PerpMarketService.test.ts
@@ -588,6 +588,29 @@ describe('PerpMarketService', () => {
     expect(market.askDepth ?? 0).toBeGreaterThan(100);
   });
 
+  it('uses the same execution engine for open preview and open execution', async () => {
+    const preview = await service.previewOpenPosition({
+      ticker: 'ABC',
+      side: 'long',
+      size: 250,
+      leverage: 10,
+    });
+
+    const open = await service.openPosition({
+      userId: 'u1',
+      ticker: 'ABC',
+      side: 'long',
+      size: 250,
+      leverage: 10,
+    });
+
+    expect(preview.quotedPrice).toBeGreaterThan(0);
+    expect(preview.executionPrice).toBeCloseTo(open.entryPrice, 8);
+    expect(preview.marginRequired).toBeCloseTo(open.marginPaid ?? 0, 8);
+    expect(preview.estimatedFee).toBeCloseTo(open.feePaid, 8);
+    expect(preview.liquidationPrice).toBeCloseTo(open.liquidationPrice, 8);
+  });
+
   describe('position rebalancing', () => {
     it('adds to position when opening same side (increases size, averages entry)', async () => {
       // Open initial LONG position at $100

--- a/packages/core/markets/perps/index.ts
+++ b/packages/core/markets/perps/index.ts
@@ -1,5 +1,6 @@
 export * from './adapters/drizzle/PerpDbAdapter';
 export * from './microstructure';
 export * from './PerpMarketService';
+export * from './PerpQuoteStateService';
 export * from './types';
 export * from './utils';

--- a/packages/core/markets/perps/types.ts
+++ b/packages/core/markets/perps/types.ts
@@ -19,6 +19,16 @@ export interface PerpMarketRecord {
   name?: string;
   /** Company logo from Organization.imageUrl when available. */
   imageUrl?: string | null;
+  /**
+   * Canonical public market price for the instrument.
+   *
+   * Convention:
+   * - this is the live public mid/spot price for the market
+   * - quote state is derived around it
+   * - execution price may differ from it based on side/size
+   * - it is not the internal fair value (`latentPrice`)
+   * - it is not the liquidation/reference mark price
+   */
   currentPrice: number;
   /** Price from 24 hours ago (for accurate change calculation) */
   price24hAgo?: number;
@@ -197,6 +207,36 @@ export interface PerpTradeResult {
   previousSize?: number;
   /** Previous entry price before modification */
   previousEntryPrice?: number;
+}
+
+export interface PerpOpenExecutionPreview {
+  ticker: string;
+  side: PerpSide;
+  size: number;
+  leverage: number;
+  /**
+   * Canonical public market price.
+   * See PerpMarketRecord.currentPrice for the contract of this field.
+   */
+  currentPrice: number;
+  markPrice?: number;
+  indexPrice?: number;
+  quotedPrice: number;
+  executionPrice: number;
+  quoteImpactPrice: number;
+  quoteImpactBps: number;
+  totalSlippageBps: number;
+  bidPrice: number;
+  askPrice: number;
+  spreadBps: number;
+  bidDepth: number;
+  askDepth: number;
+  liquidityRegime: 'thin' | 'balanced' | 'deep';
+  marginRequired: number;
+  estimatedFee: number;
+  totalRequired: number;
+  liquidationPrice: number;
+  liquidationDistancePercent: number;
 }
 
 /**

--- a/packages/engine/src/game-tick.ts
+++ b/packages/engine/src/game-tick.ts
@@ -6,7 +6,7 @@
 
 import {
   PerpDbAdapter as CorePerpDbAdapter,
-  PerpMarketService as CorePerpMarketService,
+  PerpQuoteStateService as CorePerpQuoteStateService,
   isOpenPerpPositionStateValid,
 } from '@babylon/core/markets/perps';
 import {
@@ -1035,20 +1035,8 @@ export async function executeGameTick(
 }
 
 async function refreshPerpQuoteStates(): Promise<number> {
-  const service = new CorePerpMarketService({
+  const service = new CorePerpQuoteStateService({
     db: new CorePerpDbAdapter(),
-    wallet: {
-      debit: async () => {},
-      credit: async () => {},
-      recordPnL: async () => {},
-      getBalance: async () => ({ balance: 0 }),
-    },
-    fees: {
-      tradingFeeRate: 0,
-      platformShare: 0,
-      referrerShare: 0,
-      minFeeAmount: 0,
-    },
   });
 
   return service.refreshQuoteStates();

--- a/packages/shared/src/perps-types.ts
+++ b/packages/shared/src/perps-types.ts
@@ -42,6 +42,15 @@ export interface PerpMarket {
   ticker: string;
   organizationId: string;
   name: string;
+  /**
+   * Canonical public market price for the instrument.
+   *
+   * Convention:
+   * - this is the live public mid/spot price
+   * - bid/ask/spread/depth are derived around it
+   * - execution price can differ from it based on side/size
+   * - it is not the internal fair value and not the liquidation mark price
+   */
   currentPrice: number;
   change24h: number; // Dollar change
   changePercent24h: number; // Percentage change


### PR DESCRIPTION
## Summary
- add a canonical perp open-order preview API backed by the exact same execution engine as real order placement
- extract perp quote-state refresh into a dedicated core service and document the `currentPrice` contract explicitly
- wire the new preview through perp trading UI surfaces so players see top-of-book, estimated entry, impact, fees, and liquidation from server-side pricing

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Continues the validated market realism handoff on top of `staging`
- Scope is intentionally limited to perps only

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [ ] CLI (`apps/cli`)
- [ ] Vendor docs (`docs/vendors/*`)
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Agents / runtime / A2A / MCP (`packages/agents`, `packages/a2a`, `packages/mcp`)
- [ ] API infra (`packages/api`)
- [ ] DB (`packages/db`)
- [ ] Contracts / on-chain (`packages/contracts`)
- [x] Shared types/utils (`packages/shared`)
- [ ] Tests (`packages/testing`)
- [ ] Other: …

## Non-goals / follow-ups
- No prediction-market realism changes in this PR
- No broader cleanup of remaining magic numbers yet
- No deeper refactor of post-trade price impact beyond keeping preview/execution on one canonical engine

## Changes
- add `PerpQuoteStateService` and route `game-tick` quote refresh through it instead of instantiating a trading service with stubbed wallet/fee deps
- add `previewOpenPosition` to `PerpMarketService` and expose it via `POST /api/markets/perps/preview`
- document the canonical meaning of `currentPrice` in core/shared perp types
- add `usePerpOpenPreview` and wire perp entry UIs to server-calculated preview values
- add focused tests proving preview and execution share the same engine, plus API route coverage

## Review guide
**Start here**
- `packages/core/markets/perps/PerpMarketService.ts`
- `packages/core/markets/perps/PerpQuoteStateService.ts`
- `apps/web/src/app/api/markets/perps/preview/route.ts`
- `apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- `currentPrice` is now explicitly treated as the canonical public market mid/spot, not fair value and not execution price
- preview intentionally uses the same core execution quote path as real open execution; divergence should only come from state moving between preview and submit
- `PositionDetailModal` was included because it had its own client-side perp preview path and would otherwise keep a competing pricing story in product

## Test plan
**Commands run**
- [ ] `bun run check` (Biome `check --write .`)
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test` (unit + integration)
- [ ] `bun run test:e2e` (if critical flows changed)
- [ ] `bun run contracts:test` (if contracts changed)
- [ ] `bun run db:check` (if DB schema/queries changed)

**Focused verification / manual verification**
1. `bunx biome check --write` on the touched files only.
2. `bun test packages/core/markets/perps/__tests__/PerpMarketService.test.ts`.
3. `bun test apps/web/src/app/api/markets/perps/preview/route.test.ts`.
4. `bunx tsc -p packages/core/tsconfig.json --noEmit`.
5. Attempted global commit/push hooks fail for unrelated pre-existing issues in `.tmp/wrap-api-routes-withErrorHandling.mjs` and `apps/web/src/hooks/useWalletFunding.ts`.
6. UI verification path: open a perp entry surface, vary size/leverage, confirm `Top of Book`, `Est. Entry`, `Size Impact`, fee, and liquidation fields update from preview.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates (listed below + `.env.example` updated)
- [ ] Requires DB migration (`bun run db:migrate`) / backfill / seed
- [ ] Changes cron schedule or endpoints (`vercel.json`, `CRON_SECRET`, etc.)
- [ ] Rollout behind a flag / gradual rollout

**Env vars (added/changed/removed)**
- Added: `None`
- Changed: `None`
- Removed: `None`

**DB / data migration**
- Migration(s): `None`
- Backfill/seed: `None`

**Rollout / rollback plan**
- Rollout: normal deploy on `staging`, then validate perp entry preview on the main trading surfaces.
- Rollback: revert this PR to restore previous quote refresh wiring and client-side top-of-book-only display.

## Breaking changes
- [x] None
- [ ] Yes (describe + migration guide below)

**Migration guide**
- None.

## Security / privacy
- [x] No security impact
- [ ] Needs extra review (describe)

<details>
<summary>Area-specific notes (expand if relevant)</summary>

### API / contracts between services
- Adds `POST /api/markets/perps/preview`.

### Database
- None.

### Contracts / on-chain
- None.

### Docs
- None.

</details>

## Screenshots / recordings (UI)

### Option A: Visual demo

| Feature | Before | After |
|---------|--------|-------|
| Perp entry pricing | UI showed top-of-book style pricing only | UI shows canonical server preview with top-of-book, estimated entry, impact, fees, and liquidation |
| Quote refresh wiring | `game-tick` instantiated full trading service with stubbed wallet/fees | `game-tick` refreshes quote-state through a dedicated core quote service |

*Demo script (for recording):*
1. Open perp trading terminal or modal on a liquid market.
2. Change size from small to large while keeping side/leverage fixed.
3. Verify `Est. Entry` worsens as size increases while `Top of Book` stays stable.
4. Change leverage and confirm margin / total required / liquidation values update.
5. Submit an order and verify the actual fill follows the same pricing story shown in preview.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path (`production` for most live fixes, `staging` when batching)
- [x] Handlers remain thin and portable (validate → service → map errors)
- [x] Domain logic stays in packages (no Next/React/Elysia coupling in core)
- [x] `.env.example` updated (if env changed) and variables documented above
- [x] Docs updated (and `bun run docs:generate` if needed)
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] Dependency changes are intentional (`bun.lock` updated)
- [x] Code owners requested (auto via CODEOWNERS or manual)
- [x] **Screenshots/recordings section filled** (visual demo OR explanation why N/A)
