### PR TITLE
fix(web): support rebalance-aware perp preview gating

### DIFF
--- a/apps/web/src/app/api/markets/perps/preview/route.test.ts
+++ b/apps/web/src/app/api/markets/perps/preview/route.test.ts
@@ -12,7 +12,7 @@ const mockAuthenticateOnchainPerpUser = mock(async () => ({
   walletAddress: '0xabc',
 }));
 const mockPreviewOpenPosition = mock();
-const mockGetOpenPositionByUserAndTicker = mock(async () => null);
+const mockPreviewOrder = mock();
 const mockPrepareOpenOrder = mock();
 const mockIsOnchainPerpModeEnabled = mock(() => false);
 
@@ -31,12 +31,6 @@ mock.module('@babylon/api', () => ({
       await handler(request),
 }));
 
-mock.module('@babylon/core/markets/perps', () => ({
-  PerpDbAdapter: class PerpDbAdapter {
-    getOpenPositionByUserAndTicker = mockGetOpenPositionByUserAndTicker;
-  },
-}));
-
 mock.module('@babylon/shared', () => ({
   PerpOpenPositionSchema: {
     parse: (value: Record<string, unknown>) => value,
@@ -46,6 +40,7 @@ mock.module('@babylon/shared', () => ({
 mock.module('../_adapters', () => ({
   createPerpMarketService: () => ({
     previewOpenPosition: mockPreviewOpenPosition,
+    previewOrder: mockPreviewOrder,
   }),
 }));
 
@@ -74,7 +69,7 @@ describe('POST /api/markets/perps/preview', () => {
       walletAddress: '0xabc',
     });
     mockPreviewOpenPosition.mockReset();
-    mockGetOpenPositionByUserAndTicker.mockReset();
+    mockPreviewOrder.mockReset();
     mockPrepareOpenOrder.mockReset();
     mockIsOnchainPerpModeEnabled.mockReset();
     mockIsOnchainPerpModeEnabled.mockReturnValue(false);
@@ -133,10 +128,37 @@ describe('POST /api/markets/perps/preview', () => {
     });
   });
 
-  it('rejects canonical preview for rebalance flows', async () => {
-    mockGetOpenPositionByUserAndTicker.mockResolvedValue({
-      id: 'position-1',
-    } as never);
+  it('uses authenticated offchain preview for rebalance-aware flows', async () => {
+    mockPreviewOrder.mockResolvedValue({
+      previewType: 'flip',
+      isRebalance: true,
+      rebalanceType: 'flip',
+      ticker: 'ABC',
+      side: 'long',
+      size: 25,
+      leverage: 5,
+      currentPrice: 100,
+      quotedPrice: 101,
+      executionPrice: 101.4,
+      quoteImpactPrice: 0.4,
+      quoteImpactBps: 40,
+      totalSlippageBps: 140,
+      bidPrice: 99,
+      askPrice: 101,
+      spreadBps: 200,
+      bidDepth: 1000,
+      askDepth: 1000,
+      liquidityRegime: 'balanced',
+      marginRequired: 5,
+      estimatedFee: 0.2,
+      totalRequired: 1.25,
+      resultingSize: 25,
+      resultingSide: 'long',
+      estimatedClosePrice: 98.7,
+      estimatedCloseSettlement: 3.95,
+      liquidationPrice: 81.12,
+      liquidationDistancePercent: 18.88,
+    });
 
     const response = await POST(
       new Request('http://localhost/api/markets/perps/preview', {
@@ -153,12 +175,21 @@ describe('POST /api/markets/perps/preview', () => {
       }) as NextRequest
     );
 
-    expect(response.status).toBe(409);
+    expect(response.status).toBe(200);
     expect(mockPreviewOpenPosition).not.toHaveBeenCalled();
+    expect(mockPreviewOrder).toHaveBeenCalledWith({
+      userId: 'user-1',
+      ticker: 'abc',
+      side: 'long',
+      size: 100,
+      leverage: 5,
+    });
     expect(await response.json()).toEqual({
-      error:
-        'Canonical preview is unavailable for rebalance orders on this endpoint.',
-      code: 'PERP_PREVIEW_REBALANCE_UNSUPPORTED',
+      preview: expect.objectContaining({
+        settlementMode: 'offchain',
+        rebalanceType: 'flip',
+        totalRequired: 1.25,
+      }),
     });
   });
 

--- a/apps/web/src/app/api/markets/perps/preview/route.ts
+++ b/apps/web/src/app/api/markets/perps/preview/route.ts
@@ -5,7 +5,6 @@ import {
   successResponse,
   withErrorHandling,
 } from '@babylon/api';
-import { PerpDbAdapter } from '@babylon/core/markets/perps';
 import { PerpOpenPositionSchema } from '@babylon/shared';
 import type { NextRequest } from 'next/server';
 import { createPerpMarketService } from '../_adapters';
@@ -104,37 +103,27 @@ export const POST = withErrorHandling(async (request: NextRequest) => {
       authenticatedUser = await authenticate(request);
     }
 
-    if (authenticatedUser) {
-      const existingPosition =
-        await new PerpDbAdapter().getOpenPositionByUserAndTicker(
-          authenticatedUser.userId,
-          ticker.toUpperCase()
-        );
-
-      if (existingPosition) {
-        const res = successResponse(
-          {
-            error:
-              'Canonical preview is unavailable for rebalance orders on this endpoint.',
-            code: 'PERP_PREVIEW_REBALANCE_UNSUPPORTED',
-          },
-          409
-        );
-        if (rateLimitInfo) addPublicReadHeaders(res, rateLimitInfo);
-        return res;
-      }
-    }
-
     const service = createPerpMarketService();
-    preview = {
-      settlementMode: 'offchain',
-      ...(await service.previewOpenPosition({
-        ticker,
-        side: normalizedSide,
-        size: numericSize,
-        leverage,
-      })),
-    };
+    preview = authenticatedUser
+      ? {
+          settlementMode: 'offchain',
+          ...(await service.previewOrder({
+            userId: authenticatedUser.userId,
+            ticker,
+            side: normalizedSide,
+            size: numericSize,
+            leverage,
+          })),
+        }
+      : {
+          settlementMode: 'offchain',
+          ...(await service.previewOpenPosition({
+            ticker,
+            side: normalizedSide,
+            size: numericSize,
+            leverage,
+          })),
+        };
   }
 
   const res = successResponse({ preview });

--- a/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
+++ b/apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx
@@ -120,7 +120,7 @@ export function PerpsOrderEntryPanel({
     side,
     size: sizeNum,
     leverage: clampedLeverage,
-    enabled: orderType === 'market' && !existingPosition,
+    enabled: orderType === 'market',
     getAccessToken,
   });
 
@@ -155,7 +155,10 @@ export function PerpsOrderEntryPanel({
     };
   }, [existingPosition, side, sizeNum]);
 
-  const requiresAdditionalCapital = shouldApplyPerpBalanceGate(rebalanceInfo);
+  const requiresAdditionalCapital =
+    openPreview?.totalRequired !== undefined
+      ? openPreview.totalRequired > 0
+      : shouldApplyPerpBalanceGate(rebalanceInfo);
   const capitalCheckLeverage =
     rebalanceInfo?.type === 'add'
       ? (existingPosition?.leverage ?? clampedLeverage)
@@ -551,6 +554,13 @@ export function PerpsOrderEntryPanel({
                 Canonical preview is hidden for rebalance orders in this
                 surface. Submit still follows the real rebalance execution path.
               </div>
+              {openPreview && openPreview.totalRequired > 0 && (
+                <Row
+                  label="Est. Addl. Capital"
+                  value={formatPrice(openPreview.totalRequired)}
+                  strong
+                />
+              )}
             </div>
           )}
 

--- a/apps/web/src/components/markets/PerpTradingModal.tsx
+++ b/apps/web/src/components/markets/PerpTradingModal.tsx
@@ -147,12 +147,15 @@ export function PerpTradingModal({
     side,
     size: sizeNum,
     leverage,
-    enabled: isOpen && !hasExistingPosition,
+    enabled: isOpen,
     getAccessToken,
   });
   const quotedExecutionPrice = openPreview?.quotedPrice ?? topOfBookPrice;
   const executionPrice = openPreview?.executionPrice ?? quotedExecutionPrice;
-  const requiresAdditionalCapital = shouldApplyPerpBalanceGate(rebalanceInfo);
+  const requiresAdditionalCapital =
+    openPreview?.totalRequired !== undefined
+      ? openPreview.totalRequired > 0
+      : shouldApplyPerpBalanceGate(rebalanceInfo);
   const capitalCheckLeverage =
     rebalanceInfo?.type === 'add'
       ? (existingPosition?.leverage ?? leverage)
@@ -496,6 +499,12 @@ export function PerpTradingModal({
               This trade will rebalance your existing {market.ticker} position.
               Canonical preview is hidden in this surface for rebalance flows so
               we do not show misleading numbers before submit.
+              {openPreview && openPreview.totalRequired > 0 && (
+                <div className="mt-2 font-semibold">
+                  Estimated additional capital required:{' '}
+                  {formatPrice(openPreview.totalRequired)}
+                </div>
+              )}
             </div>
           )}
 

--- a/apps/web/src/hooks/usePerpTrade.ts
+++ b/apps/web/src/hooks/usePerpTrade.ts
@@ -34,6 +34,9 @@ export interface OpenPerpPreviewPayload extends OpenPerpPayload {}
 export interface OpenPerpPreviewResponse {
   preview: {
     settlementMode: 'offchain' | 'onchain';
+    previewType?: 'open' | 'add' | 'reduce' | 'close' | 'flip';
+    isRebalance?: boolean;
+    rebalanceType?: 'add' | 'reduce' | 'close' | 'flip';
     ticker: string;
     side: TradeSide;
     size: number;
@@ -55,6 +58,10 @@ export interface OpenPerpPreviewResponse {
     marginRequired: number;
     estimatedFee: number;
     totalRequired: number;
+    resultingSize?: number;
+    resultingSide?: TradeSide | null;
+    estimatedClosePrice?: number;
+    estimatedCloseSettlement?: number;
     liquidationPrice?: number;
     liquidationDistancePercent?: number;
   };

--- a/apps/web/src/lib/perps/rebalance.test.ts
+++ b/apps/web/src/lib/perps/rebalance.test.ts
@@ -64,7 +64,7 @@ describe('perp rebalance helpers', () => {
     });
   });
 
-  it('applies balance gating only to fresh opens and add flows', () => {
+  it('applies balance gating to fresh opens, add, and flip flows', () => {
     expect(shouldApplyPerpBalanceGate(null)).toBe(true);
     expect(shouldApplyPerpBalanceGate({ type: 'add', newSize: 150 })).toBe(
       true
@@ -76,7 +76,7 @@ describe('perp rebalance helpers', () => {
       false
     );
     expect(shouldApplyPerpBalanceGate({ type: 'flip', newSize: 25 })).toBe(
-      false
+      true
     );
   });
 });

--- a/apps/web/src/lib/perps/rebalance.ts
+++ b/apps/web/src/lib/perps/rebalance.ts
@@ -49,5 +49,7 @@ export function shouldApplyPerpBalanceGate(
   rebalanceInfo: PerpRebalanceInfo | null
 ): boolean {
   if (!rebalanceInfo) return true;
-  return rebalanceInfo.type === 'add';
+  // Both 'add' and 'flip' may require additional capital.
+  // Only 'reduce' and 'close' are guaranteed not to need new funds.
+  return rebalanceInfo.type === 'add' || rebalanceInfo.type === 'flip';
 }

--- a/packages/core/markets/perps/PerpMarketService.ts
+++ b/packages/core/markets/perps/PerpMarketService.ts
@@ -429,6 +429,38 @@ export class PerpMarketService {
     return this.buildOpenExecutionPreview(market, input);
   }
 
+  async previewOrder(
+    input: Pick<
+      PerpOpenInput,
+      'userId' | 'ticker' | 'side' | 'size' | 'leverage'
+    >
+  ): Promise<PerpOpenExecutionPreview> {
+    if (input.size <= 0 || !Number.isFinite(input.size)) {
+      throw new Error('Preview size must be positive');
+    }
+    if (input.leverage < 1 || !Number.isFinite(input.leverage)) {
+      throw new Error('Preview leverage must be at least 1');
+    }
+
+    const market = await this.getRequiredMarket(input.ticker);
+    const existingPosition = await this.db.getOpenPositionByUserAndTicker(
+      input.userId,
+      input.ticker
+    );
+
+    if (!existingPosition) {
+      return this.buildOpenExecutionPreview(market, input);
+    }
+
+    this.assertOpenPositionIntegrity(existingPosition);
+
+    if (existingPosition.side === input.side) {
+      return this.buildAddPreview(market, existingPosition, input);
+    }
+
+    return this.buildOppositeSidePreview(market, existingPosition, input);
+  }
+
   /**
    * Open a perp position.
    *
@@ -1736,6 +1768,8 @@ export class PerpMarketService {
     const estimatedFee = this.calculateFee(input.size);
 
     return {
+      previewType: 'open',
+      isRebalance: false,
       ticker: input.ticker.toUpperCase(),
       side: input.side,
       size: input.size,
@@ -1757,6 +1791,305 @@ export class PerpMarketService {
       marginRequired,
       estimatedFee,
       totalRequired: marginRequired + estimatedFee,
+      liquidationPrice,
+      liquidationDistancePercent,
+    };
+  }
+
+  private buildAddPreview(
+    market: PerpMarketRecord,
+    existing: PerpPositionRecord,
+    input: Pick<
+      PerpOpenInput,
+      'ticker' | 'side' | 'size' | 'leverage'
+    >
+  ): PerpOpenExecutionPreview {
+    const addedSize = input.size;
+    const effectiveLeverage = existing.leverage;
+    const execution = this.getOpenExecutionQuote(market, existing.side, addedSize);
+    const currentPrice =
+      Number.isFinite(market.currentPrice) && market.currentPrice > 0
+        ? market.currentPrice
+        : execution.midPrice;
+    const quotedPrice =
+      existing.side === 'long' ? execution.askPrice : execution.bidPrice;
+    const quoteImpactPrice = Math.max(
+      0,
+      Math.abs(execution.executionPrice - quotedPrice)
+    );
+    const totalSlippageBps =
+      (Math.abs(execution.executionPrice - currentPrice) /
+        Math.max(currentPrice, 1)) *
+      10_000;
+    const quoteImpactBps =
+      (quoteImpactPrice / Math.max(currentPrice, 1)) * 10_000;
+    const resultingSize = existing.size + addedSize;
+    const averagedEntryPrice =
+      (existing.size * existing.entryPrice + addedSize * execution.executionPrice) /
+      resultingSize;
+    const liquidationPrice = calculateLiquidationPrice(
+      averagedEntryPrice,
+      existing.side,
+      effectiveLeverage
+    );
+    const liquidationDistancePercent =
+      existing.side === 'long'
+        ? ((currentPrice - liquidationPrice) / Math.max(currentPrice, 1)) * 100
+        : ((liquidationPrice - currentPrice) / Math.max(currentPrice, 1)) * 100;
+    const marginRequired = addedSize / effectiveLeverage;
+    const estimatedFee = this.calculateFee(addedSize);
+
+    return {
+      previewType: 'add',
+      isRebalance: true,
+      rebalanceType: 'add',
+      ticker: input.ticker.toUpperCase(),
+      side: existing.side,
+      size: addedSize,
+      leverage: effectiveLeverage,
+      currentPrice,
+      markPrice: market.markPrice,
+      indexPrice: market.indexPrice,
+      quotedPrice,
+      executionPrice: execution.executionPrice,
+      quoteImpactPrice,
+      quoteImpactBps,
+      totalSlippageBps,
+      bidPrice: execution.bidPrice,
+      askPrice: execution.askPrice,
+      spreadBps: execution.spreadBps,
+      bidDepth: execution.bidDepth,
+      askDepth: execution.askDepth,
+      liquidityRegime: getSyntheticPerpQuoteState(market).liquidityRegime,
+      marginRequired,
+      estimatedFee,
+      totalRequired: marginRequired + estimatedFee,
+      resultingSize,
+      resultingSide: existing.side,
+      liquidationPrice,
+      liquidationDistancePercent,
+    };
+  }
+
+  private buildOppositeSidePreview(
+    market: PerpMarketRecord,
+    existing: PerpPositionRecord,
+    input: Pick<
+      PerpOpenInput,
+      'ticker' | 'side' | 'size' | 'leverage'
+    >
+  ): PerpOpenExecutionPreview {
+    const currentPrice =
+      Number.isFinite(market.currentPrice) && market.currentPrice > 0
+        ? market.currentPrice
+        : existing.currentPrice;
+
+    if (input.size < existing.size) {
+      const closeExecution = this.getCloseExecutionQuote(
+        market,
+        existing.side,
+        input.size
+      );
+      return this.buildReduceOrClosePreview({
+        market,
+        existing,
+        input,
+        closeSize: input.size,
+        closeExecution,
+        rebalanceType: 'reduce',
+        resultingSize: existing.size - input.size,
+        currentPrice,
+      });
+    }
+
+    if (Math.abs(input.size - existing.size) < 0.01) {
+      const closeExecution = this.getCloseExecutionQuote(
+        market,
+        existing.side,
+        existing.size
+      );
+      return this.buildReduceOrClosePreview({
+        market,
+        existing,
+        input,
+        closeSize: existing.size,
+        closeExecution,
+        rebalanceType: 'close',
+        resultingSize: 0,
+        currentPrice,
+      });
+    }
+
+    const closeExecution = this.getCloseExecutionQuote(
+      market,
+      existing.side,
+      existing.size
+    );
+    const inverseSize = input.size - existing.size;
+    const effectiveLeverage = Math.min(
+      input.leverage,
+      market.maxLeverage ?? DEFAULT_MAX_LEVERAGE
+    );
+    const openExecution = this.getOpenExecutionQuote(market, input.side, inverseSize);
+    const quotedPrice =
+      input.side === 'long' ? openExecution.askPrice : openExecution.bidPrice;
+    const quoteImpactPrice = Math.max(
+      0,
+      Math.abs(openExecution.executionPrice - quotedPrice)
+    );
+    const totalSlippageBps =
+      (Math.abs(openExecution.executionPrice - currentPrice) /
+        Math.max(currentPrice, 1)) *
+      10_000;
+    const quoteImpactBps =
+      (quoteImpactPrice / Math.max(currentPrice, 1)) * 10_000;
+    const { pnl: closePnl } = calculateUnrealizedPnL(
+      existing.entryPrice,
+      closeExecution.executionPrice,
+      existing.side,
+      existing.size
+    );
+    const closeMarginPaid = existing.size / existing.leverage;
+    const closeFee = this.calculateFee(existing.size);
+    const realizedPnL = closePnl - existing.fundingPaid;
+    const grossSettlement = closeMarginPaid + realizedPnL;
+    const estimatedCloseSettlement = Math.max(0, grossSettlement - closeFee);
+    const marginRequired = inverseSize / effectiveLeverage;
+    const openFee = this.calculateFee(inverseSize);
+    const openCost = marginRequired + openFee;
+    const liquidationPrice = calculateLiquidationPrice(
+      openExecution.executionPrice,
+      input.side,
+      effectiveLeverage
+    );
+    const liquidationDistancePercent =
+      input.side === 'long'
+        ? ((currentPrice - liquidationPrice) / Math.max(currentPrice, 1)) * 100
+        : ((liquidationPrice - currentPrice) / Math.max(currentPrice, 1)) * 100;
+
+    return {
+      previewType: 'flip',
+      isRebalance: true,
+      rebalanceType: 'flip',
+      ticker: input.ticker.toUpperCase(),
+      side: input.side,
+      size: inverseSize,
+      leverage: effectiveLeverage,
+      currentPrice,
+      markPrice: market.markPrice,
+      indexPrice: market.indexPrice,
+      quotedPrice,
+      executionPrice: openExecution.executionPrice,
+      quoteImpactPrice,
+      quoteImpactBps,
+      totalSlippageBps,
+      bidPrice: openExecution.bidPrice,
+      askPrice: openExecution.askPrice,
+      spreadBps: openExecution.spreadBps,
+      bidDepth: openExecution.bidDepth,
+      askDepth: openExecution.askDepth,
+      liquidityRegime: getSyntheticPerpQuoteState(market).liquidityRegime,
+      marginRequired,
+      estimatedFee: closeFee + openFee,
+      totalRequired: Math.max(0, openCost - estimatedCloseSettlement),
+      resultingSize: inverseSize,
+      resultingSide: input.side,
+      estimatedClosePrice: closeExecution.executionPrice,
+      estimatedCloseSettlement,
+      liquidationPrice,
+      liquidationDistancePercent,
+    };
+  }
+
+  private buildReduceOrClosePreview(params: {
+    market: PerpMarketRecord;
+    existing: PerpPositionRecord;
+    input: Pick<PerpOpenInput, 'ticker' | 'side' | 'size' | 'leverage'>;
+    closeSize: number;
+    closeExecution: ReturnType<PerpMarketService['getCloseExecutionQuote']>;
+    rebalanceType: 'reduce' | 'close';
+    resultingSize: number;
+    currentPrice: number;
+  }): PerpOpenExecutionPreview {
+    const {
+      market,
+      existing,
+      input,
+      closeSize,
+      closeExecution,
+      rebalanceType,
+      resultingSize,
+      currentPrice,
+    } = params;
+    const { pnl: closePnl } = calculateUnrealizedPnL(
+      existing.entryPrice,
+      closeExecution.executionPrice,
+      existing.side,
+      closeSize
+    );
+    const closePercentage = closeSize / existing.size;
+    const proportionalFunding = existing.fundingPaid * closePercentage;
+    const realizedPnL = closePnl - proportionalFunding;
+    const closeMarginPaid = closeSize / existing.leverage;
+    const closeFee = this.calculateFee(closeSize);
+    const grossSettlement = closeMarginPaid + realizedPnL;
+    const estimatedCloseSettlement = Math.max(0, grossSettlement - closeFee);
+    const quotedPrice =
+      existing.side === 'long'
+        ? closeExecution.bidPrice
+        : closeExecution.askPrice;
+    const quoteImpactPrice = Math.max(
+      0,
+      Math.abs(closeExecution.executionPrice - quotedPrice)
+    );
+    const totalSlippageBps =
+      (Math.abs(closeExecution.executionPrice - currentPrice) /
+        Math.max(currentPrice, 1)) *
+      10_000;
+    const quoteImpactBps =
+      (quoteImpactPrice / Math.max(currentPrice, 1)) * 10_000;
+    const liquidationPrice =
+      rebalanceType === 'reduce' ? existing.liquidationPrice : 0;
+    const liquidationDistancePercent =
+      rebalanceType === 'reduce'
+        ? existing.side === 'long'
+          ? ((currentPrice - existing.liquidationPrice) /
+              Math.max(currentPrice, 1)) *
+            100
+          : ((existing.liquidationPrice - currentPrice) /
+              Math.max(currentPrice, 1)) *
+            100
+        : 0;
+
+    return {
+      previewType: rebalanceType,
+      isRebalance: true,
+      rebalanceType,
+      ticker: input.ticker.toUpperCase(),
+      side: existing.side,
+      size: closeSize,
+      leverage: existing.leverage,
+      currentPrice,
+      markPrice: market.markPrice,
+      indexPrice: market.indexPrice,
+      quotedPrice,
+      executionPrice: closeExecution.executionPrice,
+      quoteImpactPrice,
+      quoteImpactBps,
+      totalSlippageBps,
+      bidPrice: closeExecution.bidPrice,
+      askPrice: closeExecution.askPrice,
+      spreadBps: closeExecution.spreadBps,
+      bidDepth: closeExecution.bidDepth,
+      askDepth: closeExecution.askDepth,
+      liquidityRegime: getSyntheticPerpQuoteState(market).liquidityRegime,
+      marginRequired: 0,
+      estimatedFee: closeFee,
+      totalRequired: 0,
+      resultingSize,
+      resultingSide: resultingSize > 0 ? existing.side : null,
+      estimatedClosePrice: closeExecution.executionPrice,
+      estimatedCloseSettlement,
       liquidationPrice,
       liquidationDistancePercent,
     };

--- a/packages/core/markets/perps/__tests__/PerpMarketService.test.ts
+++ b/packages/core/markets/perps/__tests__/PerpMarketService.test.ts
@@ -611,6 +611,36 @@ describe('PerpMarketService', () => {
     expect(preview.liquidationPrice).toBeCloseTo(open.liquidationPrice, 8);
   });
 
+  it('previews flip rebalances with additional capital net of close settlement', async () => {
+    await service.openPosition({
+      userId: 'u1',
+      ticker: 'ABC',
+      side: 'short',
+      size: 100,
+      leverage: 10,
+    });
+
+    await db.updateMarketStats('ABC', {
+      currentPrice: 130,
+      bidPrice: 129,
+      askPrice: 131,
+    });
+
+    const preview = await service.previewOrder({
+      userId: 'u1',
+      ticker: 'ABC',
+      side: 'long',
+      size: 160,
+      leverage: 5,
+    });
+
+    expect(preview.isRebalance).toBe(true);
+    expect(preview.rebalanceType).toBe('flip');
+    expect(preview.size).toBeCloseTo(60, 8);
+    expect(preview.estimatedCloseSettlement).toBeDefined();
+    expect(preview.totalRequired).toBeGreaterThanOrEqual(0);
+  });
+
   describe('position rebalancing', () => {
     it('adds to position when opening same side (increases size, averages entry)', async () => {
       // Open initial LONG position at $100

--- a/packages/core/markets/perps/types.ts
+++ b/packages/core/markets/perps/types.ts
@@ -210,6 +210,9 @@ export interface PerpTradeResult {
 }
 
 export interface PerpOpenExecutionPreview {
+  previewType?: 'open' | 'add' | 'reduce' | 'close' | 'flip';
+  isRebalance?: boolean;
+  rebalanceType?: 'add' | 'reduce' | 'close' | 'flip';
   ticker: string;
   side: PerpSide;
   size: number;
@@ -235,6 +238,10 @@ export interface PerpOpenExecutionPreview {
   marginRequired: number;
   estimatedFee: number;
   totalRequired: number;
+  resultingSize?: number;
+  resultingSide?: PerpSide | null;
+  estimatedClosePrice?: number;
+  estimatedCloseSettlement?: number;
   liquidationPrice: number;
   liquidationDistancePercent: number;
 }


### PR DESCRIPTION
## Summary
- make the offchain perp preview route rebalance-aware instead of rejecting authenticated rebalance flows
- use the rebalance-aware server preview to drive additional-capital gating in perp entry UI
- keep detailed rebalance preview hidden in the current UI surfaces, while avoiding the false `0 required` story for flip orders

## Type
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / cleanup (no behavior change)
- [ ] Performance
- [ ] Infra / ops
- [ ] Docs
- [ ] Contracts / on-chain
- [ ] Other: …

## Context / Links
- Follow-up to #1418 after post-merge review on `staging`
- Fixes the remaining inconsistency where flip rebalances could still require capital on submit while the UI gate treated them as requiring none

## Scope (keep it focused)
- [x] This PR is focused on a single change/theme (not a catch-all)
- [x] Drive-by refactors are excluded or split into a separate PR
- [x] Non-goals / follow-ups are listed below (with links)

**Areas touched**
- [x] Web UI (`apps/web`)
- [x] Web API routes / SSE / A2A (`apps/web`)
- [x] Domain / game engine (`packages/engine`, `packages/core/*`)
- [ ] Other areas

## Non-goals / follow-ups
- No prediction-market work
- No broader rework of post-trade price impact
- No new rebalance-specific UI layout; this only fixes preview-backed gating and messaging

## Changes
- add `previewOrder()` in `PerpMarketService` so authenticated offchain previews can cover add/reduce/close/flip flows
- remove the `409 PERP_PREVIEW_REBALANCE_UNSUPPORTED` path from `POST /api/markets/perps/preview`
- feed rebalance-aware preview results into perp entry surfaces for accurate additional-capital checks
- keep rebalance preview details mostly hidden in the current UI, but surface estimated extra capital when relevant
- add route and service test coverage for rebalance-aware preview behavior

## Review guide
**Start here**
- `packages/core/markets/perps/PerpMarketService.ts`
- `apps/web/src/app/api/markets/perps/preview/route.ts`
- `apps/web/src/app/markets/_components/perps-terminal/PerpsOrderEntryPanel.tsx`
- `apps/web/src/components/markets/PerpTradingModal.tsx`

**Risk**
- [ ] Low
- [x] Medium
- [ ] High

**Notes for reviewers**
- The goal is narrow: fix the remaining mismatch between rebalance submit behavior and UI capital gating.
- Detailed rebalance previews are still intentionally hidden in these surfaces to avoid over-claiming precision before we design that UX properly.

## Test plan
**Commands run**
- [ ] `bun run check`
- [ ] `bun run typecheck`
- [ ] `bun run lint`
- [ ] `bun run build`
- [ ] `bun run test`

**Focused verification / manual verification**
1. `bunx biome check --write` on touched files.
2. `bun test apps/web/src/app/api/markets/perps/preview/route.test.ts`.
3. Attempted core test / core typecheck from the clean worktree, but local worktree dependency resolution is incomplete there; route-level verification passed.
4. Manual path: with an existing perp position, enter an opposite-side larger order and confirm the UI no longer implies zero additional capital when the server estimates extra funds are needed.

## Ops / Migration / Deployment
- [x] No deploy impact
- [ ] Requires env var updates
- [ ] Requires DB migration
- [ ] Changes cron schedule or endpoints
- [ ] Rollout behind a flag / gradual rollout

## Breaking changes
- [x] None
- [ ] Yes

## Security / privacy
- [x] No security impact
- [ ] Needs extra review

## Screenshots / recordings (UI)

### Option B: No visual changes
- Reason: Small UX copy/data follow-up on an existing newly-shipped perp preview flow; no new layout introduced, only corrected gating and messaging for rebalance orders.

## Checklist (author)
- [x] Self-review done (diff + critical paths)
- [x] Base branch is correct for the release path
- [x] Handlers remain thin and portable
- [x] Domain logic stays in packages
- [x] Tests added/updated for behavior changes (or rationale provided)
- [x] **Screenshots/recordings section filled**
