### PR TITLE
fix: add missing @babylon/agents dependency to packages/api

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -251,7 +251,7 @@ jobs:
           echo "🚀 Starting production server..."
           echo "🔑 Verifying NEXT_PUBLIC_PRIVY_APP_ID is available (length: ${#NEXT_PUBLIC_PRIVY_APP_ID})"
           SKIP_ENV_VALIDATION=1 bun scripts/validation/check-environment.ts || echo "⚠️  Environment check skipped in CI"
-          bunx --bun next start apps/web -p 3000 > /tmp/prod-server.log 2>&1 &
+          (cd apps/web && bunx --bun next start -p 3000) > /tmp/prod-server.log 2>&1 &
           echo $! > /tmp/prod-server.pid
           echo "📝 Server PID: $(cat /tmp/prod-server.pid)"
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -17,6 +17,7 @@
     "@anthropic-ai/sdk": "^0.71.0",
     "@aws-sdk/client-s3": "^3.943.0",
     "@aws-sdk/lib-storage": "^3.943.0",
+    "@babylon/agents": "workspace:*",
     "@babylon/contracts": "workspace:*",
     "@babylon/shared": "workspace:*",
     "@privy-io/node": "^0.8.0",


### PR DESCRIPTION
## Summary
- `packages/api` imports `@babylon/agents/agent0` in `onchain-service.ts` but didn't declare `@babylon/agents` as a dependency
- During CI `bun build` of `apps/cli`, the bundler resolves `packages/api` source transitively but can't find `@babylon/agents` from api's resolution context
- Builds fine locally because of hoisted symlinks, but fails in CI's clean install

Includes fixes from #1420 and #1422.

## Test plan
- [x] `bun build src/index.ts --outdir dist --target bun` in `apps/cli` succeeds
- [x] `bun run check` — clean
- [ ] CI `@babylon/cli#build` should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)